### PR TITLE
fix(self-host): allow password-only config refresh

### DIFF
--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -1,11 +1,66 @@
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..");
+const passwordOnlyConfig = `
+compose:
+  version: latest
+runtime:
+  nodeEnv: production
+  timezone: Etc/UTC
+web:
+  port: 9080
+  url: http://localhost:9080
+backend:
+  port: 3000
+  apiUrl: http://localhost:3000/api
+  originsAllowed:
+    - http://localhost:9080
+  compassToken: real-compass-token
+mongo:
+  username: compass
+  password: real-mongo-password
+  replicaSetKey: real-replica-key
+  uri: mongodb://compass:real-mongo-password@mongo:27017/prod_calendar?authSource=admin&replicaSet=rs0
+supertokens:
+  uri: http://supertokens:3567
+  key: real-supertokens-key
+  postgres:
+    user: supertokens
+    password: real-postgres-password
+    database: supertokens
+`;
 
 function readRepoFile(path: string): string {
   return readFileSync(join(repoRoot, path), { encoding: "utf8" });
+}
+
+function runInstallerSecretValidation(config: string) {
+  const installDir = mkdtempSync(join(tmpdir(), "compass-install-"));
+  writeFileSync(join(installDir, "compass.yaml"), config);
+
+  try {
+    return spawnSync(
+      "sh",
+      [
+        "-c",
+        `eval "$(awk '$0=="check_install_dir"{exit} {print}' self-host/install.sh)"; validate_existing_env_secrets`,
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          COMPASS_HOME: installDir,
+        },
+      },
+    );
+  } finally {
+    rmSync(installDir, { recursive: true, force: true });
+  }
 }
 
 describe("self-host docker compose", () => {
@@ -43,6 +98,25 @@ describe("self-host installer", () => {
       "I found existing Compass Docker data, but $CONFIG_FILE is missing.",
     );
   });
+
+  it("allows existing password-only configs without a Google notification token", () => {
+    const result = runInstallerSecretValidation(passwordOnlyConfig);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("google.notificationToken");
+  });
+
+  it("still rejects placeholder Google notification tokens when present", () => {
+    const result = runInstallerSecretValidation(`${passwordOnlyConfig}
+google:
+  notificationToken: change-me-gcal-notification-token-32chars
+`);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "still has the template placeholder for google.notificationToken",
+    );
+  });
 });
 
 describe("staging deploy workflow", () => {
@@ -50,10 +124,13 @@ describe("staging deploy workflow", () => {
     const workflow = readRepoFile(".github/workflows/deploy-staging.yml");
 
     expect(workflow).toContain(
-      "GCAL_NOTIFICATION_TOKEN: ${{ secrets.STAGING_GCAL_NOTIFICATION_TOKEN }}",
+      [
+        "GCAL_NOTIFICATION_TOKEN: $",
+        "{{ secrets.STAGING_GCAL_NOTIFICATION_TOKEN }}",
+      ].join(""),
     );
     expect(workflow).toContain(
-      'notificationToken: \\"${GCAL_NOTIFICATION_TOKEN}\\"',
+      ['notificationToken: \\"$', '{GCAL_NOTIFICATION_TOKEN}\\"'].join(""),
     );
   });
 });

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -326,6 +326,20 @@ validate_existing_secret() {
   fi
 }
 
+validate_existing_secret_if_present() {
+  key=$1
+  placeholder=$2
+  value=$(strip_quotes "$(read_config_value "$key")")
+
+  if [ -z "$value" ]; then
+    return
+  fi
+
+  if [ "$value" = "$placeholder" ]; then
+    fail "$CONFIG_FILE still has the template placeholder for $key. Set a real value, then rerun this installer."
+  fi
+}
+
 validate_existing_mongo_uri() {
   mongo_uri=$(strip_quotes "$(read_config_value mongo.uri)")
 
@@ -383,7 +397,7 @@ validate_existing_env_secrets() {
   validate_existing_secret supertokens.postgres.password change-me-supertokens-postgres-pass-32
   validate_existing_secret supertokens.key change-me-supertokens-key-32chars
   validate_existing_secret backend.compassToken change-me-compass-sync-token-32chars
-  validate_existing_secret google.notificationToken change-me-gcal-notification-token-32chars
+  validate_existing_secret_if_present google.notificationToken change-me-gcal-notification-token-32chars
   validate_existing_mongo_uri
 }
 


### PR DESCRIPTION
## Summary

This is a tiny follow-up for PR #1755. The YAML config work correctly makes Google optional, and the config docs say `google.notificationToken` is only required for HTTPS Google webhooks. The installer refresh validator was stricter than that: any existing `compass.yaml` without `google.notificationToken` failed validation before refresh, even for password-only installs.

## Fix

- Keep required secret checks for Mongo, SuperTokens, and the Compass sync token.
- Change the Google notification-token check to validate the token only when it is present.
- Add a shell-backed regression test showing a password-only config passes, while the old placeholder token is still rejected.

## Verification

- `bun test self-host/docker-compose.test.ts`
- `sh -n self-host/install.sh`
- `sh -n self-host/compass`
- `bun run lint`
- `bun run type-check`
