### PR TITLE
🐛 Fix(backend): Prevent duplicates during full import

### DIFF
--- a/packages/backend/src/__tests__/backend.test.start.js
+++ b/packages/backend/src/__tests__/backend.test.start.js
@@ -4,6 +4,7 @@ jest.mock("@core/logger/winston.logger", () => {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    verbose: jest.fn(),
   };
 
   return {

--- a/packages/backend/src/__tests__/helpers/mock.db.queries.ts
+++ b/packages/backend/src/__tests__/helpers/mock.db.queries.ts
@@ -1,0 +1,13 @@
+import { Collections } from "@backend/common/constants/collections";
+import mongoService from "@backend/common/services/mongo.service";
+
+export const getEventsInDb = async () => {
+  return await mongoService.db.collection(Collections.EVENT).find().toArray();
+};
+
+export const isEventCollectionEmpty = async () => {
+  return (
+    (await mongoService.db.collection(Collections.EVENT).find().toArray())
+      .length === 0
+  );
+};

--- a/packages/backend/src/__tests__/mocks.ccal/ccal.event.factory.ts
+++ b/packages/backend/src/__tests__/mocks.ccal/ccal.event.factory.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from "mongodb";
+import { faker } from "@faker-js/faker/.";
 import { Origin, Priorities } from "@core/constants/core.constants";
 import {
   Schema_Event_Recur_Base,
@@ -58,6 +59,7 @@ export const createMockInstance = (
     isAllDay: false,
     isSomeday: false,
     updatedAt: now,
+    gEventId: `mock-gcal-id-${faker.string.uuid()}`,
     ...overrides,
   };
 };

--- a/packages/backend/src/__tests__/mocks.ccal/ccal.mock.db.util.ts
+++ b/packages/backend/src/__tests__/mocks.ccal/ccal.mock.db.util.ts
@@ -1,0 +1,45 @@
+import { faker } from "@faker-js/faker/.";
+import {
+  Schema_Event_Recur_Base,
+  Schema_Event_Recur_Instance,
+} from "@core/types/event.types";
+import { Collections } from "@backend/common/constants/collections";
+import { TestSetup } from "../helpers/mock.db.setup";
+import { createMockBaseEvent, createMockInstance } from "./ccal.event.factory";
+
+export const createRecurrenceSeries = async (
+  setup: TestSetup,
+  baseOverrides: Partial<Schema_Event_Recur_Base>,
+  instanceOverrides?: Partial<Schema_Event_Recur_Instance>,
+) => {
+  // Create a recurring event with instances
+  const baseEvent = createMockBaseEvent({
+    recurrence: { rule: ["RRULE:FREQ=DAILY"] },
+    ...baseOverrides,
+  });
+
+  const instance1 = createMockInstance(baseEvent._id as string, {
+    ...instanceOverrides,
+  });
+
+  const instance2 = createMockInstance(baseEvent._id as string, {
+    ...instanceOverrides,
+    // prevents collision with instance1
+    gEventId: `mock-instance-id-${faker.string.uuid()}`,
+  });
+
+  await setup.db
+    .collection(Collections.EVENT)
+    .insertMany([baseEvent, instance1, instance2]);
+  console.log(baseEvent, instance1, instance2);
+
+  const status = await setup.db.collection(Collections.EVENT).find().toArray();
+  const meta = { createdCount: status.length };
+  return {
+    state: {
+      baseEvent,
+      instances: [instance1, instance2],
+    },
+    meta,
+  };
+};

--- a/packages/backend/src/event/queries/event.queries.ts
+++ b/packages/backend/src/event/queries/event.queries.ts
@@ -10,7 +10,7 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 import { getIdFilter } from "@backend/common/helpers/mongo.utils";
 import mongoService from "@backend/common/services/mongo.service";
 
-type Ids_Event = "_id" | "gEventId";
+export type Ids_Event = "_id" | "gEventId";
 
 /**
  * DB operations for Compass's Event collection, focused

--- a/packages/backend/src/event/queries/event.recur.queries.ts
+++ b/packages/backend/src/event/queries/event.recur.queries.ts
@@ -1,0 +1,44 @@
+import { Collections } from "@backend/common/constants/collections";
+import mongoService from "@backend/common/services/mongo.service";
+import { Ids_Event } from "./event.queries";
+
+/**
+ * DB operations for Compass's Event collection, focused
+ * on recurring event operations
+ */
+
+export class RecurringEventRepository {
+  constructor(private userId: string) {}
+
+  async cancelSeries(baseId: string) {
+    // Delete all events in the series (both base and instances)
+
+    const result = await mongoService.db
+      .collection(Collections.EVENT)
+      .deleteMany({
+        $or: [
+          { _id: baseId, user: this.userId }, // Base event
+          { "recurrence.eventId": baseId, user: this.userId }, // All instances
+        ],
+      });
+
+    const filters = [
+      { _id: baseId, user: this.userId },
+      { "recurrence.eventId": baseId, user: this.userId },
+    ];
+    console.log(filters);
+    return result;
+  }
+
+  async cancelInstance(id: string, params?: { idKey: Ids_Event }) {
+    const idKey = params?.idKey || "_id";
+    const filter = { [idKey]: id, user: this.userId };
+    console.log(filter);
+    // Delete just this specific instance
+    const result = await mongoService.db
+      .collection(Collections.EVENT)
+      .deleteOne(filter);
+
+    return result;
+  }
+}

--- a/packages/backend/src/event/queries/event.recur.queries.ts
+++ b/packages/backend/src/event/queries/event.recur.queries.ts
@@ -27,14 +27,14 @@ export class RecurringEventRepository {
       { _id: baseId, user: this.userId },
       { "recurrence.eventId": baseId, user: this.userId },
     ];
-    console.log(filters);
+    console.log("series filters", filters);
     return result;
   }
 
   async cancelInstance(id: string, params?: { idKey: Ids_Event }) {
     const idKey = params?.idKey || "_id";
     const filter = { [idKey]: id, user: this.userId };
-    console.log(filter);
+    console.log("instance filter:", filter);
     // Delete just this specific instance
     const result = await mongoService.db
       .collection(Collections.EVENT)

--- a/packages/backend/src/event/queries/event.recur.queries.ts
+++ b/packages/backend/src/event/queries/event.recur.queries.ts
@@ -1,3 +1,4 @@
+import { ObjectId } from "mongodb";
 import { Collections } from "@backend/common/constants/collections";
 import mongoService from "@backend/common/services/mongo.service";
 import { Ids_Event } from "./event.queries";
@@ -17,7 +18,7 @@ export class RecurringEventRepository {
       .collection(Collections.EVENT)
       .deleteMany({
         $or: [
-          { _id: baseId, user: this.userId }, // Base event
+          { _id: new ObjectId(baseId), user: this.userId }, // Base event
           { "recurrence.eventId": baseId, user: this.userId }, // All instances
         ],
       });

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -155,6 +155,7 @@ class EventService {
         `Only ${response.insertedCount}/${events.length} saved`,
       );
     }
+    return response;
   };
 
   /* 

--- a/packages/backend/src/event/services/recur/util/recur.gcal.util.ts
+++ b/packages/backend/src/event/services/recur/util/recur.gcal.util.ts
@@ -13,7 +13,6 @@ export class GcalParser {
     return {
       title: this.event.summary || this.event.id || "unknown",
       category: this.category,
-      changeType: this.status,
     };
   }
   private getCategory() {
@@ -33,10 +32,12 @@ export class GcalParser {
     }
   }
   private isRecurrenceBase() {
-    return (
-      this.event.recurrence !== undefined &&
-      this.event.recurringEventId === undefined
-    );
+    const isBase = this.event.recurrence !== undefined;
+    // Recurring cancellations include the recurringEventId;
+    // base cancellations do not
+    const isBaseCancellation =
+      this.event.status === "cancelled" && !this.event.recurringEventId;
+    return isBase || isBaseCancellation;
   }
   private isRecurrenceInstance() {
     return (

--- a/packages/backend/src/sync/services/import/all/import.all.gcal.ts
+++ b/packages/backend/src/sync/services/import/all/import.all.gcal.ts
@@ -1,0 +1,132 @@
+import { Origin } from "@core/constants/core.constants";
+import { Logger } from "@core/logger/winston.logger";
+import { MapEvent } from "@core/mappers/map.event";
+import {
+  gCalendar,
+  gParamsImportAllEvents,
+  gSchema$Event,
+} from "@core/types/gcal";
+import { EventError } from "@backend/common/constants/error.constants";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import gcalService from "@backend/common/services/gcal/gcal.service";
+import eventService from "@backend/event/services/event.service";
+import { Callback_EventProcessor, Map_ImportAll } from "../sync.import.types";
+
+const logger = Logger("sync.import.all.gcal");
+
+/**
+ * Generic helper: Fetches events page by page, processes using a callback, and saves.
+ */
+export const fetchAndProcessEventsPageByPage = async (
+  userId: string,
+  gcal: gCalendar,
+  calendarId: string,
+  gcalApiParams: gParamsImportAllEvents,
+  // Callback function to process each event and decide if it should be saved
+  eventProcessor: Callback_EventProcessor,
+  // Shared state accessible/modifiable by the processor
+  sharedState: Map_ImportAll,
+  captureSyncToken: boolean,
+): Promise<{
+  savedCount: number;
+  processedCount: number;
+  nextSyncToken: string | undefined;
+}> => {
+  let nextPageToken: string | undefined = undefined;
+  let finalNextSyncToken: string | undefined = undefined;
+  let totalProcessedApi = 0;
+  let totalSaved = 0;
+  const passIdentifier = gcalApiParams.singleEvents ? "Pass 2" : "Pass 1"; // For logging
+
+  logger.info(
+    `${passIdentifier}: Fetching events for ${calendarId}. Params: ${JSON.stringify(gcalApiParams)}`,
+  );
+
+  do {
+    const params: gParamsImportAllEvents = {
+      calendarId,
+      pageToken: nextPageToken,
+      maxResults: 250, // Consider making configurable
+      ...gcalApiParams, // Spread specific parameters like singleEvents
+    };
+
+    const gEventsResponse = await gcalService.getEvents(gcal, params);
+
+    // Handle cases where the API call might fail or return unexpected structure
+    if (!gEventsResponse?.data) {
+      // Check for data property
+      logger.warn(
+        `${passIdentifier}: Invalid response structure or error fetching page for ${calendarId}. PageToken: ${nextPageToken}`,
+        gEventsResponse,
+      );
+      if (!nextPageToken && totalProcessedApi === 0) {
+        // Error on first fetch is critical
+        throw error(
+          EventError.NoGevents, // Or a more specific Gcal API error
+          `${passIdentifier}: Initial fetch failed or returned invalid data for ${calendarId}`,
+        );
+      }
+      break; // Stop processing this pass/call
+    }
+
+    const eventsFromApi = gEventsResponse.data.items || []; // Ensure items is an array
+    totalProcessedApi += eventsFromApi.length;
+
+    if (eventsFromApi.length > 0) {
+      const eventsToSave: gSchema$Event[] = [];
+      eventsFromApi.forEach((event) => {
+        // Call the provided processor function
+        const shouldSave = eventProcessor(event, sharedState);
+        if (shouldSave) {
+          eventsToSave.push(event);
+        }
+      });
+
+      if (eventsToSave.length > 0) {
+        const cEvents = MapEvent.toCompass(
+          userId,
+          eventsToSave,
+          Origin.GOOGLE_IMPORT,
+        );
+        if (cEvents.length > 0) {
+          try {
+            const result = await eventService.createMany(cEvents);
+            // Safely access insertedCount (assuming result object structure)
+            const savedCount =
+              result && typeof result.insertedCount === "number"
+                ? result.insertedCount
+                : 0;
+            totalSaved += savedCount;
+            // logger.debug(`${passIdentifier}: Saved ${savedCount} events this page.`); // Reduce noise
+          } catch (dbError) {
+            logger.error(
+              `${passIdentifier}: Error saving events to database.`,
+              { error: dbError, count: cEvents.length },
+            );
+            // Potentially re-throw if database errors should halt the entire sync
+            // throw dbError;
+          }
+        }
+      }
+    }
+
+    nextPageToken = gEventsResponse.data.nextPageToken ?? undefined;
+    // Capture nextSyncToken ONLY on the last page AND if requested
+    if (captureSyncToken && !nextPageToken) {
+      finalNextSyncToken = gEventsResponse.data.nextSyncToken ?? undefined;
+      logger.info(
+        `${passIdentifier}: Reached last page. Got nextSyncToken: ${finalNextSyncToken ? "..." : "null"}`,
+      );
+    }
+  } while (nextPageToken !== undefined);
+
+  logger.info(
+    `${passIdentifier} completed for ${calendarId}. Processed ${totalProcessedApi} API events. Saved ${totalSaved} total events.`,
+  );
+
+  return {
+    savedCount: totalSaved,
+    processedCount: totalProcessedApi,
+    nextSyncToken: finalNextSyncToken, // Will be undefined if captureSyncToken was false
+  };
+};

--- a/packages/backend/src/sync/services/import/all/import.all.util.ts
+++ b/packages/backend/src/sync/services/import/all/import.all.util.ts
@@ -1,0 +1,73 @@
+import dayjs from "dayjs";
+import { Logger } from "@core/logger/winston.logger";
+import { gSchema$Event } from "@core/types/gcal";
+import { Callback_EventProcessor } from "../sync.import.types";
+
+const logger = Logger("sync.import.all.util");
+
+const getStartTimeString = (event: gSchema$Event): string | null => {
+  if (event.start?.dateTime) {
+    return event.start.dateTime;
+  }
+  if (event.start?.date) {
+    // For all-day events, represent the start as the beginning of that day in UTC
+    // This assumes MapEvent.toCompass handles all-day events similarly. Adjust if needed.
+    return dayjs(event.start.date).startOf("day").toISOString();
+  }
+  return null;
+};
+
+// Processor for Pass 1: Identifies base/single events
+export const shouldProcessDuringPass1: Callback_EventProcessor = (
+  event,
+  state,
+) => {
+  if (event.id) {
+    if (event.recurrence) {
+      const startTime = getStartTimeString(event);
+      state.baseEventStartTimes.set(event.id, startTime);
+      state.processedEventIdsPass1.add(event.id);
+      return true; // Save base event
+    } else if (!event.recurringEventId) {
+      state.processedEventIdsPass1.add(event.id);
+      return true; // Save single event
+    }
+  }
+  return false; // Don't save (e.g., instances encountered in Pass 1)
+};
+
+// Processor for Pass 2: Filters events based on shared state
+export const shouldProcessDuringPass2: Callback_EventProcessor = (
+  event,
+  state,
+) => {
+  // Filter 1: Skip event if already processed in Pass 1
+  if (state.processedEventIdsPass1.has(event.id || "")) {
+    logger.verbose(`Pass 2: Skipping event ${event.id} (processed in Pass 1).`); // Reduce noise
+    return false; // Don't save
+  }
+
+  // Filter 2: Skip first instance if start matches base event start
+  if (event.recurringEventId && event.id) {
+    const baseStartTime = state.baseEventStartTimes.get(event.recurringEventId);
+    if (baseStartTime !== undefined) {
+      const instanceStartTime = getStartTimeString(event);
+      const isFirstInstance =
+        baseStartTime &&
+        instanceStartTime &&
+        baseStartTime === instanceStartTime;
+      if (isFirstInstance) {
+        logger.verbose(
+          `Pass 2: Skipping event ${event.id} (first instance match).`,
+        ); // Reduce noise
+        return false; // Don't save
+      }
+    } else {
+      logger.warn(
+        `Pass 2: Instance ${event.id} found, base ${event.recurringEventId} unknown. Saving.`,
+      );
+    }
+  }
+  // Event passed filters
+  return true; // Save this event
+};

--- a/packages/backend/src/sync/services/import/sync.import.types.ts
+++ b/packages/backend/src/sync/services/import/sync.import.types.ts
@@ -1,6 +1,17 @@
 import { Schema_Event_Core } from "@core/types/event.types";
+import { gSchema$Event } from "@core/types/gcal";
 
 export interface EventsToModify {
   toUpdate: Schema_Event_Core[];
   toDelete: string[];
 }
+
+export type Callback_EventProcessor = (
+  event: gSchema$Event,
+  sharedState: Map_ImportAll,
+) => boolean; // Returns true if event should be saved
+
+export type Map_ImportAll = {
+  baseEventStartTimes: Map<string, string | null>;
+  processedEventIdsPass1: Set<string>;
+};

--- a/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
@@ -3,6 +3,7 @@ import { gCalendar } from "@core/types/gcal";
 import { SyncError } from "@backend/common/constants/error.constants";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import gcalService from "@backend/common/services/gcal/gcal.service";
+import { RecurringEventRepository } from "@backend/event/queries/event.recur.queries";
 import { getSync, updateSyncTokenFor } from "@backend/sync/util/sync.queries";
 import { Summary_Sync } from "../../../sync.types";
 import { GcalSyncProcessor } from "../../sync/gcal.sync.processor";
@@ -13,6 +14,7 @@ export class GCalNotificationHandler {
   constructor(
     private gcal: gCalendar,
     private userId: string,
+    private repo: RecurringEventRepository,
   ) {}
 
   /**
@@ -30,7 +32,7 @@ export class GCalNotificationHandler {
 
     if (hasChanges) {
       console.log("\nCHANGES TO PROCESS:", changes.length);
-      const processor = new GcalSyncProcessor(this.gcal, this.userId);
+      const processor = new GcalSyncProcessor(this.repo);
       const changeSummary = await processor.processEvents(changes);
       console.log("\nRESULT:", changeSummary);
       return { summary: "PROCESSED", changes: changeSummary };

--- a/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
@@ -11,11 +11,13 @@ import { GcalSyncProcessor } from "../../sync/gcal.sync.processor";
 const logger = Logger("app:gcal.notification.handler");
 
 export class GCalNotificationHandler {
+  private repo: RecurringEventRepository;
   constructor(
     private gcal: gCalendar,
     private userId: string,
-    private repo: RecurringEventRepository,
-  ) {}
+  ) {
+    this.repo = new RecurringEventRepository(userId);
+  }
 
   /**
    * Handle a Google Calendar notification

--- a/packages/backend/src/sync/services/sync/gcal.sync.processor.test.ts
+++ b/packages/backend/src/sync/services/sync/gcal.sync.processor.test.ts
@@ -147,7 +147,7 @@ describe("GcalSyncProcessor", () => {
         recurrence: ["RRULE:FREQ=DAILY"],
       });
       const gcalInstance = mockGcalEvent({
-        recurringEventId: gcalBaseEvent.id,
+        recurringEventId: gcalBaseEvent.id + "_20250325T130000Z",
       });
       // Create base and instances in Compass,
       // that point to the original gcal base
@@ -179,7 +179,7 @@ describe("GcalSyncProcessor", () => {
         kind: "calendar#event",
         id: gcalInstance.id,
         status: "cancelled",
-        recurringEventId: gcalBaseEvent.id,
+        recurringEventId: gcalBaseEvent.id + "_20250325T130000Z",
         originalStartTime: {
           date: "2025-04-10",
         },
@@ -198,7 +198,6 @@ describe("GcalSyncProcessor", () => {
       const remainingEvents = await getEventsInDb();
 
       // Verify only the instance was deleted
-      expect(remainingEvents).toHaveLength(meta.createdCount - 1);
       expect(remainingEvents).toHaveLength(meta.createdCount - 1);
       expect(remainingEvents[0]?._id.toString()).toBe(compassBaseId);
       expect(isInstance(remainingEvents[1] as unknown as Schema_Event)).toBe(

--- a/packages/backend/src/sync/services/sync/gcal.sync.processor.test.ts
+++ b/packages/backend/src/sync/services/sync/gcal.sync.processor.test.ts
@@ -1,66 +1,101 @@
-import { Categories_Recurrence } from "@core/types/event.types";
+import { ObjectId } from "mongodb";
+import {
+  Categories_Recurrence,
+  Schema_Event,
+  Schema_Event_Recur_Base,
+  Schema_Event_Recur_Instance,
+} from "@core/types/event.types";
+import {
+  TestSetup,
+  cleanupTestMongo,
+  clearCollections,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { createRecurrenceSeries } from "@backend/__tests__/mocks.ccal/ccal.mock.db.util";
 import { mockGcalEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
-import { mockGcal } from "@backend/__tests__/mocks.gcal/factories/gcal.factory";
+import { Collections } from "@backend/common/constants/collections";
+import mongoService from "@backend/common/services/mongo.service";
+import { RecurringEventRepository } from "@backend/event/queries/event.recur.queries";
+import { isInstance } from "@backend/event/services/recur/util/recur.util";
 import { GcalSyncProcessor } from "./gcal.sync.processor";
 
 describe("GcalSyncProcessor", () => {
-  let processor: GcalSyncProcessor;
-  const userId = "test-user-id";
+  let setup: TestSetup;
+  let repo: RecurringEventRepository;
 
-  beforeEach(() => {
-    const mockGcalInstance = mockGcal();
-    processor = new GcalSyncProcessor(
-      mockGcalInstance.google.calendar(),
-      userId,
-    );
+  beforeAll(async () => {
+    setup = await setupTestDb();
+    repo = new RecurringEventRepository(setup.userId);
   });
 
-  describe("processEvents", () => {
-    it("should process a regular event", async () => {
-      const regularEvent = mockGcalEvent();
-      const changes = await processor.processEvents([regularEvent]);
+  beforeEach(async () => {
+    await clearCollections(setup.db);
+  });
 
-      expect(changes).toHaveLength(1);
-      expect(changes[0]).toEqual({
-        title: regularEvent.summary,
-        category: Categories_Recurrence.STANDALONE,
-        changeType: "ACTIVE",
-        operation: "UPSERTED",
-      });
+  afterAll(async () => {
+    await cleanupTestMongo(setup);
+  });
+  it("should handle all gcal event types", async () => {
+    const processor = new GcalSyncProcessor(repo);
+
+    const regularEvent = mockGcalEvent();
+    const cancelledInstance = mockGcalEvent({
+      status: "cancelled",
+      summary: "Cancelled Instance",
+      recurringEventId: "some-recurrence-id", // this makes it an instance
+    });
+    const recurrenceBase = mockGcalEvent({
+      recurrence: ["RRULE:FREQ=DAILY"], // this makes it a base
+    });
+    const recurrenceInstance = mockGcalEvent({
+      recurringEventId: recurrenceBase.id,
+      originalStartTime: {
+        dateTime: "2025-03-24T07:30:00-05:00",
+        timeZone: "America/Chicago",
+      },
     });
 
-    it("should process a cancelled base recurrence", async () => {
-      const cancelledEvent = mockGcalEvent({
-        status: "cancelled",
-        recurrence: ["RRULE:FREQ=DAILY"],
-      });
-      const changes = await processor.processEvents([cancelledEvent]);
+    const changes = await processor.processEvents([
+      regularEvent,
+      cancelledInstance,
+      recurrenceBase,
+      recurrenceInstance,
+    ]);
 
-      expect(changes).toHaveLength(1);
-      expect(changes[0]).toEqual({
-        title: cancelledEvent.summary,
-        category: Categories_Recurrence.RECURRENCE_BASE,
-        changeType: "CANCELLED",
-        operation: "CANCELLED",
-      });
-    });
-
-    it("should process a recurring event", async () => {
-      const recurringEvent = mockGcalEvent({
-        recurrence: ["RRULE:FREQ=DAILY"],
-      });
-      const changes = await processor.processEvents([recurringEvent]);
-
-      expect(changes).toHaveLength(1);
-      expect(changes[0]).toEqual({
-        title: recurringEvent.summary,
-        category: Categories_Recurrence.RECURRENCE_BASE,
-        changeType: "ACTIVE",
-        operation: "UPSERTED",
-      });
-    });
-
+    expect(changes).toHaveLength(4);
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: regularEvent.summary,
+          category: Categories_Recurrence.STANDALONE,
+          changeType: "ACTIVE",
+          operation: "UPSERTED",
+        }),
+        expect.objectContaining({
+          title: cancelledInstance.summary,
+          category: Categories_Recurrence.RECURRENCE_INSTANCE,
+          changeType: "CANCELLED",
+          operation: "CANCELLED",
+        }),
+        expect.objectContaining({
+          title: recurrenceBase.summary,
+          category: Categories_Recurrence.RECURRENCE_BASE,
+          changeType: "ACTIVE",
+          operation: "UPSERTED",
+        }),
+        expect.objectContaining({
+          title: recurrenceInstance.summary,
+          category: Categories_Recurrence.RECURRENCE_INSTANCE,
+          changeType: "ACTIVE",
+          operation: "UPSERTED",
+        }),
+      ]),
+    );
+  });
+  describe("DELETE", () => {
     it("should process a recurring instance", async () => {
+      const processor = new GcalSyncProcessor(repo);
+
       const recurringEvent = mockGcalEvent({
         recurrence: ["RRULE:FREQ=DAILY"],
       });
@@ -82,60 +117,143 @@ describe("GcalSyncProcessor", () => {
       });
     });
 
-    it("should process multiple events", async () => {
-      const regularEvent = mockGcalEvent();
-      const cancelledInstance = mockGcalEvent({
-        status: "cancelled",
-        summary: "Cancelled Instance",
-        recurringEventId: "some-recurrence-id", // this makes it an instance
+    it("should delete base and all instances after cancelling a base", async () => {
+      const gcalBaseEvent = mockGcalEvent({
+        recurrence: ["RRULE:FREQ=DAILY"],
       });
-      const recurrenceBase = mockGcalEvent({
-        recurrence: ["RRULE:FREQ=DAILY"], // this makes it a base
-      });
-      const recurrenceInstance = mockGcalEvent({
-        recurringEventId: recurrenceBase.id,
+      const gcalInstance = mockGcalEvent({
+        recurringEventId: gcalBaseEvent.id,
         originalStartTime: {
           dateTime: "2025-03-24T07:30:00-05:00",
           timeZone: "America/Chicago",
         },
       });
 
-      const changes = await processor.processEvents([
-        regularEvent,
-        cancelledInstance,
-        recurrenceBase,
-        recurrenceInstance,
-      ]);
+      const baseCompassId = new ObjectId().toString();
+      const compassBaseEvent: Schema_Event_Recur_Base = {
+        title: gcalBaseEvent.summary as string,
+        user: setup.userId,
+        _id: baseCompassId,
+        gEventId: gcalBaseEvent.id as string,
+        recurrence: {
+          rule: ["RRULE:FREQ=DAILY"],
+        },
+      };
 
-      expect(changes).toHaveLength(4);
-      expect(changes).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            title: regularEvent.summary,
-            category: Categories_Recurrence.STANDALONE,
-            changeType: "ACTIVE",
-            operation: "UPSERTED",
-          }),
-          expect.objectContaining({
-            title: cancelledInstance.summary,
-            category: Categories_Recurrence.RECURRENCE_INSTANCE,
-            changeType: "CANCELLED",
-            operation: "CANCELLED",
-          }),
-          expect.objectContaining({
-            title: recurrenceBase.summary,
-            category: Categories_Recurrence.RECURRENCE_BASE,
-            changeType: "ACTIVE",
-            operation: "UPSERTED",
-          }),
-          expect.objectContaining({
-            title: recurrenceInstance.summary,
-            category: Categories_Recurrence.RECURRENCE_INSTANCE,
-            changeType: "ACTIVE",
-            operation: "UPSERTED",
-          }),
-        ]),
+      const compassInstanceTemplate: Schema_Event_Recur_Instance = {
+        title: gcalInstance.summary as string,
+        user: setup.userId,
+        gEventId: gcalInstance.id as string,
+        recurrence: {
+          eventId: baseCompassId,
+        },
+      };
+      await createRecurrenceSeries(
+        setup,
+        compassBaseEvent,
+        compassInstanceTemplate,
+      );
+
+      // Cancel the series
+      const cancelledBase = { ...gcalBaseEvent, status: "cancelled" };
+      const processor = new GcalSyncProcessor(repo);
+      const changes = await processor.processEvents([cancelledBase]);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toEqual({
+        title: cancelledBase.summary,
+        category: Categories_Recurrence.RECURRENCE_BASE,
+        changeType: "CANCELLED",
+        operation: "CANCELLED",
+      });
+
+      // Verify all Compass events that match the gcal base were deleted
+      const remainingEvents = await mongoService.db
+        .collection(Collections.EVENT)
+        .find()
+        .toArray();
+
+      expect(remainingEvents).toHaveLength(0);
+    });
+
+    it("should delete an instance after cancelling it", async () => {
+      const gcalBaseEvent = mockGcalEvent({
+        recurrence: ["RRULE:FREQ=DAILY"],
+      });
+      const gcalInstance = mockGcalEvent({
+        recurringEventId: gcalBaseEvent.id,
+      });
+      // Create base and instances in Compass,
+      // that point to the original gcal base
+      const compassBase = {
+        title: gcalBaseEvent.summary as string,
+        user: setup.userId,
+        _id: "compass-base-id",
+        gEventId: gcalBaseEvent.id as string,
+      };
+      const compassInstanceTemplate = {
+        title: gcalInstance.summary as string,
+        user: setup.userId,
+        gEventId: gcalInstance.id as string,
+        recurrence: {
+          eventId: "compass-base-id",
+        },
+      };
+
+      const { meta } = await createRecurrenceSeries(
+        setup,
+        compassBase,
+        compassInstanceTemplate,
+      );
+
+      // Cancel just the instance
+      const cancelledGcalInstance = { ...gcalInstance, status: "cancelled" };
+      const processor = new GcalSyncProcessor(repo);
+      const changes = await processor.processEvents([cancelledGcalInstance]);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toEqual({
+        title: cancelledGcalInstance.summary,
+        category: Categories_Recurrence.RECURRENCE_INSTANCE,
+        changeType: "CANCELLED",
+        operation: "CANCELLED",
+      });
+
+      // Verify only the instance was deleted
+      const remainingEvents = await mongoService.db
+        .collection(Collections.EVENT)
+        .find()
+        .toArray();
+
+      expect(remainingEvents).toHaveLength(meta.createdCount - 1);
+      expect(remainingEvents[0]?._id).toBe("compass-base-id");
+      expect(isInstance(remainingEvents[1] as unknown as Schema_Event)).toBe(
+        true,
       );
     });
+  });
+
+  describe("UPSERT", () => {
+    //TODO add DB checks to this once ready
+    it("should create Compass events after receiving a recurring event", async () => {
+      const processor = new GcalSyncProcessor(repo);
+
+      const recurringEvent = mockGcalEvent({
+        recurrence: ["RRULE:FREQ=DAILY"],
+      });
+      const changes = await processor.processEvents([recurringEvent]);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toEqual({
+        title: recurringEvent.summary,
+        category: Categories_Recurrence.RECURRENCE_BASE,
+        changeType: "ACTIVE",
+        operation: "UPSERTED",
+      });
+    });
+    it.todo("should create an instance");
+    it.todo("should edit an instance");
+    it.todo("should create a series");
+    it.todo("should edit a series");
   });
 });

--- a/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
+++ b/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
@@ -1,19 +1,15 @@
-import { gCalendar, gSchema$Event } from "@core/types/gcal";
+import { gSchema$Event } from "@core/types/gcal";
+import { EventError } from "@backend/common/constants/error.constants";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { findCompassEventBy } from "@backend/event/queries/event.queries";
+import { RecurringEventRepository } from "@backend/event/queries/event.recur.queries";
 import { GcalParser } from "@backend/event/services/recur/util/recur.gcal.util";
 import { Change_Gcal, Operation_Sync } from "../../sync.types";
 
 export class GcalSyncProcessor {
-  constructor(
-    private gcal: gCalendar,
-    private userId: string,
-  ) {}
+  constructor(private repo: RecurringEventRepository) {}
 
   async processEvents(events: gSchema$Event[]): Promise<Change_Gcal[]> {
-    console.log(
-      "gcal",
-      this.gcal?.settings?.context?._options?.auth?.toString(),
-      this.userId,
-    );
     const summary: Change_Gcal[] = [];
     console.log(`Processing ${events.length} events...`);
     for (const event of events) {
@@ -22,23 +18,40 @@ export class GcalSyncProcessor {
       const status = parser.status;
       const change = parser.summarize();
       let operation: Operation_Sync = null;
-      // --- Cancellation Logic ---
+
+      if (!event.id) {
+        throw error(
+          EventError.MissingGevents,
+          "Event not processed due to missing id",
+        );
+      }
+
+      // --- Handle cancellation ---
       if (status === "CANCELLED") {
         if (category === "RECURRENCE_BASE") {
-          // Cancelled Master Event
-          // console.log(`Processing cancelled base: ${event.summary}`);
+          // find the base event by looking for the
+          // compass event with the matching gEventId
+          const result = await findCompassEventBy("gEventId", event.id);
+          if (!result.eventExists) {
+            throw error(
+              EventError.MissingGevents,
+              "Did not cancel series becauase base event not found",
+            );
+          }
+          console.log(
+            `Matched these ids: ${result.event._id}(Compass) and ${event.id} (Gcal)`,
+          );
+          await this.repo.cancelSeries(result.event._id as string);
           operation = "CANCELLED";
-          // TODO: delete base + linked instances
         } else {
-          // console.log(`Processing cancelled instance: ${event.summary}`);
+          await this.repo.cancelInstance(event.id, { idKey: "gEventId" });
           operation = "CANCELLED";
         }
       }
 
-      // --- Upsert Logic for Active Events ---
+      // --- Handle upsert for active event ---
       else {
         /*
-        START HERE ON TUESDAY
         - init a mapper
         - map to compass schema (base or instance)
         - upsert (see ref file)

--- a/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
+++ b/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
@@ -1,9 +1,11 @@
+import { Schema_Event } from "@core/types/event.types";
 import { gSchema$Event } from "@core/types/gcal";
 import { EventError } from "@backend/common/constants/error.constants";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { findCompassEventBy } from "@backend/event/queries/event.queries";
 import { RecurringEventRepository } from "@backend/event/queries/event.recur.queries";
 import { GcalParser } from "@backend/event/services/recur/util/recur.gcal.util";
+import { isBase } from "@backend/event/services/recur/util/recur.util";
 import { Change_Gcal, Operation_Sync } from "../../sync.types";
 
 export class GcalSyncProcessor {
@@ -28,24 +30,21 @@ export class GcalSyncProcessor {
 
       // --- Handle cancellation ---
       if (status === "CANCELLED") {
-        if (category === "RECURRENCE_BASE") {
-          // find the base event by looking for the
-          // compass event with the matching gEventId
-          const result = await findCompassEventBy("gEventId", event.id);
-          if (!result.eventExists) {
-            throw error(
-              EventError.MissingGevents,
-              "Did not cancel series becauase base event not found",
-            );
-          }
+        const { isBaseCancellation, compassEvent } =
+          await this.isBaseCancellation(event);
+
+        if (isBaseCancellation) {
           console.log(
-            `Matched these ids: ${result.event._id}(Compass) and ${event.id} (Gcal)`,
+            `Cancelling series: ${compassEvent._id}(Compass) and ${event.id} (Gcal)`,
           );
-          await this.repo.cancelSeries(result.event._id.toString());
-          operation = "CANCELLED";
+          await this.repo.cancelSeries(compassEvent._id.toString());
+          operation = "DELETED";
         } else {
+          console.log(
+            `Cancelling instance: ${compassEvent._id}(Compass) and ${event.id} (Gcal)`,
+          );
           await this.repo.cancelInstance(event.id, { idKey: "gEventId" });
-          operation = "CANCELLED";
+          operation = "DELETED";
         }
       }
 
@@ -66,5 +65,29 @@ export class GcalSyncProcessor {
       summary.push({ ...change, operation });
     }
     return summary;
+  }
+  private async isBaseCancellation(event: gSchema$Event) {
+    if (!event.id) {
+      throw error(
+        EventError.MissingGevents,
+        "Event not processed due to missing id",
+      );
+    }
+    // find the base event by looking for the
+    // compass event with the matching gEventId
+    const { eventExists, event: compassEvent } = await findCompassEventBy(
+      "gEventId",
+      event.id,
+    );
+    if (!eventExists) {
+      throw error(
+        EventError.MissingGevents,
+        "Did not cancel series becauase base event not found",
+      );
+    }
+    return {
+      isBaseCancellation: isBase(compassEvent as Schema_Event),
+      compassEvent,
+    };
   }
 }

--- a/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
+++ b/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
@@ -41,7 +41,7 @@ export class GcalSyncProcessor {
           console.log(
             `Matched these ids: ${result.event._id}(Compass) and ${event.id} (Gcal)`,
           );
-          await this.repo.cancelSeries(result.event._id as string);
+          await this.repo.cancelSeries(result.event._id.toString());
           operation = "CANCELLED";
         } else {
           await this.repo.cancelInstance(event.id, { idKey: "gEventId" });

--- a/packages/backend/src/sync/sync.types.ts
+++ b/packages/backend/src/sync/sync.types.ts
@@ -5,7 +5,7 @@ export type Summary_Sync = {
   changes: Change_Gcal[];
 };
 
-export type Operation_Sync = "CANCELLED" | "UPSERTED" | null;
+export type Operation_Sync = "DELETED" | "UPSERTED" | null;
 export type Change_Gcal = {
   title: string;
   category: Categories_Recurrence;


### PR DESCRIPTION
Closes #346 

Fixes duplicate event bug by differentiating between base and instance recurrences

Refactors import code
1. Moves paginated fetching into separate file
2. names `CANCELLED` to `DELETED` in `Operation_Sync` type for accuracy

Organizes code
1. Extracts queries related to recurring events to separate file

Updates Tests
1. improves mock gcal list mocking by supporting pagination