### PR TITLE
fix(web): keep action menu above event forms

### DIFF
--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
@@ -60,6 +60,10 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
   bgColor,
 }) => {
   const maxZIndex = useGridMaxZIndex();
+  const menuZIndex = Math.max(
+    maxZIndex + ZIndex.LAYER_3,
+    ZIndex.MAX + ZIndex.LAYER_2,
+  );
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const openedByMouseRef = useRef(false);
@@ -181,7 +185,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
               ref={refs.setFloating}
               style={{
                 ...context.floatingStyles,
-                zIndex: maxZIndex + ZIndex.LAYER_3,
+                zIndex: menuZIndex,
               }}
               {...getFloatingProps()}
               id={menuId}


### PR DESCRIPTION
## What changed
- Raises the event form actions menu above the recently raised floating event forms.

## Bug found
- PR #1776 failed its e2e run at commit 1528e17bb931afb620b4932e3745abb4455c51d7.
- The failing mouse-delete tests could see the Delete menu item, but Playwright could not click it because the event form layer intercepted the pointer.
- The regression lined up with the PR change that moved floating event forms to z-index 21 while the actions menu still used the grid max plus 3, which can be lower than the form.

## Verification
- Reproduced before the fix: `CI=1 ./node_modules/.bin/playwright test e2e/allday/delete-allday-event-mouse.spec.ts e2e/someday/delete-someday-event-mouse.spec.ts e2e/timed/delete-event-mouse.spec.ts --project=chromium-desktop` failed the same three specs.
- After the fix: the same command passed, `3 passed`.
- `bun run type-check`
- `bun run lint`
- `git diff --check`
- `bunx react-doctor@latest . --verbose --diff` reported 100/100 with no issues.