### PR TITLE
fix(web): keep returning users on remote event storage

### DIFF
--- a/packages/web/src/common/repositories/event/event.repository.util.test.ts
+++ b/packages/web/src/common/repositories/event/event.repository.util.test.ts
@@ -1,10 +1,12 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import * as authState from "@web/auth/compass/state/auth.state.util";
+import * as googleAuthState from "@web/auth/google/state/google.auth.state";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 
-const mockIsGoogleRevoked = mock(() => false);
-
-mock.module("@web/auth/google/state/google.auth.state", () => ({
-  isGoogleRevoked: mockIsGoogleRevoked,
-}));
+const hasUserEverAuthenticatedSpy = spyOn(
+  authState,
+  "hasUserEverAuthenticated",
+);
+const isGoogleRevokedSpy = spyOn(googleAuthState, "isGoogleRevoked");
 
 const { LocalEventRepository } = await import("./local.event.repository");
 const { RemoteEventRepository } = await import("./remote.event.repository");
@@ -12,8 +14,10 @@ const { getEventRepository } = await import("./event.repository.util");
 
 describe("getEventRepository", () => {
   beforeEach(() => {
-    mockIsGoogleRevoked.mockReset();
-    mockIsGoogleRevoked.mockReturnValue(false);
+    hasUserEverAuthenticatedSpy.mockReset();
+    hasUserEverAuthenticatedSpy.mockReturnValue(false);
+    isGoogleRevokedSpy.mockReset();
+    isGoogleRevokedSpy.mockReturnValue(false);
   });
 
   it("uses remote storage when a session exists", () => {
@@ -24,9 +28,22 @@ describe("getEventRepository", () => {
     expect(getEventRepository(false)).toBeInstanceOf(LocalEventRepository);
   });
 
-  it("uses local storage when Google access was revoked", () => {
-    mockIsGoogleRevoked.mockReturnValue(true);
+  it("uses remote storage when a returning user has no active session", () => {
+    hasUserEverAuthenticatedSpy.mockReturnValue(true);
+
+    expect(getEventRepository(false)).toBeInstanceOf(RemoteEventRepository);
+  });
+
+  it("uses local storage when Google disconnected Compass", () => {
+    isGoogleRevokedSpy.mockReturnValue(true);
 
     expect(getEventRepository(true)).toBeInstanceOf(LocalEventRepository);
+  });
+
+  it("uses local storage when Google disconnected Compass for a returning user", () => {
+    hasUserEverAuthenticatedSpy.mockReturnValue(true);
+    isGoogleRevokedSpy.mockReturnValue(true);
+
+    expect(getEventRepository(false)).toBeInstanceOf(LocalEventRepository);
   });
 });

--- a/packages/web/src/common/repositories/event/event.repository.util.ts
+++ b/packages/web/src/common/repositories/event/event.repository.util.ts
@@ -1,11 +1,12 @@
 /**
  * Repository selection entry point.
  * This factory decides whether event reads/writes go to local IndexedDB or the remote API.
- * Auth state is the source of truth — authenticated users prefer remote.
+ * Google connection state, remembered auth state, and current session state decide the target.
  * Never call this directly from components; always go through sagas.
  * Start debugging "why isn't this event saving?" here.
  * Related: docs/development/web-state-guide.md
  */
+import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import { isGoogleRevoked } from "@web/auth/google/state/google.auth.state";
 import { type EventRepository } from "./event.repository.interface";
 import { LocalEventRepository } from "./local.event.repository";
@@ -15,21 +16,27 @@ import { RemoteEventRepository } from "./remote.event.repository";
  * Factory function to get the appropriate event repository based on session and authentication state.
  *
  * Repository selection logic:
- * 1. If Google access was revoked: Use LocalEventRepository
+ * 1. If Google disconnected Compass: Use LocalEventRepository
  *    - Graceful degradation until user re-authenticates
  *    - Prevents API errors from failed Google token refresh
- * 2. If no session exists: Use LocalEventRepository (IndexedDB)
- *    - Stale auth flags can outlive backend sessions, especially across local/self-host installs
- *    - Local storage keeps anonymous event creation working instead of failing with 401s
+ * 2. If user has EVER authenticated: Use RemoteEventRepository
+ *    - Prevents remote account events from disappearing when the session is temporarily missing
+ *    - Remote requests can surface the auth problem instead of silently saving locally
  * 3. If a session exists: Use RemoteEventRepository
- *    - Authenticated users persist through the backend
+ *    - Newly authenticated users persist through the backend even before remembered auth state updates
+ * 4. If user has NEVER authenticated: Use LocalEventRepository (IndexedDB)
+ *    - Events stored locally until user decides to sign in
  *
  * @param sessionExists - Whether a session currently exists (from session.doesSessionExist())
  */
 export function getEventRepository(sessionExists: boolean): EventRepository {
-  // If Google was revoked, use local storage until user re-authenticates
+  // If Google disconnected Compass, use local storage until user re-authenticates
   if (isGoogleRevoked()) {
     return new LocalEventRepository();
+  }
+
+  if (hasUserEverAuthenticated()) {
+    return new RemoteEventRepository();
   }
 
   if (sessionExists) {


### PR DESCRIPTION
## Summary
- keep returning users on remote event storage when their active session is missing
- preserve local storage fallback when Google disconnected Compass
- replace the partial module mock with spies and add repository-selection regression coverage

## Why
Returning users could otherwise be treated like anonymous users when SuperTokens reported no active session, which could make account-backed calendar data appear missing and save new events locally.

## Validation
- `bun test --cwd packages/web src/common/repositories/event/event.repository.util.test.ts`
- `bun test --cwd packages/web src/ducks/events/sagas/event.sagas.test.ts`
- `bunx biome check packages/web/src/common/repositories/event/event.repository.util.ts packages/web/src/common/repositories/event/event.repository.util.test.ts`
- `bun run test:web`