### PR TITLE
🐛 fix(backend): use updated IS_DEV value when creating Collections

### DIFF
--- a/packages/backend/src/common/constants/collections.ts
+++ b/packages/backend/src/common/constants/collections.ts
@@ -1,4 +1,4 @@
-import { IS_DEV } from "@backend/common/constants/env.constants";
+import { IS_DEV } from "./env.constants";
 
 export const Collections = {
   CALENDARLIST: IS_DEV ? "_dev.calendarlist" : "calendarlist",

--- a/packages/backend/src/common/constants/env.constants.ts
+++ b/packages/backend/src/common/constants/env.constants.ts
@@ -10,7 +10,7 @@ if (!Object.values(NodeEnv).includes(_nodeEnv)) {
   throw new Error(`Invalid NODE_ENV value: '${_nodeEnv}'`);
 }
 
-const IS_DEV = isDev(_nodeEnv);
+export const IS_DEV = isDev(_nodeEnv);
 
 const EnvSchema = z
   .object({


### PR DESCRIPTION
Follow-up fix to a bug that was introduced in #208 

This was previously using the old path, which resulted in collections always falling back to their default (prod) values, rather than using the expected values in dev