### PR TITLE
🐛 Fix: Saving an event creates 2 events rather than 1

### DIFF
--- a/packages/web/src/views/Forms/EventForm/SaveSection/SaveSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/SaveSection/SaveSection.tsx
@@ -41,7 +41,6 @@ export const SaveSection: React.FC<Props> = ({
           role="tab"
           tabIndex={0}
           title="Save event"
-          onClick={_onSubmit}
         >
           Save
         </StyledSaveBtn>


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/416


## Videos

#### Before
https://github.com/user-attachments/assets/000bee1e-156d-4fa5-9736-e701ea1858fe

#### After
https://github.com/user-attachments/assets/d37830b5-319f-4290-92cf-c6264ef15d0d

