### PR TITLE
🐛 Fix: Prevent console warning when opening form

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@atlaskit/css-reset": "^6.3.20",
     "@compass/core": "1.0.0",
-    "@floating-ui/react": "^0.19.2",
+    "@floating-ui/react": "^0.27.3",
     "@hello-pangea/dnd": "^16.2.0",
     "@phosphor-icons/react": "^2.1.7",
     "@popperjs/core": "^2.11.5",

--- a/packages/web/src/views/Calendar/components/Event/Draft/GridDraft.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Draft/GridDraft.tsx
@@ -29,7 +29,7 @@ export const GridDraft: FC<Props> = ({
   measurements,
   weekProps,
 }) => {
-  const { x, y, reference, floating, strategy } = formProps;
+  const { x, y, refs, strategy } = formProps;
 
   const onConvert = () => {
     const start = weekProps.component.startOfView.format(YEAR_MONTH_DAY_FORMAT);
@@ -63,14 +63,14 @@ export const GridDraft: FC<Props> = ({
           draftUtil.setDateBeingChanged(dateToChange);
           draftUtil.setIsResizing(true);
         }}
-        ref={reference}
+        ref={refs.setReference}
         weekProps={weekProps}
       />
 
       <div>
         {draft?.isOpen && (
           <StyledFloatContainer
-            ref={floating}
+            ref={refs.setFloating}
             strategy={strategy}
             top={y ?? 0}
             left={x ?? 0}

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvent.tsx
@@ -73,7 +73,8 @@ export const SomedayEvent = ({
 }: Props) => {
   const formType =
     category === Categories_Event.SOMEDAY_WEEK ? "sidebarWeek" : "sidebarMonth";
-  const { y, reference, floating, strategy, context } = useEventForm(formType);
+
+  const { context, refs, strategy, y } = useEventForm(formType);
 
   const [isFocused, setIsFocused] = useState(false);
 
@@ -125,7 +126,7 @@ export const SomedayEvent = ({
         role="button"
         ref={provided.innerRef}
       >
-        <div ref={reference}>
+        <div ref={refs.setReference}>
           <SomedayEventRectangle
             category={category}
             event={event}
@@ -134,11 +135,11 @@ export const SomedayEvent = ({
         </div>
       </StyledNewSomedayEvent>
 
-      <FloatingPortal>
-        {shouldOpenForm && (
+      {shouldOpenForm && (
+        <FloatingPortal>
           <FloatingFocusManager context={context}>
             <StyledFloatContainer
-              ref={floating}
+              ref={refs.setFloating}
               strategy={strategy}
               top={y ?? 40}
               left={SIDEBAR_OPEN_WIDTH}
@@ -157,8 +158,8 @@ export const SomedayEvent = ({
               />
             </StyledFloatContainer>
           </FloatingFocusManager>
-        )}
-      </FloatingPortal>
+        </FloatingPortal>
+      )}
     </>
   );
 };

--- a/packages/web/src/views/Forms/hooks/useEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEventForm.ts
@@ -4,13 +4,13 @@ import {
   offset,
   shift,
   useFloating,
-  UseFloatingProps,
+  UseFloatingOptions,
 } from "@floating-ui/react";
 
 export const useEventForm = (
   eventType: "grid" | "sidebarWeek" | "sidebarMonth"
 ) => {
-  let options: Partial<UseFloatingProps>;
+  let options: Partial<UseFloatingOptions>;
 
   if (eventType === "sidebarWeek" || eventType === "sidebarMonth") {
     const placement = eventType === "sidebarWeek" ? "right-start" : "right";
@@ -40,15 +40,14 @@ export const useEventForm = (
     };
   }
 
-  const { x, y, reference, floating, strategy, context } = useFloating(options);
+  const { context, x, y, refs, strategy } = useFloating(options);
 
   return {
+    context,
+    refs,
+    strategy,
     x,
     y,
-    reference,
-    floating,
-    strategy,
-    context,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,7 +1338,15 @@
   dependencies:
     "@floating-ui/utils" "^0.2.8"
 
-"@floating-ui/dom@^1.0.1", "@floating-ui/dom@^1.2.1":
+"@floating-ui/dom@^1.0.0":
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.13.tgz#a8a938532aea27a95121ec16e667a7cbe8c59e34"
+  integrity sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.9"
+
+"@floating-ui/dom@^1.0.1":
   version "1.6.11"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.11.tgz#8631857838d34ee5712339eb7cbdfb8ad34da723"
   integrity sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==
@@ -1346,26 +1354,31 @@
     "@floating-ui/core" "^1.6.0"
     "@floating-ui/utils" "^0.2.8"
 
-"@floating-ui/react-dom@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.3.0.tgz#4d35d416eb19811c2b0e9271100a6aa18c1579b3"
-  integrity sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==
+"@floating-ui/react-dom@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
   dependencies:
-    "@floating-ui/dom" "^1.2.1"
+    "@floating-ui/dom" "^1.0.0"
 
-"@floating-ui/react@^0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.19.2.tgz#c6e4d2097ed0dca665a7c042ddf9cdecc95e9412"
-  integrity sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==
+"@floating-ui/react@^0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.27.3.tgz#f9a30583eddd5770f3a6e1f3479a258f3df0c8c8"
+  integrity sha512-CLHnes3ixIFFKVQDdICjel8muhFLOBdQH7fgtHNPY8UbCNqbeKZ262G7K66lGQOUQWWnYocf7ZbUsLJgGfsLHg==
   dependencies:
-    "@floating-ui/react-dom" "^1.3.0"
-    aria-hidden "^1.1.3"
-    tabbable "^6.0.1"
+    "@floating-ui/react-dom" "^2.1.2"
+    "@floating-ui/utils" "^0.2.9"
+    tabbable "^6.0.0"
 
 "@floating-ui/utils@^0.2.8":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
   integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
+
+"@floating-ui/utils@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.9.tgz#50dea3616bc8191fb8e112283b49eaff03e78429"
+  integrity sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==
 
 "@headlessui/react@^1.6.4":
   version "1.7.19"
@@ -3274,13 +3287,6 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
-aria-hidden@^1.1.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.4.tgz#b78e383fdbc04d05762c78b4a25a501e736c4522"
-  integrity sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==
-  dependencies:
-    tslib "^2.0.0"
 
 aria-query@5.1.3, aria-query@~5.1.3:
   version "5.1.3"
@@ -10276,7 +10282,7 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tabbable@^6.0.1, tabbable@^6.2.0:
+tabbable@^6.0.0, tabbable@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
   integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==


### PR DESCRIPTION
This pull request closes closes #156 and includes several updates to dependencies and refactors the use of the `useFloating` hook in various components. The most important changes include updating the `@floating-ui/react` dependency, modifying the `useFloating` hook usage in multiple components, and updating the type definitions.

Dependency updates:

* Updated the `@floating-ui/react` dependency from version `^0.19.2` to `^0.27.3` in `packages/web/package.json`.

Refactoring `useFloating` hook usage:

* Modified the `GridDraft` component to use `refs.setReference` and `refs.setFloating` instead of `reference` and `floating` respectively in `packages/web/src/views/Calendar/components/Event/Draft/GridDraft.tsx`. [[1]](diffhunk://#diff-567efd8ebb35a30d0ea840d271f5009a1c6bf0b13883bafc2598433266f5348aL32-R32) [[2]](diffhunk://#diff-567efd8ebb35a30d0ea840d271f5009a1c6bf0b13883bafc2598433266f5348aL66-R73)
* Updated the `SomedayEvent` component to use `refs.setReference` and `refs.setFloating` instead of `reference` and `floating` respectively in `packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvent.tsx`. [[1]](diffhunk://#diff-11fc75ba3c6543f463ef17599af05c04adffb0136eedd10535ebafdd408a2705L76-R77) [[2]](diffhunk://#diff-11fc75ba3c6543f463ef17599af05c04adffb0136eedd10535ebafdd408a2705L128-R129) [[3]](diffhunk://#diff-11fc75ba3c6543f463ef17599af05c04adffb0136eedd10535ebafdd408a2705L137-R142) [[4]](diffhunk://#diff-11fc75ba3c6543f463ef17599af05c04adffb0136eedd10535ebafdd408a2705L160-R162)

Type definition updates:

* Changed the type `UseFloatingProps` to `UseFloatingOptions` in the `useEventForm` hook in `packages/web/src/views/Forms/hooks/useEventForm.ts`. [[1]](diffhunk://#diff-b68a3f65d7c9f115972ac9d3374865c0e6076a20784d42abb8d62ff15749743dL7-R13) [[2]](diffhunk://#diff-b68a3f65d7c9f115972ac9d3374865c0e6076a20784d42abb8d62ff15749743dL43-L51)


