### PR TITLE
:bug: fix(gcal-import): start watch during resync only when using an https endpoint

### DIFF
--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -1,5 +1,4 @@
 import { Schema_CalendarList } from "@core/types/calendar.types";
-import { Collections } from "@backend/common/constants/collections";
 import mongoService from "@backend/common/services/mongo.service";
 
 class CalendarService {
@@ -10,42 +9,31 @@ class CalendarService {
   ) => {
     const payload = calendarList.google.items;
 
-    const response = await mongoService.db
-      .collection(Collections.CALENDARLIST)
-      .updateOne(
-        { user: userId },
-        {
-          $push: {
-            [`${integration}.items`]: payload,
-          },
-        },
-      );
+    const response = await mongoService.calendar.updateOne(
+      { user: userId },
+      { $push: { [`${integration}.items`]: payload } },
+      { upsert: true },
+    );
 
     return response;
   };
 
   create = async (calendarList: Schema_CalendarList) => {
-    return await mongoService.db
-      .collection(Collections.CALENDARLIST)
-      .insertOne(calendarList);
+    return await mongoService.calendar.insertOne(calendarList);
   };
 
   async deleteAllByUser(userId: string) {
     const filter = { user: userId };
-    const response = await mongoService.db
-      .collection(Collections.CALENDARLIST)
-      .deleteMany(filter);
+    const response = await mongoService.calendar.deleteMany(filter);
 
     return response;
   }
 
   deleteByIntegrateion = async (integration: "google", userId: string) => {
-    const response = await mongoService.db
-      .collection(Collections.CALENDARLIST)
-      .updateOne(
-        { user: userId },
-        { $unset: { [`${integration}.items`]: "" } },
-      );
+    const response = await mongoService.calendar.updateOne(
+      { user: userId },
+      { $unset: { [`${integration}.items`]: "" } },
+    );
 
     return response;
   };

--- a/packages/backend/src/common/services/mongo.service.ts
+++ b/packages/backend/src/common/services/mongo.service.ts
@@ -10,6 +10,7 @@ import {
   ObjectId,
 } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
+import { Schema_CalendarList as Schema_Calendar } from "@core/types/calendar.types";
 import { Schema_Event } from "@core/types/event.types";
 import { Schema_Sync } from "@core/types/sync.types";
 import { Schema_User } from "@core/types/user.types";
@@ -23,6 +24,7 @@ const logger = Logger("app:mongo.service");
 interface InternalClient {
   db: Db;
   client: MongoClient;
+  calendar: Collection<Schema_Calendar>;
   event: Collection<Omit<Schema_Event, "_id">>;
   sync: Collection<Schema_Sync>;
   user: Collection<Schema_User>;
@@ -34,6 +36,15 @@ class MongoService {
 
   get db() {
     return this.#internalClient!.db;
+  }
+
+  /**
+   * calendar
+   *
+   * mongo collection
+   */
+  get calendar(): InternalClient["calendar"] {
+    return this.#accessInternalCollectionProps("calendar");
   }
 
   /**
@@ -103,6 +114,7 @@ class MongoService {
     return {
       db,
       client,
+      calendar: db.collection<Schema_Calendar>(Collections.CALENDARLIST),
       event: db.collection<Omit<Schema_Event, "_id">>(Collections.EVENT),
       sync: db.collection<Schema_Sync>(Collections.SYNC),
       user: db.collection<Schema_User>(Collections.USER),

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -27,6 +27,7 @@ import { getCalendarsToSync } from "@backend/sync/services/init/sync.init";
 import syncService from "@backend/sync/services/sync.service";
 import { watchEventsByGcalIds } from "@backend/sync/services/watch/sync.watch";
 import { reInitSyncByIntegration } from "@backend/sync/util/sync.queries";
+import { isUsingHttps } from "@backend/sync/util/sync.util";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 import { Summary_Delete } from "@backend/user/types/user.types";
 
@@ -208,7 +209,9 @@ class UserService {
       calListNextSyncToken,
     );
 
-    const eventWatches = await watchEventsByGcalIds(userId, gCalendarIds, gcal);
+    const eventWatches = await Promise.resolve(isUsingHttps()).then((yes) =>
+      yes ? watchEventsByGcalIds(userId, gCalendarIds, gcal) : [],
+    );
 
     await syncService.importFull(gcal, gCalendarIds, userId);
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the sync error during local development when the ngrok service which provides an `https` endpoint for the gcal sync is not active.

## Use Case

closes #765 