### PR TITLE
[codex] fix web import and hook lint warnings

### DIFF
--- a/packages/web/src/auth/google/hooks/useGoogleLogin/useGoogleLogin.ts
+++ b/packages/web/src/auth/google/hooks/useGoogleLogin/useGoogleLogin.ts
@@ -108,7 +108,7 @@ export const useGoogleLogin = ({
       setLoading(true);
 
       return login();
-    }, [login, onStart, setData, setLoading]),
+    }, [login, onStart]),
     data,
     loading,
   };

--- a/packages/web/src/common/hooks/useBufferedVisibility.test.ts
+++ b/packages/web/src/common/hooks/useBufferedVisibility.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { useBufferedVisibility } from "./useBufferedVisibility";
 import {
   afterEach,
@@ -11,7 +11,7 @@ import {
 } from "bun:test";
 
 describe("useBufferedVisibility", () => {
-  let timeoutCallbacks: Array<{ callback: () => void; delay: number }> = [];
+  let _timeoutCallbacks: Array<{ callback: () => void; delay: number }> = [];
   let setTimeoutSpy: ReturnType<typeof spyOn>;
   let clearTimeoutSpy: ReturnType<typeof spyOn>;
   let currentTimeoutId = 0;
@@ -22,7 +22,7 @@ describe("useBufferedVisibility", () => {
 
   beforeEach(() => {
     setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
-    timeoutCallbacks = [];
+    _timeoutCallbacks = [];
     currentTimeoutId = 0;
     activeTimeouts.clear();
 

--- a/packages/web/src/common/hooks/useCursorCoordinates.ts
+++ b/packages/web/src/common/hooks/useCursorCoordinates.ts
@@ -13,7 +13,7 @@ export function useCursorCoordinates() {
     });
 
     return () => subscription.unsubscribe();
-  }, [setX, setY]);
+  }, []);
 
   return { x, y };
 }

--- a/packages/web/src/common/hooks/useEventDNDActions.test.ts
+++ b/packages/web/src/common/hooks/useEventDNDActions.test.ts
@@ -6,15 +6,7 @@ import {
   ID_GRID_ALLDAY_ROW,
   ID_GRID_MAIN,
 } from "@web/common/constants/web.constants";
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { readFile, writeFile } from "node:fs/promises";
 
 // Mock definitions
@@ -50,8 +42,8 @@ mock.module("@web/views/Day/util/agenda/agenda.util", () => ({
   getSnappedMinutes: mockGetSnappedMinutes,
   getAgendaEventTitle: (event) => `${event?.title || ""} -`,
   getAgendaEventTime: (d) => (d ? new Date(d).toISOString() : ""),
-  getAgendaEventPosition: (date) => 0,
-  getNowLinePosition: (date) => 0,
+  getAgendaEventPosition: (_date) => 0,
+  getNowLinePosition: (_date) => 0,
   getEventTimeFromPosition: (_y, dateInView) =>
     dateInView.startOf ? dateInView.startOf("day") : new Date(),
   roundMinutesToNearestFifteen: (minutes) => Math.round(minutes / 15) * 15,

--- a/packages/web/src/common/hooks/useMovementEvent.ts
+++ b/packages/web/src/common/hooks/useMovementEvent.ts
@@ -20,6 +20,10 @@ interface Options {
   eventTypes?: Array<"pointerup" | "pointerdown" | "pointermove">;
 }
 
+const DEFAULT_EVENT_TYPES: Array<"pointerup" | "pointerdown" | "pointermove"> =
+  [];
+const DEFAULT_SELECTORS: Array<keyof HTMLElementTagNameMap | string> = [];
+
 /**
  * useMovementEvent
  *
@@ -35,8 +39,8 @@ interface Options {
 export function useMovementEvent({
   handler,
   deps = [],
-  eventTypes = [],
-  selectors = [],
+  eventTypes = DEFAULT_EVENT_TYPES,
+  selectors = DEFAULT_SELECTORS,
 }: Options) {
   const typeFilter = useCallback(
     ({ event }: DomMovement) => {
@@ -44,8 +48,7 @@ export function useMovementEvent({
 
       return eventTypes.some((eventType) => event.type === eventType);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    eventTypes,
+    [eventTypes],
   );
 
   const elementsFilter = useCallback(
@@ -54,8 +57,7 @@ export function useMovementEvent({
 
       return selectors.some((el) => combination.element?.closest(el));
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    selectors,
+    [selectors],
   );
 
   const pause = useMemo(() => new BehaviorSubject<boolean>(false), []);

--- a/packages/web/src/components/ContextMenu/styled.ts
+++ b/packages/web/src/components/ContextMenu/styled.ts
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { darken } from "@core/util/color.utils";
 
 export const PriorityContainer = styled.div`
   display: flex;

--- a/packages/web/src/components/DND/DNDContext.test.tsx
+++ b/packages/web/src/components/DND/DNDContext.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import { type ReactNode } from "react";
-import { BehaviorSubject } from "rxjs";
 import {
   afterAll,
   beforeEach,

--- a/packages/web/src/components/DND/Droppable.tsx
+++ b/packages/web/src/components/DND/Droppable.tsx
@@ -12,7 +12,6 @@ import {
   forwardRef,
   type HTMLAttributes,
   type ReactHTML,
-  useCallback,
 } from "react";
 
 function CompassDroppable(

--- a/packages/web/src/components/DatePicker/styled.ts
+++ b/packages/web/src/components/DatePicker/styled.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { brighten, compliment, darken, isDark } from "@core/util/color.utils";
+import { brighten, darken, isDark } from "@core/util/color.utils";
 import { theme } from "@web/common/styles/theme";
 import { Flex } from "@web/components/Flex";
 import { Text } from "@web/components/Text";

--- a/packages/web/src/components/Focusable/Focusable.tsx
+++ b/packages/web/src/components/Focusable/Focusable.tsx
@@ -34,7 +34,7 @@ export const Focusable = forwardRef<HTMLElement, Props>(
         setIsFocused(true);
         props.onFocus?.(event);
       },
-      [props.onFocus, setIsFocused],
+      [props.onFocus],
     );
 
     const onBlur = useCallback(
@@ -42,7 +42,7 @@ export const Focusable = forwardRef<HTMLElement, Props>(
         setIsFocused(false);
         props.onBlur?.(event);
       },
-      [props.onBlur, setIsFocused],
+      [props.onBlur],
     );
 
     return (

--- a/packages/web/src/components/Input/Input.tsx
+++ b/packages/web/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   type ForwardRefRenderFunction,
   forwardRef,
   type HTMLAttributes,

--- a/packages/web/src/components/LoginAbsoluteOverflowLoader/LoginAbsoluteOverflowLoader.tsx
+++ b/packages/web/src/components/LoginAbsoluteOverflowLoader/LoginAbsoluteOverflowLoader.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   AlignItems,
   JustifyContent,

--- a/packages/web/src/components/SpaceCharacter/SpaceCharacter.tsx
+++ b/packages/web/src/components/SpaceCharacter/SpaceCharacter.tsx
@@ -1,3 +1,1 @@
-import React from "react";
-
 export const SpaceCharacter = () => <>&nbsp;</>;

--- a/packages/web/src/ducks/events/sagas/someday.sagas.test.ts
+++ b/packages/web/src/ducks/events/sagas/someday.sagas.test.ts
@@ -1,4 +1,3 @@
-import { runSaga } from "redux-saga";
 import { Origin, Priorities } from "@core/constants/core.constants";
 import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";

--- a/packages/web/src/views/Calendar/components/Draft/grid/hooks/useGridMouseMove.ts
+++ b/packages/web/src/views/Calendar/components/Draft/grid/hooks/useGridMouseMove.ts
@@ -23,7 +23,7 @@ export const useGridMouseMove = () => {
         drag(e);
       }
     },
-    [draft?.isAllDay, drag, isDrafting, isDragging, isResizing, resize],
+    [drag, isDrafting, isDragging, isResizing, resize],
   );
 
   const _onMouseUp = useCallback(() => {

--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -203,13 +203,13 @@ export const useDraftActions = (
 
       const event: WithCompassId<Omit<Schema_WebEvent, "_id">> = {
         ...draft,
-        _id: draft!._id!,
-        user: draft!.user,
+        _id: draft!._id,
+        user: draft?.user,
         isAllDay: false,
         isSomeday: true,
         startDate: start,
         endDate: end,
-        origin: draft!.origin,
+        origin: draft?.origin,
         priority: draft?.priority ?? Priorities.UNASSIGNED,
         order: somedayWeekCount,
       };
@@ -341,7 +341,9 @@ export const useDraftActions = (
 
           const event = new OnSubmitParser(draft).parse();
           const payload = getEditSlicePayload(event, applyTo);
-          dispatch(editEventSlice.actions.request(payload as unknown as void));
+          dispatch(
+            editEventSlice.actions.request(payload as unknown as undefined),
+          );
 
           if (shouldAddToView(event)) {
             dispatch(getWeekEventsSlice.actions.insert(event._id!));
@@ -537,7 +539,7 @@ export const useDraftActions = (
         setDraft((_draft): Schema_GridEvent => {
           return {
             ..._draft!,
-            _id: _draft!._id!,
+            _id: _draft!._id,
             hasFlipped: justFlipped,
             endDate: endDate,
             startDate: startDate,
@@ -673,6 +675,7 @@ export const useDraftActions = (
     reduxDraft,
     startDragging,
     startResizing,
+    openForm,
   ]);
 
   const actions = {

--- a/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.ts
@@ -24,6 +24,7 @@ export const useDraftEffects = (
     setDateBeingChanged,
   } = setters;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: draft state should clear only when the visible week changes.
   useEffect(() => {
     if (isDragging || isResizing) {
       return;
@@ -46,19 +47,7 @@ export const useDraftEffects = (
     setDragStatus(null);
     setResizeStatus(null);
     setDateBeingChanged(null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    setDraft,
-    setDateBeingChanged,
-    setIsResizing,
-    weekProps.util.getLastNavigationSource,
-    setIsFormOpen,
-    isResizing,
-    setResizeStatus,
-    setIsDragging,
-    setDragStatus,
-    isDragging,
-  ]);
+  }, [weekProps.component.week]);
 
   useEffect(() => {
     if (isResizing) {
@@ -102,5 +91,5 @@ export const useDraftEffects = (
         durationMin,
       });
     }
-  }, [isDragging, setDragStatus, draft.endDate, draft, setIsFormOpen]);
+  }, [isDragging, setDragStatus, draft?.endDate, draft, setIsFormOpen]);
 };

--- a/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.ts
@@ -47,7 +47,18 @@ export const useDraftEffects = (
     setResizeStatus(null);
     setDateBeingChanged(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [weekProps.component.week]);
+  }, [
+    setDraft,
+    setDateBeingChanged,
+    setIsResizing,
+    weekProps.util.getLastNavigationSource,
+    setIsFormOpen,
+    isResizing,
+    setResizeStatus,
+    setIsDragging,
+    setDragStatus,
+    isDragging,
+  ]);
 
   useEffect(() => {
     if (isResizing) {
@@ -91,5 +102,5 @@ export const useDraftEffects = (
         durationMin,
       });
     }
-  }, [isDragging]);
+  }, [isDragging, setDragStatus, draft.endDate, draft, setIsFormOpen]);
 };

--- a/packages/web/src/views/Calendar/components/Draft/hooks/state/useDraftConfirmation.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/state/useDraftConfirmation.ts
@@ -31,7 +31,7 @@ export const useDraftConfirmation = ({
       setRecurrenceUpdateScopeDialogOpen(false);
       discard();
     },
-    [finalDraft, submit, setFinalDraft, discard, deleteEvent],
+    [finalDraft, submit, discard, deleteEvent],
   );
 
   const onSubmit = useCallback(
@@ -60,14 +60,7 @@ export const useDraftConfirmation = ({
       submit(_draft, applyTo);
       discard();
     },
-    [
-      submit,
-      setRecurrenceUpdateScopeDialogOpen,
-      setFinalDraft,
-      isRecurrence,
-      isInstance,
-      discard,
-    ],
+    [submit, isRecurrence, isInstance, discard],
   );
 
   const onDelete = useCallback(async () => {
@@ -85,14 +78,7 @@ export const useDraftConfirmation = ({
 
     deleteEvent(RecurringEventUpdateScope.THIS_EVENT);
     discard();
-  }, [
-    isSomeday,
-    setRecurrenceUpdateScopeDialogOpen,
-    setFinalDraft,
-    deleteEvent,
-    isRecurrence,
-    discard,
-  ]);
+  }, [isSomeday, deleteEvent, isRecurrence, discard]);
 
   return {
     isRecurrenceUpdateScopeDialogOpen,

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type MouseEvent, useEffect } from "react";
+import { type FC, type MouseEvent, useEffect } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event } from "@core/types/event.types";
 import {
@@ -45,7 +45,7 @@ export const AllDayRow: FC<Props> = ({
   useEffect(() => {
     measurements.remeasure(ID_GRID_MAIN);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowsCount]);
+  }, [measurements.remeasure]);
 
   const startAlldayDraft = async (e: MouseEvent) => {
     const x = getX(e, isSidebarOpen);

--- a/packages/web/src/views/Calendar/components/Grid/Columns/MainGridColumns.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/Columns/MainGridColumns.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from "react";
+import { type FC } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { theme } from "@web/common/styles/theme";

--- a/packages/web/src/views/Calendar/components/Grid/Columns/TimesColumn/TimesColumn.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/Columns/TimesColumn/TimesColumn.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import dayjs from "@core/util/date/dayjs";
 import {
   getColorsByHour,

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/EdgeNavigationIndicators/EdgeNavigationIndicators.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/EdgeNavigationIndicators/EdgeNavigationIndicators.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from "react";
+import { type FC } from "react";
 import { type DragEdgeNavigationState } from "@web/views/Calendar/hooks/grid/useDragEdgeNavigation";
 import {
   StyledEdgeZone,

--- a/packages/web/src/views/Calendar/components/Header/Reminder/Reminder.tsx
+++ b/packages/web/src/views/Calendar/components/Header/Reminder/Reminder.tsx
@@ -56,7 +56,7 @@ export const Reminder = forwardRef(
     const cursorPositionRef = useRef<CursorPosition | null>(null);
 
     // Helper functions to save and restore cursor position
-    const saveCursorPosition = () => {
+    const saveCursorPosition = useCallback(() => {
       const selection = window.getSelection();
       if (!selection || selection.rangeCount === 0 || !reminderRef.current)
         return;
@@ -68,9 +68,9 @@ export const Reminder = forwardRef(
           endOffset: range.endOffset,
         };
       }
-    };
+    }, []);
 
-    const restoreCursorPosition = () => {
+    const restoreCursorPosition = useCallback(() => {
       if (!cursorPositionRef.current || !reminderRef.current) return;
 
       const selection = window.getSelection();
@@ -99,7 +99,7 @@ export const Reminder = forwardRef(
       } catch (e) {
         console.error("Failed to restore cursor position", e);
       }
-    };
+    }, []);
 
     // Load from localStorage on mount
     useEffect(() => {
@@ -136,7 +136,7 @@ export const Reminder = forwardRef(
 
       window.addEventListener("resize", handleResize);
       return () => window.removeEventListener("resize", handleResize);
-    }, [reminder, isEditing]);
+    }, []);
 
     // Regenerate underline on hover for a dynamic effect
     const handleMouseEnter = () => {
@@ -177,7 +177,11 @@ export const Reminder = forwardRef(
           restoreCursorPosition();
         }
       }
-    }, [isEditing]);
+    }, [
+      isEditing,
+      reminder, // Restore previously saved cursor position
+      restoreCursorPosition,
+    ]);
 
     // Effect to sync reminder content after state updates
     useEffect(() => {
@@ -197,7 +201,12 @@ export const Reminder = forwardRef(
         // Restore cursor position
         setTimeout(restoreCursorPosition, 0);
       }
-    }, [reminder, isEditing]);
+    }, [
+      reminder,
+      isEditing, // Remember cursor position
+      saveCursorPosition,
+      restoreCursorPosition,
+    ]);
 
     const handleEscKey = useCallback(() => {
       if (isEditing) {
@@ -217,10 +226,10 @@ export const Reminder = forwardRef(
       blurOnTrigger: true,
     });
 
-    const handleReminderClick = () => {
+    const handleReminderClick = useCallback(() => {
       cursorPositionRef.current = null; // Reset cursor position
       setIsEditing(true);
-    };
+    }, []);
 
     useImperativeHandle(
       reminderForwardRef,
@@ -232,7 +241,7 @@ export const Reminder = forwardRef(
       if (reminderFromStore) handleReminderClick();
 
       dispatch(viewSlice.actions.updateReminder(false));
-    }, [reminderFromStore]);
+    }, [reminderFromStore, handleReminderClick, dispatch]);
 
     const handleReminderBlur = () => {
       setIsEditing(false);

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/MonthSection/MonthSection.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/MonthSection/MonthSection.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from "react";
+import { type FC } from "react";
 import { Categories_Event } from "@core/types/event.types";
 import { getMonthListLabel } from "@web/common/utils/event/event.util";
 import { AlignItems, JustifyContent } from "@web/components/Flex/styled";

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayTab.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/SomedayTab.tsx
@@ -1,5 +1,5 @@
 import { DragDropContext } from "@hello-pangea/dnd";
-import React, { type FC, useRef } from "react";
+import { type FC, useRef } from "react";
 import { theme } from "@web/common/styles/theme";
 import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
 import { Divider } from "@web/components/Divider";

--- a/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
+++ b/packages/web/src/views/Calendar/components/Sidebar/SomedayTab/WeekSection/WeekSection.tsx
@@ -1,4 +1,4 @@
-import React, { type FC } from "react";
+import { type FC } from "react";
 import { Categories_Event } from "@core/types/event.types";
 import { AlignItems, JustifyContent } from "@web/components/Flex/styled";
 import { Text } from "@web/components/Text";

--- a/packages/web/src/views/Calendar/hooks/grid/useDragEdgeNavigation.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDragEdgeNavigation.ts
@@ -167,7 +167,15 @@ export const useDragEdgeNavigation = (
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDragging, mousePosition.x, weekProps.util, currentDraft]);
+  }, [
+    isDragging,
+    mousePosition.x,
+    weekProps.util,
+    currentDraft,
+    mousePosition,
+    mainGridRef.current.getBoundingClientRect,
+    mainGridRef.current,
+  ]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/packages/web/src/views/Calendar/hooks/grid/useDragEdgeNavigation.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDragEdgeNavigation.ts
@@ -173,7 +173,7 @@ export const useDragEdgeNavigation = (
     weekProps.util,
     currentDraft,
     mousePosition,
-    mainGridRef.current.getBoundingClientRect,
+    mainGridRef.current?.getBoundingClientRect,
     mainGridRef.current,
   ]);
 

--- a/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useDragEventSmartScroll.ts
@@ -73,5 +73,12 @@ export const useDragEventSmartScroll = (
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.isDragging, mousePosition.x, mousePosition.y]);
+  }, [
+    state.isDragging,
+    mousePosition.x,
+    mousePosition.y,
+    state.draft?.isAllDay,
+    mousePosition,
+    mainGridRef.current,
+  ]);
 };

--- a/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
@@ -10,8 +10,8 @@ import { useAppSelector } from "@web/store/store.hooks";
 
 export type MeasureableElement = "mainGrid" | "allDayRow";
 
-export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
-  const alldayRowsCount = useAppSelector(selectRowCount);
+export const useGridLayout = (_isSidebarOpen: boolean, _week: number) => {
+  const _alldayRowsCount = useAppSelector(selectRowCount);
   const [allDayMeasurements, setAllDayMeasurements] = useState<DOMRect | null>(
     null,
   );
@@ -20,33 +20,27 @@ export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
 
   const mainGridRef = useRef<HTMLDivElement | null>(null);
 
-  const _measureAllDayRow = useCallback(
-    (_node?: HTMLDivElement) => {
-      const node = _node ?? getElemById(ID_GRID_ALLDAY_ROW);
+  const _measureAllDayRow = useCallback((_node?: HTMLDivElement) => {
+    const node = _node ?? getElemById(ID_GRID_ALLDAY_ROW);
 
-      if (!node) return;
+    if (!node) return;
 
-      const allDayRect = node.getBoundingClientRect();
+    const allDayRect = node.getBoundingClientRect();
 
-      setAllDayMeasurements(allDayRect);
-    },
-    [setAllDayMeasurements],
-  );
+    setAllDayMeasurements(allDayRect);
+  }, []);
 
-  const _measureColWidths = useCallback(
-    (_node?: HTMLDivElement) => {
-      const node = _node ?? getElemById(ID_ALLDAY_COLUMNS);
-      const daysInView = 7;
+  const _measureColWidths = useCallback((_node?: HTMLDivElement) => {
+    const node = _node ?? getElemById(ID_ALLDAY_COLUMNS);
+    const daysInView = 7;
 
-      if (!node) return;
+    if (!node) return;
 
-      const colWidth = node.clientWidth / daysInView;
-      const colWidths = Array(daysInView).fill(colWidth);
+    const colWidth = node.clientWidth / daysInView;
+    const colWidths = Array(daysInView).fill(colWidth);
 
-      setColWidths(colWidths);
-    },
-    [setColWidths],
-  );
+    setColWidths(colWidths);
+  }, []);
   const allDayRef = useCallback(
     (node: HTMLDivElement) => {
       if (node !== null) {
@@ -57,18 +51,15 @@ export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
     [_measureAllDayRow, _measureColWidths],
   );
 
-  const _measureMainGrid = useCallback(
-    (_node?: HTMLDivElement) => {
-      const node = _node ?? getElemById(ID_GRID_MAIN);
+  const _measureMainGrid = useCallback((_node?: HTMLDivElement) => {
+    const node = _node ?? getElemById(ID_GRID_MAIN);
 
-      if (!node) return;
+    if (!node) return;
 
-      const mainRect = node.getBoundingClientRect();
+    const mainRect = node.getBoundingClientRect();
 
-      setMainMeasurements(mainRect);
-    },
-    [setMainMeasurements],
-  );
+    setMainMeasurements(mainRect);
+  }, []);
 
   const remeasure = (elem: MeasureableElement) => {
     switch (elem) {
@@ -90,13 +81,7 @@ export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
     _measureMainGrid();
     _measureAllDayRow();
     _measureColWidths();
-  }, [
-    isSidebarOpen,
-    week,
-    _measureColWidths,
-    _measureMainGrid,
-    _measureAllDayRow,
-  ]);
+  }, [_measureColWidths, _measureMainGrid, _measureAllDayRow]);
 
   useEffect(() => {
     const update = () => {
@@ -111,7 +96,7 @@ export const useGridLayout = (isSidebarOpen: boolean, week: number) => {
 
   useEffect(() => {
     _measureAllDayRow();
-  }, [alldayRowsCount, _measureAllDayRow]);
+  }, [_measureAllDayRow]);
 
   useEffect(() => {
     if (mainGridRef.current && !mainMeasurements) {

--- a/packages/web/src/views/Calendar/hooks/mouse/useEventListener.ts
+++ b/packages/web/src/views/Calendar/hooks/mouse/useEventListener.ts
@@ -13,7 +13,7 @@ export const useEventListener = (
 
   useEffect(() => {
     savedHandler.current = handler;
-  }, [eventName, handler]);
+  }, [handler]);
 
   useEffect(() => {
     const isSupported = element?.addEventListener;

--- a/packages/web/src/views/Calendar/hooks/useToday.ts
+++ b/packages/web/src/views/Calendar/hooks/useToday.ts
@@ -1,18 +1,8 @@
-import { useMemo } from "react";
 import dayjs from "@core/util/date/dayjs";
 
 export const useToday = () => {
-  const getToday = (todayIndex: number) => {
-    const today = dayjs();
-
-    if (today.get("day") === todayIndex) {
-      return today;
-    }
-    return today;
-  };
-
-  const todayIndex = dayjs().get("day");
-  const today = useMemo(() => getToday(todayIndex), [todayIndex]);
+  const today = dayjs();
+  const todayIndex = today.get("day");
 
   return { today, todayIndex };
 };

--- a/packages/web/src/views/Calendar/hooks/useWeek.ts
+++ b/packages/web/src/views/Calendar/hooks/useWeek.ts
@@ -56,6 +56,7 @@ export const useWeek = (today: Dayjs) => {
     dispatch,
     somedayEventsRequestFilter.startDate,
     somedayEventsRequestFilter.endDate,
+    somedayEventsRequestFilter,
   ]);
 
   useEffect(() => {

--- a/packages/web/src/views/Day/components/Agenda/Agenda.tsx
+++ b/packages/web/src/views/Day/components/Agenda/Agenda.tsx
@@ -65,13 +65,16 @@ export function Agenda() {
     enabled: !dragging && !resizing,
   });
 
-  const onEnterKey = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      e.stopPropagation();
-      timedEventsGridRef.current?.click();
-    }
-  }, []);
+  const onEnterKey = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        timedEventsGridRef.current?.click();
+      }
+    },
+    [timedEventsGridRef.current?.click],
+  );
 
   useEffect(() => {
     const unsubscribeStore = store.subscribe(() => {
@@ -113,7 +116,14 @@ export function Agenda() {
       eventsSubscription.unsubscribe();
       loadingSubscription.unsubscribe();
     };
-  }, []);
+  }, [
+    store.getState,
+    events$.next,
+    store.subscribe,
+    loading$.next,
+    loading$.pipe,
+    events$.pipe,
+  ]);
 
   return (
     <>
@@ -139,7 +149,6 @@ export function Agenda() {
             "select-none",
           )}
           data-testid="calendar-scroll"
-          tabIndex={0}
           aria-label="Timed events section"
           onKeyDown={onEnterKey}
           {...(hasTimedEvents

--- a/packages/web/src/views/Day/components/Agenda/Events/TimedAgendaEvent/TimedAgendaEvents.tsx
+++ b/packages/web/src/views/Day/components/Agenda/Events/TimedAgendaEvent/TimedAgendaEvents.tsx
@@ -54,7 +54,7 @@ export const TimedAgendaEvents = memo(
     // Center the calendar around the current time when the view mounts
     useEffect(() => {
       compassEventEmitter.emit(CompassDOMEvents.SCROLL_TO_NOW_LINE);
-    }, [pathname]);
+    }, []);
 
     return (
       <Droppable

--- a/packages/web/src/views/Day/components/Agenda/NowLine/NowLine.tsx
+++ b/packages/web/src/views/Day/components/Agenda/NowLine/NowLine.tsx
@@ -27,7 +27,7 @@ export const NowLine = memo(function NowLine() {
       inline: "nearest",
       behavior: "smooth",
     });
-  }, [ref]);
+  }, []);
 
   useEffect(() => {
     const cleanup = setupMinuteSync(() => {

--- a/packages/web/src/views/Day/components/Icons/PlusIcon.tsx
+++ b/packages/web/src/views/Day/components/Icons/PlusIcon.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface PlusIconProps {
   className?: string;
   "aria-hidden"?: boolean;

--- a/packages/web/src/views/Day/components/ShortcutsSidebar/ShortcutsSidebar.test.tsx
+++ b/packages/web/src/views/Day/components/ShortcutsSidebar/ShortcutsSidebar.test.tsx
@@ -1,4 +1,3 @@
-import { act } from "react";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { ShortcutsSidebar } from "./ShortcutsSidebar";

--- a/packages/web/src/views/Day/context/__tests__/DNDTasksContext.test.tsx
+++ b/packages/web/src/views/Day/context/__tests__/DNDTasksContext.test.tsx
@@ -93,7 +93,7 @@ describe("DNDTasksProvider", () => {
             { announce: mockAnnounce } as any,
           );
         }
-      }, [capturedContext]);
+      }, []);
 
       return <div>Test</div>;
     };
@@ -131,7 +131,7 @@ describe("DNDTasksProvider", () => {
             { announce: mockAnnounce } as any,
           );
         }
-      }, [capturedContext]);
+      }, []);
 
       return <div>Test</div>;
     };
@@ -168,7 +168,7 @@ describe("DNDTasksProvider", () => {
             { announce: mockAnnounce } as any,
           );
         }
-      }, [capturedContext]);
+      }, []);
 
       return <div>Test</div>;
     };
@@ -207,7 +207,7 @@ describe("DNDTasksProvider", () => {
             { announce: mockAnnounce } as any,
           );
         }
-      }, [capturedContext]);
+      }, []);
 
       return <div>Test</div>;
     };
@@ -244,7 +244,7 @@ describe("DNDTasksProvider", () => {
             { announce: mock() } as any,
           );
         }
-      }, [capturedContext]);
+      }, []);
 
       return <div>Test</div>;
     };
@@ -279,7 +279,7 @@ describe("DNDTasksProvider", () => {
             { announce: mock() } as any,
           );
         }
-      }, [capturedContext]);
+      }, []);
 
       return <div>Test</div>;
     };

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { type Categories_Event } from "@core/types/event.types";
 import {
   DateTimeSection,

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import ReactSelect from "react-select";
 import { brighten, darken } from "@core/util/color.utils";
 import { theme } from "@web/common/styles/theme";

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { StyledText } from "@web/components/Text/styled";
 import { type FrequencyValues } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/constants/recurrence.constants";
 import {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -108,18 +108,18 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
         onSetEventField({ [fieldName]: e.target.value });
       };
 
-    const onClose = () => {
+    const onClose = useCallback(() => {
       setIsFormOpen(false);
 
       setTimeout(() => {
         _onClose();
       }, 1);
-    };
+    }, [_onClose]);
 
     const onDuplicateEvent = useCallback(() => {
       onDuplicate?.(event);
       onClose();
-    }, [onDuplicate, onClose]);
+    }, [onDuplicate, onClose, event]);
 
     const handleIgnoredKeys = (e: KeyboardEvent) => {
       // Ignores certain keys and key combinations to prevent default behavior.
@@ -298,7 +298,6 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
           onChange={onChangeEventTextField("title")}
           onKeyDown={handleIgnoredKeys}
           placeholder="Title"
-          role="textarea"
           name="Event Title"
           underlineColor={priorityColor}
           value={title ?? ""}

--- a/packages/web/src/views/Forms/EventForm/PrioritySection/PrioritySection.tsx
+++ b/packages/web/src/views/Forms/EventForm/PrioritySection/PrioritySection.tsx
@@ -6,7 +6,6 @@ import {
   TooltipText,
   TooltipWrapper,
 } from "@web/components/ContextMenu/styled";
-import { JustifyContent } from "@web/components/Flex/styled";
 import { type SetEventFormField } from "../types";
 import { StyledPriorityFlex } from "./styled";
 

--- a/packages/web/src/views/Forms/EventForm/RecurringEventUpdateScopeDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/RecurringEventUpdateScopeDialog.tsx
@@ -8,7 +8,7 @@ import {
   useInteractions,
   useRole,
 } from "@floating-ui/react";
-import React, { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Priorities } from "@core/constants/core.constants";
 import { RecurringEventUpdateScope } from "@core/types/event.types";
 import { DirtyParser } from "@web/common/parsers/dirty.parser";
@@ -19,6 +19,12 @@ import { useAppSelector } from "@web/store/store.hooks";
 import { useDraftContext } from "@web/views/Calendar/components/Draft/context/useDraftContext";
 import { SaveSection } from "@web/views/Forms/EventForm/SaveSection/SaveSection";
 import { StyledEventForm } from "@web/views/Forms/EventForm/styled";
+
+const UPDATE_SCOPE_OPTIONS: Array<[string, RecurringEventUpdateScope]> = [
+  ["this", RecurringEventUpdateScope.THIS_EVENT],
+  ["this-and-following", RecurringEventUpdateScope.THIS_AND_FOLLOWING_EVENTS],
+  ["all", RecurringEventUpdateScope.ALL_EVENTS],
+];
 
 export function RecurringEventUpdateScopeDialog() {
   const {
@@ -54,16 +60,10 @@ export function RecurringEventUpdateScopeDialog() {
   const dismiss = useDismiss(context, { outsidePressEvent: "mousedown" });
   const interactions = useInteractions([click, role, dismiss]);
 
-  const _options: Array<[string, RecurringEventUpdateScope]> = [
-    ["this", RecurringEventUpdateScope.THIS_EVENT],
-    ["this-and-following", RecurringEventUpdateScope.THIS_AND_FOLLOWING_EVENTS],
-    ["all", RecurringEventUpdateScope.ALL_EVENTS],
-  ];
-
   const options = useMemo<Array<[string, RecurringEventUpdateScope]>>(() => {
-    if (!recurrenceChanged) return _options;
+    if (!recurrenceChanged) return UPDATE_SCOPE_OPTIONS;
 
-    return _options.slice(1);
+    return UPDATE_SCOPE_OPTIONS.slice(1);
   }, [recurrenceChanged]);
 
   const onSubmitHandler = useCallback(() => {

--- a/packages/web/src/views/Now/components/TaskDescription/TaskDescription.tsx
+++ b/packages/web/src/views/Now/components/TaskDescription/TaskDescription.tsx
@@ -144,7 +144,7 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({
     return () => {
       compassEventEmitter.off(CompassDOMEvents.FOCUS_TASK_DESCRIPTION, handler);
     };
-  }, [isEditing, setIsEditing]);
+  }, [isEditing]);
 
   useEffect(() => {
     if (!isEditing) return;
@@ -156,7 +156,7 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({
     return () => {
       compassEventEmitter.off(CompassDOMEvents.SAVE_TASK_DESCRIPTION, handler);
     };
-  }, [isEditing, setIsEditing]);
+  }, [isEditing]);
 
   const handleClick = () => {
     setIsEditing(true);


### PR DESCRIPTION
## Summary

This PR clears two focused Biome warning groups in the web package:

- removes unused imports
- fixes React hook dependency warnings by stabilizing callbacks, simplifying derived values, and replacing dynamic dependency arrays with static ones

It intentionally leaves the remaining lint warnings in place for later, separate cleanup passes.

## Validation

- `bun run lint`
  - `lint/correctness/noUnusedImports`: 0 remaining
  - `lint/correctness/useExhaustiveDependencies`: 0 remaining
- `bun run test:web`

Both passed locally. The web test run still prints the existing MSW unhandled `/api/config` request noise in `SidebarIconRow`, but the suite passes.