### PR TITLE
:sparkles feat(migrations): scaffold compass migrations

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,42 @@
 /*
  * For a detailed explanation regarding each configuration property, visit:
  * https://jestjs.io/docs/configuration
+ *
  */
+
+/** @type { Exclude<Exclude<import("jest").Config["projects"], undefined>[number], string>} */
+const backendProject = {
+  displayName: "backend",
+  moduleNameMapper: {
+    "^@core(/(.*)$)?": "<rootDir>/packages/core/src/$1",
+    "^@backend/auth(/(.*)$)?": "<rootDir>/packages/backend/src/auth/$1",
+    "^@backend/calendar(/(.*)$)?": "<rootDir>/packages/backend/src/calendar/$1",
+    "^@backend/common(/(.*)$)?": "<rootDir>/packages/backend/src/common/$1",
+    "^@backend/dev(/(.*)$)?": "<rootDir>/packages/backend/src/dev/$1",
+    "^@backend/email(/(.*)$)?": "<rootDir>/packages/backend/src/email/$1",
+    "^@backend/event(/(.*)$)?": "<rootDir>/packages/backend/src/event/$1",
+    "^@backend/priority(/(.*)$)?": "<rootDir>/packages/backend/src/priority/$1",
+    "^@backend/servers(/(.*)$)?": "<rootDir>/packages/backend/src/servers/$1",
+    "^@backend/sync(/(.*)$)?": "<rootDir>/packages/backend/src/sync/$1",
+    "^@backend/user(/(.*)$)?": "<rootDir>/packages/backend/src/user/$1",
+    "^@backend/waitlist(/(.*)$)?": "<rootDir>/packages/backend/src/waitlist/$1",
+    "^@backend/__tests__(/(.*)$)?":
+      "<rootDir>/packages/backend/src/__tests__/$1",
+  },
+
+  setupFiles: ["<rootDir>/packages/core/src/__tests__/core.test.init.ts"],
+  setupFilesAfterEnv: [
+    // backend init intentionally here to accommodate @shelf/mongodb preset
+    "<rootDir>/packages/backend/src/__tests__/backend.test.init.ts",
+    "<rootDir>/packages/backend/src/__tests__/backend.test.start.ts",
+  ],
+  testMatch: ["<rootDir>/packages/backend/**/?(*.)+(spec|test).[tj]s?(x)"],
+  // A preset that is used as a base for Jest's configuration
+  preset: "@shelf/jest-mongodb", // https://jestjs.io/docs/mongodb,
+};
+
 /** @type { import("jest").Config } */
-module.exports = {
+const config = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 
@@ -85,7 +118,7 @@ module.exports = {
   // moduleNameMapper: {}
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ["<rootDir>/build"],
 
   // Activates notifications for test results
   // notify: false,
@@ -144,36 +177,24 @@ module.exports = {
         "/node_modules/(?!react-dnd|dnd-core|@react-dnd)",
       ],
     },
+    backendProject,
     {
-      displayName: "backend",
+      displayName: "scripts",
       moduleNameMapper: {
-        "^@core(/(.*)$)?": "<rootDir>/packages/core/src/$1",
-        "^@backend/auth(/(.*)$)?": "<rootDir>/packages/backend/src/auth/$1",
-        "^@backend/calendar(/(.*)$)?":
-          "<rootDir>/packages/backend/src/calendar/$1",
-        "^@backend/common(/(.*)$)?": "<rootDir>/packages/backend/src/common/$1",
-        "^@backend/dev(/(.*)$)?": "<rootDir>/packages/backend/src/dev/$1",
-        "^@backend/email(/(.*)$)?": "<rootDir>/packages/backend/src/email/$1",
-        "^@backend/event(/(.*)$)?": "<rootDir>/packages/backend/src/event/$1",
-        "^@backend/priority(/(.*)$)?":
-          "<rootDir>/packages/backend/src/priority/$1",
-        "^@backend/servers(/(.*)$)?":
-          "<rootDir>/packages/backend/src/servers/$1",
-        "^@backend/sync(/(.*)$)?": "<rootDir>/packages/backend/src/sync/$1",
-        "^@backend/user(/(.*)$)?": "<rootDir>/packages/backend/src/user/$1",
-        "^@backend/waitlist(/(.*)$)?":
-          "<rootDir>/packages/backend/src/waitlist/$1",
-        "^@backend/__tests__(/(.*)$)?":
-          "<rootDir>/packages/backend/src/__tests__/$1",
+        ...backendProject.moduleNameMapper,
+        "^@scripts(/(.*)$)?": "<rootDir>/packages/scripts/src/$1",
+        "^@scripts/commands(/(.*)$)?":
+          "<rootDir>/packages/scripts/src/commands/$1",
+        "^@scripts/common(/(.*)$)?": "<rootDir>/packages/scripts/src/common/$1",
+        "^@scripts/migrations(/(.*)$)?":
+          "<rootDir>/packages/scripts/src/migrations/$1",
+        "^@scripts/seeders(/(.*)$)?":
+          "<rootDir>/packages/scripts/src/seeders/$1",
       },
 
-      setupFiles: ["<rootDir>/packages/core/src/__tests__/core.test.init.ts"],
-      setupFilesAfterEnv: [
-        // backend init intentionally here to accommodate @shelf/mongodb preset
-        "<rootDir>/packages/backend/src/__tests__/backend.test.init.ts",
-        "<rootDir>/packages/backend/src/__tests__/backend.test.start.ts",
-      ],
-      testMatch: ["<rootDir>/packages/backend/**/?(*.)+(spec|test).[tj]s?(x)"],
+      setupFiles: [...backendProject.setupFiles],
+      setupFilesAfterEnv: [...backendProject.setupFilesAfterEnv],
+      testMatch: ["<rootDir>/packages/scripts/**/?(*.)+(spec|test).[tj]s?(x)"],
       // A preset that is used as a base for Jest's configuration
       preset: "@shelf/jest-mongodb", // https://jestjs.io/docs/mongodb,
     },
@@ -197,6 +218,7 @@ module.exports = {
   // rootDir: 'packages/web/',
   // rootDir: 'packages/backend/',
   rootDir: "./",
+  passWithNoTests: true,
 
   // A list of paths to directories that Jest should use to search for files in
   // roots: [
@@ -272,3 +294,6 @@ module.exports = {
   // Whether to use watchman for file crawling
   // watchman: true,
 };
+
+// eslint-disable-next-line no-undef
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test": "cross-env-shell TZ=Etc/UTC yarn jest",
     "test:backend": "yarn test backend",
     "test:core": "yarn test core",
-    "test:web": "yarn test web"
+    "test:web": "yarn test web",
+    "test:scripts": "yarn test scripts"
   },
   "dependencies": {
     "@compass/backend": "*",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -11,7 +11,8 @@
     "dotenv": "^16.0.1",
     "inquirer": "^8.0.0",
     "lodash.uniqby": "^4.7.0",
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.8.5",
+    "umzug": "^3.8.2"
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.1",

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -1,0 +1,119 @@
+import CompassCLI from "@scripts/cli";
+import { runBuild } from "@scripts/commands/build";
+import { startDeleteFlow } from "@scripts/commands/delete";
+import { inviteWaitlist } from "@scripts/commands/invite";
+import { NodeEnv } from "../../core/src/constants/core.constants";
+import { MigratorType } from "./common/cli.types";
+
+const mockGetCliOptions = jest.fn();
+const mockValidateBuild = jest.fn();
+const mockValidateDelete = jest.fn();
+const mockExitHelpfully = jest.fn();
+const mockRunMigrator = jest.fn();
+
+jest.mock("@scripts/cli.validator", () => {
+  return {
+    CliValidator: jest.fn().mockImplementation(() => ({
+      getCliOptions: mockGetCliOptions,
+      validateBuild: mockValidateBuild,
+      validateDelete: mockValidateDelete,
+      exitHelpfully: mockExitHelpfully,
+    })),
+  };
+});
+
+jest.mock("@scripts/commands/build.util");
+jest.mock("@scripts/commands/build");
+jest.mock("@scripts/commands/delete");
+jest.mock("@scripts/commands/invite");
+
+jest.mock("@scripts/commands/migrate", () => ({
+  runMigrator: jest
+    .fn()
+    .mockImplementation((...args) => mockRunMigrator(...args)),
+}));
+
+describe("CompassCLI", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("runs build command and calls validateBuild and runBuild", async () => {
+    mockGetCliOptions.mockReturnValue({ force: false, user: undefined });
+
+    const cli = new CompassCLI([
+      "node",
+      "cli",
+      "build",
+      "nodePckgs",
+      "-e",
+      NodeEnv.Staging,
+    ]);
+
+    await cli.run();
+
+    expect(mockValidateBuild).toHaveBeenCalled();
+    expect(runBuild).toHaveBeenCalled();
+  });
+
+  it("runs delete command and calls validateDelete and startDeleteFlow", async () => {
+    mockGetCliOptions.mockReturnValue({
+      force: true,
+      user: "user@example.com",
+    });
+
+    const cli = new CompassCLI(["node", "cli", "delete"]);
+
+    await cli.run();
+
+    expect(mockValidateDelete).toHaveBeenCalled();
+    expect(startDeleteFlow).toHaveBeenCalledWith("user@example.com", true);
+  });
+
+  it("runs invite command and calls inviteWaitlist", async () => {
+    mockGetCliOptions.mockReturnValue({});
+
+    const cli = new CompassCLI(["node", "cli", "invite"]);
+
+    await cli.run();
+
+    expect(inviteWaitlist).toHaveBeenCalled();
+  });
+
+  it("runs migrate command and does not throw", async () => {
+    mockGetCliOptions.mockReturnValue({});
+
+    const cli = new CompassCLI(["node", "cli", "migrate", "--help"]);
+
+    await cli.run();
+
+    expect(mockRunMigrator).toHaveBeenCalledWith(MigratorType.MIGRATION);
+  });
+
+  it("runs seed command and does not throw", async () => {
+    mockGetCliOptions.mockReturnValue({});
+
+    const cli = new CompassCLI(["node", "cli", "seed"]);
+
+    await cli.run();
+
+    expect(mockRunMigrator).toHaveBeenCalledWith(MigratorType.SEEDER);
+  });
+
+  it("calls exitHelpfully for unsupported command", async () => {
+    mockGetCliOptions.mockReturnValue({});
+
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(jest.fn() as never);
+
+    const cli = new CompassCLI(["node", "cli", "unknown"]);
+
+    await cli.run();
+
+    expect(mockExitHelpfully).toHaveBeenCalledWith(
+      "root",
+      "unknown is not a supported cmd",
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -10,7 +10,7 @@ import { ALL_PACKAGES, CATEGORY_VM } from "@scripts/common/cli.constants";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
 
-class CompassCli {
+export default class CompassCLI {
   private program: Command;
   private validator: CliValidator;
 
@@ -22,7 +22,6 @@ class CompassCli {
 
   public async run() {
     const options = this.validator.getCliOptions();
-    const { force, user } = options;
     const cmd = this.program.args[0];
 
     switch (true) {
@@ -32,6 +31,7 @@ class CompassCli {
         break;
       }
       case cmd === "delete": {
+        const { force, user } = options;
         this.validator.validateDelete(options);
         await startDeleteFlow(user as string, force);
         break;
@@ -41,7 +41,10 @@ class CompassCli {
         break;
       }
       case cmd === "migrate":
+        await runMigrator(MigratorType.MIGRATION);
+        break;
       case cmd === "seed": {
+        await runMigrator(MigratorType.SEEDER);
         break;
       }
       default:
@@ -89,8 +92,7 @@ class CompassCli {
       .command("migrate")
       .helpOption(false)
       .allowUnknownOption(true)
-      .description("run database schema migrations")
-      .action(() => runMigrator(MigratorType.MIGRATION));
+      .description("run database schema migrations");
 
     program
       .enablePositionalOptions(true)
@@ -98,15 +100,17 @@ class CompassCli {
       .command("seed")
       .helpOption(false)
       .allowUnknownOption(true)
-      .description("run seed migrations to populate the database with data")
-      .action(() => runMigrator(MigratorType.SEEDER));
+      .description("run seed migrations to populate the database with data");
 
     return program;
   }
 }
 
-const cli = new CompassCli(process.argv);
-cli.run().catch((err) => {
-  console.log(err);
-  process.exit(1);
-});
+if (require.main === module) {
+  const cli = new CompassCLI(process.argv);
+
+  cli.run().catch((err) => {
+    console.log(err);
+    process.exit(1);
+  });
+}

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,13 +1,14 @@
 // sort-imports-ignore
-import { Command } from "commander";
-import "./init";
+import "@scripts/init";
 
-import { CliValidator } from "./cli.validator";
-import { runBuild } from "./commands/build";
-import { startDeleteFlow } from "./commands/delete";
-import { inviteWaitlist } from "./commands/invite";
-import { runSeed } from "./commands/seed";
-import { ALL_PACKAGES, CATEGORY_VM } from "./common/cli.constants";
+import { CliValidator } from "@scripts/cli.validator";
+import { runBuild } from "@scripts/commands/build";
+import { startDeleteFlow } from "@scripts/commands/delete";
+import { inviteWaitlist } from "@scripts/commands/invite";
+import { runMigrator } from "@scripts/commands/migrate";
+import { ALL_PACKAGES, CATEGORY_VM } from "@scripts/common/cli.constants";
+import { MigratorType } from "@scripts/common/cli.types";
+import { Command } from "commander";
 
 class CompassCli {
   private program: Command;
@@ -39,9 +40,8 @@ class CompassCli {
         await inviteWaitlist();
         break;
       }
+      case cmd === "migrate":
       case cmd === "seed": {
-        this.validator.validateSeed(options);
-        await runSeed(user as string, force);
         break;
       }
       default:
@@ -84,9 +84,23 @@ class CompassCli {
     program.command("invite").description("invite users from the waitlist");
 
     program
+      .enablePositionalOptions(true)
+      .passThroughOptions(true)
+      .command("migrate")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description("run database schema migrations")
+      .action(() => runMigrator(MigratorType.MIGRATION));
+
+    program
+      .enablePositionalOptions(true)
+      .passThroughOptions(true)
       .command("seed")
-      .description("seed the database with events")
-      .option("-u, --user <id>", "specify which user to seed events for");
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description("run seed migrations to populate the database with data")
+      .action(() => runMigrator(MigratorType.SEEDER));
+
     return program;
   }
 }

--- a/packages/scripts/src/commands/migrate.ts
+++ b/packages/scripts/src/commands/migrate.ts
@@ -21,7 +21,7 @@ async function migrations(
 
   const migrations = await Promise.all(
     files.map(async (path) => {
-      const { default: Migration } = (await import(path ?? "")) as {
+      const { default: Migration } = (await import(path)) as {
         default: { new (): RunnableMigration<MigrationContext> };
       };
 

--- a/packages/scripts/src/commands/migrate.ts
+++ b/packages/scripts/src/commands/migrate.ts
@@ -1,0 +1,153 @@
+import glob from "fast-glob";
+import { readFile } from "node:fs/promises";
+import { parse, resolve, sep } from "node:path";
+import type { MigrationParams, RunnableMigration } from "umzug";
+import { MongoDBStorage, Umzug, UmzugCLI } from "umzug";
+import { MigrationContext, MigratorType } from "@scripts/common/cli.types";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+
+const logger = Logger("scripts.commands.migrations");
+
+async function migrations(
+  context: MigrationContext,
+): Promise<Array<RunnableMigration<MigrationContext>>> {
+  const { unsafe } = context;
+  const folder = `${context.migratorType.toLowerCase()}s`;
+  const migrationsRoot = resolve(__dirname, "..", folder);
+  const unsafeText = unsafe ? "unsafe " : "";
+  const fileGlob = `${migrationsRoot}/**/*.{ts,js}`;
+  const files = glob.sync(fileGlob, { absolute: true });
+
+  const migrations = await Promise.all(
+    files.map(async (path) => {
+      const { default: Migration } = (await import(path ?? "")) as {
+        default: { new (): RunnableMigration<MigrationContext> };
+      };
+
+      const migration = new Migration();
+      const name = parse(path).name;
+
+      return {
+        name,
+        path,
+        up: async (
+          params: MigrationParams<MigrationContext>,
+        ): Promise<void> => {
+          const { logger } = params.context;
+
+          logger.debug(`Running ${unsafeText}up migration(${name})`);
+          logger.debug(path);
+
+          await migration.up(params);
+
+          logger.debug(`Up migration(${name}) run successful`);
+        },
+        down: async (
+          params: MigrationParams<MigrationContext>,
+        ): Promise<void> => {
+          if (!migration.down) return;
+
+          const { logger } = params.context;
+
+          logger.debug(`Running ${unsafeText}down migration(${name})`);
+          logger.debug(path);
+
+          await migration.down(params);
+
+          logger.debug(`Down migration(${name}) ran successful`);
+        },
+      };
+    }),
+  );
+
+  return migrations.sort((prev, next) =>
+    prev.path.split("/").pop()!.localeCompare(next.path.split("/").pop()!),
+  );
+}
+
+async function template({
+  migratorType,
+  filePath,
+  migrationsRoot,
+}: {
+  migratorType: MigratorType;
+  filePath: string;
+  migrationsRoot: string;
+}): Promise<[string, string][]> {
+  const { base, name } = parse(filePath);
+  const path = resolve(migrationsRoot, base);
+
+  return readFile(
+    resolve(migrationsRoot, "..", "common", "migrator-template.ts"),
+  ).then((contents): [string, string][] => [
+    [
+      path,
+      contents
+        .toString()
+        .replace("class Template", `class ${migratorType}`)
+        .replace("{{name}}", name.split(".").pop()!)
+        .replace("{{path}}", path.replace(`${migrationsRoot}${sep}`, "")),
+    ],
+  ]);
+}
+
+async function createMigrationCli(
+  migratorType: MigratorType,
+): Promise<UmzugCLI> {
+  const folder = `${migratorType.toLowerCase()}s`;
+  const migrationsRoot = resolve(__dirname, "..", folder);
+  const collection = mongoService.db.collection(folder);
+  const storage = new MongoDBStorage({ collection });
+
+  const umzug = new Umzug<MigrationContext>({
+    storage,
+    logger: undefined,
+    migrations,
+    create: {
+      folder: migrationsRoot,
+      template: (filePath) =>
+        template({ migratorType, filePath, migrationsRoot }),
+    },
+    context: async (): Promise<MigrationContext> => {
+      const unsafe = cli.getFlagParameter("--unsafe").value;
+
+      return { logger, migratorType, unsafe };
+    },
+  });
+
+  const cli = new UmzugCLI(umzug as Umzug<object>, {
+    toolDescription: "Compass migrator",
+    toolFileName: "cli.ts",
+  });
+
+  cli.defineFlagParameter({
+    parameterLongName: "--unsafe",
+    parameterShortName: "-u",
+    description: "Run unsafe migration code within up and down methods",
+    environmentVariable: "MIGRATION_UNSAFE",
+  });
+
+  return cli;
+}
+
+export const runMigrator = async (
+  migratorType: MigratorType,
+  useDynamicDb = false,
+): Promise<void> => {
+  try {
+    await mongoService.start(useDynamicDb);
+
+    const cli = await createMigrationCli(migratorType);
+
+    await cli.executeAsync(process.argv.slice(3));
+
+    await mongoService.stop();
+
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+
+    process.exit(1);
+  }
+};

--- a/packages/scripts/src/common/cli.types.ts
+++ b/packages/scripts/src/common/cli.types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { Logger } from "@core/logger/winston.logger";
 
 export const Schema_Options_Cli_Root = z.object({
   force: z.boolean().optional(),
@@ -22,3 +23,14 @@ export type Options_Cli = Options_Cli_Root &
   Options_Cli_Delete;
 
 export type Environment_Cli = "local" | "staging" | "production";
+
+export enum MigratorType {
+  SEEDER = "Seeder",
+  MIGRATION = "Migration",
+}
+
+export interface MigrationContext {
+  logger: ReturnType<typeof Logger>;
+  migratorType: MigratorType;
+  unsafe: boolean;
+}

--- a/packages/scripts/src/common/migrator-template.ts
+++ b/packages/scripts/src/common/migrator-template.ts
@@ -1,0 +1,27 @@
+import type { MigrationParams, RunnableMigration } from "umzug";
+import { MigrationContext } from "@scripts/common/cli.types";
+
+export default class Template implements RunnableMigration<MigrationContext> {
+  readonly name: string = "{{name}}";
+  readonly path: string = "{{path}}";
+
+  async up(params: MigrationParams<MigrationContext>): Promise<void> {
+    const { context } = params;
+    const { logger } = context;
+
+    logger.debug(`running up migrations(${this.name}).`);
+
+    return Promise.resolve();
+  }
+
+  async down(params: MigrationParams<MigrationContext>): Promise<void> {
+    const { context, name, path } = params;
+    const { unsafe } = context;
+    const { logger } = context;
+    const unsafeText = unsafe ? " unsafe " : "";
+
+    logger.debug(`running${unsafeText}down migration`, { name, path });
+
+    return Promise.resolve();
+  }
+}

--- a/packages/scripts/src/seeders/2025.10.01T10.09.22.seed-user-events.ts
+++ b/packages/scripts/src/seeders/2025.10.01T10.09.22.seed-user-events.ts
@@ -1,0 +1,164 @@
+import { ObjectId } from "mongodb";
+import type { MigrationParams, RunnableMigration } from "umzug";
+import { confirm, input } from "@inquirer/prompts";
+import { MigrationContext } from "@scripts/common/cli.types";
+import { NodeEnv } from "@core/constants/core.constants";
+import {
+  CompassEventStatus,
+  CompassThisEvent,
+  RecurringEventUpdateScope,
+} from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
+import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
+import { ENV } from "@backend/common/constants/env.constants";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { UserError } from "@backend/common/errors/user/user.errors";
+import { CompassSyncProcessor } from "@backend/sync/services/sync/compass.sync.processor";
+import { findCompassUserBy } from "@backend/user/queries/user.queries";
+
+export default class Seeder implements RunnableMigration<MigrationContext> {
+  readonly name: string = "seed-user-events";
+  readonly path: string = "2025.10.01T10.09.22.seed-user-events.ts";
+
+  #generateEvents(userId: string): Array<CompassThisEvent["payload"]> {
+    const standalone = createMockStandaloneEvent({
+      user: userId,
+      isAllDay: false,
+      isSomeday: false,
+      startDate: dayjs().hour(10).minute(0).second(0).toISOString(),
+    });
+
+    return [
+      {
+        ...standalone,
+        _id: "68dd107efa3e55e40e095199",
+        user: standalone.user!,
+        startDate: standalone.startDate!,
+        endDate: standalone.endDate!,
+        origin: standalone.origin!,
+        priority: standalone.priority!,
+      },
+    ];
+  }
+
+  async #prompt(
+    params: MigrationParams<MigrationContext>,
+    direction: "up" | "down",
+  ) {
+    const controller = new AbortController();
+    const action = direction === "up" ? "Create" : "Delete";
+    const process = direction === "up" ? "seeding" : "removing seeded";
+
+    const skip = await confirm(
+      {
+        default: ENV.NODE_ENV !== NodeEnv.Development,
+        theme: { prefix: "" },
+        message: [
+          "",
+          `${process} user events`.toUpperCase(),
+          "",
+          "Skip this seeder?",
+        ].join("\n"),
+      },
+      { signal: controller.signal, clearPromptOnDone: true },
+    );
+
+    if (skip) return { user: null, proceed: false };
+
+    const user = await input(
+      {
+        theme: { prefix: "" },
+        message: "\n",
+        required: !skip,
+        validate: ObjectId.isValid,
+        transformer(input: string) {
+          return [
+            "",
+            "⚠️  WARNING ⚠️",
+            "",
+            `This command will modify user's data as follows:`,
+            `• ${action} multiple events in your Compass Calendar database`,
+            `• ${action} multiple events in your primary Google Calendar`,
+            "",
+            "🔔 RECOMMENDATION:",
+            "It's strongly recommended to use this command with a test account",
+            "rather than your personal account to avoid cluttering your calendar.",
+            "",
+            `Enter your Compass user "_id" string: ${input}`,
+          ].join("\n");
+        },
+      },
+      { signal: controller.signal },
+    );
+
+    const proceed =
+      params.context.unsafe ||
+      (await confirm({
+        theme: { prefix: "" },
+        default: params.context.unsafe,
+        message: [
+          "",
+          `Do you want to proceed with ${process} events for: >> ${user} <<`,
+        ].join("\n"),
+      }));
+
+    if (proceed) {
+      params.context.logger.debug(
+        `Starting event ${process} process for user: ${user}...`,
+      );
+    } else {
+      params.context.logger.debug(
+        `Operation cancelled. No events were ${action.toLowerCase()}ed.`,
+      );
+    }
+
+    return { user, proceed };
+  }
+
+  async #findUserOrThrow(userId: string) {
+    const user = await findCompassUserBy("_id", userId);
+
+    if (!user) {
+      throw error(
+        UserError.UserNotFound,
+        `User not found with Compass ID: ${userId}`,
+      );
+    }
+
+    return user;
+  }
+
+  async up(params: MigrationParams<MigrationContext>): Promise<void> {
+    const { user, proceed } = await this.#prompt(params, "up");
+
+    if (!proceed) return Promise.resolve();
+
+    const userId = (await this.#findUserOrThrow(user!))._id.toString();
+    const events = this.#generateEvents(userId);
+
+    await CompassSyncProcessor.processEvents(
+      events.map((payload) => ({
+        payload,
+        applyTo: RecurringEventUpdateScope.THIS_EVENT,
+        status: CompassEventStatus.CONFIRMED,
+      })),
+    );
+  }
+
+  async down(params: MigrationParams<MigrationContext>): Promise<void> {
+    const { user, proceed } = await this.#prompt(params, "down");
+
+    if (!proceed) return Promise.resolve();
+
+    const userId = (await this.#findUserOrThrow(user!))._id.toString();
+    const events = this.#generateEvents(userId);
+
+    await CompassSyncProcessor.processEvents(
+      events.map((payload) => ({
+        payload,
+        applyTo: RecurringEventUpdateScope.THIS_EVENT,
+        status: CompassEventStatus.CANCELLED,
+      })),
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,6 +2159,38 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.0.tgz#35390d0e7779626c026b11376da6789eb8389242"
   integrity sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==
 
+"@rushstack/node-core-library@5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-5.13.0.tgz#f79d6868b74be102eee75b93c37be45fb9b47ead"
+  integrity sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==
+  dependencies:
+    ajv "~8.13.0"
+    ajv-draft-04 "~1.0.0"
+    ajv-formats "~3.0.1"
+    fs-extra "~11.3.0"
+    import-lazy "~4.0.0"
+    jju "~1.4.0"
+    resolve "~1.22.1"
+    semver "~7.5.4"
+
+"@rushstack/terminal@0.15.2":
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/@rushstack/terminal/-/terminal-0.15.2.tgz#8fa030409603a22db606ecb18709050e46517add"
+  integrity sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==
+  dependencies:
+    "@rushstack/node-core-library" "5.13.0"
+    supports-color "~8.1.1"
+
+"@rushstack/ts-command-line@^4.12.2":
+  version "4.23.7"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.23.7.tgz#9c6f05a00f776c7b8ea3321e2b5a03acc5e9efa8"
+  integrity sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==
+  dependencies:
+    "@rushstack/terminal" "0.15.2"
+    "@types/argparse" "1.0.38"
+    argparse "~1.0.9"
+    string-argv "~0.3.1"
+
 "@shelf/jest-mongodb@^4.1.4":
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@shelf/jest-mongodb/-/jest-mongodb-4.3.2.tgz#b94096b9bcd8bc0bb88472b41de8f64d384bb834"
@@ -2427,6 +2459,11 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@types/argparse@1.0.38":
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
+  integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
 
 "@types/aria-query@^5.0.1":
   version "5.0.4"
@@ -3405,10 +3442,22 @@ agent-base@^7.1.2:
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
   integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
 
+ajv-draft-04@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz#3b64761b268ba0b9e668f0b41ba53fce0ad77fc8"
+  integrity sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==
+
 ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
   integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
+ajv-formats@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
   dependencies:
     ajv "^8.0.0"
 
@@ -3438,6 +3487,16 @@ ajv@^8.0.0, ajv@^8.9.0:
     fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
+
+ajv@~8.13.0:
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.13.0.tgz#a3939eaec9fb80d217ddf0c3376948c023f28c91"
+  integrity sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.4.1"
 
 alias-hq@^6.1.0:
   version "6.2.4"
@@ -3521,7 +3580,7 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-argparse@^1.0.7:
+argparse@^1.0.7, argparse@~1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -5182,7 +5241,7 @@ elliptic@^6.5.3, elliptic@^6.5.5:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-emittery@^0.13.1:
+emittery@^0.13.0, emittery@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
@@ -6086,6 +6145,15 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs-extra@~11.3.0:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.2.tgz#c838aeddc6f4a8c74dd15f85e11fe5511bfe02a4"
+  integrity sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -6319,7 +6387,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -6698,6 +6766,11 @@ import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-lazy@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
 import-local@^3.0.2:
   version "3.2.0"
@@ -7607,6 +7680,11 @@ jest@^29.0.3:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+jju@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
 jose@^4.13.1:
   version "4.15.9"
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
@@ -7745,6 +7823,15 @@ json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonfile@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.0.tgz#7c265bd1b65de6977478300087c99f1c84383f62"
+  integrity sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonwebtoken@^9.0.0:
   version "9.0.2"
@@ -9016,6 +9103,11 @@ pkg-dir@^7.0.0:
   dependencies:
     find-up "^6.3.0"
 
+pony-cause@^2.1.4:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.11.tgz#d69a20aaccdb3bdb8f74dd59e5c68d8e6772e4bd"
+  integrity sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==
+
 portfinder@^1.0.28:
   version "1.0.37"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.37.tgz#92b754ef89a11801c8efe4b0e5cd845b0064c212"
@@ -9713,7 +9805,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.0.0, resolve@^1.1.6, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0:
+resolve@^1.0.0, resolve@^1.1.6, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@~1.22.1:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
   integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
@@ -9972,6 +10064,13 @@ semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+semver@~7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.19.0:
   version "0.19.0"
@@ -10414,7 +10513,7 @@ strict-event-emitter@^0.4.3:
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz#ff347c8162b3e931e3ff5f02cfce6772c3b07eb3"
   integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
 
-string-argv@^0.3.2:
+string-argv@^0.3.2, string-argv@~0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
@@ -10708,7 +10807,7 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.1:
+supports-color@^8.0.0, supports-color@^8.1.1, supports-color@~8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -11060,6 +11159,11 @@ type-fest@^2.19.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
+type-fest@^4.0.0:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -11168,6 +11272,17 @@ typescript@^5.1.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
+umzug@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/umzug/-/umzug-3.8.2.tgz#53c2189604d36956d7b75a89128108d0e3073a9f"
+  integrity sha512-BEWEF8OJjTYVC56GjELeHl/1XjFejrD7aHzn+HldRJTx+pL1siBrKHZC8n4K/xL3bEzVA9o++qD1tK2CpZu4KA==
+  dependencies:
+    "@rushstack/ts-command-line" "^4.12.2"
+    emittery "^0.13.0"
+    fast-glob "^3.3.2"
+    pony-cause "^2.1.4"
+    type-fest "^4.0.0"
+
 unbox-primitive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz#8d9d2c9edeea8460c7f35033a88867944934d1e2"
@@ -11223,6 +11338,11 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -11236,7 +11356,7 @@ update-browserslist-db@^1.1.3:
     escalade "^3.2.0"
     picocolors "^1.1.1"
 
-uri-js@^4.2.2:
+uri-js@^4.2.2, uri-js@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to generate and run database migrations and seeders to Compass. It updates the Compass cli to support the following commands:
- `yarn cli seed` - existing command updated
- `yarn cli migrate` - new migration command

### How can this be manually tested?

Run the commands above in your terminal.
you can run the commads with an extra `--help` flag to see the available sub-commands