### PR TITLE
✨ Feat(web): Implement shortcut tooltips for someday event migrate buttons

### DIFF
--- a/packages/web/src/common/utils/shortcut.util.tsx
+++ b/packages/web/src/common/utils/shortcut.util.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Command, WindowsLogo } from "@phosphor-icons/react";
+import { DesktopOS, getDesktopOS } from "@web/common/utils/device.util";
+
+export const getMetaKey = ({ size = 14 }: { size?: number } = {}) => {
+  const desktopOS = getDesktopOS();
+  const isMacOS = desktopOS === DesktopOS.MacOS;
+
+  return isMacOS ? <Command size={size} /> : <WindowsLogo size={size} />;
+};

--- a/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { Command, WindowsLogo } from "@phosphor-icons/react";
 import { theme } from "@web/common/styles/theme";
-import { DesktopOS, getDesktopOS } from "@web/common/utils/device.util";
+import { getMetaKey } from "@web/common/utils/shortcut.util";
 import { CalendarIcon } from "@web/components/Icons/Calendar";
 import { CommandIcon } from "@web/components/Icons/Command";
 import { TodoIcon } from "@web/components/Icons/Todo";
@@ -29,12 +28,9 @@ export const SidebarIconRow = () => {
   };
 
   const getCommandPaletteShortcut = () => {
-    const desktopOS = getDesktopOS();
-    const isMacOS = desktopOS === DesktopOS.MacOS;
-
     return (
       <Text size="s" style={{ display: "flex", alignItems: "center" }}>
-        {isMacOS ? <Command size={14} /> : <WindowsLogo size={14} />} + K
+        {getMetaKey()} + K
       </Text>
     );
   };

--- a/packages/web/src/views/Forms/EventForm/MigrateBackwardButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MigrateBackwardButton.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styled from "styled-components";
+import { getMetaKey } from "@web/common/utils/shortcut.util";
+import { Text } from "@web/components/Text";
 import TooltipIconButton from "@web/components/TooltipIconButton/TooltipIconButton";
 
 const StyledMigrateBackwardButton = styled.div`
@@ -27,6 +29,11 @@ export const MigrateBackwardButton = ({
       tooltipProps={{
         description: tooltipText,
         onClick,
+        shortcut: (
+          <Text size="s" style={{ display: "flex", alignItems: "center" }}>
+            Ctrl + {getMetaKey()} + Left
+          </Text>
+        ),
       }}
     />
   );

--- a/packages/web/src/views/Forms/EventForm/MigrateForwardButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MigrateForwardButton.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styled from "styled-components";
+import { getMetaKey } from "@web/common/utils/shortcut.util";
+import { Text } from "@web/components/Text";
 import TooltipIconButton from "@web/components/TooltipIconButton/TooltipIconButton";
 
 const StyledMigrateForwardButton = styled.div`
@@ -27,6 +29,11 @@ export const MigrateForwardButton = ({
       tooltipProps={{
         description: tooltipText,
         onClick,
+        shortcut: (
+          <Text size="s" style={{ display: "flex", alignItems: "center" }}>
+            Ctrl + {getMetaKey()} + Right
+          </Text>
+        ),
       }}
     />
   );

--- a/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MoveToSidebarButton.tsx
@@ -1,23 +1,14 @@
 import React from "react";
-import { Command, WindowsLogo } from "@phosphor-icons/react";
-import { DesktopOS, getDesktopOS } from "@web/common/utils/device.util";
+import { getMetaKey } from "@web/common/utils/shortcut.util";
 import { Text } from "@web/components/Text";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import { StyledMigrateArrowInForm } from "@web/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/styled";
 
 export const MoveToSidebarButton = ({ onClick }: { onClick: () => void }) => {
   const getShortcut = () => {
-    let isMacOS = false;
-
-    const desktopOS = getDesktopOS();
-    if (desktopOS === DesktopOS.MacOS) {
-      isMacOS = true;
-    }
-
     return (
       <Text size="s" style={{ display: "flex", alignItems: "center" }}>
-        {isMacOS ? <Command size={14} /> : <WindowsLogo size={14} />} +
-        {" SHIFT "} + {","}
+        {getMetaKey()} +{" SHIFT "} + {","}
       </Text>
     );
   };

--- a/packages/web/src/views/Forms/EventForm/SaveSection/SaveSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/SaveSection/SaveSection.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { Command, WindowsLogo } from "@phosphor-icons/react";
 import { Priority } from "@core/constants/core.constants";
-import { DesktopOS, getDesktopOS } from "@web/common/utils/device.util";
+import { getMetaKey } from "@web/common/utils/shortcut.util";
 import { StyledSaveBtn } from "@web/components/Button/styled";
 import { Text } from "@web/components/Text";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
@@ -16,21 +15,13 @@ export const SaveSection: React.FC<Props> = ({
   onSubmit: _onSubmit,
   priority,
 }) => {
-  let isMacOS = false;
-
-  const desktopOs = getDesktopOS();
-  if (desktopOs === DesktopOS.MacOS) {
-    isMacOS = true;
-  }
-
   return (
     <StyledSubmitRow>
       <TooltipWrapper
         onClick={_onSubmit}
         shortcut={
           <Text size="s" style={{ display: "flex", alignItems: "center" }}>
-            {isMacOS ? <Command size={14} /> : <WindowsLogo size={14} />} +
-            Enter
+            {getMetaKey()} + Enter
           </Text>
         }
         description="Save event"


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/526
Follow up to https://github.com/SwitchbackTech/compass/pull/559

This PR implements shortcut tooltips for the someday event migrate to next/prev week/month.


## Screenshots
<img width="691" alt="image" src="https://github.com/user-attachments/assets/7f717bd0-f734-409e-b438-f4ffc86744a5" />
