### PR TITLE
✨ Feat: improve responsiveness during edits

### DIFF
--- a/packages/web/src/__tests__/Calendar/EventForm/eventform.test.tsx
+++ b/packages/web/src/__tests__/Calendar/EventForm/eventform.test.tsx
@@ -28,7 +28,7 @@ describe("Event Form", () => {
   //   await _clickHeading(user);
   //   await user.click(screen.getByRole("button", { name: /takeover world/i }));
   //   expect(
-  //     within(screen.getByTestId("somedayForm")).getByText("Takeover world")
+  //     within(screen.getRole("form", name: {"Someday Event Form"})).getByText("Takeover world")
   //   ).toBeInTheDocument();
   // }, 10000);
   it("closes when clicking outside", async () => {

--- a/packages/web/src/__tests__/Calendar/EventForm/eventform.test.tsx
+++ b/packages/web/src/__tests__/Calendar/EventForm/eventform.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { act } from "react";
 import "@testing-library/jest-dom";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -34,8 +34,12 @@ describe("Event Form", () => {
   it("closes when clicking outside", async () => {
     render(<CalendarView />, { state: preloadedState });
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: CLIMB.title }));
-    await _clickHeading(user);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: CLIMB.title }));
+      await _clickHeading(user);
+    });
+
     await waitFor(() => {
       expect(screen.queryByRole("form")).not.toBeInTheDocument();
     });
@@ -66,11 +70,15 @@ describe("Event Form", () => {
     it("dialog is not open by default", async () => {
       const user = userEvent.setup();
       const { container } = render(<CalendarView />, { state: preloadedState });
-      await user.click(
-        screen.getByRole("button", {
-          name: /climb/i,
-        })
-      );
+
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", {
+            name: /climb/i,
+          })
+        );
+      });
+
       expect(container.getElementsByClassName("startDatePicker")).toHaveLength(
         0
       );

--- a/packages/web/src/common/constants/web.constants.ts
+++ b/packages/web/src/common/constants/web.constants.ts
@@ -18,7 +18,6 @@ export const ID_SIDEBAR = "sidebar";
 export const ID_SOMEDAY_DRAFT = "somedayDraft";
 export const ID_SOMEDAY_EVENTS = "ID_SOMEDAY_EVENTS";
 export const ID_SOMEDAY_EVENT_FORM = "Someday Event Form";
-export const ID_SIDEBAR_FORM = "sidebarForm";
 
 export const OPTIONS_RECURRENCE = {
   WEEK: { value: Recurrence_Selection.WEEK, label: "week" },

--- a/packages/web/src/common/constants/web.constants.ts
+++ b/packages/web/src/common/constants/web.constants.ts
@@ -8,6 +8,7 @@ export const COLUMN_MONTH = "monthEvents";
 export const GOOGLE = "google";
 
 export const ID_ALLDAY_COLUMNS = "allDayColumns";
+export const ID_EVENT_FORM = "Event Form";
 export const ID_GRID_ALLDAY_ROW = "allDayRow";
 export const ID_GRID_EVENTS_ALLDAY = "allDayEvents";
 export const ID_GRID_EVENTS_TIMED = "timedEvents";
@@ -16,6 +17,7 @@ export const ID_MAIN = "mainSection";
 export const ID_SIDEBAR = "sidebar";
 export const ID_SOMEDAY_DRAFT = "somedayDraft";
 export const ID_SOMEDAY_EVENTS = "ID_SOMEDAY_EVENTS";
+export const ID_SOMEDAY_EVENT_FORM = "Someday Event Form";
 export const ID_SIDEBAR_FORM = "sidebarForm";
 
 export const OPTIONS_RECURRENCE = {

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -102,6 +102,12 @@ export const getDefaultEvent = (
   startDate?: string,
   endDate?: string
 ): Schema_GridEvent | null => {
+  const defaultSomeday = {
+    isAllDay: false,
+    isSomeday: true,
+    origin: Origin.COMPASS,
+    priority: Priorities.UNASSIGNED,
+  };
   switch (draftType) {
     case Categories_Event.ALLDAY:
       return {
@@ -112,12 +118,7 @@ export const getDefaultEvent = (
         endDate: startDate,
       };
     case Categories_Event.SOMEDAY_WEEK || Categories_Event.SOMEDAY_MONTH:
-      return {
-        isAllDay: false,
-        isSomeday: true,
-        origin: Origin.COMPASS,
-        priority: Priorities.UNASSIGNED,
-      };
+      return defaultSomeday;
     case Categories_Event.TIMED: {
       return {
         isAllDay: false,

--- a/packages/web/src/common/utils/index.ts
+++ b/packages/web/src/common/utils/index.ts
@@ -1,3 +1,8 @@
+import {
+  ID_EVENT_FORM,
+  ID_SOMEDAY_EVENT_FORM,
+} from "../constants/web.constants";
+
 export const headers = (token?: string) => {
   if (token) {
     return {
@@ -16,8 +21,9 @@ export const headers = (token?: string) => {
   }
 };
 
-export const isDrafting = () =>
-  document.getElementsByName("Event Form").length === 1;
+export const isEventFormOpen = () =>
+  document.getElementsByName(ID_EVENT_FORM).length === 1 ||
+  document.getElementsByName(ID_SOMEDAY_EVENT_FORM).length === 1;
 
 export const roundToNearest = (x: number, roundBy: number) =>
   Math.round(x / roundBy) * roundBy;

--- a/packages/web/src/common/utils/index.ts
+++ b/packages/web/src/common/utils/index.ts
@@ -25,6 +25,9 @@ export const isEventFormOpen = () =>
   document.getElementsByName(ID_EVENT_FORM).length === 1 ||
   document.getElementsByName(ID_SOMEDAY_EVENT_FORM).length === 1;
 
+export const isSomedayEventFormOpen = () =>
+  document.getElementsByName(ID_SOMEDAY_EVENT_FORM).length === 1;
+
 export const roundToNearest = (x: number, roundBy: number) =>
   Math.round(x / roundBy) * roundBy;
 

--- a/packages/web/src/components/Icons/Delete.tsx
+++ b/packages/web/src/components/Icons/Delete.tsx
@@ -8,5 +8,7 @@ interface Props {
 }
 
 export const DeleteIcon: React.FC<Props> = ({ onDelete, title }) => {
-  return <TrashIcon onClick={onDelete} role="button" name={title} size={27} />;
+  return (
+    <TrashIcon onClick={onDelete} role="button" aria-label={title} size={27} />
+  );
 };

--- a/packages/web/src/ducks/events/selectors/draft.selectors.ts
+++ b/packages/web/src/ducks/events/selectors/draft.selectors.ts
@@ -14,7 +14,7 @@ export const selectIsDraftingExisting = (state: RootState) =>
 
 export const selectIsDraftingSomeday = (state: RootState) =>
   state.events.draft.status.eventType === Categories_Event.SOMEDAY_WEEK ||
-  Categories_Event.SOMEDAY_MONTH;
+  state.events.draft.status.eventType === Categories_Event.SOMEDAY_MONTH;
 
 export const selectDraftId = (state: RootState) =>
   state.events.draft.event?._id;

--- a/packages/web/src/ducks/events/selectors/draft.selectors.ts
+++ b/packages/web/src/ducks/events/selectors/draft.selectors.ts
@@ -1,3 +1,4 @@
+import { Categories_Event } from "@core/types/event.types";
 import { RootState } from "@web/store";
 
 export const selectDraft = (state: RootState) => state.events.draft.event;
@@ -7,6 +8,13 @@ export const selectDraftStatus = (state: RootState) =>
 
 export const selectIsDrafting = (state: RootState) =>
   state.events.draft.status.isDrafting;
+
+export const selectIsDraftingExisting = (state: RootState) =>
+  state.events.draft.event?._id !== undefined;
+
+export const selectIsDraftingSomeday = (state: RootState) =>
+  state.events.draft.status.eventType === Categories_Event.SOMEDAY_WEEK ||
+  Categories_Event.SOMEDAY_MONTH;
 
 export const selectDraftId = (state: RootState) =>
   state.events.draft.event?._id;

--- a/packages/web/src/ducks/events/selectors/draft.selectors.ts
+++ b/packages/web/src/ducks/events/selectors/draft.selectors.ts
@@ -1,15 +1,12 @@
 import { RootState } from "@web/store";
-import { createSelector } from "reselect";
 
 export const selectDraft = (state: RootState) => state.events.draft.event;
+
 export const selectDraftStatus = (state: RootState) =>
   state.events.draft.status;
 
-export const selectDraftId = createSelector(
-  selectDraftStatus,
-  selectDraft,
-  (status, draft) => ({
-    isDrafting: status.isDrafting,
-    draftId: draft?._id,
-  })
-);
+export const selectIsDrafting = (state: RootState) =>
+  state.events.draft.status.isDrafting;
+
+export const selectDraftId = (state: RootState) =>
+  state.events.draft.event?._id;

--- a/packages/web/src/ducks/events/slices/draft.slice.ts
+++ b/packages/web/src/ducks/events/slices/draft.slice.ts
@@ -27,7 +27,7 @@ export const draftSlice = createSlice({
   name: "draft",
   initialState: initialDraft as State_DraftEvent,
   reducers: {
-    discard: (state) => initialDraft,
+    discard: () => initialDraft,
     start: (state, action: Action_DraftEvent) => {
       const { activity, event, eventType } = action.payload;
 

--- a/packages/web/src/views/Calendar/Calendar.form.test.tsx
+++ b/packages/web/src/views/Calendar/Calendar.form.test.tsx
@@ -13,25 +13,42 @@ jest.mock("@web/views/Calendar/hooks/mouse/useEventListener", () => ({
 }));
 
 describe("Event Form", () => {
-  // it("opens when clicking events", async () => {
-  //   const user = userEvent.setup();
-  //   render(<CalendarView />, { state: preloadedState });
-  //   expect(screen.queryByRole("form")).not.toBeInTheDocument();
-  //   /* timed event */
+  //   it("opens when clicking events", async () => {
+  //     const user = userEvent.setup();
+  //     render(<CalendarView />, { state: preloadedState });
+  //     expect(screen.queryByRole("form")).not.toBeInTheDocument();
+  /* timed event */
+  // await act(async () => {
   //   await user.click(screen.getByRole("button", { name: /Ty & Tim/i }));
   //   await _confirmCorrectEventFormIsOpen(TY_TIM.title);
-  //   /* multi-week event */
+  // });
+  /* multi-week event */
+  // await act(async () => {
   //   await _clickHeading(user);
-  //   await user.click(screen.getByRole("button", { name: /multiweek event/i }));
-  //   await _confirmCorrectEventFormIsOpen(MULTI_WEEK.title);
-  //   /* someday event */
-  //   await _clickHeading(user);
-  //   await user.click(screen.getByRole("button", { name: /takeover world/i }));
+  //   await user.click(
+  //     screen.getByRole("button", { name: /multiweek event/i })
+  //   );
+  // });
+  // await waitFor(
+  //   () => {
+  //     expect(screen.getByRole("form")).toBeInTheDocument();
+  //   },
+  //   { timeout: 10000 }
+  // );
+  // await _confirmCorrectEventFormIsOpen(MULTI_WEEK.title);
+  // await waitFor(() => {
   //   expect(
-  //     within(screen.getRole("form", name: {"Someday Event Form"})).getByText("Takeover world")
+  //     within(screen.getByRole("form")).getByText(MULTI_WEEK.title)
   //   ).toBeInTheDocument();
-  // }, 10000);
-  it("closes when clicking outside", async () => {
+  // });
+  // /* someday event */
+  // await _clickHeading(user);
+  // await user.click(screen.getByRole("button", { name: /takeover world/i }));
+  // expect(
+  //   within(screen.getRole("form", name: {"Someday Event Form"})).getByText("Takeover world")
+  // ).toBeInTheDocument();
+  // }, 20000);
+  it("closes after clicking outside", async () => {
     render(<CalendarView />, { state: preloadedState });
     const user = userEvent.setup();
 
@@ -44,30 +61,30 @@ describe("Event Form", () => {
       expect(screen.queryByRole("form")).not.toBeInTheDocument();
     });
   }, 10000);
-  // it("deletes event after clicking trash icon", async () => {
-  //   const user = userEvent.setup();
-  //   render(<CalendarView />, { state: preloadedState });
+  it("closes after clicking trash icon", async () => {
+    const user = userEvent.setup();
+    render(<CalendarView />, { state: preloadedState });
 
-  //   await user.click(screen.getByRole("button", { name: "Europe Trip >" }));
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Europe Trip < >" }));
+    });
 
-  //   const form = screen.getByRole("form");
-  //   const deleteBtn = within(form).getByRole("button");
-  //   await user.click(
-  //     deleteBtn
-  //     // screen.getByRole("button", {
-  //     //   name: /delete someday event/i,
-  //     // })
-  //   );
-  //   await waitFor(() => {
-  //     expect(
-  //       screen.queryByRole("button", {
-  //         name: /delete someday event/i,
-  //       })
-  //     ).not.toBeInTheDocument();
-  //   });
-  // }, 10000);
+    const form = screen.getByRole("form");
+
+    await act(async () => {
+      await user.click(
+        within(form).getByRole("button", {
+          name: /delete someday event/i,
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("form")).not.toBeInTheDocument();
+    });
+  }, 10000);
   describe("DatePicker", () => {
-    it("dialog is not open by default", async () => {
+    it("does not open dialog by default", async () => {
       const user = userEvent.setup();
       const { container } = render(<CalendarView />, { state: preloadedState });
 

--- a/packages/web/src/views/Calendar/Calendar.tsx
+++ b/packages/web/src/views/Calendar/Calendar.tsx
@@ -35,7 +35,6 @@ export const CalendarView = () => {
   const dateCalcs = useDateCalcs(measurements, gridRefs.gridScrollRef);
 
   const isCurrentWeek = weekProps.component.isCurrentWeek;
-  const startOfSelectedWeek = weekProps.component.startOfView;
   const util = weekProps.util;
   const toggleSidebar = prefs.toggleSidebar;
 
@@ -43,7 +42,8 @@ export const CalendarView = () => {
     today,
     dateCalcs,
     isCurrentWeek,
-    startOfSelectedWeek,
+    startOfView: weekProps.component.startOfView,
+    endOfView: weekProps.component.endOfView,
     util,
     scrollUtil,
     toggleSidebar,

--- a/packages/web/src/views/Calendar/components/Event/Draft/Draft.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Draft/Draft.tsx
@@ -8,7 +8,7 @@ import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout"
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
 import { getCategory } from "@web/common/utils/event.util";
 import { useEventForm } from "@web/views/Forms/hooks/useEventForm";
-import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
+import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
 
 import { getDraftContainer } from "./draft.util";
 import { GridDraft } from "./GridDraft";
@@ -39,7 +39,7 @@ export const Draft: FC<Props> = ({
   );
   const { draft, isDragging, isResizing } = draftState;
 
-  const { isDrafting } = useAppSelector(selectDraftId);
+  const isDrafting = useAppSelector(selectIsDrafting);
 
   const formProps = useEventForm("grid");
 

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -129,4 +129,6 @@ const _GridEvent = (
 };
 
 export const GridEvent = forwardRef(_GridEvent);
-export const GridEventMemo = memo(GridEvent);
+export const GridEventMemo = memo(GridEvent, (prev, next) => {
+  return prev.event === next.event && prev.measurements === next.measurements;
+});

--- a/packages/web/src/views/Calendar/components/Event/styled.ts
+++ b/packages/web/src/views/Calendar/components/Event/styled.ts
@@ -7,16 +7,16 @@ import { ZIndex } from "@web/common/constants/web.constants";
 
 interface StyledEventProps {
   allDay: boolean;
-  backgroundColor: string;
+  backgroundColor?: string;
   height: number;
-  hoverColor: string;
+  hoverColor?: string;
   isDragging: boolean;
   isInPast: boolean;
   isResizing: boolean;
   isPlaceholder: boolean;
   left: number;
   lineClamp: number;
-  opacity: number;
+  opacity?: number;
   priority: Priority;
   top: number;
   width: number;

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -1,0 +1,96 @@
+import dayjs from "dayjs";
+import React, { memo, MouseEvent } from "react";
+import { Schema_Event, Categories_Event } from "@core/types/event.types";
+import { Flex } from "@web/components/Flex";
+import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
+import { SpaceCharacter } from "@web/components/SpaceCharacter";
+import { draftSlice } from "@web/ducks/events/slices/draft.slice";
+import { useAppDispatch } from "@web/store/store.hooks";
+import { getPosition } from "@web/views/Calendar/hooks/event/getPosition";
+import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
+import { Text } from "@web/components/Text";
+
+import { StyledEvent } from "../../Event/styled";
+
+interface Props {
+  event: Schema_Event;
+  isPlaceholder: boolean;
+  measurements: Measurements_Grid;
+  startOfView: WeekProps["component"]["startOfView"];
+  endOfView: WeekProps["component"]["endOfView"];
+}
+
+const AllDayEvent = ({
+  event,
+  isPlaceholder,
+  measurements,
+  startOfView,
+  endOfView,
+}: Props) => {
+  const dispatch = useAppDispatch();
+
+  const editAllDayEvent = (event: Schema_Event) => {
+    console.log("starting to drag allday..");
+    dispatch(draftSlice.actions.startDragging({ event }));
+  };
+
+  const position = getPosition(
+    event,
+    startOfView,
+    endOfView,
+    measurements,
+    false
+  );
+
+  const onEventMouseDown = (e: MouseEvent, event: Schema_Event) => {
+    console.log("moused down on all day event");
+    e.stopPropagation();
+
+    if (!isPlaceholder) {
+      console.log("swapping ...");
+      dispatch(
+        draftSlice.actions.swap({ event, category: Categories_Event.ALLDAY })
+      );
+      return;
+    }
+
+    editAllDayEvent(event);
+  };
+
+  return (
+    <StyledEvent
+      allDay={event.isAllDay}
+      height={position.height}
+      isDragging={false}
+      isInPast={dayjs().isAfter(dayjs(event.endDate))}
+      isPlaceholder={isPlaceholder}
+      isResizing={false}
+      left={position.left}
+      lineClamp={1}
+      onMouseDown={(e) => onEventMouseDown(e, event)}
+      priority={event.priority}
+      role="button"
+      top={position.top}
+      width={position.width}
+    >
+      <Flex
+        alignItems={AlignItems.FLEX_START}
+        direction={FlexDirections.COLUMN}
+      >
+        <Text size={10.3} role="textbox">
+          {event.title}
+          <SpaceCharacter />
+        </Text>
+      </Flex>
+    </StyledEvent>
+  );
+};
+
+export const AllDayEventMemo = memo(AllDayEvent, (prev, next) => {
+  return (
+    prev.event === next.event &&
+    prev.isPlaceholder === next.isPlaceholder &&
+    prev.measurements === next.measurements
+  );
+});

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -4,8 +4,6 @@ import { Schema_Event } from "@core/types/event.types";
 import { Flex } from "@web/components/Flex";
 import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
-import { draftSlice } from "@web/ducks/events/slices/draft.slice";
-import { useAppDispatch } from "@web/store/store.hooks";
 import { getPosition } from "@web/views/Calendar/hooks/event/getPosition";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
@@ -19,6 +17,7 @@ interface Props {
   measurements: Measurements_Grid;
   startOfView: WeekProps["component"]["startOfView"];
   endOfView: WeekProps["component"]["endOfView"];
+  onMouseDown: (e: MouseEvent, event: Schema_Event) => void;
 }
 
 const AllDayEvent = ({
@@ -27,9 +26,8 @@ const AllDayEvent = ({
   measurements,
   startOfView,
   endOfView,
+  onMouseDown,
 }: Props) => {
-  const dispatch = useAppDispatch();
-
   const position = getPosition(
     event,
     startOfView,
@@ -37,12 +35,6 @@ const AllDayEvent = ({
     measurements,
     false
   );
-
-  const onEventMouseDown = (e: MouseEvent, event: Schema_Event) => {
-    e.stopPropagation();
-
-    dispatch(draftSlice.actions.startDragging({ event }));
-  };
 
   return (
     <StyledEvent
@@ -54,7 +46,7 @@ const AllDayEvent = ({
       isResizing={false}
       left={position.left}
       lineClamp={1}
-      onMouseDown={(e) => onEventMouseDown(e, event)}
+      onMouseDown={(e) => onMouseDown(e, event)}
       priority={event.priority}
       role="button"
       top={position.top}

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import React, { memo, MouseEvent } from "react";
-import { Schema_Event, Categories_Event } from "@core/types/event.types";
+import { Schema_Event } from "@core/types/event.types";
 import { Flex } from "@web/components/Flex";
 import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
@@ -30,11 +30,6 @@ const AllDayEvent = ({
 }: Props) => {
   const dispatch = useAppDispatch();
 
-  const editAllDayEvent = (event: Schema_Event) => {
-    console.log("starting to drag allday..");
-    dispatch(draftSlice.actions.startDragging({ event }));
-  };
-
   const position = getPosition(
     event,
     startOfView,
@@ -44,18 +39,9 @@ const AllDayEvent = ({
   );
 
   const onEventMouseDown = (e: MouseEvent, event: Schema_Event) => {
-    console.log("moused down on all day event");
     e.stopPropagation();
 
-    if (!isPlaceholder) {
-      console.log("swapping ...");
-      dispatch(
-        draftSlice.actions.swap({ event, category: Categories_Event.ALLDAY })
-      );
-      return;
-    }
-
-    editAllDayEvent(event);
+    dispatch(draftSlice.actions.startDragging({ event }));
   };
 
   return (

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -12,7 +12,7 @@ import {
   selectIsDraftingSomeday,
 } from "@web/ducks/events/selectors/draft.selectors";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
-import { isEventFormOpen } from "@web/common/utils";
+import { isSomedayEventFormOpen } from "@web/common/utils";
 
 import { StyledEvents } from "./styled";
 import { AllDayEventMemo } from "./AllDayEvent";
@@ -39,18 +39,13 @@ export const AllDayEvents = ({
 
     // if drafting someday event, close that
     // (but swap if drafting grid)
-    if (isDraftingSomeday) {
+    // if (isDraftingSomeday) {
+    if (isSomedayEventFormOpen()) {
       console.log("closing old someday draft");
       dispatch(draftSlice.actions.discard());
+      return;
     }
     // if (draftStatus.eventType === Categories_Event.SOMEDAY_WEEK) {
-    // if (isDrafting) {
-    // if (isEventFormOpen()) {
-    //   console.log("closing existing draft & exiting");
-    //   dispatch(draftSlice.actions.discard());
-    //   return;
-    // }
-
     // console.log("about to start dragging, cuz", draftStatus, event);
     console.log("starting drag");
     dispatch(draftSlice.actions.startDragging({ event }));

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -21,7 +21,7 @@ export const AllDayEvents = ({
   endOfView,
 }: Props) => {
   const allDayEvents = useAppSelector(selectAllDayEvents);
-  const { isDrafting, draftId } = useAppSelector(selectDraftId);
+  const { draftId } = useAppSelector(selectDraftId);
 
   return (
     <StyledEvents id={ID_GRID_EVENTS_ALLDAY}>
@@ -29,7 +29,7 @@ export const AllDayEvents = ({
         return (
           <AllDayEventMemo
             key={`${event.title}-${i}`}
-            isPlaceholder={isDrafting && event._id === draftId}
+            isPlaceholder={event._id === draftId}
             event={event}
             startOfView={startOfView}
             endOfView={endOfView}

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -21,7 +21,7 @@ export const AllDayEvents = ({
   endOfView,
 }: Props) => {
   const allDayEvents = useAppSelector(selectAllDayEvents);
-  const { draftId } = useAppSelector(selectDraftId);
+  const draftId = useAppSelector(selectDraftId);
 
   return (
     <StyledEvents id={ID_GRID_EVENTS_ALLDAY}>

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Schema_Event } from "@core/types/event.types";
+import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
+import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
+import { useAppSelector } from "@web/store/store.hooks";
+import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
+import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
+
+import { StyledEvents } from "./styled";
+import { AllDayEventMemo } from "./AllDayEvent";
+
+interface Props {
+  measurements: Measurements_Grid;
+  startOfView: WeekProps["component"]["startOfView"];
+  endOfView: WeekProps["component"]["endOfView"];
+}
+export const AllDayEvents = ({
+  measurements,
+  startOfView,
+  endOfView,
+}: Props) => {
+  const allDayEvents = useAppSelector(selectAllDayEvents);
+  const { isDrafting, draftId } = useAppSelector(selectDraftId);
+
+  return (
+    <StyledEvents id={ID_GRID_EVENTS_ALLDAY}>
+      {allDayEvents.map((event: Schema_Event, i) => {
+        return (
+          <AllDayEventMemo
+            key={`${event.title}-${i}`}
+            isPlaceholder={isDrafting && event._id === draftId}
+            event={event}
+            startOfView={startOfView}
+            endOfView={endOfView}
+            measurements={measurements}
+          />
+        );
+      })}
+    </StyledEvents>
+  );
+};

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,16 +1,11 @@
-import React, { MouseEvent, useCallback } from "react";
-import { Categories_Event, Schema_Event } from "@core/types/event.types";
+import React, { MouseEvent } from "react";
+import { Schema_Event } from "@core/types/event.types";
 import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
-import {
-  selectDraftId,
-  selectDraftStatus,
-  selectIsDrafting,
-  selectIsDraftingSomeday,
-} from "@web/ducks/events/selectors/draft.selectors";
+import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { isSomedayEventFormOpen } from "@web/common/utils";
 
@@ -28,26 +23,16 @@ export const AllDayEvents = ({
   endOfView,
 }: Props) => {
   const allDayEvents = useAppSelector(selectAllDayEvents);
-  // const isDrafting = useAppSelector(selectIsDrafting);
   const draftId = useAppSelector(selectDraftId);
-  const isDraftingSomeday = useAppSelector(selectIsDraftingSomeday);
-  // const draftStatus = useAppSelector(selectDraftStatus);
   const dispatch = useAppDispatch();
 
   const onMouseDown = (e: MouseEvent, event: Schema_Event) => {
     e.stopPropagation();
 
-    // if drafting someday event, close that
-    // (but swap if drafting grid)
-    // if (isDraftingSomeday) {
     if (isSomedayEventFormOpen()) {
-      console.log("closing old someday draft");
       dispatch(draftSlice.actions.discard());
-      return;
     }
-    // if (draftStatus.eventType === Categories_Event.SOMEDAY_WEEK) {
-    // console.log("about to start dragging, cuz", draftStatus, event);
-    console.log("starting drag");
+
     dispatch(draftSlice.actions.startDragging({ event }));
   };
 

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,27 +1,57 @@
-import React from "react";
-import { Schema_Event } from "@core/types/event.types";
+import React, { MouseEvent, useCallback } from "react";
+import { Categories_Event, Schema_Event } from "@core/types/event.types";
 import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
-import { useAppSelector } from "@web/store/store.hooks";
+import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
-import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
+import {
+  selectDraftId,
+  selectDraftStatus,
+  selectIsDrafting,
+} from "@web/ducks/events/selectors/draft.selectors";
+import { draftSlice } from "@web/ducks/events/slices/draft.slice";
+import { isEventFormOpen } from "@web/common/utils";
 
 import { StyledEvents } from "./styled";
 import { AllDayEventMemo } from "./AllDayEvent";
 
 interface Props {
+  isDrafting: boolean;
   measurements: Measurements_Grid;
   startOfView: WeekProps["component"]["startOfView"];
   endOfView: WeekProps["component"]["endOfView"];
 }
 export const AllDayEvents = ({
+  isDrafting,
   measurements,
   startOfView,
   endOfView,
 }: Props) => {
   const allDayEvents = useAppSelector(selectAllDayEvents);
+  // const isDrafting = useAppSelector(selectIsDrafting);
   const draftId = useAppSelector(selectDraftId);
+  // const draftStatus = useAppSelector(selectDraftStatus);
+  const dispatch = useAppDispatch();
+
+  const onMouseDown = (e: MouseEvent, event: Schema_Event) => {
+    e.stopPropagation();
+
+    // console.log("draftId:", draftId);
+    // if (draftStatus.eventType === Categories_Event.SOMEDAY_WEEK) {
+    // if (isDrafting) {
+    // if (isDrafting) {
+    if (isEventFormOpen()) {
+      console.log("not starting drag");
+      console.log("closing existing draft");
+      dispatch(draftSlice.actions.discard());
+      // return;
+    }
+
+    // console.log("about to start dragging, cuz", draftStatus, event);
+    console.log("starting drag");
+    dispatch(draftSlice.actions.startDragging({ event }));
+  };
 
   return (
     <StyledEvents id={ID_GRID_EVENTS_ALLDAY}>
@@ -34,6 +64,7 @@ export const AllDayEvents = ({
             startOfView={startOfView}
             endOfView={endOfView}
             measurements={measurements}
+            onMouseDown={onMouseDown}
           />
         );
       })}

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -9,6 +9,7 @@ import {
   selectDraftId,
   selectDraftStatus,
   selectIsDrafting,
+  selectIsDraftingSomeday,
 } from "@web/ducks/events/selectors/draft.selectors";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { isEventFormOpen } from "@web/common/utils";
@@ -17,13 +18,11 @@ import { StyledEvents } from "./styled";
 import { AllDayEventMemo } from "./AllDayEvent";
 
 interface Props {
-  isDrafting: boolean;
   measurements: Measurements_Grid;
   startOfView: WeekProps["component"]["startOfView"];
   endOfView: WeekProps["component"]["endOfView"];
 }
 export const AllDayEvents = ({
-  isDrafting,
   measurements,
   startOfView,
   endOfView,
@@ -31,22 +30,26 @@ export const AllDayEvents = ({
   const allDayEvents = useAppSelector(selectAllDayEvents);
   // const isDrafting = useAppSelector(selectIsDrafting);
   const draftId = useAppSelector(selectDraftId);
+  const isDraftingSomeday = useAppSelector(selectIsDraftingSomeday);
   // const draftStatus = useAppSelector(selectDraftStatus);
   const dispatch = useAppDispatch();
 
   const onMouseDown = (e: MouseEvent, event: Schema_Event) => {
     e.stopPropagation();
 
-    // console.log("draftId:", draftId);
+    // if drafting someday event, close that
+    // (but swap if drafting grid)
+    if (isDraftingSomeday) {
+      console.log("closing old someday draft");
+      dispatch(draftSlice.actions.discard());
+    }
     // if (draftStatus.eventType === Categories_Event.SOMEDAY_WEEK) {
     // if (isDrafting) {
-    // if (isDrafting) {
-    if (isEventFormOpen()) {
-      console.log("not starting drag");
-      console.log("closing existing draft");
-      dispatch(draftSlice.actions.discard());
-      // return;
-    }
+    // if (isEventFormOpen()) {
+    //   console.log("closing existing draft & exiting");
+    //   dispatch(draftSlice.actions.discard());
+    //   return;
+    // }
 
     // console.log("about to start dragging, cuz", draftStatus, event);
     console.log("starting drag");

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -1,33 +1,26 @@
 import React, { FC, MouseEvent, useEffect } from "react";
-import dayjs from "dayjs";
-import { Categories_Event, Schema_Event } from "@core/types/event.types";
+import { Categories_Event } from "@core/types/event.types";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { Ref_Callback } from "@web/common/types/util.types";
 import {
   ID_ALLDAY_COLUMNS,
   ID_GRID_ALLDAY_ROW,
-  ID_GRID_EVENTS_ALLDAY,
   ID_GRID_MAIN,
 } from "@web/common/constants/web.constants";
 import { getX } from "@web/common/utils/grid.util";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
-import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
-import { Flex } from "@web/components/Flex";
-import { Text } from "@web/components/Text";
-import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
-import { SpaceCharacter } from "@web/components/SpaceCharacter";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
-import { getPosition } from "@web/views/Calendar/hooks/event/getPosition";
 import { getDefaultEvent } from "@web/common/utils/event.util";
-import { Schema_GridEvent } from "@web/common/types/web.event.types";
 import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
+import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
+import { Schema_GridEvent } from "@web/common/types/web.event.types";
 
-import { StyledEvent } from "../../Event/styled";
 import { StyledAllDayColumns, StyledGridCol } from "../Columns/styled";
-import { StyledAllDayRow, StyledEvents } from "./styled";
+import { StyledAllDayRow } from "./styled";
+import { AllDayEvents } from "./AllDayEvents";
 
 interface Props {
   dateCalcs: DateCalcs;
@@ -46,32 +39,24 @@ export const AllDayRow: FC<Props> = ({
 }) => {
   const dispatch = useAppDispatch();
 
-  const {
-    startOfView: startOfSelectedWeekDay,
-    endOfView: endOfSelectedWeekDay,
-    weekDays,
-  } = weekProps.component;
+  const { startOfView, weekDays } = weekProps.component;
 
+  const { isDrafting } = useAppSelector(selectDraftId);
   const allDayEvents = useAppSelector(selectAllDayEvents);
   const _rowVals = allDayEvents.map((e: Schema_GridEvent) => e.row);
   const rowsCount = _rowVals.length === 0 ? 1 : Math.max(..._rowVals);
-  const { isDrafting, draftId } = useAppSelector(selectDraftId);
 
   useEffect(() => {
     measurements.remeasure(ID_GRID_MAIN);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rowsCount]);
 
-  const editAllDayEvent = (event: Schema_Event) => {
-    dispatch(draftSlice.actions.startDragging({ event }));
-  };
-
   const startAlldayDraft = (e: MouseEvent) => {
     const x = getX(e, isSidebarOpen);
     const startDate = dateCalcs.getDateStrByXY(
       x,
       e.clientY,
-      startOfSelectedWeekDay,
+      startOfView,
       YEAR_MONTH_DAY_FORMAT
     );
 
@@ -84,19 +69,6 @@ export const AllDayRow: FC<Props> = ({
     );
   };
 
-  const onEventMouseDown = (e: MouseEvent, event: Schema_Event) => {
-    e.stopPropagation();
-
-    if (isDrafting) {
-      dispatch(
-        draftSlice.actions.swap({ event, category: Categories_Event.ALLDAY })
-      );
-      return;
-    }
-
-    editAllDayEvent(event);
-  };
-
   const onSectionMouseDown = (e: MouseEvent) => {
     if (isDrafting) {
       dispatch(draftSlice.actions.discard());
@@ -104,48 +76,6 @@ export const AllDayRow: FC<Props> = ({
     }
 
     startAlldayDraft(e);
-  };
-
-  const renderAllDayEvents = () => {
-    const _allDayEvents = allDayEvents.map((event: Schema_Event, i: number) => {
-      const position = getPosition(
-        event,
-        startOfSelectedWeekDay,
-        endOfSelectedWeekDay,
-        measurements,
-        false
-      );
-
-      return (
-        <StyledEvent
-          allDay={event.isAllDay}
-          height={position.height}
-          isDragging={false}
-          isInPast={dayjs().isAfter(dayjs(event.endDate))}
-          isPlaceholder={isDrafting && event._id === draftId}
-          isResizing={false}
-          key={`${event.title}-${i}`}
-          left={position.left}
-          onMouseDown={(e) => onEventMouseDown(e, event)}
-          priority={event.priority}
-          role="button"
-          top={position.top}
-          width={position.width}
-        >
-          <Flex
-            alignItems={AlignItems.FLEX_START}
-            direction={FlexDirections.COLUMN}
-          >
-            <Text size={10.3} role="textbox">
-              {event.title}
-              <SpaceCharacter />
-            </Text>
-          </Flex>
-        </StyledEvent>
-      );
-    });
-
-    return _allDayEvents;
   };
 
   return (
@@ -159,9 +89,11 @@ export const AllDayRow: FC<Props> = ({
           <StyledGridCol color={null} key={day.format(YEAR_MONTH_DAY_FORMAT)} />
         ))}
       </StyledAllDayColumns>
-      <StyledEvents id={ID_GRID_EVENTS_ALLDAY}>
-        {renderAllDayEvents()}
-      </StyledEvents>
+      <AllDayEvents
+        measurements={measurements}
+        startOfView={weekProps.component.startOfView}
+        endOfView={weekProps.component.endOfView}
+      />
     </StyledAllDayRow>
   );
 };

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent, useEffect } from "react";
+import React, { FC, MouseEvent, useCallback, useEffect } from "react";
 import { Categories_Event } from "@core/types/event.types";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
@@ -17,6 +17,7 @@ import { getDefaultEvent } from "@web/common/utils/event.util";
 import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
 import { isEventFormOpen } from "@web/common/utils";
+import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
 
 import { StyledAllDayColumns, StyledGridCol } from "../Columns/styled";
 import { StyledAllDayRow } from "./styled";
@@ -38,6 +39,7 @@ export const AllDayRow: FC<Props> = ({
   weekProps,
 }) => {
   const dispatch = useAppDispatch();
+  const isDrafting = useAppSelector(selectIsDrafting);
 
   const { startOfView, weekDays } = weekProps.component;
 
@@ -69,11 +71,13 @@ export const AllDayRow: FC<Props> = ({
   };
 
   const onSectionMouseDown = (e: MouseEvent) => {
-    if (isEventFormOpen()) {
+    // if (isEventFormOpen()) {
+    if (isDrafting) {
       dispatch(draftSlice.actions.discard());
       return;
     }
 
+    console.log("not drafting, starting new allday draft");
     startAlldayDraft(e);
   };
 
@@ -89,6 +93,7 @@ export const AllDayRow: FC<Props> = ({
         ))}
       </StyledAllDayColumns>
       <AllDayEvents
+        isDrafting={isDrafting}
         measurements={measurements}
         startOfView={weekProps.component.startOfView}
         endOfView={weekProps.component.endOfView}

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -16,7 +16,6 @@ import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout"
 import { getDefaultEvent } from "@web/common/utils/event.util";
 import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
-import { isEventFormOpen } from "@web/common/utils";
 import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
 
 import { StyledAllDayColumns, StyledGridCol } from "../Columns/styled";

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -93,7 +93,6 @@ export const AllDayRow: FC<Props> = ({
         ))}
       </StyledAllDayColumns>
       <AllDayEvents
-        isDrafting={isDrafting}
         measurements={measurements}
         startOfView={weekProps.component.startOfView}
         endOfView={weekProps.component.endOfView}

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -14,9 +14,9 @@ import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { getDefaultEvent } from "@web/common/utils/event.util";
-import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
 import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
+import { isEventFormOpen } from "@web/common/utils";
 
 import { StyledAllDayColumns, StyledGridCol } from "../Columns/styled";
 import { StyledAllDayRow } from "./styled";
@@ -41,7 +41,6 @@ export const AllDayRow: FC<Props> = ({
 
   const { startOfView, weekDays } = weekProps.component;
 
-  const { isDrafting } = useAppSelector(selectDraftId);
   const allDayEvents = useAppSelector(selectAllDayEvents);
   const _rowVals = allDayEvents.map((e: Schema_GridEvent) => e.row);
   const rowsCount = _rowVals.length === 0 ? 1 : Math.max(..._rowVals);
@@ -70,7 +69,7 @@ export const AllDayRow: FC<Props> = ({
   };
 
   const onSectionMouseDown = (e: MouseEvent) => {
-    if (isDrafting) {
+    if (isEventFormOpen()) {
       dispatch(draftSlice.actions.discard());
       return;
     }

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent, useCallback, useEffect } from "react";
+import React, { FC, MouseEvent, useEffect } from "react";
 import { Categories_Event } from "@core/types/event.types";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
@@ -16,7 +16,7 @@ import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout"
 import { getDefaultEvent } from "@web/common/utils/event.util";
 import { selectAllDayEvents } from "@web/ducks/events/selectors/event.selectors";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
-import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
+import { isEventFormOpen } from "@web/common/utils";
 
 import { StyledAllDayColumns, StyledGridCol } from "../Columns/styled";
 import { StyledAllDayRow } from "./styled";
@@ -38,7 +38,6 @@ export const AllDayRow: FC<Props> = ({
   weekProps,
 }) => {
   const dispatch = useAppDispatch();
-  const isDrafting = useAppSelector(selectIsDrafting);
 
   const { startOfView, weekDays } = weekProps.component;
 
@@ -70,13 +69,11 @@ export const AllDayRow: FC<Props> = ({
   };
 
   const onSectionMouseDown = (e: MouseEvent) => {
-    // if (isEventFormOpen()) {
-    if (isDrafting) {
+    if (isEventFormOpen()) {
       dispatch(draftSlice.actions.discard());
       return;
     }
 
-    console.log("not drafting, starting new allday draft");
     startAlldayDraft(e);
   };
 

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
@@ -3,7 +3,7 @@ import mergeRefs from "react-merge-refs";
 import { Dayjs } from "dayjs";
 import { Categories_Event } from "@core/types/event.types";
 import { DRAFT_DURATION_MIN } from "@web/views/Calendar/layout.constants";
-import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
+import { useAppDispatch } from "@web/store/store.hooks";
 import { Ref_Callback } from "@web/common/types/util.types";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
@@ -13,7 +13,7 @@ import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout"
 import { getDefaultEvent } from "@web/common/utils/event.util";
 import { getX } from "@web/common/utils/grid.util";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
-import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
+import { isEventFormOpen } from "@web/common/utils";
 
 import { Columns } from "../Columns";
 import { GridRows } from "./GridRows";
@@ -43,10 +43,9 @@ export const MainGrid: FC<Props> = ({
 
   const { component } = weekProps;
   const { isCurrentWeek, week, weekDays } = component;
-  const { isDrafting } = useAppSelector(selectDraftId);
 
   const onMouseDown = (e: MouseEvent) => {
-    if (isDrafting) {
+    if (isEventFormOpen()) {
       dispatch(draftSlice.actions.discard());
       return;
     }

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGridEvents.tsx
@@ -8,6 +8,7 @@ import { Schema_GridEvent } from "@web/common/types/web.event.types";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { ID_GRID_EVENTS_TIMED } from "@web/common/constants/web.constants";
 import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
+import { isEventFormOpen } from "@web/common/utils";
 
 import { GridEventMemo } from "../../Event/Grid/GridEvent/GridEvent";
 
@@ -20,11 +21,11 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   const dispatch = useAppDispatch();
 
   const timedEvents = useAppSelector(selectGridEvents);
-  const { draftId, isDrafting } = useAppSelector(selectDraftId);
+  const draftId = useAppSelector(selectDraftId);
 
   const onMouseDown = (e: MouseEvent, event: Schema_Event) => {
     e.stopPropagation();
-    if (isDrafting) {
+    if (isEventFormOpen()) {
       dispatch(
         draftSlice.actions.swap({ event, category: Categories_Event.TIMED })
       );
@@ -57,7 +58,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
             event={event}
             isDragging={false}
             isDraft={false}
-            isPlaceholder={isDrafting && event._id === draftId}
+            isPlaceholder={event._id === draftId}
             isResizing={false}
             key={`initial-${event._id}`}
             measurements={measurements}

--- a/packages/web/src/views/Calendar/components/Header/Header.tsx
+++ b/packages/web/src/views/Calendar/components/Header/Header.tsx
@@ -11,13 +11,13 @@ import { getWeekDayLabel } from "@web/common/utils/event.util";
 import { WEEK_DAYS_HEIGHT } from "@web/views/Calendar/layout.constants";
 import { RootProps } from "@web/views/Calendar/calendarView.types";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
-import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { settingsSlice } from "@web/ducks/settings/slices/settings.slice";
 import { selectIsRightSidebarOpen } from "@web/ducks/settings/selectors/settings.selectors";
 import { Util_Scroll } from "@web/views/Calendar/hooks/grid/useScroll";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import { StyledListIcon } from "@web/components/Icons/List";
+import { isEventFormOpen } from "@web/common/utils";
 
 import {
   StyledHeaderRow,
@@ -47,12 +47,11 @@ export const Header: FC<Props> = ({
   const dispatch = useAppDispatch();
   const { scrollToNow } = scrollUtil;
 
-  const { isDrafting } = useAppSelector(selectDraftId);
   const isRightSidebarOpen = useAppSelector(selectIsRightSidebarOpen);
   const { startOfView } = weekProps.component;
 
   const onSectionClick = () => {
-    if (isDrafting) {
+    if (isEventFormOpen()) {
       dispatch(draftSlice.actions.discard());
       return;
     }

--- a/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/SomedayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/SomedayEvent.tsx
@@ -9,6 +9,8 @@ import { SomedayEventForm } from "@web/views/Forms/SomedayEventForm";
 import { StyledFloatContainer } from "@web/views/Forms/SomedayEventForm/styled";
 import { useEventForm } from "@web/views/Forms/hooks/useEventForm";
 import { Util_Sidebar } from "@web/views/Calendar/hooks/draft/sidebar/useSidebarUtil";
+import { draftSlice } from "@web/ducks/events/slices/draft.slice";
+import { useAppDispatch } from "@web/store/store.hooks";
 
 import { NewStyledSomedayEvent } from "./styled";
 import { SomedayEventRectangle } from "./SomedayEventRectangle";
@@ -44,6 +46,7 @@ export const SomedayEvent = ({
     category === Categories_Event.SOMEDAY_WEEK ? "sidebarWeek" : "sidebarMonth";
   const { y, reference, floating, strategy } = useEventForm(formType);
 
+  const dispatch = useAppDispatch();
   const [isFocused, setIsFocused] = useState(false);
 
   const initialFormOpen = event?.isOpen || (isDrafting && !isDragging);
@@ -52,6 +55,12 @@ export const SomedayEvent = ({
   useEffect(() => {
     setShouldOpenForm(event?.isOpen || (isDrafting && !isDragging));
   }, [event?.isOpen, isDrafting, isDragging]);
+
+  // useEffect(() => {
+  //   if (isDragging) {
+  //     dispatch(draftSlice.actions.startDragging({ event }));
+  //   }
+  // }, [dispatch, event, isDragging]);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     switch (e.key) {

--- a/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/SomedayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/SomedayEvent.tsx
@@ -9,8 +9,6 @@ import { SomedayEventForm } from "@web/views/Forms/SomedayEventForm";
 import { StyledFloatContainer } from "@web/views/Forms/SomedayEventForm/styled";
 import { useEventForm } from "@web/views/Forms/hooks/useEventForm";
 import { Util_Sidebar } from "@web/views/Calendar/hooks/draft/sidebar/useSidebarUtil";
-import { draftSlice } from "@web/ducks/events/slices/draft.slice";
-import { useAppDispatch } from "@web/store/store.hooks";
 
 import { NewStyledSomedayEvent } from "./styled";
 import { SomedayEventRectangle } from "./SomedayEventRectangle";
@@ -46,7 +44,6 @@ export const SomedayEvent = ({
     category === Categories_Event.SOMEDAY_WEEK ? "sidebarWeek" : "sidebarMonth";
   const { y, reference, floating, strategy } = useEventForm(formType);
 
-  const dispatch = useAppDispatch();
   const [isFocused, setIsFocused] = useState(false);
 
   const initialFormOpen = event?.isOpen || (isDrafting && !isDragging);
@@ -55,12 +52,6 @@ export const SomedayEvent = ({
   useEffect(() => {
     setShouldOpenForm(event?.isOpen || (isDrafting && !isDragging));
   }, [event?.isOpen, isDrafting, isDragging]);
-
-  // useEffect(() => {
-  //   if (isDragging) {
-  //     dispatch(draftSlice.actions.startDragging({ event }));
-  //   }
-  // }, [dispatch, event, isDragging]);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     switch (e.key) {

--- a/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/SomedayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/SomedayEvent.tsx
@@ -8,6 +8,7 @@ import { SIDEBAR_OPEN_WIDTH } from "@web/views/Calendar/layout.constants";
 import { SomedayEventForm } from "@web/views/Forms/SomedayEventForm";
 import { StyledFloatContainer } from "@web/views/Forms/SomedayEventForm/styled";
 import { useEventForm } from "@web/views/Forms/hooks/useEventForm";
+import { Util_Sidebar } from "@web/views/Calendar/hooks/draft/sidebar/useSidebarUtil";
 
 import { NewStyledSomedayEvent } from "./styled";
 import { SomedayEventRectangle } from "./SomedayEventRectangle";
@@ -19,8 +20,8 @@ export interface Props {
   isDragging: boolean;
   isOverGrid: boolean;
   onClose: () => void;
-  onDraft: (event: Schema_GridEvent) => void;
-  onMigrate: (event: Schema_GridEvent, location: "forward" | "back") => void;
+  onDraft: (event: Schema_GridEvent, category: Categories_Event) => void;
+  onMigrate: Util_Sidebar["onMigrate"];
   onSubmit: (event?: Schema_Event) => void;
   provided: DraggableProvided;
   setEvent: Dispatch<SetStateAction<Schema_GridEvent>>;
@@ -63,7 +64,7 @@ export const SomedayEvent = ({
 
       case Key.Enter: {
         if (!shouldOpenForm) {
-          onDraft(event);
+          onDraft(event, category);
         }
         break;
       }
@@ -82,9 +83,9 @@ export const SomedayEvent = ({
         isOverGrid={isOverGrid}
         isFocused={isFocused}
         onBlur={() => setIsFocused(false)}
-        onClick={(e: MouseEvent) => {
+        onClick={(e) => {
           e.stopPropagation();
-          onDraft(event);
+          onDraft(event, category);
         }}
         onFocus={() => setIsFocused(true)}
         onKeyDown={onKeyDown}

--- a/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/Wrappers/DraggableSomedayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/Wrappers/DraggableSomedayEvent.tsx
@@ -46,7 +46,7 @@ export const DraggableSomedayEvent: FC<Props> = ({
                 isDrafting={isDraftingThisEvent}
                 isOverGrid={isOverGrid}
                 onClose={util.close}
-                onDraft={util.onDraft}
+                onDraft={() => util.onDraft(event, category)}
                 onMigrate={util.onMigrate}
                 onSubmit={() => util.onSubmit(category)}
                 provided={provided}

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
@@ -29,11 +29,12 @@ export const useSidebar = (
 
   return {
     state: _state,
-    util: {
-      ...util,
-      setDraft: state.setDraft,
-      setIsDrafting: state.setIsDrafting,
-    },
+    util,
+    // util: {
+    // ...util,
+    // setDraft: state.setDraft,
+    // setIsDrafting: state.setIsDrafting,
+    // },
   };
 };
 

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
@@ -11,7 +11,7 @@ export const useSidebar = (
 ) => {
   const state = useSidebarState(measurements);
   const util = useSidebarUtil(dateCalcs, state);
-  useSidebarEffects(state, util);
+  useSidebarEffects(util);
 
   const _state = {
     draft: state.draft,

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
@@ -10,7 +10,12 @@ export const useSidebar = (
   dateCalcs: DateCalcs
 ) => {
   const state = useSidebarState(measurements);
-  const util = useSidebarUtil(dateCalcs, state);
+  const util = useSidebarUtil(
+    dateCalcs,
+    state,
+    state.setDraft,
+    state.setIsDrafting
+  );
   useSidebarEffects(util);
 
   const _state = {

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebar.ts
@@ -35,11 +35,6 @@ export const useSidebar = (
   return {
     state: _state,
     util,
-    // util: {
-    // ...util,
-    // setDraft: state.setDraft,
-    // setIsDrafting: state.setIsDrafting,
-    // },
   };
 };
 

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
@@ -1,10 +1,6 @@
 import { useEffect } from "react";
 import { useAppSelector } from "@web/store/store.hooks";
 import {
-  selectIsAtMonthlyLimit,
-  selectIsAtWeeklyLimit,
-} from "@web/ducks/events/selectors/someday.selectors";
-import {
   selectIsDrafting,
   selectIsDraftingExisting,
   selectIsDraftingSomeday,
@@ -15,9 +11,7 @@ import { Util_Sidebar } from "./useSidebarUtil";
 export const useSidebarEffects = (util: Util_Sidebar) => {
   const { resetLocalDraftStateIfNeeded, createDefaultSomeday } = util;
 
-  const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
-  const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
-  const isDraftingRedux = useAppSelector(selectIsDrafting);
+  const isDrafting = useAppSelector(selectIsDrafting);
   const isDraftingExisting = useAppSelector(selectIsDraftingExisting);
   const isDraftingSomeday = useAppSelector(selectIsDraftingSomeday);
 
@@ -29,9 +23,9 @@ export const useSidebarEffects = (util: Util_Sidebar) => {
   }, [isDraftingSomeday, resetLocalDraftStateIfNeeded]);
 
   useEffect(() => {
-    const shouldStartNew = isDraftingRedux && !isDraftingExisting;
+    const shouldStartNew = isDrafting && !isDraftingExisting;
     if (shouldStartNew) {
       createDefaultSomeday();
     }
-  }, [isDraftingExisting, isDraftingRedux, createDefaultSomeday]);
+  }, [isDraftingExisting, isDrafting, createDefaultSomeday]);
 };

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
@@ -64,18 +64,32 @@ export const useSidebarEffects = (util: Util_Sidebar) => {
   ]);
   */
 
+  // useEffect(() => {
+  //   if (!isDraftingRedux || isDraftingExisting) {
+  //     resetLocalDraftStateIfNeeded();
+  //   }
+  // }, [isDraftingExisting, isDraftingRedux, resetLocalDraftStateIfNeeded]);
   useEffect(() => {
+    console.log("draftingRedux?", isDraftingRedux);
     if (!isDraftingRedux) {
+      console.log("resetting local draft state...");
       resetLocalDraftStateIfNeeded();
     }
-    // also check if the drafttype changed
   }, [isDraftingRedux, resetLocalDraftStateIfNeeded]);
 
   useEffect(() => {
+    console.log("draftingRedux?", isDraftingRedux);
     const shouldStartNew = isDraftingRedux && !isDraftingExisting;
     if (shouldStartNew) {
       console.log("creating new default...");
       createDefaultSomeday();
+    } else if (!isDraftingRedux && !isDraftingExisting) {
+      console.log("resetting local draft state...");
+      // resetLocalDraftStateIfNeeded()
+    } else if (!isDraftingRedux) {
+      console.log("chtoas!!");
+    } else {
+      console.log("hmmmm");
     }
   }, [isDraftingExisting, isDraftingRedux, createDefaultSomeday]);
 };

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
@@ -1,95 +1,37 @@
-import { useCallback, useEffect, useState } from "react";
-import { Categories_Event } from "@core/types/event.types";
-import {
-  SOMEDAY_MONTH_LIMIT_MSG,
-  SOMEDAY_WEEK_LIMIT_MSG,
-} from "@core/constants/core.constants";
+import { useEffect } from "react";
 import { useAppSelector } from "@web/store/store.hooks";
 import {
   selectIsAtMonthlyLimit,
   selectIsAtWeeklyLimit,
 } from "@web/ducks/events/selectors/someday.selectors";
 import {
-  selectDraft,
-  selectDraftStatus,
   selectIsDrafting,
   selectIsDraftingExisting,
+  selectIsDraftingSomeday,
 } from "@web/ducks/events/selectors/draft.selectors";
-import { Schema_GridEvent } from "@web/common/types/web.event.types";
-import { getDefaultEvent } from "@web/common/utils/event.util";
 
 import { Util_Sidebar } from "./useSidebarUtil";
 
 export const useSidebarEffects = (util: Util_Sidebar) => {
-  const { close, resetLocalDraftStateIfNeeded, createDefaultSomeday } = util;
+  const { resetLocalDraftStateIfNeeded, createDefaultSomeday } = util;
 
-  const { eventType: draftType } = useAppSelector(selectDraftStatus);
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
   const isDraftingRedux = useAppSelector(selectIsDrafting);
   const isDraftingExisting = useAppSelector(selectIsDraftingExisting);
+  const isDraftingSomeday = useAppSelector(selectIsDraftingSomeday);
 
-  /*
   useEffect(() => {
-    // const isGridDraft =
-    //   draftType !== Categories_Event.SOMEDAY_WEEK &&
-    //   draftType !== Categories_Event.SOMEDAY_MONTH;
-
-    const isGridDraft = false;
-    if (isGridDraft) {
-      console.log("TODO closing sidebar draft so it doesn't get stale");
-      // close();
-      return;
-    }
-
-    if (draftType === Categories_Event.SOMEDAY_WEEK) {
-      if (isAtWeeklyLimit) {
-        alert(SOMEDAY_WEEK_LIMIT_MSG);
-        return;
-      }
-    } else if (draftType === Categories_Event.SOMEDAY_MONTH) {
-      if (isAtMonthlyLimit) {
-        alert(SOMEDAY_MONTH_LIMIT_MSG);
-        return;
-      }
-    }
-  }, [
-    // isDraftingRedux,
-    draftType,
-    // resetLocalDraftStateIfNeeded,
-    // setShouldTriggerDraft,
-    // close,
-    isAtWeeklyLimit,
-    isAtMonthlyLimit,
-  ]);
-  */
-
-  // useEffect(() => {
-  //   if (!isDraftingRedux || isDraftingExisting) {
-  //     resetLocalDraftStateIfNeeded();
-  //   }
-  // }, [isDraftingExisting, isDraftingRedux, resetLocalDraftStateIfNeeded]);
-  useEffect(() => {
-    console.log("draftingRedux?", isDraftingRedux);
-    if (!isDraftingRedux) {
-      console.log("resetting local draft state...");
+    const isSidebarStatePotentiallyStale = !isDraftingSomeday;
+    if (isSidebarStatePotentiallyStale) {
       resetLocalDraftStateIfNeeded();
     }
-  }, [isDraftingRedux, resetLocalDraftStateIfNeeded]);
+  }, [isDraftingSomeday, resetLocalDraftStateIfNeeded]);
 
   useEffect(() => {
-    console.log("draftingRedux?", isDraftingRedux);
     const shouldStartNew = isDraftingRedux && !isDraftingExisting;
     if (shouldStartNew) {
-      console.log("creating new default...");
       createDefaultSomeday();
-    } else if (!isDraftingRedux && !isDraftingExisting) {
-      console.log("resetting local draft state...");
-      // resetLocalDraftStateIfNeeded()
-    } else if (!isDraftingRedux) {
-      console.log("chtoas!!");
-    } else {
-      console.log("hmmmm");
     }
   }, [isDraftingExisting, isDraftingRedux, createDefaultSomeday]);
 };

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
@@ -10,94 +10,38 @@ import {
   selectIsAtWeeklyLimit,
 } from "@web/ducks/events/selectors/someday.selectors";
 import {
-  selectDraft,
   selectDraftStatus,
   selectIsDrafting,
 } from "@web/ducks/events/selectors/draft.selectors";
 
-import { State_Sidebar } from "./useSidebarState";
 import { Util_Sidebar } from "./useSidebarUtil";
 
 export const useSidebarEffects = (util: Util_Sidebar) => {
-  // const {
-  //   // draft,
-  //   // draftType,
-  //   // isDraftingNew,
-  //   // isDraftingRedux,
-  //   // somedayIds,
-  //   setDraft,
-  //   setIsDrafting,
-  //   // setIsDraftingExisting,
-  // } = state;
-  const { close, createDefaultSomeday } = util;
+  const { close, resetLocalDraftState, createDefaultSomeday } = util;
 
   const { eventType: draftType } = useAppSelector(selectDraftStatus);
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
-  // const existingDraft = useAppSelector(selectDraft);
   const isDraftingRedux = useAppSelector(selectIsDrafting);
-  // const isDraftingRedux = false;
-
-  // useEffect(() => {
-  //   setIsDraftingExisting(somedayIds.includes(draft?._id));
-  // }, [draft, somedayIds, setIsDraftingExisting]);
-
-  // useEffect(() => {
-  //   console.log("running sidebar effect after draft change...");
-  //   if (
-  //     isDraftingRedux ||
-  //     (draftType !== Categories_Event.SOMEDAY_WEEK &&
-  //       draftType !== Categories_Event.SOMEDAY_MONTH)
-  //   ) {
-  //     console.log("closing...");
-  //     setIsDrafting(false);
-  //     setDraft(null);
-  //   }
-  // }, [draftType, isDraftingRedux, setDraft, setIsDrafting]);
 
   const handleSomedayTrigger = useCallback(() => {
-    console.log("in sidebar effect after draftType:", draftType);
     if (!isDraftingRedux) {
-      console.log("not drafting, closing");
-      close();
+      console.log("resetting local draft state");
+      // close();
+      resetLocalDraftState();
       return;
     }
+    console.log("drafting ", draftType);
 
-    if (
+    const isGridDraft =
       draftType !== Categories_Event.SOMEDAY_WEEK &&
-      draftType !== Categories_Event.SOMEDAY_MONTH
-    ) {
-      console.log("not a someday draft, closing...");
+      draftType !== Categories_Event.SOMEDAY_MONTH;
+
+    if (isGridDraft) {
+      console.log("closing sidebar draft so it doesn't get stale");
       close();
       return;
     }
-    // const isNewDraft = isDraftingRedux && !isDraftingNew;
-    // if (!isNewDraft) console.log("not a new draft, returning...");
-    // if (!isNewDraft) return;
-
-    // const isDraftingExisting = isDraftingRedux === false && !isDraftingNew;
-    // const notDrafting = isDraftingRedux === false;
-
-    // if (!isDraftingRedux) {
-    //   console.log("not drafting, ignoring");
-    //   return;
-    // }
-
-    // if (!isDraftingRedux) {
-    //   console.log("redux draft gone, closing local state too... ");
-    //   close();
-    //   return;
-    // }
-
-    // if (existingDraft) {
-    //   console.log("existing draft");
-    //   // setIsDrafting(true);
-    //   // setDraft({
-    //   //   ...existingDraft,
-    //   //   isOpen: true,
-    //   // });
-    //   return;
-    // }
 
     if (draftType === Categories_Event.SOMEDAY_WEEK) {
       if (isAtWeeklyLimit) {

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
@@ -9,44 +9,95 @@ import {
   selectIsAtMonthlyLimit,
   selectIsAtWeeklyLimit,
 } from "@web/ducks/events/selectors/someday.selectors";
+import {
+  selectDraft,
+  selectDraftStatus,
+  selectIsDrafting,
+} from "@web/ducks/events/selectors/draft.selectors";
 
 import { State_Sidebar } from "./useSidebarState";
 import { Util_Sidebar } from "./useSidebarUtil";
 
-export const useSidebarEffects = (state: State_Sidebar, util: Util_Sidebar) => {
-  const {
-    draft,
-    draftType,
-    isDraftingNew,
-    isDraftingRedux,
-    somedayIds,
-    setDraft,
-    setIsDrafting,
-    setIsDraftingExisting,
-  } = state;
-  const { createDefaultSomeday } = util;
+export const useSidebarEffects = (util: Util_Sidebar) => {
+  // const {
+  //   // draft,
+  //   // draftType,
+  //   // isDraftingNew,
+  //   // isDraftingRedux,
+  //   // somedayIds,
+  //   setDraft,
+  //   setIsDrafting,
+  //   // setIsDraftingExisting,
+  // } = state;
+  const { close, createDefaultSomeday } = util;
 
+  const { eventType: draftType } = useAppSelector(selectDraftStatus);
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
+  // const existingDraft = useAppSelector(selectDraft);
+  const isDraftingRedux = useAppSelector(selectIsDrafting);
+  // const isDraftingRedux = false;
 
-  useEffect(() => {
-    setIsDraftingExisting(somedayIds.includes(draft?._id));
-  }, [draft, somedayIds, setIsDraftingExisting]);
+  // useEffect(() => {
+  //   setIsDraftingExisting(somedayIds.includes(draft?._id));
+  // }, [draft, somedayIds, setIsDraftingExisting]);
 
-  useEffect(() => {
-    if (
-      !isDraftingRedux ||
-      (draftType !== Categories_Event.SOMEDAY_WEEK &&
-        draftType !== Categories_Event.SOMEDAY_MONTH)
-    ) {
-      setIsDrafting(false);
-      setDraft(null);
-    }
-  }, [draftType, isDraftingRedux, setDraft, setIsDrafting]);
+  // useEffect(() => {
+  //   console.log("running sidebar effect after draft change...");
+  //   if (
+  //     isDraftingRedux ||
+  //     (draftType !== Categories_Event.SOMEDAY_WEEK &&
+  //       draftType !== Categories_Event.SOMEDAY_MONTH)
+  //   ) {
+  //     console.log("closing...");
+  //     setIsDrafting(false);
+  //     setDraft(null);
+  //   }
+  // }, [draftType, isDraftingRedux, setDraft, setIsDrafting]);
 
   const handleSomedayTrigger = useCallback(() => {
-    const isNewDraft = isDraftingRedux && !isDraftingNew;
-    if (!isNewDraft) return;
+    console.log("in sidebar effect after draftType:", draftType);
+    if (!isDraftingRedux) {
+      console.log("not drafting, closing");
+      close();
+      return;
+    }
+
+    if (
+      draftType !== Categories_Event.SOMEDAY_WEEK &&
+      draftType !== Categories_Event.SOMEDAY_MONTH
+    ) {
+      console.log("not a someday draft, closing...");
+      close();
+      return;
+    }
+    // const isNewDraft = isDraftingRedux && !isDraftingNew;
+    // if (!isNewDraft) console.log("not a new draft, returning...");
+    // if (!isNewDraft) return;
+
+    // const isDraftingExisting = isDraftingRedux === false && !isDraftingNew;
+    // const notDrafting = isDraftingRedux === false;
+
+    // if (!isDraftingRedux) {
+    //   console.log("not drafting, ignoring");
+    //   return;
+    // }
+
+    // if (!isDraftingRedux) {
+    //   console.log("redux draft gone, closing local state too... ");
+    //   close();
+    //   return;
+    // }
+
+    // if (existingDraft) {
+    //   console.log("existing draft");
+    //   // setIsDrafting(true);
+    //   // setDraft({
+    //   //   ...existingDraft,
+    //   //   isOpen: true,
+    //   // });
+    //   return;
+    // }
 
     if (draftType === Categories_Event.SOMEDAY_WEEK) {
       if (isAtWeeklyLimit) {
@@ -60,15 +111,9 @@ export const useSidebarEffects = (state: State_Sidebar, util: Util_Sidebar) => {
       }
     }
 
-    createDefaultSomeday();
-  }, [
-    draftType,
-    createDefaultSomeday,
-    isDraftingNew,
-    isDraftingRedux,
-    isAtWeeklyLimit,
-    isAtMonthlyLimit,
-  ]);
+    //TODO enable this to get shortcuts to work
+    // createDefaultSomeday();
+  }, [isDraftingRedux, draftType, close, isAtWeeklyLimit, isAtMonthlyLimit]);
 
   useEffect(() => {
     handleSomedayTrigger();

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Categories_Event } from "@core/types/event.types";
 import {
   SOMEDAY_MONTH_LIMIT_MSG,
@@ -10,36 +10,35 @@ import {
   selectIsAtWeeklyLimit,
 } from "@web/ducks/events/selectors/someday.selectors";
 import {
+  selectDraft,
   selectDraftStatus,
   selectIsDrafting,
 } from "@web/ducks/events/selectors/draft.selectors";
+import { Schema_GridEvent } from "@web/common/types/web.event.types";
+import { getDefaultEvent } from "@web/common/utils/event.util";
 
 import { Util_Sidebar } from "./useSidebarUtil";
 
 export const useSidebarEffects = (util: Util_Sidebar) => {
-  const { close, resetLocalDraftState, createDefaultSomeday } = util;
+  const { close, resetLocalDraftStateIfNeeded, createDefaultSomeday } = util;
 
   const { eventType: draftType } = useAppSelector(selectDraftStatus);
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
   const isDraftingRedux = useAppSelector(selectIsDrafting);
 
-  const handleSomedayTrigger = useCallback(() => {
-    if (!isDraftingRedux) {
-      console.log("resetting local draft state");
-      // close();
-      resetLocalDraftState();
-      return;
-    }
-    console.log("drafting ", draftType);
+  const [shouldTriggerDraft, setShouldTriggerDraft] = useState(false);
 
-    const isGridDraft =
-      draftType !== Categories_Event.SOMEDAY_WEEK &&
-      draftType !== Categories_Event.SOMEDAY_MONTH;
+  /*
+  useEffect(() => {
+    // const isGridDraft =
+    //   draftType !== Categories_Event.SOMEDAY_WEEK &&
+    //   draftType !== Categories_Event.SOMEDAY_MONTH;
 
+    const isGridDraft = false;
     if (isGridDraft) {
-      console.log("closing sidebar draft so it doesn't get stale");
-      close();
+      console.log("TODO closing sidebar draft so it doesn't get stale");
+      // close();
       return;
     }
 
@@ -55,11 +54,33 @@ export const useSidebarEffects = (util: Util_Sidebar) => {
       }
     }
 
-    //TODO enable this to get shortcuts to work
-    // createDefaultSomeday();
-  }, [isDraftingRedux, draftType, close, isAtWeeklyLimit, isAtMonthlyLimit]);
+    setShouldTriggerDraft(true);
+  }, [
+    // isDraftingRedux,
+    draftType,
+    // resetLocalDraftStateIfNeeded,
+    // setShouldTriggerDraft,
+    // close,
+    isAtWeeklyLimit,
+    isAtMonthlyLimit,
+  ]);
+  */
 
   useEffect(() => {
-    handleSomedayTrigger();
-  }, [handleSomedayTrigger]);
+    if (!isDraftingRedux) {
+      resetLocalDraftStateIfNeeded();
+    }
+  }, [isDraftingRedux, resetLocalDraftStateIfNeeded]);
+
+  useEffect(() => {
+    // if (shouldTriggerDraft) {
+    // const shouldStartNew =
+    //   isDraftingRedux && draftType === Categories_Event.SOMEDAY_WEEK;
+    // m: add another state that checks if it's existing or new
+    const shouldStartNew = isDraftingRedux;
+    if (shouldStartNew) {
+      console.log("setting default here...");
+      createDefaultSomeday();
+    }
+  }, [isDraftingRedux, createDefaultSomeday]);
 };

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarEffects.ts
@@ -13,6 +13,7 @@ import {
   selectDraft,
   selectDraftStatus,
   selectIsDrafting,
+  selectIsDraftingExisting,
 } from "@web/ducks/events/selectors/draft.selectors";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
 import { getDefaultEvent } from "@web/common/utils/event.util";
@@ -26,8 +27,7 @@ export const useSidebarEffects = (util: Util_Sidebar) => {
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
   const isDraftingRedux = useAppSelector(selectIsDrafting);
-
-  const [shouldTriggerDraft, setShouldTriggerDraft] = useState(false);
+  const isDraftingExisting = useAppSelector(selectIsDraftingExisting);
 
   /*
   useEffect(() => {
@@ -53,8 +53,6 @@ export const useSidebarEffects = (util: Util_Sidebar) => {
         return;
       }
     }
-
-    setShouldTriggerDraft(true);
   }, [
     // isDraftingRedux,
     draftType,
@@ -70,17 +68,14 @@ export const useSidebarEffects = (util: Util_Sidebar) => {
     if (!isDraftingRedux) {
       resetLocalDraftStateIfNeeded();
     }
+    // also check if the drafttype changed
   }, [isDraftingRedux, resetLocalDraftStateIfNeeded]);
 
   useEffect(() => {
-    // if (shouldTriggerDraft) {
-    // const shouldStartNew =
-    //   isDraftingRedux && draftType === Categories_Event.SOMEDAY_WEEK;
-    // m: add another state that checks if it's existing or new
-    const shouldStartNew = isDraftingRedux;
+    const shouldStartNew = isDraftingRedux && !isDraftingExisting;
     if (shouldStartNew) {
-      console.log("setting default here...");
+      console.log("creating new default...");
       createDefaultSomeday();
     }
-  }, [isDraftingRedux, createDefaultSomeday]);
+  }, [isDraftingExisting, isDraftingRedux, createDefaultSomeday]);
 };

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
@@ -1,12 +1,9 @@
 import { useState, useEffect } from "react";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
+import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { useAppSelector } from "@web/store/store.hooks";
-import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
-import {
-  selectDraftStatus,
-  selectIsDrafting,
-} from "@web/ducks/events/selectors/draft.selectors";
+import { selectDraftStatus } from "@web/ducks/events/selectors/draft.selectors";
 import { selectCategorizedEvents } from "@web/ducks/events/selectors/someday.selectors";
 
 import { useMousePosition } from "../useMousePosition";
@@ -20,7 +17,6 @@ export const useSidebarState = (measurements: Measurements_Grid) => {
   }, [categorizedEvents]);
 
   const { eventType: draftType } = useAppSelector(selectDraftStatus);
-  const isDraftingRedux = useAppSelector(selectIsDrafting);
 
   const [draft, setDraft] = useState<Schema_GridEvent | null>(null);
   const [isDrafting, setIsDrafting] = useState(false);
@@ -48,9 +44,9 @@ export const useSidebarState = (measurements: Measurements_Grid) => {
     somedayIds,
     somedayMonthIds,
     somedayWeekIds,
+    isDrafting,
     isDraftingNew,
     isDraftingExisting,
-    isDraftingRedux,
     isOverAllDayRow,
     isOverGrid,
     isOverMainGrid,

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
@@ -35,8 +35,11 @@ export const useSidebarState = (measurements: Measurements_Grid) => {
   const isDraftingNew =
     isDrafting && !isDraftingExisting && !somedayIds.includes(draft?._id);
   const _isDraftingRedux = isDraftingExisting || isDraftingNew;
-  const shouldPreviewOnGrid =
-    draft !== null && _isDraftingRedux && isOverGrid && !draft?.isOpen;
+  // const shouldPreviewOnGrid =
+  // draft !== null && _isDraftingRedux && isOverGrid && !draft?.isOpen;
+  //TODO fix this
+  // const shouldPreviewOnGrid = draft !== null && isOverGrid;
+  const shouldPreviewOnGrid = draft !== null && isOverGrid && !draft?.isOpen;
 
   return {
     draft,
@@ -47,6 +50,7 @@ export const useSidebarState = (measurements: Measurements_Grid) => {
     isDrafting,
     isDraftingNew,
     isDraftingExisting,
+    isDragging,
     isOverAllDayRow,
     isOverGrid,
     isOverMainGrid,

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
@@ -34,11 +34,7 @@ export const useSidebarState = (measurements: Measurements_Grid) => {
 
   const isDraftingNew =
     isDrafting && !isDraftingExisting && !somedayIds.includes(draft?._id);
-  const _isDraftingRedux = isDraftingExisting || isDraftingNew;
-  // const shouldPreviewOnGrid =
-  // draft !== null && _isDraftingRedux && isOverGrid && !draft?.isOpen;
-  //TODO fix this
-  // const shouldPreviewOnGrid = draft !== null && isOverGrid;
+
   const shouldPreviewOnGrid = draft !== null && isOverGrid && !draft?.isOpen;
 
   return {

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarState.ts
@@ -4,8 +4,8 @@ import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout"
 import { useAppSelector } from "@web/store/store.hooks";
 import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
 import {
-  selectDraftId,
   selectDraftStatus,
+  selectIsDrafting,
 } from "@web/ducks/events/selectors/draft.selectors";
 import { selectCategorizedEvents } from "@web/ducks/events/selectors/someday.selectors";
 
@@ -20,7 +20,7 @@ export const useSidebarState = (measurements: Measurements_Grid) => {
   }, [categorizedEvents]);
 
   const { eventType: draftType } = useAppSelector(selectDraftStatus);
-  const { isDrafting: isDraftingRedux } = useAppSelector(selectDraftId);
+  const isDraftingRedux = useAppSelector(selectIsDrafting);
 
   const [draft, setDraft] = useState<Schema_GridEvent | null>(null);
   const [isDrafting, setIsDrafting] = useState(false);

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -36,6 +36,7 @@ import {
   getMigrationDates,
 } from "@web/common/utils/web.date.util";
 import { selectDatesInView } from "@web/ducks/events/selectors/view.selectors";
+import { isEventFormOpen } from "@web/common/utils";
 
 import { DateCalcs } from "../../grid/useDateCalcs";
 import { State_Sidebar } from "./useSidebarState";
@@ -49,6 +50,11 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
 
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
+
+  const resetLocalDraftState = () => {
+    state.setIsDrafting(false);
+    state.setDraft(null);
+  };
 
   const close = () => {
     console.log("closing [util]...");
@@ -134,6 +140,7 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
   };
 
   const createDefaultSomeday = useCallback(() => {
+    console.log("!!!CREATING DEFAULT SOMEAY...");
     const somedayDefault = getDefaultEvent(Categories_Event.SOMEDAY_WEEK);
 
     state.setDraft({
@@ -327,6 +334,14 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
       return;
     }
 
+    if (isEventFormOpen()) {
+      console.log("** discarding existing draft");
+      dispatch(draftSlice.actions.discard());
+      return;
+    }
+    // don't start if its an allday draft
+    console.log("state status");
+    console.log(state);
     dispatch(
       draftSlice.actions.start({
         eventType: section,
@@ -382,6 +397,7 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
 
   return {
     close,
+    resetLocalDraftState,
     createDefaultSomeday,
     onDraft,
     onDragEnd,

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -150,8 +150,6 @@ export const useSidebarUtil = (
   };
 
   const createDefaultSomeday = useCallback(() => {
-    console.log("~~CREATING DEFAULT SOMEAY...");
-
     const somedayDefault = getDefaultEvent(Categories_Event.SOMEDAY_WEEK);
 
     setDraft({ ...somedayDefault, isOpen: true });
@@ -342,9 +340,7 @@ export const useSidebarUtil = (
       dispatch(draftSlice.actions.discard());
       return;
     }
-    // don't start if its an allday draft
-    console.log("state status");
-    console.log(state);
+
     dispatch(
       draftSlice.actions.start({
         eventType: section,

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -51,6 +51,7 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
 
   const close = () => {
+    console.log("closing [util]...");
     state.setIsDrafting(false);
     state.setDraft(null);
 
@@ -58,7 +59,7 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
       state.draftType === Categories_Event.SOMEDAY_WEEK ||
       state.draftType == Categories_Event.SOMEDAY_MONTH;
 
-    if (state.isDraftingRedux && isSomeday) {
+    if (state.isDraftingExisting || (state.isDraftingNew && isSomeday)) {
       dispatch(draftSlice.actions.discard());
     }
   };
@@ -169,12 +170,27 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
     }
   };
 
-  const onDraft = (event: Schema_Event) => {
+  const onDraft = (event: Schema_Event, category: Categories_Event) => {
+    // console.log("starting draft...of type:", category);
     state.setIsDrafting(true);
     state.setDraft({
       ...event,
       isOpen: true,
     });
+
+    console.log("existing?", state.isDraftingExisting);
+    dispatch(
+      draftSlice.actions.start({
+        event: event,
+        eventType: category,
+      })
+    );
+    // console.log("starting draft...of type:", category);
+    // state.setIsDrafting(true);
+    // state.setDraft({
+    //   ...event,
+    //   isOpen: true,
+    // });
   };
 
   const onDragEnd = (result: DropResult) => {
@@ -294,13 +310,10 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
   };
 
   const onSectionClick = (section: Categories_Event) => {
-    if (state.isDraftingRedux) {
+    if (state.isDrafting) {
+      console.log("assuming click out so closing");
       dispatch(draftSlice.actions.discard());
-      return;
-    }
-
-    if (state.isDraftingExisting) {
-      state.draft && close();
+      close();
       return;
     }
 

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -57,17 +57,14 @@ export const useSidebarUtil = (
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
 
   const resetLocalDraftStateIfNeeded = () => {
-    console.log("checking if we need to reset sidebar state...");
-    console.log(state);
     if (state.isDrafting) {
-      console.log("--- resetting local draft state");
+      console.log("--- resetting local draft state, prev:");
       state.setIsDrafting(false);
       state.setDraft(null);
     }
   };
 
   const close = () => {
-    console.log("closing [util]...");
     state.setIsDrafting(false);
     state.setDraft(null);
 
@@ -319,7 +316,6 @@ export const useSidebarUtil = (
 
   const onSectionClick = (section: Categories_Event) => {
     if (state.isDrafting) {
-      console.log("assuming click out so closing");
       dispatch(draftSlice.actions.discard());
       close();
       return;
@@ -336,7 +332,6 @@ export const useSidebarUtil = (
     }
 
     if (isEventFormOpen()) {
-      console.log("** discarding existing draft");
       dispatch(draftSlice.actions.discard());
       return;
     }
@@ -404,6 +399,7 @@ export const useSidebarUtil = (
     onMigrate,
     onSectionClick,
     onSubmit,
+    setDraft,
   };
 };
 

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -37,7 +37,6 @@ import {
 } from "@web/common/utils/web.date.util";
 import { selectDatesInView } from "@web/ducks/events/selectors/view.selectors";
 import { isEventFormOpen, isSomedayEventFormOpen } from "@web/common/utils";
-import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
 
 import { DateCalcs } from "../../grid/useDateCalcs";
 import { State_Sidebar } from "./useSidebarState";
@@ -56,40 +55,15 @@ export const useSidebarUtil = (
 
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
-  // const isDraftingRedux = useAppSelector(selectIsDrafting); //TODO remove
 
   const resetLocalDraftStateIfNeeded = () => {
     if (!state.isDrafting) return;
 
     if (isSomedayEventFormOpen()) {
-      console.log("resetting local draft state [closing form]");
       state.setIsDrafting(false);
       state.setDraft(null);
     }
   };
-
-  /*
-  const resetLocalDraftStateIfNeeded = () => {
-    // !state.isDrafting && console.log("skipping cuz not drafting local");
-    if (!state.isDrafting) return;
-
-    //todo need to differentiate between when you're dragging a someday
-    // and when a someday is just open and needs to be closed
-    const isLocalSomedayDraft = state.draft?.isSomeday && !isDraftingRedux;
-    if (isLocalSomedayDraft) {
-      const isSomedayFormOpen = isSomedayEventFormOpen();
-      if (isSomedayFormOpen) {
-        console.log("--- resetting local draft state [closing form]");
-        state.setIsDrafting(false);
-        state.setDraft(null);
-      } else {
-        console.log("someday form isnt open, so skipping");
-      }
-    } else {
-      console.log("drafting, but its diff");
-    }
-  };
-  */
 
   const close = () => {
     state.setIsDrafting(false);

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -41,7 +41,12 @@ import { isEventFormOpen } from "@web/common/utils";
 import { DateCalcs } from "../../grid/useDateCalcs";
 import { State_Sidebar } from "./useSidebarState";
 
-export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
+export const useSidebarUtil = (
+  dateCalcs: DateCalcs,
+  state: State_Sidebar,
+  setDraft: React.Dispatch<React.SetStateAction<Schema_GridEvent>>,
+  setIsDrafting: React.Dispatch<React.SetStateAction<boolean>>
+) => {
   const dispatch = useAppDispatch();
 
   const { start, end } = useAppSelector(selectDatesInView);
@@ -51,9 +56,12 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
   const isAtWeeklyLimit = useAppSelector(selectIsAtWeeklyLimit);
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
 
-  const resetLocalDraftState = () => {
-    state.setIsDrafting(false);
-    state.setDraft(null);
+  const resetLocalDraftStateIfNeeded = () => {
+    if (state.isDrafting) {
+      console.log("--- resetting local draft state");
+      state.setIsDrafting(false);
+      state.setDraft(null);
+    }
   };
 
   const close = () => {
@@ -140,18 +148,13 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
   };
 
   const createDefaultSomeday = useCallback(() => {
-    console.log("!!!CREATING DEFAULT SOMEAY...");
+    console.log("~~CREATING DEFAULT SOMEAY...");
+
     const somedayDefault = getDefaultEvent(Categories_Event.SOMEDAY_WEEK);
 
-    state.setDraft({
-      ...somedayDefault,
-      endDate: viewEnd.format(YEAR_MONTH_DAY_FORMAT),
-      startDate: viewStart.format(YEAR_MONTH_DAY_FORMAT),
-      isOpen: true,
-    });
-
-    state.setIsDrafting(true);
-  }, [viewStart, viewEnd]);
+    setDraft({ ...somedayDefault, isOpen: true });
+    setIsDrafting(true);
+  }, [setDraft]);
 
   const getDatesAfterDroppingOn = (
     target: "mainGrid" | "alldayRow",
@@ -397,7 +400,7 @@ export const useSidebarUtil = (dateCalcs: DateCalcs, state: State_Sidebar) => {
 
   return {
     close,
-    resetLocalDraftState,
+    resetLocalDraftStateIfNeeded,
     createDefaultSomeday,
     onDraft,
     onDragEnd,

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -57,6 +57,8 @@ export const useSidebarUtil = (
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
 
   const resetLocalDraftStateIfNeeded = () => {
+    console.log("checking if we need to reset sidebar state...");
+    console.log(state);
     if (state.isDrafting) {
       console.log("--- resetting local draft state");
       state.setIsDrafting(false);
@@ -181,21 +183,19 @@ export const useSidebarUtil = (
   };
 
   const onDraft = (event: Schema_Event, category: Categories_Event) => {
-    // console.log("starting draft...of type:", category);
     state.setIsDrafting(true);
     state.setDraft({
       ...event,
       isOpen: true,
     });
 
-    console.log("existing?", state.isDraftingExisting);
+    // console.log("existing?", state.isDraftingExisting);
     dispatch(
       draftSlice.actions.start({
         event: event,
         eventType: category,
       })
     );
-    // console.log("starting draft...of type:", category);
     // state.setIsDrafting(true);
     // state.setDraft({
     //   ...event,

--- a/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
@@ -110,6 +110,7 @@ export const useDraftUtil = (
       setDraft(reduxDraft);
 
       if (activity === "dragging") {
+        console.log("start drag");
         setIsDragging(true);
         return;
       }
@@ -365,6 +366,7 @@ export const useDraftUtil = (
   );
 
   const stopDragging = () => {
+    console.log("stop drag");
     setIsDragging(false);
     setDragStatus(null);
   };

--- a/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
@@ -110,7 +110,6 @@ export const useDraftUtil = (
       setDraft(reduxDraft);
 
       if (activity === "dragging") {
-        console.log("start drag");
         setIsDragging(true);
         return;
       }
@@ -366,7 +365,6 @@ export const useDraftUtil = (
   );
 
   const stopDragging = () => {
-    console.log("stop drag");
     setIsDragging(false);
     setDragStatus(null);
   };

--- a/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
@@ -148,7 +148,7 @@ export const useDraftUtil = (
         return { ..._draft, isOpen: false };
       });
     }
-  }, [dateCalcs, isDragging]);
+  }, [isDragging]);
 
   const convert = (start: string, end: string) => {
     if (isAtWeeklyLimit) {

--- a/packages/web/src/views/Calendar/hooks/draft/useGridMouseMove.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useGridMouseMove.ts
@@ -7,12 +7,14 @@ export const useGridMouseMove = (
   draftState: State_GridDraft,
   draftUtil: Util_GridDraft
 ) => {
-  const { draft, isDragging, isResizing } = draftState;
+  const { draft, isDrafting, isDragging, isResizing } = draftState;
 
   const { drag, resize } = draftUtil;
 
   const _onMouseMove = useCallback(
     (e: MouseEvent) => {
+      if (!isDrafting) return;
+
       if (isResizing && !draft?.isAllDay) {
         resize(e);
       } else if (isDragging) {
@@ -20,7 +22,7 @@ export const useGridMouseMove = (
         drag(e);
       }
     },
-    [draft?.isAllDay, drag, isDragging, isResizing, resize]
+    [draft?.isAllDay, drag, isDrafting, isDragging, isResizing, resize]
   );
 
   useEventListener("mousemove", _onMouseMove);

--- a/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
+++ b/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
@@ -16,6 +16,8 @@ import {
   selectIsAtWeeklyLimit,
 } from "@web/ducks/events/selectors/someday.selectors";
 import { settingsSlice } from "@web/ducks/settings/slices/settings.slice";
+import { getDefaultEvent } from "@web/common/utils/event.util";
+import { YEAR_MONTH_FORMAT } from "@core/constants/date.constants";
 
 import { DateCalcs } from "../grid/useDateCalcs";
 import { Util_Scroll } from "../grid/useScroll";
@@ -26,7 +28,8 @@ export interface ShortcutProps {
   today: Dayjs;
   dateCalcs: DateCalcs;
   isCurrentWeek: boolean;
-  startOfSelectedWeek: Dayjs;
+  startOfView: Dayjs;
+  endOfView: Dayjs;
   util: WeekProps["util"];
   scrollUtil: Util_Scroll;
   toggleSidebar: (target: "left" | "right") => void;
@@ -36,7 +39,8 @@ export const useShortcuts = ({
   today,
   dateCalcs,
   isCurrentWeek,
-  startOfSelectedWeek,
+  startOfView,
+  endOfView,
   util,
   scrollUtil,
   toggleSidebar,
@@ -63,18 +67,21 @@ export const useShortcuts = ({
           ? Categories_Event.SOMEDAY_WEEK
           : Categories_Event.SOMEDAY_MONTH;
 
+      const somedayDefault = getDefaultEvent(Categories_Event.SOMEDAY_WEEK);
       dispatch(
         draftSlice.actions.start({
           eventType,
+          event: {
+            ...somedayDefault,
+            startDate: startOfView.format(YEAR_MONTH_FORMAT),
+            endDate: endOfView.format(YEAR_MONTH_FORMAT),
+          },
         })
       );
     };
 
     const _createTimedDraft = () => {
-      const { startDate, endDate } = getDraftTimes(
-        isCurrentWeek,
-        startOfSelectedWeek
-      );
+      const { startDate, endDate } = getDraftTimes(isCurrentWeek, startOfView);
 
       dispatch(
         draftSlice.actions.start({
@@ -147,7 +154,8 @@ export const useShortcuts = ({
     isAtWeeklyLimit,
     isCurrentWeek,
     navigate,
-    startOfSelectedWeek,
+    startOfView,
+    endOfView,
     scrollUtil,
     toggleSidebar,
     util,

--- a/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
+++ b/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
@@ -8,7 +8,7 @@ import {
   SOMEDAY_WEEK_LIMIT_MSG,
 } from "@core/constants/core.constants";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
-import { isDrafting } from "@web/common/utils";
+import { isEventFormOpen } from "@web/common/utils";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import {
@@ -89,13 +89,13 @@ export const useShortcuts = ({
     };
 
     const _discardDraft = () => {
-      if (isDrafting()) {
+      if (isEventFormOpen()) {
         dispatch(draftSlice.actions.discard());
       }
     };
 
     const keyDownHandler = (e: KeyboardEvent) => {
-      if (isDrafting()) return;
+      if (isEventFormOpen()) return;
 
       const isCmdPaletteOpen =
         document.getElementById("headlessui-portal-root") !== null;

--- a/packages/web/src/views/CmdPalette/CmdPalette.tsx
+++ b/packages/web/src/views/CmdPalette/CmdPalette.tsx
@@ -14,7 +14,7 @@ import {
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
-import { isDrafting } from "@web/common/utils";
+import { isEventFormOpen } from "@web/common/utils";
 import {
   selectIsAtMonthlyLimit,
   selectIsAtWeeklyLimit,
@@ -90,7 +90,7 @@ const CmdPalette = ({
   };
 
   const _discardDraft = () => {
-    if (isDrafting()) {
+    if (isEventFormOpen()) {
       dispatch(draftSlice.actions.discard());
     }
   };

--- a/packages/web/src/views/CmdPalette/CmdPalette.tsx
+++ b/packages/web/src/views/CmdPalette/CmdPalette.tsx
@@ -1,5 +1,5 @@
 import "react-cmdk/dist/cmdk.css";
-import React, { FC, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import CommandPalette, {
   filterItems,
   getItemIndex,
@@ -28,7 +28,7 @@ import { ShortcutProps } from "../Calendar/hooks/shortcuts/useShortcuts";
 const CmdPalette = ({
   today,
   isCurrentWeek,
-  startOfSelectedWeek,
+  startOfView,
   util,
   scrollUtil,
 }: ShortcutProps) => {
@@ -72,10 +72,7 @@ const CmdPalette = ({
   };
 
   const _createTimedDraft = () => {
-    const { startDate, endDate } = getDraftTimes(
-      isCurrentWeek,
-      startOfSelectedWeek
-    );
+    const { startDate, endDate } = getDraftTimes(isCurrentWeek, startOfView);
 
     dispatch(
       draftSlice.actions.start({

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -19,6 +19,7 @@ import {
   mapToBackend,
 } from "@web/common/utils/web.date.util";
 import { StyledMigrateArrowInForm } from "@web/views/Calendar/components/LeftSidebar/SomedaySection/SomedayEvents/styled";
+import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
 
 import { FormProps, SetEventFormField } from "./types";
 import { DateTimeSection } from "./DateTimeSection";
@@ -226,7 +227,7 @@ export const EventForm: React.FC<FormProps> = ({
     <StyledEventForm
       {...props}
       isOpen={isFormOpen}
-      name="Event Form"
+      name={ID_EVENT_FORM}
       onKeyDown={onFormKeyDown}
       onMouseUp={(e) => {
         e.stopPropagation();

--- a/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
+++ b/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
@@ -6,7 +6,6 @@ import { colorNameByPriority } from "@core/constants/colors";
 import { getColor } from "@core/util/color.utils";
 import { useAppDispatch } from "@web/store/store.hooks";
 import { DeleteIcon } from "@web/components/Icons/Delete";
-import { ID_SIDEBAR_FORM } from "@web/common/constants/web.constants";
 import { getSomedayEventsSlice } from "@web/ducks/events/slices/someday.slice";
 import { PrioritySection } from "@web/views/Forms/EventForm/PrioritySection";
 import { SaveSection } from "@web/views/Forms/EventForm/SaveSection";
@@ -17,6 +16,7 @@ import {
   StyledIconRow,
   StyledTitleField,
 } from "@web/views/Forms/EventForm/styled";
+import { ID_SOMEDAY_EVENT_FORM } from "@web/common/constants/web.constants";
 
 import { RepeatSection } from "../EventForm/RepeatSection";
 
@@ -105,8 +105,7 @@ export const SomedayEventForm: React.FC<FormProps> = ({
   return (
     <StyledEventForm
       {...props}
-      name="Someday Event Form"
-      id={ID_SIDEBAR_FORM}
+      name={ID_SOMEDAY_EVENT_FORM}
       isOpen={true}
       onClick={stopPropagation}
       onKeyDown={onKeyDown}

--- a/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
+++ b/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
@@ -105,7 +105,7 @@ export const SomedayEventForm: React.FC<FormProps> = ({
   return (
     <StyledEventForm
       {...props}
-      data-testid="somedayForm"
+      name="Someday Event Form"
       id={ID_SIDEBAR_FORM}
       isOpen={true}
       onClick={stopPropagation}


### PR DESCRIPTION
closes #137 

# Improving Responsiveness During Edits

## Strategies

### Memoizing 
I added/updated memoization to the `GridEvents` and`AllDayEvents`, so that they only render when necessary. The updates to memoization involved including a custom `arePropsEqual` function, which narrows the props to just look at the event payload and the grid measurements. Previously the memo's shallow equal checks were always failing, because new references were being recreated for the other props

### Detangling State
I decoupled state from the `AllDayRow` and `MainGrid`, which was resulting in the grid rendering excessively during edits/drafts. The key strategy here was using the `isEventFormOpen()` and `isEventSomedayFormOpen()` util functions to check whether there was a pending draft occurring. Without these, the all day row, grid, and sidebar were all consuming from a combination of local state and redux state, which required tremendous coordination to get right. 

Using this DOM selection strategy is less "React-y," as it acts as an escape-hatch from the component lifecycle. Reading from the DOM is also less performant. However, those functions are only called onClicks, so the performance losses are acceptable.   

## Other Changes
1. Uses constants to access DOM elements
2. Fixing a test and colocating it. I'd eventually like to have all react-testing-library tests colocated with the component under test, rather than hidden in the `__tests__` folder like they are now. That style of separating tests from component makes sense if/when we have e2e tests. However, for now we just have local component/integration style tests, so it's nice to keep them close to encourage testing.


## Demo
The first video shows the current behavior. Whenever an element is re-rendered, it's highlighted. Notice frequently how the main grid, all day row, and grid events are re-rendering. Yikes.

https://github.com/user-attachments/assets/7f7f4b7d-a0a8-497a-b64d-48d7ada48618

This shows the behavior after this PR's code changes. Notice how the grid and events aren't rendering as frequently. The sidebar and sidebar events are still excessively rendering, but those are out-of-scope for this PR. 

https://github.com/user-attachments/assets/be8e10ec-f2ba-4db1-a2e3-db1390b0df67


