### PR TITLE
🐛 Fix: allday events not displaying if start-end date is start of week (Attempt 2)

### DIFF
--- a/packages/backend/src/event/services/event.find.test.ts
+++ b/packages/backend/src/event/services/event.find.test.ts
@@ -90,7 +90,7 @@ describe("Jan 2022: Many Formats", () => {
       const filter = getReadAllFilter("user1", {
         // make sure these match text data exactly
         start: "2022-01-01T00:00:00+03:00",
-        end: "2022-01-020T11:11:11+03:00",
+        end: "2022-01-20T11:11:11+03:00",
       });
 
       const result = await eventCollection.find(filter).toArray();

--- a/packages/backend/src/event/services/event.service.util.ts
+++ b/packages/backend/src/event/services/event.service.util.ts
@@ -15,6 +15,16 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 dayjs.extend(tz);
 dayjs.extend(utc);
 
+const validateDateFilters = (start: string, end: string) => {
+  const _isValidDate = (date: string) => {
+    return dayjs(date).isValid();
+  };
+
+  if (!_isValidDate(start) || !_isValidDate(end)) {
+    throw error(GenericError.BadRequest, "Invalid date format");
+  }
+};
+
 export const getCreateParams = (userId: string, event: Schema_Event_Core) => {
   const _event = {
     ...event,
@@ -90,6 +100,7 @@ export const getReadAllFilter = (
 
   // Add date filters if specified
   if (start && end) {
+    validateDateFilters(start, end);
     const dateFilters = _getDateFilters(isSomeday, start, end);
     Object.assign(filter, dateFilters);
   }

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -11,6 +11,10 @@ import { Categories_Event, Schema_Event } from "@core/types/event.types";
 import { validateEvent } from "@core/validators/event.validator";
 import { getUserId } from "@web/auth/auth.util";
 import { PartialMouseEvent } from "@web/common/types/util.types";
+import { toUTCOffset } from "@web/common/utils/web.date.util";
+import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
+import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
+import { getWeekEventsSlice } from "@web/ducks/events/slices/week.slice";
 import {
   COLUMN_MONTH,
   COLUMN_WEEK,
@@ -325,4 +329,29 @@ const _assembleBaseEvent = (
   };
 
   return baseEvent;
+};
+
+export const handleDispatchGetWeekEvents = (
+  startDate: string | Dayjs,
+  endDate: string | Dayjs,
+  reason: Sync_AsyncStateContextReason | Week_AsyncStateContextReason | null,
+) => {
+  const getRefreshWeekEventsReason = () => {
+    if (reason === Sync_AsyncStateContextReason.SOCKET_EVENT_CHANGED) {
+      // Hardcode enum return value for consistency and readability.
+      return Week_AsyncStateContextReason.SOCKET_EVENT_CHANGED;
+    } else if (reason === Week_AsyncStateContextReason.WEEK_VIEW_CHANGE) {
+      return Week_AsyncStateContextReason.WEEK_VIEW_CHANGE;
+    }
+
+    return reason;
+  };
+
+  return getWeekEventsSlice.actions.request({
+    startDate: toUTCOffset(startDate),
+    endDate: toUTCOffset(endDate),
+    __context: {
+      reason: getRefreshWeekEventsReason(),
+    },
+  });
 };

--- a/packages/web/src/common/utils/web.date.util.ts
+++ b/packages/web/src/common/utils/web.date.util.ts
@@ -253,6 +253,11 @@ export const toUTCOffset = (date: string | Dayjs | Date) => {
   } else return date.format(); // then already a DayJs object
 };
 
+// Given an ISO string, return a string in the format of YEAR_MONTH_DAY_FORMAT
+export const fromUTCOffset = (date: string) => {
+  return dayjs(date).format(YEAR_MONTH_DAY_FORMAT);
+};
+
 const _addTimesToDates = (dt: Schema_SelectedDates) => {
   const start = getDayjsByTimeValue(dt.startTime.value);
   const startDate = dayjs(dt.startDate)

--- a/packages/web/src/ducks/events/event.api.ts
+++ b/packages/web/src/ducks/events/event.api.ts
@@ -32,7 +32,7 @@ const EventApi = {
       );
     } else {
       return CompassApi.get(
-        `/event?start=${params.startDate}&end=${params.endDate}`,
+        `/event?start=${encodeURIComponent(params.startDate)}&end=${encodeURIComponent(params.endDate)}`,
       );
     }
   },

--- a/packages/web/src/views/Calendar/hooks/useRefresh.ts
+++ b/packages/web/src/views/Calendar/hooks/useRefresh.ts
@@ -1,11 +1,8 @@
 import { useEffect } from "react";
-import { toUTCOffset } from "@web/common/utils/web.date.util";
-import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
-import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
+import { handleDispatchGetWeekEvents } from "@web/common/utils/event.util";
 import { selectSyncState } from "@web/ducks/events/selectors/sync.selector";
 import { selectDatesInView } from "@web/ducks/events/selectors/view.selectors";
 import { resetIsFetchNeeded } from "@web/ducks/events/slices/sync.slice";
-import { getWeekEventsSlice } from "@web/ducks/events/slices/week.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 
 export const useRefresh = () => {
@@ -14,25 +11,8 @@ export const useRefresh = () => {
   const { start, end } = useAppSelector(selectDatesInView);
 
   useEffect(() => {
-    const getRefreshWeekEventsReason = () => {
-      if (reason === Sync_AsyncStateContextReason.SOCKET_EVENT_CHANGED) {
-        // Hardcode enum return value for consistency and readability.
-        return Week_AsyncStateContextReason.SOCKET_EVENT_CHANGED;
-      }
-
-      return reason;
-    };
-
     if (isFetchNeeded) {
-      dispatch(
-        getWeekEventsSlice.actions.request({
-          startDate: toUTCOffset(start),
-          endDate: toUTCOffset(end),
-          __context: {
-            reason: getRefreshWeekEventsReason(),
-          },
-        }),
-      );
+      dispatch(handleDispatchGetWeekEvents(start, end, reason));
       dispatch(resetIsFetchNeeded());
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/web/src/views/Calendar/hooks/useWeek.ts
+++ b/packages/web/src/views/Calendar/hooks/useWeek.ts
@@ -1,11 +1,10 @@
 import { Dayjs } from "dayjs";
 import { useEffect, useMemo, useState } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
-import { toUTCOffset } from "@web/common/utils/web.date.util";
+import { handleDispatchGetWeekEvents } from "@web/common/utils/event.util";
 import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
 import { getSomedayEventsSlice } from "@web/ducks/events/slices/someday.slice";
 import { updateDates } from "@web/ducks/events/slices/view.slice";
-import { getWeekEventsSlice } from "@web/ducks/events/slices/week.slice";
 import { useAppDispatch } from "@web/store/store.hooks";
 import { Category_View } from "@web/views/Calendar/calendarView.types";
 
@@ -29,13 +28,11 @@ export const useWeek = (today: Dayjs) => {
 
   useEffect(() => {
     dispatch(
-      getWeekEventsSlice.actions.request({
-        startDate: toUTCOffset(start),
-        endDate: toUTCOffset(end),
-        __context: {
-          reason: Week_AsyncStateContextReason.WEEK_VIEW_CHANGE,
-        },
-      }),
+      handleDispatchGetWeekEvents(
+        start,
+        end,
+        Week_AsyncStateContextReason.WEEK_VIEW_CHANGE,
+      ),
     );
   }, [dispatch, end, start]);
 


### PR DESCRIPTION
## Description
Follow up to https://github.com/SwitchbackTech/compass/pull/440
Closes https://github.com/SwitchbackTech/compass/issues/428

This PR solves the issue by aiming at solving it from the frontend side.

It resolves it by sending an additional HTTP request specifically for all day events. This works because the additional HTTP request is sent under date filters that are different than the get events HTTP request (uses YYYY-MM-DD format rather than ISO 8601)

Sadly, this introduces an additional HTTP request to be sent, which would degrade performance. This is the only way to resolve this issue solely from the frontend side that I know of.

This could be further optimized by implementing a backend side solution to send 2 database requests in 1 HTTP request, rather than sending 2 database requests in 2 HTTP requests, but since the goal is to implement a frontend solution only, I omitted doing that.