### PR TITLE
:bug: fix(duplicate-event): fix event duplication - backend

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -44,8 +44,6 @@ class EventController {
       // Handle both single object and array cases
       const events = Array.isArray(body) ? body : [body];
 
-      console.log(events);
-
       await this.processEvents(
         events.map((e) => ({
           payload: { ...e, user },


### PR DESCRIPTION
## What does this PR do?

**Backend fix**

The duplicate functionality was completely broken for both calendar and someday events. When users attempted to duplicate an event via right-click context menu or the Meta+D keyboard shortcut, no new event was created and the UI did not update. This regression was introduced in commit `2de11df` during the recent refactoring of draft actions.

## Root Cause

The `duplicateEvent` function in `useDraftActions.ts` was incorrectly passing the original event's `_id` to the submit function:

```typescript
const duplicateEvent = useCallback(() => {
  const draft = MapEvent.removeProviderData({
    ...reduxDraft,
  }) as Schema_GridEvent;

  submit(draft); // ❌ This includes the original _id
  discard();
}, [reduxDraft, submit, discard]);
```

When an event has an existing `_id`, the submit function treats it as an edit operation rather than a create operation, causing the duplicate to overwrite the original event instead of creating a new one.