### PR TITLE
✨ Feat(web): handle overlapping events

### DIFF
--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -22,6 +22,11 @@ export interface Schema_GridEvent extends Schema_Event {
   hasFlipped?: boolean;
   isOpen?: boolean;
   row?: number; //TODO: delete if not used
+  position: {
+    isOverlapping: boolean;
+    widthMultiplier: number; // EG: 0.5 for half width
+    horizontalOrder: number;
+  };
 }
 
 export interface Schema_OptimisticEvent extends Schema_Event {

--- a/packages/web/src/common/utils/event.util.test.ts
+++ b/packages/web/src/common/utils/event.util.test.ts
@@ -1,4 +1,8 @@
-import { isEventInRange } from "./event.util";
+import {
+  isEventInRange,
+  adjustOverlappingEvents,
+  assembleGridEvent,
+} from "./event.util";
 
 describe("isEventInRange", () => {
   it("returns true if event is in range", () => {
@@ -16,5 +20,200 @@ describe("isEventInRange", () => {
       end: "2022-03-19",
     };
     expect(isEventInRange(event, dates)).toBe(false);
+  });
+});
+
+describe("adjustOverlappingEvents", () => {
+  // Helper function that constructs a date string from hour:minute input.
+  // Makes date time strings easier to read
+  const time = (time: string) => `2025-01-27T${time}:00+03:00`;
+
+  it("Sorts events by start time", () => {
+    const eventA = assembleGridEvent({
+      _id: "A",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+    const eventB = assembleGridEvent({
+      _id: "B",
+      startDate: time("07:15"),
+      endDate: time("07:45"),
+    });
+
+    const adjustedEvents = adjustOverlappingEvents([eventA, eventB]);
+
+    expect(adjustedEvents[0].startDate).toBe(eventB.startDate);
+    expect(adjustedEvents[1].startDate).toBe(eventA.startDate);
+  });
+
+  it("Returns the same array if no events overlap", () => {
+    const eventA = assembleGridEvent({
+      _id: "A",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+    const eventB = assembleGridEvent({
+      _id: "B",
+      startDate: time("08:00"),
+      endDate: time("08:30"),
+    });
+
+    const adjustedEvents = adjustOverlappingEvents([eventA, eventB]);
+
+    expect(adjustedEvents).toEqual([eventA, eventB]);
+  });
+
+  it("Adjusts events that overlap", () => {
+    const eventA = assembleGridEvent({
+      _id: "A",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+    const eventB = assembleGridEvent({
+      _id: "B",
+      startDate: time("07:45"),
+      endDate: time("08:15"),
+    });
+
+    const adjustedEvents = adjustOverlappingEvents([eventA, eventB]);
+
+    expect(adjustedEvents[0].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[0].position.horizontalOrder).toBe(1);
+    expect(adjustedEvents[1].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[1].position.horizontalOrder).toBe(2);
+  });
+
+  it("Does not modify events that do not overlap", () => {
+    const eventA = assembleGridEvent({
+      _id: "A",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+    const eventB = assembleGridEvent({
+      _id: "B",
+      startDate: time("07:45"),
+      endDate: time("08:15"),
+    });
+    const nonOverlappingEventC = assembleGridEvent({
+      _id: "C",
+      startDate: time("09:45"),
+      endDate: time("10:15"),
+    });
+
+    const adjustedEvents = adjustOverlappingEvents([
+      eventA,
+      eventB,
+      nonOverlappingEventC,
+    ]);
+
+    expect(adjustedEvents[0].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[0].position.horizontalOrder).toBe(1);
+    expect(adjustedEvents[1].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[1].position.horizontalOrder).toBe(2);
+    // Non-overlapping event should not be modified
+    expect(adjustedEvents[2]).toStrictEqual(nonOverlappingEventC);
+  });
+
+  it("Adjusts events that indirectly overlap", () => {
+    const eventA = assembleGridEvent({
+      _id: "A",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+    const eventB = assembleGridEvent({
+      _id: "B",
+      startDate: time("07:45"),
+      endDate: time("08:15"),
+    });
+    const eventC = assembleGridEvent({
+      _id: "C",
+      // `eventC` starts when `eventA` ends, does not directly overlap, but should still be adjusted because it indirectly overlaps due to `eventB`
+      startDate: time("08:00"),
+      endDate: time("08:30"),
+    });
+
+    const adjustedEvents = adjustOverlappingEvents([eventA, eventB, eventC]);
+
+    expect(adjustedEvents[0].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[0].position.horizontalOrder).toBe(1);
+    expect(adjustedEvents[1].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[1].position.horizontalOrder).toBe(2);
+    expect(adjustedEvents[2].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[2].position.horizontalOrder).toBe(3);
+  });
+
+  it("Adjusts events that overlap in 2 distinct groups", () => {
+    // Group 1
+    const eventA = assembleGridEvent({
+      _id: "A",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+    const eventB = assembleGridEvent({
+      _id: "B",
+      startDate: time("07:45"),
+      endDate: time("08:15"),
+    });
+    const eventC = assembleGridEvent({
+      _id: "C",
+      startDate: time("08:00"),
+      endDate: time("08:30"),
+    });
+
+    // Group 2
+    const eventD = assembleGridEvent({
+      _id: "D",
+      startDate: time("10:00"),
+      endDate: time("11:00"),
+    });
+    const eventE = assembleGridEvent({
+      _id: "E",
+      startDate: time("10:30"),
+      endDate: time("11:30"),
+    });
+
+    const adjustedEvents = adjustOverlappingEvents([
+      eventA,
+      eventB,
+      eventC,
+      eventD,
+      eventE,
+    ]);
+
+    // Group 1
+    expect(adjustedEvents[0].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[0].position.horizontalOrder).toBe(1);
+    expect(adjustedEvents[1].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[1].position.horizontalOrder).toBe(2);
+    expect(adjustedEvents[2].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[2].position.horizontalOrder).toBe(3);
+
+    // Group 2
+    expect(adjustedEvents[3].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[3].position.horizontalOrder).toBe(1);
+    expect(adjustedEvents[4].position.isOverlapping).toBe(true);
+    expect(adjustedEvents[4].position.horizontalOrder).toBe(2);
+  });
+
+  it("Orders alphabetically if start and end times are the same", () => {
+    const eventA = assembleGridEvent({
+      _id: "A",
+      title: "A",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+    const eventB = assembleGridEvent({
+      _id: "B",
+      title: "B",
+      startDate: time("07:30"),
+      endDate: time("08:00"),
+    });
+
+    const adjustedEvents = adjustOverlappingEvents([eventA, eventB]);
+
+    expect(adjustedEvents[0].title).toBe("A");
+    expect(adjustedEvents[0].position.horizontalOrder).toBe(1);
+    expect(adjustedEvents[1].title).toBe("B");
+    expect(adjustedEvents[1].position.horizontalOrder).toBe(2);
   });
 });

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -87,23 +87,28 @@ export const getCategory = (event: Schema_Event) => {
 
 export const assembleGridEvent = (
   event: Partial<Schema_GridEvent>
-): Schema_GridEvent => ({
-  _id: event._id || "",
-  title: event.title || "",
-  description: event.description || "",
-  startDate: event.startDate || "",
-  endDate: event.endDate || "",
-  user: event.user || "",
-  isAllDay: event.isAllDay || false,
-  isSomeday: event.isSomeday || false,
-  origin: event.origin || Origin.COMPASS,
-  priority: event.priority || Priorities.UNASSIGNED,
-  position: event.position || {
+): Schema_GridEvent => {
+  // TODO: Maybe move to a constants file?
+  const DEFAULT_POSITION = {
     isOverlapping: false,
     widthMultiplier: 1,
     horizontalOrder: 1,
-  },
-});
+  };
+
+  return {
+    _id: event._id || "",
+    title: event.title || "",
+    description: event.description || "",
+    startDate: event.startDate || "",
+    endDate: event.endDate || "",
+    user: event.user || "",
+    isAllDay: event.isAllDay || false,
+    isSomeday: event.isSomeday || false,
+    origin: event.origin || Origin.COMPASS,
+    priority: event.priority || Priorities.UNASSIGNED,
+    position: event.position || DEFAULT_POSITION,
+  };
+};
 
 export const getDefaultEvent = (
   draftType: Categories_Event,

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -243,7 +243,9 @@ export const replaceIdWithOptimisticId = (
   return _event;
 };
 
-export const adjustOverlappingEvents = (events: Schema_GridEvent[]) => {
+export const adjustOverlappingEvents = (
+  events: Schema_GridEvent[]
+): Schema_GridEvent[] => {
   // Deep copy events
   let adjustedEvents = events.map((event) => ({
     ...event,

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -85,19 +85,39 @@ export const getCategory = (event: Schema_Event) => {
   return Categories_Event.TIMED;
 };
 
+export const assembleGridEvent = (
+  event: Partial<Schema_GridEvent>
+): Schema_GridEvent => ({
+  _id: event._id || "",
+  title: event.title || "",
+  description: event.description || "",
+  startDate: event.startDate || "",
+  endDate: event.endDate || "",
+  user: event.user || "",
+  isAllDay: event.isAllDay || false,
+  isSomeday: event.isSomeday || false,
+  origin: event.origin || Origin.COMPASS,
+  priority: event.priority || Priorities.UNASSIGNED,
+  position: event.position || {
+    isOverlapping: false,
+    widthMultiplier: 1,
+    horizontalOrder: 1,
+  },
+});
+
 export const getDefaultEvent = (
   draftType: Categories_Event,
   startDate?: string,
   endDate?: string
 ): Schema_GridEvent | null => {
-  const defaultEvent: Schema_GridEvent = {
+  const defaultEvent = assembleGridEvent({
     priority: Priorities.UNASSIGNED,
     position: {
       isOverlapping: false,
       widthMultiplier: 1,
       horizontalOrder: 1,
     },
-  };
+  });
 
   const defaultSomeday = {
     ...defaultEvent,

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -90,18 +90,28 @@ export const getDefaultEvent = (
   startDate?: string,
   endDate?: string
 ): Schema_GridEvent | null => {
+  const defaultEvent: Schema_GridEvent = {
+    priority: Priorities.UNASSIGNED,
+    position: {
+      isOverlapping: false,
+      widthMultiplier: 1,
+      horizontalOrder: 1,
+    },
+  };
+
   const defaultSomeday = {
+    ...defaultEvent,
     isAllDay: false,
     isSomeday: true,
     origin: Origin.COMPASS,
-    priority: Priorities.UNASSIGNED,
   };
+
   switch (draftType) {
     case Categories_Event.ALLDAY:
       return {
+        ...defaultEvent,
         isAllDay: true,
         isSomeday: false,
-        priority: Priorities.UNASSIGNED,
         startDate,
         endDate: startDate,
       };
@@ -109,9 +119,9 @@ export const getDefaultEvent = (
       return defaultSomeday;
     case Categories_Event.TIMED: {
       return {
+        ...defaultEvent,
         isAllDay: false,
         isSomeday: false,
-        priority: Priorities.UNASSIGNED,
         startDate,
         endDate,
       };
@@ -139,10 +149,6 @@ export const handleError = (error: Error) => {
     // api interceptor will handle these
     return;
   }
-
-  console.log(error.message);
-  console.log(error.stack);
-  console.log(error);
 
   if (code === Status.INTERNAL_SERVER) {
     alert("Something went wrong behind the scenes. Please try again later.");

--- a/packages/web/src/common/utils/grid.util.ts
+++ b/packages/web/src/common/utils/grid.util.ts
@@ -442,7 +442,7 @@ export const getAbsoluteLeftPosition = (
         }
 
         if (
-          event.position.isOverlapping &&
+          event.position?.isOverlapping &&
           event.position.horizontalOrder > 1
         ) {
           positionStart += eventWidth * (event.position.horizontalOrder - 1);

--- a/packages/web/src/common/utils/grid.util.ts
+++ b/packages/web/src/common/utils/grid.util.ts
@@ -18,6 +18,7 @@ import {
   GRID_X_PADDING_TOTAL,
   SIDEBAR_OPEN_WIDTH,
 } from "@web/views/Calendar/layout.constants";
+import { Schema_GridEvent } from "@web/common/types/web.event.types";
 
 dayjs.extend(dayOfYear);
 dayjs.extend(weekPlugin);
@@ -399,9 +400,17 @@ export const getEventCategory = (
 export const getLeftPosition = (
   category: Category,
   startIndex: number,
-  widths: number[]
+  colWidths: number[],
+  event: Schema_GridEvent,
+  eventWidth: number
 ) => {
-  const left = getAbsoluteLeftPosition(category, startIndex, widths);
+  const left = getAbsoluteLeftPosition(
+    category,
+    startIndex,
+    colWidths,
+    event,
+    eventWidth
+  );
 
   return left;
 };
@@ -409,7 +418,9 @@ export const getLeftPosition = (
 export const getAbsoluteLeftPosition = (
   category: Category,
   startIndex: number,
-  widths: number[]
+  colWidths: number[],
+  event: Schema_GridEvent,
+  eventWidth: number
 ) => {
   let positionStart: number;
   switch (category) {
@@ -422,9 +433,16 @@ export const getAbsoluteLeftPosition = (
     case Category.ThisToFutureWeek:
       {
         // add up from 0 index to startIndex
-        positionStart = widths.reduce((accum, width, index) => {
+        positionStart = colWidths.reduce((accum, width, index) => {
           return index < startIndex ? accum + width : accum;
         }, 0);
+
+        if (
+          event.position.isOverlapping &&
+          event.position.horizontalOrder > 1
+        ) {
+          positionStart += eventWidth * (event.position.horizontalOrder - 1);
+        }
       }
       break;
     default: {

--- a/packages/web/src/common/utils/grid.util.ts
+++ b/packages/web/src/common/utils/grid.util.ts
@@ -401,8 +401,8 @@ export const getLeftPosition = (
   category: Category,
   startIndex: number,
   colWidths: number[],
-  event: Schema_GridEvent,
-  eventWidth: number
+  event?: Schema_GridEvent,
+  eventWidth?: number
 ) => {
   const left = getAbsoluteLeftPosition(
     category,
@@ -419,8 +419,8 @@ export const getAbsoluteLeftPosition = (
   category: Category,
   startIndex: number,
   colWidths: number[],
-  event: Schema_GridEvent,
-  eventWidth: number
+  event?: Schema_GridEvent,
+  eventWidth?: number
 ) => {
   let positionStart: number;
   switch (category) {
@@ -436,6 +436,10 @@ export const getAbsoluteLeftPosition = (
         positionStart = colWidths.reduce((accum, width, index) => {
           return index < startIndex ? accum + width : accum;
         }, 0);
+
+        if (!event || !eventWidth) {
+          return positionStart;
+        }
 
         if (
           event.position.isOverlapping &&

--- a/packages/web/src/ducks/events/selectors/event.selectors.ts
+++ b/packages/web/src/ducks/events/selectors/event.selectors.ts
@@ -3,6 +3,7 @@ import { Schema_Event } from "@core/types/event.types";
 import { RootState } from "@web/store";
 import { assignEventsToRow } from "@web/common/utils/grid.util";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
+import { assembleGridEvent } from "@web/common/utils/event.util";
 
 export const selectAllDayEvents = createSelector(
   (state: RootState) => state.events.entities.value || {},
@@ -36,14 +37,7 @@ export const selectGridEvents = createSelector(
 
     const weekEvents: Schema_GridEvent[] = weekEventsMapped
       .filter((e: Schema_Event) => e !== undefined && !e.isAllDay)
-      .map((e) => ({
-        ...e,
-        position: {
-          isOverlapping: false,
-          widthMultiplier: 1,
-          horizontalOrder: 0,
-        },
-      }));
+      .map(assembleGridEvent);
 
     return weekEvents;
   }

--- a/packages/web/src/ducks/events/selectors/event.selectors.ts
+++ b/packages/web/src/ducks/events/selectors/event.selectors.ts
@@ -34,9 +34,16 @@ export const selectGridEvents = createSelector(
     if (!("data" in weekIds) || weekIds.data.length === 0) return [];
     const weekEventsMapped = weekIds.data.map((_id: string) => entities[_id]);
 
-    const weekEvents = weekEventsMapped.filter(
-      (e: Schema_Event) => e !== undefined && !e.isAllDay
-    );
+    const weekEvents: Schema_GridEvent[] = weekEventsMapped
+      .filter((e: Schema_Event) => e !== undefined && !e.isAllDay)
+      .map((e) => ({
+        ...e,
+        position: {
+          isOverlapping: false,
+          widthMultiplier: 1,
+          horizontalOrder: 0,
+        },
+      }));
 
     return weekEvents;
   }

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGridEvents.tsx
@@ -11,6 +11,7 @@ import { selectDraftId } from "@web/ducks/events/selectors/draft.selectors";
 import { isEventFormOpen } from "@web/common/utils";
 
 import { GridEventMemo } from "../../Event/Grid/GridEvent/GridEvent";
+import { adjustOverlappingEvents } from "@web/common/utils/event.util";
 
 interface Props {
   measurements: Measurements_Grid;
@@ -22,6 +23,8 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
 
   const timedEvents = useAppSelector(selectGridEvents);
   const draftId = useAppSelector(selectDraftId);
+
+  const adjustedEvents = adjustOverlappingEvents(timedEvents);
 
   const onMouseDown = (e: MouseEvent, event: Schema_Event) => {
     e.stopPropagation();
@@ -52,7 +55,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
 
   return (
     <div id={ID_GRID_EVENTS_TIMED}>
-      {timedEvents.map((event: Schema_GridEvent) => {
+      {adjustedEvents.map((event: Schema_GridEvent) => {
         return (
           <GridEventMemo
             event={event}

--- a/packages/web/src/views/Calendar/hooks/event/getPosition.ts
+++ b/packages/web/src/views/Calendar/hooks/event/getPosition.ts
@@ -22,6 +22,8 @@ export const getPosition = (
   measurements: Measurements_Grid,
   isDraft: boolean
 ) => {
+  if (!event) return null; // TS Guard
+
   const { colWidths } = measurements;
   const start = dayjs(event.startDate);
   const end = dayjs(event.endDate);
@@ -29,15 +31,11 @@ export const getPosition = (
   const category = getEventCategory(start, end, startOfView, endOfView);
   const startIndex = start.get("day");
 
-  let left = getLeftPosition(category, startIndex, colWidths);
-
-  if (isDraft || !event.isAllDay) {
-    left += GRID_MARGIN_LEFT;
-  }
-
   let height: number;
   let top: number;
   let width: number;
+  let left: number;
+
   if (event.isAllDay) {
     height = EVENT_ALLDAY_HEIGHT;
     top = 23 * (event?.row || 1); // found by experimenting with what 'looked right'
@@ -50,7 +48,7 @@ export const getPosition = (
       colWidths
     );
   } else {
-    width = colWidths[startIndex];
+    width = colWidths[startIndex] * event.position.widthMultiplier;
     const widthBuffer = 11;
     width -= widthBuffer;
 
@@ -63,6 +61,12 @@ export const getPosition = (
     const durationHours = duration * MS_IN_HR;
     height = hourHeight * durationHours;
     height -= DRAFT_PADDING_BOTTOM;
+  }
+
+  left = getLeftPosition(category, startIndex, colWidths, event, width);
+
+  if (isDraft || !event.isAllDay) {
+    left += GRID_MARGIN_LEFT;
   }
 
   const position = { height, left, top, width };


### PR DESCRIPTION
This PR handles detecting and displaying overlapping events so that they're not on top of one another, effectively being hidden and causing bad UX when attempting to view or drag/edit them.

[handle_overlapping_events.webm](https://github.com/user-attachments/assets/5d20983c-eed9-44a2-b3ee-9ae5e4800a5e)
