### PR TITLE
🐛 Fix: Disable newly created event from being editing during optimistic render cycle

### DIFF
--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -30,6 +30,13 @@ export const hoverColorByPriority = {
   [Priorities.SELF]: brighten(c.blueGray200),
 };
 
+export const disabledColorByPriority = {
+  [Priorities.UNASSIGNED]: darken(c.blueGray400, 30),
+  [Priorities.WORK]: darken(c.blueGray100, 30),
+  [Priorities.RELATIONS]: darken(c.teal, 30),
+  [Priorities.SELF]: darken(c.blueGray200, 30),
+};
+
 export const gradientByPriority = {
   [Priorities.UNASSIGNED]: `linear-gradient(90deg, ${darken(
     UNASSIGNED,

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -30,13 +30,6 @@ export const hoverColorByPriority = {
   [Priorities.SELF]: brighten(c.blueGray200),
 };
 
-export const disabledColorByPriority = {
-  [Priorities.UNASSIGNED]: darken(c.blueGray400, 30),
-  [Priorities.WORK]: darken(c.blueGray100, 30),
-  [Priorities.RELATIONS]: darken(c.teal, 30),
-  [Priorities.SELF]: darken(c.blueGray200, 30),
-};
-
 export const gradientByPriority = {
   [Priorities.UNASSIGNED]: `linear-gradient(90deg, ${darken(
     UNASSIGNED,

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -18,7 +18,10 @@ import {
 import { getPosition } from "@web/views/Calendar/hooks/event/getPosition";
 import { getLineClamp } from "@web/common/utils/grid.util";
 import { getTimesLabel } from "@web/common/utils/web.date.util";
-import { ZIndex } from "@web/common/constants/web.constants";
+import {
+  ID_OPTIMISTIC_PREFIX,
+  ZIndex,
+} from "@web/common/constants/web.constants";
 import { Text } from "@web/components/Text";
 
 import { StyledEvent, StyledEventScaler, StyledEventTitle } from "../../styled";
@@ -56,6 +59,7 @@ const _GridEvent = (
   const { component } = weekProps;
 
   const isInPast = dayjs().isAfter(dayjs(_event.endDate));
+  const isOptimistic = _event._id?.startsWith(ID_OPTIMISTIC_PREFIX);
   const event = _event;
 
   const position = getPosition(
@@ -79,10 +83,13 @@ const _GridEvent = (
       isDragging={isDragging}
       isInPast={isInPast}
       isPlaceholder={isPlaceholder}
+      isOptimistic={isOptimistic}
       isResizing={isResizing}
       left={position.left}
       lineClamp={lineClamp}
       onMouseDown={(e) => {
+        if (isOptimistic) return;
+
         onEventMouseDown(event, e);
       }}
       priority={event.priority}

--- a/packages/web/src/views/Calendar/components/Event/styled.ts
+++ b/packages/web/src/views/Calendar/components/Event/styled.ts
@@ -5,6 +5,7 @@ import { Text } from "@web/components/Text";
 import { ZIndex } from "@web/common/constants/web.constants";
 import {
   colorByPriority,
+  disabledColorByPriority,
   hoverColorByPriority,
 } from "@web/common/styles/theme.util";
 
@@ -13,10 +14,12 @@ interface StyledEventProps {
   backgroundColor?: string;
   height: number;
   hoverColor?: string;
+  disabledColor?: string;
   isDragging: boolean;
   isInPast: boolean;
   isResizing: boolean;
   isPlaceholder: boolean;
+  isOptimistic: boolean;
   left: number;
   lineClamp: number;
   opacity?: number;
@@ -43,6 +46,7 @@ export const StyledEvent = styled.div.attrs<StyledEventProps>((props) => {
     hoverColor: props.isPlaceholder
       ? null
       : hoverColorByPriority[props.priority],
+    disabledColor: disabledColorByPriority[props.priority],
     opacity: props.isPlaceholder ? 0.5 : null,
     ref: props.ref,
     top: props.top,
@@ -71,11 +75,19 @@ export const StyledEvent = styled.div.attrs<StyledEventProps>((props) => {
   &:hover {
     transition: background-color 0.35s linear;
 
-    ${({ isPlaceholder, isResizing, hoverColor, theme }) =>
+    ${({
+      isPlaceholder,
+      isResizing,
+      isOptimistic,
+      hoverColor,
+      disabledColor,
+      theme,
+    }) =>
       !isPlaceholder &&
       !isResizing &&
       `
-      background-color: ${hoverColor};
+      background-color: ${isOptimistic ? disabledColor : hoverColor};
+      cursor: ${isOptimistic ? "wait" : "pointer"};
       drop-shadow(2px 4px 4px ${theme.color.shadow.default});
       `};
   }

--- a/packages/web/src/views/Calendar/components/Event/styled.ts
+++ b/packages/web/src/views/Calendar/components/Event/styled.ts
@@ -1,11 +1,10 @@
 import styled from "styled-components";
 import { Priority } from "@core/constants/core.constants";
-import { brighten } from "@core/util/color.utils";
+import { brighten, darken } from "@core/util/color.utils";
 import { Text } from "@web/components/Text";
 import { ZIndex } from "@web/common/constants/web.constants";
 import {
   colorByPriority,
-  disabledColorByPriority,
   hoverColorByPriority,
 } from "@web/common/styles/theme.util";
 
@@ -14,7 +13,6 @@ interface StyledEventProps {
   backgroundColor?: string;
   height: number;
   hoverColor?: string;
-  disabledColor?: string;
   isDragging: boolean;
   isInPast: boolean;
   isResizing: boolean;
@@ -46,7 +44,6 @@ export const StyledEvent = styled.div.attrs<StyledEventProps>((props) => {
     hoverColor: props.isPlaceholder
       ? null
       : hoverColorByPriority[props.priority],
-    disabledColor: disabledColorByPriority[props.priority],
     opacity: props.isPlaceholder ? 0.5 : null,
     ref: props.ref,
     top: props.top,
@@ -76,20 +73,20 @@ export const StyledEvent = styled.div.attrs<StyledEventProps>((props) => {
     transition: background-color 0.35s linear;
 
     ${({
+      backgroundColor,
+      isOptimistic,
       isPlaceholder,
       isResizing,
-      isOptimistic,
       hoverColor,
-      disabledColor,
       theme,
     }) =>
       !isPlaceholder &&
       !isResizing &&
       `
-      background-color: ${isOptimistic ? disabledColor : hoverColor};
+      background-color: ${isOptimistic ? darken(backgroundColor) : hoverColor};
       cursor: ${isOptimistic ? "wait" : "pointer"};
       drop-shadow(2px 4px 4px ${theme.color.shadow.default});
-      `};
+     `};
   }
 
   &.active {


### PR DESCRIPTION
### Description

While you already proposed a solution for this issue [here](https://github.com/SwitchbackTech/compass/issues/201#issue-2758833319), preventing the user from initially DnD or editing the event did not seem very UI/UX friendly to me.

I thought about and researched other solutions, the best solution to handle this issue is to implement **Transactional State Management** to handle this type of transient data, but this implementation itself is split into many strategies.

Each strategy has its own pros and cons, but they all share 1 same con and that is they are difficult to implement and adds lots of overhead.

The 2nd best approach was to simply display a loading indication when the event is initially being created, removing the optimistic approach entirely.

But this would:

- Undo some of the work we did
- Conflict with a comment you gave [here](https://github.com/SwitchbackTech/compass/pull/181#issuecomment-2538639603)

So the best thing we can do here is to implement your proposed solution which is disabling edits during its optimistic status.

I tried my best to make it UI/UX friendly by displaying a different cursor and a distinct background color to indicate we are doing some loading to the user.

I included all this extra context as logs for future reference and your own consideration.

### Demo
[Peek 2024-12-28 16-31.webm](https://github.com/user-attachments/assets/4dad0455-0cb7-432e-876e-7bab70a11999)
