### PR TITLE
🐛 Fix: editing all day event using context menu creates duplicate event in UI

### DIFF
--- a/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
+++ b/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
@@ -86,7 +86,9 @@ export const ContextMenuWrapper = ({
       dispatch(
         draftSlice.actions.start({
           activity: "eventRightClick",
-          eventType: Categories_Event.TIMED,
+          eventType: event.isAllDay
+            ? Categories_Event.ALLDAY
+            : Categories_Event.TIMED,
           event,
         }),
       );


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/334

When right clicking on an all day event then clicking edit, the all day events creates a copy of itself in the bottom relative to where the edit click occurred.

This issue occurs due to us not providing the incorrect event type when creating a draft in the global store. Statically providing a timed event category type means that the draft will always render in the timed events grid area rather than the all day grid area.

## Videos

#### Before
[Peek 2025-04-01.webm](https://github.com/user-attachments/assets/de988432-0fab-4d55-993f-dd58fd906301)


#### After
[Peek 2025-04-01.webm](https://github.com/user-attachments/assets/fcbb422a-8e58-4748-b169-a81dc9025fa5)
