### PR TITLE
🐛 Fix: dragging an event with its form window open does not work

### DIFF
--- a/packages/web/src/views/Calendar/hooks/grid/useGridEventMouseDown.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useGridEventMouseDown.ts
@@ -95,10 +95,6 @@ export const useGridEventMouseDown = (
         if (timeoutId.current) {
           clearTimeout(timeoutId.current);
         }
-        if (isEventFormOpen()) {
-          cleanup(element, onMouseMove, onMouseUp);
-          return;
-        }
         onDrag(event);
         cleanup(element, onMouseMove, onMouseUp);
       }


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/298

I'm not sure why we have the below removed piece of code, but it was the culprit behind the issue.

I read the code comments about allowing drag only if form is open, but I couldn't comprehend it.

If it was part of an important UX logic we can revisit this in the future

## Videos

#### Before
[Peek.webm](https://github.com/user-attachments/assets/6c5bd296-a940-42a8-8206-391058a5bbb7)


#### After
[Peek.webm](https://github.com/user-attachments/assets/65424633-4353-45a4-b7ad-cee010c762ed)
