### PR TITLE
chore(ci): add type-check workflow

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   type-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -3,6 +3,39 @@ name: Test
 on: [push]
 
 jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.18
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install Dependencies
+        run: |
+          bun install --frozen-lockfile
+
+      - name: Run type-check
+        run: |
+          bun run type-check
+
   unit:
     runs-on: ubuntu-latest
     strategy:

--- a/e2e/utils/oauth-test-utils.ts
+++ b/e2e/utils/oauth-test-utils.ts
@@ -7,10 +7,17 @@ import "./compass-window";
  * - Mocks API endpoints
  */
 export const prepareOAuthTestPage = async (page: Page) => {
+  page.on("dialog", async (dialog) => {
+    await dialog.dismiss().catch(() => undefined);
+  });
+
   // Enable test mode before app loads
   await page.addInitScript(() => {
     // Enable e2e test mode - this exposes test hooks in the app
     window.__COMPASS_E2E_TEST__ = true;
+    window.alert = () => undefined;
+    window.confirm = () => true;
+    window.prompt = () => null;
   });
 
   // Mock API endpoints to prevent real network calls

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -58,7 +58,6 @@ process.on("SIGQUIT", () => {
   void gracefulShutdown();
 });
 
-// @ts-expect-error -- import.meta.main is Bun-native; tsconfig targets commonjs
 if (import.meta.main) {
   void start();
 }

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -1,5 +1,5 @@
 import cors from "cors";
-import SuperTokens, { type RecipeListFunction } from "supertokens-node";
+import SuperTokens from "supertokens-node";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
@@ -88,7 +88,7 @@ const googleThirdPartyOverride: NonNullable<ThirdPartyTypeInput["override"]> = {
   },
 };
 
-const getThirdPartyRecipes = (): RecipeListFunction[] => {
+const getThirdPartyRecipes = (): ReturnType<typeof ThirdParty.init>[] => {
   const clientId = ENV.GOOGLE_CLIENT_ID;
   const clientSecret = ENV.GOOGLE_CLIENT_SECRET;
 

--- a/packages/backend/src/priority/priority.routes.config.ts
+++ b/packages/backend/src/priority/priority.routes.config.ts
@@ -13,19 +13,14 @@ export class PriorityRoutes extends CommonRoutesConfig {
     this.app
       .route(`/api/priority`)
       .all(verifySession())
-      //@ts-expect-error
       .get(PriorityController.readAll)
-      //@ts-expect-error
       .post(PriorityController.create);
 
     this.app
       .route(`/api/priority/:id`)
       .all([verifySession(), validateIdParam])
-      //@ts-expect-error
       .get(PriorityController.readById)
-      //@ts-expect-error
       .put(PriorityController.update)
-      //@ts-expect-error
       .delete(PriorityController.delete);
 
     return this.app;

--- a/packages/scripts/src/migrations/2025.10.13T14.22.21.migrate-sync-watch-data.ts
+++ b/packages/scripts/src/migrations/2025.10.13T14.22.21.migrate-sync-watch-data.ts
@@ -50,10 +50,16 @@ export default class Migration implements RunnableMigration<MigrationContext> {
 
       const watchDocuments: Array<Schema_Watch> = [];
 
-      const syncDocs = (syncDoc.google?.events ?? [])
-        .map((doc) => Migration.OldSyncDetailsSchema.safeParse(doc).data)
-        .filter((d) => ExpirationDateSchema.safeParse(d?.expiration).success)
-        .filter((doc) => doc !== undefined);
+      const syncDocs = (syncDoc.google?.events ?? []).flatMap((doc) => {
+        const parsed = Migration.OldSyncDetailsSchema.safeParse(doc);
+
+        if (!parsed.success) return [];
+        if (!ExpirationDateSchema.safeParse(parsed.data.expiration).success) {
+          return [];
+        }
+
+        return [parsed.data];
+      });
 
       const gcal = await getGcalClient(syncDoc.user).catch((err) => {
         logger.error(

--- a/packages/scripts/src/migrations/2025.10.18T20.01.14.migrate-events-to-new-events-collection.ts
+++ b/packages/scripts/src/migrations/2025.10.18T20.01.14.migrate-events-to-new-events-collection.ts
@@ -112,15 +112,18 @@ export default class Migration implements RunnableMigration<MigrationContext> {
       if (recurrence) {
         const { eventId } = recurrence;
         if (eventId) {
-          const rule =
-            rrules.get(eventId) ??
-            (await mongoService.event
-              .findOne({ _id: new ObjectId(eventId) })
-              .then((e) => {
-                if (!Array.isArray(e?.recurrence?.rule)) return undefined;
+          let rule = rrules.get(eventId);
+          if (!rule) {
+            const baseEvent = await mongoService.event.findOne({
+              _id: new ObjectId(eventId),
+            });
 
-                return rrules.set(eventId, e?.recurrence?.rule).get(eventId);
-              }));
+            const baseRule = baseEvent?.recurrence?.rule;
+            if (Array.isArray(baseRule)) {
+              rule = baseRule;
+              rrules.set(eventId, rule);
+            }
+          }
 
           if (!Array.isArray(rule)) {
             logger.warn(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ const TEST_PORT = 9150;
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
   workers: 2,
   expect: {
     timeout: 10_000,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,18 @@
     "packages/scripts/src/**/*.d.ts",
     "packages/scripts/src/commands/dev.js"
   ],
+  "exclude": [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "packages/scripts/src/testing/core.jest-compat.ts",
+    "packages/scripts/src/testing/core.preload.ts"
+  ],
   "compilerOptions": {
-    "target": "ES2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "target": "ES2022" /* Specify ECMAScript target version. */,
+    "module": "ES2022" /* Specify module code generation. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     "allowJs": true /* Allow javascript files to be compiled. */,
     "checkJs": true /* Report errors in .js files. */,
@@ -47,7 +56,7 @@
     "noPropertyAccessFromIndexSignature": true /* Require undeclared properties from index signatures to use element accesses. */,
 
     /* Module Resolution Options */
-    // "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "moduleResolution": "node" /* Specify module resolution strategy. */,
     // "baseUrl": "./packages" /* Base directory to resolve non-absolute module names. */,
     "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
     "paths": {
@@ -60,7 +69,11 @@
     },
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    "types": [
+      "bun-types",
+      "jest",
+      "node"
+    ] /* Type declaration files to be included in compilation. */,
     "allowUnreachableCode": true,
     "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,


### PR DESCRIPTION
## Summary

This adds a dedicated `type-check` job to the existing unit-test GitHub Actions workflow, so `bun run type-check` is enforced by CI instead of only being a local/manual check.

The root type-check was not clean on `origin/main`, so this PR also tightens the root TypeScript config and fixes the few source issues that blocked it from becoming a reliable CI gate.

After opening the PR, CI also exposed an e2e flake in the OAuth sidebar connection-status test: Playwright hit a native JavaScript dialog while the page/session was closing and reported `Page.handleJavaScriptDialog`. This PR now makes the OAuth e2e harness neutralize native dialogs during those mocked OAuth tests, and enables CI-only Playwright retries so transient browser/session flakes get another attempt without changing local fail-fast behavior.

## What changed

- Added a separate `type-check` job to `.github/workflows/test-unit.yml`.
- The new job mirrors the existing unit-test setup:
  - checkout
  - Node 24
  - Bun 1.2.18
  - Bun dependency cache
  - `bun install --frozen-lockfile`
  - `bun run type-check`
- Updated the root TypeScript config so the root no-emit check focuses on source files, while package test runners remain responsible for test files.
- Made runtime globals explicit for TypeScript by including Bun, Jest, and Node types.
- Updated the root compiler target/module to handle current Bun scripts and `import.meta` usage.
- Removed stale TypeScript suppressions that are no longer needed.
- Cleaned up a couple of migration-script typing issues so the source check passes without weakening the check.
- Hardened the OAuth e2e test setup against native `alert`/`confirm`/`prompt` dialogs.
- Added CI-only Playwright retries; local e2e runs still use zero retries.

## Why

The TypeScript upgrade showed that CI did not currently prove the repo type-checks. Package tests are useful, but they do not catch the same class of compiler/configuration issues. This makes type-checking a first-class CI signal going forward.

The OAuth e2e update keeps mocked OAuth tests focused on app state instead of failing on browser dialog plumbing during CI teardown.

## Validation

- `bun run type-check` passed.
- `bun run test:scripts` passed.
- `bun run test:backend` passed when run by itself.
- `bun run lint` exited successfully with the existing repo warning backlog.
- `bun run format:check` completed without changes.
- `git diff --check` passed.
- `bunx playwright test e2e/oauth --project=chromium-desktop --repeat-each=5` passed: 70/70.
- `CI=1 bun run test:e2e` passed locally: 30 passed, 3 skipped.

## Note

I initially ran backend and scripts tests at the same time locally and backend hit the known local Mongo test harness collision around `globalConfig.json`. Rerunning backend by itself passed, and CI runs jobs in isolated runners.
