### PR TITLE
chore: cleanup datepicker and connection tone

### DIFF
--- a/docs/development/coding-conventions.md
+++ b/docs/development/coding-conventions.md
@@ -17,6 +17,11 @@ This document keeps only the local conventions that are useful to repeat inside 
 - Add comments only when they explain non-obvious behavior, constraints, or cross-file coupling.
 - If a flow needs more than a short code comment, prefer a repo doc and link to it.
 
+## Frontend: one component per file
+
+- Put each React component in its own file. Do not define multiple components in the same module (for example, a screen-level component plus a small presentational subcomponent used only there).
+- **Example:** If `DatePicker` uses a `MonthNavButton`, use `DatePicker.tsx` and `MonthNavButton.tsx` (typically in the same directory), instead of defining both in `DatePicker.tsx`.
+
 ## Cleanup
 
 - Do not add dead code, speculative scaffolding, or half-implemented branches.

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
@@ -15,7 +15,6 @@ export type GoogleUiConfig = {
   };
   sidebarStatus: {
     tooltip: string;
-    tone?: "default" | "warning";
     isDisabled: boolean;
     iconColor?: IconColor;
     dialog?: {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -6,6 +6,7 @@ import {
 } from "./useConnectGoogle.types";
 
 const COMMAND_ICON: CommandActionIcon = "CloudArrowUpIcon";
+type RepairDialog = NonNullable<GoogleUiConfig["sidebarStatus"]["dialog"]>;
 
 export const buildGoogleConnectRequest = (
   redirectURIInfo: GoogleAuthCodeRequest["redirectURIInfo"],
@@ -13,6 +14,14 @@ export const buildGoogleConnectRequest = (
   thirdPartyId: "google",
   clientType: "web",
   redirectURIInfo,
+});
+
+const buildRepairDialog = (onRepairGoogle: () => void): RepairDialog => ({
+  title: "Calendar sync needs repair",
+  description:
+    "Your Google Calendar has run into a sync issue. Repairing will re-import your recent events to make sure everything is up to date.",
+  repairLabel: "Repair",
+  onRepair: onRepairGoogle,
 });
 
 export const getGoogleConnectionConfig = (
@@ -30,7 +39,6 @@ export const getGoogleConnectionConfig = (
         },
         sidebarStatus: {
           tooltip: "Checking Google Calendar status…",
-          tone: "default",
           isDisabled: true,
         },
       };
@@ -44,15 +52,8 @@ export const getGoogleConnectionConfig = (
         sidebarStatus: {
           iconColor: "warning",
           tooltip: "Repairing Google Calendar in the background.",
-          tone: "warning",
           isDisabled: true,
-          dialog: {
-            title: "Calendar sync needs repair",
-            description:
-              "Your Google Calendar has run into a sync issue. Repairing will re-import your recent events to make sure everything is up to date.",
-            repairLabel: "Repair",
-            onRepair: onRepairGoogle,
-          },
+          dialog: buildRepairDialog(onRepairGoogle),
         },
       };
     case "NOT_CONNECTED":
@@ -66,7 +67,6 @@ export const getGoogleConnectionConfig = (
         sidebarStatus: {
           iconColor: "muted",
           tooltip: "Google Calendar not connected. Click to connect.",
-          tone: "default",
           isDisabled: false,
           onSelect: onConnectGoogle,
         },
@@ -82,7 +82,6 @@ export const getGoogleConnectionConfig = (
         sidebarStatus: {
           iconColor: "error",
           tooltip: "Google Calendar needs reconnecting. Click to reconnect.",
-          tone: "default",
           isDisabled: false,
           onSelect: onConnectGoogle,
         },
@@ -96,7 +95,6 @@ export const getGoogleConnectionConfig = (
         },
         sidebarStatus: {
           tooltip: "Google Calendar is syncing in the background.",
-          tone: "default",
           isDisabled: true,
         },
       };
@@ -111,15 +109,8 @@ export const getGoogleConnectionConfig = (
         sidebarStatus: {
           iconColor: "warning",
           tooltip: "Google Calendar needs repair. Click to repair.",
-          tone: "warning",
           isDisabled: false,
-          dialog: {
-            title: "Calendar sync needs repair",
-            description:
-              "Your Google Calendar has run into a sync issue. Repairing will re-import your recent events to make sure everything is up to date.",
-            repairLabel: "Repair",
-            onRepair: onRepairGoogle,
-          },
+          dialog: buildRepairDialog(onRepairGoogle),
         },
       };
     case "HEALTHY":
@@ -132,7 +123,6 @@ export const getGoogleConnectionConfig = (
         sidebarStatus: {
           iconColor: "muted",
           tooltip: "Google Calendar connected.",
-          tone: "default",
           isDisabled: true,
         },
       };

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -5,6 +5,7 @@ import ReactDatePicker, { type ReactDatePickerProps } from "react-datepicker";
 import { darken, isDark } from "@core/util/color.utils";
 import dayjs from "@core/util/date/dayjs";
 import { theme } from "@web/common/styles/theme";
+import { MonthNavButton } from "@web/components/DatePicker/MonthNavButton";
 import {
   ChangeDayButtonsStyledFlex,
   MonthContainerStyled,
@@ -26,7 +27,6 @@ export interface Props extends ReactDatePickerProps {
   displayDate?: Date;
   inputColor?: string;
   isOpen?: boolean;
-  onInputBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   view: "sidebar" | "grid";
   withTodayButton?: boolean;
 }
@@ -35,21 +35,18 @@ export interface CalendarRef extends HTMLDivElement {
   input: HTMLInputElement;
 }
 
-export const DatePicker: React.FC<Props> = ({
-  animationOnToggle = true,
-  autoFocus: _autoFocus = false,
-  bgColor = theme.color.bg.primary,
-  calendarClassName,
-  inputColor,
-  isOpen = true,
-  onSelect = () => null,
-  onInputBlur,
-  onCalendarClose = () => null,
-  onCalendarOpen = () => null,
-  view,
-  withTodayButton = true,
-  ...props
-}) => {
+export const DatePicker: React.FC<Props> = (datePickerProps) => {
+  const {
+    animationOnToggle = true,
+    autoFocus: _autoFocus = false,
+    bgColor = theme.color.bg.primary,
+    calendarClassName,
+    inputColor,
+    isOpen = true,
+    view,
+    withTodayButton = true,
+    ...props
+  } = datePickerProps;
   const datepickerRef = useRef<CalendarRef>(null);
   const headerColor =
     view === "sidebar"
@@ -95,29 +92,26 @@ export const DatePicker: React.FC<Props> = ({
       dateFormat={"M-d-yyyy"}
       formatWeekDay={(day) => day[0]}
       open={isOpen}
+      {...props}
       onCalendarOpen={() => {
-        onCalendarOpen();
+        datePickerProps.onCalendarOpen?.();
       }}
       onCalendarClose={() => {
-        onCalendarClose();
+        datePickerProps.onCalendarClose?.();
       }}
       onClickOutside={() => {
-        onCalendarClose();
+        datePickerProps.onCalendarClose?.();
       }}
       onSelect={(date, event: React.SyntheticEvent<Event> | undefined) => {
-        onSelect(date, event);
+        datePickerProps.onSelect?.(date, event);
       }}
       portalId="root"
-      ref={datepickerRef as any}
+      ref={(instance) => {
+        datepickerRef.current = instance as unknown as CalendarRef | null;
+      }}
       showPopperArrow={false}
-      renderCustomHeader={({
-        monthDate,
-        increaseMonth,
-        decreaseMonth,
-        changeMonth,
-        changeYear,
-        customHeaderCount,
-      }) => {
+      renderCustomHeader={(headerProps) => {
+        const { customHeaderCount, monthDate } = headerProps;
         const selectedMonth = dayjs(monthDate).format("MMM YYYY");
         const currentMonth = dayjs().format("MMM YYYY");
 
@@ -135,66 +129,32 @@ export const DatePicker: React.FC<Props> = ({
             {!customHeaderCount && (
               <Flex alignItems={AlignItems.CENTER}>
                 <ChangeDayButtonsStyledFlex>
-                  <button
-                    onClick={decreaseMonth}
-                    aria-label="Previous month"
-                    onMouseEnter={(e) =>
-                      (e.currentTarget.style.backgroundColor =
-                        "rgba(255,255,255,0.2)")
-                    }
-                    onMouseLeave={(e) =>
-                      (e.currentTarget.style.backgroundColor = "transparent")
-                    }
-                    style={{
-                      cursor: "pointer",
-                      color: headerColor,
-                      background: "transparent",
-                      border: "none",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      width: "24px",
-                      height: "24px",
-                      borderRadius: "50%",
-                      transition: "background-color 0.2s",
+                  <MonthNavButton
+                    ariaLabel="Previous month"
+                    color={headerColor}
+                    onClick={() => {
+                      headerProps.decreaseMonth();
                     }}
                   >
                     <ChevronLeftIcon />
-                  </button>
-                  <button
-                    onClick={increaseMonth}
-                    aria-label="Next month"
-                    onMouseEnter={(e) =>
-                      (e.currentTarget.style.backgroundColor =
-                        "rgba(255,255,255,0.2)")
-                    }
-                    onMouseLeave={(e) =>
-                      (e.currentTarget.style.backgroundColor = "transparent")
-                    }
-                    style={{
-                      cursor: "pointer",
-                      color: headerColor,
-                      background: "transparent",
-                      border: "none",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      width: "24px",
-                      height: "24px",
-                      borderRadius: "50%",
-                      transition: "background-color 0.2s",
+                  </MonthNavButton>
+                  <MonthNavButton
+                    ariaLabel="Next month"
+                    color={headerColor}
+                    onClick={() => {
+                      headerProps.increaseMonth();
                     }}
                   >
                     <ChevronRightIcon />
-                  </button>
+                  </MonthNavButton>
                 </ChangeDayButtonsStyledFlex>
                 {withTodayButton && (
                   <TodayStyledText
                     isCurrentDate={currentMonth === selectedMonth}
                     cursor="pointer"
                     onClick={() => {
-                      changeMonth(dayjs().month());
-                      changeYear(dayjs().year());
+                      headerProps.changeMonth(dayjs().month());
+                      headerProps.changeYear(dayjs().year());
                     }}
                     color={theme.color.text.light}
                     size="l"
@@ -207,7 +167,6 @@ export const DatePicker: React.FC<Props> = ({
           </StyledHeaderFlex>
         );
       }}
-      {...props}
     />
   );
 };

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -43,6 +43,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
     calendarClassName,
     inputColor,
     isOpen = true,
+    portalId = "root",
     view,
     withTodayButton = true,
     ...props
@@ -105,7 +106,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
       onSelect={(date, event: React.SyntheticEvent<Event> | undefined) => {
         datePickerProps.onSelect?.(date, event);
       }}
-      portalId="root"
+      portalId={portalId}
       ref={(instance) => {
         datepickerRef.current = instance as unknown as CalendarRef | null;
       }}

--- a/packages/web/src/components/DatePicker/MonthNavButton.tsx
+++ b/packages/web/src/components/DatePicker/MonthNavButton.tsx
@@ -1,0 +1,44 @@
+import type React from "react";
+
+const MONTH_NAV_BUTTON_HOVER_COLOR = "rgba(255,255,255,0.2)";
+
+type MonthNavButtonProps = {
+  ariaLabel: string;
+  children: React.ReactNode;
+  color: string;
+  onClick: () => void;
+};
+
+export const MonthNavButton = ({
+  ariaLabel,
+  children,
+  color,
+  onClick,
+}: MonthNavButtonProps) => (
+  <button
+    aria-label={ariaLabel}
+    onClick={onClick}
+    onMouseEnter={(e) => {
+      e.currentTarget.style.backgroundColor = MONTH_NAV_BUTTON_HOVER_COLOR;
+    }}
+    onMouseLeave={(e) => {
+      e.currentTarget.style.backgroundColor = "transparent";
+    }}
+    style={{
+      cursor: "pointer",
+      color,
+      background: "transparent",
+      border: "none",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      width: "24px",
+      height: "24px",
+      borderRadius: "50%",
+      transition: "background-color 0.2s",
+    }}
+    type="button"
+  >
+    {children}
+  </button>
+);


### PR DESCRIPTION
- Removed the optional `tone` property from the sidebar status in the Google UI configuration to streamline state management.
- Introduced a new `buildRepairDialog` function to encapsulate repair dialog creation, enhancing code clarity and reusability.
- Updated the `getGoogleConnectionConfig` function to utilize the new repair dialog logic, improving user interaction during repair processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/config refactors that mainly remove unused state and extract small helpers; behavior should be unchanged aside from potential minor DatePicker event/portalId handling differences.
> 
> **Overview**
> Streamlines Google Calendar connection UI config by removing `sidebarStatus.tone` and extracting a reusable `buildRepairDialog` helper used by the *repairing* and *attention* states.
> 
> Refactors `DatePicker` to be more prop-driven (defaulting `portalId`, calling callbacks via optional chaining, and updating the ref assignment) and extracts the month navigation buttons into a new `MonthNavButton` component. Adds a coding convention doc rule enforcing *one React component per file*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40c036478142b36452186d6a4d9f1aab8c55274d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->