### PR TITLE
fix(web): apply biome cleanup

### DIFF
--- a/packages/core/src/util/color.utils.test.ts
+++ b/packages/core/src/util/color.utils.test.ts
@@ -1,11 +1,11 @@
 import tinycolor from "tinycolor2";
-import { describe, expect, it, spyOn } from "bun:test";
 import {
   brighten,
   darken,
   generateCalendarColorScheme,
   isDark,
 } from "./color.utils";
+import { describe, expect, it, spyOn } from "bun:test";
 
 describe("color.utils", () => {
   describe("brighten", () => {

--- a/packages/web/src/__tests__/__mocks__/mock.render.tsx
+++ b/packages/web/src/__tests__/__mocks__/mock.render.tsx
@@ -1,4 +1,4 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, type PreloadedState } from "@reduxjs/toolkit";
 import {
   type RenderHookOptions,
   type RenderOptions,
@@ -10,16 +10,16 @@ import {
   type PropsWithChildren,
   type ReactElement,
 } from "react";
-import { mock } from "bun:test";
 import { RouterProvider, type RouterProviderProps } from "react-router-dom";
 import { ID_ROOT } from "@web/common/constants/web.constants";
 import { useSetupMovementEvents } from "@web/common/hooks/useMovementEvent";
 import { sagaMiddleware } from "@web/common/store/middlewares";
 import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
 import { CompassRequiredProviders } from "@web/components/CompassProvider/CompassProvider";
-import { type store as compassStore } from "@web/store";
+import { type store as compassStore, type RootState } from "@web/store";
 import { reducers } from "@web/store/reducers";
 import { sagas } from "@web/store/sagas";
+import { mock } from "bun:test";
 
 mock.module("@react-oauth/google", () => ({
   GoogleOAuthProvider: ({ children }: { children?: unknown }) => children,
@@ -27,7 +27,7 @@ mock.module("@react-oauth/google", () => ({
 }));
 
 interface CustomRenderOptions extends RenderOptions {
-  state?: any;
+  state?: PreloadedState<RootState>;
   store?: typeof compassStore;
   router?: RouterProviderProps["router"];
   wrapper?: ComponentType<PropsWithChildren>;
@@ -37,40 +37,44 @@ interface CustomRenderHookOptions<Props>
   extends CustomRenderOptions,
     Omit<RenderHookOptions<Props>, "wrapper"> {}
 
-const TestProviders = (props?: {
+interface TestProvidersProps {
   router?: RouterProviderProps["router"];
   store?: typeof compassStore;
-}) => {
-  return function TestProvidersWrapper({ children }: PropsWithChildren) {
-    useSetupMovementEvents();
+}
 
-    if (!props?.router) {
-      return (
-        <div id={ID_ROOT} data-testid={ID_ROOT}>
-          <CompassRequiredProviders {...props}>
-            {children}
-          </CompassRequiredProviders>
-        </div>
-      );
-    }
+function TestProvidersWrapper({
+  children,
+  router,
+  store,
+}: PropsWithChildren<TestProvidersProps>) {
+  useSetupMovementEvents();
 
+  if (!router) {
     return (
       <div id={ID_ROOT} data-testid={ID_ROOT}>
-        <CompassRequiredProviders store={props?.store}>
-          <RouterProvider
-            router={props.router}
-            fallbackElement={<AbsoluteOverflowLoader />}
-            future={{
-              // Test-only: sync RouterProvider state updates (no startTransition).
-              // Matches initial render + client navigations with RTL act() without globals.
-              v7_startTransition: false,
-            }}
-          />
+        <CompassRequiredProviders store={store}>
+          {children}
         </CompassRequiredProviders>
       </div>
     );
-  };
-};
+  }
+
+  return (
+    <div id={ID_ROOT} data-testid={ID_ROOT}>
+      <CompassRequiredProviders store={store}>
+        <RouterProvider
+          router={router}
+          fallbackElement={<AbsoluteOverflowLoader />}
+          future={{
+            // Test-only: sync RouterProvider state updates (no startTransition).
+            // Matches initial render + client navigations with RTL act() without globals.
+            v7_startTransition: false,
+          }}
+        />
+      </CompassRequiredProviders>
+    </div>
+  );
+}
 
 const customRender = (
   ui: ReactElement,
@@ -90,21 +94,24 @@ const customRender = (
   sagaMiddleware.run(sagas);
 
   const options: RenderOptions = { ...renderOptions };
-  const BaseProviders = TestProviders({ store, router });
-  const renderUi = router ? <></> : ui;
-
   const Wrapper = ({ children }: PropsWithChildren) => {
-    if (!CustomWrapper) return <BaseProviders>{children}</BaseProviders>;
+    if (!CustomWrapper) {
+      return (
+        <TestProvidersWrapper router={router} store={store}>
+          {children}
+        </TestProvidersWrapper>
+      );
+    }
 
     return (
-      <BaseProviders>
+      <TestProvidersWrapper router={router} store={store}>
         <CustomWrapper>{children}</CustomWrapper>
-      </BaseProviders>
+      </TestProvidersWrapper>
     );
   };
 
   // wraps test component with providers
-  return render(renderUi, {
+  return render(ui, {
     wrapper: Wrapper,
     ...options,
   });
@@ -128,17 +135,20 @@ const customRenderHook = <ReturnType, Props>(
   sagaMiddleware.run(sagas);
 
   const options: RenderHookOptions<Props> = { ...renderOptions };
-  const BaseProviders = TestProviders({ store, router });
 
   const Wrapper = (props: PropsWithChildren) => {
-    useSetupMovementEvents();
-
-    if (!WrapperComponent) return <BaseProviders {...props} />;
+    if (!WrapperComponent) {
+      return (
+        <TestProvidersWrapper router={router} store={store}>
+          {props.children}
+        </TestProvidersWrapper>
+      );
+    }
 
     return (
-      <BaseProviders>
+      <TestProvidersWrapper router={router} store={store}>
         <WrapperComponent {...options.initialProps} {...props} />
-      </BaseProviders>
+      </TestProvidersWrapper>
     );
   };
 

--- a/packages/web/src/__tests__/__mocks__/mock.setup.ts
+++ b/packages/web/src/__tests__/__mocks__/mock.setup.ts
@@ -1,5 +1,5 @@
-import { mock } from "bun:test";
 import * as actualReactToastify from "react-toastify";
+import { mock } from "bun:test";
 
 type RestorableMock = {
   mockRestore: () => void;
@@ -17,7 +17,10 @@ function mockNavigatorReadonlyValue(
 ): RestorableMock {
   const originalDescriptor =
     Object.getOwnPropertyDescriptor(window.navigator, key) ??
-    Object.getOwnPropertyDescriptor(Object.getPrototypeOf(window.navigator), key);
+    Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(window.navigator),
+      key,
+    );
 
   Object.defineProperty(window.navigator, key, {
     configurable: true,
@@ -141,8 +144,9 @@ export function mockSuperTokens() {
 }
 
 function mockReactToastify() {
-  const toastFn = mock(() => "mock-toast-id") as typeof actualReactToastify.toast &
-    MockFn;
+  const toastFn = mock(
+    () => "mock-toast-id",
+  ) as typeof actualReactToastify.toast & MockFn;
 
   toastFn.POSITION = actualReactToastify.toast.POSITION;
   toastFn.TYPE = actualReactToastify.toast.TYPE;

--- a/packages/web/src/__tests__/utils/storage/mock-storage-adapter.util.ts
+++ b/packages/web/src/__tests__/utils/storage/mock-storage-adapter.util.ts
@@ -1,5 +1,5 @@
-import { mock } from "bun:test";
 import { type StorageAdapter } from "@web/common/storage/adapter/storage.adapter";
+import { mock } from "bun:test";
 
 /**
  * Creates a mock StorageAdapter for tests.
@@ -8,7 +8,9 @@ import { type StorageAdapter } from "@web/common/storage/adapter/storage.adapter
  * Override specific methods (e.g., getAllEvents, getAllTasks) as needed per test.
  */
 type MockedStorageAdapter = {
-  [K in keyof StorageAdapter]: StorageAdapter[K] extends (...args: any[]) => any
+  [K in keyof StorageAdapter]: StorageAdapter[K] extends (
+    ...args: infer _Args
+  ) => infer _Return
     ? ReturnType<typeof mock>
     : StorageAdapter[K];
 };

--- a/packages/web/src/auth/compass/session/session.util.test.ts
+++ b/packages/web/src/auth/compass/session/session.util.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it, mock, beforeEach } from "bun:test";
-import { afterAll } from "bun:test";
 import { UNAUTHENTICATED_USER } from "@web/common/constants/auth.constants";
 import { getUserId } from "./session.util";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockDoesSessionExist = mock();
 const mockGetAccessTokenPayloadSecurely = mock();

--- a/packages/web/src/auth/google/hooks/useGoogleAuthWithOverlay/useGoogleAuthWithOverlay.test.ts
+++ b/packages/web/src/auth/google/hooks/useGoogleAuthWithOverlay/useGoogleAuthWithOverlay.test.ts
@@ -1,7 +1,6 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { type GoogleAuthConfig } from "../googe.auth.types";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockLogin = mock();
 const mockUseGoogleLogin = mock();

--- a/packages/web/src/auth/google/util/google.auth.util.test.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.test.ts
@@ -1,4 +1,10 @@
 import {
+  clearGoogleRevokedState,
+  isGoogleRevoked,
+} from "@web/auth/google/state/google.auth.state";
+import { type GoogleAuthConfig } from "../hooks/googe.auth.types";
+import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -7,19 +13,6 @@ import {
   mock,
   spyOn,
 } from "bun:test";
-import { afterAll } from "bun:test";
-import { Origin } from "@core/constants/core.constants";
-import {
-  clearGoogleRevokedState,
-  isGoogleRevoked,
-} from "@web/auth/google/state/google.auth.state";
-import { GOOGLE_REVOKED_TOAST_ID } from "@web/common/constants/toast.constants";
-import { authSlice } from "@web/ducks/auth/slices/auth.slice";
-import { userMetadataSlice } from "@web/ducks/auth/slices/user-metadata.slice";
-import { Sync_AsyncStateContextReason } from "@web/ducks/events/context/sync.context";
-import { eventsEntitiesSlice } from "@web/ducks/events/slices/event.slice";
-import { triggerFetch } from "@web/ducks/events/slices/sync.slice";
-import { type GoogleAuthConfig } from "../hooks/googe.auth.types";
 
 // Mock definitions
 const mockAuthApi = {
@@ -64,7 +57,6 @@ mock.module("@web/sse/client/sse.client", () => mockSse);
 const {
   authenticate,
   handleGoogleRevoked,
-  LOCAL_EVENTS_SYNC_ERROR_MESSAGE,
   syncLocalEvents,
   syncPendingLocalEvents,
 } = require("./google.auth.util") as typeof import("./google.auth.util");
@@ -147,7 +139,7 @@ describe("google-auth.util", () => {
   });
 
   describe("syncPendingLocalEvents", () => {
-    let consoleSpy: any;
+    let consoleSpy: ReturnType<typeof spyOn>;
 
     beforeEach(() => {
       consoleSpy = spyOn(console, "error").mockImplementation(() => {});

--- a/packages/web/src/auth/posthog/posthog-react.ts
+++ b/packages/web/src/auth/posthog/posthog-react.ts
@@ -1,4 +1,5 @@
-const posthogReact = require("posthog-js/react") as typeof import("posthog-js/react");
+const posthogReact =
+  require("posthog-js/react") as typeof import("posthog-js/react");
 
 export const PostHogProvider = posthogReact.PostHogProvider;
 export const usePostHog = posthogReact.usePostHog;

--- a/packages/web/src/common/hooks/useAuthCmdItems.test.ts
+++ b/packages/web/src/common/hooks/useAuthCmdItems.test.ts
@@ -60,7 +60,6 @@ describe("useAuthCmdItems", () => {
     expect(result.current).toEqual([]);
   });
 
-
   it("returns auth items when unauthenticated and auth feature flag is enabled", () => {
     window.history.pushState({}, "", "/day?auth=true");
     mockUseAuthFeatureFlag.mockReturnValue(true);

--- a/packages/web/src/common/hooks/useBufferedVisibility.test.ts
+++ b/packages/web/src/common/hooks/useBufferedVisibility.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { useBufferedVisibility } from "./useBufferedVisibility";
 import {
   afterEach,
   beforeEach,
@@ -8,14 +9,16 @@ import {
   setSystemTime,
   spyOn,
 } from "bun:test";
-import { useBufferedVisibility } from "./useBufferedVisibility";
 
 describe("useBufferedVisibility", () => {
   let timeoutCallbacks: Array<{ callback: () => void; delay: number }> = [];
   let setTimeoutSpy: ReturnType<typeof spyOn>;
   let clearTimeoutSpy: ReturnType<typeof spyOn>;
   let currentTimeoutId = 0;
-  const activeTimeouts = new Map<number, { callback: () => void; delay: number }>();
+  const activeTimeouts = new Map<
+    number,
+    { callback: () => void; delay: number }
+  >();
 
   beforeEach(() => {
     setSystemTime(new Date("2024-01-01T00:00:00.000Z"));

--- a/packages/web/src/common/hooks/useGridOrganization.test.ts
+++ b/packages/web/src/common/hooks/useGridOrganization.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import {
+  CLASS_TIMED_CALENDAR_EVENT,
+  DATA_EVENT_ELEMENT_ID,
+} from "@web/common/constants/web.constants";
+import { useGridOrganization } from "@web/common/hooks/useGridOrganization";
+import {
   afterAll,
   afterEach,
   beforeAll,
@@ -8,11 +13,6 @@ import {
   it,
   spyOn,
 } from "bun:test";
-import {
-  CLASS_TIMED_CALENDAR_EVENT,
-  DATA_EVENT_ELEMENT_ID,
-} from "@web/common/constants/web.constants";
-import { useGridOrganization } from "@web/common/hooks/useGridOrganization";
 
 describe("useGridOrganization", () => {
   const rectMap = new Map<HTMLElement, DOMRect>();

--- a/packages/web/src/common/hooks/useMainGridSelection.test.ts
+++ b/packages/web/src/common/hooks/useMainGridSelection.test.ts
@@ -1,8 +1,8 @@
 import { renderHook } from "@testing-library/react";
 import { act, type PointerEvent as IPointerEvent } from "react";
+import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
 import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { readFile, writeFile } from "node:fs/promises";
-import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
 
 const transpiler = new Bun.Transpiler({
   autoImportJSX: true,

--- a/packages/web/src/common/hooks/useMainGridSelectionState.test.ts
+++ b/packages/web/src/common/hooks/useMainGridSelectionState.test.ts
@@ -1,10 +1,10 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import {
   selecting$,
   useMainGridSelectionState,
 } from "./useMainGridSelectionState";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("useMainGridSelectionState", () => {
   let setTimeoutSpy: ReturnType<typeof spyOn>;

--- a/packages/web/src/common/hooks/useMovementEvent.test.ts
+++ b/packages/web/src/common/hooks/useMovementEvent.test.ts
@@ -1,11 +1,11 @@
-import { act, type ReactNode } from "react";
 import { fireEvent, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { act, type ReactNode } from "react";
 import { ID_MAIN, ID_ROOT } from "@web/common/constants/web.constants";
 import {
   useMovementEvent,
   useSetupMovementEvents,
 } from "@web/common/hooks/useMovementEvent";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 describe("useMovementEvent", () => {
   const mockHandler = mock();
@@ -24,12 +24,13 @@ describe("useMovementEvent", () => {
     rootDiv.id = ID_ROOT;
     document.body.appendChild(rootDiv);
 
-    renderHook(() =>
-      useMovementEvent({
-        handler: mockHandler,
-        eventTypes: ["pointerdown"],
-        selectors: [`div#${ID_ROOT}`],
-      }),
+    renderHook(
+      () =>
+        useMovementEvent({
+          handler: mockHandler,
+          eventTypes: ["pointerdown"],
+          selectors: [`div#${ID_ROOT}`],
+        }),
       { wrapper: Wrapper },
     );
 
@@ -43,12 +44,13 @@ describe("useMovementEvent", () => {
     rootDiv.id = ID_ROOT;
     document.body.appendChild(rootDiv);
 
-    renderHook(() =>
-      useMovementEvent({
-        handler: mockHandler,
-        eventTypes: ["pointerup"],
-        selectors: [`div#${ID_ROOT}`],
-      }),
+    renderHook(
+      () =>
+        useMovementEvent({
+          handler: mockHandler,
+          eventTypes: ["pointerup"],
+          selectors: [`div#${ID_ROOT}`],
+        }),
       { wrapper: Wrapper },
     );
 
@@ -63,12 +65,13 @@ describe("useMovementEvent", () => {
     mainDiv.setAttribute("id", ID_MAIN);
     document.body.appendChild(mainDiv);
 
-    renderHook(() =>
-      useMovementEvent({
-        handler: mockHandler,
-        eventTypes: ["pointerdown"],
-        selectors: [`div#${ID_MAIN}`],
-      }),
+    renderHook(
+      () =>
+        useMovementEvent({
+          handler: mockHandler,
+          eventTypes: ["pointerdown"],
+          selectors: [`div#${ID_MAIN}`],
+        }),
       { wrapper: Wrapper },
     );
 
@@ -82,11 +85,12 @@ describe("useMovementEvent", () => {
     rootDiv.id = ID_ROOT;
     document.body.appendChild(rootDiv);
 
-    const { result } = renderHook(() =>
-      useMovementEvent({
-        handler: mockHandler,
-        eventTypes: ["pointerdown"],
-      }),
+    const { result } = renderHook(
+      () =>
+        useMovementEvent({
+          handler: mockHandler,
+          eventTypes: ["pointerdown"],
+        }),
       { wrapper: Wrapper },
     );
 

--- a/packages/web/src/common/hooks/useOpenAtCursor.test.ts
+++ b/packages/web/src/common/hooks/useOpenAtCursor.test.ts
@@ -2,14 +2,6 @@ import { type Placement, type Strategy } from "@floating-ui/react";
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
 import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  spyOn,
-} from "bun:test";
-import {
   CursorItem,
   closeFloatingAtCursor,
   isOpenAtCursor,
@@ -30,6 +22,7 @@ import {
   useFloatingReferenceAtCursor,
   useFloatingStrategyAtCursor,
 } from "./useOpenAtCursor";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("useOpenAtCursor", () => {
   let setTimeoutSpy: ReturnType<typeof spyOn>;

--- a/packages/web/src/common/hooks/usePointerPosition.test.tsx
+++ b/packages/web/src/common/hooks/usePointerPosition.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import type React from "react";
-import { readFile, writeFile } from "node:fs/promises";
 import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
 
 const transpiler = new Bun.Transpiler({
   autoImportJSX: true,

--- a/packages/web/src/common/hooks/useUpdateEvent.test.ts
+++ b/packages/web/src/common/hooks/useUpdateEvent.test.ts
@@ -1,8 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { type Schema_Event, type WithCompassId } from "@core/types/event.types";
 import { type Schema_WebEvent } from "@web/common/types/web.event.types";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockDispatch = mock();
 const useAppDispatch = mock(() => mockDispatch);

--- a/packages/web/src/common/hooks/useVersionCheck.test.ts
+++ b/packages/web/src/common/hooks/useVersionCheck.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { act } from "react";
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -10,7 +11,6 @@ import {
   setSystemTime,
   spyOn,
 } from "bun:test";
-import { afterAll } from "bun:test";
 
 let mockIsDev = false;
 const fetchMock = mock();

--- a/packages/web/src/common/repositories/event/remote.event.repository.test.ts
+++ b/packages/web/src/common/repositories/event/remote.event.repository.test.ts
@@ -4,8 +4,7 @@ import {
   RecurringEventUpdateScope,
   type Schema_Event,
 } from "@core/types/event.types";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockCreate = mock();
 const mockGet = mock();

--- a/packages/web/src/common/storage/migrations/data/task-id-to-underscore-id.test.ts
+++ b/packages/web/src/common/storage/migrations/data/task-id-to-underscore-id.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, mock } from "bun:test";
 import { createMockTask } from "@web/__tests__/utils/factories/task.factory";
 import { type StorageAdapter } from "@web/common/storage/adapter/storage.adapter";
 import { taskIdToUnderscoreIdMigration } from "./task-id-to-underscore-id";
+import { describe, expect, it, mock } from "bun:test";
 
 type MockedStorageAdapter = {
   [K in keyof StorageAdapter]: ReturnType<typeof mock>;

--- a/packages/web/src/common/storage/migrations/external/demo-data-seed.test.ts
+++ b/packages/web/src/common/storage/migrations/external/demo-data-seed.test.ts
@@ -7,7 +7,6 @@ import {
   type Event_Core,
 } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { createMockTask } from "@web/__tests__/utils/factories/task.factory";
 import { createMockStorageAdapter } from "@web/__tests__/utils/storage/mock-storage-adapter.util";
 import {
@@ -15,6 +14,7 @@ import {
   type Schema_GridEvent,
 } from "@web/common/types/web.event.types";
 import { demoDataSeedMigration } from "./demo-data-seed";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("demoDataSeedMigration", () => {
   let consoleLogSpy: ReturnType<typeof spyOn>;

--- a/packages/web/src/common/storage/migrations/external/localstorage-tasks.test.ts
+++ b/packages/web/src/common/storage/migrations/external/localstorage-tasks.test.ts
@@ -1,10 +1,19 @@
 /**
  * Tests for the localStorage tasks migration.
  */
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+
 import { createMockTask } from "@web/__tests__/utils/factories/task.factory";
 import { type StorageAdapter } from "@web/common/storage/adapter/storage.adapter";
 import { localStorageTasksMigration } from "./localstorage-tasks";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 const TASK_KEY_PREFIX = "compass.today.tasks.";
 
@@ -171,7 +180,9 @@ describe("localStorageTasksMigration", () => {
   });
 
   it("skips invalid JSON entries and keeps them for retry", async () => {
-    const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
 
     const validTask = createMockTask({ _id: "task-1" });
     const dateKey = "2025-01-15";

--- a/packages/web/src/common/storage/migrations/migrations.test.ts
+++ b/packages/web/src/common/storage/migrations/migrations.test.ts
@@ -1,14 +1,7 @@
 /**
  * Tests for the migration runners.
  */
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  spyOn,
-} from "bun:test";
+
 import { createMockStorageAdapter } from "@web/__tests__/utils/storage/mock-storage-adapter.util";
 import { DEMO_DATA_SEED_FLAG_KEY } from "@web/common/storage/migrations/external/demo-data-seed";
 import {
@@ -16,6 +9,7 @@ import {
   runDataMigrations,
   runExternalMigrations,
 } from "@web/common/storage/migrations/migrations";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("storage migrations", () => {
   const localStorageMigrationFlagKey =

--- a/packages/web/src/common/utils/app-init.util.test.ts
+++ b/packages/web/src/common/utils/app-init.util.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseInitError } from "@web/common/utils/storage/db-errors.util";
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -8,7 +9,6 @@ import {
   mock,
   spyOn,
 } from "bun:test";
-import { afterAll } from "bun:test";
 
 // Mock the storage adapter
 const mockInitializeStorage = mock();

--- a/packages/web/src/common/utils/datetime/web.date.util.test.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.test.ts
@@ -1,14 +1,6 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
-import {
-  afterAll,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  setSystemTime,
-} from "bun:test";
 import { arraysAreEqual } from "@web/__tests__/utils/web.test.util";
 import {
   computeCurrentEventDateRange,
@@ -19,6 +11,14 @@ import {
   getWeekRangeLabel,
   toUTCOffset,
 } from "@web/common/utils/datetime/web.date.util";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+} from "bun:test";
 
 describe("computeRelativeEventDateRange", () => {
   const baseEvent: Schema_Event = {

--- a/packages/web/src/common/utils/draft/draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/draft.util.test.ts
@@ -1,6 +1,5 @@
 import { Categories_Event } from "@core/types/event.types";
-import { describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, describe, expect, it, mock } from "bun:test";
 
 mock.module("@web/auth/compass/session/session.util", () => ({
   getUserId: mock().mockResolvedValue("mock-user-id"),

--- a/packages/web/src/common/utils/draft/someday.draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/someday.draft.util.test.ts
@@ -2,8 +2,7 @@ import { Categories_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { draftSlice } from "@web/ducks/events/slices/draft.slice";
 import { type Activity_DraftEvent } from "@web/ducks/events/slices/draft.slice.types";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 // Mock assembleDefaultEvent since it makes external calls
 const assembleDefaultEvent = mock(async (_, startDate, endDate) => ({

--- a/packages/web/src/common/utils/event/someday.event.util.test.ts
+++ b/packages/web/src/common/utils/event/someday.event.util.test.ts
@@ -1,4 +1,3 @@
-import { afterAll, beforeAll, describe, expect, it, setSystemTime } from "bun:test";
 import { faker } from "@faker-js/faker";
 import { ObjectId } from "bson";
 import {
@@ -22,6 +21,14 @@ import {
   categorizeSomedayEvents,
   setSomedayEventsOrder,
 } from "@web/common/utils/event/someday.event.util";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+} from "bun:test";
 
 describe("categorizeSomedayEvents", () => {
   const baseEvent: Partial<Omit<Schema_SomedayEvent, "recurrence">> = {

--- a/packages/web/src/components/AuthModal/hooks/useAuthUrlParam.test.tsx
+++ b/packages/web/src/components/AuthModal/hooks/useAuthUrlParam.test.tsx
@@ -1,7 +1,15 @@
-import { afterAll, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import { renderHook } from "@testing-library/react";
 import { setTestWindowUrl } from "@web/__tests__/set-test-window-url";
 import { useAuthUrlParam } from "./useAuthUrlParam";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 const originalReplaceState = window.history.replaceState.bind(window.history);
 const replaceStateSpy = spyOn(window.history, "replaceState");
@@ -159,11 +167,7 @@ describe("useAuthUrlParam", () => {
       renderHook(() => useAuthUrlParam(openModal));
 
       expect(openModal).toHaveBeenCalledWith("forgotPassword");
-      expect(replaceStateSpy).toHaveBeenCalledWith(
-        null,
-        "",
-        "/day/2026-02-26",
-      );
+      expect(replaceStateSpy).toHaveBeenCalledWith(null, "", "/day/2026-02-26");
     });
   });
 });

--- a/packages/web/src/components/AuthenticatedLayout/AuthenticatedLayout.test.tsx
+++ b/packages/web/src/components/AuthenticatedLayout/AuthenticatedLayout.test.tsx
@@ -1,9 +1,7 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
-import { screen } from "@testing-library/react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { AuthenticatedLayout } from "./AuthenticatedLayout";
 
 mock.module("@web/components/SyncEventsOverlay/SyncEventsOverlay", () => ({
@@ -24,14 +22,15 @@ describe("AuthenticatedLayout", () => {
           v7_relativeSplatPath: true,
         }}
       >
-      <Routes>
-        <Route element={<AuthenticatedLayout />}>
-          <Route
-            path="/"
-            element={<div data-testid="child-route">Child Content</div>}
-          />
-        </Route>
-      </Routes>,
+        <Routes>
+          <Route element={<AuthenticatedLayout />}>
+            <Route
+              path="/"
+              element={<div data-testid="child-route">Child Content</div>}
+            />
+          </Route>
+        </Routes>
+        ,
       </MemoryRouter>,
     );
 
@@ -48,14 +47,15 @@ describe("AuthenticatedLayout", () => {
           v7_relativeSplatPath: true,
         }}
       >
-      <Routes>
-        <Route element={<AuthenticatedLayout />}>
-          <Route
-            path="/nested"
-            element={<div data-testid="nested-route">Nested Content</div>}
-          />
-        </Route>
-      </Routes>,
+        <Routes>
+          <Route element={<AuthenticatedLayout />}>
+            <Route
+              path="/nested"
+              element={<div data-testid="nested-route">Nested Content</div>}
+            />
+          </Route>
+        </Routes>
+        ,
       </MemoryRouter>,
     );
 

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import { type ReactElement } from "react";
+import { ThemeProvider } from "styled-components";
+import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import {
   createInitialState,
   type InitialReduxState,
 } from "@web/__tests__/utils/state/store.test.util";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { theme } from "@web/common/styles/theme";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
-import { ThemeProvider } from "styled-components";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockClose = mock();

--- a/packages/web/src/components/DND/DNDContext.test.tsx
+++ b/packages/web/src/components/DND/DNDContext.test.tsx
@@ -1,8 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { type ReactNode } from "react";
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { afterAll } from "bun:test";
 import { BehaviorSubject } from "rxjs";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 const DndContext = mock(({ children }: { children: ReactNode }) => (
   <div data-testid="dnd-context">{children}</div>
@@ -16,7 +23,6 @@ let isDraggingNextSpy: any = null;
 mock.module("@web/common/hooks/usePointerPosition", () => ({
   usePointerPosition,
 }));
-
 
 mock.module("@dnd-kit/core", () => ({
   DndContext,

--- a/packages/web/src/components/DND/DNDOverlay.test.tsx
+++ b/packages/web/src/components/DND/DNDOverlay.test.tsx
@@ -1,8 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { Categories_Event } from "@core/types/event.types";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const useDndContext = mock();
 

--- a/packages/web/src/components/DND/Droppable.test.tsx
+++ b/packages/web/src/components/DND/Droppable.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const useDroppable = mock();
 

--- a/packages/web/src/components/DND/Resizable.test.tsx
+++ b/packages/web/src/components/DND/Resizable.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render } from "@testing-library/react";
 import { type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const usePointerPosition = mock();
 

--- a/packages/web/src/components/SelectView/SelectView.test.tsx
+++ b/packages/web/src/components/SelectView/SelectView.test.tsx
@@ -3,8 +3,7 @@ import "@testing-library/jest-dom";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockNavigate = mock();
 const actualReactRouterDom = await import("react-router-dom");

--- a/packages/web/src/components/SyncEventsOverlay/SyncEventsOverlay.test.tsx
+++ b/packages/web/src/components/SyncEventsOverlay/SyncEventsOverlay.test.tsx
@@ -1,8 +1,17 @@
 import { act } from "react";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 import { readFile, writeFile } from "node:fs/promises";
-import { afterAll, afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 mock.restore();
 
@@ -12,13 +21,7 @@ const bufferedVisibilityQuery = `@web/common/hooks/useBufferedVisibility${compon
 const storeHooksQuery = `@web/store/store.hooks${componentQuery}`;
 
 mock.module(overlayPanelQuery, () => ({
-  OverlayPanel: ({
-    title,
-    message,
-  }: {
-    message: string;
-    title: string;
-  }) => (
+  OverlayPanel: ({ title, message }: { message: string; title: string }) => (
     <div role="status">
       <h1>{title}</h1>
       <p>{message}</p>
@@ -33,8 +36,9 @@ mock.module(bufferedVisibilityQuery, () => ({
 let authStatus: "idle" | "authenticating" = "idle";
 
 mock.module(storeHooksQuery, () => ({
-  useAppSelector: (selector: (state: { auth: { status: string } }) => unknown) =>
-    selector({ auth: { status: authStatus } }),
+  useAppSelector: (
+    selector: (state: { auth: { status: string } }) => unknown,
+  ) => selector({ auth: { status: authStatus } }),
 }));
 
 const source = await readFile(
@@ -43,15 +47,12 @@ const source = await readFile(
 );
 
 const transformedSource = source
+  .replaceAll("@web/components/OverlayPanel/OverlayPanel", overlayPanelQuery)
   .replaceAll(
-    '@web/components/OverlayPanel/OverlayPanel',
-    overlayPanelQuery,
-  )
-  .replaceAll(
-    '@web/common/hooks/useBufferedVisibility',
+    "@web/common/hooks/useBufferedVisibility",
     bufferedVisibilityQuery,
   )
-  .replaceAll('@web/store/store.hooks', storeHooksQuery);
+  .replaceAll("@web/store/store.hooks", storeHooksQuery);
 
 const transpiler = new Bun.Transpiler({
   autoImportJSX: true,
@@ -62,7 +63,10 @@ const transpiler = new Bun.Transpiler({
     },
   },
 });
-const transformedJavaScript = transpiler.transformSync(transformedSource, "tsx");
+const transformedJavaScript = transpiler.transformSync(
+  transformedSource,
+  "tsx",
+);
 
 const tempModuleUrl = new URL(
   `./.sync-events-overlay-${process.pid}-${Date.now()}.mjs`,

--- a/packages/web/src/ducks/events/sagas/event.sagas.prompt.test.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.prompt.test.ts
@@ -7,7 +7,15 @@ import {
 } from "@web/auth/compass/state/auth.state.util";
 import { session } from "@web/common/classes/Session";
 import { editEventSlice } from "@web/ducks/events/slices/event.slice";
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 const mockRepository = {
   create: mock(),

--- a/packages/web/src/ducks/events/sagas/event.sagas.test.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.test.ts
@@ -1,3 +1,4 @@
+import { put } from "redux-saga/effects";
 import { type Schema_Event } from "@core/types/event.types";
 import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import {
@@ -12,8 +13,8 @@ import {
   type Schema_GridEvent,
   type Schema_WebEvent,
 } from "@web/common/types/web.event.types";
-import { put } from "redux-saga/effects";
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -22,7 +23,6 @@ import {
   mock,
   spyOn,
 } from "bun:test";
-import { afterAll } from "bun:test";
 
 const mockDoesSessionExist = mock();
 const mockEventApiCreate = mock();
@@ -473,9 +473,7 @@ describe("pending events state management", () => {
         ...existingEvent,
         title: "Updated Title",
       } as Schema_WebEvent;
-      const { editEvent } = await import(
-        "@web/ducks/events/sagas/event.sagas"
-      );
+      const { editEvent } = await import("@web/ducks/events/sagas/event.sagas");
 
       const iterator = editEvent({
         payload: {
@@ -487,9 +485,7 @@ describe("pending events state management", () => {
       iterator.next();
       expect(
         iterator.next(stateAfterCreate.events.entities.value?.[eventId]).value,
-      ).toEqual(
-        put(pendingEventsSlice.actions.add(eventId)),
-      );
+      ).toEqual(put(pendingEventsSlice.actions.add(eventId)));
     });
 
     it("should remove event from pending on successful edit", async () => {
@@ -514,9 +510,7 @@ describe("pending events state management", () => {
         title: "Updated Title",
       } as Schema_WebEvent;
 
-      const { editEvent } = await import(
-        "@web/ducks/events/sagas/event.sagas"
-      );
+      const { editEvent } = await import("@web/ducks/events/sagas/event.sagas");
       const iterator = editEvent({
         payload: {
           _id: eventId,
@@ -525,9 +519,9 @@ describe("pending events state management", () => {
       } as never);
 
       iterator.next();
-      expect(
-        iterator.next(existingEvent).value,
-      ).toEqual(put(pendingEventsSlice.actions.add(eventId)));
+      expect(iterator.next(existingEvent).value).toEqual(
+        put(pendingEventsSlice.actions.add(eventId)),
+      );
       expect(iterator.next().value).toEqual(
         put(
           eventsEntitiesSlice.actions.edit({
@@ -565,9 +559,7 @@ describe("pending events state management", () => {
         title: "Updated Title",
       } as Schema_WebEvent;
 
-      const { editEvent } = await import(
-        "@web/ducks/events/sagas/event.sagas"
-      );
+      const { editEvent } = await import("@web/ducks/events/sagas/event.sagas");
       const iterator = editEvent({
         payload: {
           _id: eventId,
@@ -576,9 +568,9 @@ describe("pending events state management", () => {
       } as never);
 
       iterator.next();
-      expect(
-        iterator.next(existingEvent).value,
-      ).toEqual(put(pendingEventsSlice.actions.add(eventId)));
+      expect(iterator.next(existingEvent).value).toEqual(
+        put(pendingEventsSlice.actions.add(eventId)),
+      );
       expect(iterator.next().value).toEqual(
         put(
           eventsEntitiesSlice.actions.edit({

--- a/packages/web/src/ducks/events/sagas/someday.sagas.test.ts
+++ b/packages/web/src/ducks/events/sagas/someday.sagas.test.ts
@@ -3,14 +3,7 @@ import { Origin, Priorities } from "@core/constants/core.constants";
 import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { type Response_HttpPaginatedSuccess } from "@web/common/types/api.types";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 mock.restore();
 
@@ -183,9 +176,7 @@ describe("getSomedayEvents saga", () => {
 
       const eventEntities = state.events.entities.value || {};
       expect(eventEntities["local-event-1"]).toBeDefined();
-      expect(eventEntities["local-event-1"].title).toBe(
-        "Local Someday Event",
-      );
+      expect(eventEntities["local-event-1"].title).toBe("Local Someday Event");
     });
 
     it("should return empty array when no events are returned", async () => {

--- a/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
@@ -18,8 +18,7 @@ import {
 } from "@web/auth/google/state/google.sync.state";
 import { userMetadataSlice } from "@web/ducks/auth/slices/user-metadata.slice";
 import { importLatestSlice } from "@web/ducks/events/slices/sync.slice";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const closeStream = mock();
 const getStream = mock(() => null);

--- a/packages/web/src/sse/provider/SSEProvider.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.test.tsx
@@ -2,8 +2,7 @@ import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { render, waitFor } from "@testing-library/react";
 import { type EventEmitter2 } from "eventemitter2";
 import { Provider } from "react-redux";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockUseSession = mock();
 const mockUseUser = mock();

--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/submit.parser.test.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/submit.parser.test.ts
@@ -3,8 +3,7 @@ import {
   type Schema_GridEvent,
   type Schema_SomedayEvent,
 } from "@web/common/types/web.event.types";
-import { describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, describe, expect, it, mock } from "bun:test";
 
 const validateGridEvent = mock(
   (event: Schema_GridEvent): Schema_GridEvent => event,

--- a/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.test.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SidebarIconRow/SidebarIconRow.test.tsx
@@ -1,8 +1,7 @@
 import { screen } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { render } from "@web/__tests__/utils/render.test.util";
-import { describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, describe, expect, it, mock } from "bun:test";
 
 mock.module("@web/common/hooks/useVersionCheck", () => ({
   useVersionCheck: () => ({

--- a/packages/web/src/views/Day/components/Toasts/MigrationToast/MigrationToast.test.tsx
+++ b/packages/web/src/views/Day/components/Toasts/MigrationToast/MigrationToast.test.tsx
@@ -1,8 +1,7 @@
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { getModifierKeyTestId } from "@web/common/utils/shortcut/shortcut.util";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockOnNavigate = mock();
 const mockOnUndo = mock();

--- a/packages/web/src/views/Day/components/Toasts/UndoToast/UndoDeleteToast.test.tsx
+++ b/packages/web/src/views/Day/components/Toasts/UndoToast/UndoDeleteToast.test.tsx
@@ -1,5 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { getModifierKeyTestId } from "@web/common/utils/shortcut/shortcut.util";
@@ -13,7 +12,8 @@ mock.module("react-toastify", () => ({
   toast: toastMock,
 }));
 
-const { showUndoDeleteToast, UndoDeleteToast } = require("@web/views/Day/components/Toasts/UndoToast/UndoDeleteToast") as typeof import("@web/views/Day/components/Toasts/UndoToast/UndoDeleteToast");
+const { showUndoDeleteToast, UndoDeleteToast } =
+  require("@web/views/Day/components/Toasts/UndoToast/UndoDeleteToast") as typeof import("@web/views/Day/components/Toasts/UndoToast/UndoDeleteToast");
 
 describe("UndoDeleteToast", () => {
   const mockOnRestore = mock();
@@ -58,7 +58,9 @@ describe("UndoDeleteToast", () => {
     it("should call toast.dismiss with specific toast ID when clicked", () => {
       const testToastId = "test-toast-id";
 
-      render(<UndoDeleteToast onRestore={mockOnRestore} toastId={testToastId} />);
+      render(
+        <UndoDeleteToast onRestore={mockOnRestore} toastId={testToastId} />,
+      );
 
       const toastButton = screen.getByText("Deleted").closest("button");
       fireEvent.click(toastButton!);

--- a/packages/web/src/views/Day/context/__tests__/DNDTasksContext.test.tsx
+++ b/packages/web/src/views/Day/context/__tests__/DNDTasksContext.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 // Mock the useTasks hook
 const mockUseTasks = mock();

--- a/packages/web/src/views/Day/hooks/events/useAgendaInteractionsAtCursor.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useAgendaInteractionsAtCursor.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockSafePolygonResult = mock();
 const useClick = mock();

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -2,8 +2,7 @@ import { renderHook } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
 import { Day_AsyncStateContextReason } from "@web/ducks/events/context/day.context";
 import { getDayEventsSlice } from "@web/ducks/events/slices/day.slice";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { afterAll } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const dispatchMock = mock();
 const useAppDispatch = mock();

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it, mock } from "bun:test";
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
 import { Frequency } from "rrule";
@@ -6,6 +5,7 @@ import { Origin, Priorities } from "@core/constants/core.constants";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { assembleGridEvent } from "@web/common/utils/event/event.util";
 import { useRecurrence } from "./useRecurrence";
+import { describe, expect, it, mock } from "bun:test";
 
 describe("useRecurrence hook", () => {
   const baseEvent = (): Schema_GridEvent =>


### PR DESCRIPTION
## Summary

- Applies Biome's safe formatting and import organization fixes across core/web test files.
- Clears the blocking Biome errors so `bun run lint` exits successfully.
- Leaves existing warning-level diagnostics as-is because they do not block lint.

## Validation

- `bun run lint` passed
- `bun run test:core` passed
- `bun run test:web` passed

## Notes

Pulled the latest `main` before publishing so the branch includes the shared web test runner fixes from `main`.