### PR TITLE
Fix: adjust preview event when changing times in form

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -276,6 +276,7 @@ export const EventForm: React.FC<FormProps> = ({
 
       <DateTimeSection
         bgColor={getColor(colorNameByPriority[priority])}
+        event={event}
         category={category}
         endTime={endTime}
         isEndDatePickerOpen={isEndDatePickerOpen}
@@ -289,6 +290,7 @@ export const EventForm: React.FC<FormProps> = ({
         startTime={startTime}
         setIsEndDatePickerOpen={setIsEndDatePickerOpen}
         setIsStartDatePickerOpen={setIsStartDatePickerOpen}
+        setEvent={setEvent}
       />
 
       <StyledDescriptionField


### PR DESCRIPTION
This fixes #46 

Things to consider:
- As shown in the video below, a trace of the event before modifying the time is displayed (like when dragging or resizing) until after submitting the form. I'm not sure if that's fine or should update like the draft.

Video demonstration of how it works now:

https://github.com/SwitchbackTech/compass/assets/71569727/742c89d9-72d0-4af2-8134-fabcc3fb363c

