### PR TITLE
fix(web): stabilize week view measurements

### DIFF
--- a/e2e/navigation/week-view-switch.spec.ts
+++ b/e2e/navigation/week-view-switch.spec.ts
@@ -1,0 +1,147 @@
+import { expect, type Page, test } from "@playwright/test";
+
+type ViewName = "day" | "now" | "week";
+
+const shortcutByView = {
+  day: "d",
+  now: "n",
+  week: "w",
+} as const satisfies Record<ViewName, string>;
+
+const collectUnexpectedConsoleErrors = (page: Page) => {
+  const errors: string[] = [];
+
+  page.on("console", (message) => {
+    if (message.type() !== "error") {
+      return;
+    }
+
+    const text = message.text();
+    if (text.includes("Maximum update depth exceeded")) {
+      errors.push(text);
+    }
+  });
+
+  return errors;
+};
+
+const viewButton = (page: Page, view: ViewName) => {
+  return page
+    .getByRole("button", {
+      name: new RegExp(`select view, currently ${view}`, "i"),
+    })
+    .first();
+};
+
+const viewOption = (page: Page, view: ViewName) => {
+  return page.getByRole("option", {
+    name: new RegExp(`^${view}$`, "i"),
+  });
+};
+
+const expectShortcutHint = async (page: Page, view: ViewName) => {
+  await expect(
+    viewOption(page, view).getByText(shortcutByView[view], { exact: true }),
+  ).toBeVisible();
+};
+
+const openViewMenu = async (page: Page, currentView: ViewName) => {
+  await expect(viewButton(page, currentView)).toBeVisible();
+  await viewButton(page, currentView).click();
+  await expect(page.getByTestId("view-select-dropdown")).toBeVisible();
+};
+
+test.describe("View dropdown", () => {
+  test("opens with the current Week option selected and shortcut hints visible", async ({
+    page,
+  }) => {
+    await page.goto("/week");
+
+    await openViewMenu(page, "week");
+
+    await expect(viewOption(page, "now")).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    await expect(viewOption(page, "day")).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    await expect(viewOption(page, "week")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await expectShortcutHint(page, "now");
+    await expectShortcutHint(page, "day");
+    await expectShortcutHint(page, "week");
+  });
+
+  test("dismisses with Escape without changing routes", async ({ page }) => {
+    await page.goto("/week");
+
+    await openViewMenu(page, "week");
+    await page.keyboard.press("Escape");
+
+    await expect(page.getByTestId("view-select-dropdown")).toHaveCount(0);
+    await expect(page).toHaveURL(/\/week$/);
+    await expect(viewButton(page, "week")).toBeVisible();
+  });
+
+  test("selecting the current Week option closes the menu and stays on Week", async ({
+    page,
+  }) => {
+    await page.goto("/week");
+
+    await openViewMenu(page, "week");
+    await viewOption(page, "week").click();
+
+    await expect(page.getByTestId("view-select-dropdown")).toHaveCount(0);
+    await expect(page).toHaveURL(/\/week$/);
+    await expect(viewButton(page, "week")).toBeVisible();
+  });
+
+  test("switches from Week to Day and paints the Day view", async ({
+    page,
+  }) => {
+    const consoleErrors = collectUnexpectedConsoleErrors(page);
+
+    await page.goto("/week");
+
+    await openViewMenu(page, "week");
+    await viewOption(page, "day").click();
+
+    await expect(page).toHaveURL(/\/day\/\d{4}-\d{2}-\d{2}$/);
+    await expect(viewButton(page, "day")).toBeVisible();
+    await expect(viewButton(page, "week")).toHaveCount(0);
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("switches from Week to Now and paints the Now view", async ({
+    page,
+  }) => {
+    const consoleErrors = collectUnexpectedConsoleErrors(page);
+
+    await page.goto("/week");
+
+    await openViewMenu(page, "week");
+    await viewOption(page, "now").click();
+
+    await expect(page).toHaveURL(/\/now$/);
+    await expect(viewButton(page, "now")).toBeVisible();
+    await expect(viewButton(page, "week")).toHaveCount(0);
+    expect(consoleErrors).toEqual([]);
+  });
+
+  test("supports keyboard navigation and Enter selection", async ({ page }) => {
+    await page.goto("/week");
+
+    await openViewMenu(page, "week");
+    await viewOption(page, "week").focus();
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("Enter");
+
+    await expect(page).toHaveURL(/\/now$/);
+    await expect(viewButton(page, "now")).toBeVisible();
+  });
+});

--- a/packages/web/src/common/types/util.types.ts
+++ b/packages/web/src/common/types/util.types.ts
@@ -44,7 +44,7 @@ export interface WidthPixels {
   };
 }
 
-export type Ref_Callback = (node: HTMLDivElement) => void;
+export type Ref_Callback = (node: HTMLDivElement | null) => void;
 
 export type PartialMouseEvent = Pick<
   MouseEvent,

--- a/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx
@@ -1,10 +1,9 @@
-import { type FC, type MouseEvent, useEffect } from "react";
+import { type FC, type MouseEvent } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event } from "@core/types/event.types";
 import {
   ID_ALLDAY_COLUMNS,
   ID_GRID_ALLDAY_ROW,
-  ID_GRID_MAIN,
 } from "@web/common/constants/web.constants";
 import { type Ref_Callback } from "@web/common/types/util.types";
 import { assembleDefaultEvent } from "@web/common/utils/event/event.util";
@@ -24,6 +23,7 @@ import { StyledAllDayColumns, StyledAllDayRow } from "./styled";
 interface Props {
   dateCalcs: DateCalcs;
   allDayRef: Ref_Callback;
+  allDayRowRef: Ref_Callback;
   isSidebarOpen: boolean;
   measurements: Measurements_Grid;
   weekProps: WeekProps;
@@ -31,6 +31,7 @@ interface Props {
 
 export const AllDayRow: FC<Props> = ({
   allDayRef,
+  allDayRowRef,
   dateCalcs,
   isSidebarOpen,
   measurements,
@@ -41,11 +42,6 @@ export const AllDayRow: FC<Props> = ({
   const { startOfView, weekDays } = weekProps.component;
   const rowsCount = useAppSelector(selectRowCount);
   const isDrafting = useAppSelector(selectIsDrafting);
-
-  useEffect(() => {
-    measurements.remeasure(ID_GRID_MAIN);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [measurements.remeasure]);
 
   const startAlldayDraft = async (e: MouseEvent) => {
     const x = getX(e, isSidebarOpen);
@@ -86,6 +82,7 @@ export const AllDayRow: FC<Props> = ({
   return (
     <StyledAllDayRow
       id={ID_GRID_ALLDAY_ROW}
+      ref={allDayRowRef}
       rowsCount={rowsCount}
       onMouseDown={onMouseDown}
     >

--- a/packages/web/src/views/Calendar/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/Grid.tsx
@@ -29,7 +29,7 @@ export const Grid: FC<Props> = ({
   today,
   weekProps,
 }) => {
-  const { allDayRef, mainGridRef } = gridRefs;
+  const { allDayRef, allDayRowRef, mainGridElementRef, mainGridRef } = gridRefs;
 
   // Handle drag-to-edge navigation for both timed and all-day events
   const dragEdgeState = useDragEdgeNavigation(mainGridRef, weekProps);
@@ -45,6 +45,7 @@ export const Grid: FC<Props> = ({
     >
       <AllDayRow
         allDayRef={allDayRef}
+        allDayRowRef={allDayRowRef}
         dateCalcs={dateCalcs}
         isSidebarOpen={isSidebarOpen}
         measurements={measurements}
@@ -54,6 +55,7 @@ export const Grid: FC<Props> = ({
       <MainGrid
         dateCalcs={dateCalcs}
         isSidebarOpen={isSidebarOpen}
+        mainGridElementRef={mainGridElementRef}
         mainGridRef={mainGridRef}
         measurements={measurements}
         today={today}

--- a/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx
@@ -2,6 +2,7 @@ import { type FC, type MouseEvent, type MutableRefObject } from "react";
 import { Categories_Event } from "@core/types/event.types";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
+import { type Ref_Callback } from "@web/common/types/util.types";
 import { getHourLabels } from "@web/common/utils/datetime/web.date.util";
 import { assembleDefaultEvent } from "@web/common/utils/event/event.util";
 import { getX } from "@web/common/utils/grid/grid.util";
@@ -25,6 +26,7 @@ import { DRAFT_DURATION_MIN } from "@web/views/Calendar/layout.constants";
 interface Props {
   dateCalcs: DateCalcs;
   isSidebarOpen: boolean;
+  mainGridElementRef: Ref_Callback;
   mainGridRef: MutableRefObject<HTMLDivElement | null>;
   measurements: Measurements_Grid;
   today: Dayjs;
@@ -34,6 +36,7 @@ interface Props {
 export const MainGrid: FC<Props> = ({
   dateCalcs,
   isSidebarOpen,
+  mainGridElementRef,
   mainGridRef,
   measurements,
   today,
@@ -79,7 +82,7 @@ export const MainGrid: FC<Props> = ({
   return (
     <StyledMainGrid
       id={ID_GRID_MAIN}
-      ref={mainGridRef}
+      ref={mainGridElementRef}
       tabIndex={-1}
       className="overflow-y-auto focus:outline-none"
     >
@@ -91,11 +94,8 @@ export const MainGrid: FC<Props> = ({
       />
 
       <StyledGridWithTimeLabels>
-        {getHourLabels(true).map((dayTime, index) => (
-          <StyledGridRow
-            key={`${dayTime}-${index}:dayTimes`}
-            onMouseDown={onMouseDown}
-          />
+        {getHourLabels(true).map((dayTime) => (
+          <StyledGridRow key={dayTime} onMouseDown={onMouseDown} />
         ))}
       </StyledGridWithTimeLabels>
 

--- a/packages/web/src/views/Calendar/hooks/grid/useGridLayout.test.tsx
+++ b/packages/web/src/views/Calendar/hooks/grid/useGridLayout.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { type FC, useRef } from "react";
+import { Provider } from "react-redux";
+import { store } from "@web/store";
+import { useGridLayout } from "./useGridLayout";
+import { describe, expect, it } from "bun:test";
+
+type ObserverRecord = {
+  node: Element;
+  callback: ResizeObserverCallback;
+};
+
+const observers: ObserverRecord[] = [];
+
+class TestResizeObserver implements ResizeObserver {
+  private callback: ResizeObserverCallback;
+  disconnect = () => {};
+  observe = (node: Element) => {
+    observers.push({
+      node,
+      callback: this.callback,
+    });
+  };
+  unobserve = () => {};
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+}
+
+const setRect = (node: HTMLElement, rect: Partial<DOMRectReadOnly>) => {
+  const next = {
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: rect.width ?? 0,
+    bottom: rect.height ?? 0,
+    width: 0,
+    height: 0,
+    ...rect,
+  };
+
+  node.getBoundingClientRect = () => next as DOMRect;
+};
+
+const triggerResize = (node: Element) => {
+  for (const observer of observers.filter((entry) => entry.node === node)) {
+    observer.callback([], observer as unknown as ResizeObserver);
+  }
+};
+
+const GridLayoutHarness: FC = () => {
+  const renderCountRef = useRef(0);
+  renderCountRef.current += 1;
+
+  const { gridRefs, measurements } = useGridLayout(false, 18);
+
+  return (
+    <div>
+      <div
+        data-testid="all-day-row"
+        ref={(node) => {
+          if (!node) {
+            gridRefs.allDayRowRef(null);
+            return;
+          }
+          setRect(node, { width: 700, height: 48 });
+          gridRefs.allDayRowRef(node);
+        }}
+      />
+      <div
+        data-testid="all-day-columns"
+        ref={(node) => {
+          if (!node) {
+            gridRefs.allDayRef(null);
+            return;
+          }
+          Object.defineProperty(node, "clientWidth", {
+            configurable: true,
+            value: 700,
+          });
+          setRect(node, { width: 700, height: 48 });
+          gridRefs.allDayRef(node);
+        }}
+      />
+      <div
+        data-testid="main-grid"
+        ref={(node) => {
+          if (!node) {
+            gridRefs.mainGridElementRef(null);
+            return;
+          }
+          setRect(node, { width: 700, height: 770 });
+          gridRefs.mainGridElementRef(node);
+        }}
+      />
+      <output data-testid="render-count">{renderCountRef.current}</output>
+      <output data-testid="hour-height">
+        {measurements.hourHeight.toString()}
+      </output>
+      <output data-testid="col-widths">
+        {measurements.colWidths.join(",")}
+      </output>
+    </div>
+  );
+};
+
+const renderHarness = () =>
+  render(
+    <Provider store={store}>
+      <GridLayoutHarness />
+    </Provider>,
+  );
+
+describe("useGridLayout", () => {
+  it("measures grid elements from callback refs and derives column widths", async () => {
+    observers.length = 0;
+    window.ResizeObserver =
+      TestResizeObserver as unknown as typeof ResizeObserver;
+    globalThis.ResizeObserver =
+      TestResizeObserver as unknown as typeof ResizeObserver;
+
+    renderHarness();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hour-height")).toHaveTextContent("70");
+      expect(screen.getByTestId("col-widths")).toHaveTextContent(
+        "100,100,100,100,100,100,100",
+      );
+    });
+  });
+
+  it("does not re-render when ResizeObserver reports unchanged measurements", async () => {
+    observers.length = 0;
+    window.ResizeObserver =
+      TestResizeObserver as unknown as typeof ResizeObserver;
+    globalThis.ResizeObserver =
+      TestResizeObserver as unknown as typeof ResizeObserver;
+
+    renderHarness();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hour-height")).toHaveTextContent("70");
+    });
+
+    const before = Number(screen.getByTestId("render-count").textContent);
+
+    triggerResize(screen.getByTestId("main-grid"));
+    triggerResize(screen.getByTestId("all-day-columns"));
+
+    await Promise.resolve();
+
+    expect(Number(screen.getByTestId("render-count").textContent)).toBe(before);
+  });
+});

--- a/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
+++ b/packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts
@@ -1,120 +1,138 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  ID_ALLDAY_COLUMNS,
-  ID_GRID_ALLDAY_ROW,
-  ID_GRID_MAIN,
-} from "@web/common/constants/web.constants";
-import { getElemById } from "@web/common/utils/grid/grid.util";
+import { useCallback, useRef, useState } from "react";
 import { selectRowCount } from "@web/ducks/events/selectors/event.selectors";
 import { useAppSelector } from "@web/store/store.hooks";
 
-export type MeasureableElement = "mainGrid" | "allDayRow";
+type MeasurementSnapshot = Pick<
+  DOMRectReadOnly,
+  "bottom" | "height" | "left" | "right" | "top" | "width" | "x" | "y"
+>;
+
+const DAYS_IN_VIEW = 7;
+
+const toMeasurementSnapshot = (rect: DOMRectReadOnly): MeasurementSnapshot => ({
+  bottom: rect.bottom,
+  height: rect.height,
+  left: rect.left,
+  right: rect.right,
+  top: rect.top,
+  width: rect.width,
+  x: rect.x,
+  y: rect.y,
+});
+
+const areMeasurementsEqual = (
+  current: MeasurementSnapshot | null | undefined,
+  next: MeasurementSnapshot,
+) => {
+  return (
+    current?.bottom === next.bottom &&
+    current.height === next.height &&
+    current.left === next.left &&
+    current.right === next.right &&
+    current.top === next.top &&
+    current.width === next.width &&
+    current.x === next.x &&
+    current.y === next.y
+  );
+};
 
 export const useGridLayout = (_isSidebarOpen: boolean, _week: number) => {
   const _alldayRowsCount = useAppSelector(selectRowCount);
-  const [allDayMeasurements, setAllDayMeasurements] = useState<DOMRect | null>(
-    null,
-  );
-  const [mainMeasurements, setMainMeasurements] = useState<DOMRect | null>();
-  const [colWidths, setColWidths] = useState<number[]>([]);
+  const [allDayMeasurements, setAllDayMeasurements] =
+    useState<MeasurementSnapshot | null>(null);
+  const [allDayColumnsMeasurements, setAllDayColumnsMeasurements] =
+    useState<MeasurementSnapshot | null>(null);
+  const [mainMeasurements, setMainMeasurements] =
+    useState<MeasurementSnapshot | null>(null);
 
   const mainGridRef = useRef<HTMLDivElement | null>(null);
+  const observersRef = useRef(new Map<string, ResizeObserver>());
 
-  const _measureAllDayRow = useCallback((_node?: HTMLDivElement) => {
-    const node = _node ?? getElemById(ID_GRID_ALLDAY_ROW);
-
-    if (!node) return;
-
-    const allDayRect = node.getBoundingClientRect();
-
-    setAllDayMeasurements(allDayRect);
+  const updateAllDayRowMeasurement = useCallback((node: HTMLDivElement) => {
+    const next = toMeasurementSnapshot(node.getBoundingClientRect());
+    setAllDayMeasurements((current) =>
+      areMeasurementsEqual(current, next) ? current : next,
+    );
   }, []);
 
-  const _measureColWidths = useCallback((_node?: HTMLDivElement) => {
-    const node = _node ?? getElemById(ID_ALLDAY_COLUMNS);
-    const daysInView = 7;
-
-    if (!node) return;
-
-    const colWidth = node.clientWidth / daysInView;
-    const colWidths = Array(daysInView).fill(colWidth);
-
-    setColWidths(colWidths);
+  const updateAllDayColumnsMeasurement = useCallback((node: HTMLDivElement) => {
+    const next = toMeasurementSnapshot(node.getBoundingClientRect());
+    setAllDayColumnsMeasurements((current) =>
+      areMeasurementsEqual(current, next) ? current : next,
+    );
   }, []);
-  const allDayRef = useCallback(
-    (node: HTMLDivElement) => {
-      if (node !== null) {
-        _measureAllDayRow(node);
-        _measureColWidths(node);
+
+  const updateMainGridMeasurement = useCallback((node: HTMLDivElement) => {
+    const next = toMeasurementSnapshot(node.getBoundingClientRect());
+    setMainMeasurements((current) =>
+      areMeasurementsEqual(current, next) ? current : next,
+    );
+  }, []);
+
+  const observeElement = useCallback(
+    (
+      key: string,
+      node: HTMLDivElement | null,
+      measure: (node: HTMLDivElement) => void,
+    ) => {
+      observersRef.current.get(key)?.disconnect();
+      observersRef.current.delete(key);
+
+      if (!node) {
+        return;
       }
+
+      measure(node);
+
+      if (typeof ResizeObserver === "undefined") {
+        return;
+      }
+
+      const observer = new ResizeObserver(() => measure(node));
+      observer.observe(node);
+      observersRef.current.set(key, observer);
     },
-    [_measureAllDayRow, _measureColWidths],
+    [],
   );
 
-  const _measureMainGrid = useCallback((_node?: HTMLDivElement) => {
-    const node = _node ?? getElemById(ID_GRID_MAIN);
+  const allDayRowRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observeElement("allDayRow", node, updateAllDayRowMeasurement);
+    },
+    [observeElement, updateAllDayRowMeasurement],
+  );
 
-    if (!node) return;
+  const allDayRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      observeElement("allDayColumns", node, updateAllDayColumnsMeasurement);
+    },
+    [observeElement, updateAllDayColumnsMeasurement],
+  );
 
-    const mainRect = node.getBoundingClientRect();
+  const mainGridElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      mainGridRef.current = node;
+      observeElement("mainGrid", node, updateMainGridMeasurement);
+    },
+    [observeElement, updateMainGridMeasurement],
+  );
 
-    setMainMeasurements(mainRect);
-  }, []);
-
-  const remeasure = (elem: MeasureableElement) => {
-    switch (elem) {
-      case "mainGrid": {
-        _measureMainGrid();
-        break;
-      }
-      case "allDayRow": {
-        break;
-      }
-      default: {
-        console.error("failed to specify which element to measure");
-        break;
-      }
-    }
-  };
-
-  useEffect(() => {
-    _measureMainGrid();
-    _measureAllDayRow();
-    _measureColWidths();
-  }, [_measureColWidths, _measureMainGrid, _measureAllDayRow]);
-
-  useEffect(() => {
-    const update = () => {
-      _measureAllDayRow();
-      _measureColWidths();
-      _measureMainGrid();
-    };
-
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
-  }, [_measureAllDayRow, _measureColWidths, _measureMainGrid]);
-
-  useEffect(() => {
-    _measureAllDayRow();
-  }, [_measureAllDayRow]);
-
-  useEffect(() => {
-    if (mainGridRef.current && !mainMeasurements) {
-      _measureMainGrid(mainGridRef.current);
-    }
-  }, [_measureMainGrid, mainMeasurements]);
+  const colWidths = allDayColumnsMeasurements?.width
+    ? Array(DAYS_IN_VIEW).fill(allDayColumnsMeasurements.width / DAYS_IN_VIEW)
+    : [];
 
   return {
     gridRefs: {
       allDayRef,
+      allDayRowRef,
+      mainGridElementRef,
       mainGridRef,
     },
     measurements: {
       allDayRow: allDayMeasurements,
       colWidths,
       mainGrid: mainMeasurements,
-      hourHeight: mainMeasurements?.height ? mainMeasurements?.height / 11 : 0,
-      remeasure,
+      hourHeight: mainMeasurements?.height ? mainMeasurements.height / 11 : 0,
     },
   };
 };


### PR DESCRIPTION
## Summary
- Move Week view DOM measurement into `useGridLayout` so grid elements are measured from callback refs instead of child-triggered effects.
- Guard measurement updates so unchanged sizes do not cause repeated React state updates.
- Add browser regression coverage for switching from Week to Day/Now through the view dropdown, plus focused hook coverage for stable measurement behavior.

## Why
Switching away from Week through the view menu could update the URL while the visible calendar view stayed stuck on Week. The underlying issue was the Week grid measurement flow: `AllDayRow` could trigger main-grid remeasurement from an effect, and measurement state was updated even when the measured values had not changed. That created an update loop during route/view changes.

This PR makes the layout hook the single owner of measurement setup and only updates state when the measured numbers actually change.

## Reviewer Notes
- `AllDayRow` no longer asks the layout system to remeasure from an effect.
- `MainGrid` still exposes the readable `mainGridRef` used by existing drag/scroll hooks, while measurement uses a callback ref.
- Column widths are derived from the latest measured all-day column width instead of being stored separately.

## Validation
- `bunx playwright test e2e/navigation/week-view-switch.spec.ts`
- `cd packages/web && NODE_ENV=test TZ=Etc/UTC bun test src/views/Calendar/hooks/grid/useGridLayout.test.tsx src/views/Calendar/Calendar.render.test.tsx`
- `cd packages/web && NODE_ENV=test TZ=Etc/UTC bun test src/components/SelectView/SelectView.test.tsx`
- `bun run test:web`
- `bun run type-check`
- `bunx biome check e2e/navigation/week-view-switch.spec.ts packages/web/src/views/Calendar/hooks/grid/useGridLayout.ts packages/web/src/views/Calendar/hooks/grid/useGridLayout.test.tsx packages/web/src/views/Calendar/components/Grid/Grid.tsx packages/web/src/views/Calendar/components/Grid/AllDayRow/AllDayRow.tsx packages/web/src/views/Calendar/components/Grid/MainGrid/MainGrid.tsx packages/web/src/common/types/util.types.ts`

Note: `bun run lint` still reports existing unrelated backend lint debt, but the touched files pass Biome cleanly.
