### PR TITLE
Update self-hosting docs and server auth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ https://github.com/user-attachments/assets/ba7b91b9-1984-49f2-afc6-7fcda1100b31
 - Command palette
 - Event tagging, resizing, duplicating, reordering
 - Drag & drop
-- 2-way sync with Google Calendar
+- Google Calendar sync when configured
 - Google OAuth authentication
 - User session management with Supertokens
 - Email capture via Kit
 
 ### Current Limitations
 
-- Only supports primary Google Calendar (no sub-calendars)
+- No UI to choose which Google calendars sync
 - No sharing, locations, reminders, or mobile app
 
 We're actively working on improvements – check out our [roadmap](https://github.com/orgs/SwitchbackTech/projects/4).
@@ -49,7 +49,7 @@ We're actively working on improvements – check out our [roadmap](https://githu
 
 - **Frontend**: React, Redux, Tailwind CSS, TypeScript, Bun
 - **Backend**: Node.js, Express, TypeScript, MongoDB
-- **Integrations**: Google Calendar API, Google OAuth2, Socket.io
+- **Integrations**: Google Calendar API, Google OAuth2, Server-Sent Events
 - **Testing**: Bun, React Testing Library, Playwright
 
 ## Getting Started
@@ -60,7 +60,7 @@ Head over to [app.compasscalendar.com](https://app.compasscalendar.com?utm_sourc
 
 ### Self-host Compass
 
-Run Compass on your own machine and keep your calendar data on your own infrastructure.
+Run Compass on your own machine with the local Docker installer. Password-only self-hosting is supported; Google Calendar is optional.
 
 With Docker Desktop installed and running, install the local self-hosted stack:
 
@@ -68,7 +68,7 @@ With Docker Desktop installed and running, install the local self-hosted stack:
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
 ```
 
-See [docs/self-hosting.md](./docs/self-hosting.md) for the full guide, including the inspect-before-run install path and manual setup notes.
+See [docs/self-hosting.md](./docs/self-hosting.md) to choose the right self-hosting guide and read the local install, backup, Google Calendar, and server-hosting notes.
 
 ### Run Locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,7 @@
 
 Internal documentation for engineers and agents working in the Compass repo.
 
-Start with [AGENTS.md](../AGENTS.md) for repo rules and command defaults. Use
-this index for codebase shape, subsystem behavior, and acceptance runbooks.
+Start with [AGENTS.md](../AGENTS.md) for repo rules and command defaults. Use this index for codebase shape, subsystem behavior, and acceptance runbooks.
 
 ## Start Here
 
@@ -13,19 +12,10 @@ this index for codebase shape, subsystem behavior, and acceptance runbooks.
 
 ## Common Change Paths
 
-- Auth or session behavior:
-  [Frontend Runtime Flow](./frontend/frontend-runtime-flow.md),
-  [Password Auth Flow](./features/password-auth-flow.md),
-  [Google Sync And SSE Flow](./features/google-sync-and-sse-flow.md)
-- Event shape or recurrence behavior:
-  [Event And Task Domain Model](./architecture/event-and-task-domain-model.md),
-  [Recurrence Handling](./features/recurring-events-handling.md)
-- Local-first or storage behavior:
-  [Offline Storage And Migrations](./features/offline-storage-and-migrations.md)
-- Backend routes and API behavior:
-  [Backend Route Map](./backend/README.md),
-  [Backend Request Flow](./backend/backend-request-flow.md),
-  [Backend Error Handling](./backend/backend-error-handling.md)
+- Auth or session behavior: [Frontend Runtime Flow](./frontend/frontend-runtime-flow.md), [Password Auth Flow](./features/password-auth-flow.md), [Google Sync And SSE Flow](./features/google-sync-and-sse-flow.md)
+- Event shape or recurrence behavior: [Event And Task Domain Model](./architecture/event-and-task-domain-model.md), [Recurrence Handling](./features/recurring-events-handling.md)
+- Local-first or storage behavior: [Offline Storage And Migrations](./features/offline-storage-and-migrations.md)
+- Backend routes and API behavior: [Backend Route Map](./backend/README.md), [Backend Request Flow](./backend/backend-request-flow.md), [Backend Error Handling](./backend/backend-error-handling.md)
 
 ## Runtime Flows
 
@@ -44,6 +34,9 @@ this index for codebase shape, subsystem behavior, and acceptance runbooks.
 - [Local Development](./development/local-development.md)
 - [Hosting Modes](./development/hosting-modes.md)
 - [Self-Hosting](./self-hosting.md)
+- [Self-Hosting Local Quickstart](./self-hosting/local-quickstart.md)
+- [Self-Hosting Backups And Restore](./self-hosting/backups-and-restore.md)
+- [Self-Hosting Google Calendar](./self-hosting/google-calendar.md)
 - [Testing Playbook](./development/testing-playbook.md)
 - [Types And Validation](./development/types-and-validation.md)
 - [CLI And Maintenance Commands](./development/cli-and-maintenance-commands.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ Start with [AGENTS.md](../AGENTS.md) for repo rules and command defaults. Use th
 - [Self-Hosting Local Quickstart](./self-hosting/local-quickstart.md)
 - [Self-Hosting Backups And Restore](./self-hosting/backups-and-restore.md)
 - [Self-Hosting Google Calendar](./self-hosting/google-calendar.md)
+- [Self-Hosting Server Guide](./self-hosting/server-guide.md)
+- [Self-Hosting Advanced Manual Setup](./self-hosting/advanced-manual.md)
 - [Testing Playbook](./development/testing-playbook.md)
 - [Types And Validation](./development/types-and-validation.md)
 - [CLI And Maintenance Commands](./development/cli-and-maintenance-commands.md)

--- a/docs/development/hosting-modes.md
+++ b/docs/development/hosting-modes.md
@@ -70,7 +70,7 @@ A quick read across hosting contexts and account states:
 | Signup / first login         | Local events sync up to the backend               |
 | Authenticated (any mode)     | Backend → configured MongoDB                     |
 | Google connect               | Backend stores Google credentials and starts sync |
-| Google sync running          | Backend ⇄ Google Calendar, pushes updates to the browser via SSE |
+| Google sync running          | Backend ⇄ Google Calendar, pushes updates to the browser via SSE when Google and webhook delivery are configured |
 
 For storage behavior and migration specifics, see [Offline Storage And Migrations](../features/offline-storage-and-migrations.md). For the Google side, see [Google Sync And SSE Flow](../features/google-sync-and-sse-flow.md).
 
@@ -80,7 +80,7 @@ A few things that trip up new contributors:
 
 - **SuperTokens ≠ event storage.** SuperTokens stores identity and sessions. Compass events live in MongoDB (or IndexedDB when anonymous).
 - **MongoDB stores events after signup, not before.** Anonymous events never touch the backend.
-- **Google sync is independent from account mode.** Self-hosted account mode supports Google sync, but the backend still requires the Google env values at startup today. See [Local Development](./local-development.md) for the backend env contract.
+- **Google sync is independent from account mode.** Self-hosted account mode can run without Google. Google sign-in/connect requires Google OAuth credentials, and Google-to-Compass watch notifications require a public HTTPS webhook URL. See [Local Development](./local-development.md) for the backend env contract.
 - **Tasks stay local.** Tasks currently live in IndexedDB regardless of account state. Backend task persistence is not wired up yet.
 
 ## Deeper Docs

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -76,7 +76,7 @@ Optional but behavior-changing:
 - `EMAILER_API_SECRET`
 - `EMAILER_USER_TAG_ID`
 
-Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set. When Google is enabled and the effective Google webhook URL uses HTTPS, `TOKEN_GCAL_NOTIFICATION` is required for Google Calendar webhook validation.
+Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set to real, non-placeholder values. When Google is enabled and the effective Google webhook URL uses HTTPS, `TOKEN_GCAL_NOTIFICATION` is required for Google Calendar webhook validation.
 
 Derived backend values:
 

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -76,9 +76,7 @@ Optional but behavior-changing:
 - `EMAILER_API_SECRET`
 - `EMAILER_USER_TAG_ID`
 
-Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
-are set. When Google is enabled and the effective Google webhook URL uses HTTPS,
-`TOKEN_GCAL_NOTIFICATION` is required for Google Calendar webhook validation.
+Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set. When Google is enabled and the effective Google webhook URL uses HTTPS, `TOKEN_GCAL_NOTIFICATION` is required for Google Calendar webhook validation.
 
 Derived backend values:
 
@@ -91,7 +89,8 @@ Primary files:
 
 - `packages/scripts/src/common/cli.constants.ts`
 - `packages/scripts/src/common/cli.utils.ts`
-- `packages/web/webpack.config.mjs`
+- `packages/web/build.ts`
+- `packages/web/dev.ts`
 
 Variables used by CLI/build flows:
 
@@ -113,16 +112,16 @@ Important variables:
 - `POSTHOG_KEY`
 - `POSTHOG_HOST`
 
-`GOOGLE_CLIENT_ID` is optional. When it is missing, the web app hides Google
-sign-in and Google Calendar connection actions.
+`GOOGLE_CLIENT_ID` is optional. When it is missing, the web app hides Google sign-in and Google Calendar connection actions.
 
 `BACKEND_BASEURL` is derived from `API_BASEURL`.
 
-Webpack behavior (`packages/web/webpack.config.mjs`):
+Bun build/dev behavior:
 
-- local/staging/production builds load `packages/backend/.env.local`, `.env.staging`, or `.env.production`
-- missing env files are a warning, not a hard failure; values can come from `process.env`
-- test mode skips env-file loading entirely
+- `packages/web/build.ts` injects `BASEURL` as `API_BASEURL` for production builds
+- `packages/web/dev.ts` does the same for the local web dev server
+- `GOOGLE_CLIENT_ID` is injected when present
+- if `API_BASEURL` is not injected, the web app falls back to `PORT` and builds `http://localhost:<PORT>/api`
 
 ## Practical Mode Matrix
 
@@ -174,15 +173,9 @@ When testing changes around event loading, explicitly decide which user state yo
 
 ## Google Calendar Webhook Notes
 
-Google OAuth and Google Calendar Watch have different local requirements.
-Google sign-in can use localhost redirect URLs, but Calendar Watch
-notifications are server-to-server callbacks from Google to Compass. For those
-callbacks, Google needs an HTTPS backend URL that it can reach from the public
-internet.
+Google OAuth and Google Calendar Watch have different local requirements. Google sign-in can use localhost redirect URLs, but Calendar Watch notifications are server-to-server callbacks from Google to Compass. For those callbacks, Google needs an HTTPS backend URL that it can reach from the public internet.
 
-Compass does not start a local tunnel automatically. Google Calendar webhook
-watch flows use `GCAL_WEBHOOK_BASEURL` when it is set and fall back to
-`BASEURL` when it is not set.
+Compass does not start a local tunnel automatically. Google Calendar webhook watch flows use `GCAL_WEBHOOK_BASEURL` when it is set and fall back to `BASEURL` when it is not set.
 
 For normal local development:
 
@@ -190,12 +183,9 @@ For normal local development:
 BASEURL=http://localhost:3000/api
 ```
 
-Google sign-in, Google Calendar connect, and initial import can still work, but
-live Google-to-Compass notifications are skipped because Google cannot call a
-local HTTP backend.
+Google sign-in, Google Calendar connect, and initial import can still work, but live Google-to-Compass notifications are skipped because Google cannot call a local HTTP backend.
 
-For local end-to-end Google Watch testing, run a temporary HTTPS tunnel to the
-backend:
+For local end-to-end Google Watch testing, run a temporary HTTPS tunnel to the backend:
 
 ```bash
 cloudflared tunnel --url http://localhost:3000
@@ -208,11 +198,9 @@ BASEURL=http://localhost:3000/api
 GCAL_WEBHOOK_BASEURL=https://<generated-host>.trycloudflare.com/api
 ```
 
-Keep `BASEURL` local so the browser and Server-Sent Events continue using
-localhost. Only Google's webhook POST requests should use the tunnel.
+Keep `BASEURL` local so the browser and Server-Sent Events continue using localhost. Only Google's webhook POST requests should use the tunnel.
 
-Stop the tunnel when testing is complete. Do not use personal calendars with
-sensitive data for manual tunnel tests.
+Stop the tunnel when testing is complete. Do not use personal calendars with sensitive data for manual tunnel tests.
 
 ## Common Failure Modes
 
@@ -220,8 +208,6 @@ sensitive data for manual tunnel tests.
 - backend/web/cli read from `.env.local`; using `.env` instead leaves required variables unset
 - web points at the wrong API base URL
 - session exists but user profile fetch fails
-- sync endpoints work but notification/watch setup is skipped because neither
-  `GCAL_WEBHOOK_BASEURL` nor `BASEURL` is public HTTPS
-- `GCAL_WEBHOOK_BASEURL` points to a tunnel without `/api`, so Google posts to
-  the wrong route
+- sync endpoints work but notification/watch setup is skipped because neither `GCAL_WEBHOOK_BASEURL` nor `BASEURL` is public HTTPS
+- `GCAL_WEBHOOK_BASEURL` points to a tunnel without `/api`, so Google posts to the wrong route
 - backend starts but `/api/health` returns `500` because `MONGO_URI` or database reachability is broken

--- a/docs/development/troubleshoot.md
+++ b/docs/development/troubleshoot.md
@@ -14,14 +14,21 @@ Interpret the result like this:
 - `500`: the backend is running but database connectivity failed
 - connection refused or timeout: the backend is not listening yet, or the port/base URL is wrong
 
+For the local self-host installer, the same backend health check is:
+
+```bash
+curl -i http://localhost:3000/api/health
+```
+
+The self-host web app is served at `http://localhost:9080`.
+
 ## SSE Stream Not Connected Or Not Receiving Events
 
 Compass realtime updates now use Server-Sent Events over:
 
 - `GET /api/events/stream`
 
-If UI data is stale after backend writes or sync activity, verify transport before
-digging into business logic.
+If UI data is stale after backend writes or sync activity, verify transport before digging into business logic.
 
 Quick checks:
 
@@ -29,8 +36,7 @@ Quick checks:
 2. open browser Network tab and verify `/api/events/stream` stays open with `200`
 3. verify response headers include `content-type: text/event-stream`
 4. confirm periodic `: keepalive` frames are visible (roughly every 25 seconds)
-5. trigger a known publish path (for example event write or import) and verify
-   named events appear (`EVENT_CHANGED`, `IMPORT_GCAL_*`, `USER_METADATA`)
+5. trigger a known publish path (for example event write or import) and verify named events appear (`EVENT_CHANGED`, `IMPORT_GCAL_*`, `USER_METADATA`)
 
 If the stream does not open:
 
@@ -65,9 +71,7 @@ When you encounter a mismatch user id, the user in your mongo collection is not 
 bun run cli delete -u <email>
 ```
 
-The delete flow removes both Compass data and SuperTokens auth state. The
-browser cleanup screen only clears local browser storage after the server-side
-purge is complete.
+The delete flow removes both Compass data and SuperTokens auth state. The browser cleanup screen only clears local browser storage after the server-side purge is complete.
 
 See [CLI And Maintenance Commands](./cli-and-maintenance-commands.md) for the current delete flow.
 
@@ -84,9 +88,7 @@ To fix this:
 
 ## Google Calendar Repair Fails Or Stops Unexpectedly
 
-When a user triggers repair from the UI (`Repair Google Calendar`) and the flow
-does not complete as expected, first classify the failure mode from the message
-and SSE behavior.
+When a user triggers repair from the UI (`Repair Google Calendar`) and the flow does not complete as expected, first classify the failure mode from the message and SSE behavior.
 
 ### Quota / rate-limit during repair
 
@@ -94,8 +96,7 @@ If the user sees:
 
 - `Google Calendar repair hit a Google API limit. Please wait a few minutes and try again.`
 
-then backend detected a Google quota/rate-limit response (`403`/`429`), and this
-is usually transient.
+then backend detected a Google quota/rate-limit response (`403`/`429`), and this is usually transient.
 
 Recommended action:
 
@@ -105,25 +106,19 @@ Recommended action:
 
 ### Revoked token during repair
 
-If access was revoked (for example Google returns `invalid_grant`), backend
-prunes Google data and emits `GOOGLE_REVOKED`.
+If access was revoked (for example Google returns `invalid_grant`), backend prunes Google data and emits `GOOGLE_REVOKED`.
 
 Operational notes:
 
-- this path does **not** end with an `IMPORT_GCAL_END` payload with
-  `status: "ERRORED"`
-- UI should transition to reconnect-required behavior rather than repeatedly
-  retrying repair
+- this path does **not** end with an `IMPORT_GCAL_END` payload with `status: "ERRORED"`
+- UI should transition to reconnect-required behavior rather than repeatedly retrying repair
 - user action is to reconnect Google, then allow sync/import restart
 
 ## Google Connect Aborts With Local Events Sync Error
 
-When a password-authenticated user connects Google from an existing session, the
-client now attempts to sync IndexedDB-only Compass events **before**
-`POST /api/auth/google/connect`.
+When a password-authenticated user connects Google from an existing session, the client now attempts to sync IndexedDB-only Compass events **before** `POST /api/auth/google/connect`.
 
-If that pre-connect local sync fails, connect is intentionally aborted and the
-user sees:
+If that pre-connect local sync fails, connect is intentionally aborted and the user sees:
 
 - `We could not sync your local events. Your changes are still saved on this device.`
 

--- a/docs/features/google-sync-and-sse-flow.md
+++ b/docs/features/google-sync-and-sse-flow.md
@@ -7,6 +7,8 @@ Compass sync is bidirectional:
 
 Realtime updates use **Server-Sent Events** (one HTTP connection per tab, server pushes named events). The browser `EventSource` connects to `GET /api/events/stream` with the session cookie.
 
+For local self-hosting, keep one boundary clear: browser API/SSE traffic can use localhost, but Google-to-Compass watch notifications are server-to-server POSTs from Google. Those notification POSTs need a public HTTPS backend URL if you want Google-side changes to arrive without a manual repair/import.
+
 ## High-Level Architecture
 
 ```mermaid

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,11 +45,11 @@ Docker volume backups do **not** back up browser IndexedDB data. That includes t
 
 `./compass update` pulls newer Compass code and rebuilds the stack. It is not a rollback tool.
 
-## What Is Not Promised Here
+## What this guide does not set up yet
 
 These docs intentionally do not claim support that has not been verified:
 
-- no beginner public-server hosting guide yet
+- no fully verified beginner public-server runbook yet
 - no end-to-end verified public-domain SuperTokens setup yet
 - no built-in HTTPS certificate or reverse proxy setup
 - no built-in backup scheduler

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -14,7 +14,7 @@ You can self-host Compass with only email/password signup. You do not need Googl
 | [Backups And Restore](./self-hosting/backups-and-restore.md) | You want to preserve or restore signed-in event data and auth data. |
 | [Google Calendar](./self-hosting/google-calendar.md) | You want to understand no-Google mode, optional local Google OAuth/import, or public HTTPS Google watch notifications. |
 | [Advanced Manual Setup](./self-hosting/advanced-manual.md) | You want to run the pieces yourself instead of using the installer. |
-| [Server Hosting Guide](./self-hosting/server-guide.md) | You want the best current one-domain server shape, with limitations called out. |
+| [Server Hosting Guide](./self-hosting/server-guide.md) | You want to serve Compass from a public domain with Docker Compose and Caddy. |
 
 ## What The Local Installer Actually Does
 
@@ -47,16 +47,14 @@ Docker volume backups do **not** back up browser IndexedDB data. That includes t
 
 ## What this guide does not set up yet
 
-These docs intentionally do not claim support that has not been verified:
+These docs keep the default path focused on local Docker self-hosting. They do not set up:
 
-- no fully verified beginner public-server runbook yet
-- no end-to-end verified public-domain SuperTokens setup yet
-- no built-in HTTPS certificate or reverse proxy setup
-- no built-in backup scheduler
-- no automatic restore flow
-- no rollback command for `./compass update`
-- no Docker backup for browser IndexedDB data
-- no continuous Google Calendar sync on the local-only install
+- a built-in HTTPS certificate or reverse proxy
+- a built-in backup scheduler
+- an automatic restore flow
+- a rollback command for `./compass update`
+- Docker backups for browser IndexedDB data
+- continuous Google Calendar sync on the local-only install
 
 Google Calendar is optional. See [Google Calendar](./self-hosting/google-calendar.md) for the difference between no-Google mode, local Google OAuth/import, and public HTTPS watch notifications.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -50,7 +50,7 @@ Docker volume backups do **not** back up browser IndexedDB data. That includes t
 These docs intentionally do not claim support that has not been verified:
 
 - no beginner public-server hosting guide yet
-- no verified public-domain SuperTokens setup yet
+- no end-to-end verified public-domain SuperTokens setup yet
 - no built-in HTTPS certificate or reverse proxy setup
 - no built-in backup scheduler
 - no automatic restore flow

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -14,7 +14,7 @@ You can self-host Compass with only email/password signup. You do not need Googl
 | [Backups And Restore](./self-hosting/backups-and-restore.md) | You want to preserve or restore signed-in event data and auth data. |
 | [Google Calendar](./self-hosting/google-calendar.md) | You want to understand no-Google mode, optional local Google OAuth/import, or public HTTPS Google watch notifications. |
 | [Advanced Manual Setup](./self-hosting/advanced-manual.md) | You want to run the pieces yourself instead of using the installer. |
-| [Server Hosting Status](./self-hosting/server-guide.md) | You are considering a public server. This is not a verified beginner path yet. |
+| [Server Hosting Guide](./self-hosting/server-guide.md) | You want the best current one-domain server shape, with limitations called out. |
 
 ## What The Local Installer Actually Does
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,275 +1,71 @@
 # Self-Hosting Compass
 
-Run Compass on your own computer with Docker Desktop, so your calendar data stays on your machine.
+This page helps you choose the right self-hosting guide for personal use.
 
-This guide has two paths:
+The supported self-host path in this repo today is **local Docker self-hosting**: Compass runs on your own computer, the web app is available at `http://localhost:9080`, and the backend API is available at `http://localhost:3000/api`.
 
-- **Installer (recommended):** one command sets everything up in `~/compass`.
-- **Manual setup (fallback):** run the pieces yourself if the installer does not fit your needs.
+You can self-host Compass with only email/password signup. You do not need Google Calendar to use Compass locally.
 
-The installer is for **local use only** — it runs Compass on your own computer, not on a server that other people on the internet can reach. For server deployments, see [Running On A Server](#running-on-a-server).
+## Choose A Guide
 
-In this guide, `~/compass` means a folder named `compass` in your home directory, for example `/Users/alex/compass` on macOS or `/home/alex/compass` on Linux. The installer creates this folder for you.
+| Guide | Use it when |
+| --- | --- |
+| [Local Quickstart](./self-hosting/local-quickstart.md) | You want the recommended local Docker install on your own Mac or Linux machine. |
+| [Backups And Restore](./self-hosting/backups-and-restore.md) | You want to preserve or restore signed-in event data and auth data. |
+| [Google Calendar](./self-hosting/google-calendar.md) | You want to understand no-Google mode, optional local Google OAuth/import, or public HTTPS Google watch notifications. |
+| [Advanced Manual Setup](./self-hosting/advanced-manual.md) | You want to run the pieces yourself instead of using the installer. |
+| [Server Hosting Status](./self-hosting/server-guide.md) | You are considering a public server. This is not a verified beginner path yet. |
 
-## Before You Start
+## What The Local Installer Actually Does
 
-You need:
+The installer is a local Docker installer, not a general public-server installer.
 
-- A Mac or Linux machine.
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running. Docker is what runs Compass and its database. If Docker Desktop is not running, the installer will not work.
+It creates `~/compass`, writes generated secrets to `~/compass/.env`, copies the helper command to `~/compass/compass`, and starts a Docker Compose stack.
 
-No account, key, or Google setup is required to get Compass running locally.
+The local stack exposes only:
+
+- Web app: `http://localhost:9080`
+- Backend API: `http://localhost:3000/api`
+
+The compose file binds those two ports to `127.0.0.1`, so they are intended for the same computer only. MongoDB, SuperTokens Core, and the SuperTokens Postgres database stay on Docker's internal network.
+
+## Important Data Warning
+
+Keep `~/compass/.env`.
+
+That file contains generated passwords and tokens used by the existing Docker volumes. If the Docker volumes remain on your machine but `~/compass/.env` is lost, a new `.env` can generate different database credentials and lock you out of the old data.
+
+Before running `./compass update`, make a backup of:
+
+- `~/compass/.env`
+- the Mongo Docker volume
+- the SuperTokens Postgres Docker volume
+
+Docker volume backups do **not** back up browser IndexedDB data. That includes tasks and anonymous or pre-signup local data.
+
+`./compass update` pulls newer Compass code and rebuilds the stack. It is not a rollback tool.
+
+## What Is Not Promised Here
+
+These docs intentionally do not claim support that has not been verified:
+
+- no beginner public-server hosting guide yet
+- no verified public-domain SuperTokens setup yet
+- no built-in HTTPS certificate or reverse proxy setup
+- no built-in backup scheduler
+- no automatic restore flow
+- no rollback command for `./compass update`
+- no Docker backup for browser IndexedDB data
+- no continuous Google Calendar sync on the local-only install
+
+Google Calendar is optional. See [Google Calendar](./self-hosting/google-calendar.md) for the difference between no-Google mode, local Google OAuth/import, and public HTTPS watch notifications.
 
 ## Quick Install
 
-Once Docker Desktop is running, open a terminal and run:
+If you are ready to use the local Docker path:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
 ```
 
-The installer will:
-
-1. Create a folder at `~/compass` for your install.
-2. Download the Compass code into `~/compass/app`.
-3. Write a configuration file at `~/compass/.env` with sensible defaults.
-4. Copy a helper script to `~/compass/compass` that you use to manage the install.
-5. Start Compass with Docker Compose and wait until it is ready.
-6. Try to open Compass in your browser.
-
-When it finishes, Compass is available at:
-
-- Web app: [http://localhost:9080](http://localhost:9080)
-- Backend API: [http://localhost:3000/api](http://localhost:3000/api)
-
-If your browser does not open automatically, open [http://localhost:9080](http://localhost:9080) manually.
-
-The installer does not collect telemetry and does not call Compass-owned services after installation. It fetches code from GitHub to install or update Compass.
-
-### Prefer To Read The Script First?
-
-If you want to inspect the installer before running it:
-
-```bash
-curl -fsSLO https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh
-less install.sh
-sh install.sh
-```
-
-## Managing Your Install
-
-After install, you manage Compass from the `~/compass` folder using the `./compass` helper:
-
-```bash
-cd ~/compass
-./compass status
-```
-
-Available commands:
-
-| Command              | What it does                                                                 |
-| -------------------- | ---------------------------------------------------------------------------- |
-| `./compass start`    | Start Compass.                                                               |
-| `./compass stop`     | Stop Compass. Your data is not deleted.                                      |
-| `./compass restart`  | Stop and start Compass.                                                      |
-| `./compass status`   | Show whether Compass is running.                                             |
-| `./compass logs`     | Show recent logs from the running containers.                                |
-| `./compass rebuild`  | Rebuild the app (needed after certain config changes — see below).           |
-| `./compass update`   | Pull the latest Compass code and rebuild.                                    |
-| `./compass open`     | Open Compass in your browser.                                                |
-
-### When To Use `rebuild`
-
-A few settings become part of the web app when it is built, so editing them in `~/compass/.env` has no effect until you rebuild. This includes:
-
-- Optional Google OAuth client values (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`)
-- `FRONTEND_URL`
-- `BASEURL`
-
-After editing any of these, run:
-
-```bash
-cd ~/compass
-./compass rebuild
-```
-
-### When To Use `update`
-
-`./compass update` pulls the latest Compass code and rebuilds the app. It only works if the installer cloned Compass with Git.
-
-If the installer fell back to downloading an archive because `git` was not available on your machine, `./compass update` cannot update you. Install Git, download the installer script, and run `sh install.sh` from your terminal to refresh Compass.
-
-Stopping Compass does not delete your data. Neither does `update` or `rebuild`.
-
-## What The Installer Runs
-
-The installer uses Docker Compose to run a small set of containers:
-
-| Container        | Where it is reachable                                            | What it is for                                   |
-| ---------------- | ---------------------------------------------------------------- | ------------------------------------------------ |
-| Web app          | `http://localhost:9080`                                          | The Compass UI in your browser.                  |
-| Backend API      | `http://localhost:3000/api`                                      | Compass's server.                                |
-| MongoDB          | Internal Docker network only                                     | Stores signed-in Compass events and user profile data. |
-| SuperTokens Core | Internal Docker network only                                     | Handles signup, login, and sessions.             |
-| Postgres         | Internal Docker network only                                     | Durable storage used by SuperTokens.             |
-
-Only the web app and backend are reachable from your browser, and only at `localhost` on your own machine. MongoDB, SuperTokens Core, and Postgres stay on an internal Docker network; nothing outside the Compass containers can connect to them.
-
-### Google Calendar Sync
-
-Google auth and Google Calendar sync are **not** configured by the local installer. Compass runs in password-only mode unless you provide Google OAuth credentials.
-
-You can add your own Google OAuth client values to `~/compass/.env` and run `./compass rebuild` to try Google sign-in and the Google Calendar connect flow. However, keeping Compass continuously in sync with Google Calendar, so new or changed Google events appear automatically, requires an HTTPS backend that is reachable from the public internet. The local installer does not set that up. For that, see [Running On A Server](#running-on-a-server).
-
-## Where Your Data Lives
-
-Compass stores data in a few different places. What ends up where depends on whether you are signed in.
-
-**Before you sign up:** events and tasks are kept in your browser's local storage (IndexedDB). No data is written to MongoDB until you sign up.
-
-**After you sign up:**
-
-- SuperTokens creates your auth account (stored in Postgres).
-- Events you had in the browser are copied into MongoDB.
-- From then on, event changes go through the backend and are saved in MongoDB.
-- Tasks still live in your browser. There is no backend task storage yet.
-
-### Files On Disk
-
-- `~/compass` — your install folder. Contains the helper command, config, and app files.
-- `~/compass/.env` — local configuration and generated secrets.
-- `~/compass/compass` — the helper script you run as `./compass ...`.
-- `~/compass/app` — the Compass source code used to build the containers.
-
-### Docker Volumes
-
-Inside Docker, Compass stores its data in volumes managed by Docker itself. With the default project name, these volumes are called:
-
-- `compass_compass_mongo_data` — MongoDB data (Compass accounts' calendar data).
-- `compass_compass_supertokens_postgres_data` — Postgres data (SuperTokens auth).
-
-If you set `COMPOSE_PROJECT_NAME` to something else, the volume names will change to match.
-
-Stopping Compass does **not** delete these volumes. To back up your account data, back up these Docker volumes. Browser-only tasks do not have a backup or export path today.
-
-For more on how data flows in each mode, see [Hosting Modes](./development/hosting-modes.md).
-
-## Manual Setup
-
-Use manual setup only if you want to run the services yourself or customize things the installer does not cover.
-
-### What Manual Setup Needs
-
-Compass is a web app and a backend API. In manual setup, you provide the runtime pieces the backend expects.
-
-**You provide:**
-
-- A machine you can run services on. Your laptop is fine for personal use.
-- [Bun](https://bun.sh) to install dependencies and run the backend and web app.
-- Node.js 24+ if you plan to make a production build. You can skip this while running in dev mode.
-- A **MongoDB** instance for signed-in event data.
-- A **SuperTokens** setup for signup, login, and sessions. Managed SuperTokens is an option. If you self-host SuperTokens Core, connect it to Postgres for durable auth storage. (The installer handles this Postgres dependency for you; manual setup does not.)
-
-**Optional:**
-
-- A **Google Cloud project**, only if you want Google auth or to connect Google Calendar.
-
-Leave Google credentials unset for password-only mode. If you provide Google credentials, provide both the client ID and client secret. Ongoing Google Calendar watch notifications need an HTTPS, publicly reachable backend URL. In local development this can be supplied with `GCAL_WEBHOOK_BASEURL`; in production/self-hosting this is usually just the public `BASEURL`.
-
-### Manual Steps
-
-1. **Get the code.**
-
-   ```bash
-   git clone https://github.com/SwitchbackTech/compass.git
-   cd compass
-   ```
-
-2. **Install dependencies.**
-
-   ```bash
-   bun install
-   ```
-
-3. **Create your backend env file and edit it.**
-
-   ```bash
-   cp packages/backend/.env.local.example packages/backend/.env.local
-   ```
-
-   Open `packages/backend/.env.local` and fill in:
-
-   - `MONGO_URI` for your MongoDB.
-   - SuperTokens values for your managed SuperTokens instance or self-hosted Core. If you self-host Core, connect it to Postgres.
-   - Optional Google credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`) if you want Google sign-in and Google Calendar sync. Leave both unset for password-only self-hosted mode.
-
-   For the full list and what each variable does, see [Local Development](./development/local-development.md).
-
-4. **Start the backend.**
-
-   ```bash
-   bun run dev:backend
-   ```
-
-   The backend listens on `http://localhost:3000` and exposes its API under `/api`.
-
-5. **Start the web app** in another terminal.
-
-   ```bash
-   bun run dev:web
-   ```
-
-6. **Open Compass** at [http://localhost:9080](http://localhost:9080).
-
-You can check the backend with:
-
-```bash
-curl http://localhost:3000/api/health
-```
-
-A `200` response means the backend is running and can reach MongoDB.
-
-### Customizing After Setup
-
-- **Point at a different MongoDB** by updating `MONGO_URI`.
-- **Use a different SuperTokens instance** by updating the SuperTokens values in your env file.
-- **Use Google OAuth locally** by creating a Google Cloud project, adding real credentials to your env file, and restarting the backend. Ongoing Google Calendar watch notifications also need an HTTPS, publicly reachable backend URL. In local development, use `GCAL_WEBHOOK_BASEURL` for that callback URL while keeping `BASEURL` pointed at localhost.
-
-### Running On A Server
-
-The local installer does not handle server deployments. For a server, run the same basic pieces yourself: a backend process, a built web app, MongoDB, and either managed SuperTokens or self-hosted SuperTokens Core. If you self-host SuperTokens Core, run Postgres for its auth storage. The web app and backend need public URLs; MongoDB, SuperTokens Core, and Postgres only need to be reachable from the backend or each other.
-
-Here's what differs from a laptop setup:
-
-- **A domain and public URLs.** Your web app and backend API need to be reachable from your users' browsers. Point a domain or subdomains at your server so you have stable URLs.
-- **HTTPS.** Required in practice, especially if you want Google Calendar sync. Google OAuth only accepts HTTPS redirect URLs, except for `localhost`. A reverse proxy like Caddy, nginx, or Cloudflare is the common pattern.
-- **Public URLs in your env file.** Update `FRONTEND_URL`, `BASEURL`, and `CORS` to match your real public URLs. `BASEURL` is baked into the web app at build time, so rebuild the web app after changing it.
-- **Build the web app for production.** In dev mode (`bun run dev:web`) the web app is served live. For a server, build it once from the repo root with `bun run build:web` and serve the built files through your reverse proxy or any static web server.
-- **Keep the backend process running.** `bun run dev:backend` is fine for a laptop but is not meant for long-running use. On a server, run the backend under systemd, a container, pm2, or another process manager.
-- **Google Cloud configuration.** If you configure Google Calendar sync, set up your Google Cloud project with your public web origin and backend HTTPS URL so Google can reach the backend for watch notifications.
-- **Backend-only data services.** MongoDB, SuperTokens Core, and Postgres should not be exposed to the public internet unless you intentionally secure that access.
-
-#### Server Deployment Checklist
-
-1. Choose the public URLs you want for the web app and backend API.
-2. Set `FRONTEND_URL`, `BASEURL`, and `CORS` in `packages/backend/.env.local` to match those URLs.
-3. Build the web app from the repo root with `bun run build:web`.
-4. Run the backend under a process manager so it restarts on crashes and reboots.
-5. Put a reverse proxy in front of the web app and backend, and terminate HTTPS there.
-6. Verify `/api/health` returns `200` when hit through your public backend URL.
-7. Create an account through your public web URL to confirm signup end-to-end.
-8. Optional: configure your Google Cloud project, then connect Google Calendar from inside Compass.
-
-See [Local Development](./development/local-development.md) for the full list of environment variables the backend and web build expect.
-
-## Next Steps
-
-- **Back up account data** by backing up the Docker volumes above (or your manually managed MongoDB/Postgres storage).
-- **Try Google auth/connect flows locally** by adding your own Google OAuth credentials to `~/compass/.env`, then running `./compass rebuild`.
-- **Deploy on a server** by following the [Server Deployment Checklist](#server-deployment-checklist).
-
-If something is not working or you want to dig deeper:
-
-- [Self-host runtime README](../self-host/README.md) — quick troubleshooting for the local installer, helper commands, Docker volumes, and `.env` issues.
-- [Local Development](./development/local-development.md) — full environment variable reference and troubleshooting tips.
-- [Hosting Modes](./development/hosting-modes.md) — how data flows in each mode.
+For the full local guide, read [Local Quickstart](./self-hosting/local-quickstart.md).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,69 +1,85 @@
 # Self-Hosting Compass
 
-This page helps you choose the right self-hosting guide for personal use.
+Self-hosting Compass means running it on a computer you control instead of using `app.compasscalendar.com`.
 
-The supported self-host path in this repo today is **local Docker self-hosting**: Compass runs on your own computer, the web app is available at `http://localhost:9080`, and the backend API is available at `http://localhost:3000/api`.
+The supported path today is **local Docker self-hosting**: install on your Mac or Linux machine, open the web app at `http://localhost:9080`, sign up with email and password. Google Calendar is optional.
 
-You can self-host Compass with only email/password signup. You do not need Google Calendar to use Compass locally.
+## What Compass is made of
 
-## Choose A Guide
+When you run the installer, you get a stack of small services on your machine. Only the web app and backend API are reachable from your browser. The rest stay private inside Docker.
+
+```text
+                    Your browser
+                 ┌──────┴──────┐
+                 │             │
+              loads UI      API calls
+                 │             │
+                 ▼             ▼
+       ┌────────────────┐ ┌───────────────────────┐
+       │ web container  │ │ backend container     │
+       │ localhost:9080 │ │ localhost:3000/api    │
+       └────────────────┘ └─────┬───────────┬─────┘
+                                │           │
+                                ▼           ▼
+                          ┌──────────┐ ┌────────────────────┐
+                          │ MongoDB  │ │ SuperTokens Core   │
+                          │ (events) │ │ (signup, login)    │
+                          └──────────┘ └─────────┬──────────┘
+                                                 ▼
+                                          ┌──────────────┐
+                                          │ Postgres     │
+                                          │ (auth data)  │
+                                          └──────────────┘
+```
+
+Two important things this picture doesn't show:
+
+- **Your tasks live in your browser**, not in Mongo. They're stored in IndexedDB. Docker volume backups do not include them.
+- **The installer creates a folder at `~/compass`** to hold your `.env` file, the helper script, and the app source. That folder is the only thing on your machine the installer touches outside Docker.
+
+## Three flavors of self-hosting
+
+Most people want the first one. Pick based on where you want Compass to live and whether you want Google Calendar.
+
+- **On your laptop, no Google.** The default. Run the installer, open `localhost:9080`, sign up with email and password. This is the recommended path.
+- **On your laptop, with Google sign-in or import.** Same install, plus your own Google OAuth client added to `~/compass/.env`. Continuous Google Calendar sync (Google pushing changes to Compass) needs a public HTTPS URL, so it isn't part of this path.
+- **On a public server.** A VPS with Docker, your own domain, and Caddy in front for HTTPS. More setup, more responsibility. Use this when you want Compass reachable from anywhere or want full Google Calendar sync.
+
+## Choose a guide
 
 | Guide | Use it when |
 | --- | --- |
-| [Local Quickstart](./self-hosting/local-quickstart.md) | You want the recommended local Docker install on your own Mac or Linux machine. |
-| [Backups And Restore](./self-hosting/backups-and-restore.md) | You want to preserve or restore signed-in event data and auth data. |
+| [Local quickstart](./self-hosting/local-quickstart.md) | You want the recommended local Docker install on your own Mac or Linux machine. |
+| [Backups and restore](./self-hosting/backups-and-restore.md) | You want to preserve or restore signed-in event data and auth data. |
 | [Google Calendar](./self-hosting/google-calendar.md) | You want to understand no-Google mode, optional local Google OAuth/import, or public HTTPS Google watch notifications. |
-| [Advanced Manual Setup](./self-hosting/advanced-manual.md) | You want to run the pieces yourself instead of using the installer. |
-| [Server Hosting Guide](./self-hosting/server-guide.md) | You want to serve Compass from a public domain with Docker Compose and Caddy. |
+| [Server hosting guide](./self-hosting/server-guide.md) | You want to serve Compass from a public domain with Docker Compose and Caddy. |
+| [Advanced manual setup](./self-hosting/advanced-manual.md) | You want to run the pieces yourself instead of using the installer. |
 
-## What The Local Installer Actually Does
+## The one warning that matters
 
-The installer is a local Docker installer, not a general public-server installer.
-
-It creates `~/compass`, writes generated secrets to `~/compass/.env`, copies the helper command to `~/compass/compass`, and starts a Docker Compose stack.
-
-The local stack exposes only:
-
-- Web app: `http://localhost:9080`
-- Backend API: `http://localhost:3000/api`
-
-The compose file binds those two ports to `127.0.0.1`, so they are intended for the same computer only. MongoDB, SuperTokens Core, and the SuperTokens Postgres database stay on Docker's internal network.
-
-## Important Data Warning
-
-Keep `~/compass/.env`.
-
-That file contains generated passwords and tokens used by the existing Docker volumes. If the Docker volumes remain on your machine but `~/compass/.env` is lost, a new `.env` can generate different database credentials and lock you out of the old data.
-
-Before running `./compass update`, make a backup of:
-
-- `~/compass/.env`
-- the Mongo Docker volume
-- the SuperTokens Postgres Docker volume
-
-Docker volume backups do **not** back up browser IndexedDB data. That includes tasks and anonymous or pre-signup local data.
-
-`./compass update` pulls newer Compass code and rebuilds the stack. It is not a rollback tool.
+> **Warning: keep `~/compass/.env`.**
+>
+> That file holds the generated passwords and tokens that match your Docker volumes. If the volumes stay but `.env` is gone, a new install creates different credentials and locks you out of the old data.
+>
+> Before `./compass update` or anything that touches the install, back up `~/compass/.env`, the Mongo volume, and the SuperTokens Postgres volume together. They're a set. See [Backups and restore](./self-hosting/backups-and-restore.md). Browser IndexedDB data (tasks, pre-signup events) is not included.
 
 ## What this guide does not set up yet
 
 These docs keep the default path focused on local Docker self-hosting. They do not set up:
 
-- a built-in HTTPS certificate or reverse proxy
+- a built-in HTTPS certificate or reverse proxy (the [server guide](./self-hosting/server-guide.md) covers this manually with Caddy)
 - a built-in backup scheduler
 - an automatic restore flow
 - a rollback command for `./compass update`
 - Docker backups for browser IndexedDB data
-- continuous Google Calendar sync on the local-only install
+- continuous Google Calendar sync on the local-only install (see [Google Calendar](./self-hosting/google-calendar.md) for why)
 
-Google Calendar is optional. See [Google Calendar](./self-hosting/google-calendar.md) for the difference between no-Google mode, local Google OAuth/import, and public HTTPS watch notifications.
+## Quick install
 
-## Quick Install
-
-If you are ready to use the local Docker path:
+If you're ready to use the local Docker path, install Docker Desktop, make sure it's running, then run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
 ```
 
-For the full local guide, read [Local Quickstart](./self-hosting/local-quickstart.md).
+For the full local guide, including what to expect, how to manage the install, and troubleshooting, read [Local quickstart](./self-hosting/local-quickstart.md).

--- a/docs/self-hosting/advanced-manual.md
+++ b/docs/self-hosting/advanced-manual.md
@@ -1,0 +1,81 @@
+# Advanced Manual Setup
+
+Use this only if the local installer does not fit your needs.
+
+For most personal self-hosting, use [Local Quickstart](./local-quickstart.md) instead.
+
+Manual setup means you run the pieces yourself. It is not a beginner public server guide.
+
+## Pieces You Provide
+
+Compass needs:
+
+- the Compass web app
+- the Compass backend API
+- MongoDB for signed-in event data
+- SuperTokens for signup, login, and sessions
+- durable SuperTokens storage, usually Postgres
+
+Optional:
+
+- Google OAuth credentials, only if you want Google sign-in or Google Calendar connection
+
+Leave Google credentials unset for password-only mode.
+
+## Local Manual Steps
+
+From the repo root:
+
+```bash
+git clone https://github.com/SwitchbackTech/compass.git
+cd compass
+bun install
+cp packages/backend/.env.local.example packages/backend/.env.local
+```
+
+Edit `packages/backend/.env.local` and provide:
+
+- `MONGO_URI`
+- `SUPERTOKENS_URI`
+- `SUPERTOKENS_KEY`
+- `TOKEN_COMPASS_SYNC`
+- `FRONTEND_URL`
+- `BASEURL`
+- `CORS`
+
+Then start the backend:
+
+```bash
+bun run dev:backend
+```
+
+In another terminal, start the web app:
+
+```bash
+bun run dev:web
+```
+
+Open [http://localhost:9080](http://localhost:9080).
+
+Check backend health with:
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+## Google In Manual Setup
+
+Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set.
+
+Google sign-in and local import can use localhost during development. Google watch notifications need a public HTTPS webhook URL that Google can reach.
+
+For local watch testing, keep browser traffic local and set only the Google webhook callback base URL to a public HTTPS tunnel:
+
+```bash
+BASEURL=http://localhost:3000/api
+GCAL_WEBHOOK_BASEURL=https://<public-https-host>/api
+```
+
+## Public Servers
+
+Do not treat this page as a public production guide. See [Server Hosting Status](./server-guide.md) for the current public-server blocker.

--- a/docs/self-hosting/advanced-manual.md
+++ b/docs/self-hosting/advanced-manual.md
@@ -1,30 +1,26 @@
-# Advanced Manual Setup
+# Run Compass without the installer
 
-Use this only if the local installer does not fit your needs.
+For when the local installer doesn't fit. Most personal self-hosting should use [Local quickstart](./local-quickstart.md) instead.
 
-For most personal self-hosting, use [Local Quickstart](./local-quickstart.md) instead.
+This page assumes you already know what MongoDB, SuperTokens, and Bun are, and you're comfortable wiring them together yourself. It is not a public-server guide. For server hosting, see [Server hosting guide](./server-guide.md).
 
-Manual setup means you run the pieces yourself. It is not a beginner public server guide.
-
-## Pieces You Provide
+## What you provide
 
 Compass needs:
 
 - the Compass web app
 - the Compass backend API
-- MongoDB for signed-in event data
-- SuperTokens for signup, login, and sessions
-- durable SuperTokens storage, usually Postgres
+- MongoDB (for signed-in event data)
+- SuperTokens Core (for signup, login, and sessions)
+- Postgres for SuperTokens
 
 Optional:
 
-- Google OAuth credentials, only if you want Google sign-in or Google Calendar connection
+- Google OAuth credentials, if you want Google sign-in or Google Calendar import
 
 Leave Google credentials unset for password-only mode.
 
-## Local Manual Steps
-
-From the repo root:
+## Local manual setup
 
 ```bash
 git clone https://github.com/SwitchbackTech/compass.git
@@ -33,7 +29,7 @@ bun install
 cp packages/backend/.env.local.example packages/backend/.env.local
 ```
 
-Edit `packages/backend/.env.local` and provide:
+Edit `packages/backend/.env.local` and set at minimum:
 
 - `MONGO_URI`
 - `SUPERTOKENS_URI`
@@ -43,39 +39,26 @@ Edit `packages/backend/.env.local` and provide:
 - `BASEURL`
 - `CORS`
 
-Then start the backend:
+Start the backend:
 
 ```bash
 bun run dev:backend
 ```
 
-In another terminal, start the web app:
+In a second terminal, start the web app:
 
 ```bash
 bun run dev:web
 ```
 
-Open [http://localhost:9080](http://localhost:9080).
-
-Check backend health with:
+Open [http://localhost:9080](http://localhost:9080). Confirm the backend with:
 
 ```bash
 curl http://localhost:3000/api/health
 ```
 
-## Google In Manual Setup
+## Google in manual setup
 
-Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set to real, non-placeholder values.
+Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set to real, non-placeholder values. Watch notifications need a public HTTPS webhook URL Google can reach.
 
-Google sign-in and local import can use localhost during development. Google watch notifications need a public HTTPS webhook URL that Google can reach.
-
-For local watch testing, keep browser traffic local and set only the Google webhook callback base URL to a public HTTPS tunnel:
-
-```bash
-BASEURL=http://localhost:3000/api
-GCAL_WEBHOOK_BASEURL=https://<public-https-host>/api
-```
-
-## Public Servers
-
-Do not treat this page as a public production guide. See [Server Hosting Guide](./server-guide.md) for the recommended one-domain server shape.
+For the three modes (Off, Local sign-in & import, Public watch notifications) and the `GCAL_WEBHOOK_BASEURL` development pattern, see [Google Calendar](./google-calendar.md).

--- a/docs/self-hosting/advanced-manual.md
+++ b/docs/self-hosting/advanced-manual.md
@@ -78,4 +78,4 @@ GCAL_WEBHOOK_BASEURL=https://<public-https-host>/api
 
 ## Public Servers
 
-Do not treat this page as a public production guide. See [Server Hosting Status](./server-guide.md) for the current public-server blocker.
+Do not treat this page as a public production guide. See [Server Hosting Guide](./server-guide.md) for the recommended one-domain server shape.

--- a/docs/self-hosting/advanced-manual.md
+++ b/docs/self-hosting/advanced-manual.md
@@ -65,7 +65,7 @@ curl http://localhost:3000/api/health
 
 ## Google In Manual Setup
 
-Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set.
+Google is disabled unless both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set to real, non-placeholder values.
 
 Google sign-in and local import can use localhost during development. Google watch notifications need a public HTTPS webhook URL that Google can reach.
 

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -78,6 +78,12 @@ The commands above put backups in `~/compass-backups` so they are not removed if
 
 If your volume names are different, replace the two `compass_...` volume names in the commands.
 
+To see the Compass volumes on your machine:
+
+```bash
+docker volume ls | grep compass
+```
+
 ## Restore A Backup
 
 Only restore onto a Compass install you are willing to replace.
@@ -118,6 +124,23 @@ docker run --rm \
 ```
 
 If your volume names are different, replace the two `compass_...` volume names in the commands before running them.
+
+## Verify The Restore
+
+After starting Compass again:
+
+```bash
+cd ~/compass
+./compass status
+```
+
+Then open Compass and check:
+
+- you can sign in with the same account
+- your events are present
+- the backend health check works: `http://localhost:3000/api/health`
+
+If sign-in fails after restoring old volumes, make sure you restored the `.env` file from the same backup as the Docker volumes.
 
 ## Missing `.env` With Old Docker Volumes
 

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -50,22 +50,22 @@ From the installed Compass folder:
 
 ```bash
 cd ~/compass
-backup_dir="$PWD/backups/$(date +%Y%m%d-%H%M%S)"
-mkdir -p "$backup_dir"
+BACKUP_DIR="$HOME/compass-backups/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$BACKUP_DIR"
 
 ./compass stop
 
-cp -p .env "$backup_dir/compass.env"
+cp -p .env "$BACKUP_DIR/compass.env"
 
 docker run --rm \
   -v compass_compass_mongo_data:/volume \
-  -v "$backup_dir":/backup \
+  -v "$BACKUP_DIR":/backup \
   alpine \
   sh -c 'cd /volume && tar czf /backup/mongo-volume.tgz .'
 
 docker run --rm \
   -v compass_compass_supertokens_postgres_data:/volume \
-  -v "$backup_dir":/backup \
+  -v "$BACKUP_DIR":/backup \
   alpine \
   sh -c 'cd /volume && tar czf /backup/supertokens-postgres-volume.tgz .'
 
@@ -74,21 +74,23 @@ docker run --rm \
 
 Keep the whole backup folder together. The `.env` file and volume archives are a set.
 
+Keep at least one backup outside `~/compass`, such as on another disk or in a private backup location. If you delete `~/compass`, any backups stored inside it are deleted too.
+
 If your volume names are different, replace the two `compass_...` volume names in the commands.
 
 ## Restore A Backup
 
 Only restore onto a Compass install you are willing to replace.
 
-Set `backup_dir` to the folder you created during backup:
+Set `BACKUP_DIR` to the folder you created during backup:
 
 ```bash
 cd ~/compass
-backup_dir="$PWD/backups/YYYYMMDD-HHMMSS"
+BACKUP_DIR="$HOME/compass-backups/YYYYMMDD-HHMMSS"
 
 ./compass stop
 
-cp -p "$backup_dir/compass.env" .env
+cp -p "$BACKUP_DIR/compass.env" .env
 
 docker run --rm \
   -v compass_compass_mongo_data:/volume \
@@ -97,7 +99,7 @@ docker run --rm \
 
 docker run --rm \
   -v compass_compass_mongo_data:/volume \
-  -v "$backup_dir":/backup \
+  -v "$BACKUP_DIR":/backup \
   alpine \
   sh -c 'cd /volume && tar xzf /backup/mongo-volume.tgz'
 
@@ -108,7 +110,7 @@ docker run --rm \
 
 docker run --rm \
   -v compass_compass_supertokens_postgres_data:/volume \
-  -v "$backup_dir":/backup \
+  -v "$BACKUP_DIR":/backup \
   alpine \
   sh -c 'cd /volume && tar xzf /backup/supertokens-postgres-volume.tgz'
 

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -1,52 +1,47 @@
-# Backups And Restore
+# Back up and restore your data
 
-This page covers the local Docker self-host install created by `self-host/install.sh`.
+For the local Docker install created by `self-host/install.sh`. Backups are manual today. The installer and `./compass update` do not create them for you.
 
-Backups are manual today. The installer and `./compass update` do not create a backup for you.
+## Why this matters
 
-## What To Back Up
+> **Warning.** If you run `./compass update` without a backup and something goes wrong, there is no rollback. The update command rebuilds Compass with newer code. It does not snapshot your old data or your old app version.
+>
+> If `~/compass/.env` is lost while the Docker volumes still exist, a new install generates fresh database passwords that won't match the old volumes. You'll be locked out of your existing events and accounts.
 
-Back up all three of these together:
+Your three things to keep, **together as a set**:
 
 1. `~/compass/.env`
-2. the Mongo Docker volume
-3. the SuperTokens Postgres Docker volume
+2. the Mongo Docker volume (events)
+3. the SuperTokens Postgres Docker volume (accounts and sessions)
 
-With the default install, the Docker volumes are:
+## What's not in a Docker backup
+
+Browser IndexedDB data is not included. That means:
+
+- tasks
+- anonymous events created before signup
+- any pre-signup local data not yet copied to the backend
+
+There's no repo-supported export for browser-only data yet.
+
+## Find your volume names
+
+The default install creates:
 
 - `compass_compass_mongo_data`
 - `compass_compass_supertokens_postgres_data`
 
-If you changed `COMPOSE_PROJECT_NAME`, the volume names use that project name instead of `compass`.
-
-## What This Does Not Back Up
-
-Docker volume backups do not back up browser IndexedDB data.
-
-That means these are not included:
-
-- tasks
-- anonymous events before signup
-- pre-signup local data that has not been copied to the backend yet
-
-Those browser-only data types do not have a repo-supported export or backup command yet.
-
-## Back Up Before Updating
-
-Before running:
+If you set a custom `COMPOSE_PROJECT_NAME` at install time, the volume names use that prefix instead of `compass`. To list the Compass volumes on your machine:
 
 ```bash
-cd ~/compass
-./compass update
+docker volume ls | grep compass
 ```
 
-make a backup.
+The commands below assume the default names. Replace them if yours differ.
 
-`./compass update` pulls newer Compass code, rebuilds, and restarts the stack. It does not keep a rollback copy of your old data or old app version.
+## Make a backup
 
-## Make A Backup
-
-From the installed Compass folder:
+From `~/compass`:
 
 ```bash
 cd ~/compass
@@ -72,21 +67,11 @@ docker run --rm \
 ./compass start
 ```
 
-Keep the whole backup folder together. The `.env` file and volume archives are a set.
+Backups land in `~/compass-backups`, outside `~/compass`, so they survive if you ever delete the install folder. Keep the whole timestamped folder together. The `.env` file and the two volume archives are useless apart.
 
-The commands above put backups in `~/compass-backups` so they are not removed if you delete `~/compass`.
+## Restore a backup
 
-If your volume names are different, replace the two `compass_...` volume names in the commands.
-
-To see the Compass volumes on your machine:
-
-```bash
-docker volume ls | grep compass
-```
-
-## Restore A Backup
-
-Only restore onto a Compass install you are willing to replace.
+> **Warning: restore replaces existing data.** The commands below wipe both Docker volumes and overwrite `.env`. Only run them on an install you're willing to replace.
 
 Set `BACKUP_DIR` to the folder you created during backup:
 
@@ -123,11 +108,7 @@ docker run --rm \
 ./compass start
 ```
 
-If your volume names are different, replace the two `compass_...` volume names in the commands before running them.
-
-## Verify The Restore
-
-After starting Compass again:
+## Verify the restore
 
 ```bash
 cd ~/compass
@@ -138,14 +119,12 @@ Then open Compass and check:
 
 - you can sign in with the same account
 - your events are present
-- the backend health check works: `http://localhost:3000/api/health`
+- the backend health check responds: `http://localhost:3000/api/health`
 
-If sign-in fails after restoring old volumes, make sure you restored the `.env` file from the same backup as the Docker volumes.
+If sign-in fails, the most likely cause is a `.env` and volume pair from different backups. Restore the matching `.env` from the same backup folder as the volumes.
 
-## Missing `.env` With Old Docker Volumes
+## If `.env` is missing but old volumes exist
 
-If Docker volumes still exist but `~/compass/.env` is missing, the installer stops.
+The installer stops in this case on purpose. A fresh `.env` would have new credentials that don't match the old volumes.
 
-That is intentional. A fresh `.env` would contain new generated credentials, and those credentials may not match the old volumes.
-
-To keep old data, restore the matching `.env` file first.
+To keep the old data, restore the matching `.env` from a backup, then rerun the installer.

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -74,7 +74,7 @@ docker run --rm \
 
 Keep the whole backup folder together. The `.env` file and volume archives are a set.
 
-Keep at least one backup outside `~/compass`, such as on another disk or in a private backup location. If you delete `~/compass`, any backups stored inside it are deleted too.
+The commands above put backups in `~/compass-backups` so they are not removed if you delete `~/compass`.
 
 If your volume names are different, replace the two `compass_...` volume names in the commands.
 

--- a/docs/self-hosting/backups-and-restore.md
+++ b/docs/self-hosting/backups-and-restore.md
@@ -1,0 +1,126 @@
+# Backups And Restore
+
+This page covers the local Docker self-host install created by `self-host/install.sh`.
+
+Backups are manual today. The installer and `./compass update` do not create a backup for you.
+
+## What To Back Up
+
+Back up all three of these together:
+
+1. `~/compass/.env`
+2. the Mongo Docker volume
+3. the SuperTokens Postgres Docker volume
+
+With the default install, the Docker volumes are:
+
+- `compass_compass_mongo_data`
+- `compass_compass_supertokens_postgres_data`
+
+If you changed `COMPOSE_PROJECT_NAME`, the volume names use that project name instead of `compass`.
+
+## What This Does Not Back Up
+
+Docker volume backups do not back up browser IndexedDB data.
+
+That means these are not included:
+
+- tasks
+- anonymous events before signup
+- pre-signup local data that has not been copied to the backend yet
+
+Those browser-only data types do not have a repo-supported export or backup command yet.
+
+## Back Up Before Updating
+
+Before running:
+
+```bash
+cd ~/compass
+./compass update
+```
+
+make a backup.
+
+`./compass update` pulls newer Compass code, rebuilds, and restarts the stack. It does not keep a rollback copy of your old data or old app version.
+
+## Make A Backup
+
+From the installed Compass folder:
+
+```bash
+cd ~/compass
+backup_dir="$PWD/backups/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$backup_dir"
+
+./compass stop
+
+cp -p .env "$backup_dir/compass.env"
+
+docker run --rm \
+  -v compass_compass_mongo_data:/volume \
+  -v "$backup_dir":/backup \
+  alpine \
+  sh -c 'cd /volume && tar czf /backup/mongo-volume.tgz .'
+
+docker run --rm \
+  -v compass_compass_supertokens_postgres_data:/volume \
+  -v "$backup_dir":/backup \
+  alpine \
+  sh -c 'cd /volume && tar czf /backup/supertokens-postgres-volume.tgz .'
+
+./compass start
+```
+
+Keep the whole backup folder together. The `.env` file and volume archives are a set.
+
+If your volume names are different, replace the two `compass_...` volume names in the commands.
+
+## Restore A Backup
+
+Only restore onto a Compass install you are willing to replace.
+
+Set `backup_dir` to the folder you created during backup:
+
+```bash
+cd ~/compass
+backup_dir="$PWD/backups/YYYYMMDD-HHMMSS"
+
+./compass stop
+
+cp -p "$backup_dir/compass.env" .env
+
+docker run --rm \
+  -v compass_compass_mongo_data:/volume \
+  alpine \
+  sh -c 'find /volume -mindepth 1 -maxdepth 1 -exec rm -rf {} +'
+
+docker run --rm \
+  -v compass_compass_mongo_data:/volume \
+  -v "$backup_dir":/backup \
+  alpine \
+  sh -c 'cd /volume && tar xzf /backup/mongo-volume.tgz'
+
+docker run --rm \
+  -v compass_compass_supertokens_postgres_data:/volume \
+  alpine \
+  sh -c 'find /volume -mindepth 1 -maxdepth 1 -exec rm -rf {} +'
+
+docker run --rm \
+  -v compass_compass_supertokens_postgres_data:/volume \
+  -v "$backup_dir":/backup \
+  alpine \
+  sh -c 'cd /volume && tar xzf /backup/supertokens-postgres-volume.tgz'
+
+./compass start
+```
+
+If your volume names are different, replace the two `compass_...` volume names in the commands before running them.
+
+## Missing `.env` With Old Docker Volumes
+
+If Docker volumes still exist but `~/compass/.env` is missing, the installer stops.
+
+That is intentional. A fresh `.env` would contain new generated credentials, and those credentials may not match the old volumes.
+
+To keep old data, restore the matching `.env` file first.

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -1,66 +1,71 @@
-# Google Calendar
+# Add Google Calendar (optional)
 
-Google Calendar is optional for self-hosting.
+Google Calendar is optional for self-hosting. Compass works fine with email and password alone. Pick a mode based on what you actually need.
 
-Use the local Docker install without Google first unless you specifically need Google sign-in, Google import, or Google-to-Compass watch notifications.
+## The three modes
 
-## Use Compass without Google
+| Mode | What it does | What you need | Who it's for |
+| --- | --- | --- | --- |
+| **Off (default)** | Google sign-in and connect actions are hidden. Email/password signup works normally. | Nothing. | Everyone who doesn't need Google. |
+| **Local sign-in & import** | Google sign-in works. One-time Google Calendar import works. No continuous sync. | A Google Cloud OAuth client that allows `http://localhost:9080`, plus `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `~/compass/.env`. | Local installs that want Google sign-in or a one-time import. |
+| **Public watch notifications** | Google can notify Compass when calendar events change. | A public HTTPS URL Google can reach, real Google OAuth credentials, `TOKEN_GCAL_NOTIFICATION` set, and verified Google watch registration and repair on this install. | Server installs only. See [Server hosting guide](./server-guide.md). |
 
-This is the default local self-host path.
+Most local self-hosters want **Off** or **Local sign-in & import**. Continuous sync needs a public server because Google sends notifications over the public internet.
 
-The installer writes placeholder Google OAuth values so Compass can start without a Google Cloud project. Compass treats those placeholder values as not configured, so Google sign-in and Google Calendar connect actions are hidden in the normal UI.
+## Off (default)
 
-Use email/password signup. Event create, edit, and delete work without a Google connection.
+The installer writes placeholder Google OAuth values to `~/compass/.env`. Compass treats those placeholders as not configured, so Google sign-in and Google Calendar connect actions stay hidden in the UI.
 
-## Add Google sign-in and import locally
+Sign up with email and password. Event create, edit, and delete all work without a Google connection. Nothing more to do.
 
-This is an optional add-on.
+## Local sign-in & import
 
-This page documents the boundary between local OAuth/import and public webhook delivery. It is not a promise that a specific Google Cloud project is configured correctly until someone tests that project with real credentials.
+This is an optional add-on for the local install. Browser-driven flows (sign-in, one-time import) work. Watch notifications do not, because Google can't reach `localhost`.
 
-You can try Google sign-in or connect Google Calendar from a local install by adding real Google OAuth values to `~/compass/.env`, then rebuilding:
+Add real Google OAuth values to `~/compass/.env`:
+
+```bash
+GOOGLE_CLIENT_ID=<your-google-client-id>
+GOOGLE_CLIENT_SECRET=<your-google-client-secret>
+```
+
+Then rebuild so the web app picks up the new values:
 
 ```bash
 cd ~/compass
-# edit GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in .env
 ./compass rebuild
 ```
 
-The local web app runs at `http://localhost:9080`, and the backend API runs at `http://localhost:3000/api`.
+In your Google Cloud OAuth client, allow the local origin. The web OAuth flow reports the browser origin as the redirect origin, so the local install needs `http://localhost:9080` configured.
 
-The current web OAuth flow reports the browser origin as the Google redirect origin, so local OAuth setup should allow `http://localhost:9080` in the Google OAuth client configuration.
+This path doesn't make your local backend public. It's for sign-in and one-time import only.
 
-This local path is intended for Google sign-in/connect and initial import when the Google OAuth project is configured correctly. It does not make the local backend public.
+## Public watch notifications
 
-## Receive Google Calendar changes automatically
-
-Google-to-Compass watch notifications are different from browser traffic.
-
-For Google to notify Compass about changes made in Google Calendar, Google must be able to send HTTPS `POST` requests to:
+For Google to notify Compass when something changes in Google Calendar, Google must be able to send HTTPS `POST` requests to:
 
 ```text
 /api/sync/gcal/notifications
 ```
 
-The local installer does not create a public HTTPS URL. On the default local install, Compass can run without registering Google watches.
+The local installer doesn't create a public HTTPS URL, so a default local install can't receive these. You have two paths:
 
-For development testing, the backend supports `GCAL_WEBHOOK_BASEURL` as a separate public HTTPS base URL for Google webhook callbacks. Keep normal app traffic local:
+- **Run Compass on a public server.** The recommended path. See [Server hosting guide](./server-guide.md).
+- **Use a public HTTPS tunnel for webhooks only (development).** The backend supports `GCAL_WEBHOOK_BASEURL` as a separate public HTTPS base URL for Google webhook callbacks. Browser API traffic and Server-Sent Events keep using localhost:
 
-```bash
-BASEURL=http://localhost:3000/api
-GCAL_WEBHOOK_BASEURL=https://<public-https-host>/api
-```
+  ```bash
+  BASEURL=http://localhost:3000/api
+  GCAL_WEBHOOK_BASEURL=https://<public-https-host>/api
+  ```
 
-That setting is for Google webhook POSTs only. Browser API traffic and Server-Sent Events can keep using localhost.
+  This is for Google webhook POSTs only.
 
-## Before calling Google sync continuous
+Before you call continuous Google Calendar sync "working" on any self-host install, verify all of these on that specific install:
 
-Do not claim continuous Google Calendar sync for a self-host install unless the specific install has all of this working:
+- real Google OAuth credentials configured
+- backend reachable by Google over public HTTPS
+- `TOKEN_GCAL_NOTIFICATION` set
+- Google watch registration succeeds
+- watch repair and refresh behavior holds up over time
 
-- real Google OAuth credentials
-- a backend that Google can reach over public HTTPS
-- `TOKEN_GCAL_NOTIFICATION` configured when the webhook URL uses HTTPS
-- Google watch registration succeeding
-- watch repair/refresh behavior verified for that install
-
-The repo has code paths for Google watches and repair, but the local installer does not configure public HTTPS delivery or prove long-running watch maintenance for a personal self-host setup.
+The repo has the code paths for Google watches and repair. The local installer doesn't configure public HTTPS or prove long-running watch maintenance for you.

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -8,7 +8,7 @@ Use the local Docker install without Google first unless you specifically need G
 
 This is the default local self-host path.
 
-The installer writes placeholder Google OAuth values so Compass can start without a Google Cloud project. The web app treats those placeholder values as not configured, so Google sign-in and Google Calendar connect actions are hidden in the normal UI.
+The installer writes placeholder Google OAuth values so Compass can start without a Google Cloud project. Compass treats those placeholder values as not configured, so Google sign-in and Google Calendar connect actions are hidden in the normal UI.
 
 Use email/password signup. Event create, edit, and delete work without a Google connection.
 

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -1,0 +1,66 @@
+# Google Calendar
+
+Google Calendar is optional for self-hosting.
+
+Use the local Docker install without Google first unless you specifically need Google sign-in, Google import, or Google-to-Compass watch notifications.
+
+## Path 1: No Google
+
+This is the default local self-host path.
+
+The installer writes placeholder Google OAuth values so Compass can start without a Google Cloud project. The web app treats those placeholder values as not configured, so Google sign-in and Google Calendar connect actions are hidden in the normal UI.
+
+Use email/password signup. Event create, edit, and delete work without a Google connection.
+
+## Path 2: Local Google OAuth And Import
+
+This is an optional add-on.
+
+This page documents the boundary between local OAuth/import and public webhook delivery. It is not a promise that a specific Google Cloud project is configured correctly until someone tests that project with real credentials.
+
+You can try Google sign-in or connect Google Calendar from a local install by adding real Google OAuth values to `~/compass/.env`, then rebuilding:
+
+```bash
+cd ~/compass
+# edit GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in .env
+./compass rebuild
+```
+
+The local web app runs at `http://localhost:9080`, and the backend API runs at `http://localhost:3000/api`.
+
+The current web OAuth flow reports the browser origin as the Google redirect origin, so local OAuth setup should allow `http://localhost:9080` in the Google OAuth client configuration.
+
+This local path is intended for Google sign-in/connect and initial import when the Google OAuth project is configured correctly. It does not make the local backend public.
+
+## Path 3: Public HTTPS Watch Notifications
+
+Google-to-Compass watch notifications are different from browser traffic.
+
+For Google to notify Compass about changes made in Google Calendar, Google must be able to send HTTPS `POST` requests to:
+
+```text
+/api/sync/gcal/notifications
+```
+
+The local installer does not create a public HTTPS URL. On the default local install, Compass can run without registering Google watches.
+
+For development testing, the backend supports `GCAL_WEBHOOK_BASEURL` as a separate public HTTPS base URL for Google webhook callbacks. Keep normal app traffic local:
+
+```bash
+BASEURL=http://localhost:3000/api
+GCAL_WEBHOOK_BASEURL=https://<public-https-host>/api
+```
+
+That setting is for Google webhook POSTs only. Browser API traffic and Server-Sent Events can keep using localhost.
+
+## Continuous Sync Claim
+
+Do not claim continuous Google Calendar sync for a self-host install unless the specific install has all of this working:
+
+- real Google OAuth credentials
+- a backend that Google can reach over public HTTPS
+- `TOKEN_GCAL_NOTIFICATION` configured when the webhook URL uses HTTPS
+- Google watch registration succeeding
+- watch repair/refresh behavior verified for that install
+
+The repo has code paths for Google watches and repair, but the local installer does not configure public HTTPS delivery or prove long-running watch maintenance for a personal self-host setup.

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -4,7 +4,7 @@ Google Calendar is optional for self-hosting.
 
 Use the local Docker install without Google first unless you specifically need Google sign-in, Google import, or Google-to-Compass watch notifications.
 
-## Path 1: No Google
+## Use Compass without Google
 
 This is the default local self-host path.
 
@@ -12,7 +12,7 @@ The installer writes placeholder Google OAuth values so Compass can start withou
 
 Use email/password signup. Event create, edit, and delete work without a Google connection.
 
-## Path 2: Local Google OAuth And Import
+## Add Google sign-in and import locally
 
 This is an optional add-on.
 
@@ -32,7 +32,7 @@ The current web OAuth flow reports the browser origin as the Google redirect ori
 
 This local path is intended for Google sign-in/connect and initial import when the Google OAuth project is configured correctly. It does not make the local backend public.
 
-## Path 3: Public HTTPS Watch Notifications
+## Receive Google Calendar changes automatically
 
 Google-to-Compass watch notifications are different from browser traffic.
 
@@ -53,7 +53,7 @@ GCAL_WEBHOOK_BASEURL=https://<public-https-host>/api
 
 That setting is for Google webhook POSTs only. Browser API traffic and Server-Sent Events can keep using localhost.
 
-## Continuous Sync Claim
+## Before calling Google sync continuous
 
 Do not claim continuous Google Calendar sync for a self-host install unless the specific install has all of this working:
 

--- a/docs/self-hosting/local-quickstart.md
+++ b/docs/self-hosting/local-quickstart.md
@@ -1,0 +1,166 @@
+# Local Quickstart
+
+This is the recommended self-host path for one person running Compass on their own computer.
+
+It is local-only Docker self-hosting. It does not publish Compass to the internet and it does not require Google Calendar.
+
+## Before You Start
+
+You need:
+
+- a Mac or Linux machine
+- Docker Desktop or Docker Engine with Docker Compose
+- a terminal
+- internet access to download Compass from GitHub
+
+Make sure Docker is running before you start.
+
+## Install
+
+Run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
+```
+
+If you want to inspect the installer first:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh
+less install.sh
+sh install.sh
+```
+
+The installer will:
+
+1. create `~/compass`
+2. download the Compass app into `~/compass/app`
+3. write `~/compass/.env` with local defaults and generated secrets
+4. copy the helper command to `~/compass/compass`
+5. build and start Compass with Docker Compose
+6. wait for the backend health check
+7. try to open Compass in your browser
+
+When it finishes, open:
+
+- Web app: [http://localhost:9080](http://localhost:9080)
+- Backend API: [http://localhost:3000/api](http://localhost:3000/api)
+
+The backend health check is:
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+## What Runs
+
+The Docker Compose stack runs:
+
+| Service | Reachable from your computer? | Purpose |
+| --- | --- | --- |
+| web | Yes, `http://localhost:9080` | Compass in your browser |
+| backend | Yes, `http://localhost:3000/api` | Compass API |
+| mongo | No, Docker network only | Signed-in Compass event data |
+| supertokens | No, Docker network only | Signup, login, and sessions |
+| supertokens-db | No, Docker network only | SuperTokens Postgres data |
+
+The compose file binds the web and backend ports to `127.0.0.1`, so this path is for local use on the same computer.
+
+## Sign In Without Google
+
+Google is optional.
+
+The local installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup. Use email/password signup for the normal local self-host path.
+
+After signup, event data is stored in the Mongo Docker volume. Tasks still live in your browser's IndexedDB.
+
+## Manage Compass
+
+Run helper commands from `~/compass`:
+
+```bash
+cd ~/compass
+./compass status
+```
+
+Commands:
+
+| Command | What it does |
+| --- | --- |
+| `./compass start` | Start Compass. |
+| `./compass stop` | Stop Compass without deleting data. |
+| `./compass restart` | Stop and start Compass. |
+| `./compass rebuild` | Rebuild images, then start Compass. |
+| `./compass logs` | Follow container logs. |
+| `./compass status` | Show container status. |
+| `./compass update` | Pull newer Compass code, rebuild, and restart. |
+| `./compass open` | Open Compass in your browser. |
+
+## Keep `~/compass/.env`
+
+Do not delete `~/compass/.env` unless you are intentionally starting over.
+
+It contains generated database passwords and tokens that match the existing Docker volumes. If the volumes remain but the `.env` file is gone, a new install can create different credentials and fail to read the old data.
+
+Before `./compass update`, follow [Backups And Restore](./backups-and-restore.md).
+
+`./compass update` is not a rollback tool.
+
+## Common Problems
+
+### Docker Is Not Running
+
+Start Docker, wait until it is ready, then rerun the installer or helper command.
+
+### Port `9080` Or `3000` Is Already In Use
+
+Compass needs:
+
+- `9080` for the web app
+- `3000` for the backend API
+
+Stop the other process using that port, then rerun the installer.
+
+### Compass Is Already Installed
+
+Use the installed helper:
+
+```bash
+cd ~/compass
+./compass status
+./compass restart
+```
+
+Do not run `self-host/compass` directly from the repo. That file is only the template copied into `~/compass`.
+
+### Docker Volumes Exist But `~/compass/.env` Is Missing
+
+The installer stops in this case to protect old data.
+
+Choose one path:
+
+- restore the matching `~/compass/.env`, then rerun the installer
+- start a separate install with a different `COMPASS_HOME` and `COMPOSE_PROJECT_NAME`
+- delete the old Docker volumes only after confirming you do not need them
+
+Example separate install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | env COMPASS_HOME="$HOME/compass-new" COMPOSE_PROJECT_NAME=compass_new sh
+```
+
+### Google Does Not Appear
+
+That is expected in the default local install. Google Calendar is an optional add-on. See [Google Calendar](./google-calendar.md).
+
+## What This Path Does Not Do
+
+The local installer does not set up:
+
+- a public server
+- HTTPS certificates
+- a reverse proxy
+- automatic backups
+- restore automation
+- update rollback
+- continuous Google Calendar watch notifications

--- a/docs/self-hosting/local-quickstart.md
+++ b/docs/self-hosting/local-quickstart.md
@@ -1,29 +1,38 @@
-# Local Quickstart
+# Run Compass on your computer
 
 This is the recommended self-host path for one person running Compass on their own computer.
 
-It is local-only Docker self-hosting. It does not publish Compass to the internet and it does not require Google Calendar.
+## What to expect
 
-## Before You Start
+About 5 to 10 minutes, mostly waiting for Docker to download images. The installer creates a single folder at `~/compass`, generates secrets, and starts a Docker Compose stack. Nothing else on your machine is touched.
+
+When it finishes, you'll have:
+
+- the Compass web app at [http://localhost:9080](http://localhost:9080)
+- the Compass API at [http://localhost:3000/api](http://localhost:3000/api)
+- five Docker containers running locally (web, backend, Mongo, SuperTokens, Postgres)
+- a `~/compass` folder with your `.env`, the `./compass` helper script, and the app source
+
+The install is reversible. To uninstall, stop the stack, delete the Docker volumes, and delete `~/compass`.
+
+## Before you start
 
 You need:
 
 - a Mac or Linux machine
-- Docker Desktop or Docker Engine with Docker Compose
+- Docker Desktop or Docker Engine with Docker Compose, **running**
 - a terminal
-- internet access to download Compass from GitHub
-
-Make sure Docker is running before you start.
+- internet access to pull Compass from GitHub
 
 ## Install
 
-Run:
+Run the installer:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
 ```
 
-If you want to inspect the installer first:
+If you'd rather inspect it first:
 
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh
@@ -31,48 +40,43 @@ less install.sh
 sh install.sh
 ```
 
-The installer will:
+The installer:
 
-1. create `~/compass`
-2. download the Compass app into `~/compass/app`
-3. write `~/compass/.env` with local defaults and generated secrets
-4. copy the helper command to `~/compass/compass`
-5. build and start Compass with Docker Compose
-6. wait for the backend health check
-7. try to open Compass in your browser
+1. creates `~/compass`
+2. downloads the Compass app into `~/compass/app`
+3. writes `~/compass/.env` with local defaults and generated secrets
+4. copies the helper command to `~/compass/compass`
+5. builds and starts Compass with Docker Compose
+6. waits for the backend health check
+7. tries to open Compass in your browser
 
-When it finishes, open:
+When it's done, open [http://localhost:9080](http://localhost:9080).
 
-- Web app: [http://localhost:9080](http://localhost:9080)
-- Backend API: [http://localhost:3000/api](http://localhost:3000/api)
-
-The backend health check is:
+If you want to confirm the backend is up:
 
 ```bash
 curl http://localhost:3000/api/health
 ```
 
-## What Runs
-
-The Docker Compose stack runs:
+## What runs
 
 | Service | Reachable from your computer? | Purpose |
 | --- | --- | --- |
 | web | Yes, `http://localhost:9080` | Compass in your browser |
 | backend | Yes, `http://localhost:3000/api` | Compass API |
-| mongo | No, Docker network only | Signed-in Compass event data |
-| supertokens | No, Docker network only | Signup, login, and sessions |
+| mongo | No, Docker network only | Signed-in event data |
+| supertokens | No, Docker network only | Signup, login, sessions |
 | supertokens-db | No, Docker network only | SuperTokens Postgres data |
 
-The compose file binds the web and backend ports to `127.0.0.1`, so this path is for local use on the same computer.
+The compose file binds the web and backend ports to `127.0.0.1`. This path is for the same computer only.
 
-## Sign In Without Google
+## Sign in without Google
 
-Google is optional.
+Google is optional. The installer writes placeholder Google OAuth values so Compass can start without a Google Cloud project, and Compass treats those placeholders as "not configured" — Google sign-in and connect actions stay hidden.
 
-The local installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup. Use email/password signup for the normal local self-host path.
+Use email and password. After signup, your events live in the Mongo Docker volume. Tasks live in your browser's IndexedDB.
 
-After signup, event data is stored in the Mongo Docker volume. Tasks still live in your browser's IndexedDB.
+If you want to add Google later, see [Google Calendar](./google-calendar.md).
 
 ## Manage Compass
 
@@ -82,8 +86,6 @@ Run helper commands from `~/compass`:
 cd ~/compass
 ./compass status
 ```
-
-Commands:
 
 | Command | What it does |
 | --- | --- |
@@ -96,34 +98,39 @@ Commands:
 | `./compass update` | Pull newer Compass code, rebuild, and restart. |
 | `./compass open` | Open Compass in your browser. |
 
-## Keep `~/compass/.env`
+`./compass logs` is usually the fastest way to find out why something isn't behaving.
 
-Do not delete `~/compass/.env` unless you are intentionally starting over.
+## Day-to-day lifecycle
 
-It contains generated database passwords and tokens that match the existing Docker volumes. If the volumes remain but the `.env` file is gone, a new install can create different credentials and fail to read the old data.
+**Do I need to leave my computer on?** Yes. Compass runs locally. If your machine sleeps or shuts down, Compass pauses or stops with it. When your machine wakes up, Docker may bring the containers back. If Compass is not running, use `./compass start`.
 
-Before `./compass update`, follow [Backups And Restore](./backups-and-restore.md).
+**Does Compass start when I reboot?** Only if Docker is set to start at login (the default for Docker Desktop) and Docker has restarted the containers. If not, run `./compass start`.
 
-`./compass update` is not a rollback tool.
+**Where is my data?** Events are in the Mongo Docker volume (`compass_compass_mongo_data`). Auth is in the Postgres volume (`compass_compass_supertokens_postgres_data`). Tasks are in your browser's IndexedDB.
 
-## Common Problems
+**How do I update?** Back up first (see below), then `./compass update`. There's no rollback.
 
-### Docker Is Not Running
+**How do I uninstall?** `./compass stop`, then `docker volume rm compass_compass_mongo_data compass_compass_supertokens_postgres_data`, then `rm -rf ~/compass`. This wipes your data. Make a backup first if you want to keep it.
 
-Start Docker, wait until it is ready, then rerun the installer or helper command.
+## Before updating
 
-### Port `9080` Or `3000` Is Already In Use
+`./compass update` rebuilds Compass with newer code. It is not a rollback tool, and it does not back up your data. Back up `~/compass/.env`, the Mongo volume, and the SuperTokens Postgres volume **together** before you run it. See [Backups and restore](./backups-and-restore.md).
 
-Compass needs:
+The `.env` warning matters: see [the warning on the landing page](../self-hosting.md#the-one-warning-that-matters) if you haven't already.
 
-- `9080` for the web app
-- `3000` for the backend API
+## Troubleshooting
 
-Stop the other process using that port, then rerun the installer.
+### Docker is not running
 
-### Compass Is Already Installed
+Start Docker, wait until it reports ready, then rerun the installer or helper command.
 
-Use the installed helper:
+### Port `9080` or `3000` is already in use
+
+Compass needs `9080` for the web app and `3000` for the backend API. Stop the other process using that port, then rerun the installer.
+
+### Compass is already installed
+
+Use the installed helper, not the repo template:
 
 ```bash
 cd ~/compass
@@ -131,17 +138,17 @@ cd ~/compass
 ./compass restart
 ```
 
-Do not run `self-host/compass` directly from the repo. That file is only the template copied into `~/compass`.
+There are two `compass` helper scripts. `self-host/compass` in this repo is the template the installer copies. `~/compass/compass` is the one you run day to day. Don't run the repo copy directly.
 
-### Docker Volumes Exist But `~/compass/.env` Is Missing
+### Docker volumes exist but `~/compass/.env` is missing
 
-The installer stops in this case to protect old data.
+The installer stops in this case to protect old data. A fresh `.env` would have new generated credentials that don't match the old volumes.
 
 Choose one path:
 
 - restore the matching `~/compass/.env`, then rerun the installer
 - start a separate install with a different `COMPASS_HOME` and `COMPOSE_PROJECT_NAME`
-- delete the old Docker volumes only after confirming you do not need them
+- delete the old Docker volumes only after confirming you don't need them
 
 Example separate install:
 
@@ -149,18 +156,28 @@ Example separate install:
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | env COMPASS_HOME="$HOME/compass-new" COMPOSE_PROJECT_NAME=compass_new sh
 ```
 
-### Google Does Not Appear
+### `./compass update` does not work
 
-That is expected in the default local install. Google Calendar is an optional add-on. See [Google Calendar](./google-calendar.md).
+`./compass update` only works when the installer used Git to download Compass. If Git wasn't available at install time, the installer fell back to a downloaded archive. Install Git, download the installer, and run `sh install.sh` again to refresh.
 
-## What This Path Does Not Do
+### Changes to `~/compass/.env` aren't showing up
 
-The local installer does not set up:
+Some values are baked into the web app at build time. After changing any of these, run `./compass rebuild` (a plain `./compass restart` won't pick them up):
 
-- a public server
-- HTTPS certificates
-- a reverse proxy
-- automatic backups
-- restore automation
-- update rollback
-- continuous Google Calendar watch notifications
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `FRONTEND_URL`
+- `BASEURL`
+
+### Compass starts but the browser doesn't open
+
+Open [http://localhost:9080](http://localhost:9080) yourself, or run:
+
+```bash
+cd ~/compass
+./compass open
+```
+
+### Google sign-in or Google Calendar doesn't work locally
+
+Expected on the default install. The placeholder OAuth values are treated as "not configured." See [Google Calendar](./google-calendar.md) for how to add real credentials and what limits the local install has.

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -8,12 +8,27 @@ Server hosting should be possible with a small set of configuration changes, but
 
 ## Current Blocker
 
-The backend SuperTokens setup currently hardcodes localhost domains in `packages/backend/src/common/middleware/supertokens.middleware.ts`:
+The regular backend CORS middleware already reads configured origins from `CORS`. That is not the main server-hosting blocker.
+
+The blocker is the SuperTokens setup in `packages/backend/src/common/middleware/supertokens.middleware.ts`. It currently hardcodes localhost domains:
 
 - API domain: `http://localhost:3000`
 - website domain: `http://localhost:9080`
 
-Until that behavior is made configurable and verified with a real public domain, these docs should not claim that public-domain signup, login, or Google auth work on a server.
+The SuperTokens CORS helper also hardcodes the local web origin.
+
+That means setting `BASEURL=https://compass.example.com/api`, `FRONTEND_URL=https://compass.example.com`, and `CORS=https://compass.example.com` is not enough yet. The app may serve, but auth redirects, cookies, CORS, password reset links, or session behavior can fail.
+
+A likely first fix is to derive the SuperTokens domains from the configured URLs:
+
+```ts
+const apiDomain = new URL(ENV.BASEURL).origin;
+const websiteDomain = new URL(ENV.FRONTEND_URL).origin;
+```
+
+Then the SuperTokens CORS helper should use the configured allowed origins instead of one hardcoded localhost origin.
+
+Until that behavior is implemented and verified with a real public domain, these docs should not claim that public-domain signup, login, or Google auth work on a server.
 
 ## Target Shape, Not Yet Verified
 
@@ -26,6 +41,13 @@ If public server hosting is supported later, use one coherent path instead of se
 - proxy `/api/*` to the backend
 - proxy all other paths to the web app
 - keep MongoDB, SuperTokens Core, and Postgres private to the server or Docker network
+
+Start with one domain first:
+
+- Frontend: `https://compass.example.com`
+- Backend: `https://compass.example.com/api`
+
+That avoids extra cross-site cookie complexity. A separate domain such as `https://api.compass.example.com` can be supported later, but it is a harder beginner path.
 
 That path still needs implementation and verification before it becomes a beginner guide.
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -1,55 +1,174 @@
-# Server Hosting Status
+# Server Hosting Guide
 
-Compass does not yet have a verified beginner server-hosting guide.
+This guide describes the recommended first server setup for one person hosting Compass on a small VPS.
 
-The local Docker installer is still the supported path. It runs Compass on the same machine at `localhost` and is designed for personal local use.
+Use this when you are comfortable SSHing into a server and checking each step yourself. If you want the lowest-risk path, use [Local Quickstart](./local-quickstart.md) instead.
 
-Server authentication should now be configurable, but server hosting should not be documented as a copy-paste setup until it has been tested on a real HTTPS domain.
+This server path has not yet been proven as a fully beginner-friendly production runbook. The guide keeps to one setup and calls out what still needs careful testing.
 
-## Current Status
+## Recommended Shape
 
-The backend CORS middleware reads configured origins from `CORS`.
+Use one public domain:
 
-The SuperTokens setup in `packages/backend/src/common/middleware/supertokens.middleware.ts` now derives its domains from the configured URLs:
+- Frontend: `https://compass.example.com`
+- Backend API: `https://compass.example.com/api`
 
-- API domain: origin of `BASEURL`
-- website domain: origin of `FRONTEND_URL`
+Run Compass with Docker Compose on the server, keep the Compass containers bound to `127.0.0.1`, and put Caddy in front of them for HTTPS.
 
-The SuperTokens CORS helper also uses the configured `CORS` origins, with a fallback to the `FRONTEND_URL` origin.
+This avoids the extra cookie and browser complexity of a separate API domain such as `https://api.compass.example.com`. That can be supported later, but it is a harder beginner path.
 
-For a one-domain server setup, the expected values would look like:
+## What You Need
+
+- an Ubuntu VPS
+- Docker and Docker Compose on the server
+- a domain name pointed at the server
+- Caddy for HTTPS reverse proxying
+- SSH access to the server
+
+The examples below use `compass.example.com`. Replace it with your real domain.
+
+## Install Compass On The Server
+
+SSH into the server, make sure Docker is running, then install Compass:
 
 ```bash
-BASEURL=https://compass.example.com/api
+curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
+```
+
+The installer creates `~/compass`, writes `~/compass/.env`, and starts the local Docker stack.
+
+By default, the stack listens only on the server itself:
+
+- web: `127.0.0.1:9080`
+- backend: `127.0.0.1:3000`
+
+That is good for server hosting. Caddy can reach those local ports, but the database containers are not exposed to the public internet.
+
+## Configure Public URLs
+
+Edit the generated env file:
+
+```bash
+cd ~/compass
+nano .env
+```
+
+Set these values:
+
+```bash
 FRONTEND_URL=https://compass.example.com
+BASEURL=https://compass.example.com/api
 CORS=https://compass.example.com
 ```
 
-That removes the known localhost-only auth configuration issue, but it has not been verified end-to-end on a real public domain yet. Until that happens, these docs should not claim that public-domain signup, login, password reset, sessions, or Google auth work on a server.
+Leave `WEB_PORT=9080` and `PORT=3000` unless you know you need different local ports.
 
-## Target Shape, Not Yet Verified
+After changing `.env`, rebuild Compass so the web app receives the new backend URL:
 
-If public server hosting is supported later, use one coherent path instead of several half-documented options:
+```bash
+./compass rebuild
+```
 
-- Ubuntu VPS
-- Docker Compose
-- Caddy for HTTPS
-- one public domain, for example `https://compass.example.com`
-- proxy `/api/*` to the backend
-- proxy all other paths to the web app
-- keep MongoDB, SuperTokens Core, and Postgres private to the server or Docker network
+## Configure Caddy
 
-Start with one domain first:
+Put Caddy on the same server as Compass and proxy one domain to the two local Compass ports.
 
-- Frontend: `https://compass.example.com`
-- Backend: `https://compass.example.com/api`
+Example Caddyfile:
 
-That avoids extra cross-site cookie complexity. A separate domain such as `https://api.compass.example.com` can be supported later, but it is a harder beginner path.
+```caddyfile
+compass.example.com {
+	handle /api/* {
+		reverse_proxy 127.0.0.1:3000
+	}
 
-That path still needs implementation and verification before it becomes a beginner guide.
+	handle {
+		reverse_proxy 127.0.0.1:9080
+	}
+}
+```
 
-## Do Not Use The Local Installer As A Public Server Installer
+Reload Caddy after changing its config.
 
-The local installer binds web and backend ports to `127.0.0.1`. That is good for personal local use, but it is not a public server setup.
+Then check:
 
-Avoid exposing MongoDB, SuperTokens, or Postgres to the public internet. A safe server setup should keep those services private and expose only the web app and API through HTTPS.
+```bash
+curl https://compass.example.com/api/health
+```
+
+A healthy backend returns a JSON response with `"status":"ok"`.
+
+## Sign In And Test The Basics
+
+Open `https://compass.example.com` in your browser.
+
+Test the password-only path first:
+
+1. create an account with email/password
+2. sign out
+3. sign back in
+4. create an event
+5. edit the event
+6. delete the event
+7. restart Compass with `./compass restart`
+8. sign in again and confirm events are still there
+
+Do this before adding Google Calendar. It keeps the first server test focused on Compass, auth, and storage.
+
+## Google Calendar
+
+Google Calendar is optional.
+
+If you want Google sign-in or Google Calendar connect, add real Google OAuth values to `~/compass/.env` and rebuild:
+
+```bash
+GOOGLE_CLIENT_ID=<your-google-client-id>
+GOOGLE_CLIENT_SECRET=<your-google-client-secret>
+TOKEN_GCAL_NOTIFICATION=<long-random-secret>
+```
+
+Your Google Cloud OAuth app must allow the public Compass domain. For the one-domain setup, use:
+
+- authorized JavaScript origin: `https://compass.example.com`
+- authorized redirect URI: `https://compass.example.com`
+
+Google-to-Compass watch notifications need Google to reach the backend over public HTTPS. With this server guide, that means `https://compass.example.com/api`.
+
+Do not claim continuous Google Calendar sync is working until you have tested Google connect, import, webhook delivery, and watch renewal behavior on your server.
+
+## Backups
+
+Before updating or experimenting with server config, back up:
+
+- `~/compass/.env`
+- the Mongo Docker volume
+- the SuperTokens Postgres Docker volume
+
+Use [Backups And Restore](./backups-and-restore.md).
+
+Docker backups do not include browser IndexedDB data, including tasks and anonymous or pre-signup local data.
+
+## Updating
+
+From the installed folder:
+
+```bash
+cd ~/compass
+./compass update
+```
+
+Back up first. `./compass update` rebuilds Compass; it is not a rollback tool.
+
+## Limits Of This Guide
+
+This guide gives one coherent server shape, but it is still not a fully verified beginner production runbook.
+
+Known limits:
+
+- HTTPS and Caddy setup are outside the Compass installer.
+- Backups are manual.
+- Restore is manual.
+- Rollback is manual.
+- Google Calendar continuous sync still needs server-specific verification.
+- A separate API domain is not the recommended first path.
+
+Avoid exposing MongoDB, SuperTokens, or Postgres to the public internet. A safe server setup keeps those services private and exposes only the web app and API through HTTPS.

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -1,52 +1,62 @@
-# Server Hosting Guide
+# Run Compass on a server
 
-This guide describes the recommended first server setup for one person hosting Compass on a small VPS.
+This guide describes the recommended first server setup for one person hosting Compass on a small VPS. One public domain, Compass on `127.0.0.1`, Caddy in front for HTTPS.
 
-Use this when you are comfortable SSHing into a server and checking each step yourself. If you only want Compass on your own computer, use [Local Quickstart](./local-quickstart.md) instead.
+If you only want Compass on your own computer, use [Local quickstart](./local-quickstart.md) instead.
 
-## Recommended Shape
+## Before you start
 
-Use one public domain:
+This path assumes you're comfortable with:
+
+- SSH and editing files on a remote Linux machine
+- DNS records (pointing a domain at a server's IP)
+- installing Docker on Ubuntu
+- editing config files like `~/compass/.env` and a Caddyfile
+
+Plan for **30 to 60 minutes** end to end, mostly waiting on DNS propagation, image pulls, and Caddy's first certificate fetch.
+
+You'll need:
+
+- an Ubuntu VPS with Docker and Docker Compose installed
+- a domain name pointed at the server's public IP
+- Caddy installed on the same server
+- SSH access
+
+The examples use `compass.example.com`. Replace it with your real domain everywhere.
+
+## The shape
+
+One public domain, two paths:
 
 - Frontend: `https://compass.example.com`
 - Backend API: `https://compass.example.com/api`
 
-Run Compass with Docker Compose on the server, keep the Compass containers bound to `127.0.0.1`, and put Caddy in front of them for HTTPS.
+Compass binds to `127.0.0.1:9080` and `127.0.0.1:3000` on the server. Caddy proxies the public domain to those local ports and handles HTTPS automatically.
 
-This avoids the extra cookie and browser complexity of a separate API domain such as `https://api.compass.example.com`. That can be supported later, but it is a harder beginner path.
+A separate API domain like `https://api.compass.example.com` may be possible, but it adds cookie and CORS complexity. This guide uses one domain for the first server install.
 
-## What You Need
+## Steps in order
 
-- an Ubuntu VPS
-- Docker and Docker Compose on the server
-- a domain name pointed at the server
-- Caddy for HTTPS reverse proxying
-- SSH access to the server
+Order matters. The helper script's health check uses `BASEURL`, so set up Caddy **before** changing `BASEURL` to your public URL. Otherwise the rebuild fails its health check against an HTTPS URL that isn't routed yet.
 
-The examples below use `compass.example.com`. Replace it with your real domain.
+1. SSH into the server and install Compass with the local installer.
+2. Configure Caddy to proxy `compass.example.com` to `127.0.0.1:9080` and `/api/*` to `127.0.0.1:3000`.
+3. Verify Caddy can reach the local backend over HTTPS.
+4. Edit `~/compass/.env` to use your public URLs, then `./compass rebuild`.
+5. Sign in over HTTPS and run the basic tests below.
+6. (Optional) Add Google Calendar.
 
-## Install Compass On The Server
-
-SSH into the server, make sure Docker is running, then install Compass:
+## 1. Install Compass on the server
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
 ```
 
-The installer creates `~/compass`, writes `~/compass/.env`, and starts the local Docker stack.
+The installer creates `~/compass`, writes `~/compass/.env`, and starts the local Docker stack on `127.0.0.1:9080` (web) and `127.0.0.1:3000` (backend). The database containers stay on Docker's internal network and aren't exposed publicly.
 
-By default, the stack listens only on the server itself:
+## 2. Configure Caddy
 
-- web: `127.0.0.1:9080`
-- backend: `127.0.0.1:3000`
-
-That is good for server hosting. Caddy can reach those local ports, but the database containers are not exposed to the public internet.
-
-## Configure Caddy
-
-Put Caddy on the same server as Compass and proxy one domain to the two local Compass ports.
-
-Example Caddyfile:
+Put Caddy on the same server as Compass. Example Caddyfile:
 
 ```caddyfile
 compass.example.com {
@@ -60,28 +70,28 @@ compass.example.com {
 }
 ```
 
-Reload Caddy after changing its config.
+Reload Caddy after saving.
 
-Then check that Caddy can reach the local backend:
+## 3. Verify Caddy can reach the backend
 
 ```bash
 curl -f https://compass.example.com/api/health
 ```
 
-A healthy backend returns a JSON response with `"status":"ok"`.
+A healthy backend returns JSON with `"status":"ok"`. If this fails, Caddy isn't routing to the backend yet. Fix that before moving on.
 
-## Configure HTTPS before rebuilding with public URLs
+## 4. Switch Compass to your public URLs
 
-The helper script uses `BASEURL` for its backend health check. Because of that, set up Caddy before changing `BASEURL` to your public HTTPS URL.
+> **Warning.** Don't change `BASEURL` until step 3 succeeds. The helper script uses `BASEURL` for its own health check during rebuild. If `BASEURL` points at an HTTPS URL Caddy can't serve yet, the rebuild fails.
 
-After Caddy is working, edit the generated env file:
+Edit the env file:
 
 ```bash
 cd ~/compass
 nano .env
 ```
 
-Set these values:
+Set:
 
 ```bash
 FRONTEND_URL=https://compass.example.com
@@ -89,93 +99,60 @@ BASEURL=https://compass.example.com/api
 CORS=https://compass.example.com
 ```
 
-Leave `WEB_PORT=9080` and `PORT=3000` unless you know you need different local ports.
+Leave `WEB_PORT=9080` and `PORT=3000` unless you have a specific reason to change them.
 
-After changing `.env`, rebuild Compass so the web app receives the new backend URL:
+Rebuild so the web app receives the new backend URL:
 
 ```bash
 cd ~/compass
 ./compass rebuild
 ```
 
-If you need the helper to check the local backend directly while `BASEURL` stays public, add this optional value to `~/compass/.env`:
+> **Tip.** If you ever need the helper to check the local backend directly while `BASEURL` stays public, add `COMPASS_HEALTH_URL=http://127.0.0.1:3000/api/health` to `~/compass/.env`. Most one-domain installs don't need this once Caddy is working.
 
-```bash
-COMPASS_HEALTH_URL=http://127.0.0.1:3000/api/health
-```
+## 5. Sign in and test the basics
 
-Most one-domain installs should not need that override once Caddy is working.
+Open `https://compass.example.com` in a browser. Run the password-only path first, before adding Google:
 
-## Sign In And Test The Basics
-
-Open `https://compass.example.com` in your browser.
-
-Test the password-only path first:
-
-1. create an account with email/password
+1. create an account with email and password
 2. sign out
 3. sign back in
 4. create an event
 5. edit the event
 6. delete the event
-7. restart Compass with `./compass restart`
-8. sign in again and confirm events are still there
+7. `./compass restart`
+8. sign in again and confirm the events are still there
 
-Do this before adding Google Calendar. It keeps the first server test focused on Compass, auth, and storage.
+Doing this before Google keeps the first server test focused on Compass, auth, and storage.
 
-## Google Calendar
+## 6. Add Google Calendar (optional)
 
-Google Calendar is optional.
+If you want Google sign-in or Google Calendar watch notifications, see [Google Calendar — Public watch notifications](./google-calendar.md#public-watch-notifications). The short version:
 
-If you want Google sign-in or Google Calendar connect, add real Google OAuth values to `~/compass/.env` and rebuild:
+- add `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `TOKEN_GCAL_NOTIFICATION` to `~/compass/.env`
+- in your Google OAuth client, set the authorized JavaScript origin and redirect URI to `https://compass.example.com`
+- `./compass rebuild`
 
-```bash
-GOOGLE_CLIENT_ID=<your-google-client-id>
-GOOGLE_CLIENT_SECRET=<your-google-client-secret>
-TOKEN_GCAL_NOTIFICATION=<long-random-secret>
-```
-
-Your Google Cloud OAuth app must allow the public Compass domain. For the one-domain setup, use:
-
-- authorized JavaScript origin: `https://compass.example.com`
-- authorized redirect URI: `https://compass.example.com`
-
-Google-to-Compass watch notifications need Google to reach the backend over public HTTPS. With this server guide, that means `https://compass.example.com/api`.
-
-Before relying on continuous Google Calendar sync, test Google connect, import, webhook delivery, and watch renewal behavior on your server.
-
-## Backups
-
-Before updating or experimenting with server config, back up:
-
-- `~/compass/.env`
-- the Mongo Docker volume
-- the SuperTokens Postgres Docker volume
-
-Use [Backups And Restore](./backups-and-restore.md).
-
-Docker backups do not include browser IndexedDB data, including tasks and anonymous or pre-signup local data.
+Test Google connect, import, webhook delivery, and watch renewal on this install before relying on continuous sync.
 
 ## Updating
 
-From the installed folder:
+> **Warning: back up before every update.** `./compass update` rebuilds with newer code. There is no rollback. Back up `~/compass/.env`, the Mongo volume, and the SuperTokens Postgres volume **together**. See [Backups and restore](./backups-and-restore.md).
+
+Then:
 
 ```bash
 cd ~/compass
 ./compass update
 ```
 
-Back up first. `./compass update` rebuilds Compass; it is not a rollback tool.
+## What this guide leaves to you
 
-## What This Guide Leaves To You
-
-This guide gives one coherent server shape. It does not automate everything a production service usually needs.
+This guide gives one coherent server shape. It doesn't automate everything a production service usually needs.
 
 - HTTPS and Caddy setup are outside the Compass installer.
-- Backups are manual.
-- Restore is manual.
-- Rollback is manual.
+- Backups, restore, and rollback are manual.
 - Google Calendar continuous sync needs server-specific setup and testing.
 - A separate API domain is not the recommended first path.
 
-Avoid exposing MongoDB, SuperTokens, or Postgres to the public internet. A safe server setup keeps those services private and exposes only the web app and API through HTTPS.
+> **Warning.** Don't expose MongoDB, SuperTokens, or Postgres to the public internet. A safe server keeps those private and exposes only the web app and API through HTTPS.

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -44,31 +44,6 @@ By default, the stack listens only on the server itself:
 
 That is good for server hosting. Caddy can reach those local ports, but the database containers are not exposed to the public internet.
 
-## Configure Public URLs
-
-Edit the generated env file:
-
-```bash
-cd ~/compass
-nano .env
-```
-
-Set these values:
-
-```bash
-FRONTEND_URL=https://compass.example.com
-BASEURL=https://compass.example.com/api
-CORS=https://compass.example.com
-```
-
-Leave `WEB_PORT=9080` and `PORT=3000` unless you know you need different local ports.
-
-After changing `.env`, rebuild Compass so the web app receives the new backend URL:
-
-```bash
-./compass rebuild
-```
-
 ## Configure Caddy
 
 Put Caddy on the same server as Compass and proxy one domain to the two local Compass ports.
@@ -89,13 +64,49 @@ compass.example.com {
 
 Reload Caddy after changing its config.
 
-Then check:
+Then check that Caddy can reach the local backend:
 
 ```bash
-curl https://compass.example.com/api/health
+curl -f https://compass.example.com/api/health
 ```
 
 A healthy backend returns a JSON response with `"status":"ok"`.
+
+## Configure HTTPS before rebuilding with public URLs
+
+The helper script uses `BASEURL` for its backend health check. Because of that, set up Caddy before changing `BASEURL` to your public HTTPS URL.
+
+After Caddy is working, edit the generated env file:
+
+```bash
+cd ~/compass
+nano .env
+```
+
+Set these values:
+
+```bash
+FRONTEND_URL=https://compass.example.com
+BASEURL=https://compass.example.com/api
+CORS=https://compass.example.com
+```
+
+Leave `WEB_PORT=9080` and `PORT=3000` unless you know you need different local ports.
+
+After changing `.env`, rebuild Compass so the web app receives the new backend URL:
+
+```bash
+cd ~/compass
+./compass rebuild
+```
+
+If you need the helper to check the local backend directly while `BASEURL` stays public, add this optional value to `~/compass/.env`:
+
+```bash
+COMPASS_HEALTH_URL=http://127.0.0.1:3000/api/health
+```
+
+Most one-domain installs should not need that override once Caddy is working.
 
 ## Sign In And Test The Basics
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -1,0 +1,34 @@
+# Server Hosting Status
+
+This is not a supported beginner server-hosting guide yet.
+
+The path supported by these docs is local Docker self-hosting on one computer. Public server hosting needs more runtime work and testing before the docs should present it as a copy-paste path.
+
+## Current Blocker
+
+The backend SuperTokens setup currently hardcodes localhost domains in `packages/backend/src/common/middleware/supertokens.middleware.ts`:
+
+- API domain: `http://localhost:3000`
+- website domain: `http://localhost:9080`
+
+Until that behavior is made configurable and verified with a real public domain, these docs should not claim that public-domain signup, login, or Google auth work on a server.
+
+## Target Shape, Not Yet Verified
+
+If public server hosting is supported later, use one coherent path instead of several half-documented options:
+
+- Ubuntu VPS
+- Docker Compose
+- Caddy for HTTPS
+- one public domain, for example `https://compass.example.com`
+- proxy `/api/*` to the backend
+- proxy all other paths to the web app
+- keep MongoDB, SuperTokens Core, and Postgres private to the server or Docker network
+
+That path still needs implementation and verification before it becomes a beginner guide.
+
+## Do Not Use The Local Installer As A Public Server Installer
+
+The local installer binds web and backend ports to `127.0.0.1`. That is good for personal local use, but it is not a public server setup.
+
+Do not work around that by exposing Docker database ports or copying random reverse-proxy snippets into production. The public server path needs explicit auth-domain, HTTPS, proxy, backup, and restore testing first.

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -1,8 +1,10 @@
 # Server Hosting Status
 
-This is not a supported beginner server-hosting guide yet.
+Compass does not yet have a verified beginner server-hosting guide.
 
-The path supported by these docs is local Docker self-hosting on one computer. Public server hosting needs more runtime work and testing before the docs should present it as a copy-paste path.
+The local Docker installer is still the supported path. It runs Compass on the same machine at `localhost` and is designed for personal local use.
+
+Server hosting should be possible with a small set of configuration changes, but it should not be documented as a copy-paste setup until authentication has been tested on a real HTTPS domain.
 
 ## Current Blocker
 
@@ -31,4 +33,4 @@ That path still needs implementation and verification before it becomes a beginn
 
 The local installer binds web and backend ports to `127.0.0.1`. That is good for personal local use, but it is not a public server setup.
 
-Do not work around that by exposing Docker database ports or copying random reverse-proxy snippets into production. The public server path needs explicit auth-domain, HTTPS, proxy, backup, and restore testing first.
+Avoid exposing MongoDB, SuperTokens, or Postgres to the public internet. A safe server setup should keep those services private and expose only the web app and API through HTTPS.

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -4,31 +4,28 @@ Compass does not yet have a verified beginner server-hosting guide.
 
 The local Docker installer is still the supported path. It runs Compass on the same machine at `localhost` and is designed for personal local use.
 
-Server hosting should be possible with a small set of configuration changes, but it should not be documented as a copy-paste setup until authentication has been tested on a real HTTPS domain.
+Server authentication should now be configurable, but server hosting should not be documented as a copy-paste setup until it has been tested on a real HTTPS domain.
 
-## Current Blocker
+## Current Status
 
-The regular backend CORS middleware already reads configured origins from `CORS`. That is not the main server-hosting blocker.
+The backend CORS middleware reads configured origins from `CORS`.
 
-The blocker is the SuperTokens setup in `packages/backend/src/common/middleware/supertokens.middleware.ts`. It currently hardcodes localhost domains:
+The SuperTokens setup in `packages/backend/src/common/middleware/supertokens.middleware.ts` now derives its domains from the configured URLs:
 
-- API domain: `http://localhost:3000`
-- website domain: `http://localhost:9080`
+- API domain: origin of `BASEURL`
+- website domain: origin of `FRONTEND_URL`
 
-The SuperTokens CORS helper also hardcodes the local web origin.
+The SuperTokens CORS helper also uses the configured `CORS` origins, with a fallback to the `FRONTEND_URL` origin.
 
-That means setting `BASEURL=https://compass.example.com/api`, `FRONTEND_URL=https://compass.example.com`, and `CORS=https://compass.example.com` is not enough yet. The app may serve, but auth redirects, cookies, CORS, password reset links, or session behavior can fail.
+For a one-domain server setup, the expected values would look like:
 
-A likely first fix is to derive the SuperTokens domains from the configured URLs:
-
-```ts
-const apiDomain = new URL(ENV.BASEURL).origin;
-const websiteDomain = new URL(ENV.FRONTEND_URL).origin;
+```bash
+BASEURL=https://compass.example.com/api
+FRONTEND_URL=https://compass.example.com
+CORS=https://compass.example.com
 ```
 
-Then the SuperTokens CORS helper should use the configured allowed origins instead of one hardcoded localhost origin.
-
-Until that behavior is implemented and verified with a real public domain, these docs should not claim that public-domain signup, login, or Google auth work on a server.
+That removes the known localhost-only auth configuration issue, but it has not been verified end-to-end on a real public domain yet. Until that happens, these docs should not claim that public-domain signup, login, password reset, sessions, or Google auth work on a server.
 
 ## Target Shape, Not Yet Verified
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -2,9 +2,7 @@
 
 This guide describes the recommended first server setup for one person hosting Compass on a small VPS.
 
-Use this when you are comfortable SSHing into a server and checking each step yourself. If you want the lowest-risk path, use [Local Quickstart](./local-quickstart.md) instead.
-
-This server path has not yet been proven as a fully beginner-friendly production runbook. The guide keeps to one setup and calls out what still needs careful testing.
+Use this when you are comfortable SSHing into a server and checking each step yourself. If you only want Compass on your own computer, use [Local Quickstart](./local-quickstart.md) instead.
 
 ## Recommended Shape
 
@@ -144,7 +142,7 @@ Your Google Cloud OAuth app must allow the public Compass domain. For the one-do
 
 Google-to-Compass watch notifications need Google to reach the backend over public HTTPS. With this server guide, that means `https://compass.example.com/api`.
 
-Do not claim continuous Google Calendar sync is working until you have tested Google connect, import, webhook delivery, and watch renewal behavior on your server.
+Before relying on continuous Google Calendar sync, test Google connect, import, webhook delivery, and watch renewal behavior on your server.
 
 ## Backups
 
@@ -169,17 +167,15 @@ cd ~/compass
 
 Back up first. `./compass update` rebuilds Compass; it is not a rollback tool.
 
-## Limits Of This Guide
+## What This Guide Leaves To You
 
-This guide gives one coherent server shape, but it is still not a fully verified beginner production runbook.
-
-Known limits:
+This guide gives one coherent server shape. It does not automate everything a production service usually needs.
 
 - HTTPS and Caddy setup are outside the Compass installer.
 - Backups are manual.
 - Restore is manual.
 - Rollback is manual.
-- Google Calendar continuous sync still needs server-specific verification.
+- Google Calendar continuous sync needs server-specific setup and testing.
 - A separate API domain is not the recommended first path.
 
 Avoid exposing MongoDB, SuperTokens, or Postgres to the public internet. A safe server setup keeps those services private and exposes only the web app and API through HTTPS.

--- a/packages/backend/src/auth/controllers/auth.controller.test.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.test.ts
@@ -37,5 +37,33 @@ describe("auth.controller", () => {
         description: AuthError.GoogleNotConfigured.description,
       });
     });
+
+    it("rejects Google connect when self-host placeholder credentials are configured", async () => {
+      const originalClientId = ENV.GOOGLE_CLIENT_ID;
+      const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
+      ENV.GOOGLE_CLIENT_ID =
+        "compass-self-host-placeholder.apps.googleusercontent.com";
+      ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+      const promise = jest.fn();
+
+      try {
+        authController.connectGoogle(
+          {
+            body: {},
+            session: { getUserId: () => "507f1f77bcf86cd799439011" },
+          } as never,
+          { promise } as never,
+        );
+      } finally {
+        ENV.GOOGLE_CLIENT_ID = originalClientId;
+        ENV.GOOGLE_CLIENT_SECRET = originalClientSecret;
+      }
+
+      expect(promise).toHaveBeenCalledTimes(1);
+      await expect(promise.mock.calls[0][0]).rejects.toMatchObject({
+        code: AuthError.GoogleNotConfigured.code,
+        description: AuthError.GoogleNotConfigured.description,
+      });
+    });
   });
 });

--- a/packages/backend/src/auth/controllers/auth.controller.test.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.test.ts
@@ -1,3 +1,7 @@
+import {
+  SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
+  SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+} from "@core/constants/core.constants";
 import { ENV } from "@backend/common/constants/env.constants";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import authController from "./auth.controller";
@@ -41,9 +45,8 @@ describe("auth.controller", () => {
     it("rejects Google connect when self-host placeholder credentials are configured", async () => {
       const originalClientId = ENV.GOOGLE_CLIENT_ID;
       const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
-      ENV.GOOGLE_CLIENT_ID =
-        "compass-self-host-placeholder.apps.googleusercontent.com";
-      ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+      ENV.GOOGLE_CLIENT_ID = SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER;
+      ENV.GOOGLE_CLIENT_SECRET = SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER;
       const promise = jest.fn();
 
       try {

--- a/packages/backend/src/auth/services/google/clients/google.oauth.client.test.ts
+++ b/packages/backend/src/auth/services/google/clients/google.oauth.client.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { calendar } from "@googleapis/calendar";
 import { BaseError } from "@core/errors/errors.base";
+import { ENV } from "@backend/common/constants/env.constants";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import GoogleOAuthClient from "./google.oauth.client";
 
@@ -56,6 +57,23 @@ describe("GoogleOAuthClient", () => {
       version: "v3",
       auth: client.oauthClient,
     });
+  });
+
+  it("throws when self-host placeholder credentials are configured", () => {
+    const originalClientId = ENV.GOOGLE_CLIENT_ID;
+    const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
+    ENV.GOOGLE_CLIENT_ID =
+      "compass-self-host-placeholder.apps.googleusercontent.com";
+    ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+
+    try {
+      expect(() => new GoogleOAuthClient()).toThrow(
+        AuthError.GoogleNotConfigured.description,
+      );
+    } finally {
+      ENV.GOOGLE_CLIENT_ID = originalClientId;
+      ENV.GOOGLE_CLIENT_SECRET = originalClientSecret;
+    }
   });
 
   it("throws when getGoogleUserInfo is called without an id token", async () => {

--- a/packages/backend/src/auth/services/google/clients/google.oauth.client.test.ts
+++ b/packages/backend/src/auth/services/google/clients/google.oauth.client.test.ts
@@ -1,5 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { calendar } from "@googleapis/calendar";
+import {
+  SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
+  SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+} from "@core/constants/core.constants";
 import { BaseError } from "@core/errors/errors.base";
 import { ENV } from "@backend/common/constants/env.constants";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
@@ -62,9 +66,8 @@ describe("GoogleOAuthClient", () => {
   it("throws when self-host placeholder credentials are configured", () => {
     const originalClientId = ENV.GOOGLE_CLIENT_ID;
     const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
-    ENV.GOOGLE_CLIENT_ID =
-      "compass-self-host-placeholder.apps.googleusercontent.com";
-    ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+    ENV.GOOGLE_CLIENT_ID = SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER;
+    ENV.GOOGLE_CLIENT_SECRET = SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER;
 
     try {
       expect(() => new GoogleOAuthClient()).toThrow(

--- a/packages/backend/src/auth/services/google/clients/google.oauth.client.ts
+++ b/packages/backend/src/auth/services/google/clients/google.oauth.client.ts
@@ -8,7 +8,10 @@ import {
 } from "@core/types/auth.types";
 import { type gCalendar } from "@core/types/gcal";
 import { StringV4Schema } from "@core/types/type.utils";
-import { ENV } from "@backend/common/constants/env.constants";
+import {
+  ENV,
+  isGoogleConfigured,
+} from "@backend/common/constants/env.constants";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 
@@ -16,7 +19,11 @@ class GoogleOAuthClient {
   oauthClient: OAuth2Client;
 
   constructor() {
-    if (!ENV.GOOGLE_CLIENT_ID || !ENV.GOOGLE_CLIENT_SECRET) {
+    if (
+      !ENV.GOOGLE_CLIENT_ID ||
+      !ENV.GOOGLE_CLIENT_SECRET ||
+      !isGoogleConfigured(ENV)
+    ) {
       throw error(
         AuthError.GoogleNotConfigured,
         "Google OAuth client unavailable",

--- a/packages/backend/src/common/constants/env.constants.test.ts
+++ b/packages/backend/src/common/constants/env.constants.test.ts
@@ -138,6 +138,15 @@ describe("env.constants", () => {
     );
   });
 
+  it("treats a blank Google webhook base URL as unset", () => {
+    const env = parseBackendEnv({
+      ...validEnv,
+      GCAL_WEBHOOK_BASEURL: "",
+    });
+
+    expect(env.GCAL_WEBHOOK_BASEURL).toBeUndefined();
+  });
+
   it("rejects a non-HTTPS Google webhook base URL", () => {
     expect(() =>
       parseBackendEnv({

--- a/packages/backend/src/common/constants/env.constants.test.ts
+++ b/packages/backend/src/common/constants/env.constants.test.ts
@@ -66,7 +66,7 @@ describe("env.constants", () => {
     ).toThrow("Google configuration requires both client ID and secret");
   });
 
-  it("reports Google as configured only when both credentials are present", () => {
+  it("reports Google as configured only when both usable credentials are present", () => {
     const env = parseBackendEnv({
       ...validEnv,
       BASEURL: "http://localhost:3000/api",
@@ -75,6 +75,36 @@ describe("env.constants", () => {
     });
 
     expect(isGoogleConfigured(env)).toBe(true);
+  });
+
+  it("treats self-host Google placeholders as not configured", () => {
+    const env = parseBackendEnv({
+      ...validEnv,
+      GOOGLE_CLIENT_ID:
+        "compass-self-host-placeholder.apps.googleusercontent.com",
+      GOOGLE_CLIENT_SECRET: "compass-self-host-placeholder-secret",
+    });
+
+    expect(isGoogleConfigured(env)).toBe(false);
+  });
+
+  it("rejects mixed real and placeholder Google credentials", () => {
+    expect(() =>
+      parseBackendEnv({
+        ...validEnv,
+        GOOGLE_CLIENT_ID: "client-id",
+        GOOGLE_CLIENT_SECRET: "compass-self-host-placeholder-secret",
+      }),
+    ).toThrow("Google configuration requires both client ID and secret");
+
+    expect(() =>
+      parseBackendEnv({
+        ...validEnv,
+        GOOGLE_CLIENT_ID:
+          "compass-self-host-placeholder.apps.googleusercontent.com",
+        GOOGLE_CLIENT_SECRET: "client-secret",
+      }),
+    ).toThrow("Google configuration requires both client ID and secret");
   });
 
   it("requires a Google notification token for HTTPS Google watch callbacks", () => {

--- a/packages/backend/src/common/constants/env.constants.test.ts
+++ b/packages/backend/src/common/constants/env.constants.test.ts
@@ -1,4 +1,8 @@
 import {
+  SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
+  SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+} from "@core/constants/core.constants";
+import {
   ENV,
   getApiBaseURL,
   isGoogleConfigured,
@@ -80,9 +84,8 @@ describe("env.constants", () => {
   it("treats self-host Google placeholders as not configured", () => {
     const env = parseBackendEnv({
       ...validEnv,
-      GOOGLE_CLIENT_ID:
-        "compass-self-host-placeholder.apps.googleusercontent.com",
-      GOOGLE_CLIENT_SECRET: "compass-self-host-placeholder-secret",
+      GOOGLE_CLIENT_ID: SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
+      GOOGLE_CLIENT_SECRET: SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
     });
 
     expect(isGoogleConfigured(env)).toBe(false);
@@ -93,15 +96,14 @@ describe("env.constants", () => {
       parseBackendEnv({
         ...validEnv,
         GOOGLE_CLIENT_ID: "client-id",
-        GOOGLE_CLIENT_SECRET: "compass-self-host-placeholder-secret",
+        GOOGLE_CLIENT_SECRET: SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
       }),
     ).toThrow("Google configuration requires both client ID and secret");
 
     expect(() =>
       parseBackendEnv({
         ...validEnv,
-        GOOGLE_CLIENT_ID:
-          "compass-self-host-placeholder.apps.googleusercontent.com",
+        GOOGLE_CLIENT_ID: SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
         GOOGLE_CLIENT_SECRET: "client-secret",
       }),
     ).toThrow("Google configuration requires both client ID and secret");

--- a/packages/backend/src/common/constants/env.constants.ts
+++ b/packages/backend/src/common/constants/env.constants.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
-import { NodeEnv, PORT_DEFAULT_BACKEND } from "@core/constants/core.constants";
+import {
+  NodeEnv,
+  PORT_DEFAULT_BACKEND,
+  SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
+  SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+} from "@core/constants/core.constants";
 import { Logger } from "@core/logger/winston.logger";
 import { isDev } from "@core/util/env.util";
 
 const logger = Logger("app:constants");
-const GOOGLE_CLIENT_ID_PLACEHOLDER =
-  "compass-self-host-placeholder.apps.googleusercontent.com";
-const GOOGLE_CLIENT_SECRET_PLACEHOLDER = "compass-self-host-placeholder-secret";
 
 const _nodeEnv = process.env["NODE_ENV"] as NodeEnv;
 
@@ -89,14 +91,14 @@ const isUsableGoogleClientId = (clientId?: string): boolean =>
   Boolean(
     clientId &&
       clientId !== "undefined" &&
-      clientId !== GOOGLE_CLIENT_ID_PLACEHOLDER,
+      clientId !== SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
   );
 
 const isUsableGoogleClientSecret = (clientSecret?: string): boolean =>
   Boolean(
     clientSecret &&
       clientSecret !== "undefined" &&
-      clientSecret !== GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+      clientSecret !== SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
   );
 
 export const isGoogleConfigured = (

--- a/packages/backend/src/common/constants/env.constants.ts
+++ b/packages/backend/src/common/constants/env.constants.ts
@@ -4,6 +4,9 @@ import { Logger } from "@core/logger/winston.logger";
 import { isDev } from "@core/util/env.util";
 
 const logger = Logger("app:constants");
+const GOOGLE_CLIENT_ID_PLACEHOLDER =
+  "compass-self-host-placeholder.apps.googleusercontent.com";
+const GOOGLE_CLIENT_SECRET_PLACEHOLDER = "compass-self-host-placeholder-secret";
 
 const _nodeEnv = process.env["NODE_ENV"] as NodeEnv;
 
@@ -42,8 +45,10 @@ const EnvSchema = z
   })
   .strict()
   .superRefine((env, context) => {
-    const hasGoogleClientId = Boolean(env.GOOGLE_CLIENT_ID);
-    const hasGoogleClientSecret = Boolean(env.GOOGLE_CLIENT_SECRET);
+    const hasGoogleClientId = isUsableGoogleClientId(env.GOOGLE_CLIENT_ID);
+    const hasGoogleClientSecret = isUsableGoogleClientSecret(
+      env.GOOGLE_CLIENT_SECRET,
+    );
     const isGoogleConfigComplete = hasGoogleClientId && hasGoogleClientSecret;
 
     if (hasGoogleClientId !== hasGoogleClientSecret) {
@@ -80,9 +85,25 @@ type RawBackendEnv = Record<string, string | undefined>;
 
 export type BackendEnv = z.infer<typeof EnvSchema>;
 
+const isUsableGoogleClientId = (clientId?: string): boolean =>
+  Boolean(
+    clientId &&
+      clientId !== "undefined" &&
+      clientId !== GOOGLE_CLIENT_ID_PLACEHOLDER,
+  );
+
+const isUsableGoogleClientSecret = (clientSecret?: string): boolean =>
+  Boolean(
+    clientSecret &&
+      clientSecret !== "undefined" &&
+      clientSecret !== GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+  );
+
 export const isGoogleConfigured = (
   env: Pick<BackendEnv, "GOOGLE_CLIENT_ID" | "GOOGLE_CLIENT_SECRET">,
-): boolean => Boolean(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET);
+): boolean =>
+  isUsableGoogleClientId(env.GOOGLE_CLIENT_ID) &&
+  isUsableGoogleClientSecret(env.GOOGLE_CLIENT_SECRET);
 
 export function parseBackendEnv(rawEnv: RawBackendEnv): BackendEnv {
   const nodeEnv = rawEnv["NODE_ENV"] as NodeEnv;

--- a/packages/backend/src/common/constants/env.constants.ts
+++ b/packages/backend/src/common/constants/env.constants.ts
@@ -119,7 +119,7 @@ export function parseBackendEnv(rawEnv: RawBackendEnv): BackendEnv {
     EMAILER_SECRET: rawEnv["EMAILER_API_SECRET"],
     EMAILER_USER_TAG_ID: rawEnv["EMAILER_USER_TAG_ID"],
     FRONTEND_URL: rawEnv["FRONTEND_URL"],
-    GCAL_WEBHOOK_BASEURL: rawEnv["GCAL_WEBHOOK_BASEURL"],
+    GCAL_WEBHOOK_BASEURL: rawEnv["GCAL_WEBHOOK_BASEURL"] || undefined,
     MONGO_URI: rawEnv["MONGO_URI"],
     NODE_ENV: nodeEnv,
     TZ: rawEnv["TZ"],

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -6,11 +6,7 @@ import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
 import ThirdParty from "supertokens-node/recipe/thirdparty";
 import UserMetadata from "supertokens-node/recipe/usermetadata";
-import {
-  APP_NAME,
-  PORT_DEFAULT_BACKEND,
-  PORT_DEFAULT_WEB,
-} from "@core/constants/core.constants";
+import { APP_NAME } from "@core/constants/core.constants";
 import googleAuthService from "@backend/auth/services/google/google.auth.service";
 import { ENV } from "@backend/common/constants/env.constants";
 import {
@@ -188,9 +184,9 @@ describe("supertokens.middleware", () => {
       expect(initArg.appInfo).toMatchObject({
         appName: APP_NAME,
         apiBasePath: "/api",
-        apiDomain: `http://localhost:${PORT_DEFAULT_BACKEND}`,
+        apiDomain: new URL(ENV.BASEURL).origin,
         websiteBasePath: "/login",
-        websiteDomain: `http://localhost:${PORT_DEFAULT_WEB}`,
+        websiteDomain: new URL(ENV.FRONTEND_URL).origin,
       });
 
       expect(initArg.supertokens).toMatchObject({
@@ -207,6 +203,30 @@ describe("supertokens.middleware", () => {
         { recipe: "session" },
         { recipe: "usermetadata" },
       ]);
+    });
+
+    it("uses configured public URLs for SuperTokens domains", () => {
+      const originalBaseUrl = ENV.BASEURL;
+      const originalFrontendUrl = ENV.FRONTEND_URL;
+
+      ENV.BASEURL = "https://compass.example.com/api";
+      ENV.FRONTEND_URL = "https://compass.example.com";
+
+      try {
+        initSupertokens();
+
+        const initArg = getFirstCallArg<{
+          appInfo: Record<string, unknown>;
+        }>(mockedSuperTokensInit);
+
+        expect(initArg.appInfo).toMatchObject({
+          apiDomain: "https://compass.example.com",
+          websiteDomain: "https://compass.example.com",
+        });
+      } finally {
+        ENV.BASEURL = originalBaseUrl;
+        ENV.FRONTEND_URL = originalFrontendUrl;
+      }
     });
 
     it("omits the Google third-party provider when Google is not configured", () => {
@@ -834,16 +854,39 @@ describe("supertokens.middleware", () => {
       const arg = getFirstCallArg<{
         allowedHeaders: string[];
         credentials: boolean;
-        origin: string;
+        origin: string[];
       }>(mockedCors);
       expect(arg.credentials).toBe(true);
-      expect(arg.origin).toBe("http://localhost:9080");
+      expect(arg.origin).toEqual(ENV.ORIGINS_ALLOWED);
 
       expect(arg.allowedHeaders).toEqual([
         "content-type",
         "st-auth-mode",
         "st-auth-mode",
       ]);
+    });
+
+    it("falls back to the configured frontend origin when allowed origins are empty", () => {
+      const originalAllowedOrigins = ENV.ORIGINS_ALLOWED;
+      const originalFrontendUrl = ENV.FRONTEND_URL;
+      const corsReturn = jest.fn();
+      mockedCors.mockReturnValue(corsReturn);
+
+      ENV.ORIGINS_ALLOWED = [];
+      ENV.FRONTEND_URL = "https://compass.example.com/day";
+
+      try {
+        supertokensCors();
+
+        const arg = getFirstCallArg<{
+          origin: string[];
+        }>(mockedCors);
+
+        expect(arg.origin).toEqual(["https://compass.example.com"]);
+      } finally {
+        ENV.ORIGINS_ALLOWED = originalAllowedOrigins;
+        ENV.FRONTEND_URL = originalFrontendUrl;
+      }
     });
   });
 });

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -6,7 +6,11 @@ import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
 import ThirdParty from "supertokens-node/recipe/thirdparty";
 import UserMetadata from "supertokens-node/recipe/usermetadata";
-import { APP_NAME } from "@core/constants/core.constants";
+import {
+  APP_NAME,
+  SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
+  SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+} from "@core/constants/core.constants";
 import googleAuthService from "@backend/auth/services/google/google.auth.service";
 import { ENV } from "@backend/common/constants/env.constants";
 import {
@@ -258,9 +262,8 @@ describe("supertokens.middleware", () => {
     it("omits the Google third-party provider for self-host placeholder credentials", () => {
       const originalClientId = ENV.GOOGLE_CLIENT_ID;
       const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
-      ENV.GOOGLE_CLIENT_ID =
-        "compass-self-host-placeholder.apps.googleusercontent.com";
-      ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+      ENV.GOOGLE_CLIENT_ID = SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER;
+      ENV.GOOGLE_CLIENT_SECRET = SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER;
 
       try {
         initSupertokens();

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -255,6 +255,33 @@ describe("supertokens.middleware", () => {
       ]);
     });
 
+    it("omits the Google third-party provider for self-host placeholder credentials", () => {
+      const originalClientId = ENV.GOOGLE_CLIENT_ID;
+      const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
+      ENV.GOOGLE_CLIENT_ID =
+        "compass-self-host-placeholder.apps.googleusercontent.com";
+      ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+
+      try {
+        initSupertokens();
+      } finally {
+        ENV.GOOGLE_CLIENT_ID = originalClientId;
+        ENV.GOOGLE_CLIENT_SECRET = originalClientSecret;
+      }
+
+      expect(mockedThirdPartyInit).not.toHaveBeenCalled();
+      const initArg = getFirstCallArg<{
+        recipeList: unknown[];
+      }>(mockedSuperTokensInit);
+
+      expect(initArg.recipeList).toEqual([
+        { recipe: "emailpassword" },
+        { recipe: "dashboard" },
+        { recipe: "session" },
+        { recipe: "usermetadata" },
+      ]);
+    });
+
     it("wires EmailPassword name validation", async () => {
       initSupertokens();
 

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -12,7 +12,10 @@ import UserMetadata from "supertokens-node/recipe/usermetadata";
 import { APP_NAME } from "@core/constants/core.constants";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
-import { ENV } from "@backend/common/constants/env.constants";
+import {
+  ENV,
+  isGoogleConfigured,
+} from "@backend/common/constants/env.constants";
 import {
   createEmailPasswordUser,
   createGoogleUser,
@@ -88,7 +91,7 @@ const getThirdPartyRecipes = (): ReturnType<typeof ThirdParty.init>[] => {
   const clientId = ENV.GOOGLE_CLIENT_ID;
   const clientSecret = ENV.GOOGLE_CLIENT_SECRET;
 
-  if (!clientId || !clientSecret) {
+  if (!clientId || !clientSecret || !isGoogleConfigured(ENV)) {
     return [];
   }
 

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -9,11 +9,7 @@ import {
   type TypeInput as ThirdPartyTypeInput,
 } from "supertokens-node/recipe/thirdparty/types";
 import UserMetadata from "supertokens-node/recipe/usermetadata";
-import {
-  APP_NAME,
-  PORT_DEFAULT_BACKEND,
-  PORT_DEFAULT_WEB,
-} from "@core/constants/core.constants";
+import { APP_NAME } from "@core/constants/core.constants";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { ENV } from "@backend/common/constants/env.constants";
@@ -106,14 +102,23 @@ const getThirdPartyRecipes = (): ReturnType<typeof ThirdParty.init>[] => {
   ];
 };
 
+const getSupertokensApiDomain = () => new URL(ENV.BASEURL).origin;
+
+const getSupertokensWebsiteDomain = () => new URL(ENV.FRONTEND_URL).origin;
+
+const getSupertokensAllowedOrigins = () =>
+  ENV.ORIGINS_ALLOWED.length > 0
+    ? ENV.ORIGINS_ALLOWED
+    : [getSupertokensWebsiteDomain()];
+
 export const initSupertokens = () => {
   SuperTokens.init({
     appInfo: {
       appName: APP_NAME,
       apiBasePath: "/api",
-      apiDomain: `http://localhost:${PORT_DEFAULT_BACKEND}`,
+      apiDomain: getSupertokensApiDomain(),
       websiteBasePath: "/login",
-      websiteDomain: `http://localhost:${PORT_DEFAULT_WEB}`,
+      websiteDomain: getSupertokensWebsiteDomain(),
     },
     supertokens: {
       connectionURI: ENV.SUPERTOKENS_URI,
@@ -234,7 +239,7 @@ export const initSupertokens = () => {
 
 export const supertokensCors = () =>
   cors({
-    origin: `http://localhost:${PORT_DEFAULT_WEB}`,
+    origin: getSupertokensAllowedOrigins(),
     allowedHeaders: [
       "content-type",
       "st-auth-mode",

--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -27,4 +27,28 @@ describe("GET /api/config", () => {
       ENV.GOOGLE_CLIENT_SECRET = originalClientSecret;
     }
   });
+
+  it("reports Google unavailable for self-host placeholder credentials", async () => {
+    const originalClientId = ENV.GOOGLE_CLIENT_ID;
+    const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
+    ENV.GOOGLE_CLIENT_ID =
+      "compass-self-host-placeholder.apps.googleusercontent.com";
+    ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+
+    try {
+      const response = await baseDriver
+        .getServer()
+        .get("/api/config")
+        .expect(Status.OK);
+
+      expect(response.body).toEqual({
+        google: {
+          isConfigured: false,
+        },
+      });
+    } finally {
+      ENV.GOOGLE_CLIENT_ID = originalClientId;
+      ENV.GOOGLE_CLIENT_SECRET = originalClientSecret;
+    }
+  });
 });

--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -1,3 +1,7 @@
+import {
+  SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
+  SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER,
+} from "@core/constants/core.constants";
 import { Status } from "@core/errors/status.codes";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 import { ENV } from "@backend/common/constants/env.constants";
@@ -31,9 +35,8 @@ describe("GET /api/config", () => {
   it("reports Google unavailable for self-host placeholder credentials", async () => {
     const originalClientId = ENV.GOOGLE_CLIENT_ID;
     const originalClientSecret = ENV.GOOGLE_CLIENT_SECRET;
-    ENV.GOOGLE_CLIENT_ID =
-      "compass-self-host-placeholder.apps.googleusercontent.com";
-    ENV.GOOGLE_CLIENT_SECRET = "compass-self-host-placeholder-secret";
+    ENV.GOOGLE_CLIENT_ID = SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER;
+    ENV.GOOGLE_CLIENT_SECRET = SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER;
 
     try {
       const response = await baseDriver

--- a/packages/backend/src/event/event.routes.config.ts
+++ b/packages/backend/src/event/event.routes.config.ts
@@ -7,8 +7,8 @@ import eventController from "./controllers/event.controller";
 /**
  * Event Routes Configuration
  *
- * Handles calendar event CRUD operations and synchronization with Google Calendar.
- * Most operations require Google Calendar connection for bi-directional sync.
+ * Handles calendar event CRUD operations. When a user has connected Google,
+ * event changes can also trigger Google Calendar sync side effects.
  */
 export class EventRoutes extends CommonRoutesConfig {
   constructor(app: express.Application) {
@@ -24,11 +24,9 @@ export class EventRoutes extends CommonRoutesConfig {
      * Creates a new calendar event
      *
      * @auth Required - Supertokens session
-     * @auth Required for POST - Google Calendar connection
      * @body {Object} event - Event data (title, start, end, etc.)
      * @returns {Array|Object} All events (GET) or created event (POST)
      * @throws {401} Unauthorized - Invalid session
-     * @throws {403} Forbidden - No Google Calendar connection (POST)
      * @throws {400} Bad Request - Invalid event data (POST)
      */
     this.app
@@ -93,12 +91,10 @@ export class EventRoutes extends CommonRoutesConfig {
      * Deletes a specific event
      *
      * @auth Required - Supertokens session
-     * @auth Required for PUT/DELETE - Google Calendar connection
      * @param {string} id - Event ID
      * @body {Object} event - Updated event data (PUT only)
      * @returns {Object} Event data (GET) or operation result (PUT/DELETE)
      * @throws {401} Unauthorized - Invalid session
-     * @throws {403} Forbidden - No Google Calendar connection (PUT/DELETE)
      * @throws {404} Not Found - Event not found
      * @throws {400} Bad Request - Invalid event data (PUT)
      */

--- a/packages/core/src/constants/core.constants.ts
+++ b/packages/core/src/constants/core.constants.ts
@@ -1,5 +1,9 @@
 export const APP_NAME = "Compass Calendar";
 export const GCAL_NOTIFICATION_ENDPOINT = `/sync/gcal/notifications`;
+export const SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER =
+  "compass-self-host-placeholder.apps.googleusercontent.com";
+export const SELF_HOST_GOOGLE_CLIENT_SECRET_PLACEHOLDER =
+  "compass-self-host-placeholder-secret";
 export const MB_50 = 50000000; // in bytes
 export const MS_IN_HR = 2.7777777777778e-7;
 export const PORT_DEFAULT_BACKEND = 3000;

--- a/packages/web/src/common/constants/env.constants.test.ts
+++ b/packages/web/src/common/constants/env.constants.test.ts
@@ -1,3 +1,4 @@
+import { SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER } from "@core/constants/core.constants";
 import { describe, expect, it } from "bun:test";
 
 process.env.PORT = "3000";
@@ -29,11 +30,9 @@ describe("isGoogleAuthConfigured", () => {
     expect(isGoogleAuthConfigured()).toBe(false);
     expect(isGoogleAuthConfigured("")).toBe(false);
     expect(isGoogleAuthConfigured("undefined")).toBe(false);
-    expect(
-      isGoogleAuthConfigured(
-        "compass-self-host-placeholder.apps.googleusercontent.com",
-      ),
-    ).toBe(false);
+    expect(isGoogleAuthConfigured(SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER)).toBe(
+      false,
+    );
   });
 
   it("accepts a custom Google client ID", () => {

--- a/packages/web/src/common/constants/env.constants.ts
+++ b/packages/web/src/common/constants/env.constants.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER } from "@core/constants/core.constants";
 import { isDev } from "@core/util/env.util";
 
 export const getApiBaseUrl = (apiBaseUrl?: string, port?: string): string => {
@@ -42,14 +43,11 @@ export const ENV_WEB = webEnvSchema.parse({
 
 export const IS_DEV = isDev(ENV_WEB.NODE_ENV);
 
-const GOOGLE_CLIENT_ID_PLACEHOLDER =
-  "compass-self-host-placeholder.apps.googleusercontent.com";
-
 export const isGoogleAuthConfigured = (clientId?: string): boolean =>
   Boolean(
     clientId &&
       clientId !== "undefined" &&
-      clientId !== GOOGLE_CLIENT_ID_PLACEHOLDER,
+      clientId !== SELF_HOST_GOOGLE_CLIENT_ID_PLACEHOLDER,
   );
 
 export const IS_GOOGLE_AUTH_CONFIGURED = isGoogleAuthConfigured(

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -128,7 +128,7 @@ cd ~/compass
 
 ### Google login or Google Calendar sync does not work locally
 
-The local installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup. See [Google Calendar](../docs/self-hosting/google-calendar.md) for the difference between no-Google mode, local Google OAuth/import, and public HTTPS Google watch notifications.
+The local installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup. Compass treats those placeholders as not configured. See [Google Calendar](../docs/self-hosting/google-calendar.md) for the difference between no-Google mode, local Google OAuth/import, and public HTTPS Google watch notifications.
 
 ## Where Your Data Lives
 

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -1,177 +1,28 @@
 # Compass Self-Host Runtime
 
-## What This Folder Is
-
 This folder contains the files used by the local Compass self-host installer.
 
-If you are installing Compass for the first time, start with [Local Quickstart](../docs/self-hosting/local-quickstart.md). The main [Self-Hosting Compass](../docs/self-hosting.md) page helps you choose the right guide.
+If you're installing Compass for the first time, **start with [Local quickstart](../docs/self-hosting/local-quickstart.md)**. The [Self-Hosting Compass](../docs/self-hosting.md) page helps you choose the right guide and explains what runs where.
 
-This README is the quick reference for the installer files in this folder and the place to start when a local install gets confusing.
-
-In this README, `~/compass` means a `compass` folder in your home folder, such as `/Users/alex/compass` on macOS or `/home/alex/compass` on Linux. It is not a folder inside this repo.
+This README is a quick reference for what each file in this folder does. For install steps, troubleshooting, backups, Google Calendar, and server hosting, see the docs above.
 
 ## Install Compass
 
-Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) first and make sure it is running. Docker is what runs Compass and its local databases.
-
-Then run:
+With Docker Desktop running:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
 ```
 
-The installer creates `~/compass`, writes `~/compass/.env`, copies the helper script to `~/compass/compass`, starts Compass, and tries to open the app in your browser.
+Compass will be available at `http://localhost:9080` (web) and `http://localhost:3000/api` (backend). The compose stack binds those ports to `127.0.0.1` and is not a public-server installer.
 
-When the install finishes, Compass should be available at:
+## Files in this folder
 
-- Web app: http://localhost:9080
-- Backend API: http://localhost:3000/api
+- `install.sh` — the installer. Sets up `~/compass`, writes `~/compass/.env`, copies the helper script, and places app files under `~/compass/app`.
+- `compass` — the helper script template. The installer copies it to `~/compass/compass`. Don't run this copy directly; run `~/compass/compass` after install.
+- `docker-compose.yml` — the Docker Compose stack used by the installed app.
+- `Dockerfile.web`, `Dockerfile.backend`, `Dockerfile.mongo` — the images for the web app, backend, and local MongoDB.
+- `serve-web.ts` — the small web server that serves the built web app inside the web container.
+- `.env.example` — example environment values that mirror what the installer writes to `~/compass/.env`.
 
-This is a local Docker install. The compose stack binds the web and backend ports to `127.0.0.1`, and it is not a public-server installer.
-
-## Manage Compass After Install
-
-After install, use the helper script from the installed folder:
-
-```bash
-cd ~/compass
-./compass status
-```
-
-Common commands:
-
-```bash
-./compass start     # start Compass
-./compass stop      # stop Compass without deleting data
-./compass restart   # stop then start
-./compass rebuild   # rebuild images, then start
-./compass logs      # follow container logs
-./compass status    # show container status
-./compass update    # pull the latest Compass, then rebuild
-./compass open      # open Compass in your browser
-```
-
-Use `./compass logs` when something starts but does not behave correctly. It is usually the fastest way to see what Docker is unhappy about.
-
-Before `./compass update`, back up `~/compass/.env` and the Docker volumes. The update command rebuilds Compass; it is not a rollback tool.
-
-## Troubleshooting
-
-### Docker is not running
-
-Start Docker Desktop, wait until it says Docker is running, then rerun the installer or helper command.
-
-### Port `9080` or `3000` is already in use
-
-Compass uses `9080` for the web app and `3000` for the backend API. If another app is already using one of those ports, stop that app and rerun the installer.
-
-### Compass is already installed
-
-If `~/compass` already exists, use the installed helper instead of running the repo copy:
-
-```bash
-cd ~/compass
-./compass status
-./compass restart
-```
-
-There are two `compass` helper scripts:
-
-- `self-host/compass` in this repo is a template.
-- `~/compass/compass` is the installed helper you should run day to day.
-
-Do not run `self-host/compass` directly from the repo.
-
-### Docker volumes exist but `~/compass/.env` is missing
-
-Docker volumes can remain on your machine even after `~/compass` is deleted. Those volumes may contain old Compass data.
-
-If the installer finds those volumes but cannot find `~/compass/.env`, it stops before creating a new install. This protects you from creating new database passwords that could lock you out of the old data.
-
-Choose one path:
-
-- Keep the old data: restore the matching `~/compass/.env`, then rerun the installer.
-- Start a separate fresh install: use a different `COMPASS_HOME` and `COMPOSE_PROJECT_NAME`.
-- Start over completely: remove the old Docker volumes yourself after confirming you do not need that data.
-
-Example second install:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | env COMPASS_HOME="$HOME/compass-new" COMPOSE_PROJECT_NAME=compass_new sh
-```
-
-### `./compass update` does not work
-
-`./compass update` only works when the installer used Git to download Compass.
-
-If Git was not available during install, the installer used a downloaded archive instead. In that case, install Git, download the installer script, and run `sh install.sh` from your terminal to refresh Compass.
-
-### Changes to `~/compass/.env` are not showing up
-
-Some settings are baked into the web app when it is built. After changing any of these values, run `./compass rebuild`:
-
-- `GOOGLE_CLIENT_ID`
-- `GOOGLE_CLIENT_SECRET`
-- `FRONTEND_URL`
-- `BASEURL`
-
-A plain `./compass restart` is not enough for those values.
-
-### Compass starts but the browser does not open
-
-Open http://localhost:9080 manually. You can also run:
-
-```bash
-cd ~/compass
-./compass open
-```
-
-### Google login or Google Calendar sync does not work locally
-
-The local installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup. Compass treats those placeholders as not configured. See [Google Calendar](../docs/self-hosting/google-calendar.md) for the difference between no-Google mode, local Google OAuth/import, and public HTTPS Google watch notifications.
-
-## Where Your Data Lives
-
-Compass data can live in a few places:
-
-- MongoDB stores signed-in Compass event data.
-- Postgres stores SuperTokens auth data, such as accounts and sessions.
-- Browser-only task data lives in your browser and is not stored in Docker volumes.
-- Anonymous or pre-signup local data also lives in browser IndexedDB until it is copied to the backend after signup.
-
-By default, Docker creates these volumes:
-
-- `compass_compass_mongo_data`
-- `compass_compass_supertokens_postgres_data`
-
-These names change if you set `COMPOSE_PROJECT_NAME` to something other than the default.
-
-Stopping Compass does not delete these volumes. Your data stays on disk until you remove the volumes yourself.
-
-Keep `~/compass/.env` with these volumes. It contains generated secrets that the existing volumes need. For backup commands, see [Backups And Restore](../docs/self-hosting/backups-and-restore.md).
-
-## Google Calendar Limitations
-
-Google auth and Google Calendar sync are not fully configured by the local installer. The installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup.
-
-You can add your own Google OAuth values to `~/compass/.env` and run `./compass rebuild` to try Google sign-in or the Google Calendar connect flow. Google-to-Compass watch notifications need a public HTTPS backend that Google can reach, plus verified watch registration and repair behavior for that install. The local installer does not set that up.
-
-For the current public server guide, see [Server Hosting Guide](../docs/self-hosting/server-guide.md).
-
-## Ports and Services
-
-The stack runs with Docker Compose. Only the web app and backend API are exposed on your machine:
-
-- Web app: http://localhost:9080
-- Backend API: http://localhost:3000/api
-
-MongoDB, SuperTokens Core, and Postgres run inside Docker and are not exposed on localhost.
-
-## Files In This Folder
-
-- `install.sh` is the installer. It sets up `~/compass`, writes `~/compass/.env`, copies the helper script, and places app files under `~/compass/app`.
-- `compass` is the helper script template. The installer copies it to `~/compass/compass`.
-- `docker-compose.yml` is the Docker Compose stack used by the installed app.
-- `Dockerfile.web`, `Dockerfile.backend`, and `Dockerfile.mongo` build the web, backend, and local MongoDB images.
-- `serve-web.ts` is the small web server that serves the built web app inside the web container.
-- `.env.example` shows example environment values that mirror what the installer writes to `~/compass/.env`.
+In this folder and the docs, `~/compass` means a `compass` folder in your home directory (e.g., `/Users/alex/compass` on macOS, `/home/alex/compass` on Linux). It is not a folder inside this repo.

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -156,7 +156,7 @@ Google auth and Google Calendar sync are not fully configured by the local insta
 
 You can add your own Google OAuth values to `~/compass/.env` and run `./compass rebuild` to try Google sign-in or the Google Calendar connect flow. Google-to-Compass watch notifications need a public HTTPS backend that Google can reach, plus verified watch registration and repair behavior for that install. The local installer does not set that up.
 
-For the current public server status, see [Server Hosting Status](../docs/self-hosting/server-guide.md).
+For the current public server guide, see [Server Hosting Guide](../docs/self-hosting/server-guide.md).
 
 ## Ports and Services
 

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -4,20 +4,15 @@
 
 This folder contains the files used by the local Compass self-host installer.
 
-If you are installing Compass for the first time, start with the full guide in
-[Self-Hosting Compass](../docs/self-hosting.md). This README is the quick
-reference for the installer files in this folder and the place to start when a
-local install gets confusing.
+If you are installing Compass for the first time, start with [Local Quickstart](../docs/self-hosting/local-quickstart.md). The main [Self-Hosting Compass](../docs/self-hosting.md) page helps you choose the right guide.
 
-In this README, `~/compass` means a `compass` folder in your home folder, such
-as `/Users/alex/compass` on macOS or `/home/alex/compass` on Linux. It is not a
-folder inside this repo.
+This README is the quick reference for the installer files in this folder and the place to start when a local install gets confusing.
+
+In this README, `~/compass` means a `compass` folder in your home folder, such as `/Users/alex/compass` on macOS or `/home/alex/compass` on Linux. It is not a folder inside this repo.
 
 ## Install Compass
 
-Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) first
-and make sure it is running. Docker is what runs Compass and its local
-databases.
+Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) first and make sure it is running. Docker is what runs Compass and its local databases.
 
 Then run:
 
@@ -25,14 +20,14 @@ Then run:
 curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
 ```
 
-The installer creates `~/compass`, writes `~/compass/.env`, copies the helper
-script to `~/compass/compass`, starts Compass, and tries to open the app in your
-browser.
+The installer creates `~/compass`, writes `~/compass/.env`, copies the helper script to `~/compass/compass`, starts Compass, and tries to open the app in your browser.
 
 When the install finishes, Compass should be available at:
 
 - Web app: http://localhost:9080
 - Backend API: http://localhost:3000/api
+
+This is a local Docker install. The compose stack binds the web and backend ports to `127.0.0.1`, and it is not a public-server installer.
 
 ## Manage Compass After Install
 
@@ -56,25 +51,23 @@ Common commands:
 ./compass open      # open Compass in your browser
 ```
 
-Use `./compass logs` when something starts but does not behave correctly. It is
-usually the fastest way to see what Docker is unhappy about.
+Use `./compass logs` when something starts but does not behave correctly. It is usually the fastest way to see what Docker is unhappy about.
+
+Before `./compass update`, back up `~/compass/.env` and the Docker volumes. The update command rebuilds Compass; it is not a rollback tool.
 
 ## Troubleshooting
 
 ### Docker is not running
 
-Start Docker Desktop, wait until it says Docker is running, then rerun the
-installer or helper command.
+Start Docker Desktop, wait until it says Docker is running, then rerun the installer or helper command.
 
 ### Port `9080` or `3000` is already in use
 
-Compass uses `9080` for the web app and `3000` for the backend API. If another
-app is already using one of those ports, stop that app and rerun the installer.
+Compass uses `9080` for the web app and `3000` for the backend API. If another app is already using one of those ports, stop that app and rerun the installer.
 
 ### Compass is already installed
 
-If `~/compass` already exists, use the installed helper instead of running the
-repo copy:
+If `~/compass` already exists, use the installed helper instead of running the repo copy:
 
 ```bash
 cd ~/compass
@@ -91,21 +84,15 @@ Do not run `self-host/compass` directly from the repo.
 
 ### Docker volumes exist but `~/compass/.env` is missing
 
-Docker volumes can remain on your machine even after `~/compass` is deleted.
-Those volumes may contain old Compass data.
+Docker volumes can remain on your machine even after `~/compass` is deleted. Those volumes may contain old Compass data.
 
-If the installer finds those volumes but cannot find `~/compass/.env`, it stops
-before creating a new install. This protects you from creating new database
-passwords that could lock you out of the old data.
+If the installer finds those volumes but cannot find `~/compass/.env`, it stops before creating a new install. This protects you from creating new database passwords that could lock you out of the old data.
 
 Choose one path:
 
-- Keep the old data: restore the matching `~/compass/.env`, then rerun the
-  installer.
-- Start a separate fresh install: use a different `COMPASS_HOME` and
-  `COMPOSE_PROJECT_NAME`.
-- Start over completely: remove the old Docker volumes yourself after confirming
-  you do not need that data.
+- Keep the old data: restore the matching `~/compass/.env`, then rerun the installer.
+- Start a separate fresh install: use a different `COMPASS_HOME` and `COMPOSE_PROJECT_NAME`.
+- Start over completely: remove the old Docker volumes yourself after confirming you do not need that data.
 
 Example second install:
 
@@ -117,14 +104,11 @@ curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-ho
 
 `./compass update` only works when the installer used Git to download Compass.
 
-If Git was not available during install, the installer used a downloaded archive
-instead. In that case, install Git, download the installer script, and run
-`sh install.sh` from your terminal to refresh Compass.
+If Git was not available during install, the installer used a downloaded archive instead. In that case, install Git, download the installer script, and run `sh install.sh` from your terminal to refresh Compass.
 
 ### Changes to `~/compass/.env` are not showing up
 
-Some settings are baked into the web app when it is built. After changing any of
-these values, run `./compass rebuild`:
+Some settings are baked into the web app when it is built. After changing any of these values, run `./compass rebuild`:
 
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
@@ -144,10 +128,7 @@ cd ~/compass
 
 ### Google login or Google Calendar sync does not work locally
 
-The local installer writes placeholder Google OAuth values so Compass can start
-without a Google Cloud setup. See
-[Google Calendar Limitations](#google-calendar-limitations) for what works
-locally and what needs a public server.
+The local installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup. See [Google Calendar](../docs/self-hosting/google-calendar.md) for the difference between no-Google mode, local Google OAuth/import, and public HTTPS Google watch notifications.
 
 ## Where Your Data Lives
 
@@ -155,55 +136,42 @@ Compass data can live in a few places:
 
 - MongoDB stores signed-in Compass event data.
 - Postgres stores SuperTokens auth data, such as accounts and sessions.
-- Browser-only task data lives in your browser and is not stored in Docker
-  volumes.
+- Browser-only task data lives in your browser and is not stored in Docker volumes.
+- Anonymous or pre-signup local data also lives in browser IndexedDB until it is copied to the backend after signup.
 
 By default, Docker creates these volumes:
 
 - `compass_compass_mongo_data`
 - `compass_compass_supertokens_postgres_data`
 
-These names change if you set `COMPOSE_PROJECT_NAME` to something other than the
-default.
+These names change if you set `COMPOSE_PROJECT_NAME` to something other than the default.
 
-Stopping Compass does not delete these volumes. Your data stays on disk until
-you remove the volumes yourself.
+Stopping Compass does not delete these volumes. Your data stays on disk until you remove the volumes yourself.
+
+Keep `~/compass/.env` with these volumes. It contains generated secrets that the existing volumes need. For backup commands, see [Backups And Restore](../docs/self-hosting/backups-and-restore.md).
 
 ## Google Calendar Limitations
 
-Google auth and Google Calendar sync are not fully configured by the local
-installer. The installer writes placeholder Google OAuth values so Compass can
-start without a Google Cloud setup.
+Google auth and Google Calendar sync are not fully configured by the local installer. The installer writes placeholder Google OAuth values so Compass can start without a Google Cloud setup.
 
-You can add your own Google OAuth values to `~/compass/.env` and run
-`./compass rebuild` to try Google sign-in or the Google Calendar connect flow.
-Continuous Google Calendar sync needs an HTTPS backend that Google can reach
-from the public internet. The local installer does not set that up.
+You can add your own Google OAuth values to `~/compass/.env` and run `./compass rebuild` to try Google sign-in or the Google Calendar connect flow. Google-to-Compass watch notifications need a public HTTPS backend that Google can reach, plus verified watch registration and repair behavior for that install. The local installer does not set that up.
 
-For the server setup, see [Self-Hosting Compass](../docs/self-hosting.md).
+For the current public server status, see [Server Hosting Status](../docs/self-hosting/server-guide.md).
 
 ## Ports and Services
 
-The stack runs with Docker Compose. Only the web app and backend API are exposed
-on your machine:
+The stack runs with Docker Compose. Only the web app and backend API are exposed on your machine:
 
 - Web app: http://localhost:9080
 - Backend API: http://localhost:3000/api
 
-MongoDB, SuperTokens Core, and Postgres run inside Docker and are not exposed on
-localhost.
+MongoDB, SuperTokens Core, and Postgres run inside Docker and are not exposed on localhost.
 
 ## Files In This Folder
 
-- `install.sh` is the installer. It sets up `~/compass`, writes
-  `~/compass/.env`, copies the helper script, and places app files under
-  `~/compass/app`.
-- `compass` is the helper script template. The installer copies it to
-  `~/compass/compass`.
+- `install.sh` is the installer. It sets up `~/compass`, writes `~/compass/.env`, copies the helper script, and places app files under `~/compass/app`.
+- `compass` is the helper script template. The installer copies it to `~/compass/compass`.
 - `docker-compose.yml` is the Docker Compose stack used by the installed app.
-- `Dockerfile.web`, `Dockerfile.backend`, and `Dockerfile.mongo` build the web,
-  backend, and local MongoDB images.
-- `serve-web.ts` is the small web server that serves the built web app inside
-  the web container.
-- `.env.example` shows example environment values that mirror what the
-  installer writes to `~/compass/.env`.
+- `Dockerfile.web`, `Dockerfile.backend`, and `Dockerfile.mongo` build the web, backend, and local MongoDB images.
+- `serve-web.ts` is the small web server that serves the built web app inside the web container.
+- `.env.example` shows example environment values that mirror what the installer writes to `~/compass/.env`.

--- a/self-host/compass
+++ b/self-host/compass
@@ -64,6 +64,7 @@ load_env() {
   compass_ref=$(strip_quotes "$(read_env_value COMPASS_REF)")
   frontend_url=$(strip_quotes "$(read_env_value FRONTEND_URL)")
   baseurl=$(strip_quotes "$(read_env_value BASEURL)")
+  health_url=$(strip_quotes "$(read_env_value COMPASS_HEALTH_URL)")
 
   if [ "$COMPASS_REF_FROM_SHELL" -eq 0 ] && [ -n "$compass_ref" ]; then
     COMPASS_REF=$compass_ref
@@ -71,7 +72,7 @@ load_env() {
 
   PROJECT_NAME=${COMPASS_PROJECT_NAME:-${compose_project_name:-compass}}
   APP_URL=${frontend_url:-http://localhost:9080}
-  HEALTH_URL=$(append_health_path "${baseurl:-http://localhost:3000/api}")
+  HEALTH_URL=${COMPASS_HEALTH_URL:-${health_url:-$(append_health_path "${baseurl:-http://localhost:3000/api}")}}
   ENV_LOADED=1
 }
 

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("self-host docker compose", () => {
+  it("passes the Google webhook override to the backend container", () => {
+    const compose = readFileSync(join(import.meta.dir, "docker-compose.yml"), {
+      encoding: "utf8",
+    });
+
+    expect(compose).toContain(
+      "GCAL_WEBHOOK_BASEURL: $".concat("{GCAL_WEBHOOK_BASEURL:-}"),
+    );
+  });
+});

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       CHANNEL_EXPIRATION_MIN: ${CHANNEL_EXPIRATION_MIN:-10}
       CORS: ${CORS:-http://localhost:9080,http://localhost:3000}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:9080}
+      GCAL_WEBHOOK_BASEURL: ${GCAL_WEBHOOK_BASEURL:-}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-compass-self-host-placeholder.apps.googleusercontent.com}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-compass-self-host-placeholder-secret}
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -374,10 +374,11 @@ load_runtime_config() {
 
   frontend_url=$(strip_quotes "$(read_env_value FRONTEND_URL)")
   baseurl=$(strip_quotes "$(read_env_value BASEURL)")
+  health_url=$(strip_quotes "$(read_env_value COMPASS_HEALTH_URL)")
 
   APP_URL=${frontend_url:-http://localhost:$WEB_PORT_VALUE}
   BASEURL_VALUE=${baseurl:-http://localhost:$PORT_VALUE/api}
-  HEALTH_URL=$(append_health_path "$BASEURL_VALUE")
+  HEALTH_URL=${COMPASS_HEALTH_URL:-${health_url:-$(append_health_path "$BASEURL_VALUE")}}
 }
 
 random_hex() {


### PR DESCRIPTION
## Summary
- Reworked the self-hosting docs into clearer paths for local quickstart, backups, Google Calendar, manual setup, and server hosting
- Added a practical one-domain server guide and tightened backup/restore instructions
- Made SuperTokens use configured public URLs instead of hardcoded localhost values, with tests to cover the new behavior
- Cleaned up a few stale docs and comments around SSE, Webpack, and Google auth flow

## Testing
- Backend SuperTokens test suite passed
- Web env constant test passed
- Type-check passed
- Markdown link and whitespace checks passed
- Caddy config example validated
- Local helper behavior was exercised with a simulated health-check override