### PR TITLE
✨ feat(toast): prevent duplicate toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "yarn jest",
     "test:backend": "yarn jest backend",
     "test:core": "yarn test core",
-    "test:web": "yarn test web"
+    "test:web": "yarn test web",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
     "@compass/backend": "*",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "test": "yarn jest",
     "test:backend": "yarn jest backend",
     "test:core": "yarn test core",
-    "test:web": "yarn test web",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "test:web": "yarn test web"
   },
   "dependencies": {
     "@compass/backend": "*",

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,7 +1,7 @@
 // sort-imports-ignore
 import * as http from "http";
 import { logger } from "./init";
-// eslint-disable-next-line prettier/prettier
+
 import { ENV } from "./common/constants/env.constants";
 import mongoService from "./common/services/mongo.service";
 import { initExpressServer } from "./servers/express/express.server";

--- a/packages/backend/src/auth/auth.routes.config.ts
+++ b/packages/backend/src/auth/auth.routes.config.ts
@@ -28,7 +28,7 @@ export class AuthRoutes extends CommonRoutesConfig {
       .route(`/api/auth/session`)
       .all(authMiddleware.verifyIsDev)
       //@ts-expect-error res.promise is not returning response types correctly
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+
       .post(authController.createSession)
       .get([
         verifySession(),

--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -42,7 +42,6 @@ const parseUserId = async (res: SessionResponse, e: Error) => {
 
   if (e instanceof GaxiosError) {
     if ("syncToken" in e.config.params) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const syncToken = e.config.params.syncToken as string;
       const sync = await getSyncByToken(syncToken);
 

--- a/packages/backend/src/init.ts
+++ b/packages/backend/src/init.ts
@@ -6,7 +6,7 @@ moduleAlias.addAliases({
   "@backend": `${__dirname}`,
   "@core": `${path.resolve(__dirname, "../../core/src")}`,
 });
-// eslint-disable-next-line prettier/prettier
+
 import { Logger } from "@core/logger/winston.logger";
 
 const dotenvResult = dotenv.config();

--- a/packages/backend/src/servers/websocket/websocket.util.test.ts
+++ b/packages/backend/src/servers/websocket/websocket.util.test.ts
@@ -40,9 +40,8 @@ describe("handleBackgroundCalendarChange", () => {
     webSocketServer.addConnection(userId, socketId);
     webSocketServer.handleBackgroundCalendarChange(userId);
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(mockIo.to).toHaveBeenCalledWith(socketId);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+
     expect(mockIo.emit).toHaveBeenCalledWith(EVENT_CHANGED);
   });
   it("ignores change if no connection between client and ws server", () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,7 +1,7 @@
 // sort-imports-ignore
 import { Command } from "commander";
 import "./init";
-// eslint-disable-next-line prettier/prettier
+
 import { CliValidator } from "./cli.validator";
 import { runBuild } from "./commands/build";
 import { startDeleteFlow } from "./commands/delete";

--- a/packages/scripts/src/commands/build.ts
+++ b/packages/scripts/src/commands/build.ts
@@ -36,7 +36,7 @@ const buildNodePckgs = async (options: Options_Cli) => {
   log.info("Compiling node packages ...");
   shell.exec(
     "yarn tsc --project tsconfig.build.json",
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     async function (code: number) {
       if (code !== 0) {
         log.error("Exiting because of compilation errors");

--- a/packages/web/src/common/utils/event.util.ts
+++ b/packages/web/src/common/utils/event.util.ts
@@ -22,6 +22,7 @@ import {
   Schema_OptimisticEvent,
   Schema_SomedayEventsColumn,
 } from "../types/web.event.types";
+import { toastWithoutDuplication } from "./toast";
 
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
@@ -210,7 +211,9 @@ export const handleError = (error: Error) => {
   }
 
   if (code === Status.INTERNAL_SERVER) {
-    alert("Something went wrong behind the scenes. Please try again later.");
+    toastWithoutDuplication(
+      "Something went wrong behind the scenes. Please try again later.",
+    );
     window.location.reload();
   }
 

--- a/packages/web/src/common/utils/overlap/overlap.ts
+++ b/packages/web/src/common/utils/overlap/overlap.ts
@@ -4,7 +4,7 @@ import { Schema_GridEvent } from "@web/common/types/web.event.types";
 export const adjustOverlappingEvents = (
   events: Schema_GridEvent[],
 ): Schema_GridEvent[] => {
-  let adjustedEvents = deepCopyEvents(events);
+  const adjustedEvents = deepCopyEvents(events);
   adjustedEvents.sort((a, b) => dayjs(a.startDate).diff(dayjs(b.startDate)));
 
   const processedEvents = new Set<string>();

--- a/packages/web/src/common/utils/toast/index.ts
+++ b/packages/web/src/common/utils/toast/index.ts
@@ -1,0 +1,14 @@
+import { toast } from "react-toastify";
+
+type Toast_Args = Parameters<typeof toast>;
+export const toastWithoutDuplication = (
+  content: Toast_Args[0],
+  options: Toast_Args[1] = {},
+) => {
+  if (!options.toastId) {
+    options.toastId = window.btoa(JSON.stringify(content));
+  }
+  if (!toast.isActive(options.toastId)) {
+    toast(content, options);
+  }
+};

--- a/packages/web/src/components/Tooltip/Tooltip.tsx
+++ b/packages/web/src/components/Tooltip/Tooltip.tsx
@@ -32,7 +32,7 @@ export const TooltipTrigger = forwardRef<
   HTMLProps<HTMLElement> & { asChild?: boolean }
 >(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
   const context = useTooltipContext();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+
   const childrenRef = (children as any).ref;
   const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
 

--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -15,6 +15,7 @@ import {
   prepEvtBeforeSubmit,
 } from "@web/common/utils/event.util";
 import { getX } from "@web/common/utils/grid.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import {
   selectDraft,
   selectDraftStatus,
@@ -139,7 +140,7 @@ export const useDraftActions = (
 
   const convert = (start: string, end: string) => {
     if (isAtWeeklyLimit) {
-      alert(SOMEDAY_WEEK_LIMIT_MSG);
+      toastWithoutDuplication(SOMEDAY_WEEK_LIMIT_MSG);
       return;
     }
 

--- a/packages/web/src/views/Calendar/components/Draft/sidebar/hooks/useSidebarActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/sidebar/hooks/useSidebarActions.ts
@@ -22,6 +22,7 @@ import {
   prepEvtBeforeSubmit,
 } from "@web/common/utils/event.util";
 import { getX } from "@web/common/utils/grid.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import {
   getDatesByCategory,
   getMigrationDates,
@@ -320,12 +321,12 @@ export const useSidebarActions = (
     }
 
     if (section === Categories_Event.SOMEDAY_WEEK && isAtWeeklyLimit) {
-      alert(SOMEDAY_WEEK_LIMIT_MSG);
+      toastWithoutDuplication(SOMEDAY_WEEK_LIMIT_MSG);
       return;
     }
 
     if (section === Categories_Event.SOMEDAY_MONTH && isAtMonthlyLimit) {
-      alert(SOMEDAY_MONTH_LIMIT_MSG);
+      toastWithoutDuplication(SOMEDAY_MONTH_LIMIT_MSG);
       return;
     }
 

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -6,6 +6,7 @@ import React, {
   memo,
   useMemo,
 } from "react";
+import { toast } from "react-toastify";
 import { Priorities } from "@core/constants/core.constants";
 import {
   DATA_EVENT_ELEMENT_ID,
@@ -16,6 +17,7 @@ import { isOptimisticEvent } from "@web/common/utils/event.util";
 import { getLineClamp } from "@web/common/utils/grid.util";
 import { isRightClick } from "@web/common/utils/mouse/mouse.util";
 import { getEventPosition } from "@web/common/utils/position.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { getTimesLabel } from "@web/common/utils/web.date.util";
 import { Flex } from "@web/components/Flex";
 import {
@@ -93,7 +95,7 @@ const _GridEvent = (
     onMouseDown: (e: MouseEvent) => {
       if (isRecurring) {
         console.log(event);
-        alert("Can't edit recurring events (yet)");
+        toastWithoutDuplication("Can't edit recurring events (yet)");
         e.stopPropagation();
         return;
       }
@@ -140,7 +142,9 @@ const _GridEvent = (
                 showResizeCursor={!isPlaceholder && !isResizing && !isDragging}
                 onMouseDown={(e) => {
                   if (isRecurring) {
-                    alert("Can't edit recurring events (yet)");
+                    toastWithoutDuplication(
+                      "Can't edit recurring events (yet)",
+                    );
                     e.stopPropagation();
                     return;
                   }
@@ -155,7 +159,9 @@ const _GridEvent = (
                 showResizeCursor={!isPlaceholder && !isResizing && !isDragging}
                 onMouseDown={(e) => {
                   if (isRecurring) {
-                    alert("Can't edit recurring events (yet)");
+                    toastWithoutDuplication(
+                      "Can't edit recurring events (yet)",
+                    );
                     e.stopPropagation();
                     return;
                   }

--- a/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -6,7 +6,6 @@ import React, {
   memo,
   useMemo,
 } from "react";
-import { toast } from "react-toastify";
 import { Priorities } from "@core/constants/core.constants";
 import {
   DATA_EVENT_ELEMENT_ID,

--- a/packages/web/src/views/Calendar/components/Event/styled.ts
+++ b/packages/web/src/views/Calendar/components/Event/styled.ts
@@ -24,10 +24,15 @@ interface StyledEventProps {
   priority: Priority;
   top: number;
   width: number;
+  isRecurring: boolean;
 }
 
 export const StyledEvent = styled.div.attrs<StyledEventProps>((props) => {
   const getBgColor = () => {
+    if (props.isRecurring || props.isInPast) {
+      return darken(colorByPriority[props.priority], 50);
+    }
+
     if (props.isResizing || props.isDragging) {
       return brighten(colorByPriority[props.priority]);
     }

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -1,10 +1,12 @@
 import dayjs from "dayjs";
 import React, { MouseEvent, memo } from "react";
+import { toast } from "react-toastify";
 import { Priorities } from "@core/constants/core.constants";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { Schema_GridEvent } from "@web/common/types/web.event.types";
 import { isOptimisticEvent } from "@web/common/utils/event.util";
 import { getEventPosition } from "@web/common/utils/position.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { Flex } from "@web/components/Flex";
 import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
@@ -55,7 +57,7 @@ const AllDayEvent = ({
     onMouseDown: (e: MouseEvent) => {
       if (isRecurring) {
         console.log(event);
-        alert("Can't edit recurring events (yet)");
+        toastWithoutDuplication("Can't edit recurring events (yet)...");
         e.stopPropagation();
         return;
       }

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { toast } from "react-toastify";
 import { Categories_Event, Schema_Event } from "@core/types/event.types";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { Flex } from "@web/components/Flex";
 import { AlignItems, JustifyContent } from "@web/components/Flex/styled";
 import { FlexDirections } from "@web/components/Flex/styled";
@@ -62,7 +64,7 @@ export const SomedayEventRectangle = ({
             <StyledRecurrenceText
               onClick={(e) => {
                 e.stopPropagation();
-                alert("Can't migrate recurring events");
+                toastWithoutDuplication("Can't migrate recurring events");
               }}
               title="Can't migrate recurring events"
             >

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
@@ -26,7 +26,7 @@ export const WeekSection: FC<Props> = ({
   weekLabel,
   gridRefs,
 }) => {
-  const isCurrentWeek = (label: String): boolean => {
+  const isCurrentWeek = (label: string): boolean => {
     const [start, end] = label.split(" - ");
     const [month, startDay] = start.split(".").map(Number);
     const endDay = Number(end);

--- a/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
+++ b/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
@@ -13,6 +13,7 @@ import { ID_HEADER_NOTE_INPUT } from "@web/common/constants/web.constants";
 import { isEventFormOpen } from "@web/common/utils";
 import { createTimedDraft } from "@web/common/utils/draft/draft.util";
 import { createSomedayDraft } from "@web/common/utils/draft/someday.draft.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import {
   selectIsAtMonthlyLimit,
   selectIsAtWeeklyLimit,
@@ -67,11 +68,11 @@ export const useShortcuts = ({
       category: Categories_Event.SOMEDAY_WEEK | Categories_Event.SOMEDAY_MONTH,
     ) => {
       if (category === Categories_Event.SOMEDAY_WEEK && isAtWeeklyLimit) {
-        alert(SOMEDAY_WEEK_LIMIT_MSG);
+        toastWithoutDuplication(SOMEDAY_WEEK_LIMIT_MSG);
         return;
       }
       if (category === Categories_Event.SOMEDAY_MONTH && isAtMonthlyLimit) {
-        alert(SOMEDAY_MONTH_LIMIT_MSG);
+        toastWithoutDuplication(SOMEDAY_MONTH_LIMIT_MSG);
         return;
       }
 

--- a/packages/web/src/views/CmdPalette/CmdPalette.tsx
+++ b/packages/web/src/views/CmdPalette/CmdPalette.tsx
@@ -6,6 +6,7 @@ import CommandPalette, {
 } from "react-cmdk";
 import "react-cmdk/dist/cmdk.css";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 import {
   SOMEDAY_MONTH_LIMIT_MSG,
   SOMEDAY_WEEK_LIMIT_MSG,
@@ -15,6 +16,7 @@ import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { isEventFormOpen } from "@web/common/utils";
 import { createTimedDraft } from "@web/common/utils/draft/draft.util";
 import { createSomedayDraft } from "@web/common/utils/draft/someday.draft.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import {
   selectIsAtMonthlyLimit,
   selectIsAtWeeklyLimit,
@@ -54,11 +56,11 @@ const CmdPalette = ({
     category: Categories_Event.SOMEDAY_WEEK | Categories_Event.SOMEDAY_MONTH,
   ) => {
     if (category === Categories_Event.SOMEDAY_WEEK && isAtWeeklyLimit) {
-      alert(SOMEDAY_WEEK_LIMIT_MSG);
+      toastWithoutDuplication(SOMEDAY_WEEK_LIMIT_MSG);
       return;
     }
     if (category === Categories_Event.SOMEDAY_MONTH && isAtMonthlyLimit) {
-      alert(SOMEDAY_MONTH_LIMIT_MSG);
+      toastWithoutDuplication(SOMEDAY_MONTH_LIMIT_MSG);
       return;
     }
 

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
@@ -4,6 +4,7 @@ import { Key } from "ts-key-enum";
 import { MONTH_DAY_YEAR } from "@core/constants/date.constants";
 import { darken } from "@core/util/color.utils";
 import { shouldAdjustComplimentDate } from "@web/common/utils/datetime/web.datetime.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { dateIsValid } from "@web/common/utils/web.date.util";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
 import { AlignItems } from "@web/components/Flex/styled";
@@ -76,7 +77,7 @@ export const DatePickers: FC<Props> = ({
         const isInvalid = val !== undefined && !dateIsValid(val);
 
         if (isInvalid) {
-          alert(`Sorry, IDK what to do with a ${picker} date of '${val}'
+          toastWithoutDuplication(`Sorry, IDK what to do with a ${picker} date of '${val}'
           Make sure it's in '${MONTH_DAY_YEAR}' and try again`);
           return;
         }

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { OptionsOrDependencyArray } from "react-hotkeys-hook/dist/types";
+import { toast } from "react-toastify";
 import { Key } from "ts-key-enum";
 import { Priorities } from "@core/constants/core.constants";
 import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
@@ -17,6 +18,7 @@ import {
 } from "@web/common/styles/theme.util";
 import { SelectOption } from "@web/common/types/component.types";
 import { getCategory } from "@web/common/utils/event.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { mapToBackend } from "@web/common/utils/web.date.util";
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection";
 import { DeleteButton } from "@web/views/Forms/EventForm/DeleteButton";
@@ -171,7 +173,9 @@ export const EventForm: React.FC<FormProps> = ({
     const { startDate, endDate } = mapToBackend(selectedDateTimes);
 
     if (dayjs(startDate).isAfter(dayjs(endDate))) {
-      alert("uff-dah, looks like you got the start & end times mixed up");
+      toastWithoutDuplication(
+        "uff-dah, looks like you got the start & end times mixed up",
+      );
       return;
     }
 

--- a/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
+++ b/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
@@ -1,11 +1,11 @@
 import React, { KeyboardEvent, MouseEvent, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { OptionsOrDependencyArray } from "react-hotkeys-hook/dist/types";
-import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { Key } from "ts-key-enum";
 import { ID_SOMEDAY_EVENT_FORM } from "@web/common/constants/web.constants";
 import { colorByPriority } from "@web/common/styles/theme.util";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { getSomedayEventsSlice } from "@web/ducks/events/slices/someday.slice";
 import { useAppDispatch } from "@web/store/store.hooks";
 import { DeleteButton } from "@web/views/Forms/EventForm/DeleteButton";
@@ -76,7 +76,7 @@ export const SomedayEventForm: React.FC<FormProps> = ({
       const eventTitle = isRecurrence
         ? `Deleted all future ${recurTitle}`
         : `Deleted ${title}`;
-      toast(eventTitle);
+      toastWithoutDuplication(eventTitle);
     }
 
     onClose();

--- a/packages/web/src/views/Login/Login.tsx
+++ b/packages/web/src/views/Login/Login.tsx
@@ -7,6 +7,7 @@ import { useAuthCheck } from "@web/auth/useAuthCheck";
 import { AuthApi } from "@web/common/apis/auth.api";
 import { WaitlistApi } from "@web/common/apis/waitlist.api";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
 import { LoginAbsoluteOverflowLoader } from "@web/components/LoginAbsoluteOverflowLoader/LoginAbsoluteOverflowLoader";
 import {
@@ -91,12 +92,14 @@ export const LoginView = () => {
     onSuccess: async ({ code, scope, state }) => {
       const isFromHacker = state !== antiCsrfToken;
       if (isFromHacker) {
-        alert("Nice try, hacker");
+        toastWithoutDuplication("Nice try, hacker");
         return;
       }
 
       if (isMissingPermissions(scope)) {
-        alert("Missing permissions, please click all the checkboxes");
+        toastWithoutDuplication(
+          "Missing permissions, please click all the checkboxes",
+        );
         return;
       }
 
@@ -106,13 +109,13 @@ export const LoginView = () => {
         setIsAuthenticated(true);
       } catch (e) {
         console.error(e);
-        alert("Login failed. Please try again.");
+        toastWithoutDuplication("Login failed. Please try again.");
       } finally {
         setIsAuthenticating(false);
       }
     },
     onError: (error) => {
-      alert(`Login failed because: ${error.error}`);
+      toastWithoutDuplication(`Login failed because: ${error.error}`);
       console.error(error);
     },
   });

--- a/packages/web/src/views/Logout/Logout.tsx
+++ b/packages/web/src/views/Logout/Logout.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Session, { signOut } from "supertokens-auth-react/recipe/session";
 import { SyncApi } from "@web/common/apis/sync.api";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { toastWithoutDuplication } from "@web/common/utils/toast";
 import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
 import { AlignItems, FlexDirections } from "@web/components/Flex/styled";
 import { StyledLogin } from "../Login/styled";
@@ -17,13 +18,13 @@ export const LogoutView = () => {
     const checkSession = async () => {
       const isLoggedIn = await Session.doesSessionExist();
       if (!isLoggedIn) {
-        alert("You're not logged in");
+        toastWithoutDuplication("You're not logged in");
         navigate(ROOT_ROUTES.LOGIN);
       }
     };
 
     checkSession().catch((e) => {
-      alert(e);
+      toastWithoutDuplication(e);
       console.error(e);
     });
   }, [navigate]);
@@ -36,7 +37,7 @@ export const LogoutView = () => {
 
     setIsLoggingOut(false);
 
-    alert("You logged out - see ya! ✌");
+    toastWithoutDuplication("You logged out - see ya! ✌");
     navigate(ROOT_ROUTES.LOGIN);
   };
 


### PR DESCRIPTION
Replaces the intrusive browser alert() with a non-blocking toast notification when a user attempts to edit a recurring event. This enhances UX and keeps interactions smoother.

Closes #445 .