### PR TITLE
Potential fix for code scanning alert no. 53: Prototype-polluting merge call

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,7 +11,7 @@
     "exponential-backoff": "^3.1.2",
     "express": "^4.17.1",
     "helmet": "^7.0.0",
-    "lodash.mergewith": "^4.6.2",
+    "lodash.mergewith": "^4.6.3",
     "mongodb": "6.3",
     "morgan": "^1.10.0",
     "rrule": "^2.7.2",


### PR DESCRIPTION
Potential fix for [https://github.com/SwitchbackTech/compass/security/code-scanning/53](https://github.com/SwitchbackTech/compass/security/code-scanning/53)

In general, fix prototype-polluting merge issues by using a patched merge implementation and avoiding unsafe recursive merge behavior on untrusted input. The least disruptive fix here is to keep current logic but upgrade `lodash.mergewith` to a non-vulnerable version so the same merge call remains functionally equivalent while removing the known vulnerability.

Best single fix with minimal functionality change:
- Update `packages/backend/package.json` dependency `lodash.mergewith` from `^4.6.2` to `^4.6.3` (patched release line).
- No code-path behavior change is required in controller/service snippets, since the existing API usage remains valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
