### PR TITLE
🐛 Fix:(web): Enhance UX for draft event start date time calculation on mousedown

### DIFF
--- a/packages/web/src/common/utils/index.ts
+++ b/packages/web/src/common/utils/index.ts
@@ -34,6 +34,9 @@ export const roundToNearest = (x: number, roundBy: number) =>
 export const roundToNext = (number: number, roundBy: number): number =>
   Math.ceil(number / roundBy) * roundBy;
 
+export const roundToPrev = (number: number, roundBy: number): number =>
+  Math.floor(number / roundBy) * roundBy;
+
 export const sortLowToHigh = (vals: number[]) =>
   [...vals].sort(function (a, b) {
     return a - b;

--- a/packages/web/src/views/Calendar/hooks/grid/useDateCalcs.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDateCalcs.ts
@@ -1,10 +1,9 @@
-import { useLayoutEffect, useRef } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import weekPlugin from "dayjs/plugin/weekOfYear";
 import { HOURS_AM_FORMAT } from "@core/constants/date.constants";
-import { roundToNearest } from "@web/common/utils";
+import { roundToPrev } from "@web/common/utils";
 import { GRID_TIME_STEP } from "@web/views/Calendar/layout.constants";
 import { ACCEPTED_TIMES } from "@web/common/constants/web.constants";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
@@ -70,12 +69,18 @@ export const useDateCalcs = (
   };
 
   const getMinuteByY = (y: number) => {
+    if (!measurements.mainGrid) return 0; // TS guard. This should never happen
+
     const scrollTop = scrollRef.current.scrollTop;
+    // gridY is the distance from the top of the grid (main grid) to the click
     const gridY = y - measurements.mainGrid.top + scrollTop;
 
     const decimalMinute = (gridY / measurements.hourHeight) * 60;
-    const roundedMinute = roundToNearest(decimalMinute, GRID_TIME_STEP);
-    const finalMinute = Math.max(0, roundedMinute); // prevents negative number when clicking all-day row
+
+    const flooredMinute = roundToPrev(decimalMinute, GRID_TIME_STEP);
+
+    const finalMinute = Math.max(0, flooredMinute); // prevents negative number when clicking all-day row
+
     return finalMinute;
   };
 


### PR DESCRIPTION
This is a proactive fix that I did while working on [210](https://github.com/SwitchbackTech/compass/issues/210)

This does not fix 210. I felt the need to work on it because:
- I saw an opportunity for UX enhancement
- Fixing it will strengthen my understanding of the codebase (events and draft events time calculation)

I will continue work on 210 and ship a fix for it in the next PR

Here's a before and after:

#### Before
[draft_event_ux_enhancement_before.webm](https://github.com/user-attachments/assets/1e890e87-89d8-4ab9-8953-2bf9e22785e1)

**You can notice that even though the click was outside the 8am timeframe, it counted towards 8am**

#### After
[draft_event_ux_enhancement_after.webm](https://github.com/user-attachments/assets/34e70148-1161-4958-95ab-51521b802ede)

The click now accurately counts towards 7:45 - 8am timeframe