### PR TITLE
🐛 fix(web): update onboarding flow to include active users in waitlist check

### DIFF
--- a/packages/backend/src/waitlist/controller/waitlist.controller.ts
+++ b/packages/backend/src/waitlist/controller/waitlist.controller.ts
@@ -111,8 +111,8 @@ export class WaitlistController {
       isOnWaitlist,
       isInvited,
       isActive,
-      firstName: waitlistRecord?.firstName,
-      lastName: waitlistRecord?.lastName,
+      firstName: waitlistRecord?.firstName ?? existingUser?.firstName,
+      lastName: waitlistRecord?.lastName ?? existingUser?.lastName,
     });
   }
 }

--- a/packages/web/src/components/Onboarding/steps/EmailStep.tsx
+++ b/packages/web/src/components/Onboarding/steps/EmailStep.tsx
@@ -93,6 +93,9 @@ export const EmailStep: React.FC<OnboardingStepProps> = ({
       if (data.isOnWaitlist && data.isInvited) {
         onNext();
       }
+      if (data.isActive) {
+        onNext();
+      }
     } catch (error) {
       console.error("Error checking waitlist status:", error);
     } finally {

--- a/packages/web/src/components/Onboarding/steps/EmailStep.tsx
+++ b/packages/web/src/components/Onboarding/steps/EmailStep.tsx
@@ -90,10 +90,7 @@ export const EmailStep: React.FC<OnboardingStepProps> = ({
       setWaitlistStatus(data);
       setFirstName(data.firstName ?? "Sailor");
 
-      if (data.isOnWaitlist && data.isInvited) {
-        onNext();
-      }
-      if (data.isActive) {
+      if ((data.isOnWaitlist && data.isInvited) || data.isActive) {
         onNext();
       }
     } catch (error) {


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/701

* Ensure users marked as active are also allowed to proceed to the next step in the onboarding flow.
* Adjust backend to source firstName and lastName from existingUser if not available in waitlistRecord.