### PR TITLE
:bug: feat(sync-queries): remove reliance on positional operator for sync-update queries

### DIFF
--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
@@ -5,6 +5,7 @@ import type {
   MethodOptions,
   StreamMethodOptions,
 } from "googleapis/build/src/apis/calendar";
+import { Status } from "@core/errors/status.codes";
 import type {
   WithGcalId,
   gSchema$CalendarListEntry,
@@ -261,6 +262,23 @@ export const mockGcal = ({
           nextSyncToken: calendarListNextSyncToken,
         },
       })),
+    },
+    channels: {
+      ...calendar.channels,
+      stop: jest.fn(
+        async (
+          params: calendar_v3.Params$Resource$Channels$Stop,
+          options: MethodOptions = {},
+        ): GaxiosPromise<gSchema$Channel> =>
+          Promise.resolve({
+            config: options,
+            statusText: "OK",
+            status: Status.NO_CONTENT,
+            data: params.requestBody as gSchema$Channel,
+            headers: options.headers!,
+            request: { responseURL: params.requestBody!.address! },
+          }),
+      ),
     },
   }));
 };

--- a/packages/core/src/types/sync.types.ts
+++ b/packages/core/src/types/sync.types.ts
@@ -77,7 +77,7 @@ export interface Schema_Sync {
     calendarlist: {
       gCalendarId: string;
       nextSyncToken: string;
-      lastSyncedAt: Date;
+      lastSyncedAt?: Date;
     }[];
     events: Payload_Sync_Events[];
   };


### PR DESCRIPTION
## What does this PR do?

This PR updates the `sync-queries`. Refactors the update and create functions to rely on the `createSync` and `updateSync`functions, and removes reliance on mongo positional operators.

## Use Case

closes #603 