### PR TITLE
🐛 Fix(backend): Improve auth error handling during full-sync response

### DIFF
--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -76,13 +76,18 @@ class AuthController {
         tokens
       );
 
-      const user = await findCompassUserBy("google.googleId", gUser.sub);
+      const { authMethod, user } = await compassAuthService.determineAuthMethod(
+        gUser.sub
+      );
+      const { cUserId } =
+        authMethod === "login"
+          ? await this.login(
+              user as WithId<Schema_User>,
+              gcalClient,
+              gRefreshToken
+            )
+          : await this.signup(gUser, gcalClient, gRefreshToken);
 
-      const { cUserId } = user
-        ? await this.login(user, gcalClient, gRefreshToken)
-        : await this.signup(gUser, gcalClient, gRefreshToken);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
       const sUserId = supertokens.convertToRecipeUserId(cUserId);
       await Session.createNewSession(req, res, "public", sUserId);
 

--- a/packages/backend/src/auth/services/compass.auth.service.ts
+++ b/packages/backend/src/auth/services/compass.auth.service.ts
@@ -1,6 +1,33 @@
 import Session from "supertokens-node/recipe/session";
+import { SyncError } from "@backend/common/constants/error.constants";
+import { getSync } from "@backend/sync/util/sync.queries";
+import { canDoIncrementalSync } from "@backend/sync/util/sync.utils";
+import { findCompassUserBy } from "@backend/user/queries/user.queries";
+import { error } from "@backend/common/errors/handlers/error.handler";
 
 class CompassAuthService {
+  determineAuthMethod = async (gUserId: string) => {
+    const user = await findCompassUserBy("google.googleId", gUserId);
+
+    if (!user) {
+      return { authMethod: "signup", user: null };
+    }
+    const userId = user._id.toString();
+
+    const sync = await getSync({ userId });
+    if (!sync) {
+      throw error(
+        SyncError.NoSyncRecordForUser,
+        "Did not verify sync record for user"
+      );
+    }
+
+    const canLogin = canDoIncrementalSync(sync);
+    const authMethod = user && canLogin ? "login" : "signup";
+
+    return { authMethod, user };
+  };
+
   revokeSessionsByUser = async (userId: string) => {
     const sessionsRevoked = await Session.revokeAllSessionsForUser(userId);
     return { sessionsRevoked: sessionsRevoked.length };

--- a/packages/backend/src/common/types/sync.types.ts
+++ b/packages/backend/src/common/types/sync.types.ts
@@ -14,7 +14,7 @@ export interface Summary_Resync {
     events?: "success";
     sync?: UpdateResult;
   };
-  revoke: {
+  revoke?: {
     sessionsRevoked?: number;
   };
 }

--- a/packages/backend/src/sync/util/sync.utils.ts
+++ b/packages/backend/src/sync/util/sync.utils.ts
@@ -160,6 +160,13 @@ export const hasGoogleHeaders = (headers: object) => {
   return hasHeaders;
 };
 
+export const canDoIncrementalSync = (sync: Schema_Sync) => {
+  const everyCalendarHasSyncToken = sync.google?.events?.every(
+    (event) => event.nextSyncToken !== null
+  );
+  return everyCalendarHasSyncToken;
+};
+
 export const isUsingHttps = () =>
   ENV.BASEURL !== undefined && ENV.BASEURL.includes("https");
 

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -142,12 +142,11 @@ class UserService {
 
   reSyncGoogleData = async (userId: string) => {
     logger.warn(`Re-syncing google data for user: ${userId}`);
-    const summary: Summary_Resync = { _delete: {}, recreate: {}, revoke: {} };
+    const summary: Summary_Resync = { _delete: {}, recreate: {} };
 
     try {
       summary._delete = await this._deleteBeforeReSyncingGoogle(userId);
       summary.recreate = await this._reSyncGoogle(userId);
-      summary.revoke = await compassAuthService.revokeSessionsByUser(userId);
 
       return { result: Result_Resync.SUCCESS, summary };
     } catch (e) {


### PR DESCRIPTION
Address the behavior described in the linked bug in 2 ways:
1. Prevents doing an incremental sync for a user who doesn't have the necessary field (`google.events.nextSyncToken`
2. Removes the step that revokes a user's session when resyncing their google data


Closes #83 