### PR TITLE
fix(web): duplicate week events

### DIFF
--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -1,7 +1,40 @@
+import { renderHook } from "@testing-library/react";
 import { Origin, Priorities } from "@core/constants/core.constants";
+import { Categories_Event } from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
+import {
+  createInitialState,
+  type InitialReduxState,
+} from "@web/__tests__/utils/state/store.test.util";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { createEventSlice } from "@web/ducks/events/slices/event.slice";
+import {
+  type Setters_Draft,
+  type State_Draft_Local,
+} from "@web/views/Calendar/components/Draft/hooks/state/useDraftState";
+import { type DateCalcs } from "@web/views/Calendar/hooks/grid/useDateCalcs";
+import { type WeekProps } from "@web/views/Calendar/hooks/useWeek";
 import { getDragDurationMinutes } from "./drag-duration.util";
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockDispatch = mock();
+let currentState: InitialReduxState = createInitialState();
+
+mock.module("@web/store/store.hooks", () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (selector: (state: InitialReduxState) => unknown) =>
+    selector(currentState),
+}));
+
+mock.module(
+  "@web/views/Calendar/components/Draft/hooks/effects/useDraftEffects",
+  () => ({
+    useDraftEffects: mock(),
+  }),
+);
+
+const { useDraftActions } =
+  require("./useDraftActions") as typeof import("./useDraftActions");
 
 const createDraft = (
   overrides: Partial<Schema_GridEvent> = {},
@@ -37,5 +70,92 @@ describe("getDragDurationMinutes", () => {
         durationMin: 45,
       }),
     ).toBe(45);
+  });
+});
+
+const createState = (
+  overrides: Partial<State_Draft_Local> = {},
+): State_Draft_Local => ({
+  dateBeingChanged: "endDate",
+  draft: createDraft(),
+  dragStatus: null,
+  isDragging: false,
+  isFormOpen: true,
+  isFormOpenBeforeDragging: null,
+  isResizing: false,
+  resizeStatus: null,
+  ...overrides,
+});
+
+const createSetters = (
+  overrides: Partial<Setters_Draft> = {},
+): Setters_Draft => ({
+  setDateBeingChanged: mock(),
+  setDraft: mock(),
+  setDragStatus: mock(),
+  setIsDragging: mock(),
+  setIsFormOpen: mock(),
+  setIsFormOpenBeforeDragging: mock(),
+  setIsResizing: mock(),
+  setResizeStatus: mock(),
+  ...overrides,
+});
+
+const dateCalcs = {} as DateCalcs;
+
+const weekProps = {
+  component: {
+    endOfView: dayjs("2024-01-21T23:59:59.999Z"),
+    startOfView: dayjs("2024-01-15T00:00:00.000Z"),
+    week: 3,
+  },
+  util: {
+    getLastNavigationSource: () => "manual",
+  },
+} as unknown as WeekProps;
+
+describe("useDraftActions", () => {
+  beforeEach(() => {
+    const draft = createDraft();
+    currentState = createInitialState();
+    currentState.events.draft = {
+      event: draft,
+      status: {
+        activity: "eventRightClick",
+        dateToResize: null,
+        eventType: Categories_Event.TIMED,
+        isDrafting: true,
+      },
+    };
+    currentState.events.getWeekEvents = {
+      error: null,
+      isProcessing: false,
+      isSuccess: true,
+      reason: null,
+      value: {
+        count: 1,
+        data: [draft._id],
+        offset: 0,
+        page: 1,
+        pageSize: 1,
+      },
+    };
+    mockDispatch.mockClear();
+  });
+
+  it("creates a new event when duplicating an existing week event", () => {
+    const { result } = renderHook(() =>
+      useDraftActions(createState(), createSetters(), dateCalcs, weekProps),
+    );
+
+    result.current.duplicateEvent();
+
+    const createAction = mockDispatch.mock.calls.find(
+      ([action]) => action.type === createEventSlice.actionNames.request,
+    )?.[0];
+
+    expect(createAction).toBeDefined();
+    expect(createAction.payload._id).not.toBe("event-1");
+    expect(createAction.payload.title).toBe("Seed event");
   });
 });

--- a/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Calendar/components/Draft/hooks/actions/useDraftActions.ts
@@ -23,10 +23,7 @@ import {
   type Schema_GridEvent,
   type Schema_WebEvent,
 } from "@web/common/types/web.event.types";
-import {
-  addId,
-  assembleDefaultEvent,
-} from "@web/common/utils/event/event.util";
+import { assembleDefaultEvent } from "@web/common/utils/event/event.util";
 import { type Payload_EditEvent } from "@web/ducks/events/event.types";
 import {
   selectDraft,
@@ -374,8 +371,9 @@ export const useDraftActions = (
     const draft = MapEvent.removeProviderData({
       ...(reduxDraft as Schema_Event),
     }) as Schema_GridEvent;
+    const { _id: _duplicatedEventId, ...duplicateDraft } = draft;
 
-    submit(addId(draft));
+    submit(duplicateDraft);
     discard();
   }, [reduxDraft, submit, discard]);
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -1,0 +1,101 @@
+import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+import { Origin, Priorities } from "@core/constants/core.constants";
+import { type Schema_Event } from "@core/types/event.types";
+import { theme } from "@web/common/styles/theme";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module(
+  "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection",
+  () => ({
+    DateControlsSection: () => null,
+  }),
+);
+
+mock.module(
+  "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection",
+  () => ({
+    RecurrenceSection: () => null,
+  }),
+);
+
+mock.module("@web/views/Forms/EventForm/EventActionMenu", () => ({
+  EventActionMenu: () => null,
+}));
+
+mock.module("@web/views/Forms/EventForm/PrioritySection", () => ({
+  PrioritySection: () => null,
+}));
+
+mock.module("@web/views/Forms/EventForm/SaveSection", () => ({
+  SaveSection: () => null,
+}));
+
+const { EventForm } = require("./EventForm") as typeof import("./EventForm");
+
+function dispatchModD(target: HTMLElement) {
+  const modifierKey = resolveModifier("Mod");
+  const isControl = modifierKey === "Control";
+
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      ctrlKey: isControl,
+      key: "d",
+      metaKey: !isControl,
+    }),
+  );
+}
+
+const createEvent = (): Schema_Event => ({
+  _id: "event-1",
+  description: "",
+  endDate: "2026-04-24T15:00:00.000Z",
+  isAllDay: false,
+  isSomeday: false,
+  origin: Origin.COMPASS,
+  priority: Priorities.UNASSIGNED,
+  startDate: "2026-04-24T14:00:00.000Z",
+  title: "Keyboard duplicate event",
+  user: "user-1",
+});
+
+describe("EventForm", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+  });
+
+  it("duplicates the event with Mod+D while the title field is focused", async () => {
+    const event = createEvent();
+    const onDuplicate = mock();
+
+    render(
+      <ThemeProvider theme={theme}>
+        <EventForm
+          event={event}
+          isDraft={false}
+          isExistingEvent={true}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={onDuplicate}
+          onSubmit={mock()}
+          setEvent={mock()}
+        />
+      </ThemeProvider>,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    titleField.focus();
+
+    dispatchModD(titleField);
+
+    await waitFor(() => {
+      expect(onDuplicate).toHaveBeenCalledTimes(1);
+    });
+    expect(onDuplicate).toHaveBeenCalledWith(event);
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -229,10 +229,11 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
 
     useAppHotkey(
       "Mod+D",
-      () => {
+      (keyboardEvent) => {
+        keyboardEvent.preventDefault();
         onDuplicate?.(event);
       },
-      { enabled: true },
+      EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
     );
 
     useAppHotkey(


### PR DESCRIPTION
closes #1705 

## Summary
- Fix Week view event duplication so duplicated events are created as new Events instead of being discarded as unchanged.
- Fix Cmd/Ctrl+D in the Event form so it works while the title field is focused.
- Add regression coverage for both duplicate paths.

## Root cause
Week duplication reused the existing Event identity, so the save flow treated the duplicate as the same unchanged Event and discarded it. The keyboard shortcut also ignored input focus, so it did not run while typing in the form.

## Verification
- `NODE_ENV=test TZ=Etc/UTC PORT=3000 bun test --preload ./src/__tests__/web.preload.ts src/views/Forms/EventForm/EventForm.test.tsx src/views/Calendar/components/Draft/hooks/actions/useDraftActions.test.ts`
- `git diff --check`