### PR TITLE
fix(backend): update 410 error handling with force flag

### DIFF
--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -119,12 +119,14 @@ const handleGoogleError = async (
   }
 
   if (isFullSyncRequired(e)) {
-    userService.restartGoogleCalendarSync(userId).catch((err) => {
-      logger.error(
-        `Something went wrong with resyncing google calendars for user: ${userId}`,
-        err,
-      );
-    });
+    userService
+      .restartGoogleCalendarSync(userId, { force: true })
+      .catch((err) => {
+        logger.error(
+          `Something went wrong with resyncing google calendars for user: ${userId}`,
+          err,
+        );
+      });
 
     res.status(Status.BAD_REQUEST).send({ message: "Full sync in progress." });
 

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -105,12 +105,14 @@ export class SyncController {
           return;
         } else if (isFullSyncRequired(e as Error) && userId) {
           // do not await this call
-          userService.restartGoogleCalendarSync(userId).catch((err) => {
-            logger.error(
-              `Something went wrong with resyncing google calendars for user: ${userId}`,
-              err,
-            );
-          });
+          userService
+            .restartGoogleCalendarSync(userId, { force: true })
+            .catch((err) => {
+              logger.error(
+                `Something went wrong with resyncing google calendars for user: ${userId}`,
+                err,
+              );
+            });
 
           res.status(Status.OK).send({ message: "Full sync in progress." });
 

--- a/packages/backend/src/sync/services/maintain/sync.maintenance.ts
+++ b/packages/backend/src/sync/services/maintain/sync.maintenance.ts
@@ -142,7 +142,7 @@ export const refreshWatch = async (
       };
     } catch (e) {
       if (isFullSyncRequired(e as Error)) {
-        userService.restartGoogleCalendarSync(r.user);
+        userService.restartGoogleCalendarSync(r.user, { force: true });
         resynced = true;
       } else {
         logger.error(


### PR DESCRIPTION
Closes #1422 

- Updated `restartGoogleCalendarSync` method to accept an options parameter for forced synchronization.
- Modified error handling in `SyncController` and `error.express.handler` to utilize the new forced restart functionality.
- Enhanced tests to cover scenarios for both forced and non-forced sync operations, ensuring correct behavior based on user import status.

This change improves the flexibility of the Google Calendar synchronization process, allowing for more robust handling of sync operations in various states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect Google Calendar sync control flow and can trigger additional stop/start imports under error conditions; incorrect forcing logic could cause unnecessary resyncs or load, but is scoped and covered by tests.
> 
> **Overview**
> **Google Calendar sync restarts can now be forced.** `restartGoogleCalendarSync` accepts an options arg (`{ force?: boolean }`) and will skip restarts when the user’s import is already `completed`, unless `force` is set (still avoids interrupting an active `importing` run).
> 
> Error paths that detect `isFullSyncRequired` (Express Google error handler, sync notification controller, and watch maintenance refresh) now trigger a **forced** restart to ensure a full resync proceeds even if metadata says import previously finished. Tests add coverage for forced vs non-forced restart behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60396607fa720461d9fcf9e647b690f8ff7c2927. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->