### PR TITLE
🐛 fix(gcal-notifications) cleanup stale sync records

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -4,7 +4,6 @@ import { Logger } from "@core/logger/winston.logger";
 import { Payload_Sync_Notif } from "@core/types/sync.types";
 import { shouldImportGCal } from "@core/util/event/event.util";
 import { SyncError } from "@backend/common/errors/sync/sync.errors";
-import { UserError } from "@backend/common/errors/user/user.errors";
 import {
   isFullSyncRequired,
   isInvalidGoogleToken,
@@ -33,26 +32,17 @@ export class SyncController {
       const channelId = req.headers["x-goog-channel-id"] as string;
       const resourceId = req.headers["x-goog-resource-id"] as string;
 
-      const sync = await getSync({ channelId, resourceId });
-      if (!sync || !sync.user) {
-        logger.error(
-          `Sync error occurred, but couldnt find user based on this resourceId: ${resourceId}`,
-        );
-        logger.debug(res);
-        res.status(Status.BAD_REQUEST).send(UserError.MissingUserIdField);
-        return;
-      }
-
-      const userId = sync.user;
-
       if (isInvalidGoogleToken(e as Error)) {
+        const sync = await getSync({ channelId, resourceId });
+        const userId = sync!.user;
+
         console.warn(`Cleaning data after this user revoked access: ${userId}`);
-        await userService.deleteCompassDataForUser(sync.user, false);
+        await userService.deleteCompassDataForUser(userId, false);
         res.status(Status.GONE).send("User revoked access, deleted all data");
         return;
 
-        const msg = `Ignored update due to revoked access for resourceId: ${JSON.stringify(
-          resourceId,
+        const msg = `Ignored update due to revoked access for channelId: ${JSON.stringify(
+          channelId,
         )}
         `;
         console.warn(msg);
@@ -64,12 +54,23 @@ export class SyncController {
       if (isFullSyncRequired(e as Error)) {
         return SyncController.importGCal(req, res);
       }
+
+      if (
+        e instanceof Error &&
+        e.message === SyncError.NoSyncRecordForUser.description
+      ) {
+        logger.error(e);
+        logger.debug(res);
+        res.status(Status.BAD_REQUEST).send(SyncError.NoSyncRecordForUser);
+        return;
+      }
+
       if (
         e instanceof Error &&
         e.message === SyncError.NoSyncToken.description
       ) {
         logger.debug(
-          `Ignored notification due to missing sync token for resourceId: ${resourceId}`,
+          `Ignored notification due to missing sync token for channelId: ${channelId}`,
         );
         // returning 204 instead of 500 so client doesn't
         // attempt to retry

--- a/packages/backend/src/sync/services/import/sync.import.ts
+++ b/packages/backend/src/sync/services/import/sync.import.ts
@@ -497,18 +497,23 @@ export class SyncImport {
       return sync.google.events;
     }
 
-    await updateSync(
-      Resource_Sync.CALENDAR,
-      userId,
-      sync.google.calendarlist[0]!.gCalendarId,
-      { nextSyncToken: calListNextSyncToken },
-      undefined,
+    await Promise.all(
+      gCalendarIds.map((gCalendarId) =>
+        updateSync(
+          Resource_Sync.CALENDAR,
+          userId,
+          gCalendarId,
+          { nextSyncToken: calListNextSyncToken },
+          undefined,
+        ),
+      ),
     );
 
     const eventWatchPayloads = assembleEventWatchPayloads(
       sync as Schema_Sync,
       gCalendarIds,
     );
+
     await syncService.startWatchingGcalEventsById(
       userId,
       eventWatchPayloads, // Watch all selected calendars

--- a/packages/backend/src/sync/util/sync.queries.test.ts
+++ b/packages/backend/src/sync/util/sync.queries.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { Resource_Sync } from "@core/types/sync.types";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
@@ -12,7 +13,6 @@ import {
   getSync,
   updateSync,
 } from "@backend/sync/util/sync.queries";
-import { Resource_Sync } from "../../../../core/src/types/sync.types";
 
 describe("sync.queries: ", () => {
   describe("nextPageToken", () => {
@@ -402,7 +402,17 @@ describe("sync.queries: ", () => {
       expect(updatedSync?.google.events).toBeUndefined();
 
       expect(updatedSync).toEqual(
-        expect.objectContaining({ user: userId, google: { calendarlist: [] } }),
+        expect.objectContaining({
+          user: userId,
+          google: {
+            calendarlist: [
+              expect.objectContaining({
+                gCalendarId: calendarId,
+                lastSyncedAt: expect.any(Date),
+              }),
+            ],
+          },
+        }),
       );
     });
 
@@ -447,7 +457,18 @@ describe("sync.queries: ", () => {
       expect(updatedSync?.google.calendarlist).toBeUndefined();
 
       expect(updatedSync).toEqual(
-        expect.objectContaining({ user: userId, google: { events: [] } }),
+        expect.objectContaining({
+          user: userId,
+          google: {
+            events: [
+              expect.objectContaining({
+                gCalendarId: calendarId,
+                resourceId,
+                lastSyncedAt: expect.any(Date),
+              }),
+            ],
+          },
+        }),
       );
     });
   });

--- a/packages/backend/src/sync/util/sync.queries.ts
+++ b/packages/backend/src/sync/util/sync.queries.ts
@@ -123,11 +123,11 @@ export const deleteWatchData = async (
     ...filter,
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { userId, ...pullFilter } = filter;
-
   return await mongoService.sync.updateOne(watchFilter, {
-    $pull: { [`google.${resource}`]: pullFilter },
+    $unset: {
+      [`google.${resource}.$.channelId`]: "",
+      [`google.${resource}.$.expiration`]: "",
+    },
   });
 };
 

--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -72,7 +72,7 @@ export interface Schema_Event {
   recurrence?: {
     rule?: string[];
     eventId?: string;
-  };
+  } | null;
   startDate?: string;
   title?: string;
   updatedAt?: Date | string;


### PR DESCRIPTION
## What does this PR do?

This PR cleans up stale sync watches by `channelId` and resolves the `No Sync record - 400` error for existing channels in GCal.

## Use Case

closes #622 