### PR TITLE
🐛 fix: keep new event on grid during save

### DIFF
--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -56,6 +56,7 @@ export interface Schema_Event {
   title?: string;
   updatedAt?: Date;
   user?: string;
+  optimistic?: boolean;
 }
 
 export interface Query_Event extends Query {

--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -56,7 +56,6 @@ export interface Schema_Event {
   title?: string;
   updatedAt?: Date;
   user?: string;
-  optimistic?: boolean;
 }
 
 export interface Query_Event extends Query {

--- a/packages/web/src/common/constants/web.constants.ts
+++ b/packages/web/src/common/constants/web.constants.ts
@@ -16,6 +16,7 @@ export const ID_DATEPICKER_SIDEBAR = "sidebarDatePicker";
 export const ID_SOMEDAY_DRAFT = "somedayDraft";
 export const ID_SOMEDAY_EVENTS = "ID_SOMEDAY_EVENTS";
 export const ID_SOMEDAY_EVENT_FORM = "Someday Event Form";
+export const ID_OPTIMISTIC_PREFIX = "optimistic";
 
 export const OPTIONS_RECURRENCE = {
   WEEK: { value: Recurrence_Selection.WEEK, label: "week" },

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -9,8 +9,9 @@ export enum Recurrence_Selection {
 export interface Schema_GridEvent extends Schema_Event {
   hasFlipped?: boolean;
   importanceIndex?: number;
-  isOpen?: boolean;
   isEditing?: boolean;
+  isOpen?: boolean;
+  isOptimistic?: boolean;
   row?: number;
   siblingsCount?: number;
 }

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -11,7 +11,6 @@ export interface Schema_GridEvent extends Schema_Event {
   importanceIndex?: number;
   isEditing?: boolean;
   isOpen?: boolean;
-  isOptimistic?: boolean;
   row?: number;
   siblingsCount?: number;
 }

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -211,12 +211,12 @@ export const prepEvtBeforeSubmit = (draft: Schema_GridEvent) => {
 export const normalizedEventsSchema = () =>
   new schema.Entity("events", {}, { idAttribute: "_id" });
 
-export const createOptimisticEvent = (event: Schema_Event) => {
-  const _event = {
+export const createOptimisticEvent = (event: Schema_GridEvent) => {
+  const _event: Schema_GridEvent = {
     ...event,
     _id: `optimistic-${uuidv4()}`,
     optimistic: true,
-  } as Schema_Event;
+  };
 
   return _event;
 };

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -14,7 +14,11 @@ import {
   Schema_SomedayEventsColumn,
 } from "../types/web.event.types";
 import { removeGridFields } from "./grid.util";
-import { COLUMN_WEEK, COLUMN_MONTH } from "../constants/web.constants";
+import {
+  COLUMN_WEEK,
+  COLUMN_MONTH,
+  ID_OPTIMISTIC_PREFIX,
+} from "../constants/web.constants";
 
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
@@ -207,11 +211,10 @@ export const prepEvtBeforeSubmit = (draft: Schema_GridEvent) => {
   return event;
 };
 
-export const createOptimisticEvent = (event: Schema_GridEvent) => {
-  const _event: Schema_GridEvent = {
+export const createOptimisticEvent = (event: Schema_Event) => {
+  const _event: Schema_Event = {
     ...event,
-    _id: `optimistic-${uuidv4()}`,
-    isOptimistic: true,
+    _id: `${ID_OPTIMISTIC_PREFIX}-${uuidv4()}`,
   };
 
   return _event;

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -215,7 +215,7 @@ export const createOptimisticEvent = (event: Schema_GridEvent) => {
   const _event: Schema_GridEvent = {
     ...event,
     _id: `optimistic-${uuidv4()}`,
-    optimistic: true,
+    isOptimistic: true,
   };
 
   return _event;

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -1,4 +1,3 @@
-import { schema } from "normalizr";
 import dayjs, { Dayjs } from "dayjs";
 import { v4 as uuidv4 } from "uuid";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
@@ -207,9 +206,6 @@ export const prepEvtBeforeSubmit = (draft: Schema_GridEvent) => {
 
   return event;
 };
-
-export const normalizedEventsSchema = () =>
-  new schema.Entity("events", {}, { idAttribute: "_id" });
 
 export const createOptimisticEvent = (event: Schema_GridEvent) => {
   const _event: Schema_GridEvent = {

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -1,5 +1,6 @@
 import { schema } from "normalizr";
 import dayjs, { Dayjs } from "dayjs";
+import { v4 as uuidv4 } from "uuid";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import isBetween from "dayjs/plugin/isBetween";
@@ -209,3 +210,13 @@ export const prepEvtBeforeSubmit = (draft: Schema_GridEvent) => {
 
 export const normalizedEventsSchema = () =>
   new schema.Entity("events", {}, { idAttribute: "_id" });
+
+export const createOptimisticEvent = (event: Schema_Event) => {
+  const _event = {
+    ...event,
+    _id: `optimistic-${uuidv4()}`,
+    optimistic: true,
+  } as Schema_Event;
+
+  return _event;
+};

--- a/packages/web/src/ducks/events/event.types.ts
+++ b/packages/web/src/ducks/events/event.types.ts
@@ -86,7 +86,7 @@ export interface Payload_EditEvent {
 
 export interface Payload_ReplaceEvent {
   oldEventId: string;
-  newEvent: Schema_Event;
+  newEventId: string;
 }
 
 export interface Payload_GetPaginatedEvents extends Filters_Pagination {

--- a/packages/web/src/ducks/events/event.types.ts
+++ b/packages/web/src/ducks/events/event.types.ts
@@ -45,6 +45,10 @@ export interface Action_InsertEvents extends Action {
   payload: Entities_Event | undefined;
 }
 
+export interface Action_ReplaceEvent extends Action {
+  payload: Payload_ReplaceEvent;
+}
+
 export interface Action_TimezoneChange extends Action {
   payload: { timezone: string };
 }
@@ -78,6 +82,11 @@ export interface Payload_EditEvent {
   event: Schema_Event;
   applyTo?: Categories_Recur;
   shouldRemove?: boolean;
+}
+
+export interface Payload_ReplaceEvent {
+  oldEventId: string;
+  newEvent: Schema_Event;
 }
 
 export interface Payload_GetPaginatedEvents extends Filters_Pagination {

--- a/packages/web/src/ducks/events/sagas/event.saga.util.ts
+++ b/packages/web/src/ducks/events/sagas/event.saga.util.ts
@@ -1,0 +1,56 @@
+import { schema } from "normalizr";
+import { put } from "redux-saga/effects";
+import { normalize } from "normalizr";
+import { Schema_Event } from "@core/types/event.types";
+
+import { getSomedayEventsSlice } from "../slices/someday.slice";
+import { getWeekEventsSlice } from "../slices/week.slice";
+import { eventsEntitiesSlice } from "../slices/event.slice";
+
+export function* insertOptimisticEvent(
+  event: Schema_Event,
+  isSomeday: boolean
+) {
+  if (isSomeday) {
+    yield put(getSomedayEventsSlice.actions.insert(event._id));
+  } else {
+    yield put(getWeekEventsSlice.actions.insert(event._id));
+  }
+  yield put(
+    eventsEntitiesSlice.actions.insert(
+      normalize<Schema_Event>(event, normalizedEventsSchema()).entities.events
+    )
+  );
+}
+
+export function* updateEventId(
+  oldId: string,
+  newId: string,
+  isSomeday: boolean
+) {
+  if (isSomeday) {
+    yield put(
+      getSomedayEventsSlice.actions.replace({
+        oldSomedayId: oldId,
+        newSomedayId: newId,
+      })
+    );
+  } else {
+    yield put(
+      getWeekEventsSlice.actions.replace({
+        oldWeekId: oldId,
+        newWeekId: newId,
+      })
+    );
+  }
+
+  yield put(
+    eventsEntitiesSlice.actions.replace({
+      oldEventId: oldId,
+      newEvent: newId,
+    })
+  );
+}
+
+export const normalizedEventsSchema = () =>
+  new schema.Entity("events", {}, { idAttribute: "_id" });

--- a/packages/web/src/ducks/events/sagas/event.saga.util.ts
+++ b/packages/web/src/ducks/events/sagas/event.saga.util.ts
@@ -2,13 +2,14 @@ import { schema } from "normalizr";
 import { put } from "redux-saga/effects";
 import { normalize } from "normalizr";
 import { Schema_Event } from "@core/types/event.types";
+import { Schema_GridEvent } from "@web/common/types/web.event.types";
 
 import { getSomedayEventsSlice } from "../slices/someday.slice";
 import { getWeekEventsSlice } from "../slices/week.slice";
 import { eventsEntitiesSlice } from "../slices/event.slice";
 
 export function* insertOptimisticEvent(
-  event: Schema_Event,
+  event: Schema_GridEvent,
   isSomeday: boolean
 ) {
   if (isSomeday) {
@@ -23,22 +24,22 @@ export function* insertOptimisticEvent(
   );
 }
 
-export function* updateEventId(
-  oldId: string,
+export function* replaceOptimisticId(
+  optimisticId: string,
   newId: string,
   isSomeday: boolean
 ) {
   if (isSomeday) {
     yield put(
       getSomedayEventsSlice.actions.replace({
-        oldSomedayId: oldId,
+        oldSomedayId: optimisticId,
         newSomedayId: newId,
       })
     );
   } else {
     yield put(
       getWeekEventsSlice.actions.replace({
-        oldWeekId: oldId,
+        oldWeekId: optimisticId,
         newWeekId: newId,
       })
     );
@@ -46,7 +47,7 @@ export function* updateEventId(
 
   yield put(
     eventsEntitiesSlice.actions.replace({
-      oldEventId: oldId,
+      oldEventId: optimisticId,
       newEventId: newId,
     })
   );

--- a/packages/web/src/ducks/events/sagas/event.saga.util.ts
+++ b/packages/web/src/ducks/events/sagas/event.saga.util.ts
@@ -47,7 +47,7 @@ export function* updateEventId(
   yield put(
     eventsEntitiesSlice.actions.replace({
       oldEventId: oldId,
-      newEvent: newId,
+      newEventId: newId,
     })
   );
 }

--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -13,6 +13,7 @@ import {
   createOptimisticEvent,
   handleError,
 } from "@web/common/utils/event.util";
+import { Schema_GridEvent } from "@web/common/types/web.event.types";
 
 import {
   createEventSlice,
@@ -139,16 +140,14 @@ function* createEvent({ payload }: Action_CreateEvent) {
 }
 
 export function* deleteEvent({ payload }: Action_DeleteEvent) {
-  // TODO: Ideally we should pass the entire event object instead of just its id
-  // to the `deleteEvent` payload. Gives us more context to work with.
   const event = (yield select((state: RootState) =>
     selectEventById(state, payload._id)
-  )) as Schema_Event;
+  )) as Schema_GridEvent;
 
   try {
     yield put(getWeekEventsSlice.actions.delete(payload));
     yield put(eventsEntitiesSlice.actions.delete(payload));
-    if (!event.optimistic) {
+    if (!event.isOptimistic) {
       yield call(EventApi.delete, payload._id);
     }
 

--- a/packages/web/src/ducks/events/slices/event.slice.ts
+++ b/packages/web/src/ducks/events/slices/event.slice.ts
@@ -10,6 +10,7 @@ import {
   Action_DeleteEvent,
   Action_EditEvent,
   Action_InsertEvents,
+  Action_ReplaceEvent,
   Action_TimezoneChange,
   Entities_Event,
   Payload_EditEvent,
@@ -51,6 +52,10 @@ export const eventsEntitiesSlice = createSlice({
     },
     insert: (state, action: Action_InsertEvents) => {
       state.value = { ...state.value, ...action.payload };
+    },
+    replace: (state, action: Action_ReplaceEvent) => {
+      delete state.value[action.payload.oldEventId];
+      state.value[action.payload.newEvent._id] = action.payload.newEvent;
     },
     updateAfterTzChange: (state, action: Action_TimezoneChange) => {
       const nextState = changeTimezones(state, action.payload.timezone);

--- a/packages/web/src/ducks/events/slices/event.slice.ts
+++ b/packages/web/src/ducks/events/slices/event.slice.ts
@@ -55,7 +55,10 @@ export const eventsEntitiesSlice = createSlice({
     },
     replace: (state, action: Action_ReplaceEvent) => {
       const { oldEventId, newEventId } = action.payload;
+
       state.value[newEventId] = state.value[oldEventId];
+      state.value[newEventId]._id = newEventId;
+
       delete state.value[oldEventId];
     },
     updateAfterTzChange: (state, action: Action_TimezoneChange) => {

--- a/packages/web/src/ducks/events/slices/event.slice.ts
+++ b/packages/web/src/ducks/events/slices/event.slice.ts
@@ -54,8 +54,9 @@ export const eventsEntitiesSlice = createSlice({
       state.value = { ...state.value, ...action.payload };
     },
     replace: (state, action: Action_ReplaceEvent) => {
-      delete state.value[action.payload.oldEventId];
-      state.value[action.payload.newEvent._id] = action.payload.newEvent;
+      const { oldEventId, newEventId } = action.payload;
+      state.value[newEventId] = state.value[oldEventId];
+      delete state.value[oldEventId];
     },
     updateAfterTzChange: (state, action: Action_TimezoneChange) => {
       const nextState = changeTimezones(state, action.payload.timezone);

--- a/packages/web/src/ducks/events/slices/someday.slice.ts
+++ b/packages/web/src/ducks/events/slices/someday.slice.ts
@@ -29,6 +29,18 @@ export const getSomedayEventsSlice = createAsyncSlice<
       }
     },
 
+    replace: (
+      state,
+      action: { payload: { oldSomedayId: string; newSomedayId: string } }
+    ) => {
+      state.value.data = state.value.data.map((id: string) => {
+        if (id === action.payload.oldSomedayId) {
+          return action.payload.newSomedayId;
+        }
+        return id;
+      });
+    },
+
     reorder: (state, action) => {
       return;
     },

--- a/packages/web/src/ducks/events/slices/week.slice.ts
+++ b/packages/web/src/ducks/events/slices/week.slice.ts
@@ -25,5 +25,16 @@ export const getWeekEventsSlice = createAsyncSlice<
         state.value.data.push(action.payload);
       }
     },
+    replace: (
+      state,
+      action: { payload: { oldWeekId: string; newWeekId: string } }
+    ) => {
+      state.value.data = state.value.data.map((id: string) => {
+        if (id === action.payload.oldWeekId) {
+          return action.payload.newWeekId;
+        }
+        return id;
+      });
+    },
   },
 });

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -8,9 +8,9 @@
   // "exclude": ["./src/node_modules", "**/*.test.ts"],
   "compilerOptions": {
     "allowUnreachableCode": true,
-    // "target": "es5",
-    // "module": "es6",
-    // "moduleResolution": "node",
+    "target": "es6",
+    "module": "Node16",
+    "moduleResolution": "node16",
     // "declaration": true, // originally set to true, commented during refactor
     // "strict": true,
     // "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,


### PR DESCRIPTION
Fixes [this](https://github.com/SwitchbackTech/compass/issues/145)

Uses an optimistic UI rendering approach.

I believe Optimistic UI approach is the simplest and easiest solution under the current circumstances.

There are a couple of edge cases that needs to be handled that I believed were out of scope of this issue, but should be tackled in the future; during the timespan where the optimistically generated event is created and the HTTP request returns a response from the server:

- The event cannot be drag and dropped
- The event cannot be deleted (would delete a local version but the API would re-generate a new one after the HTTP request returns a response)

We can tackle these separately