### PR TITLE
fix(self-host): check installer health locally

### DIFF
--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -217,9 +217,9 @@ sudo systemctl restart caddy
 
 ## 5. Switch Compass to your public URLs
 
-> **Warning.** Don't change `BASEURL` until step 4 succeeds. Compass uses
-> `BASEURL` for health checks. If `BASEURL` points at an HTTPS URL Caddy can't
-> serve yet, the health check fails even if the containers are running.
+> **Warning.** Don't change `BASEURL` until step 4 succeeds. The browser uses
+> `BASEURL` for API requests. If `BASEURL` points at an HTTPS URL Caddy can't
+> serve yet, the app can load but cannot reach the backend.
 
 Edit the env file:
 
@@ -268,7 +268,7 @@ cd ~/compass
 ./compass logs backend
 ```
 
-> **Tip.** If you ever need the helper to check the local backend directly while `BASEURL` stays public, add `COMPASS_HEALTH_URL=http://127.0.0.1:3000/api/health` to `~/compass/.env`. Most one-domain installs don't need this once Caddy is working.
+> **Tip.** The `./compass` helper checks backend health through localhost using `PORT`. Set `COMPASS_HEALTH_URL` only if you move the backend health endpoint to a different local address.
 
 ## 6. Sign in and test the basics
 

--- a/packages/web/src/common/constants/more.cmd.constants.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.ts
@@ -28,8 +28,7 @@ export const moreCommandPaletteItems: Array<{
         children: `Version: ${typeof BUILD_VERSION === "string" ? BUILD_VERSION : "dev"}`,
         icon: "InformationCircleIcon",
         onClick: () => {
-          const v =
-            typeof BUILD_VERSION === "string" ? BUILD_VERSION : "dev";
+          const v = typeof BUILD_VERSION === "string" ? BUILD_VERSION : "dev";
           void navigator.clipboard.writeText(v);
         },
       },

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -253,23 +253,6 @@ read_env_value() {
   fi
 }
 
-append_health_path() {
-  base_url=$1
-
-  while :; do
-    case $base_url in
-      */)
-        base_url=${base_url%/}
-        ;;
-      *)
-        break
-        ;;
-    esac
-  done
-
-  printf '%s/health\n' "$base_url"
-}
-
 load_runtime_config() {
   web_port=$(strip_quotes "$(read_env_value WEB_PORT)")
   backend_port=$(strip_quotes "$(read_env_value PORT)")
@@ -280,11 +263,10 @@ load_runtime_config() {
   validate_port_value PORT "$PORT_VALUE"
 
   frontend_url=$(strip_quotes "$(read_env_value FRONTEND_URL)")
-  baseurl=$(strip_quotes "$(read_env_value BASEURL)")
   health_url=$(strip_quotes "$(read_env_value COMPASS_HEALTH_URL)")
 
   APP_URL=${frontend_url:-http://localhost:$WEB_PORT_VALUE}
-  HEALTH_URL=${COMPASS_HEALTH_URL:-${health_url:-$(append_health_path "${baseurl:-http://localhost:$PORT_VALUE/api}")}}
+  HEALTH_URL=${COMPASS_HEALTH_URL:-${health_url:-http://localhost:$PORT_VALUE/api/health}}
 }
 
 random_hex() {


### PR DESCRIPTION
## Summary

This fixes a self-host installer health-check drift that showed up in the daily bug scan.

A recent fix changed the installed `./compass` helper so backend health checks use the local backend port instead of the public `BASEURL`. That was the right behavior because self-host installs start before Caddy or a public domain may be ready.

The installer has its own copy of the health-check setup, though, and it still derived the health URL from `BASEURL`. Fresh installs could therefore still fail with the old behavior: the containers could be healthy on `localhost:3000`, but the installer would poll something like `https://cal.yourdomain.com/api/health` before the public HTTPS route existed.

## What changed

- Updated `self-host/install.sh` so its default health check is `http://localhost:$PORT_VALUE/api/health`.
- Removed the now-unused installer helper that appended `/health` to `BASEURL`.
- Updated the self-host server guide so it describes `BASEURL` as the browser API URL, not the helper health-check URL.
- Included one formatting-only cleanup in `more.cmd.constants.ts` because repo lint was failing on that existing formatting issue.

## Reviewer focus

The key thing to review is whether installer health checks should always default to the local backend port unless `COMPASS_HEALTH_URL` is explicitly set. That matches the already-fixed `self-host/compass` helper and avoids requiring public Caddy routing during install.

## Verification

- `sh -n self-host/install.sh`
- `sh -n self-host/compass`
- `bun run type-check`
- `bun run lint`