### PR TITLE
🐛 Fix: Implement better snapping when dragging events from sidebar to grid

### DIFF
--- a/packages/web/src/common/types/util.types.ts
+++ b/packages/web/src/common/types/util.types.ts
@@ -4,7 +4,10 @@ export interface AssignResult {
   fits: boolean;
   rowNum?: number;
 }
-
+export interface Coordinates {
+  x: number;
+  y: number;
+}
 export interface Option_Time {
   label: string;
   value: string;

--- a/packages/web/src/views/Calendar/Calendar.tsx
+++ b/packages/web/src/views/Calendar/Calendar.tsx
@@ -73,6 +73,7 @@ export const CalendarView = () => {
           dateCalcs={dateCalcs}
           measurements={measurements}
           weekProps={weekProps}
+          gridRefs={gridRefs}
         />
       )}
       <StyledCalendar direction={FlexDirections.COLUMN} id={ID_MAIN}>

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
@@ -7,10 +7,14 @@ import { AlignItems, FlexWrap } from "@web/components/Flex/styled";
 import { Text } from "@web/components/Text";
 import { SOMEDAY_EVENT_HEIGHT } from "@web/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/styled";
 import { EVENT_ALLDAY_HEIGHT } from "@web/views/Calendar/layout.constants";
-import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import {
+  Measurements_Grid,
+  Refs_Grid,
+} from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
+import { snapToGrid } from "@web/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid";
 
 import { getItemStyles, layerStyles, StyledGridEventPreview } from "./styled";
 
@@ -23,6 +27,7 @@ export interface Props {
   measurements: Measurements_Grid;
   mouseCoords: { x: number; y: number };
   startOfView: WeekProps["component"]["startOfView"];
+  gridScrollRef: Refs_Grid["gridScrollRef"];
 }
 
 export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
@@ -34,6 +39,7 @@ export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
   measurements,
   mouseCoords,
   startOfView,
+  gridScrollRef,
 }) {
   const { colWidths } = measurements;
   const { x, y } = mouseCoords;
@@ -72,9 +78,16 @@ export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
   const height = getHeight();
   const width = getWidth();
 
+  const [snappedX, snappedY] = snapToGrid(
+    x,
+    y,
+    measurements,
+    gridScrollRef.current?.scrollTop || 0
+  );
+
   return (
     <div style={layerStyles}>
-      <div style={getItemStyles({ x: 0, y: 0 }, { x, y })}>
+      <div style={getItemStyles({ x: snappedX, y: snappedY })}>
         <StyledGridEventPreview
           className={"active"}
           duration={1}

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
@@ -15,6 +15,7 @@ import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
 import { snapToGrid } from "@web/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid";
+import { MouseCoords } from "@web/views/Calendar/hooks/draft/useMousePosition";
 
 import { getItemStyles, layerStyles, StyledGridEventPreview } from "./styled";
 
@@ -25,7 +26,7 @@ export interface Props {
   isOverAllDayRow: boolean;
   isOverMainGrid: boolean;
   measurements: Measurements_Grid;
-  mouseCoords: { x: number; y: number };
+  mouseCoords: MouseCoords;
   startOfView: WeekProps["component"]["startOfView"];
   gridScrollRef: Refs_Grid["gridScrollRef"];
 }

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
@@ -79,7 +79,7 @@ export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
   const height = getHeight();
   const width = getWidth();
 
-  const [snappedX, snappedY] = snapToGrid(
+  const { x: snappedX, y: snappedY } = snapToGrid(
     x,
     y,
     measurements,

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -2,6 +2,7 @@ import {
   MeasureableElement,
   Measurements_Grid,
 } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import { MouseCoords } from "@web/views/Calendar/hooks/draft/useMousePosition";
 
 import { snapToGrid } from "./snap.grid";
 describe("snapToGrid", () => {
@@ -28,9 +29,12 @@ describe("snapToGrid", () => {
   };
 
   it("returns the cursor position if measurements are not available", () => {
+    const mouseCoords: MouseCoords = { x: 200, y: 300 };
+    const scrollTop = 0;
+
     const result = snapToGrid(
-      200,
-      300,
+      mouseCoords.x,
+      mouseCoords.y,
       {
         mainGrid: null,
         allDayRow: null,
@@ -40,14 +44,24 @@ describe("snapToGrid", () => {
           console.log("foo", elem);
         },
       },
-      0
+      scrollTop
     );
-    expect(result).toEqual([200, 300]);
+
+    expect(result).toEqual([mouseCoords.x, mouseCoords.y]);
   });
 
   it("returns the cursor position if cursor is not within the grid", () => {
-    const result = snapToGrid(200, 50, measurements, 0);
-    expect(result).toEqual([200, 50]);
+    const mouseCoords: MouseCoords = { x: 200, y: 50 };
+    const scrollTop = 0;
+
+    const result = snapToGrid(
+      mouseCoords.x,
+      mouseCoords.y,
+      measurements,
+      scrollTop
+    );
+
+    expect(result).toEqual([mouseCoords.x, mouseCoords.y]);
   });
 
   it("snaps the cursor position to the nearest grid interval", () => {

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -7,7 +7,7 @@ import { snapToGrid, MAIN_GRID_TIME_COLUMN_WIDTH } from "./snap.grid";
 import { Coordinates } from "@web/common/types/util.types";
 
 // 7 day main grid
-describe("snapToGrid. 7 day grid", () => {
+describe("snapToGrid", () => {
   const measurements: Measurements_Grid = {
     mainGrid: {
       top: 100,
@@ -51,205 +51,206 @@ describe("snapToGrid. 7 day grid", () => {
     mouseCoords.y = DEFAULT_Y;
   });
 
-  it("returns the cursor position if measurements are not available", () => {
-    const result = snapToGrid(
-      mouseCoords.x,
-      mouseCoords.y,
-      {
-        mainGrid: null,
-        allDayRow: null,
-        colWidths: [],
-        hourHeight: 0,
-        remeasure: (elem: MeasureableElement) => {
-          console.log("foo", elem);
+  describe("Edge Cases", () => {
+    it("Returns the cursor position if measurements are not available", () => {
+      const result = snapToGrid(
+        mouseCoords.x,
+        mouseCoords.y,
+        {
+          mainGrid: null,
+          allDayRow: null,
+          colWidths: [],
+          hourHeight: 0,
+          remeasure: (elem: MeasureableElement) => {
+            console.log("foo", elem);
+          },
         },
-      },
-      0
-    );
+        0
+      );
 
-    expect(result).toEqual({
-      x: mouseCoords.x,
-      y: mouseCoords.y,
+      expect(result).toEqual({
+        x: mouseCoords.x,
+        y: mouseCoords.y,
+      });
+    });
+
+    it("Returns the cursor position if cursor is not within the grid", () => {
+      const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+
+      expect(result).toEqual({
+        x: mouseCoords.x,
+        y: mouseCoords.y,
+      });
     });
   });
 
-  it("returns the cursor position if cursor is not within the grid", () => {
-    const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+  describe("Horizontal Snap", () => {
+    it("Snaps X to correct day column", () => {
+      let result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    expect(result).toEqual({
-      x: mouseCoords.x,
-      y: mouseCoords.y,
+      const expectedY = mouseCoords.y;
+      const expectedX = mainGrid.left;
+
+      expect(result).toEqual({ x: expectedX, y: expectedY });
+
+      // Simulate moving the mouse to the right very very close to the next
+      // column, but don't cross its boundary. We should remain in the same
+      // column (because we didn't cross the boundary)
+      mouseCoords.x =
+        mouseCoords.x +
+        measurements.colWidths[0] -
+        // "1px". This helps us not cross the boundary
+        1;
+
+      // Expect to still be in the same column
+      result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+
+      expect(result).toEqual({ x: expectedX, y: expectedY });
+    });
+    it("Snaps X to correct day column when scrolled", () => {
+      const scrollTop = measurements.hourHeight * 3;
+
+      let result = snapToGrid(
+        mouseCoords.x,
+        mouseCoords.y,
+        measurements,
+        scrollTop
+      );
+
+      const expectedY = mouseCoords.y;
+      const expectedX = mainGrid.left;
+
+      expect(result).toEqual({ x: expectedX, y: expectedY });
+
+      mouseCoords.x = mouseCoords.x + measurements.colWidths[0] - 1;
+
+      result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+
+      expect(result).toEqual({ x: expectedX, y: expectedY });
+    });
+    it("Correctly updates X to next day column when cursor is moved to the next column", () => {
+      const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+
+      const expectedY = DEFAULT_Y;
+      const expectedX = mainGrid.left;
+
+      expect(result).toEqual({ x: expectedX, y: expectedY });
+
+      // Move the cursor to the next column
+      mouseCoords.x = mouseCoords.x + measurements.colWidths[0];
+
+      const nextResult = snapToGrid(
+        mouseCoords.x,
+        mouseCoords.y,
+        measurements,
+        0
+      );
+
+      const expectedNextX = expectedX + measurements.colWidths[0];
+
+      expect(nextResult).toEqual({ x: expectedNextX, y: expectedY });
+    });
+    it("Correctly updates X to prev day column when cursor is moved to the prev column", () => {
+      mouseCoords.x = mouseCoords.x + measurements.colWidths[0];
+
+      const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+
+      const expectedX = mainGrid.left + measurements.colWidths[0];
+
+      expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
+
+      // Move the cursor to the previous column
+      mouseCoords.x = mouseCoords.x - measurements.colWidths[0];
+
+      const nextResult = snapToGrid(
+        mouseCoords.x,
+        mouseCoords.y,
+        measurements,
+        0
+      );
+
+      const expectedNextX = expectedX - measurements.colWidths[0];
+
+      expect(nextResult).toEqual({ x: expectedNextX, y: DEFAULT_Y });
     });
   });
+  describe("Vertical Snap", () => {
+    it("Snaps Y to correct time interval", () => {
+      const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-  it("Snaps Y to correct time interval", () => {
-    const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+      const expectedX = mainGrid.left;
 
-    const expectedX = mainGrid.left;
+      expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
 
-    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
+      // Move the cursor down a little
+      mouseCoords.y = mouseCoords.y + 5;
 
-    // Move the cursor down a little
-    mouseCoords.y = mouseCoords.y + 5;
+      // Expect result to still be the same
+      expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
+    });
+    it("Snaps Y to correct time interval when scrolled", () => {
+      // Scroll down a few hour rows. This can be changed to any number and we will
+      // still always get the same result as long as we scroll down hour rows consistently.
+      const HOURS_TO_SCROLL = 3;
+      const scrollTop = measurements.hourHeight * HOURS_TO_SCROLL;
 
-    // Expect result to still be the same
-    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
-  });
+      const result = snapToGrid(
+        mouseCoords.x,
+        mouseCoords.y,
+        measurements,
+        scrollTop
+      );
 
-  it("Snaps X to correct day column", () => {
-    let result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+      const expectedY = DEFAULT_Y;
+      const expectedX = mainGrid.left;
 
-    const expectedY = mouseCoords.y;
-    const expectedX = mainGrid.left;
+      expect(result).toEqual({ x: expectedX, y: expectedY });
+    });
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
+    it("Correctly updates Y to next time interval when cursor is moved to the next interval", () => {
+      const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    // Simulate moving the mouse to the right very very close to the next
-    // column, but don't cross its boundary. We should remain in the same
-    // column (because we didn't cross the boundary)
-    mouseCoords.x =
-      mouseCoords.x +
-      measurements.colWidths[0] -
-      // "1px". This helps us not cross the boundary
-      1;
+      const expectedX = mainGrid.left;
 
-    // Expect to still be in the same column
-    result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+      expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
-  });
+      mouseCoords.y = mouseCoords.y + measurements.hourHeight;
 
-  it("Snaps Y to correct time interval when scrolled", () => {
-    // Scroll down a few hour rows. This can be changed to any number and we will
-    // still always get the same result as long as we scroll down hour rows consistently.
-    const HOURS_TO_SCROLL = 3;
-    const scrollTop = measurements.hourHeight * HOURS_TO_SCROLL;
+      const nextResult = snapToGrid(
+        mouseCoords.x,
+        mouseCoords.y,
+        measurements,
+        0
+      );
 
-    const result = snapToGrid(
-      mouseCoords.x,
-      mouseCoords.y,
-      measurements,
-      scrollTop
-    );
+      const expectedNextY = DEFAULT_Y + measurements.hourHeight;
 
-    const expectedY = DEFAULT_Y;
-    const expectedX = mainGrid.left;
+      expect(nextResult).toEqual({ x: expectedX, y: expectedNextY });
+    });
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
-  });
+    it("Correctly updates Y to prev time interval when cursor is moved to the prev interval", () => {
+      mouseCoords.y = mouseCoords.y + measurements.hourHeight;
 
-  it("Snaps X to correct day column when scrolled", () => {
-    const scrollTop = measurements.hourHeight * 3;
+      const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    let result = snapToGrid(
-      mouseCoords.x,
-      mouseCoords.y,
-      measurements,
-      scrollTop
-    );
+      const expectedY = DEFAULT_Y + measurements.hourHeight;
+      const expectedX = mainGrid.left;
 
-    const expectedY = mouseCoords.y;
-    const expectedX = mainGrid.left;
+      expect(result).toEqual({ x: expectedX, y: expectedY });
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
+      // Move the cursor up to the previous time interval
+      mouseCoords.y = mouseCoords.y - measurements.hourHeight;
 
-    mouseCoords.x = mouseCoords.x + measurements.colWidths[0] - 1;
+      const nextResult = snapToGrid(
+        mouseCoords.x,
+        mouseCoords.y,
+        measurements,
+        0
+      );
 
-    result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
+      const expectedNextY = expectedY - measurements.hourHeight;
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
-  });
-
-  it("Correctly updates Y to next time interval when cursor is moved to the next interval", () => {
-    const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
-
-    const expectedX = mainGrid.left;
-
-    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
-
-    mouseCoords.y = mouseCoords.y + measurements.hourHeight;
-
-    const nextResult = snapToGrid(
-      mouseCoords.x,
-      mouseCoords.y,
-      measurements,
-      0
-    );
-
-    const expectedNextY = DEFAULT_Y + measurements.hourHeight;
-
-    expect(nextResult).toEqual({ x: expectedX, y: expectedNextY });
-  });
-
-  it("Correctly updates X to next day column when cursor is moved to the next column", () => {
-    const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
-
-    const expectedY = DEFAULT_Y;
-    const expectedX = mainGrid.left;
-
-    expect(result).toEqual({ x: expectedX, y: expectedY });
-
-    // Move the cursor to the next column
-    mouseCoords.x = mouseCoords.x + measurements.colWidths[0];
-
-    const nextResult = snapToGrid(
-      mouseCoords.x,
-      mouseCoords.y,
-      measurements,
-      0
-    );
-
-    const expectedNextX = expectedX + measurements.colWidths[0];
-
-    expect(nextResult).toEqual({ x: expectedNextX, y: expectedY });
-  });
-
-  it("Correctly updates Y to prev time interval when cursor is moved to the prev interval", () => {
-    mouseCoords.y = mouseCoords.y + measurements.hourHeight;
-
-    const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
-
-    const expectedY = DEFAULT_Y + measurements.hourHeight;
-    const expectedX = mainGrid.left;
-
-    expect(result).toEqual({ x: expectedX, y: expectedY });
-
-    // Move the cursor up to the previous time interval
-    mouseCoords.y = mouseCoords.y - measurements.hourHeight;
-
-    const nextResult = snapToGrid(
-      mouseCoords.x,
-      mouseCoords.y,
-      measurements,
-      0
-    );
-
-    const expectedNextY = expectedY - measurements.hourHeight;
-
-    expect(nextResult).toEqual({ x: expectedX, y: expectedNextY });
-  });
-
-  it("Correctly updates X to prev day column when cursor is moved to the prev column", () => {
-    mouseCoords.x = mouseCoords.x + measurements.colWidths[0];
-
-    const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
-
-    const expectedX = mainGrid.left + measurements.colWidths[0];
-
-    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
-
-    // Move the cursor to the previous column
-    mouseCoords.x = mouseCoords.x - measurements.colWidths[0];
-
-    const nextResult = snapToGrid(
-      mouseCoords.x,
-      mouseCoords.y,
-      measurements,
-      0
-    );
-
-    const expectedNextX = expectedX - measurements.colWidths[0];
-
-    expect(nextResult).toEqual({ x: expectedNextX, y: DEFAULT_Y });
+      expect(nextResult).toEqual({ x: expectedX, y: expectedNextY });
+    });
   });
 });

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { MouseCoords } from "@web/views/Calendar/hooks/draft/useMousePosition";
 
-import { snapToGrid, TIME_COLUMN_WIDTH } from "./snap.grid";
+import { snapToGrid, MAIN_GRID_TIME_COLUMN_WIDTH } from "./snap.grid";
 
 // 7 day main grid
 describe("snapToGrid. 7 day grid", () => {
@@ -41,8 +41,8 @@ describe("snapToGrid. 7 day grid", () => {
   // Override main grid
   const mainGrid = {
     ...measurementsMainGrid,
-    // Real "left" for main grid. See comment for TIME_COLUMN_WIDTH in snap.grid.ts for why we do this
-    left: measurementsMainGrid.left + TIME_COLUMN_WIDTH,
+    // Real "left" for main grid. See comment for MAIN_GRID_TIME_COLUMN_WIDTH in snap.grid.ts for why we do this
+    left: measurementsMainGrid.left + MAIN_GRID_TIME_COLUMN_WIDTH,
   };
 
   afterEach(() => {

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -5,7 +5,7 @@ import {
 import { MouseCoords } from "@web/views/Calendar/hooks/draft/useMousePosition";
 
 import { snapToGrid } from "./snap.grid";
-describe("snapToGrid", () => {
+describe("snapToGrid. 7 day grid", () => {
   const measurements: Measurements_Grid = {
     mainGrid: {
       top: 100,
@@ -21,7 +21,7 @@ describe("snapToGrid", () => {
       },
     },
     hourHeight: 60,
-    colWidths: [100, 100, 100, 100, 100, 100, 100],
+    colWidths: Array(7).fill(100) as number[],
     allDayRow: null,
     remeasure: (elem: MeasureableElement) => {
       console.log("remeasuring element", elem);

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -30,9 +30,9 @@ describe("snapToGrid. 7 day grid", () => {
     },
   };
 
-  const defaultX = 105;
-  const defaultY = 160;
-  const mouseCoords: Coordinates = { x: defaultX, y: defaultY };
+  const DEFAULT_X = 105;
+  const DEFAULT_Y = 160;
+  const mouseCoords: Coordinates = { x: DEFAULT_X, y: DEFAULT_Y };
 
   // Hack to tell TS that measurements.mainGrid is not null in below "it" blocks
   if (!measurements.mainGrid) return;
@@ -47,8 +47,8 @@ describe("snapToGrid. 7 day grid", () => {
 
   afterEach(() => {
     // Reset mouse coords incase they were changed
-    mouseCoords.x = defaultX;
-    mouseCoords.y = defaultY;
+    mouseCoords.x = DEFAULT_X;
+    mouseCoords.y = DEFAULT_Y;
   });
 
   it("returns the cursor position if measurements are not available", () => {
@@ -85,16 +85,15 @@ describe("snapToGrid. 7 day grid", () => {
   it("Snaps Y to correct time interval", () => {
     const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    const expectedY = 160;
     const expectedX = mainGrid.left;
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
+    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
 
     // Move the cursor down a little
     mouseCoords.y = mouseCoords.y + 5;
 
     // Expect result to still be the same
-    expect(result).toEqual({ x: expectedX, y: expectedY });
+    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
   });
 
   it("Snaps X to correct day column", () => {
@@ -133,7 +132,7 @@ describe("snapToGrid. 7 day grid", () => {
       scrollTop
     );
 
-    const expectedY = 160;
+    const expectedY = DEFAULT_Y;
     const expectedX = mainGrid.left;
 
     expect(result).toEqual({ x: expectedX, y: expectedY });
@@ -164,12 +163,10 @@ describe("snapToGrid. 7 day grid", () => {
   it("Correctly updates Y to next time interval when cursor is moved to the next interval", () => {
     const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    const expectedY = 160;
     const expectedX = mainGrid.left;
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
+    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
 
-    // Move the cursor down to the next time interval
     mouseCoords.y = mouseCoords.y + measurements.hourHeight;
 
     const nextResult = snapToGrid(
@@ -179,7 +176,7 @@ describe("snapToGrid. 7 day grid", () => {
       0
     );
 
-    const expectedNextY = expectedY + measurements.hourHeight;
+    const expectedNextY = DEFAULT_Y + measurements.hourHeight;
 
     expect(nextResult).toEqual({ x: expectedX, y: expectedNextY });
   });
@@ -187,7 +184,7 @@ describe("snapToGrid. 7 day grid", () => {
   it("Correctly updates X to next day column when cursor is moved to the next column", () => {
     const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    const expectedY = 160;
+    const expectedY = DEFAULT_Y;
     const expectedX = mainGrid.left;
 
     expect(result).toEqual({ x: expectedX, y: expectedY });
@@ -212,7 +209,7 @@ describe("snapToGrid. 7 day grid", () => {
 
     const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    const expectedY = 160 + measurements.hourHeight;
+    const expectedY = DEFAULT_Y + measurements.hourHeight;
     const expectedX = mainGrid.left;
 
     expect(result).toEqual({ x: expectedX, y: expectedY });
@@ -237,10 +234,9 @@ describe("snapToGrid. 7 day grid", () => {
 
     const result = snapToGrid(mouseCoords.x, mouseCoords.y, measurements, 0);
 
-    const expectedY = 160;
     const expectedX = mainGrid.left + measurements.colWidths[0];
 
-    expect(result).toEqual({ x: expectedX, y: expectedY });
+    expect(result).toEqual({ x: expectedX, y: DEFAULT_Y });
 
     // Move the cursor to the previous column
     mouseCoords.x = mouseCoords.x - measurements.colWidths[0];
@@ -254,6 +250,6 @@ describe("snapToGrid. 7 day grid", () => {
 
     const expectedNextX = expectedX - measurements.colWidths[0];
 
-    expect(nextResult).toEqual({ x: expectedNextX, y: expectedY });
+    expect(nextResult).toEqual({ x: expectedNextX, y: DEFAULT_Y });
   });
 });

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -2,9 +2,9 @@ import {
   MeasureableElement,
   Measurements_Grid,
 } from "@web/views/Calendar/hooks/grid/useGridLayout";
-import { MouseCoords } from "@web/views/Calendar/hooks/draft/useMousePosition";
 
 import { snapToGrid, MAIN_GRID_TIME_COLUMN_WIDTH } from "./snap.grid";
+import { Coordinates } from "@web/common/types/util.types";
 
 // 7 day main grid
 describe("snapToGrid. 7 day grid", () => {
@@ -32,7 +32,7 @@ describe("snapToGrid. 7 day grid", () => {
 
   const defaultX = 105;
   const defaultY = 160;
-  const mouseCoords: MouseCoords = { x: defaultX, y: defaultY };
+  const mouseCoords: Coordinates = { x: defaultX, y: defaultY };
 
   // Hack to tell TS that measurements.mainGrid is not null in below "it" blocks
   if (!measurements.mainGrid) return;

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -1,0 +1,81 @@
+import {
+  MeasureableElement,
+  Measurements_Grid,
+} from "@web/views/Calendar/hooks/grid/useGridLayout";
+
+import { snapToGrid } from "./snap.grid";
+describe("snapToGrid", () => {
+  const measurements: Measurements_Grid = {
+    mainGrid: {
+      top: 100,
+      left: 50,
+      height: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      bottom: 0,
+      right: 0,
+      toJSON: function () {
+        throw new Error("Function not implemented.");
+      },
+    },
+    hourHeight: 60,
+    colWidths: [100, 100, 100, 100, 100, 100, 100],
+    allDayRow: null,
+    remeasure: (elem: MeasureableElement) => {
+      console.log("remeasuring element", elem);
+    },
+  };
+
+  it("returns the cursor position if measurements are not available", () => {
+    const result = snapToGrid(
+      200,
+      300,
+      {
+        mainGrid: null,
+        allDayRow: null,
+        colWidths: [],
+        hourHeight: 0,
+        remeasure: (elem: MeasureableElement) => {
+          console.log("foo", elem);
+        },
+      },
+      0
+    );
+    expect(result).toEqual([200, 300]);
+  });
+
+  it("returns the cursor position if cursor is not within the grid", () => {
+    const result = snapToGrid(200, 50, measurements, 0);
+    expect(result).toEqual([200, 50]);
+  });
+
+  it("snaps the cursor position to the nearest grid interval", () => {
+    const result = snapToGrid(200, 150, measurements, 0);
+    expect(result).toEqual([200, 160]);
+  });
+
+  it("accounts for scrolling when snapping the cursor position", () => {
+    const result = snapToGrid(200, 150, measurements, 50);
+    expect(result).toEqual([200, 110]);
+  });
+
+  it("handles snapping when cursor is within the grid", () => {
+    const result = snapToGrid(200, 200, measurements, 0);
+    expect(result).toEqual([200, 220]);
+  });
+
+  it("handles snapping when cursor is within the grid and scrolled", () => {
+    const result = snapToGrid(200, 200, measurements, 50);
+    expect(result).toEqual([200, 170]);
+  });
+
+  it("handles snapping when cursor is within the grid and scrolled with different column widths", () => {
+    const customMeasurements: Measurements_Grid = {
+      ...measurements,
+      colWidths: [120, 120, 120, 120, 120, 120, 120],
+    };
+    const result = snapToGrid(250, 200, customMeasurements, 50);
+    expect(result).toEqual([250, 170]);
+  });
+});

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.test.ts
@@ -34,7 +34,7 @@ describe("snapToGrid. 7 day grid", () => {
   const defaultY = 160;
   const mouseCoords: MouseCoords = { x: defaultX, y: defaultY };
 
-  // Hack to tell TS that measurements.mainGrid is not null
+  // Hack to tell TS that measurements.mainGrid is not null in below "it" blocks
   if (!measurements.mainGrid) return;
   const { mainGrid: measurementsMainGrid } = measurements;
 

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
@@ -1,7 +1,41 @@
-export const snapToGrid = (x: number, y: number): [number, number] => {
-  const yInterval = 10; // hacky way to get snap feel; not accurate
-  const snappedY = Math.round(y / yInterval) * yInterval;
-  const snappedX = x;
+import { roundToPrev } from "@web/common/utils";
+import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import { GRID_TIME_STEP } from "@web/views/Calendar/layout.constants";
+
+export const snapToGrid = (
+  cursorX: number,
+  cursorY: number,
+  measurements: Measurements_Grid,
+  scrollTop: number
+): [number, number] => {
+  if (!measurements.mainGrid) {
+    // Fallback in case measurements are not available
+    return [cursorX, cursorY];
+  }
+
+  // Check if the cursor is within the bounds of the main grid
+  const isCursorWithinGrid = cursorY > measurements.mainGrid.top;
+
+  let snappedY = cursorY;
+
+  if (isCursorWithinGrid) {
+    // Calculate the cursor's Y position relative to the grid's top and account for scrolling
+    const gridY = cursorY - measurements.mainGrid.top + scrollTop;
+
+    // Convert the grid time interval to a fractional hour (assuming GRID_TIME_STEP is in minutes and will never be larger than 60)
+    const fractionalHour = GRID_TIME_STEP / 60;
+
+    // Calculate the height of a single grid time interval in pixels
+    const intervalHeightInPixels = measurements.hourHeight * fractionalHour;
+
+    // Snap the relative Y position to the nearest grid interval
+    const snappedRelativeY = roundToPrev(gridY, intervalHeightInPixels);
+
+    // Adjust snappedY to position the event relative to the grid's top
+    snappedY = measurements.mainGrid.top - scrollTop + snappedRelativeY;
+  }
+
+  const snappedX = cursorX;
 
   return [snappedX, snappedY];
 };

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
@@ -69,7 +69,6 @@ export const snapToGrid = (
   scrollTop: number
 ): [number, number] => {
   if (!measurements.mainGrid) {
-    // Fallback in case measurements are not available
     return [cursorX, cursorY];
   }
 

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
@@ -12,7 +12,7 @@ export interface SnappedCoords {
 // Ideally we should fix how `mainGrid.left` is calculated to not include half the width of time column and
 // include only the grid interactivity area (i.e. day columns).
 // For now, we estimate the width of the time column to be 55px
-export const TIME_COLUMN_WIDTH = 55;
+export const MAIN_GRID_TIME_COLUMN_WIDTH = 55;
 
 // TODO: Draw a step by step diagram to explain how the snapping works? (Might
 // help facilitate quicker understanding of the code)
@@ -48,7 +48,8 @@ const snapXToGrid = (
   if (!measurements.mainGrid) return cursorX; // TS guard
 
   // Calculate the cursor's X position relative to the grid's left and account for scrolling
-  const gridX = cursorX - TIME_COLUMN_WIDTH - measurements.mainGrid.left;
+  const gridX =
+    cursorX - MAIN_GRID_TIME_COLUMN_WIDTH - measurements.mainGrid.left;
 
   // Width of a single grid column (right now it appears the width is the same for across all columns, even in
   // different view ports, so we can reliably use the first column width)
@@ -64,7 +65,7 @@ const snapXToGrid = (
 
   // Adjust snappedX to position the event relative to the grid's left
   const snappedX =
-    measurements.mainGrid.left + TIME_COLUMN_WIDTH + snappedRelativeX;
+    measurements.mainGrid.left + MAIN_GRID_TIME_COLUMN_WIDTH + snappedRelativeX;
 
   return snappedX;
 };

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
@@ -2,6 +2,11 @@ import { roundToPrev } from "@web/common/utils";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { GRID_TIME_STEP } from "@web/views/Calendar/layout.constants";
 
+export interface SnappedCoords {
+  x: number;
+  y: number;
+}
+
 const snapYToGrid = (
   cursorY: number,
   measurements: Measurements_Grid,
@@ -67,9 +72,9 @@ export const snapToGrid = (
   cursorY: number,
   measurements: Measurements_Grid,
   scrollTop: number
-): [number, number] => {
+): SnappedCoords => {
   if (!measurements.mainGrid) {
-    return [cursorX, cursorY];
+    return { x: cursorX, y: cursorY };
   }
 
   // Check if the cursor is within the bounds of the main grid
@@ -83,5 +88,5 @@ export const snapToGrid = (
     snappedX = snapXToGrid(cursorX, measurements);
   }
 
-  return [snappedX, snappedY];
+  return { x: snappedX, y: snappedY };
 };

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/snap.grid.ts
@@ -7,6 +7,15 @@ export interface SnappedCoords {
   y: number;
 }
 
+// `measurements.mainGrid.left` includes half the width of time column. It does not start at the first day column.
+// due to that, we need to account for its width, otherwise snappedX will be off.
+// Ideally we should fix how `mainGrid.left` is calculated to not include half the width of time column and
+// include only the grid interactivity area (i.e. day columns).
+// For now, we estimate the width of the time column to be 55px
+export const TIME_COLUMN_WIDTH = 55;
+
+// TODO: Draw a step by step diagram to explain how the snapping works? (Might
+// help facilitate quicker understanding of the code)
 const snapYToGrid = (
   cursorY: number,
   measurements: Measurements_Grid,
@@ -26,8 +35,8 @@ const snapYToGrid = (
   // Snap the relative Y position to the nearest grid interval
   const snappedRelativeY = roundToPrev(gridY, intervalHeightInPixels);
 
-  // Adjust snappedY to position the event relative to the grid's top
-  const snappedY = measurements.mainGrid.top - scrollTop + snappedRelativeY;
+  // Adjust snappedY to position the event relative to the page's viewport
+  const snappedY = snappedRelativeY + measurements.mainGrid.top - scrollTop;
 
   return snappedY;
 };
@@ -37,13 +46,6 @@ const snapXToGrid = (
   measurements: Measurements_Grid
 ): number => {
   if (!measurements.mainGrid) return cursorX; // TS guard
-
-  // `mainGrid.left` includes half the width of time column. It does not start at the first day column.
-  // due to that, we need to account for its width, otherwise snappedX will be off.
-  // Ideally we should fix how `mainGrid.left` is calculated to not include half the width of time column and
-  // include only the grid interactivity area (i.e. day columns).
-  // For now, we estimate the width of the time column to be 55px
-  const TIME_COLUMN_WIDTH = 55;
 
   // Calculate the cursor's X position relative to the grid's left and account for scrolling
   const gridX = cursorX - TIME_COLUMN_WIDTH - measurements.mainGrid.left;

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/styled.ts
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/styled.ts
@@ -6,28 +6,17 @@ import { ZIndex } from "@web/common/constants/web.constants";
 import { theme } from "@web/common/styles/theme";
 import { hoverColorByPriority } from "@web/common/styles/theme.util";
 
-import { snapToGrid } from "./snap.grid";
-
-export const getItemStyles = (
-  initialOffset: XYCoord | null,
-  currentOffset: XYCoord | null
-) => {
-  if (!initialOffset || !currentOffset) {
+export const getItemStyles = (currentOffset: XYCoord | null) => {
+  if (!currentOffset) {
     return {
       display: "none",
     };
   }
 
-  let { x, y } = currentOffset;
-
-  // snap logic
-  x -= initialOffset.x;
-  y -= initialOffset.y;
-  [x, y] = snapToGrid(x, y);
-  x += initialOffset.x;
-  y += initialOffset.y;
+  const { x, y } = currentOffset;
 
   const transform = `translate(${x}px, ${y}px)`;
+
   return {
     transform,
     WebkitTransform: transform,

--- a/packages/web/src/views/Calendar/components/Sidebar/Sidebar.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,10 @@
 import React, { FC } from "react";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
-import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import {
+  Measurements_Grid,
+  Refs_Grid,
+} from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { useAppSelector } from "@web/store/store.hooks";
 import { selectSidebarTab } from "@web/ducks/events/selectors/view.selectors";
 
@@ -15,12 +18,14 @@ interface Props {
   dateCalcs: DateCalcs;
   measurements: Measurements_Grid;
   weekProps: WeekProps;
+  gridRefs: Refs_Grid;
 }
 
 export const Sidebar: FC<Props & React.HTMLAttributes<HTMLDivElement>> = ({
   dateCalcs,
   measurements,
   weekProps,
+  gridRefs,
 }: Props) => {
   const weekStart = weekProps.component.startOfView;
   const weekEnd = weekProps.component.endOfView;
@@ -42,6 +47,7 @@ export const Sidebar: FC<Props & React.HTMLAttributes<HTMLDivElement>> = ({
             sidebarProps={sidebarProps}
             viewStart={weekStart}
             viewEnd={weekEnd}
+            gridRefs={gridRefs}
           />
         )}
         {tab === "monthWidget" && (

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/MonthSection/MonthSection.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/MonthSection/MonthSection.tsx
@@ -2,7 +2,10 @@ import React, { FC } from "react";
 import { Categories_Event } from "@core/types/event.types";
 import { SidebarProps } from "@web/views/Calendar/hooks/draft/sidebar/useSidebar";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
-import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import {
+  Measurements_Grid,
+  Refs_Grid,
+} from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { Text } from "@web/components/Text";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { AlignItems, JustifyContent } from "@web/components/Flex/styled";
@@ -16,6 +19,7 @@ interface Props {
   measurements: Measurements_Grid;
   somedayProps: SidebarProps;
   viewStart: WeekProps["component"]["startOfView"];
+  gridRefs: Refs_Grid;
 }
 
 export const MonthSection: FC<Props> = ({
@@ -23,6 +27,7 @@ export const MonthSection: FC<Props> = ({
   measurements,
   somedayProps,
   viewStart,
+  gridRefs,
 }) => {
   const monthLabel = getMonthListLabel(viewStart);
 
@@ -43,6 +48,7 @@ export const MonthSection: FC<Props> = ({
         measurements={measurements}
         sidebarProps={somedayProps}
         viewStart={viewStart}
+        gridScrollRef={gridRefs.gridScrollRef}
       />
     </SidebarSection>
   );

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvents.tsx
@@ -7,7 +7,10 @@ import {
   GRID_X_START,
   SIDEBAR_OPEN_WIDTH,
 } from "@web/views/Calendar/layout.constants";
-import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import {
+  Measurements_Grid,
+  Refs_Grid,
+} from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { SidebarProps } from "@web/views/Calendar/hooks/draft/sidebar/useSidebar";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { GridEventPreview } from "@web/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview";
@@ -23,6 +26,7 @@ interface Props {
   measurements: Measurements_Grid;
   sidebarProps: SidebarProps;
   viewStart: WeekProps["component"]["startOfView"];
+  gridScrollRef: Refs_Grid["gridScrollRef"];
 }
 
 export const SomedayEvents: FC<Props> = ({
@@ -31,6 +35,7 @@ export const SomedayEvents: FC<Props> = ({
   measurements,
   sidebarProps,
   viewStart,
+  gridScrollRef,
 }) => {
   const { state, util } = sidebarProps;
   const gridX = state.mouseCoords.x - (SIDEBAR_OPEN_WIDTH + GRID_X_START);
@@ -57,6 +62,7 @@ export const SomedayEvents: FC<Props> = ({
           measurements={measurements}
           mouseCoords={state.mouseCoords}
           startOfView={viewStart}
+          gridScrollRef={gridScrollRef}
         />
       )}
 

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayTab.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayTab.tsx
@@ -5,7 +5,10 @@ import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
 import { Divider } from "@web/components/Divider";
 import { useAppSelector } from "@web/store/store.hooks";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
-import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import {
+  Measurements_Grid,
+  Refs_Grid,
+} from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { theme } from "@web/common/styles/theme";
 import { SidebarProps } from "@web/views/Calendar/hooks/draft/sidebar/useSidebar";
@@ -20,6 +23,7 @@ interface Props {
   sidebarProps: SidebarProps;
   viewStart: WeekProps["component"]["startOfView"];
   viewEnd: WeekProps["component"]["endOfView"];
+  gridRefs: Refs_Grid;
 }
 
 export const SomedayTab: FC<Props> = ({
@@ -28,6 +32,7 @@ export const SomedayTab: FC<Props> = ({
   sidebarProps,
   viewEnd,
   viewStart,
+  gridRefs,
 }) => {
   const isProcessing = useAppSelector(selectIsGetSomedayEventsProcessing);
 
@@ -46,6 +51,7 @@ export const SomedayTab: FC<Props> = ({
         sidebarProps={sidebarProps}
         viewStart={viewStart}
         weekLabel={weekLabel}
+        gridRefs={gridRefs}
       />
 
       <Divider
@@ -60,6 +66,7 @@ export const SomedayTab: FC<Props> = ({
         measurements={measurements}
         somedayProps={sidebarProps}
         viewStart={viewStart}
+        gridRefs={gridRefs}
       />
     </SidebarContent>
   );

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
@@ -3,7 +3,10 @@ import { Categories_Event } from "@core/types/event.types";
 import { Text } from "@web/components/Text";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
 import { SidebarProps } from "@web/views/Calendar/hooks/draft/sidebar/useSidebar";
-import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
+import {
+  Measurements_Grid,
+  Refs_Grid,
+} from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { AlignItems, JustifyContent } from "@web/components/Flex/styled";
 
@@ -16,6 +19,7 @@ interface Props {
   sidebarProps: SidebarProps;
   viewStart: WeekProps["component"]["startOfView"];
   weekLabel: string;
+  gridRefs: Refs_Grid;
 }
 
 export const WeekSection: FC<Props> = ({
@@ -24,6 +28,7 @@ export const WeekSection: FC<Props> = ({
   sidebarProps,
   viewStart,
   weekLabel,
+  gridRefs,
 }) => {
   return (
     <SidebarSection>
@@ -42,6 +47,7 @@ export const WeekSection: FC<Props> = ({
         measurements={measurements}
         sidebarProps={sidebarProps}
         viewStart={viewStart}
+        gridScrollRef={gridRefs.gridScrollRef}
       />
     </SidebarSection>
   );

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -12,7 +12,6 @@ import {
 } from "@core/types/event.types";
 import { DropResult } from "@hello-pangea/dnd";
 import { ID_SOMEDAY_DRAFT } from "@web/common/constants/web.constants";
-import { getUserId } from "@web/auth/auth.util";
 import { DropResult_ReactDND } from "@web/common/types/dnd.types";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -21,6 +20,8 @@ import {
   prepEvtBeforeSubmit,
 } from "@web/common/utils/event.util";
 import { getX } from "@web/common/utils/grid.util";
+import { getUserId } from "@web/auth/auth.util";
+import { Coordinates } from "@web/common/types/util.types";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import {
   createEventSlice,
@@ -39,7 +40,6 @@ import {
 import { selectDatesInView } from "@web/ducks/events/selectors/view.selectors";
 import { isEventFormOpen, isSomedayEventFormOpen } from "@web/common/utils";
 import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
-import { MouseCoords } from "@web/views/Calendar/hooks/draft/useMousePosition";
 
 import { DateCalcs } from "../../grid/useDateCalcs";
 import { State_Sidebar } from "./useSidebarState";
@@ -159,7 +159,7 @@ export const useSidebarUtil = (
 
   const getDatesAfterDroppingOn = (
     target: "mainGrid" | "alldayRow",
-    mouseCoords: MouseCoords
+    mouseCoords: Coordinates
   ) => {
     const x = getX(mouseCoords.x, true);
     const y = mouseCoords.y;

--- a/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/sidebar/useSidebarUtil.ts
@@ -39,6 +39,7 @@ import {
 import { selectDatesInView } from "@web/ducks/events/selectors/view.selectors";
 import { isEventFormOpen, isSomedayEventFormOpen } from "@web/common/utils";
 import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
+import { MouseCoords } from "@web/views/Calendar/hooks/draft/useMousePosition";
 
 import { DateCalcs } from "../../grid/useDateCalcs";
 import { State_Sidebar } from "./useSidebarState";
@@ -158,7 +159,7 @@ export const useSidebarUtil = (
 
   const getDatesAfterDroppingOn = (
     target: "mainGrid" | "alldayRow",
-    mouseCoords: { x: number; y: number }
+    mouseCoords: MouseCoords
   ) => {
     const x = getX(mouseCoords.x, true);
     const y = mouseCoords.y;

--- a/packages/web/src/views/Calendar/hooks/draft/useMousePosition.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useMousePosition.ts
@@ -4,11 +4,7 @@ import {
   SIDEBAR_X_START,
   GRID_Y_START,
 } from "@web/views/Calendar/layout.constants";
-
-export interface MouseCoords {
-  x: number;
-  y: number;
-}
+import { Coordinates } from "@web/common/types/util.types";
 
 export const useMousePosition = (
   isDragging: boolean,
@@ -19,7 +15,7 @@ export const useMousePosition = (
   const [isOverMainGrid, setIsOverMainGrid] = useState(false);
   const [isOverAllDayRow, setIsOverAllDayRow] = useState(false);
 
-  const [mouseCoords, setMouseCoords] = useState<MouseCoords>({ x: 0, y: 0 });
+  const [mouseCoords, setMouseCoords] = useState<Coordinates>({ x: 0, y: 0 });
 
   const { allDayRow } = measurements;
 

--- a/packages/web/src/views/Calendar/hooks/draft/useMousePosition.ts
+++ b/packages/web/src/views/Calendar/hooks/draft/useMousePosition.ts
@@ -5,6 +5,11 @@ import {
   GRID_Y_START,
 } from "@web/views/Calendar/layout.constants";
 
+export interface MouseCoords {
+  x: number;
+  y: number;
+}
+
 export const useMousePosition = (
   isDragging: boolean,
   isFormOpen: boolean,
@@ -14,7 +19,7 @@ export const useMousePosition = (
   const [isOverMainGrid, setIsOverMainGrid] = useState(false);
   const [isOverAllDayRow, setIsOverAllDayRow] = useState(false);
 
-  const [mouseCoords, setMouseCoords] = useState({ x: 0, y: 0 });
+  const [mouseCoords, setMouseCoords] = useState<MouseCoords>({ x: 0, y: 0 });
 
   const { allDayRow } = measurements;
 


### PR DESCRIPTION
## Description

Fixes [issue](https://github.com/SwitchbackTech/compass/issues/210)

This PR handles implementing more accurate snapping when dragging someday events to the grid.

The issue the PR addresses happens due to a calculation mismatch between 2 methods: `GridEventPreview:getTimePreview()` and `GridEventPreview/styled:getItemStyles()`. This is due to the methods relying on different calculation variables, producing different results in certain mouse movement edge cases.

The PR fixes that by matching the calculation logic inside the `getItemStyles` method with the `getTimePreview` method (it does not do it directly, because as a small refactor, we extracted snapping logic from `getItemStyles` inside its dedicated `snapToGrid` function. See `snapToGrid`)

To achieve that, we needed to feed calculation logic variable dependencies inside the tree, hence, why we needed to prop drill.

This is a common pattern inside the application and it is anti best practice. Ideally we should be using something like React context to feed variables down the tree without prop drilling.

I thought this type of refactor is out of scope of this PR, and I also felt like I was spending too much time on this PR so I wanted to tie things up and consult you from here.

As a side quest I snuck in an extra feature, horizontal snapping! (I took inspiration from google calendar and felt like we should implement it here too)

## Results
Please take a look at the before and after, you will notice the following:
- Event time accuracy issue is resolved
- Horizontal (column based) snapping is implemented

#### Before
[vertical_snap_before.webm](https://github.com/user-attachments/assets/2e727453-6d59-4d84-8f46-681f0160d8dd)


#### After
[vertical_snap_after.webm](https://github.com/user-attachments/assets/3f93afe8-d593-4b4f-9daf-c716ef99b8dd)
