### PR TITLE
:sparkles: feat(gcal-import): use single causal txn during import

### DIFF
--- a/packages/backend/src/sync/util/sync.queries.ts
+++ b/packages/backend/src/sync/util/sync.queries.ts
@@ -274,11 +274,12 @@ export const updateSyncTokenFor = async (
 export const getGCalEventsSyncPageToken = async (
   userId: string,
   gCalendarId: string,
+  session?: ClientSession,
 ): Promise<string | undefined> => {
-  const response = await mongoService.sync.findOne({
-    user: userId,
-    "google.events.gCalendarId": gCalendarId,
-  });
+  const response = await mongoService.sync.findOne(
+    { user: userId, "google.events.gCalendarId": gCalendarId },
+    { session },
+  );
 
   return response?.google.events.find((e) => e.gCalendarId === gCalendarId)
     ?.nextPageToken;


### PR DESCRIPTION
## What does this PR do?

This PR uses a single mongo transaction and enforces causal consistency when saving the gcal events.

## Use Case

closes #747 