### PR TITLE
feat: add SidebarIconRow component for calendar sidebar navigation

### DIFF
--- a/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.tsx
@@ -24,6 +24,7 @@ import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import {
   IconRow,
   LeftIconGroup,
+  RightIconGroup,
 } from "@web/views/Calendar/components/Sidebar/styled";
 
 const getGoogleStatusIcon = ({
@@ -112,19 +113,6 @@ export const SidebarIconRow = () => {
     <IconRow>
       <LeftIconGroup>
         <TooltipWrapper
-          description="Open command palette"
-          shortcut={getCommandPaletteShortcut()}
-          onClick={toggleCmdPalette}
-        >
-          <CommandIcon
-            color={
-              isCmdPaletteOpen
-                ? theme.color.text.darkPlaceholder
-                : theme.color.text.light
-            }
-          />
-        </TooltipWrapper>
-        <TooltipWrapper
           description="Open tasks"
           shortcut="SHIFT + 1"
           onClick={() => dispatch(viewSlice.actions.updateSidebarTab("tasks"))}
@@ -152,6 +140,21 @@ export const SidebarIconRow = () => {
             }
           />
         </TooltipWrapper>
+      </LeftIconGroup>
+      <RightIconGroup>
+        <TooltipWrapper
+          description="Open command palette"
+          shortcut={getCommandPaletteShortcut()}
+          onClick={toggleCmdPalette}
+        >
+          <CommandIcon
+            color={
+              isCmdPaletteOpen
+                ? theme.color.text.light
+                : theme.color.text.darkPlaceholder
+            }
+          />
+        </TooltipWrapper>
         <TooltipWrapper
           description={sidebarStatus.tooltip}
           disabled={sidebarStatus.isDisabled}
@@ -172,7 +175,7 @@ export const SidebarIconRow = () => {
             <RefreshIcon color={theme.color.text.accent} />
           </TooltipWrapper>
         ) : undefined}
-      </LeftIconGroup>
+      </RightIconGroup>
     </IconRow>
   );
 };

--- a/packages/web/src/views/Calendar/components/Sidebar/styled.ts
+++ b/packages/web/src/views/Calendar/components/Sidebar/styled.ts
@@ -47,12 +47,18 @@ export const IconRow = styled(Flex)<SectionProps>`
   border-top: 1px solid ${({ theme }) => theme.color.border.primary};
   height: ${ICON_ROW_HEIGHT}px;
   flex-direction: ${FlexDirections.ROW};
+  justify-content: space-between;
   padding: 0 25px;
   position: absolute;
   width: 100%;
 `;
 
 export const LeftIconGroup = styled.div`
+  gap: 20px;
+  display: flex;
+`;
+
+export const RightIconGroup = styled.div`
   gap: 20px;
   display: flex;
 `;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only layout change that repositions icons and tweaks active color styling; no data flow or backend behavior changes.
> 
> **Overview**
> Reorganizes the calendar sidebar icon row into **left** (navigation: Tasks/Month) and **right** (command palette, Google sync status, import spinner, update refresh) groups, spacing them with `justify-content: space-between`.
> 
> Moves the command palette button from the left group to the right and adjusts its active/inactive icon color to match the new grouping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9b8523a84e3b20b29ee4fbbfdedecfd89de1557. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->