### PR TITLE
fix(web): Runtime error when dragging an all day event

### DIFF
--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -184,9 +184,13 @@ export const useDraftActions = (
         const x = getX(e, isSidebarOpen);
         const startEndDurationMin = dragStatus?.durationMin || 0;
 
+        const y = draft.isAllDay
+          ? e.clientY
+          : e.clientY - draft.position.dragOffset.y;
+
         let eventStart = dateCalcs.getDateByXY(
           x,
-          e.clientY - draft.position.dragOffset.y,
+          y,
           weekProps.component.startOfView,
         );
 


### PR DESCRIPTION
Closes https://github.com/SwitchbackTech/compass/issues/364

Stemmed from 0b47a5cf0dd302798a4c6bcbd24f8f0d2b84edb7 Where we forgot to check for all day events, since we don't handle any drag offset for all day events.