### PR TITLE
📜 Docs: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: 🐞 Bug Report
-    url: https://github.com/SwitchbackTech/compass/issues/new?template=2-bug-report.yml
-    about: Report a bug or unexpected behavior
-  - name: ✨ Feature Request
-    url: https://github.com/SwitchbackTech/compass/issues/new?template=1-feature-request.yml
-    about: Suggest a new feature or enhancement
   - name: 💬 Discord Community
     url: https://www.discord.gg/H3DVMnKmUd
     about: Join our Discord for general questions and discussion


### PR DESCRIPTION
Another follow-up to #843 

- Removed links for Bug Report and Feature Request templates to streamline the issue creation process.
- Retained the Discord community link for user engagement and support.