### PR TITLE
✨ Feat: Add Duration log during event import

### DIFF
--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -131,6 +131,7 @@ class UserService {
         "Did not tag subscriber due to missing EMAILER_ ENV value(s)",
       );
     } else {
+      logger.debug("Adding tag to subscriber");
       const subscriber = mapCompassUserToEmailSubscriber(cUser);
       await EmailService.addTagToSubscriber(subscriber, ENV.EMAILER_TAG_ID);
     }

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -131,7 +131,6 @@ class UserService {
         "Did not tag subscriber due to missing EMAILER_ ENV value(s)",
       );
     } else {
-      logger.debug("Adding tag to subscriber");
       const subscriber = mapCompassUserToEmailSubscriber(cUser);
       await EmailService.addTagToSubscriber(subscriber, ENV.EMAILER_TAG_ID);
     }


### PR DESCRIPTION
Closes #423 by adding log statements during sign up. We can improve this in the future by tracking these in a centralized place, but this is good enough for now.

Also slightly improves performance by increasing the max event size from 500 to 1000.

### Example Times

**User 1: 36k events**
Some examples:
36500 events @ 500 events / request = 42 seconds

```
   
    167|backend  | 25-05-16 13:01:11 [info] sync.import.all.gcal: Pass 2 completed for <user>
    167|backend  |     Processed Gcal events: 36503
    167|backend  |     Saved Compass events: 36503
    167|backend  |     Duration: 42.61s
    167|backend  |
```

36500 events @ 1000 events / request= 36s
```
    168|backend  | 25-05-16 13:07:11 [info] sync.import.all.gcal: Pass 2 completed for <user>
    168|backend  |     Processed Gcal events: 36503
    168|backend  |     Saved Compass events: 36503
    168|backend  |     Duration: 35.80s
    168|backend  |
```

36500 events @ 1000 events / request = 29s
```
169|backend  |     Max results / page: 1000
169|backend  |     Processed Gcal events: 36503
169|backend  |     Saved Compass events: 36503
169|backend  |     Duration: 28.68s
```

**User 2: 7k events**

6 seconds
```
106|backend  |     Max results / page: 1000
106|backend  |     Processed Gcal events: 7133
106|backend  |     Saved Compass events: 7133
106|backend  |     Duration: 6.63s
106|backend  |
106|backend  | 25-05-17 21:31:00 [info] app:sync.import: importAllEvents completed for <user>. Total API events processed: 7684. Total base/single saved in Pass 1: 11, Total new instances/single saved in Pass 2: 7133. Total Saved/Changed: 7144. Final nextSyncToken acquired.
```

**User 3: 26k**

```
106|backend  |     Max results / page: 1000
106|backend  |     Processed Gcal events: 26211
106|backend  |     Saved Compass events: 26211
106|backend  |     Duration: 25.02s
106|backend  |
```