### PR TITLE
🐛 fix(web): opening & closing someday event draft form using shortcuts leaves hanging draft state

### DIFF
--- a/packages/web/src/common/utils/draft/someday.draft.util.ts
+++ b/packages/web/src/common/utils/draft/someday.draft.util.ts
@@ -6,6 +6,10 @@ import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { Activity_DraftEvent } from "@web/ducks/events/slices/draft.slice.types";
 import { assembleDefaultEvent } from "../event.util";
 
+/** @deprecated
+ * `createSomedayDraft` should not be called outside `useSidebarActions.createSomedayDraft`
+ * Consider removing
+ */
 export const createSomedayDraft = async (
   category: Categories_Event.SOMEDAY_WEEK | Categories_Event.SOMEDAY_MONTH,
   startOfView: Dayjs,

--- a/packages/web/src/views/Calendar/Calendar.tsx
+++ b/packages/web/src/views/Calendar/Calendar.tsx
@@ -12,11 +12,11 @@ import { DraftProvider } from "./components/Draft/context/DraftProvider";
 import { SidebarDraftProvider } from "./components/Draft/sidebar/context/SidebarDraftProvider";
 import { Grid } from "./components/Grid/";
 import { Header } from "./components/Header/Header";
+import { Shortcuts } from "./components/Shortcuts";
 import { Sidebar } from "./components/Sidebar/Sidebar";
 import { useDateCalcs } from "./hooks/grid/useDateCalcs";
 import { useGridLayout } from "./hooks/grid/useGridLayout";
 import { useScroll } from "./hooks/grid/useScroll";
-import { useShortcuts } from "./hooks/shortcuts/useShortcuts";
 import { useRefresh } from "./hooks/useRefresh";
 import { useToday } from "./hooks/useToday";
 import { useWeek } from "./hooks/useWeek";
@@ -52,8 +52,6 @@ export const CalendarView = () => {
     scrollUtil,
   };
 
-  useShortcuts(shortcutProps);
-
   const rootProps: RootProps = {
     component: { today: today },
   };
@@ -69,36 +67,38 @@ export const CalendarView = () => {
         isSidebarOpen={isSidebarOpen}
       >
         <SidebarDraftProvider dateCalcs={dateCalcs} measurements={measurements}>
-          <ContextMenuWrapper id="sidebar-context-menu">
-            <Draft measurements={measurements} weekProps={weekProps} />
-            {isSidebarOpen && (
-              <Sidebar
-                dateCalcs={dateCalcs}
-                measurements={measurements}
-                weekProps={weekProps}
-                gridRefs={gridRefs}
-              />
-            )}
-          </ContextMenuWrapper>
-          <StyledCalendar direction={FlexDirections.COLUMN} id={ID_MAIN}>
-            <Header
-              rootProps={rootProps}
-              scrollUtil={scrollUtil}
-              today={today}
-              weekProps={weekProps}
-            />
-
-            <ContextMenuWrapper id="grid-context-menu">
-              <Grid
-                dateCalcs={dateCalcs}
-                isSidebarOpen={isSidebarOpen}
-                gridRefs={gridRefs}
-                measurements={measurements}
+          <Shortcuts shortcutsProps={shortcutProps}>
+            <ContextMenuWrapper id="sidebar-context-menu">
+              <Draft measurements={measurements} weekProps={weekProps} />
+              {isSidebarOpen && (
+                <Sidebar
+                  dateCalcs={dateCalcs}
+                  measurements={measurements}
+                  weekProps={weekProps}
+                  gridRefs={gridRefs}
+                />
+              )}
+            </ContextMenuWrapper>
+            <StyledCalendar direction={FlexDirections.COLUMN} id={ID_MAIN}>
+              <Header
+                rootProps={rootProps}
+                scrollUtil={scrollUtil}
                 today={today}
                 weekProps={weekProps}
               />
-            </ContextMenuWrapper>
-          </StyledCalendar>
+
+              <ContextMenuWrapper id="grid-context-menu">
+                <Grid
+                  dateCalcs={dateCalcs}
+                  isSidebarOpen={isSidebarOpen}
+                  gridRefs={gridRefs}
+                  measurements={measurements}
+                  today={today}
+                  weekProps={weekProps}
+                />
+              </ContextMenuWrapper>
+            </StyledCalendar>
+          </Shortcuts>
         </SidebarDraftProvider>
       </DraftProvider>
     </Styled>

--- a/packages/web/src/views/Calendar/components/Draft/sidebar/hooks/useSidebarActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/sidebar/hooks/useSidebarActions.ts
@@ -353,19 +353,19 @@ export const useSidebarActions = (
     close();
   };
 
-  const onPlaceholderClick = async (section: Categories_Event) => {
+  const createSomedayDraft = async (category: Categories_Event) => {
     if (isDrafting) {
       dispatch(draftSlice.actions.discard());
       close();
       return;
     }
 
-    if (section === Categories_Event.SOMEDAY_WEEK && isAtWeeklyLimit) {
+    if (category === Categories_Event.SOMEDAY_WEEK && isAtWeeklyLimit) {
       alert(SOMEDAY_WEEK_LIMIT_MSG);
       return;
     }
 
-    if (section === Categories_Event.SOMEDAY_MONTH && isAtMonthlyLimit) {
+    if (category === Categories_Event.SOMEDAY_MONTH && isAtMonthlyLimit) {
       alert(SOMEDAY_MONTH_LIMIT_MSG);
       return;
     }
@@ -380,7 +380,7 @@ export const useSidebarActions = (
     dispatch(
       draftSlice.actions.start({
         activity: "sidebarClick",
-        eventType: section,
+        eventType: category,
         event,
       }),
     );
@@ -571,17 +571,15 @@ export const useSidebarActions = (
   return {
     close,
     closeForm,
-    createDefaultSomeday,
     discard,
     handleChange,
     onDraft,
     onDragEnd,
     onDragStart,
     onMigrate,
-    onPlaceholderClick,
+    createSomedayDraft,
     onSubmit,
     reset,
-    resetLocalDraftStateIfNeeded,
     setDraft,
   };
 };

--- a/packages/web/src/views/Calendar/components/Draft/sidebar/hooks/useSidebarState.ts
+++ b/packages/web/src/views/Calendar/components/Draft/sidebar/hooks/useSidebarState.ts
@@ -22,7 +22,7 @@ export const useSidebarState = (measurements: Measurements_Grid) => {
   const [isDraftingExisting, setIsDraftingExisting] = useState(false);
   const [isSomedayFormOpen, setIsSomedayFormOpen] = useState(false);
 
-  const isDragging = isDrafting && draft !== null;
+  const isDragging = isDrafting && draft !== null; // TODO: Probably not a good way to determine if we are dragging, consider refactoring or removing this comment.
   const { isOverAllDayRow, isOverGrid, isOverMainGrid, mouseCoords } =
     useMousePosition(isDNDing, isSomedayFormOpen, measurements);
 

--- a/packages/web/src/views/Calendar/components/Shortcuts.tsx
+++ b/packages/web/src/views/Calendar/components/Shortcuts.tsx
@@ -1,0 +1,16 @@
+import {
+  ShortcutProps,
+  useShortcuts,
+} from "@web/views/Calendar/hooks/shortcuts/useShortcuts";
+
+export function Shortcuts({
+  children,
+  shortcutsProps,
+}: {
+  children: React.ReactNode;
+  shortcutsProps: ShortcutProps;
+}) {
+  useShortcuts(shortcutsProps);
+
+  return children;
+}

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
@@ -7,6 +7,7 @@ import { Priorities } from "@core/constants/core.constants";
 import { Categories_Event, Schema_Event } from "@core/types/event.types";
 import { computeCurrentEventDateRange } from "@web/common/utils/web.date.util";
 import { useDraftForm } from "@web/views/Calendar/components/Draft/hooks/state/useDraftForm";
+import { SidebarDraftContextValue } from "@web/views/Calendar/components/Draft/sidebar/context/SidebarDraftContext";
 import { useSidebarContext } from "@web/views/Calendar/components/Draft/sidebar/context/useSidebarContext";
 import { Setters_Sidebar } from "@web/views/Calendar/components/Draft/sidebar/hooks/useSidebarState";
 import { SIDEBAR_OPEN_WIDTH } from "@web/views/Calendar/layout.constants";
@@ -42,7 +43,8 @@ export const SomedayEventContainer = ({
   setEvent,
   weekViewRange,
 }: Props) => {
-  const { actions, setters, state } = useSidebarContext();
+  const context = useSidebarContext() as SidebarDraftContextValue;
+  const { state, actions, setters } = context;
 
   const formProps = useDraftForm(
     category,

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvents.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEvents.tsx
@@ -32,7 +32,13 @@ export const SomedayEvents: FC<Props> = ({
   viewStart,
   mainGridRef,
 }) => {
-  const { actions, state } = useSidebarContext();
+  const context = useSidebarContext();
+  const draftCategory = useAppSelector(selectDraftCategory);
+
+  if (!context) return null; // TS Guard
+
+  const { state } = context;
+
   const gridX = state.mouseCoords.x - (SIDEBAR_OPEN_WIDTH + GRID_X_START);
   const dayIndex = dateCalcs.getDayNumberByX(gridX);
 
@@ -41,7 +47,6 @@ export const SomedayEvents: FC<Props> = ({
       category === Categories_Event.SOMEDAY_WEEK ? COLUMN_WEEK : COLUMN_MONTH
     ];
 
-  const draftCategory = useAppSelector(selectDraftCategory);
   const isDraftingNew = state.isDraftingNew && draftCategory === category;
 
   return (
@@ -66,7 +71,6 @@ export const SomedayEvents: FC<Props> = ({
             category={category}
             column={column}
             key={COLUMN_WEEK}
-            onPlaceholderClick={actions.onPlaceholderClick}
             isDraftingNew={isDraftingNew}
           />
         </div>

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventsContainer/SomedayEventsContainer.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayEvents/SomedayEventsContainer/SomedayEventsContainer.tsx
@@ -34,14 +34,12 @@ export interface Props {
   column: {
     id: string;
   };
-  onPlaceholderClick: (category: Categories_Event) => void;
   isDraftingNew: boolean;
 }
 
 export const SomedayEventsContainer: FC<Props> = ({
   category,
   column,
-  onPlaceholderClick,
   isDraftingNew,
 }) => {
   const context = useSidebarContext();
@@ -63,7 +61,7 @@ export const SomedayEventsContainer: FC<Props> = ({
             ? "Add to month"
             : "Add to week"
         }
-        onClick={() => onPlaceholderClick(category)}
+        onClick={() => context.actions.createSomedayDraft(category)}
         shortcut={category === Categories_Event.SOMEDAY_MONTH ? "M" : "W"}
       >
         {children}

--- a/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
+++ b/packages/web/src/views/Calendar/hooks/shortcuts/useShortcuts.ts
@@ -13,7 +13,6 @@ import { ID_REMINDER_INPUT } from "@web/common/constants/web.constants";
 import { isEventFormOpen } from "@web/common/utils";
 import { createAlldayDraft } from "@web/common/utils/draft/draft.util";
 import { createTimedDraft } from "@web/common/utils/draft/draft.util";
-import { createSomedayDraft } from "@web/common/utils/draft/someday.draft.util";
 import {
   selectIsAtMonthlyLimit,
   selectIsAtWeeklyLimit,
@@ -25,6 +24,7 @@ import {
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { viewSlice } from "@web/ducks/events/slices/view.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
+import { useSidebarContext } from "@web/views/Calendar/components/Draft/sidebar/context/useSidebarContext";
 import { DateCalcs } from "../grid/useDateCalcs";
 import { Util_Scroll } from "../grid/useScroll";
 import { WeekProps } from "../useWeek";
@@ -49,6 +49,7 @@ export const useShortcuts = ({
   scrollUtil,
 }: ShortcutProps) => {
   const dispatch = useAppDispatch();
+  const context = useSidebarContext(true);
   const navigate = useNavigate();
 
   const isAtMonthlyLimit = useAppSelector(selectIsAtMonthlyLimit);
@@ -76,18 +77,12 @@ export const useShortcuts = ({
         return;
       }
 
+      context?.actions.createSomedayDraft(category);
+
       // If sidebar is closed, open it first
       if (!isSidebarOpen) {
         dispatch(viewSlice.actions.toggleSidebar());
       }
-
-      await createSomedayDraft(
-        category,
-        startOfView,
-        endOfView,
-        "createShortcut",
-        dispatch,
-      );
 
       if (tab !== "tasks") {
         dispatch(viewSlice.actions.updateSidebarTab("tasks"));


### PR DESCRIPTION
## Description
Closes https://github.com/SwitchbackTech/compass/issues/745

- Centralize create someday draft logic between the shortcut event and the placeholder button event
- Simplify create someday draft logic
- Handle few TS errors along the way


We still need to centralize logic for creating someday draft in the command palette component too, but needed to get to a stopping point.