### PR TITLE
Fix: create someday events during onboarding

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -51,10 +51,10 @@ class EventController {
         const _id = new ObjectId().toString();
         const event = { ...eventData, _id, user };
 
-        CompassCoreEventSchema.parse(event);
+        const safeEvent = CompassCoreEventSchema.parse(event);
 
         await this.processEvent(
-          event,
+          safeEvent,
           CompassEventStatus.CONFIRMED,
           RecurringEventUpdateScope.THIS_EVENT,
         );

--- a/packages/backend/src/event/event.routes.config.ts
+++ b/packages/backend/src/event/event.routes.config.ts
@@ -13,7 +13,6 @@ export class EventRoutes extends CommonRoutesConfig {
     this.app
       .route(`/api/event`)
       .all(verifySession())
-      //@ts-ignore
       .get(eventController.readAll)
       //@ts-ignore
       .post(eventController.create);
@@ -21,33 +20,23 @@ export class EventRoutes extends CommonRoutesConfig {
     this.app
       .route(`/api/event/deleteMany`)
       .all(verifySession())
-      //@ts-ignore
       .delete(eventController.deleteMany);
 
     this.app
       .route(`/api/event/reorder`)
       .all(verifySession())
-      //@ts-ignore
       .put(eventController.reorder);
-
-    // this.app.route(`/api/event/updateMany`).all(verifySession());
-    //@ts-ignore
-    // .post(eventController.updateMany);
 
     this.app
       .route(`/api/event/delete-all/:userId`)
       .all([verifySession(), authMiddleware.verifyIsDev])
-      //@ts-ignore
       .delete(eventController.deleteAllByUser);
 
     this.app
       .route(`/api/event/:id`)
       .all(verifySession())
-      //@ts-ignore
       .get(eventController.readById)
-      //@ts-ignore
       .put(eventController.update)
-      //@ts-ignore
       .delete(eventController.delete);
 
     return this.app;

--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -269,6 +269,7 @@ export type CompassThisAndFollowingEvent = z.infer<
 >;
 export type CompassAllEvents = z.infer<typeof CompassAllEventsSchema>;
 export type CompassEvent = z.infer<typeof CompassEventSchema>;
+export type CompassCoreEvent = z.infer<typeof CompassCoreEventSchema>;
 export type EventUpdatePayload = z.infer<typeof EventUpdateSchema>;
 
 export type WithCompassId<T> = T & { _id: string };

--- a/packages/web/src/ducks/events/event.api.ts
+++ b/packages/web/src/ducks/events/event.api.ts
@@ -1,5 +1,6 @@
 import { AxiosPromise } from "axios";
 import {
+  CompassCoreEvent,
   Params_Events,
   Payload_Order,
   RecurringEventUpdateScope,
@@ -8,7 +9,7 @@ import {
 import { CompassApi } from "@web/common/apis/compass.api";
 
 const EventApi = {
-  create: (event: Schema_Event | Schema_Event[]) => {
+  create: (event: Schema_Event | Schema_Event[] | CompassCoreEvent[]) => {
     return CompassApi.post(`/event`, event);
   },
   delete: (_id: string, applyTo?: RecurringEventUpdateScope) => {

--- a/packages/web/src/views/Onboarding/steps/events/SomedaySandbox/SomedaySandbox.tsx
+++ b/packages/web/src/views/Onboarding/steps/events/SomedaySandbox/SomedaySandbox.tsx
@@ -159,11 +159,8 @@ export const SomedaySandbox: React.FC<OnboardingStepProps> = ({
                 Nice work. Who said being organized had to be complicated?
               </OnboardingText>
               <OnboardingText>
-                To continue, click the right arrow
-              </OnboardingText>
-              <OnboardingText>
-                You can also hit the ⇨ key (there's a shortcut for everything
-                here)
+                To continue, click the right arrow or press the 'k' key (There's
+                a shortcut for everything here)
               </OnboardingText>
               <div style={{ marginTop: "40px" }}>
                 <CheckboxContainer>

--- a/packages/web/src/views/Onboarding/steps/events/SomedaySandbox/sandbox.util.test.ts
+++ b/packages/web/src/views/Onboarding/steps/events/SomedaySandbox/sandbox.util.test.ts
@@ -104,7 +104,6 @@ describe("sandbox.util", () => {
         isSomeday: true,
         origin: "compass",
         priority: "work",
-        order: 0,
       });
 
       expect(weekEvent.startDate).toBeDefined();
@@ -131,7 +130,6 @@ describe("sandbox.util", () => {
         isSomeday: true,
         origin: "compass",
         priority: "self",
-        order: 0,
       });
     });
 
@@ -154,28 +152,6 @@ describe("sandbox.util", () => {
       expect(createdEvents[1].priority).toBe("self");
       expect(createdEvents[2].priority).toBe("relations");
       expect(createdEvents[3].priority).toBe("unassigned");
-    });
-
-    it("should set correct order for events", async () => {
-      const { EventApi } = require("@web/ducks/events/event.api");
-
-      const weekTasks = [
-        { text: "Week task 1", color: "#ff6b6b" },
-        { text: "Week task 2", color: "#4ecdc4" },
-      ];
-      const monthTasks = [
-        { text: "Month task 1", color: "#45b7d1" },
-        { text: "Month task 2", color: "#ff6b6b" },
-      ];
-
-      await createAndSubmitEvents(weekTasks, monthTasks);
-
-      const createdEvents = EventApi.create.mock.calls[0][0];
-
-      expect(createdEvents[0].order).toBe(0); // First week task
-      expect(createdEvents[1].order).toBe(1); // Second week task
-      expect(createdEvents[2].order).toBe(0); // First month task
-      expect(createdEvents[3].order).toBe(1); // Second month task
     });
 
     it("should handle empty task arrays", async () => {

--- a/packages/web/src/views/Onboarding/steps/events/SomedaySandbox/sandbox.util.ts
+++ b/packages/web/src/views/Onboarding/steps/events/SomedaySandbox/sandbox.util.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { Origin, Priorities } from "@core/constants/core.constants";
 import {
   Categories_Event,
+  CompassCoreEvent,
   Schema_Event,
   Schema_Event_Core,
 } from "@core/types/event.types";
@@ -24,7 +25,7 @@ export const createAndSubmitEvents = async (
   monthTasks: { text: string; color: string }[],
 ): Promise<void> => {
   // Create events from week tasks
-  const weekEvents: Schema_Event[] = [];
+  const weekEvents: CompassCoreEvent[] = [];
   for (let i = 0; i < weekTasks.length; i++) {
     const event = await createEventFromTask(
       weekTasks[i],
@@ -35,7 +36,7 @@ export const createAndSubmitEvents = async (
   }
 
   // Create events from month tasks
-  const monthEvents: Schema_Event[] = [];
+  const monthEvents: CompassCoreEvent[] = [];
   for (let i = 0; i < monthTasks.length; i++) {
     const event = await createEventFromTask(
       monthTasks[i],
@@ -56,7 +57,7 @@ const createEventFromTask = async function (
   task: { text: string; color: string },
   category: Categories_Event.SOMEDAY_WEEK | Categories_Event.SOMEDAY_MONTH,
   order: number,
-): Promise<Schema_Event_Core> {
+): Promise<CompassCoreEvent> {
   const userId = await getUserId();
   const now = dayjs();
 
@@ -68,6 +69,7 @@ const createEventFromTask = async function (
     weekEnd,
   );
 
+  //@ts-expect-error - not supporting FE-generated _ids yet
   return {
     title: task.text,
     description: "",
@@ -78,6 +80,5 @@ const createEventFromTask = async function (
     isSomeday: true,
     origin: Origin.COMPASS,
     priority: getPriorityFromColor(task.color),
-    order,
   };
 };


### PR DESCRIPTION
Closes #938 

This pull request introduces support for a new event type, `CompassCoreEvent`, across the backend and frontend, and updates the event creation flow to handle both single and multiple events. It also improves type safety and onboarding instructions. The most important changes are grouped below:

**Backend Enhancements:**

* Added the `CompassCoreEvent` type to the core event types and updated the event controller to accept and process both single and multiple `CompassCoreEvent` objects in the `create` endpoint, improving flexibility for bulk event creation. [[1]](diffhunk://#diff-e1ea1ebfd38ec0378096c1227cb258adfe2b56a5a6800e87ad8bc399ea62b9feR6-L9) [[2]](diffhunk://#diff-e1ea1ebfd38ec0378096c1227cb258adfe2b56a5a6800e87ad8bc399ea62b9feL27-R27) [[3]](diffhunk://#diff-e1ea1ebfd38ec0378096c1227cb258adfe2b56a5a6800e87ad8bc399ea62b9feL38-R61) [[4]](diffhunk://#diff-a021ef181a81658b0c0cef1b920ee6bb7d257c5d80d5cc08c880c45e2960d7daR272)
* Cleaned up route definitions in `event.routes.config.ts` by removing unnecessary `@ts-ignore` comments for improved code clarity.

**Frontend & API Updates:**

* Updated the event API to allow sending both `Schema_Event` and `CompassCoreEvent` (including arrays) when creating events, ensuring compatibility with backend changes. [[1]](diffhunk://#diff-673fca09b65cc64947a6d4f3216372e93f036e7861bb2083c700380cac6689f5R3) [[2]](diffhunk://#diff-673fca09b65cc64947a6d4f3216372e93f036e7861bb2083c700380cac6689f5L11-R12)
* Refactored the onboarding sandbox utilities to use `CompassCoreEvent` throughout event creation logic, improving type consistency and preparing for future backend requirements (including a note about frontend-generated `_id`s). [[1]](diffhunk://#diff-82cdd0d1b397bac51366a3d76f2d78def4ac93d1db345fb2c727e45030de2760R5) [[2]](diffhunk://#diff-82cdd0d1b397bac51366a3d76f2d78def4ac93d1db345fb2c727e45030de2760L27-R28) [[3]](diffhunk://#diff-82cdd0d1b397bac51366a3d76f2d78def4ac93d1db345fb2c727e45030de2760L38-R39) [[4]](diffhunk://#diff-82cdd0d1b397bac51366a3d76f2d78def4ac93d1db345fb2c727e45030de2760L59-R60) [[5]](diffhunk://#diff-82cdd0d1b397bac51366a3d76f2d78def4ac93d1db345fb2c727e45030de2760R72) [[6]](diffhunk://#diff-82cdd0d1b397bac51366a3d76f2d78def4ac93d1db345fb2c727e45030de2760L81)

**User Experience:**

* Updated onboarding instructions to clarify that users can now press the 'k' key as a shortcut to continue, improving accessibility and user guidance.