### PR TITLE
Hide recurrence controls without backend support

### DIFF
--- a/packages/web/build.ts
+++ b/packages/web/build.ts
@@ -1,9 +1,9 @@
-import { execSync } from "child_process";
-import path from "path";
 import { postcssPlugin } from "./plugins/postcss.plugin";
+import { execSync } from "node:child_process";
+import path from "node:path";
 
 function getBuildHash(): string {
-  const fallbackBuildRef = process.env["COMPASS_BUILD_REF"] || "self-host";
+  const fallbackBuildRef = process.env.COMPASS_BUILD_REF || "self-host";
   const compassRepoRoot = path.resolve(import.meta.dir, "../..");
 
   try {
@@ -43,7 +43,7 @@ const define: Record<string, string> = {
     GOOGLE_CLIENT_ID: GOOGLE_CLIENT_ID || "",
     POSTHOG_KEY: process.env.POSTHOG_KEY || "",
     POSTHOG_HOST: process.env.POSTHOG_HOST || "",
-    PORT: process.env.WEB_PORT || "9080",
+    PORT: process.env.PORT || "3000",
   }),
   BUILD_VERSION: JSON.stringify(BUILD_VERSION),
 };

--- a/packages/web/dev.ts
+++ b/packages/web/dev.ts
@@ -1,8 +1,8 @@
-import { watch } from "fs";
-import path from "path";
 import { postcssPlugin } from "./plugins/postcss.plugin";
+import { watch } from "node:fs";
+import path from "node:path";
 
-const PORT = Number(process.env.WEB_PORT) || 9080;
+const WEB_PORT = Number(process.env.WEB_PORT) || 9080;
 const OUTDIR = path.resolve(import.meta.dir, "../../build/web");
 const SRCDIR = path.resolve(import.meta.dir, "src");
 
@@ -22,7 +22,7 @@ const define: Record<string, string> = {
     GOOGLE_CLIENT_ID: GOOGLE_CLIENT_ID || "",
     POSTHOG_KEY: process.env.POSTHOG_KEY || "",
     POSTHOG_HOST: process.env.POSTHOG_HOST || "",
-    PORT: String(PORT),
+    PORT: process.env.PORT || "3000",
   }),
   BUILD_VERSION: JSON.stringify("dev"),
 };
@@ -69,7 +69,7 @@ async function build() {
 // Initial build before serving
 console.log("[compass] building...");
 await build();
-console.log(`[compass] dev server → http://localhost:${PORT}`);
+console.log(`[compass] dev server → http://localhost:${WEB_PORT}`);
 
 if (IS_DEV) {
   // Watch src/ and rebuild on changes (debounced) — dev mode only
@@ -93,7 +93,7 @@ const LIVE_RELOAD_SCRIPT = IS_DEV
   : "";
 
 Bun.serve({
-  port: PORT,
+  port: WEB_PORT,
   // Prevent Bun from closing long-lived SSE connections prematurely.
   // Default is 10 s which produces "[Bun.serve]: request timed out" noise in CI.
   idleTimeout: IS_DEV ? 255 : 0,

--- a/packages/web/src/auth/compass/state/auth.state.util.real.ts
+++ b/packages/web/src/auth/compass/state/auth.state.util.real.ts
@@ -90,7 +90,7 @@ export function updateAuthState(updates: Partial<AuthState>): void {
 
 /**
  * Marks that the user has authenticated at least once.
- * Once set, the app will always use RemoteEventRepository instead of LocalEventRepository.
+ * Once set, the app prefers RemoteEventRepository when the backend is available.
  * This prevents the UX issue where events disappear after login due to cleared IndexedDB.
  * Also clears any revoked state since user is re-authenticating.
  */

--- a/packages/web/src/auth/compass/state/auth.state.util.ts
+++ b/packages/web/src/auth/compass/state/auth.state.util.ts
@@ -90,7 +90,7 @@ export function updateAuthState(updates: Partial<AuthState>): void {
 
 /**
  * Marks that the user has authenticated at least once.
- * Once set, the app will always use RemoteEventRepository instead of LocalEventRepository.
+ * Once set, the app prefers RemoteEventRepository when the backend is available.
  * This prevents the UX issue where events disappear after login due to cleared IndexedDB.
  * Also clears any revoked state since user is re-authenticating.
  */

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+const getLastKnownEmail = mock(() => "person@example.com");
+const markUserAsAuthenticated = mock();
+const showSessionExpiredToast = mock();
+const getProfile = mock();
+
+mock.module("@web/auth/compass/state/auth.state.util", () => ({
+  getLastKnownEmail,
+  markUserAsAuthenticated,
+}));
+
+mock.module("@web/common/apis/user.api", () => ({
+  UserApi: {
+    getProfile,
+  },
+}));
+
+mock.module("@web/common/utils/toast/error-toast.util", () => ({
+  showSessionExpiredToast,
+}));
+
+async function importHook() {
+  const moduleUrl = new URL(
+    `./useLoadProfile.ts?test=${Math.random().toString(36).slice(2)}`,
+    import.meta.url,
+  );
+
+  return import(moduleUrl.href);
+}
+
+describe("useLoadProfile", () => {
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    getLastKnownEmail.mockClear().mockReturnValue("person@example.com");
+    markUserAsAuthenticated.mockClear();
+    showSessionExpiredToast.mockClear();
+    getProfile.mockClear();
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not log backend-unavailable profile failures in frontend-only mode", async () => {
+    const error = new Error("Request failed");
+    error.name = "ApiError";
+    getProfile.mockRejectedValue(error);
+    const { useLoadProfile } = await importHook();
+
+    const { result } = renderHook(() => useLoadProfile(true));
+
+    await waitFor(() => {
+      expect(result.current.email).toBeNull();
+    });
+    expect(getProfile).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
@@ -6,6 +6,7 @@ import {
   markUserAsAuthenticated,
 } from "@web/auth/compass/state/auth.state.util";
 import { UserApi } from "@web/common/apis/user.api";
+import { isBackendUnavailableError } from "@web/common/apis/util/backend-unavailable-error.util";
 import { showSessionExpiredToast } from "@web/common/utils/toast/error-toast.util";
 
 export type UseLoadProfileResult = {
@@ -51,6 +52,10 @@ export function useLoadProfile(
 
         if (isUnauthorized) {
           showSessionExpiredToast();
+          return;
+        }
+
+        if (isBackendUnavailableError(e)) {
           return;
         }
 

--- a/packages/web/src/common/apis/base/base.api.test.ts
+++ b/packages/web/src/common/apis/base/base.api.test.ts
@@ -1,0 +1,45 @@
+import {
+  isBackendUnavailable,
+  markBackendUnavailable,
+  resetBackendAvailabilityForTests,
+} from "../util/backend-unavailable-error.util";
+import { BaseApi } from "./base.api";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const originalFetch = globalThis.fetch;
+
+describe("BaseApi backend availability", () => {
+  beforeEach(() => {
+    BaseApi.defaults.adapter = undefined;
+    resetBackendAvailabilityForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    BaseApi.defaults.adapter = undefined;
+    resetBackendAvailabilityForTests();
+  });
+
+  it("marks the backend unavailable when fetch cannot reach it", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new TypeError("Failed to fetch")),
+    ) as typeof fetch;
+
+    await expect(BaseApi.get("/event")).rejects.toMatchObject({
+      name: "ApiError",
+    });
+
+    expect(isBackendUnavailable()).toBe(true);
+  });
+
+  it("marks the backend available when a response arrives", async () => {
+    markBackendUnavailable();
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response("{}", { status: 200 })),
+    ) as typeof fetch;
+
+    await BaseApi.get("/config");
+
+    expect(isBackendUnavailable()).toBe(false);
+  });
+});

--- a/packages/web/src/common/apis/base/base.api.ts
+++ b/packages/web/src/common/apis/base/base.api.ts
@@ -11,6 +11,11 @@ import {
   handleErrorResponse,
   isApiError,
 } from "../util/api.util";
+import {
+  isBackendUnavailableError,
+  markBackendAvailable,
+  markBackendUnavailable,
+} from "../util/backend-unavailable-error.util";
 
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
@@ -30,10 +35,12 @@ const request = async <T>(
 
   try {
     if (BaseApi.defaults.adapter) {
-      return await BaseApi.defaults.adapter<T>({
+      const result = await BaseApi.defaults.adapter<T>({
         ...requestConfig,
         body,
       });
+      markBackendAvailable();
+      return result;
     }
 
     const response = await fetch(getRequestUrl(url), {
@@ -45,6 +52,7 @@ const request = async <T>(
       },
       method,
     });
+    markBackendAvailable();
     const data = await getResponseData(response);
     const result = {
       config: requestConfig,
@@ -60,6 +68,10 @@ const request = async <T>(
 
     return result;
   } catch (error) {
+    if (isBackendUnavailableError(error)) {
+      markBackendUnavailable();
+    }
+
     if (isApiError(error)) {
       return handleErrorResponse<ApiResponse<T>>(error);
     }

--- a/packages/web/src/common/apis/util/backend-unavailable-error.util.test.ts
+++ b/packages/web/src/common/apis/util/backend-unavailable-error.util.test.ts
@@ -1,0 +1,49 @@
+import {
+  isBackendUnavailable,
+  isBackendUnavailableError,
+  markBackendAvailable,
+  markBackendUnavailable,
+  resetBackendAvailabilityForTests,
+} from "./backend-unavailable-error.util";
+
+beforeEach(() => {
+  resetBackendAvailabilityForTests();
+});
+
+describe("isBackendUnavailableError", () => {
+  it("detects API errors with no backend response", () => {
+    const error = new Error("Request failed");
+    error.name = "ApiError";
+
+    expect(isBackendUnavailableError(error)).toBe(true);
+  });
+
+  it("detects raw fetch failures", () => {
+    expect(isBackendUnavailableError(new TypeError("Failed to fetch"))).toBe(
+      true,
+    );
+  });
+
+  it("does not treat server responses as backend availability failures", () => {
+    const error = new Error("Request failed with status 500");
+    error.name = "ApiError";
+
+    expect(isBackendUnavailableError(error)).toBe(false);
+  });
+});
+
+describe("backend availability", () => {
+  it("tracks when the backend is unavailable", () => {
+    markBackendUnavailable();
+
+    expect(isBackendUnavailable()).toBe(true);
+  });
+
+  it("clears unavailable state when the backend responds", () => {
+    markBackendUnavailable();
+
+    markBackendAvailable();
+
+    expect(isBackendUnavailable()).toBe(false);
+  });
+});

--- a/packages/web/src/common/apis/util/backend-unavailable-error.util.ts
+++ b/packages/web/src/common/apis/util/backend-unavailable-error.util.ts
@@ -1,0 +1,28 @@
+let isBackendUnavailableFlag = false;
+
+export function isBackendUnavailableError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    (error.name === "ApiError" && error.message === "Request failed") ||
+    error.message === "Failed to fetch"
+  );
+}
+
+export function isBackendUnavailable(): boolean {
+  return isBackendUnavailableFlag;
+}
+
+export function markBackendAvailable(): void {
+  isBackendUnavailableFlag = false;
+}
+
+export function markBackendUnavailable(): void {
+  isBackendUnavailableFlag = true;
+}
+
+export function resetBackendAvailabilityForTests(): void {
+  isBackendUnavailableFlag = false;
+}

--- a/packages/web/src/common/constants/env.constants.test.ts
+++ b/packages/web/src/common/constants/env.constants.test.ts
@@ -1,5 +1,28 @@
-import { isGoogleAuthConfigured } from "./env.constants";
 import { describe, expect, it } from "bun:test";
+
+process.env.PORT = "3000";
+
+const { getApiBaseUrl, isGoogleAuthConfigured } = await import(
+  "./env.constants"
+);
+
+describe("getApiBaseUrl", () => {
+  it("defaults to the local backend API using the configured port", () => {
+    expect(getApiBaseUrl(undefined, "3001")).toBe("http://localhost:3001/api");
+  });
+
+  it("uses the configured API base URL when provided", () => {
+    expect(getApiBaseUrl("https://calendar.example.com/api")).toBe(
+      "https://calendar.example.com/api",
+    );
+  });
+
+  it("requires a port when no API base URL is configured", () => {
+    expect(() => getApiBaseUrl()).toThrow(
+      "PORT is required when API_BASEURL is not configured",
+    );
+  });
+});
 
 describe("isGoogleAuthConfigured", () => {
   it("rejects missing and placeholder Google client IDs", () => {

--- a/packages/web/src/common/constants/env.constants.ts
+++ b/packages/web/src/common/constants/env.constants.ts
@@ -1,8 +1,19 @@
 import { z } from "zod";
 import { isDev } from "@core/util/env.util";
 
-const API_BASEURL =
-  process.env["API_BASEURL"] || `http://localhost:${process.env["PORT"]}`;
+export const getApiBaseUrl = (apiBaseUrl?: string, port?: string): string => {
+  if (apiBaseUrl) {
+    return apiBaseUrl;
+  }
+
+  if (!port) {
+    throw new Error("PORT is required when API_BASEURL is not configured");
+  }
+
+  return `http://localhost:${port}/api`;
+};
+
+const API_BASEURL = getApiBaseUrl(process.env.API_BASEURL, process.env.PORT);
 const BACKEND_BASEURL = API_BASEURL.replace(/\/[^/]*$/, "");
 
 const webEnvSchema = z.object({
@@ -23,10 +34,10 @@ const webEnvSchema = z.object({
 export const ENV_WEB = webEnvSchema.parse({
   API_BASEURL,
   BACKEND_BASEURL,
-  GOOGLE_CLIENT_ID: process.env["GOOGLE_CLIENT_ID"],
-  NODE_ENV: process.env["NODE_ENV"],
-  POSTHOG_KEY: process.env["POSTHOG_KEY"],
-  POSTHOG_HOST: process.env["POSTHOG_HOST"],
+  GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+  NODE_ENV: process.env.NODE_ENV,
+  POSTHOG_KEY: process.env.POSTHOG_KEY,
+  POSTHOG_HOST: process.env.POSTHOG_HOST,
 });
 
 export const IS_DEV = isDev(ENV_WEB.NODE_ENV);

--- a/packages/web/src/common/repositories/event/event.repository.util.test.ts
+++ b/packages/web/src/common/repositories/event/event.repository.util.test.ts
@@ -1,5 +1,9 @@
 import * as authState from "@web/auth/compass/state/auth.state.util";
 import * as googleAuthState from "@web/auth/google/state/google.auth.state";
+import {
+  markBackendUnavailable,
+  resetBackendAvailabilityForTests,
+} from "@web/common/apis/util/backend-unavailable-error.util";
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const hasUserEverAuthenticatedSpy = spyOn(
@@ -18,6 +22,7 @@ describe("getEventRepository", () => {
     hasUserEverAuthenticatedSpy.mockReturnValue(false);
     isGoogleRevokedSpy.mockReset();
     isGoogleRevokedSpy.mockReturnValue(false);
+    resetBackendAvailabilityForTests();
   });
 
   it("uses remote storage when a session exists", () => {
@@ -45,5 +50,18 @@ describe("getEventRepository", () => {
     isGoogleRevokedSpy.mockReturnValue(true);
 
     expect(getEventRepository(false)).toBeInstanceOf(LocalEventRepository);
+  });
+
+  it("uses local storage for a returning user when the backend is unavailable", () => {
+    hasUserEverAuthenticatedSpy.mockReturnValue(true);
+    markBackendUnavailable();
+
+    expect(getEventRepository(false)).toBeInstanceOf(LocalEventRepository);
+  });
+
+  it("uses local storage for an active session when the backend is unavailable", () => {
+    markBackendUnavailable();
+
+    expect(getEventRepository(true)).toBeInstanceOf(LocalEventRepository);
   });
 });

--- a/packages/web/src/common/repositories/event/event.repository.util.ts
+++ b/packages/web/src/common/repositories/event/event.repository.util.ts
@@ -8,6 +8,7 @@
  */
 import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import { isGoogleRevoked } from "@web/auth/google/state/google.auth.state";
+import { isBackendUnavailable } from "@web/common/apis/util/backend-unavailable-error.util";
 import { type EventRepository } from "./event.repository.interface";
 import { LocalEventRepository } from "./local.event.repository";
 import { RemoteEventRepository } from "./remote.event.repository";
@@ -19,12 +20,15 @@ import { RemoteEventRepository } from "./remote.event.repository";
  * 1. If Google disconnected Compass: Use LocalEventRepository
  *    - Graceful degradation until user re-authenticates
  *    - Prevents API errors from failed Google token refresh
- * 2. If user has EVER authenticated: Use RemoteEventRepository
+ * 2. If the backend is unavailable: Use LocalEventRepository
+ *    - Keeps frontend-only development and self-hosted UI-only deployments usable
+ *    - Events remain saved in IndexedDB instead of failing remote requests
+ * 3. If user has EVER authenticated: Use RemoteEventRepository
  *    - Prevents remote account events from disappearing when the session is temporarily missing
  *    - Remote requests can surface the auth problem instead of silently saving locally
- * 3. If a session exists: Use RemoteEventRepository
+ * 4. If a session exists: Use RemoteEventRepository
  *    - Newly authenticated users persist through the backend even before remembered auth state updates
- * 4. If user has NEVER authenticated: Use LocalEventRepository (IndexedDB)
+ * 5. If user has NEVER authenticated: Use LocalEventRepository (IndexedDB)
  *    - Events stored locally until user decides to sign in
  *
  * @param sessionExists - Whether a session currently exists (from session.doesSessionExist())
@@ -32,6 +36,10 @@ import { RemoteEventRepository } from "./remote.event.repository";
 export function getEventRepository(sessionExists: boolean): EventRepository {
   // If Google disconnected Compass, use local storage until user re-authenticates
   if (isGoogleRevoked()) {
+    return new LocalEventRepository();
+  }
+
+  if (isBackendUnavailable()) {
     return new LocalEventRepository();
   }
 

--- a/packages/web/src/common/repositories/event/remote.event.repository.test.ts
+++ b/packages/web/src/common/repositories/event/remote.event.repository.test.ts
@@ -4,6 +4,10 @@ import {
   RecurringEventUpdateScope,
   type Schema_Event,
 } from "@core/types/event.types";
+import {
+  isBackendUnavailable,
+  resetBackendAvailabilityForTests,
+} from "@web/common/apis/util/backend-unavailable-error.util";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockCreate = mock();
@@ -11,6 +15,8 @@ const mockGet = mock();
 const mockEdit = mock();
 const mockDelete = mock();
 const mockReorder = mock();
+const mockPutEvent = mock();
+const mockGetEvents = mock();
 
 mock.module("@web/ducks/events/event.api", () => ({
   EventApi: {
@@ -22,8 +28,21 @@ mock.module("@web/ducks/events/event.api", () => ({
   },
 }));
 
+mock.module("@web/common/storage/adapter/adapter", () => ({
+  getStorageAdapter: () => ({
+    getEvents: mockGetEvents,
+    putEvent: mockPutEvent,
+  }),
+}));
+
 const { RemoteEventRepository } =
   require("./remote.event.repository") as typeof import("./remote.event.repository");
+
+function createBackendUnavailableError(): Error {
+  const error = new Error("Request failed");
+  error.name = "ApiError";
+  return error;
+}
 
 describe("RemoteEventRepository", () => {
   let repository: RemoteEventRepository;
@@ -34,6 +53,9 @@ describe("RemoteEventRepository", () => {
     mockEdit.mockClear();
     mockDelete.mockClear();
     mockReorder.mockClear();
+    mockPutEvent.mockClear();
+    mockGetEvents.mockClear();
+    resetBackendAvailabilityForTests();
     repository = new RemoteEventRepository();
   });
 
@@ -64,6 +86,22 @@ describe("RemoteEventRepository", () => {
 
       expect(mockCreate).toHaveBeenCalledWith(events);
       expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("saves locally when the backend is unavailable", async () => {
+      const event: Schema_Event = {
+        _id: "event-1",
+        title: "Test Event",
+      };
+
+      mockCreate.mockRejectedValue(createBackendUnavailableError());
+      mockPutEvent.mockResolvedValue(undefined);
+
+      await repository.create(event);
+
+      expect(mockCreate).toHaveBeenCalledWith(event);
+      expect(mockPutEvent).toHaveBeenCalledWith(event);
+      expect(isBackendUnavailable()).toBe(true);
     });
   });
 
@@ -126,6 +164,28 @@ describe("RemoteEventRepository", () => {
       expect(result.startDate).toBe(params.startDate);
       expect(result.endDate).toBe(params.endDate);
       expect(result.someday).toBe(params.someday);
+    });
+
+    it("loads local events when the backend is unavailable", async () => {
+      const params: Params_Events = {
+        startDate: "2024-01-01",
+        endDate: "2024-01-31",
+        someday: false,
+      };
+      const localEvents = [{ _id: "event-1", title: "Local Event" }];
+
+      mockGet.mockRejectedValue(createBackendUnavailableError());
+      mockGetEvents.mockResolvedValue(localEvents);
+
+      const result = await repository.get(params);
+
+      expect(mockGet).toHaveBeenCalledWith(params);
+      expect(mockGetEvents).toHaveBeenCalledWith(
+        params.startDate,
+        params.endDate,
+        params.someday,
+      );
+      expect(result.data).toEqual(localEvents);
     });
   });
 

--- a/packages/web/src/common/repositories/event/remote.event.repository.ts
+++ b/packages/web/src/common/repositories/event/remote.event.repository.ts
@@ -4,41 +4,63 @@ import {
   type RecurringEventUpdateScope,
   type Schema_Event,
 } from "@core/types/event.types";
+import {
+  isBackendUnavailableError,
+  markBackendUnavailable,
+} from "@web/common/apis/util/backend-unavailable-error.util";
 import { EventApi } from "@web/ducks/events/event.api";
 import { type Response_GetEventsSuccess } from "@web/ducks/events/event.types";
 import { type EventRepository } from "./event.repository.interface";
+import { LocalEventRepository } from "./local.event.repository";
 
 export class RemoteEventRepository implements EventRepository {
+  private readonly localRepository = new LocalEventRepository();
+
+  private async withLocalFallback<RemoteResult, LocalResult = RemoteResult>(
+    remoteOperation: () => Promise<RemoteResult>,
+    localOperation: () => Promise<LocalResult>,
+  ): Promise<RemoteResult | LocalResult> {
+    try {
+      return await remoteOperation();
+    } catch (error) {
+      if (!isBackendUnavailableError(error)) {
+        throw error;
+      }
+
+      markBackendUnavailable();
+      return localOperation();
+    }
+  }
+
   async create(event: Schema_Event | Schema_Event[]): Promise<void> {
-    await EventApi.create(event);
+    await this.withLocalFallback(
+      () => EventApi.create(event),
+      () => this.localRepository.create(event),
+    );
   }
 
   async get(params: Params_Events): Promise<Response_GetEventsSuccess> {
-    const response = await EventApi.get(params);
+    return this.withLocalFallback(
+      async () => {
+        const response = await EventApi.get(params);
 
-    // API responses have a .data property, and the backend returns
-    // the data in the shape of Response_HttpPaginatedSuccess<Schema_Event[]>
-    // We combine it with params to create Response_GetEventsSuccess
-
-    // Handle case where API returns array directly vs wrapped in pagination object
-    const result: Response_GetEventsSuccess = Array.isArray(response.data)
-      ? {
-          // API returned array directly - wrap it in pagination format
-          data: response.data,
-          count: response.data.length,
-          page: 1,
-          pageSize: response.data.length,
-          offset: 0,
-          startDate: params.startDate,
-          endDate: params.endDate,
-        }
-      : {
-          // API returned pagination object - merge with params
-          ...params,
-          ...response.data,
-        };
-
-    return result;
+        return Array.isArray(response.data)
+          ? {
+              data: response.data,
+              count: response.data.length,
+              page: 1,
+              pageSize: response.data.length,
+              offset: 0,
+              startDate: params.startDate,
+              endDate: params.endDate,
+            }
+          : {
+              ...params,
+              ...response.data,
+            };
+      },
+      () => this.localRepository.get(params),
+    );
   }
 
   async edit(
@@ -46,17 +68,26 @@ export class RemoteEventRepository implements EventRepository {
     event: Schema_Event,
     params: { applyTo?: RecurringEventUpdateScope },
   ): Promise<void> {
-    await EventApi.edit(_id, event, params);
+    await this.withLocalFallback(
+      () => EventApi.edit(_id, event, params),
+      () => this.localRepository.edit(_id, event, params),
+    );
   }
 
   async delete(
     _id: string,
     applyTo?: RecurringEventUpdateScope,
   ): Promise<void> {
-    await EventApi.delete(_id, applyTo);
+    await this.withLocalFallback(
+      () => EventApi.delete(_id, applyTo),
+      () => this.localRepository.delete(_id, applyTo),
+    );
   }
 
   async reorder(order: Payload_Order[]): Promise<void> {
-    await EventApi.reorder(order);
+    await this.withLocalFallback(
+      () => EventApi.reorder(order),
+      () => this.localRepository.reorder(order),
+    );
   }
 }

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -6,6 +6,42 @@ import {
 } from "@web/common/types/web.event.types";
 import { addId, isEventInRange } from "@web/common/utils/event/event.util";
 import { _assembleGridEvent } from "@web/ducks/events/sagas/saga.util";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+const { handleError } = await import("@web/common/utils/event/event.util");
+
+describe("handleError", () => {
+  const alertMock = mock();
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    global.alert = alertMock as typeof global.alert;
+    alertMock.mockClear();
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not log or alert backend-unavailable errors", () => {
+    const error = new Error("Request failed");
+    error.name = "ApiError";
+
+    handleError(error);
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+});
 
 describe("isEventInRange", () => {
   it("returns true if event is in range", () => {

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -9,6 +9,7 @@ import {
 } from "@core/types/event.types";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { getUserId } from "@web/auth/compass/session/session.util";
+import { isBackendUnavailableError } from "@web/common/apis/util/backend-unavailable-error.util";
 import {
   CLASS_TIMED_CALENDAR_EVENT,
   DATA_EVENT_ELEMENT_ID,
@@ -217,8 +218,12 @@ export const getWeekDayLabel = (day: Dayjs | Date) => {
 };
 
 export const handleError = (error: Error) => {
+  if (isBackendUnavailableError(error)) {
+    return;
+  }
+
   const codesToIgnore = [Status.NOT_FOUND, Status.GONE, Status.UNAUTHORIZED];
-  const code = parseInt(error.message.slice(-3));
+  const code = parseInt(error.message.slice(-3), 10);
   if (codesToIgnore.includes(code)) {
     // api interceptor will handle these
     return;

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.test.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.test.ts
@@ -1,0 +1,24 @@
+import { getAuthSubmitErrorMessage } from "./useAuthFormHandlers.util";
+import { describe, expect, it } from "bun:test";
+
+describe("getAuthSubmitErrorMessage", () => {
+  it("does not show raw API failure text when the backend cannot be reached", () => {
+    const error = new Error("Request failed");
+    error.name = "ApiError";
+
+    expect(getAuthSubmitErrorMessage(error, "Unable to log in")).toBe(
+      "Unable to reach the Compass server. Check that your backend is running and try again.",
+    );
+  });
+
+  it("does not show raw fetch failure text when the backend cannot be reached", () => {
+    expect(
+      getAuthSubmitErrorMessage(
+        new TypeError("Failed to fetch"),
+        "Unable to log in",
+      ),
+    ).toBe(
+      "Unable to reach the Compass server. Check that your backend is running and try again.",
+    );
+  });
+});

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -8,6 +8,7 @@ import {
   type ResetPasswordFormData,
   type SignUpFormData,
 } from "@web/auth/compass/schemas/auth.schemas";
+import { getAuthSubmitErrorMessage } from "./useAuthFormHandlers.util";
 import { type AuthView } from "./useAuthModal";
 
 const AUTH_TOKEN_QUERY_SCHEMA = z.object({
@@ -69,6 +70,7 @@ export function useAuthFormHandlers({
     return getAuthTokenQueryParams().token;
   }, [authToken]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: submit errors should clear when the auth modal changes view.
   useEffect(() => {
     setSubmitError(null);
   }, [currentView]);
@@ -102,9 +104,7 @@ export function useAuthFormHandlers({
             return;
         }
       } catch (error) {
-        setSubmitError(
-          error instanceof Error ? error.message : "Unable to sign up",
-        );
+        setSubmitError(getAuthSubmitErrorMessage(error, "Unable to sign up"));
       } finally {
         setIsSubmitting(false);
       }
@@ -144,9 +144,7 @@ export function useAuthFormHandlers({
             return;
         }
       } catch (error) {
-        setSubmitError(
-          error instanceof Error ? error.message : "Unable to log in",
-        );
+        setSubmitError(getAuthSubmitErrorMessage(error, "Unable to log in"));
       } finally {
         setIsSubmitting(false);
       }
@@ -174,9 +172,9 @@ export function useAuthFormHandlers({
             throw new Error(response.reason);
         }
       } catch (error) {
-        throw error instanceof Error
-          ? error
-          : new Error("Unable to send reset email");
+        throw new Error(
+          getAuthSubmitErrorMessage(error, "Unable to send reset email"),
+        );
       } finally {
         setIsSubmitting(false);
       }
@@ -223,7 +221,7 @@ export function useAuthFormHandlers({
         }
       } catch (error) {
         setSubmitError(
-          error instanceof Error ? error.message : "Unable to reset password",
+          getAuthSubmitErrorMessage(error, "Unable to reset password"),
         );
       } finally {
         setIsSubmitting(false);

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.util.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.util.ts
@@ -1,0 +1,16 @@
+import { isBackendUnavailableError } from "@web/common/apis/util/backend-unavailable-error.util";
+
+export function getAuthSubmitErrorMessage(
+  error: unknown,
+  fallbackMessage: string,
+): string {
+  if (error instanceof Error) {
+    if (isBackendUnavailableError(error)) {
+      return "Unable to reach the Compass server. Check that your backend is running and try again.";
+    }
+
+    return error.message;
+  }
+
+  return fallbackMessage;
+}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -85,6 +85,20 @@ describe("RecurrenceSection", () => {
     expect(setEventSpy).not.toHaveBeenCalled();
   });
 
+  it("shows the backend requirement before sign-in when the backend is unavailable", async () => {
+    markBackendUnavailable();
+    renderRecurrenceSection({ authenticated: false });
+
+    expect(
+      screen.getByText(
+        "Start the Compass backend and MongoDB to use recurring events.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Sign in to use recurring events."),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps recurrence settings hidden when a signed-in user's backend is unavailable", async () => {
     const user = userEvent.setup();
     markBackendUnavailable();
@@ -93,7 +107,7 @@ describe("RecurrenceSection", () => {
     expect(screen.getByText("Repeat")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Recurring events need the Compass backend and MongoDB running.",
+        "Start the Compass backend and MongoDB to use recurring events.",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Every")).not.toBeInTheDocument();

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -4,11 +4,15 @@ import { useCallback, useState } from "react";
 import { ThemeProvider } from "styled-components";
 import { Origin, Priorities } from "@core/constants/core.constants";
 import { SessionContext } from "@web/auth/compass/session/SessionProvider";
+import {
+  markBackendUnavailable,
+  resetBackendAvailabilityForTests,
+} from "@web/common/apis/util/backend-unavailable-error.util";
 import { theme } from "@web/common/styles/theme";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { assembleGridEvent } from "@web/common/utils/event/event.util";
 import { RecurrenceSection } from "./RecurrenceSection";
-import { describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const baseEvent = (): Schema_GridEvent =>
   assembleGridEvent({
@@ -59,6 +63,10 @@ function renderRecurrenceSection({
 }
 
 describe("RecurrenceSection", () => {
+  beforeEach(() => {
+    resetBackendAvailabilityForTests();
+  });
+
   it("keeps recurrence settings hidden for local users", async () => {
     const user = userEvent.setup();
     const { setEventSpy } = renderRecurrenceSection({ authenticated: false });
@@ -66,6 +74,25 @@ describe("RecurrenceSection", () => {
     expect(screen.getByText("Repeat")).toBeInTheDocument();
     expect(
       screen.getByText("Sign in to use recurring events."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Every")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ends on:")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /repeat/i }));
+
+    expect(screen.queryByText("Every")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ends on:")).not.toBeInTheDocument();
+    expect(setEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps recurrence settings hidden when a signed-in user's backend is unavailable", async () => {
+    const user = userEvent.setup();
+    markBackendUnavailable();
+    const { setEventSpy } = renderRecurrenceSection({ authenticated: true });
+
+    expect(screen.getByText("Repeat")).toBeInTheDocument();
+    expect(
+      screen.getByText("Start the backend to use recurring events."),
     ).toBeInTheDocument();
     expect(screen.queryByText("Every")).not.toBeInTheDocument();
     expect(screen.queryByText("Ends on:")).not.toBeInTheDocument();

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useCallback, useState } from "react";
+import { ThemeProvider } from "styled-components";
+import { Origin, Priorities } from "@core/constants/core.constants";
+import { SessionContext } from "@web/auth/compass/session/SessionProvider";
+import { theme } from "@web/common/styles/theme";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { assembleGridEvent } from "@web/common/utils/event/event.util";
+import { RecurrenceSection } from "./RecurrenceSection";
+import { describe, expect, it, mock } from "bun:test";
+
+const baseEvent = (): Schema_GridEvent =>
+  assembleGridEvent({
+    _id: "event-1",
+    title: "Test Event",
+    description: "",
+    startDate: "2026-04-24T14:00:00.000Z",
+    endDate: "2026-04-24T15:00:00.000Z",
+    priority: Priorities.UNASSIGNED,
+    origin: Origin.COMPASS,
+    isSomeday: false,
+    user: "user-1",
+  });
+
+function renderRecurrenceSection({
+  authenticated,
+}: {
+  authenticated: boolean;
+}) {
+  const setAuthenticated = mock();
+  const setEventSpy = mock();
+
+  function Harness() {
+    const [event, setEvent] = useState<Schema_GridEvent | null>(baseEvent());
+    const handleSetEvent = useCallback<typeof setEvent>((nextEvent) => {
+      setEventSpy(nextEvent);
+      setEvent(nextEvent);
+    }, []);
+
+    if (!event) return null;
+
+    return (
+      <SessionContext.Provider value={{ authenticated, setAuthenticated }}>
+        <ThemeProvider theme={theme}>
+          <RecurrenceSection
+            bgColor="#f8d784"
+            event={event}
+            setEvent={handleSetEvent}
+          />
+        </ThemeProvider>
+      </SessionContext.Provider>
+    );
+  }
+
+  const view = render(<Harness />);
+
+  return { ...view, setEventSpy };
+}
+
+describe("RecurrenceSection", () => {
+  it("keeps recurrence settings hidden for local users", async () => {
+    const user = userEvent.setup();
+    const { setEventSpy } = renderRecurrenceSection({ authenticated: false });
+
+    expect(screen.getByText("Repeat")).toBeInTheDocument();
+    expect(
+      screen.getByText("Sign in to use recurring events."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Every")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ends on:")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /repeat/i }));
+
+    expect(screen.queryByText("Every")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ends on:")).not.toBeInTheDocument();
+    expect(setEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows recurrence settings after signed-in users enable repeat", async () => {
+    const user = userEvent.setup();
+    renderRecurrenceSection({ authenticated: true });
+
+    expect(screen.queryByText("Every")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /edit recurrence/i }));
+
+    expect(await screen.findByText("Every")).toBeInTheDocument();
+    expect(screen.getByText("Ends on:")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -92,7 +92,9 @@ describe("RecurrenceSection", () => {
 
     expect(screen.getByText("Repeat")).toBeInTheDocument();
     expect(
-      screen.getByText("Start the backend to use recurring events."),
+      screen.getByText(
+        "Recurring events need the Compass backend and MongoDB running.",
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Every")).not.toBeInTheDocument();
     expect(screen.queryByText("Ends on:")).not.toBeInTheDocument();

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
@@ -1,5 +1,6 @@
-import React, { type Dispatch, type SetStateAction } from "react";
+import { type Dispatch, type SetStateAction } from "react";
 import { Priorities } from "@core/constants/core.constants";
+import { useSession } from "@web/auth/compass/session/useSession";
 import { hoverColorByPriority } from "@web/common/styles/theme.util";
 import {
   type Schema_GridEvent,
@@ -25,19 +26,23 @@ export const RecurrenceSection = ({
   event,
   setEvent,
 }: RecurrenceSectionProps) => {
+  const { authenticated } = useSession();
   const recurrenceHook = useRecurrence(event, { setEvent });
   const { setInterval, setFreq, setWeekDays, setUntil } = recurrenceHook;
   const { weekDays, interval, freq, until, toggleRecurrence } = recurrenceHook;
   const { hasRecurrence } = recurrenceHook;
+  const isRecurrenceDisabled = !authenticated;
 
   return (
     <StyledRepeatRow direction={FlexDirections.COLUMN}>
       <RecurrenceToggle
+        disabled={isRecurrenceDisabled}
+        disabledMessage="Sign in to use recurring events."
         hasRecurrence={hasRecurrence}
         toggleRecurrence={toggleRecurrence}
       />
 
-      <ConditionalRender condition={hasRecurrence}>
+      <ConditionalRender condition={hasRecurrence && !isRecurrenceDisabled}>
         <RecurrenceIntervalSelect
           bgColor={bgColor}
           initialValue={interval}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
@@ -1,6 +1,7 @@
 import { type Dispatch, type SetStateAction } from "react";
 import { Priorities } from "@core/constants/core.constants";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { isBackendUnavailable } from "@web/common/apis/util/backend-unavailable-error.util";
 import { hoverColorByPriority } from "@web/common/styles/theme.util";
 import {
   type Schema_GridEvent,
@@ -31,13 +32,16 @@ export const RecurrenceSection = ({
   const { setInterval, setFreq, setWeekDays, setUntil } = recurrenceHook;
   const { weekDays, interval, freq, until, toggleRecurrence } = recurrenceHook;
   const { hasRecurrence } = recurrenceHook;
-  const isRecurrenceDisabled = !authenticated;
+  const isRecurrenceDisabled = !authenticated || isBackendUnavailable();
+  const disabledMessage = authenticated
+    ? "Start the backend to use recurring events."
+    : "Sign in to use recurring events.";
 
   return (
     <StyledRepeatRow direction={FlexDirections.COLUMN}>
       <RecurrenceToggle
         disabled={isRecurrenceDisabled}
-        disabledMessage="Sign in to use recurring events."
+        disabledMessage={disabledMessage}
         hasRecurrence={hasRecurrence}
         toggleRecurrence={toggleRecurrence}
       />

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
@@ -34,7 +34,7 @@ export const RecurrenceSection = ({
   const { hasRecurrence } = recurrenceHook;
   const isRecurrenceDisabled = !authenticated || isBackendUnavailable();
   const disabledMessage = authenticated
-    ? "Start the backend to use recurring events."
+    ? "Recurring events need the Compass backend and MongoDB running."
     : "Sign in to use recurring events.";
 
   return (

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
@@ -32,9 +32,10 @@ export const RecurrenceSection = ({
   const { setInterval, setFreq, setWeekDays, setUntil } = recurrenceHook;
   const { weekDays, interval, freq, until, toggleRecurrence } = recurrenceHook;
   const { hasRecurrence } = recurrenceHook;
-  const isRecurrenceDisabled = !authenticated || isBackendUnavailable();
-  const disabledMessage = authenticated
-    ? "Recurring events need the Compass backend and MongoDB running."
+  const isBackendDown = isBackendUnavailable();
+  const isRecurrenceDisabled = !authenticated || isBackendDown;
+  const disabledMessage = isBackendDown
+    ? "Start the Compass backend and MongoDB to use recurring events."
     : "Sign in to use recurring events.";
 
   return (

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceToggle.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceToggle.tsx
@@ -7,35 +7,48 @@ import {
   StyledRepeatRow,
   StyledRepeatText,
   StyledRepeatTextContainer,
+  StyledRepeatUnavailableText,
 } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/styled";
 
 export interface RecurrenceToggleProps {
+  disabled?: boolean;
+  disabledMessage?: string;
   hasRecurrence: boolean;
   toggleRecurrence: () => void;
 }
 
 export const RecurrenceToggle = ({
+  disabled = false,
+  disabledMessage,
   hasRecurrence,
   toggleRecurrence,
 }: RecurrenceToggleProps) => {
+  const onToggle = useCallback(() => {
+    if (disabled) return;
+    toggleRecurrence();
+  }, [disabled, toggleRecurrence]);
+
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        toggleRecurrence();
+        onToggle();
       }
     },
-    [toggleRecurrence],
+    [onToggle],
   );
 
   return (
     <StyledRepeatRow>
       <ConditionalRender condition={hasRecurrence}>
-        <StyledRepeatContainer onClick={toggleRecurrence}>
+        <StyledRepeatContainer $disabled={disabled} onClick={onToggle}>
           <StyledRepeatText
+            aria-disabled={disabled || undefined}
             hasRepeat={hasRecurrence}
             onKeyDown={handleKeyDown}
             tabIndex={0}
+            title={disabled ? disabledMessage : undefined}
+            $disabled={disabled}
           >
             <RepeatIcon size={18} />
             <span>Repeat</span>
@@ -45,15 +58,24 @@ export const RecurrenceToggle = ({
 
       <ConditionalRender condition={!hasRecurrence}>
         <StyledRepeatTextContainer
-          aria-label="Edit recurrence"
-          onClick={toggleRecurrence}
+          aria-disabled={disabled || undefined}
+          aria-label={disabled ? "Repeat" : "Edit recurrence"}
+          $disabled={disabled}
+          onClick={onToggle}
           onKeyDown={handleKeyDown}
           role="button"
           tabIndex={0}
+          title={disabled ? disabledMessage : undefined}
         >
           <RepeatIcon size={18} />
           <span>Repeat</span>
         </StyledRepeatTextContainer>
+      </ConditionalRender>
+
+      <ConditionalRender condition={Boolean(disabled && disabledMessage)}>
+        <StyledRepeatUnavailableText>
+          {disabledMessage}
+        </StyledRepeatUnavailableText>
       </ConditionalRender>
     </StyledRepeatRow>
   );

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/styled.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/styled.ts
@@ -2,9 +2,12 @@ import styled from "styled-components";
 import { darken } from "@core/util/color.utils";
 import { Flex } from "@web/components/Flex";
 
-export const StyledRepeatContainer = styled.div`
+export const StyledRepeatContainer = styled.div<{
+  $disabled?: boolean;
+}>`
   margin-bottom: ${({ theme }) => theme.spacing.xs};
-  cursor: pointer;
+  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+  opacity: ${({ $disabled }) => ($disabled ? 0.7 : 1)};
 `;
 
 export const StyledRepeatRow = styled(Flex)`
@@ -17,6 +20,7 @@ export const StyledRepeatRow = styled(Flex)`
 `;
 
 export const StyledRepeatText = styled.span<{
+  $disabled?: boolean;
   hasRepeat: boolean;
 }>`
   display: inline-flex;
@@ -37,16 +41,20 @@ export const StyledRepeatText = styled.span<{
   }
 
   &:hover {
-    cursor: pointer;
-    color: ${({ theme }) => theme.color.text.dark};
-    background-color: ${({ theme }) => theme.color.border.primary};
+    cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+    color: ${({ $disabled, theme }) =>
+      $disabled ? theme.color.text.darkPlaceholder : theme.color.text.dark};
+    background-color: ${({ $disabled, theme }) =>
+      $disabled ? "transparent" : theme.color.border.primary};
   }
   &:focus {
     box-shadow: 0 0 0 2px ${({ theme }) => theme.color.border.primaryDark};
   }
 `;
 
-export const StyledRepeatTextContainer = styled(Flex)`
+export const StyledRepeatTextContainer = styled(Flex)<{
+  $disabled?: boolean;
+}>`
   align-items: center;
   border-radius: ${({ theme }) => theme.shape.borderRadius};
   gap: ${({ theme }) => theme.spacing.xs};
@@ -56,7 +64,8 @@ export const StyledRepeatTextContainer = styled(Flex)`
   padding: 2px 8px;
   color: ${({ theme }) => theme.color.text.darkPlaceholder};
   font-size: ${({ theme }) => theme.text.size.m};
-  cursor: pointer;
+  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+  opacity: ${({ $disabled }) => ($disabled ? 0.7 : 1)};
   transition:
     color ${({ theme }) => theme.transition.default} ease,
     filter ${({ theme }) => theme.transition.default} ease;
@@ -68,13 +77,20 @@ export const StyledRepeatTextContainer = styled(Flex)`
   }
 
   &:hover {
-    color: ${({ theme }) => theme.color.text.dark};
-    background-color: ${({ theme }) => theme.color.border.primary};
+    color: ${({ $disabled, theme }) =>
+      $disabled ? theme.color.text.darkPlaceholder : theme.color.text.dark};
+    background-color: ${({ $disabled, theme }) =>
+      $disabled ? "transparent" : theme.color.border.primary};
   }
 
   &:focus {
     box-shadow: 0 0 0 2px ${({ theme }) => theme.color.border.primaryDark};
   }
+`;
+
+export const StyledRepeatUnavailableText = styled.span`
+  color: ${({ theme }) => theme.color.text.darkPlaceholder};
+  font-size: ${({ theme }) => theme.text.size.s};
 `;
 
 export const StyledWeekDay = styled.button<{

--- a/packages/web/src/views/Logout/Logout.test.tsx
+++ b/packages/web/src/views/Logout/Logout.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ThemeProvider } from "styled-components";
+import { theme } from "@web/common/styles/theme";
+import { afterAll, describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+
+const signOut = mock();
+const clearAuthenticationState = mock();
+const getLastKnownEmail = mock();
+const markUserAsAuthenticated = mock();
+
+mock.module("@web/common/classes/Session", () => ({
+  session: {
+    signOut,
+  },
+}));
+
+mock.module("@web/auth/compass/state/auth.state.util", () => ({
+  clearAnonymousCalendarChangeSignUpPrompt: mock(),
+  clearAuthenticationState,
+  getAuthState: mock(),
+  getLastKnownEmail,
+  hasUserEverAuthenticated: mock(),
+  markAnonymousCalendarChangeForSignUpPrompt: mock(),
+  markUserAsAuthenticated,
+  shouldShowAnonymousCalendarChangeSignUpPrompt: mock(),
+  subscribeToAuthState: mock(),
+  updateAuthState: mock(),
+}));
+
+const { LogoutView } = await import("./Logout");
+
+describe("LogoutView", () => {
+  it("navigates away even when session sign-out does not finish", async () => {
+    signOut.mockReturnValue(new Promise(() => undefined));
+
+    render(
+      <ThemeProvider theme={theme}>
+        <MemoryRouter
+          initialEntries={["/logout"]}
+          future={{
+            v7_relativeSplatPath: true,
+            v7_startTransition: true,
+          }}
+        >
+          <Routes>
+            <Route path="/logout" element={<LogoutView />} />
+            <Route path="/day" element={<div>Day view</div>} />
+          </Routes>
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /signout/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Day view")).toBeInTheDocument();
+    });
+    expect(clearAuthenticationState).toHaveBeenCalledTimes(1);
+  });
+});
+
+afterAll(() => {
+  mock.restore();
+});

--- a/packages/web/src/views/Logout/Logout.tsx
+++ b/packages/web/src/views/Logout/Logout.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { clearAuthenticationState } from "@web/auth/compass/state/auth.state.util";
 import { session } from "@web/common/classes/Session";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
@@ -14,11 +15,13 @@ export const LogoutView = () => {
   const logout = async () => {
     setIsLoggingOut(true);
 
-    await session.signOut();
+    void session.signOut().catch((error) => {
+      console.warn("Failed to complete backend sign-out:", error);
+    });
 
+    clearAuthenticationState();
     setIsLoggingOut(false);
 
-    alert("You logged out - see ya! ✌");
     navigate(ROOT_ROUTES.DAY);
   };
 


### PR DESCRIPTION
## Why

The main purpose of this PR is to keep recurring event controls out of local/frontend-only mode. Recurring events depend on the backend-backed event model and MongoDB; IndexedDB local storage is not meant to fully handle that behavior. When Compass is running with only the web app, or when a self-hosted/custom setup has the web app up but the backend or MongoDB is unavailable, the UI should not invite users into recurrence flows that cannot be supported safely.

While tracing that issue, we found the broader cause: the frontend still tried to use backend-backed paths in several places even when the backend was not reachable. That meant users could see raw `ApiError: Request failed` messages, event changes could keep trying the API instead of saving locally, and sign out could stall while the browser repeatedly attempted backend session requests.

This PR makes the web app degrade cleanly when the backend is unavailable. It does not try to turn signed-in cloud usage into a full offline-sync mode.

## What changed

- Disable recurrence controls unless the user is signed in and the backend is reachable.
- Show a clearer recurrence message when the backend is unavailable: “Start the Compass backend and MongoDB to use recurring events.”
- Detect when the browser cannot reach the backend and remember that state while the app is running.
- Fall back to local event storage when backend requests fail because the backend is unavailable.
- Keep frontend-only users on the IndexedDB path instead of repeatedly trying remote event requests.
- Hide raw backend connection errors from auth/profile flows and show friendlier auth messaging.
- Make logout clear the local signed-in state and navigate immediately, while attempting backend sign-out in the background.
- Make the web dev/build API fallback point at the backend port instead of the frontend port.

## Validation

- `bun run test:web`
- `bunx biome check` on the touched web files
- Focused recurrence/backend-unavailable/logout tests after the latest recurrence copy update
- Manual browser check with the backend shut down: logout returned to the day view quickly instead of stalling

The focused Biome check passed with existing console warnings in the web build/dev scripts.