### PR TITLE
🐛 Fix: All day event doesn't disappear after changing the week - Attempt #2

### DIFF
--- a/packages/web/src/ducks/events/event.types.ts
+++ b/packages/web/src/ducks/events/event.types.ts
@@ -77,6 +77,7 @@ export interface Payload_EditEvent {
   applyTo?: Categories_Recur;
   _id: string;
   event: Schema_Event;
+  shouldRemove: boolean;
 }
 
 export interface Payload_GetPaginatedEvents extends Filters_Pagination {

--- a/packages/web/src/ducks/events/event.types.ts
+++ b/packages/web/src/ducks/events/event.types.ts
@@ -74,10 +74,10 @@ interface Payload_DeleteEvent {
 }
 
 export interface Payload_EditEvent {
-  applyTo?: Categories_Recur;
   _id: string;
   event: Schema_Event;
-  shouldRemove: boolean;
+  applyTo?: Categories_Recur;
+  shouldRemove?: boolean;
 }
 
 export interface Payload_GetPaginatedEvents extends Filters_Pagination {

--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -166,6 +166,9 @@ export function* deleteSomedayEvent({ payload }: Action_DeleteEvent) {
 export function* editEvent({ payload }: Action_EditEvent) {
   try {
     yield put(eventsEntitiesSlice.actions.edit(payload));
+    if (payload.shouldRemove) {
+      yield put(eventsEntitiesSlice.actions.delete({ _id: payload._id }));
+    }
     yield call(EventApi.edit, payload._id, payload.event, {
       applyTo: payload.applyTo,
     });

--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -164,13 +164,15 @@ export function* deleteSomedayEvent({ payload }: Action_DeleteEvent) {
 }
 
 export function* editEvent({ payload }: Action_EditEvent) {
+  const { _id, applyTo, event, shouldRemove } = payload;
+
   try {
-    yield put(eventsEntitiesSlice.actions.edit(payload));
-    if (payload.shouldRemove) {
-      yield put(eventsEntitiesSlice.actions.delete({ _id: payload._id }));
-    }
-    yield call(EventApi.edit, payload._id, payload.event, {
-      applyTo: payload.applyTo,
+    shouldRemove
+      ? yield put(eventsEntitiesSlice.actions.delete({ _id }))
+      : yield put(eventsEntitiesSlice.actions.edit(payload));
+
+    yield call(EventApi.edit, _id, event, {
+      applyTo: applyTo,
     });
     yield put(editEventSlice.actions.success());
   } catch (error) {

--- a/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
@@ -378,19 +378,17 @@ export const useDraftUtil = (
   const submit = (draft: Schema_GridEvent) => {
     const event = prepEvtBeforeSubmit(draft);
     const { startOfView, endOfView } = weekProps.component;
-    const eventEndsBeforeCurrentViewStart = dayjs(event.endDate).isBefore(
-      startOfView
-    );
-    const eventBeginsAfterCurrentViewEnd = dayjs(event.startDate).isAfter(
-      endOfView
-    );
-    // If the event will be rendered outside of view, marks it to be removed from store
-    const shouldRemove =
-      eventEndsBeforeCurrentViewStart || eventBeginsAfterCurrentViewEnd;
-    const payload = { _id: event._id, event, shouldRemove };
+
     const isExisting = event._id;
-    // include param for how to handle recurrences
     if (isExisting) {
+      const isOutsideView =
+        !dayjs(event.startDate).isBetween(startOfView, endOfView, null, "[]") &&
+        !dayjs(event.endDate).isBetween(startOfView, endOfView, null, "[]");
+
+      const _payload = { _id: event._id, event };
+      const payload = isOutsideView
+        ? { ..._payload, shouldRemove: true }
+        : _payload;
       dispatch(editEventSlice.actions.request(payload));
     } else {
       dispatch(createEventSlice.actions.request(event));

--- a/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
@@ -385,10 +385,8 @@ export const useDraftUtil = (
         !dayjs(event.startDate).isBetween(startOfView, endOfView, null, "[]") &&
         !dayjs(event.endDate).isBetween(startOfView, endOfView, null, "[]");
 
-      const _payload = { _id: event._id, event };
-      const payload = isOutsideView
-        ? { ..._payload, shouldRemove: true }
-        : _payload;
+      const shouldRemove = isOutsideView ? true : false;
+      const payload = { _id: event._id, event, shouldRemove };
       dispatch(editEventSlice.actions.request(payload));
     } else {
       dispatch(createEventSlice.actions.request(event));

--- a/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useDraftUtil.ts
@@ -377,16 +377,21 @@ export const useDraftUtil = (
 
   const submit = (draft: Schema_GridEvent) => {
     const event = prepEvtBeforeSubmit(draft);
-
+    const { startOfView, endOfView } = weekProps.component;
+    const eventEndsBeforeCurrentViewStart = dayjs(event.endDate).isBefore(
+      startOfView
+    );
+    const eventBeginsAfterCurrentViewEnd = dayjs(event.startDate).isAfter(
+      endOfView
+    );
+    // If the event will be rendered outside of view, marks it to be removed from store
+    const shouldRemove =
+      eventEndsBeforeCurrentViewStart || eventBeginsAfterCurrentViewEnd;
+    const payload = { _id: event._id, event, shouldRemove };
     const isExisting = event._id;
     // include param for how to handle recurrences
     if (isExisting) {
-      dispatch(
-        editEventSlice.actions.request({
-          _id: event._id,
-          event,
-        })
-      );
+      dispatch(editEventSlice.actions.request(payload));
     } else {
       dispatch(createEventSlice.actions.request(event));
     }


### PR DESCRIPTION
This is a better, non-style-level fix for #178 

As you suggested, I've added some logic into `useDraftUtil.ts:submit` to check if the updated event will be rendered inside current view. If not, it marks the event to be removed from the store after the update. Now once we save an event with dates for a different week, it immediately disapers from the screen.

All automated tests have passed.

However, the "flicking" event with full width still persists for some milliseconds once you change weeks. I'm not sure yet what is the cause of this, but I will let the PR open while I give a look on this.