### PR TITLE
🐛 Fix: Draft event duration not preserved when mousing down

### DIFF
--- a/packages/web/src/views/Calendar/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Calendar/components/Draft/grid/GridDraft.tsx
@@ -2,7 +2,9 @@ import React, { FC, MouseEvent } from "react";
 import { FloatingFocusManager } from "@floating-ui/react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event } from "@core/types/event.types";
+import { PartialMouseEvent } from "@web/common/types/util.types";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
+import { getEventDragOffset } from "@web/common/utils/event.util";
 import { useGridEventMouseDown } from "@web/views/Calendar/hooks/grid/useGridEventMouseDown";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
@@ -35,7 +37,20 @@ export const GridDraft: FC<Props> = ({ measurements, weekProps }) => {
   };
 
   const handleClick = () => {};
-  const handleDrag = () => {
+  const handleDrag = (_: Schema_GridEvent, moveEvent: PartialMouseEvent) => {
+    if (!draft) return; // TS Guard
+
+    const newDraft = {
+      ...draft,
+      position: {
+        ...draft.position,
+        dragOffset: getEventDragOffset(draft, moveEvent),
+        initialX: moveEvent.clientX,
+        initialY: moveEvent.clientY,
+      },
+    };
+
+    setDraft(newDraft);
     startDragging();
   };
 

--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -79,12 +79,10 @@ export const useDraftActions = (
   } = setters;
 
   const startDragging = useCallback(() => {
-    setDraft(reduxDraft);
     setIsDragging(true);
   }, [reduxDraft]);
 
   const startResizing = useCallback(() => {
-    setDraft(reduxDraft);
     setIsResizing(true);
     setDateBeingChanged(dateToResize);
   }, [reduxDraft, dateToResize]);
@@ -406,11 +404,13 @@ export const useDraftActions = (
     }
 
     if (activity === "dragging") {
+      setDraft(reduxDraft as Schema_GridEvent);
       startDragging();
       return;
     }
 
     if (activity === "resizing") {
+      setDraft(reduxDraft as Schema_GridEvent);
       startResizing();
     }
   }, [activity, startDragging, startResizing, create, isDrafting]);


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/357

When mousing down on a new draft, the duration is reset instead of being preserved.
This bug was introduced in https://github.com/SwitchbackTech/compass/pull/361

This PR resolves this issue, by preserving the duration and adding support for maintaining cursor position for draft events

## Videos


#### Before

https://github.com/user-attachments/assets/f2ca0fbb-4424-41c9-b054-5f800b115eb6



#### After
https://github.com/user-attachments/assets/72c6f52f-389d-4885-a8b7-24a6fc69c5c0

