### PR TITLE
✨ Feat: Add support for syncing recurring event CREATE (readonly)

### DIFF
--- a/packages/backend/src/__tests__/helpers/mock.events.init.ts
+++ b/packages/backend/src/__tests__/helpers/mock.events.init.ts
@@ -7,8 +7,8 @@ import {
   gSchema$EventBase,
   gSchema$EventInstance,
 } from "@core/types/gcal";
+import { isBase } from "@core/util/event.util";
 import { Collections } from "@backend/common/constants/collections";
-import { isBase } from "@backend/event/services/recur/util/recur.util";
 import { mockGcalEvents } from "../mocks.gcal/mocks.gcal/factories/gcal.event.factory";
 
 export interface State_AfterGcalImport {

--- a/packages/backend/src/__tests__/helpers/mock.events.init.ts
+++ b/packages/backend/src/__tests__/helpers/mock.events.init.ts
@@ -3,9 +3,9 @@ import { Origin } from "@core/constants/core.constants";
 import { MapEvent } from "@core/mappers/map.event";
 import { Schema_Event, WithCompassId } from "@core/types/event.types";
 import {
-  gSchema$BaseEvent,
   gSchema$Event,
-  gSchema$InstanceEvent,
+  gSchema$EventBase,
+  gSchema$EventInstance,
 } from "@core/types/gcal";
 import { Collections } from "@backend/common/constants/collections";
 import { isBase } from "@backend/event/services/recur/util/recur.util";
@@ -13,11 +13,11 @@ import { mockGcalEvents } from "../mocks.gcal/mocks.gcal/factories/gcal.event.fa
 
 export interface State_AfterGcalImport {
   gcalEvents: {
-    all: (gSchema$Event | gSchema$BaseEvent | gSchema$InstanceEvent)[];
+    all: (gSchema$Event | gSchema$EventBase | gSchema$EventInstance)[];
     regular: gSchema$Event;
     cancelled: gSchema$Event;
-    recurring: gSchema$BaseEvent;
-    instances: gSchema$InstanceEvent[];
+    recurring: gSchema$EventBase;
+    instances: gSchema$EventInstance[];
   };
   compassEvents: WithCompassId<Schema_Event>[];
 }

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.set.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.set.ts
@@ -1,0 +1,51 @@
+import { gSchema$EventBase } from "@core/types/gcal";
+import {
+  mockRecurringBaseEvent,
+  mockRecurringInstances,
+  mockRegularGcalEvent,
+} from "./gcal.event.factory";
+
+/* Sets of events, pre-organized as a convenience for testing */
+
+export const mockGcalEvents = () => {
+  // Create a base recurring event
+  const baseRecurringEvent = mockRecurringBaseEvent({
+    id: "recurring-1",
+    summary: "Recurrence",
+    recurrence: ["RRULE:FREQ=WEEKLY"],
+  }) as gSchema$EventBase;
+
+  // Create instances of the recurring event
+  const instances = mockRecurringInstances(baseRecurringEvent, 2, 7);
+
+  // Create a regular event
+  const regularEvent = mockRegularGcalEvent({
+    id: "regular-1",
+    summary: "Regular Event",
+  });
+
+  // Create a cancelled event
+  const cancelledEvent = mockRegularGcalEvent({
+    id: "cancelled-1",
+    status: "cancelled",
+    summary: "Cancelled Event",
+  });
+
+  const all = [baseRecurringEvent, ...instances, regularEvent, cancelledEvent];
+
+  return {
+    gcalEvents: {
+      baseRecurringEvent,
+      instances,
+      regularEvent,
+      cancelledEvent,
+      all,
+    },
+    meta: {
+      total: all.length,
+      instances: instances.length,
+      base: 1,
+      cancelled: 1,
+    },
+  };
+};

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.test.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.test.ts
@@ -1,0 +1,39 @@
+import {
+  mockRecurringBaseEvent,
+  mockRecurringInstances,
+} from "./gcal.event.factory";
+
+describe("mockRecurringInstances", () => {
+  it("should not include 'recurrence'", () => {
+    const base = mockRecurringBaseEvent();
+    const instances = mockRecurringInstances(base, 2, 7);
+    instances.forEach((instance) => {
+      expect(instance).not.toHaveProperty("recurrence");
+    });
+  });
+  it("should create the correct number of instances", () => {
+    const base = mockRecurringBaseEvent();
+    const instances = mockRecurringInstances(base, 2, 7);
+    expect(instances).toHaveLength(2);
+  });
+  it("should include 'recurringEventId' that points to the base event", () => {
+    const base = mockRecurringBaseEvent();
+    const instances = mockRecurringInstances(base, 2, 7);
+    instances.forEach((instance) => {
+      expect(instance.recurringEventId).toBe(base.id);
+    });
+  });
+  it("should make instances times in the future from the base time", () => {
+    const base = mockRecurringBaseEvent();
+    const instances = mockRecurringInstances(base, 2, 7);
+    const baseStart = new Date(base.start?.dateTime as string);
+    instances.forEach((instance) => {
+      const instanceStart = new Date(instance.start?.dateTime as string);
+      expect(instanceStart.getTime()).toBeGreaterThan(baseStart.getTime());
+
+      const instanceEnd = new Date(instance.end?.dateTime as string);
+      const baseEnd = new Date(base.end?.dateTime as string);
+      expect(instanceEnd.getTime()).toBeGreaterThan(baseEnd.getTime());
+    });
+  });
+});

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.test.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.test.ts
@@ -1,3 +1,4 @@
+import { gSchema$EventInstance } from "@core/types/gcal";
 import {
   mockRecurringBaseEvent,
   mockRecurringInstances,
@@ -23,11 +24,20 @@ describe("mockRecurringInstances", () => {
       expect(instance.recurringEventId).toBe(base.id);
     });
   });
-  it("should make instances times in the future from the base time", () => {
+  it("should make the first instance start and end at the same time as the base event", () => {
+    const base = mockRecurringBaseEvent();
+    const instances = mockRecurringInstances(base, 2, 7);
+    const firstInstance = instances[0] as gSchema$EventInstance;
+
+    expect(firstInstance.start?.dateTime).toBe(base.start?.dateTime);
+    expect(firstInstance.end?.dateTime).toBe(base.end?.dateTime);
+  });
+  it("should make instances start and end in the future from the base time (except for the first one)", () => {
     const base = mockRecurringBaseEvent();
     const instances = mockRecurringInstances(base, 2, 7);
     const baseStart = new Date(base.start?.dateTime as string);
-    instances.forEach((instance) => {
+    instances.forEach((instance, index) => {
+      if (index === 0) return; // first instance is the same as the base
       const instanceStart = new Date(instance.start?.dateTime as string);
       expect(instanceStart.getTime()).toBeGreaterThan(baseStart.getTime());
 

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.ts
@@ -15,6 +15,21 @@ export const mockRegularEvent = (): WithGcalId<gSchema$Event> => ({
   status: "confirmed",
 });
 
+/**
+ * Returns a base event and its instances
+ * @param count - The number of instances to create
+ * @param repeatIntervalInDays - The interval between instances
+ * @returns An array containing the base event and its instances
+ */
+export const mockRecurringEvents = (
+  count: number,
+  repeatIntervalInDays: number,
+): (gSchema$EventBase | gSchema$EventInstance)[] => {
+  const base = mockRecurringBaseEvent();
+  const instances = mockRecurringInstances(base, count, repeatIntervalInDays);
+  return [base, ...instances];
+};
+
 export const mockRecurringBaseEvent = (
   overrides: Partial<gSchema$EventBase> = {},
 ): gSchema$EventBase => ({

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.ts
@@ -41,17 +41,22 @@ export const mockRecurringInstances = (
 
   return Array.from({ length: count }, (_, index) => {
     const instanceDate = new Date(baseDate);
-    // Prevent the first instance from being the same as the base date
-    instanceDate.setDate(
-      instanceDate.getDate() + (index + 1) * repeatIntervalInDays,
-    );
+    // For index 0, keep the same date as base
+    // For subsequent instances, add the interval
+    if (index > 0) {
+      instanceDate.setDate(
+        instanceDate.getDate() + index * repeatIntervalInDays,
+      );
+    }
 
     const endDate = new Date(endDateTime);
-    endDate.setDate(endDate.getDate() + (index + 1) * repeatIntervalInDays);
+    if (index > 0) {
+      endDate.setDate(endDate.getDate() + index * repeatIntervalInDays);
+    }
 
     const instance = {
       ...base,
-      id: `${base.id}-${index}`,
+      id: `${base.id}-instance-${index + 1}`,
       summary: `${base.summary}-instance-${index + 1}`,
       recurringEventId: base.id,
       start: {

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.ts
@@ -1,9 +1,14 @@
 import { faker } from "@faker-js/faker";
 import { Origin, Priorities } from "@core/constants/core.constants";
-import { gSchema$Event } from "@core/types/gcal";
+import {
+  WithGcalId,
+  gSchema$Event,
+  gSchema$EventBase,
+  gSchema$EventInstance,
+} from "@core/types/gcal";
 
-export const mockRegularEvent = (): gSchema$Event => ({
-  id: faker.string.uuid(),
+export const mockRegularEvent = (): WithGcalId<gSchema$Event> => ({
+  id: faker.string.nanoid(),
   summary: faker.lorem.sentence(),
   start: { dateTime: faker.date.future().toISOString() },
   end: { dateTime: faker.date.future().toISOString() },
@@ -11,18 +16,18 @@ export const mockRegularEvent = (): gSchema$Event => ({
 });
 
 export const mockRecurringEvent = (
-  overrides: Partial<gSchema$Event> = {},
-): gSchema$Event => ({
+  overrides: Partial<gSchema$EventBase> = {},
+): gSchema$EventBase => ({
   ...mockRegularEvent(),
   recurrence: ["RRULE:FREQ=WEEKLY"],
   ...overrides,
 });
 
 const mockRecurringInstances = (
-  event: gSchema$Event,
+  event: gSchema$EventBase,
   count: number,
   repeatIntervalInDays: number,
-): gSchema$Event[] => {
+): gSchema$EventInstance[] => {
   if (!event.start?.dateTime || !event.end?.dateTime) {
     throw new Error("Event must have start and end dates");
   }
@@ -57,7 +62,7 @@ const mockRecurringInstances = (
   });
 };
 
-export const mockGcalEvent = (
+export const mockRegularGcalEvent = (
   overrides: Partial<gSchema$Event> = {},
 ): gSchema$Event => {
   const id = faker.string.uuid();
@@ -93,9 +98,9 @@ export const mockGcalEvent = (
 };
 
 export const mockGcalEvents = (repeatIntervalInDays = 7) => {
-  const regularEvent = mockGcalEvent();
-  const cancelledEvent = mockGcalEvent({ status: "cancelled" });
-  const recurringEvent = mockGcalEvent({
+  const regularEvent = mockRegularGcalEvent();
+  const cancelledEvent = mockRegularGcalEvent({ status: "cancelled" });
+  const recurringEvent = mockRecurringEvent({
     recurrence: ["RRULE:FREQ=DAILY;INTERVAL=7"],
   });
 

--- a/packages/backend/src/__tests__/mocks.gcal/mocks.gcal/factories/gcal.event.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/mocks.gcal/factories/gcal.event.factory.ts
@@ -44,11 +44,15 @@ export const mockRegularEvent = (): gSchema$Event => ({
 
 export const mockRecurringEvent = (
   overrides: Partial<gSchema$Event> = {},
-): gSchema$EventBase => ({
-  ...mockRegularEvent(),
-  recurrence: ["RRULE:FREQ=WEEKLY"],
-  ...overrides,
-});
+): gSchema$EventBase => {
+  const regular = mockRegularEvent();
+  const base = {
+    ...regular,
+    recurrence: ["RRULE:FREQ=WEEKLY"],
+    ...overrides,
+  };
+  return base as gSchema$EventBase;
+};
 
 const mockRecurringInstances = (
   event: gSchema$Event,

--- a/packages/backend/src/__tests__/mocks.gcal/mocks.gcal/factories/gcal.event.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/mocks.gcal/factories/gcal.event.factory.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { Origin, Priorities } from "@core/constants/core.constants";
 import {
-  gSchema$BaseEvent,
   gSchema$Event,
-  gSchema$InstanceEvent,
+  gSchema$EventBase,
+  gSchema$EventInstance,
 } from "@core/types/gcal";
 import { convertToRfc5545 } from "@core/util/date.utils";
 
@@ -14,9 +14,9 @@ import { convertToRfc5545 } from "@core/util/date.utils";
  * @returns A cancelled instance of the base event
  */
 export const mockCancelledInstance = (
-  baseEvent: gSchema$BaseEvent,
+  baseEvent: gSchema$EventBase,
   instanceStart: string,
-): gSchema$InstanceEvent => {
+): gSchema$EventInstance => {
   const instanceStartRfc5545 = convertToRfc5545(instanceStart);
   if (!instanceStartRfc5545) {
     throw new Error("Invalid instance start date");
@@ -44,9 +44,8 @@ export const mockRegularEvent = (): gSchema$Event => ({
 
 export const mockRecurringEvent = (
   overrides: Partial<gSchema$Event> = {},
-): gSchema$BaseEvent => ({
+): gSchema$EventBase => ({
   ...mockRegularEvent(),
-  // @ts-expect-error overriding the null type
   recurrence: ["RRULE:FREQ=WEEKLY"],
   ...overrides,
 });
@@ -55,7 +54,7 @@ const mockRecurringInstances = (
   event: gSchema$Event,
   count: number,
   repeatIntervalInDays: number,
-): gSchema$InstanceEvent[] => {
+): gSchema$EventInstance[] => {
   if (!event.start?.dateTime || !event.end?.dateTime) {
     throw new Error("Event must have start and end dates");
   }
@@ -80,7 +79,7 @@ const mockRecurringInstances = (
       ...event,
       id: `${event.id}_${instanceStart}`, // matches gcal id format
       summary: `${event.summary}: Instance ${index}`,
-      recurringEventId: event.id,
+      recurringEventId: event.id as string,
       start: {
         dateTime: instanceDate.toISOString(),
         timeZone: startTimeZone,

--- a/packages/backend/src/common/services/gcal/gcal.utils.ts
+++ b/packages/backend/src/common/services/gcal/gcal.utils.ts
@@ -21,6 +21,18 @@ export const cancelledEventsIds = (events: gSchema$Event[]) => {
   return cancelledIds;
 };
 
+export const categorizeGcalEvents = (events: gSchema$Event[]) => {
+  const baseEvent = events.find(
+    (event) => event.recurrence && !event.recurringEventId,
+  );
+  const instances = events.filter((event) => event.recurringEventId);
+
+  const cancelledEvents = events.filter(
+    (event) => event.status === "cancelled",
+  );
+  return { baseEvent, instances, cancelledEvents };
+};
+
 export const getEmailFromUrl = (url: string) => {
   const emailMatch = url.match(/\/calendars\/([^/]+)\/events/);
 

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -1,4 +1,4 @@
-import { OptionalId } from "mongodb";
+import { Document, Filter, OptionalId } from "mongodb";
 import {
   Origin,
   Priorities,
@@ -252,7 +252,7 @@ class EventService {
     userId: string,
     query: Query_Event,
   ): Promise<Schema_Event_Core[] | BaseError> => {
-    const filter = getReadAllFilter(userId, query);
+    const filter = getReadAllFilter(userId, query) as Filter<Document>;
 
     if (query.someday) {
       const response = (await mongoService.db

--- a/packages/backend/src/event/services/recur/parse/recur.gcal.parse.ts
+++ b/packages/backend/src/event/services/recur/parse/recur.gcal.parse.ts
@@ -1,6 +1,7 @@
 import { gSchema$Event } from "@core/types/gcal";
 import { GenericError } from "@backend/common/constants/error.constants";
 import { error } from "@backend/common/errors/handlers/error.handler";
+import { categorizeGcalEvents } from "@backend/common/services/gcal/gcal.utils";
 
 type SeriesAction =
   | "CREATE_SERIES" // New recurring event
@@ -50,15 +51,7 @@ class GCalParser {
         "Next action not determine because no events provided",
       );
     }
-    const baseEvent = events.find(
-      (event) => event.recurrence && !event.recurringEventId,
-    );
-    const instances = events.filter((event) => event.recurringEventId);
-
-    const cancelledEvents = events.filter(
-      (event) => event.status === "cancelled",
-    );
-    return { baseEvent, instances, cancelledEvents };
+    return categorizeGcalEvents(events);
   };
 
   public determineNextAction = (): ActionAnalysis => {

--- a/packages/backend/src/event/services/recur/queries/event.recur.queries.ts
+++ b/packages/backend/src/event/services/recur/queries/event.recur.queries.ts
@@ -1,63 +1,11 @@
-import { error } from "console";
 import { ObjectId } from "mongodb";
-import { Schema_Event } from "@core/types/event.types";
 import { Collections } from "@backend/common/constants/collections";
-import { GenericError } from "@backend/common/constants/error.constants";
 import mongoService from "@backend/common/services/mongo.service";
 
 /**
  * DB operations for Compass's Event collection, focused
  * on recurring event operations
  */
-
-export const insertBaseEvent = async (event: Schema_Event) => {
-  const eventWithId = {
-    ...event,
-    _id: event._id ? new ObjectId(event._id) : new ObjectId(),
-  };
-  return mongoService.db.collection(Collections.EVENT).insertOne(eventWithId);
-};
-
-export const insertEventInstances = async (instances: Schema_Event[]) => {
-  const instancesWithIds = instances.map((instance) => ({
-    ...instance,
-    _id: instance._id ? new ObjectId(instance._id) : new ObjectId(),
-  }));
-  return mongoService.db
-    .collection(Collections.EVENT)
-    .insertMany(instancesWithIds);
-};
-
-export const updateBaseEventRecurrence = async (
-  gEventId: string,
-  recurrence: { rule: string[]; eventId: string },
-) => {
-  return mongoService.db
-    .collection(Collections.EVENT)
-    .updateOne({ gEventId }, { $set: { recurrence } });
-};
-
-export const deleteFutureInstances = async (
-  baseEventId: string,
-  fromDate: string,
-) => {
-  return mongoService.db.collection(Collections.EVENT).deleteMany({
-    "recurrence.eventId": baseEventId,
-    startDate: { $gte: fromDate },
-  });
-};
-
-export const deleteAllInstances = async (baseEventId: string) => {
-  return mongoService.db.collection(Collections.EVENT).deleteMany({
-    "recurrence.eventId": baseEventId,
-  });
-};
-
-export const deleteInstance = async (gEventId: string) => {
-  return mongoService.db.collection(Collections.EVENT).deleteOne({
-    gEventId,
-  });
-};
 
 export const deleteInstances = async (userId: string, baseId: string) => {
   if (typeof baseId !== "string") {
@@ -70,34 +18,6 @@ export const deleteInstances = async (userId: string, baseId: string) => {
       _id: { $ne: new ObjectId(baseId) },
       "recurrence.eventId": { $eq: baseId },
     });
-
-  return response;
-};
-
-export const updateFutureInstances = async (
-  userId: string,
-  event: Schema_Event,
-) => {
-  const baseId = event.recurrence?.eventId;
-  if (!baseId) {
-    throw error(
-      GenericError.BadRequest,
-      "Failed to update future instances (No base event id)",
-    );
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { _id, startDate, endDate, user, ...eventWithEligibleFields } = event;
-
-  const futureInstances = {
-    user: userId,
-    "recurrence.eventId": baseId,
-    startDate: { $gt: event.startDate },
-  };
-
-  const response = await mongoService.db
-    .collection(Collections.EVENT)
-    .updateMany(futureInstances, { $set: eventWithEligibleFields });
 
   return response;
 };

--- a/packages/backend/src/event/services/recur/util/recur.util.ts
+++ b/packages/backend/src/event/services/recur/util/recur.util.ts
@@ -35,26 +35,6 @@ export const assembleInstances = (
 
   return events;
 };
-/**
- * Base events have an `eventId` and an empty `rule`
- * @param event
- * @returns
- */
-export const isBase = (event: Schema_Event) => {
-  return (
-    event.recurrence?.rule !== undefined &&
-    event.recurrence.eventId === undefined
-  );
-};
-
-/**
- * Instances have an `eventId` and an empty `rule`
- * @param event
- * @returns
- */
-export const isInstance = (event: Schema_Event) => {
-  return event.recurrence?.eventId && event.recurrence?.rule === undefined;
-};
 
 const _generateInstances = (
   rule: string,

--- a/packages/backend/src/sync/services/import/all/import.all.util.ts
+++ b/packages/backend/src/sync/services/import/all/import.all.util.ts
@@ -52,30 +52,6 @@ export const shouldProcessDuringPass2: Callback_EventProcessor = (
     return false; // Don't save
   }
 
-  // Filter 2: Skip first instance if start matches base event start
-  if (gEvent.recurringEventId && gEvent.id) {
-    const baseStartTime = state.baseEventStartTimes.get(
-      gEvent.recurringEventId,
-    );
-    if (baseStartTime !== undefined) {
-      const instanceStartTime = getStartTimeString(gEvent);
-      const isFirstInstance =
-        baseStartTime &&
-        instanceStartTime &&
-        baseStartTime === instanceStartTime;
-      if (isFirstInstance) {
-        logger.verbose(
-          `Pass 2: Skipping event ${gEvent.summary} (first instance match).`,
-        ); // Reduce noise
-        return false; // Don't save
-      }
-    } else {
-      logger.warn(
-        `Pass 2: Instance ${gEvent.id} found, base ${gEvent.recurringEventId} unknown. Saving.`,
-      );
-    }
-  }
-  // Event passed filters
   return true; // Save this event
 };
 

--- a/packages/backend/src/sync/services/import/sync.import.full.test.ts
+++ b/packages/backend/src/sync/services/import/sync.import.full.test.ts
@@ -4,35 +4,19 @@ import {
   cleanupTestMongo,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
-import {
-  mockGcalEventsv2,
-  mockRecurringEvent,
-} from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
+import { mockGcalEvents } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory.set";
 import { mockGcal } from "@backend/__tests__/mocks.gcal/factories/gcal.factory";
 import mongoService from "@backend/common/services/mongo.service";
 import { createSyncImport } from "./sync.import";
 
-// Mock Google Calendar API responses
+// Mock Google Calendar API responses,
 jest.mock("googleapis", () => {
-  const { allEvents: gcalEvents } = mockGcalEventsv2();
-  const googleapis = mockGcal({ events: gcalEvents });
+  const { gcalEvents } = mockGcalEvents();
+  const googleapis = mockGcal({ events: gcalEvents.all });
   return googleapis;
 });
 
-// Mock Gcal Instances API response
-// jest.mock("@backend/common/services/gcal/gcal.service", () => ({
-//   __esModule: true,
-//   default: {
-//     getEvents: jest.fn().mockResolvedValue({
-//       data: { items: mockGcalEventsv2().allEvents },
-//     }),
-//     getEventInstances: jest.fn().mockResolvedValue({
-//       data: { items: mockGcalEventsv2().instances },
-//     }),
-//   },
-// }));
-
-describe("SyncImport", () => {
+describe("SyncImport: Full", () => {
   let syncImport: Awaited<ReturnType<typeof createSyncImport>>;
   let setup: Awaited<ReturnType<typeof setupTestDb>>;
 
@@ -132,18 +116,6 @@ describe("SyncImport", () => {
       });
 
       expect(duplicateEvents).toHaveLength(0);
-    });
-  });
-
-  describe("Series Import", () => {
-    it("should import a series when provided a gcal base event", async () => {
-      const baseRecurringGcalEvent = mockRecurringEvent();
-      const result = await syncImport.importSeries(
-        setup.userId,
-        "test-calendar",
-        baseRecurringGcalEvent,
-      );
-      expect(result).toHaveLength(100);
     });
   });
 });

--- a/packages/backend/src/sync/services/import/sync.import.full.test.ts
+++ b/packages/backend/src/sync/services/import/sync.import.full.test.ts
@@ -34,8 +34,9 @@ describe("SyncImport: Full", () => {
   });
 
   describe("Full import", () => {
-    it("should not import the first instance of a recurring event (just the base)", async () => {
-      // including the first instance would result in 2 events with the same start date
+    it("should import the first instance of a recurring event (and the base)", async () => {
+      // Importing both the bae and first instance helps us find the series recurrence rule.
+      // To prevent duplicates in the UI, the GET API will not return the base event
       await syncImport.importAllEvents(setup.userId, "test-calendar");
 
       const currentEventsInDb = await mongoService.event.find().toArray();
@@ -46,17 +47,19 @@ describe("SyncImport: Full", () => {
 
       const baseStart = recurringEvents[0]?.startDate;
       const firstInstanceStart = recurringEvents[1]?.startDate;
-      expect(baseStart).not.toEqual(firstInstanceStart);
+      expect(baseStart).toEqual(firstInstanceStart);
     });
 
     it("should connect instances to their base events", async () => {
       await syncImport.importAllEvents(setup.userId, "test-calendar");
       const { baseEvents, instanceEvents } = await getCategorizedEventsInDb();
 
-      expect(instanceEvents).toHaveLength(1); // 2 instances total, but 1 is skipped because it has the same start date as the base event
-      expect(instanceEvents[0]?.recurrence?.eventId).toBe(
-        baseEvents[0]?._id?.toString(),
-      );
+      expect(instanceEvents).toHaveLength(2);
+      instanceEvents.forEach((instance) => {
+        expect(instance.recurrence?.eventId).toBe(
+          baseEvents[0]?._id?.toString(),
+        );
+      });
     });
     it("should include regular and recurring events and skip cancelled events", async () => {
       const { totalProcessed, totalChanged, nextSyncToken } =
@@ -65,8 +68,8 @@ describe("SyncImport: Full", () => {
       const currentEventsInDb = await mongoService.event.find().toArray();
 
       expect(totalProcessed).toBe(5); // base + 2 instances + regular + cancelled
-      expect(totalChanged).toBe(3); // base + 1 instances + regular - cancelled
-      expect(currentEventsInDb).toHaveLength(3); // base + 1 instance + regular - cancelled
+      expect(totalChanged).toBe(4); // base + 2 instances + regular - cancelled
+      expect(currentEventsInDb).toHaveLength(4); // base + 2 instances + regular - cancelled
       // Verify we have the base recurring event
       const baseEvents = currentEventsInDb.filter(
         (e) => e.recurrence?.rule !== undefined,
@@ -78,7 +81,7 @@ describe("SyncImport: Full", () => {
       const instanceEvents = currentEventsInDb.filter(
         (e) => e.recurrence?.eventId !== undefined,
       );
-      expect(instanceEvents).toHaveLength(1); // 2 instances total, but 1 is skipped because it has the same start date as the base event
+      expect(instanceEvents).toHaveLength(2);
       expect(instanceEvents.map((e) => e.gEventId)).toEqual(
         expect.arrayContaining(["recurring-1-instance-2"]),
       );

--- a/packages/backend/src/sync/services/import/sync.import.series.test.ts
+++ b/packages/backend/src/sync/services/import/sync.import.series.test.ts
@@ -1,0 +1,70 @@
+import {
+  filterBaseEvents,
+  filterExistingInstances,
+} from "@core/util/event.util";
+import {
+  cleanupCollections,
+  cleanupTestMongo,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { mockRecurringBaseEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
+import { mockGcalEvents } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory.set";
+import mongoService from "@backend/common/services/mongo.service";
+import { createSyncImport } from "./sync.import";
+
+// Mock Gcal Instances API response
+jest.mock("@backend/common/services/gcal/gcal.service", () => ({
+  __esModule: true,
+  default: {
+    getEventInstances: jest.fn().mockResolvedValue({
+      data: { items: mockGcalEvents().gcalEvents.instances },
+    }),
+  },
+}));
+
+describe("SyncImport: Series", () => {
+  let syncImport: Awaited<ReturnType<typeof createSyncImport>>;
+  let setup: Awaited<ReturnType<typeof setupTestDb>>;
+
+  beforeAll(async () => {
+    setup = await setupTestDb();
+    syncImport = await createSyncImport(setup.userId);
+  });
+
+  beforeEach(async () => {
+    await cleanupCollections(setup.db);
+  });
+
+  afterAll(async () => {
+    await cleanupTestMongo(setup);
+  });
+
+  it("should import a series when provided a gcal base event", async () => {
+    /* Assemble */
+    const baseRecurringGcalEvent = mockRecurringBaseEvent();
+
+    /* Act */
+    // trigger a series import with base event
+    const result = await syncImport.importSeries(
+      setup.userId,
+      "test-calendar",
+      baseRecurringGcalEvent,
+    );
+
+    /* Assert */
+    // make sure this is the same function being used in the mock at the top of this file
+    const expectedInstances = mockGcalEvents().gcalEvents.instances.length;
+    // validate return value
+    expect(result.insertedCount).toEqual(1 + expectedInstances);
+
+    // validate DB state
+    const currentEventsInDb = await mongoService.event.find().toArray();
+
+    const baseEvents = filterBaseEvents(currentEventsInDb);
+    expect(baseEvents).toHaveLength(1);
+
+    const instancesInDb = filterExistingInstances(currentEventsInDb);
+    expect(instancesInDb).toHaveLength(expectedInstances);
+    // expect(recurringEvents[0]?.gEventId).toBe(baseRecurringGcalEvent.id);
+  });
+});

--- a/packages/backend/src/sync/services/import/sync.import.types.ts
+++ b/packages/backend/src/sync/services/import/sync.import.types.ts
@@ -1,9 +1,9 @@
 import { ObjectId } from "mongodb";
-import { Schema_Event_Core } from "@core/types/event.types";
+import { Schema_Event } from "@core/types/event.types";
 import { gSchema$Event } from "@core/types/gcal";
 
 export interface EventsToModify {
-  toUpdate: Schema_Event_Core[];
+  toUpdate: Schema_Event[];
   toDelete: string[];
 }
 

--- a/packages/backend/src/sync/services/import/sync.import.util.ts
+++ b/packages/backend/src/sync/services/import/sync.import.util.ts
@@ -36,6 +36,13 @@ export const assembleEventOperations = (
   return bulkOperations;
 };
 
+/**
+ * Organizes gcal events by type and returns the events to delete and the events to update
+ * @param events - The events, organized by type. The 'toUpdate' object contains two arrays:
+ * - 'recurring': A *subset* of the events to update, which does not include all expanded instances
+ * - 'nonRecurring': The non-recurring events
+ * @returns The events to delete and the events to update
+ */
 export const organizeGcalEventsByType = (events: gSchema$Event[]) => {
   const toDelete = cancelledEventsIds(events);
 

--- a/packages/backend/src/sync/services/sync/gcal.sync.processor.test.util.ts
+++ b/packages/backend/src/sync/services/sync/gcal.sync.processor.test.util.ts
@@ -1,9 +1,6 @@
 import { Event_Core, Schema_Event } from "@core/types/event.types";
+import { isBase, isExistingInstance } from "@core/util/event.util";
 import { State_AfterGcalImport } from "@backend/__tests__/helpers/mock.events.init";
-import {
-  isBase,
-  isInstance,
-} from "@backend/event/services/recur/util/recur.util";
 
 /** Utility assertions for the gcal sync processor tests */
 export const baseHasRecurrenceRule = async (
@@ -23,7 +20,7 @@ export const noInstancesAfterSplitDate = async (
   const splitDate = new Date(splitDateStr);
   const futureInstances = events.filter(
     (e) =>
-      isInstance(e as unknown as Schema_Event) &&
+      isExistingInstance(e as unknown as Schema_Event) &&
       new Date(e.startDate) > splitDate,
   );
   expect(futureInstances).toHaveLength(0);

--- a/packages/core/src/mappers/map.event.test.ts
+++ b/packages/core/src/mappers/map.event.test.ts
@@ -2,7 +2,6 @@ import { recurring } from "@core/__mocks__/events/gcal/gcal.recurring";
 import { timed } from "@core/__mocks__/events/gcal/gcal.timed";
 import { Schema_Event } from "@core/types/event.types";
 import { gSchema$Event } from "@core/types/gcal";
-import { mockGcalEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { gcalEvents } from "../__mocks__/events/gcal/gcal.event";
 import { Origin, Priorities } from "../constants/core.constants";
 import { MapEvent } from "./map.event";

--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -111,6 +111,14 @@ const Recurrence = z.object({
   eventId: z.string().optional(),
 });
 
+export type Recurrence = Schema_Event_Recur_Base | Schema_Event_Recur_Instance;
+export type RecurrenceWithId =
+  | WithCompassId<Schema_Event_Recur_Instance>
+  | WithCompassId<Schema_Event_Recur_Base>;
+export type RecurrenceWithoutId =
+  | WithoutCompassId<Schema_Event_Recur_Instance>
+  | WithoutCompassId<Schema_Event_Recur_Base>;
+
 export const CoreEventSchema = z.object({
   _id: z.string().optional(),
   description: z.string().nullable().optional(),
@@ -134,3 +142,4 @@ export const CoreEventSchema = z.object({
 export type Event_Core = z.infer<typeof CoreEventSchema>;
 
 export type WithCompassId<T> = T & { _id: string };
+export type WithoutCompassId<T> = Omit<T, "_id">;

--- a/packages/core/src/types/gcal.d.ts
+++ b/packages/core/src/types/gcal.d.ts
@@ -19,10 +19,12 @@ export declare type gSchema$CalendarListEntry =
   calendar_v3.Schema$CalendarListEntry;
 export declare type gSchema$Channel = calendar.calendar_v3.Schema$Channel;
 export declare type gSchema$Event = calendar.calendar_v3.Schema$Event;
-export declare type gSchema$BaseEvent = WithGcalId<
+export declare type gSchema$EventBase = WithGcalId<
   WithRecurrenceRule<gSchema$Event>
 >;
-export declare type gSchema$InstanceEvent = WithGcalId<gSchema$Event>;
+export declare type gSchema$EventInstance = WithGcalId<
+  WithRecurrencePointer<gSchema$Event>
+>;
 
 export declare type gSchema$Events = calendar.calendar_v3.Schema$Events;
 export declare type gSchema$Events$Union = gSchema$Events | gSchema$Events[];

--- a/packages/core/src/util/event.util.ts
+++ b/packages/core/src/util/event.util.ts
@@ -1,4 +1,4 @@
-import { Schema_Event } from "@core/types/event.types";
+import { Schema_Event, Schema_Event_Recur_Base } from "@core/types/event.types";
 import { gSchema$Event } from "@core/types/gcal";
 
 export const isAllDay = (event: Schema_Event) =>
@@ -10,3 +10,21 @@ export const isAllDay = (event: Schema_Event) =>
 export const notCancelled = (e: gSchema$Event) => {
   return e.status && e.status !== "cancelled";
 };
+
+/**
+ * Filters the base events
+ * @param e - The events array
+ * @returns The base events
+ */
+export const filterBaseEvents = (e: Schema_Event[]) => {
+  const baseEvents = e.filter((e) => e.recurrence?.rule !== undefined);
+  return baseEvents as Schema_Event_Recur_Base[];
+};
+
+/**
+ * Filters the recurring events (base or instance)
+ * @param e - The events array
+ * @returns The recurring events (base or instance)
+ */
+export const filterRecurringEvents = (e: Schema_Event[]) =>
+  e.filter((e) => e.recurrence !== undefined);

--- a/packages/core/src/util/event.util.ts
+++ b/packages/core/src/util/event.util.ts
@@ -1,11 +1,45 @@
-import { Schema_Event, Schema_Event_Recur_Base } from "@core/types/event.types";
+import {
+  Recurrence,
+  Schema_Event,
+  Schema_Event_Recur_Base,
+  Schema_Event_Recur_Instance,
+} from "@core/types/event.types";
 import { gSchema$Event } from "@core/types/gcal";
+
+export const categorizeRecurringEvents = (events: Recurrence[]) => {
+  const baseEvent = events.find(isBase) as Schema_Event_Recur_Base;
+  const instances = events.filter(
+    (e) => e !== baseEvent,
+  ) as Schema_Event_Recur_Instance[];
+  return { baseEvent, instances };
+};
 
 export const isAllDay = (event: Schema_Event) =>
   event !== undefined &&
   // 'YYYY-MM-DD' has 10 chars
   event.startDate?.length === 10 &&
   event.endDate?.length === 10;
+
+/**
+ * Base events have an `eventId` and an empty `rule`
+ * @param event
+ * @returns
+ */
+export const isBase = (event: Schema_Event) => {
+  return (
+    event.recurrence?.rule !== undefined &&
+    event.recurrence.eventId === undefined
+  );
+};
+
+/**
+ * Instances have an `eventId` and an empty `rule`
+ * @param event
+ * @returns
+ */
+export const isExistingInstance = (event: Schema_Event) => {
+  return event.recurrence?.eventId && event.recurrence?.rule === undefined;
+};
 
 export const notCancelled = (e: gSchema$Event) => {
   return e.status && e.status !== "cancelled";
@@ -26,5 +60,5 @@ export const filterBaseEvents = (e: Schema_Event[]) => {
  * @param e - The events array
  * @returns The recurring events (base or instance)
  */
-export const filterRecurringEvents = (e: Schema_Event[]) =>
-  e.filter((e) => e.recurrence !== undefined);
+export const filterExistingInstances = (e: Schema_Event[]) =>
+  e.filter(isExistingInstance);


### PR DESCRIPTION
Closes #358 

### Summary of changes

Create a new base and instances after receiving a notification from gcal with a new base event
- Updates import logic to allow the first instance to be imported
- Filters out the base event when returning data in the GET
- The above two changes allow us to have access to the `recurrence` rule, without needing to duplicate the base recurrence on the first instance in the UI

Convenience changes:
- Adds date util for filtering event categories


Status of the recurring event read-only feature:
✅ DELETE ALL
✅ DELETE ONE
✅ UPDATE ONE
✅ DELETE THIS AND FOLLOWING
✅ CREATE ALL (this PR)
❌ UPDATE ALL (future PR)
❌ UPDATE THIS AND FOLLOWING (future PR)