### PR TITLE
:sparkles: feat(notifications): send seprate socket events for calendar and someday events

### DIFF
--- a/packages/backend/src/servers/websocket/websocket.server.ts
+++ b/packages/backend/src/servers/websocket/websocket.server.ts
@@ -10,6 +10,8 @@ import {
   IMPORT_GCAL_START,
   RESULT_IGNORED,
   RESULT_NOTIFIED_CLIENT,
+  SOMEDAY_EVENT_CHANGED,
+  SOMEDAY_EVENT_CHANGE_PROCESSED,
   USER_METADATA,
   USER_REFRESH_TOKEN,
   USER_SIGN_OUT,
@@ -61,7 +63,18 @@ class WebSocketServer {
     socket.on(
       EVENT_CHANGE_PROCESSED,
       handleWsError(() => {
-        logger.debug(`Client successfully processed updated: ${socket.id}`);
+        logger.debug(
+          `Client(${socket.id}) successfully processed event changes`,
+        );
+      }),
+    );
+
+    socket.on(
+      SOMEDAY_EVENT_CHANGE_PROCESSED,
+      handleWsError(() => {
+        logger.debug(
+          `Client(${socket.id}) successfully processed someday event changes`,
+        );
       }),
     );
 
@@ -229,6 +242,10 @@ class WebSocketServer {
 
   handleBackgroundCalendarChange(userId: string) {
     return this.notifyUser(userId, EVENT_CHANGED);
+  }
+
+  handleBackgroundSomedayChange(userId: string) {
+    return this.notifyUser(userId, SOMEDAY_EVENT_CHANGED);
   }
 }
 

--- a/packages/backend/src/sync/services/sync/__tests__/compass.symc.processor.test.ts
+++ b/packages/backend/src/sync/services/sync/__tests__/compass.symc.processor.test.ts
@@ -1,0 +1,134 @@
+import { faker } from "@faker-js/faker";
+import {
+  EVENT_CHANGED,
+  SOMEDAY_EVENT_CHANGED,
+} from "@core/constants/websocket.constants";
+import {
+  Categories_Recurrence,
+  CompassEvent,
+  CompassEventStatus,
+  RecurringEventUpdateScope,
+} from "@core/types/event.types";
+import {
+  createMockBaseEvent,
+  createMockStandaloneEvent,
+} from "@core/util/test/ccal.event.factory";
+import { webSocketServer } from "@backend/servers/websocket/websocket.server";
+import { CompassSyncProcessor } from "@backend/sync/services/sync/compass.sync.processor";
+import { Event_Transition } from "@backend/sync/sync.types";
+
+// Import the enum
+
+describe("CompassSyncProcessor.getNotificationType", () => {
+  it("returns EVENT_CHANGED for non-SOMEDAY transitions", () => {
+    const transition: Event_Transition = {
+      transition: [Categories_Recurrence.STANDALONE, "STANDALONE_CONFIRMED"],
+      title: faker.lorem.sentence(),
+      operation: "STANDALONE_UPDATED",
+      category: Categories_Recurrence.STANDALONE,
+    };
+
+    expect(CompassSyncProcessor["getNotificationType"](transition)).toEqual([
+      EVENT_CHANGED,
+      EVENT_CHANGED,
+    ]);
+  });
+
+  it("returns SOMEDAY_EVENT_CHANGED for SOMEDAY transitions", () => {
+    const transition: Event_Transition = {
+      transition: [
+        Categories_Recurrence.STANDALONE_SOMEDAY,
+        "STANDALONE_SOMEDAY_CONFIRMED",
+      ],
+      title: faker.lorem.sentence(),
+      operation: "STANDALONE_SOMEDAY_UPDATED",
+      category: Categories_Recurrence.STANDALONE_SOMEDAY,
+    };
+
+    expect(CompassSyncProcessor["getNotificationType"](transition)).toEqual([
+      SOMEDAY_EVENT_CHANGED,
+      SOMEDAY_EVENT_CHANGED,
+    ]);
+  });
+
+  it("returns mixed notifications for mixed transitions", () => {
+    const transition: Event_Transition = {
+      transition: [
+        Categories_Recurrence.STANDALONE_SOMEDAY,
+        "STANDALONE_CONFIRMED",
+      ],
+      title: faker.lorem.sentence(),
+      operation: "STANDALONE_CREATED",
+      category: Categories_Recurrence.STANDALONE_SOMEDAY,
+    };
+
+    expect(CompassSyncProcessor["getNotificationType"](transition)).toEqual([
+      SOMEDAY_EVENT_CHANGED,
+      EVENT_CHANGED,
+    ]);
+  });
+});
+
+describe("CompassSyncProcessor.notifyClients", () => {
+  beforeEach(() => {
+    jest.spyOn(webSocketServer, "handleBackgroundCalendarChange").mockClear();
+    jest.spyOn(webSocketServer, "handleBackgroundSomedayChange").mockClear();
+  });
+
+  it("notifies correct users and events", () => {
+    const calendarSpy = jest.spyOn(
+      webSocketServer,
+      "handleBackgroundCalendarChange",
+    );
+
+    const somedaySpy = jest.spyOn(
+      webSocketServer,
+      "handleBackgroundSomedayChange",
+    );
+
+    const applyTo = RecurringEventUpdateScope.THIS_EVENT;
+    const status = CompassEventStatus.CONFIRMED;
+    const userA = faker.database.mongodbObjectId();
+    const userB = faker.database.mongodbObjectId();
+
+    const events: CompassEvent[] = [
+      {
+        applyTo,
+        status,
+        payload: createMockBaseEvent({
+          user: userA,
+        }) as CompassEvent["payload"],
+      },
+      {
+        applyTo,
+        status,
+        payload: createMockStandaloneEvent({
+          isSomeday: true,
+          user: userB,
+        }) as CompassEvent["payload"],
+      },
+    ];
+
+    const summary: Event_Transition[] = [
+      {
+        title: events[0]!.payload.title!,
+        transition: [null, "RECURRENCE_BASE_CONFIRMED"],
+        operation: "RECURRENCE_BASE_CREATED",
+        category: Categories_Recurrence.RECURRENCE_BASE,
+      },
+      {
+        title: events[1]!.payload.title!,
+        transition: [null, "STANDALONE_SOMEDAY_CONFIRMED"],
+        operation: "STANDALONE_SOMEDAY_CREATED",
+        category: Categories_Recurrence.STANDALONE_SOMEDAY,
+      },
+    ];
+
+    CompassSyncProcessor["notifyClients"](events, summary);
+
+    expect(calendarSpy).toHaveBeenCalledWith(userA);
+    expect(calendarSpy).toHaveBeenCalledWith(userB);
+    expect(somedaySpy).toHaveBeenCalledWith(userA);
+    expect(somedaySpy).toHaveBeenCalledWith(userB);
+  });
+});

--- a/packages/core/src/constants/websocket.constants.ts
+++ b/packages/core/src/constants/websocket.constants.ts
@@ -1,5 +1,6 @@
 // server to client events
 export const EVENT_CHANGED = "EVENT_CHANGED";
+export const SOMEDAY_EVENT_CHANGED = "SOMEDAY_EVENT_CHANGED";
 export const EVENT_RECEIVED = "EVENT_RECEIVED";
 
 export const RESULT_IGNORED = "IGNORED";
@@ -15,5 +16,6 @@ export const IMPORT_GCAL_END = "IMPORT_GCAL_END";
 
 // client to server events
 export const EVENT_CHANGE_PROCESSED = "EVENT_CHANGE_PROCESSED";
+export const SOMEDAY_EVENT_CHANGE_PROCESSED = "SOMEDAY_EVENT_CHANGE_PROCESSED";
 
 export const FETCH_USER_METADATA = "FETCH_USER_METADATA";

--- a/packages/core/src/types/websocket.types.ts
+++ b/packages/core/src/types/websocket.types.ts
@@ -5,6 +5,7 @@ import { UserMetadata } from "@core/types/user.types";
 
 export interface ClientToServerEvents {
   EVENT_CHANGE_PROCESSED: () => void;
+  SOMEDAY_EVENT_CHANGE_PROCESSED: () => void;
   FETCH_USER_METADATA: () => void;
 }
 
@@ -28,6 +29,7 @@ export interface InterServerEvents {
 
 export interface ServerToClientEvents {
   EVENT_CHANGED: () => void;
+  SOMEDAY_EVENT_CHANGED: () => void;
   USER_SIGN_OUT: () => void;
   USER_REFRESH_TOKEN: () => void;
   USER_METADATA: (data: UserMetadata) => void;


### PR DESCRIPTION
## What does this PR do?

This PR sends seprate socket events for calendar and someday events changes

## Use Case

closes #978 and #979