### PR TITLE
fix(self-host): keep helper on runtime version config

### DIFF
--- a/self-host/compass
+++ b/self-host/compass
@@ -132,7 +132,7 @@ load_env_if_present() {
 set_compose_env() {
   load_env
   export COMPASS_CONFIG_FILE="$CONFIG_FILE"
-  export COMPASS_VERSION="$(strip_quotes "$(read_config_value compose.version)")"
+  export COMPASS_VERSION="$(strip_quotes "$(read_config_value runtime.version)")"
   export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"
   export PORT="$(strip_quotes "$(read_config_value backend.port)")"
   export MONGO_INITDB_ROOT_USERNAME="$(strip_quotes "$(read_config_value mongo.username)")"

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -52,15 +52,24 @@ describe("self-host installer", () => {
   });
 });
 
+describe("self-host helper", () => {
+  it("reads the Docker image version from runtime.version", () => {
+    const helper = readRepoFile("self-host/compass");
+
+    expect(helper).toContain("read_config_value runtime.version");
+    expect(helper).not.toContain("read_config_value compose.version");
+  });
+});
+
 describe("staging deploy workflow", () => {
   it("writes the Google Calendar notification token with Google credentials", () => {
-    const workflow = readRepoFile(".github/workflows/deploy-staging.yml");
+    const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
 
     expect(workflow).toContain(
-      "GCAL_NOTIFICATION_TOKEN: ${{ secrets.STAGING_GCAL_NOTIFICATION_TOKEN }}",
+      "GCAL_NOTIFICATION_TOKEN: $" + "{{ secrets.GCAL_NOTIFICATION_TOKEN }}",
     );
     expect(workflow).toContain(
-      'notificationToken: \\"${GCAL_NOTIFICATION_TOKEN}\\"',
+      'notificationToken: \\"$' + '{GCAL_NOTIFICATION_TOKEN}\\"',
     );
   });
 });


### PR DESCRIPTION
## Summary

- Updates the self-host helper to read the Docker image tag from `runtime.version`, matching the runtime-version config migration in PR #1770.
- Updates the self-host regression test so it covers the helper's version key and the new reusable deploy workflow file.

## Bug found

PR #1770 moved `compose.version` to `runtime.version` in the schema, installer, examples, and deploy-generated config, but `self-host/compass` still read `compose.version`. During `./compass update`, that leaves `COMPASS_VERSION` empty and lets Compose fall back to `latest`, so a deploy for a specific release tag can accidentally pull `latest` instead.

## Verification

- `bun test self-host/docker-compose.test.ts`
- `sh -n self-host/compass && sh -n self-host/install.sh`
- `bun run type-check`
- `bun run test:scripts`
- `bunx biome check self-host/docker-compose.test.ts self-host/compass`

Note: full `bun run lint` still fails on existing import-order issues in `packages/scripts/src/commands/delete/delete.ts` and `packages/scripts/src/common/cli.utils.ts`; the changed files pass the focused Biome check.
