### PR TITLE
fix(ci): update staging deploy for self-hosted local services

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,14 +32,15 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
           SSH_USER: ${{ vars.STAGING_SSH_USER }}
           SSH_HOST: ${{ vars.STAGING_SSH_HOST }}
-          SUPERTOKENS_URI: ${{ vars.STAGING_SUPERTOKENS_URI }}
-          # Sensitive 
+          # Sensitive
           COMPASS_SYNC_TOKEN: ${{ secrets.STAGING_COMPASS_SYNC_TOKEN }}
           GCAL_NOTIFICATION_TOKEN: ${{ secrets.STAGING_GCAL_NOTIFICATION_TOKEN }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.STAGING_GOOGLE_CLIENT_SECRET }}
-          MONGO_URI: ${{ secrets.STAGING_MONGO_URI }}
+          MONGO_PASSWORD: ${{ secrets.STAGING_MONGO_PASSWORD }}
+          MONGO_REPLICA_SET_KEY: ${{ secrets.STAGING_MONGO_REPLICA_SET_KEY }}
           SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
           SUPERTOKENS_KEY: ${{ secrets.STAGING_SUPERTOKENS_KEY }}
+          SUPERTOKENS_POSTGRES_PASSWORD: ${{ secrets.STAGING_SUPERTOKENS_POSTGRES_PASSWORD }}
         run: |
           echo "Deploying Compass ${RELEASE_TAG} to staging"
           mkdir -p ~/.ssh
@@ -47,25 +48,38 @@ jobs:
           chmod 600 ~/.ssh/staging_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
           printf '%s\n' \
+            'compose:' \
+            "  version: \"${RELEASE_TAG}\"" \
             'runtime:' \
             '  nodeEnv: production' \
             '  timezone: Etc/UTC' \
             'web:' \
+            '  port: 9080' \
             "  url: \"${FRONTEND_URL}\"" \
             'backend:' \
+            '  port: 3000' \
             "  apiUrl: \"${BACKEND_API_URL}\"" \
             '  originsAllowed:' \
             "    - \"${FRONTEND_URL}\"" \
             "  compassToken: \"${COMPASS_SYNC_TOKEN}\"" \
             'mongo:' \
-            "  uri: \"${MONGO_URI}\"" \
+            '  username: compass' \
+            "  password: \"${MONGO_PASSWORD}\"" \
+            "  replicaSetKey: \"${MONGO_REPLICA_SET_KEY}\"" \
+            "  uri: \"mongodb://compass:${MONGO_PASSWORD}@mongo:27017/staging_calendar?authSource=admin&replicaSet=rs0\"" \
             'supertokens:' \
-            "  uri: \"${SUPERTOKENS_URI}\"" \
+            '  uri: http://supertokens:3567' \
             "  key: \"${SUPERTOKENS_KEY}\"" \
+            '  postgres:' \
+            '    user: supertokens' \
+            "    password: \"${SUPERTOKENS_POSTGRES_PASSWORD}\"" \
+            '    database: supertokens' \
             'google:' \
             "  clientId: \"${GOOGLE_CLIENT_ID}\"" \
             "  clientSecret: \"${GOOGLE_CLIENT_SECRET}\"" \
             "  notificationToken: \"${GCAL_NOTIFICATION_TOKEN}\"" \
             | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml"
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compose.yaml -o ~/compass/compose.yaml"
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update"


### PR DESCRIPTION
## Summary

Updates the staging deployment workflow to use **local self-hosted services** instead of cloud services, properly testing the self-host setup.

## Changes

- Generate proper self-hosted config with local mongo/supertokens containers
- Add credentials for local services:
  - `mongo.username`, `mongo.password`, `mongo.replicaSetKey`
  - `supertokens.postgres.user`, `supertokens.postgres.password`, `supertokens.postgres.database`
- Use local URIs (`mongo:27017`, `supertokens:3567`) instead of cloud services
- Download `compose.yaml` and `compass` helper matching the release tag
- Add `compose.version` and port configs required by compose.yaml

## New Secrets Required

Before merging, add these GitHub secrets:

| Secret | Description | Example |
|--------|-------------|---------|
| `STAGING_MONGO_PASSWORD` | Password for local mongo | Generate with `openssl rand -hex 32` |
| `STAGING_MONGO_REPLICA_SET_KEY` | Mongo replica set keyfile | Generate with `openssl rand -hex 32` |
| `STAGING_SUPERTOKENS_POSTGRES_PASSWORD` | Password for supertokens postgres | Generate with `openssl rand -hex 32` |

## Secrets No Longer Needed

These can be removed after migration:
- `STAGING_MONGO_URI` (now constructed from password)
- `STAGING_SUPERTOKENS_URI` (now hardcoded to local service)

## Test Plan

- [ ] Add the new secrets to GitHub repo settings
- [ ] Merge this PR
- [ ] Trigger staging deploy with `gh workflow run deploy-staging.yml -f tag=main`
- [ ] Verify all containers start healthy
- [ ] Verify backend can connect to local mongo and supertokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)