### PR TITLE
fix(web): handle somedays start-end date range miscomputation in edge scenarios

### DIFF
--- a/packages/web/src/common/utils/web.date.util.ts
+++ b/packages/web/src/common/utils/web.date.util.ts
@@ -375,3 +375,13 @@ export const computeRelativeEventDateRange = (
     endDate: end.format(),
   };
 };
+
+export const computeSomedayEventsRequestFilter = (start: Dayjs, end: Dayjs) => {
+  const startDate = start.subtract(1, "month").endOf("month");
+  const endDate = start.endOf("month").add(1, "week");
+
+  return {
+    startDate: toUTCOffset(startDate),
+    endDate: toUTCOffset(endDate),
+  };
+};

--- a/packages/web/src/views/Calendar/hooks/useRefresh.ts
+++ b/packages/web/src/views/Calendar/hooks/useRefresh.ts
@@ -1,6 +1,9 @@
 import dayjs from "dayjs";
 import { useEffect } from "react";
-import { toUTCOffset } from "@web/common/utils/web.date.util";
+import {
+  computeSomedayEventsRequestFilter,
+  toUTCOffset,
+} from "@web/common/utils/web.date.util";
 import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
 import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
 import { selectImportLatestState } from "@web/ducks/events/selectors/sync.selector";
@@ -36,8 +39,11 @@ export const useRefresh = () => {
         }),
       );
 
-      const startDate = dayjs(start).startOf("month").format();
-      const endDate = dayjs(end).endOf("month").format();
+      const { startDate, endDate } = computeSomedayEventsRequestFilter(
+        dayjs(start),
+        dayjs(end),
+      );
+
       dispatch(
         getSomedayEventsSlice.actions.request({
           startDate,

--- a/packages/web/src/views/Calendar/hooks/useWeek.ts
+++ b/packages/web/src/views/Calendar/hooks/useWeek.ts
@@ -1,6 +1,9 @@
 import { Dayjs } from "dayjs";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { toUTCOffset } from "@web/common/utils/web.date.util";
+import {
+  computeSomedayEventsRequestFilter,
+  toUTCOffset,
+} from "@web/common/utils/web.date.util";
 import { Week_AsyncStateContextReason } from "@web/ducks/events/context/week.context";
 import { getSomedayEventsSlice } from "@web/ducks/events/slices/someday.slice";
 import { updateDates } from "@web/ducks/events/slices/view.slice";
@@ -39,10 +42,7 @@ export const useWeek = (today: Dayjs) => {
   }, [dispatch, end, start]);
 
   const somedayEventsRequestFilter = useMemo(() => {
-    return {
-      startDate: toUTCOffset(start.startOf("month")),
-      endDate: toUTCOffset(end.endOf("month")),
-    };
+    return computeSomedayEventsRequestFilter(start, end);
   }, [end, start]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Closes https://github.com/SwitchbackTech/compass/issues/945

Did a small refactor to ensure that somedays refetching is consistent by using `computeSomedayEventsRequestFilter` helper