### PR TITLE
fix(web): handle allday events when manually filtering by start-end date

### DIFF
--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -172,8 +172,8 @@ function* getEvents(
 
     const events = EventDateUtils.filterEventsByStartEndDate(
       res.data,
-      payload.startDate,
-      payload.endDate,
+      payload.startDate as string,
+      payload.endDate as string,
     );
 
     const normalizedEvents = normalize<Schema_Event>(events, [

--- a/packages/web/src/ducks/events/sagas/saga.util.ts
+++ b/packages/web/src/ducks/events/sagas/saga.util.ts
@@ -97,6 +97,17 @@ export const EventDateUtils = {
     endDate: string,
   ) => {
     return events.filter((event) => {
+      if (event.isAllDay) {
+        const belongsInRange =
+          dayjs(event.startDate).isSameOrAfter(startDate) ||
+          dayjs(event.endDate).isSameOrBefore(endDate) ||
+          // is between start and end date
+          (dayjs(startDate).isBetween(event.startDate, event.endDate) &&
+            dayjs(endDate).isBetween(event.startDate, event.endDate));
+
+        return belongsInRange;
+      }
+
       return (
         dayjs(event.startDate).isSameOrAfter(startDate) &&
         dayjs(event.endDate).isSameOrBefore(endDate)


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/532

allday events were not handled properly since they could span outside the week's start-end date. this PR adds logic to handle that.