### PR TITLE
Hide Someday buckets from Day view sidebar

### DIFF
--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import dayjs from "@core/util/date/dayjs";
+import { afterAll, describe, expect, it, mock } from "bun:test";
+
+mock.module("./PlannerMonthPicker/PlannerMonthPicker", () => ({
+  PlannerMonthPicker: () => <div>Calendar picker</div>,
+}));
+
+mock.module("./PlannerAccountSummary/PlannerAccountSummary", () => ({
+  PlannerAccountSummary: () => <div>Account summary</div>,
+}));
+
+mock.module("./PlannerSidebarActions/PlannerSidebarActions", () => ({
+  PlannerSidebarActions: () => <div>Sidebar actions</div>,
+}));
+
+mock.module("./ShortcutsOverlay/ShortcutsOverlay", () => ({
+  ShortcutsOverlay: () => null,
+}));
+
+mock.module("./SomedayEventSections/SomedayEventSections", () => ({
+  SomedayEventSections: () => <div>Week and month planning buckets</div>,
+}));
+
+const { PlannerSidebar } =
+  require("./PlannerSidebar") as typeof import("./PlannerSidebar");
+
+const renderSidebar = (props?: { showSomedayEventSections?: boolean }) => {
+  render(
+    <PlannerSidebar
+      calendarDate={dayjs("2026-05-12")}
+      onSelectDate={mock()}
+      shortcutSections={[]}
+      viewEnd={dayjs("2026-05-16")}
+      viewStart={dayjs("2026-05-10")}
+      {...props}
+    />,
+  );
+};
+
+describe("PlannerSidebar", () => {
+  it("shows Someday event sections by default", () => {
+    renderSidebar();
+
+    expect(screen.getByRole("region", { name: "Someday events" })).toBeTruthy();
+    expect(screen.getByText("Week and month planning buckets")).toBeTruthy();
+  });
+
+  it("hides Someday event sections when requested", () => {
+    renderSidebar({ showSomedayEventSections: false });
+
+    expect(screen.queryByRole("region", { name: "Someday events" })).toBeNull();
+    expect(screen.queryByText("Week and month planning buckets")).toBeNull();
+    expect(screen.getByText("Calendar picker")).toBeTruthy();
+    expect(screen.getByText("Account summary")).toBeTruthy();
+    expect(screen.getByText("Sidebar actions")).toBeTruthy();
+  });
+});
+
+afterAll(() => {
+  mock.restore();
+});

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
@@ -21,6 +21,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   monthsShown?: number;
   onSelectDate: (date: Dayjs) => void;
   shortcutSections: ShortcutOverlaySection[];
+  showSomedayEventSections?: boolean;
   viewEnd: Dayjs;
   viewStart: Dayjs;
 }
@@ -33,6 +34,7 @@ export function PlannerSidebar({
   monthsShown = 1,
   onSelectDate,
   shortcutSections,
+  showSomedayEventSections = true,
   viewEnd,
   viewStart,
   ...props
@@ -55,16 +57,18 @@ export function PlannerSidebar({
 
         <PlannerAccountSummary />
 
-        <section aria-label="Unscheduled events" className="space-y-4">
-          <SomedayEventSections
-            calendarDate={calendarDate}
-            dateCalcs={dateCalcs}
-            gridRefs={gridRefs}
-            measurements={measurements}
-            viewEnd={viewEnd}
-            viewStart={viewStart}
-          />
-        </section>
+        {showSomedayEventSections ? (
+          <section aria-label="Someday events" className="space-y-4">
+            <SomedayEventSections
+              calendarDate={calendarDate}
+              dateCalcs={dateCalcs}
+              gridRefs={gridRefs}
+              measurements={measurements}
+              viewEnd={viewEnd}
+              viewStart={viewStart}
+            />
+          </section>
+        ) : null}
       </div>
 
       <PlannerSidebarActions

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -12,9 +12,7 @@ import {
 } from "@web/common/utils/dom/event-emitter.util";
 import { openEventFormEditEvent } from "@web/common/utils/event/event.util";
 import { getShortcuts } from "@web/common/utils/shortcut/data/shortcuts.data";
-import { SidebarDraftProvider } from "@web/components/PlannerSidebar/draft/context/SidebarDraftProvider";
 import { PlannerSidebar } from "@web/components/PlannerSidebar/PlannerSidebar";
-import { usePlannerSidebarSomedayEvents } from "@web/components/PlannerSidebar/usePlannerSidebarSomedayEvents";
 import { selectIsSidebarOpen } from "@web/ducks/events/selectors/view.selectors";
 import { viewSlice } from "@web/ducks/events/slices/view.slice";
 import { useAppDispatch, useAppSelector } from "@web/store/store.hooks";
@@ -78,9 +76,6 @@ export const DayViewContent = memo(() => {
 
   const plannerViewStart = dateInView.startOf("week");
   const plannerViewEnd = dateInView.endOf("week");
-  usePlannerSidebarSomedayEvents(plannerViewStart, {
-    isEnabled: isSidebarOpen,
-  });
 
   const toggleSidebar = useCallback(() => {
     dispatch(viewSlice.actions.toggleSidebar());
@@ -177,19 +172,14 @@ export const DayViewContent = memo(() => {
       <Dedication />
 
       {isSidebarOpen ? (
-        <SidebarDraftProvider
-          onGoToDate={navigateToDate}
+        <PlannerSidebar
+          calendarDate={dateInView}
+          onSelectDate={navigateToDate}
+          shortcutSections={shortcutSections}
+          showSomedayEventSections={false}
           viewEnd={plannerViewEnd}
           viewStart={plannerViewStart}
-        >
-          <PlannerSidebar
-            calendarDate={dateInView}
-            onSelectDate={navigateToDate}
-            shortcutSections={shortcutSections}
-            viewEnd={plannerViewEnd}
-            viewStart={plannerViewStart}
-          />
-        </SidebarDraftProvider>
+        />
       ) : null}
 
       <StyledCalendar>


### PR DESCRIPTION
## Summary

- hides the Someday week/month buckets from the Day view sidebar
- keeps the Day sidebar calendar, account row, footer controls, and shortcuts overlay
- leaves Week view unchanged so Someday planning still lives there

## Why

Day view should feel like the focused daily execution surface. Showing the Someday week/month buckets there made the screen feel like it had multiple task lists, even though those buckets are really event-planning surfaces.

## Verification

- NODE_ENV=test TZ=Etc/UTC bun test --preload ./src/__tests__/web.preload.ts ./src/components/PlannerSidebar/PlannerSidebar.test.tsx
- bun run lint
- bun run type-check
- browser check on /day/2026-05-12, /day date navigation, and /week

## Notes

During browser verification, the local dev app still showed existing backend CORS/session-refresh console noise when the backend was not running for this UI-only check.