### PR TITLE
fix(ci-cd): use PAT to push tag so publish-images.yml is triggered

### DIFF
--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -19,6 +19,8 @@ jobs:
           fetch-depth: 0
 
       - name: Bump patch version and push tag
+        env:
+          COMPASS_PAT: ${{ secrets.COMPASS_CI_TOKEN }}
         run: |
           LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           [ -z "$LATEST" ] && LATEST="v0.0.0"
@@ -30,4 +32,4 @@ jobs:
           NEW_TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "Bumping ${LATEST} → ${NEW_TAG}"
           git tag "$NEW_TAG"
-          git push origin "$NEW_TAG"
+          git push "https://x-access-token:${COMPASS_CI_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$NEW_TAG"

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -69,17 +69,9 @@ All secrets go in **GitHub → Settings → Secrets and variables → Actions**:
 
 | Secret | Value |
 |---|---|
-| `GITHUB_PAT` | Fine-grained PAT — see below |
+| `COMPASS_CI_TOKEN` | Fine-grained PAT needed for the bump and tag workflow |
 | `DOCKERHUB_USERNAME` | Docker Hub username for the `switchbacktech` org |
 | `DOCKERHUB_TOKEN` | Docker Hub personal access token (Read & Write) |
 | `STAGING_SSH_HOST` | VPS IP address or hostname |
 | `STAGING_SSH_USER` | Linux user on the VPS that owns `~/compass` |
 | `STAGING_SSH_KEY` | Private key from the deploy keypair (the `compass-staging-deploy` file, not `.pub`) |
-
-### Why GITHUB_PAT is needed
-
-GitHub intentionally prevents workflows from triggering other workflows when using the default `GITHUB_TOKEN`. This blocks infinite loops, but it also means a tag pushed by `bump-and-tag.yml` via `GITHUB_TOKEN` would never trigger `publish-images.yml`.
-
-Using a Personal Access Token (PAT) instead is treated as a human actor pushing the tag, so `publish-images.yml` fires normally.
-
-**Creating the PAT**: GitHub → avatar → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token. Set repository access to `compass` only, and grant `Contents: Read and write`. No other permissions needed.

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -69,8 +69,17 @@ All secrets go in **GitHub → Settings → Secrets and variables → Actions**:
 
 | Secret | Value |
 |---|---|
+| `GITHUB_PAT` | Fine-grained PAT — see below |
 | `DOCKERHUB_USERNAME` | Docker Hub username for the `switchbacktech` org |
 | `DOCKERHUB_TOKEN` | Docker Hub personal access token (Read & Write) |
 | `STAGING_SSH_HOST` | VPS IP address or hostname |
 | `STAGING_SSH_USER` | Linux user on the VPS that owns `~/compass` |
 | `STAGING_SSH_KEY` | Private key from the deploy keypair (the `compass-staging-deploy` file, not `.pub`) |
+
+### Why GITHUB_PAT is needed
+
+GitHub intentionally prevents workflows from triggering other workflows when using the default `GITHUB_TOKEN`. This blocks infinite loops, but it also means a tag pushed by `bump-and-tag.yml` via `GITHUB_TOKEN` would never trigger `publish-images.yml`.
+
+Using a Personal Access Token (PAT) instead is treated as a human actor pushing the tag, so `publish-images.yml` fires normally.
+
+**Creating the PAT**: GitHub → avatar → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token. Set repository access to `compass` only, and grant `Contents: Read and write`. No other permissions needed.


### PR DESCRIPTION
## Summary

- `bump-and-tag.yml` was pushing the new version tag using the default `GITHUB_TOKEN`, which GitHub intentionally blocks from triggering downstream workflows (to prevent infinite loops)
- Switches to a fine-grained PAT  for the tag push so `publish-images.yml` fires correctly

## Required secret

Add `GH_PAT` in **GitHub → Settings → Secrets → Actions**:
- Type: fine-grained PAT
- Repository access: `compass` only
- Permission: `Contents: Read & Write`

## Test plan

- [x] Add `GH_PAT` secret, merge this PR
- [ ] Verify `bump-and-tag.yml` creates a new patch tag
- [ ] Verify `publish-images.yml` fires from that tag → images updated on Docker Hub
- [ ] Verify `deploy-staging` job SSHes into VPS and runs `./compass update`

### Why COMPASS_CI_TOKEN is needed

GitHub intentionally prevents workflows from triggering other workflows when using the default `GITHUB_TOKEN`. This blocks infinite loops, but it also means a tag pushed by `bump-and-tag.yml` via `GITHUB_TOKEN` would never trigger `publish-images.yml`.

Using a Personal Access Token (PAT) instead is treated as a human actor pushing the tag, so `publish-images.yml` fires normally.

**Creating the token**: GitHub → avatar → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token. Set repository access to `compass` only, and grant `Contents: Read and write`.
