### PR TITLE
Refactor to remove explicit any usages

### DIFF
--- a/packages/backend/src/common/errors/handlers/error.unexpected.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.unexpected.handler.ts
@@ -9,7 +9,9 @@ process.on("uncaughtException", (error: Error) => {
 
 // get the unhandled promise rejections/exceptions and throw it to the
 // `uncaughtException` fallback handler
-//@ts-expect-error
-process.on("unhandledRejection", (reason: Error, promise: Promise<any>) => {
-  throw reason;
-});
+process.on(
+  "unhandledRejection",
+  (reason: unknown, _promise: Promise<unknown>) => {
+    throw reason;
+  },
+);

--- a/packages/core/src/util/wait-until-event.util.ts
+++ b/packages/core/src/util/wait-until-event.util.ts
@@ -16,8 +16,7 @@ export async function waitUntilEvent<
   return new Promise((resolve, reject) => {
     const eventEmitter = emitter as EventEmitter;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const listener = (...payload: any[]) => {
+    const listener = (...payload: unknown[]) => {
       afterEvent(...(payload as Payload))
         .then(resolve)
         .catch(reject);

--- a/packages/web/declaration.d.ts
+++ b/packages/web/declaration.d.ts
@@ -35,10 +35,8 @@ interface Window {
   __COMPASS_E2E_TEST__?: boolean;
   /** Redux store exposed for test action dispatch. Set by packages/web/src/store/index.ts. */
   __COMPASS_E2E_STORE__?: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dispatch: (action: any) => any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getState: () => any;
+    dispatch: import("@web/store").AppDispatch;
+    getState: () => import("@web/store").RootState;
   };
   /** Session test hooks exposed by SessionProvider for e2e auth control. */
   __COMPASS_E2E_HOOKS__?: {

--- a/packages/web/src/common/hooks/useEventDNDActions.test.ts
+++ b/packages/web/src/common/hooks/useEventDNDActions.test.ts
@@ -1,3 +1,4 @@
+import { type DragEndEvent } from "@dnd-kit/core";
 import { renderHook } from "@testing-library/react";
 import { BehaviorSubject } from "rxjs";
 import { Categories_Event } from "@core/types/event.types";
@@ -107,6 +108,11 @@ await writeFile(useEventDNDActionsTempUrl, useEventDNDActionsJavaScript);
 
 const { useEventDNDActions } = await import(useEventDNDActionsTempUrl.href);
 
+type DndMonitorCall = [{ onDragEnd: (event: DragEndEvent) => void }];
+type DndMonitorMock = typeof useDndMonitor & {
+  mock: { calls: DndMonitorCall[] };
+};
+
 describe("useEventDNDActions", () => {
   const mockEvent = {
     _id: "event-1",
@@ -134,12 +140,11 @@ describe("useEventDNDActions", () => {
   });
 
   describe("onDragEnd", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let onDragEnd: (event: any) => void;
+    let onDragEnd: (event: DragEndEvent) => void;
 
     beforeEach(() => {
       renderHook(() => useEventDNDActions());
-      onDragEnd = (useDndMonitor as any).mock.calls[0][0].onDragEnd;
+      onDragEnd = (useDndMonitor as DndMonitorMock).mock.calls[0][0].onDragEnd;
     });
 
     it("should handle timed event move in main grid", () => {
@@ -156,7 +161,7 @@ describe("useEventDNDActions", () => {
       };
       const over = { id: ID_GRID_MAIN };
 
-      onDragEnd({ active, over });
+      onDragEnd({ active, over } as unknown as DragEndEvent);
 
       const expectedStartDate = dayjs(mockEvent.startDate)
         .startOf("day")
@@ -193,7 +198,7 @@ describe("useEventDNDActions", () => {
       };
       const over = { id: ID_GRID_MAIN };
 
-      onDragEnd({ active, over });
+      onDragEnd({ active, over } as unknown as DragEndEvent);
 
       const expectedStartDate = dayjs(allDayEvent.startDate)
         .startOf("day")
@@ -228,7 +233,7 @@ describe("useEventDNDActions", () => {
       };
       const over = { id: ID_GRID_ALLDAY_ROW };
 
-      onDragEnd({ active, over });
+      onDragEnd({ active, over } as unknown as DragEndEvent);
 
       const expectedStartDate = dayjs(mockEvent.startDate)
         .startOf("day")
@@ -255,7 +260,7 @@ describe("useEventDNDActions", () => {
       const active = { data: { current: null } };
       const over = null;
 
-      onDragEnd({ active, over });
+      onDragEnd({ active, over } as unknown as DragEndEvent);
 
       expect(mockUpdateEvent).not.toHaveBeenCalled();
     });

--- a/packages/web/src/common/hooks/useEventResizeActions.test.ts
+++ b/packages/web/src/common/hooks/useEventResizeActions.test.ts
@@ -86,7 +86,7 @@ describe("useEventResizeActions", () => {
 
   // Mock bounds element
   const mockBounds = document.createElement("div");
-  let getBoundingClientRectSpy: any;
+  let getBoundingClientRectSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     mockUpdateEvent.mockClear();
@@ -100,7 +100,7 @@ describe("useEventResizeActions", () => {
     mockOpenGetValue.mockReturnValue(false);
     // Ensure selector returns no stored event so saveDraftOnly path is testable
     mockSelectEventById.mockReturnValue(null);
-    mockUpdateDraft.mockImplementation((update: any) => {
+    mockUpdateDraft.mockImplementation((update: Partial<Schema_Event>) => {
       mockSetDraft({ ...mockEvent, ...update });
     });
 

--- a/packages/web/src/common/utils/command-palette/resolve-command-palette.util.ts
+++ b/packages/web/src/common/utils/command-palette/resolve-command-palette.util.ts
@@ -1,0 +1,8 @@
+export function resolveCommandPalette<T>(moduleValue: T): T {
+  // Bun's __toESM(mod, nodeInterop=1) wraps CJS+__esModule modules so
+  // .default can point at the whole export object. Unwrap one level to reach
+  // the actual component function.
+  const maybeWrapped = moduleValue as T & { default?: T };
+
+  return maybeWrapped.default ?? moduleValue;
+}

--- a/packages/web/src/components/DND/DNDContext.test.tsx
+++ b/packages/web/src/components/DND/DNDContext.test.tsx
@@ -17,7 +17,7 @@ const usePointerPosition = mock();
 const useSensor = mock();
 const useSensors = mock();
 const { isDraggingEvent$ } = require("@web/common/hooks/useIsDraggingEvent");
-let isDraggingNextSpy: any = null;
+let isDraggingNextSpy: ReturnType<typeof spyOn> | null = null;
 
 mock.module("@web/common/hooks/usePointerPosition", () => ({
   usePointerPosition,

--- a/packages/web/src/components/Focusable/Focusable.tsx
+++ b/packages/web/src/components/Focusable/Focusable.tsx
@@ -2,18 +2,17 @@ import {
   type FocusEvent,
   forwardRef,
   type HTMLAttributes,
-  type PropsWithChildren,
   useCallback,
   useState,
 } from "react";
-import { type StyledComponent } from "styled-components";
+import { type AnyStyledComponent } from "styled-components";
 import { type UnderlinedInput } from "@web/common/types/component.types";
 import { Divider } from "@web/components/Divider";
 
 export interface Props extends UnderlinedInput, HTMLAttributes<HTMLElement> {
   autoFocus?: boolean;
   underlineColor?: string;
-  Component: StyledComponent<any, any, PropsWithChildren<any>, never>;
+  Component: AnyStyledComponent;
 }
 
 export const Focusable = forwardRef<HTMLElement, Props>(

--- a/packages/web/src/components/Tooltip/Tooltip.tsx
+++ b/packages/web/src/components/Tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ import {
   type HTMLProps,
   isValidElement,
   type ReactNode,
+  type Ref,
 } from "react";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { useGridMaxZIndex } from "@web/common/hooks/useGridMaxZIndex";
@@ -32,7 +33,9 @@ export const TooltipTrigger = forwardRef<
 >(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
   const context = useTooltipContext();
 
-  const childrenRef = (children as any).ref;
+  const childrenRef = isValidElement(children)
+    ? (children as { ref?: Ref<HTMLElement> }).ref
+    : undefined;
   const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
 
   // `asChild` allows the user to pass any element as the anchor

--- a/packages/web/src/views/CmdPalette/CmdPalette.tsx
+++ b/packages/web/src/views/CmdPalette/CmdPalette.tsx
@@ -9,6 +9,7 @@ import { Categories_Event } from "@core/types/event.types";
 import { moreCommandPaletteItems } from "@web/common/constants/more.cmd.constants";
 import { useAuthCmdItems } from "@web/common/hooks/useAuthCmdItems";
 import { useGoogleCmdItems } from "@web/common/hooks/useGoogleCmdItems";
+import { resolveCommandPalette } from "@web/common/utils/command-palette/resolve-command-palette.util";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
 import { onEventTargetVisibility } from "@web/common/utils/dom/event-target-visibility.util";
 import {
@@ -27,11 +28,7 @@ import { settingsSlice } from "@web/ducks/settings/slices/settings.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 import { type ShortcutProps } from "@web/views/Calendar/hooks/shortcuts/useWeekShortcuts";
 
-// Bun's __toESM(mod, nodeInterop=1) wraps CJS+__esModule modules so .default = whole exports.
-// Unwrap one level to reach the actual component function.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const CommandPalette = ((_CommandPalette as any).default ??
-  _CommandPalette) as typeof _CommandPalette;
+const CommandPalette = resolveCommandPalette(_CommandPalette);
 
 const CmdPalette = ({
   today,

--- a/packages/web/src/views/Day/components/DayCmdPalette.tsx
+++ b/packages/web/src/views/Day/components/DayCmdPalette.tsx
@@ -6,6 +6,7 @@ import { moreCommandPaletteItems } from "@web/common/constants/more.cmd.constant
 import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
 import { useAuthCmdItems } from "@web/common/hooks/useAuthCmdItems";
 import { useGoogleCmdItems } from "@web/common/hooks/useGoogleCmdItems";
+import { resolveCommandPalette } from "@web/common/utils/command-palette/resolve-command-palette.util";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
 import {
   openEventFormCreateEvent,
@@ -15,11 +16,7 @@ import { selectIsCmdPaletteOpen } from "@web/ducks/settings/selectors/settings.s
 import { settingsSlice } from "@web/ducks/settings/slices/settings.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 
-// Bun's __toESM(mod, nodeInterop=1) wraps CJS+__esModule modules so .default = whole exports.
-// Unwrap one level to reach the actual component function.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const CommandPalette = ((_CommandPalette as any).default ??
-  _CommandPalette) as typeof _CommandPalette;
+const CommandPalette = resolveCommandPalette(_CommandPalette);
 
 interface DayCmdPaletteProps {
   onGoToToday?: () => void;

--- a/packages/web/src/views/Day/context/__tests__/DNDTasksContext.test.tsx
+++ b/packages/web/src/views/Day/context/__tests__/DNDTasksContext.test.tsx
@@ -1,5 +1,12 @@
+import {
+  type DragStart,
+  type DragUpdate,
+  type DropResult,
+  type ResponderProvided,
+} from "@hello-pangea/dnd";
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { type useTasks as useTasksFn } from "@web/views/Day/hooks/tasks/useTasks";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 // Mock the useTasks hook
@@ -13,6 +20,12 @@ const { DNDTasksProvider } =
   require("@web/views/Day/context/DNDTasksContext") as typeof import("@web/views/Day/context/DNDTasksContext");
 const { useDNDTasksContext } =
   require("@web/views/Day/hooks/tasks/useDNDTasks") as typeof import("@web/views/Day/hooks/tasks/useDNDTasks");
+
+type DNDTasksContextValue = ReturnType<typeof useDNDTasksContext>;
+type MinimalTasksContext = Pick<
+  ReturnType<typeof useTasksFn>,
+  "tasks" | "setSelectedTaskIndex" | "reorderTasks"
+>;
 
 describe("DNDTasksProvider", () => {
   const mockTasks = [
@@ -39,23 +52,59 @@ describe("DNDTasksProvider", () => {
     mockReorderTasks.mockClear();
     mockSetSelectedTaskIndex.mockClear();
     mockUseTasks.mockClear();
-    mockUseTasks.mockReturnValue({
+    const mockTasksContext: MinimalTasksContext = {
       tasks: mockTasks,
       setSelectedTaskIndex: mockSetSelectedTaskIndex,
       reorderTasks: mockReorderTasks,
-    } as any);
+    };
+
+    mockUseTasks.mockReturnValue(mockTasksContext);
+  });
+
+  const provided = (announce = mock()): ResponderProvided => ({ announce });
+
+  const dragStart = (index: number): DragStart => ({
+    draggableId: `task-${index + 1}`,
+    type: "task",
+    source: { droppableId: "task-list", index },
+    mode: "FLUID",
+  });
+
+  const dragUpdate = (
+    sourceIndex: number,
+    destinationIndex: number,
+  ): DragUpdate => ({
+    draggableId: `task-${sourceIndex + 1}`,
+    type: "task",
+    source: { droppableId: "task-list", index: sourceIndex },
+    destination: { droppableId: "task-list", index: destinationIndex },
+    combine: null,
+    mode: "FLUID",
+  });
+
+  const dropResult = (
+    sourceIndex: number,
+    destinationIndex: number | null,
+    reason: DropResult["reason"] = "DROP",
+  ): DropResult => ({
+    draggableId: `task-${sourceIndex + 1}`,
+    type: "task",
+    source: { droppableId: "task-list", index: sourceIndex },
+    destination:
+      destinationIndex == null
+        ? null
+        : { droppableId: "task-list", index: destinationIndex },
+    reason,
+    combine: null,
+    mode: "FLUID",
   });
 
   it("should provide DND context to children", async () => {
-    let contextValue: any = null;
+    let contextValue: DNDTasksContextValue | null = null;
 
     const TestComponent = () => {
-      try {
-        contextValue = useDNDTasksContext();
-        return <div data-testid="context-value">has-context</div>;
-      } catch {
-        return <div data-testid="context-value">no-context</div>;
-      }
+      contextValue = useDNDTasksContext();
+      return <div data-testid="context-value">has-context</div>;
     };
 
     render(
@@ -76,22 +125,14 @@ describe("DNDTasksProvider", () => {
     const mockAnnounce = mock();
 
     // Create a test component that calls the context functions directly
-    let capturedContext: any = null;
+    let capturedContext: DNDTasksContextValue | null = null;
 
     const TestComponent = () => {
       capturedContext = useDNDTasksContext();
 
       React.useEffect(() => {
         if (capturedContext) {
-          capturedContext.onDragStart(
-            {
-              draggableId: "task-1",
-              type: "task",
-              source: { droppableId: "task-list", index: 0 },
-              mode: "FLUID",
-            },
-            { announce: mockAnnounce } as any,
-          );
+          capturedContext.onDragStart(dragStart(0), provided(mockAnnounce));
         }
       }, []);
 
@@ -111,25 +152,14 @@ describe("DNDTasksProvider", () => {
   it("should call reorderTasks and announce on drag end with valid destination", () => {
     const mockAnnounce = mock();
 
-    let capturedContext: any = null;
+    let capturedContext: DNDTasksContextValue | null = null;
 
     const TestComponent = () => {
       capturedContext = useDNDTasksContext();
 
       React.useEffect(() => {
         if (capturedContext) {
-          capturedContext.onDragEnd(
-            {
-              draggableId: "task-1",
-              type: "task",
-              source: { droppableId: "task-list", index: 0 },
-              destination: { droppableId: "task-list", index: 1 },
-              reason: "DROP",
-              combine: null,
-              mode: "FLUID",
-            },
-            { announce: mockAnnounce } as any,
-          );
+          capturedContext.onDragEnd(dropResult(0, 1), provided(mockAnnounce));
         }
       }, []);
 
@@ -149,7 +179,7 @@ describe("DNDTasksProvider", () => {
   it("should announce on drag update", () => {
     const mockAnnounce = mock();
 
-    let capturedContext: any = null;
+    let capturedContext: DNDTasksContextValue | null = null;
 
     const TestComponent = () => {
       capturedContext = useDNDTasksContext();
@@ -157,15 +187,8 @@ describe("DNDTasksProvider", () => {
       React.useEffect(() => {
         if (capturedContext) {
           capturedContext.onDragUpdate(
-            {
-              draggableId: "task-1",
-              type: "task",
-              source: { droppableId: "task-list", index: 0 },
-              destination: { droppableId: "task-list", index: 1 },
-              combine: null,
-              mode: "FLUID",
-            },
-            { announce: mockAnnounce } as any,
+            dragUpdate(0, 1),
+            provided(mockAnnounce),
           );
         }
       }, []);
@@ -187,7 +210,7 @@ describe("DNDTasksProvider", () => {
   it("should announce cancellation on drag end", () => {
     const mockAnnounce = mock();
 
-    let capturedContext: any = null;
+    let capturedContext: DNDTasksContextValue | null = null;
 
     const TestComponent = () => {
       capturedContext = useDNDTasksContext();
@@ -195,16 +218,8 @@ describe("DNDTasksProvider", () => {
       React.useEffect(() => {
         if (capturedContext) {
           capturedContext.onDragEnd(
-            {
-              draggableId: "task-1",
-              type: "task",
-              source: { droppableId: "task-list", index: 0 },
-              destination: null,
-              reason: "CANCEL",
-              combine: null,
-              mode: "FLUID",
-            },
-            { announce: mockAnnounce } as any,
+            dropResult(0, null, "CANCEL"),
+            provided(mockAnnounce),
           );
         }
       }, []);
@@ -224,25 +239,14 @@ describe("DNDTasksProvider", () => {
   });
 
   it("should not call reorderTasks when destination is null", () => {
-    let capturedContext: any = null;
+    let capturedContext: DNDTasksContextValue | null = null;
 
     const TestComponent = () => {
       capturedContext = useDNDTasksContext();
 
       React.useEffect(() => {
         if (capturedContext) {
-          capturedContext.onDragEnd(
-            {
-              draggableId: "task-1",
-              type: "task",
-              source: { droppableId: "task-list", index: 0 },
-              destination: null,
-              reason: "DROP",
-              combine: null,
-              mode: "FLUID",
-            },
-            { announce: mock() } as any,
-          );
+          capturedContext.onDragEnd(dropResult(0, null), provided());
         }
       }, []);
 
@@ -259,25 +263,14 @@ describe("DNDTasksProvider", () => {
   });
 
   it("should not call reorderTasks when destination index equals source index", () => {
-    let capturedContext: any = null;
+    let capturedContext: DNDTasksContextValue | null = null;
 
     const TestComponent = () => {
       capturedContext = useDNDTasksContext();
 
       React.useEffect(() => {
         if (capturedContext) {
-          capturedContext.onDragEnd(
-            {
-              draggableId: "task-1",
-              type: "task",
-              source: { droppableId: "task-list", index: 0 },
-              destination: { droppableId: "task-list", index: 0 },
-              reason: "DROP",
-              combine: null,
-              mode: "FLUID",
-            },
-            { announce: mock() } as any,
-          );
+          capturedContext.onDragEnd(dropResult(0, 0), provided());
         }
       }, []);
 

--- a/packages/web/src/views/Day/hooks/events/agenda-event.test-util.ts
+++ b/packages/web/src/views/Day/hooks/events/agenda-event.test-util.ts
@@ -1,0 +1,37 @@
+import { type FocusEvent, type MouseEvent } from "react";
+import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
+import { mock } from "bun:test";
+
+type AgendaPointerEvent = MouseEvent<Element> | FocusEvent<Element>;
+
+const createAgendaEvent = (currentTarget: Element): AgendaPointerEvent =>
+  ({
+    preventDefault: mock(),
+    stopPropagation: mock(),
+    currentTarget,
+  }) as unknown as AgendaPointerEvent;
+
+export const createAgendaTarget = ({
+  eventClass,
+  eventId,
+}: {
+  eventClass?: string;
+  eventId?: string;
+} = {}) => {
+  const element = document.createElement("button");
+
+  if (!eventClass) {
+    return { element, event: createAgendaEvent(element), reference: null };
+  }
+
+  const reference = document.createElement("div");
+  reference.className = eventClass;
+
+  if (eventId) {
+    reference.setAttribute(DATA_EVENT_ELEMENT_ID, eventId);
+  }
+
+  reference.appendChild(element);
+
+  return { element, event: createAgendaEvent(element), reference };
+};

--- a/packages/web/src/views/Day/hooks/events/useAgendaInteractionsAtCursor.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useAgendaInteractionsAtCursor.test.ts
@@ -1,3 +1,4 @@
+import { type useFloating } from "@floating-ui/react";
 import { renderHook } from "@testing-library/react";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -23,8 +24,7 @@ const { useAgendaInteractionsAtCursor } =
 describe("useAgendaInteractionsAtCursor", () => {
   const mockFloating = {
     context: {},
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
+  } as unknown as ReturnType<typeof useFloating>;
 
   beforeEach(() => {
     mockSafePolygonResult.mockClear();

--- a/packages/web/src/views/Day/hooks/events/useOpenAgendaEventPreview.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useOpenAgendaEventPreview.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { ObjectId } from "bson";
+import { type FocusEvent, type MouseEvent } from "react";
 import { BehaviorSubject } from "rxjs";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -65,6 +66,15 @@ mock.module("@web/store/store.hooks", () => ({
 const { useOpenAgendaEventPreview } =
   require("@web/views/Day/hooks/events/useOpenAgendaEventPreview") as typeof import("@web/views/Day/hooks/events/useOpenAgendaEventPreview");
 
+type AgendaPointerEvent = MouseEvent<Element> | FocusEvent<Element>;
+
+const createAgendaEvent = (currentTarget: Element): AgendaPointerEvent =>
+  ({
+    preventDefault: mock(),
+    stopPropagation: mock(),
+    currentTarget,
+  }) as unknown as AgendaPointerEvent;
+
 describe("useOpenAgendaEventPreview", () => {
   beforeEach(() => {
     eventsStore.query.mockClear();
@@ -90,33 +100,25 @@ describe("useOpenAgendaEventPreview", () => {
     const eventId = "123";
     const eventClass = "event-class";
     const mockEvent = { _id: eventId, title: "Test Event" };
-    const mockReference = {
-      getAttribute: mock().mockReturnValue(eventId),
-    };
-    const mockElement = {
-      closest: mock().mockReturnValue(mockReference),
-    };
-    const mockEventObj = {
-      preventDefault: mock(),
-      stopPropagation: mock(),
-      currentTarget: mockElement,
-    };
+    const mockReference = document.createElement("div");
+    mockReference.className = eventClass;
+    mockReference.setAttribute(DATA_EVENT_ELEMENT_ID, eventId);
+
+    const mockElement = document.createElement("button");
+    mockReference.appendChild(mockElement);
+
+    const mockEventObj = createAgendaEvent(mockElement);
 
     getEventClass.mockReturnValue(eventClass);
     eventsStore.query.mockReturnValue(mockEvent);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.current(mockEventObj as any);
+    result.current(mockEventObj);
 
     expect(mockEventObj.preventDefault).toHaveBeenCalled();
     expect(mockEventObj.stopPropagation).toHaveBeenCalled();
     expect(getEventClass).toHaveBeenCalledWith(mockElement);
-    expect(mockElement.closest).toHaveBeenCalledWith(`.${eventClass}`);
-    expect(mockReference.getAttribute).toHaveBeenCalledWith(
-      DATA_EVENT_ELEMENT_ID,
-    );
     expect(eventsStore.query).toHaveBeenCalled();
     expect(setActiveEvent).toHaveBeenCalledWith(mockEvent._id);
     expect(openFloatingAtCursor).toHaveBeenCalledWith({
@@ -128,24 +130,19 @@ describe("useOpenAgendaEventPreview", () => {
 
   it("should not open event preview if event id is missing", () => {
     const eventClass = "event-class";
-    const mockReference = {
-      getAttribute: mock().mockReturnValue(null),
-    };
-    const mockElement = {
-      closest: mock().mockReturnValue(mockReference),
-    };
-    const mockEventObj = {
-      preventDefault: mock(),
-      stopPropagation: mock(),
-      currentTarget: mockElement,
-    };
+    const mockReference = document.createElement("div");
+    mockReference.className = eventClass;
+
+    const mockElement = document.createElement("button");
+    mockReference.appendChild(mockElement);
+
+    const mockEventObj = createAgendaEvent(mockElement);
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.current(mockEventObj as any);
+    result.current(mockEventObj);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();
@@ -153,21 +150,14 @@ describe("useOpenAgendaEventPreview", () => {
 
   it("should not open event preview if reference is missing", () => {
     const eventClass = "event-class";
-    const mockElement = {
-      closest: mock().mockReturnValue(null),
-    };
-    const mockEventObj = {
-      preventDefault: mock(),
-      stopPropagation: mock(),
-      currentTarget: mockElement,
-    };
+    const mockElement = document.createElement("button");
+    const mockEventObj = createAgendaEvent(mockElement);
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.current(mockEventObj as any);
+    result.current(mockEventObj);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();
@@ -194,25 +184,21 @@ describe("useOpenAgendaEventPreview", () => {
 
     const eventClass = "event-class";
     const mockEvent = { _id: pendingEventId, title: "Pending Event" };
-    const mockReference = {
-      getAttribute: mock().mockReturnValue(pendingEventId),
-    };
-    const mockElement = {
-      closest: mock().mockReturnValue(mockReference),
-    };
-    const mockEventObj = {
-      preventDefault: mock(),
-      stopPropagation: mock(),
-      currentTarget: mockElement,
-    };
+    const mockReference = document.createElement("div");
+    mockReference.className = eventClass;
+    mockReference.setAttribute(DATA_EVENT_ELEMENT_ID, pendingEventId);
+
+    const mockElement = document.createElement("button");
+    mockReference.appendChild(mockElement);
+
+    const mockEventObj = createAgendaEvent(mockElement);
 
     getEventClass.mockReturnValue(eventClass);
     eventsStore.query.mockReturnValue(mockEvent);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.current(mockEventObj as any);
+    result.current(mockEventObj);
 
     expect(mockEventObj.preventDefault).toHaveBeenCalled();
     expect(mockEventObj.stopPropagation).toHaveBeenCalled();

--- a/packages/web/src/views/Day/hooks/events/useOpenAgendaEventPreview.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useOpenAgendaEventPreview.test.ts
@@ -1,8 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { ObjectId } from "bson";
-import { type FocusEvent, type MouseEvent } from "react";
 import { BehaviorSubject } from "rxjs";
-import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
+import { createAgendaTarget } from "./agenda-event.test-util";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const CursorItem = { EventPreview: "event-preview" };
@@ -66,15 +65,6 @@ mock.module("@web/store/store.hooks", () => ({
 const { useOpenAgendaEventPreview } =
   require("@web/views/Day/hooks/events/useOpenAgendaEventPreview") as typeof import("@web/views/Day/hooks/events/useOpenAgendaEventPreview");
 
-type AgendaPointerEvent = MouseEvent<Element> | FocusEvent<Element>;
-
-const createAgendaEvent = (currentTarget: Element): AgendaPointerEvent =>
-  ({
-    preventDefault: mock(),
-    stopPropagation: mock(),
-    currentTarget,
-  }) as unknown as AgendaPointerEvent;
-
 describe("useOpenAgendaEventPreview", () => {
   beforeEach(() => {
     eventsStore.query.mockClear();
@@ -100,49 +90,39 @@ describe("useOpenAgendaEventPreview", () => {
     const eventId = "123";
     const eventClass = "event-class";
     const mockEvent = { _id: eventId, title: "Test Event" };
-    const mockReference = document.createElement("div");
-    mockReference.className = eventClass;
-    mockReference.setAttribute(DATA_EVENT_ELEMENT_ID, eventId);
-
-    const mockElement = document.createElement("button");
-    mockReference.appendChild(mockElement);
-
-    const mockEventObj = createAgendaEvent(mockElement);
+    const { element, event, reference } = createAgendaTarget({
+      eventClass,
+      eventId,
+    });
 
     getEventClass.mockReturnValue(eventClass);
     eventsStore.query.mockReturnValue(mockEvent);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    result.current(mockEventObj);
+    result.current(event);
 
-    expect(mockEventObj.preventDefault).toHaveBeenCalled();
-    expect(mockEventObj.stopPropagation).toHaveBeenCalled();
-    expect(getEventClass).toHaveBeenCalledWith(mockElement);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(getEventClass).toHaveBeenCalledWith(element);
     expect(eventsStore.query).toHaveBeenCalled();
     expect(setActiveEvent).toHaveBeenCalledWith(mockEvent._id);
     expect(openFloatingAtCursor).toHaveBeenCalledWith({
       nodeId: CursorItem.EventPreview,
       placement: "right",
-      reference: mockReference,
+      reference,
     });
   });
 
   it("should not open event preview if event id is missing", () => {
     const eventClass = "event-class";
-    const mockReference = document.createElement("div");
-    mockReference.className = eventClass;
-
-    const mockElement = document.createElement("button");
-    mockReference.appendChild(mockElement);
-
-    const mockEventObj = createAgendaEvent(mockElement);
+    const { event } = createAgendaTarget({ eventClass });
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    result.current(mockEventObj);
+    result.current(event);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();
@@ -150,14 +130,13 @@ describe("useOpenAgendaEventPreview", () => {
 
   it("should not open event preview if reference is missing", () => {
     const eventClass = "event-class";
-    const mockElement = document.createElement("button");
-    const mockEventObj = createAgendaEvent(mockElement);
+    const { event } = createAgendaTarget();
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    result.current(mockEventObj);
+    result.current(event);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();
@@ -184,24 +163,20 @@ describe("useOpenAgendaEventPreview", () => {
 
     const eventClass = "event-class";
     const mockEvent = { _id: pendingEventId, title: "Pending Event" };
-    const mockReference = document.createElement("div");
-    mockReference.className = eventClass;
-    mockReference.setAttribute(DATA_EVENT_ELEMENT_ID, pendingEventId);
-
-    const mockElement = document.createElement("button");
-    mockReference.appendChild(mockElement);
-
-    const mockEventObj = createAgendaEvent(mockElement);
+    const { event } = createAgendaTarget({
+      eventClass,
+      eventId: pendingEventId,
+    });
 
     getEventClass.mockReturnValue(eventClass);
     eventsStore.query.mockReturnValue(mockEvent);
 
     const { result } = renderHook(() => useOpenAgendaEventPreview());
 
-    result.current(mockEventObj);
+    result.current(event);
 
-    expect(mockEventObj.preventDefault).toHaveBeenCalled();
-    expect(mockEventObj.stopPropagation).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
     expect(eventsStore.query).toHaveBeenCalled();
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();

--- a/packages/web/src/views/Day/hooks/events/useOpenEventContextMenu.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useOpenEventContextMenu.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from "@testing-library/react";
+import { type FocusEvent, type MouseEvent } from "react";
 import { BehaviorSubject } from "rxjs";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -48,6 +49,15 @@ mock.module("@web/views/Day/util/agenda/focus.util", () => ({
 const { useOpenEventContextMenu } =
   require("@web/views/Day/hooks/events/useOpenEventContextMenu") as typeof import("@web/views/Day/hooks/events/useOpenEventContextMenu");
 
+type AgendaPointerEvent = MouseEvent<Element> | FocusEvent<Element>;
+
+const createAgendaEvent = (currentTarget: Element): AgendaPointerEvent =>
+  ({
+    preventDefault: mock(),
+    stopPropagation: mock(),
+    currentTarget,
+  }) as unknown as AgendaPointerEvent;
+
 describe("useOpenEventContextMenu", () => {
   beforeEach(() => {
     eventsStore.query.mockClear();
@@ -60,33 +70,25 @@ describe("useOpenEventContextMenu", () => {
     const eventId = "123";
     const eventClass = "event-class";
     const mockEvent = { _id: eventId, title: "Test Event" };
-    const mockReference = {
-      getAttribute: mock().mockReturnValue(eventId),
-    };
-    const mockElement = {
-      closest: mock().mockReturnValue(mockReference),
-    };
-    const mockEventObj = {
-      preventDefault: mock(),
-      stopPropagation: mock(),
-      currentTarget: mockElement,
-    };
+    const mockReference = document.createElement("div");
+    mockReference.className = eventClass;
+    mockReference.setAttribute(DATA_EVENT_ELEMENT_ID, eventId);
+
+    const mockElement = document.createElement("button");
+    mockReference.appendChild(mockElement);
+
+    const mockEventObj = createAgendaEvent(mockElement);
 
     getEventClass.mockReturnValue(eventClass);
     eventsStore.query.mockReturnValue(mockEvent);
 
     const { result } = renderHook(() => useOpenEventContextMenu());
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.current(mockEventObj as any);
+    result.current(mockEventObj);
 
     expect(mockEventObj.preventDefault).toHaveBeenCalled();
     expect(mockEventObj.stopPropagation).toHaveBeenCalled();
     expect(getEventClass).toHaveBeenCalledWith(mockElement);
-    expect(mockElement.closest).toHaveBeenCalledWith(`.${eventClass}`);
-    expect(mockReference.getAttribute).toHaveBeenCalledWith(
-      DATA_EVENT_ELEMENT_ID,
-    );
     expect(eventsStore.query).toHaveBeenCalled();
     expect(setActiveEvent).toHaveBeenCalledWith(mockEvent._id);
     expect(openFloatingAtCursor).toHaveBeenCalledWith({
@@ -98,24 +100,19 @@ describe("useOpenEventContextMenu", () => {
 
   it("should not open event context menu if event id is missing", () => {
     const eventClass = "event-class";
-    const mockReference = {
-      getAttribute: mock().mockReturnValue(null),
-    };
-    const mockElement = {
-      closest: mock().mockReturnValue(mockReference),
-    };
-    const mockEventObj = {
-      preventDefault: mock(),
-      stopPropagation: mock(),
-      currentTarget: mockElement,
-    };
+    const mockReference = document.createElement("div");
+    mockReference.className = eventClass;
+
+    const mockElement = document.createElement("button");
+    mockReference.appendChild(mockElement);
+
+    const mockEventObj = createAgendaEvent(mockElement);
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenEventContextMenu());
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.current(mockEventObj as any);
+    result.current(mockEventObj);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();
@@ -123,21 +120,14 @@ describe("useOpenEventContextMenu", () => {
 
   it("should not open event context menu if reference is missing", () => {
     const eventClass = "event-class";
-    const mockElement = {
-      closest: mock().mockReturnValue(null),
-    };
-    const mockEventObj = {
-      preventDefault: mock(),
-      stopPropagation: mock(),
-      currentTarget: mockElement,
-    };
+    const mockElement = document.createElement("button");
+    const mockEventObj = createAgendaEvent(mockElement);
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenEventContextMenu());
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    result.current(mockEventObj as any);
+    result.current(mockEventObj);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();

--- a/packages/web/src/views/Day/hooks/events/useOpenEventContextMenu.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useOpenEventContextMenu.test.ts
@@ -1,7 +1,6 @@
 import { renderHook } from "@testing-library/react";
-import { type FocusEvent, type MouseEvent } from "react";
 import { BehaviorSubject } from "rxjs";
-import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
+import { createAgendaTarget } from "./agenda-event.test-util";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const CursorItem = { EventContextMenu: "event-context-menu" };
@@ -49,15 +48,6 @@ mock.module("@web/views/Day/util/agenda/focus.util", () => ({
 const { useOpenEventContextMenu } =
   require("@web/views/Day/hooks/events/useOpenEventContextMenu") as typeof import("@web/views/Day/hooks/events/useOpenEventContextMenu");
 
-type AgendaPointerEvent = MouseEvent<Element> | FocusEvent<Element>;
-
-const createAgendaEvent = (currentTarget: Element): AgendaPointerEvent =>
-  ({
-    preventDefault: mock(),
-    stopPropagation: mock(),
-    currentTarget,
-  }) as unknown as AgendaPointerEvent;
-
 describe("useOpenEventContextMenu", () => {
   beforeEach(() => {
     eventsStore.query.mockClear();
@@ -70,49 +60,39 @@ describe("useOpenEventContextMenu", () => {
     const eventId = "123";
     const eventClass = "event-class";
     const mockEvent = { _id: eventId, title: "Test Event" };
-    const mockReference = document.createElement("div");
-    mockReference.className = eventClass;
-    mockReference.setAttribute(DATA_EVENT_ELEMENT_ID, eventId);
-
-    const mockElement = document.createElement("button");
-    mockReference.appendChild(mockElement);
-
-    const mockEventObj = createAgendaEvent(mockElement);
+    const { element, event, reference } = createAgendaTarget({
+      eventClass,
+      eventId,
+    });
 
     getEventClass.mockReturnValue(eventClass);
     eventsStore.query.mockReturnValue(mockEvent);
 
     const { result } = renderHook(() => useOpenEventContextMenu());
 
-    result.current(mockEventObj);
+    result.current(event);
 
-    expect(mockEventObj.preventDefault).toHaveBeenCalled();
-    expect(mockEventObj.stopPropagation).toHaveBeenCalled();
-    expect(getEventClass).toHaveBeenCalledWith(mockElement);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(getEventClass).toHaveBeenCalledWith(element);
     expect(eventsStore.query).toHaveBeenCalled();
     expect(setActiveEvent).toHaveBeenCalledWith(mockEvent._id);
     expect(openFloatingAtCursor).toHaveBeenCalledWith({
       nodeId: CursorItem.EventContextMenu,
       placement: "bottom",
-      reference: mockReference,
+      reference,
     });
   });
 
   it("should not open event context menu if event id is missing", () => {
     const eventClass = "event-class";
-    const mockReference = document.createElement("div");
-    mockReference.className = eventClass;
-
-    const mockElement = document.createElement("button");
-    mockReference.appendChild(mockElement);
-
-    const mockEventObj = createAgendaEvent(mockElement);
+    const { event } = createAgendaTarget({ eventClass });
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenEventContextMenu());
 
-    result.current(mockEventObj);
+    result.current(event);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();
@@ -120,14 +100,13 @@ describe("useOpenEventContextMenu", () => {
 
   it("should not open event context menu if reference is missing", () => {
     const eventClass = "event-class";
-    const mockElement = document.createElement("button");
-    const mockEventObj = createAgendaEvent(mockElement);
+    const { event } = createAgendaTarget();
 
     getEventClass.mockReturnValue(eventClass);
 
     const { result } = renderHook(() => useOpenEventContextMenu());
 
-    result.current(mockEventObj);
+    result.current(event);
 
     expect(setActiveEvent).not.toHaveBeenCalled();
     expect(openFloatingAtCursor).not.toHaveBeenCalled();

--- a/packages/web/src/views/Now/components/NowCmdPalette.tsx
+++ b/packages/web/src/views/Now/components/NowCmdPalette.tsx
@@ -5,17 +5,14 @@ import { moreCommandPaletteItems } from "@web/common/constants/more.cmd.constant
 import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
 import { useAuthCmdItems } from "@web/common/hooks/useAuthCmdItems";
 import { useGoogleCmdItems } from "@web/common/hooks/useGoogleCmdItems";
+import { resolveCommandPalette } from "@web/common/utils/command-palette/resolve-command-palette.util";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
 import { onEventTargetVisibility } from "@web/common/utils/dom/event-target-visibility.util";
 import { selectIsCmdPaletteOpen } from "@web/ducks/settings/selectors/settings.selectors";
 import { settingsSlice } from "@web/ducks/settings/slices/settings.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
 
-// Bun's __toESM(mod, nodeInterop=1) wraps CJS+__esModule modules so .default = whole exports.
-// Unwrap one level to reach the actual component function.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const CommandPalette = ((_CommandPalette as any).default ??
-  _CommandPalette) as typeof _CommandPalette;
+const CommandPalette = resolveCommandPalette(_CommandPalette);
 
 export const NowCmdPalette = () => {
   const dispatch = useAppDispatch();


### PR DESCRIPTION
## Summary
- Replace broad `any` usages with narrower event and store types across backend, core, and web code.
- Factor the command-palette module unwrap into a shared helper so the same Bun-specific logic is used in one place.
- Tighten tests to use real DOM and DnD event shapes where practical.

## Testing
- Unit tests updated to cover the typed helpers and event flows.
- Not run (not requested).