### PR TITLE
:bug: fix(shutdown): catch ngrok dynamic import error

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -62,8 +62,8 @@ async function closeHttpServer(): Promise<void> {
 
 async function closeNGrokServer(): Promise<void> {
   const url = process.env["NGROK_DOMAIN_FULL"];
-  const ngrok = await import("@ngrok/ngrok");
-  const ngrokListener = url ? await ngrok.getListenerByUrl(url) : undefined;
+  const ngrok = await import("@ngrok/ngrok").catch(() => undefined);
+  const ngrokListener = url ? await ngrok?.getListenerByUrl(url) : undefined;
 
   if (ngrokListener) {
     // do not wait for this promise,

--- a/packages/backend/src/servers/ngrok/ngrok.server.ts
+++ b/packages/backend/src/servers/ngrok/ngrok.server.ts
@@ -29,10 +29,10 @@ export function initNgrokServer(
 
   listener.on("connect", async () => {
     try {
-      const ngrok = await import("@ngrok/ngrok");
+      const ngrok = await import("@ngrok/ngrok").catch(() => undefined);
       const addr = getServerUri(httpServer);
 
-      const server = await ngrok.connect({
+      const server = await ngrok?.connect({
         addr,
         authtoken_from_env: true,
         authtoken,
@@ -41,7 +41,7 @@ export function initNgrokServer(
         domain,
       });
 
-      listener.emit("connected", server);
+      if (server) listener.emit("connected", server);
     } catch (error) {
       listener.emit("error", error as Error);
     }


### PR DESCRIPTION
## What does this PR do?
 
This PR ensures that the `ngrok` dynamic module import does not trigger errors during shutdown.

## Use Case

closes #657 