### PR TITLE
chore: upgrade actions/checkout to v6 in sync-docs workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -14,9 +14,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: SwitchbackTech/compass-docs
           token: ${{ secrets.COMPASS_DOCS_TOKEN }}


### PR DESCRIPTION
## What changed

`sync-docs.yml`: `actions/checkout@v4` → `actions/checkout@v6` (both occurrences).

## Why

`actions/checkout@v4` runs on Node.js 20, which is deprecated on GitHub Actions runners starting June 2, 2026. `@v6` runs on Node.js 24 and matches the version already used in `test-unit.yml` and `test-e2e.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)