### PR TITLE
🐛 Fix: fetch events when receiving re-fetch request from socket without flashing them in the UI

### DIFF
--- a/packages/web/src/ducks/events/context/sync.context.ts
+++ b/packages/web/src/ducks/events/context/sync.context.ts
@@ -1,0 +1,3 @@
+export enum Sync_AsyncStateContextReason {
+  SOCKET_EVENT_CHANGED = "SOCKET_EVENT_CHANGED",
+}

--- a/packages/web/src/ducks/events/context/week.context.ts
+++ b/packages/web/src/ducks/events/context/week.context.ts
@@ -1,0 +1,4 @@
+export enum Week_AsyncStateContextReason {
+  WEEK_VIEW_CHANGE = "WEEK_VIEW_CHANGE",
+  SOCKET_EVENT_CHANGED = "SOCKET_EVENT_CHANGED",
+}

--- a/packages/web/src/ducks/events/event.types.ts
+++ b/packages/web/src/ducks/events/event.types.ts
@@ -1,6 +1,7 @@
 import { Action } from "redux";
 import { Priorities } from "@core/constants/core.constants";
 import { Categories_Recur, Schema_Event } from "@core/types/event.types";
+import { SliceStateContext } from "@web/common/store/helpers";
 import {
   Filters_Pagination,
   Response_HttpPaginatedSuccess,
@@ -93,7 +94,7 @@ export interface Payload_GetPaginatedEvents extends Filters_Pagination {
   priorities: Priorities[];
 }
 
-export interface Payload_GetEvents {
+export interface Payload_GetEvents extends SliceStateContext {
   startDate: string;
   endDate: string;
 }

--- a/packages/web/src/ducks/events/selectors/sync.selector.ts
+++ b/packages/web/src/ducks/events/selectors/sync.selector.ts
@@ -1,4 +1,3 @@
 import { RootState } from "@web/store";
 
-export const selectIsRefetchNeeded = (state: RootState) =>
-  state.sync.isFetchNeeded;
+export const selectSyncState = (state: RootState) => state.sync;

--- a/packages/web/src/ducks/events/selectors/util.selectors.ts
+++ b/packages/web/src/ducks/events/selectors/util.selectors.ts
@@ -1,4 +1,6 @@
+import { createSelector } from "reselect";
 import { isProcessing, isSuccess } from "@web/common/store/helpers";
+import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
 import { RootState } from "@web/store";
 
 type SectionType_Sidebar = "someday" | "currentMonth";
@@ -10,8 +12,18 @@ export const selectIsProcessing = (state: RootState) =>
   isProcessing(state.events.createEvent) ||
   isProcessing(state.events.getWeekEvents);
 
-export const selectIsGetWeekEventsProcessing = (state: RootState) =>
-  isProcessing(state.events.getWeekEvents);
+export const selectIsGetWeekEventsProcessingWithReason = createSelector(
+  (state: RootState) => state.events.getWeekEvents,
+  (state) => {
+    const _isProcessing = isProcessing(state);
+    const _reason = state.reason as Week_AsyncStateContextReason;
+
+    return {
+      isProcessing: _isProcessing,
+      reason: _reason,
+    };
+  },
+);
 
 export const selectEventIdsBySectionType = (
   state: RootState,

--- a/packages/web/src/ducks/events/slices/sync.slice.ts
+++ b/packages/web/src/ducks/events/slices/sync.slice.ts
@@ -1,22 +1,48 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
+
+type Payload_TriggerFetch = {
+  reason?: Sync_AsyncStateContextReason;
+};
 
 interface State_Sync {
   isFetchNeeded: boolean;
+  reason: null | Sync_AsyncStateContextReason;
 }
 
 const initialState: State_Sync = {
   isFetchNeeded: false,
+  reason: null,
 };
 
 export const syncSlice = createSlice({
   name: "sync",
   initialState,
   reducers: {
-    resetIsFetchNeeded: (state) => {
-      state.isFetchNeeded = false;
+    triggerFetch: {
+      reducer: (
+        state,
+        action: PayloadAction<Payload_TriggerFetch | undefined>,
+      ) => {
+        state.isFetchNeeded = true;
+        state.reason = action.payload?.reason || null;
+      },
+      prepare: (payload?: Payload_TriggerFetch) => {
+        return {
+          payload: payload || ({} as Payload_TriggerFetch),
+        };
+      },
     },
-    triggerFetch: (state) => {
-      state.isFetchNeeded = true;
+    resetIsFetchNeeded: {
+      reducer: (state) => {
+        state.isFetchNeeded = false;
+        state.reason = null;
+      },
+      prepare: () => {
+        return {
+          payload: {},
+        };
+      },
     },
   },
 });

--- a/packages/web/src/socket/SocketProvider.tsx
+++ b/packages/web/src/socket/SocketProvider.tsx
@@ -5,6 +5,7 @@ import { EVENT_CHANGED } from "@core/constants/websocket.constants";
 import { ServerToClientEvents } from "@core/types/websocket.types";
 import { useUser } from "@web/auth/UserContext";
 import { ENV_WEB } from "@web/common/constants/env.constants";
+import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
 import { triggerFetch } from "@web/ducks/events/slices/sync.slice";
 
 const SocketProvider = ({ children }: { children: ReactNode }) => {
@@ -27,7 +28,11 @@ const SocketProvider = ({ children }: { children: ReactNode }) => {
   });
 
   socket.on(EVENT_CHANGED, () => {
-    dispatch(triggerFetch());
+    dispatch(
+      triggerFetch({
+        reason: Sync_AsyncStateContextReason.SOCKET_EVENT_CHANGED,
+      }),
+    );
   });
 
   return children;

--- a/packages/web/src/views/Calendar/hooks/useRefresh.ts
+++ b/packages/web/src/views/Calendar/hooks/useRefresh.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { toUTCOffset } from "@web/common/utils/web.date.util";
-import { selectIsRefetchNeeded } from "@web/ducks/events/selectors/sync.selector";
+import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
+import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
+import { selectSyncState } from "@web/ducks/events/selectors/sync.selector";
 import { selectDatesInView } from "@web/ducks/events/selectors/view.selectors";
 import { resetIsFetchNeeded } from "@web/ducks/events/slices/sync.slice";
 import { getWeekEventsSlice } from "@web/ducks/events/slices/week.slice";
@@ -8,18 +10,31 @@ import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 
 export const useRefresh = () => {
   const dispatch = useAppDispatch();
-  const isRefreshNeeded = useAppSelector(selectIsRefetchNeeded);
+  const { isFetchNeeded, reason } = useAppSelector(selectSyncState);
   const { start, end } = useAppSelector(selectDatesInView);
 
   useEffect(() => {
-    if (isRefreshNeeded) {
+    const getRefreshWeekEventsReason = () => {
+      if (reason === Sync_AsyncStateContextReason.SOCKET_EVENT_CHANGED) {
+        // Hardcode enum return value for consistency and readability.
+        return Week_AsyncStateContextReason.SOCKET_EVENT_CHANGED;
+      }
+
+      return reason;
+    };
+
+    if (isFetchNeeded) {
       dispatch(
         getWeekEventsSlice.actions.request({
           startDate: toUTCOffset(start),
           endDate: toUTCOffset(end),
+          __context: {
+            reason: getRefreshWeekEventsReason(),
+          },
         }),
       );
       dispatch(resetIsFetchNeeded());
     }
-  }, [dispatch, end, isRefreshNeeded, start]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, end, isFetchNeeded, start]);
 };

--- a/packages/web/src/views/Calendar/hooks/useWeek.ts
+++ b/packages/web/src/views/Calendar/hooks/useWeek.ts
@@ -2,6 +2,7 @@ import { Dayjs } from "dayjs";
 import { useEffect, useMemo, useState } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { toUTCOffset } from "@web/common/utils/web.date.util";
+import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
 import { getSomedayEventsSlice } from "@web/ducks/events/slices/someday.slice";
 import { updateDates } from "@web/ducks/events/slices/view.slice";
 import { getWeekEventsSlice } from "@web/ducks/events/slices/week.slice";
@@ -31,6 +32,9 @@ export const useWeek = (today: Dayjs) => {
       getWeekEventsSlice.actions.request({
         startDate: toUTCOffset(start),
         endDate: toUTCOffset(end),
+        __context: {
+          reason: Week_AsyncStateContextReason.WEEK_VIEW_CHANGE,
+        },
       }),
     );
   }, [dispatch, end, start]);


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/384

This fix implements a lot of boilerplate code, but it can be easily summed up this way:

- The root issue is: when we re-fetch the events, we stop rendering them `MainGridEvents:84` and `AllDayEvents:59` until we finish re-fetching
- This causes the events "flashing" in the UI
- If we remove this condition (rendering only when we don't have an active request condition), we re-produce https://github.com/SwitchbackTech/compass/issues/186
- That is why we need some way to know **why** we are refetching, so that we can decide whether to continuously render the events or pause rendering them when a request is in flight
- The rest is boilerplate code that implements the **why** part, setting up a context object (for scalability) and inside it a `reason` property

