### PR TITLE
fix(sign-up-import-gcal): prevent sync data from being initiali…

### DIFF
--- a/packages/backend/src/__tests__/drivers/sync.driver.ts
+++ b/packages/backend/src/__tests__/drivers/sync.driver.ts
@@ -1,0 +1,41 @@
+import { WithId } from "mongodb";
+import { faker } from "@faker-js/faker";
+import { Schema_User } from "@core/types/user.types";
+import mongoService from "@backend/common/services/mongo.service";
+import { Schema_Sync } from "../../../../core/src/types/sync.types";
+
+export class SyncDriver {
+  static async createSync(
+    user: Pick<WithId<Schema_User>, "_id">,
+    defaultUser = false,
+  ): Promise<WithId<Schema_Sync>> {
+    const gCalendarId = defaultUser ? "test-calendar" : faker.string.uuid();
+    const nextSyncToken = faker.internet.jwt();
+
+    const syncRecord: Schema_Sync = {
+      user: user._id.toString(),
+      google: {
+        calendarlist: [
+          {
+            gCalendarId,
+            nextSyncToken,
+            lastSyncedAt: new Date(),
+          },
+        ],
+        events: [
+          {
+            gCalendarId,
+            resourceId: faker.string.nanoid(),
+            channelId: faker.string.uuid(),
+            expiration: new Date(Date.now() + 3600000).toISOString(),
+            nextSyncToken,
+          },
+        ],
+      },
+    };
+
+    const created = await mongoService.sync.insertOne(syncRecord);
+
+    return { _id: created.insertedId, ...syncRecord };
+  }
+}

--- a/packages/backend/src/__tests__/drivers/user.driver.ts
+++ b/packages/backend/src/__tests__/drivers/user.driver.ts
@@ -1,0 +1,28 @@
+import { WithId } from "mongodb";
+import { faker } from "@faker-js/faker";
+import { Schema_User } from "@core/types/user.types";
+import mongoService from "@backend/common/services/mongo.service";
+
+export class UserDriver {
+  static async createUser(): Promise<WithId<Schema_User>> {
+    const firstName = faker.person.firstName();
+    const lastName = faker.person.lastName();
+
+    const user: Schema_User = {
+      email: faker.internet.email(),
+      firstName,
+      lastName,
+      name: `${firstName} ${lastName}`,
+      locale: faker.location.language().alpha2,
+      google: {
+        googleId: faker.string.uuid(),
+        picture: faker.internet.url({ protocol: "https" }),
+        gRefreshToken: faker.internet.jwt(),
+      },
+    };
+
+    const created = await mongoService.user.insertOne(user);
+
+    return { _id: created.insertedId, ...user };
+  }
+}

--- a/packages/backend/src/__tests__/drivers/waitlist.driver.ts
+++ b/packages/backend/src/__tests__/drivers/waitlist.driver.ts
@@ -1,0 +1,28 @@
+import { WithId } from "mongodb";
+import { Schema_User } from "@core/types/user.types";
+import { Schema_Waitlist } from "@core/types/waitlist/waitlist.types";
+import mongoService from "@backend/common/services/mongo.service";
+
+export class WaitListDriver {
+  static async createWaitListRecord(
+    user: Pick<WithId<Schema_User>, "email" | "firstName" | "lastName">,
+  ): Promise<WithId<Schema_Waitlist>> {
+    const waitListRecord: Schema_Waitlist = {
+      email: user.email,
+      schemaVersion: "0",
+      source: "other",
+      firstName: user.firstName,
+      lastName: user.lastName,
+      currentlyPayingFor: ["superhuman", "notion"],
+      howClearAboutValues: "not-clear",
+      workingTowardsMainGoal: "yes",
+      isWillingToShare: false,
+      status: "waitlisted",
+      waitlistedAt: new Date().toISOString(),
+    };
+
+    const created = await mongoService.waitlist.insertOne(waitListRecord);
+
+    return { _id: created.insertedId, ...waitListRecord };
+  }
+}

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -117,7 +117,7 @@ class SyncController {
         if (!proceed) {
           webSocketServer.handleImportGCalEnd(
             userId,
-            `User ${userId} is already importing GCal, ignoring this request`,
+            `User ${userId} gcal import is in progress or completed, ignoring this request`,
           );
 
           return;

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
 import { Payload_Sync_Notif } from "@core/types/sync.types";
+import { shouldImportGCal } from "@core/util/event/event.util";
 import { getGcalClient } from "@backend/auth/services/google.auth.service";
 import { SyncError } from "@backend/common/errors/sync/sync.errors";
 import { UserError } from "@backend/common/errors/user/user.errors";
@@ -96,17 +97,24 @@ class SyncController {
   importGCal = async (req: Request, res: Response): Promise<Response> => {
     const userId = req.session!.getUserId()!;
     const gcalClient = await getGcalClient(userId);
-    const gCalendarIds = await initSync(gcalClient, userId);
-    const lastGCalSync = new Date().toUTCString();
+    const sync = await getSync({ userId });
+
+    let gCalendarIds: string[] =
+      sync?.google.calendarlist.map((item) => item.gCalendarId) ?? [];
+
+    if (!sync) gCalendarIds = await initSync(gcalClient, userId);
+
+    logger.debug(
+      `starting gCal(${gCalendarIds.toString()}) imports for user(${userId})`,
+    );
 
     webSocketServer.handleImportGCalStart(userId);
 
     userService
       .fetchUserMetadata(userId)
-      .then(async (metadata) => {
-        const sync = metadata.sync ?? {};
-
-        if (sync?.importGCal?.importing) {
+      .then(shouldImportGCal)
+      .then(async (proceed) => {
+        if (!proceed) {
           webSocketServer.handleImportGCalEnd(
             userId,
             `User ${userId} is already importing GCal, ignoring this request`,
@@ -117,21 +125,26 @@ class SyncController {
 
         await userService.updateUserMetadata({
           userId,
-          data: { sync: { importGCal: { importing: true, lastGCalSync } } },
+          data: { sync: { importGCal: "importing" } },
         });
 
         await syncService.importFull(gcalClient, gCalendarIds, userId);
 
         await userService.updateUserMetadata({
           userId,
-          data: { sync: { importGCal: { importing: false } } },
+          data: { sync: { importGCal: "completed" } },
         });
 
         webSocketServer.handleImportGCalEnd(userId);
         webSocketServer.handleBackgroundCalendarChange(userId);
       })
-      .catch((err) => {
+      .catch(async (err) => {
         const message = `Import gCal failed for user: ${userId}`;
+
+        await userService.updateUserMetadata({
+          userId,
+          data: { sync: { importGCal: "errored" } },
+        });
 
         webSocketServer.handleImportGCalEnd(userId, message);
 

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -16,10 +16,5 @@ export interface Schema_User {
 }
 
 export interface UserMetadata extends SupertokensUserMetadata.JSONObject {
-  sync?: {
-    importGCal?: {
-      importing?: boolean; // gCal import in progress
-      lastGCalSync?: string; // utc Date string
-    };
-  };
+  sync?: { importGCal?: "importing" | "errored" | "completed" | "restart" };
 }

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -16,5 +16,7 @@ export interface Schema_User {
 }
 
 export interface UserMetadata extends SupertokensUserMetadata.JSONObject {
-  sync?: { importGCal?: "importing" | "errored" | "completed" | "restart" };
+  sync?: {
+    importGCal?: "importing" | "errored" | "completed" | "restart" | null;
+  };
 }

--- a/packages/core/src/util/event/event.util.ts
+++ b/packages/core/src/util/event/event.util.ts
@@ -4,6 +4,7 @@ import {
   Schema_Event_Recur_Base,
   Schema_Event_Recur_Instance,
 } from "@core/types/event.types";
+import { UserMetadata } from "@core/types/user.types";
 
 /** Event utilities for Compass events */
 
@@ -83,3 +84,17 @@ export const filterBaseEvents = (e: Schema_Event[]) => {
  */
 export const filterExistingInstances = (e: Schema_Event[]) =>
   e.filter(isExistingInstance);
+
+export const shouldImportGCal = (metadata: UserMetadata): boolean => {
+  const sync = metadata.sync;
+
+  switch (sync?.importGCal) {
+    case "importing":
+    case "completed":
+      return false;
+    case "restart":
+    case "errored":
+    default:
+      return true;
+  }
+};

--- a/packages/web/src/socket/SocketProvider.tsx
+++ b/packages/web/src/socket/SocketProvider.tsx
@@ -11,6 +11,7 @@ import {
   USER_SIGN_OUT,
 } from "@core/constants/websocket.constants";
 import { UserMetadata } from "@core/types/user.types";
+import { shouldImportGCal } from "@core/util/event/event.util";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
 import {
@@ -98,12 +99,12 @@ const SocketProvider = ({ children }: { children: ReactNode }) => {
   }, [dispatch]);
 
   const onMetadataFetch = useCallback(
-    (data: UserMetadata) => {
-      const { importing, lastGCalSync } = data.sync?.importGCal ?? {};
+    (metadata: UserMetadata) => {
+      const importGcal = shouldImportGCal(metadata);
 
-      onImportStart(importing);
+      onImportStart(metadata.sync?.importGCal === "importing");
 
-      if (!importing && !lastGCalSync) {
+      if (importGcal) {
         dispatch(importGCalSlice.actions.request(undefined));
       }
     },


### PR DESCRIPTION
## What does this PR do?

This PR 
- Prevents the sync initialization from happening multiple times.
- Updates the google calendar sync metadata to rely on statuses
- Prevents the google calendar import from running after completion.

## Use Case

Closes #603, #604, #594 

## Additional Context

N/A