### PR TITLE
feat: auto-sync docs/ to compass-docs on push

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -7,6 +7,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,32 @@
+name: Sync docs to compass-docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: SwitchbackTech/compass-docs
+          token: ${{ secrets.COMPASS_DOCS_TOKEN }}
+          path: compass-docs
+
+      - name: Sync docs
+        run: rsync -av --delete docs/ compass-docs/docs/
+
+      - name: Commit and push if changed
+        working-directory: compass-docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "sync: update docs from compass"
+          git push


### PR DESCRIPTION
## What changed

Adds `.github/workflows/sync-docs.yml` — a GitHub Action that keeps the [compass-docs](https://github.com/SwitchbackTech/compass-docs) site in sync with this repo's `docs/` directory automatically.

## How it works

1. Triggers on any push to `main` that touches `docs/**` (plus `workflow_dispatch` for manual runs)
2. Checks out both this repo and `compass-docs`
3. `rsync --delete` copies `docs/` → `compass-docs/docs/`, mirroring the folder structure exactly
4. Commits and pushes to `compass-docs` only if something changed
5. Vercel detects the push and auto-deploys to `docs.compasscalendar.com`

## Before merging

A repository secret must exist in **this repo**:

| Secret name | Value |
|---|---|
| `COMPASS_DOCS_TOKEN` | Fine-grained PAT with **Contents: Read and write** scoped to `SwitchbackTech/compass-docs` |

## Test plan

- [ ] Confirm `COMPASS_DOCS_TOKEN` secret is set in this repo's Actions secrets
- [ ] Merge this PR
- [ ] Trigger `sync-docs` manually via Actions → workflow_dispatch
- [ ] Verify a "sync: update docs from compass" commit appears in compass-docs
- [ ] Verify Vercel deploys and content appears at docs.compasscalendar.com
- [ ] Edit a file in `docs/` → push to main → confirm end-to-end flow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)