### PR TITLE
📜 Docs: Remove Feature Title Input from Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.yml
@@ -9,12 +9,6 @@ body:
       value: |
         Thanks for taking the time to fill out this feature request!
 
-  - type: input
-    attributes:
-      label: Feature Title
-      description: Provide a short and descriptive title for the feature request.
-      placeholder: Add Fancy New Thing
-
   - type: textarea
     attributes:
       label: Feature Description


### PR DESCRIPTION
The issue itself requires a title, so this field is redundant and just slows the process down. Snip snip ✂️