### PR TITLE
🐛 Fix(web):  implement on focus highlight for icon button

### DIFF
--- a/packages/web/src/components/IconButton/styled.ts
+++ b/packages/web/src/components/IconButton/styled.ts
@@ -30,8 +30,10 @@ export const StyledIconButton = styled.button<IconButtonProps>`
   justify-content: center;
   transition:
     background-color 0.3s ease,
-    transform 0.2s ease;
+    transform 0.2s ease,
+    border-color 0.2s ease;
   font-size: ${({ size = "medium" }) => sizeMap[size]}px;
+  border: 2px solid transparent;
 
   &:hover {
     transform: scale(1.05);
@@ -44,5 +46,9 @@ export const StyledIconButton = styled.button<IconButtonProps>`
   &:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    border-color: ${({ theme }) => theme.color.border.primary};
   }
 `;


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/637

## Screenshots

<img width="627" height="333" alt="image" src="https://github.com/user-attachments/assets/b395121d-3a5d-42ef-8966-99ef7cb3161b" />
