### PR TITLE
[codex] fix week event drag save

### DIFF
--- a/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.test.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { Origin, Priorities } from "@core/constants/core.constants";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import {
+  type Setters_Draft,
+  type State_Draft_Local,
+  type Status_Drag,
+} from "@web/views/Calendar/components/Draft/hooks/state/useDraftState";
+import { type WeekProps } from "@web/views/Calendar/hooks/useWeek";
+import { useDraftEffects } from "./useDraftEffects";
+import { describe, expect, it, mock } from "bun:test";
+
+const createDraft = (
+  overrides: Partial<Schema_GridEvent> = {},
+): Schema_GridEvent => ({
+  _id: "event-1",
+  title: "Moved event",
+  startDate: "2024-01-15T10:00:00.000Z",
+  endDate: "2024-01-15T11:00:00.000Z",
+  isAllDay: false,
+  isSomeday: false,
+  origin: Origin.COMPASS,
+  priority: Priorities.UNASSIGNED,
+  user: "user-1",
+  position: {
+    isOverlapping: false,
+    widthMultiplier: 1,
+    horizontalOrder: 1,
+    dragOffset: { y: 0 },
+    initialX: null,
+    initialY: null,
+  },
+  ...overrides,
+});
+
+const createState = (
+  overrides: Partial<State_Draft_Local> = {},
+): State_Draft_Local => ({
+  dateBeingChanged: "endDate",
+  draft: createDraft(),
+  dragStatus: { durationMin: 60, hasMoved: true },
+  isDragging: true,
+  isFormOpen: false,
+  isFormOpenBeforeDragging: null,
+  isResizing: false,
+  resizeStatus: null,
+  ...overrides,
+});
+
+const createSetters = (
+  overrides: Partial<Setters_Draft> = {},
+): Setters_Draft => ({
+  setDateBeingChanged: mock(),
+  setDraft: mock(),
+  setDragStatus: mock(),
+  setIsDragging: mock(),
+  setIsFormOpen: mock(),
+  setIsFormOpenBeforeDragging: mock(),
+  setIsResizing: mock(),
+  setResizeStatus: mock(),
+  ...overrides,
+});
+
+const weekProps = {
+  component: { week: "2024-01-15" },
+  util: {
+    getLastNavigationSource: () => "manual",
+  },
+} as unknown as WeekProps;
+
+describe("useDraftEffects", () => {
+  it("preserves movement tracking while refreshing drag duration", async () => {
+    const setDragStatus = mock();
+    const setters = createSetters({ setDragStatus });
+
+    renderHook(() =>
+      useDraftEffects(createState(), setters, weekProps, true, async () => {}),
+    );
+
+    await waitFor(() => expect(setDragStatus).toHaveBeenCalled());
+
+    const updateDragStatus = setDragStatus.mock.calls.at(-1)?.[0];
+
+    expect(typeof updateDragStatus).toBe("function");
+    expect(
+      (updateDragStatus as (status: Status_Drag) => Status_Drag)({
+        durationMin: 60,
+        hasMoved: true,
+      }),
+    ).toEqual({ durationMin: 60, hasMoved: true });
+  });
+});

--- a/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.ts
@@ -87,9 +87,10 @@ export const useDraftEffects = (
       setIsFormOpen(false);
       const durationMin = dayjs(draft.endDate).diff(draft.startDate, "minutes");
 
-      setDragStatus({
+      setDragStatus((dragStatus) => ({
         durationMin,
-      });
+        hasMoved: dragStatus?.hasMoved,
+      }));
     }
   }, [isDragging, setDragStatus, draft?.endDate, draft, setIsFormOpen]);
 };


### PR DESCRIPTION
## Summary
- Fix week event drag state so moved events save on mouse release instead of reopening the form.
- Add a regression test that preserves the moved marker while drag metadata refreshes.

## Root cause
During week-event dragging, the drag duration refresh replaced the drag status object and erased the marker that said the event had actually moved. Mouse release then looked like a click, so the form opened and no save happened.

## Validation
- `NODE_ENV=test TZ=Etc/UTC bun test src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.test.ts`
- `bunx biome check packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.ts packages/web/src/views/Calendar/components/Draft/hooks/effects/useDraftEffects.test.ts`
- `bun run test:web`

## Notes
- `bun run type-check` currently fails on `origin/main` with `tsconfig.json(62,27): error TS5103: Invalid value for --ignoreDeprecations`; this PR does not change that config.

Closes #1696