### PR TITLE
docs: add self-hosting guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ node_modules/
 playwright-report/
 test-results/
 blob-report/
+docs/superpowers/
 
 #core
 packages/core/build/

--- a/README.md
+++ b/README.md
@@ -59,9 +59,15 @@ We're actively working on improvements – check out our [roadmap](https://githu
 
 Head over to [app.compasscalendar.com](https://app.compasscalendar.com?utm_source=github&utm_medium=referral&utm_campaign=readme). No signup required
 
+### Self-host Compass
+
+Run Compass on your own machine and keep your calendar data on your own infrastructure.
+
+See [docs/self-hosting.md](./docs/self-hosting.md) for the manual self-hosting guide. A one-command installer is planned, but not available yet.
+
 ### Run Locally
 
-Want to poke around or self-host?
+Want to poke around as a developer?
 
 [Read the technical docs](https://github.com/SwitchbackTech/compass/tree/main/docs): All the info you'd need to get started, including guides on how to install, test, build, deploy, and contribute.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,9 @@ Start with [AGENTS.md](../AGENTS.md) for repo rules, commands, and conventions. 
 
 ## Development And Operations
 
-- [Env And Dev Modes](./development/env-and-dev-modes.md)
+- [Local Development](./development/local-development.md)
+- [Hosting Modes](./development/hosting-modes.md)
+- [Self-Hosting](./self-hosting.md)
 - [Testing Playbook](./development/testing-playbook.md)
 - [Web State Guide](./development/web-state-guide.md)
 - [Types And Validation](./development/types-and-validation.md)

--- a/docs/development/agent-onboarding.md
+++ b/docs/development/agent-onboarding.md
@@ -54,7 +54,7 @@ Before implementing or modifying features, consult the relevant requirements doc
 - Auth or session behavior:
   [Frontend Runtime Flow](../frontend/frontend-runtime-flow.md),
   [Password Auth Flow](../features/password-auth-flow.md),
-  [Env And Dev Modes](./env-and-dev-modes.md)
+  [Local Development](./local-development.md)
 - Backend endpoints:
   [Backend Request Flow](../backend/backend-request-flow.md),
   [API Documentation](../backend/api-documentation.md)

--- a/docs/development/hosting-modes.md
+++ b/docs/development/hosting-modes.md
@@ -1,0 +1,93 @@
+# Hosting Modes
+
+Compass behaves differently depending on two things: **where the app is hosted**, and **whether the user has an account**. Together, those two choices decide what you need to set up, where data lives, and which subsystems are involved.
+
+This guide is a map. When you want the detail behind a behavior, follow the links to the relevant subsystem doc.
+
+## Why This Exists
+
+The runtime mode affects:
+
+- which services must be running
+- which environment values are required
+- where events, tasks, identity, and sessions are stored
+- what you need to reproduce a bug
+- how you debug auth and sync behavior
+
+When you are debugging anything storage-, auth-, or sync-related, the first question is almost always: which hosting context and account state is the user in?
+
+## Quick Matrix
+
+| Hosting context | Account state | Calendar/event data location |
+| ---------------- | ------------- | ---------------------------- |
+| Compass Cloud (`app.compasscalendar.com`) | Anonymous | Browser IndexedDB |
+| Compass Cloud (`app.compasscalendar.com`) | Signed in | Compass backend -> Compass MongoDB |
+| Self-hosted | Anonymous | Browser IndexedDB |
+| Self-hosted | Signed in | Operator backend -> configured MongoDB |
+
+Tasks currently stay in IndexedDB in every mode. That will change once backend task persistence is added.
+
+## Anonymous Browser State
+
+The lightest state. Useful for trying Compass without creating an account.
+
+- no account, no login
+- events and tasks live in the browser's IndexedDB
+- calendar and task data never leave the browser
+
+This is the same story everywhere: on [app.compasscalendar.com](https://app.compasscalendar.com) and on a self-hosted install before the user signs up. The web app might be served from Compass Cloud or from a self-hosted server, but either way, anonymous calendar and task data stay in the browser.
+
+## Self-Hosted Account Mode
+
+The operator runs their own backend with their own infrastructure. This is the path that [docs/self-hosting.md](../self-hosting.md) walks through.
+
+- operator runs the Compass backend
+- signup and login go through SuperTokens (either operator-configured or a default local instance)
+- on the first authenticated session, local events migrate from IndexedDB to the backend
+- authenticated writes go to the operator's configured `MONGO_URI`
+- Google Calendar is opt-in and uses the operator's own Google Cloud project
+
+For the runtime env and required variables, see [Local Development](./local-development.md).
+
+## Hosted Compass Cloud Account Mode
+
+The signed-in state on the managed product at [app.compasscalendar.com](https://app.compasscalendar.com).
+
+- Compass-operated backend
+- Compass-owned MongoDB and SuperTokens configuration
+- Compass production Google Cloud setup
+- the end user does not run or configure any infrastructure
+
+From the frontend's point of view, signed-in users here look the same as signed-in self-hosted users. The difference is on the other side: the backend they talk to is Compass-operated.
+
+## Data Flow Summary
+
+A quick read across hosting contexts and account states:
+
+| State                        | Where writes go                                   |
+| ---------------------------- | ------------------------------------------------- |
+| Anonymous                    | Browser IndexedDB                                 |
+| Signup / first login         | Local events sync up to the backend               |
+| Authenticated (any mode)     | Backend → configured MongoDB                     |
+| Google connect               | Backend stores Google credentials and starts sync |
+| Google sync running          | Backend ⇄ Google Calendar, pushes updates to the browser via SSE |
+
+For storage behavior and migration specifics, see [Offline Storage And Migrations](../features/offline-storage-and-migrations.md). For the Google side, see [Google Sync And SSE Flow](../features/google-sync-and-sse-flow.md).
+
+## Common Confusions
+
+A few things that trip up new contributors:
+
+- **SuperTokens ≠ event storage.** SuperTokens stores identity and sessions. Compass events live in MongoDB (or IndexedDB when anonymous).
+- **MongoDB stores events after signup, not before.** Anonymous events never touch the backend.
+- **Google sync is independent from account mode.** Self-hosted account mode supports Google sync, but the backend still requires the Google env values at startup today. See [Local Development](./local-development.md) for the backend env contract.
+- **Tasks stay local.** Tasks currently live in IndexedDB regardless of account state. Backend task persistence is not wired up yet.
+
+## Deeper Docs
+
+- [Password Auth Flow](../features/password-auth-flow.md)
+- [Offline Storage And Migrations](../features/offline-storage-and-migrations.md)
+- [Local Development](./local-development.md)
+- [Deploy](./deploy.md)
+- [Google Sync And SSE Flow](../features/google-sync-and-sse-flow.md)
+- [API Documentation](../backend/api-documentation.md)

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -1,4 +1,4 @@
-# Env And Dev Modes
+# Local Development
 
 Compass has multiple workable development modes. Pick the lightest mode that supports the feature you are changing.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,166 @@
+# Self-Hosting Compass
+
+Run Compass on your own machine and keep your calendar data on your own infrastructure.
+
+This guide walks through the manual setup path: what you need to provide, what Compass expects to be running, and what to expect once everything is up. You don't need to be a systems expert, but you should be comfortable running a few commands and editing a config file.
+
+> **Note:** A one-command installer is planned. Until it ships, use the manual steps below.
+
+## What Compass Needs
+
+Compass is a web app plus a backend API. It doesn't bundle a database or an auth server — it expects both to exist and to be reachable from the backend.
+
+**You provide:**
+
+- A machine you can run services on. Your laptop is fine for personal use.
+- [Bun](https://bun.sh) for installing dependencies and running the backend and web app.
+- Node.js 24+ if you plan to make a production build. You can skip this while running in dev mode.
+- A **MongoDB** instance. Stores your events once you sign up. The simplest path is a managed service like MongoDB Atlas (the free tier is plenty for personal use). You can also run MongoDB in Docker or install it directly on your machine.
+- A **SuperTokens** instance. Handles signup, login, and sessions. The simplest path is the managed SuperTokens SaaS (free tier is plenty for personal use). You can also run the SuperTokens core in Docker.
+
+**Optional:**
+
+- A **Google Cloud project**, only if you want Compass to sync with Google Calendar.
+
+> **Heads up:** Google Calendar sync is optional, but the backend currently still requires Google env values to start. Until that's fixed, provide real or placeholder Google values in your env file even if you don't plan to connect Google Calendar.
+
+**Compass provides:**
+
+- The web app and backend, plus all the logic that reads and writes your events.
+- Local-first storage in the browser before you sign up — you can use Compass immediately without configuring anything else.
+- Migration of your browser-local events into your MongoDB when you create an account.
+- Google Calendar sync once you connect a Google Cloud project.
+
+## Setup Steps
+
+1. **Get the code.**
+
+   ```bash
+   git clone https://github.com/SwitchbackTech/compass.git
+   cd compass
+   ```
+
+2. **Install dependencies.**
+
+   ```bash
+   bun install
+   ```
+
+3. **Create your backend env file and edit it.**
+
+   ```bash
+   cp packages/backend/.env.local.example packages/backend/.env.local
+   ```
+
+   Open `packages/backend/.env.local` and fill in:
+
+   - `MONGO_URI` — connection string for your MongoDB.
+   - SuperTokens values — the URI and key for your SuperTokens instance.
+   - Google credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`) — required for the backend to start even if you aren't planning to use Google Calendar. Paste in real credentials if you have a Google Cloud project, or keep the placeholder values from the example file until you do.
+
+   For the full list and what each variable does, see [Local Development](./development/local-development.md).
+
+4. **Start the backend.**
+
+   ```bash
+   bun run dev:backend
+   ```
+
+   The backend listens on `http://localhost:3000` and exposes its API under `/api`.
+
+5. **Start the web app** in another terminal.
+
+   ```bash
+   bun run dev:web
+   ```
+
+6. **Open Compass** at [http://localhost:9080](http://localhost:9080).
+
+   You can start using it immediately — no account required.
+
+## What To Expect
+
+Once both commands are running, here's where everything lives by default:
+
+| Piece                | Where it is                                            |
+| -------------------- | ------------------------------------------------------ |
+| Web app              | [http://localhost:9080](http://localhost:9080)         |
+| Backend API          | [http://localhost:3000/api](http://localhost:3000/api) |
+| MongoDB              | Whatever you set `MONGO_URI` to                        |
+| SuperTokens          | Whatever SuperTokens instance you configured           |
+| Google Calendar sync | Off until you configure Google credentials             |
+
+If the web app loads but signup fails, check that your backend is running and that MongoDB and SuperTokens are reachable from it. The backend has a health endpoint for a quick check:
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+A `200` response means the backend is running and can reach MongoDB.
+
+## Accounts And Where Your Data Lives
+
+Compass stores data in different places depending on whether you're signed in.
+
+- **Before you sign up:** your events and tasks live in your browser's local storage (IndexedDB). Calendar and task data are not sent to MongoDB.
+- **When you sign up:** SuperTokens creates your account, and any events you already had in the browser are copied into your MongoDB. From then on, event changes go through the backend.
+- **Tasks stay in your browser** before and after signup. Backend task storage is not available yet.
+
+**Backing up your data:**
+
+- **Back up your MongoDB regularly.** Account events are stored there, so any MongoDB backup approach works — `mongodump` for self-hosted Mongo, or the built-in snapshot feature of a managed service like Atlas.
+- **Tasks only live in the browser's IndexedDB** and don't have a backup or export path today. If browser storage is cleared or you move to a new device, those tasks are gone. A proper task export story is still to come.
+
+For a fuller picture of how data flows in each mode, see [Hosting Modes](./development/hosting-modes.md).
+
+## Customizing After Setup
+
+You don't have to change anything past the first run. When you're ready:
+
+- **Point at a different MongoDB** by updating `MONGO_URI`. A managed MongoDB service, a container on your machine, or a remote server all work.
+- **Use a different SuperTokens instance** by updating the SuperTokens values in `.env.local`.
+- **Enable Google Calendar** by creating a Google Cloud project, adding real credentials to `.env.local`, and restarting the backend.
+
+## Running On A Server
+
+Running Compass on a server is the same shape as running it on your laptop. The pieces don't change — a backend process, a built web app, a MongoDB, and a SuperTokens instance. What changes is the wiring: the web app and backend need public URLs, and everything has to be configured with those real URLs instead of `localhost`. MongoDB and SuperTokens only need to be reachable from the backend; they don't have to be public.
+
+Here's what differs from a laptop setup:
+
+- **A domain and public URLs.** Your web app and backend API need to be reachable from your users' browsers. Point a domain (or two subdomains) at your server so you have stable URLs to use.
+- **HTTPS.** Required in practice, especially if you want Google Calendar sync — Google OAuth only accepts HTTPS redirect URLs (except for `localhost`). Putting a reverse proxy like Caddy, nginx, or Cloudflare in front of Compass is the common pattern, and it handles HTTPS termination for you.
+- **Public URLs in your env file.** Update `FRONTEND_URL`, `BASEURL`, and `CORS` to match your real public URLs. `BASEURL` is baked into the web app at build time, so rebuild the web app after changing it.
+- **Build the web app for production.** In dev mode (`bun run dev:web`) the web app is served live. For a server, build it once from the repo root with `bun run build:web` (this loads the backend env file so `BASEURL` is injected into the bundle correctly) and serve the built files through your reverse proxy or any static web server.
+- **Keep the backend process running.** `bun run dev:backend` is fine for a laptop but isn't meant for long-running use. On a server, run the backend under systemd, a container, pm2, or whatever process manager you're comfortable with, so it restarts on crashes and reboots.
+- **Google Cloud configuration.** If you enable Google Calendar sync, configure your Google Cloud project with your public web origin for OAuth, and make sure your backend API has a public HTTPS URL so Google can deliver Calendar notifications to it.
+- **MongoDB and SuperTokens as backend-only services.** A managed MongoDB service and a managed SuperTokens deployment are the simplest path. If you self-host them, they need to be reachable from the backend — same server, private network, or public internet with access controls — but they don't need to be exposed to the outside world.
+
+### Server Deployment Checklist
+
+A short, ordered pass for taking a laptop setup to a server:
+
+1. Choose the public URLs you want for the web app and backend API.
+2. Set `FRONTEND_URL`, `BASEURL`, and `CORS` in `packages/backend/.env.local` to match those URLs.
+3. Build the web app from the repo root with `bun run build:web`.
+4. Run the backend under a process manager (systemd, a container, pm2, etc.) so it restarts on crashes and reboots.
+5. Put a reverse proxy (Caddy, nginx, Cloudflare) in front of both and terminate HTTPS there.
+6. Verify `/api/health` returns `200` when hit through your public backend URL.
+7. Create an account through your public web URL to confirm signup end-to-end.
+8. (Optional) Configure your Google Cloud project with your public web origin and backend HTTPS URL, then connect Google Calendar from inside Compass.
+
+A dedicated server deployment guide is still to be written. Until then, [Local Development](./development/local-development.md) has the full list of environment variables the backend and web build expect.
+
+## Next Steps
+
+You don't need a dedicated guide for most follow-up work — each one is a small change against your existing setup:
+
+- **Swap MongoDB, SuperTokens, or enable Google sync** — follow the [Customizing After Setup](#customizing-after-setup) section above. Each change is an env-file edit plus a backend restart.
+- **Back up account events** — run `mongodump` against your `MONGO_URI` on a schedule, or turn on your managed MongoDB's built-in backups.
+- **Deploy on a server** — follow the [Server Deployment Checklist](#server-deployment-checklist) above.
+
+If something isn't working or you need to dig deeper:
+
+- [Local Development](./development/local-development.md) — full environment variable contract and troubleshooting tips
+- [Hosting Modes](./development/hosting-modes.md) — how data flows in each mode
+
+Dedicated guides for Google Cloud setup, self-hosted MongoDB, self-hosted SuperTokens, and a full backup playbook are on the roadmap.


### PR DESCRIPTION
## Summary

Adds the first pass of Compass self-hosting documentation and clarifies the difference between local development setup and product hosting/account modes.

This PR is docs-only. It intentionally does **not** implement the future one-command installer; that will happen in a follow-up branch.

## What changed

- Added a short README entry point for self-hosting.
- Added `docs/self-hosting.md` for people manually setting up Compass today.
- Added `docs/development/hosting-modes.md` for contributors to understand hosting context, account state, and data ownership.
- Renamed `docs/development/env-and-dev-modes.md` to `docs/development/local-development.md` so local developer setup is not confused with hosting modes.
- Updated docs index and onboarding links to use the new names.
- Added `docs/superpowers/` to `.gitignore` so future brainstorming/design drafts do not get committed by default.

## Why

We identified two separate audiences that needed different docs:

- **People self-hosting Compass** need practical setup guidance: what services they provide, what Compass provides, how to start the app, and where their data lives.
- **Contributors** need a mental model for how Compass behaves across anonymous browser use, self-hosted account mode, and hosted Compass Cloud.

Splitting those concerns keeps the public self-hosting guide approachable while still giving contributors the deeper map they need.

## Important behavior captured

- Anonymous users can use Compass without an account; events and tasks stay in browser IndexedDB.
- After signup, local events migrate to the MongoDB configured for that backend.
- Tasks currently stay in IndexedDB even after signup.
- Self-hosted account mode needs MongoDB and SuperTokens.
- Google Calendar sync is optional as a product behavior, but the backend currently still requires Google env values at startup.
- Server deployments need public web/API URLs, HTTPS, correct `FRONTEND_URL` / `BASEURL` / `CORS`, and MongoDB/SuperTokens reachable from the backend.

## Validation

- Checked local markdown links in the touched docs.
- Reviewed the branch diff against `main` to ensure this branch is docs-focused.
- Moved the work from the earlier misleading `feat/one-cmd-dev-setup` branch to `docs/add-self-hosting-docs`; the actual installer work will be handled separately.

## Follow-up work

- Make Google config optional for password-only self-hosted account mode: #1659.
- Build the future one-command self-host installer.
- Add deeper self-hosting guides for Google Cloud setup, MongoDB setup/backups, SuperTokens setup, and server deployment.