### PR TITLE
refactor(web): update StyledWeekDay and StyledIntervalInput for improved styling

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/styled.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/styled.ts
@@ -81,12 +81,13 @@ export const StyledWeekDay = styled.button<{
   bgColor: string;
   selected: boolean;
 }>`
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  border: 1px solid ${({ theme }) => theme.color.border.primaryDark};
   background-color: ${({ bgColor }) => bgColor};
+  border: 1px solid ${({ theme }) => theme.color.border.primaryDark};
+  border-radius: 50%;
+  font-size: ${({ theme }) => theme.text.size.m};
+  height: 24px;
   transition: ${({ theme }) => theme.transition.default};
+  width: 24px;
 
   cursor: pointer;
   ${({ selected, theme }) =>
@@ -118,6 +119,7 @@ export const StyledIntervalInput = styled.input<{
   border: 1px solid transparent;
   text-align: center;
   border-radius: ${({ theme }) => theme.shape.borderRadius};
+  font-size: ${({ theme }) => theme.text.size.s};
   padding: 0 4px;
   background-color: ${({ bgColor }) => bgColor};
   margin-left: ${({ theme }) => theme.spacing.xs};


### PR DESCRIPTION
Follow-up to #934 that corrects the font size for the recurrence section

### Before
<img width="492" height="513" alt="Screenshot 2025-10-23 at 9 21 14 PM" src="https://github.com/user-attachments/assets/c2823e2d-9f17-4ee6-b0cd-5a294cf8109e" />



### After

<img width="495" height="486" alt="Screenshot 2025-10-23 at 9 29 08 PM" src="https://github.com/user-attachments/assets/5320e65f-da06-4ca6-90fe-1e540f8654c0" />


