### PR TITLE
fix(backend): repair backend test runner

### DIFF
--- a/packages/backend/src/servers/sse/sse.server.test.ts
+++ b/packages/backend/src/servers/sse/sse.server.test.ts
@@ -62,9 +62,9 @@ describe("SSE Server", () => {
       const userId = new ObjectId().toString();
 
       const stream = baseDriver.openSSEStream({ userId });
-      const eventPromise = stream.waitForEvent(EVENT_CHANGED, 2000);
+      await stream.waitForEvent(USER_METADATA, 2000);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      const eventPromise = stream.waitForEvent(EVENT_CHANGED, 2000);
 
       const { sseServer } = await import("./sse.server");
       sseServer.handleBackgroundCalendarChange(userId);
@@ -78,9 +78,9 @@ describe("SSE Server", () => {
       const userId = new ObjectId().toString();
 
       const stream = baseDriver.openSSEStream({ userId });
-      const eventPromise = stream.waitForEvent(SOMEDAY_EVENT_CHANGED, 2000);
+      await stream.waitForEvent(USER_METADATA, 2000);
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      const eventPromise = stream.waitForEvent(SOMEDAY_EVENT_CHANGED, 2000);
 
       const { sseServer } = await import("./sse.server");
       sseServer.handleBackgroundSomedayChange(userId);
@@ -132,10 +132,9 @@ describe("SSE Server", () => {
       const otherUserId = new ObjectId().toString();
 
       const stream = baseDriver.openSSEStream({ userId });
+      await stream.waitForEvent(USER_METADATA, 2000);
 
       const eventPromise = stream.waitForEvent(EVENT_CHANGED, 300);
-
-      await new Promise((resolve) => setTimeout(resolve, 50));
 
       const { sseServer } = await import("./sse.server");
       sseServer.handleBackgroundCalendarChange(otherUserId);

--- a/packages/core/src/__tests__/mock.setup.ts
+++ b/packages/core/src/__tests__/mock.setup.ts
@@ -1,47 +1,7 @@
 import { faker as mockFaker } from "@faker-js/faker";
 import { default as mockMergeWith } from "lodash.mergewith";
-import { createRequire } from "node:module";
-
-const require = createRequire(import.meta.url);
-const bunTest = (() => {
-  try {
-    return require("bun:test") as {
-      mock: {
-        module: (id: string, factory: () => object) => void;
-      };
-    };
-  } catch {
-    return null;
-  }
-})();
 
 export const mockBSON = () => {
-  if (bunTest) {
-    bunTest.mock.module("bson", () => ({
-      ObjectId: class ObjectId {
-        #value: string;
-
-        constructor(value?: string) {
-          if (value && !ObjectId.isValid(value)) {
-            throw new Error("Invalid ObjectId");
-          }
-
-          this.#value = value ?? mockFaker.database.mongodbObjectId();
-        }
-
-        toString() {
-          return this.#value;
-        }
-
-        static isValid(value?: string) {
-          return /^[a-fA-F0-9]{24}$/.test(value ?? "");
-        }
-      },
-    }));
-
-    return;
-  }
-
   jest.mock("bson", () => ({
     ObjectId: class ObjectId {
       #value: string;

--- a/packages/scripts/src/testing/core.jest-compat.ts
+++ b/packages/scripts/src/testing/core.jest-compat.ts
@@ -11,3 +11,5 @@ const { applyBunJestCompat } = nodeRequire(
 };
 
 applyBunJestCompat(bunJest, bunMock);
+
+(globalThis as typeof globalThis & { jest: typeof bunJest }).jest = bunJest;


### PR DESCRIPTION
## Summary
- restore the shared mock helper so backend Jest can load it without encountering Bun-only `import.meta` code
- expose the Bun Jest compatibility object as global `jest` for core tests
- make the web test preload install the shared compatibility setup before it imports core test startup
- expose Bun test `expect` globally for web tests that import `@testing-library/jest-dom` directly
- make the SSE tests wait for the stream readiness event instead of relying on a fixed delay

## Why Tests Were Failing
The backend test suite failed before running any actual tests because a shared core mock helper imported Bun-specific module-loading code. Backend tests still run through Jest, and Jest transformed that helper as CommonJS, leaving an `import.meta` expression that Jest could not execute. That caused every backend suite that loaded the shared setup to fail immediately.

After the helper was simplified to use `jest.mock`, core tests needed the Bun/Jest compatibility object exposed globally. The core runner already loads that compatibility file, so the fix there was to make its `jest` object available on `globalThis`.

The web test job then failed because it imports the same core test startup but did not load the compatibility file first. That meant `mockBSON()` called `jest.mock` before web had a compatible global `jest`, and the web preload stopped before creating the DOM globals. Once that was fixed, the remaining web failures came from tests that import `@testing-library/jest-dom` directly; those imports expect `expect` to be global, so the preload now exposes the same Bun `expect` object it already extends.

One SSE test also failed intermittently in the full suite. The test opened an event stream, slept for 50ms, and then published an event. Under full-suite load, the stream was sometimes not subscribed yet, so the event was missed and the test timed out. The test now waits for the initial user metadata event before publishing follow-up events.

## Verification
- `bun run test:web`
- `bun run test:core`
- `./node_modules/.bin/biome check packages/core/src/__tests__/mock.setup.ts packages/scripts/src/testing/core.jest-compat.ts packages/backend/src/servers/sse/sse.server.test.ts packages/web/src/__tests__/web.preload.ts`

## Notes
- I also retried `bun run test:backend`; the backend suites now get past the original Jest parse issue, but the local run hit Mongo memory-server startup timeouts (`Instance failed to start within 10000ms`). The backend job had already passed on CI for this branch before the web-preload-only follow-up.