### PR TITLE
feat(web): opt-in to react-router v7 features

### DIFF
--- a/packages/web/src/__tests__/__mocks__/mock.render.tsx
+++ b/packages/web/src/__tests__/__mocks__/mock.render.tsx
@@ -27,7 +27,12 @@ const AllTheProviders =
         <GoogleOAuthProvider clientId="anyClientId">
           <GlobalStyle />
           <ThemeProvider theme={theme}>
-            <BrowserRouter>
+            <BrowserRouter
+              future={{
+                v7_startTransition: true,
+                v7_relativeSplatPath: true,
+              }}
+            >
               <Provider store={store}>{children}</Provider>
             </BrowserRouter>
           </ThemeProvider>

--- a/packages/web/src/routers/index.tsx
+++ b/packages/web/src/routers/index.tsx
@@ -4,32 +4,38 @@ import { ProtectedRoute } from "@web/auth/ProtectedRoute";
 import { UserProvider } from "@web/auth/UserContext";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import SocketProvider from "@web/socket/SocketProvider";
-import { LoginView } from "@web/views/Login";
 import { LogoutView } from "@web/views/Logout";
 import { NotFoundView } from "@web/views/NotFound";
 import OnboardingFlow from "@web/views/Onboarding/OnboardingFlow";
 import { RootView } from "@web/views/Root";
 
-const router = createBrowserRouter([
+const router = createBrowserRouter(
+  [
+    {
+      path: ROOT_ROUTES.ROOT,
+      element: (
+        <ProtectedRoute>
+          <UserProvider>
+            <SocketProvider>
+              <RootView />
+            </SocketProvider>
+          </UserProvider>
+        </ProtectedRoute>
+      ),
+    },
+    {
+      path: ROOT_ROUTES.LOGIN,
+      element: <OnboardingFlow />,
+    },
+    { path: ROOT_ROUTES.LOGOUT, element: <LogoutView /> },
+    { path: "*", element: <NotFoundView /> },
+  ],
   {
-    path: ROOT_ROUTES.ROOT,
-    element: (
-      <ProtectedRoute>
-        <UserProvider>
-          <SocketProvider>
-            <RootView />
-          </SocketProvider>
-        </UserProvider>
-      </ProtectedRoute>
-    ),
+    future: {
+      v7_relativeSplatPath: true,
+    },
   },
-  {
-    path: ROOT_ROUTES.LOGIN,
-    element: <OnboardingFlow />,
-  },
-  { path: ROOT_ROUTES.LOGOUT, element: <LogoutView /> },
-  { path: "*", element: <NotFoundView /> },
-]);
+);
 
 export const RootRouter = () => {
   return <RouterProvider router={router} />;


### PR DESCRIPTION
This pull request updates the React Router configuration to enable new v7 features and future-proof routing behavior. The main changes are the addition of the `future` prop with specific flags in both the test mock provider and the main router setup.

Closes #1049 

Routing configuration updates:

* Added the `future` prop to the `BrowserRouter` in `mock.render.tsx` to enable `v7_startTransition` and `v7_relativeSplatPath` features, which prepare the codebase for React Router v7 improvements.
* Updated the `createBrowserRouter` call in `routers/index.tsx` to include the `future` option with `v7_relativeSplatPath`, ensuring consistent route matching and compatibility with upcoming router changes.

General code organization:

* Refactored the router array argument in `routers/index.tsx` for clarity and to accommodate the new `future` configuration.

## Before
<img width="731" height="729" alt="before" src="https://github.com/user-attachments/assets/029a46b4-6128-465e-964e-b4155aa7726c" />

## After

<img width="738" height="261" alt="after" src="https://github.com/user-attachments/assets/0432e4b8-acb1-41fc-9aae-7b5b4a75f4fa" />
