### PR TITLE
🐛 Fix: replace move to sidebar shortcut hotkey. Attempt 2

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -43,7 +43,7 @@ test("start date picker opens and then closes when clicking the end input", asyn
   expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 });
 
-test("should call onConvert when meta+shift+< keyboard shortcut is used", async () => {
+test("should call onConvert when meta+< keyboard shortcut is used", async () => {
   const sampleEvent: Schema_Event = {
     _id: "event123",
     title: "Test Event for Hotkey",
@@ -74,8 +74,8 @@ test("should call onConvert when meta+shift+< keyboard shortcut is used", async 
   expect(screen.getByRole("form")).toBeInTheDocument();
 
   await act(async () => {
-    // Simulate pressing Meta, then 'K', then releasing them
-    await userEvent.keyboard("{Meta>}{K}{/Meta}");
+    // Simulate pressing Meta, then '<', then releasing them
+    await userEvent.keyboard("{Meta>}{<}{/Meta}");
   });
 
   expect(mockOnConvert).toHaveBeenCalledTimes(1);

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -74,8 +74,8 @@ test("should call onConvert when meta+shift+< keyboard shortcut is used", async 
   expect(screen.getByRole("form")).toBeInTheDocument();
 
   await act(async () => {
-    // Simulate pressing Meta, then '[', then releasing them
-    await userEvent.keyboard("{Meta>}{[}{/Meta}");
+    // Simulate pressing Meta, then 'K', then releasing them
+    await userEvent.keyboard("{Meta>}{K}{/Meta}");
   });
 
   expect(mockOnConvert).toHaveBeenCalledTimes(1);

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -43,7 +43,7 @@ test("start date picker opens and then closes when clicking the end input", asyn
   expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 });
 
-test("should call onConvert when meta+< keyboard shortcut is used", async () => {
+test("should call onConvert when meta+< (meta + shift + comma) keyboard shortcut is used", async () => {
   const sampleEvent: Schema_Event = {
     _id: "event123",
     title: "Test Event for Hotkey",
@@ -74,8 +74,8 @@ test("should call onConvert when meta+< keyboard shortcut is used", async () => 
   expect(screen.getByRole("form")).toBeInTheDocument();
 
   await act(async () => {
-    // Simulate pressing Meta, then '<', then releasing them
-    await userEvent.keyboard("{Meta>}{<}{/Meta}");
+    // Simulate pressing & holding Meta, then Shift, then comma (AKA '<'), then releasing
+    await userEvent.keyboard("{Meta>}{Shift>}{Comma}");
   });
 
   expect(mockOnConvert).toHaveBeenCalledTimes(1);

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -136,9 +136,13 @@ export const EventForm: React.FC<FormProps> = ({
     onClose();
   };
 
-  const ignoreDelete = (e: KeyboardEvent) => {
+  const handleIgnoredKeys = (e: KeyboardEvent) => {
     if (e.key === Key.Backspace) {
       e.stopPropagation();
+    }
+
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      e.preventDefault();
     }
   };
 
@@ -204,8 +208,12 @@ export const EventForm: React.FC<FormProps> = ({
   };
 
   useHotkeys(
-    "meta+[",
+    "meta+k",
     () => {
+      if (isDraft) {
+        return;
+      }
+
       onConvert?.();
     },
     hotkeysOptions,
@@ -272,7 +280,7 @@ export const EventForm: React.FC<FormProps> = ({
       <StyledTitle
         autoFocus
         onChange={onChangeEventTextField("title")}
-        onKeyDown={ignoreDelete}
+        onKeyDown={handleIgnoredKeys}
         placeholder="Title"
         role="textarea"
         name="Event Title"
@@ -294,7 +302,7 @@ export const EventForm: React.FC<FormProps> = ({
       <StyledDescription
         underlineColor={priorityColor}
         onChange={onChangeEventTextField("description")}
-        onKeyDown={ignoreDelete}
+        onKeyDown={handleIgnoredKeys}
         placeholder="Description"
         ref={descriptionRef}
         value={event.description || ""}

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -141,7 +141,7 @@ export const EventForm: React.FC<FormProps> = ({
       e.stopPropagation();
     }
 
-    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "<") {
       e.preventDefault();
     }
   };
@@ -208,7 +208,7 @@ export const EventForm: React.FC<FormProps> = ({
   };
 
   useHotkeys(
-    "meta+k",
+    "meta+<",
     () => {
       if (isDraft) {
         return;

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -208,7 +208,7 @@ export const EventForm: React.FC<FormProps> = ({
   };
 
   useHotkeys(
-    "meta+<",
+    "meta+shift+comma",
     () => {
       if (isDraft) {
         return;

--- a/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
@@ -16,7 +16,7 @@ export const MoveToSidebarButton = ({ onClick }: { onClick: () => void }) => {
 
     return (
       <Text size="m" style={{ display: "flex", alignItems: "center" }}>
-        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} +{"["}
+        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} +{"K"}
       </Text>
     );
   };

--- a/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
@@ -16,7 +16,8 @@ export const MoveToSidebarButton = ({ onClick }: { onClick: () => void }) => {
 
     return (
       <Text size="m" style={{ display: "flex", alignItems: "center" }}>
-        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} +{"<"}
+        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} +
+        {" SHIFT "} + {","}
       </Text>
     );
   };

--- a/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
@@ -16,7 +16,7 @@ export const MoveToSidebarButton = ({ onClick }: { onClick: () => void }) => {
 
     return (
       <Text size="m" style={{ display: "flex", alignItems: "center" }}>
-        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} +{"K"}
+        {isMacOS ? <Command size={16} /> : <WindowsLogo size={16} />} +{"<"}
       </Text>
     );
   };


### PR DESCRIPTION
Closes #350 by making the shortcut `META + SHIFT + COMMA` AKA `META + SHIFT + 

English keyboards have the `<` and the `,` on the same key, so this is also effectively  `META + <` for those users.