### PR TITLE
Fix missing drag placeholder

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,6 +87,23 @@ _Avoid_: Someday task
 A temporary event shape used while the user edits, drags, or resizes before
 saving.
 
+**Interaction Overlay**:
+The temporary moving visual shown while a user drags or resizes an Event.
+
+**Source Event Element**:
+The original rendered Event element that an interaction starts from. During an
+**Interaction Overlay**, the source can either stay visible as a dimmed
+placeholder or be hidden while the overlay moves.
+
+**Source Element Overlay Mode**:
+The interaction choice for the **Source Event Element** while an
+**Interaction Overlay** is active. `dim-source` means keep the original Event
+visible, faded, and non-interactive so the user can still see where it came
+from. `hide-source` means hide the original Event while the overlay is moving.
+Use `dim-source` for drag interactions where the original slot should remain
+visible; use `hide-source` only when showing both the source and overlay would
+make the resize or motion state confusing.
+
 **Base Event**:
 A recurring event that owns the series recurrence rule.
 _Avoid_: parent event

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
@@ -1,5 +1,4 @@
 import { type CalendarInteractionPoint } from "./CalendarInteractionSession";
-import { type SourceElementInteractionTreatment } from "./dom/source/sourceElementVisibility";
 
 export interface FloatingInteractionOverlayMount {
   clone: HTMLElement;
@@ -19,12 +18,12 @@ export type FloatingInteractionOverlayUpdate = {
   width?: number;
 } | null;
 
+export type SourceElementOverlayMode = "hide-source" | "dim-source";
+
 export interface CalendarInteractionAdapter<TTarget, TVisual, TResult> {
   getTarget(event: PointerEvent): TTarget | null;
   getSourceElement(target: TTarget): HTMLElement;
-  getSourceElementTreatment?(
-    target: TTarget,
-  ): SourceElementInteractionTreatment;
+  getSourceElementOverlayMode?(target: TTarget): SourceElementOverlayMode;
   createVisual(input: {
     pointerStart: CalendarInteractionPoint;
     sourceElement: HTMLElement;

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
@@ -1,4 +1,5 @@
 import { type CalendarInteractionPoint } from "./CalendarInteractionSession";
+import { type SourceElementInteractionTreatment } from "./dom/source/sourceElementVisibility";
 
 export interface FloatingInteractionOverlayMount {
   clone: HTMLElement;
@@ -21,6 +22,9 @@ export type FloatingInteractionOverlayUpdate = {
 export interface CalendarInteractionAdapter<TTarget, TVisual, TResult> {
   getTarget(event: PointerEvent): TTarget | null;
   getSourceElement(target: TTarget): HTMLElement;
+  getSourceElementTreatment?(
+    target: TTarget,
+  ): SourceElementInteractionTreatment;
   createVisual(input: {
     pointerStart: CalendarInteractionPoint;
     sourceElement: HTMLElement;

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
@@ -1,11 +1,11 @@
 import {
   type CalendarInteractionAdapter,
   type FloatingInteractionOverlayMount,
+  type SourceElementOverlayMode,
 } from "./CalendarInteractionAdapter";
 import { createCalendarInteractionEngine } from "./CalendarInteractionEngine";
 import { createInteractionClone } from "./dom/clone/createInteractionClone";
 import { FloatingInteractionOverlay } from "./dom/overlay/FloatingInteractionOverlay";
-import { type SourceElementInteractionTreatment } from "./dom/source/sourceElementVisibility";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 interface TestTarget {
@@ -42,10 +42,12 @@ const makePointerEvent = (
     pointerId,
   });
 
+const SOURCE_ELEMENT_INTERACTION_ATTRIBUTE = "data-calendar-interaction-source";
+
 const createHarness = ({
-  sourceTreatment,
+  sourceOverlayMode,
 }: {
-  sourceTreatment?: SourceElementInteractionTreatment;
+  sourceOverlayMode?: SourceElementOverlayMode;
 } = {}) => {
   document.body.innerHTML = "";
   document.body.style.cursor = "";
@@ -101,8 +103,8 @@ const createHarness = ({
       },
     ),
     getSourceElement: mock((resolvedTarget) => resolvedTarget.source),
-    ...(sourceTreatment
-      ? { getSourceElementTreatment: mock(() => sourceTreatment) }
+    ...(sourceOverlayMode
+      ? { getSourceElementOverlayMode: mock(() => sourceOverlayMode) }
       : {}),
     getTarget: mock(() => target),
     updateVisual: mock(({ pointer, visual }) => ({
@@ -255,9 +257,9 @@ describe("CalendarInteractionEngine", () => {
     });
   });
 
-  it("can keep the source visible as a placeholder during motion", () => {
+  it("can keep the source visible as a dimmed placeholder during motion", () => {
     const { engine, flushFrame, source } = createHarness({
-      sourceTreatment: "placeholder",
+      sourceOverlayMode: "dim-source",
     });
 
     engine.handlePointerDown(makePointerEvent("pointerdown", { x: 10, y: 10 }));
@@ -266,7 +268,7 @@ describe("CalendarInteractionEngine", () => {
     expect(source.style.visibility).toBe("visible");
     expect(source.style.opacity).toBe("0.5");
     expect(source.style.pointerEvents).toBe("none");
-    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
+    expect(source).toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
 
     flushFrame();
     engine.handlePointerUp(makePointerEvent("pointerup"));
@@ -274,7 +276,24 @@ describe("CalendarInteractionEngine", () => {
     expect(source.style.visibility).toBe("visible");
     expect(source.style.opacity).toBe("");
     expect(source.style.pointerEvents).toBe("");
-    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
+    expect(source).not.toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
+  });
+
+  it("restores only the styles changed by the source overlay mode", () => {
+    const { engine, flushFrame, source } = createHarness();
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 10, y: 10 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 36, y: 10 }));
+
+    source.style.opacity = "0.25";
+    source.style.pointerEvents = "auto";
+
+    flushFrame();
+    engine.handlePointerUp(makePointerEvent("pointerup"));
+
+    expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("0.25");
+    expect(source.style.pointerEvents).toBe("auto");
   });
 
   it("commits the current visual and restores the source on pointer up", () => {

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
@@ -5,6 +5,7 @@ import {
 import { createCalendarInteractionEngine } from "./CalendarInteractionEngine";
 import { createInteractionClone } from "./dom/clone/createInteractionClone";
 import { FloatingInteractionOverlay } from "./dom/overlay/FloatingInteractionOverlay";
+import { type SourceElementInteractionTreatment } from "./dom/source/sourceElementVisibility";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 interface TestTarget {
@@ -41,7 +42,11 @@ const makePointerEvent = (
     pointerId,
   });
 
-const createHarness = () => {
+const createHarness = ({
+  sourceTreatment,
+}: {
+  sourceTreatment?: SourceElementInteractionTreatment;
+} = {}) => {
   document.body.innerHTML = "";
   document.body.style.cursor = "";
   document.documentElement.style.cursor = "";
@@ -96,6 +101,9 @@ const createHarness = () => {
       },
     ),
     getSourceElement: mock((resolvedTarget) => resolvedTarget.source),
+    ...(sourceTreatment
+      ? { getSourceElementTreatment: mock(() => sourceTreatment) }
+      : {}),
     getTarget: mock(() => target),
     updateVisual: mock(({ pointer, visual }) => ({
       overlay: {
@@ -245,6 +253,28 @@ describe("CalendarInteractionEngine", () => {
       active: true,
       phase: "motion",
     });
+  });
+
+  it("can keep the source visible as a placeholder during motion", () => {
+    const { engine, flushFrame, source } = createHarness({
+      sourceTreatment: "placeholder",
+    });
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 10, y: 10 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 36, y: 10 }));
+
+    expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("0.5");
+    expect(source.style.pointerEvents).toBe("none");
+    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
+
+    flushFrame();
+    engine.handlePointerUp(makePointerEvent("pointerup"));
+
+    expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("");
+    expect(source.style.pointerEvents).toBe("");
+    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
   });
 
   it("commits the current visual and restores the source on pointer up", () => {

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -299,7 +299,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     mountOverlay(overlayMount);
     preparedSource = prepareSourceElementForInteraction(
       pendingSession.sourceElement,
-      resolvedOptions.adapter.getSourceElementTreatment?.(
+      resolvedOptions.adapter.getSourceElementOverlayMode?.(
         pendingSession.target,
       ),
     );

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -16,8 +16,8 @@ import {
 import { hasExceededCalendarInteractionMoveThreshold } from "./calendarInteractionPointer";
 import { FloatingInteractionOverlay } from "./dom/overlay/FloatingInteractionOverlay";
 import {
-  type HiddenSourceElement,
-  hideSourceElement,
+  type PreparedSourceElement,
+  prepareSourceElementForInteraction,
   restoreSourceElement,
 } from "./dom/source/sourceElementVisibility";
 
@@ -87,7 +87,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
   let latestPointer: CalendarInteractionPoint | null = null;
   let metrics = resolvedOptions.createMetrics();
   let overlay: FloatingInteractionOverlay | null = null;
-  let hiddenSource: HiddenSourceElement | null = null;
+  let preparedSource: PreparedSourceElement | null = null;
   let previousFrameTimestamp: number | null = null;
   let rafId: unknown = null;
   let session: CalendarInteractionSession<TTarget, TVisual> = {
@@ -297,7 +297,12 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       visual,
     });
     mountOverlay(overlayMount);
-    hiddenSource = hideSourceElement(pendingSession.sourceElement);
+    preparedSource = prepareSourceElementForInteraction(
+      pendingSession.sourceElement,
+      resolvedOptions.adapter.getSourceElementTreatment?.(
+        pendingSession.target,
+      ),
+    );
     activatedAt = resolvedOptions.now();
     latestPointer = pendingSession.startPoint;
     metrics.active = true;
@@ -393,9 +398,9 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     overlay?.unmount();
     overlay = null;
 
-    if (hiddenSource) {
-      restoreSourceElement(hiddenSource);
-      hiddenSource = null;
+    if (preparedSource) {
+      restoreSourceElement(preparedSource);
+      preparedSource = null;
     }
 
     latestPointer = null;

--- a/packages/web/src/common/calendar-interaction/dom/source/sourceElementVisibility.ts
+++ b/packages/web/src/common/calendar-interaction/dom/source/sourceElementVisibility.ts
@@ -1,23 +1,40 @@
-export interface HiddenSourceElement {
+export type SourceElementInteractionTreatment = "hidden" | "placeholder";
+
+export interface PreparedSourceElement {
   element: HTMLElement;
+  opacity: string;
+  pointerEvents: string;
   visibility: string;
 }
 
-export const hideSourceElement = (
+export const prepareSourceElementForInteraction = (
   element: HTMLElement,
-): HiddenSourceElement => {
-  const hiddenSource = {
+  treatment: SourceElementInteractionTreatment = "hidden",
+): PreparedSourceElement => {
+  const preparedSource = {
     element,
+    opacity: element.style.opacity,
+    pointerEvents: element.style.pointerEvents,
     visibility: element.style.visibility,
   };
 
   element.setAttribute("data-calendar-interaction-placeholder", "true");
+
+  if (treatment === "placeholder") {
+    element.style.opacity = "0.5";
+    element.style.pointerEvents = "none";
+
+    return preparedSource;
+  }
+
   element.style.visibility = "hidden";
 
-  return hiddenSource;
+  return preparedSource;
 };
 
-export const restoreSourceElement = (hiddenSource: HiddenSourceElement) => {
-  hiddenSource.element.removeAttribute("data-calendar-interaction-placeholder");
-  hiddenSource.element.style.visibility = hiddenSource.visibility;
+export const restoreSourceElement = (source: PreparedSourceElement) => {
+  source.element.removeAttribute("data-calendar-interaction-placeholder");
+  source.element.style.opacity = source.opacity;
+  source.element.style.pointerEvents = source.pointerEvents;
+  source.element.style.visibility = source.visibility;
 };

--- a/packages/web/src/common/calendar-interaction/dom/source/sourceElementVisibility.ts
+++ b/packages/web/src/common/calendar-interaction/dom/source/sourceElementVisibility.ts
@@ -1,40 +1,62 @@
-export type SourceElementInteractionTreatment = "hidden" | "placeholder";
+import { type SourceElementOverlayMode } from "../../CalendarInteractionAdapter";
 
-export interface PreparedSourceElement {
+interface HiddenSourceElement {
   element: HTMLElement;
-  opacity: string;
-  pointerEvents: string;
+  overlayMode: "hide-source";
   visibility: string;
 }
 
+interface DimmedSourceElement {
+  element: HTMLElement;
+  opacity: string;
+  overlayMode: "dim-source";
+  pointerEvents: string;
+}
+
+export type PreparedSourceElement = HiddenSourceElement | DimmedSourceElement;
+
+const SOURCE_ELEMENT_INTERACTION_ATTRIBUTE = "data-calendar-interaction-source";
+
 export const prepareSourceElementForInteraction = (
   element: HTMLElement,
-  treatment: SourceElementInteractionTreatment = "hidden",
+  overlayMode: SourceElementOverlayMode = "hide-source",
 ): PreparedSourceElement => {
-  const preparedSource = {
-    element,
-    opacity: element.style.opacity,
-    pointerEvents: element.style.pointerEvents,
-    visibility: element.style.visibility,
-  };
+  element.setAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE, "true");
 
-  element.setAttribute("data-calendar-interaction-placeholder", "true");
+  if (overlayMode === "dim-source") {
+    const source = {
+      element,
+      opacity: element.style.opacity,
+      overlayMode,
+      pointerEvents: element.style.pointerEvents,
+    };
 
-  if (treatment === "placeholder") {
     element.style.opacity = "0.5";
     element.style.pointerEvents = "none";
 
-    return preparedSource;
+    return source;
   }
+
+  const source = {
+    element,
+    overlayMode,
+    visibility: element.style.visibility,
+  };
 
   element.style.visibility = "hidden";
 
-  return preparedSource;
+  return source;
 };
 
 export const restoreSourceElement = (source: PreparedSourceElement) => {
-  source.element.removeAttribute("data-calendar-interaction-placeholder");
-  source.element.style.opacity = source.opacity;
-  source.element.style.pointerEvents = source.pointerEvents;
+  source.element.removeAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
+
+  if (source.overlayMode === "dim-source") {
+    source.element.style.opacity = source.opacity;
+    source.element.style.pointerEvents = source.pointerEvents;
+
+    return;
+  }
+
   source.element.style.visibility = source.visibility;
 };

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
@@ -84,6 +84,22 @@ const makePointerEvent = (
   return event;
 };
 
+const SOURCE_ELEMENT_INTERACTION_ATTRIBUTE = "data-calendar-interaction-source";
+
+const expectSourceDimmed = (source: HTMLElement) => {
+  expect(source.style.visibility).toBe("visible");
+  expect(source.style.opacity).toBe("0.5");
+  expect(source.style.pointerEvents).toBe("none");
+  expect(source).toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
+};
+
+const expectSourceRestored = (source: HTMLElement) => {
+  expect(source.style.visibility).toBe("visible");
+  expect(source.style.opacity).toBe("");
+  expect(source.style.pointerEvents).toBe("");
+  expect(source).not.toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
+};
+
 const createHarness = ({
   eventOverrides,
   isPending = false,
@@ -335,9 +351,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
       makePointerEvent("pointermove", { target: child, x: 430, y: 30 }),
     );
 
-    expect(source.style.visibility).toBe("visible");
-    expect(source.style.opacity).toBe("0.5");
-    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
+    expectSourceDimmed(source);
     expect(onMotionActivation).toHaveBeenCalled();
 
     flushFrame();
@@ -365,9 +379,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
         type: "allDayDragEnd",
       }),
     );
-    expect(source.style.visibility).toBe("visible");
-    expect(source.style.opacity).toBe("");
-    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
+    expectSourceRestored(source);
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeNull();
@@ -422,9 +434,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
     );
     flushFrame();
 
-    expect(source.style.visibility).toBe("visible");
-    expect(source.style.opacity).toBe("0.5");
-    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
+    expectSourceDimmed(source);
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeTruthy();
@@ -433,9 +443,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
       makePointerEvent("pointercancel", { target: child, x: 430, y: 30 }),
     );
 
-    expect(source.style.visibility).toBe("visible");
-    expect(source.style.opacity).toBe("");
-    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
+    expectSourceRestored(source);
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeNull();

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
@@ -335,7 +335,9 @@ describe("WeekInteractionAdapter all-day drag", () => {
       makePointerEvent("pointermove", { target: child, x: 430, y: 30 }),
     );
 
-    expect(source.style.visibility).toBe("hidden");
+    expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("0.5");
+    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
     expect(onMotionActivation).toHaveBeenCalled();
 
     flushFrame();
@@ -364,6 +366,8 @@ describe("WeekInteractionAdapter all-day drag", () => {
       }),
     );
     expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("");
+    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeNull();
@@ -418,7 +422,9 @@ describe("WeekInteractionAdapter all-day drag", () => {
     );
     flushFrame();
 
-    expect(source.style.visibility).toBe("hidden");
+    expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("0.5");
+    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeTruthy();
@@ -428,6 +434,8 @@ describe("WeekInteractionAdapter all-day drag", () => {
     );
 
     expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("");
+    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeNull();

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
@@ -365,7 +365,9 @@ describe("WeekInteractionAdapter timed drag", () => {
       makePointerEvent("pointermove", { target: child, x: 320, y: 1120 }),
     );
 
-    expect(source.style.visibility).toBe("hidden");
+    expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("0.5");
+    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
     expect(onMotionActivation).toHaveBeenCalledWith(
       expect.objectContaining({ event }),
     );
@@ -397,6 +399,8 @@ describe("WeekInteractionAdapter timed drag", () => {
       }),
     );
     expect(source.style.visibility).toBe("visible");
+    expect(source.style.opacity).toBe("");
+    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeNull();

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
@@ -89,6 +89,22 @@ const makePointerEvent = (
   return event;
 };
 
+const SOURCE_ELEMENT_INTERACTION_ATTRIBUTE = "data-calendar-interaction-source";
+
+const expectSourceDimmed = (source: HTMLElement) => {
+  expect(source.style.visibility).toBe("visible");
+  expect(source.style.opacity).toBe("0.5");
+  expect(source.style.pointerEvents).toBe("none");
+  expect(source).toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
+};
+
+const expectSourceRestored = (source: HTMLElement) => {
+  expect(source.style.visibility).toBe("visible");
+  expect(source.style.opacity).toBe("");
+  expect(source.style.pointerEvents).toBe("");
+  expect(source).not.toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
+};
+
 const createHarness = ({
   isPending = false,
   mainGridScrollTop = 0,
@@ -365,9 +381,7 @@ describe("WeekInteractionAdapter timed drag", () => {
       makePointerEvent("pointermove", { target: child, x: 320, y: 1120 }),
     );
 
-    expect(source.style.visibility).toBe("visible");
-    expect(source.style.opacity).toBe("0.5");
-    expect(source).toHaveAttribute("data-calendar-interaction-placeholder");
+    expectSourceDimmed(source);
     expect(onMotionActivation).toHaveBeenCalledWith(
       expect.objectContaining({ event }),
     );
@@ -398,9 +412,7 @@ describe("WeekInteractionAdapter timed drag", () => {
         hasMoved: true,
       }),
     );
-    expect(source.style.visibility).toBe("visible");
-    expect(source.style.opacity).toBe("");
-    expect(source).not.toHaveAttribute("data-calendar-interaction-placeholder");
+    expectSourceRestored(source);
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
     ).toBeNull();

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -319,8 +319,8 @@ export const createWeekInteractionAdapter = ({
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
-      getSourceElementTreatment: (target) =>
-        isDragTarget(target) ? "placeholder" : "hidden",
+      getSourceElementOverlayMode: (target) =>
+        isDragTarget(target) ? "dim-source" : "hide-source",
       getTarget: (event) => getInteractionTarget(event),
       updateVisual: ({ pointer, target, timestamp, visual }) => {
         rebuildLayoutIfNeeded(target);

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -319,6 +319,8 @@ export const createWeekInteractionAdapter = ({
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
+      getSourceElementTreatment: (target) =>
+        isDragTarget(target) ? "placeholder" : "hidden",
       getTarget: (event) => getInteractionTarget(event),
       updateVisual: ({ pointer, target, timestamp, visual }) => {
         rebuildLayoutIfNeeded(target);


### PR DESCRIPTION
## Summary

Fixes #1783.

Saved timed and all-day event drags now leave the original event visible as a dim placeholder while the moving overlay follows the pointer. This restores the expected visual anchor that disappeared after PR #1776 moved saved-event drags onto the shared interaction engine.

The shared engine still defaults to hiding the source element. Week saved-event drag targets now opt into placeholder treatment, while resize targets keep the hidden-source behavior so resize overlays remain clear.

## Validation

- `bun test --cwd packages/web src/common/calendar-interaction/CalendarInteractionEngine.test.ts src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayResize.test.ts` - 44 pass, 0 fail
- `bun run type-check` - passed
- `bunx biome check` on the touched files - passed
- Browser smoke on `http://localhost:9080/week` - timed and all-day drags showed the source placeholder during drag and cleared it after release

## Lint note

`bun run lint` still fails on unrelated existing repo issues outside this patch: `self-host/docker-compose.test.ts` template-placeholder/format warnings and import ordering in `packages/web/src/views/Week/interaction/WeekPointerCaptureBoundary.tsx`.
