### PR TITLE
✨ Feat: Support custom context menu for someday events

### DIFF
--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -237,9 +237,29 @@ export const isEventInRange = (
   return isStartDateInRange || isEndDateInRange;
 };
 
-export const isOptimisticEvent = (event: Schema_GridEvent) => {
+export const isOptimisticEvent = (event: Schema_Event) => {
   const isOptimistic = event._id?.startsWith(ID_OPTIMISTIC_PREFIX) || false;
   return isOptimistic;
+};
+
+export const getSomedayEventCategory = (
+  event: Schema_Event,
+): Categories_Event.SOMEDAY_MONTH | Categories_Event.SOMEDAY_WEEK => {
+  if (!event.isSomeday) {
+    throw new Error(
+      `Event is not a someday event. Event: ${JSON.stringify(event)}`,
+    );
+  }
+
+  const startDate = dayjs(event.startDate);
+  const endDate = dayjs(event.endDate);
+
+  const diffInDays = endDate.diff(startDate, "day");
+
+  if (diffInDays > 7) {
+    return Categories_Event.SOMEDAY_MONTH;
+  }
+  return Categories_Event.SOMEDAY_WEEK;
 };
 
 export const prepEvtAfterDraftDrop = (

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -3,9 +3,13 @@ import { Copy, PenNib, Trash } from "@phosphor-icons/react";
 import { Priorities } from "@core/constants/core.constants";
 import { colorByPriority } from "@web/common/styles/theme.util";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
-import { assembleGridEvent } from "@web/common/utils/event.util";
+import {
+  assembleGridEvent,
+  getSomedayEventCategory,
+} from "@web/common/utils/event.util";
 import IconButton from "@web/components/IconButton/IconButton";
 import { useDraftContext } from "@web/views/Calendar/components/Draft/context/useDraftContext";
+import { useSidebarContext } from "@web/views/Calendar/components/Draft/sidebar/context/useSidebarContext";
 import {
   MenuItem,
   MenuItemLabel,
@@ -29,6 +33,8 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
   const { actions, setters } = useDraftContext();
   const { openForm, deleteEvent, duplicateEvent, submit } = actions;
   const { setDraft } = setters;
+
+  const sidebarContext = useSidebarContext(true);
 
   const [selectedPriority, setSelectedPriority] = useState(event.priority);
 
@@ -57,9 +63,17 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
   };
 
   const handleEdit = () => {
-    setDraft(assembleGridEvent(event));
-    openForm();
-    close();
+    if (!event.isSomeday) {
+      setDraft(assembleGridEvent(event));
+      openForm();
+      close();
+    } else {
+      const sidebarActions = sidebarContext?.actions;
+      if (!sidebarActions) return; // TS Guard
+      const category = getSomedayEventCategory(event);
+      sidebarActions.onDraft(event, category);
+      close();
+    }
   };
 
   const menuActions: ContextMenuAction[] = [

--- a/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
+++ b/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
@@ -17,6 +17,7 @@ import {
   selectAllDayEvents,
   selectGridEvents,
 } from "@web/ducks/events/selectors/event.selectors";
+import { selectSomedayEvents } from "@web/ducks/events/selectors/someday.selectors";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { ContextMenu } from "./ContextMenu";
@@ -29,6 +30,8 @@ export const ContextMenuWrapper = ({
   const dispatch = useAppDispatch();
   const timedEvents = useAppSelector(selectGridEvents);
   const allDayEvents = useAppSelector(selectAllDayEvents);
+  const somedayEvents = useAppSelector(selectSomedayEvents);
+
   const draftEvent = useAppSelector(selectDraft);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -49,7 +52,8 @@ export const ContextMenuWrapper = ({
   const getSelectedEvent = (eventId: string) => {
     const selectedEvent =
       timedEvents.find((ev) => ev._id === eventId) ||
-      allDayEvents.find((ev) => ev._id === eventId);
+      allDayEvents.find((ev) => ev._id === eventId) ||
+      Object.values(somedayEvents).find((ev) => ev._id === eventId);
 
     if (!selectedEvent) {
       throw new Error("Selected event not found");

--- a/packages/web/src/views/Calendar/Calendar.tsx
+++ b/packages/web/src/views/Calendar/Calendar.tsx
@@ -69,15 +69,17 @@ export const CalendarView = () => {
         isSidebarOpen={isSidebarOpen}
       >
         <SidebarDraftProvider dateCalcs={dateCalcs} measurements={measurements}>
-          <Draft measurements={measurements} weekProps={weekProps} />
-          {isSidebarOpen && (
-            <Sidebar
-              dateCalcs={dateCalcs}
-              measurements={measurements}
-              weekProps={weekProps}
-              gridRefs={gridRefs}
-            />
-          )}
+          <ContextMenuWrapper>
+            <Draft measurements={measurements} weekProps={weekProps} />
+            {isSidebarOpen && (
+              <Sidebar
+                dateCalcs={dateCalcs}
+                measurements={measurements}
+                weekProps={weekProps}
+                gridRefs={gridRefs}
+              />
+            )}
+          </ContextMenuWrapper>
         </SidebarDraftProvider>
         <StyledCalendar direction={FlexDirections.COLUMN} id={ID_MAIN}>
           <Header

--- a/packages/web/src/views/Calendar/components/Draft/sidebar/context/useSidebarContext.ts
+++ b/packages/web/src/views/Calendar/components/Draft/sidebar/context/useSidebarContext.ts
@@ -1,9 +1,12 @@
 import { useContext } from "react";
 import { SidebarDraftContext } from "./SidebarDraftContext";
 
-export const useSidebarContext = () => {
+export const useSidebarContext = (suppressContextError = false) => {
   const context = useContext(SidebarDraftContext);
   if (!context) {
+    if (suppressContextError) {
+      return null;
+    }
     throw new Error(
       "useSidebarContext must be used within SidebarDraftProvider",
     );

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvent/SomedayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvent/SomedayEvent.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DraggableProvided, DraggableStateSnapshot } from "@hello-pangea/dnd";
 import { Priorities } from "@core/constants/core.constants";
 import { Categories_Event, Schema_Event } from "@core/types/event.types";
+import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { Props_DraftForm } from "@web/views/Calendar/components/Draft/hooks/state/useDraftForm";
 import { Actions_Sidebar } from "@web/views/Calendar/components/Draft/sidebar/hooks/useSidebarActions";
 import { SomedayEventRectangle } from "../SomedayEventContainer/SomedayEventRectangle";
@@ -43,23 +44,26 @@ export const SomedayEvent = ({
 }: Props) => {
   const style = getStyle(snapshot, isOverGrid, provided.draggableProps.style);
 
+  const somedayEventProps = {
+    [DATA_EVENT_ELEMENT_ID]: event._id,
+    ...provided.draggableProps,
+    ...provided.dragHandleProps,
+    style,
+    isDragging,
+    isDrafting,
+    isOverGrid,
+    isFocused,
+    onBlur,
+    onClick,
+    onFocus,
+    onKeyDown,
+    priority,
+    role: "button",
+    ref: provided.innerRef,
+  };
+
   return (
-    <StyledNewSomedayEvent
-      {...provided.draggableProps}
-      {...provided.dragHandleProps}
-      style={style}
-      isDragging={isDragging}
-      isDrafting={isDrafting}
-      isOverGrid={isOverGrid}
-      isFocused={isFocused}
-      onBlur={onBlur}
-      onClick={onClick}
-      onFocus={onFocus}
-      onKeyDown={onKeyDown}
-      priority={priority}
-      role="button"
-      ref={provided.innerRef}
-    >
+    <StyledNewSomedayEvent {...somedayEventProps}>
       <SomedayEventRectangle
         category={category}
         event={event}

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
@@ -59,7 +59,9 @@ export const SomedayEventContainer = ({
         isOverGrid={isOverGrid}
         isFocused={isFocused}
         onBlur={() => setIsFocused(false)}
-        onClick={() => actions.onDraft(event, category)}
+        onClick={() => {
+          actions.onDraft(event, category);
+        }}
         onFocus={() => setIsFocused(true)}
         onKeyDown={() => console.log("onKeyDown")}
         priority={event.priority || Priorities.UNASSIGNED}


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/426
Closes https://github.com/SwitchbackTech/compass/issues/427

Support displaying custom context menu items for someday events, allowing someday events to utilize the same menu items which act as shortcuts to certain event actions.

Reason why we addressed 2 issues in the same PR is because the 2 issues are very closely related in terms of code implementation so it would have been counter intuitive to create separate PRs for them.


## Videos

https://github.com/user-attachments/assets/04ba348c-0f26-4764-8819-424c78796ef0

