### PR TITLE
:bug: fix(gcal-event): add null checks to object access

### DIFF
--- a/packages/backend/src/sync/services/import/sync.import.util.ts
+++ b/packages/backend/src/sync/services/import/sync.import.util.ts
@@ -94,7 +94,7 @@ export const assignIdsToEvents = (
     const isBaseEvent = isBase(event);
     const isInstance = isInstanceWithoutId(event);
     const isRegularEvent = !isBaseEvent && !isInstance;
-    const baseEventId = event?.gRecurringEventId ?? event.gEventId!;
+    const baseEventId = event?.gRecurringEventId ?? event?.gEventId!;
 
     if (!idMaps.get(baseEventId)) idMaps.set(baseEventId, new ObjectId());
 

--- a/packages/core/src/util/event/event.util.ts
+++ b/packages/core/src/util/event/event.util.ts
@@ -55,7 +55,7 @@ export const isInstanceWithoutId = (event: Schema_Event | Event_API) => {
   return (
     event?.recurrence?.rule === undefined &&
     event?.recurrence?.eventId === undefined &&
-    typeof event.gRecurringEventId === "string"
+    typeof event?.gRecurringEventId === "string"
   );
 };
 
@@ -65,7 +65,7 @@ export const isInstanceWithoutId = (event: Schema_Event | Event_API) => {
  * @returns
  */
 export const isExistingInstance = (event: Schema_Event | Event_API) => {
-  return event.recurrence?.eventId && event.recurrence?.rule === undefined;
+  return event?.recurrence?.eventId && event?.recurrence?.rule === undefined;
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

This PR fixes the `Cannot read properties of undefined (reading 'gRecurringEventId')` thrown when processing a gcal `standalone event deleted` event.

## Use Case

closes #668 