### PR TITLE
:bug: fix(duplicate-error): remove calendar provider data on duplicate

### DIFF
--- a/packages/core/src/mappers/map.event.ts
+++ b/packages/core/src/mappers/map.event.ts
@@ -36,6 +36,22 @@ export namespace MapEvent {
     return mapped;
   };
 
+  export const removeProviderData = (
+    event: WithId<Omit<Schema_Event, "_id">> | Schema_Event,
+  ): Omit<Schema_Event, "_id" | "gEventId" | "gRecurringEventId"> => {
+    const {
+      _id, // eslint-disable-line @typescript-eslint/no-unused-vars
+      gEventId, // eslint-disable-line @typescript-eslint/no-unused-vars
+      gRecurringEventId, // eslint-disable-line @typescript-eslint/no-unused-vars
+      recurrence,
+      ...coreEvent
+    } = event;
+
+    return recurrence?.eventId
+      ? { ...coreEvent, recurrence: { rule: recurrence.rule } }
+      : coreEvent;
+  };
+
   export const removeIdentifyingData = (
     event: WithId<Omit<Schema_Event, "_id">> | Schema_Event,
   ): Omit<
@@ -48,14 +64,11 @@ export namespace MapEvent {
     | "recurrence"
   > => {
     const {
-      _id, // eslint-disable-line @typescript-eslint/no-unused-vars
       order, // eslint-disable-line @typescript-eslint/no-unused-vars
       allDayOrder, // eslint-disable-line @typescript-eslint/no-unused-vars
       recurrence, // eslint-disable-line @typescript-eslint/no-unused-vars
-      gEventId, // eslint-disable-line @typescript-eslint/no-unused-vars
-      gRecurringEventId, // eslint-disable-line @typescript-eslint/no-unused-vars
       ...coreEvent
-    } = event;
+    } = MapEvent.removeProviderData(event);
 
     return coreEvent;
   };

--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -49,6 +49,7 @@ import {
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { GRID_TIME_STEP } from "@web/views/Calendar/layout.constants";
+import { MapEvent } from "../../../../../../../../core/src/mappers/map.event";
 
 export const useDraftActions = (
   draftState: State_Draft_Local,
@@ -346,8 +347,10 @@ export const useDraftActions = (
   );
 
   const duplicateEvent = useCallback(() => {
-    const draft = { ...reduxDraft } as Schema_GridEvent;
-    delete draft._id;
+    const draft = MapEvent.removeProviderData({
+      ...reduxDraft,
+    }) as Schema_GridEvent;
+
     submit(draft);
     discard();
   }, [reduxDraft, submit, discard]);


### PR DESCRIPTION
## What does this PR do?

This PR removes calendar identifying provider data from duplicated events before saving.

## Use Case

 closes #939