### PR TITLE
:sparkles: feat(edit-recurrence): include start date instance if not in recurrence

### DIFF
--- a/packages/backend/src/event/classes/gcal.event.rrule.test.ts
+++ b/packages/backend/src/event/classes/gcal.event.rrule.test.ts
@@ -44,7 +44,6 @@ describe("GcalEventRRule: ", () => {
     });
 
     expect(rrule.toString()).toContain("RRULE:FREQ=DAILY");
-    expect(rrule.toString()).toContain(`COUNT=${GCAL_MAX_RECURRENCES}`);
     expect(rrule.count()).toBe(GCAL_MAX_RECURRENCES);
     expect(rrule.all()).toHaveLength(GCAL_MAX_RECURRENCES);
   });


### PR DESCRIPTION
## What does this PR do?

This PR includes the start date event as the first recurring event, if it is excluded in the recurrence instance.

## Use Case

closes #1024