### PR TITLE
fix(ci): strip v prefix from Docker image version in staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,14 +42,16 @@ jobs:
           SUPERTOKENS_KEY: ${{ secrets.STAGING_SUPERTOKENS_KEY }}
           SUPERTOKENS_POSTGRES_PASSWORD: ${{ secrets.STAGING_SUPERTOKENS_POSTGRES_PASSWORD }}
         run: |
-          echo "Deploying Compass ${RELEASE_TAG} to staging"
+          # Strip 'v' prefix for Docker image tags (v0.5.18 -> 0.5.18)
+          IMAGE_VERSION="${RELEASE_TAG#v}"
+          echo "Deploying Compass ${RELEASE_TAG} (image version: ${IMAGE_VERSION}) to staging"
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
           printf '%s\n' \
             'compose:' \
-            "  version: \"${RELEASE_TAG}\"" \
+            "  version: \"${IMAGE_VERSION}\"" \
             'runtime:' \
             '  nodeEnv: production' \
             '  timezone: Etc/UTC' \


### PR DESCRIPTION
## Summary

Fixes staging deploy failing with "image not found" error.

## Root Cause

- Docker publish workflow tags images as `0.5.18` (without `v` prefix)
- Deploy workflow was setting `compose.version: "v0.5.18"` (with `v` prefix)
- Result: Docker couldn't find `switchbacktech/compass-mongo:v0.5.18`

## Fix

Strip the `v` prefix when setting the image version:
```bash
IMAGE_VERSION="${RELEASE_TAG#v}"  # v0.5.18 -> 0.5.18
```

## Variables After Fix

| Variable | Value | Used For |
|----------|-------|----------|
| `RELEASE_TAG` | `v0.5.18` | Git refs (curl downloads) |
| `IMAGE_VERSION` | `0.5.18` | Docker image tags |

## Test Plan

After merge, retrigger the staging deploy - should successfully pull images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)