### PR TITLE
chore(config): update typescript

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@types/node": "^22.13.10",
         "@types/node-fetch": "^2.6.13",
         "jest": "^29.0.3",
-        "typescript": "^5.1.6",
+        "typescript": "^6.0.3",
       },
     },
     "packages/backend": {
@@ -69,7 +69,7 @@
       "devDependencies": {
         "@faker-js/faker": "^9.6.0",
         "@types/tinycolor2": "^1.4.6",
-        "typescript": "^5.1.6",
+        "typescript": "^6.0.3",
       },
     },
     "packages/scripts": {
@@ -86,7 +86,7 @@
       "devDependencies": {
         "@types/inquirer": "^9.0.1",
         "@types/node": "^24.7.2",
-        "typescript": "^5.1.6",
+        "typescript": "^6.0.3",
       },
     },
     "packages/web": {
@@ -145,13 +145,13 @@
         "msw": "^1.0.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.14",
-        "typescript": "^5.1.6",
+        "typescript": "^6.0.3",
         "typescript-plugin-css-modules": "^5.0.1",
       },
     },
   },
   "overrides": {
-    "typescript": "5.1.6",
+    "typescript": "6.0.3",
     "glob": "^13.0.6",
     "onetime": "^5.1.2",
   },
@@ -2142,7 +2142,7 @@
 
     "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 
-    "typescript": ["typescript@5.1.6", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-compare": ["typescript-compare@0.0.2", "", { "dependencies": { "typescript-logic": "^0.0.0" } }, "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA=="],
 

--- a/package.json
+++ b/package.json
@@ -53,16 +53,16 @@
     "@types/node": "^22.13.10",
     "@types/node-fetch": "^2.6.13",
     "jest": "^29.0.3",
-    "typescript": "^5.1.6"
+    "typescript": "^6.0.3"
   },
   "resolutions": {
     "glob": "^13.0.6",
-    "typescript": "5.1.6",
+    "typescript": "6.0.3",
     "onetime": "^5.1.2"
   },
   "overrides": {
     "glob": "^13.0.6",
-    "typescript": "5.1.6",
+    "typescript": "6.0.3",
     "onetime": "^5.1.2"
   },
   "workspaces": [

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -58,7 +58,6 @@ process.on("SIGQUIT", () => {
   void gracefulShutdown();
 });
 
-// @ts-expect-error -- import.meta.main is Bun-native; tsconfig targets commonjs
 if (import.meta.main) {
   void start();
 }

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -1,5 +1,5 @@
 import cors from "cors";
-import SuperTokens, { type RecipeListFunction } from "supertokens-node";
+import SuperTokens from "supertokens-node";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
@@ -88,7 +88,7 @@ const googleThirdPartyOverride: NonNullable<ThirdPartyTypeInput["override"]> = {
   },
 };
 
-const getThirdPartyRecipes = (): RecipeListFunction[] => {
+const getThirdPartyRecipes = (): ReturnType<typeof ThirdParty.init>[] => {
   const clientId = ENV.GOOGLE_CLIENT_ID;
   const clientSecret = ENV.GOOGLE_CLIENT_SECRET;
 

--- a/packages/backend/src/priority/priority.routes.config.ts
+++ b/packages/backend/src/priority/priority.routes.config.ts
@@ -13,19 +13,14 @@ export class PriorityRoutes extends CommonRoutesConfig {
     this.app
       .route(`/api/priority`)
       .all(verifySession())
-      //@ts-expect-error
       .get(PriorityController.readAll)
-      //@ts-expect-error
       .post(PriorityController.create);
 
     this.app
       .route(`/api/priority/:id`)
       .all([verifySession(), validateIdParam])
-      //@ts-expect-error
       .get(PriorityController.readById)
-      //@ts-expect-error
       .put(PriorityController.update)
-      //@ts-expect-error
       .delete(PriorityController.delete);
 
     return this.app;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
     "@types/tinycolor2": "^1.4.6",
-    "typescript": "^5.1.6"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "bson": "^6.10.4",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@types/inquirer": "^9.0.1",
     "@types/node": "^24.7.2",
-    "typescript": "^5.1.6"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -58,7 +58,7 @@
     "msw": "^1.0.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.14",
-    "typescript": "^5.1.6",
+    "typescript": "^6.0.3",
     "typescript-plugin-css-modules": "^5.0.1"
   },
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,18 @@
     "packages/scripts/src/**/*.d.ts",
     "packages/scripts/src/commands/dev.js"
   ],
+  "exclude": [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "packages/scripts/src/testing/core.jest-compat.ts",
+    "packages/scripts/src/testing/core.preload.ts"
+  ],
   "compilerOptions": {
-    "target": "ES2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "target": "ES2022" /* Specify ECMAScript target version. */,
+    "module": "ES2022" /* Specify module code generation. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     "allowJs": true /* Allow javascript files to be compiled. */,
     "checkJs": true /* Report errors in .js files. */,
@@ -47,9 +56,10 @@
     "noPropertyAccessFromIndexSignature": true /* Require undeclared properties from index signatures to use element accesses. */,
 
     /* Module Resolution Options */
-    // "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "moduleResolution": "node" /* Specify module resolution strategy. */,
     // "baseUrl": "./packages" /* Base directory to resolve non-absolute module names. */,
     "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "ignoreDeprecations": "6.0",
     "paths": {
       /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
       /* include all packages so cross-imports work */
@@ -60,7 +70,11 @@
     },
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    "types": [
+      "bun-types",
+      "jest",
+      "node"
+    ] /* Type declaration files to be included in compilation. */,
     "allowUnreachableCode": true,
     "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,


### PR DESCRIPTION
## Summary

This updates Compass to the latest TypeScript release, `6.0.3`, across the root workspace and the package-level TypeScript dev dependencies.

The compiler upgrade exposed a few places where our project configuration and source annotations had fallen behind the runtime shape of the repo. This PR updates the root TypeScript config for the newer compiler, keeps the root no-emit check focused on production/source files, and removes stale TypeScript suppressions that are no longer needed.

## What changed

- Updated TypeScript from `5.1.6` to `6.0.3` in the root package, package manifests, lockfile, resolutions, and overrides.
- Updated the root TypeScript config to work cleanly with TypeScript 6:
  - acknowledged the current `baseUrl` deprecation with `ignoreDeprecations`
  - made runtime/test globals explicit through `types`
  - moved the root check target/module to `ES2022`
  - kept the root type-check focused on app/source files while package test runners continue validating test files
- Removed stale TypeScript suppressions in backend routing and app startup code.
- Avoided importing a stale SuperTokens root type by deriving the ThirdParty recipe return type directly from `ThirdParty.init`.

## Validation

- `bun run verify` passed:
  - backend tests
  - core tests
  - scripts tests
  - web tests
  - type-check
- `bun run lint` exited successfully. It still reports the repo's existing warning backlog, but no blocking failure.
- `bun run build:web` passed.
- `bun run build:backend --environment staging` passed. The build warned that `packages/backend/.env.staging` was not present locally, but the backend bundle and dependency install completed successfully.

## Notes

The documented `bun run cli build ...` command is currently stale in this checkout; the active build scripts are `bun run build:web` and `bun run build:backend --environment staging`. I used those actual scripts for validation.
