### PR TITLE
fix(backend): return session data upon user session creation

### DIFF
--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -46,15 +46,17 @@ class AuthController {
     }
 
     if (cUserId) {
-      await compassAuthService.createSessionForUser(cUserId);
+      const sessionData =
+        await compassAuthService.createSessionForUser(cUserId);
+
+      res.promise({
+        message: `User session created for ${cUserId}`,
+        accessToken: sessionData.accessToken,
+      });
     } else {
       res.promise({ error: "User doesn't exist" });
       return;
     }
-
-    res.promise({
-      message: `User session created for ${cUserId}`,
-    });
   };
 
   getUserIdFromSession = (req: SessionRequest, res: Res_Promise) => {


### PR DESCRIPTION
This pull request makes a minor improvement to the `AuthController` by ensuring that the `accessToken` from the newly created session is included in the response when a user session is created. This change helps clients receive the token directly after session creation.

- Added the `accessToken` from `sessionData` to the response object when a user session is successfully created in `auth.controller.ts`.

Closes #941 