### PR TITLE
feat(backend): update waitlist schema

### DIFF
--- a/packages/backend/src/__tests__/drivers/waitlist.driver.ts
+++ b/packages/backend/src/__tests__/drivers/waitlist.driver.ts
@@ -9,14 +9,13 @@ export class WaitListDriver {
   ): Schema_Waitlist {
     return {
       email: user.email,
-      schemaVersion: "0",
+      schemaVersion: "1",
       source: "other",
       firstName: user.firstName,
       lastName: user.lastName,
+      profession: "Software Engineer",
       currentlyPayingFor: ["superhuman", "notion"],
-      howClearAboutValues: "not-clear",
-      workingTowardsMainGoal: "yes",
-      isWillingToShare: false,
+      anythingElse: "I'm a test",
       status: "waitlisted",
       waitlistedAt: new Date().toISOString(),
     };

--- a/packages/backend/src/waitlist/controller/waitlist.controller-add.test.ts
+++ b/packages/backend/src/waitlist/controller/waitlist.controller-add.test.ts
@@ -1,5 +1,8 @@
 import request from "supertest";
-import type { Answers } from "@core/types/waitlist/waitlist.answer.types";
+import type {
+  Answers,
+  Answers_v1,
+} from "@core/types/waitlist/waitlist.answer.types";
 
 describe("POST /api/waitlist", () => {
   beforeEach(() => jest.resetModules());
@@ -37,16 +40,14 @@ describe("POST /api/waitlist", () => {
     app.use(express.json());
     app.post("/api/waitlist", WaitlistController.addToWaitlist);
 
-    const answers: Answers = {
+    const answers: Answers_v1 = {
       source: "social-media",
       firstName: "Jo",
       lastName: "Schmo",
       email: "test@example.com",
       currentlyPayingFor: [],
-      howClearAboutValues: "not-clear",
-      workingTowardsMainGoal: "yes",
-      isWillingToShare: false,
-      schemaVersion: "0",
+      schemaVersion: "1",
+      anythingElse: "I'm a test",
     };
     const res = await request(app).post("/api/waitlist").send(answers);
 

--- a/packages/backend/src/waitlist/controller/waitlist.controller-add.test.ts
+++ b/packages/backend/src/waitlist/controller/waitlist.controller-add.test.ts
@@ -1,8 +1,5 @@
 import request from "supertest";
-import type {
-  Answers,
-  Answers_v1,
-} from "@core/types/waitlist/waitlist.answer.types";
+import type { Answers_v1 } from "@core/types/waitlist/waitlist.answer.types";
 
 describe("POST /api/waitlist", () => {
   beforeEach(() => jest.resetModules());
@@ -41,12 +38,13 @@ describe("POST /api/waitlist", () => {
     app.post("/api/waitlist", WaitlistController.addToWaitlist);
 
     const answers: Answers_v1 = {
+      email: "test@example.com",
+      schemaVersion: "1",
       source: "social-media",
       firstName: "Jo",
       lastName: "Schmo",
-      email: "test@example.com",
+      profession: "Founder",
       currentlyPayingFor: [],
-      schemaVersion: "1",
       anythingElse: "I'm a test",
     };
     const res = await request(app).post("/api/waitlist").send(answers);
@@ -66,16 +64,14 @@ describe("POST /api/waitlist", () => {
     app.use(express.json());
     app.post("/api/waitlist", WaitlistController.addToWaitlist);
 
-    const answers: Answers = {
+    const answers: Answers_v1 = {
+      email: "test@example.com",
+      schemaVersion: "1",
       source: "other",
       firstName: "Jo",
       lastName: "Schmo",
-      email: "test@example.com",
       currentlyPayingFor: [],
-      howClearAboutValues: "not-clear",
-      workingTowardsMainGoal: "yes",
-      isWillingToShare: false,
-      schemaVersion: "0",
+      profession: "Founder",
     };
     const res = await request(app).post("/api/waitlist").send(answers);
     expect(res.status).toBe(500);

--- a/packages/backend/src/waitlist/controller/waitlist.controller.ts
+++ b/packages/backend/src/waitlist/controller/waitlist.controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { z } from "zod";
 import { BaseError } from "@core/errors/errors.base";
 import { Logger } from "@core/logger/winston.logger";
-import { AnswerMap } from "@core/types/waitlist/waitlist.answer.types";
+import { Answers } from "@core/types/waitlist/waitlist.answer.types";
 import { Schema_Waitlist } from "@core/types/waitlist/waitlist.types";
 import { isMissingWaitlistTagId } from "@backend/common/constants/env.util";
 import { findCompassUserBy } from "../../user/queries/user.queries";
@@ -22,7 +22,7 @@ export class WaitlistController {
       return res.status(500).json({ error: "Emailer values are missing" });
     }
 
-    const parseResult = AnswerMap.v0.safeParse(req.body);
+    const parseResult = Answers.v1.safeParse(req.body);
     if (!parseResult.success) {
       return res
         .status(400)

--- a/packages/backend/src/waitlist/service/waitlist.service.ts
+++ b/packages/backend/src/waitlist/service/waitlist.service.ts
@@ -1,7 +1,7 @@
 import { Logger } from "@core/logger/winston.logger";
 import { mapWaitlistUserToEmailSubscriber } from "@core/mappers/subscriber/map.subscriber";
 import { Subscriber } from "@core/types/email/email.types";
-import { Answers } from "@core/types/waitlist/waitlist.answer.types";
+import { Answers_v1 } from "@core/types/waitlist/waitlist.answer.types";
 import {
   Result_InviteToWaitlist,
   Result_Waitlist,
@@ -16,7 +16,7 @@ const logger = Logger("app:waitlist.service");
 class WaitlistService {
   static async addToWaitlist(
     email: string,
-    answer: Answers,
+    answer: Answers_v1,
   ): Promise<Result_Waitlist> {
     if (ENV.EMAILER_SECRET && ENV.EMAILER_WAITLIST_TAG_ID) {
       const subscriber: Subscriber = {

--- a/packages/core/src/types/waitlist/waitlist.answer.types.ts
+++ b/packages/core/src/types/waitlist/waitlist.answer.types.ts
@@ -1,27 +1,18 @@
 import { z } from "zod";
 
-/* v0 */
-export const Schema_Answers_v0 = z.object({
+/* v1 */
+export const Schema_Answers_v1 = z.object({
   email: z.string().email(),
-  schemaVersion: z.literal("0"),
+  schemaVersion: z.literal("1"),
   source: z.enum(["search-engine", "social-media", "friend", "other"]),
   firstName: z.string().min(2),
   lastName: z.string().min(2),
+  profession: z.string().optional(),
   currentlyPayingFor: z.array(z.string()).optional(),
-  howClearAboutValues: z.enum(["not-clear", "somewhat-clear", "very-clear"]),
-  workingTowardsMainGoal: z.enum([
-    "yes",
-    "no-but-want-to",
-    "no-and-dont-want-to",
-  ]),
-  isWillingToShare: z.boolean(),
   anythingElse: z.string().optional(),
 });
-export type Answers_v0 = z.infer<typeof Schema_Answers_v0>;
+export type Answers_v1 = z.infer<typeof Schema_Answers_v1>;
 
-export type Answers = Answers_v0; // make a union type when adding more versions
-
-export const AnswerMap = {
-  v0: Schema_Answers_v0,
-  //v1: Schema_Answers_v1 <-- Extend/change for new version to avoid migration
+export const Answers = {
+  v1: Schema_Answers_v1,
 };

--- a/packages/core/src/types/waitlist/waitlist.types.ts
+++ b/packages/core/src/types/waitlist/waitlist.types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Schema_Answers_v0 } from "./waitlist.answer.types";
+import { Schema_Answers_v1 } from "./waitlist.answer.types";
 
 export interface Result_Waitlist {
   status: "waitlisted" | "ignored";
@@ -11,9 +11,10 @@ export interface Result_InviteToWaitlist {
 
 const Schema_Status = z.enum(["waitlisted", "invited", "active"]);
 
-const Schema_Waitlist_v0 = Schema_Answers_v0.extend({
+const Schema_Waitlist_v1 = Schema_Answers_v1.extend({
   status: Schema_Status,
   waitlistedAt: z.string().datetime(),
 });
-export type Schema_Waitlist_v0 = z.infer<typeof Schema_Waitlist_v0>;
-export type Schema_Waitlist = Schema_Waitlist_v0; // make a union type when adding more versions
+
+export type Schema_Waitlist_v1 = z.infer<typeof Schema_Waitlist_v1>;
+export type Schema_Waitlist = Schema_Waitlist_v1;


### PR DESCRIPTION
Closes #812 

This PR updates the waitlist schema from version 0 to version 1, simplifying the data structure by removing several boolean and enum fields while adding new optional fields for profession and general feedback.

Key Changes:
- Changed schemaVersion from "0" to "1" in waitlist driver and controller.
- Updated waitlist answer types to include new fields and removed deprecated ones.
- Adjusted tests to reflect changes in the waitlist schema and ensure compatibility with the new version.
- Introduced profession and anythingElse fields in the waitlist data structure.

<img width="1076" height="718" alt="Screenshot 2025-08-28 at 7 02 50 PM" src="https://github.com/user-attachments/assets/1632c917-abca-4db4-bfc9-2581d8b9b45c" />
