### PR TITLE
✨ feat(web): add Discord link to command palette

### DIFF
--- a/packages/web/src/views/CmdPalette/CmdPalette.tsx
+++ b/packages/web/src/views/CmdPalette/CmdPalette.tsx
@@ -182,6 +182,13 @@ const CmdPalette = ({
             target: "_blank",
           },
           {
+            id: "discord",
+            children: "Discord",
+            icon: "ChatBubbleLeftRightIcon",
+            href: "https://www.discord.gg/H3DVMnKmUd",
+            target: "_blank",
+          },
+          {
             id: "terms",
             children: "Terms",
             icon: "DocumentTextIcon",


### PR DESCRIPTION
Closes #675 

This pull request introduces a minor update to the `CmdPalette` component by adding a new external link to Discord. This change enhances user access to community support and engagement.

* Added a "Discord" menu item to the command palette, with an icon and a link to the official Discord server (`CmdPalette.tsx`).

<img width="1147" height="1113" alt="Screenshot 2025-08-08 at 7 48 25 AM" src="https://github.com/user-attachments/assets/297565d5-70da-438c-ba58-ace7f0492a08" />

