### PR TITLE
🐛 Fix: Date picker not closing after selecting date #131

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateTimeSection/DateTimeSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateTimeSection/DateTimeSection.tsx
@@ -135,24 +135,6 @@ export const DateTimeSection: FC<Props> = ({
     setIsStartDatePickerOpen(false);
   };
 
-  const openEndDatePicker = () => {
-    if (isStartDatePickerOpen) {
-      setIsStartDatePickerOpen(false);
-    }
-    if (!isEndDatePickerOpen) {
-      setIsEndDatePickerOpen(true);
-    }
-  };
-
-  const openStartDatePicker = () => {
-    if (isEndDatePickerOpen) {
-      setIsEndDatePickerOpen(false);
-    }
-    if (!isStartDatePickerOpen) {
-      setIsStartDatePickerOpen(true);
-    }
-  };
-
   const onPickerKeyDown = (
     picker: "start" | "end",
     e: React.KeyboardEvent<HTMLDivElement>
@@ -279,11 +261,7 @@ export const DateTimeSection: FC<Props> = ({
       {category === Categories_Event.ALLDAY && (
         <>
           <StyledDateFlex alignItems={AlignItems.CENTER}>
-            <div
-              onFocus={openStartDatePicker}
-              onMouseUp={stopPropagation}
-              onMouseDown={stopPropagation}
-            >
+            <div onMouseUp={stopPropagation} onMouseDown={stopPropagation}>
               <DatePicker
                 bgColor={darken(bgColor, 15)}
                 calendarClassName="startDatePicker"
@@ -305,11 +283,7 @@ export const DateTimeSection: FC<Props> = ({
           </StyledDateFlex>
 
           <StyledDateFlex alignItems={AlignItems.CENTER}>
-            <div
-              onFocus={openEndDatePicker}
-              onMouseUp={stopPropagation}
-              onMouseDown={stopPropagation}
-            >
+            <div onMouseUp={stopPropagation} onMouseDown={stopPropagation}>
               <DatePicker
                 bgColor={darken(bgColor, 15)}
                 calendarClassName="endDatePicker"


### PR DESCRIPTION
This fixes #131.

The problem was caused by DatePicker's wrapper div onFocus, which was calling the openEndDatePicker and openStartDatePicker functions. Those functions were setting DatePicker's state to keep it open. As the open/close logic of DatePicker is managed by the DatePicker component itself, there is no need to have those functions anymore (I guess they were part of some older implementation logic).

All tests have passed.