### PR TITLE
🐛 fix(web): Make recurrence field nullable

### DIFF
--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -139,7 +139,7 @@ export const CoreEventSchema = z.object({
   gRecurringEventId: z.string().optional(),
   origin: z.nativeEnum(Origin),
   priority: z.nativeEnum(Priorities),
-  recurrence: Recurrence.optional(),
+  recurrence: Recurrence.nullable().optional(),
   startDate: z.union([
     z.string().datetime({ offset: true }),
     z.string().date(),


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/771

Fixes a zod validation runtime error due to recurrence field being passed as null.

`.optional()` only makes it accept undefined values, so we needed the `nullable()` call as well