### PR TITLE
fix(web): replace move to sidebar shortcut hotkey

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -74,8 +74,8 @@ test("should call onConvert when meta+shift+< keyboard shortcut is used", async 
   expect(screen.getByRole("form")).toBeInTheDocument();
 
   await act(async () => {
-    // Simulate pressing Meta, then Shift, then '<', then releasing them
-    await userEvent.keyboard("{Meta>}{Shift>}{<}{/Shift}{/Meta}");
+    // Simulate pressing Meta, then '[', then releasing them
+    await userEvent.keyboard("{Meta>}{[}{/Meta}");
   });
 
   expect(mockOnConvert).toHaveBeenCalledTimes(1);

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -204,7 +204,7 @@ export const EventForm: React.FC<FormProps> = ({
   };
 
   useHotkeys(
-    "meta+shift+<",
+    "meta+[",
     () => {
       onConvert?.();
     },

--- a/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
@@ -16,8 +16,7 @@ export const MoveToSidebarButton = ({ onClick }: { onClick: () => void }) => {
 
     return (
       <Text size="m" style={{ display: "flex", alignItems: "center" }}>
-        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} + SHIFT +
-        {"<"}
+        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} +{"["}
       </Text>
     );
   };


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/350

the current hotkey combination did not work. This new combination is simpler and guaranteed to work (for english keyboard layouts)