### PR TITLE
✨ Feat(web): better UI for migrate event buttons

### DIFF
--- a/packages/web/src/views/Forms/EventForm/MigrateBackwardButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MigrateBackwardButton.tsx
@@ -1,15 +1,8 @@
 import React from "react";
-import styled from "styled-components";
+import { ArrowLeft } from "@phosphor-icons/react";
 import { getMetaKey } from "@web/common/utils/shortcut.util";
 import { Text } from "@web/components/Text";
 import TooltipIconButton from "@web/components/TooltipIconButton/TooltipIconButton";
-
-const StyledMigrateBackwardButton = styled.div`
-  font-size: 25px;
-  &:hover {
-    cursor: pointer;
-  }
-`;
 
 export const MigrateBackwardButton = ({
   onClick,
@@ -20,18 +13,14 @@ export const MigrateBackwardButton = ({
 }) => {
   return (
     <TooltipIconButton
-      component={
-        <StyledMigrateBackwardButton id="migrate-backward-button" role="button">
-          {"<"}
-        </StyledMigrateBackwardButton>
-      }
+      icon={<ArrowLeft />}
       buttonProps={{ "aria-label": tooltipText }}
       tooltipProps={{
         description: tooltipText,
         onClick,
         shortcut: (
           <Text size="s" style={{ display: "flex", alignItems: "center" }}>
-            Ctrl + {getMetaKey()} + Left
+            CTRL + {getMetaKey()} + Left
           </Text>
         ),
       }}

--- a/packages/web/src/views/Forms/EventForm/MigrateForwardButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/MigrateForwardButton.tsx
@@ -1,15 +1,8 @@
 import React from "react";
-import styled from "styled-components";
+import { ArrowRight } from "@phosphor-icons/react";
 import { getMetaKey } from "@web/common/utils/shortcut.util";
 import { Text } from "@web/components/Text";
 import TooltipIconButton from "@web/components/TooltipIconButton/TooltipIconButton";
-
-const StyledMigrateForwardButton = styled.div`
-  font-size: 25px;
-  &:hover {
-    cursor: pointer;
-  }
-`;
 
 export const MigrateForwardButton = ({
   onClick,
@@ -20,18 +13,14 @@ export const MigrateForwardButton = ({
 }) => {
   return (
     <TooltipIconButton
-      component={
-        <StyledMigrateForwardButton id="migrate-forward-button" role="button">
-          {">"}
-        </StyledMigrateForwardButton>
-      }
+      icon={<ArrowRight />}
       buttonProps={{ "aria-label": tooltipText }}
       tooltipProps={{
         description: tooltipText,
         onClick,
         shortcut: (
           <Text size="s" style={{ display: "flex", alignItems: "center" }}>
-            Ctrl + {getMetaKey()} + Right
+            CTRL + {getMetaKey()} + Right
           </Text>
         ),
       }}

--- a/packages/web/src/views/Forms/EventForm/styled.ts
+++ b/packages/web/src/views/Forms/EventForm/styled.ts
@@ -42,6 +42,7 @@ export const StyledIconRow = styled(Flex)`
   align-items: center;
   gap: 30px;
   justify-content: end;
+  margin-bottom: 10px;
 `;
 
 export const StyledSubmitButton = styled(PriorityButton)`


### PR DESCRIPTION
## Description
- use the right arrow and left icons from phosphoricons
- capitalize `CTRL`. This is to keep our casing consistent (We already have SHIFT in another shortcut)
- Add slight margins between icons and title field.