### PR TITLE
🐛 Fix: Time pickers returning wrong value when defaulted

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateTimeSection/TimePicker/TimePickers.tsx
@@ -72,7 +72,7 @@ export const TimePickers: FC<Props> = ({
       }
     }
 
-    const defaultOption = changed === "start" ? startTime : endTime;
+    const defaultOption = changed === "start" ? endTime : startTime;
     return defaultOption;
   };
 


### PR DESCRIPTION
Fixes #263 

## Old Behavior

https://github.com/user-attachments/assets/2179c3aa-fb96-4600-9aa5-73d3b32203dc

## New Behavior


https://github.com/user-attachments/assets/de0892d4-ba56-4e1f-bdfb-6c1a43822aeb

Apologies for not following the contribution guidelines. I did not see them initially and just wanted to take a look at this issue.
