### PR TITLE
🐛 Fix: TypeScript build error

### DIFF
--- a/packages/backend/src/auth/auth.routes.config.ts
+++ b/packages/backend/src/auth/auth.routes.config.ts
@@ -18,23 +18,16 @@ export class AuthRoutes extends CommonRoutesConfig {
     /**
      * Checks whether user's google access token is still valid
      */
-    this.app.route(`/api/auth/google`).get([
-      verifySession(),
-      //@ts-expect-error res.promise is not returning response types correctly
-      authController.verifyGToken,
-    ]);
+    this.app
+      .route(`/api/auth/google`)
+      .get([verifySession(), authController.verifyGToken]);
 
     this.app
       .route(`/api/auth/session`)
       .all(authMiddleware.verifyIsDev)
-      //@ts-expect-error res.promise is not returning response types correctly
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       .post(authController.createSession)
-      .get([
-        verifySession(),
-        //@ts-expect-error res.promise is not returning response types correctly
-        authController.getUserIdFromSession,
-      ]);
+      .get([verifySession(), authController.getUserIdFromSession]);
 
     this.app
       .route(`/api/auth/session/revoke`)
@@ -44,11 +37,12 @@ export class AuthRoutes extends CommonRoutesConfig {
     /**
      * Google calls this route after successful oauth
      */
-    this.app.route(`/api/oauth/google`).post([
-      authMiddleware.verifyGoogleOauthCode,
-      //@ts-expect-error res.promise is not returning response types correctly
-      authController.loginOrSignup,
-    ]);
+    this.app
+      .route(`/api/oauth/google`)
+      .post([
+        authMiddleware.verifyGoogleOauthCode,
+        authController.loginOrSignup,
+      ]);
 
     return this.app;
   }

--- a/packages/backend/src/common/middleware/promise.middleware.ts
+++ b/packages/backend/src/common/middleware/promise.middleware.ts
@@ -30,7 +30,7 @@ export const requestMiddleware = () => {
     res: Res_Promise,
     next: express.NextFunction,
   ) => {
-    res.promise = (p: Promise<any> | SyncFunction) => {
+    res.promise = (p: Promise<any> | SyncFunction | unknown) => {
       let toResolve: Promise<unknown> | (() => any);
 
       if (p instanceof Promise) {
@@ -41,9 +41,11 @@ export const requestMiddleware = () => {
         toResolve = Promise.resolve(p);
       }
 
-      return toResolve
+      toResolve
         .then((data) => sendResponse(res, data as D))
         .catch((e) => handleExpressError(res, e));
+
+      return res;
     };
 
     return next();


### PR DESCRIPTION
Closes #589 

## Summary
- clean up unused `@ts-expect-error` directives in AuthRoutes
- update `res.promise` middleware to return `Response`

## Testing
- `yarn test`
- `npx tsc --project tsconfig.build.json`


------
https://chatgpt.com/codex/tasks/task_b_686bdbf834708320bdaae8aeab4ca188