### PR TITLE
chore(config): disable literal key lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -41,6 +41,9 @@
         "useHookAtTopLevel": "warn",
         "useYield": "warn"
       },
+      "complexity": {
+        "useLiteralKeys": "off"
+      },
       "style": {
         "useImportType": {
           "level": "warn",


### PR DESCRIPTION
## Summary

This disables Biome's `useLiteralKeys` rule instead of rewriting existing bracket access across the repo.

The rule is mostly a readability preference for this codebase. Leaving the existing property access alone avoids broad mechanical churn in env setup, tests, schema conversion helpers, and parser internals.

## Validation

- `bun run lint`
  - Exits successfully.
  - No `useLiteralKeys` diagnostics appear in normal lint output.
- `bunx biome check . --max-diagnostics=none --reporter=json`
  - Reports `literalKey=0`, `warnings=694`, `infos=31`.
