### PR TITLE
fix(web): prevent no-op drag form

### DIFF
--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.test.ts
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.test.ts
@@ -1,0 +1,31 @@
+import { shouldReopenFormAfterNoopSavedMutation } from "./WeekInteractionCoordinator";
+import { describe, expect, it } from "bun:test";
+
+describe("shouldReopenFormAfterNoopSavedMutation", () => {
+  it("does not open the form for a no-op drag that started from the closed form state", () => {
+    expect(
+      shouldReopenFormAfterNoopSavedMutation({
+        hadFormOpenBeforeInteraction: false,
+        hasMoved: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("reopens the form after a no-op interaction if it was open before motion started", () => {
+    expect(
+      shouldReopenFormAfterNoopSavedMutation({
+        hadFormOpenBeforeInteraction: true,
+        hasMoved: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not handle moved interactions as no-op form restoration", () => {
+    expect(
+      shouldReopenFormAfterNoopSavedMutation({
+        hadFormOpenBeforeInteraction: true,
+        hasMoved: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -31,6 +31,12 @@ interface Props extends PropsWithChildren {
   weekProps: WeekProps;
 }
 
+type SavedMutationCommitResult =
+  | WeekAllDayDragCommitResult
+  | WeekAllDayResizeCommitResult
+  | WeekTimedDragCommitResult
+  | WeekTimedResizeCommitResult;
+
 export const WeekInteractionCoordinator: FC<Props> = ({
   children,
   getLayoutSources,
@@ -104,18 +110,11 @@ export const WeekInteractionCoordinator: FC<Props> = ({
     );
   };
 
-  const commitSavedMutation = (
-    result:
-      | WeekAllDayDragCommitResult
-      | WeekAllDayResizeCommitResult
-      | WeekTimedDragCommitResult
-      | WeekTimedResizeCommitResult,
-  ) => {
+  const commitSavedMutation = (result: SavedMutationCommitResult) => {
     if (!result.hasMoved) {
-      if (result.event.isAllDay) {
-        openAllDayEvent(result.event);
-      } else {
-        openTimedEvent(result.event);
+      if (shouldReopenFormAfterNoopSavedMutation(result)) {
+        setters.setDraft(result.event);
+        actions.openForm();
       }
       return;
     }
@@ -161,6 +160,13 @@ export const WeekInteractionCoordinator: FC<Props> = ({
     </WeekPointerCaptureBoundary>
   );
 };
+
+export const shouldReopenFormAfterNoopSavedMutation = (
+  result: Pick<
+    SavedMutationCommitResult,
+    "hadFormOpenBeforeInteraction" | "hasMoved"
+  >,
+) => !result.hasMoved && result.hadFormOpenBeforeInteraction;
 
 const mapEventsById = (events: Schema_GridEvent[]) => {
   const eventsById = new Map<string, Schema_GridEvent>();


### PR DESCRIPTION
## Summary
- treat no-op saved drag/resize commits as no action when the event form was closed before motion started
- preserve the existing behavior of restoring the form if it had been open before the interaction
- add focused coverage for the no-op form restoration decision

Fixes #1785

## Tests
- `bun install --frozen-lockfile`
- `bun test --cwd packages/web src/views/Week/interaction/WeekInteractionCoordinator.test.ts src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts`
- `tsc --noEmit`
- `tsc -p packages/web/tsconfig.app.json --noEmit`
- `tsc -p packages/web/tsconfig.test.json --noEmit`
- `bun packages/scripts/src/testing/run.ts web`

Note: `bun run lint` still reports existing issues in `self-host/docker-compose.test.ts` and `packages/web/src/views/Week/interaction/WeekPointerCaptureBoundary.tsx`; the touched files pass `biome check`.