### PR TITLE
:white_check_mark: test(rrule): gen event instances with GCalEventRule

### DIFF
--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.batch.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.batch.ts
@@ -1,40 +1,22 @@
-import dayjs from "dayjs";
-import { faker } from "@faker-js/faker/.";
 import { gSchema$EventBase } from "@core/types/gcal";
 import {
-  generateGcalId,
   mockRecurringGcalBaseEvent,
   mockRecurringGcalInstances,
   mockRegularGcalEvent,
-} from "./gcal.event.factory";
+} from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 
 /* Batch of events, pre-organized as a convenience for testing */
 
-export const mockAndCategorizeGcalEvents = (
-  baseId?: string,
-  fixedStart?: string,
-  fixedEnd?: string,
-) => {
-  // Use fixed times if provided, otherwise fallback to defaults
-  const tz = faker.location.timeZone();
-  const tzStart = fixedStart ? dayjs.tz.guess() : tz;
-
-  const startDateTime = dayjs.tz(fixedStart ?? faker.date.future(), tzStart);
-
-  const endDateTime =
-    dayjs.tz(fixedEnd, tzStart) || startDateTime.add(1, "hour");
-
+export const mockAndCategorizeGcalEvents = () => {
   // Create a base recurring event
-  const baseRecurringEvent = mockRecurringGcalBaseEvent({
-    id: baseId || generateGcalId(),
-    summary: "Recurrence",
-    recurrence: ["RRULE:FREQ=WEEKLY"],
-    start: { dateTime: startDateTime.toRFC3339OffsetString(), timeZone: tz },
-    end: { dateTime: endDateTime.toRFC3339OffsetString(), timeZone: tz },
-  }) as gSchema$EventBase;
+  const baseRecurringEvent = mockRecurringGcalBaseEvent(
+    { summary: "Recurrence" },
+    false,
+    { count: 3 },
+  ) as gSchema$EventBase;
 
   // Create instances of the recurring event
-  const instances = mockRecurringGcalInstances(baseRecurringEvent, 2, 7);
+  const instances = mockRecurringGcalInstances(baseRecurringEvent);
 
   // Create a regular event
   const regularEvent = mockRegularGcalEvent({

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.test.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.event.factory.test.ts
@@ -6,30 +6,30 @@ import {
 
 describe("mockRecurringInstances", () => {
   it("should not include 'recurrence'", () => {
-    const base = mockRecurringGcalBaseEvent();
-    const instances = mockRecurringGcalInstances(base, 2, 7);
+    const base = mockRecurringGcalBaseEvent({}, false, { count: 2 });
+    const instances = mockRecurringGcalInstances(base);
     instances.forEach((instance) => {
       expect(instance).not.toHaveProperty("recurrence");
     });
   });
 
   it("should create the correct number of instances", () => {
-    const base = mockRecurringGcalBaseEvent();
-    const instances = mockRecurringGcalInstances(base, 2, 7);
+    const base = mockRecurringGcalBaseEvent({}, false, { count: 2 });
+    const instances = mockRecurringGcalInstances(base);
     expect(instances).toHaveLength(2);
   });
 
   it("should include 'recurringEventId' that points to the base event", () => {
-    const base = mockRecurringGcalBaseEvent();
-    const instances = mockRecurringGcalInstances(base, 2, 7);
+    const base = mockRecurringGcalBaseEvent({}, false, { count: 2 });
+    const instances = mockRecurringGcalInstances(base);
     instances.forEach((instance) => {
       expect(instance.recurringEventId).toBe(base.id);
     });
   });
 
   it("should make the first instance start and end at the same time as the base event", () => {
-    const base = mockRecurringGcalBaseEvent();
-    const instances = mockRecurringGcalInstances(base, 2, 7);
+    const base = mockRecurringGcalBaseEvent({}, false, { count: 2 });
+    const instances = mockRecurringGcalInstances(base);
     const firstInstance = instances[0] as gSchema$EventInstance;
 
     expect(firstInstance.start?.dateTime).toBe(base.start?.dateTime);
@@ -37,8 +37,8 @@ describe("mockRecurringInstances", () => {
   });
 
   it("should make instances start and end in the future from the base time (except for the first one)", () => {
-    const base = mockRecurringGcalBaseEvent();
-    const instances = mockRecurringGcalInstances(base, 2, 7);
+    const base = mockRecurringGcalBaseEvent({}, false, { count: 2 });
+    const instances = mockRecurringGcalInstances(base);
     const baseStart = new Date(base.start?.dateTime as string);
     instances.forEach((instance, index) => {
       if (index === 0) return; // first instance is the same as the base
@@ -52,14 +52,14 @@ describe("mockRecurringInstances", () => {
   });
 
   it("should create recurring instances", () => {
-    const event = mockRecurringGcalBaseEvent();
-    const instances = mockRecurringGcalInstances(event, 3, 7);
+    const event = mockRecurringGcalBaseEvent({}, false, { count: 3 });
+    const instances = mockRecurringGcalInstances(event);
     expect(instances).toHaveLength(3);
   });
 
   it("should use RFC3339_OFFSET for start and end times", () => {
-    const event = mockRecurringGcalBaseEvent();
-    const instances = mockRecurringGcalInstances(event, 3, 7);
+    const event = mockRecurringGcalBaseEvent({}, false, { count: 3 });
+    const instances = mockRecurringGcalInstances(event);
     const hasTZOffset = (ts: string) => {
       return (
         // @ts-expect-error assuming string has enough length

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
@@ -1,20 +1,22 @@
 import type { GaxiosPromise } from "gaxios";
 import type { calendar_v3 } from "googleapis";
 import { GoogleApis } from "googleapis";
-import type { MethodOptions } from "googleapis/build/src/apis/calendar";
+import type {
+  MethodOptions,
+  StreamMethodOptions,
+} from "googleapis/build/src/apis/calendar";
 import type {
   gSchema$CalendarListEntry,
   gSchema$Channel,
   gSchema$Event,
-  gSchema$EventBase,
   gSchema$Events,
 } from "@core/types/gcal";
 import {
   isBaseGCalEvent,
   isInstanceGCalEvent,
   isRegularGCalEvent,
-} from "../../../../../core/src/util/event/gcal.event.util";
-import { mockRecurringGcalEvents } from "./gcal.event.factory";
+} from "@core/util/event/gcal.event.util";
+import { mockRecurringGcalEvents } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 
 /**
  * Generates a paginated events object for the Google Calendar API.
@@ -87,6 +89,79 @@ export const mockGcal = ({
     ...calendar,
     events: {
       ...calendar.events,
+      get: jest.fn(async (params: calendar_v3.Params$Resource$Events$Get) => {
+        const { eventId } = params;
+        const event = events.find((e) => e.id === eventId);
+
+        if (!event) throw new Error(`Event with id ${eventId} not found`);
+
+        return Promise.resolve({
+          statusText: "OK",
+          status: 200,
+          data: event,
+        });
+      }),
+      insert: jest.fn(
+        async (
+          params: calendar_v3.Params$Resource$Events$Insert,
+          options: StreamMethodOptions = { responseType: "stream" },
+        ): GaxiosPromise<gSchema$Event> => {
+          events.push(params.requestBody as gSchema$Event);
+
+          return Promise.resolve({
+            config: options,
+            statusText: "OK",
+            status: 200,
+            data: params.requestBody as gSchema$Event,
+            headers: options.headers!,
+            request: { responseURL: params.requestBody!.id! },
+          });
+        },
+      ),
+      patch: jest.fn(
+        async (
+          params: calendar_v3.Params$Resource$Events$Patch,
+          options: MethodOptions = {},
+        ): GaxiosPromise<gSchema$Event> => {
+          const { eventId } = params;
+          const eventIndex = events.findIndex((e) => e.id === eventId);
+
+          if (eventIndex === -1) {
+            throw new Error(`Event with id ${eventId} not found`);
+          }
+
+          const updatedEvent = { ...events[eventIndex], ...params.requestBody };
+
+          events[eventIndex] = updatedEvent;
+
+          return Promise.resolve({
+            config: options,
+            statusText: "OK",
+            status: 200,
+            data: updatedEvent,
+            headers: options.headers!,
+            request: { responseURL: updatedEvent.id! },
+          });
+        },
+      ),
+      delete: jest.fn(
+        async (params: calendar_v3.Params$Resource$Events$Delete) => {
+          const { eventId } = params;
+          const eventIndex = events.findIndex((e) => e.id === eventId);
+
+          if (eventIndex === -1) {
+            throw new Error(`Event with id ${eventId} not found`);
+          }
+
+          events.splice(eventIndex, 1);
+
+          return Promise.resolve({
+            statusText: "OK",
+            status: 204,
+            data: {},
+          });
+        },
+      ),
       list: jest.fn(
         async (params: { pageToken?: string; singleEvents?: boolean }) => {
           // When singleEvents is false, only return base events and regular events - without instance events
@@ -129,16 +204,16 @@ export const mockGcal = ({
       instances: jest.fn(async (params: { eventId: string }) => {
         const { eventId: id } = params;
 
-        const baseEvent = events.find(isBaseGCalEvent) as gSchema$EventBase;
+        const baseEvent = events.find((e) => e.id === id);
 
-        const data = mockRecurringGcalEvents({ ...baseEvent, id }, 3, 7);
+        if (!baseEvent) throw new Error(`Event with id ${id} not found`);
+
+        const data = mockRecurringGcalEvents({ ...baseEvent, id });
 
         return {
           statusText: "OK",
           status: 200,
-          data: {
-            items: data.instances,
-          },
+          data: { items: data.instances },
         };
       }),
       watch: jest.fn(

--- a/packages/backend/src/event/services/event.service.util.ts
+++ b/packages/backend/src/event/services/event.service.util.ts
@@ -11,7 +11,7 @@ import {
 import { isSameMonth } from "@core/util/date/date.util";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
-import mongoService from "../../common/services/mongo.service";
+import mongoService from "@backend/common/services/mongo.service";
 
 dayjs.extend(tz);
 dayjs.extend(utc);
@@ -74,12 +74,12 @@ export const getDeleteByIdFilter = (
 export const getReadAllFilter = (
   userId: string,
   query: Query_Event,
-): Filter<Schema_Event> => {
+): Filter<Omit<Schema_Event, "_id">> => {
   const { end, someday, start, priorities } = query;
   const isSomeday = someday === "true";
 
   // Start with basic user filter
-  const filter: Filter<Schema_Event> = { user: userId };
+  const filter: Filter<Omit<Schema_Event, "_id">> = { user: userId };
 
   // Add isSomeday condition
   filter["isSomeday"] = isSomeday;

--- a/packages/backend/src/event/services/recur/util/recur.gcal.util.ts
+++ b/packages/backend/src/event/services/recur/util/recur.gcal.util.ts
@@ -1,5 +1,6 @@
 import { Categories_Recurrence } from "@core/types/event.types";
 import { gSchema$Event } from "@core/types/gcal";
+import { isGcalInstanceId } from "@core/util/event/gcal.event.util";
 
 export class GcalParser {
   constructor(private event: gSchema$Event) {
@@ -61,16 +62,9 @@ export class GcalParser {
     const hasInstancesPropertiesThatAreUndefined =
       this.event.originalStartTime !== undefined &&
       this.event.recurringEventId !== undefined;
-    if (hasInstancesPropertiesThatAreUndefined) {
-      return true;
-    }
 
-    const hasInstanceId =
-      this.event.id?.includes("_") && this.event.id?.endsWith("Z");
-    if (hasInstanceId) {
-      return true;
-    }
+    if (hasInstancesPropertiesThatAreUndefined) return true;
 
-    return false;
+    return isGcalInstanceId(this.event);
   }
 }

--- a/packages/backend/src/sync/services/import/sync.import.series.test.ts
+++ b/packages/backend/src/sync/services/import/sync.import.series.test.ts
@@ -3,15 +3,16 @@ import {
   filterBaseEvents,
   filterExistingInstances,
 } from "@core/util/event/event.util";
+import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
+import { getEventsInDb } from "@backend/__tests__/helpers/mock.db.queries";
 import {
   cleanupCollections,
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
+import { simulateGoogleCalendarEventCreation } from "@backend/__tests__/helpers/mock.events.init";
 import { mockRecurringGcalBaseEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
-import { UtilDriver } from "../../../__tests__/drivers/util.driver";
-import { getEventsInDb } from "../../../__tests__/helpers/mock.db.queries";
-import { createSyncImport } from "./sync.import";
+import { createSyncImport } from "@backend/sync/services/import/sync.import";
 
 describe("SyncImport: Series", () => {
   beforeAll(setupTestDb);
@@ -26,6 +27,9 @@ describe("SyncImport: Series", () => {
     const syncImport = await createSyncImport(user._id.toString());
 
     const baseRecurringGcalEvent = mockRecurringGcalBaseEvent();
+
+    //simulate event creation in Google Calendar
+    await simulateGoogleCalendarEventCreation(baseRecurringGcalEvent);
 
     /* Act */
     // trigger a series import with base event

--- a/packages/backend/src/sync/services/sync/__tests__/gcal.sync.processor.delete.util.ts
+++ b/packages/backend/src/sync/services/sync/__tests__/gcal.sync.processor.delete.util.ts
@@ -1,12 +1,15 @@
 import { ObjectId, WithId } from "mongodb";
+import { Schema_User } from "@core/types/user.types";
 import { createRecurrenceSeries } from "@backend/__tests__/mocks.db/ccal.mock.db.util";
 import { mockRecurringGcalEvents } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
-import { Schema_User } from "../../../../../../core/src/types/user.types";
 
 export const createSeries = async (user: WithId<Schema_User>) => {
   // Create base and instances in Compass,
   // that point to the original gcal base
-  const { base: gcalBase } = mockRecurringGcalEvents({}, 2, 7);
+  const { base: gcalBase } = mockRecurringGcalEvents({}, false, {
+    count: 2,
+    interval: 7,
+  });
 
   const compassBaseId = new ObjectId().toString();
   const compassBase = {

--- a/packages/backend/src/sync/services/sync/__tests__/gcal.sync.processor.test.util.ts
+++ b/packages/backend/src/sync/services/sync/__tests__/gcal.sync.processor.test.util.ts
@@ -8,6 +8,7 @@ import {
   Schema_Event_Recur_Instance,
 } from "@core/types/event.types";
 import { gSchema$EventBase, gSchema$EventInstance } from "@core/types/gcal";
+import { Schema_User } from "@core/types/user.types";
 import {
   categorizeEvents,
   isBase,
@@ -19,7 +20,6 @@ import { createRecurrenceSeries } from "@backend/__tests__/mocks.db/ccal.mock.db
 import { mockRecurringGcalInstances } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { Event_API } from "@backend/common/types/backend.event.types";
 import { validateEventSafely } from "@backend/common/validators/validate.event";
-import { Schema_User } from "../../../../../../core/src/types/user.types";
 
 dayjs.extend(timezone);
 
@@ -40,8 +40,6 @@ export const createCompassSeriesFromGcalBase = async (
 ) => {
   const gcalInstance = mockRecurringGcalInstances(
     gBase,
-    1,
-    1,
   )[0] as gSchema$EventInstance;
 
   const baseCompassId = new ObjectId().toString();

--- a/packages/backend/src/sync/services/sync/__tests__/gcal.sync.processor.upsert.base.test.ts
+++ b/packages/backend/src/sync/services/sync/__tests__/gcal.sync.processor.upsert.base.test.ts
@@ -7,7 +7,10 @@ import {
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
-import { simulateDbAfterGcalImport } from "@backend/__tests__/helpers/mock.events.init";
+import {
+  simulateDbAfterGcalImport,
+  simulateGoogleCalendarEventCreation,
+} from "@backend/__tests__/helpers/mock.events.init";
 import { mockRecurringGcalBaseEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { RecurringEventRepository } from "@backend/event/services/recur/repo/recur.event.repo";
 import {
@@ -36,6 +39,8 @@ describe("GcalSyncProcessor UPSERT: BASE", () => {
     await simulateDbAfterGcalImport(user._id.toString());
 
     const newBase = mockRecurringGcalBaseEvent();
+
+    await simulateGoogleCalendarEventCreation(newBase);
 
     const processor = new GcalSyncProcessor(repo);
     const changes = await processor.processEvents([newBase]);

--- a/packages/core/src/util/event/event.util.ts
+++ b/packages/core/src/util/event/event.util.ts
@@ -39,7 +39,7 @@ export const isAllDay = (event: Schema_Event | Event_API) =>
  * @param event
  * @returns
  */
-export const isBase = (event: Schema_Event | Event_API) => {
+export const isBase = (event: Pick<Schema_Event | Event_API, "recurrence">) => {
   return (
     event?.recurrence?.rule !== undefined &&
     event?.recurrence?.eventId === undefined
@@ -64,7 +64,9 @@ export const isInstanceWithoutId = (event: Schema_Event | Event_API) => {
  * @param event
  * @returns
  */
-export const isExistingInstance = (event: Schema_Event | Event_API) => {
+export const isExistingInstance = (
+  event: Pick<Schema_Event | Event_API, "recurrence">,
+) => {
   return event?.recurrence?.eventId && event?.recurrence?.rule === undefined;
 };
 


### PR DESCRIPTION
## What does this PR do?

This PR leverages the `GcalEventRule` class to generate Google calendar event instances from base events.

## Use Case

closes #686 