### PR TITLE
ci: use matrix to run project tests separately

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -5,6 +5,10 @@ on: [push]
 jobs:
   unit:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [core, web, backend, scripts]
 
     steps:
       - name: Check out Git repository
@@ -20,8 +24,8 @@ jobs:
         run: |
           yarn install --frozen-lockfile --network-timeout 300000
 
-      - name: Run tests
+      - name: Run ${{ matrix.project }} tests
         env:
           TZ: ${{ vars.TZ }}
         run: |
-          yarn test
+          yarn test ${{ matrix.project }}


### PR DESCRIPTION

closes #1521 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Run unit tests in parallel using a matrix strategy to improve isolation and reduce execution time.

---
<p><a href="https://cursor.com/agents/bc-254da468-eb1c-4b52-afb9-88ae34dd4b7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-254da468-eb1c-4b52-afb9-88ae34dd4b7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->