### PR TITLE
🐛 Fix: Ensure backend service provides user id when updating an event

### DIFF
--- a/packages/backend/src/event/queries/event.queries.ts
+++ b/packages/backend/src/event/queries/event.queries.ts
@@ -53,7 +53,10 @@ export const updateEvent = async (
   eventId: string,
   event: Schema_Event
 ) => {
-  const _event = { ...event };
+  const _event = {
+    ...event,
+    user: userId,
+  };
 
   if ("_id" in event) {
     delete _event._id; // mongo doesn't allow changing this field directly


### PR DESCRIPTION
Should fix [issue](https://github.com/SwitchbackTech/compass/issues/207)

After attempting to reproduce the issue and following the trail, I realized the error mentioned in the issue is occurring whenever an event is unlinked from a user (a `user` property, that represents the user id, does not exist in the mongodb event document)

the `user` property is unlinked whenever we overwrite the event without a `user` property.

This happens because we rely on frontend request body event payload containing a `user` property, but as explained below there are instances when its not provided.

Update Event API relies on providing event id and user id to MongoDB API in order to update an event. The frontend provides the event object which contains the event id and the user id.

The issues are:
- When editing the event, the user id inside the request body event payload is not provided sometimes (no 100% reproduce rate but happens often enough)
- We should not depend on the frontend to provide a user id, backend service should overwrite it based on the authenticated user. This ensures that the software does not have a security risk

Interestingly I could not reproduce this behaviour on production, I reproduced it only on latest upstream changes.

As for why the frontend is not providing the user id sometimes, I am still investigating this.

Even if this PR solves the issue, we should still investigate why this unexpected behaviour is occurring as it could be a cause for larger issues in the future