### PR TITLE
🐛 fix: simplify session creation to only use compass user ID

### DIFF
--- a/packages/core/src/types/auth.types.ts
+++ b/packages/core/src/types/auth.types.ts
@@ -23,10 +23,6 @@ export interface User_Google {
   tokens: Credentials;
 }
 
-export interface UserInfo_Compass {
-  cUserId?: string;
-  email?: string;
-}
 export interface UserInfo_Google {
   gUser: TokenPayload;
   tokens: Credentials;


### PR DESCRIPTION
Closes #545 by requiring a valid user id before creating a session 