### PR TITLE
ci: migrate staging secrets to GitHub Environment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -83,17 +83,6 @@ jobs:
             "  notificationToken: \"${GCAL_NOTIFICATION_TOKEN}\"" \
             | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"
-          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "ls -la ~/compass/compass.yaml && docker inspect compass-backend-1 --format '{{json .Mounts}}' 2>/dev/null || true"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
-          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update" || {
-            echo "--- supertokens logs ---"
-            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-supertokens-1 2>&1 | tail -40" || true
-            echo "--- supertokens-db logs ---"
-            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-supertokens-db-1 2>&1 | tail -20" || true
-            echo "--- mongo logs ---"
-            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-mongo-1 2>&1 | tail -40" || true
-            echo "--- backend logs ---"
-            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-backend-1 2>&1 | tail -60" || true
-            exit 1
-          }
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -85,4 +85,10 @@ jobs:
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
-          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update"
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update" || {
+            echo "--- supertokens logs ---"
+            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-supertokens-1 2>&1 | tail -40" || true
+            echo "--- supertokens-db logs ---"
+            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-supertokens-db-1 2>&1 | tail -20" || true
+            exit 1
+          }

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -92,5 +92,7 @@ jobs:
             ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-supertokens-db-1 2>&1 | tail -20" || true
             echo "--- mongo logs ---"
             ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-mongo-1 2>&1 | tail -40" || true
+            echo "--- backend logs ---"
+            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-backend-1 2>&1 | tail -60" || true
             exit 1
           }

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -59,6 +59,8 @@ jobs:
           tail -1 ~/.ssh/staging_key
           wc -l ~/.ssh/staging_key
           ssh -v -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" echo ok 2>&1 | grep -E "Offering|Authentications|denied|identity|key_load|Will attempt|publickey"
+          echo "Public key being offered (paste this into authorized_keys on the server):"
+          ssh-keygen -y -f ~/.ssh/staging_key
           echo "=== END DEBUG ==="
           printf '%s\n' \
             'compose:' \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -50,18 +50,6 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
-
-          # DEBUG - remove before merge
-          echo "=== DEBUG ==="
-          echo "SSH_USER: '${SSH_USER}'"
-          echo "SSH_HOST: '${SSH_HOST}'"
-          head -1 ~/.ssh/staging_key
-          tail -1 ~/.ssh/staging_key
-          wc -l ~/.ssh/staging_key
-          ssh -v -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" echo ok 2>&1 | grep -E "Offering|Authentications|denied|identity|key_load|Will attempt|publickey"
-          echo "Public key being offered (paste this into authorized_keys on the server):"
-          ssh-keygen -y -f ~/.ssh/staging_key
-          echo "=== END DEBUG ==="
           printf '%s\n' \
             'compose:' \
             "  version: \"${IMAGE_VERSION}\"" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -83,6 +83,7 @@ jobs:
             "  notificationToken: \"${GCAL_NOTIFICATION_TOKEN}\"" \
             | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "ls -la ~/compass/compass.yaml && docker inspect compass-backend-1 --format '{{json .Mounts}}' 2>/dev/null || true"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update" || {

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -50,6 +50,16 @@ jobs:
           echo "$SSH_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+
+          # DEBUG - remove before merge
+          echo "=== DEBUG ==="
+          echo "SSH_USER: '${SSH_USER}'"
+          echo "SSH_HOST: '${SSH_HOST}'"
+          head -1 ~/.ssh/staging_key
+          tail -1 ~/.ssh/staging_key
+          wc -l ~/.ssh/staging_key
+          ssh -v -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" echo ok 2>&1 | grep -E "Offering|Authentications|denied|identity|key_load|Will attempt|publickey"
+          echo "=== END DEBUG ==="
           printf '%s\n' \
             'compose:' \
             "  version: \"${IMAGE_VERSION}\"" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -82,7 +82,7 @@ jobs:
             "  clientSecret: \"${GOOGLE_CLIENT_SECRET}\"" \
             "  notificationToken: \"${GCAL_NOTIFICATION_TOKEN}\"" \
             | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
-                "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml"
+                "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${RELEASE_TAG}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update" || {

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -90,5 +90,7 @@ jobs:
             ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-supertokens-1 2>&1 | tail -40" || true
             echo "--- supertokens-db logs ---"
             ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-supertokens-db-1 2>&1 | tail -20" || true
+            echo "--- mongo logs ---"
+            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "docker logs compass-mongo-1 2>&1 | tail -40" || true
             exit 1
           }

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,26 +21,27 @@ jobs:
   deploy:
     name: Deploy release to staging
     runs-on: ubuntu-latest
+    environment: Staging
 
     steps:
       - name: Deploy release to staging
         env:
           # Non-sensitive
-          BACKEND_API_URL: ${{ vars.STAGING_BACKEND_API_URL }}
-          FRONTEND_URL: ${{ vars.STAGING_FRONTEND_URL }}
-          GOOGLE_CLIENT_ID: ${{ vars.STAGING_GOOGLE_CLIENT_ID }}
+          BACKEND_API_URL: ${{ vars.BACKEND_API_URL }}
+          FRONTEND_URL: ${{ vars.FRONTEND_URL }}
+          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
           RELEASE_TAG: ${{ inputs.tag }}
-          SSH_USER: ${{ vars.STAGING_SSH_USER }}
-          SSH_HOST: ${{ vars.STAGING_SSH_HOST }}
+          SSH_USER: ${{ vars.SSH_USER }}
+          SSH_HOST: ${{ vars.SSH_HOST }}
           # Sensitive
-          COMPASS_SYNC_TOKEN: ${{ secrets.STAGING_COMPASS_SYNC_TOKEN }}
-          GCAL_NOTIFICATION_TOKEN: ${{ secrets.STAGING_GCAL_NOTIFICATION_TOKEN }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.STAGING_GOOGLE_CLIENT_SECRET }}
-          MONGO_PASSWORD: ${{ secrets.STAGING_MONGO_PASSWORD }}
-          MONGO_REPLICA_SET_KEY: ${{ secrets.STAGING_MONGO_REPLICA_SET_KEY }}
-          SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
-          SUPERTOKENS_KEY: ${{ secrets.STAGING_SUPERTOKENS_KEY }}
-          SUPERTOKENS_POSTGRES_PASSWORD: ${{ secrets.STAGING_SUPERTOKENS_POSTGRES_PASSWORD }}
+          COMPASS_SYNC_TOKEN: ${{ secrets.COMPASS_SYNC_TOKEN }}
+          GCAL_NOTIFICATION_TOKEN: ${{ secrets.GCAL_NOTIFICATION_TOKEN }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          MONGO_PASSWORD: ${{ secrets.MONGO_PASSWORD }}
+          MONGO_REPLICA_SET_KEY: ${{ secrets.MONGO_REPLICA_SET_KEY }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SUPERTOKENS_KEY: ${{ secrets.SUPERTOKENS_KEY }}
+          SUPERTOKENS_POSTGRES_PASSWORD: ${{ secrets.SUPERTOKENS_POSTGRES_PASSWORD }}
         run: |
           # Strip 'v' prefix for Docker image tags (v0.5.18 -> 0.5.18)
           IMAGE_VERSION="${RELEASE_TAG#v}"

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -95,7 +95,7 @@ Secrets and variables are split between repository level (shared across workflow
 
 | Secret | Value |
 |---|---|
-| `SSH_KEY` | Private key from the deploy keypair (the `compass-staging-deploy` file, not `.pub`) |
+| `SSH_KEY` | Private key from the deploy keypair |
 | `COMPASS_SYNC_TOKEN` | Token for compass sync |
 | `GCAL_NOTIFICATION_TOKEN` | Google Calendar notification token |
 | `GOOGLE_CLIENT_SECRET` | OAuth client secret |

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -80,14 +80,34 @@ show which release triggered or motivated the deploy.
 Manual staging redeploys do not rebuild images. Run `Deploy staging` with an
 existing tag after confirming the desired image tags already exist on Docker Hub.
 
-### Required secrets
+### Required secrets and variables
 
-All secrets go in **GitHub → Settings → Secrets and variables → Actions**:
+Secrets and variables are split between repository level (shared across workflows) and the `Staging` GitHub Environment (scoped to the deploy job).
 
-| Secret | Value |
+**Repository-level** — GitHub → Settings → Secrets and variables → Actions:
+
+| Name | Value |
 |---|---|
 | `DOCKERHUB_USERNAME` | Docker Hub username for the `switchbacktech` org |
 | `DOCKERHUB_TOKEN` | Docker Hub personal access token (Read & Write) |
-| `STAGING_SSH_HOST` | VPS IP address or hostname |
-| `STAGING_SSH_USER` | Linux user on the VPS that owns `~/compass` |
-| `STAGING_SSH_KEY` | Private key from the deploy keypair (the `compass-staging-deploy` file, not `.pub`) |
+
+**`Staging` environment** — GitHub → Settings → Environments → Staging:
+
+| Secret | Value |
+|---|---|
+| `SSH_KEY` | Private key from the deploy keypair (the `compass-staging-deploy` file, not `.pub`) |
+| `COMPASS_SYNC_TOKEN` | Token for compass sync |
+| `GCAL_NOTIFICATION_TOKEN` | Google Calendar notification token |
+| `GOOGLE_CLIENT_SECRET` | OAuth client secret |
+| `MONGO_PASSWORD` | MongoDB compass user password |
+| `MONGO_REPLICA_SET_KEY` | MongoDB replica set key |
+| `SUPERTOKENS_KEY` | SuperTokens API key |
+| `SUPERTOKENS_POSTGRES_PASSWORD` | SuperTokens PostgreSQL password |
+
+| Variable | Value |
+|---|---|
+| `SSH_HOST` | VPS IP address or hostname |
+| `SSH_USER` | Linux user on the VPS that owns `~/compass` |
+| `BACKEND_API_URL` | Staging backend API URL |
+| `FRONTEND_URL` | Staging frontend URL |
+| `GOOGLE_CLIENT_ID` | OAuth client ID |


### PR DESCRIPTION
## Summary

- Adds `environment: Staging` to the deploy job in `deploy-staging.yml`
- Removes all `STAGING_` prefixes from 8 secrets and 5 variables — environment scoping replaces the naming convention
- Updates `docs/CI-CD/workflows.md` to document the repository-level vs environment-level secret split

## Pre-merge validation

**Before merging**, manually trigger the `Deploy staging` workflow from this branch to confirm secrets resolve correctly:

1. Go to **Actions → Deploy staging → Run workflow**
2. Select branch `ci/migrate-staging-secrets-to-environment`
3. Enter an existing tag (e.g. the latest release)
4. Confirm the run succeeds end-to-end (SSH connects, `./compass update` runs)

## Post-merge cleanup

Once the deploy is confirmed working, delete the old `STAGING_`-prefixed secrets and variables from repository-level Actions secrets.

Closes #1767