### PR TITLE
:bug fix(autocomplete-keypress): do not handle window events with empty keyboard key

### DIFF
--- a/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.ts
@@ -179,6 +179,8 @@ export function useDayViewShortcuts(config: KeyboardShortcutsConfig) {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      if (!e.key) return;
+
       const key = e.key.toLowerCase();
       const target = e.target as EventTarget | null;
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes autocomplete selection error on the task title input.

## Use Case

closes #1291