### PR TITLE
:sparkles: feat(rrule): add gcal event rrule parser

### DIFF
--- a/packages/backend/src/event/classes/gcal.event.rrule.test.ts
+++ b/packages/backend/src/event/classes/gcal.event.rrule.test.ts
@@ -1,0 +1,226 @@
+import { faker } from "@faker-js/faker";
+import { GCAL_MAX_RECURRENCES } from "@core/constants/core.constants";
+import {
+  isInstanceGCalEvent,
+  parseGCalEventDate,
+} from "@core/util/event/gcal.event.util";
+import { mockRecurringGcalBaseEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
+import { GcalEventRRule } from "@backend/event/classes/gcal.event.rrule";
+import dayjs from "../../../../core/src/util/date/dayjs";
+import { isInstanceWithoutId } from "../../../../core/src/util/event/event.util";
+
+describe("GcalEventRRule: ", () => {
+  it(`should return the correct number of events based on rrule count`, () => {
+    const count = faker.number.int({ min: 1, max: GCAL_MAX_RECURRENCES });
+    const rruleString = `RRULE:FREQ=DAILY;COUNT=${count}`;
+    const baseEvent = mockRecurringGcalBaseEvent();
+
+    const rrule = new GcalEventRRule({
+      ...baseEvent,
+      recurrence: [rruleString],
+    });
+
+    expect(rrule.toString()).toContain("RRULE:FREQ=DAILY");
+    expect(rrule.toString()).toContain(`COUNT=${count}`);
+    expect(rrule.count()).toBe(count);
+    expect(rrule.all()).toHaveLength(count);
+  });
+
+  it(`should adjust the COUNT in the rrule string to a maximum of ${GCAL_MAX_RECURRENCES}`, () => {
+    const rruleString = "RRULE:FREQ=DAILY;COUNT=1000";
+    const baseEvent = mockRecurringGcalBaseEvent();
+
+    const rrule = new GcalEventRRule({
+      ...baseEvent,
+      recurrence: [rruleString],
+    });
+
+    expect(rrule.toString()).toContain("RRULE:FREQ=DAILY");
+    expect(rrule.toString()).toContain(`COUNT=${GCAL_MAX_RECURRENCES}`);
+    expect(rrule.count()).toBe(GCAL_MAX_RECURRENCES);
+    expect(rrule.all()).toHaveLength(GCAL_MAX_RECURRENCES);
+  });
+
+  it("should return the rrule in system timezone", () => {
+    const baseEvent = mockRecurringGcalBaseEvent();
+    const rrule = new GcalEventRRule(baseEvent);
+    const startDate = parseGCalEventDate(baseEvent.start);
+    const events = rrule.all();
+
+    expect(rrule.options.dtstart.toISOString()).toEqual(
+      startDate.toISOString(),
+    );
+
+    expect(events).toEqual(expect.arrayContaining([startDate.toDate()]));
+  });
+
+  describe("toRecurrence", () => {
+    it("should return the recurrence string as an array", () => {
+      const baseEvent = mockRecurringGcalBaseEvent();
+      const rrule = new GcalEventRRule(baseEvent);
+      const recurrence = rrule.toRecurrence();
+
+      expect(recurrence).toBeInstanceOf(Array);
+      expect(recurrence.length).toBeGreaterThan(0);
+
+      expect(recurrence.some((rule) => rule.startsWith("RRULE:"))).toEqual(
+        true,
+      );
+    });
+  });
+
+  describe("instances", () => {
+    it(`should return a maximum of ${GCAL_MAX_RECURRENCES} gcal instances if no count is supplied in the recurrence`, () => {
+      const baseEvent = mockRecurringGcalBaseEvent();
+      const recurrence = ["RRULE:FREQ=DAILY"];
+      const rrule = new GcalEventRRule({ ...baseEvent, recurrence });
+      const instances = rrule.instances();
+
+      expect(instances).toBeInstanceOf(Array);
+      expect(instances).toHaveLength(GCAL_MAX_RECURRENCES);
+      expect(instances.every(isInstanceGCalEvent)).toEqual(true);
+    });
+
+    it(`should return a maximum of ${GCAL_MAX_RECURRENCES} gcal instances if count exceeds maximum gcal recurrence`, () => {
+      const baseEvent = mockRecurringGcalBaseEvent();
+      const recurrence = ["RRULE:FREQ=DAILY;COUNT=1000"];
+      const rrule = new GcalEventRRule({ ...baseEvent, recurrence });
+      const instances = rrule.instances();
+
+      expect(instances).toBeInstanceOf(Array);
+      expect(instances).toHaveLength(GCAL_MAX_RECURRENCES);
+      expect(instances.every(isInstanceGCalEvent)).toEqual(true);
+    });
+
+    it("should return the correct number of gcal instances based on rrule count", () => {
+      const baseEvent = mockRecurringGcalBaseEvent();
+      const count = faker.number.int({ min: 1, max: GCAL_MAX_RECURRENCES });
+      const recurrence = [`RRULE:FREQ=DAILY;COUNT=${count}`];
+      const rrule = new GcalEventRRule({ ...baseEvent, recurrence });
+      const instances = rrule.instances();
+
+      expect(instances).toBeInstanceOf(Array);
+      expect(instances).toHaveLength(count);
+    });
+
+    it("should return gcal instances with the correct date format and timezone for an ALLDAY base event", () => {
+      const baseEvent = mockRecurringGcalBaseEvent({}, true);
+      const recurrence = ["RRULE:FREQ=DAILY;COUNT=10"];
+      const rrule = new GcalEventRRule({ ...baseEvent, recurrence });
+      const instances = rrule.instances();
+      const startDate = parseGCalEventDate(baseEvent.start);
+      const endDate = parseGCalEventDate(baseEvent.end);
+      const dateFormat = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+      instances.forEach((instance, index) => {
+        expect(instance.start).toBeDefined();
+        expect(instance.end).toBeDefined();
+        expect(instance.start?.date).toBeDefined();
+        expect(instance.end?.date).toBeDefined();
+        expect(instance.start?.timeZone).toBeDefined();
+        expect(instance.end?.timeZone).toBeDefined();
+
+        expect(instance.start?.timeZone).toEqual(baseEvent.start?.timeZone);
+        expect(instance.end?.timeZone).toEqual(baseEvent.start?.timeZone);
+
+        expect(instance.start?.date).toEqual(
+          startDate.add(index, "day").format(dateFormat),
+        );
+
+        expect(instance.end?.date).toEqual(
+          endDate.add(index, "day").format(dateFormat),
+        );
+      });
+    });
+
+    it("should return gcal instances with the correct date format and timezone for a TIMED base event", () => {
+      const baseEvent = mockRecurringGcalBaseEvent();
+      const recurrence = ["RRULE:FREQ=DAILY;COUNT=10"];
+      const rrule = new GcalEventRRule({ ...baseEvent, recurrence });
+      const instances = rrule.instances();
+      const startDate = parseGCalEventDate(baseEvent.start);
+      const endDate = parseGCalEventDate(baseEvent.end);
+      const dateFormat = dayjs.DateFormat.RFC3339_OFFSET;
+
+      instances.forEach((instance, index) => {
+        expect(instance.start).toBeDefined();
+        expect(instance.end).toBeDefined();
+        expect(instance.start?.dateTime).toBeDefined();
+        expect(instance.end?.dateTime).toBeDefined();
+        expect(instance.start?.timeZone).toBeDefined();
+        expect(instance.end?.timeZone).toBeDefined();
+
+        expect(instance.start?.timeZone).toEqual(baseEvent.start?.timeZone);
+        expect(instance.end?.timeZone).toEqual(baseEvent.start?.timeZone);
+
+        expect(instance.start?.dateTime).toEqual(
+          startDate.add(index, "day").format(dateFormat),
+        );
+
+        expect(instance.end?.dateTime).toEqual(
+          endDate.add(index, "day").format(dateFormat),
+        );
+      });
+    });
+  });
+
+  describe("compassInstances", () => {
+    it("should return compass events based on the rrule instances for a TIMED base event", () => {
+      const userId = faker.string.uuid();
+      const baseEvent = mockRecurringGcalBaseEvent();
+      const recurrence = ["RRULE:FREQ=DAILY;COUNT=10"];
+      const rrule = new GcalEventRRule({ ...baseEvent, recurrence });
+      const instances = rrule.compassInstances(userId);
+      const startDate = parseGCalEventDate(baseEvent.start);
+      const endDate = parseGCalEventDate(baseEvent.end);
+      const dateFormat = dayjs.DateFormat.RFC3339_OFFSET;
+
+      expect(instances).toBeInstanceOf(Array);
+      expect(instances.length).toBeGreaterThan(0);
+
+      instances.forEach((instance, index) => {
+        expect(instance.user).toEqual(userId);
+        expect(instance.startDate).toBeDefined();
+        expect(instance.endDate).toBeDefined();
+        expect(isInstanceWithoutId(instance)).toEqual(true);
+
+        expect(instance.startDate).toEqual(
+          startDate.add(index, "day").format(dateFormat),
+        );
+
+        expect(instance.endDate).toEqual(
+          endDate.add(index, "day").format(dateFormat),
+        );
+      });
+    });
+
+    it("should return compass events based on the rrule instances for an ALLDAY base event", () => {
+      const userId = faker.string.uuid();
+      const baseEvent = mockRecurringGcalBaseEvent({}, true);
+      const recurrence = ["RRULE:FREQ=DAILY;COUNT=10"];
+      const rrule = new GcalEventRRule({ ...baseEvent, recurrence });
+      const instances = rrule.compassInstances(userId);
+      const startDate = parseGCalEventDate(baseEvent.start);
+      const endDate = parseGCalEventDate(baseEvent.end);
+      const dateFormat = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+      expect(instances).toBeInstanceOf(Array);
+      expect(instances.length).toBeGreaterThan(0);
+
+      instances.forEach((instance, index) => {
+        expect(instance.user).toEqual(userId);
+        expect(instance.startDate).toBeDefined();
+        expect(instance.endDate).toBeDefined();
+        expect(isInstanceWithoutId(instance)).toEqual(true);
+
+        expect(instance.startDate).toEqual(
+          startDate.add(index, "day").format(dateFormat),
+        );
+
+        expect(instance.endDate).toEqual(
+          endDate.add(index, "day").format(dateFormat),
+        );
+      });
+    });
+  });
+});

--- a/packages/backend/src/event/classes/gcal.event.rrule.ts
+++ b/packages/backend/src/event/classes/gcal.event.rrule.ts
@@ -1,0 +1,107 @@
+import { omit } from "lodash";
+import { Options, RRule, RRuleStrOptions, rrulestr } from "rrule";
+import { GCAL_MAX_RECURRENCES } from "@core/constants/core.constants";
+import { gEventToCompassEvent } from "@core/mappers/map.event";
+import { Event_Core } from "@core/types/event.types";
+import {
+  gSchema$Event,
+  gSchema$EventBase,
+  gSchema$EventInstance,
+} from "@core/types/gcal";
+import dayjs from "@core/util/date/dayjs";
+import {
+  getGcalEventDateFormat,
+  parseGCalEventDate,
+} from "@core/util/event/gcal.event.util";
+
+export class GcalEventRRule extends RRule {
+  #event: gSchema$Event;
+  #isAllDay: boolean;
+  #dateKey: "date" | "dateTime";
+  #dateFormat: string;
+  #durationMs!: number;
+
+  constructor(
+    event: gSchema$EventBase,
+    options: Partial<Pick<Options, "count" | "freq" | "interval">> = {},
+  ) {
+    super(GcalEventRRule.#initOptions(event, options));
+
+    this.#event = event;
+    this.#isAllDay = "date" in this.#event.start!;
+    this.#dateKey = this.#isAllDay ? "date" : "dateTime";
+    this.#dateFormat = getGcalEventDateFormat(this.#event.start);
+
+    const { start, end } = this.#event;
+    const startDate = parseGCalEventDate(start);
+    const endDate = parseGCalEventDate(end);
+
+    this.#durationMs = endDate.diff(startDate, "milliseconds");
+  }
+
+  static #initOptions(
+    event: gSchema$EventBase,
+    options: Partial<Pick<Options, "count" | "freq" | "interval">> = {},
+  ): Partial<Options> {
+    const startDate = parseGCalEventDate(event.start);
+    const dtstart = startDate.local().toDate();
+    const tzid = dayjs.tz.guess();
+    const opts: Partial<RRuleStrOptions> = { dtstart, tzid };
+    const recurrence = event.recurrence?.join("\n").trim();
+    const valid = recurrence?.length > 0;
+    const rruleSet = valid ? rrulestr(recurrence!, opts) : { origOptions: {} };
+    const rruleOptions = { ...rruleSet.origOptions, ...options };
+    const rawCount = rruleOptions.count ?? GCAL_MAX_RECURRENCES;
+    const count = Math.min(rawCount, GCAL_MAX_RECURRENCES);
+
+    return { ...rruleOptions, count, dtstart, tzid };
+  }
+
+  toRecurrence(): string[] {
+    return this.toString().split("\n");
+  }
+
+  /**
+   * instances
+   *
+   * @memberof GcalEventRRule
+   * @description Returns all instances of the event based on the recurrence rule.
+   * @note **This is a test-only method for now, it is not to be used in production.**
+   */
+  instances(): gSchema$EventInstance[] {
+    return this.all().map((date) => {
+      const timezone = dayjs.tz.guess();
+      const tzid = this.#event.start?.timeZone ?? timezone;
+      const startDate = dayjs(date).tz(tzid);
+      const endDate = startDate.add(this.#durationMs, "milliseconds");
+
+      return omit(
+        {
+          ...this.#event,
+          id: `${this.#event.id}_${startDate.toRRuleDTSTARTString(this.#isAllDay)}`,
+          recurringEventId: this.#event.id!,
+          start: {
+            [this.#dateKey]: startDate?.format(this.#dateFormat),
+            timeZone: this.#event.start?.timeZone ?? timezone,
+          },
+          end: {
+            [this.#dateKey]: endDate.format(this.#dateFormat),
+            timeZone: this.#event.end?.timeZone ?? timezone,
+          },
+        },
+        ["recurrence"],
+      );
+    });
+  }
+
+  /**
+   * compassInstances
+   *
+   * @memberof GcalEventRRule
+   * @description Returns all instances of the event mapped to Compass Event format.
+   * @note **This is a test-only method for now, it is not to be used in production.**
+   */
+  compassInstances(userId: string): Event_Core[] {
+    return this.instances().map((event) => gEventToCompassEvent(event, userId));
+  }
+}

--- a/packages/core/src/constants/core.constants.ts
+++ b/packages/core/src/constants/core.constants.ts
@@ -43,6 +43,7 @@ export enum Priorities {
 export const RRULE_COUNT_WEEKS = 12;
 export const RRULE_COUNT_MONTHS = 3;
 export const RRULE_WEEK_START = "SU";
+export const GCAL_MAX_RECURRENCES = 730;
 
 export const RRULE = {
   WEEK: `RRULE:FREQ=WEEKLY;COUNT=${RRULE_COUNT_WEEKS};INTERVAL=1;BYDAY=${RRULE_WEEK_START}`,

--- a/packages/core/src/util/event/gcal.event.util.ts
+++ b/packages/core/src/util/event/gcal.event.util.ts
@@ -8,7 +8,8 @@ export const isCancelledGCalEvent = (e: gSchema$Event): boolean => {
 };
 
 export const isGcalInstanceId = (e: gSchema$Event): boolean =>
-  !!e.id && new RegExp(`^${e.recurringEventId}_\\d+T\\d+Z$`, "i").test(e.id);
+  typeof e.id === "string" &&
+  new RegExp(`^${e.recurringEventId}_\\d+(T\\d+Z?)?$`, "i").test(e.id);
 
 /**
  * isBaseGCalEvent


### PR DESCRIPTION
## What does this PR do?

This PR adds the `GcalEventRRule` parser for parsing rrules in base Google calendar events.

## Use Case

closes #684 