### PR TITLE
✨ Feat: Auto scroll when dragging

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,7 +35,6 @@
     "react-dom": "^18.1.0",
     "react-google-button": "^0.8.0",
     "react-hotkeys-hook": "^4.4.1",
-    "react-merge-refs": "^1.1.0",
     "react-modal": "^3.16.1",
     "react-redux": "^8.1.2",
     "react-router-dom": "^6.8.1",

--- a/packages/web/src/views/Calendar/Calendar.tsx
+++ b/packages/web/src/views/Calendar/Calendar.tsx
@@ -33,9 +33,9 @@ export const CalendarView = () => {
     weekProps.component.week,
   );
 
-  const scrollUtil = useScroll(gridRefs.gridScrollRef);
+  const scrollUtil = useScroll(gridRefs.mainGridRef);
 
-  const dateCalcs = useDateCalcs(measurements, gridRefs.gridScrollRef);
+  const dateCalcs = useDateCalcs(measurements, gridRefs.mainGridRef);
 
   const isCurrentWeek = weekProps.component.isCurrentWeek;
   const util = weekProps.util;

--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -159,38 +159,40 @@ export const useDraftActions = (
   const drag = useCallback(
     (e: MouseEvent) => {
       const updateTimesDuringDrag = (e: MouseEvent) => {
-        setDraft((_draft) => {
-          const x = getX(e, isSidebarOpen);
-          const startEndDurationMin = dragStatus?.durationMin || 0;
+        if (!draft) return;
 
-          let eventStart = dateCalcs.getDateByXY(
-            x,
-            e.clientY,
-            weekProps.component.startOfView,
-          );
+        const x = getX(e, isSidebarOpen);
+        const startEndDurationMin = dragStatus?.durationMin || 0;
 
-          let eventEnd = eventStart.add(startEndDurationMin, "minutes");
+        let eventStart = dateCalcs.getDateByXY(
+          x,
+          e.clientY,
+          weekProps.component.startOfView,
+        );
 
-          if (!_draft.isAllDay) {
-            // Edge case: timed events' end times can overflow past midnight at the bottom of the grid.
-            // Below logic prevents that from occurring.
-            if (eventEnd.date() !== eventStart.date()) {
-              eventEnd = eventEnd.hour(0).minute(0);
-              eventStart = eventEnd.subtract(startEndDurationMin, "minutes");
-            }
+        let eventEnd = eventStart.add(startEndDurationMin, "minutes");
+
+        if (!draft.isAllDay) {
+          // Edge case: timed events' end times can overflow past midnight at the bottom of the grid.
+          // Below logic prevents that from occurring.
+          if (eventEnd.date() !== eventStart.date()) {
+            eventEnd = eventEnd.hour(0).minute(0);
+            eventStart = eventEnd.subtract(startEndDurationMin, "minutes");
           }
+        }
 
-          return {
-            ..._draft,
-            startDate: _draft.isAllDay
-              ? eventStart.format(YEAR_MONTH_DAY_FORMAT)
-              : eventStart.format(),
-            endDate: _draft.isAllDay
-              ? eventEnd.format(YEAR_MONTH_DAY_FORMAT)
-              : eventEnd.format(),
-            priority: _draft?.priority || Priorities.UNASSIGNED,
-          };
-        });
+        const _draft: Schema_GridEvent = {
+          ...draft,
+          startDate: draft.isAllDay
+            ? eventStart.format(YEAR_MONTH_DAY_FORMAT)
+            : eventStart.format(),
+          endDate: draft.isAllDay
+            ? eventEnd.format(YEAR_MONTH_DAY_FORMAT)
+            : eventEnd.format(),
+          priority: draft.priority || Priorities.UNASSIGNED,
+        };
+
+        setDraft(_draft);
       };
 
       if (!isDragging) {

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
@@ -28,7 +28,7 @@ export interface Props {
   measurements: Measurements_Grid;
   mouseCoords: MouseCoords;
   startOfView: WeekProps["component"]["startOfView"];
-  gridScrollRef: Refs_Grid["gridScrollRef"];
+  mainGridRef: Refs_Grid["mainGridRef"];
 }
 
 export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
@@ -40,7 +40,7 @@ export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
   measurements,
   mouseCoords,
   startOfView,
-  gridScrollRef,
+  mainGridRef,
 }) {
   const { colWidths } = measurements;
   const { x, y } = mouseCoords;
@@ -83,7 +83,7 @@ export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
     x,
     y,
     measurements,
-    gridScrollRef.current?.scrollTop || 0,
+    mainGridRef.current?.scrollTop || 0
   );
 
   return (

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEventPreview/GridEventPreview.tsx
@@ -83,7 +83,7 @@ export const GridEventPreview: FC<Props> = memo(function GridEventPreview({
     x,
     y,
     measurements,
-    mainGridRef.current?.scrollTop || 0
+    mainGridRef.current?.scrollTop || 0,
   );
 
   return (

--- a/packages/web/src/views/Calendar/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/Grid.tsx
@@ -24,7 +24,7 @@ export const Grid: FC<Props> = ({
   today,
   weekProps,
 }) => {
-  const { allDayRef, gridScrollRef, mainGridRef } = gridRefs;
+  const { allDayRef, mainGridRef } = gridRefs;
 
   return (
     <>
@@ -41,7 +41,6 @@ export const Grid: FC<Props> = ({
         isSidebarOpen={isSidebarOpen}
         mainGridRef={mainGridRef}
         measurements={measurements}
-        scrollRef={gridScrollRef}
         today={today}
         weekProps={weekProps}
       />

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
@@ -45,6 +45,8 @@ export const MainGrid: FC<Props> = ({
   const { isCurrentWeek, week, weekDays } = component;
   const isDrafting = useAppSelector(selectIsDrafting);
 
+  useDragEventSmartScroll(mainGridRef);
+
   const onMouseDown = async (e: MouseEvent) => {
     if (isDrafting) {
       dispatch(draftSlice.actions.discard());
@@ -73,8 +75,6 @@ export const MainGrid: FC<Props> = ({
       draftSlice.actions.startResizing({ event, dateToChange: "endDate" }),
     );
   };
-
-  useDragEventSmartScroll(mainGridRef);
 
   return (
     <StyledMainGrid id={ID_GRID_MAIN} ref={mainGridRef}>

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
@@ -1,13 +1,10 @@
-import React, { FC, MouseEvent } from "react";
-import mergeRefs from "react-merge-refs";
+import React, { FC, MouseEvent, MutableRefObject } from "react";
 import { Dayjs } from "dayjs";
 import { Categories_Event } from "@core/types/event.types";
 import { DRAFT_DURATION_MIN } from "@web/views/Calendar/layout.constants";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
-import { Ref_Callback } from "@web/common/types/util.types";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
-import { Ref_Grid } from "@web/views/Calendar/components/Grid/grid.types";
 import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { assembleDefaultEvent } from "@web/common/utils/event.util";
@@ -28,10 +25,9 @@ import { isRightClick } from "@web/common/utils/mouse/mouse.util";
 interface Props {
   dateCalcs: DateCalcs;
   isSidebarOpen: boolean;
-  mainGridRef: Ref_Callback;
+  mainGridRef: MutableRefObject<HTMLDivElement | null>;
   measurements: Measurements_Grid;
   today: Dayjs;
-  scrollRef: Ref_Grid;
   weekProps: WeekProps;
 }
 
@@ -41,7 +37,6 @@ export const MainGrid: FC<Props> = ({
   mainGridRef,
   measurements,
   today,
-  scrollRef,
   weekProps,
 }) => {
   const dispatch = useAppDispatch();
@@ -80,7 +75,7 @@ export const MainGrid: FC<Props> = ({
   };
 
   return (
-    <StyledMainGrid id={ID_GRID_MAIN} ref={mergeRefs([mainGridRef, scrollRef])}>
+    <StyledMainGrid id={ID_GRID_MAIN} ref={mainGridRef}>
       <MainGridColumns
         isCurrentWeek={isCurrentWeek}
         today={today}

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
@@ -21,6 +21,7 @@ import { MainGridEvents } from "./MainGridEvents";
 import { MainGridColumns } from "../Columns/MainGridColumns";
 import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
 import { isRightClick } from "@web/common/utils/mouse/mouse.util";
+import { useDragEventSmartScroll } from "@web/views/Calendar/hooks/grid/useDragEventSmartScroll";
 
 interface Props {
   dateCalcs: DateCalcs;
@@ -40,7 +41,6 @@ export const MainGrid: FC<Props> = ({
   weekProps,
 }) => {
   const dispatch = useAppDispatch();
-
   const { component } = weekProps;
   const { isCurrentWeek, week, weekDays } = component;
   const isDrafting = useAppSelector(selectIsDrafting);
@@ -73,6 +73,8 @@ export const MainGrid: FC<Props> = ({
       draftSlice.actions.startResizing({ event, dateToChange: "endDate" }),
     );
   };
+
+  useDragEventSmartScroll(mainGridRef);
 
   return (
     <StyledMainGrid id={ID_GRID_MAIN} ref={mainGridRef}>

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/MonthSection/MonthSection.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/MonthSection/MonthSection.tsx
@@ -48,7 +48,7 @@ export const MonthSection: FC<Props> = ({
         measurements={measurements}
         sidebarProps={somedayProps}
         viewStart={viewStart}
-        gridScrollRef={gridRefs.gridScrollRef}
+        mainGridRef={gridRefs.mainGridRef}
       />
     </SidebarSection>
   );

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvents.tsx
@@ -27,7 +27,7 @@ interface Props {
   measurements: Measurements_Grid;
   sidebarProps: SidebarProps;
   viewStart: WeekProps["component"]["startOfView"];
-  gridScrollRef: Refs_Grid["gridScrollRef"];
+  mainGridRef: Refs_Grid["mainGridRef"];
 }
 
 const getSomedayEvents = (
@@ -49,7 +49,7 @@ export const SomedayEvents: FC<Props> = ({
   measurements,
   sidebarProps,
   viewStart,
-  gridScrollRef,
+  mainGridRef,
 }) => {
   const { state, util } = sidebarProps;
   const gridX = state.mouseCoords.x - (SIDEBAR_OPEN_WIDTH + GRID_X_START);
@@ -75,7 +75,7 @@ export const SomedayEvents: FC<Props> = ({
           measurements={measurements}
           mouseCoords={state.mouseCoords}
           startOfView={viewStart}
-          gridScrollRef={gridScrollRef}
+          mainGridRef={mainGridRef}
         />
       )}
 

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
@@ -47,7 +47,7 @@ export const WeekSection: FC<Props> = ({
         measurements={measurements}
         sidebarProps={sidebarProps}
         viewStart={viewStart}
-        gridScrollRef={gridRefs.gridScrollRef}
+        mainGridRef={gridRefs.mainGridRef}
       />
     </SidebarSection>
   );

--- a/packages/web/src/views/Calendar/hooks/grid/useDateCalcs.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDateCalcs.ts
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react";
 import dayjs, { Dayjs } from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
@@ -9,15 +10,13 @@ import { ACCEPTED_TIMES } from "@web/common/constants/web.constants";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { GRID_X_START } from "@web/views/Calendar/layout.constants";
 
-import { Ref_Grid } from "../../components/Grid/grid.types";
-
 dayjs.extend(weekPlugin);
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
 export const useDateCalcs = (
   measurements: Measurements_Grid,
-  scrollRef: Ref_Grid,
+  mainGridRef: MutableRefObject<HTMLDivElement | null>
 ) => {
   const getDateByX = (x: number, firstDayInView: Dayjs) => {
     const gridX = x - GRID_X_START;
@@ -45,7 +44,7 @@ export const useDateCalcs = (
     x: number,
     y: number,
     firstDayInView: Dayjs,
-    format?: string,
+    format?: string
   ) => {
     const date = getDateByXY(x, y, firstDayInView);
 
@@ -71,7 +70,7 @@ export const useDateCalcs = (
   const getMinuteByY = (y: number) => {
     if (!measurements.mainGrid) return 0; // TS guard. This should never happen
 
-    const scrollTop = scrollRef.current.scrollTop;
+    const scrollTop = mainGridRef.current?.scrollTop || 0;
     // gridY is the distance from the top of the grid (main grid) to the click
     const gridY = y - measurements.mainGrid.top + scrollTop;
 

--- a/packages/web/src/views/Calendar/hooks/grid/useDateCalcs.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDateCalcs.ts
@@ -16,7 +16,7 @@ dayjs.extend(timezone);
 
 export const useDateCalcs = (
   measurements: Measurements_Grid,
-  mainGridRef: MutableRefObject<HTMLDivElement | null>
+  mainGridRef: MutableRefObject<HTMLDivElement | null>,
 ) => {
   const getDateByX = (x: number, firstDayInView: Dayjs) => {
     const gridX = x - GRID_X_START;
@@ -44,7 +44,7 @@ export const useDateCalcs = (
     x: number,
     y: number,
     firstDayInView: Dayjs,
-    format?: string
+    format?: string,
   ) => {
     const date = getDateByXY(x, y, firstDayInView);
 

--- a/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
@@ -1,0 +1,71 @@
+import { selectDraft } from "@web/ducks/events/selectors/draft.selectors";
+import { useAppSelector } from "@web/store/store.hooks";
+import { MutableRefObject, useEffect, useState, useRef } from "react";
+
+const SCROLL_SPEED = 10;
+const EDGE_THRESHOLD = 50;
+
+export const useDragEventSmartScroll = (
+  mainGridRef: MutableRefObject<HTMLDivElement | null>,
+) => {
+  const draftEvent = useAppSelector(selectDraft);
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  const scrollRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!draftEvent) return;
+
+    const updateMousePosition = (event: MouseEvent) => {
+      setMousePosition({ x: event.clientX, y: event.clientY });
+    };
+
+    window.addEventListener("mousemove", updateMousePosition);
+
+    return () => {
+      window.removeEventListener("mousemove", updateMousePosition);
+    };
+  }, [draftEvent]);
+
+  useEffect(() => {
+    if (!draftEvent || !mainGridRef.current) return;
+
+    const container = mainGridRef.current;
+
+    const scrollIfNeeded = () => {
+      if (!container) return;
+
+      const { top, bottom } = container.getBoundingClientRect();
+      const { y } = mousePosition;
+
+      let scrollAmount = 0;
+
+      const isAtTop = container.scrollTop === 0;
+      const isAtBottom =
+        container.scrollTop + container.clientHeight >= container.scrollHeight;
+
+      if (y < top + EDGE_THRESHOLD && !isAtTop) {
+        scrollAmount = -SCROLL_SPEED;
+      } else if (y > bottom - EDGE_THRESHOLD && !isAtBottom) {
+        scrollAmount = SCROLL_SPEED;
+      }
+
+      if (scrollAmount !== 0) {
+        container.scrollTop += scrollAmount;
+        scrollRef.current = requestAnimationFrame(scrollIfNeeded);
+      } else {
+        scrollRef.current = null;
+      }
+    };
+
+    if (!scrollRef.current) {
+      scrollRef.current = requestAnimationFrame(scrollIfNeeded);
+    }
+
+    return () => {
+      if (scrollRef.current) {
+        cancelAnimationFrame(scrollRef.current);
+        scrollRef.current = null;
+      }
+    };
+  }, [mousePosition, draftEvent]);
+};

--- a/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
@@ -7,12 +7,13 @@ const EDGE_THRESHOLD = 50;
 export const useDragEventSmartScroll = (
   mainGridRef: MutableRefObject<HTMLDivElement | null>,
 ) => {
-  const draftContext = useDraftContext();
+  const { state } = useDraftContext();
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const scrollRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!draftContext.state.isDragging) return;
+    if (!state.isDragging) return;
+    if (state.draft?.isAllDay) return;
 
     const updateMousePosition = (event: MouseEvent) => {
       setMousePosition({ x: event.clientX, y: event.clientY });
@@ -23,7 +24,7 @@ export const useDragEventSmartScroll = (
     return () => {
       window.removeEventListener("mousemove", updateMousePosition);
     };
-  }, [draftContext.state.isDragging]);
+  }, [state.isDragging]);
 
   useEffect(() => {
     if (!mainGridRef.current) return;

--- a/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
@@ -1,5 +1,4 @@
-import { selectDraft } from "@web/ducks/events/selectors/draft.selectors";
-import { useAppSelector } from "@web/store/store.hooks";
+import { useDraftContext } from "@web/views/Calendar/components/Draft/context/useDraftContext";
 import { MutableRefObject, useEffect, useState, useRef } from "react";
 
 const SCROLL_SPEED = 10;
@@ -8,12 +7,12 @@ const EDGE_THRESHOLD = 50;
 export const useDragEventSmartScroll = (
   mainGridRef: MutableRefObject<HTMLDivElement | null>,
 ) => {
-  const draftEvent = useAppSelector(selectDraft);
+  const draftContext = useDraftContext();
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const scrollRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!draftEvent) return;
+    if (!draftContext.state.isDragging) return;
 
     const updateMousePosition = (event: MouseEvent) => {
       setMousePosition({ x: event.clientX, y: event.clientY });
@@ -24,10 +23,10 @@ export const useDragEventSmartScroll = (
     return () => {
       window.removeEventListener("mousemove", updateMousePosition);
     };
-  }, [draftEvent]);
+  }, [draftContext.state.isDragging]);
 
   useEffect(() => {
-    if (!draftEvent || !mainGridRef.current) return;
+    if (!mainGridRef.current) return;
 
     const container = mainGridRef.current;
 
@@ -67,5 +66,6 @@ export const useDragEventSmartScroll = (
         scrollRef.current = null;
       }
     };
-  }, [mousePosition, draftEvent]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mousePosition]);
 };

--- a/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
@@ -10,7 +10,7 @@ export type MeasureableElement = "mainGrid" | "allDayRow";
 
 export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
   const [allDayMeasurements, setAllDayMeasurements] = useState<DOMRect | null>(
-    null
+    null,
   );
   const [mainMeasurements, setMainMeasurements] = useState<DOMRect | null>();
   const [colWidths, setColWidths] = useState<number[]>([]);

--- a/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
@@ -10,7 +10,7 @@ export type MeasureableElement = "mainGrid" | "allDayRow";
 
 export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
   const [allDayMeasurements, setAllDayMeasurements] = useState<DOMRect | null>(
-    null,
+    null
   );
   const [mainMeasurements, setMainMeasurements] = useState<DOMRect | null>();
   const [colWidths, setColWidths] = useState<number[]>([]);
@@ -39,16 +39,7 @@ export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
     }
   }, []);
 
-  const gridScrollRef = useRef<HTMLDivElement | null>(null);
-
-  const mainGridRef = useCallback(
-    (node: HTMLDivElement) => {
-      if (node !== null && !mainMeasurements) {
-        _measureMainGrid(node);
-      }
-    },
-    [mainMeasurements],
-  );
+  const mainGridRef = useRef<HTMLDivElement | null>(null);
 
   const _measureAllDayRow = (node?: HTMLDivElement) => {
     if (node) {
@@ -103,10 +94,15 @@ export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
     }
   };
 
+  useEffect(() => {
+    if (mainGridRef.current && !mainMeasurements) {
+      _measureMainGrid(mainGridRef.current);
+    }
+  }, [mainGridRef.current]);
+
   return {
     gridRefs: {
       allDayRef,
-      gridScrollRef,
       mainGridRef,
     },
     measurements: {

--- a/packages/web/src/views/Calendar/hooks/grid/useScroll.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useScroll.ts
@@ -1,21 +1,23 @@
 import { getCurrentMinute } from "@web/common/utils/grid.util";
-import { useCallback, useEffect } from "react";
+import { MutableRefObject, useCallback, useEffect } from "react";
 
-import { Ref_Grid } from "../../components/Grid/grid.types";
-
-export const useScroll = (timedGridRef: Ref_Grid) => {
+export const useScroll = (
+  timedGridRef: MutableRefObject<HTMLDivElement | null>,
+) => {
   const scrollToNow = useCallback(() => {
     const rows = 11;
-    const gridRowHeight = (timedGridRef.current.clientHeight || 0) / rows;
+    const gridRowHeight = (timedGridRef.current?.clientHeight || 0) / rows;
     const minuteHeight = gridRowHeight / 60;
 
     const buffer = 150;
     const top = getCurrentMinute() * minuteHeight - buffer;
 
-    timedGridRef.current.scroll({
-      top,
-      behavior: "smooth",
-    });
+    if (timedGridRef.current) {
+      timedGridRef.current.scroll({
+        top,
+        behavior: "smooth",
+      });
+    }
   }, [timedGridRef]);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9527,11 +9527,6 @@ react-lifecycles-compat@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-merge-refs@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
-  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
-
 react-modal@^3.16.1:
   version "3.16.1"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.16.1.tgz#34018528fc206561b1a5467fc3beeaddafb39b2b"


### PR DESCRIPTION
### Description

Closes [issue](https://github.com/SwitchbackTech/compass/issues/241)

This PR implements an auto scroll feature to auto scroll the user when they drag an event to the bottom or top edge of the main grid area.

It handled refactoring parts of the code along the way, mainly removing `gridScrollRef` to simplify the code.

It also handled fixing a bug caused by an edge case that was always present, but became more apparent with this new feature. The bug is: when dragging an event to the very bottom of the screen, you can place the event in a way that the end date would overflow outside the bottom edge of the main grid area container. Details in below video:

### Summary:

- Feature: Implement auto scroll when user drags an event to the bottom/top of the main grid
- Chore: Remove `gridScrollRef`
- handle edge case with dragging an event to very bottom of the page

Introduces known bugs: #267 #266 


### Videos

#### Before
[auto_scroll_event_overflow_jittering_before.webm](https://github.com/user-attachments/assets/cc26cbe7-4a7d-4b92-83e4-f65f457737ca)
[auto_scroll_before.webm](https://github.com/user-attachments/assets/00c943e9-18ee-43b0-a905-2af543bfeac9)


#### After
[auto_scroll_event_overflow_jittering_after.webm](https://github.com/user-attachments/assets/05a6597a-0bcc-48c0-a444-5fbdb894b667)
[auto_scroll_after.webm](https://github.com/user-attachments/assets/97aa7555-e08e-48a0-b8e9-2210ee66278a)
