### PR TITLE
Fix misspellings in backend logs

### DIFF
--- a/packages/backend/src/common/errors/generic/generic.errors.ts
+++ b/packages/backend/src/common/errors/generic/generic.errors.ts
@@ -25,7 +25,7 @@ export const GenericError: GenericErrors = {
     isOperational: true,
   },
   NotSure: {
-    description: "Not sure why error occured. See logs",
+    description: "Not sure why error occurred. See logs",
     status: Status.UNSURE,
     isOperational: true,
   },

--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -80,7 +80,7 @@ export const handleExpressError = async (
     const userId = await parseUserId(res, e);
     if (!userId) {
       logger.error(
-        "Express error occured, but couldn't handle due to missing userId",
+        "Express error occurred, but couldn't handle due to missing userId",
       );
       res.status(Status.BAD_REQUEST).send(UserError.MissingUserIdField);
       return;

--- a/packages/backend/src/common/errors/handlers/error.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.ts
@@ -48,7 +48,7 @@ class ErrorHandler {
 
   exitAfterProgrammerError(): void {
     logger.error(
-      "Programmer error occured. Exiting to prevent app instability",
+      "Programmer error occurred. Exiting to prevent app instability",
     );
     // uses 500 as code for the response error, but if the error is one of our own,
     // then a more accurate code will be given in the payload

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -32,7 +32,7 @@ class SyncController {
       const sync = await getSync({ resourceId });
       if (!sync || !sync.user) {
         logger.error(
-          `Sync error occured, but couldnt find user based on this resourceId: ${resourceId}`,
+          `Sync error occurred, but couldnt find user based on this resourceId: ${resourceId}`,
         );
         logger.debug(res);
         res.status(Status.BAD_REQUEST).send(UserError.MissingUserIdField);

--- a/packages/backend/src/sync/services/import/sync.import.ts
+++ b/packages/backend/src/sync/services/import/sync.import.ts
@@ -266,7 +266,7 @@ export class SyncImport {
     if (!response) {
       throw error(
         SyncError.NoEventChanges,
-        "Import ignorede due to no response from gcal",
+        "Import ignored due to no response from gcal",
       );
     }
 


### PR DESCRIPTION
## Summary
- correct typos in backend error messages

## Testing
- `yarn test` *(fails: could not download yarn)*
- `yarn run "lint -f"` *(fails: could not download yarn)*