### PR TITLE
fix(web): Grid scrolls indefinitely when user drags event down

### DIFF
--- a/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
@@ -68,5 +68,6 @@ export const useDragEventSmartScroll = (
         scrollRef.current = null;
       }
     };
-  }, [mousePosition]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.isDragging, mousePosition.x, mousePosition.y]);
 };


### PR DESCRIPTION
## Description

Fixes https://github.com/SwitchbackTech/compass/issues/266

It's a pretty straightforward fix. We just needed to let the `useEffect` know when we stopped dragging so it can stop auto scrolling accordingly.

## Videos

#### Before
[Peek 2025-03-15 11-04.webm](https://github.com/user-attachments/assets/4a6b3641-988d-4159-a824-1ea7fcbc1c4e)


#### After
[Peek.webm](https://github.com/user-attachments/assets/95fc372b-5338-4f99-b6ff-5df44156871b)
