### PR TITLE
:bug: fix(gcal-import): Invoke  '.send' manually on http response

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -151,7 +151,7 @@ class SyncController {
         logger.error(message, err);
       });
 
-    return res.status(204);
+    return res.status(204).send();
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR Invokes `.send` manually on `/import-gcal` Express http response.

## Use Case

closes #604 