### PR TITLE
🐛 Fix: Date validation error when creating someday event using W shortcut

### DIFF
--- a/packages/web/src/common/utils/draft/someday.draft.util.ts
+++ b/packages/web/src/common/utils/draft/someday.draft.util.ts
@@ -1,6 +1,6 @@
 import { Dayjs } from "dayjs";
 import { Dispatch } from "redux";
-import { YEAR_MONTH_FORMAT } from "@core/constants/date.constants";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event } from "@core/types/event.types";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { Activity_DraftEvent } from "@web/ducks/events/slices/draft.slice.types";
@@ -13,8 +13,8 @@ export const createSomedayDraft = async (
   activity: Activity_DraftEvent,
   dispatch: Dispatch,
 ) => {
-  const startDate = startOfView.format(YEAR_MONTH_FORMAT);
-  const endDate = endOfView.format(YEAR_MONTH_FORMAT);
+  const startDate = startOfView.format(YEAR_MONTH_DAY_FORMAT);
+  const endDate = endOfView.format(YEAR_MONTH_DAY_FORMAT);
 
   const event = await assembleDefaultEvent(category, startDate, endDate);
 


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/551

issue was because we were using `YEAR_MONTH_FORMAT` which is 'YYYY-MM', meaning an incorrect date format was being passed to zod and that was triggering the error.