### PR TITLE
feat(gcal): implement exponential backoff and rate limiting for Google Calendar API requests

### DIFF
--- a/packages/backend/src/common/services/gcal/gcal.service.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.ts
@@ -1,5 +1,6 @@
 import type { GaxiosResponse } from "gaxios";
 import { GCAL_NOTIFICATION_ENDPOINT } from "@core/constants/core.constants";
+import { Logger } from "@core/logger/winston.logger";
 import type {
   gCalendar,
   gParamsEventsList,
@@ -15,8 +16,13 @@ import { IDSchemaV4 } from "@core/types/type.utils";
 import { GCAL_PRIMARY } from "@backend/common/constants/backend.constants";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { GcalError } from "@backend/common/errors/integration/gcal/gcal.errors";
+import { isGoogleRepairQuotaError } from "@backend/common/services/gcal/gcal.utils";
 import { getBaseURL } from "@backend/servers/ngrok/ngrok.utils";
 import { encodeChannelToken } from "@backend/sync/util/watch.util";
+
+const logger = Logger("app:gcal.service");
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 class GCalService {
   private validateGCalResponse<T>(
@@ -87,9 +93,28 @@ class GCalService {
   }
 
   async getEvents(gcal: gCalendar, params: gParamsEventsList) {
-    const response = await gcal.events.list(params);
+    const maxRetries = 5;
+    let delay = 1000; // Start with 1 second
 
-    return this.validateGCalResponse(response);
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const response = await gcal.events.list(params);
+        return this.validateGCalResponse(response);
+      } catch (e) {
+        if (isGoogleRepairQuotaError(e) && attempt < maxRetries) {
+          logger.warn(
+            `Rate limited on calendar ${params.calendarId}, waiting ${delay}ms before retry ${attempt + 1}/${maxRetries}`,
+          );
+          await sleep(delay);
+          delay *= 2; // Exponential backoff: 1s, 2s, 4s, 8s, 16s
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    // This should never be reached due to the throw in catch, but TypeScript needs it
+    throw error(GcalError.Unsure, "Failed to fetch events after max retries");
   }
 
   async *getBaseRecurringEventInstances({
@@ -137,6 +162,11 @@ class GCalService {
         typeof nextPageToken === "string" && nextPageToken.length > 0;
 
       yield { nextPageToken, nextSyncToken, items };
+
+      // Rate limiting delay between pages to avoid hitting Google's 600 queries/min limit
+      if (hasNextPage) {
+        await sleep(200); // 200ms between pages = max 300 pages/min
+      }
     } while (hasNextPage);
   }
 
@@ -187,6 +217,11 @@ class GCalService {
         typeof nextSyncToken === "string" && nextSyncToken.length > 0;
 
       yield { nextPageToken, nextSyncToken, items };
+
+      // Rate limiting delay between pages to avoid hitting Google's 600 queries/min limit
+      if (hasNextPage) {
+        await sleep(200); // 200ms between pages = max 300 pages/min
+      }
     } while (hasNextPage || !isLastPage);
   }
 

--- a/packages/backend/src/sync/services/import/sync.import.ts
+++ b/packages/backend/src/sync/services/import/sync.import.ts
@@ -39,6 +39,8 @@ import { isUsingHttps } from "@backend/sync/util/sync.util";
 
 const logger = Logger("app:sync.import");
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export type WithCompassObjectId<T> = Omit<T, "_id"> & { _id: ObjectId };
 
 export type RecurrenceWithObjectId =
@@ -342,24 +344,34 @@ export class SyncImport {
       nextSyncToken,
       nextPageToken,
     } of gCalResponse) {
-      await Promise.allSettled(
-        items.map(async (baseEvent) => {
-          const instanceStats = await this.importEventInstances(
-            userId,
-            calendarId,
-            baseEvent,
-            perPage,
-            session,
-          );
+      // Process events in batches to avoid rate limiting
+      const batchSize = 10;
+      for (let i = 0; i < items.length; i += batchSize) {
+        const batch = items.slice(i, i + batchSize);
+        await Promise.allSettled(
+          batch.map(async (baseEvent) => {
+            const instanceStats = await this.importEventInstances(
+              userId,
+              calendarId,
+              baseEvent,
+              perPage,
+              session,
+            );
 
-          const totalBaseEventsSaved =
-            instanceStats.totalSaved - instanceStats.totalInstancesSaved;
+            const totalBaseEventsSaved =
+              instanceStats.totalSaved - instanceStats.totalInstancesSaved;
 
-          stats.totalChanged += instanceStats.totalSaved;
-          stats.totalProcessed += instanceStats.totalProcessed;
-          stats.totalBaseEventsChanged += totalBaseEventsSaved;
-        }),
-      );
+            stats.totalChanged += instanceStats.totalSaved;
+            stats.totalProcessed += instanceStats.totalProcessed;
+            stats.totalBaseEventsChanged += totalBaseEventsSaved;
+          }),
+        );
+
+        // Small delay between batches to stay under rate limits
+        if (i + batchSize < items.length) {
+          await sleep(100);
+        }
+      }
 
       await updateSync(
         Resource_Sync.EVENTS,

--- a/packages/backend/src/sync/services/sync.service.ts
+++ b/packages/backend/src/sync/services/sync.service.ts
@@ -59,6 +59,8 @@ import userMetadataService from "@backend/user/services/user-metadata.service";
 
 const logger = Logger("app:sync.service");
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 class SyncService {
   private activeFullSyncRestarts = new Set<string>();
 
@@ -277,25 +279,30 @@ class SyncService {
     try {
       const syncImport = await createSyncImport(gcal);
 
-      const eventImports = await Promise.all(
-        gCalendarIds.map(async (gCalId) => {
-          const { nextSyncToken, ...result } = await syncImport.importAllEvents(
-            userId,
-            gCalId,
-            2500,
-          );
+      // Process calendars sequentially to avoid rate limiting
+      const eventImports = [];
+      for (const gCalId of gCalendarIds) {
+        const { nextSyncToken, ...result } = await syncImport.importAllEvents(
+          userId,
+          gCalId,
+          2500,
+        );
 
-          await updateSync(
-            Resource_Sync.EVENTS,
-            userId,
-            gCalId,
-            { nextSyncToken },
-            session,
-          );
+        await updateSync(
+          Resource_Sync.EVENTS,
+          userId,
+          gCalId,
+          { nextSyncToken },
+          session,
+        );
 
-          return { gCalId, ...result };
-        }),
-      );
+        eventImports.push({ gCalId, ...result });
+
+        // Delay between calendars to stay under rate limits
+        if (gCalendarIds.indexOf(gCalId) < gCalendarIds.length - 1) {
+          await sleep(1000); // 1 second between calendars
+        }
+      }
 
       await session.commitTransaction();
 


### PR DESCRIPTION
- Added exponential backoff mechanism for handling rate limits in getEvents method.
- Introduced sleep function to manage delays between retries and page requests.
- Updated getBaseRecurringEventInstances and sync service to include rate limiting delays between calendar imports and event batches.
- Enhanced error handling for Google Calendar API responses to improve reliability.

Related to #727 
