### PR TITLE
feat: update bun tests, part iii

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.test.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.test.ts
@@ -5,7 +5,7 @@ import {
   EVENT_CHANGED,
   GOOGLE_REVOKED,
   IMPORT_GCAL_END,
-  IMPORT_GCAL_START,
+  USER_METADATA,
 } from "@core/constants/sse.constants";
 import { Status } from "@core/errors/status.codes";
 import { type ImportGCalEndPayload } from "@core/types/sse.types";
@@ -569,6 +569,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,
@@ -601,6 +602,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,
@@ -636,6 +638,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,
@@ -676,6 +679,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,
@@ -716,6 +720,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,
@@ -756,6 +761,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,
@@ -806,6 +812,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,
@@ -834,6 +841,7 @@ describe("SyncController", () => {
           userId,
           sessionId: randomUUID(),
         });
+        await stream.waitForEvent(USER_METADATA, importTimeoutMs);
         const importEndPromise = stream.waitForEvent(
           IMPORT_GCAL_END,
           importTimeoutMs,

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -15,7 +15,7 @@ const mockGetCliOptions = jest.fn();
 const mockValidateBuild = jest.fn();
 const mockValidateDelete = jest.fn();
 const mockExitHelpfully = jest.fn();
-const mockRunMigrator = jest.fn();
+const mockRunMigrator = jest.fn((): Promise<void> => Promise.resolve());
 
 jest.mock("@scripts/cli.validator", () => {
   return {
@@ -28,14 +28,27 @@ jest.mock("@scripts/cli.validator", () => {
   };
 });
 
-jest.mock("@scripts/commands/build.util");
-jest.mock("@scripts/commands/build");
-jest.mock("@scripts/commands/delete/delete");
+jest.mock("@scripts/commands/build.util", () => ({
+  __esModule: true,
+  copyNodeConfigsToBuild: jest.fn(),
+  createNodeDirs: jest.fn(),
+  installDependencies: jest.fn(),
+  removeOldBuildFor: jest.fn(),
+}));
+
+jest.mock("@scripts/commands/build", () => ({
+  __esModule: true,
+  runBuild: jest.fn(),
+}));
+
+jest.mock("@scripts/commands/delete/delete", () => ({
+  __esModule: true,
+  startDeleteFlow: jest.fn(),
+}));
 
 jest.mock("@scripts/commands/migrate", () => ({
-  runMigrator: jest
-    .fn()
-    .mockImplementation((...args) => mockRunMigrator(...args)),
+  __esModule: true,
+  runMigrator: jest.fn((type: MigratorType) => mockRunMigrator(type)),
 }));
 
 describe("CompassCLI", () => {

--- a/packages/scripts/src/testing/apply-bun-jest-compat.cjs
+++ b/packages/scripts/src/testing/apply-bun-jest-compat.cjs
@@ -1,0 +1,138 @@
+"use strict";
+
+const { createRequire } = require("node:module");
+
+const compatFilePath = __filename;
+
+function getCallerRequire() {
+  const stack = new Error().stack?.split("\n") ?? [];
+
+  for (const frame of stack.slice(2)) {
+    const match =
+      frame.match(/\((.*):\d+:\d+\)$/) ?? frame.match(/at (.*):\d+:\d+$/);
+    const file = match?.[1];
+
+    if (
+      file &&
+      file !== compatFilePath &&
+      !file.includes("core.jest-compat") &&
+      !file.includes("apply-bun-jest-compat")
+    ) {
+      return createRequire(file);
+    }
+  }
+
+  return require;
+}
+
+function resolveModule(moduleName) {
+  const callerRequire = getCallerRequire();
+
+  try {
+    return {
+      callerRequire,
+      resolvedModule: callerRequire.resolve(moduleName),
+    };
+  } catch {
+    return {
+      callerRequire,
+      resolvedModule: moduleName,
+    };
+  }
+}
+
+const actualModules = new Map();
+
+function autoMockValue(bunJest, value, seen) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  const primitiveType = typeof value;
+
+  if (
+    primitiveType === "string" ||
+    primitiveType === "number" ||
+    primitiveType === "boolean" ||
+    primitiveType === "bigint" ||
+    primitiveType === "symbol"
+  ) {
+    return value;
+  }
+
+  if (primitiveType === "function") {
+    return bunJest.fn(value);
+  }
+
+  if (typeof value === "object") {
+    if (seen.has(value)) {
+      return seen.get(value);
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) => autoMockValue(bunJest, item, seen));
+    }
+
+    const out = {};
+    seen.set(value, out);
+
+    for (const key in value) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+
+      if (descriptor?.get || descriptor?.set) {
+        continue;
+      }
+
+      try {
+        out[key] = autoMockValue(bunJest, value[key], seen);
+      } catch {
+        // ignore TDZ / non-readable props
+      }
+    }
+
+    return out;
+  }
+
+  return value;
+}
+
+function applyBunJestCompat(bunJest, bunMock) {
+  const jestCompat = bunJest;
+
+  jestCompat.requireActual = (moduleName) => {
+    const { callerRequire, resolvedModule } = resolveModule(moduleName);
+
+    if (!actualModules.has(resolvedModule)) {
+      actualModules.set(resolvedModule, callerRequire(moduleName));
+    }
+
+    return actualModules.get(resolvedModule);
+  };
+
+  jestCompat.createMockFromModule = (moduleName) => {
+    const actual = jestCompat.requireActual(moduleName);
+
+    return autoMockValue(bunJest, actual, new WeakMap());
+  };
+
+  jestCompat.requireMock = (moduleName) => {
+    const { callerRequire } = resolveModule(moduleName);
+
+    return callerRequire(moduleName);
+  };
+
+  jestCompat.mocked = (item) => item;
+
+  jestCompat.mock = (moduleName, factory) => {
+    const actualModule = jestCompat.requireActual(moduleName);
+    const { resolvedModule } = resolveModule(moduleName);
+
+    bunMock.module(resolvedModule, () => {
+      return factory ? factory() : actualModule;
+    });
+
+    return bunJest;
+  };
+}
+
+module.exports = { applyBunJestCompat };

--- a/packages/scripts/src/testing/apply-bun-jest-compat.cjs
+++ b/packages/scripts/src/testing/apply-bun-jest-compat.cjs
@@ -70,7 +70,20 @@ function autoMockValue(bunJest, value, seen) {
     }
 
     if (Array.isArray(value)) {
-      return value.map((item) => autoMockValue(bunJest, item, seen));
+      const out = [];
+      seen.set(value, out);
+
+      for (let i = 0; i < value.length; i++) {
+        if (i in value) {
+          try {
+            out[i] = autoMockValue(bunJest, value[i], seen);
+          } catch {
+            // ignore TDZ / non-readable props
+          }
+        }
+      }
+
+      return out;
     }
 
     const out = {};

--- a/packages/scripts/src/testing/core.jest-compat.ts
+++ b/packages/scripts/src/testing/core.jest-compat.ts
@@ -1,63 +1,13 @@
 import { jest as bunJest, mock as bunMock } from "bun:test";
 import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-type JestCompat = {
-  mock(moduleName: string, factory?: () => unknown): typeof bunJest;
-  requireActual<T>(moduleName: string): T;
+const nodeRequire = createRequire(import.meta.url);
+const { applyBunJestCompat } = nodeRequire(
+  join(dirname(fileURLToPath(import.meta.url)), "apply-bun-jest-compat.cjs"),
+) as {
+  applyBunJestCompat: (j: typeof bunJest, m: typeof bunMock) => void;
 };
 
-const actualModules = new Map<string, unknown>();
-const jestCompat = bunJest as unknown as JestCompat;
-
-function getCallerRequire(): ReturnType<typeof createRequire> {
-  const stack = new Error().stack?.split("\n") ?? [];
-
-  for (const frame of stack.slice(2)) {
-    const match =
-      frame.match(/\((.*):\d+:\d+\)$/) ?? frame.match(/at (.*):\d+:\d+$/);
-    const file = match?.[1];
-
-    if (file && file !== __filename) {
-      return createRequire(file);
-    }
-  }
-
-  return require;
-}
-
-function resolveModule(moduleName: string) {
-  const callerRequire = getCallerRequire();
-
-  try {
-    return {
-      callerRequire,
-      resolvedModule: callerRequire.resolve(moduleName),
-    };
-  } catch {
-    return {
-      callerRequire,
-      resolvedModule: moduleName,
-    };
-  }
-}
-
-jestCompat.requireActual = <T>(moduleName: string): T => {
-  const { callerRequire, resolvedModule } = resolveModule(moduleName);
-
-  if (!actualModules.has(resolvedModule)) {
-    actualModules.set(resolvedModule, callerRequire(moduleName));
-  }
-
-  return actualModules.get(resolvedModule) as T;
-};
-
-jestCompat.mock = (moduleName: string, factory?: () => unknown) => {
-  const actualModule = jestCompat.requireActual(moduleName);
-  const { resolvedModule } = resolveModule(moduleName);
-
-  bunMock.module(resolvedModule, () => {
-    return factory ? factory() : actualModule;
-  });
-
-  return bunJest;
-};
+applyBunJestCompat(bunJest, bunMock);

--- a/packages/web/src/__tests__/__mocks__/mock.setup.ts
+++ b/packages/web/src/__tests__/__mocks__/mock.setup.ts
@@ -95,8 +95,37 @@ export function mockSuperTokens() {
 }
 
 function mockReactToastify() {
-  mockModule("react-toastify", () => {
-    return jest.createMockFromModule("react-toastify");
+  jest.mock("react-toastify", () => {
+    const actual =
+      jest.requireActual<typeof import("react-toastify")>("react-toastify");
+    const baseToast = actual.toast;
+    const toastFn = jest
+      .fn()
+      .mockReturnValue("mock-toast-id") as typeof baseToast &
+      jest.MockedFunction<typeof baseToast>;
+
+    toastFn.POSITION = baseToast.POSITION;
+    toastFn.TYPE = baseToast.TYPE;
+    toastFn.dismiss = jest.fn();
+    toastFn.error = jest.fn();
+    toastFn.info = jest.fn();
+    toastFn.isActive = jest.fn();
+    toastFn.success = jest.fn();
+    toastFn.update = jest.fn();
+    toastFn.warning = jest.fn();
+    toastFn.warn = jest.fn();
+    toastFn.loading = jest.fn();
+    toastFn.promise = jest.fn();
+    toastFn.dark = jest.fn();
+    toastFn.done = jest.fn();
+    toastFn.onChange = jest.fn();
+    toastFn.clearWaitingQueue = jest.fn();
+
+    return {
+      ...actual,
+      default: toastFn,
+      toast: toastFn,
+    };
   });
 }
 

--- a/packages/web/src/__tests__/patched-jest.cjs
+++ b/packages/web/src/__tests__/patched-jest.cjs
@@ -1,0 +1,30 @@
+"use strict";
+
+const { createRequire } = require("node:module");
+const path = require("node:path");
+
+const nodeRequire = createRequire(__filename);
+const applyCompatPath = path.join(
+  __dirname,
+  "../../../scripts/src/testing/apply-bun-jest-compat.cjs",
+);
+
+function loadJest() {
+  try {
+    const bunTest = nodeRequire("bun:test");
+    const { applyBunJestCompat } = nodeRequire(applyCompatPath);
+    applyBunJestCompat(bunTest.jest, bunTest.mock);
+    globalThis.jest = bunTest.jest;
+    return bunTest.jest;
+  } catch {
+    if (globalThis.jest) {
+      return globalThis.jest;
+    }
+
+    return nodeRequire("@jest/globals").jest;
+  }
+}
+
+const jestBinding = loadJest();
+
+exports.jest = jestBinding;

--- a/packages/web/src/__tests__/patched-jest.d.ts
+++ b/packages/web/src/__tests__/patched-jest.d.ts
@@ -1,0 +1,3 @@
+import type { jest as JestNamespace } from "@jest/globals";
+
+export declare const jest: typeof JestNamespace;

--- a/packages/web/src/__tests__/set-test-window-url.ts
+++ b/packages/web/src/__tests__/set-test-window-url.ts
@@ -1,0 +1,12 @@
+/**
+ * Updates the jsdom URL via the History API so `window.location` stays consistent
+ * without replacing the non-configurable `location` object.
+ */
+export function setTestWindowUrl(url: string): void {
+  const resolved = new URL(url, "http://localhost");
+  window.history.replaceState(
+    {},
+    "",
+    `${resolved.pathname}${resolved.search}${resolved.hash}`,
+  );
+}

--- a/packages/web/src/__tests__/web.preload.ts
+++ b/packages/web/src/__tests__/web.preload.ts
@@ -1,0 +1,252 @@
+// sort-imports-ignore — side-effect import order matters
+import { afterAll, afterEach, beforeAll, beforeEach, expect } from "bun:test";
+import { JSDOM } from "jsdom";
+import { createRequire } from "node:module";
+import { jest as jestBinding } from "./patched-jest.cjs";
+
+globalThis.jest = jestBinding;
+import "@core/__tests__/core.test.init";
+import "@core/__tests__/core.test.start";
+import "./web.test.init";
+import {
+  appendTailwindCss,
+  getTailwindCss,
+} from "./__mocks__/mock.tailwindcss";
+import { mockNodeModules } from "./__mocks__/mock.setup";
+import { server } from "./__mocks__/server/mock.server";
+
+const requireMatchers = createRequire(import.meta.path);
+const jestDomMatchers = requireMatchers(
+  "@testing-library/jest-dom/dist/matchers.js",
+) as Record<string, unknown>;
+expect.extend(jestDomMatchers);
+
+Bun.plugin({
+  name: "web-test-asset-stubs",
+  setup(build) {
+    build.onResolve({ filter: /\.(css|less)$/ }, () => ({
+      path: "virtual:web-test-empty-style",
+      namespace: "web-test-stub",
+    }));
+
+    build.onResolve({ filter: /\.(jpe?g|png|gif)$/i }, () => ({
+      path: "virtual:web-test-file-stub",
+      namespace: "web-test-stub",
+    }));
+
+    build.onResolve({ filter: /\.svg$/ }, () => ({
+      path: "virtual:web-test-svg-stub",
+      namespace: "web-test-stub",
+    }));
+
+    build.onLoad({ filter: /.*/, namespace: "web-test-stub" }, (args) => {
+      if (args.path === "virtual:web-test-empty-style") {
+        return { contents: "export default {};", loader: "js" };
+      }
+
+      if (args.path === "virtual:web-test-file-stub") {
+        return { contents: 'export default "test-file-stub";', loader: "js" };
+      }
+
+      if (args.path === "virtual:web-test-svg-stub") {
+        return {
+          contents: `
+import { createElement, forwardRef } from "react";
+const SvgrMock = forwardRef((props, ref) => createElement("span", { ref, ...props }));
+SvgrMock.displayName = "SvgrMock";
+export const ReactComponent = SvgrMock;
+export default SvgrMock;
+`,
+          loader: "tsx",
+        };
+      }
+    });
+  },
+});
+
+const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+
+const { window } = dom;
+
+globalThis.window = window as unknown as Window & typeof globalThis;
+globalThis.document = window.document;
+globalThis.navigator = window.navigator;
+globalThis.location = window.location;
+globalThis.history = window.history;
+globalThis.localStorage = window.localStorage;
+globalThis.sessionStorage = window.sessionStorage;
+globalThis.HTMLElement = window.HTMLElement;
+globalThis.HTMLAnchorElement = window.HTMLAnchorElement;
+globalThis.Node = window.Node;
+globalThis.self = window;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const noopAlert = () => {};
+window.alert = noopAlert;
+globalThis.alert = noopAlert;
+
+class MockObserver<T> implements IntersectionObserver, ResizeObserver {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_callback: T, _options?: IntersectionObserverInit) {}
+
+  root!: Document | Element | null;
+  rootMargin!: string;
+  thresholds!: readonly number[];
+  observe = (...args: unknown[]): unknown => args;
+  unobserve = (...args: unknown[]): unknown => args;
+  disconnect = (...args: unknown[]): unknown => args;
+  takeRecords = (): IntersectionObserverEntry[] => [];
+}
+
+class MediaQuery implements MediaQueryList {
+  matches = false;
+  media: string;
+  onchange = null;
+
+  constructor(query: string) {
+    this.media = query;
+  }
+
+  addListener(): void {}
+
+  removeListener(): void {}
+
+  removeEventListener(): void {}
+
+  addEventListener(): void {}
+
+  dispatchEvent(): boolean {
+    return true;
+  }
+}
+
+function getPointerEvent(mouseEvent: typeof globalThis.MouseEvent) {
+  class PointerEvent extends mouseEvent implements globalThis.PointerEvent {
+    altitudeAngle: number;
+    azimuthAngle: number;
+    height: number;
+    isPrimary: boolean;
+    pointerId: number;
+    pointerType: string;
+    pressure: number;
+    tangentialPressure: number;
+    tiltX: number;
+    tiltY: number;
+    twist: number;
+    width: number;
+
+    constructor(type: string, eventInitDict?: PointerEventInit) {
+      super(type, eventInitDict);
+      this.altitudeAngle = eventInitDict?.altitudeAngle ?? 0;
+      this.azimuthAngle = eventInitDict?.azimuthAngle ?? 0;
+      this.height = eventInitDict?.height ?? 1;
+      this.isPrimary = eventInitDict?.isPrimary ?? false;
+      this.pointerId = eventInitDict?.pointerId ?? 0;
+      this.pointerType = eventInitDict?.pointerType ?? "";
+      this.pressure = eventInitDict?.pressure ?? 0;
+      this.tangentialPressure = eventInitDict?.tangentialPressure ?? 0;
+      this.tiltX = eventInitDict?.tiltX ?? 0;
+      this.tiltY = eventInitDict?.tiltY ?? 0;
+      this.twist = eventInitDict?.twist ?? 0;
+      this.width = eventInitDict?.width ?? 1;
+    }
+
+    getCoalescedEvents(): globalThis.PointerEvent[] {
+      throw new Error("Method not implemented.");
+    }
+
+    getPredictedEvents(): globalThis.PointerEvent[] {
+      throw new Error("Method not implemented.");
+    }
+  }
+
+  return PointerEvent;
+}
+
+const css = await getTailwindCss();
+appendTailwindCss(window.document, css);
+
+window.HTMLElement.prototype.scroll = () => {};
+window.HTMLElement.prototype.scrollIntoView = () => {};
+window.document.elementFromPoint = () => null;
+window.PointerEvent = getPointerEvent(window.MouseEvent);
+
+window.fetch = globalThis.fetch.bind(globalThis);
+window.Blob = globalThis.Blob;
+window.File = globalThis.File;
+window.FormData = globalThis.FormData;
+window.Headers = globalThis.Headers;
+window.Request = globalThis.Request;
+window.Response = globalThis.Response;
+window.XMLHttpRequest = globalThis.XMLHttpRequest;
+window.ArrayBuffer = globalThis.ArrayBuffer;
+window.Uint8Array = globalThis.Uint8Array;
+window.Uint8ClampedArray = globalThis.Uint8ClampedArray;
+window.Uint16Array = globalThis.Uint16Array;
+window.Uint32Array = globalThis.Uint32Array;
+window.Int8Array = globalThis.Int8Array;
+window.Int16Array = globalThis.Int16Array;
+window.Int32Array = globalThis.Int32Array;
+window.Float32Array = globalThis.Float32Array;
+window.Float64Array = globalThis.Float64Array;
+window.DataView = globalThis.DataView;
+window.SharedArrayBuffer = globalThis.SharedArrayBuffer;
+window.Atomics = globalThis.Atomics;
+window.WebAssembly = globalThis.WebAssembly;
+
+window.URL.createObjectURL = globalThis.URL.createObjectURL.bind(window.URL);
+window.URL.revokeObjectURL = globalThis.URL.revokeObjectURL.bind(window.URL);
+
+window.IntersectionObserver =
+  MockObserver<IntersectionObserverCallback> as unknown as typeof IntersectionObserver;
+window.ResizeObserver =
+  MockObserver<ResizeObserverCallback> as unknown as typeof ResizeObserver;
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string): MediaQueryList => new MediaQuery(query),
+});
+
+const originalGetContext = window.HTMLCanvasElement.prototype.getContext;
+window.HTMLCanvasElement.prototype.getContext = function (
+  this: HTMLCanvasElement,
+  contextId: string,
+  ...args: unknown[]
+) {
+  if (contextId === "2d") {
+    return {
+      font: "",
+      measureText: (text: string) => ({ width: text.length * 7 }),
+    } as unknown as CanvasRenderingContext2D;
+  }
+
+  return originalGetContext.apply(this, [contextId, ...args] as never);
+};
+
+await import("fake-indexeddb/auto");
+
+if (typeof globalThis.structuredClone === "undefined") {
+  globalThis.structuredClone = (obj: unknown) => {
+    return JSON.parse(JSON.stringify(obj));
+  };
+}
+
+mockNodeModules();
+
+beforeEach(() => {
+  jestBinding.clearAllMocks();
+  const sessionModule = jestBinding.requireMock(
+    "supertokens-web-js/recipe/session",
+  ) as {
+    doesSessionExist?: { mockResolvedValue: (v: boolean) => void };
+  };
+  sessionModule.doesSessionExist?.mockResolvedValue(true);
+});
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+afterAll(() => jestBinding.restoreAllMocks());

--- a/packages/web/src/common/apis/compass.api.test.ts
+++ b/packages/web/src/common/apis/compass.api.test.ts
@@ -5,11 +5,21 @@ import type {
   InternalAxiosRequestConfig,
 } from "axios";
 import { toast } from "react-toastify";
-import { signOut } from "supertokens-web-js/recipe/session";
 import { Status } from "@core/errors/status.codes";
+import { setTestWindowUrl } from "@web/__tests__/set-test-window-url";
+import { session } from "@web/common/classes/Session";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { GOOGLE_REVOKED_TOAST_ID } from "@web/common/constants/toast.constants";
+import {
+  assignLocation,
+  reloadLocation,
+} from "@web/common/utils/browser/browser-navigation.util";
 import { CompassApi } from "./compass.api";
+
+jest.mock("@web/common/utils/browser/browser-navigation.util", () => ({
+  assignLocation: jest.fn(),
+  reloadLocation: jest.fn(),
+}));
 
 jest.mock("supertokens-web-js/recipe/session", () => {
   const actual = jest.requireActual("supertokens-web-js/recipe/session");
@@ -28,19 +38,12 @@ jest.mock("supertokens-web-js/recipe/session", () => {
   };
 });
 
-const assignMock = jest.fn();
-const reloadMock = jest.fn();
+const assignMock = jest.mocked(assignLocation);
+const reloadMock = jest.mocked(reloadLocation);
 const originalAdapter = CompassApi.defaults.adapter;
 
 const setLocationPath = (pathname: string) => {
-  Object.defineProperty(window, "location", {
-    configurable: true,
-    value: {
-      assign: assignMock,
-      reload: reloadMock,
-      pathname,
-    } as unknown as Location,
-  });
+  setTestWindowUrl(pathname);
 };
 
 const createAxiosError = (
@@ -88,10 +91,11 @@ describe("CompassApi interceptor auth handling", () => {
     jest.clearAllMocks();
     assignMock.mockReset();
     reloadMock.mockReset();
-    (signOut as jest.Mock).mockResolvedValue(undefined);
-    (toast.isActive as jest.Mock).mockReturnValue(false);
+    (session.signOut as jest.Mock).mockResolvedValue(undefined);
+    jest.spyOn(toast, "isActive").mockReturnValue(false);
+    jest.spyOn(toast, "error").mockReturnValue("toast-id" as never);
     setLocationPath(ROOT_ROUTES.NOW);
-    jest.spyOn(window, "alert").mockImplementation(() => undefined);
+    jest.spyOn(globalThis, "alert").mockImplementation(() => undefined);
     jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
@@ -103,10 +107,10 @@ describe("CompassApi interceptor auth handling", () => {
   it("signs out and redirects to day when Google token is invalid", async () => {
     await triggerErrorResponse(Status.NOT_FOUND);
 
-    expect(window.alert).toHaveBeenCalledWith(
+    expect(globalThis.alert).toHaveBeenCalledWith(
       "Login required, cuz security 😇",
     );
-    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(session.signOut).toHaveBeenCalledTimes(1);
     expect(assignMock).toHaveBeenCalledWith(ROOT_ROUTES.DAY);
   });
 
@@ -115,7 +119,7 @@ describe("CompassApi interceptor auth handling", () => {
 
     await triggerErrorResponse(Status.NOT_FOUND);
 
-    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(session.signOut).toHaveBeenCalledTimes(1);
     expect(assignMock).not.toHaveBeenCalled();
   });
 
@@ -131,13 +135,14 @@ describe("CompassApi interceptor auth handling", () => {
         draggable: false,
       }),
     );
-    expect(window.alert).not.toHaveBeenCalled();
-    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(globalThis.alert).not.toHaveBeenCalled();
+    expect(session.signOut).toHaveBeenCalledTimes(1);
     expect(assignMock).toHaveBeenCalledWith(ROOT_ROUTES.DAY);
   });
 
   it("does not enqueue duplicate session-expired toasts when already active", async () => {
-    (toast.isActive as jest.Mock)
+    jest
+      .spyOn(toast, "isActive")
       .mockReturnValueOnce(false)
       .mockReturnValue(true);
 
@@ -151,7 +156,7 @@ describe("CompassApi interceptor auth handling", () => {
     await triggerErrorResponse(Status.REDUX_REFRESH_NEEDED);
 
     expect(reloadMock).toHaveBeenCalledTimes(1);
-    expect(signOut).not.toHaveBeenCalled();
+    expect(session.signOut).not.toHaveBeenCalled();
     expect(assignMock).not.toHaveBeenCalled();
   });
 
@@ -159,15 +164,15 @@ describe("CompassApi interceptor auth handling", () => {
     await triggerErrorResponse(Status.INTERNAL_SERVER);
 
     expect(console.error).toHaveBeenCalled();
-    expect(signOut).not.toHaveBeenCalled();
+    expect(session.signOut).not.toHaveBeenCalled();
     expect(assignMock).not.toHaveBeenCalled();
   });
 
   it("does not sign out or redirect on /user/profile 404", async () => {
     await triggerErrorResponse(Status.NOT_FOUND, "/user/profile");
 
-    expect(window.alert).not.toHaveBeenCalled();
-    expect(signOut).not.toHaveBeenCalled();
+    expect(globalThis.alert).not.toHaveBeenCalled();
+    expect(session.signOut).not.toHaveBeenCalled();
     expect(assignMock).not.toHaveBeenCalled();
   });
 
@@ -189,7 +194,7 @@ describe("CompassApi interceptor auth handling", () => {
         "Google access revoked. Your Google data has been removed.",
         toastExpectation,
       );
-      expect(signOut).not.toHaveBeenCalled();
+      expect(session.signOut).not.toHaveBeenCalled();
       expect(assignMock).not.toHaveBeenCalled();
     }
   });

--- a/packages/web/src/common/apis/compass.api.ts
+++ b/packages/web/src/common/apis/compass.api.ts
@@ -5,6 +5,10 @@ import { getApiErrorCode } from "@web/common/apis/compass.api.util";
 import { session } from "@web/common/classes/Session";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
+import {
+  assignLocation,
+  reloadLocation,
+} from "@web/common/utils/browser/browser-navigation.util";
 import { showSessionExpiredToast } from "@web/common/utils/toast/error-toast.util";
 import { handleGoogleRevoked } from "../../auth/google/util/google.auth.util";
 
@@ -31,7 +35,7 @@ const signOut = async (status: SignoutStatus) => {
   if (window.location.pathname.startsWith(ROOT_ROUTES.DAY)) {
     return;
   }
-  window.location.assign(ROOT_ROUTES.DAY);
+  assignLocation(ROOT_ROUTES.DAY);
 };
 
 CompassApi.interceptors.response.use(
@@ -43,7 +47,7 @@ CompassApi.interceptors.response.use(
     const requestUrl = error?.config?.url;
 
     if (status === Status.REDUX_REFRESH_NEEDED) {
-      window.location.reload();
+      reloadLocation();
       return Promise.resolve();
     }
 

--- a/packages/web/src/common/utils/browser/browser-navigation.util.ts
+++ b/packages/web/src/common/utils/browser/browser-navigation.util.ts
@@ -1,0 +1,7 @@
+export function assignLocation(url: string): void {
+  window.location.assign(url);
+}
+
+export function reloadLocation(): void {
+  window.location.reload();
+}

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -252,9 +252,33 @@ const _getNextWeekInSameMonth = (weekStart: Dayjs) => {
   return { startDate, endDate };
 };
 
+const _isoUtcOffsetMinutes = (value: string): number | undefined => {
+  const trimmed = value.trim();
+
+  if (/Z$/i.test(trimmed)) {
+    return 0;
+  }
+
+  const match = trimmed.match(/([+-])(\d{2}):(\d{2})$/);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const sign = match[1] === "+" ? 1 : -1;
+
+  return sign * (parseInt(match[2], 10) * 60 + parseInt(match[3], 10));
+};
+
 const _getTimeLabel = (date: string) => {
-  const orig = dayjs(date).format(HOURS_AM_FORMAT);
-  return orig.replace(":00", "");
+  const offsetMinutes = _isoUtcOffsetMinutes(date);
+  const parsed = dayjs(date);
+  const formatted =
+    offsetMinutes !== undefined
+      ? parsed.utcOffset(offsetMinutes).format(HOURS_AM_FORMAT)
+      : parsed.format(HOURS_AM_FORMAT);
+
+  return formatted.replace(":00", "");
 };
 
 export const computeCurrentEventDateRange = (

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -23,6 +23,7 @@ import {
   type Schema_WebEvent,
   type WithId,
 } from "@web/common/types/web.event.types";
+import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import {
   focusElement,
@@ -227,7 +228,7 @@ export const handleError = (error: Error) => {
 
   if (code === Status.INTERNAL_SERVER) {
     alert("Something went wrong behind the scenes. Please try again later.");
-    window.location.reload();
+    reloadLocation();
   }
 
   alert(error);

--- a/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.tsx
@@ -1,5 +1,6 @@
 import { useVersionCheck } from "@web/common/hooks/useVersionCheck";
 import { theme } from "@web/common/styles/theme";
+import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { getModifierKeyIcon } from "@web/common/utils/shortcut/shortcut.util";
 import { CalendarIcon } from "@web/components/Icons/Calendar";
 import { CommandIcon } from "@web/components/Icons/Command";
@@ -25,7 +26,7 @@ export const SidebarIconRow = () => {
   const { isUpdateAvailable } = useVersionCheck();
 
   const handleUpdateReload = () => {
-    window.location.reload();
+    reloadLocation();
   };
 
   const toggleCmdPalette = () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly test/runtime compatibility changes for Bun, but it also tweaks time-label formatting to respect ISO timezone offsets and wraps navigation calls, which could subtly affect UI behavior and error handling.
> 
> **Overview**
> Updates the Bun test setup to provide fuller `jest` compatibility (`requireActual`, `createMockFromModule`, `requireMock`, `mocked`) and adds a web preload that boots jsdom, stubs assets, installs matchers, and centralizes mock initialization.
> 
> Stabilizes existing tests by adjusting mocks (e.g., `react-toastify` and CLI command modules), adding a helper to change the jsdom URL without redefining `window.location`, and ensuring backend SSE import tests wait for the initial `USER_METADATA` event before asserting `IMPORT_GCAL_END`.
> 
> Refactors browser navigation side effects behind `assignLocation`/`reloadLocation` and updates the API interceptor and a few call sites to use them, and fixes `_getTimeLabel` to honor explicit ISO `Z`/`±HH:MM` offsets when formatting time ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3870b914a244665445678432dacaf9d122d02a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->