### PR TITLE
🧪 Test: fix calendar render test

### DIFF
--- a/packages/core/src/__mocks__/v1/events/events.misc.ts
+++ b/packages/core/src/__mocks__/v1/events/events.misc.ts
@@ -14,11 +14,10 @@ export const CHILL_ALL_DAY: Schema_Event = {
   origin: Origin.GOOGLE_IMPORT,
   title: "chill all day",
   description: "just chillin",
-  priorities: [],
+  priority: Priorities.RELATIONS,
   isAllDay: true,
   startDate: "2022-09-23",
   endDate: "2022-09-24",
-  priority: Priorities.RELATIONS,
 };
 export const CLIMB: Schema_Event = {
   _id: "62322b127837957382660217",
@@ -27,11 +26,10 @@ export const CLIMB: Schema_Event = {
   origin: Origin.GOOGLE_IMPORT,
   title: "Climb",
   description: "",
-  priorities: [],
+  priority: Priorities.WORK,
   isAllDay: false,
   startDate: "2022-03-01T17:00:00-06:00",
   endDate: "2022-03-01T19:00:00-06:00",
-  priority: Priorities.WORK,
 };
 export const EUROPE_TRIP: Schema_Event = {
   _id: "6262d2840138892cb743444a",
@@ -58,11 +56,10 @@ export const MARCH_1: Schema_Event = {
   origin: Origin.GOOGLE_IMPORT,
   title: "Mar 1",
   description: "",
-  priorities: [],
+  priority: Priorities.WORK,
   isAllDay: true,
   startDate: "2022-03-01",
   endDate: "2022-03-02",
-  priority: Priorities.WORK,
 };
 export const GROCERIES: Schema_Event = {
   _id: "620c177bfadfdec705cdd70a",
@@ -71,11 +68,10 @@ export const GROCERIES: Schema_Event = {
   origin: Origin.GOOGLE_IMPORT,
   title: "groceries",
   description: "foo",
-  priorities: [],
+  priority: Priorities.RELATIONS,
   isAllDay: false,
   startDate: "2022-02-21T11:45:00-06:00",
   endDate: "2022-02-21T12:45:00-06:00",
-  priority: Priorities.RELATIONS,
 };
 export const MULTI_WEEK: Schema_Event = {
   _id: "62322b12783795738266022e",
@@ -84,12 +80,11 @@ export const MULTI_WEEK: Schema_Event = {
   origin: Origin.GOOGLE_IMPORT,
   title: "multiweek event",
   description: "",
-  priorities: [],
+  priority: Priorities.WORK,
   isAllDay: true,
   isSomeday: false,
   startDate: "2022-09-01T00:00:00-06:00",
   endDate: "2022-09-22T00:00:00-06:00",
-  priority: Priorities.WORK,
 };
 export const TY_TIM: Schema_Event = {
   _id: "62322b127837957382660231",
@@ -98,8 +93,7 @@ export const TY_TIM: Schema_Event = {
   origin: Origin.GOOGLE_IMPORT,
   title: "Ty & Tim",
   description:
-    "──────────\n\nTim Schuster is inviting you to a scheduled Zoom meeting.\n\nJoin Zoom Meeting\nhttps://us02web.zoom.us/j/87324397243?pwd=ZmpuYitCelZYVll0aDdiVUNXejdzdz09\n\nMeeting ID: 873 2439 7243\nPasscode: 305275\nOne tap mobile\n+16465588656,,87324397243#,,,,*305275# US (New York)\n+13017158592,,87324397243#,,,,*305275# US (Washington DC)\n\nDial by your location\n        +1 646 558 8656 US (New York)\n        +1 301 715 8592 US (Washington DC)\n        +1 312 626 6799 US (Chicago)\n        +1 669 900 9128 US (San Jose)\n        +1 253 215 8782 US (Tacoma)\n        +1 346 248 7799 US (Houston)\nMeeting ID: 873 2439 7243\nPasscode: 305275\nFind your local number: https://us02web.zoom.us/u/kdbALZcOSa\n\n\n──────────",
-  priorities: [],
+    "──────────\n\nTim S is inviting you to a scheduled Zoom meeting.\n\nJoin Zoom Meeting\nhttps://us02web.zoom.us/j/87324397243?pwd=ZmpuYitCelZYVll0aDdiVUNXejdzdz09\n\nMeeting ID: 873 2439 7243\nPasscode: 305275\nOne tap mobile\n+16465588656,,87324397243#,,,,*305275# US (New York)\n+13017158592,,87324397243#,,,,*305275# US (Washington DC)\n\nDial by your location\n        +1 646 558 8656 US (New York)\n        +1 301 715 8592 US (Washington DC)\n        +1 312 626 6799 US (Chicago)\n        +1 669 900 9128 US (San Jose)\n        +1 253 215 8782 US (Tacoma)\n        +1 346 248 7799 US (Houston)\nMeeting ID: 873 2439 7243\nPasscode: 305275\nFind your local number: https://us02web.zoom.us/u/kdbALZcOSa\n\n\n──────────",
   isAllDay: false,
   isSomeday: false,
   startDate: "2022-03-01T12:15:00-06:00",

--- a/packages/web/src/__tests__/Calendar/calendar.render.test.tsx
+++ b/packages/web/src/__tests__/Calendar/calendar.render.test.tsx
@@ -27,10 +27,6 @@ describe("Calendar: Display without State", () => {
       render(<CalendarView />);
     });
 
-    /* current year in YYYY format */
-    // const currentYear = new Date().getFullYear().toString(); // YYYY
-    // expect(screen.getByText(currentYear)).toBeInTheDocument();
-
     /* week nav arrows */
     expect(
       screen.getByRole("navigation", {
@@ -68,9 +64,5 @@ describe("Calendar: Display with State", () => {
     expect(
       screen.getByRole("button", { name: /groceries/i }),
     ).toBeInTheDocument();
-
-    //   expect(
-    //     screen.getByRole("button", { name: /chill all day/i })
-    //   ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/Calendar/calendar.render.test.utils.ts
+++ b/packages/web/src/__tests__/Calendar/calendar.render.test.utils.ts
@@ -128,8 +128,22 @@ export const createInitialState = (
 };
 
 export const freshenEventStartEndDate = (event: Schema_Event): Schema_Event => {
-  const newStartDate = dayjs(new Date()).add(1, "day").format();
-  const newEndDate = dayjs(new Date()).add(3, "day").format();
+  // Set event to start on the current week's Thursday at 11am and end at 12pm (timed event)
+  const now = dayjs();
+  const startOfWeek = now.startOf("week"); // Sunday
+  const thursday = startOfWeek.add(4, "day"); // Thursday
+  const newStartDate = thursday
+    .hour(11)
+    .minute(0)
+    .second(0)
+    .millisecond(0)
+    .format();
+  const newEndDate = thursday
+    .hour(12)
+    .minute(0)
+    .second(0)
+    .millisecond(0)
+    .format();
   return { ...event, startDate: newStartDate, endDate: newEndDate };
 };
 

--- a/packages/web/src/__tests__/Calendar/calendar.render.test.utils.ts
+++ b/packages/web/src/__tests__/Calendar/calendar.render.test.utils.ts
@@ -1,6 +1,131 @@
 import dayjs from "dayjs";
 import { PreloadedState } from "redux";
 import { Schema_Event } from "@core/types/event.types";
+import { RootState } from "@web/store";
+
+// Type for the initial state that can be passed to PreloadedState
+export type InitialReduxState = PreloadedState<RootState>;
+
+// Type for the simplified test state that matches our mock
+type TestState = {
+  events: {
+    getSomedayEvents?: {
+      value: {
+        data: string[];
+        count: number;
+        pageSize: number;
+        offset?: number;
+        page?: number;
+        [key: string]: unknown;
+      } | null;
+      isProcessing: boolean;
+      isSuccess: boolean;
+      error: unknown;
+      reason: string | null;
+    };
+    getWeekEvents?: {
+      value: {
+        data: string[];
+        count: number;
+        pageSize: number;
+        offset?: number;
+        page?: number;
+        [key: string]: unknown;
+      } | null;
+      isProcessing: boolean;
+      isSuccess: boolean;
+      error: unknown;
+      reason: string | null;
+    };
+    entities?: {
+      value: Record<string, unknown>;
+    };
+  };
+};
+
+// Helper to create initial state with sensible defaults
+export const createInitialState = (
+  partialState: Partial<RootState> = {},
+): InitialReduxState => {
+  const now = new Date();
+  const oneWeekLater = new Date(now);
+  oneWeekLater.setDate(now.getDate() + 7);
+
+  return {
+    events: {
+      entities: { value: {} },
+      getWeekEvents: {
+        value: null,
+        isProcessing: false,
+        error: null,
+        isSuccess: false,
+        reason: null,
+      },
+      getSomedayEvents: {
+        value: null,
+        isProcessing: false,
+        error: null,
+        isSuccess: false,
+        reason: null,
+      },
+      getCurrentMonthEvents: {
+        value: null,
+        isProcessing: false,
+        error: null,
+        isSuccess: false,
+        reason: null,
+      },
+      createEvent: {
+        isProcessing: false,
+        error: null,
+        value: null,
+        isSuccess: false,
+        reason: null,
+      },
+      editEvent: {
+        isProcessing: false,
+        error: null,
+        value: null,
+        isSuccess: false,
+        reason: null,
+      },
+      deleteEvent: {
+        isProcessing: false,
+        error: null,
+        value: null,
+        isSuccess: false,
+        reason: null,
+      },
+      draft: {
+        event: null,
+        status: {
+          activity: null,
+          isDrafting: false,
+          eventType: null,
+          dateToResize: null,
+        },
+      },
+    },
+    view: {
+      dates: {
+        start: now.toISOString(),
+        end: oneWeekLater.toISOString(),
+      },
+      sidebar: {
+        tab: "tasks",
+        isOpen: true,
+      },
+    },
+    settings: {
+      isCmdPaletteOpen: false,
+    },
+    sync: {
+      isFetchNeeded: false,
+      reason: null,
+    },
+    ...partialState,
+  };
+};
 
 export const freshenEventStartEndDate = (event: Schema_Event): Schema_Event => {
   const newStartDate = dayjs(new Date()).add(1, "day").format();
@@ -9,32 +134,46 @@ export const freshenEventStartEndDate = (event: Schema_Event): Schema_Event => {
 };
 
 export const findAndUpdateEventInPreloadedState = (
-  preloadedState: ReturnType<PreloadedState>,
+  preloadedState: TestState,
   eventId: string,
   callback: (event: Schema_Event) => Schema_Event,
-) => {
+): TestState => {
   if (!eventId) {
     throw new Error("Event ID is required");
   }
 
-  const event = preloadedState.events.entities.value[eventId];
+  // Early return for invalid event ID
+  if (!eventId) {
+    throw new Error("Event ID is required");
+  }
+
+  // Safely access the events with proper null checks
+  const events = preloadedState?.events?.entities?.value;
+  if (!events) {
+    throw new Error("Events state is not properly initialized");
+  }
+
+  const event = events[eventId];
   if (!event) {
     throw new Error(`Event with id ${eventId} not found`);
   }
 
-  const newPreloadedState = {
+  // Create a deep copy of the event to avoid mutations
+  const eventCopy = JSON.parse(JSON.stringify(event));
+  const updatedEvent = callback(eventCopy);
+
+  // Return new state with updated event
+  return {
     ...preloadedState,
     events: {
       ...preloadedState.events,
       entities: {
         ...preloadedState.events.entities,
         value: {
-          ...preloadedState.events.entities.value,
-          [eventId]: callback(event),
+          ...events,
+          [eventId]: updatedEvent,
         },
       },
     },
   };
-
-  return newPreloadedState;
 };

--- a/packages/web/src/__tests__/__mocks__/mock.render.tsx
+++ b/packages/web/src/__tests__/__mocks__/mock.render.tsx
@@ -13,6 +13,11 @@ import { GlobalStyle } from "@web/components/GlobalStyle";
 import { reducers } from "@web/store/reducers";
 import { sagas } from "@web/store/sagas";
 
+type CustomRenderOptions = Omit<RenderOptions, "wrapper"> & {
+  state?: any;
+  store?: ReturnType<typeof configureStore>;
+};
+
 const customRender = (
   ui: ReactElement,
   {
@@ -23,9 +28,8 @@ const customRender = (
       reducer: reducers,
       preloadedState: state,
     }),
-
     ...renderOptions
-  } = {},
+  }: CustomRenderOptions = {},
 ) => {
   sagaMiddleware.run(sagas);
 

--- a/packages/web/src/__tests__/__mocks__/state/state.weekEvents.ts
+++ b/packages/web/src/__tests__/__mocks__/state/state.weekEvents.ts
@@ -66,7 +66,7 @@ export const preloadedState: InitialReduxState = {
     },
     sidebar: {
       tab: "tasks",
-      isOpen: false,
+      isOpen: true,
     },
   },
 };

--- a/packages/web/src/__tests__/__mocks__/state/state.weekEvents.ts
+++ b/packages/web/src/__tests__/__mocks__/state/state.weekEvents.ts
@@ -7,36 +7,66 @@ import {
   MULTI_WEEK,
   TY_TIM,
 } from "@core/__mocks__/v1/events/events.misc";
+import { InitialReduxState } from "@web/__tests__/Calendar/calendar.render.test.utils";
 
-export const preloadedState = {
+export const preloadedState: InitialReduxState = {
   events: {
     getSomedayEvents: {
       value: {
-        data: [EUROPE_TRIP._id],
+        data: [EUROPE_TRIP._id as string],
+        count: 0,
+        pageSize: 0,
       },
+      isProcessing: false,
+      isSuccess: false,
+      error: undefined,
+      reason: null,
     },
     getWeekEvents: {
       value: {
         data: [
-          CLIMB._id,
-          CHILL_ALL_DAY._id,
-          GROCERIES._id,
-          MARCH_1._id,
-          MULTI_WEEK._id,
-          TY_TIM._id,
+          CLIMB._id as string,
+          CHILL_ALL_DAY._id as string,
+          GROCERIES._id as string,
+          MARCH_1._id as string,
+          MULTI_WEEK._id as string,
+          TY_TIM._id as string,
         ],
+        count: 0,
+        pageSize: 0,
       },
+      isProcessing: false,
+      isSuccess: false,
+      error: undefined,
+      reason: null,
     },
     entities: {
       value: {
-        [CLIMB._id]: CLIMB,
-        [CHILL_ALL_DAY._id]: CHILL_ALL_DAY,
-        [EUROPE_TRIP._id]: EUROPE_TRIP,
-        [GROCERIES._id]: GROCERIES,
-        [MARCH_1._id]: MARCH_1,
-        [MULTI_WEEK._id]: MULTI_WEEK,
-        [TY_TIM._id]: TY_TIM,
+        [CLIMB._id as string]: CLIMB,
+        [CHILL_ALL_DAY._id as string]: CHILL_ALL_DAY,
+        [EUROPE_TRIP._id as string]: EUROPE_TRIP,
+        [GROCERIES._id as string]: GROCERIES,
+        [MARCH_1._id as string]: MARCH_1,
+        [MULTI_WEEK._id as string]: MULTI_WEEK,
+        [TY_TIM._id as string]: TY_TIM,
       },
+    },
+  },
+  settings: {
+    isCmdPaletteOpen: false,
+  },
+  sync: {
+    isFetchNeeded: false,
+    reason: null,
+  },
+  view: {
+    dates: {
+      start: "",
+      end: "",
+    },
+    sidebar: {
+      tab: "tasks",
+      isOpen: false,
     },
   },
 };


### PR DESCRIPTION
Fix: Calendar Timed Event Test Reliability (calendar.render.test.tsx)

### Problem
- The test Calendar: Display with State > displays timed events was intermittently failing. The root cause was that the test utility freshenEventStartEndDate set the event date to a relative range that did not always align with the current calendar view, causing the "groceries" event to be filtered out and not rendered.

### Solution
- Updated freshenEventStartEndDate:
- This utility now sets the test event’s start and end date to the current week’s Thursday (11am–12pm). This guarantees that the event will always be visible in the main calendar grid during the test, regardless of when the test is run.
Impact
- The test for displaying timed events is now reliable and deterministic.
- No production code was changed; only test utilities were updated.

### How to Verify

```sh
yarn test packages/web/src/__tests__/Calendar/calendar.render.test.tsx and confirm all tests pass consistently.
```

Closes #483
