### PR TITLE
feat(web): Implement dynamic loading messages when signing up takes too long

### DIFF
--- a/packages/web/src/components/LoginAbsoluteOverflowLoader/LoginAbsoluteOverflowLoader.tsx
+++ b/packages/web/src/components/LoginAbsoluteOverflowLoader/LoginAbsoluteOverflowLoader.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+import { AlignItems, JustifyContent, Props } from "@web/components/Flex/styled";
+import { LoadingMessage, ProgressBar, Styled, StyledSpinner } from "./styled";
+
+/**
+ * Absolute overflow loader customized to handle login flow
+ */
+export const LoginAbsoluteOverflowLoader = (props: Props) => {
+  const [showMessage, setShowMessage] = useState(false);
+  const [currentMessage, setCurrentMessage] = useState(MESSAGE_TEXT);
+
+  useEffect(() => {
+    const firstTimer = setTimeout(() => {
+      setShowMessage(true);
+    }, MESSAGE_TIMEOUT);
+
+    const secondTimer = setTimeout(() => {
+      setCurrentMessage(SECOND_MESSAGE_TEXT);
+    }, MESSAGE_TIMEOUT + SECOND_MESSAGE_TIMEOUT);
+
+    return () => {
+      clearTimeout(firstTimer);
+      clearTimeout(secondTimer);
+    };
+  }, []);
+
+  return (
+    <Styled
+      justifyContent={JustifyContent.CENTER}
+      alignItems={AlignItems.CENTER}
+      {...props}
+    >
+      <StyledSpinner />
+      {showMessage && (
+        <LoadingMessage key={currentMessage}>
+          <div>{currentMessage}</div>
+          <ProgressBar />
+        </LoadingMessage>
+      )}
+    </Styled>
+  );
+};
+
+// 1st msg
+const MESSAGE_TEXT = "This can take a while. Please hang tight.";
+const MESSAGE_TIMEOUT = 7000;
+
+// 2nd msg
+const SECOND_MESSAGE_TEXT =
+  "Almost there! We're finalizing your calendar setup.";
+const SECOND_MESSAGE_TIMEOUT = 15000;

--- a/packages/web/src/components/LoginAbsoluteOverflowLoader/styled.ts
+++ b/packages/web/src/components/LoginAbsoluteOverflowLoader/styled.ts
@@ -1,0 +1,104 @@
+import styled, { keyframes } from "styled-components";
+import { c } from "@web/common/styles/colors";
+import { Flex } from "@web/components/Flex";
+
+export const Styled = styled(Flex)`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  backdrop-filter: blur(5px);
+`;
+
+const spinnerAnimation = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+export const StyledSpinner = styled.div`
+  margin: 60px auto;
+  font-size: 4px;
+  position: relative;
+  text-indent: -9999em;
+  border-top: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-right: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-left: 1.1em solid #ffffff;
+  transform: translateZ(0);
+  animation: ${spinnerAnimation} 1.1s infinite linear;
+
+  border-radius: 50%;
+  width: 10em;
+  height: 10em;
+
+  &:after {
+    border-radius: 50%;
+    width: 10em;
+    height: 10em;
+  }
+`;
+
+const progressAnimation = keyframes`
+  0% {
+    left: -35%;
+    right: 100%;
+  }
+  60% {
+    left: 100%;
+    right: -90%;
+  }
+  100% {
+    left: 100%;
+    right: -90%;
+  }
+`;
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+export const LoadingMessage = styled.div`
+  position: absolute;
+  bottom: 40%;
+  left: 50%;
+  transform: translateX(-50%);
+  color: ${c.white100};
+  font-size: 16px;
+  text-align: center;
+  width: 100%;
+  max-width: 400px;
+  animation: ${fadeIn} 0.8s ease-in-out;
+
+  div {
+    margin-bottom: 15px;
+  }
+`;
+
+export const ProgressBar = styled.div`
+  width: 100%;
+  height: 3px;
+  background-color: ${c.gray800};
+  border-radius: 3px;
+  overflow: hidden;
+  position: relative;
+
+  &:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    height: 100%;
+    background: linear-gradient(90deg, ${c.blue100}, ${c.purple});
+    animation: ${progressAnimation} 1.5s ease-in-out infinite;
+    width: 45%;
+  }
+`;

--- a/packages/web/src/views/Login/Login.tsx
+++ b/packages/web/src/views/Login/Login.tsx
@@ -6,8 +6,8 @@ import { useGoogleLogin } from "@react-oauth/google";
 import { useAuthCheck } from "@web/auth/useAuthCheck";
 import { AuthApi } from "@web/common/apis/auth.api";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
-import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
 import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
+import { LoginAbsoluteOverflowLoader } from "@web/components/LoginAbsoluteOverflowLoader/LoginAbsoluteOverflowLoader";
 import {
   Card,
   CardHeader,
@@ -95,7 +95,7 @@ export const LoginView = () => {
           alignItems={AlignItems.CENTER}
           direction={FlexDirections.COLUMN}
         >
-          {isAuthenticating && <AbsoluteOverflowLoader />}
+          {isAuthenticating && <LoginAbsoluteOverflowLoader />}
 
           <Card>
             <CardHeader>


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/391

When user signs up to platform, they are prompted to log in with google, this helps authenticates them and migrates their google calendar events to our platform (if any exist)

If they have a lot of google calendar events, migration can take too long, meaning the signup process will take too long.

This PR implements dynamic loading messages to let the user know the signup may take a while and to reassure the user  everything is OK

## Videos


https://github.com/user-attachments/assets/906a1ae0-771a-4d4a-b5fe-dfc9cbeddff5

