### PR TITLE
fix(self-host): default helper to selfhost profile

### DIFF
--- a/self-host/compass
+++ b/self-host/compass
@@ -132,6 +132,7 @@ load_env_if_present() {
 set_compose_env() {
   load_env
   export COMPASS_CONFIG_FILE="$CONFIG_FILE"
+  export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhost}"
   export COMPASS_VERSION="$(strip_quotes "$(read_config_value runtime.version)")"
   export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"
   export PORT="$(strip_quotes "$(read_config_value backend.port)")"

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -53,6 +53,14 @@ describe("self-host installer", () => {
 });
 
 describe("self-host helper", () => {
+  it("defaults Docker Compose to the self-host profile", () => {
+    const helper = readRepoFile("self-host/compass");
+
+    expect(helper).toContain(
+      'COMPOSE_PROFILES="' + "$" + '{COMPOSE_PROFILES-selfhost}"',
+    );
+  });
+
   it("reads the Docker image version from runtime.version", () => {
     const helper = readRepoFile("self-host/compass");
 


### PR DESCRIPTION
## Summary

- Defaults the installed self-host helper to the same selfhost Docker Compose profile used by the installer.
- Adds a regression check so the helper keeps that default while still allowing callers to override COMPOSE_PROFILES.

## Bug found

PR #1770 moved the local backing services behind the selfhost Compose profile. The installer set that profile for first install, but the installed ./compass helper did not. After install, running ./compass start, restart, or update with no COMPOSE_PROFILES set would ask Docker Compose for only backend and web, leaving mongo and SuperTokens out of the self-host stack.

Concrete proof from the branch:
- docker compose --project-name compass-scan -f self-host/compose.yaml config --services => backend, web
- COMPOSE_PROFILES=selfhost docker compose --project-name compass-scan -f self-host/compose.yaml config --services => mongo, supertokens-db, supertokens, backend, web

## Verification

- bun test self-host/docker-compose.test.ts
- sh -n self-host/compass
- sh -n self-host/install.sh
- docker compose --project-name compass-scan -f self-host/compose.yaml config --services
- COMPOSE_PROFILES=selfhost docker compose --project-name compass-scan -f self-host/compose.yaml config --services
- bunx biome check self-host/docker-compose.test.ts self-host/compass
- bun run type-check

Note: bun run lint still fails on existing import-order issues in packages/scripts/src/commands/delete/delete.ts and packages/scripts/src/common/cli.utils.ts; the new self-host test lint issue was fixed and the focused Biome check passes.