### PR TITLE
:white_check_mark: test(jest): use ephemeral test states

### DIFF
--- a/packages/backend/src/__tests__/helpers/mock.setup.ts
+++ b/packages/backend/src/__tests__/helpers/mock.setup.ts
@@ -11,15 +11,28 @@ import { mockGcal } from "@backend/__tests__/mocks.gcal/factories/gcal.factory";
 import { ENV } from "@backend/common/constants/env.constants";
 import { SupertokensAccessTokenPayload } from "@backend/common/types/supertokens.types";
 
+export interface CompassTestState {
+  events: ReturnType<typeof mockAndCategorizeGcalEvents>;
+}
+
+function mockCompassTestState() {
+  jest.mock(
+    "compass-test-state",
+    () => ({ events: { ...mockAndCategorizeGcalEvents() } }),
+    { virtual: true },
+  );
+}
+
+export function compassTestState(): CompassTestState {
+  return jest.requireMock<CompassTestState>("compass-test-state");
+}
+
 function mockGoogleapis() {
   mockModule("googleapis", (googleapis: { google: GoogleApis }) => {
-    const { gcalEvents } = mockAndCategorizeGcalEvents();
-
     return {
       google: {
         ...googleapis.google,
         calendar: mockGcal({
-          events: gcalEvents.all,
           googleapis: googleapis.google,
         }),
       },
@@ -197,6 +210,8 @@ export function mockModule<T>(
 }
 
 export function mockNodeModules() {
+  beforeEach(mockCompassTestState);
+  afterEach(() => jest.unmock("compass-test-state"));
   mockWinstonLogger();
   mockHttpLoggingMiddleware();
   mockGoogleapis();


### PR DESCRIPTION
## What does this PR do

This PR creates a mock virtual jest module `compass-test-state`, used to store the test state for each test.
The `compass-test-state` module is reset for every test.

## Use Case

closes #689