### PR TITLE
fix(web): clean web test warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ packages/**/yarn.lock
 .idea/
 .mcp.json
 .vscode/
+.yarn-cache/
 
 build/
 buildcache/

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--cache-folder .yarn-cache

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "dev:update": "git checkout main && git pull && yarn",
     "dev:web": "cd packages/web && yarn webpack serve --mode=development --node-env=local",
     "postinstall": "husky install | chmod ug+x .husky/*",
-    "test": "cross-env TZ=Etc/UTC yarn jest",
+    "test": "cross-env TZ=Etc/UTC ./node_modules/.bin/jest",
     "test:e2e": "playwright test",
     "test:backend": "yarn test backend",
     "test:core": "yarn test core",
-    "test:web": "yarn test web",
+    "test:web": "cross-env TZ=Etc/UTC ./node_modules/.bin/jest web",
     "test:scripts": "yarn test scripts",
     "type-check": "tsc --noEmit"
   },

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -14,6 +14,9 @@ import { ENV_WEB } from "@web/common/constants/env.constants";
 import { freshenEventStartEndDate } from "@web/views/Calendar/calendar.render.test.utils";
 
 export const globalHandlers = [
+  rest.get("http://localhost/version.json", (_req, res, ctx) => {
+    return res(ctx.json({ version: "dev" }));
+  }),
   rest.get(`${ENV_WEB.API_BASEURL}/event`, (req, res, ctx) => {
     const getSomedayEvents = req.url.searchParams.get("someday");
     if (getSomedayEvents) {
@@ -75,13 +78,14 @@ export const globalHandlers = [
     return res(ctx.json({ isNewUser: true }));
   }),
   rest.post(`${ENV_WEB.API_BASEURL}/session/refresh`, (_req, res, ctx) => {
-    ctx.set("access-token", faker.internet.jwt());
-    ctx.set("front-token", faker.internet.jwt());
-    ctx.set("refresh-token", faker.internet.jwt());
-    ctx.cookie("sAccessToken", faker.internet.jwt());
-    ctx.cookie("sFrontendToken", faker.internet.jwt());
-    ctx.cookie("sRefreshToken", faker.internet.jwt());
-
-    return res(ctx.json({ ok: true }));
+    return res(
+      ctx.set("access-token", faker.internet.jwt()),
+      ctx.set("front-token", faker.internet.jwt()),
+      ctx.set("refresh-token", faker.internet.jwt()),
+      ctx.cookie("sAccessToken", faker.internet.jwt()),
+      ctx.cookie("sFrontendToken", faker.internet.jwt()),
+      ctx.cookie("sRefreshToken", faker.internet.jwt()),
+      ctx.json({ ok: true }),
+    );
   }),
 ];

--- a/packages/web/src/__tests__/web.test.start.ts
+++ b/packages/web/src/__tests__/web.test.start.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
   const sessionModule = jest.requireMock("supertokens-web-js/recipe/session");
   sessionModule.doesSessionExist?.mockResolvedValue(true);
 });
-beforeAll(() => server.listen());
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 afterAll(() => jest.restoreAllMocks());

--- a/packages/web/src/common/hooks/useVersionCheck.test.ts
+++ b/packages/web/src/common/hooks/useVersionCheck.test.ts
@@ -49,7 +49,7 @@ describe("useVersionCheck", () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringMatching(/^\/version\.json\?t=\d+$/),
+      expect.stringMatching(/^http:\/\/localhost\/version\.json\?t=\d+$/),
       expect.objectContaining({
         cache: "no-store",
         headers: { "Cache-Control": "no-cache" },

--- a/packages/web/src/common/hooks/useVersionCheck.ts
+++ b/packages/web/src/common/hooks/useVersionCheck.ts
@@ -10,6 +10,16 @@ const versionResponseSchema = z.object({
   version: z.string().optional(),
 });
 
+function getVersionCheckUrl() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const url = new URL("/version.json", window.location.origin);
+  url.searchParams.set("t", Date.now().toString());
+  return url.toString();
+}
+
 export interface VersionCheckResult {
   isUpdateAvailable: boolean;
   currentVersion: string;
@@ -35,10 +45,15 @@ export const useVersionCheck = (): VersionCheckResult => {
       return;
     }
 
+    const versionCheckUrl = getVersionCheckUrl();
+    if (!versionCheckUrl) {
+      return;
+    }
+
     isCheckingRef.current = true;
 
     try {
-      const response = await fetch(`/version.json?t=${Date.now()}`, {
+      const response = await fetch(versionCheckUrl, {
         cache: "no-store",
         headers: { "Cache-Control": "no-cache" },
       });

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement, type ReactNode } from "react";
+import { act } from "react";
 import { MemoryRouter } from "react-router-dom";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -100,6 +101,12 @@ const renderWithProviders = (
   );
 };
 
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
 describe("AuthModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -118,7 +125,10 @@ describe("AuthModal", () => {
         screen.queryByRole("heading", { name: /hey, welcome back/i }),
       ).not.toBeInTheDocument();
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+      await flushEffects();
 
       await waitFor(() => {
         expect(
@@ -131,7 +141,10 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+      await flushEffects();
 
       await waitFor(() => {
         expect(
@@ -143,7 +156,10 @@ describe("AuthModal", () => {
       const backdrop = screen.getByRole("presentation");
       expect(backdrop).toBeInTheDocument();
 
-      await user.click(backdrop);
+      await act(async () => {
+        await user.click(backdrop);
+      });
+      await flushEffects();
 
       await waitFor(() => {
         expect(
@@ -156,7 +172,10 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+      await flushEffects();
 
       await waitFor(() => {
         expect(
@@ -168,7 +187,10 @@ describe("AuthModal", () => {
       const backdrop = screen.getByRole("presentation");
       backdrop.focus();
 
-      await user.keyboard("{Escape}");
+      await act(async () => {
+        await user.keyboard("{Escape}");
+      });
+      await flushEffects();
 
       await waitFor(() => {
         expect(
@@ -183,7 +205,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         const signUpSwitch = screen.getByRole("button", { name: /^sign up$/i });
@@ -195,7 +219,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         expect(
@@ -203,7 +229,9 @@ describe("AuthModal", () => {
         ).toBeInTheDocument();
       });
 
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      });
 
       await waitFor(() => {
         expect(
@@ -219,7 +247,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       // Login form - no Name field
       await waitFor(() => {
@@ -228,7 +258,9 @@ describe("AuthModal", () => {
       });
 
       // Switch to sign up
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      });
 
       await waitFor(() => {
         expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
@@ -241,7 +273,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
@@ -253,7 +287,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         // Look for the submit button by type - CTA is "login"
@@ -267,14 +303,18 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
       });
 
-      await user.type(screen.getByLabelText(/email/i), "invalid-email");
-      await user.tab(); // Blur the field
+      await act(async () => {
+        await user.type(screen.getByLabelText(/email/i), "invalid-email");
+        await user.tab();
+      });
 
       await waitFor(() => {
         expect(
@@ -287,7 +327,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         expect(
@@ -295,9 +337,11 @@ describe("AuthModal", () => {
         ).toBeInTheDocument();
       });
 
-      await user.click(
-        screen.getByRole("button", { name: /forgot password/i }),
-      );
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", { name: /forgot password/i }),
+        );
+      });
 
       await waitFor(() => {
         expect(
@@ -312,8 +356,19 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^sign up$/i }),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      });
 
       await waitFor(() => {
         expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
@@ -326,15 +381,28 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^sign up$/i }),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      });
 
       await waitFor(() => {
         expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
       });
 
-      await user.type(screen.getByLabelText(/password/i), "short");
-      await user.tab();
+      await act(async () => {
+        await user.type(screen.getByLabelText(/password/i), "short");
+        await user.tab();
+      });
 
       await waitFor(() => {
         expect(
@@ -347,8 +415,19 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^sign up$/i }),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      });
 
       await waitFor(() => {
         expect(
@@ -356,7 +435,9 @@ describe("AuthModal", () => {
         ).toBeInTheDocument();
       });
 
-      await user.type(screen.getByLabelText(/name/i), "Alex");
+      await act(async () => {
+        await user.type(screen.getByLabelText(/name/i), "Alex");
+      });
 
       await waitFor(() => {
         expect(
@@ -373,10 +454,21 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
-      await user.click(
-        screen.getByRole("button", { name: /forgot password/i }),
-      );
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /forgot password/i }),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", { name: /forgot password/i }),
+        );
+      });
 
       await waitFor(() => {
         expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
@@ -390,19 +482,32 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
-      await user.click(
-        screen.getByRole("button", { name: /forgot password/i }),
-      );
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /forgot password/i }),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", { name: /forgot password/i }),
+        );
+      });
 
       await waitFor(() => {
         expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
       });
 
-      await user.type(screen.getByLabelText(/email/i), "test@example.com");
-      await user.click(
-        screen.getByRole("button", { name: /send reset link/i }),
-      );
+      await act(async () => {
+        await user.type(screen.getByLabelText(/email/i), "test@example.com");
+        await user.click(
+          screen.getByRole("button", { name: /send reset link/i }),
+        );
+      });
 
       await waitFor(() => {
         expect(screen.getByText(/check your email/i)).toBeInTheDocument();
@@ -413,10 +518,21 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
-      await user.click(
-        screen.getByRole("button", { name: /forgot password/i }),
-      );
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /forgot password/i }),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", { name: /forgot password/i }),
+        );
+      });
 
       await waitFor(() => {
         expect(
@@ -424,9 +540,11 @@ describe("AuthModal", () => {
         ).toBeInTheDocument();
       });
 
-      await user.click(
-        screen.getByRole("button", { name: /back to sign in/i }),
-      );
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", { name: /back to sign in/i }),
+        );
+      });
 
       await waitFor(() => {
         expect(
@@ -444,7 +562,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         const googleButton = screen.getByRole("button", {
@@ -459,7 +579,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         expect(
@@ -467,9 +589,11 @@ describe("AuthModal", () => {
         ).toBeInTheDocument();
       });
 
-      await user.click(
-        screen.getByRole("button", { name: /continue with google/i }),
-      );
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", { name: /continue with google/i }),
+        );
+      });
 
       expect(mockGoogleLogin).toHaveBeenCalled();
     });
@@ -478,7 +602,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         expect(
@@ -486,7 +612,9 @@ describe("AuthModal", () => {
         ).toHaveTextContent(/continue with google/i);
       });
 
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+      });
 
       // Google button label stays consistent as "Continue with Google"
       await waitFor(() => {
@@ -502,7 +630,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         expect(
@@ -518,7 +648,9 @@ describe("AuthModal", () => {
       const user = userEvent.setup();
       renderWithProviders(<ModalTrigger />);
 
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await act(async () => {
+        await user.click(screen.getByRole("button", { name: /open modal/i }));
+      });
 
       await waitFor(() => {
         const termsLink = screen.getByRole("link", {
@@ -721,7 +853,9 @@ describe("AccountIcon", () => {
       expect(screen.getByLabelText(/log in/i)).toBeInTheDocument();
     });
 
-    await user.click(screen.getByLabelText(/log in/i));
+    await act(async () => {
+      await user.click(screen.getByLabelText(/log in/i));
+    });
 
     await waitFor(() => {
       expect(

--- a/packages/web/src/components/AuthModal/forms/LoginForm.test.tsx
+++ b/packages/web/src/components/AuthModal/forms/LoginForm.test.tsx
@@ -1,3 +1,4 @@
+import { act } from "react";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -26,8 +27,10 @@ describe("LogInForm", () => {
       renderSignInForm();
 
       const emailInput = screen.getByLabelText(/email/i);
-      await user.click(emailInput);
-      await user.type(emailInput, "invalid");
+      await act(async () => {
+        await user.click(emailInput);
+        await user.type(emailInput, "invalid");
+      });
 
       expect(
         screen.queryByText(/please enter a valid email address/i),
@@ -38,8 +41,10 @@ describe("LogInForm", () => {
       const user = userEvent.setup();
       renderSignInForm();
 
-      await user.type(screen.getByLabelText(/email/i), "invalid-email");
-      await user.tab();
+      await act(async () => {
+        await user.type(screen.getByLabelText(/email/i), "invalid-email");
+        await user.tab();
+      });
 
       await waitFor(() => {
         expect(
@@ -53,8 +58,10 @@ describe("LogInForm", () => {
       renderSignInForm();
 
       const emailInput = screen.getByLabelText(/email/i);
-      await user.type(emailInput, "invalid");
-      await user.tab();
+      await act(async () => {
+        await user.type(emailInput, "invalid");
+        await user.tab();
+      });
 
       await waitFor(() => {
         expect(
@@ -62,8 +69,10 @@ describe("LogInForm", () => {
         ).toBeInTheDocument();
       });
 
-      await user.click(emailInput);
-      await user.type(emailInput, "@example.com");
+      await act(async () => {
+        await user.click(emailInput);
+        await user.type(emailInput, "@example.com");
+      });
 
       await waitFor(() => {
         expect(
@@ -78,7 +87,9 @@ describe("LogInForm", () => {
       renderSignInForm();
 
       const form = screen.getByLabelText(/email/i).closest("form");
-      if (form) fireEvent.submit(form);
+      if (form) {
+        act(() => fireEvent.submit(form));
+      }
 
       await waitFor(() => {
         expect(screen.getByText(/email is required/i)).toBeInTheDocument();
@@ -90,7 +101,9 @@ describe("LogInForm", () => {
       renderSignInForm();
 
       const form = screen.getByLabelText(/email/i).closest("form");
-      if (form) fireEvent.submit(form);
+      if (form) {
+        act(() => fireEvent.submit(form));
+      }
 
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
@@ -99,9 +112,11 @@ describe("LogInForm", () => {
       const user = userEvent.setup();
       renderSignInForm();
 
-      await user.type(screen.getByLabelText(/email/i), "test@example.com");
-      await user.type(screen.getByLabelText(/password/i), "password123");
-      await user.click(screen.getByRole("button", { name: /^log in$/i }));
+      await act(async () => {
+        await user.type(screen.getByLabelText(/email/i), "test@example.com");
+        await user.type(screen.getByLabelText(/password/i), "password123");
+        await user.click(screen.getByRole("button", { name: /^log in$/i }));
+      });
 
       await waitFor(() => {
         expect(mockOnSubmit).toHaveBeenCalledWith({
@@ -115,9 +130,11 @@ describe("LogInForm", () => {
       const user = userEvent.setup();
       renderSignInForm();
 
-      await user.type(screen.getByLabelText(/email/i), "Test@Example.COM");
-      await user.type(screen.getByLabelText(/password/i), "password123");
-      await user.click(screen.getByRole("button", { name: /^log in$/i }));
+      await act(async () => {
+        await user.type(screen.getByLabelText(/email/i), "Test@Example.COM");
+        await user.type(screen.getByLabelText(/password/i), "password123");
+        await user.click(screen.getByRole("button", { name: /^log in$/i }));
+      });
 
       await waitFor(() => {
         expect(mockOnSubmit).toHaveBeenCalledWith({
@@ -140,8 +157,10 @@ describe("LogInForm", () => {
       const user = userEvent.setup();
       renderSignInForm();
 
-      await user.type(screen.getByLabelText(/email/i), "test@example.com");
-      await user.type(screen.getByLabelText(/password/i), "password123");
+      await act(async () => {
+        await user.type(screen.getByLabelText(/email/i), "test@example.com");
+        await user.type(screen.getByLabelText(/password/i), "password123");
+      });
 
       const submitButton = screen.getByRole("button", { name: /^log in$/i });
       expect(submitButton).not.toBeDisabled();
@@ -153,9 +172,11 @@ describe("LogInForm", () => {
       const user = userEvent.setup();
       renderSignInForm();
 
-      await user.click(
-        screen.getByRole("button", { name: /forgot password/i }),
-      );
+      await act(async () => {
+        await user.click(
+          screen.getByRole("button", { name: /forgot password/i }),
+        );
+      });
 
       expect(mockOnForgotPassword).toHaveBeenCalled();
     });

--- a/packages/web/src/components/AuthModal/hooks/useZodForm.test.tsx
+++ b/packages/web/src/components/AuthModal/hooks/useZodForm.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { act } from "react";
 import { z } from "zod";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -50,7 +50,9 @@ describe("useZodForm", () => {
     const user = userEvent.setup();
     render(<TestForm />);
 
-    await user.type(screen.getByLabelText(/email/i), "invalid");
+    await act(async () => {
+      await user.type(screen.getByLabelText(/email/i), "invalid");
+    });
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
@@ -58,8 +60,10 @@ describe("useZodForm", () => {
     const user = userEvent.setup();
     render(<TestForm />);
 
-    await user.type(screen.getByLabelText(/email/i), "invalid");
-    await user.tab();
+    await act(async () => {
+      await user.type(screen.getByLabelText(/email/i), "invalid");
+      await user.tab();
+    });
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/invalid email/i);
@@ -71,15 +75,19 @@ describe("useZodForm", () => {
     render(<TestForm />);
 
     const emailInput = screen.getByLabelText(/email/i);
-    await user.type(emailInput, "invalid");
-    await user.tab();
+    await act(async () => {
+      await user.type(emailInput, "invalid");
+      await user.tab();
+    });
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/invalid email/i);
     });
 
-    await user.click(emailInput);
-    await user.type(emailInput, "@example.com");
+    await act(async () => {
+      await user.click(emailInput);
+      await user.type(emailInput, "@example.com");
+    });
 
     await waitFor(() => {
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
@@ -90,7 +98,9 @@ describe("useZodForm", () => {
     render(<TestForm />);
 
     const form = screen.getByLabelText(/email/i).closest("form");
-    if (form) fireEvent.submit(form);
+    if (form) {
+      act(() => fireEvent.submit(form));
+    }
 
     await waitFor(() => {
       expect(screen.getByText(/email is required/i)).toBeInTheDocument();
@@ -107,8 +117,10 @@ describe("useZodForm", () => {
     const user = userEvent.setup();
     render(<TestForm />);
 
-    await user.type(screen.getByLabelText(/email/i), "test@example.com");
-    await user.type(screen.getByLabelText(/name/i), "Alex");
+    await act(async () => {
+      await user.type(screen.getByLabelText(/email/i), "test@example.com");
+      await user.type(screen.getByLabelText(/name/i), "Alex");
+    });
 
     expect(screen.getByRole("button", { name: /submit/i })).not.toBeDisabled();
   });

--- a/packages/web/src/components/DND/Draggable.tsx
+++ b/packages/web/src/components/DND/Draggable.tsx
@@ -47,14 +47,21 @@ function CompassDraggable(
   >,
   _ref: ForwardedRef<HTMLElement | null>,
 ) {
-  const { as, asChild, style, onContextMenu, children, ...elementProps } =
-    props;
+  const {
+    as,
+    asChild,
+    children,
+    dndProps,
+    onContextMenu,
+    style,
+    ...elementProps
+  } = props;
 
   const { setNodeRef, attributes, listeners, transform, isDragging, over } =
     useDraggable({
-      ...props.dndProps,
-      id: props.dndProps.id ?? new ObjectId().toString(),
-      disabled: props.dndProps.disabled ?? false,
+      ...dndProps,
+      id: dndProps.id ?? new ObjectId().toString(),
+      disabled: dndProps.disabled ?? false,
     });
 
   const ref = useMergeRefs([_ref, setNodeRef]);
@@ -82,7 +89,7 @@ function CompassDraggable(
         ...children.props,
         dndProps: {
           over,
-          id: props.dndProps.id,
+          id: dndProps.id,
           listeners,
           isDragging,
           setDisabled: undefined,

--- a/packages/web/src/views/Day/components/Shortcuts/ShortcutTip.test.tsx
+++ b/packages/web/src/views/Day/components/Shortcuts/ShortcutTip.test.tsx
@@ -1,3 +1,4 @@
+import { act } from "react";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -56,7 +57,9 @@ describe("ShortcutTip", () => {
     expect(screen.queryByText("C")).not.toBeInTheDocument();
 
     // Hover over button to show shortcut
-    await user.hover(button);
+    await act(async () => {
+      await user.hover(button);
+    });
     await waitFor(() => {
       expect(screen.getByText("C")).toBeInTheDocument();
     });
@@ -77,7 +80,9 @@ describe("ShortcutTip", () => {
     expect(screen.queryByText("Cmd + K")).not.toBeInTheDocument();
 
     // Hover over button to show shortcut
-    await user.hover(button);
+    await act(async () => {
+      await user.hover(button);
+    });
     await waitFor(() => {
       expect(screen.getByText("Cmd + K")).toBeInTheDocument();
     });
@@ -94,13 +99,17 @@ describe("ShortcutTip", () => {
     const button = screen.getByText("Test Button");
 
     // Hover to show shortcut
-    await user.hover(button);
+    await act(async () => {
+      await user.hover(button);
+    });
     await waitFor(() => {
       expect(screen.getByText("C")).toBeInTheDocument();
     });
 
     // Move mouse away to hide shortcut
-    await user.unhover(button);
+    await act(async () => {
+      await user.unhover(button);
+    });
     await waitFor(() => {
       expect(screen.queryByText("C")).not.toBeInTheDocument();
     });

--- a/packages/web/src/views/Day/components/Task/DraggableTask.test.tsx
+++ b/packages/web/src/views/Day/components/Task/DraggableTask.test.tsx
@@ -7,6 +7,19 @@ import { createMockTask } from "@web/__tests__/utils/factories/task.factory";
 import { DraggableTask } from "@web/views/Day/components/Task/DraggableTask";
 import { type TaskContext } from "@web/views/Day/context/TaskContext";
 
+jest.mock("@floating-ui/react", () => ({
+  autoUpdate: jest.fn(),
+  inline: jest.fn(() => ({})),
+  offset: jest.fn(() => ({})),
+  useFloating: jest.fn(() => ({
+    refs: {
+      setReference: jest.fn(),
+      setFloating: jest.fn(),
+    },
+    floatingStyles: {},
+  })),
+}));
+
 const mockTask = createMockTask({ _id: "task-1" });
 
 const defaultTasksProps: NonNullable<React.ContextType<typeof TaskContext>> = {
@@ -47,23 +60,17 @@ const renderDraggableTask = (
   index = 0,
   tasksProps = defaultTasksProps,
 ) => {
-  return act(() =>
-    render(
-      <DragDropContext onDragEnd={jest.fn()}>
-        <Droppable droppableId="test-droppable">
-          {(provided) => (
-            <div ref={provided.innerRef} {...provided.droppableProps}>
-              <DraggableTask
-                task={task}
-                index={index}
-                tasksProps={tasksProps}
-              />
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>,
-    ),
+  return render(
+    <DragDropContext onDragEnd={jest.fn()}>
+      <Droppable droppableId="test-droppable">
+        {(provided) => (
+          <div ref={provided.innerRef} {...provided.droppableProps}>
+            <DraggableTask task={task} index={index} tasksProps={tasksProps} />
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </DragDropContext>,
   );
 };
 
@@ -150,5 +157,9 @@ describe("DraggableTask", () => {
     });
 
     expect(dragHandle).toHaveClass("opacity-100");
+
+    act(() => {
+      fireEvent.mouseUp(dragHandle);
+    });
   });
 });

--- a/packages/web/src/views/Day/components/Task/DraggableTask.tsx
+++ b/packages/web/src/views/Day/components/Task/DraggableTask.tsx
@@ -7,6 +7,25 @@ import { getStyle } from "@web/views/Calendar/components/Sidebar/SomedayTab/Some
 import { Task } from "@web/views/Day/components/Task/Task";
 import { type useTasks } from "@web/views/Day/hooks/tasks/useTasks";
 
+function getFiniteFloatingStyles(
+  styles: ReturnType<typeof useFloating>["floatingStyles"],
+) {
+  const nextStyles = { ...styles };
+
+  if (
+    typeof nextStyles.left === "number" &&
+    !Number.isFinite(nextStyles.left)
+  ) {
+    delete nextStyles.left;
+  }
+
+  if (typeof nextStyles.top === "number" && !Number.isFinite(nextStyles.top)) {
+    delete nextStyles.top;
+  }
+
+  return nextStyles;
+}
+
 export function DraggableTask({
   task,
   index,
@@ -67,7 +86,11 @@ export function DraggableTask({
             <button
               {...draggableProvider.dragHandleProps}
               ref={isFloatingEnabled ? refs.setFloating : undefined}
-              style={isFloatingEnabled ? floatingStyles : undefined}
+              style={
+                isFloatingEnabled
+                  ? getFiniteFloatingStyles(floatingStyles)
+                  : undefined
+              }
               aria-label={`Reorder ${task.title}`}
               aria-describedby={`description-${task._id}`}
               onFocus={() => setSelectedTaskIndex(index)}

--- a/packages/web/src/views/Day/view/DayView.route.test.tsx
+++ b/packages/web/src/views/Day/view/DayView.route.test.tsx
@@ -5,6 +5,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import dayjs from "@core/util/date/dayjs";
 import { render } from "@web/__tests__/__mocks__/mock.render";
+import { prepareEmptyStorageForTests } from "@web/__tests__/utils/storage/indexeddb.test.util";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import {
   loadDayData,
@@ -84,7 +85,10 @@ describe("TodayView Routing", () => {
       );
       return actual.useDayViewShortcuts(config);
     });
-    localStorage.clear();
+  });
+
+  beforeEach(async () => {
+    await prepareEmptyStorageForTests();
   });
 
   it("should show today's date when navigating to /day", async () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -18,6 +18,7 @@ test("start date picker opens and then closes when clicking the end input", asyn
   const mockOnSubmit = jest.fn();
   const mockSetEvent = jest.fn();
   const mockOnDelete = jest.fn();
+  const user = userEvent.setup({ skipHover: true });
 
   render(
     <div>
@@ -34,14 +35,14 @@ test("start date picker opens and then closes when clicking the end input", asyn
     </div>,
   );
 
-  await _clickStartInput();
+  await _clickStartInput(user);
 
   // Check if the date picker is open
   expect(
     screen.getByRole("combobox", { name: /datepicker/i }),
   ).toBeInTheDocument();
 
-  await _clickEndInput();
+  await _clickEndInput(user);
 
   // Check if the date picker is closed
   expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
@@ -61,6 +62,7 @@ test("should call onConvert when meta+< (meta + shift + comma) keyboard shortcut
   const mockSetEvent = jest.fn();
 
   const mockOnDelete = jest.fn();
+  const user = userEvent.setup({ skipHover: true });
 
   render(
     <div>
@@ -81,9 +83,7 @@ test("should call onConvert when meta+< (meta + shift + comma) keyboard shortcut
   expect(screen.getByRole("form")).toBeInTheDocument();
 
   await act(async () => {
-    // Simulate pressing & holding control then shift then left arrow
-
-    await userEvent.keyboard("{Control>}{Meta>}{ArrowLeft}");
+    await user.keyboard("{Control>}{Meta>}{ArrowLeft}");
   });
 
   expect(mockOnConvert).toHaveBeenCalledTimes(1);
@@ -107,6 +107,7 @@ test("should call onDuplicate when meta+d keyboard shortcut is used", async () =
   const mockSetEvent = jest.fn();
   const mockOnDelete = jest.fn();
   const mockOnDuplicate = jest.fn();
+  const user = userEvent.setup({ skipHover: true });
 
   render(
     <div>
@@ -128,8 +129,7 @@ test("should call onDuplicate when meta+d keyboard shortcut is used", async () =
   expect(screen.getByRole("form")).toBeInTheDocument();
 
   await act(async () => {
-    // Simulate pressing Meta + d
-    await userEvent.keyboard("{Meta>}d{/Meta}");
+    await user.keyboard("{Meta>}d{/Meta}");
   });
 
   expect(mockOnDuplicate).toHaveBeenCalledTimes(1);
@@ -142,7 +142,7 @@ test("should call onDuplicate when meta+d keyboard shortcut is used", async () =
 });
 
 test("should call duplicateEvent when duplicate icon btn is clicked", async () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ skipHover: true });
 
   const sampleEvent: Schema_Event = {
     _id: "event123",
@@ -190,7 +190,9 @@ test("should call duplicateEvent when duplicate icon btn is clicked", async () =
   await waitFor(() => {
     expect(screen.getByText("Duplicate Event")).toBeInTheDocument();
   });
-  await user.click(screen.getByText("Duplicate Event"));
+  await act(async () => {
+    await user.click(screen.getByText("Duplicate Event"));
+  });
 
   expect(mockOnDuplicate).toHaveBeenCalledTimes(1);
   expect(mockOnDuplicate).toHaveBeenCalledWith(sampleEvent);
@@ -206,20 +208,20 @@ test("should call duplicateEvent when duplicate icon btn is clicked", async () =
   expect(mockOnConvert).not.toHaveBeenCalled();
 });
 
-const _clickStartInput = async () => {
+const _clickStartInput = async (user: ReturnType<typeof userEvent.setup>) => {
   const startDateInput = screen.getByRole("textbox", {
     name: /pick start date/i,
   });
   await act(async () => {
-    await userEvent.click(startDateInput);
+    await user.click(startDateInput);
   });
 };
 
-const _clickEndInput = async () => {
+const _clickEndInput = async (user: ReturnType<typeof userEvent.setup>) => {
   const endDateInput = screen.getByRole("textbox", {
     name: /pick end date/i,
   });
   await act(async () => {
-    await userEvent.click(endDateInput);
+    await user.click(endDateInput);
   });
 };

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.test.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.test.ts
@@ -18,16 +18,19 @@ jest.mock("@web/ducks/events/slices/event.slice", () => ({
     actions: {
       request: jest.fn(),
     },
+    reducer: jest.fn(() => ({})),
   },
   editEventSlice: {
     actions: {
       request: jest.fn(),
     },
+    reducer: jest.fn(() => ({})),
   },
   deleteEventSlice: {
     actions: {
       request: jest.fn(),
     },
+    reducer: jest.fn(() => ({})),
   },
   eventsEntitiesSlice: {
     reducer: jest.fn(() => ({})),

--- a/packages/web/src/views/Now/components/NowCmdPalette.test.tsx
+++ b/packages/web/src/views/Now/components/NowCmdPalette.test.tsx
@@ -1,10 +1,58 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { act } from "react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { render } from "@web/__tests__/__mocks__/mock.render";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
 import { NowCmdPalette } from "@web/views/Now/components/NowCmdPalette";
 
+jest.mock("react-cmdk", () => {
+  const React = require("react");
+
+  const CommandPalette = ({
+    children,
+    isOpen,
+    onChangeSearch,
+    placeholder,
+    search,
+  }: any) => {
+    if (!isOpen) {
+      return null;
+    }
+
+    return (
+      <div>
+        <input
+          onChange={(event) => onChangeSearch(event.target.value)}
+          placeholder={placeholder}
+          value={search}
+        />
+        {children}
+      </div>
+    );
+  };
+
+  CommandPalette.Page = ({ children }: any) => <div>{children}</div>;
+  CommandPalette.List = ({ children, heading }: any) => (
+    <section>
+      <h2>{heading}</h2>
+      {children}
+    </section>
+  );
+  CommandPalette.ListItem = ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  );
+  CommandPalette.FreeSearchAction = () => <div>No results</div>;
+
+  return {
+    __esModule: true,
+    default: CommandPalette,
+    filterItems: (items: unknown) => items,
+    getItemIndex: () => 0,
+  };
+});
+
 // Mock pressKey
 jest.mock("@web/common/utils/dom/event-emitter.util", () => ({
+  ...jest.requireActual("@web/common/utils/dom/event-emitter.util"),
   pressKey: jest.fn(),
 }));
 
@@ -70,28 +118,28 @@ describe("NowCmdPalette", () => {
     expect(screen.getByText("Log Out [z]")).toBeInTheDocument();
   });
 
-  it("should trigger pressKey('d') when 'Go to Day' is clicked", () => {
+  it("should trigger pressKey('d') when 'Go to Day' is clicked", async () => {
     render(<NowCmdPalette />, { state: initialState });
-    fireEvent.click(screen.getByText("Go to Day [d]"));
-    expect(pressKey).toHaveBeenCalledWith("d");
+    act(() => fireEvent.click(screen.getByText("Go to Day [d]")));
+    await waitFor(() => expect(pressKey).toHaveBeenCalledWith("d"));
   });
 
-  it("should trigger pressKey('w') when 'Go to Week' is clicked", () => {
+  it("should trigger pressKey('w') when 'Go to Week' is clicked", async () => {
     render(<NowCmdPalette />, { state: initialState });
-    fireEvent.click(screen.getByText("Go to Week [w]"));
-    expect(pressKey).toHaveBeenCalledWith("w");
+    act(() => fireEvent.click(screen.getByText("Go to Week [w]")));
+    await waitFor(() => expect(pressKey).toHaveBeenCalledWith("w"));
   });
 
-  it("should trigger pressKey('r') when 'Edit Reminder' is clicked", () => {
+  it("should trigger pressKey('r') when 'Edit Reminder' is clicked", async () => {
     render(<NowCmdPalette />, { state: initialState });
-    fireEvent.click(screen.getByText("Edit Reminder [r]"));
-    expect(pressKey).toHaveBeenCalledWith("r");
+    act(() => fireEvent.click(screen.getByText("Edit Reminder [r]")));
+    await waitFor(() => expect(pressKey).toHaveBeenCalledWith("r"));
   });
 
-  it("should trigger pressKey('z') when 'Log Out' is clicked", () => {
+  it("should trigger pressKey('z') when 'Log Out' is clicked", async () => {
     render(<NowCmdPalette />, { state: initialState });
-    fireEvent.click(screen.getByText("Log Out [z]"));
-    expect(pressKey).toHaveBeenCalledWith("z");
+    act(() => fireEvent.click(screen.getByText("Log Out [z]")));
+    await waitFor(() => expect(pressKey).toHaveBeenCalledWith("z"));
   });
 
   describe("Google Calendar authentication status", () => {
@@ -119,20 +167,19 @@ describe("NowCmdPalette", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("triggers login when 'Connect Google Calendar' is clicked and not authenticated", () => {
+    it("triggers login when 'Connect Google Calendar' is clicked and not authenticated", async () => {
       mockAuthenticated = false;
       render(<NowCmdPalette />, { state: initialState });
 
-      fireEvent.click(screen.getByText("Connect Google Calendar"));
-
-      expect(mockLogin).toHaveBeenCalled();
+      act(() => fireEvent.click(screen.getByText("Connect Google Calendar")));
+      await waitFor(() => expect(mockLogin).toHaveBeenCalled());
     });
 
-    it("does not trigger login when 'Google Calendar Connected' is clicked", () => {
+    it("does not trigger login when 'Google Calendar Connected' is clicked", async () => {
       mockAuthenticated = true;
       render(<NowCmdPalette />, { state: initialState });
 
-      fireEvent.click(screen.getByText("Google Calendar Connected"));
+      act(() => fireEvent.click(screen.getByText("Google Calendar Connected")));
 
       expect(mockLogin).not.toHaveBeenCalled();
     });

--- a/packages/web/src/views/Now/view/NowView.test.tsx
+++ b/packages/web/src/views/Now/view/NowView.test.tsx
@@ -10,6 +10,18 @@ jest.mock("../shortcuts/useNowShortcuts", () => ({
   useNowShortcuts: jest.fn(),
 }));
 
+jest.mock("@web/views/Now/view/NowViewContent", () => ({
+  NowViewContent: () => <div data-testid="now-view-content" />,
+}));
+
+jest.mock("@web/views/Now/hooks/useAvailableTasks", () => ({
+  useAvailableTasks: () => ({
+    availableTasks: [],
+    allTasks: [],
+    hasCompletedTasks: false,
+  }),
+}));
+
 describe("NowView", () => {
   it("renders the shortcuts overlay", async () => {
     await renderWithMemoryRouter(<NowView />, [ROOT_ROUTES.NOW]);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly test-only churn, but it also changes runtime behavior in `useVersionCheck` (absolute/SSR-safe URL) and drag-handle styling (filters invalid floating coordinates), which could affect update polling and task reordering UI positioning.
> 
> **Overview**
> **Reduces web test flakiness/warnings and tightens test harness behavior.** Jest/MSW setup is updated to fail on unhandled requests, mock `/version.json`, and standardize token/cookie response mocking.
> 
> Updates `useVersionCheck` to build an absolute, SSR-safe `version.json` URL, and hardens drag-handle rendering by stripping non-finite `@floating-ui` positioning values. A broad set of web tests are adjusted to wrap interactions in `act`, use consistent `userEvent` instances (often with `skipHover`), and add missing mocks (e.g., `react-cmdk`, `@floating-ui/react`, IndexedDB storage reset, slice reducers) to eliminate React/Jest warnings.
> 
> Also adds a repo-local Yarn cache (`.yarn-cache/`) and tweaks root test scripts to invoke the local `jest` binary explicitly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bbb02693541797f2e17249c398ff3e928291ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


.yarn-cache/ is a repo-local cache directory for Yarn v1 package tarballs and metadata.

Without it, Yarn uses a global cache location under the user account. In some CI/sandboxed environments that location is unavailable or unwritable, which causes noisy fallback/cache warnings during commands like yarn test web.

With:

[.yarnrc](app://-/index.html?hostId=local#)
[.gitignore](app://-/index.html?hostId=local#)
Yarn is told to use .yarn-cache/ inside the repo, and that directory is ignored by git. It does not change app behavior or dependencies; it only changes where Yarn stores its downloaded cache so commands run quietly and predictably.