### PR TITLE
🐛 Fix: event removal logic for multi-week spanning events

### DIFF
--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -101,11 +101,20 @@ export const useDraftActions = (
 
     const isExisting = event._id;
     if (isExisting) {
-      const isOutsideView =
-        !dayjs(event.startDate).isBetween(startOfView, endOfView, null, "[]") &&
-        !dayjs(event.endDate).isBetween(startOfView, endOfView, null, "[]");
+      const isDateWithinView = (date: string) =>
+        dayjs(date).isBetween(startOfView, endOfView, null, "[]");
 
-      const shouldRemove = isOutsideView ? true : false;
+      const isStartDateInView = isDateWithinView(event.startDate);
+      const isEndDateInView = isDateWithinView(event.endDate);
+      const doesEventSpanView =
+        dayjs(event.startDate).isBefore(startOfView) &&
+        dayjs(event.endDate).isAfter(endOfView);
+
+      const isEventCompletelyOutsideView =
+        !isStartDateInView && !isEndDateInView && !doesEventSpanView;
+
+      const shouldRemove = isEventCompletelyOutsideView;
+
       const payload = { _id: event._id, event, shouldRemove };
       dispatch(editEventSlice.actions.request(payload));
     } else {


### PR DESCRIPTION
## Description

Previously, events that spanned across multiple weeks were incorrectly removed when both start and end dates fell outside the current week view. Added a check for events that span across the entire view period to ensure they remain visible even when their start/end dates are outside the current week. This fixes cases where long-running events (e.g., Jan 1 - Jan 20) would disappear from middle weeks (e.g., Jan 7 - Jan 14).

## Videos

#### Before
[Peek 2025-03-10 08-37.webm](https://github.com/user-attachments/assets/588747a0-5faa-4052-be1c-f88fabc54d14)

#### After
[Peek 2025-03-10 08-36.webm](https://github.com/user-attachments/assets/9aef2574-4067-4142-ad3b-2fa6a3c68b3a)
