### PR TITLE
Enable enter to open someday events

### DIFF
--- a/packages/web/src/views/Calendar/Calendar.form.test.tsx
+++ b/packages/web/src/views/Calendar/Calendar.form.test.tsx
@@ -21,7 +21,10 @@ describe("Event Form", () => {
     const user = userEvent.setup();
 
     await act(async () => {
-      await user.click(screen.getByRole("button", { name: CLIMB.title }));
+      const climbBtn = document.querySelector(
+        `[data-event-id="${CLIMB._id}"]`,
+      ) as HTMLElement;
+      await user.click(climbBtn);
     });
 
     await act(async () => {
@@ -64,11 +67,10 @@ describe("Event Form", () => {
       const { container } = render(<CalendarView />, { state: preloadedState });
 
       await act(async () => {
-        await user.click(
-          screen.getByRole("button", {
-            name: /climb/i,
-          }),
-        );
+        const climbBtn = document.querySelector(
+          `[data-event-id="${CLIMB._id}"]`,
+        ) as HTMLElement;
+        await user.click(climbBtn);
       });
 
       expect(container.getElementsByClassName("startDatePicker")).toHaveLength(

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.test.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.test.tsx
@@ -1,13 +1,9 @@
 import React from "react";
+import { DraggableProvided, DraggableStateSnapshot } from "@hello-pangea/dnd";
 import "@testing-library/jest-dom";
-import userEvent from "@testing-library/user-event";
 import { LEARN_CHINESE } from "@core/__mocks__/v1/events/events.misc";
 import { Categories_Event } from "@core/types/event.types";
-import {
-  fireEvent,
-  render,
-  screen,
-} from "@web/__tests__/__mocks__/mock.render";
+import { fireEvent, render } from "@web/__tests__/__mocks__/mock.render";
 import { SidebarDraftContext } from "../../../../Draft/sidebar/context/SidebarDraftContext";
 import { SomedayEventContainer } from "./SomedayEventContainer";
 
@@ -60,12 +56,16 @@ describe("SomedayEventContainer keyboard interactions", () => {
           onSubmit={jest.fn()}
           provided={
             {
-              draggableProps: {},
+              draggableProps: {
+                "data-rfd-draggable-context-id": "mock-context",
+                "data-rfd-draggable-id": "mock-id",
+                style: {},
+              },
               dragHandleProps: null,
               innerRef: jest.fn(),
-            } as any
+            } as DraggableProvided
           }
-          snapshot={{ isDragging: false } as any}
+          snapshot={{ isDragging: false } as DraggableStateSnapshot}
           setEvent={jest.fn()}
           weekViewRange={{ startDate: "2020-01-01", endDate: "2020-01-07" }}
         />

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.test.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { LEARN_CHINESE } from "@core/__mocks__/v1/events/events.misc";
+import { Categories_Event } from "@core/types/event.types";
+import {
+  fireEvent,
+  render,
+  screen,
+} from "@web/__tests__/__mocks__/mock.render";
+import { SidebarDraftContext } from "../../../../Draft/sidebar/context/SidebarDraftContext";
+import { SomedayEventContainer } from "./SomedayEventContainer";
+
+jest.mock(
+  "@web/views/Calendar/components/Draft/hooks/state/useDraftForm",
+  () => ({
+    useDraftForm: () => ({
+      context: {},
+      refs: { setFloating: jest.fn(), setReference: jest.fn() },
+      strategy: "absolute",
+      x: 0,
+      y: 0,
+      getReferenceProps: () => ({}),
+      getFloatingProps: () => ({}),
+    }),
+  }),
+);
+
+describe("SomedayEventContainer keyboard interactions", () => {
+  it("opens the form when Enter is pressed", async () => {
+    const onDraft = jest.fn();
+    const contextValue = {
+      state: {
+        draft: null,
+        isDrafting: false,
+        isOverGrid: false,
+        isSomedayFormOpen: false,
+      } as any,
+      setters: {
+        setIsSomedayFormOpen: jest.fn(),
+      } as any,
+      actions: {
+        onDraft,
+        onMigrate: jest.fn(),
+        discard: jest.fn(),
+        reset: jest.fn(),
+        closeForm: jest.fn(),
+        close: jest.fn(),
+      } as any,
+    };
+
+    render(
+      <SidebarDraftContext.Provider value={contextValue as any}>
+        <SomedayEventContainer
+          category={Categories_Event.SOMEDAY_WEEK}
+          event={LEARN_CHINESE}
+          isDrafting={false}
+          isDragging={false}
+          isOverGrid={false}
+          onSubmit={jest.fn()}
+          provided={
+            {
+              draggableProps: {},
+              dragHandleProps: null,
+              innerRef: jest.fn(),
+            } as any
+          }
+          snapshot={{ isDragging: false } as any}
+          setEvent={jest.fn()}
+          weekViewRange={{ startDate: "2020-01-01", endDate: "2020-01-07" }}
+        />
+      </SidebarDraftContext.Provider>,
+    );
+
+    const btn = document.querySelector(
+      `[data-event-id="${LEARN_CHINESE._id}"]`,
+    )! as HTMLElement;
+    btn.focus();
+    fireEvent.keyDown(btn, { key: "Enter" });
+
+    expect(onDraft).toHaveBeenCalledTimes(1);
+    expect(onDraft).toHaveBeenCalledWith(
+      LEARN_CHINESE,
+      Categories_Event.SOMEDAY_WEEK,
+    );
+  });
+});

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
@@ -55,6 +55,7 @@ export const SomedayEventContainer = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === Key.Enter) {
       e.preventDefault();
+      e.stopPropagation();
       actions.onDraft(event, category);
     }
   };

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Key } from "ts-key-enum";
 import { FloatingFocusManager, FloatingPortal } from "@floating-ui/react";
 import { DraggableProvided, DraggableStateSnapshot } from "@hello-pangea/dnd";
 import { Priorities } from "@core/constants/core.constants";
@@ -51,6 +52,13 @@ export const SomedayEventContainer = ({
 
   const [isFocused, setIsFocused] = useState(false);
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === Key.Enter) {
+      e.preventDefault();
+      actions.onDraft(event, category);
+    }
+  };
+
   const isDraftingThisEvent =
     state.isDrafting && state.draft?._id === event._id;
 
@@ -68,7 +76,7 @@ export const SomedayEventContainer = ({
           actions.onDraft(event, category);
         }}
         onFocus={() => setIsFocused(true)}
-        onKeyDown={() => console.log("onKeyDown")}
+        onKeyDown={handleKeyDown}
         priority={event.priority || Priorities.UNASSIGNED}
         provided={provided}
         snapshot={snapshot}


### PR DESCRIPTION
## Summary
Closes https://github.com/SwitchbackTech/compass/issues/538

- allow Enter to open Someday event forms
- cover SomedayEventContainer keyboard interaction
- use data-event-id in Calendar form tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_686b396ed3c88326a2889d95c2c13f6b