### PR TITLE
🐛 Fix: Someday event in wrong location after creating with 'm' shortcut

### DIFF
--- a/packages/web/src/common/utils/draft/someday.draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/someday.draft.util.test.ts
@@ -1,0 +1,106 @@
+import dayjs from "dayjs";
+import { Categories_Event } from "@core/types/event.types";
+import { draftSlice } from "@web/ducks/events/slices/draft.slice";
+import { Activity_DraftEvent } from "@web/ducks/events/slices/draft.slice.types";
+import { assembleDefaultEvent } from "../event.util";
+import { createSomedayDraft } from "./someday.draft.util";
+
+// Mock assembleDefaultEvent since it makes external calls
+jest.mock("../event.util", () => ({
+  assembleDefaultEvent: jest
+    .fn()
+    .mockImplementation(async (category, startDate, endDate) => ({
+      _id: "mock-id",
+      user: "mock-user",
+      title: "",
+      startDate,
+      endDate,
+      isAllDay: false,
+      isSomeday: true,
+    })),
+}));
+
+describe("createSomedayDraft", () => {
+  const mockDispatch = jest.fn();
+  const mockActivity: Activity_DraftEvent = "sidebarClick";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should set correct dates for week category", async () => {
+    const startOfView = dayjs("2024-03-10"); // A Sunday
+    const endOfView = startOfView.add(6, "days"); // Saturday
+
+    await createSomedayDraft(
+      Categories_Event.SOMEDAY_WEEK,
+      startOfView,
+      endOfView,
+      mockActivity,
+      mockDispatch,
+    );
+
+    const expectedStart = "2024-03-10";
+    const expectedEnd = "2024-03-16";
+
+    expect(assembleDefaultEvent).toHaveBeenCalledWith(
+      Categories_Event.SOMEDAY_WEEK,
+      expectedStart,
+      expectedEnd,
+    );
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      draftSlice.actions.start({
+        activity: mockActivity,
+        eventType: Categories_Event.SOMEDAY_WEEK,
+        event: {
+          _id: "mock-id",
+          user: "mock-user",
+          title: "",
+          startDate: expectedStart,
+          endDate: expectedEnd,
+          isAllDay: false,
+          isSomeday: true,
+        },
+      }),
+    );
+  });
+
+  it("should set correct dates for month category", async () => {
+    const startOfView = dayjs("2024-02-29"); // Leap year February
+    const endOfView = startOfView.add(6, "days"); // Crosses into March but should be ignored
+
+    await createSomedayDraft(
+      Categories_Event.SOMEDAY_MONTH,
+      startOfView,
+      endOfView,
+      mockActivity,
+      mockDispatch,
+    );
+
+    const expectedStart = "2024-02-01";
+    const expectedEnd = "2024-02-29";
+
+    expect(assembleDefaultEvent).toHaveBeenCalledWith(
+      Categories_Event.SOMEDAY_MONTH,
+      expectedStart,
+      expectedEnd,
+    );
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      draftSlice.actions.start({
+        activity: mockActivity,
+        eventType: Categories_Event.SOMEDAY_MONTH,
+        event: {
+          _id: "mock-id",
+          user: "mock-user",
+          title: "",
+          startDate: expectedStart,
+          endDate: expectedEnd,
+          isAllDay: false,
+          isSomeday: true,
+        },
+      }),
+    );
+  });
+});

--- a/packages/web/src/common/utils/draft/someday.draft.util.ts
+++ b/packages/web/src/common/utils/draft/someday.draft.util.ts
@@ -13,8 +13,19 @@ export const createSomedayDraft = async (
   activity: Activity_DraftEvent,
   dispatch: Dispatch,
 ) => {
-  const startDate = startOfView.format(YEAR_MONTH_DAY_FORMAT);
-  const endDate = endOfView.format(YEAR_MONTH_DAY_FORMAT);
+  let startDate: string;
+  let endDate: string;
+
+  if (category === Categories_Event.SOMEDAY_WEEK) {
+    startDate = startOfView.format(YEAR_MONTH_DAY_FORMAT);
+    endDate = endOfView.format(YEAR_MONTH_DAY_FORMAT);
+  } else {
+    // Someday month
+    startDate = startOfView.startOf("month").format(YEAR_MONTH_DAY_FORMAT);
+    // `endDate` is the last day of the month, hence why we need to use `startOfView`, because
+    // `endOfView` could be in the next month relative to `startOfView`
+    endDate = startOfView.endOf("month").format(YEAR_MONTH_DAY_FORMAT);
+  }
 
   const event = await assembleDefaultEvent(category, startDate, endDate);
 


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/569
This was due to use not computing the start-end date correctly when the someday event category is month


## Videos

https://github.com/user-attachments/assets/7cdb5db2-c679-4572-b2bd-2a419df19496

