### PR TITLE
🐛 Fix: Allow cursor change to `row-resize` by using z-index in StyledEventScaler 

### DIFF
--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -121,12 +121,14 @@ const _GridEvent = (
                 showResizeCursor={!isPlaceholder && !isResizing && !isDragging}
                 onMouseDown={(e) => onScalerMouseDown(event, e, "startDate")}
                 top="-0.25px"
+                zIndex={ZIndex.LAYER_4}
               />
 
               <StyledEventScaler
                 bottom="-0.25px"
                 showResizeCursor={!isPlaceholder && !isResizing && !isDragging}
                 onMouseDown={(e) => onScalerMouseDown(event, e, "endDate")}
+                zIndex={ZIndex.LAYER_4}
               />
             </>
           </>

--- a/packages/web/src/views/Calendar/components/Event/styled.ts
+++ b/packages/web/src/views/Calendar/components/Event/styled.ts
@@ -114,6 +114,7 @@ export interface ScalerProps {
   showResizeCursor: boolean;
   bottom?: string;
   top?: string;
+  zIndex?: number;
 }
 
 export const StyledEventScaler = styled.div.attrs<ScalerProps>((props) => {
@@ -130,4 +131,5 @@ export const StyledEventScaler = styled.div.attrs<ScalerProps>((props) => {
   top: ${(props) => props.top};
   bottom: ${(props) => props.bottom};
   ${(props) => props.showResizeCursor && `cursor: row-resize`};
+  ${({ zIndex }) => zIndex && `z-index: ${zIndex}`}
 `;


### PR DESCRIPTION
Closes #248 

The z-index of the text in the event rectangle was preventing the cursor from changing. Increasing the z-index of the scalers fixed thid.

----
This pull request includes changes to enhance the styling of event scalers in the calendar view by adding a `zIndex` property. The most important changes include modifications to the `ScalerProps` interface and the `StyledEventScaler` component to support the new `zIndex` property.

Styling enhancements:

* [`packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx`](diffhunk://#diff-5721933c4be83998cce8f7358189dbf22f9cc59124295b6df4feccd9e6e5d370R124-R131): Added `zIndex` property to the event scalers to ensure proper layering.
* [`packages/web/src/views/Calendar/components/Event/styled.ts`](diffhunk://#diff-f569de75bc8de4aecbd29ffe59eb189e4110bc3291fe224561b0c7f07bcdb939R117): Updated `ScalerProps` interface to include an optional `zIndex` property.
* [`packages/web/src/views/Calendar/components/Event/styled.ts`](diffhunk://#diff-f569de75bc8de4aecbd29ffe59eb189e4110bc3291fe224561b0c7f07bcdb939R134): Modified `StyledEventScaler` component to apply the `zIndex` property if provided.