### PR TITLE
🔨 feat(dedupe-sync): add cli script to remove duplicate compass user sync

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -10,10 +10,12 @@
     "commander": "^10.0.0",
     "dotenv": "^16.0.1",
     "inquirer": "^8.0.0",
+    "lodash.uniqby": "^4.7.0",
     "shelljs": "^0.8.5"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.1",
+    "@types/lodash.uniqby": "^4.7.9",
     "@types/node": "^20.6.3",
     "@types/shelljs": "^0.8.15",
     "ts-node-dev": "^2.0.0",

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -6,6 +6,7 @@ import { CliValidator } from "./cli.validator";
 import { runBuild } from "./commands/build";
 import { startDeleteFlow } from "./commands/delete";
 import { inviteWaitlist } from "./commands/invite";
+import { startSyncDuplicateMergeFlow } from "./commands/merge-sync";
 import { runSeed } from "./commands/seed";
 import { ALL_PACKAGES, CATEGORY_VM } from "./common/cli.constants";
 
@@ -33,6 +34,10 @@ class CompassCli {
       case cmd === "delete": {
         this.validator.validateDelete(options);
         await startDeleteFlow(user as string, force);
+        break;
+      }
+      case cmd === "merge-duplicate-sync": {
+        await startSyncDuplicateMergeFlow(force);
         break;
       }
       case cmd === "invite": {
@@ -80,6 +85,10 @@ class CompassCli {
         "-u, --user [id | email]",
         "specify which user to run script for",
       );
+
+    program
+      .command("merge-duplicate-sync")
+      .description("merge duplicate users sync data in the compass database");
 
     program.command("invite").description("invite users from the waitlist");
 

--- a/packages/scripts/src/commands/merge-sync.ts
+++ b/packages/scripts/src/commands/merge-sync.ts
@@ -1,0 +1,156 @@
+import pkg from "inquirer";
+import uniqBy from "lodash.uniqby";
+import { log } from "@scripts/common/cli.utils";
+import { WithCompassId } from "@core/types/event.types";
+import { Schema_Sync } from "@core/types/sync.types";
+import mongoService from "@backend/common/services/mongo.service";
+
+const { prompt } = pkg;
+
+type AggregateParams = Parameters<typeof mongoService.sync.aggregate>;
+type Pipeline = AggregateParams[0];
+type AggregateOptions = Exclude<AggregateParams[1], undefined>;
+type ClientSession = AggregateOptions["session"];
+
+function mergeDuplicateSyncRecords({
+  _id: user,
+  items: duplicates,
+}: WithCompassId<{ items: Schema_Sync[] }>) {
+  return duplicates.reduce(
+    (aggregate, duplicate): Schema_Sync => ({
+      ...aggregate,
+      google: {
+        calendarlist: uniqBy(
+          [
+            ...duplicate.google.calendarlist,
+            ...(aggregate.google?.calendarlist ?? []),
+          ],
+          "gCalendarId",
+        ),
+        events: uniqBy(
+          [...duplicate.google.events, ...(aggregate.google?.events ?? [])],
+          ({ channelId, gCalendarId, resourceId }) =>
+            `${channelId}_${gCalendarId}_${resourceId}`,
+        ),
+      },
+      user,
+    }),
+    {} as Schema_Sync,
+  );
+}
+
+async function getMatchingUsers(): Promise<
+  Array<WithCompassId<{ items: Schema_Sync[] }>>
+> {
+  log.info("Fetching Duplicate Compass sync user data");
+
+  const pipeline: Pipeline = [
+    { $group: { _id: "$user", items: { $push: "$$ROOT" } } },
+    { $match: { $expr: { $gt: [{ $size: "$items" }, 1] } } },
+  ];
+
+  return mongoService.sync
+    .aggregate<WithCompassId<{ items: Schema_Sync[] }>>(pipeline)
+    .toArray();
+}
+
+async function deleteMatchingUsersSyncRecords(
+  records: Array<WithCompassId<{ items: Schema_Sync[] }>>,
+  session?: ClientSession,
+): Promise<{ deletedCount: number }> {
+  log.info("Deleting Compass sync data for matching users");
+
+  const { deletedCount } = await mongoService.sync.deleteMany(
+    { user: { $in: records.map(({ _id }) => _id) } },
+    { session },
+  );
+
+  log.info(`${deletedCount} sync data deleted for ${records.length} users`);
+
+  return { deletedCount };
+}
+
+async function saveMergedUsersSyncRecords(
+  records: Array<WithCompassId<{ items: Schema_Sync[] }>>,
+  session?: ClientSession,
+): Promise<{ insertedCount: number }> {
+  const newRecords: Schema_Sync[] = records.map(mergeDuplicateSyncRecords);
+
+  const { insertedCount } = await mongoService.sync.insertMany(newRecords, {
+    session,
+  });
+
+  log.info(`${insertedCount} sync data created for ${records.length} users`);
+
+  return { insertedCount };
+}
+
+export const mergeCompassSyncDataForMatchingUsers = async (
+  records: Array<WithCompassId<{ items: Schema_Sync[] }>>,
+) => {
+  const session = await mongoService.startSession();
+
+  try {
+    log.info("Merging Compass sync data for matching users");
+
+    session.startTransaction();
+
+    const { deletedCount } = await deleteMatchingUsersSyncRecords(
+      records,
+      session,
+    );
+
+    const { insertedCount } = await saveMergedUsersSyncRecords(
+      records,
+      session,
+    );
+
+    await session.commitTransaction();
+
+    log.success(
+      `Merge results: ${JSON.stringify({ deletedCount, insertedCount }, null, 2)}`,
+    );
+  } catch (error: unknown) {
+    await session.abortTransaction();
+
+    log.error(
+      `Rolling back all merge sync operations due to error:\n${(error as Error).stack}`,
+    );
+  } finally {
+    process.exit(0);
+  }
+};
+
+export const startSyncDuplicateMergeFlow = async (force = false) => {
+  await mongoService.start();
+
+  const records = await getMatchingUsers();
+  const noOfUsers = records.length;
+
+  log.info(`Found duplicate Compass sync data for ${noOfUsers} user(s)`);
+
+  if (noOfUsers === 0) process.exit(0);
+
+  if (force === true) return mergeCompassSyncDataForMatchingUsers(records);
+
+  const questions = [
+    {
+      type: "confirm",
+      name: "mergeSync",
+      message: `This will merge the Compass sync data for all matching ${noOfUsers} user(s).\nContinue?`,
+    },
+  ];
+
+  return prompt(questions)
+    .then(async (a: { mergeSync: boolean }) => {
+      if (a.mergeSync) {
+        log.info(`Okie dokie, merging ${noOfUsers} users Compass sync data...`);
+
+        return mergeCompassSyncDataForMatchingUsers(records);
+      } else {
+        log.info("No worries, see ya next time");
+        process.exit(0);
+      }
+    })
+    .catch((err) => log.error(err.message));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,6 +2708,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.uniqby@^4.7.9":
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash.uniqby/-/lodash.uniqby-4.7.9.tgz#10bacba9cf3263c6e07ae11d953de6ada6605104"
+  integrity sha512-rjrXji/seS6BZJRgXrU2h6FqxRVufsbq/HE0Tx0SdgbtlWr2YmD/M64BlYEYYlaMcpZwy32IYVkMfUMYlPuv0w==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.17.17"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.17.tgz#fb85a04f47e9e4da888384feead0de05f7070355"
@@ -8002,6 +8009,11 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
+
+lodash.uniqby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+  integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
 lodash@>=4.17.21, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"


### PR DESCRIPTION
## What does this PR do?

This PR dedupes the users's Compass sync data, preventing the mongo db sync queries from failing

## Use Case

closes #662 