### PR TITLE
refactor(events): centralize event read shaping

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,6 +63,10 @@ _Avoid_: logged out
 **Event**:
 A Compass calendar item represented by the shared event contract.
 
+**Event Read Shape**:
+The rule that decides which Events belong in a visible calendar or sidebar read
+window, and how those Events are shaped before the UI receives them.
+
 **Standalone Event**:
 A single event that is not part of a recurring series.
 

--- a/packages/backend/src/event/read/backend-event-read.adapter.ts
+++ b/packages/backend/src/event/read/backend-event-read.adapter.ts
@@ -1,5 +1,6 @@
 import { type Document, ObjectId, type WithId } from "mongodb";
 import {
+  type Priority,
   SOMEDAY_MONTHLY_LIMIT,
   SOMEDAY_WEEKLY_LIMIT,
 } from "@core/constants/core.constants";
@@ -41,6 +42,7 @@ export const readBackendEvents = async (
       mode: isSomeday ? "someday" : "calendar",
       startDate: query.start ?? FALLBACK_START_DATE,
       endDate: query.end ?? FALLBACK_END_DATE,
+      priorities: parsePriorityQuery(query.priorities),
     },
     events: events.map(mapMongoEvent),
     baseEventsById,
@@ -72,3 +74,11 @@ const mapMongoEvent = (
   ...event,
   _id: event._id.toString(),
 });
+
+const parsePriorityQuery = (priorities: Query_Event["priorities"]) => {
+  if (!priorities) {
+    return undefined;
+  }
+
+  return priorities.split(",") as Priority[];
+};

--- a/packages/backend/src/event/read/backend-event-read.adapter.ts
+++ b/packages/backend/src/event/read/backend-event-read.adapter.ts
@@ -1,0 +1,74 @@
+import { type Document, ObjectId, type WithId } from "mongodb";
+import {
+  SOMEDAY_MONTHLY_LIMIT,
+  SOMEDAY_WEEKLY_LIMIT,
+} from "@core/constants/core.constants";
+import { shapeEventRead } from "@core/event-read/event-read-shape";
+import {
+  type Query_Event,
+  type Schema_Event,
+  type Schema_Event_Core,
+} from "@core/types/event.types";
+import { isInstance } from "@core/util/event/event.util";
+import mongoService from "@backend/common/services/mongo.service";
+import { getReadCandidateFilter } from "./backend-event-read.filter";
+
+const FALLBACK_START_DATE = "0001-01-01T00:00:00.000Z";
+const FALLBACK_END_DATE = "9999-12-31T23:59:59.999Z";
+
+export const readBackendEvents = async (
+  userId: string,
+  query: Query_Event,
+): Promise<Schema_Event_Core[]> => {
+  const filter = getReadCandidateFilter(userId, query) as Document;
+  const isSomeday = query.someday === "true";
+
+  const events = isSomeday
+    ? await mongoService.event
+        .find(filter)
+        .limit(SOMEDAY_WEEKLY_LIMIT + SOMEDAY_MONTHLY_LIMIT)
+        .sort({ startDate: 1 })
+        .toArray()
+    : await mongoService.event.find(filter).toArray();
+
+  const baseEvents = await getBaseEventsForInstances(userId, events);
+  const baseEventsById = Object.fromEntries(
+    baseEvents.map((event) => [event._id?.toString(), event]),
+  );
+
+  const result = shapeEventRead({
+    window: {
+      mode: isSomeday ? "someday" : "calendar",
+      startDate: query.start ?? FALLBACK_START_DATE,
+      endDate: query.end ?? FALLBACK_END_DATE,
+    },
+    events: events.map(mapMongoEvent),
+    baseEventsById,
+  });
+
+  return result.data as Schema_Event_Core[];
+};
+
+const getBaseEventsForInstances = async (
+  userId: string,
+  events: Array<WithId<Omit<Schema_Event, "_id">>>,
+) => {
+  const baseEventIds = events
+    .filter(isInstance)
+    .map((event) => event.recurrence?.eventId)
+    .filter((eventId): eventId is string => typeof eventId === "string")
+    .map((eventId) => new ObjectId(eventId));
+
+  const baseEvents = await mongoService.event
+    .find({ user: userId, _id: { $in: baseEventIds } })
+    .toArray();
+
+  return baseEvents.map(mapMongoEvent);
+};
+
+const mapMongoEvent = (
+  event: WithId<Omit<Schema_Event, "_id">>,
+): Schema_Event => ({
+  ...event,
+  _id: event._id.toString(),
+});

--- a/packages/backend/src/event/read/backend-event-read.filter.ts
+++ b/packages/backend/src/event/read/backend-event-read.filter.ts
@@ -1,4 +1,5 @@
 import { type Filter } from "mongodb";
+import { type Priority } from "@core/constants/core.constants";
 import { type Query_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 
@@ -14,7 +15,7 @@ export const getReadCandidateFilter = (
   filter["isSomeday"] = isSomeday;
 
   if (priorities) {
-    filter["priorities"] = { $in: priorities.split(",") };
+    filter["priority"] = { $in: priorities.split(",") as Priority[] };
   }
 
   if (start && end) {

--- a/packages/backend/src/event/read/backend-event-read.filter.ts
+++ b/packages/backend/src/event/read/backend-event-read.filter.ts
@@ -1,0 +1,87 @@
+import { type Filter } from "mongodb";
+import { type Query_Event, type Schema_Event } from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
+
+export const getReadCandidateFilter = (
+  userId: string,
+  query: Query_Event,
+): Filter<Omit<Schema_Event, "_id">> => {
+  const { end, someday, start, priorities } = query;
+  const isSomeday = someday === "true";
+
+  const filter: Filter<Omit<Schema_Event, "_id">> = { user: userId };
+
+  filter["isSomeday"] = isSomeday;
+
+  if (priorities) {
+    filter["priorities"] = { $in: priorities.split(",") };
+  }
+
+  if (start && end) {
+    const dateFilters = getDateFilters(isSomeday, start, end);
+    Object.assign(filter, dateFilters);
+  }
+
+  filter["recurrence.rule"] = { $exists: false };
+
+  return filter;
+};
+
+const getDateFilters = (isSomeday: boolean, start: string, end: string) => {
+  const { inBetweenStart, inBetweenEnd, overlapping } = getDateFilterOptions(
+    start,
+    end,
+  );
+  const isSameMonth = dayjs.utc(start).isSame(dayjs.utc(end), "month");
+  const overlapOrBetween =
+    isSomeday && isSameMonth
+      ? [inBetweenStart, overlapping]
+      : [inBetweenStart, inBetweenEnd, overlapping];
+
+  return {
+    $or: overlapOrBetween,
+  };
+};
+
+const getDateFilterOptions = (start: string, end: string) => {
+  const overlapping = {
+    startDate: {
+      $lte: start,
+    },
+    endDate: {
+      $gte: end,
+    },
+  };
+
+  const inBetweenStart = {
+    $and: [
+      {
+        startDate: {
+          $gte: start,
+        },
+      },
+      {
+        startDate: {
+          $lte: end,
+        },
+      },
+    ],
+  };
+
+  const inBetweenEnd = {
+    $and: [
+      {
+        endDate: {
+          $gte: start,
+        },
+      },
+      {
+        endDate: {
+          $lte: end,
+        },
+      },
+    ],
+  };
+
+  return { overlapping, inBetweenStart, inBetweenEnd };
+};

--- a/packages/backend/src/event/services/event.find.allday.test.ts
+++ b/packages/backend/src/event/services/event.find.allday.test.ts
@@ -6,7 +6,8 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import mongoService from "@backend/common/services/mongo.service";
-import { getReadAllFilter } from "@backend/event/services/event.service.util";
+import { getReadCandidateFilter } from "@backend/event/read/backend-event-read.filter";
+import eventService from "@backend/event/services/event.service";
 
 describe("Mar 6 - 12, 2022: All-Day Events", () => {
   let filter: Filter<Omit<Schema_Event, "_id">>;
@@ -17,7 +18,7 @@ describe("Mar 6 - 12, 2022: All-Day Events", () => {
 
     await mongoService.event.insertMany(mockEventSetMar22);
 
-    filter = getReadAllFilter("user1", {
+    filter = getReadCandidateFilter("user1", {
       start: "2022-03-06T00:00:00-07:00",
       end: "2022-03-12T23:59:59-07:00",
     });
@@ -42,5 +43,31 @@ describe("Mar 6 - 12, 2022: All-Day Events", () => {
   it("ignores events next week", () => {
     expect(titles.includes("Mar 13")).toBe(false);
     expect(titles.includes("Mar 13 - 16")).toBe(false);
+  });
+});
+
+describe("All-Day Event read shape", () => {
+  beforeAll(async () => {
+    await setupTestDb();
+    await mongoService.event.insertOne({
+      user: "user-start-day",
+      title: "Start of Week",
+      isAllDay: true,
+      isSomeday: false,
+      startDate: "2026-04-06",
+      endDate: "2026-04-07",
+    });
+  });
+
+  afterAll(cleanupTestDb);
+
+  it("returns an all-day event that starts on the requested window start", async () => {
+    const result = await eventService.readAll("user-start-day", {
+      start: "2026-04-06T00:00:00.000Z",
+      end: "2026-04-13T00:00:00.000Z",
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.map((event) => event.title)).toContain("Start of Week");
   });
 });

--- a/packages/backend/src/event/services/event.find.test.ts
+++ b/packages/backend/src/event/services/event.find.test.ts
@@ -1,449 +1,188 @@
-import { type Filter, ObjectId, type WithId } from "mongodb";
+import { ObjectId } from "mongodb";
 import { mockEventSetJan22 } from "@core/__mocks__/v1/events/events.22jan";
 import { mockEventSetSomeday1 } from "@core/__mocks__/v1/events/events.someday.1";
-import { gEventToCompassEvent, MapEvent } from "@core/mappers/map.event";
-import {
-  Categories_Recurrence,
-  CompassEventStatus,
-  type CompassThisEvent,
-  RecurringEventUpdateScope,
-  type Schema_Event,
-} from "@core/types/event.types";
-import { isBase, isInstance } from "@core/util/event/event.util";
-import { createMockBaseEvent } from "@core/util/test/ccal.event.factory";
-import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
+import { isBase } from "@core/util/event/event.util";
 import {
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
-import {
-  mockRecurringGcalBaseEvent,
-  mockRecurringGcalInstances,
-} from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import mongoService from "@backend/common/services/mongo.service";
-import { testCompassSeries } from "@backend/event/classes/compass.event.parser.test.util";
-import { getReadAllFilter } from "@backend/event/services/event.service.util";
-import { CompassToGoogleEventPropagation } from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation";
+import { getReadCandidateFilter } from "@backend/event/read/backend-event-read.filter";
+import eventService from "@backend/event/services/event.service";
 
-describe("Jan 2022: Many Formats", () => {
-  const gBase = mockRecurringGcalBaseEvent({}, false, { count: 10 });
-  const gInstances = mockRecurringGcalInstances(gBase);
+describe("event read candidates", () => {
   const userId = "user1";
-  const base = gEventToCompassEvent(gBase, userId);
-  const instances = MapEvent.toCompass(userId, gInstances);
-
-  const allEvents: Array<Omit<Schema_Event, "_id">> = [
-    ...mockEventSetJan22,
-    ...mockEventSetSomeday1,
-    ...instances,
-  ];
 
   beforeAll(async () => {
     await setupTestDb();
-
-    const { insertedId } = await mongoService.event.insertOne({
-      ...base,
-      _id: mongoService.objectId(),
-    });
-
-    // link instances to base
-    instances.forEach((i) =>
-      Object.assign(i, { recurrence: { eventId: insertedId.toString() } }),
-    );
-
-    await mongoService.event.insertMany(allEvents);
+    await mongoService.event.insertMany([
+      ...mockEventSetJan22,
+      ...mockEventSetSomeday1,
+    ]);
   });
 
   afterAll(cleanupTestDb);
 
-  it("returns events by provided user only", async () => {
-    const filter = getReadAllFilter(userId, {
-      start: "1999-01-01",
-      end: "2039-12-12",
-    });
-    const events = await mongoService.event.find(filter).toArray();
-    events.forEach((e) => expect(e.user).toBe(userId));
-  });
-  it("does NOT transform query dates to ISO format", () => {
-    /*
-    it shouldn't transform the format, because mongo
-    will do that during its date comparison
-
-    this depends on the frontend passing the date values in the correct format
-     */
-    const start = "2011-10-20T00:00:00-10:00";
-    const end = "2011-11-26T00:00:00-10:00";
-    const filter = getReadAllFilter("123user", {
-      start,
-      end,
-    });
-    const flatFilter = _flatten(filter, {}) as Filter<Schema_Event>;
-    expect(flatFilter["$lte"]).not.toEqual(new Date(start).toISOString());
-    expect(flatFilter["$gte"]).not.toEqual(new Date(end).toISOString());
-  });
-
-  describe("Recurring Events", () => {
-    it("Does not return the base event - just instances", async () => {
-      const filter = getReadAllFilter(userId, {
-        start: "1999-01-01",
-        end: "2099-01-01",
-      });
-
-      const result = await mongoService.event.find(filter).toArray();
-
-      // base is not returned
-      const baseEvents = result.filter(isBase);
-      expect(baseEvents).toHaveLength(0);
-
-      const instances = result.filter(isInstance);
-      expect(instances).toHaveLength(gInstances.length);
-    });
-
-    it("excludes base calendar recurring events when someday=false", async () => {
-      // Create a base calendar recurring event (isSomeday: false)
-      const baseCalendarRecurringEvent = createMockBaseEvent({
-        user: userId,
-        isSomeday: false,
-      });
-
-      // Insert the test event
-      await mongoService.event.insertOne({
-        ...baseCalendarRecurringEvent,
-        _id: mongoService.objectId(baseCalendarRecurringEvent._id),
-      });
-
-      // Query for calendar events (not someday)
-      const filter = getReadAllFilter(userId, {
-        start: "2023-10-01",
-        end: "2023-10-31",
-      });
-      const result = await mongoService.event.find(filter).toArray();
-
-      // Should NOT include the base calendar recurring event
-      const baseCalendarRecurringEvents = result.filter(
-        (e) => isBase(e) && e.isSomeday === false,
-      );
-
-      expect(baseCalendarRecurringEvents).toHaveLength(0);
-    });
-  });
-
-  describe("finds events with exact same timestamps", () => {
-    test("format: TZ offset", async () => {
-      const filter = getReadAllFilter(userId, {
-        // make sure these match text data exactly
-        start: "2022-01-01T00:00:00+03:00",
-        end: "2022-01-020T11:11:11+03:00",
-      });
-
-      const result = await mongoService.event.find(filter).toArray();
-      const titles = result.map((e) => e.title);
-      expect(titles.includes("Jan 1 (times)")).toBe(true);
-    });
-    test("format: UTC", async () => {
-      const filter = getReadAllFilter(userId, {
-        // make sure these match text data exactly
-        start: "2022-01-01T00:11:00Z",
-        end: "2022-01-02T00:12:00Z",
-      });
-
-      const result = await mongoService.event.find(filter).toArray();
-      const titles = result.map((e) => e.title);
-      expect(titles.includes("Jan 1 (UTC times)")).toBe(true);
-    });
-  });
-
-  describe("finds event within 1 day", () => {
-    it("format: TZ offset with +", async () => {
-      const tzOffsetFilter = getReadAllFilter(userId, {
-        start: "2022-01-01T00:00:00+03:00",
-        end: "2022-01-01T23:59:59+03:00",
-      });
-
-      const offsetResult = await mongoService.event
-        .find(tzOffsetFilter)
-        .toArray();
-      const offsetTitles = offsetResult.map((e) => e.title);
-      expect(offsetTitles.includes("Jan 1 (times)")).toBe(true);
-    });
-
-    it("format: TZ offset with -", async () => {
-      const filter = getReadAllFilter(userId, {
-        start: "2022-01-01T00:00:00-07:00",
-        end: "2022-01-03T00:00:00-07:00",
-      });
-
-      const result = await mongoService.event.find(filter).toArray();
-      _jan1ToJan3Assertions(result);
-    });
-  });
-
-  it("finds events within days range: UTC", async () => {
-    const filter = getReadAllFilter(userId, {
+  it("fetches calendar candidates broadly enough for read shaping", async () => {
+    const filter = getReadCandidateFilter(userId, {
       start: "2022-01-01T00:00:00Z",
       end: "2022-01-03T00:00:00Z",
     });
 
     const result = await mongoService.event.find(filter).toArray();
-    _jan1ToJan3Assertions(result);
+    const titles = result.map((event) => event.title);
+
+    expect(titles).toEqual(
+      expect.arrayContaining([
+        "Dec 31 - Jan 1",
+        "Dec 31 - Feb 2",
+        "Jan 1",
+        "Jan 1 - Jan 3",
+        "Jan 2",
+        "Jan 3",
+        "Jan 3 - Feb 3",
+      ]),
+    );
+    expect(result.every((event) => event.user === userId)).toBe(true);
+    expect(result.every((event) => event.isSomeday !== true)).toBe(true);
+    expect(result.some(isBase)).toBe(false);
   });
 
-  it("finds events within week range: TZ offset", async () => {
-    const filter = getReadAllFilter(userId, {
-      start: "2022-01-01T00:00:00+06:00",
-      end: "2022-01-21T23:59:59+06:00",
+  it("fetches someday candidates broadly enough across date boundaries", async () => {
+    const filter = getReadCandidateFilter(userId, {
+      someday: "true",
+      start: "2023-05-28",
+      end: "2023-06-03",
     });
 
     const result = await mongoService.event.find(filter).toArray();
-    const titles = result.map((e) => e.title);
-    expect(titles.includes("Jan 1 - Jan 21")).toBe(true);
-    expect(titles.includes("Jan 1 - Jan 21 (times)")).toBe(true);
-  });
+    const titles = result.map((event) => event.title);
 
-  it("finds events within month range: TZ offset", async () => {
-    const filter = getReadAllFilter(userId, {
-      start: "2022-01-01T00:00:00-02:00",
-      end: "2022-04-20T23:59:59-02:00",
-    });
-
-    const result = await mongoService.event.find(filter).toArray();
-    const titles = result.map((e) => e.title);
-
-    expect(titles.includes("Jan 1 - Apr 20")).toBe(true);
-    expect(titles.includes("Jan 1 - Apr 20 (times)")).toBe(true);
-  });
-
-  it("finds events within year range: TZ offset", async () => {
-    const filter = getReadAllFilter(userId, {
-      start: "2022-01-01T00:00:00-02:00",
-      end: "2023-01-01T23:59:59-02:00",
-    });
-
-    const result = await mongoService.event.find(filter).toArray();
-    const titles = result.map((e) => e.title);
-
-    expect(titles.includes("Jan 1 2022 - Jan 1 2023")).toBe(true);
-    expect(titles.includes("Jan 1 2022 - Jan 1 2023 (times)")).toBe(true);
-  });
-
-  describe("Someday Events", () => {
-    it("excludes someday events by default", async () => {
-      const filter = getReadAllFilter(userId, {}); // no someday query
-      const result = await mongoService.event.find(filter).toArray();
-
-      const somedayEvents = result.filter((e) => e.isSomeday === true);
-
-      expect(somedayEvents).toHaveLength(0);
-    });
-    it("only returns someday events (not timed) when someday query provided", async () => {
-      const filter = getReadAllFilter(userId, { someday: "true" });
-      const result = await mongoService.event.find(filter).toArray();
-
-      const somedayEvents = result.filter((e) => e.isSomeday === true);
-      const onlyReturnsSomedayEvents = result.length === somedayEvents.length;
-      expect(onlyReturnsSomedayEvents).toBe(true);
-    });
-    it("returns someday events when providing YYYY-MM-DD: week", async () => {
-      const filter = getReadAllFilter(userId, {
-        someday: "true",
-        start: "2023-10-01",
-        end: "2023-10-07",
-      });
-
-      const result = await mongoService.event.find(filter).toArray();
-
-      expect(result).toHaveLength(1);
-      expect(result[0]?.title).toBe("Beginning of Month");
-    });
-    it("honors TZ offset: week", async () => {
-      const filter = getReadAllFilter(userId, {
-        someday: "true",
-        start: "2023-09-30T23:59:59-05:00",
-        end: "2023-10-08T23:59:59-05:00",
-      });
-
-      const result = await mongoService.event.find(filter).toArray();
-      expect(result).toHaveLength(1);
-      expect(result[0]?.title).toBe("Beginning of Month");
-
-      const filterOneSecLater = getReadAllFilter(userId, {
-        someday: "true",
-        start: "2023-10-01T00:00:00-05:00",
-        end: "2023-10-08T23:59:59-05:00",
-      });
-
-      const result2 = await mongoService.event
-        .find(filterOneSecLater)
-        .toArray();
-      expect(result2).toHaveLength(0);
-    });
-    it("returns someday events when providing hour-min-sec: month", async () => {
-      const filter = getReadAllFilter(userId, {
-        someday: "true",
-        start: "2023-06-01",
-        end: "2023-06-30",
-      });
-
-      const result = await mongoService.event.find(filter).toArray();
-
-      expect(result).toHaveLength(1);
-      expect(result[0]?.title).toBe("First Sunday of New Month");
-    });
-
-    describe("Multi-Month Events", () => {
-      it("finds events that span 2 months: YMD", async () => {
-        const filter = getReadAllFilter(userId, {
-          someday: "true",
-          start: "2023-05-28",
-          end: "2023-06-03",
-        });
-
-        const result = await mongoService.event.find(filter).toArray();
-        expect(result).toHaveLength(2);
-        expect(result[0]?.title).toBe("Multi-Month 1");
-        expect(result[1]?.title).toBe("Multi-Month 2");
-      });
-      it("finds events that span 2 months: HMS", async () => {
-        const filter = getReadAllFilter(userId, {
-          someday: "true",
-          start: "2023-05-28T00:00:00-05:00",
-          end: "2023-06-03T23:59:59-05:00",
-        });
-
-        const result = await mongoService.event.find(filter).toArray();
-        expect(result).toHaveLength(1);
-        expect(result[0]?.title).toBe("Multi-Month 1");
-      });
-      it("finds events that span 4 months", async () => {
-        const filterYMD = getReadAllFilter(userId, {
-          someday: "true",
-          start: "2023-01-28",
-          end: "2023-03-27",
-        });
-
-        const result = await mongoService.event.find(filterYMD).toArray();
-        expect(result).toHaveLength(1);
-        expect(result[0]?.title).toBe("Multi-Month 2");
-
-        const filterHMS = getReadAllFilter(userId, {
-          someday: "true",
-          start: "2023-01-28T00:00:00-05:00",
-          end: "2023-03-27T23:59:59-05:00",
-        });
-
-        const resultHMS = await mongoService.event.find(filterHMS).toArray();
-        expect(resultHMS).toHaveLength(1);
-        expect(result[0]?.title).toBe("Multi-Month 2");
-      });
-    });
-
-    it("excludes base someday recurring events when someday query provided", async () => {
-      // Create a base someday recurring event
-      const baseSomedayRecurringEvent = createMockBaseEvent({
-        user: userId,
-        isSomeday: true,
-      });
-
-      // Insert the test event
-      await mongoService.event.insertOne({
-        ...baseSomedayRecurringEvent,
-        _id: new ObjectId(baseSomedayRecurringEvent._id),
-      });
-
-      // Query for someday events
-      const filter = getReadAllFilter(userId, { someday: "true" });
-      const result = await mongoService.event.find(filter).toArray();
-
-      // Should exclude the base someday recurring event
-      const baseSomedayRecurringEvents = result.filter(
-        (e) => isBase(e) && e.isSomeday,
-      );
-
-      expect(baseSomedayRecurringEvents).toHaveLength(0);
-    });
-
-    it("includes instance someday recurring events when someday query provided", async () => {
-      // Create a base someday recurring event
-      const { user: _user } = await UtilDriver.setupTestUser();
-      const user = _user._id.toString();
-      const isSomeday = true;
-      const recurrence = { rule: ["RRULE:FREQ=WEEKLY;COUNT=10"] };
-      const payload = createMockBaseEvent({ isSomeday, user, recurrence });
-
-      const changes = await CompassToGoogleEventPropagation.processEvents([
-        {
-          payload: payload as CompassThisEvent["payload"],
-          applyTo: RecurringEventUpdateScope.THIS_EVENT,
-          status: CompassEventStatus.CONFIRMED,
-        },
-      ]);
-
-      expect(changes).toEqual(
-        expect.arrayContaining([
-          {
-            title: payload.title,
-            transition: [null, "RECURRENCE_BASE_SOMEDAY_CONFIRMED"],
-            category: Categories_Recurrence.RECURRENCE_BASE_SOMEDAY,
-            operation: "RECURRENCE_BASE_SOMEDAY_CREATED",
-          },
-        ]),
-      );
-
-      // check that event is in db
-      await testCompassSeries(payload, 10);
-
-      // Query for someday events
-      const filter = getReadAllFilter(user, { someday: "true" });
-      const result = await mongoService.event.find(filter).toArray();
-
-      // Should not include the base someday recurring event
-      const baseSomedayRecurringEvents = result.filter(
-        (e) => isBase(e) && e.isSomeday,
-      );
-
-      expect(baseSomedayRecurringEvents).toHaveLength(0);
-
-      const instanceSomedayRecurringEvents = result.filter(
-        (e) => isInstance(e) && e.isSomeday,
-      );
-
-      expect(instanceSomedayRecurringEvents.length).toBeGreaterThan(0);
-    });
+    expect(titles).toEqual(
+      expect.arrayContaining(["Multi-Month 1", "Multi-Month 2"]),
+    );
+    expect(result.every((event) => event.user === userId)).toBe(true);
+    expect(result.every((event) => event.isSomeday === true)).toBe(true);
+    expect(result.some(isBase)).toBe(false);
   });
 });
 
-const _jan1ToJan3Assertions = (
-  result: Array<WithId<Omit<Schema_Event, "_id">>>,
-) => {
-  const titles = result.map((e) => e.title!);
-
-  expect(titles.includes("Dec 31 - Jan 1")).toBe(true);
-  expect(titles.includes("Dec 31 - Feb 2")).toBe(true);
-  expect(titles.includes("Jan 1")).toBe(true);
-  expect(titles.includes("Jan 1 - Jan 3")).toBe(true);
-  expect(titles.includes("Jan 1 - Jan 3 (times)")).toBe(true);
-  expect(titles.includes("Jan 2")).toBe(true);
-  expect(titles.includes("Jan 3")).toBe(true);
-  expect(titles.includes("Jan 3 - Feb 3")).toBe(true);
-
-  expect(titles.includes("Jan 1 2021")).toBe(false);
-  expect(titles.includes("Jan 1 2021 (times)")).toBe(false);
-  expect(titles.includes("Dec 31")).toBe(false);
-  expect(titles.includes("Jan 4")).toBe(false);
-  expect(titles.includes("Jan 1 2023")).toBe(false);
-};
-
-/* useful for deeply nested objects, like Mongo filters */
-const _flatten = (
-  obj: Record<string, unknown>,
-  out: Record<string, unknown>,
-) => {
-  Object.keys(obj).forEach((key) => {
-    if (typeof obj[key] === "object") {
-      out = _flatten(obj[key] as Record<string, unknown>, out); // recursive call for nested
-    } else {
-      out[key] = obj[key]; // direct assign for values
-    }
+describe("eventService.readAll", () => {
+  beforeAll(async () => {
+    await setupTestDb();
   });
-  return out;
-};
+
+  afterAll(cleanupTestDb);
+
+  it("returns shaped calendar events and attaches base recurrence to instances", async () => {
+    const user = "calendar-read-user";
+    const baseId = new ObjectId();
+
+    await mongoService.event.insertMany([
+      {
+        _id: baseId,
+        user,
+        title: "Weekly Base",
+        isAllDay: false,
+        isSomeday: false,
+        startDate: "2026-04-06T15:00:00.000Z",
+        endDate: "2026-04-06T16:00:00.000Z",
+        recurrence: { rule: ["RRULE:FREQ=WEEKLY;COUNT=2"] },
+      },
+      {
+        user,
+        title: "Standalone",
+        isAllDay: false,
+        isSomeday: false,
+        startDate: "2026-04-06T15:00:00.000Z",
+        endDate: "2026-04-06T16:00:00.000Z",
+      },
+      {
+        user,
+        title: "Weekly Instance",
+        isAllDay: false,
+        isSomeday: false,
+        startDate: "2026-04-07T15:00:00.000Z",
+        endDate: "2026-04-07T16:00:00.000Z",
+        recurrence: { eventId: baseId.toString() },
+      },
+      {
+        user,
+        title: "Someday Task",
+        isAllDay: false,
+        isSomeday: true,
+        startDate: "2026-04-07T15:00:00.000Z",
+        endDate: "2026-04-07T16:00:00.000Z",
+      },
+    ]);
+
+    const result = await eventService.readAll(user, {
+      start: "2026-04-01T00:00:00.000Z",
+      end: "2026-04-30T23:59:59.999Z",
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) return;
+
+    const titles = result.map((event) => event.title);
+    expect(titles).toEqual(
+      expect.arrayContaining(["Standalone", "Weekly Instance"]),
+    );
+    expect(titles).not.toContain("Weekly Base");
+    expect(titles).not.toContain("Someday Task");
+
+    const instance = result.find((event) => event.title === "Weekly Instance");
+    expect(instance?.recurrence).toEqual({
+      eventId: baseId.toString(),
+      rule: ["RRULE:FREQ=WEEKLY;COUNT=2"],
+    });
+  });
+
+  it("repairs missing order values when returning someday events", async () => {
+    const user = "someday-order-user";
+    await mongoService.event.insertMany([
+      {
+        user,
+        title: "Missing Order 1",
+        isSomeday: true,
+        startDate: "2026-04-06T15:00:00.000Z",
+        endDate: "2026-04-06T16:00:00.000Z",
+      },
+      {
+        user,
+        title: "Existing Order",
+        isSomeday: true,
+        startDate: "2026-04-07T15:00:00.000Z",
+        endDate: "2026-04-07T16:00:00.000Z",
+        order: 4,
+      },
+      {
+        user,
+        title: "Missing Order 2",
+        isSomeday: true,
+        startDate: "2026-04-08T15:00:00.000Z",
+        endDate: "2026-04-08T16:00:00.000Z",
+      },
+    ]);
+
+    const result = await eventService.readAll(user, {
+      someday: "true",
+      start: "2026-04-01T00:00:00.000Z",
+      end: "2026-04-30T23:59:59.999Z",
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) return;
+
+    expect(
+      result.map((event) => ({
+        title: event.title,
+        order: event.order,
+      })),
+    ).toEqual([
+      { title: "Missing Order 1", order: 5 },
+      { title: "Existing Order", order: 4 },
+      { title: "Missing Order 2", order: 6 },
+    ]);
+  });
+});

--- a/packages/backend/src/event/services/event.find.test.ts
+++ b/packages/backend/src/event/services/event.find.test.ts
@@ -65,6 +65,14 @@ describe("event read candidates", () => {
     expect(result.every((event) => event.isSomeday === true)).toBe(true);
     expect(result.some(isBase)).toBe(false);
   });
+
+  it("filters candidates by the event priority field", () => {
+    const filter = getReadCandidateFilter(userId, {
+      priorities: "work,self",
+    });
+
+    expect(filter.priority).toEqual({ $in: ["work", "self"] });
+  });
 });
 
 describe("eventService.readAll", () => {

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -1,15 +1,10 @@
 import { type GaxiosError } from "gaxios";
 import {
   type ClientSession,
-  type Document,
   type Filter,
   ObjectId,
   type WithId,
 } from "mongodb";
-import {
-  SOMEDAY_MONTHLY_LIMIT,
-  SOMEDAY_WEEKLY_LIMIT,
-} from "@core/constants/core.constants";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { MapEvent } from "@core/mappers/map.event";
@@ -36,7 +31,7 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { reorderEvents } from "@backend/event/queries/event.queries";
-import { getReadAllFilter } from "@backend/event/services/event.service.util";
+import { readBackendEvents } from "@backend/event/read/backend-event-read.adapter";
 import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 
 class EventService {
@@ -95,61 +90,7 @@ class EventService {
     userId: string,
     query: Query_Event,
   ): Promise<Schema_Event_Core[] | BaseError> => {
-    const filter = getReadAllFilter(userId, query) as Filter<Document>;
-
-    let events: Array<WithId<Omit<Schema_Event, "_id">>>;
-
-    if (query.someday) {
-      events = await mongoService.event
-        .find(filter)
-        .limit(SOMEDAY_WEEKLY_LIMIT + SOMEDAY_MONTHLY_LIMIT)
-        .sort({ startDate: 1 })
-        .toArray();
-    } else {
-      events = await mongoService.event.find(filter).toArray();
-    }
-
-    const baseEventIds = events
-      .filter(isInstance)
-      .map((e) => new ObjectId(e.recurrence?.eventId));
-
-    const baseEvents = await mongoService.event
-      .find({ user: userId, _id: { $in: baseEventIds } })
-      .toArray();
-
-    return events
-      .map((event) => {
-        if (isInstance(event)) {
-          const baseEvent = baseEvents.find(
-            ({ _id }) => _id.toString() === event.recurrence?.eventId,
-          );
-
-          if (!baseEvent) {
-            console.error(
-              new BaseError(
-                "Skipping instance. Base event not found for instance",
-                `Tried with user: ${userId} and _id: ${event._id.toString()}`,
-                Status.NOT_FOUND,
-                true,
-              ),
-            );
-
-            return undefined;
-          }
-
-          return {
-            ...event,
-            _id: event._id.toString(),
-            recurrence: {
-              eventId: baseEvent._id.toString(),
-              rule: baseEvent.recurrence?.rule,
-            },
-          };
-        }
-
-        return { ...event, _id: event._id.toString() } as Schema_Event_Core;
-      })
-      .filter((e) => e) as Schema_Event_Core[];
+    return readBackendEvents(userId, query);
   };
 
   readById = async (userId: string, eventId: string) => {

--- a/packages/backend/src/event/services/event.service.util.ts
+++ b/packages/backend/src/event/services/event.service.util.ts
@@ -1,10 +1,8 @@
 import { type Filter, ObjectId, type WithId } from "mongodb";
 import {
-  type Query_Event,
   type Schema_Event,
   type Schema_Event_Core,
 } from "@core/types/event.types";
-import dayjs from "@core/util/date/dayjs";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 
@@ -45,95 +43,4 @@ export const getDeleteByIdFilter = (
   };
 
   return baseOrFutureInstance;
-};
-
-export const getReadAllFilter = (
-  userId: string,
-  query: Query_Event,
-): Filter<Omit<Schema_Event, "_id">> => {
-  const { end, someday, start, priorities } = query;
-  const isSomeday = someday === "true";
-
-  // Start with basic user filter
-  const filter: Filter<Omit<Schema_Event, "_id">> = { user: userId };
-
-  // Add isSomeday condition
-  filter["isSomeday"] = isSomeday;
-
-  // Add priorities if specified
-  if (priorities) {
-    filter["priorities"] = { $in: priorities.split(",") };
-  }
-
-  // Add date filters if specified
-  if (start && end) {
-    const dateFilters = _getDateFilters(isSomeday, start, end);
-    Object.assign(filter, dateFilters);
-  }
-
-  filter["recurrence.rule"] = { $exists: false };
-
-  return filter;
-};
-
-const _getDateFilters = (isSomeday: boolean, start: string, end: string) => {
-  const { inBetweenStart, inBetweenEnd, overlapping } = _getDateFilterOptions(
-    start,
-    end,
-  );
-  const _isSameMonth = dayjs.utc(start).isSame(dayjs.utc(end), "month");
-  const overLapOrBetween =
-    isSomeday && _isSameMonth
-      ? [inBetweenStart, overlapping]
-      : [inBetweenStart, inBetweenEnd, overlapping];
-
-  const dateFilters = {
-    $or: overLapOrBetween,
-  };
-
-  return dateFilters;
-};
-
-const _getDateFilterOptions = (start: string, end: string) => {
-  // includes overlaps (starts before AND ends after dates)
-  const overlapping = {
-    startDate: {
-      $lte: start,
-    },
-    endDate: {
-      $gte: end,
-    },
-  };
-
-  const inBetweenStart = {
-    $and: [
-      {
-        startDate: {
-          $gte: start,
-        },
-      },
-      {
-        startDate: {
-          $lte: end,
-        },
-      },
-    ],
-  };
-
-  const inBetweenEnd = {
-    $and: [
-      {
-        endDate: {
-          $gte: start,
-        },
-      },
-      {
-        endDate: {
-          $lte: end,
-        },
-      },
-    ],
-  };
-
-  return { overlapping, inBetweenStart, inBetweenEnd };
 };

--- a/packages/core/src/event-read/event-read-shape.test.ts
+++ b/packages/core/src/event-read/event-read-shape.test.ts
@@ -64,6 +64,32 @@ describe("shapeEventRead", () => {
     expect(result.data.map((event) => event._id)).toEqual(["first-day"]);
   });
 
+  it("excludes all-day calendar events that start on the exclusive window end", () => {
+    const lastDayAllDayEvent = makeEvent({
+      _id: "last-day",
+      isAllDay: true,
+      startDate: "2026-04-12",
+      endDate: "2026-04-13",
+    });
+    const nextDayAllDayEvent = makeEvent({
+      _id: "next-day",
+      isAllDay: true,
+      startDate: "2026-04-13",
+      endDate: "2026-04-14",
+    });
+
+    const result = shapeEventRead({
+      window: {
+        mode: "calendar",
+        startDate: "2026-04-06T00:00:00-05:00",
+        endDate: "2026-04-13T00:00:00-05:00",
+      },
+      events: [lastDayAllDayEvent, nextDayAllDayEvent],
+    });
+
+    expect(result.data.map((event) => event._id)).toEqual(["last-day"]);
+  });
+
   it("excludes base events and returns instances with base recurrence rules", () => {
     const baseEvent = makeEvent({
       _id: "base",

--- a/packages/core/src/event-read/event-read-shape.test.ts
+++ b/packages/core/src/event-read/event-read-shape.test.ts
@@ -1,0 +1,124 @@
+import { Origin, Priorities } from "@core/constants/core.constants";
+import { type Schema_Event } from "@core/types/event.types";
+import { shapeEventRead } from "./event-read-shape";
+import { describe, expect, it } from "bun:test";
+
+const makeEvent = (overrides: Partial<Schema_Event> = {}): Schema_Event => ({
+  _id: "event-1",
+  title: "Event",
+  startDate: "2026-04-06T15:00:00.000Z",
+  endDate: "2026-04-06T16:00:00.000Z",
+  isAllDay: false,
+  isSomeday: false,
+  origin: Origin.COMPASS,
+  priority: Priorities.UNASSIGNED,
+  user: "user-1",
+  ...overrides,
+});
+
+const calendarWindow = {
+  mode: "calendar" as const,
+  startDate: "2026-04-06T00:00:00.000Z",
+  endDate: "2026-04-13T00:00:00.000Z",
+};
+
+describe("shapeEventRead", () => {
+  it("returns timed calendar events fully inside the requested window", () => {
+    const insideEvent = makeEvent({ _id: "inside" });
+    const outsideEvent = makeEvent({
+      _id: "outside",
+      startDate: "2026-04-05T15:00:00.000Z",
+      endDate: "2026-04-05T16:00:00.000Z",
+    });
+
+    const result = shapeEventRead({
+      window: calendarWindow,
+      events: [insideEvent, outsideEvent],
+    });
+
+    expect(result.data.map((event) => event._id)).toEqual(["inside"]);
+    expect(result.count).toBe(1);
+    expect(result.startDate).toBe(calendarWindow.startDate);
+    expect(result.endDate).toBe(calendarWindow.endDate);
+  });
+
+  it("returns all-day calendar events that overlap the requested window", () => {
+    const firstDayAllDayEvent = makeEvent({
+      _id: "first-day",
+      isAllDay: true,
+      startDate: "2026-04-06",
+      endDate: "2026-04-07",
+    });
+    const previousAllDayEvent = makeEvent({
+      _id: "previous-day",
+      isAllDay: true,
+      startDate: "2026-04-05",
+      endDate: "2026-04-06",
+    });
+
+    const result = shapeEventRead({
+      window: calendarWindow,
+      events: [firstDayAllDayEvent, previousAllDayEvent],
+    });
+
+    expect(result.data.map((event) => event._id)).toEqual(["first-day"]);
+  });
+
+  it("excludes base events and returns instances with base recurrence rules", () => {
+    const baseEvent = makeEvent({
+      _id: "base",
+      recurrence: { rule: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const instanceEvent = makeEvent({
+      _id: "instance",
+      recurrence: { eventId: "base" },
+    });
+
+    const result = shapeEventRead({
+      window: calendarWindow,
+      events: [baseEvent, instanceEvent],
+      baseEventsById: { base: baseEvent },
+    });
+
+    expect(result.data.map((event) => event._id)).toEqual(["instance"]);
+    expect(result.data[0]?.recurrence).toEqual({
+      eventId: "base",
+      rule: ["RRULE:FREQ=WEEKLY"],
+    });
+  });
+
+  it("repairs missing someday order values deterministically", () => {
+    const somedayWindow = {
+      mode: "someday" as const,
+      startDate: "2026-04-01T00:00:00.000Z",
+      endDate: "2026-04-30T23:59:59.999Z",
+    };
+    const orderedSomeday = makeEvent({
+      _id: "ordered",
+      isSomeday: true,
+      order: 2,
+    });
+    const missingOrderA = makeEvent({
+      _id: "missing-a",
+      isSomeday: true,
+      order: undefined,
+    });
+    const missingOrderB = makeEvent({
+      _id: "missing-b",
+      isSomeday: true,
+      order: undefined,
+    });
+    const calendarEvent = makeEvent({ _id: "calendar", isSomeday: false });
+
+    const result = shapeEventRead({
+      window: somedayWindow,
+      events: [missingOrderA, orderedSomeday, calendarEvent, missingOrderB],
+    });
+
+    expect(result.data.map((event) => [event._id, event.order])).toEqual([
+      ["missing-a", 3],
+      ["ordered", 2],
+      ["missing-b", 4],
+    ]);
+  });
+});

--- a/packages/core/src/event-read/event-read-shape.test.ts
+++ b/packages/core/src/event-read/event-read-shape.test.ts
@@ -121,4 +121,25 @@ describe("shapeEventRead", () => {
       ["missing-b", 4],
     ]);
   });
+
+  it("filters events by requested priorities", () => {
+    const workEvent = makeEvent({
+      _id: "work",
+      priority: Priorities.WORK,
+    });
+    const selfEvent = makeEvent({
+      _id: "self",
+      priority: Priorities.SELF,
+    });
+
+    const result = shapeEventRead({
+      window: {
+        ...calendarWindow,
+        priorities: [Priorities.WORK],
+      },
+      events: [workEvent, selfEvent],
+    });
+
+    expect(result.data.map((event) => event._id)).toEqual(["work"]);
+  });
 });

--- a/packages/core/src/event-read/event-read-shape.ts
+++ b/packages/core/src/event-read/event-read-shape.ts
@@ -14,6 +14,7 @@ export const shapeEventRead = ({
 }: EventReadShapeInput): EventReadShapeResult => {
   const data = events
     .filter((event) => matchesMode(event, window.mode))
+    .filter((event) => matchesPriorities(event, window.priorities))
     .filter((event) => isVisibleInWindow(event, window))
     .map((event) => shapeRecurringEvent(event, baseEventsById))
     .filter((event): event is Schema_Event => Boolean(event));
@@ -40,6 +41,17 @@ const matchesMode = (
   }
 
   return event.isSomeday !== true;
+};
+
+const matchesPriorities = (
+  event: Schema_Event,
+  priorities: EventReadShapeInput["window"]["priorities"],
+) => {
+  if (!priorities?.length) {
+    return true;
+  }
+
+  return Boolean(event.priority && priorities.includes(event.priority));
 };
 
 const isVisibleInWindow = (

--- a/packages/core/src/event-read/event-read-shape.ts
+++ b/packages/core/src/event-read/event-read-shape.ts
@@ -1,0 +1,151 @@
+import { type Schema_Event } from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
+import { isBase, isInstance } from "@core/util/event/event.util";
+import {
+  type EventReadShapeInput,
+  type EventReadShapeResult,
+} from "./event-read.types";
+
+export const shapeEventRead = ({
+  window,
+  events,
+  baseEventsById,
+  repairSomedayOrder = true,
+}: EventReadShapeInput): EventReadShapeResult => {
+  const data = events
+    .filter((event) => matchesMode(event, window.mode))
+    .filter((event) => isVisibleInWindow(event, window))
+    .map((event) => shapeRecurringEvent(event, baseEventsById))
+    .filter((event): event is Schema_Event => Boolean(event));
+
+  const shapedData =
+    window.mode === "someday" && repairSomedayOrder
+      ? repairSomedayOrders(data)
+      : data;
+
+  return {
+    data: shapedData,
+    count: shapedData.length,
+    startDate: window.startDate,
+    endDate: window.endDate,
+  };
+};
+
+const matchesMode = (
+  event: Schema_Event,
+  mode: EventReadShapeInput["window"]["mode"],
+) => {
+  if (mode === "someday") {
+    return event.isSomeday === true;
+  }
+
+  return event.isSomeday !== true;
+};
+
+const isVisibleInWindow = (
+  event: Schema_Event,
+  window: EventReadShapeInput["window"],
+) => {
+  if (!event.startDate || !event.endDate) {
+    return false;
+  }
+
+  if (isBase(event)) {
+    return false;
+  }
+
+  const eventWithDates = {
+    startDate: event.startDate,
+    endDate: event.endDate,
+  };
+
+  if (event.isAllDay) {
+    return allDayEventOverlapsWindow(eventWithDates, window);
+  }
+
+  return timedEventIsInsideWindow(eventWithDates, window);
+};
+
+const allDayEventOverlapsWindow = (
+  event: Required<Pick<Schema_Event, "startDate" | "endDate">>,
+  window: EventReadShapeInput["window"],
+) => {
+  const eventStart = dayjs(event.startDate).utc(true);
+  const eventEnd = dayjs(event.endDate).utc(true);
+  const rangeStart = dayjs(window.startDate);
+  const rangeEnd = dayjs(window.endDate);
+
+  return eventStart.isBefore(rangeEnd) && eventEnd.isAfter(rangeStart);
+};
+
+const timedEventIsInsideWindow = (
+  event: Required<Pick<Schema_Event, "startDate" | "endDate">>,
+  window: EventReadShapeInput["window"],
+) => {
+  const eventStart = dayjs(event.startDate).utc(true);
+  const eventEnd = dayjs(event.endDate).utc(true);
+
+  return (
+    eventStart.isSameOrAfter(window.startDate) &&
+    eventEnd.isSameOrBefore(window.endDate)
+  );
+};
+
+const shapeRecurringEvent = (
+  event: Schema_Event,
+  baseEventsById: EventReadShapeInput["baseEventsById"],
+) => {
+  if (!isInstance(event)) {
+    return event;
+  }
+
+  if (!baseEventsById) {
+    return event;
+  }
+
+  const baseEventId = event.recurrence?.eventId;
+  const baseEvent =
+    typeof baseEventId === "string" ? baseEventsById[baseEventId] : undefined;
+
+  if (!baseEvent) {
+    return undefined;
+  }
+
+  return {
+    ...event,
+    recurrence: {
+      eventId: baseEvent._id,
+      rule: baseEvent.recurrence?.rule,
+    },
+  };
+};
+
+const repairSomedayOrders = (events: Schema_Event[]) => {
+  if (events.length === 0) return events;
+
+  const existingOrders = events
+    .map((event) => event.order)
+    .filter(
+      (order): order is number =>
+        typeof order === "number" && !Number.isNaN(order),
+    )
+    .sort((a, b) => a - b);
+
+  if (existingOrders.length === 0) {
+    return events.map((event, index) => ({ ...event, order: index }));
+  }
+
+  const highestOrder = existingOrders[existingOrders.length - 1] ?? 0;
+  let nextNewOrder = highestOrder + 1;
+
+  return events.map((event) => {
+    if (typeof event.order === "number" && !Number.isNaN(event.order)) {
+      return event;
+    }
+
+    const order = nextNewOrder;
+    nextNewOrder += 1;
+
+    return { ...event, order };
+  });
+};

--- a/packages/core/src/event-read/event-read-shape.ts
+++ b/packages/core/src/event-read/event-read-shape.ts
@@ -82,12 +82,34 @@ const allDayEventOverlapsWindow = (
   event: Required<Pick<Schema_Event, "startDate" | "endDate">>,
   window: EventReadShapeInput["window"],
 ) => {
-  const eventStart = dayjs(event.startDate).utc(true);
-  const eventEnd = dayjs(event.endDate).utc(true);
   const rangeStart = dayjs(window.startDate);
   const rangeEnd = dayjs(window.endDate);
+  const eventStart = dayjs(event.startDate).utcOffset(
+    getExplicitOffsetMinutes(window.endDate),
+    true,
+  );
+  const eventEnd = dayjs(event.endDate).utcOffset(
+    getExplicitOffsetMinutes(window.startDate),
+    true,
+  );
 
   return eventStart.isBefore(rangeEnd) && eventEnd.isAfter(rangeStart);
+};
+
+const getExplicitOffsetMinutes = (value: string) => {
+  if (/T.*Z$/.test(value)) {
+    return 0;
+  }
+
+  const offset = value.match(/T.*([+-])(\d{2}):?(\d{2})$/);
+  if (!offset) {
+    return dayjs(value).utcOffset();
+  }
+
+  const [, sign, hours, minutes] = offset;
+  const direction = sign === "-" ? -1 : 1;
+
+  return direction * (Number(hours) * 60 + Number(minutes));
 };
 
 const timedEventIsInsideWindow = (

--- a/packages/core/src/event-read/event-read.types.ts
+++ b/packages/core/src/event-read/event-read.types.ts
@@ -1,3 +1,4 @@
+import { type Priority } from "@core/constants/core.constants";
 import { type Schema_Event } from "@core/types/event.types";
 
 export type EventReadMode = "calendar" | "someday";
@@ -6,6 +7,7 @@ export type EventReadWindow = {
   mode: EventReadMode;
   startDate: string;
   endDate: string;
+  priorities?: Priority[];
 };
 
 export type EventReadShapeInput = {

--- a/packages/core/src/event-read/event-read.types.ts
+++ b/packages/core/src/event-read/event-read.types.ts
@@ -1,0 +1,23 @@
+import { type Schema_Event } from "@core/types/event.types";
+
+export type EventReadMode = "calendar" | "someday";
+
+export type EventReadWindow = {
+  mode: EventReadMode;
+  startDate: string;
+  endDate: string;
+};
+
+export type EventReadShapeInput = {
+  window: EventReadWindow;
+  events: Schema_Event[];
+  baseEventsById?: Record<string, Schema_Event | undefined>;
+  repairSomedayOrder?: boolean;
+};
+
+export type EventReadShapeResult = {
+  data: Schema_Event[];
+  count: number;
+  startDate: string;
+  endDate: string;
+};

--- a/packages/core/src/types/event.types.test.ts
+++ b/packages/core/src/types/event.types.test.ts
@@ -1,0 +1,20 @@
+import { Origin, Priorities } from "@core/constants/core.constants";
+import { CoreEventSchema } from "./event.types";
+import { describe, expect, it } from "bun:test";
+
+describe("CoreEventSchema", () => {
+  it("preserves someday order values", () => {
+    const parsedEvent = CoreEventSchema.parse({
+      _id: "507f1f77bcf86cd799439011",
+      startDate: "2026-04-06T15:00:00.000Z",
+      endDate: "2026-04-06T16:00:00.000Z",
+      isSomeday: true,
+      order: 3,
+      origin: Origin.COMPASS,
+      priority: Priorities.UNASSIGNED,
+      user: "user-1",
+    });
+
+    expect(parsedEvent.order).toBe(3);
+  });
+});

--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -64,6 +64,7 @@ export interface Params_Events {
   startDate: string;
   endDate: string;
   someday: boolean;
+  priorities?: Priority[];
 }
 
 export interface Payload_Order {

--- a/packages/core/src/types/event.types.ts
+++ b/packages/core/src/types/event.types.ts
@@ -64,7 +64,6 @@ export interface Params_Events {
   startDate: string;
   endDate: string;
   someday: boolean;
-  dontAdjustDates?: boolean;
 }
 
 export interface Payload_Order {
@@ -167,6 +166,7 @@ export const CoreEventSchema = z.object({
   isSomeday: z.boolean().optional(),
   gEventId: z.string().optional(),
   gRecurringEventId: z.string().optional(),
+  order: z.number().optional(),
   origin: z.nativeEnum(Origin),
   priority: z.nativeEnum(Priorities),
   recurrence: Recurrence.optional(),

--- a/packages/web/src/__tests__/utils/storage/mock-storage-adapter.util.ts
+++ b/packages/web/src/__tests__/utils/storage/mock-storage-adapter.util.ts
@@ -26,7 +26,6 @@ export function createMockStorageAdapter(): MockedStorageAdapter {
     deleteTask: mock().mockResolvedValue(undefined),
     moveTask: mock().mockResolvedValue(undefined),
     clearAllTasks: mock().mockResolvedValue(undefined),
-    getEvents: mock().mockResolvedValue([]),
     getAllEvents: mock().mockResolvedValue([]),
     putEvent: mock().mockResolvedValue(undefined),
     putEvents: mock().mockResolvedValue(undefined),

--- a/packages/web/src/common/constants/more.cmd.constants.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.ts
@@ -28,8 +28,7 @@ export const moreCommandPaletteItems: Array<{
         children: `Version: ${typeof BUILD_VERSION === "string" ? BUILD_VERSION : "dev"}`,
         icon: "InformationCircleIcon",
         onClick: () => {
-          const v =
-            typeof BUILD_VERSION === "string" ? BUILD_VERSION : "dev";
+          const v = typeof BUILD_VERSION === "string" ? BUILD_VERSION : "dev";
           void navigator.clipboard.writeText(v);
         },
       },

--- a/packages/web/src/common/repositories/event/local.event.repository.test.ts
+++ b/packages/web/src/common/repositories/event/local.event.repository.test.ts
@@ -1,5 +1,5 @@
 import { Origin, Priorities } from "@core/constants/core.constants";
-import { type Event_Core } from "@core/types/event.types";
+import { type Event_Core, type Params_Events } from "@core/types/event.types";
 import { LocalEventRepository } from "@web/common/repositories/event/local.event.repository";
 import {
   isLocalDemoEvent,
@@ -73,5 +73,23 @@ describe("LocalEventRepository", () => {
       eventId: "base-event",
       rule: ["RRULE:FREQ=WEEKLY"],
     });
+  });
+
+  it("filters local reads by requested priorities", async () => {
+    getAllEvents.mockResolvedValue([
+      makeEvent({ _id: "work-event", priority: Priorities.WORK }),
+      makeEvent({ _id: "self-event", priority: Priorities.SELF }),
+    ]);
+
+    const params: Params_Events = {
+      startDate: "2026-05-05T00:00:00.000Z",
+      endDate: "2026-05-06T00:00:00.000Z",
+      someday: false,
+      priorities: [Priorities.WORK],
+    };
+
+    const result = await new LocalEventRepository().get(params);
+
+    expect(result.data.map((event) => event._id)).toEqual(["work-event"]);
   });
 });

--- a/packages/web/src/common/repositories/event/local.event.repository.test.ts
+++ b/packages/web/src/common/repositories/event/local.event.repository.test.ts
@@ -46,4 +46,32 @@ describe("LocalEventRepository", () => {
 
     expect(isLocalDemoEvent(putEvent.mock.calls[0][0])).toBe(true);
   });
+
+  it("shapes local calendar reads like backend reads", async () => {
+    const baseEvent = makeEvent({
+      _id: "base-event",
+      recurrence: { rule: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const instanceEvent = makeEvent({
+      _id: "instance-event",
+      recurrence: { eventId: "base-event" },
+    });
+    const somedayEvent = makeEvent({
+      _id: "someday-event",
+      isSomeday: true,
+    });
+    getAllEvents.mockResolvedValue([baseEvent, instanceEvent, somedayEvent]);
+
+    const result = await new LocalEventRepository().get({
+      startDate: "2026-05-05T00:00:00.000Z",
+      endDate: "2026-05-06T00:00:00.000Z",
+      someday: false,
+    });
+
+    expect(result.data.map((event) => event._id)).toEqual(["instance-event"]);
+    expect(result.data[0]?.recurrence).toEqual({
+      eventId: "base-event",
+      rule: ["RRULE:FREQ=WEEKLY"],
+    });
+  });
 });

--- a/packages/web/src/common/repositories/event/local.event.repository.ts
+++ b/packages/web/src/common/repositories/event/local.event.repository.ts
@@ -9,6 +9,7 @@ import { getStorageAdapter } from "@web/common/storage/adapter/adapter";
 import { preserveLocalEventMarker } from "@web/common/storage/types/local-event.types";
 import { type Response_GetEventsSuccess } from "@web/ducks/events/event.types";
 import { type EventRepository } from "./event.repository.interface";
+import { LocalEventReadAdapter } from "./read/local-event-read.adapter";
 
 /**
  * Local event repository implementation using the storage adapter.
@@ -44,21 +45,7 @@ export class LocalEventRepository implements EventRepository {
   }
 
   async get(params: Params_Events): Promise<Response_GetEventsSuccess> {
-    const events = await this.adapter.getEvents(
-      params.startDate,
-      params.endDate,
-      params.someday,
-    );
-
-    return {
-      data: events as Schema_Event[],
-      count: events.length,
-      page: 1,
-      pageSize: events.length || 1,
-      offset: 0,
-      startDate: params.startDate,
-      endDate: params.endDate,
-    };
+    return new LocalEventReadAdapter(this.adapter).get(params);
   }
 
   async edit(

--- a/packages/web/src/common/repositories/event/read/local-event-read.adapter.ts
+++ b/packages/web/src/common/repositories/event/read/local-event-read.adapter.ts
@@ -22,6 +22,7 @@ export class LocalEventReadAdapter {
         mode: params.someday ? "someday" : "calendar",
         startDate: params.startDate,
         endDate: params.endDate,
+        priorities: params.priorities,
       },
       events,
       baseEventsById,

--- a/packages/web/src/common/repositories/event/read/local-event-read.adapter.ts
+++ b/packages/web/src/common/repositories/event/read/local-event-read.adapter.ts
@@ -1,0 +1,37 @@
+import { shapeEventRead } from "@core/event-read/event-read-shape";
+import { type Params_Events, type Schema_Event } from "@core/types/event.types";
+import { isBase } from "@core/util/event/event.util";
+import { type StorageAdapter } from "@web/common/storage/adapter/storage.adapter";
+import { type Response_GetEventsSuccess } from "@web/ducks/events/event.types";
+
+export class LocalEventReadAdapter {
+  constructor(private readonly adapter: StorageAdapter) {}
+
+  async get(params: Params_Events): Promise<Response_GetEventsSuccess> {
+    const storedEvents = await this.adapter.getAllEvents();
+    const events = storedEvents as Schema_Event[];
+    const baseEventsById = Object.fromEntries(
+      events
+        .filter(isBase)
+        .filter((event) => typeof event._id === "string")
+        .map((event) => [event._id as string, event]),
+    );
+
+    const result = shapeEventRead({
+      window: {
+        mode: params.someday ? "someday" : "calendar",
+        startDate: params.startDate,
+        endDate: params.endDate,
+      },
+      events,
+      baseEventsById,
+    });
+
+    return {
+      ...result,
+      page: 1,
+      pageSize: result.data.length || 1,
+      offset: 0,
+    };
+  }
+}

--- a/packages/web/src/common/repositories/event/remote.event.repository.test.ts
+++ b/packages/web/src/common/repositories/event/remote.event.repository.test.ts
@@ -17,6 +17,7 @@ const mockDelete = mock();
 const mockReorder = mock();
 const mockPutEvent = mock();
 const mockGetEvents = mock();
+const mockGetAllEvents = mock();
 
 mock.module("@web/ducks/events/event.api", () => ({
   EventApi: {
@@ -31,6 +32,7 @@ mock.module("@web/ducks/events/event.api", () => ({
 mock.module("@web/common/storage/adapter/adapter", () => ({
   getStorageAdapter: () => ({
     getEvents: mockGetEvents,
+    getAllEvents: mockGetAllEvents,
     putEvent: mockPutEvent,
   }),
 }));
@@ -56,6 +58,7 @@ describe("RemoteEventRepository", () => {
     mockReorder.mockClear();
     mockPutEvent.mockClear();
     mockGetEvents.mockClear();
+    mockGetAllEvents.mockClear();
     resetBackendAvailabilityForTests();
     repository = new RemoteEventRepository();
   });
@@ -173,19 +176,23 @@ describe("RemoteEventRepository", () => {
         endDate: "2024-01-31",
         someday: false,
       };
-      const localEvents = [{ _id: "event-1", title: "Local Event" }];
+      const localEvents = [
+        {
+          _id: "event-1",
+          title: "Local Event",
+          startDate: "2024-01-05T15:00:00.000Z",
+          endDate: "2024-01-05T16:00:00.000Z",
+          isSomeday: false,
+        },
+      ];
 
       mockGet.mockRejectedValue(createBackendUnavailableError());
-      mockGetEvents.mockResolvedValue(localEvents);
+      mockGetAllEvents.mockResolvedValue(localEvents);
 
       const result = await repository.get(params);
 
       expect(mockGet).toHaveBeenCalledWith(params);
-      expect(mockGetEvents).toHaveBeenCalledWith(
-        params.startDate,
-        params.endDate,
-        params.someday,
-      );
+      expect(mockGetAllEvents).toHaveBeenCalledTimes(1);
       expect(result.data).toEqual(localEvents);
     });
   });

--- a/packages/web/src/common/storage/adapter/indexeddb.adapter.ts
+++ b/packages/web/src/common/storage/adapter/indexeddb.adapter.ts
@@ -1,5 +1,4 @@
 import Dexie, { type Table } from "dexie";
-import { isDateRangeOverlapping } from "@core/util/date/date.util";
 import { type LocalStoredEvent } from "@web/common/storage/types/local-event.types";
 import {
   normalizeTask,
@@ -190,28 +189,6 @@ export class IndexedDBAdapter implements StorageAdapter {
   }
 
   // ─── Event Operations ──────────────────────────────────────────────────────
-
-  async getEvents(
-    startDate: string,
-    endDate: string,
-    isSomeday?: boolean,
-  ): Promise<LocalStoredEvent[]> {
-    const allEvents = await this.db.events.toArray();
-
-    return allEvents.filter((event) => {
-      if (!event.startDate || !event.endDate) return false;
-      if (isSomeday !== undefined && event.isSomeday !== isSomeday) {
-        return false;
-      }
-      return isDateRangeOverlapping(
-        event.startDate,
-        event.endDate,
-        startDate,
-        endDate,
-        "day",
-      );
-    });
-  }
 
   async getAllEvents(): Promise<LocalStoredEvent[]> {
     return this.db.events.toArray();

--- a/packages/web/src/common/storage/adapter/storage.adapter.ts
+++ b/packages/web/src/common/storage/adapter/storage.adapter.ts
@@ -81,15 +81,6 @@ export interface StorageAdapter {
   // ─── Event Operations ──────────────────────────────────────────────────────
 
   /**
-   * Get events overlapping a date range.
-   */
-  getEvents(
-    startDate: string,
-    endDate: string,
-    isSomeday?: boolean,
-  ): Promise<LocalStoredEvent[]>;
-
-  /**
    * Get all events without filtering.
    */
   getAllEvents(): Promise<LocalStoredEvent[]>;

--- a/packages/web/src/common/storage/migrations/data/task-id-to-underscore-id.test.ts
+++ b/packages/web/src/common/storage/migrations/data/task-id-to-underscore-id.test.ts
@@ -18,7 +18,6 @@ function createMockAdapter(): MockedStorageAdapter {
     deleteTask: mock().mockResolvedValue(undefined),
     moveTask: mock().mockResolvedValue(undefined),
     clearAllTasks: mock().mockResolvedValue(undefined),
-    getEvents: mock().mockResolvedValue([]),
     getAllEvents: mock().mockResolvedValue([]),
     putEvent: mock().mockResolvedValue(undefined),
     putEvents: mock().mockResolvedValue(undefined),

--- a/packages/web/src/common/storage/migrations/external/localstorage-tasks.test.ts
+++ b/packages/web/src/common/storage/migrations/external/localstorage-tasks.test.ts
@@ -46,7 +46,6 @@ function createMockAdapter(): MockedStorageAdapter {
     deleteTask: mock().mockResolvedValue(undefined),
     moveTask: mock().mockResolvedValue(undefined),
     clearAllTasks: mock().mockResolvedValue(undefined),
-    getEvents: mock().mockResolvedValue([]),
     getAllEvents: mock().mockResolvedValue([]),
     putEvent: mock().mockResolvedValue(undefined),
     putEvents: mock().mockResolvedValue(undefined),

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -4,7 +4,7 @@ import {
   type Schema_GridEvent,
   type Schema_WebEvent,
 } from "@web/common/types/web.event.types";
-import { addId, isEventInRange } from "@web/common/utils/event/event.util";
+import { addId } from "@web/common/utils/event/event.util";
 import { _assembleGridEvent } from "@web/ducks/events/sagas/saga.util";
 import {
   afterEach,
@@ -40,26 +40,6 @@ describe("handleError", () => {
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
     expect(alertMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("isEventInRange", () => {
-  it("returns true if event is in range", () => {
-    const event = { start: "2022-03-15", end: "2022-03-15" };
-    const dates = {
-      start: "2022-03-14",
-      end: "2022-03-19",
-    };
-    expect(isEventInRange(event, dates)).toBe(true);
-  });
-
-  it("returns false if event is not in range", () => {
-    const event = { start: "2022-03-15", end: "2022-03-15" };
-    const dates = {
-      start: "2022-03-16",
-      end: "2022-03-19",
-    };
-    expect(isEventInRange(event, dates)).toBe(false);
   });
 });
 

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -251,26 +251,6 @@ export const handleError = (error: Error) => {
   alert(error);
 };
 
-export const isEventInRange = (
-  eventDate: { start: string; end: string },
-  rangeDate: { start: string; end: string },
-) => {
-  const isStartDateInRange = dayjs(eventDate.start).isBetween(
-    rangeDate.start,
-    rangeDate.end,
-    "day",
-    "[]",
-  );
-  const isEndDateInRange = dayjs(eventDate.end).isBetween(
-    rangeDate.start,
-    rangeDate.end,
-    "day",
-    "[]",
-  );
-
-  return isStartDateInRange || isEndDateInRange;
-};
-
 export const getEventCursorStyle = (
   isDragging: boolean,
   isPending = false,

--- a/packages/web/src/common/utils/event/someday.event.util.test.ts
+++ b/packages/web/src/common/utils/event/someday.event.util.test.ts
@@ -17,10 +17,7 @@ import {
   type Schema_SomedayEvent,
   type Schema_SomedayEventsColumn,
 } from "@web/common/types/web.event.types";
-import {
-  categorizeSomedayEvents,
-  setSomedayEventsOrder,
-} from "@web/common/utils/event/someday.event.util";
+import { categorizeSomedayEvents } from "@web/common/utils/event/someday.event.util";
 import {
   afterAll,
   beforeAll,
@@ -220,109 +217,6 @@ describe("categorizeSomedayEvents", () => {
   });
 });
 
-describe("setSomedayEventsOrder", () => {
-  const createEvent = (id: string, order?: number): Schema_Event => ({
-    _id: id,
-    ...(order !== undefined && { order }),
-  });
-
-  it("should return empty array for empty input", () => {
-    expect(setSomedayEventsOrder([])).toEqual([]);
-  });
-
-  it("should assign sequential orders starting from 0 when no events have orders", () => {
-    const events = [createEvent("1"), createEvent("2"), createEvent("3")];
-
-    const result = setSomedayEventsOrder(events);
-
-    expect(result).toEqual([
-      { ...events[0], order: 0 },
-      { ...events[1], order: 1 },
-      { ...events[2], order: 2 },
-    ]);
-  });
-
-  it("should preserve existing valid orders", () => {
-    const events = [
-      createEvent("1", 5),
-      createEvent("2", 2),
-      createEvent("3", 8),
-    ];
-
-    const result = setSomedayEventsOrder(events);
-
-    expect(result).toEqual(events);
-  });
-
-  it("should append missing orders after the highest existing order", () => {
-    const events = [
-      createEvent("1", 0),
-      createEvent("2"),
-      createEvent("3", 3),
-      createEvent("4"),
-      createEvent("5", 5),
-    ];
-
-    const result = setSomedayEventsOrder(events);
-
-    expect(result).toEqual([
-      { ...events[0], order: 0 },
-      { ...events[1], order: 6 },
-      { ...events[2], order: 3 },
-      { ...events[3], order: 7 },
-      { ...events[4], order: 5 },
-    ]);
-  });
-
-  it("should append to end when no gaps available", () => {
-    const events = [
-      createEvent("1", 0),
-      createEvent("2", 1),
-      createEvent("3"), // Should get order 3
-      createEvent("4", 2),
-      createEvent("5"), // Should get order 4
-    ];
-
-    const result = setSomedayEventsOrder(events);
-
-    expect(result).toEqual([
-      { ...events[0], order: 0 },
-      { ...events[1], order: 1 },
-      { ...events[2], order: 3 },
-      { ...events[3], order: 2 },
-      { ...events[4], order: 4 },
-    ]);
-  });
-
-  it("should handle mix of valid and invalid order values", () => {
-    const events = [
-      createEvent("1", 1),
-      { ...createEvent("2"), order: Number.NaN }, // Should get order 5
-      { ...createEvent("3"), order: undefined }, // Should get order 6
-      createEvent("4", 4),
-      { ...createEvent("5"), order: undefined }, // Should get order 7
-    ];
-
-    const result = setSomedayEventsOrder(events);
-
-    expect(result).toEqual([
-      { ...events[0], order: 1 },
-      { ...events[1], order: 5 },
-      { ...events[2], order: 6 },
-      { ...events[3], order: 4 },
-      { ...events[4], order: 7 },
-    ]);
-  });
-
-  it("should handle single event without order", () => {
-    const events = [createEvent("1")];
-
-    const result = setSomedayEventsOrder(events);
-
-    expect(result).toEqual([{ ...events[0], order: 0 }]);
-  });
-});
-
 describe("computeRelativeEventDateRange", () => {
   const baseEvent: Schema_Event = {
     _id: "test-id",
@@ -409,80 +303,6 @@ describe("computeRelativeEventDateRange", () => {
       expect(result.columns[COLUMN_WEEK].eventIds).toEqual([
         eventIdB,
         eventIdA,
-      ]);
-    });
-
-    it("should assign sequential orders for events without order", () => {
-      const eventIdA = new ObjectId().toString();
-      const eventIdB = new ObjectId().toString();
-      // Add all required properties for Schema_Event
-      const events = [
-        {
-          ...baseEvent,
-          _id: eventIdA,
-          isSomeday: true,
-          origin: Origin.COMPASS,
-          priority: Priorities.UNASSIGNED,
-          user: "test-user",
-        },
-        {
-          ...baseEvent,
-          _id: eventIdB,
-          isSomeday: true,
-          origin: Origin.COMPASS,
-          priority: Priorities.UNASSIGNED,
-          user: "test-user",
-        },
-      ];
-
-      const result = setSomedayEventsOrder(events as Schema_Event[]);
-
-      expect(result).toEqual([
-        { ...events[0], order: 0 },
-        { ...events[1], order: 1 },
-      ]);
-    });
-
-    it("should append missing order values for events", () => {
-      const eventIdA = new ObjectId().toString();
-      const eventIdB = new ObjectId().toString();
-      const eventIdC = new ObjectId().toString();
-      // Add all required properties for Schema_Event
-      const events = [
-        {
-          ...baseEvent,
-          _id: eventIdA,
-          order: 0,
-          isSomeday: true,
-          origin: Origin.COMPASS,
-          priority: Priorities.UNASSIGNED,
-          user: "test-user",
-        },
-        {
-          ...baseEvent,
-          _id: eventIdB,
-          isSomeday: true,
-          origin: Origin.COMPASS,
-          priority: Priorities.UNASSIGNED,
-          user: "test-user",
-        }, // Should get order 4
-        {
-          ...baseEvent,
-          _id: eventIdC,
-          order: 3,
-          isSomeday: true,
-          origin: Origin.COMPASS,
-          priority: Priorities.UNASSIGNED,
-          user: "test-user",
-        },
-      ];
-
-      const result = setSomedayEventsOrder(events as Schema_Event[]);
-
-      expect(result).toEqual([
-        { ...events[0], order: 0 },
-        { ...events[1], order: 4 },
-        { ...events[2], order: 3 },
       ]);
     });
 

--- a/packages/web/src/common/utils/event/someday.event.util.ts
+++ b/packages/web/src/common/utils/event/someday.event.util.ts
@@ -102,42 +102,6 @@ export const categorizeSomedayEvents = (
   return sortedData;
 };
 
-/**
- * See https://github.com/SwitchbackTech/compass/issues/512 for more context.
- * Should be removed after we ensure that backend sets the order field for all someday events.
- */
-export const setSomedayEventsOrder = (
-  events: Schema_Event[],
-): Schema_Event[] => {
-  if (events.length === 0) return [];
-
-  // Get existing valid orders
-  const existingOrders = events
-    .map((e) => e.order)
-    .filter(
-      (order): order is number =>
-        typeof order === "number" && !Number.isNaN(order),
-    )
-    .sort((a, b) => a - b);
-
-  // If no valid orders exist, assign sequential orders starting from 0
-  if (existingOrders.length === 0) {
-    return events.map((event, index) => ({ ...event, order: index }));
-  }
-
-  const highestOrder = existingOrders[existingOrders.length - 1];
-
-  let nextNewOrder = highestOrder + 1;
-  return events.map((event) => {
-    if (typeof event.order === "number" && !Number.isNaN(event.order)) {
-      return event;
-    }
-
-    const order = nextNewOrder++;
-    return { ...event, order };
-  });
-};
-
 export const isSomedayEventActionMenuOpen = () => {
   const actionMenu = document.getElementById(ID_SOMEDAY_EVENT_ACTION_MENU);
   return !!actionMenu;

--- a/packages/web/src/ducks/events/event.api.test.ts
+++ b/packages/web/src/ducks/events/event.api.test.ts
@@ -1,0 +1,49 @@
+import { Priorities } from "@core/constants/core.constants";
+import {
+  type ApiAdapter,
+  type ApiRequestConfig,
+} from "@web/common/apis/api.types";
+import { BaseApi } from "@web/common/apis/base/base.api";
+import { EventApi } from "./event.api";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("EventApi.get", () => {
+  afterEach(() => {
+    BaseApi.defaults.adapter = undefined;
+  });
+
+  it("sends priority filters with event reads", async () => {
+    const requests: ApiRequestConfig[] = [];
+    const adapter: ApiAdapter = async <T>(
+      config: ApiRequestConfig & { body?: unknown },
+    ) => {
+      requests.push(config);
+
+      return {
+        config,
+        data: {
+          data: [],
+          count: 0,
+          page: 1,
+          pageSize: 0,
+          offset: 0,
+        } as T,
+        headers: new Headers(),
+        status: 200,
+        statusText: "OK",
+      };
+    };
+    BaseApi.defaults.adapter = adapter;
+
+    await EventApi.get({
+      startDate: "2026-04-01",
+      endDate: "2026-05-01",
+      someday: false,
+      priorities: [Priorities.WORK, Priorities.SELF],
+    });
+
+    expect(requests[0]?.url).toBe(
+      "/event?start=2026-04-01&end=2026-05-01&priorities=work,self",
+    );
+  });
+});

--- a/packages/web/src/ducks/events/event.api.ts
+++ b/packages/web/src/ducks/events/event.api.ts
@@ -30,15 +30,16 @@ const EventApi = {
     return BaseApi.put<void>(`/event/${_id}`, event);
   },
   get: (params: Params_Events) => {
-    if (params.someday) {
-      return BaseApi.get<Response_HttpPaginatedSuccess<Schema_Event[]>>(
-        `/event?someday=true&start=${params.startDate}&end=${params.endDate}`,
-      );
-    } else {
-      return BaseApi.get<Response_HttpPaginatedSuccess<Schema_Event[]>>(
-        `/event?start=${params.startDate}&end=${params.endDate}`,
-      );
+    const query = params.someday ? ["someday=true"] : [];
+    query.push(`start=${params.startDate}`, `end=${params.endDate}`);
+
+    if (params.priorities?.length) {
+      query.push(`priorities=${params.priorities.join(",")}`);
     }
+
+    return BaseApi.get<Response_HttpPaginatedSuccess<Schema_Event[]>>(
+      `/event?${query.join("&")}`,
+    );
   },
   reorder: (order: Payload_Order[]) => {
     return BaseApi.put(`/event/reorder`, order);

--- a/packages/web/src/ducks/events/sagas/event.sagas.test.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.test.ts
@@ -162,20 +162,14 @@ describe("getWeekEvents saga", () => {
     sagaTask = sagaMiddleware.run(sagas);
   });
 
-  it("filters repository results by the requested date range", async () => {
-    const previousDayEvent = createMockStandaloneEvent({
-      _id: "previous-day-event",
-      startDate: "2026-04-05T15:00:00.000Z",
-      endDate: "2026-04-05T16:00:00.000Z",
-      isAllDay: false,
-    } as Partial<Schema_Event>);
+  it("requests week events without adjusting the requested date range", async () => {
     const requestedRangeEvent = createMockStandaloneEvent({
       _id: "requested-range-event",
       startDate: "2026-04-06T15:00:00.000Z",
       endDate: "2026-04-06T16:00:00.000Z",
       isAllDay: false,
     } as Partial<Schema_Event>);
-    mockLocalEvents.push(previousDayEvent, requestedRangeEvent);
+    mockLocalEvents.push(requestedRangeEvent);
 
     store.dispatch(
       getWeekEventsSlice.actions.request({
@@ -188,7 +182,7 @@ describe("getWeekEvents saga", () => {
 
     expect(mockLocalRepository.get).toHaveBeenCalledWith(
       expect.objectContaining({
-        startDate: "2026-04-05T00:00:00+00:00",
+        startDate: "2026-04-06T00:00:00.000Z",
         endDate: "2026-04-13T00:00:00.000Z",
       }),
     );

--- a/packages/web/src/ducks/events/sagas/event.sagas.test.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.test.ts
@@ -1,5 +1,5 @@
 import { put } from "redux-saga/effects";
-import { type Schema_Event } from "@core/types/event.types";
+import { type Params_Events, type Schema_Event } from "@core/types/event.types";
 import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import {
   clearAnonymousCalendarChangeSignUpPrompt,
@@ -21,6 +21,7 @@ import {
   expect,
   it,
   mock,
+  setSystemTime,
   spyOn,
 } from "bun:test";
 
@@ -48,7 +49,7 @@ const mockLocalRepository = {
       mockLocalEvents[index] = event;
     }
   }),
-  get: mock(async () => ({
+  get: mock(async (_params?: Params_Events) => ({
     data: [...mockLocalEvents],
     count: mockLocalEvents.length,
     page: 1,
@@ -105,6 +106,9 @@ const { pendingEventsSlice } = await import(
 );
 const { getWeekEventsSlice } = await import(
   "@web/ducks/events/slices/week.slice"
+);
+const { getCurrentMonthEventsSlice } = await import(
+  "@web/ducks/events/slices/event.slice"
 );
 const { sagas } = await import("@web/store/sagas");
 const { OnSubmitParser } = await import(
@@ -189,6 +193,63 @@ describe("getWeekEvents saga", () => {
     expect(store.getState().events.getWeekEvents.value?.data).toEqual([
       "requested-range-event",
     ]);
+  });
+});
+
+describe("getCurrentMonthEvents saga", () => {
+  let store: ReturnType<typeof createStoreWithEvents>;
+
+  beforeEach(() => {
+    clearApiMocks();
+    setSystemTime(new Date("2026-04-15T12:00:00.000Z"));
+    mockDoesSessionExist.mockResolvedValue(false);
+    store = createStoreWithEvents([]);
+    sagaTask = sagaMiddleware.run(sagas);
+  });
+
+  afterEach(() => {
+    setSystemTime();
+  });
+
+  it("requests a next-month exclusive end so all-day events on the final day are visible", async () => {
+    const finalDayAllDayEvent = createMockStandaloneEvent({
+      _id: "final-day",
+      startDate: "2026-04-30",
+      endDate: "2026-05-01",
+      isAllDay: true,
+    } as Partial<Schema_Event>);
+
+    mockLocalRepository.get.mockImplementationOnce(
+      async (params?: Params_Events) => ({
+        data: params?.endDate === "2026-05-01" ? [finalDayAllDayEvent] : [],
+        count: params?.endDate === "2026-05-01" ? 1 : 0,
+        page: 1,
+        pageSize: 1,
+        offset: 0,
+        startDate: params?.startDate ?? "",
+        endDate: params?.endDate ?? "",
+      }),
+    );
+
+    store.dispatch(
+      getCurrentMonthEventsSlice.actions.request({
+        pageSize: 10,
+        priorities: [],
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockLocalRepository.get).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDate: "2026-04-01",
+        endDate: "2026-05-01",
+      }),
+    );
+    const currentMonthState = store.getState().events.getCurrentMonthEvents as {
+      value?: { data?: unknown };
+    };
+    expect(currentMonthState.value?.data).toEqual(["final-day"]);
   });
 });
 

--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -44,7 +44,6 @@ import {
   _assembleGridEvent,
   _createOptimisticGridEvent,
   _editEvent,
-  EventDateUtils,
   normalizedEventsSchema,
 } from "@web/ducks/events/sagas/saga.util";
 import { selectEventById } from "@web/ducks/events/selectors/event.selectors";
@@ -250,20 +249,10 @@ function* getEvents(payload: GetEventsPayload) {
       throw new Error("Event query requires startDate and endDate");
     }
 
-    const _payload = EventDateUtils.adjustStartEndDate(
-      payload as Params_Events,
-    );
-
     const res = (yield call(
       [repository, "get"],
-      _payload,
+      payload as Params_Events,
     )) as Response_GetEventsSuccess;
-
-    const events = EventDateUtils.filterEventsByStartEndDate(
-      res.data,
-      payload.startDate,
-      payload.endDate,
-    );
 
     // Validate response data exists before normalizing
     if (!res.data || !Array.isArray(res.data)) {
@@ -272,7 +261,7 @@ function* getEvents(payload: GetEventsPayload) {
       );
     }
 
-    const normalizedEvents = normalize<Schema_Event>(events, [
+    const normalizedEvents = normalize<Schema_Event>(res.data, [
       normalizedEventsSchema(),
     ]);
 
@@ -304,7 +293,6 @@ export function* getDayEvents({ payload }: Action_GetEvents) {
   try {
     const data = (yield call(getEvents, {
       ...payload,
-      dontAdjustDates: true,
       someday: false,
     })) as Response_GetEventsSaga;
 

--- a/packages/web/src/ducks/events/sagas/event.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/event.sagas.ts
@@ -212,8 +212,9 @@ export function* editEvent({ payload }: Action_EditEvent) {
 
 export function* getCurrentMonthEvents({ payload }: Action_GetPaginatedEvents) {
   try {
-    const startDate = dayjs().startOf("month").format(YEAR_MONTH_DAY_FORMAT);
-    const endDate = dayjs().endOf("month").format(YEAR_MONTH_DAY_FORMAT);
+    const monthStart = dayjs().startOf("month");
+    const startDate = monthStart.format(YEAR_MONTH_DAY_FORMAT);
+    const endDate = monthStart.add(1, "month").format(YEAR_MONTH_DAY_FORMAT);
     const data: Response_GetEventsSaga = (yield* getEvents({
       ...payload,
       startDate,

--- a/packages/web/src/ducks/events/sagas/saga.util.ts
+++ b/packages/web/src/ducks/events/sagas/saga.util.ts
@@ -1,11 +1,9 @@
 import { call, put, type SelectEffect, select } from "@redux-saga/core/effects";
 import { normalize, schema } from "normalizr";
 import {
-  type Params_Events,
   type RecurringEventUpdateScope,
   type Schema_Event,
 } from "@core/types/event.types";
-import dayjs from "@core/util/date/dayjs";
 import { session } from "@web/common/classes/Session";
 import { getEventRepository } from "@web/common/repositories/event/event.repository.util";
 import {
@@ -113,58 +111,3 @@ export function* _createOptimisticGridEvent(
 
 export const normalizedEventsSchema = () =>
   new schema.Entity("events", {}, { idAttribute: "_id" });
-
-// Meant to be a hotfix to address issue where backend returns date
-// filtered events in an inconsistent way.
-// See https://github.com/SwitchbackTech/compass/issues/428
-// Should be removed after backend is fixed
-export const EventDateUtils = {
-  /**
-   * Adjusts start and end dates for event queries
-   */
-  adjustStartEndDate: (payload: Params_Events) => {
-    if (payload.someday || payload.dontAdjustDates) return payload;
-
-    // Make start date 1 day before the start date
-    const startDate = dayjs(payload.startDate).subtract(1, "day").format();
-    const endDate = payload.endDate;
-
-    return {
-      ...payload,
-      startDate,
-      endDate,
-    };
-  },
-
-  /**
-   * Filters events by start and end date range
-   * Handles comparison between different date formats (raw dates vs ISO 8601)
-   */
-  filterEventsByStartEndDate: (
-    events: Schema_Event[],
-    startDate: string,
-    endDate: string,
-  ) => {
-    return events.filter((event) => {
-      const eventStart = dayjs(event.startDate).utc(true); // use local time - until we use actual dates
-      const eventEnd = dayjs(event.endDate).utc(true); // This is exclusive, so the event ends at the very start of the end date
-
-      if (event.isAllDay) {
-        // For all-day events with exclusive end dates (e.g., Mon event: start="2025-09-08", end="2025-09-09")
-        // Check if the event overlaps with the requested date range
-        const rangeStart = dayjs(startDate);
-        const rangeEnd = dayjs(endDate);
-
-        // Event overlaps if: event starts before range ends AND event ends after range starts
-        const overlaps =
-          eventStart.isBefore(rangeEnd) && eventEnd.isAfter(rangeStart);
-
-        return overlaps;
-      }
-
-      return (
-        eventStart.isSameOrAfter(startDate) && eventEnd.isSameOrBefore(endDate)
-      );
-    });
-  },
-} as const;

--- a/packages/web/src/ducks/events/sagas/someday.sagas.ts
+++ b/packages/web/src/ducks/events/sagas/someday.sagas.ts
@@ -6,7 +6,6 @@ import * as eventRepositoryUtil from "@web/common/repositories/event/event.repos
 import { type Payload_NormalizedAsyncAction } from "@web/common/types/entity.types";
 import { type Schema_OptimisticEvent } from "@web/common/types/web.event.types";
 import { handleError } from "@web/common/utils/event/event.util";
-import { setSomedayEventsOrder } from "@web/common/utils/event/someday.event.util";
 import {
   type Action_ConvertEvent,
   type Action_DeleteEvent,
@@ -124,9 +123,7 @@ export function* getSomedayEvents({ payload }: Action_GetEvents): Generator {
       }),
     )) as Response_GetEventsSuccess;
 
-    const events = setSomedayEventsOrder(res.data);
-
-    const normalizedEvents = normalize<Schema_Event>(events, [
+    const normalizedEvents = normalize<Schema_Event>(res.data, [
       normalizedEventsSchema(),
     ]);
     yield put(


### PR DESCRIPTION
## Summary

This PR adds the first behavior-preserving slice of the Event Read Shape module. The goal is to make calendar and Someday reads go through one shared rule before the UI receives Events, while keeping today's single-day behavior and public contracts intact.

The important product behavior stays the same:

- Calendar reads still return standalone Events and recurring instances.
- Calendar reads still hide Someday Events and recurrence base Events.
- Timed Events still have to be fully inside the requested read window.
- All-day Events still use overlap semantics with an exclusive end date.
- Someday reads still feed the existing sidebar buckets, but the read result now arrives with repaired `order` values.
- Current-month reads now use the first day of the next month as the exclusive end, so all-day Events on the final day of the month stay visible.
- Priority filters now travel through the web request, backend candidate lookup, and shared read shape.
- No HTTP query shape changed.
- No IndexedDB schema changed.
- No Mongo migration was added.

## What Moved

### Shared read rules moved into core

New home:

- `packages/core/src/event-read/event-read.types.ts`
- `packages/core/src/event-read/event-read-shape.ts`
- `packages/core/src/event-read/event-read-shape.test.ts`

This new module owns the shared answer to: “which Events belong in this visible calendar/sidebar read window?”

It now handles:

- calendar vs Someday read mode
- hiding Someday Events from calendar reads
- hiding calendar Events from Someday reads
- hiding recurrence base Events
- keeping recurring instances
- attaching base recurrence rules to instances when the caller provides base Events
- all-day overlap behavior
- timed Event inside-window behavior
- requested priority filtering
- deterministic Someday order repair

### Backend read shaping moved out of `event.service.ts`

Old location:

- `packages/backend/src/event/services/event.service.ts`
- `packages/backend/src/event/services/event.service.util.ts`

New backend read seam:

- `packages/backend/src/event/read/backend-event-read.adapter.ts`
- `packages/backend/src/event/read/backend-event-read.filter.ts`

The backend-specific module now owns the storage concerns:

- broad Mongo candidate lookup
- Mongo priority filtering against the Event `priority` field
- fetching recurrence base Events for instances
- converting Mongo ObjectIds to string ids
- calling `shapeEventRead(...)` before `eventService.readAll(...)` returns

`event.service.ts` now delegates read behavior instead of carrying the read rules inline.

### Local IndexedDB reads moved behind a local read adapter

Old path:

- `LocalEventRepository.get(...)` depended on adapter-level filtered reads.
- `StorageAdapter.getEvents(...)` and `IndexedDBAdapter.getEvents(...)` owned local date filtering.

New path:

- `packages/web/src/common/repositories/event/read/local-event-read.adapter.ts`
- `packages/web/src/common/repositories/event/local.event.repository.ts`

The local repository now reads all local Events with `getAllEvents()`, gathers local recurrence base Events, and calls the same core `shapeEventRead(...)` function the backend uses.

Local reads also pass requested priorities into the shared shape so backend reads and IndexedDB fallback reads agree.

Because this made the old adapter-level date filtering obsolete, this PR removes:

- `StorageAdapter.getEvents(...)`
- `IndexedDBAdapter.getEvents(...)`
- the now-unused `isDateRangeOverlapping` import in `indexeddb.adapter.ts`
- stale `getEvents` test mocks

### Saga-side read shaping moved down into repositories

Old path:

- `packages/web/src/ducks/events/sagas/event.sagas.ts`
- `packages/web/src/ducks/events/sagas/saga.util.ts`
- `packages/web/src/ducks/events/sagas/someday.sagas.ts`
- `packages/web/src/common/utils/event/someday.event.util.ts`

New path:

- calendar/Someday read inclusion rules live in `packages/core/src/event-read/event-read-shape.ts`
- backend reads call that through `backend-event-read.adapter.ts`
- local reads call that through `local-event-read.adapter.ts`

This removes the week-read “start one day earlier” workaround from the saga. The saga now asks for the requested range directly and trusts the repository result to be shaped.

The current-month saga still owns the month window it asks for, but it now sends a next-month exclusive end instead of the date-only final day. That preserves the exclusive-end read rule while keeping all-day Events on the last day of the month visible.

Someday order repair also moved out of `someday.sagas.ts` and into the shared read shape, so both backend and local reads get the same repaired result.

### Core schema now preserves Someday order

`CoreEventSchema` now includes optional `order`, with coverage in:

- `packages/core/src/types/event.types.test.ts`

This prevents backend writes from stripping Someday order values. Older Events that still do not have `order` are handled by read repair.

## Cleanup Included

After the read seam landed, this PR removes low-value leftovers:

- deleted unused `isEventInRange(...)` from `packages/web/src/common/utils/event/event.util.ts`
- removed the old `isEventInRange` tests
- trimmed backend raw Mongo filter tests so they only check that candidate retrieval is broad enough
- moved user-visible backend expectations to `eventService.readAll(...)` tests
- removed duplicate local Someday order-repair coverage because core and backend already guard that behavior
- deleted the stale untracked architecture HTML artifact that still described the old saga workaround
- fixed one formatter-only lint issue in `packages/web/src/common/constants/more.cmd.constants.ts`

## Review Follow-up Fixes

After the first push, two read-shape misses were fixed:

- Month-end all-day Events: `getCurrentMonthEvents` no longer requests `YYYY-MM-DD` for the last day of the month as the read end. It now requests the first day of the next month, matching the exclusive-end read shape and keeping all-day Events on the final day visible.
- Priority filtering: the backend candidate filter now queries `priority`, not `priorities`; the web Event API now sends `priorities=...`; `Params_Events` can carry priority filters; and `shapeEventRead(...)` applies priority filters so local IndexedDB reads match backend reads.

## Tests / Verification

Ran against the branch after refreshing it onto the latest `origin/main`:

- `bun run test:core`
- `set -a; source packages/backend/.env.local; set +a; ./node_modules/.bin/jest --selectProjects backend --runTestsByPath packages/backend/src/event/services/event.find.test.ts packages/backend/src/event/services/event.find.allday.test.ts --runInBand`
- `bun test --cwd packages/web src/common/repositories/event/local.event.repository.test.ts src/common/repositories/event/remote.event.repository.test.ts src/ducks/events/event.api.test.ts src/ducks/events/sagas/event.sagas.test.ts src/ducks/events/sagas/someday.sagas.test.ts src/common/utils/event/someday.event.util.test.ts src/common/utils/event/event.util.test.ts src/common/storage/migrations/data/task-id-to-underscore-id.test.ts src/common/storage/migrations/external/localstorage-tasks.test.ts src/common/storage/migrations/migrations.test.ts src/common/storage/migrations/external/demo-data-seed.test.ts`
- `bun run type-check`
- `bun run lint`
- `git diff --check`

The backend command still prints the existing `.env.local` parse warning before Jest starts, but the focused backend tests pass.

## Follow-up Boundary

This PR does not add multi-day Event display behavior. It only creates the read seam so the future multi-day rule can replace the current single-day rule in one shared place.
