### PR TITLE
🐛 Fix(web): Prevent long titles from breaking form length and event widths

### DIFF
--- a/packages/web/src/views/Calendar/components/Sidebar/styled.ts
+++ b/packages/web/src/views/Calendar/components/Sidebar/styled.ts
@@ -70,7 +70,7 @@ export const SidebarTabContainer = styled.div`
   height: calc(100% - ${ICON_ROW_HEIGHT}px);
   overflow: auto;
   padding: 0 25px;
-  width: 100%;
+  width: ${SIDEBAR_OPEN_WIDTH}px;
 
   ::-webkit-scrollbar {
     width: 8px;

--- a/packages/web/src/views/Forms/EventForm/styled.ts
+++ b/packages/web/src/views/Forms/EventForm/styled.ts
@@ -5,6 +5,7 @@ import { Flex } from "@web/components/Flex";
 import { Textarea } from "@web/components/Textarea";
 import { hoverColorByPriority } from "@web/common/styles/theme.util";
 import { PriorityButton } from "@web/components/Button/styled";
+import { Input } from "@web/components/Input";
 
 import { StyledFormProps } from "./types";
 
@@ -56,9 +57,10 @@ export const StyledSubmitRow = styled(Flex)`
   padding-top: 18px;
 `;
 
-export const StyledTitle = styled(Textarea)`
+export const StyledTitle = styled(Input)`
   background: transparent;
   font-size: ${({ theme }) => theme.text.size["5xl"]};
+  font-weight: 600;
   &:hover {
     filter: brightness(90%);
   }


### PR DESCRIPTION
This pull request addresses #142 and includes changes to the `packages/web/src/views/Calendar/components/Sidebar/styled.ts` and `packages/web/src/views/Forms/EventForm/styled.ts` files. The changes focus on updating the styling and component usage within these files.

Styling and component updates:

* [`packages/web/src/views/Calendar/components/Sidebar/styled.ts`](diffhunk://#diff-9ec2728937642a617e7865dacbb4becdac60f3d46072bac5a2e3e7ddc91e80e2L73-R73): Changed the width of the `SidebarTabContainer` from 100% to a fixed width defined by `SIDEBAR_OPEN_WIDTH`.
* [`packages/web/src/views/Forms/EventForm/styled.ts`](diffhunk://#diff-72d2ad197368c949bb555de867e062cbcf20c77ea38a3f01a66c7b6749d4b8deR8): Added an import for the `Input` component from `@web/components/Input`.
* [`packages/web/src/views/Forms/EventForm/styled.ts`](diffhunk://#diff-72d2ad197368c949bb555de867e062cbcf20c77ea38a3f01a66c7b6749d4b8deL59-R63): Updated the `StyledTitle` component to use `Input` instead of `Textarea` and added a font-weight property.

---

Working demo: 

https://github.com/user-attachments/assets/c384f39f-83c8-4382-8055-560ddbaeb174

