### PR TITLE
feat(ci-cd): auto bump patch version and deploy to staging on merge

### DIFF
--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -1,0 +1,33 @@
+name: Bump version and tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Bump patch version and push tag
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          [ -z "$LATEST" ] && LATEST="v0.0.0"
+          VERSION="${LATEST#v}"
+          MAJOR="${VERSION%%.*}"
+          REST="${VERSION#*.}"
+          MINOR="${REST%%.*}"
+          PATCH="${REST#*.}"
+          NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+          echo "Bumping ${LATEST} → ${NEW_TAG}"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"

--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -19,6 +19,8 @@ jobs:
           fetch-depth: 0
 
       - name: Bump patch version and push tag
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           [ -z "$LATEST" ] && LATEST="v0.0.0"
@@ -30,4 +32,6 @@ jobs:
           NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "Bumping ${LATEST} → ${NEW_TAG}"
           git tag "$NEW_TAG"
-          git push origin "$NEW_TAG"
+          # Push with PAT so the tag event triggers publish-images.yml.
+          # GITHUB_TOKEN pushes are intentionally blocked from triggering downstream workflows.
+          git push "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git" "$NEW_TAG"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -74,3 +74,16 @@ jobs:
             switchbacktech/compass-web:${{ steps.version.outputs.version }}
             switchbacktech/compass-web:${{ steps.version.outputs.minor }}
             switchbacktech/compass-web:latest
+
+  deploy-staging:
+    needs: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to staging
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          script: cd ~/compass && ./compass update

--- a/docs/CI-CD/README.md
+++ b/docs/CI-CD/README.md
@@ -1,6 +1,6 @@
 # CI/CD
 
-Compass uses GitHub Actions for continuous integration and Docker Hub for distributing self-host images.
+Compass uses GitHub Actions for continuous integration, Docker Hub for image distribution, and a Hetzner VPS for staging.
 
 ## Workflows
 
@@ -8,8 +8,31 @@ Compass uses GitHub Actions for continuous integration and Docker Hub for distri
 |---|---|---|
 | Test | Push / PR to `main` | Runs lint, type-check, and unit tests |
 | CodeQL | Push / PR to `main` | Static security analysis |
-| Publish Docker images | Push a `v*.*.*` tag | Builds and publishes self-host images to Docker Hub |
+| Bump version and tag | Push to `main` | Auto-increments patch version, pushes a new semver tag |
+| Publish Docker images | Push a `v*.*.*` tag | Builds images, pushes to Docker Hub, deploys to staging |
 | Sync docs to compass-docs | Push to `main` touching `docs/**` | Mirrors this `docs/` directory to docs.compasscalendar.com |
+
+---
+
+## Release Flow
+
+Every PR merge to `main` triggers a fully automated chain:
+
+```
+PR merged to main
+  └─► bump-and-tag.yml        — reads latest tag, pushes v1.2.X+1
+        └─► publish-images.yml — builds & pushes images to Docker Hub
+              └─► deploy-staging  — SSHes into Hetzner VPS, runs ./compass update
+```
+
+**Monthly minor/major releases** remain manual: a maintainer pushes a tag like `v1.3.0` or `v2.0.0`, which skips the bump step and goes straight to publish + deploy.
+
+### Removing a test tag
+
+```sh
+git push origin --delete v1.2.3
+git tag -d v1.2.3
+```
 
 ---
 
@@ -19,7 +42,7 @@ Source: [`.github/workflows/publish-images.yml`](../../.github/workflows/publish
 
 ### How it works
 
-1. A maintainer pushes a git tag matching `v[0-9]+.[0-9]+.[0-9]+` (e.g. `v1.2.3`).
+1. A semver tag matching `v[0-9]+.[0-9]+.[0-9]+` is pushed (either by `bump-and-tag.yml` or manually).
 2. The workflow strips the `v` prefix and derives two tag aliases:
    - `1.2.3` — exact patch version
    - `1.2` — floating minor alias
@@ -28,30 +51,53 @@ Source: [`.github/workflows/publish-images.yml`](../../.github/workflows/publish
    - `switchbacktech/compass-mongo`
    - `switchbacktech/compass-web`
 4. Each image gets all three tags: `1.2.3`, `1.2`, and `latest`.
+5. After all images are pushed, the `deploy-staging` job runs.
 
-### Manually publishing a release
+### Tag pattern rules
 
-Although tags are created automatically as part of the release flow, you can also create them manually to publish images from a local branch.
+Only clean semver tags trigger the workflow. Tags with suffixes (e.g. `v1.2.3-test`) do not match and are safe to push for local testing without triggering a deploy.
 
-```sh
-git tag v1.2.3
-git push origin v1.2.3
-```
+### Web image build-args
 
-Watch progress in the [Actions tab](https://github.com/SwitchbackTech/compass/actions). After the workflow completes, all three images appear on Docker Hub under the `switchbacktech` org.
+`BASEURL` and `GOOGLE_CLIENT_ID` are baked into the web bundle at compile time. The published image ships with localhost defaults. Users who need a custom API domain or real Google credentials must rebuild the web image locally using the commented-out `build:` blocks in `docker-compose.yml`.
 
-### Removing a test tag
+---
 
-```sh
-git push origin --delete v1.2.3
-git tag -d v1.2.3
-```
+## Staging Deploy
+
+Source: `deploy-staging` job in [`.github/workflows/publish-images.yml`](../../.github/workflows/publish-images.yml)
+
+The deploy job SSHes into the Hetzner staging VPS and runs `./compass update`, which pulls the latest Docker Hub images and restarts the stack. This mirrors exactly what self-hosters do to update their installations — intentionally, so we catch any issues early.
+
+### One-time VPS setup
+
+These steps run once by a maintainer. After this, all deploys are automated.
+
+1. **Provision** a Hetzner VPS and SSH in as root
+2. **Install Docker**: follow [docs.docker.com/engine/install](https://docs.docker.com/engine/install/)
+3. **Run the Compass installer**:
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
+   ```
+4. **Edit `~/compass/.env`** — set staging-specific values (domain, Google OAuth creds, secrets)
+5. **Generate a deploy SSH keypair** (run locally, not on the VPS):
+   ```sh
+   ssh-keygen -t ed25519 -C "compass-staging-deploy" -f compass-staging-deploy
+   ```
+6. **Add the public key** to `~/.ssh/authorized_keys` on the VPS:
+   ```sh
+   ssh-copy-id -i compass-staging-deploy.pub <user>@<vps-ip>
+   ```
+7. **Add the private key** as `STAGING_SSH_KEY` in GitHub secrets (see table below)
 
 ### Required secrets
 
-Two secrets must be set in **GitHub → Settings → Secrets and variables → Actions**:
+All secrets go in **GitHub → Settings → Secrets and variables → Actions**:
 
 | Secret | Value |
 |---|---|
 | `DOCKERHUB_USERNAME` | Docker Hub username for the `switchbacktech` org |
 | `DOCKERHUB_TOKEN` | Docker Hub personal access token (Read & Write) |
+| `STAGING_SSH_HOST` | Hetzner VPS IP address or hostname |
+| `STAGING_SSH_USER` | Linux user on the VPS that owns `~/compass` |
+| `STAGING_SSH_KEY` | Private key from the deploy keypair (the `compass-staging-deploy` file, not `.pub`) |

--- a/docs/CI-CD/README.md
+++ b/docs/CI-CD/README.md
@@ -1,6 +1,6 @@
 # CI/CD
 
-Compass uses GitHub Actions for continuous integration, Docker Hub for image distribution, and a Hetzner VPS for staging.
+Compass uses GitHub Actions for continuous integration, Docker Hub for image distribution, and a VPS for staging.
 
 ## Workflows
 
@@ -22,7 +22,7 @@ Every PR merge to `main` triggers a fully automated chain:
 PR merged to main
   └─► bump-and-tag.yml        — reads latest tag, pushes v1.2.X+1
         └─► publish-images.yml — builds & pushes images to Docker Hub
-              └─► deploy-staging  — SSHes into Hetzner VPS, runs ./compass update
+              └─► deploy-staging  — SSHes into VPS, runs ./compass update
 ```
 
 **Monthly minor/major releases** remain manual: a maintainer pushes a tag like `v1.3.0` or `v2.0.0`, which skips the bump step and goes straight to publish + deploy.
@@ -67,27 +67,33 @@ Only clean semver tags trigger the workflow. Tags with suffixes (e.g. `v1.2.3-te
 
 Source: `deploy-staging` job in [`.github/workflows/publish-images.yml`](../../.github/workflows/publish-images.yml)
 
-The deploy job SSHes into the Hetzner staging VPS and runs `./compass update`, which pulls the latest Docker Hub images and restarts the stack. This mirrors exactly what self-hosters do to update their installations — intentionally, so we catch any issues early.
+The deploy job SSHes into the staging VPS and runs `./compass update`, which pulls the latest Docker Hub images and restarts the stack. This mirrors exactly what self-hosters do to update their installations — intentionally, so we catch any issues early.
 
 ### One-time VPS setup
 
 These steps run once by a maintainer. After this, all deploys are automated.
 
-1. **Provision** a Hetzner VPS and SSH in as root
+1. **Provision** a VPS and SSH in as root
 2. **Install Docker**: follow [docs.docker.com/engine/install](https://docs.docker.com/engine/install/)
 3. **Run the Compass installer**:
+
    ```sh
    curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
    ```
+
 4. **Edit `~/compass/.env`** — set staging-specific values (domain, Google OAuth creds, secrets)
 5. **Generate a deploy SSH keypair** (run locally, not on the VPS):
+
    ```sh
    ssh-keygen -t ed25519 -C "compass-staging-deploy" -f compass-staging-deploy
    ```
+
 6. **Add the public key** to `~/.ssh/authorized_keys` on the VPS:
+
    ```sh
    ssh-copy-id -i compass-staging-deploy.pub <user>@<vps-ip>
    ```
+
 7. **Add the private key** as `STAGING_SSH_KEY` in GitHub secrets (see table below)
 
 ### Required secrets
@@ -98,6 +104,6 @@ All secrets go in **GitHub → Settings → Secrets and variables → Actions**:
 |---|---|
 | `DOCKERHUB_USERNAME` | Docker Hub username for the `switchbacktech` org |
 | `DOCKERHUB_TOKEN` | Docker Hub personal access token (Read & Write) |
-| `STAGING_SSH_HOST` | Hetzner VPS IP address or hostname |
+| `STAGING_SSH_HOST` | VPS IP address or hostname |
 | `STAGING_SSH_USER` | Linux user on the VPS that owns `~/compass` |
 | `STAGING_SSH_KEY` | Private key from the deploy keypair (the `compass-staging-deploy` file, not `.pub`) |

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -1,8 +1,6 @@
-# CI/CD
+# Workflows
 
 Compass uses GitHub Actions for continuous integration, Docker Hub for image distribution, and a VPS for staging.
-
-## Workflows
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
@@ -46,7 +44,7 @@ Source: [`.github/workflows/publish-images.yml`](../../.github/workflows/publish
 2. The workflow strips the `v` prefix and derives two tag aliases:
    - `1.2.3` — exact patch version
    - `1.2` — floating minor alias
-3. It builds and pushes three images to Docker Hub:
+3. It builds and pushes three images to [our Docker Hub](https://hub.docker.com/repositories/switchbacktech):
    - `switchbacktech/compass-backend`
    - `switchbacktech/compass-mongo`
    - `switchbacktech/compass-web`
@@ -57,44 +55,13 @@ Source: [`.github/workflows/publish-images.yml`](../../.github/workflows/publish
 
 Only clean semver tags trigger the workflow. Tags with suffixes (e.g. `v1.2.3-test`) do not match and are safe to push for local testing without triggering a deploy.
 
-### Web image build-args
-
-`BASEURL` and `GOOGLE_CLIENT_ID` are baked into the web bundle at compile time. The published image ships with localhost defaults. Users who need a custom API domain or real Google credentials must rebuild the web image locally using the commented-out `build:` blocks in `docker-compose.yml`.
-
 ---
 
 ## Staging Deploy
 
 Source: `deploy-staging` job in [`.github/workflows/publish-images.yml`](../../.github/workflows/publish-images.yml)
 
-The deploy job SSHes into the staging VPS and runs `./compass update`, which pulls the latest Docker Hub images and restarts the stack. This mirrors exactly what self-hosters do to update their installations — intentionally, so we catch any issues early.
-
-### One-time VPS setup
-
-These steps run once by a maintainer. After this, all deploys are automated.
-
-1. **Provision** a VPS and SSH in as root
-2. **Install Docker**: follow [docs.docker.com/engine/install](https://docs.docker.com/engine/install/)
-3. **Run the Compass installer**:
-
-   ```sh
-   curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/main/self-host/install.sh | sh
-   ```
-
-4. **Edit `~/compass/.env`** — set staging-specific values (domain, Google OAuth creds, secrets)
-5. **Generate a deploy SSH keypair** (run locally, not on the VPS):
-
-   ```sh
-   ssh-keygen -t ed25519 -C "compass-staging-deploy" -f compass-staging-deploy
-   ```
-
-6. **Add the public key** to `~/.ssh/authorized_keys` on the VPS:
-
-   ```sh
-   ssh-copy-id -i compass-staging-deploy.pub <user>@<vps-ip>
-   ```
-
-7. **Add the private key** as `STAGING_SSH_KEY` in GitHub secrets (see table below)
+The deploy job SSHes into the staging VPS and runs `./compass update`, which pulls the latest Docker Hub images and restarts the stack.
 
 ### Required secrets
 

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -1,4 +1,4 @@
-# Back up and restore your data
+# Back up and Restore
 
 For the Docker install created by `self-host/install.sh` on your server. Backups are manual today. The installer and `./compass update` do not create them for you.
 

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -1,4 +1,4 @@
-# Add Google Calendar (optional)
+# Add Google Calendar
 
 Google Calendar is optional for self-hosting. Compass works fine with email and password alone. Pick a mode based on what you actually need.
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -1,4 +1,4 @@
-# Run Compass on a server
+# Setup Compass On A Server
 
 This guide describes the recommended first server setup for one person hosting Compass on a small VPS. One public domain, Compass on `127.0.0.1`, Caddy in front for HTTPS.
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -433,6 +433,9 @@ write_env_if_missing() {
   umask 077
   TMP_ENV=$COMPASS_HOME/.env.$$
   cat > "$TMP_ENV" <<EOF
+# See for a detailed description of each variable here:
+# https://docs.compasscalendar.com/docs/self-hosting/environment-variables
+
 # Compose
 COMPASS_VERSION=$COMPASS_VERSION
 
@@ -446,9 +449,9 @@ TZ=Etc/UTC
 LOG_LEVEL=info
 
 # Local URLs
-FRONTEND_URL=http://localhost:9080
-BASEURL=http://localhost:3000/api
-CORS=http://localhost:9080,http://localhost:3000
+FRONTEND_URL=https://cal.yourdomain.com
+BASEURL=https://cal.yourdomain.com/api
+CORS=https://cal.yourdomain.com
 
 # Compass MongoDB
 MONGO_INITDB_ROOT_USERNAME=compass
@@ -579,7 +582,7 @@ EOF
     $ENV_FILE
   Then rebuild the web image (BASEURL and GOOGLE_CLIENT_ID are baked in at build time):
     $HELPER_FILE rebuild
-  See docs/Self-Hosting/google-calendar.md for setup instructions.
+  See https://docs.compasscalendar.com/docs/self-hosting/google-calendar
 EOF
   else
     cat <<EOF

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -3,6 +3,11 @@
 COMPASS_HOME=${COMPASS_HOME:-$HOME/compass}
 COMPASS_VERSION=${COMPASS_VERSION:-latest}
 COMPASS_RAW_URL=https://raw.githubusercontent.com/SwitchbackTech/compass
+# 'latest' is a Docker Hub tag, not a git ref. Map it to 'main' for raw file downloads.
+case $COMPASS_VERSION in
+  latest) COMPASS_GIT_REF=main ;;
+  *)      COMPASS_GIT_REF=$COMPASS_VERSION ;;
+esac
 
 ENV_FILE=$COMPASS_HOME/.env
 MARKER_FILE=$COMPASS_HOME/.compass-self-host
@@ -479,7 +484,7 @@ EOF
 download_compose_file() {
   tmp_compose=$COMPASS_HOME/docker-compose.yml.$$
   info "Downloading docker-compose.yml for Compass ${COMPASS_VERSION}."
-  curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_VERSION}/self-host/docker-compose.yml" -o "$tmp_compose" \
+  curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_GIT_REF}/self-host/docker-compose.yml" -o "$tmp_compose" \
     || fail "Could not download docker-compose.yml for version ${COMPASS_VERSION}. Check that the version exists."
 
   if [ -f "$COMPOSE_FILE" ]; then
@@ -491,7 +496,7 @@ download_compose_file() {
 
 download_helper() {
   info "Downloading compass helper for Compass ${COMPASS_VERSION}."
-  curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_VERSION}/self-host/compass" -o "$HELPER_FILE" \
+  curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_GIT_REF}/self-host/compass" -o "$HELPER_FILE" \
     || fail "Could not download compass helper for version ${COMPASS_VERSION}."
   chmod +x "$HELPER_FILE" || fail "Could not make $HELPER_FILE executable."
 }


### PR DESCRIPTION
## Summary

- Adds `bump-and-tag.yml`: fires on every merge to `main`, reads the latest semver tag, increments the patch, and pushes the new tag using a PAT so `publish-images.yml` is triggered (default `GITHUB_TOKEN` pushes are intentionally blocked from triggering downstream workflows)
- Adds `deploy-staging` job to `publish-images.yml`: SSHes into Hetzner VPS and runs `./compass update` after all images are pushed
- Fixes `install.sh`: `latest` is a Docker Hub tag, not a git ref — maps it to `main` for raw file downloads
- Updates `docs/CI-CD/README.md` with the full chain, one-time VPS setup steps, and the expanded secrets table

## Full flow after merge

```
PR merged to main
  └─► bump-and-tag.yml        — pushes v1.2.X+1 via PAT
        └─► publish-images.yml — builds & pushes images to Docker Hub
              └─► deploy-staging  — ./compass update on Hetzner VPS
```

Monthly minor/major releases remain manual (push a `v1.3.0` tag directly).

## Secrets required before this is fully operational

| Secret | Purpose |
|---|---|
| `GH_PAT` | Fine-grained PAT with Contents: Read & Write on this repo — lets bump-and-tag push a tag that triggers publish-images |
| `STAGING_SSH_HOST` | Hetzner VPS IP |
| `STAGING_SSH_USER` | Linux user on VPS |
| `STAGING_SSH_KEY` | Private deploy SSH key |

## Test plan

- [ ] Add `GH_PAT` secret, merge this PR → verify `bump-and-tag.yml` creates a new patch tag
- [ ] Verify `publish-images.yml` fires from that tag and new images appear on Docker Hub
- [ ] After VPS setup + SSH secrets added, verify `deploy-staging` exits 0 and `./compass status` on VPS shows updated containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)