### PR TITLE
fix(backend): handle instance -> standalone conversion

### DIFF
--- a/packages/backend/src/event/classes/gcal.event.parser.ts
+++ b/packages/backend/src/event/classes/gcal.event.parser.ts
@@ -281,6 +281,29 @@ export class GcalEventParser {
     return [...seriesChanges, ...baseChanges];
   }
 
+  async instanceToStandalone(
+    session?: ClientSession,
+  ): Promise<Event_Transition[]> {
+    const event = gEventToCompassEvent(this.#event, this.userId);
+
+    const {
+      recurrence, // eslint-disable-line @typescript-eslint/no-unused-vars
+      gRecurringEventId, // eslint-disable-line @typescript-eslint/no-unused-vars
+      ...eventWithoutProps
+    } = event;
+
+    return this.upsertCompassEvent(
+      {
+        $unset: { recurrence: 1, gRecurringEventId: 1 },
+        $set: {
+          ...eventWithoutProps,
+          updatedAt: new Date(),
+        },
+      },
+      session,
+    );
+  }
+
   async standaloneToSeries(session?: ClientSession) {
     this.#logger.info(
       `UPDATING ${this.getTransitionString()}: ${this.#event.id} to series`,

--- a/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
+++ b/packages/backend/src/sync/services/sync/gcal.sync.processor.ts
@@ -80,6 +80,8 @@ export class GcalSyncProcessor {
         return parser.createSeries(session);
       case "STANDALONE->>RECURRENCE_BASE_CONFIRMED":
         return parser.standaloneToSeries(session);
+      case "RECURRENCE_INSTANCE->>STANDALONE_CONFIRMED":
+        return parser.instanceToStandalone(session);
       case "RECURRENCE_BASE->>STANDALONE_CONFIRMED":
         return parser.seriesToStandalone(session);
       case "RECURRENCE_INSTANCE->>RECURRENCE_BASE_CONFIRMED":


### PR DESCRIPTION
Closes #1434 

- Implemented `instanceToStandalone` method in `GcalEventParser` to convert recurrence instances into standalone events, enhancing event management capabilities.
- Updated `GcalSyncProcessor` to handle the new conversion case in the event processing logic.
- Added unit tests to validate the functionality of detaching instances into standalone events, ensuring correct behavior and data integrity during synchronization.

This change improves the flexibility of the Google Calendar synchronization process, allowing users to manage their events more effectively.