### PR TITLE
🐛 Fix (onboarding): Trigger next screen after email

### DIFF
--- a/packages/web/src/components/Onboarding/steps/EmailStep.tsx
+++ b/packages/web/src/components/Onboarding/steps/EmailStep.tsx
@@ -81,6 +81,7 @@ export const EmailStep: React.FC<OnboardingStepProps> = ({
       const data = await WaitlistApi.getWaitlistStatus(email.trim());
       setWaitlistStatus(data);
       setFirstName(data.firstName ?? "Sailor");
+      onNext();
     } catch (error) {
       console.error("Error checking waitlist status:", error);
     } finally {


### PR DESCRIPTION
This pull request makes a small improvement to the onboarding flow by advancing to the next step after successfully checking the waitlist status.

* The `EmailStep` component now calls `onNext()` after retrieving and setting the waitlist status, ensuring the user progresses in the onboarding process.

This was blocking user activity, because the page wasn't responding to the button click.

Closes #678 