### PR TITLE
:sparkles: feat(timezone): set timezone and use UTC as default

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -16,6 +16,7 @@ BASEURL=http://localhost:3000/api
 CORS=http://localhost:3000,http://localhost:9080,https://app.yourdomain.com
 LOG_LEVEL=debug         # options: error, warn, info, http, verbose, debug, silly
 NODE_ENV=development    # options: development, production
+TZ="UTC"                # set a timezone for this process - prefer UTC
 PORT=3000               # Node.js server
 # Unique tokens for auth
 #   These defaults are fine for development, but

--- a/packages/backend/src/__tests__/backend.test.init.ts
+++ b/packages/backend/src/__tests__/backend.test.init.ts
@@ -1,3 +1,4 @@
+import dayjs from "@core/util/date/dayjs";
 import { mockNodeModules } from "@backend/__tests__/helpers/mock.setup";
 
 process.env["BASEURL"] = "https://foo.yourdomain.app";
@@ -5,6 +6,7 @@ process.env["CORS"] =
   "https://foo.yourdomain.app,http://localhost:3000,http://localhost:9080";
 process.env["LOG_LEVEL"] = "debug";
 process.env["NODE_ENV"] = "test";
+process.env["TZ"] = "UTC";
 process.env["PORT"] = "3000";
 process.env["MONGO_URI"] = "foo";
 process.env["DB"] = "test-db";
@@ -19,5 +21,7 @@ process.env["EMAILER_WAITLIST_INVITE_TAG_ID"] = "7654321";
 process.env["EMAILER_USER_TAG_ID"] = "910111213";
 process.env["TOKEN_GCAL_NOTIFICATION"] = "secretToken1";
 process.env["TOKEN_COMPASS_SYNC"] = "secretToken2";
+
+dayjs.tz.setDefault(process.env.TZ);
 
 mockNodeModules();

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,6 +1,10 @@
 // sort-imports-ignore
 import { logger } from "./init"; //must be first import
 
+import dayjs from "@core/util/date/dayjs";
+
+dayjs.tz.setDefault(ENV.TZ);
+
 import { ENV } from "@backend/common/constants/env.constants";
 import mongoService from "@backend/common/services/mongo.service";
 import { initExpressServer } from "@backend/servers/express/express.server";

--- a/packages/backend/src/common/constants/env.constants.ts
+++ b/packages/backend/src/common/constants/env.constants.ts
@@ -6,6 +6,7 @@ import { isDev } from "@core/util/env.util";
 const logger = Logger("app:constants");
 
 const _nodeEnv = process.env["NODE_ENV"] as NodeEnv;
+
 if (!Object.values(NodeEnv).includes(_nodeEnv)) {
   throw new Error(`Invalid NODE_ENV value: '${_nodeEnv}'`);
 }
@@ -25,6 +26,7 @@ const EnvSchema = z
     EMAILER_USER_TAG_ID: z.string().nonempty().optional(),
     MONGO_URI: z.string().nonempty(),
     NODE_ENV: z.nativeEnum(NodeEnv),
+    TZ: z.string().nonempty().default("UTC"),
     ORIGINS_ALLOWED: z.array(z.string().nonempty()).default([]),
     PORT: z.string().nonempty().default(PORT_DEFAULT_BACKEND.toString()),
     SUPERTOKENS_URI: z.string().nonempty(),
@@ -62,6 +64,7 @@ export const ENV = {
   EMAILER_USER_TAG_ID: process.env["EMAILER_USER_TAG_ID"],
   MONGO_URI: process.env["MONGO_URI"],
   NODE_ENV: _nodeEnv,
+  TZ: process.env.TZ,
   ORIGINS_ALLOWED: process.env["CORS"] ? process.env["CORS"].split(",") : [],
   PORT: process.env["PORT"],
   SUPERTOKENS_URI: process.env["SUPERTOKENS_URI"],


### PR DESCRIPTION
## What does this PR do?

This PR leverages the `TZ` environment variable to set the global timezone for the Compass API. It also sets the default timezone to `UTC` if the environment variable setting is not present.


## Use Case

closes [#625](https://github.com/SwitchbackTech/compass/issues/625)