### PR TITLE
fix: change duplicate event shortcut from CTRL+d to META+d (#446)

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -85,6 +85,52 @@ test("should call onConvert when meta+< (meta + shift + comma) keyboard shortcut
   expect(mockOnDelete).not.toHaveBeenCalled();
 });
 
+test("should call onDuplicate when meta+d keyboard shortcut is used", async () => {
+  const sampleEvent: Schema_Event = {
+    _id: "event123",
+    title: "Test Event for Duplication",
+    startDate: "2025-04-10",
+    endDate: "2025-04-10",
+    isAllDay: false,
+  };
+  const mockOnClose = jest.fn();
+  const mockOnConvert = jest.fn();
+  const mockOnSubmit = jest.fn();
+  const mockSetEvent = jest.fn();
+  const mockOnDelete = jest.fn();
+  const mockOnDuplicate = jest.fn();
+
+  render(
+    <div>
+      <EventForm
+        event={sampleEvent}
+        onClose={mockOnClose}
+        onConvert={mockOnConvert}
+        onSubmit={mockOnSubmit}
+        setEvent={mockSetEvent}
+        onDelete={mockOnDelete}
+        onDuplicate={mockOnDuplicate}
+      />
+    </div>,
+  );
+
+  // Ensure the form is rendered
+  expect(screen.getByRole("form")).toBeInTheDocument();
+
+  await act(async () => {
+    // Simulate pressing Meta + d
+    await userEvent.keyboard("{Meta>}d{/Meta}");
+  });
+
+  expect(mockOnDuplicate).toHaveBeenCalledTimes(1);
+  expect(mockOnDuplicate).toHaveBeenCalledWith(sampleEvent);
+
+  expect(mockOnClose).not.toHaveBeenCalled();
+  expect(mockOnSubmit).not.toHaveBeenCalled();
+  expect(mockOnDelete).not.toHaveBeenCalled();
+  expect(mockOnConvert).not.toHaveBeenCalled();
+});
+
 const _clickStartInput = async () => {
   const startDateInput = screen.getByRole("textbox", {
     name: /pick start date/i,

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -260,7 +260,7 @@ export const EventForm: React.FC<FormProps> = ({
   );
 
   useHotkeys(
-    "ctrl+d",
+    "meta+d",
     () => {
       onDuplicate?.(event);
     },


### PR DESCRIPTION
Problem
- META + d was creating browser bookmarks instead of duplicating events
- CTRL + d was duplicating events (inconsistent with other META shortcuts)
- Browser's default bookmark shortcut (META + d) was interfering with app functionality

Solution
- ✅ Changed duplicate event hotkey from `"ctrl+d"` to `"meta+d"`
- ✅ Existing `preventDefault()` logic stops browser bookmark creation
- ✅ Added comprehensive test coverage for META + d keyboard shortcut
- ✅ Maintains consistency with other META key shortcuts in the app

Testing
- ✅ Unit test verifies META + d calls `onDuplicate` correctly
- ✅ Test confirms no unintended side effects (other functions not called)
- ✅ Existing `handleIgnoredKeys` prevents browser default behavior

Changes
- `packages/web/src/views/Forms/EventForm/EventForm.tsx`: Updated hotkey handler
- `packages/web/src/views/Forms/EventForm/EventForm.test.tsx`: Added test coverage

Closes #446