### PR TITLE
🐛 Fix: Implement hotfix to address events start of week date filter not being returned consistently

### DIFF
--- a/packages/core/src/__mocks__/v1/events/events.misc.ts
+++ b/packages/core/src/__mocks__/v1/events/events.misc.ts
@@ -74,7 +74,7 @@ export const GROCERIES: Schema_Event = {
   priorities: [],
   isAllDay: false,
   startDate: "2022-02-21T11:45:00-06:00",
-  endDate: "2022-02-212T12:45:00-06:00",
+  endDate: "2022-02-21T12:45:00-06:00",
   priority: Priorities.RELATIONS,
 };
 export const MULTI_WEEK: Schema_Event = {

--- a/packages/web/src/__tests__/Calendar/calendar.render.test.tsx
+++ b/packages/web/src/__tests__/Calendar/calendar.render.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import "@testing-library/jest-dom";
 import { screen, waitFor } from "@testing-library/react";
+import { GROCERIES } from "@core/__mocks__/v1/events/events.misc";
+import { findAndUpdateEventInPreloadedState } from "@web/__tests__/Calendar/calendar.render.test.utils";
+import { freshenEventStartEndDate } from "@web/__tests__/Calendar/calendar.render.test.utils";
 import { preloadedState } from "@web/__tests__/__mocks__/state/state.weekEvents";
 import { getWeekDayLabel } from "@web/common/utils/event.util";
 import { CalendarView } from "@web/views/Calendar";
@@ -52,9 +55,15 @@ describe("Calendar: Display without State", () => {
 });
 
 describe("Calendar: Display with State", () => {
-  it("dispays timed events", async () => {
+  it("displays timed events", async () => {
+    const newPreloadedState = findAndUpdateEventInPreloadedState(
+      preloadedState,
+      GROCERIES._id as string,
+      freshenEventStartEndDate,
+    );
+
     await waitFor(() => {
-      render(<CalendarView />, { state: preloadedState });
+      render(<CalendarView />, { state: newPreloadedState });
     });
     expect(
       screen.getByRole("button", { name: /groceries/i }),

--- a/packages/web/src/__tests__/Calendar/calendar.render.test.utils.ts
+++ b/packages/web/src/__tests__/Calendar/calendar.render.test.utils.ts
@@ -1,0 +1,40 @@
+import dayjs from "dayjs";
+import { PreloadedState } from "redux";
+import { Schema_Event } from "@core/types/event.types";
+
+export const freshenEventStartEndDate = (event: Schema_Event): Schema_Event => {
+  const newStartDate = dayjs(new Date()).add(1, "day").format();
+  const newEndDate = dayjs(new Date()).add(3, "day").format();
+  return { ...event, startDate: newStartDate, endDate: newEndDate };
+};
+
+export const findAndUpdateEventInPreloadedState = (
+  preloadedState: ReturnType<PreloadedState>,
+  eventId: string,
+  callback: (event: Schema_Event) => Schema_Event,
+) => {
+  if (!eventId) {
+    throw new Error("Event ID is required");
+  }
+
+  const event = preloadedState.events.entities.value[eventId];
+  if (!event) {
+    throw new Error(`Event with id ${eventId} not found`);
+  }
+
+  const newPreloadedState = {
+    ...preloadedState,
+    events: {
+      ...preloadedState.events,
+      entities: {
+        ...preloadedState.events.entities,
+        value: {
+          ...preloadedState.events.entities.value,
+          [eventId]: callback(event),
+        },
+      },
+    },
+  };
+
+  return newPreloadedState;
+};

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -7,6 +7,7 @@ import {
   MULTI_WEEK,
   TY_TIM,
 } from "@core/__mocks__/v1/events/events.misc";
+import { freshenEventStartEndDate } from "@web/__tests__/Calendar/calendar.render.test.utils";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 
 export const globalHandlers = [
@@ -28,7 +29,14 @@ export const globalHandlers = [
       );
     }
 
-    const events = [CLIMB, MARCH_1, MULTI_WEEK, TY_TIM, GROCERIES];
+    const events = [
+      CLIMB,
+      MARCH_1,
+      MULTI_WEEK,
+      TY_TIM,
+      // TODO: Need some way to inject the event into globalHandlers.events in a more dynamic way.
+      freshenEventStartEndDate(GROCERIES),
+    ];
     return res(ctx.json(events));
   }),
   rest.delete(`${ENV_WEB.API_BASEURL}/event/:id`, (req, res, ctx) => {

--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -37,6 +37,7 @@ import {
 import { getSomedayEventsSlice } from "../slices/someday.slice";
 import { getWeekEventsSlice } from "../slices/week.slice";
 import {
+  EventDateUtils,
   insertOptimisticEvent,
   normalizedEventsSchema,
   replaceOptimisticId,
@@ -161,12 +162,21 @@ function* getEvents(
       yield put(eventsEntitiesSlice.actions.insert(payload.data));
       return { data: payload.data };
     }
+
+    const _payload = EventDateUtils.adjustStartEndDate(payload);
+
     const res: Response_GetEventsSuccess = (yield call(
       EventApi.get,
-      payload,
+      _payload,
     )) as Response_GetEventsSuccess;
 
-    const normalizedEvents = normalize<Schema_Event>(res.data, [
+    const events = EventDateUtils.filterEventsByStartEndDate(
+      res.data,
+      payload.startDate,
+      payload.endDate,
+    );
+
+    const normalizedEvents = normalize<Schema_Event>(events, [
       normalizedEventsSchema(),
     ]);
 


### PR DESCRIPTION
Closes https://github.com/SwitchbackTech/compass/issues/428

This hotfix resolves the issue by adjusting start date to be 1 day before the actual start date, this allows us to extend our date range to cover additional events that may not be returned. We ensure that the returned events match the initial date range by manually filtering them.