### PR TITLE
[codex] keep week events inside day lanes

### DIFF
--- a/packages/web/src/common/utils/position/position.util.test.ts
+++ b/packages/web/src/common/utils/position/position.util.test.ts
@@ -1,10 +1,40 @@
 import dayjs from "@core/util/date/dayjs";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
   getAllDayEventWidth,
   getEventCategory,
   getLeftPosition,
+  getTimedEventPosition,
   widthMinusPadding,
 } from "@web/common/utils/position/position.util";
+import {
+  GRID_MARGIN_LEFT,
+  TIMED_EVENT_COLUMN_INSET,
+} from "@web/views/Calendar/layout.constants";
+
+const createTimedEvent = (
+  overrides: Partial<Schema_GridEvent> = {},
+): Schema_GridEvent =>
+  ({
+    _id: "timed-event",
+    endDate: "2022-02-22T16:00:00.000Z",
+    isAllDay: false,
+    isSomeday: false,
+    position: {
+      dragOffset: { x: 0, y: 0 },
+      horizontalOrder: 1,
+      initialX: null,
+      initialY: null,
+      isOverlapping: false,
+      totalEventsInGroup: 1,
+      widthMultiplier: 1,
+    },
+    recurrence: undefined,
+    startDate: "2022-02-22T15:00:00.000Z",
+    title: "Timed event",
+    user: "user",
+    ...overrides,
+  }) as Schema_GridEvent;
 
 describe("getAllDayEventWidth", () => {
   it("is never wider than 1 week", () => {
@@ -152,6 +182,32 @@ describe("getAllDayEventWidth", () => {
         [1, 1, 1, 1, 1, 1, 1],
       ),
     ).toBe(7);
+  });
+});
+
+describe("getTimedEventPosition", () => {
+  it("keeps a timed event inset inside its day column", () => {
+    const colWidth = 100;
+    const startIndex = 2;
+    const columnLeft = GRID_MARGIN_LEFT + colWidth * startIndex;
+    const columnRight = columnLeft + colWidth;
+    const position = getTimedEventPosition(
+      createTimedEvent(),
+      dayjs("2022-02-20"),
+      dayjs("2022-02-26"),
+      {
+        allDayRow: null,
+        colWidths: Array(7).fill(colWidth),
+        hourHeight: 60,
+        mainGrid: null,
+      },
+      false,
+    );
+
+    expect(position.left).toBe(columnLeft + TIMED_EVENT_COLUMN_INSET);
+    expect(position.width).toBe(colWidth - TIMED_EVENT_COLUMN_INSET * 2);
+    expect(position.left).toBeGreaterThan(columnLeft);
+    expect(position.left + position.width).toBeLessThan(columnRight);
   });
 });
 

--- a/packages/web/src/common/utils/position/position.util.ts
+++ b/packages/web/src/common/utils/position/position.util.ts
@@ -11,6 +11,7 @@ import {
   EVENT_ALLDAY_ROW_HEIGHT,
   EVENT_PADDING_RIGHT,
   GRID_MARGIN_LEFT,
+  TIMED_EVENT_COLUMN_INSET,
 } from "@web/views/Calendar/layout.constants";
 
 export const getAbsoluteLeftPosition = (
@@ -268,7 +269,7 @@ const getRelativeLeftPosition = (
 
   const isTimedEvent = event?.isAllDay === false;
   if (isTimedEvent) {
-    adjustment += GRID_MARGIN_LEFT;
+    adjustment += GRID_MARGIN_LEFT + TIMED_EVENT_COLUMN_INSET;
   }
 
   const relativeLeft = initialLeft + adjustment;
@@ -287,7 +288,7 @@ export const getTimedEventWidth = (
     : // Else, we want the width to be whatever the event's width multiplier is
       colWidths[startIndex] * widthMultiplier;
 
-  const BUFFER_WIDTH = 11;
+  const BUFFER_WIDTH = TIMED_EVENT_COLUMN_INSET * 2;
   width -= BUFFER_WIDTH;
   return width;
 };

--- a/packages/web/src/views/Calendar/layout.constants.ts
+++ b/packages/web/src/views/Calendar/layout.constants.ts
@@ -11,6 +11,7 @@ export const EVENT_ALLDAY_GAP = 3;
 /** Height of the row containing the all-day event. Not to be confused with `EVENT_ALLDAY_HEIGHT` */
 export const EVENT_ALLDAY_ROW_HEIGHT = EVENT_ALLDAY_HEIGHT + EVENT_ALLDAY_GAP;
 export const EVENT_PADDING_RIGHT = 10;
+export const TIMED_EVENT_COLUMN_INSET = 5;
 /** Minimum rendered event height (px) to show the time label below the title.
  *  Below this the label is suppressed to prevent overflow on short events.
  *  At typical hourHeight (~65px/hr): 30-min ≈ 33px (hidden), 45-min ≈ 49px (shown). */


### PR DESCRIPTION
## Summary

This fixes week-view timed events so they stay inside their own day lane instead of visually spilling into neighboring columns. The event boxes now use an equal inset on both sides of the day column, which keeps them centered while still taking almost the full width of that day.

## Why

After the week header/grid alignment work, timed events could appear flush against a column boundary and look like they were crossing into another day. That made the week view harder to scan and made it unclear which day owned the event.

## What changed

- Added a shared timed-event column inset value.
- Applied that inset to timed event left positioning and width calculation.
- Added a focused test that checks timed events stay inside their column boundaries.

## Validation

- `bun test packages/web/src/common/utils/position/position.util.test.ts`
- `bunx biome check packages/web/src/common/utils/position/position.util.ts packages/web/src/common/utils/position/position.util.test.ts packages/web/src/views/Calendar/layout.constants.ts`
- `bun run type-check`
