### PR TITLE
fix(backend): incomplete string escaping or encoding

### DIFF
--- a/packages/backend/src/common/services/gcal/gcal.utils.ts
+++ b/packages/backend/src/common/services/gcal/gcal.utils.ts
@@ -39,7 +39,11 @@ export const getEmailFromUrl = (url: string) => {
   const emailMatch = url.match(/\/calendars\/([^/]+)\/events/);
 
   if (emailMatch && emailMatch[1]) {
-    return emailMatch[1].replace("%40", "@");
+    try {
+      return decodeURIComponent(emailMatch[1]);
+    } catch {
+      return null;
+    }
   }
 
   return null;


### PR DESCRIPTION
Potential fix for [https://github.com/SwitchbackTech/compass/security/code-scanning/44](https://github.com/SwitchbackTech/compass/security/code-scanning/44)

Use URL decoding for the captured path segment instead of manually replacing a single token.

Best fix in this file (`packages/backend/src/common/services/gcal/gcal.utils.ts`), around `getEmailFromUrl` lines 38–45:
- Replace `emailMatch[1].replace("%40", "@")` with `decodeURIComponent(emailMatch[1])`.
- Wrap decoding in `try/catch` so malformed percent-encoding doesn’t throw and break flow; return `null` on decode failure (same fallback style as current function).

This preserves existing behavior for valid inputs and improves correctness for all encoded characters (including multiple `%40` occurrences).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
