### PR TITLE
🐛 Fix(web): added hotkeys to move grid events to sidebar ctrl+meta+left

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -276,7 +276,7 @@ export const EventForm: React.FC<FormProps> = ({
   );
 
   useHotkeys(
-    "meta+ctrl+left",
+    "ctrl+meta+left",
     () => {
       if (isDraft) {
         return;

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -228,18 +228,6 @@ export const EventForm: React.FC<FormProps> = ({
   };
 
   useHotkeys(
-    "meta+shift+comma",
-    () => {
-      if (isDraft) {
-        return;
-      }
-
-      onConvert?.();
-    },
-    hotkeysOptions,
-  );
-
-  useHotkeys(
     "delete",
     () => {
       if (isDraft) {
@@ -285,6 +273,22 @@ export const EventForm: React.FC<FormProps> = ({
       enableOnFormTags: true,
     },
     [isFormOpen, onSubmitForm],
+  );
+
+  useHotkeys(
+    "meta+ctrl+left",
+    () => {
+      if (isDraft) {
+        return;
+      }
+
+      onConvert?.();
+    },
+    {
+      enabled: isFormOpen,
+      enableOnFormTags: true,
+    },
+    [isFormOpen],
   );
   return (
     <StyledEventForm


### PR DESCRIPTION
@that-one-arab  this should be good


Closes https://github.com/SwitchbackTech/compass/issues/584