### PR TITLE
🐛: Fix ESLint configuration for Prettier plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,6 @@ import path from "path";
 import tseslint from "typescript-eslint";
 import { fileURLToPath } from "url";
 import pluginJs from "@eslint/js";
-import sortImports from "@trivago/prettier-plugin-sort-imports";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -71,6 +70,12 @@ export default [
   },
   // these plugins adjust other parts of this config,
   // so keep them down here
-  prettierEslint,
-  sortImports,
+  {
+    plugins: {
+      prettier: prettierEslint,
+    },
+    rules: {
+      ...prettierEslint.configs.recommended.rules,
+    },
+  },
 ];


### PR DESCRIPTION
This corrects a syntax error in the eslint config which was causing Eslint to crash. 

Follow-up to #269. Related to #271, #149, and #257. 

Replaced direct plugin usage in eslint config with plugin object.

The flat config system expects each item in the array to be a valid configuration object Plugins need to be explicitly registered in the plugins field


## Before

```
[Error - 6:55:34 AM] ConfigError: Config (unnamed): Unexpected key "meta" found.
    at rethrowConfigError (/Users/tyler/src/switchback/compass/node_modules/@eslint/config-array/dist/cjs/index.cjs:328:8)
    at /Users/tyler/src/switchback/compass/node_modules/@eslint/config-array/dist/cjs/index.cjs:1174:5
    at Array.reduce (<anonymous>)
    at FlatConfigArray.getConfigWithStatus (/Users/tyler/src/switchback/compass/node_modules/@eslint/config-array/dist/cjs/index.cjs:1167:43)
    at FlatConfigArray.getConfigStatus (/Users/tyler/src/switchback/compass/node_modules/@eslint/config-array/dist/cjs/index.cjs:1209:15)
    at ESLint.lintText (/Users/tyler/src/switchback/compass/node_modules/eslint/lib/eslint/eslint.js:912:39)
    at async /Users/tyler/.cursor/extensions/dbaeumer.vscode-eslint-3.0.10/server/out/eslintServer.js:1:26981
    at async M (/Users/tyler/.cursor/extensions/dbaeumer.vscode-eslint-3.0.10/server/out/eslintServer.js:1:19807)
    at async /Users/tyler/.cursor/extensions/dbaeumer.vscode-eslint-3.0.10/server/out/eslintServer.js:1:234554
    at async /Users/tyler/.cursor/extensions/dbaeumer.vscode-eslint-3.0.10/server/out/eslintServer.js:1:63886
```

## After

```
[Info  - 6:50:54 AM] ESLint server is starting.
[Info  - 6:50:54 AM] ESLint server running in node v20.18.1
[Info  - 6:50:54 AM] ESLint server is running.
[Info  - 6:50:54 AM] ESLint library loaded from: /Users/tyler/src/switchback/compass/node_modules/eslint/lib/api.js
[Info  - 6:50:55 AM] Server process exited successfully

```