### PR TITLE
docs: note that docs/ is auto-mirrored to the docsite

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@ Internal documentation for engineers and agents working in the Compass repo.
 
 Start with [AGENTS.md](../AGENTS.md) for repo rules and command defaults. Use this index for codebase shape, subsystem behavior, and acceptance runbooks.
 
+## How docs get published
+
+Markdown files in this `docs/` directory are automatically mirrored to [docs.compasscalendar.com](https://docs.compasscalendar.com). A GitHub Action detects any push to `main` that touches `docs/**` and syncs the changes to the doc site — no manual steps needed. Just edit the markdown here and the live site updates itself.
+
 ## Start Here
 
 - [Repo Architecture](./architecture/repo-architecture.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Start with [AGENTS.md](../AGENTS.md) for repo rules and command defaults. Use th
 
 ## How docs get published
 
-Markdown files in this `docs/` directory are automatically mirrored to [docs.compasscalendar.com](https://docs.compasscalendar.com). A GitHub Action detects any push to `main` that touches `docs/**` and syncs the changes to the doc site — no manual steps needed. Just edit the markdown here and the live site updates itself.
+Markdown files in this `docs/` directory are automatically mirrored to [docs.compasscalendar.com](https://docs.compasscalendar.com). A GitHub Action detects any push to `main` that touches `docs/**` and syncs the changes to the doc site. Just edit any of the markdown in `docs/` and the doc site will update itself upon merge.
 
 ## Start Here
 


### PR DESCRIPTION
Adds a short "How docs get published" blurb to `docs/README.md` so contributors know their changes go live automatically without any extra steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)