### PR TITLE
Move Now description shortcut to E and add explicit save action

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -41,33 +41,35 @@ Helpful notes:
 
 ## Shortcut Reference
 
-| Shortcut               | View      | Action                            |
-| ---------------------- | --------- | --------------------------------- |
-| `D`                    | Global    | Navigate to Day view              |
-| `W`                    | Global    | Navigate to Week view             |
-| `N`                    | Global    | Navigate to Now view              |
-| `R`                    | Global    | Edit personal reminder note       |
-| `Z`                    | Global    | Log out                           |
-| `Cmd+K` / `Ctrl+K`     | Global    | Open command palette              |
-| `[`                    | Global    | Toggle sidebar                    |
-| `J`                    | Day view  | Previous day                      |
-| `K`                    | Day view  | Next day                          |
-| `T`                    | Day view  | Go to today                       |
-| `U`                    | Day view  | Focus task list                   |
-| `C`                    | Day view  | Create task                       |
-| `E`                    | Day view  | Edit focused task                 |
-| `Delete` / `Backspace` | Day view  | Delete focused task               |
-| `Enter`                | Day view  | Mark focused task complete        |
-| `Ctrl+Meta+ArrowRight` | Day view  | Move focused task to next day     |
-| `Ctrl+Meta+ArrowLeft`  | Day view  | Move focused task to previous day |
-| `Cmd+Z` / `Ctrl+Z`     | Day view  | Undo last action                  |
-| `J`                    | Week view | Previous week                     |
-| `K`                    | Week view | Next week                         |
-| `T`                    | Week view | Go to today                       |
-| `C`                    | Week view | Create timed event                |
-| `A`                    | Week view | Create all-day event              |
-| `Shift+W`              | Week view | Create Someday Week event         |
-| `Shift+M`              | Week view | Create Someday Month event        |
+| Shortcut                    | View      | Action                            |
+| --------------------------- | --------- | --------------------------------- |
+| `D`                         | Global    | Navigate to Day view              |
+| `W`                         | Global    | Navigate to Week view             |
+| `N`                         | Global    | Navigate to Now view              |
+| `R`                         | Global    | Edit personal reminder note       |
+| `Z`                         | Global    | Log out                           |
+| `Cmd+K` / `Ctrl+K`          | Global    | Open command palette              |
+| `[`                         | Global    | Toggle sidebar                    |
+| `J`                         | Day view  | Previous day                      |
+| `K`                         | Day view  | Next day                          |
+| `T`                         | Day view  | Go to today                       |
+| `U`                         | Day view  | Focus task list                   |
+| `C`                         | Day view  | Create task                       |
+| `E`                         | Day view  | Edit focused task                 |
+| `Delete` / `Backspace`      | Day view  | Delete focused task               |
+| `Enter`                     | Day view  | Mark focused task complete        |
+| `Ctrl+Meta+ArrowRight`      | Day view  | Move focused task to next day     |
+| `Ctrl+Meta+ArrowLeft`       | Day view  | Move focused task to previous day |
+| `Cmd+Z` / `Ctrl+Z`          | Day view  | Undo last action                  |
+| `E`                         | Now view  | Edit focused task description     |
+| `Cmd+Enter` / `Ctrl+Enter`  | Now view  | Save focused task description     |
+| `J`                         | Week view | Previous week                     |
+| `K`                         | Week view | Next week                         |
+| `T`                         | Week view | Go to today                       |
+| `C`                         | Week view | Create timed event                |
+| `A`                         | Week view | Create all-day event              |
+| `Shift+W`                   | Week view | Create Someday Week event         |
+| `Shift+M`                   | Week view | Create Someday Month event        |
 
 ---
 
@@ -76,6 +78,8 @@ Helpful notes:
 ### UX
 
 Pressing `D`, `W`, or `N` from anywhere in the app (while not focused in an input) navigates to Day view, Week view, or Now view respectively.
+
+View shortcuts keep the same meaning in Now mode. `D` still navigates to Day view.
 
 ### Steps
 

--- a/docs/acceptance/tasks.md
+++ b/docs/acceptance/tasks.md
@@ -284,12 +284,12 @@ Pressing Enter in Now mode marks the focused task complete and automatically mov
 
 ### UX
 
-Pressing `D` while a task is focused in Now mode opens an inline description editor (max 255 characters). Pressing Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) saves the description.
+Pressing `E` while a task is focused in Now mode opens an inline description editor (max 255 characters). Pressing Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) saves the description.
 
 ### Steps
 
 1. Enter Now mode and select a task.
-2. Press `D`.
+2. Press `E`.
 3. Type a description (keep it under 255 characters).
 4. Press Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux) to save.
 

--- a/packages/web/src/common/utils/shortcut/data/shortcuts.data.test.ts
+++ b/packages/web/src/common/utils/shortcut/data/shortcuts.data.test.ts
@@ -120,9 +120,13 @@ describe("shortcuts.data", () => {
         isNow: true,
       });
 
-      expect(shortcuts.nowShortcuts).toHaveLength(6);
-      expect(shortcuts.nowShortcuts[0]).toEqual({
+      expect(shortcuts.globalShortcuts).toContainEqual({
         k: "d",
+        label: "Day",
+      });
+      expect(shortcuts.nowShortcuts).toHaveLength(5);
+      expect(shortcuts.nowShortcuts[0]).toEqual({
+        k: "e",
         label: "Edit description",
       });
       expect(shortcuts.nowShortcuts[1]).toEqual({
@@ -138,7 +142,7 @@ describe("shortcuts.data", () => {
         k: "Enter",
         label: "Mark complete",
       });
-      expect(shortcuts.nowShortcuts[5]).toEqual({
+      expect(shortcuts.nowShortcuts).not.toContainEqual({
         k: "Esc",
         label: "Back to Today",
       });

--- a/packages/web/src/common/utils/shortcut/data/shortcuts.data.ts
+++ b/packages/web/src/common/utils/shortcut/data/shortcuts.data.ts
@@ -71,12 +71,11 @@ export const getShortcuts = (config: ShortcutsConfig = {}) => {
   }
   if (isNow) {
     nowShortcuts = [
-      { k: "d", label: "Edit description" },
+      { k: "e", label: "Edit description" },
       { k: "Mod+Enter", label: "Save description" },
       { k: "j", label: "Previous task" },
       { k: "k", label: "Next task" },
       { k: "Enter", label: "Mark complete" },
-      { k: "Esc", label: "Back to Today" },
     ];
   }
 

--- a/packages/web/src/views/Now/components/NowCmdPalette.tsx
+++ b/packages/web/src/views/Now/components/NowCmdPalette.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import _CommandPalette, { filterItems, getItemIndex } from "react-cmdk";
 import "react-cmdk/dist/cmdk.css";
+import { useNavigate } from "react-router-dom";
 import { moreCommandPaletteItems } from "@web/common/constants/more.cmd.constants";
 import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
 import { useAuthCmdItems } from "@web/common/hooks/useAuthCmdItems";
@@ -16,6 +17,7 @@ const CommandPalette = resolveCommandPalette(_CommandPalette);
 
 export const NowCmdPalette = () => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const open = useAppSelector(selectIsCmdPaletteOpen);
   const [page] = useState<"root">("root");
   const [search, setSearch] = useState("");
@@ -32,13 +34,13 @@ export const NowCmdPalette = () => {
             id: "go-to-day",
             children: `Go to Day [${VIEW_SHORTCUTS.day.key}]`,
             icon: "CalendarDaysIcon",
-            onClick: () => pressKey(VIEW_SHORTCUTS.day.key),
+            onClick: () => navigate(VIEW_SHORTCUTS.day.route),
           },
           {
             id: "go-to-week",
             children: `Go to Week [${VIEW_SHORTCUTS.week.key}]`,
             icon: "CalendarIcon",
-            onClick: () => pressKey(VIEW_SHORTCUTS.week.key),
+            onClick: () => navigate(VIEW_SHORTCUTS.week.route),
           },
           {
             id: "edit-reminder",

--- a/packages/web/src/views/Now/components/TaskDescription/TaskDescription.test.tsx
+++ b/packages/web/src/views/Now/components/TaskDescription/TaskDescription.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "styled-components";
+import { theme } from "@web/common/styles/theme";
+import {
+  CompassDOMEvents,
+  compassEventEmitter,
+} from "@web/common/utils/dom/event-emitter.util";
+import { TaskDescription } from "./TaskDescription";
+
+function renderTaskDescription({
+  description = "",
+  onSave = mock(),
+}: {
+  description?: string;
+  onSave?: (description: string) => void;
+} = {}) {
+  render(
+    <ThemeProvider theme={theme}>
+      <TaskDescription description={description} onSave={onSave} />
+    </ThemeProvider>,
+  );
+
+  return { onSave };
+}
+
+describe("TaskDescription", () => {
+  it("saves the edited description from a visible save button", async () => {
+    const user = userEvent.setup();
+    const onSave = mock();
+    renderTaskDescription({ description: "Old notes", onSave });
+
+    await user.click(screen.getByText("Old notes"));
+    const descriptionInput = screen.getByPlaceholderText(
+      "Add a description...",
+    );
+
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, "New notes");
+    await user.click(screen.getByRole("button", { name: /save description/i }));
+
+    expect(onSave).toHaveBeenCalledWith("New notes");
+    await waitFor(() => {
+      expect(screen.getByText("New notes")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the keyboard shortcut on the save button tooltip", async () => {
+    const user = userEvent.setup();
+    renderTaskDescription({ description: "Notes" });
+
+    await user.click(screen.getByText("Notes"));
+    const saveButton = screen.getByRole("button", {
+      name: /save description/i,
+    });
+
+    await user.hover(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Mod+Enter")).toBeInTheDocument();
+    });
+  });
+
+  it("saves the edited description from the keyboard save shortcut", async () => {
+    const user = userEvent.setup();
+    const onSave = mock();
+    renderTaskDescription({ description: "Old notes", onSave });
+
+    await user.click(screen.getByText("Old notes"));
+    const descriptionInput = screen.getByPlaceholderText(
+      "Add a description...",
+    );
+
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, "New notes");
+    act(() => {
+      compassEventEmitter.emit(CompassDOMEvents.SAVE_TASK_DESCRIPTION);
+    });
+
+    expect(onSave).toHaveBeenCalledWith("New notes");
+    await waitFor(() => {
+      expect(screen.getByText("New notes")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/views/Now/components/TaskDescription/TaskDescription.tsx
+++ b/packages/web/src/views/Now/components/TaskDescription/TaskDescription.tsx
@@ -1,12 +1,13 @@
-import { Pencil } from "@phosphor-icons/react";
+import { FloppyDisk, Pencil } from "@phosphor-icons/react";
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import {
   CompassDOMEvents,
   compassEventEmitter,
 } from "@web/common/utils/dom/event-emitter.util";
 import { Textarea } from "@web/components/Textarea";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 
 const MAX_DESCRIPTION_LENGTH = 255;
 const NEAR_LIMIT_THRESHOLD = Math.floor(MAX_DESCRIPTION_LENGTH * 0.9); // 90% of max
@@ -107,8 +108,36 @@ const CharacterCount = styled.div<{ isNearLimit: boolean }>`
   font-size: ${({ theme }) => theme.text.size.s};
   color: ${({ isNearLimit, theme }) =>
     isNearLimit ? theme.color.status.error : theme.color.text.lighter};
-  text-align: right;
+`;
+
+const EditorActions = styled.div`
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
   margin-top: 4px;
+`;
+
+const SaveButton = styled.button`
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: ${({ theme }) => theme.shape.borderRadius};
+  color: ${({ theme }) => theme.color.text.light};
+  cursor: pointer;
+  display: inline-flex;
+  height: 28px;
+  justify-content: center;
+  padding: 4px;
+  width: 28px;
+  transition: ${({ theme }) => theme.transition.default};
+
+  &:hover,
+  &:focus {
+    background-color: ${({ theme }) => theme.color.border.primary};
+    filter: brightness(110%);
+    outline: none;
+  }
 `;
 
 export const TaskDescription: React.FC<TaskDescriptionProps> = ({
@@ -146,28 +175,36 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({
     };
   }, [isEditing]);
 
+  const saveDescription = useCallback(() => {
+    setIsEditing(false);
+    if (value !== originalValueRef.current) {
+      onSave(value);
+      originalValueRef.current = value;
+    }
+  }, [onSave, value]);
+
   useEffect(() => {
     if (!isEditing) return;
 
-    const handler = () => textareaRef.current?.blur();
-
-    compassEventEmitter.on(CompassDOMEvents.SAVE_TASK_DESCRIPTION, handler);
+    compassEventEmitter.on(
+      CompassDOMEvents.SAVE_TASK_DESCRIPTION,
+      saveDescription,
+    );
 
     return () => {
-      compassEventEmitter.off(CompassDOMEvents.SAVE_TASK_DESCRIPTION, handler);
+      compassEventEmitter.off(
+        CompassDOMEvents.SAVE_TASK_DESCRIPTION,
+        saveDescription,
+      );
     };
-  }, [isEditing]);
+  }, [isEditing, saveDescription]);
 
   const handleClick = () => {
     setIsEditing(true);
   };
 
   const handleBlur = () => {
-    setIsEditing(false);
-    if (value !== originalValueRef.current) {
-      onSave(value);
-      originalValueRef.current = value;
-    }
+    saveDescription();
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -201,9 +238,21 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({
             id={TASK_DESCRIPTION_ID}
             className="overflow-y-auto"
           />
-          <CharacterCount isNearLimit={isNearLimit}>
-            {value.length}/{MAX_DESCRIPTION_LENGTH}
-          </CharacterCount>
+          <EditorActions>
+            <CharacterCount isNearLimit={isNearLimit}>
+              {value.length}/{MAX_DESCRIPTION_LENGTH}
+            </CharacterCount>
+            <TooltipWrapper description="Save description" shortcut="Mod+Enter">
+              <SaveButton
+                aria-label="Save description"
+                onClick={saveDescription}
+                onMouseDown={(event) => event.preventDefault()}
+                type="button"
+              >
+                <FloppyDisk size={18} weight="regular" />
+              </SaveButton>
+            </TooltipWrapper>
+          </EditorActions>
         </>
       ) : (
         <DescriptionText

--- a/packages/web/src/views/Now/context/NowViewProvider.tsx
+++ b/packages/web/src/views/Now/context/NowViewProvider.tsx
@@ -28,9 +28,13 @@ export const NowViewContext = createContext<NowViewContextValue | undefined>(
 
 interface NowViewProviderProps {
   children: React.ReactNode;
+  onToggleSidebar?: () => void;
 }
 
-export function NowViewProvider({ children }: NowViewProviderProps) {
+export function NowViewProvider({
+  children,
+  onToggleSidebar,
+}: NowViewProviderProps) {
   const navigate = useNavigate();
   const { availableTasks, allTasks, hasCompletedTasks } = useAvailableTasks();
   const { focusedTask, setFocusedTask } = useFocusedTask({ availableTasks });
@@ -131,13 +135,13 @@ export function NowViewProvider({ children }: NowViewProviderProps) {
     setFocusedTask,
   ]);
 
-  // Single call to useNowShortcuts at provider level
   useNowShortcuts({
     focusedTask,
     availableTasks,
     onPreviousTask: handlePreviousTask,
     onNextTask: handleNextTask,
     onCompleteTask: handleCompleteTask,
+    onToggleSidebar,
   });
 
   const value: NowViewContextValue = {

--- a/packages/web/src/views/Now/shortcuts/useNowShortcuts.test.tsx
+++ b/packages/web/src/views/Now/shortcuts/useNowShortcuts.test.tsx
@@ -1,0 +1,73 @@
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import { renderHook, waitFor } from "@testing-library/react";
+import { type PropsWithChildren } from "react";
+import { MemoryRouter } from "react-router-dom";
+import {
+  CompassDOMEvents,
+  compassEventEmitter,
+  pressKey,
+} from "@web/common/utils/dom/event-emitter.util";
+import { useNowShortcuts } from "./useNowShortcuts";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+function wrapper({ children }: PropsWithChildren) {
+  return (
+    <HotkeysProvider>
+      <MemoryRouter
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      >
+        {children}
+      </MemoryRouter>
+    </HotkeysProvider>
+  );
+}
+
+describe("useNowShortcuts", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    compassEventEmitter.removeAllListeners(
+      CompassDOMEvents.FOCUS_TASK_DESCRIPTION,
+    );
+  });
+
+  it("uses E to focus the task description", async () => {
+    const onFocusDescription = mock();
+    compassEventEmitter.on(
+      CompassDOMEvents.FOCUS_TASK_DESCRIPTION,
+      onFocusDescription,
+    );
+    renderHook(() => useNowShortcuts(), { wrapper });
+
+    pressKey("e");
+
+    await waitFor(() => {
+      expect(onFocusDescription).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not use D for the task description shortcut", async () => {
+    const onFocusDescription = mock();
+    compassEventEmitter.on(
+      CompassDOMEvents.FOCUS_TASK_DESCRIPTION,
+      onFocusDescription,
+    );
+    renderHook(() => useNowShortcuts(), { wrapper });
+
+    pressKey("d");
+
+    await waitFor(() => {
+      expect(onFocusDescription).not.toHaveBeenCalled();
+    });
+  });
+
+  it("toggles the sidebar with [", async () => {
+    const onToggleSidebar = mock();
+    renderHook(() => useNowShortcuts({ onToggleSidebar }), { wrapper });
+
+    pressKey("[");
+
+    await waitFor(() => {
+      expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/web/src/views/Now/shortcuts/useNowShortcuts.ts
+++ b/packages/web/src/views/Now/shortcuts/useNowShortcuts.ts
@@ -1,6 +1,4 @@
 import { useCallback } from "react";
-import { useNavigate } from "react-router-dom";
-import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { ID_REMINDER_INPUT } from "@web/common/constants/web.constants";
 import { useAppHotkey, useAppHotkeyUp } from "@web/common/hooks/useAppHotkey";
 import { type Task } from "@web/common/types/task.types";
@@ -18,10 +16,6 @@ interface Props {
   onToggleSidebar?: () => void;
 }
 
-/**
- * Hook to handle keyboard shortcuts for the Now view
- * Handles both global navigation shortcuts (n, d, w) and task-specific shortcuts (j, k)
- */
 export function useNowShortcuts(props?: Props) {
   const {
     focusedTask = null,
@@ -32,8 +26,6 @@ export function useNowShortcuts(props?: Props) {
     onToggleSidebar,
   } = props || {};
 
-  const navigate = useNavigate();
-
   const handleTaskNavigation = useCallback(
     (handler?: () => void) => {
       if (!focusedTask || availableTasks.length === 0) return;
@@ -43,7 +35,7 @@ export function useNowShortcuts(props?: Props) {
     [focusedTask, availableTasks.length],
   );
 
-  useAppHotkeyUp("D", () => {
+  useAppHotkeyUp("E", () => {
     compassEventEmitter.emit(CompassDOMEvents.FOCUS_TASK_DESCRIPTION);
   });
 
@@ -67,7 +59,6 @@ export function useNowShortcuts(props?: Props) {
   });
 
   const handleEnterKey = useCallback(() => {
-    // Don't trigger if the reminder input is focused
     const activeElement = document.activeElement as HTMLElement | null;
     if (activeElement?.id === ID_REMINDER_INPUT) {
       return;
@@ -77,18 +68,6 @@ export function useNowShortcuts(props?: Props) {
 
   useAppHotkeyUp("Enter", handleEnterKey);
 
-  useAppHotkey(
-    "Escape",
-    () => {
-      navigate(ROOT_ROUTES.DAY);
-    },
-    {
-      ignoreInputs: false,
-      blurOnTrigger: true,
-    },
-  );
-
-  // Sidebar shortcut
   useAppHotkeyUp("[", () => {
     onToggleSidebar?.();
   });

--- a/packages/web/src/views/Now/view/NowView.tsx
+++ b/packages/web/src/views/Now/view/NowView.tsx
@@ -8,7 +8,6 @@ import { Header } from "@web/views/Day/components/Header/Header";
 import { ShortcutsSidebar } from "@web/views/Day/components/ShortcutsSidebar/ShortcutsSidebar";
 import { NowCmdPalette } from "@web/views/Now/components/NowCmdPalette";
 import { NowViewProvider } from "@web/views/Now/context/NowViewProvider";
-import { useNowShortcuts } from "@web/views/Now/shortcuts/useNowShortcuts";
 import { NowViewContent } from "@web/views/Now/view/NowViewContent";
 
 export const NowView = () => {
@@ -26,10 +25,8 @@ export const NowView = () => {
     return () => togglePointerMovementTracking(false);
   }, [togglePointerMovementTracking]);
 
-  useNowShortcuts({ onToggleSidebar: toggleSidebar });
-
   return (
-    <NowViewProvider>
+    <NowViewProvider onToggleSidebar={toggleSidebar}>
       <NowCmdPalette />
       <StyledCalendar>
         <Header


### PR DESCRIPTION
## Summary
- Changes the Now view description shortcut from `D` to `E` so it no longer conflicts with view navigation.
- Adds a visible save button and keeps `Cmd+Enter` / `Ctrl+Enter` as the save shortcut for editing task descriptions.
- Updates the Now command palette, shortcut data, tests, and acceptance docs to match the new behavior.

## Testing
- Added and updated unit tests for Now shortcuts, shortcut data, and task description editing.
- Ran the web test suite for the affected tests.
- Verified type-check and lint locally.