### PR TITLE
Update Mongo calls for `FindOneAndUpdate` and `FindOneAndReplace`

### DIFF
--- a/packages/backend/src/__tests__/event.recur/recur.custom.wip.ts
+++ b/packages/backend/src/__tests__/event.recur/recur.custom.wip.ts
@@ -1,7 +1,0 @@
-// describe("Event Recurrence: Custom", () => {
-//   it.todo("supports weekly on MWF");
-//   test.todo("supports monthly recurrence");
-//   test.todo("supports monthly on date recurrence");
-//   test.todo("supports monthly on week # recurrence");
-//   test.todo("supports annual recurrence");
-// });

--- a/packages/backend/src/event/queries/event.queries.ts
+++ b/packages/backend/src/event/queries/event.queries.ts
@@ -67,10 +67,10 @@ export const updateEvent = async (
       { returnDocument: "after" }
     );
 
-  if (!response || response["value"] === null || !response["ok"]) {
+  if (!response) {
     throw error(EventError.NoMatchingEvent, "Prompt Redux refresh");
   }
-  return response["value"];
+  return response;
 };
 
 export const updateFutureInstances = async (

--- a/packages/backend/src/priority/services/priority.service.ts
+++ b/packages/backend/src/priority/services/priority.service.ts
@@ -43,6 +43,7 @@ class PriorityService {
           name: data.name,
         }
       );
+
       if (priorityExists) {
         throw new BaseError(
           "Priority Exists",
@@ -51,6 +52,7 @@ class PriorityService {
           true
         );
       }
+
       const doc = Object.assign({}, data, { user: userId });
       const response = await mongoService.db
         .collection(Collections.PRIORITY)
@@ -62,6 +64,7 @@ class PriorityService {
         name: data.name,
         color: data.color,
       };
+
       return priority;
     }
   }
@@ -92,7 +95,8 @@ class PriorityService {
   }
 
   async deleteAllByUser(userId: string) {
-    const filter = { user: userId };
+    const filter = { user: { $eq: userId } };
+
     const response = await mongoService.db
       .collection(Collections.PRIORITY)
       .deleteMany(filter);
@@ -100,7 +104,11 @@ class PriorityService {
   }
 
   async deleteById(id: string, userId: string) {
-    const filter = { _id: mongoService.objectId(id), user: userId };
+    const filter = {
+      _id: { $eq: mongoService.objectId(id) },
+      user: { $eq: userId },
+    };
+
     const response = await mongoService.db
       .collection(Collections.PRIORITY)
       .deleteOne(filter);
@@ -126,11 +134,12 @@ class PriorityService {
 
     return priority;
   }
+
   async updateById(id: string, priority: PriorityReq, userId: string) {
     const response = await mongoService.db
       .collection(Collections.PRIORITY)
       .findOneAndUpdate(
-        { _id: mongoService.objectId(id), user: userId },
+        { _id: { $eq: mongoService.objectId(id) }, user: { $eq: userId } },
         { $set: priority },
         { returnDocument: "after" }
       );

--- a/packages/backend/src/priority/services/priority.service.ts
+++ b/packages/backend/src/priority/services/priority.service.ts
@@ -131,16 +131,15 @@ class PriorityService {
       .collection(Collections.PRIORITY)
       .findOneAndUpdate(
         { _id: mongoService.objectId(id), user: userId },
-        { priority },
+        { $set: priority },
         { returnDocument: "after" }
       );
 
-    if (!response || response["value"] === null || response["ok"] !== 0) {
+    if (!response) {
       return new BaseError("Update Failed", "Ensure id is correct", 400, true);
     }
 
-    const updatedPriority = response["value"] as unknown as Schema_Priority;
-    return updatedPriority;
+    return response as unknown as Schema_Priority;
   }
 }
 


### PR DESCRIPTION
These outdated calls caused errors, because the code was looking for response keys that were removed in a recent version. This bug surfaced during the mongo update in #73.

closes #74 