### PR TITLE
fix(backend): change connection error logging level from error to debug

### DIFF
--- a/packages/backend/src/servers/websocket/websocket.server.ts
+++ b/packages/backend/src/servers/websocket/websocket.server.ts
@@ -214,7 +214,7 @@ class WebSocketServer {
     this.wsServer.on("connection", handleWsError(this.onConnection.bind(this)));
 
     this.wsServer.engine.on("connection_error", (err: Error) => {
-      logger.error(`Connection error: ${err.message}`);
+      logger.debug(`Connection error: ${err.message}`);
     });
 
     return this.wsServer;


### PR DESCRIPTION
Reduce log noise by downgrading WebSocket connection errors from error to debug level and optionally disabling automatic reconnection attempts for unauthenticated clients.
