### PR TITLE
test(backend): add coverage for getEmailFromUrl decoding edge cases

### DIFF
--- a/packages/backend/src/common/services/gcal/gcal.util.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.util.test.ts
@@ -94,4 +94,17 @@ describe("Gaxios response parsing", () => {
       "https://www.googleapis.com/calendar/v3/calendars/foo%40bar.com/events?syncToken=!!!!!!!!!!!!!!!jqgYQwNWZ_QyyHyycChpiZHJvaGl1aHyyyyyyymxvZmMwaXZodjN2ZxoMCO7Xj6sGEICGncADwD4B";
     expect(getEmailFromUrl(url)).toBe("foo@bar.com");
   });
+  it("decodes additional percent-encoded characters beyond %40", () => {
+    const url =
+      "https://www.googleapis.com/calendar/v3/calendars/foo%2Bbar%40example.com/events";
+    expect(getEmailFromUrl(url)).toBe("foo+bar@example.com");
+  });
+  it("returns null for malformed percent-encoding", () => {
+    const url =
+      "https://www.googleapis.com/calendar/v3/calendars/foo%GGbar%40example.com/events";
+    expect(getEmailFromUrl(url)).toBeNull();
+  });
+  it("returns null when URL has no calendar segment", () => {
+    expect(getEmailFromUrl("https://www.googleapis.com/calendar/v3/events")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds three new test cases to `gcal.util.test.ts` to cover the `decodeURIComponent` fix introduced in PR #1666
- Tests validate: multi-character percent-decoding (e.g. `%2B`), null return on malformed encoding (`%GG`), and null return when URL has no calendar segment
- These tests are designed to be merged alongside or after #1666 — two of the three will fail against the current source intentionally, as they verify the new behavior

## Test plan

- [ ] Merge or cherry-pick alongside [PR #1666](https://github.com/SwitchbackTech/compass/pull/1666)
- [ ] Run `bun run test:backend` — all four tests in the `"Gaxios response parsing"` block should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)