### PR TITLE
docs: simplify section headings for consistency

### DIFF
--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -1,4 +1,4 @@
-# Compass Backend
+# Backend
 
 Backend service for auth/session management, event persistence, Google sync,
 and SSE notifications.

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -1,4 +1,4 @@
-# Self-Hosting Compass
+# Self-Hosting
 
 Self-hosting Compass means running it on a server you control instead of using `app.compasscalendar.com`.
 


### PR DESCRIPTION
## What changed

- `docs/backend/README.md`: `# Compass Backend` → `# Backend`
- `docs/self-hosting/README.md`: `# Self-Hosting Compass` → `# Self-Hosting`

## Why

Docusaurus uses the H1 from a directory's README.md as the sidebar category label. These two headings were inconsistent with the other sections (acceptance, architecture, development, features, frontend) which all use simple single-word labels. This makes the sidebar uniform.

Once merged, the sync workflow will automatically push the change to compass-docs and Vercel will redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)