### PR TITLE
Fix/1020 layout shift

### DIFF
--- a/packages/web/src/views/Calendar/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/Grid.tsx
@@ -48,7 +48,6 @@ export const Grid: FC<Props> = ({
         measurements={measurements}
         today={today}
         weekProps={weekProps}
-        dragEdgeState={dragEdgeState}
       />
       <EdgeNavigationIndicators dragEdgeState={dragEdgeState} />
     </div>

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
@@ -77,7 +77,7 @@ export const MainGrid: FC<Props> = ({
   };
 
   return (
-    <StyledMainGrid id={ID_GRID_MAIN} ref={mainGridRef}>
+    <StyledMainGrid id={ID_GRID_MAIN} ref={mainGridRef} tabIndex={-1}>
       <MainGridColumns
         isCurrentWeek={isCurrentWeek}
         today={today}

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
@@ -10,7 +10,6 @@ import { selectIsDrafting } from "@web/ducks/events/selectors/draft.selectors";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
-import { DragEdgeNavigationState } from "@web/views/Calendar/hooks/grid/useDragEdgeNavigation";
 import { useDragEventSmartScroll } from "@web/views/Calendar/hooks/grid/useDragEventSmartScroll";
 import { Measurements_Grid } from "@web/views/Calendar/hooks/grid/useGridLayout";
 import { WeekProps } from "@web/views/Calendar/hooks/useWeek";
@@ -30,7 +29,6 @@ interface Props {
   measurements: Measurements_Grid;
   today: Dayjs;
   weekProps: WeekProps;
-  dragEdgeState: DragEdgeNavigationState;
 }
 
 export const MainGrid: FC<Props> = ({
@@ -40,7 +38,6 @@ export const MainGrid: FC<Props> = ({
   measurements,
   today,
   weekProps,
-  dragEdgeState,
 }) => {
   const dispatch = useAppDispatch();
   const { component } = weekProps;


### PR DESCRIPTION
Closes #1020 

This pull request simplifies the props and improves accessibility in the calendar grid components. The most important changes are the removal of the unused `dragEdgeState` prop from `MainGrid` and the addition of a `tabIndex` for better keyboard navigation.

Props and type cleanup:

* Removed the `dragEdgeState` prop from the `MainGrid` component and its associated type import, as it is no longer needed. (`packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx`) [[1]](diffhunk://#diff-fce7225dd89a3fb282e1a89f8202072f1d046fd395c4a300fd44f168b68ec3feL13) [[2]](diffhunk://#diff-fce7225dd89a3fb282e1a89f8202072f1d046fd395c4a300fd44f168b68ec3feL33) [[3]](diffhunk://#diff-fce7225dd89a3fb282e1a89f8202072f1d046fd395c4a300fd44f168b68ec3feL43)
* Stopped passing the `dragEdgeState` prop from the `Grid` component to `MainGrid`. (`packages/web/src/views/Calendar/components/Grid/Grid.tsx`)

Accessibility improvement:

* Added `tabIndex={-1}` to the `StyledMainGrid` element to improve keyboard accessibility. (`packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx`)