### PR TITLE
fix: save events locally without active session

### DIFF
--- a/packages/web/src/common/constants/env.constants.test.ts
+++ b/packages/web/src/common/constants/env.constants.test.ts
@@ -1,0 +1,20 @@
+import { isGoogleAuthConfigured } from "./env.constants";
+import { describe, expect, it } from "bun:test";
+
+describe("isGoogleAuthConfigured", () => {
+  it("rejects missing and placeholder Google client IDs", () => {
+    expect(isGoogleAuthConfigured()).toBe(false);
+    expect(isGoogleAuthConfigured("undefined")).toBe(false);
+    expect(
+      isGoogleAuthConfigured(
+        "compass-self-host-placeholder.apps.googleusercontent.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts a custom Google client ID", () => {
+    expect(
+      isGoogleAuthConfigured("1234567890-example.apps.googleusercontent.com"),
+    ).toBe(true);
+  });
+});

--- a/packages/web/src/common/constants/env.constants.ts
+++ b/packages/web/src/common/constants/env.constants.ts
@@ -30,3 +30,17 @@ export const ENV_WEB = webEnvSchema.parse({
 });
 
 export const IS_DEV = isDev(ENV_WEB.NODE_ENV);
+
+const GOOGLE_CLIENT_ID_PLACEHOLDER =
+  "compass-self-host-placeholder.apps.googleusercontent.com";
+
+export const isGoogleAuthConfigured = (clientId?: string): boolean =>
+  Boolean(
+    clientId &&
+      clientId !== "undefined" &&
+      clientId !== GOOGLE_CLIENT_ID_PLACEHOLDER,
+  );
+
+export const IS_GOOGLE_AUTH_CONFIGURED = isGoogleAuthConfigured(
+  ENV_WEB.GOOGLE_CLIENT_ID,
+);

--- a/packages/web/src/common/repositories/event/event.repository.util.test.ts
+++ b/packages/web/src/common/repositories/event/event.repository.util.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockIsGoogleRevoked = mock(() => false);
+
+mock.module("@web/auth/google/state/google.auth.state", () => ({
+  isGoogleRevoked: mockIsGoogleRevoked,
+}));
+
+const { LocalEventRepository } = await import("./local.event.repository");
+const { RemoteEventRepository } = await import("./remote.event.repository");
+const { getEventRepository } = await import("./event.repository.util");
+
+describe("getEventRepository", () => {
+  beforeEach(() => {
+    mockIsGoogleRevoked.mockReset();
+    mockIsGoogleRevoked.mockReturnValue(false);
+  });
+
+  it("uses remote storage when a session exists", () => {
+    expect(getEventRepository(true)).toBeInstanceOf(RemoteEventRepository);
+  });
+
+  it("uses local storage when no session exists", () => {
+    expect(getEventRepository(false)).toBeInstanceOf(LocalEventRepository);
+  });
+
+  it("uses local storage when Google access was revoked", () => {
+    mockIsGoogleRevoked.mockReturnValue(true);
+
+    expect(getEventRepository(true)).toBeInstanceOf(LocalEventRepository);
+  });
+});

--- a/packages/web/src/common/repositories/event/event.repository.util.ts
+++ b/packages/web/src/common/repositories/event/event.repository.util.ts
@@ -6,7 +6,6 @@
  * Start debugging "why isn't this event saving?" here.
  * Related: docs/development/web-state-guide.md
  */
-import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import { isGoogleRevoked } from "@web/auth/google/state/google.auth.state";
 import { type EventRepository } from "./event.repository.interface";
 import { LocalEventRepository } from "./local.event.repository";
@@ -19,11 +18,11 @@ import { RemoteEventRepository } from "./remote.event.repository";
  * 1. If Google access was revoked: Use LocalEventRepository
  *    - Graceful degradation until user re-authenticates
  *    - Prevents API errors from failed Google token refresh
- * 2. If user has EVER authenticated: Always use RemoteEventRepository
- *    - This prevents the UX issue where events disappear after login due to cleared IndexedDB
- *    - Even if session is temporarily invalid, we use remote (user will be prompted to re-auth)
- * 3. If user has NEVER authenticated: Use LocalEventRepository (IndexedDB)
- *    - Events stored locally until user decides to sign in
+ * 2. If no session exists: Use LocalEventRepository (IndexedDB)
+ *    - Stale auth flags can outlive backend sessions, especially across local/self-host installs
+ *    - Local storage keeps anonymous event creation working instead of failing with 401s
+ * 3. If a session exists: Use RemoteEventRepository
+ *    - Authenticated users persist through the backend
  *
  * @param sessionExists - Whether a session currently exists (from session.doesSessionExist())
  */
@@ -33,15 +32,6 @@ export function getEventRepository(sessionExists: boolean): EventRepository {
     return new LocalEventRepository();
   }
 
-  const hasAuthenticated = hasUserEverAuthenticated();
-
-  // Once a user has authenticated, ALWAYS use remote repository
-  // This ensures events don't disappear due to empty IndexedDB after login
-  if (hasAuthenticated) {
-    return new RemoteEventRepository();
-  }
-
-  // User has never authenticated - use session state to decide
   if (sessionExists) {
     return new RemoteEventRepository();
   }

--- a/packages/web/src/common/utils/shortcut/data/shortcuts.data.test.ts
+++ b/packages/web/src/common/utils/shortcut/data/shortcuts.data.test.ts
@@ -14,7 +14,7 @@ describe("shortcuts.data", () => {
         k: "r",
         label: "Edit reminder",
       });
-      expect(shortcuts.globalShortcuts[4]).toEqual({ k: "z", label: "Logout" });
+      expect(shortcuts.globalShortcuts[4]).toEqual({ k: "z", label: "Log in" });
       expect(shortcuts.globalShortcuts[5]).toEqual({
         k: "Mod+k",
         label: "Command Palette",
@@ -35,6 +35,12 @@ describe("shortcuts.data", () => {
         k: "t",
         label: "Go to today",
       });
+    });
+
+    it("shows logout when authenticated", () => {
+      const shortcuts = getShortcuts({ isAuthenticated: true });
+
+      expect(shortcuts.globalShortcuts[4]).toEqual({ k: "z", label: "Logout" });
     });
 
     it("should show 'Scroll to now' when currentDate is today", () => {

--- a/packages/web/src/common/utils/shortcut/data/shortcuts.data.ts
+++ b/packages/web/src/common/utils/shortcut/data/shortcuts.data.ts
@@ -4,20 +4,27 @@ import { type Shortcut } from "@web/common/types/global.shortcut.types";
 
 interface ShortcutsConfig {
   isHome?: boolean;
+  isAuthenticated?: boolean;
   isToday?: boolean;
   isNow?: boolean;
   currentDate?: dayjs.Dayjs;
 }
 
 export const getShortcuts = (config: ShortcutsConfig = {}) => {
-  const { isHome = false, isToday = true, isNow = false, currentDate } = config;
+  const {
+    isAuthenticated = false,
+    isHome = false,
+    isToday = true,
+    isNow = false,
+    currentDate,
+  } = config;
 
   const globalShortcuts: Shortcut[] = [
     { k: VIEW_SHORTCUTS.now.key, label: VIEW_SHORTCUTS.now.label },
     { k: VIEW_SHORTCUTS.day.key, label: VIEW_SHORTCUTS.day.label },
     { k: VIEW_SHORTCUTS.week.key, label: VIEW_SHORTCUTS.week.label },
     { k: "r", label: "Edit reminder" },
-    { k: "z", label: "Logout" },
+    { k: "z", label: isAuthenticated ? "Logout" : "Log in" },
     { k: "Mod+k", label: "Command Palette" },
   ];
 

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -40,6 +40,13 @@ mock.module("@web/auth/google/hooks/useGoogleAuth/useGoogleAuth", () => ({
   }),
 }));
 
+mock.module("@web/common/constants/env.constants", () => ({
+  ENV_WEB: {
+    GOOGLE_CLIENT_ID: "test-client-id",
+  },
+  IS_GOOGLE_AUTH_CONFIGURED: true,
+}));
+
 const mockCompleteAuthentication = mock();
 mock.module("@web/auth/compass/hooks/useCompleteAuthentication", () => ({
   useCompleteAuthentication: () => mockCompleteAuthentication,

--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -1,6 +1,7 @@
 import { DotIcon } from "@phosphor-icons/react";
 import { type FC, useCallback, useEffect, useRef, useState } from "react";
 import { useGoogleAuth } from "@web/auth/google/hooks/useGoogleAuth/useGoogleAuth";
+import { IS_GOOGLE_AUTH_CONFIGURED } from "@web/common/constants/env.constants";
 import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { AuthButton } from "./components/AuthButton";
@@ -97,7 +98,8 @@ export const AuthModal: FC = () => {
   }
 
   const showAuthSwitch = isLoginView || currentView === "signUp";
-  const showGoogleAuth = currentView !== "resetPassword";
+  const showGoogleAuth =
+    currentView !== "resetPassword" && IS_GOOGLE_AUTH_CONFIGURED;
   const showSubmitError =
     submitError !== null && (isLoginView || currentView === "signUp");
   const trimmedName = signUpName.trim();

--- a/packages/web/src/ducks/events/sagas/event.sagas.test.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.test.ts
@@ -94,7 +94,7 @@ const { sagaMiddleware } = await import("@web/common/store/middlewares");
 const { selectIsEventPending } = await import(
   "@web/ducks/events/selectors/pending.selectors"
 );
-const { createEventSlice, editEventSlice } = await import(
+const { createEventSlice } = await import(
   "@web/ducks/events/slices/event.slice"
 );
 const { eventsEntitiesSlice } = await import(
@@ -446,6 +446,25 @@ describe("pending events state management", () => {
 
       const state = store.getState();
       // Event should be removed from pending even on error
+      expect(state.events.pendingEvents.eventIds).toHaveLength(0);
+    });
+
+    it("should not delete remotely when authenticated creation fails", async () => {
+      mockDoesSessionExist.mockResolvedValue(true);
+      mockEventApiCreate.mockRejectedValue(new Error("API Error"));
+
+      const gridEvent = createMockStandaloneEvent() as Schema_GridEvent;
+      const event = new OnSubmitParser(gridEvent).parse() as Schema_Event;
+
+      store.dispatch(createEventSlice.actions.request(event));
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const state = store.getState();
+
+      expect(mockEventApiCreate).toHaveBeenCalledTimes(1);
+      expect(mockEventApiDelete).not.toHaveBeenCalled();
+      expect(Object.keys(state.events.entities.value ?? {})).toHaveLength(0);
       expect(state.events.pendingEvents.eventIds).toHaveLength(0);
     });
   });

--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -138,10 +138,10 @@ export function* createEvent({ payload }: Action_CreateEvent): Generator {
     yield put(createEventSlice.actions.success());
   } catch (error) {
     yield put(pendingEventsSlice.actions.remove(event._id));
+    yield put(getWeekEventsSlice.actions.delete({ _id: event._id }));
+    yield put(getDayEventsSlice.actions.delete({ _id: event._id }));
+    yield put(eventsEntitiesSlice.actions.delete({ _id: event._id }));
     yield put(createEventSlice.actions.error());
-    yield call(deleteEvent, {
-      payload: { _id: event._id },
-    } as Action_DeleteEvent);
     handleError(error as Error);
   }
 }

--- a/packages/web/src/views/Calendar/hooks/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/views/Calendar/hooks/shortcuts/useGlobalShortcuts.ts
@@ -1,8 +1,10 @@
 import { type RegisterableHotkey } from "@tanstack/react-hotkeys";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useSession } from "@web/auth/compass/session/useSession";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
 import { useAppHotkey, useAppHotkeyUp } from "@web/common/hooks/useAppHotkey";
+import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { viewSlice } from "@web/ducks/events/slices/view.slice";
 import { settingsSlice } from "@web/ducks/settings/slices/settings.slice";
 import { useAppDispatch } from "@web/store/store.hooks";
@@ -13,6 +15,8 @@ import { useAppDispatch } from "@web/store/store.hooks";
  */
 export function useGlobalShortcuts() {
   const dispatch = useAppDispatch();
+  const { authenticated } = useSession();
+  const { openModal } = useAuthModal();
   const navigate = useNavigate();
   const location = useLocation();
   const nowHotkey = VIEW_SHORTCUTS.now.key.toUpperCase() as RegisterableHotkey;
@@ -39,7 +43,12 @@ export function useGlobalShortcuts() {
   });
 
   useAppHotkeyUp("Z", () => {
-    navigate(ROOT_ROUTES.LOGOUT);
+    if (authenticated) {
+      navigate(ROOT_ROUTES.LOGOUT);
+      return;
+    }
+
+    openModal("login");
   });
 
   useAppHotkeyUp("R", () => {

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback } from "react";
 import dayjs from "@core/util/date/dayjs";
+import { useSession } from "@web/auth/compass/session/useSession";
 import { useCompassRefs } from "@web/common/hooks/useCompassRefs";
 import { useEventDNDActions } from "@web/common/hooks/useEventDNDActions";
 import { useGridOrganization } from "@web/common/hooks/useGridOrganization";
@@ -33,6 +34,7 @@ import {
 
 export const DayViewContent = memo(() => {
   const { isSidebarOpen, toggleSidebar } = useSidebarState();
+  const { authenticated } = useSession();
 
   const selectionActions = useMainGridSelectionActions();
   const { timedEventsGridRef } = useCompassRefs();
@@ -56,7 +58,10 @@ export const DayViewContent = memo(() => {
     undoToastId,
   } = useTasks();
   const dateInView = useDateInView();
-  const shortcuts = getShortcuts({ currentDate: dateInView });
+  const shortcuts = getShortcuts({
+    currentDate: dateInView,
+    isAuthenticated: authenticated,
+  });
 
   const { navigateToNextDay, navigateToPreviousDay, navigateToToday } =
     useDateNavigation();

--- a/packages/web/src/views/Now/view/NowView.tsx
+++ b/packages/web/src/views/Now/view/NowView.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useSession } from "@web/auth/compass/session/useSession";
 import { usePointerPosition } from "@web/common/hooks/usePointerPosition";
 import { useSidebarState } from "@web/common/hooks/useSidebarState";
 import { getShortcuts } from "@web/common/utils/shortcut/data/shortcuts.data";
@@ -11,9 +12,11 @@ import { useNowShortcuts } from "@web/views/Now/shortcuts/useNowShortcuts";
 import { NowViewContent } from "@web/views/Now/view/NowViewContent";
 
 export const NowView = () => {
+  const { authenticated } = useSession();
   const { togglePointerMovementTracking } = usePointerPosition();
   const { isSidebarOpen, toggleSidebar } = useSidebarState();
   const { globalShortcuts, nowShortcuts } = getShortcuts({
+    isAuthenticated: authenticated,
     isNow: true,
   });
 

--- a/self-host/.env.example
+++ b/self-host/.env.example
@@ -21,7 +21,8 @@ CORS=http://localhost:9080,http://localhost:3000
 # Compass MongoDB
 MONGO_INITDB_ROOT_USERNAME=compass
 MONGO_INITDB_ROOT_PASSWORD=change-me-mongo-password-32chars
-MONGO_URI=mongodb://compass:change-me-mongo-password-32chars@mongo:27017/prod_calendar?authSource=admin
+MONGO_REPLICA_SET_KEY=change-me-mongo-replica-set-key-32chars
+MONGO_URI=mongodb://compass:change-me-mongo-password-32chars@mongo:27017/prod_calendar?authSource=admin&replicaSet=rs0
 
 # SuperTokens Postgres
 SUPERTOKENS_POSTGRES_USER=supertokens

--- a/self-host/Dockerfile.mongo
+++ b/self-host/Dockerfile.mongo
@@ -1,0 +1,8 @@
+FROM mongo:8.0
+
+COPY self-host/mongo-entrypoint.sh /usr/local/bin/compass-mongo-entrypoint
+
+RUN chmod +x /usr/local/bin/compass-mongo-entrypoint
+
+ENTRYPOINT ["compass-mongo-entrypoint"]
+CMD ["mongod", "--replSet", "rs0", "--bind_ip_all", "--keyFile", "/data/configdb/mongo-keyfile"]

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -11,7 +11,7 @@ Here, `~/compass` means a `compass` folder in your home folder, such as `/Users/
 - `install.sh` — the installer. Sets up `~/compass`, writes `~/compass/.env`, copies the helper script, and places the app files under `~/compass/app`.
 - `compass` — a template of the helper script. The installer copies this to `~/compass/compass`. Don't run it directly from the repo; run the installed copy in `~/compass`.
 - `docker-compose.yml` — the Docker Compose stack used by the installed app.
-- `Dockerfile.web`, `Dockerfile.backend` — images for the web and backend services.
+- `Dockerfile.web`, `Dockerfile.backend`, `Dockerfile.mongo` — images for the web, backend, and local MongoDB services.
 - `serve-web.ts` — the tiny web server that serves the built web app inside the web container.
 - `.env.example` — example environment values that mirror what the installer writes to `~/compass/.env`.
 

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-compass-self-host-placeholder.apps.googleusercontent.com}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-compass-self-host-placeholder-secret}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      MONGO_URI: ${MONGO_URI:-mongodb://compass:change-me-mongo-password-32chars@mongo:27017/prod_calendar?authSource=admin}
+      MONGO_URI: ${MONGO_URI:-mongodb://compass:change-me-mongo-password-32chars@mongo:27017/prod_calendar?authSource=admin&replicaSet=rs0}
       NODE_ENV: ${NODE_ENV:-production}
       PORT: "3000"
       SUPERTOKENS_KEY: ${SUPERTOKENS_KEY:-change-me-supertokens-key-32chars}
@@ -58,10 +58,13 @@ services:
       start_period: 20s
 
   mongo:
-    image: mongo:8.0
+    build:
+      context: ..
+      dockerfile: self-host/Dockerfile.mongo
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-compass}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-change-me-mongo-password-32chars}
+      MONGO_REPLICA_SET_KEY: ${MONGO_REPLICA_SET_KEY:?MONGO_REPLICA_SET_KEY is required}
     volumes:
       - compass_mongo_data:/data/db
     restart: unless-stopped
@@ -69,7 +72,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "mongosh --quiet --username \"$$MONGO_INITDB_ROOT_USERNAME\" --password \"$$MONGO_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --eval 'db.adminCommand({ ping: 1 }).ok'",
+          "mongosh --quiet --username \"$$MONGO_INITDB_ROOT_USERNAME\" --password \"$$MONGO_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --eval 'try { const status = rs.status(); if (status.ok === 1 && status.myState === 1) quit(0); } catch (e) { try { rs.initiate({ _id: \"rs0\", members: [{ _id: 0, host: \"mongo:27017\" }] }); } catch (initError) { if (!String(initError).includes(\"already initialized\")) throw initError; } } const status = rs.status(); quit(status.ok === 1 && status.myState === 1 ? 0 : 1);'",
         ]
       interval: 10s
       timeout: 5s

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -429,10 +429,73 @@ validate_existing_mongo_uri() {
   esac
 }
 
+ensure_existing_generated_secret() {
+  key=$1
+  label=$2
+  value=$(strip_quotes "$(read_env_value "$key")")
+
+  if [ -n "$value" ]; then
+    return
+  fi
+
+  secret=$(generate_secret "$label") || exit 1
+  printf '\n%s=%s\n' "$key" "$secret" >> "$ENV_FILE" \
+    || fail "Could not add $key to $ENV_FILE."
+  chmod 600 "$ENV_FILE" || fail "Could not secure $ENV_FILE."
+  info "Added missing $key to $ENV_FILE."
+}
+
+ensure_existing_local_mongo_uri_replica_set() {
+  mongo_uri=$(strip_quotes "$(read_env_value MONGO_URI)")
+
+  case $mongo_uri in
+    *mongo:27017*) ;;
+    *)
+      return
+      ;;
+  esac
+
+  case $mongo_uri in
+    *replicaSet=*)
+      return
+      ;;
+  esac
+
+  separator="?"
+  case $mongo_uri in
+    *\?*)
+      separator="&"
+      ;;
+  esac
+
+  TMP_ENV=$COMPASS_HOME/.env.$$
+  while IFS= read -r line || [ -n "$line" ]; do
+    case $line in
+      MONGO_URI=*)
+        printf 'MONGO_URI=%s%sreplicaSet=rs0\n' "$mongo_uri" "$separator"
+        ;;
+      *)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done < "$ENV_FILE" > "$TMP_ENV" \
+    || fail "Could not update $ENV_FILE with MongoDB replica set settings."
+
+  chmod 600 "$TMP_ENV" || fail "Could not secure temporary env file."
+  mv "$TMP_ENV" "$ENV_FILE" \
+    || fail "Could not update $ENV_FILE with MongoDB replica set settings."
+  TMP_ENV=
+  info "Updated local MONGO_URI to use MongoDB replica set rs0."
+}
+
 validate_existing_env_secrets() {
   [ -f "$ENV_FILE" ] || return
 
+  ensure_existing_generated_secret MONGO_REPLICA_SET_KEY "MongoDB replica set key"
+  ensure_existing_local_mongo_uri_replica_set
+
   validate_existing_secret MONGO_INITDB_ROOT_PASSWORD change-me-mongo-password-32chars
+  validate_existing_secret MONGO_REPLICA_SET_KEY change-me-mongo-replica-set-key-32chars
   validate_existing_secret SUPERTOKENS_POSTGRES_PASSWORD change-me-supertokens-postgres-pass-32
   validate_existing_secret SUPERTOKENS_KEY change-me-supertokens-key-32chars
   validate_existing_secret TOKEN_COMPASS_SYNC change-me-compass-sync-token-32chars
@@ -448,6 +511,7 @@ write_env_if_missing() {
   fi
 
   mongo_password=$(generate_secret "MongoDB password") || exit 1
+  mongo_replica_set_key=$(generate_secret "MongoDB replica set key") || exit 1
   supertokens_postgres_password=$(generate_secret "SuperTokens Postgres password") || exit 1
   supertokens_key=$(generate_secret "SuperTokens API key") || exit 1
   compass_sync_token=$(generate_secret "Compass sync token") || exit 1
@@ -477,7 +541,8 @@ CORS=http://localhost:9080,http://localhost:3000
 # Compass MongoDB
 MONGO_INITDB_ROOT_USERNAME=compass
 MONGO_INITDB_ROOT_PASSWORD=$mongo_password
-MONGO_URI=mongodb://compass:$mongo_password@mongo:27017/prod_calendar?authSource=admin
+MONGO_REPLICA_SET_KEY=$mongo_replica_set_key
+MONGO_URI=mongodb://compass:$mongo_password@mongo:27017/prod_calendar?authSource=admin&replicaSet=rs0
 
 # SuperTokens Postgres
 SUPERTOKENS_POSTGRES_USER=supertokens

--- a/self-host/mongo-entrypoint.sh
+++ b/self-host/mongo-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ -z "${MONGO_REPLICA_SET_KEY:-}" ]; then
+  echo "MONGO_REPLICA_SET_KEY is required." >&2
+  exit 1
+fi
+
+mkdir -p /data/configdb
+printf '%s\n' "$MONGO_REPLICA_SET_KEY" > /data/configdb/mongo-keyfile
+chown mongodb:mongodb /data/configdb/mongo-keyfile
+chmod 400 /data/configdb/mongo-keyfile
+
+exec docker-entrypoint.sh "$@"


### PR DESCRIPTION
## Summary

- Use the local IndexedDB event repository whenever there is no active SuperTokens session.
- Keep authenticated users on the remote repository when a session exists.
- Add repository-selection coverage for active session, missing session, and Google-revoked fallback.

## Why

A browser can keep `compass.auth.hasAuthenticated=true` from an older hosted/dev/self-host session even when the new local backend has no valid session. In that state, anonymous event creation was routed to the backend and failed with `401`, causing the optimistic event to disappear. Without an active session, event writes should stay local.

## Validation

- Rebuilt the local self-host install with this change.
- Reproduced stale auth state by setting `localStorage.compass.auth.hasAuthenticated=true` without a valid session.
- Created a calendar event successfully; no `POST /api/event` request was sent.
- `bunx biome check packages/web/src/common/repositories/event/event.repository.util.ts packages/web/src/common/repositories/event/event.repository.util.test.ts`
- `bun run test:core`

Known: direct `bun test --cwd packages/web ...` still hits the existing web test harness global issue (`jest` / browser globals), unrelated to this change.