### PR TITLE
:sparkles: feat(gcal-import): add timeout to the import gcal endpoint

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -95,6 +95,8 @@ class SyncController {
   };
 
   importGCal = async (req: Request, res: Response): Promise<Response> => {
+    req.setTimeout(1000); // set short timeout for this request
+
     const userId = req.session!.getUserId()!;
     const gcalClient = await getGcalClient(userId);
     const sync = await getSync({ userId });


### PR DESCRIPTION
## What does this PR do?

This PR adds a 1 second timeout to the `/import-gcal` endoint

## Use Case

closes #746 