### PR TITLE
🐛 Fix(web): make cursor row-resize upon hover

### DIFF
--- a/packages/web/src/views/Calendar/components/Event/Draft/Draft.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Draft/Draft.tsx
@@ -37,7 +37,7 @@ export const Draft: FC<Props> = ({
     weekProps,
     isSidebarOpen
   );
-  const { draft, isDragging } = draftState;
+  const { draft, isDragging, isResizing } = draftState;
 
   const { isDrafting } = useAppSelector(selectDraftId);
 
@@ -58,6 +58,7 @@ export const Draft: FC<Props> = ({
           draftUtil={draftUtil}
           formProps={formProps}
           isDragging={isDragging}
+          isResizing={isResizing}
           measurements={measurements}
           weekProps={weekProps}
         />

--- a/packages/web/src/views/Calendar/components/Event/Draft/GridDraft.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Draft/GridDraft.tsx
@@ -15,6 +15,7 @@ interface Props {
   draftUtil: GridDraftProps["draftUtil"];
   formProps: EventFormProps;
   isDragging: boolean;
+  isResizing: boolean;
   measurements: Measurements_Grid;
   weekProps: WeekProps;
 }
@@ -24,6 +25,7 @@ export const GridDraft: FC<Props> = ({
   draftUtil,
   formProps,
   isDragging,
+  isResizing,
   measurements,
   weekProps,
 }) => {
@@ -43,7 +45,7 @@ export const GridDraft: FC<Props> = ({
         isDragging={isDragging}
         isDraft={true}
         isPlaceholder={false}
-        isResizing={false}
+        isResizing={isResizing}
         key={`draft-${draft?._id}`}
         measurements={measurements}
         onEventMouseDown={(event: Schema_GridEvent, e: MouseEvent) => {

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -96,21 +96,19 @@ const _GridEvent = (
               isDrafting={isDragging || isResizing}
               isPlaceholder={isPlaceholder}
             />
-            {!isPlaceholder && !isDragging && (
-              <>
-                <StyledEventScaler
-                  isDragging={isDragging}
-                  onMouseDown={(e) => onScalerMouseDown(event, e, "startDate")}
-                  top="-1px"
-                />
+            <>
+              <StyledEventScaler
+                showResizeCursor={!isPlaceholder && !isResizing && !isDragging}
+                onMouseDown={(e) => onScalerMouseDown(event, e, "startDate")}
+                top="-1px"
+              />
 
-                <StyledEventScaler
-                  bottom="-1px"
-                  isDragging={isDragging}
-                  onMouseDown={(e) => onScalerMouseDown(event, e, "endDate")}
-                />
-              </>
-            )}
+              <StyledEventScaler
+                bottom="-1px"
+                showResizeCursor={!isPlaceholder && !isResizing && !isDragging}
+                onMouseDown={(e) => onScalerMouseDown(event, e, "endDate")}
+              />
+            </>
           </>
         )}
       </Flex>

--- a/packages/web/src/views/Calendar/components/Event/styled.ts
+++ b/packages/web/src/views/Calendar/components/Event/styled.ts
@@ -65,7 +65,6 @@ export const StyledEvent = styled.div.attrs<StyledEventProps>((props) => {
   z-index: ${ZIndex.LAYER_1};
 
   &:hover {
-    cursor: default;
     transition: background-color 0.35s linear;
 
     ${({ isPlaceholder, isResizing, hoverColor }) =>
@@ -95,8 +94,8 @@ export const StyledEvent = styled.div.attrs<StyledEventProps>((props) => {
 `;
 
 export interface ScalerProps {
+  showResizeCursor: boolean;
   bottom?: string;
-  isDragging: boolean;
   top?: string;
 }
 
@@ -113,5 +112,5 @@ export const StyledEventScaler = styled.div.attrs<ScalerProps>((props) => {
   left: 0;
   top: ${(props) => props.top};
   bottom: ${(props) => props.bottom};
-  ${(props) => !props.isDragging && `cursor: ns-resize`};
+  ${(props) => props.showResizeCursor && `cursor: row-resize`};
 `;


### PR DESCRIPTION
and revert back to default upon resize/drag. before this, the cursor would toggle between the default and row-resize during drag/resize, which was distracting for users.

Closes #117 