### PR TITLE
🐛 Fix: event form window blocking context menu items

### DIFF
--- a/packages/web/src/common/constants/web.constants.ts
+++ b/packages/web/src/common/constants/web.constants.ts
@@ -20,6 +20,7 @@ export const ID_SOMEDAY_EVENTS = "ID_SOMEDAY_EVENTS";
 export const ID_SOMEDAY_EVENT_FORM = "Someday Event Form";
 export const ID_OPTIMISTIC_PREFIX = "optimistic";
 export const DATA_EVENT_ELEMENT_ID = "data-event-id";
+export const ID_CONTEXT_MENU_ITEMS = "context-menu-items";
 
 export const OPTIONS_RECURRENCE = {
   WEEK: { value: Recurrence_Selection.WEEK, label: "week" },

--- a/packages/web/src/common/utils/index.ts
+++ b/packages/web/src/common/utils/index.ts
@@ -1,4 +1,5 @@
 import {
+  ID_CONTEXT_MENU_ITEMS,
   ID_EVENT_FORM,
   ID_SOMEDAY_EVENT_FORM,
 } from "../constants/web.constants";
@@ -27,6 +28,11 @@ export const isEventFormOpen = () =>
 
 export const isSomedayEventFormOpen = () =>
   document.getElementsByName(ID_SOMEDAY_EVENT_FORM).length === 1;
+
+export const isContextMenuOpen = () => {
+  const contextMenuItems = document.getElementById(ID_CONTEXT_MENU_ITEMS);
+  return !!contextMenuItems;
+};
 
 export const roundToNearest = (x: number, roundBy: number) =>
   Math.round(x / roundBy) * roundBy;

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Copy, PenNib, Trash } from "@phosphor-icons/react";
 import { Priorities } from "@core/constants/core.constants";
+import { ID_CONTEXT_MENU_ITEMS } from "@web/common/constants/web.constants";
 import { colorByPriority } from "@web/common/styles/theme.util";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -110,7 +111,7 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
   ];
 
   return (
-    <>
+    <div id={ID_CONTEXT_MENU_ITEMS}>
       <PriorityContainer>
         {priorities.map((priority) => (
           <PriorityCircle
@@ -133,6 +134,6 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
           <MenuItemLabel>{item.label}</MenuItemLabel>
         </MenuItem>
       ))}
-    </>
+    </div>
   );
 }

--- a/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
+++ b/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
@@ -23,8 +23,10 @@ import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { ContextMenu } from "./ContextMenu";
 
 export const ContextMenuWrapper = ({
+  id,
   children,
 }: {
+  id: string;
   children: React.ReactNode;
 }) => {
   const dispatch = useAppDispatch();
@@ -106,7 +108,11 @@ export const ContextMenuWrapper = ({
   };
 
   return (
-    <div style={{ display: "contents" }} onContextMenu={handleContextMenu}>
+    <div
+      id={id}
+      style={{ display: "contents" }}
+      onContextMenu={handleContextMenu}
+    >
       {children}
       {isOpen && (
         <ContextMenu

--- a/packages/web/src/views/Calendar/Calendar.tsx
+++ b/packages/web/src/views/Calendar/Calendar.tsx
@@ -69,7 +69,7 @@ export const CalendarView = () => {
         isSidebarOpen={isSidebarOpen}
       >
         <SidebarDraftProvider dateCalcs={dateCalcs} measurements={measurements}>
-          <ContextMenuWrapper>
+          <ContextMenuWrapper id="sidebar-context-menu">
             <Draft measurements={measurements} weekProps={weekProps} />
             {isSidebarOpen && (
               <Sidebar
@@ -89,7 +89,7 @@ export const CalendarView = () => {
             weekProps={weekProps}
           />
 
-          <ContextMenuWrapper>
+          <ContextMenuWrapper id="grid-context-menu">
             <Grid
               dateCalcs={dateCalcs}
               isSidebarOpen={isSidebarOpen}

--- a/packages/web/src/views/Calendar/components/Draft/hooks/state/useDraftForm.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/state/useDraftForm.ts
@@ -1,5 +1,6 @@
 import { OpenChangeReason } from "@floating-ui/react";
 import { Categories_Event } from "@core/types/event.types";
+import { isContextMenuOpen } from "@web/common/utils";
 import { useEventForm } from "@web/views/Forms/hooks/useEventForm";
 
 export const useDraftForm = (
@@ -10,6 +11,14 @@ export const useDraftForm = (
   setIsFormOpen: (isOpen: boolean) => void,
 ) => {
   const handleDiscard = (reason?: OpenChangeReason) => {
+    if (isContextMenuOpen()) {
+      // Prevent discard if context menu is open.
+      // Discarding the event will mess with the context menu
+      // logic flow because the context menu depends on having
+      // a draft event selected.
+      return;
+    }
+
     reset();
 
     if (reason === "escape-key") {


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/433

A race condition of sorts was occurring where context menu depends on having a draft event and opening the event form window then clicking on a context menu item would reset the draft event before the context menu action reads its value.

We now check if the context menu is open, and we avoid resetting the draft event accordingly.