### PR TITLE
🐛 fix: skip waitlist check on localhost

### DIFF
--- a/packages/web/src/components/Onboarding/OnboardingDemo.tsx
+++ b/packages/web/src/components/Onboarding/OnboardingDemo.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { IS_DEV } from "@web/common/constants/env.constants";
 import {
   useOnboarding,
   withProvider,
@@ -34,12 +35,17 @@ const OnboardingDemo_: React.FC = () => {
       id: "welcome",
       component: (props: OnboardingStepProps) => <WelcomeStep {...props} />,
     },
-    {
+  ];
+
+  if (!IS_DEV) {
+    // only show email step in prod in order
+    // to allow contributors on localhost through
+    loginSteps.push({
       id: "email",
       component: EmailStep,
       disableRightArrow: true,
-    },
-  ];
+    });
+  }
 
   const onboardingSteps: OnboardingStepType[] = [
     {


### PR DESCRIPTION
Closes #742  by allowing local contributors to use the app without having to be on the waitlist.

This serves the purpose of lowering the bar for contributors. If someone is willing to help us out, then we shouldn't make it unnecessarily difficult for them to do so.

Without this fix, a local contributor would have to add their own waitlist entry to the `waitlist` collection. This is an unintuitive process, since a contributor won't have a landing page with a waitlist flow like we do in production.

Making the waitlist email check conditional allows contributors to still go through the onboarding flow without requiring them to do anything beforehand.

----

This pull request updates the onboarding flow in `OnboardingDemo.tsx` to conditionally show the email step only in production environments. This allows contributors working locally to bypass the email step, streamlining their onboarding experience.

Environment-based onboarding flow:

* Added a check for the `IS_DEV` constant to conditionally include the email step in the onboarding process only when not in development mode (`OnboardingDemo.tsx`). [[1]](diffhunk://#diff-36b0072ca534b4e80e0141c8e734725892ae782179c15b5e9b9be8fd2f9224caR3) [[2]](diffhunk://#diff-36b0072ca534b4e80e0141c8e734725892ae782179c15b5e9b9be8fd2f9224caL37-R48)