### PR TITLE
🐛 Fix: Delay when dragging an all day event with its form window open

### DIFF
--- a/packages/web/src/views/Calendar/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Calendar/components/Draft/grid/GridDraft.tsx
@@ -55,7 +55,7 @@ export const GridDraft: FC<Props> = ({ measurements, weekProps }) => {
   };
 
   const { onMouseDown } = useGridEventMouseDown(
-    Categories_Event.TIMED,
+    draft?.isAllDay ? Categories_Event.ALLDAY : Categories_Event.TIMED,
     handleClick,
     handleDrag,
   );


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/345

Root issue was due to providing an incorrect `eventType` which mapped to an incorrect `element` (`element` being either the main grid area of the all day row)

## Videos

#### Before
https://github.com/user-attachments/assets/1d5a63e2-56bc-4ad5-b65f-9ba89eee9a49

#### After
https://github.com/user-attachments/assets/249ba5d3-60e7-4965-9b50-251bd777a365

