### PR TITLE
🐛 Fix(web): Duplicate shortcut tooltip using wrong label

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DuplicateButton.tsx
+++ b/packages/web/src/views/Forms/EventForm/DuplicateButton.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Copy } from "@phosphor-icons/react";
+import { getMetaKey } from "@web/common/utils/shortcut.util";
+import { Text } from "@web/components/Text";
 import TooltipIconButton from "@web/components/TooltipIconButton/TooltipIconButton";
 
 export const DuplicateButton = ({ onClick }: { onClick: () => void }) => {
@@ -8,7 +10,11 @@ export const DuplicateButton = ({ onClick }: { onClick: () => void }) => {
       icon={<Copy />}
       buttonProps={{ "aria-label": "Duplicate Event [Meta+D]" }}
       tooltipProps={{
-        shortcut: "Meta+D",
+        shortcut: (
+          <Text size="s" style={{ display: "flex", alignItems: "center" }}>
+            {getMetaKey()} + D
+          </Text>
+        ),
         description: "Duplicate Event",
         onClick,
       }}


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/537

## Screenshots

<img width="703" height="459" alt="image" src="https://github.com/user-attachments/assets/53ebad9c-4a8f-4acc-9d79-a184960262c3" />
