### PR TITLE
🐛 Fix: Handle NoSyncToken error during gcal notification

### DIFF
--- a/packages/backend/src/common/constants/error.constants.ts
+++ b/packages/backend/src/common/constants/error.constants.ts
@@ -186,7 +186,7 @@ export const SyncError = {
   },
   NoSyncToken: {
     description: "No syncToken",
-    status: Status.NO_CONTENT,
+    status: Status.INTERNAL_SERVER,
     isOperational: true,
   },
   NoEventChanges: {


### PR DESCRIPTION
Logs instead message instead of full error to signify that this is a known scenario and not something we need to do anything about

Closes #379 