### PR TITLE
feat(auth): implement session user synchronization and related tests

### DIFF
--- a/packages/web/src/auth/session/SessionProvider.test.tsx
+++ b/packages/web/src/auth/session/SessionProvider.test.tsx
@@ -1,0 +1,63 @@
+import { useContext } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { syncLocalTaskUsersToAuthenticatedUser } from "@web/common/utils/sync/local-task-user-sync.util";
+import { SessionContext, SessionProvider } from "./SessionProvider";
+
+jest.mock("@web/common/utils/sync/local-task-user-sync.util");
+
+function SessionTestHarness() {
+  const { setAuthenticated } = useContext(SessionContext);
+
+  return (
+    <div>
+      <button onClick={() => setAuthenticated(true)} type="button">
+        Set Authenticated
+      </button>
+      <button onClick={() => setAuthenticated(false)} type="button">
+        Set Unauthenticated
+      </button>
+    </div>
+  );
+}
+
+describe("SessionProvider", () => {
+  const mockSyncLocalTaskUsersToAuthenticatedUser =
+    syncLocalTaskUsersToAuthenticatedUser as jest.MockedFunction<
+      typeof syncLocalTaskUsersToAuthenticatedUser
+    >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSyncLocalTaskUsersToAuthenticatedUser.mockResolvedValue(0);
+  });
+
+  it("does not sync task users when authenticated is false", () => {
+    render(
+      <SessionProvider>
+        <SessionTestHarness />
+      </SessionProvider>,
+    );
+
+    expect(mockSyncLocalTaskUsersToAuthenticatedUser).not.toHaveBeenCalled();
+  });
+
+  it("syncs task users when authenticated becomes true", async () => {
+    render(
+      <SessionProvider>
+        <SessionTestHarness />
+      </SessionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set Authenticated" }));
+
+    await waitFor(() => {
+      expect(mockSyncLocalTaskUsersToAuthenticatedUser).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set Unauthenticated" }),
+    );
+  });
+});

--- a/packages/web/src/auth/session/SessionProvider.tsx
+++ b/packages/web/src/auth/session/SessionProvider.tsx
@@ -13,6 +13,7 @@ import { session } from "@web/common/classes/Session";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { markUserAsAuthenticated } from "@web/common/utils/storage/auth-state.util";
+import { syncLocalTaskUsersToAuthenticatedUser } from "@web/common/utils/sync/local-task-user-sync.util";
 import * as socket from "@web/socket/provider/SocketProvider";
 import { CompassSession } from "./session.types";
 
@@ -116,6 +117,19 @@ export function SessionProvider({ children }: PropsWithChildren<{}>) {
       };
     }
   }, []);
+
+  useEffect(() => {
+    if (!authenticated) {
+      return;
+    }
+
+    void syncLocalTaskUsersToAuthenticatedUser().catch((error) => {
+      console.error(
+        "Failed to sync local task users after authentication:",
+        error,
+      );
+    });
+  }, [authenticated]);
 
   return (
     <SessionContext.Provider

--- a/packages/web/src/common/utils/sync/local-task-user-sync.util.test.ts
+++ b/packages/web/src/common/utils/sync/local-task-user-sync.util.test.ts
@@ -1,0 +1,119 @@
+import { createTestTask } from "@web/__tests__/utils/repositories/repository.test.factory";
+import { prepareEmptyStorageForTests } from "@web/__tests__/utils/storage/indexeddb.test.util";
+import { getUserId } from "@web/auth/auth.util";
+import { UNAUTHENTICATED_USER } from "@web/common/constants/auth.constants";
+import {
+  ensureStorageReady,
+  getStorageAdapter,
+  resetStorage,
+} from "@web/common/storage/adapter/adapter";
+import { syncLocalTaskUsersToAuthenticatedUser } from "./local-task-user-sync.util";
+
+jest.mock("@web/auth/auth.util");
+
+describe("syncLocalTaskUsersToAuthenticatedUser", () => {
+  const mockGetUserId = getUserId as jest.MockedFunction<typeof getUserId>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    resetStorage();
+    await prepareEmptyStorageForTests();
+    await ensureStorageReady();
+  });
+
+  afterEach(() => {
+    resetStorage();
+  });
+
+  it("rewrites unauthenticated users across multiple dates", async () => {
+    mockGetUserId.mockResolvedValue("mongo-user-id");
+    const adapter = getStorageAdapter();
+
+    await adapter.putTasks("2024-01-01", [
+      createTestTask({ _id: "task-1", user: UNAUTHENTICATED_USER }),
+      createTestTask({ _id: "task-2", user: "already-authenticated-user" }),
+    ]);
+    await adapter.putTasks("2024-01-02", [
+      createTestTask({ _id: "task-3", user: UNAUTHENTICATED_USER }),
+    ]);
+
+    const syncedCount = await syncLocalTaskUsersToAuthenticatedUser();
+
+    expect(syncedCount).toBe(2);
+    await expect(adapter.getTasks("2024-01-01")).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: "task-1", user: "mongo-user-id" }),
+        expect.objectContaining({
+          _id: "task-2",
+          user: "already-authenticated-user",
+        }),
+      ]),
+    );
+    await expect(adapter.getTasks("2024-01-02")).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: "task-3", user: "mongo-user-id" }),
+      ]),
+    );
+  });
+
+  it("returns 0 when there are no tasks", async () => {
+    mockGetUserId.mockResolvedValue("mongo-user-id");
+
+    await expect(syncLocalTaskUsersToAuthenticatedUser()).resolves.toBe(0);
+  });
+
+  it("returns 0 and does not rewrite when user is unauthenticated", async () => {
+    mockGetUserId.mockResolvedValue(UNAUTHENTICATED_USER);
+    const adapter = getStorageAdapter();
+    await adapter.putTasks("2024-01-01", [
+      createTestTask({ _id: "task-1", user: UNAUTHENTICATED_USER }),
+    ]);
+
+    const syncedCount = await syncLocalTaskUsersToAuthenticatedUser();
+
+    expect(syncedCount).toBe(0);
+    await expect(adapter.getTasks("2024-01-01")).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ _id: "task-1", user: UNAUTHENTICATED_USER }),
+      ]),
+    );
+  });
+
+  it("returns 0 when all tasks already have authenticated users", async () => {
+    mockGetUserId.mockResolvedValue("mongo-user-id");
+    const adapter = getStorageAdapter();
+    await adapter.putTasks("2024-01-01", [
+      createTestTask({ _id: "task-1", user: "already-authenticated-user" }),
+    ]);
+
+    await expect(syncLocalTaskUsersToAuthenticatedUser()).resolves.toBe(0);
+    await expect(adapter.getTasks("2024-01-01")).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          _id: "task-1",
+          user: "already-authenticated-user",
+        }),
+      ]),
+    );
+  });
+
+  it("throws when user id lookup fails", async () => {
+    mockGetUserId.mockRejectedValue(new Error("Failed to resolve user id"));
+
+    await expect(syncLocalTaskUsersToAuthenticatedUser()).rejects.toThrow(
+      "Failed to resolve user id",
+    );
+  });
+
+  it("throws when loading tasks fails", async () => {
+    mockGetUserId.mockResolvedValue("mongo-user-id");
+    const adapter = getStorageAdapter();
+    jest
+      .spyOn(adapter, "getAllTasks")
+      .mockRejectedValueOnce(new Error("Failed to load tasks"));
+
+    await expect(syncLocalTaskUsersToAuthenticatedUser()).rejects.toThrow(
+      "Failed to load tasks",
+    );
+  });
+});

--- a/packages/web/src/common/utils/sync/local-task-user-sync.util.ts
+++ b/packages/web/src/common/utils/sync/local-task-user-sync.util.ts
@@ -1,0 +1,59 @@
+import { getUserId } from "@web/auth/auth.util";
+import { UNAUTHENTICATED_USER } from "@web/common/constants/auth.constants";
+import {
+  ensureStorageReady,
+  getStorageAdapter,
+} from "@web/common/storage/adapter/adapter";
+import { Task } from "@web/common/types/task.types";
+
+export async function syncLocalTaskUsersToAuthenticatedUser(): Promise<number> {
+  await ensureStorageReady();
+
+  const userId = await getUserId();
+  if (!userId || userId === UNAUTHENTICATED_USER) {
+    return 0;
+  }
+
+  const adapter = getStorageAdapter();
+  const allTasks = await adapter.getAllTasks();
+  if (allTasks.length === 0) {
+    return 0;
+  }
+
+  const tasksByDateKey = new Map<string, Task[]>();
+
+  for (const storedTask of allTasks) {
+    const { dateKey, ...task } = storedTask;
+    const tasksForDate = tasksByDateKey.get(dateKey);
+    if (tasksForDate) {
+      tasksForDate.push(task);
+      continue;
+    }
+
+    tasksByDateKey.set(dateKey, [task]);
+  }
+
+  let syncedCount = 0;
+
+  for (const [dateKey, tasks] of tasksByDateKey.entries()) {
+    let isDateUpdated = false;
+
+    const updatedTasks = tasks.map((task) => {
+      if (task.user !== UNAUTHENTICATED_USER) {
+        return task;
+      }
+
+      syncedCount += 1;
+      isDateUpdated = true;
+      return { ...task, user: userId };
+    });
+
+    if (!isDateUpdated) {
+      continue;
+    }
+
+    await adapter.putTasks(dateKey, updatedTasks);
+  }
+
+  return syncedCount;
+}


### PR DESCRIPTION
- Added `syncLocalTaskUsersToAuthenticatedUser` utility to synchronize task users with the authenticated user upon login.
- Updated `SessionProvider` to trigger synchronization when the authentication state changes.
- Introduced tests for `SessionProvider` to verify synchronization behavior based on authentication status.
- Enhanced `LocalTaskRepository` to normalize unauthenticated users when saving tasks.
- Added comprehensive tests for the synchronization utility to ensure correct behavior across various scenarios.
Closes #1467 