### PR TITLE
✨ Feat: Add seed command to create sample events in bulk

### DIFF
--- a/packages/scripts/src/__tests__/seed.test.ts
+++ b/packages/scripts/src/__tests__/seed.test.ts
@@ -1,0 +1,58 @@
+import { _confirm } from "@scripts/common/cli.utils";
+import mongoService from "@backend/common/services/mongo.service";
+import eventService from "@backend/event/services/event.service";
+import { startSeedFlow } from "../commands/seed";
+
+jest.mock("@backend/event/services/event.service");
+jest.mock("@backend/common/services/mongo.service");
+jest.mock("@scripts/common/cli.utils", () => ({
+  _confirm: jest.fn(),
+  log: {
+    info: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("seed command", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.exit = jest.fn() as any;
+  });
+
+  it("should create sample events when force flag is true", async () => {
+    await startSeedFlow(true);
+
+    expect(mongoService.waitUntilConnected).toHaveBeenCalled();
+    expect(_confirm).not.toHaveBeenCalled();
+    expect(eventService.createEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it("should prompt for confirmation when force flag is false", async () => {
+    (_confirm as jest.Mock).mockResolvedValue(true);
+
+    await startSeedFlow(false);
+
+    expect(_confirm).toHaveBeenCalled();
+    expect(eventService.createEvent).toHaveBeenCalledTimes(3);
+  });
+
+  it("should exit when user denies confirmation", async () => {
+    (_confirm as jest.Mock).mockResolvedValue(false);
+
+    await startSeedFlow(false);
+
+    expect(_confirm).toHaveBeenCalled();
+    expect(eventService.createEvent).not.toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("should handle errors gracefully", async () => {
+    const error = new Error("Test error");
+    (eventService.createEvent as jest.Mock).mockRejectedValue(error);
+
+    await startSeedFlow(true);
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -6,6 +6,7 @@ import { CliValidator } from "./cli.validator";
 import { runBuild } from "./commands/build";
 import { startDeleteFlow } from "./commands/delete";
 import { inviteWaitlist } from "./commands/invite";
+import { startSeedFlow } from "./commands/seed";
 import { ALL_PACKAGES, CATEGORY_VM } from "./common/cli.constants";
 
 class CompassCli {
@@ -36,6 +37,10 @@ class CompassCli {
       }
       case cmd === "invite": {
         await inviteWaitlist();
+        break;
+      }
+      case cmd === "seed": {
+        await startSeedFlow(force);
         break;
       }
       default:
@@ -76,6 +81,14 @@ class CompassCli {
       );
 
     program.command("invite").description("invite users from the waitlist");
+
+    program
+      .command("seed")
+      .description(
+        "create sample events in bulk in Compass and Google Calendar",
+      )
+      .option("-f, --force", "skip confirmation prompt");
+
     return program;
   }
 }

--- a/packages/scripts/src/commands/seed.ts
+++ b/packages/scripts/src/commands/seed.ts
@@ -1,0 +1,72 @@
+import { _confirm, log } from "@scripts/common/cli.utils";
+import mongoService from "@backend/common/services/mongo.service";
+import eventService from "@backend/event/services/event.service";
+
+const WARNING_MESSAGE = `⚠️ WARNING ⚠️
+
+This operation will:
+1. Create multiple events in your Compass calendar
+2. Create multiple events in your main Google Calendar
+
+It is recommended to use a test account instead of your personal account.
+
+Do you want to continue?`;
+
+export const startSeedFlow = async (force = false) => {
+  await mongoService.waitUntilConnected();
+  if (!force) {
+    const shouldProceed = await _confirm(WARNING_MESSAGE);
+    if (!shouldProceed) {
+      log.info("Operation cancelled by user");
+      process.exit(0);
+    }
+  }
+
+  try {
+    log.info("Creating sample events...");
+
+    const sampleEvents = [
+      {
+        title: "Weekly Team Meeting",
+        description: "Weekly meeting to discuss project progress",
+        start: new Date(Date.now() + 24 * 60 * 60 * 1000), // tomorrow
+        duration: 60, // 60 minutes
+        isRecurring: true,
+        recurrence: {
+          frequency: "weekly",
+          interval: 1,
+        },
+      },
+      {
+        title: "Sprint Review",
+        description: "Review achieved goals and plan next sprint",
+        start: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // in 2 days
+        duration: 120, // 2 hours
+        isRecurring: false,
+      },
+      {
+        title: "1:1 with Mentor",
+        description: "Individual mentoring session",
+        start: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000), // in 3 days
+        duration: 30, // 30 minutes
+        isRecurring: true,
+        recurrence: {
+          frequency: "biweekly",
+          interval: 2,
+        },
+      },
+    ];
+
+    for (const eventData of sampleEvents) {
+      await eventService.createEvent(eventData);
+      log.info(`✓ Event created: ${eventData.title}`);
+    }
+
+    log.success("Sample events created successfully");
+  } catch (error) {
+    log.error(`Error creating sample events: ${error}`);
+    process.exit(1);
+  }
+
+  process.exit(0);
+};


### PR DESCRIPTION
Closes #507

Changes:
- Added warning message about creation of multiple events in Compass and Google Calendar
- Added recommendation to use test account instead of personal account
- Implemented user confirmation prompt before proceeding
- Added --force flag to skip confirmation
- Added unit tests
- Updated documentation