### PR TITLE
refactor(config): migrate runtime and build flows to bun

### DIFF
--- a/.cursorrules/development.md
+++ b/.cursorrules/development.md
@@ -18,7 +18,8 @@ bun install
 - Takes ~3.5 minutes
 - NEVER CANCEL the installation
 - Set timeout to 10+ minutes
-- Bun manages dependencies and script entrypoints; Node 24+ still runs the backend, CLI, Jest, and webpack processes
+- Bun is the primary install/runtime entrypoint. `bun run cli`, `bun run dev:backend`, and `bun run test:core` execute directly through Bun.
+- Node 24+ is still required for retained tooling such as the web/backend/scripts Jest suites and the production Node build output
 
 ### Environment Configuration
 

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           TZ: ${{ vars.TZ }}
         run: |
-          bun run test ${{ matrix.project }}
+          bun run test:${{ matrix.project }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,8 @@ Example: `import { foo } from '@compass/core'` not `import { foo } from '../../.
 
 - Install dependencies: `bun install`
   - Takes ~3.5 minutes. Set timeout to 10+ minutes.
-  - Bun manages dependencies and script entrypoints; Node 24+ still runs the backend, CLI, Jest, and webpack processes.
+  - Bun is the primary install/runtime entrypoint. `bun run cli`, `bun run dev:backend`, core tests, and build packaging now execute through Bun directly.
+  - Node 24+ is still required for retained tooling: the web/backend/scripts Jest suites and the production Node build output.
 - Copy environment template: `cp packages/backend/.env.local.example packages/backend/.env.local`
 
 ### Development Servers
@@ -84,7 +85,7 @@ Example: `import { foo } from '@compass/core'` not `import { foo } from '../../.
 
 ### Testing
 
-Run `bun run test:core`, `bun run test:web`, and `bun run test:backend` after making changes. Use `bun run test:scripts` for scripts package tests. Avoid `bun run test` (full suite) in restricted network environments—MongoDB binary download may fail.
+Run `bun run test:core`, `bun run test:web`, and `bun run test:backend` after making changes. Use `bun run test:scripts` for scripts package tests. The current test strategy is hybrid: `test:core` uses `bun test`, while `test:web`, `test:backend`, and `test:scripts` still route to the retained Jest harness. Avoid `bun run test` (full suite) in restricted network environments—MongoDB binary download may fail.
 
 #### Writing Tests in `@compass/web`
 
@@ -101,6 +102,7 @@ Run `bun run test:core`, `bun run test:web`, and `bun run test:backend` after ma
 - **Backend tests**: `bun run test:backend`
 - **Scripts tests**: `bun run test:scripts`
 - **Full test suite**: `bun run test`
+- `test:core` is Bun-native; the other package test commands intentionally retain Jest for now.
 
 ### Building
 
@@ -162,8 +164,8 @@ packages/core/src/
 ### Repository Operations
 
 - `bun install` - 3.5 minutes
-- `bun run test:core` - ~2 seconds (all pass)
-- `bun run test:web` - ~15 seconds (all pass)
+- `bun run test:core` - ~2 seconds (Bun test, all pass)
+- `bun run test:web` - ~15 seconds (retained Jest suite, all pass)
 - `bun run test:backend` - ~15 seconds (all pass)
 - `bun run test:scripts` - scripts package tests
 - `bun run dev:web` - ~10 seconds to start
@@ -194,7 +196,8 @@ packages/core/src/
 
 ### CI/CD Integration
 
-- GitHub Actions unit tests run in `.github/workflows/test-unit.yml` as a matrix (`core`, `web`, `backend`, `scripts`) using `bun run test <project>` on `push`.
+- GitHub Actions unit tests run in `.github/workflows/test-unit.yml` as a matrix (`core`, `web`, `backend`, `scripts`) using `bun run test:<project>` on `push`.
+- The root test dispatcher keeps the current hybrid model: core runs through `bun test`, and web/backend/scripts use the retained Jest harness.
 - End-to-end tests run separately in `.github/workflows/test-e2e.yml` on pull requests to `main`.
 
 ## Troubleshooting
@@ -223,8 +226,8 @@ packages/core/src/
 ### Root Level Commands
 
 - `bun run cli [command]` - Access CLI tools for build, seed, delete operations
-- `bun run dev:web` - Start webpack dev server
-- `bun run dev:backend` - Start backend server (requires full environment)
+- `bun run dev:web` - Start the Bun-wrapped webpack dev server
+- `bun run dev:backend` - Start the backend directly with Bun watch mode (requires full environment)
 - `bun run test` - Run all tests (fails in restricted environments)
 - `bun run test:core` - Run core package tests only
 - `bun run test:web` - Run web package tests only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This section provides specific guidelines for AI coding agents working on Compas
    bun run dev:web  # Verify frontend works
    ```
 
-   Bun is the package manager for this repo. Node.js 24+ is still required because the app runtime and current tooling execute on Node.
+   Bun is the primary package manager and command runner for this repo. Node.js 24+ is still required for retained tooling such as the web/backend/scripts Jest suites and the production Node build output.
 
 3. **Understand the Codebase**
    - Use `bun run ai:index` to generate semantic search index
@@ -244,7 +244,7 @@ The `ai-tools/` directory contains helper scripts:
 Run any tool with:
 
 ```bash
-bunx ts-node ai-tools/<script-name>.ts
+bun ai-tools/<script-name>.ts
 ```
 
 ### Resources for AI Agents

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ We're actively working on improvements – check out our [roadmap](https://githu
 - **Frontend**: React, Redux, Tailwind CSS, TypeScript, Webpack
 - **Backend**: Node.js, Express, TypeScript, MongoDB
 - **Integrations**: Google Calendar API, Google OAuth2, Socket.io
-- **Testing**: Jest, React Testing Library
-- **Other**: Bun for package management and Node.js for runtime/tooling
+- **Testing**: Bun test (core), retained Jest suites (web/backend/scripts), React Testing Library, Playwright
+- **Other**: Bun is the primary install/runtime/build entrypoint; webpack and Playwright are intentionally retained
 
 ## Getting Started
 
@@ -65,7 +65,7 @@ Want to poke around or self-host?
 
 [Read the technical docs](https://github.com/SwitchbackTech/compass/tree/main/docs): All the info you'd need to get started, including guides on how to install, test, build, deploy, and contribute.
 
-Use Bun for dependency installation and script entrypoints. Node.js 24+ is still required because the current backend, CLI, Jest, and webpack flows continue to run on Node.
+Use Bun for dependency installation and the default repo commands. Bun now runs the CLI, backend dev flow, core tests, and package builds directly. Node.js 24+ is still required for retained tooling such as the web/backend/scripts Jest suites and the production Node build output.
 
 ### Development Workflow
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
         "ajv": "^8.18.0",
         "baseline-browser-mapping": "^2.9.11",
         "concurrently": "^8.0.1",
-        "cross-env": "^7.0.3",
         "eslint": "^9.20.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-lerna": "^2.0.0",
@@ -38,8 +37,6 @@
         "jest": "^29.0.3",
         "lint-staged": "^15.2.10",
         "prettier": "^3.5.1",
-        "ts-node": "^10.9.1",
-        "ts-node-dev": "^2.0.0",
         "typescript": "^5.1.6",
         "typescript-eslint": "^8.24.0",
       },
@@ -72,13 +69,11 @@
         "@types/express": "^4.17.13",
         "@types/jest": "^29.0.0",
         "@types/lodash.mergewith": "^4.6.9",
-        "@types/module-alias": "^2.0.1",
         "@types/morgan": "^1.9.4",
         "@types/node": "^22.13.10",
         "@types/supertest": "^6.0.3",
         "jest-environment-node": "^29.7.0",
         "supertest": "^7.1.0",
-        "tsconfig-paths": "^4.1.2",
       },
     },
     "packages/core": {
@@ -117,8 +112,6 @@
         "@types/inquirer": "^9.0.1",
         "@types/node": "^24.7.2",
         "@types/shelljs": "^0.8.15",
-        "ts-node-dev": "^2.0.0",
-        "tsconfig-paths": "^4.0.0",
         "typescript": "^5.1.6",
       },
     },
@@ -1018,8 +1011,6 @@
 
     "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
 
-    "@types/module-alias": ["@types/module-alias@2.0.4", "", {}, "sha512-5+G/QXO/DvHZw60FjvbDzO4JmlD/nG5m2/vVGt25VN1eeP3w2bCoks1Wa7VuptMPM1TxJdx6RjO70N9Fw0nZPA=="],
-
     "@types/morgan": ["@types/morgan@1.9.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -1063,10 +1054,6 @@
     "@types/sockjs": ["@types/sockjs@0.3.36", "", { "dependencies": { "@types/node": "*" } }, "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
-
-    "@types/strip-bom": ["@types/strip-bom@3.0.0", "", {}, "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ=="],
-
-    "@types/strip-json-comments": ["@types/strip-json-comments@0.0.30", "", {}, "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="],
 
     "@types/styled-components": ["@types/styled-components@5.1.36", "", { "dependencies": { "@types/hoist-non-react-statics": "*", "@types/react": "*", "csstype": "^3.2.2" } }, "sha512-pGMRNY5G2rNDKEv2DOiFYa7Ft1r0jrhmgBwHhOMzPTgCjO76bCot0/4uEfqj7K0Jf1KdQmDtAuaDk9EAs9foSw=="],
 
@@ -1438,8 +1425,6 @@
 
     "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
 
-    "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
-
     "cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -1565,8 +1550,6 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "duplexer": ["duplexer@0.1.2", "", {}, "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="],
-
-    "dynamic-dedupe": ["dynamic-dedupe@0.3.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
@@ -2260,8 +2243,6 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
-
     "module-alias": ["module-alias@2.3.4", "", {}, "sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w=="],
 
     "mongodb": ["mongodb@6.3.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.1.0", "bson": "^6.2.0", "mongodb-connection-string-url": "^3.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.1.0", "gcp-metadata": "^5.2.0", "kerberos": "^2.0.1", "mongodb-client-encryption": ">=6.0.0 <7", "snappy": "^7.2.2", "socks": "^2.7.1" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-tt0KuGjGtLUhLoU263+xvQmPHEGTw5LbcNC73EoFRYgSHwZt5tsoJC110hDyO1kjQzpgNrpdcSza9PknWN4LrA=="],
@@ -2598,8 +2579,6 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
-    "rimraf": ["rimraf@2.7.1", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w=="],
-
     "rrule": ["rrule@2.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -2694,11 +2673,11 @@
 
     "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
 
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+    "source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
     "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
 
@@ -2845,10 +2824,6 @@
     "ts-key-enum": ["ts-key-enum@2.0.13", "", {}, "sha512-zixs6j8+NhzazLUQ1SiFrlo1EFWG/DbqLuUGcWWZ5zhwjRT7kbi1hBlofxdqel+h28zrby2It5TrOyKp04kvqw=="],
 
     "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-script": "dist/bin-script-deprecated.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
-
-    "ts-node-dev": ["ts-node-dev@2.0.0", "", { "dependencies": { "chokidar": "^3.5.1", "dynamic-dedupe": "^0.3.0", "minimist": "^1.2.6", "mkdirp": "^1.0.4", "resolve": "^1.0.0", "rimraf": "^2.6.1", "source-map-support": "^0.5.12", "tree-kill": "^1.2.2", "ts-node": "^10.4.0", "tsconfig": "^7.0.0" }, "peerDependencies": { "node-notifier": "*", "typescript": "*" }, "optionalPeers": ["node-notifier"], "bin": { "ts-node-dev": "lib/bin.js", "tsnd": "lib/bin.js" } }, "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w=="],
-
-    "tsconfig": ["tsconfig@7.0.0", "", { "dependencies": { "@types/strip-bom": "^3.0.0", "@types/strip-json-comments": "0.0.30", "strip-bom": "^3.0.0", "strip-json-comments": "^2.0.0" } }, "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
@@ -3015,8 +2990,6 @@
     "xmlbuilder": ["xmlbuilder@13.0.2", "", {}, "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
-
-    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -3204,6 +3177,8 @@
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "clean-css/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -3218,11 +3193,15 @@
 
     "css-loader/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "css-tree/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "cssstyle/cssom": ["cssom@0.3.8", "", {}, "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="],
 
     "data-urls/whatwg-url": ["whatwg-url@11.0.0", "", { "dependencies": { "tr46": "^3.0.0", "webidl-conversions": "^7.0.0" } }, "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ=="],
 
     "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
@@ -3264,6 +3243,8 @@
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "istanbul-lib-source-maps/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "jest-changed-files/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "jest-changed-files/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -3290,8 +3271,6 @@
 
     "jest-runner/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
-    "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
-
     "jest-runtime/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "jest-runtime/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
@@ -3313,6 +3292,8 @@
     "jsonwebtoken/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "less/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "less/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "lint-staged/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -3400,6 +3381,8 @@
 
     "sockjs/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
+    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -3408,19 +3391,15 @@
 
     "stylus/@adobe/css-tools": ["@adobe/css-tools@4.3.3", "", {}, "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ=="],
 
-    "stylus/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
-
     "svgo/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "svgo/sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
+    "terser/source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "ts-node-dev/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
-
-    "tsconfig/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -3653,6 +3632,8 @@
     "serve-index/http-errors/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
     "styled-components/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "terser/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "webpack-cli/rechoir/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 

--- a/docs/development/cli-and-maintenance-commands.md
+++ b/docs/development/cli-and-maintenance-commands.md
@@ -16,7 +16,7 @@ bun run cli <command>
 
 Environment loading:
 
-- `bun run cli` runs Node with `--env-file=packages/backend/.env.local`.
+- `bun run cli` runs the TypeScript entrypoint directly through Bun with `--env-file=packages/backend/.env.local`.
 - Keep local development variables in `packages/backend/.env.local` (bootstrap from `.env.local.example`).
 
 ## CLI URL Resolution Contract
@@ -54,7 +54,8 @@ Implementation:
 Use for:
 
 - production-style web builds
-- compiled node package output
+- compiled Node package output
+- Bun-managed production dependency installation in `build/node`
 
 ### Delete
 
@@ -181,7 +182,7 @@ bun run cli migrate executed
 - Treat delete flows as destructive unless proven otherwise.
 - For migration work, inspect existing migration naming and ordering first.
 - For build work, confirm whether you need `web` or `nodePckgs`.
-- `bun run cli` always loads `packages/backend/.env.local` through the root script; build-time environment selection changes which backend env file is copied or loaded by the underlying command.
+- `bun run cli` always loads `packages/backend/.env.local` through the root Bun script; build-time environment selection changes which backend env file is copied or loaded by the underlying command.
 
 ## Quick Reference
 

--- a/docs/development/env-and-dev-modes.md
+++ b/docs/development/env-and-dev-modes.md
@@ -44,7 +44,7 @@ cp packages/backend/.env.local.example packages/backend/.env.local
 
 Runtime note:
 
-- `bun run dev:backend`, `bun run dev:web`, and `bun run cli ...` load variables from `packages/backend/.env.local` via Node's `--env-file`.
+- `bun run dev:backend`, `bun run dev:web`, and `bun run cli ...` load variables from `packages/backend/.env.local` through Bun's `--env-file`.
 
 ## Backend Environment Contract
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -107,7 +107,7 @@ Use this document to find the first files to inspect for common Compass changes.
 
 ## Test Anchors
 
-- Root Jest project config: `jest.config.js`
+- Retained Jest project config for `web`, `backend`, and `scripts`: `jest.config.js`
 - Core test setup: `packages/core/src/__tests__`
 - Web test setup: `packages/web/src/__tests__`
 - Web mock server handlers: `packages/web/src/__tests__/__mocks__/server/mock.handlers.ts`

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -28,23 +28,27 @@ Unit workflow (`test-unit.yml`):
 - triggers on `push`
 - runs a matrix across `core`, `web`, `backend`, and `scripts`
 - uses `fail-fast: false`, so one failing lane does not cancel the others
-- runs `bun run test <project>` in each lane after dependency install
+- runs `bun run test:<project>` in each lane after dependency install
 - passes timezone through `TZ: ${{ vars.TZ }}`
 
 Local parity commands:
 
 ```bash
-bun run test core
-bun run test web
-bun run test backend
-bun run test scripts
+bun run test:core
+bun run test:web
+bun run test:backend
+bun run test:scripts
 ```
-
-`bun run test:<project>` aliases are equivalent and usually easier to remember.
 
 E2E workflow (`test-e2e.yml`) is separate and runs on pull requests to `main` via `bun run test:e2e`.
 
-## Jest Project Layout
+## Current Test Strategy
+
+- `bun run test:core` uses `bun test` with a small compatibility preload for the core BSON mock setup.
+- `bun run test:web`, `bun run test:backend`, and `bun run test:scripts` intentionally retain the existing Jest harness while their hoist-heavy module-mocking patterns are migrated.
+- `bun run test:<project>` is the stable CI-facing entrypoint for every package; the root dispatcher chooses the correct runner per project.
+
+## Retained Jest Layout
 
 Source:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -245,9 +245,7 @@ const config = {
   passWithNoTests: true,
 
   // A list of paths to directories that Jest should use to search for files in
-  // roots: [
-  //   "<rootDir>"
-  // ],
+  roots: ["<rootDir>/packages"],
 
   // Allows you to use a custom runner instead of Jest's default test runner
   // runner: "jest-runner",

--- a/package.json
+++ b/package.json
@@ -18,21 +18,21 @@
     "@compass/scripts": "packages/scripts/src"
   },
   "scripts": {
-    "cli": "cross-env TZ=Etc/UTC node --env-file=packages/backend/.env.local -r ts-node/register/transpile-only -r tsconfig-paths/register packages/scripts/src/cli.ts",
+    "cli": "TZ=Etc/UTC bun --env-file=packages/backend/.env.local packages/scripts/src/cli.ts",
     "debug:supertokens": "export DEBUG=com.supertokens && bun run dev:backend",
     "debug:web": "http-server build/web/",
     "dev:backend -verbose": "export DEBUG=* && bun run dev:backend",
-    "dev:backend": "cd packages/backend && cross-env TZ=Etc/UTC node --env-file=.env.local ../../node_modules/ts-node-dev/lib/bin.js --respawn --pretty --exit-child --debounce --transpile-only -r tsconfig-paths/register src/app.ts",
+    "dev:backend": "cd packages/backend && TZ=Etc/UTC bun --env-file=.env.local --watch src/app.ts",
     "dev:update": "git checkout main && git pull && bun install",
-    "dev:web": "cd packages/web && node --env-file=../backend/.env.local ../../node_modules/.bin/webpack serve --mode=development --node-env=local",
+    "dev:web": "cd packages/web && TZ=Etc/UTC bun --env-file=../backend/.env.local ../../node_modules/webpack-cli/bin/cli.js serve --mode=development --node-env=local",
     "postinstall": "husky install | chmod ug+x .husky/*",
-    "test": "cross-env TZ=Etc/UTC ./node_modules/.bin/jest",
-    "test:e2e": "playwright test",
-    "test:backend": "cross-env TZ=Etc/UTC ./node_modules/.bin/jest --selectProjects backend",
-    "test:core": "bun run test core",
-    "test:web": "cross-env TZ=Etc/UTC ./node_modules/.bin/jest web",
-    "test:scripts": "bun run test scripts",
-    "type-check": "tsc --noEmit"
+    "test": "TZ=Etc/UTC bun packages/scripts/src/testing/run.ts",
+    "test:e2e": "bunx playwright test",
+    "test:backend": "TZ=Etc/UTC bun packages/scripts/src/testing/run.ts backend",
+    "test:core": "TZ=Etc/UTC bun packages/scripts/src/testing/run.ts core",
+    "test:web": "TZ=Etc/UTC bun packages/scripts/src/testing/run.ts web",
+    "test:scripts": "TZ=Etc/UTC bun packages/scripts/src/testing/run.ts scripts",
+    "type-check": "TZ=Etc/UTC bunx tsc --noEmit"
   },
   "dependencies": {
     "@compass/backend": "*",
@@ -57,7 +57,6 @@
     "@typescript-eslint/parser": "^8.0.0",
     "baseline-browser-mapping": "^2.9.11",
     "concurrently": "^8.0.1",
-    "cross-env": "^7.0.3",
     "eslint": "^9.20.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-lerna": "^2.0.0",
@@ -69,8 +68,6 @@
     "jest": "^29.0.3",
     "lint-staged": "^15.2.10",
     "prettier": "^3.5.1",
-    "ts-node": "^10.9.1",
-    "ts-node-dev": "^2.0.0",
     "typescript": "^5.1.6",
     "typescript-eslint": "^8.24.0"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,12 +29,10 @@
     "@types/express": "^4.17.13",
     "@types/jest": "^29.0.0",
     "@types/lodash.mergewith": "^4.6.9",
-    "@types/module-alias": "^2.0.1",
     "@types/morgan": "^1.9.4",
     "@types/node": "^22.13.10",
     "@types/supertest": "^6.0.3",
     "jest-environment-node": "^29.7.0",
-    "supertest": "^7.1.0",
-    "tsconfig-paths": "^4.1.2"
+    "supertest": "^7.1.0"
   }
 }

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -65,7 +65,7 @@ async function closeNGrokServer(): Promise<void> {
   if (ngrokListener) {
     // do not wait for this promise,
     // underlying rust process termination not finished
-    ngrokListener.close();
+    void ngrokListener.close();
     ngrokServer?.emit("close");
   }
 }
@@ -86,9 +86,17 @@ ngrokServer?.on("connected", onNgrokConnected);
 ngrokServer?.on("error", onNgrokError);
 ngrokServer?.on("close", onNgrokClose);
 
-// gracefully shutdown server - mostly for development respawn with ts-node
-process.on("SIGTERM", gracefulShutdown);
-process.on("SIGINT", gracefulShutdown);
-process.on("SIGQUIT", gracefulShutdown);
+// graceful shutdown keeps Bun watch restarts and local exits clean
+process.on("SIGTERM", () => {
+  void gracefulShutdown();
+});
+process.on("SIGINT", () => {
+  void gracefulShutdown();
+});
+process.on("SIGQUIT", () => {
+  void gracefulShutdown();
+});
 
-if (require.main === module) start();
+if (require.main === module) {
+  void start();
+}

--- a/packages/backend/src/init.ts
+++ b/packages/backend/src/init.ts
@@ -1,15 +1,24 @@
 // sort-imports-ignore
-import moduleAlias from "module-alias";
 import path from "path";
+import { createRequire } from "node:module";
 
 type AliasApi = {
   addAliases(aliases: Record<string, string>): void;
 };
-const aliasApi = moduleAlias as unknown as AliasApi;
-aliasApi.addAliases({
-  "@backend": `${__dirname}`,
-  "@core": `${path.resolve(__dirname, "../../core/src")}`,
-});
+
+const isBuildRuntime =
+  typeof (globalThis as { Bun?: unknown }).Bun === "undefined" &&
+  __dirname.includes(`${path.sep}build${path.sep}`);
+
+if (isBuildRuntime) {
+  const require = createRequire(__filename);
+  const aliasApi = require("module-alias") as AliasApi;
+
+  aliasApi.addAliases({
+    "@backend": `${__dirname}`,
+    "@core": `${path.resolve(__dirname, "../../core/src")}`,
+  });
+}
 
 import { Logger } from "@core/logger/winston.logger";
 

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "ts-node": {
-    "files": true,
-    // Skip typechecking for faster development
-    "transpileOnly": true,
-    "compilerOptions": {
-      // compilerOptions specified here will override those declared below,
-      // but *only* in ts-node.  Useful if you want ts-node and tsc to use
-      // different options with a single tsconfig.json.
-    }
-  },
   "compilerOptions": {
     "sourceMap": false,
     "inlineSourceMap": true

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -18,8 +18,6 @@
     "@types/inquirer": "^9.0.1",
     "@types/node": "^24.7.2",
     "@types/shelljs": "^0.8.15",
-    "ts-node-dev": "^2.0.0",
-    "tsconfig-paths": "^4.0.0",
     "typescript": "^5.1.6"
   }
 }

--- a/packages/scripts/src/commands/build.ts
+++ b/packages/scripts/src/commands/build.ts
@@ -1,4 +1,3 @@
-import shell from "shelljs";
 import { COMPASS_ROOT_DEV, PCKG } from "@scripts/common/cli.constants";
 import { type Options_Cli } from "@scripts/common/cli.types";
 import { getEnvironmentAnswer, log } from "@scripts/common/cli.utils";
@@ -8,6 +7,18 @@ import {
   installDependencies,
   removeOldBuildFor,
 } from "./build.util";
+
+type BunRuntime = {
+  spawnSync(input: {
+    cmd: string[];
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+    stderr?: "inherit";
+    stdout?: "inherit";
+  }): { exitCode: number };
+};
+
+const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
 
 export const runBuild = async (options: Options_Cli) => {
   const packages = options.packages as string[];
@@ -29,12 +40,15 @@ const buildNodePckgs = async (options: Options_Cli) => {
   await copyNodeConfigsToBuild(options);
 
   log.info("Compiling node packages ...");
-  const result = shell.exec(
-    "./node_modules/.bin/tsc --project tsconfig.build.json",
-  );
-  if (result.code !== 0) {
+  const result = bunRuntime.spawnSync({
+    cmd: ["bunx", "tsc", "--project", "tsconfig.build.json"],
+    cwd: COMPASS_ROOT_DEV,
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+  if (result.exitCode !== 0) {
     log.error("Exiting because of compilation errors");
-    process.exit(result.code);
+    process.exit(result.exitCode);
   }
 
   log.success("Compiled node pckgs");
@@ -47,13 +61,24 @@ const buildWeb = (options: Options_Cli) => {
   const environment = options.environment as string;
 
   log.info("Compiling web files...");
-  shell.cd(`${COMPASS_ROOT_DEV}/packages/web`);
-  const result = shell.exec(
-    `../../node_modules/.bin/webpack --mode=production --node-env=${environment}`,
-  );
-  if (result.code !== 0) {
+  const result = bunRuntime.spawnSync({
+    cmd: [
+      "bun",
+      "../../node_modules/webpack-cli/bin/cli.js",
+      "--mode=production",
+      `--node-env=${environment}`,
+    ],
+    cwd: `${COMPASS_ROOT_DEV}/packages/web`,
+    env: {
+      ...process.env,
+      TZ: process.env["TZ"] ?? "Etc/UTC",
+    },
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+  if (result.exitCode !== 0) {
     log.error("Webpack compilation failed");
-    process.exit(result.code);
+    process.exit(result.exitCode);
   }
 
   log.success(`Done building web files.`);

--- a/packages/scripts/src/commands/build.util.ts
+++ b/packages/scripts/src/commands/build.util.ts
@@ -8,6 +8,17 @@ import {
 import { type Options_Cli } from "@scripts/common/cli.types";
 import { _confirm, fileExists, log } from "@scripts/common/cli.utils";
 
+type BunRuntime = {
+  spawnSync(input: {
+    cmd: string[];
+    cwd?: string;
+    stderr?: "inherit";
+    stdout?: "inherit";
+  }): { exitCode: number };
+};
+
+const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
+
 /**
  * Utilities for building a project
  */
@@ -43,6 +54,13 @@ export const copyNodeConfigsToBuild = async (options: Options_Cli) => {
 
   log.info("Copying package configs to build ...");
   shell.cp(`${COMPASS_ROOT_DEV}/package.json`, `${NODE_BUILD}/package.json`);
+  shell.cp(`${COMPASS_ROOT_DEV}/bun.lock`, `${NODE_BUILD}/bun.lock`);
+
+  const bunfigPath = `${COMPASS_ROOT_DEV}/bunfig.toml`;
+
+  if (fileExists(bunfigPath)) {
+    shell.cp(bunfigPath, `${NODE_BUILD}/bunfig.toml`);
+  }
 
   shell.cp(
     `${COMPASS_ROOT_DEV}/packages/backend/package.json`,
@@ -63,16 +81,22 @@ export const createNodeDirs = () => {
 export const installDependencies = () => {
   log.info("Installing dependencies...");
 
-  shell.cd(`${COMPASS_BUILD_DEV}/node`);
-
-  // Use npm for production install so build output stays package-manager agnostic.
-  // --loglevel=error suppresses deprecation warnings from transitive dependencies
-  const result = shell.exec(
-    "npm install --omit=dev --ignore-scripts --loglevel=error",
-  );
-  if (result.code !== 0) {
+  const result = bunRuntime.spawnSync({
+    cmd: [
+      "bun",
+      "install",
+      "--production",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--no-progress",
+    ],
+    cwd: `${COMPASS_BUILD_DEV}/node`,
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+  if (result.exitCode !== 0) {
     log.error("Exiting due to error during dependency installation");
-    process.exit(result.code);
+    process.exit(result.exitCode);
   }
 
   log.success(`Done building node packages.`);

--- a/packages/scripts/src/testing/bun-test.d.ts
+++ b/packages/scripts/src/testing/bun-test.d.ts
@@ -1,0 +1,6 @@
+declare module "bun:test" {
+  export const jest: Record<string, unknown>;
+  export const mock: {
+    module(moduleName: string, factory: () => unknown): void;
+  };
+}

--- a/packages/scripts/src/testing/core.jest-compat.ts
+++ b/packages/scripts/src/testing/core.jest-compat.ts
@@ -1,0 +1,63 @@
+import { jest as bunJest, mock as bunMock } from "bun:test";
+import { createRequire } from "node:module";
+
+type JestCompat = {
+  mock(moduleName: string, factory?: () => unknown): typeof bunJest;
+  requireActual<T>(moduleName: string): T;
+};
+
+const actualModules = new Map<string, unknown>();
+const jestCompat = bunJest as unknown as JestCompat;
+
+function getCallerRequire(): ReturnType<typeof createRequire> {
+  const stack = new Error().stack?.split("\n") ?? [];
+
+  for (const frame of stack.slice(2)) {
+    const match =
+      frame.match(/\((.*):\d+:\d+\)$/) ?? frame.match(/at (.*):\d+:\d+$/);
+    const file = match?.[1];
+
+    if (file && file !== __filename) {
+      return createRequire(file);
+    }
+  }
+
+  return require;
+}
+
+function resolveModule(moduleName: string) {
+  const callerRequire = getCallerRequire();
+
+  try {
+    return {
+      callerRequire,
+      resolvedModule: callerRequire.resolve(moduleName),
+    };
+  } catch {
+    return {
+      callerRequire,
+      resolvedModule: moduleName,
+    };
+  }
+}
+
+jestCompat.requireActual = <T>(moduleName: string): T => {
+  const { callerRequire, resolvedModule } = resolveModule(moduleName);
+
+  if (!actualModules.has(resolvedModule)) {
+    actualModules.set(resolvedModule, callerRequire(moduleName));
+  }
+
+  return actualModules.get(resolvedModule) as T;
+};
+
+jestCompat.mock = (moduleName: string, factory?: () => unknown) => {
+  const actualModule = jestCompat.requireActual(moduleName);
+  const { resolvedModule } = resolveModule(moduleName);
+
+  bunMock.module(resolvedModule, () => {
+    return factory ? factory() : actualModule;
+  });
+
+  return bunJest;
+};

--- a/packages/scripts/src/testing/core.preload.ts
+++ b/packages/scripts/src/testing/core.preload.ts
@@ -1,0 +1,4 @@
+// sort-imports-ignore
+import "./core.jest-compat";
+import "@core/__tests__/core.test.init";
+import "@core/__tests__/core.test.start";

--- a/packages/scripts/src/testing/run.ts
+++ b/packages/scripts/src/testing/run.ts
@@ -1,0 +1,92 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+type BunRuntime = {
+  spawnSync(input: {
+    cmd: string[];
+    cwd?: string;
+    env?: Record<string, string | undefined>;
+    stderr?: "inherit";
+    stdin?: "inherit";
+    stdout?: "inherit";
+  }): { exitCode: number };
+};
+
+type ProjectConfig = {
+  cmd: string[];
+};
+
+const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
+
+const TEST_PROJECTS = {
+  backend: {
+    cmd: ["./node_modules/.bin/jest", "--selectProjects", "backend"],
+  },
+  core: {
+    cmd: [
+      "bun",
+      "test",
+      "packages/core/src",
+      "--preload",
+      "packages/scripts/src/testing/core.preload.ts",
+    ],
+  },
+  scripts: {
+    cmd: ["./node_modules/.bin/jest", "scripts"],
+  },
+  web: {
+    cmd: ["./node_modules/.bin/jest", "web"],
+  },
+} satisfies Record<string, ProjectConfig>;
+
+function assertBackendEnvFile() {
+  const envFilePath = resolve(process.cwd(), "packages/backend/.env.local");
+
+  if (!existsSync(envFilePath)) {
+    return;
+  }
+
+  process.env["BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD"] = "true";
+}
+
+function runProject(projectName: keyof typeof TEST_PROJECTS) {
+  const project = TEST_PROJECTS[projectName];
+
+  const result = bunRuntime.spawnSync({
+    cmd: project.cmd,
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      TZ: process.env["TZ"] ?? "Etc/UTC",
+    },
+    stderr: "inherit",
+    stdin: "inherit",
+    stdout: "inherit",
+  });
+
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
+  }
+}
+
+function main() {
+  assertBackendEnvFile();
+
+  const requestedProject = process.argv[2] as
+    | keyof typeof TEST_PROJECTS
+    | undefined;
+
+  if (requestedProject) {
+    runProject(requestedProject);
+    return;
+  }
+
+  for (const projectName of Object.keys(TEST_PROJECTS) as Array<
+    keyof typeof TEST_PROJECTS
+  >) {
+    runProject(projectName);
+  }
+}
+
+main();

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -1,15 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "ts-node": {
-    "files": true,
-    // Skip typechecking for faster development
-    "transpileOnly": true,
-    "compilerOptions": {
-      // compilerOptions specified here will override those declared below,
-      // but *only* in ts-node.  Useful if you want ts-node and tsc to use
-      // different options with a single tsconfig.json.
-    }
-  },
   "compilerOptions": {
     "sourceMap": false
   }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "**/*.test.ts", "**/__mocks__/**/*"]
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/__mocks__/**/*",
+    "packages/scripts/src/testing/**/*"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "packages/core/src/**/*.ts",
     "packages/backend/src/**/*.ts",
     "packages/scripts/src/**/*.ts",
+    "packages/scripts/src/**/*.d.ts",
     "packages/scripts/src/commands/dev.js"
   ],
   "compilerOptions": {


### PR DESCRIPTION
## Summary
- switch root cli, backend dev, web dev, and e2e commands to Bun-managed entrypoints
- replace Node-era backend startup glue with Bun-compatible runtime setup while keeping built Node output working
- move node package build/install flow to Bun and add a Bun-based test dispatcher with Bun-native core tests
- keep Jest intentionally for web, backend, and scripts tests, and update Jest config to ignore generated build output
- refresh CI and repo docs to reflect the Bun-first workflow and current hybrid test strategy

## Testing
- `bun run cli --help`
- `bun run test:core`
- `bun run test:web`
- `./node_modules/.bin/eslint packages/backend/src/app.ts packages/backend/src/init.ts packages/scripts/src/commands/build.ts packages/scripts/src/commands/build.util.ts packages/scripts/src/testing/run.ts packages/scripts/src/testing/core.preload.ts packages/scripts/src/testing/core.jest-compat.ts`
- `bunx tsc --noEmit --pretty false` *(fails due to pre-existing repo type errors)*
- `bun run test:backend` *(not verified in sandbox; mongodb-memory-server port binding is restricted)*
- `bun run test:scripts` *(not verified in sandbox; mongodb-memory-server port binding is restricted)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewires core developer workflows (CLI, dev servers, tests, and build packaging) and changes the build-time module-alias behavior, which could cause CI/dev regressions if any edge cases differ under Bun.
> 
> **Overview**
> Moves the repo to a **Bun-first** workflow by switching root scripts for `cli`, `dev:web`, `dev:backend`, `test:*`, `type-check`, and `test:e2e` to Bun-managed entrypoints and removing `cross-env`, `ts-node`, and `ts-node-dev` usage.
> 
> Introduces a Bun-based test dispatcher (`packages/scripts/src/testing/run.ts`) with a *hybrid* strategy: `core` runs via `bun test` with a small Jest-compat preload, while `web`/`backend`/`scripts` continue running in the existing Jest harness; CI is updated to call `bun run test:<project>`.
> 
> Updates build packaging to run compilation and webpack via `Bun.spawnSync`, installs production deps in `build/node` via `bun install --production`, and adjusts backend startup/shutdown for Bun watch mode while keeping Node build output working via conditional `module-alias` setup. Documentation is refreshed to reflect the new commands and test strategy, and Jest config is tightened to only search under `packages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ed39b4e75fc937272fe86fd85b6a0ecc16a09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->