### PR TITLE
docs(selfhost): update self-host backup restore workflow

### DIFF
--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -35,7 +35,6 @@ flowchart TD
 - New self-host install: [Run Compass on a server](./server-guide.md)
 - Backups and restore: [Back up and restore your data](./backup-and-restore.md)
 - Google Calendar: [Add Google Calendar](./google-calendar.md)
-- Manual Bun setup: [Run Compass without the installer](./advanced-manual.md)
 - Monitoring: [Monitoring](./monitoring.md)
 
 ## What you still need to handle yourself

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -267,12 +267,17 @@ cp -p "$BACKUP_DIR/compass.yaml" "$CHECK_DIR/compass.yaml"
 
 cd "$CHECK_DIR"
 
+# Keep `backend.port` at 3000. The backend listens on that port inside the
+# container; the temporary project only changes the host-side binding to 13000.
 sed -i.bak \
   -e 's/^  port: 9080$/  port: 19080/' \
-  -e 's/^  port: 3000$/  port: 13000/' \
   -e 's#http://localhost:9080#http://localhost:19080#g' \
   -e 's#http://localhost:3000/api#http://localhost:13000/api#g' \
   compass.yaml
+
+sed -i.bak \
+  -e 's#127.0.0.1:${PORT:-3000}:3000#127.0.0.1:13000:3000#' \
+  compose.yaml
 
 docker volume create "${CHECK_PROJECT}_compass_mongo_data"
 docker volume create "${CHECK_PROJECT}_compass_mongo_configdb"
@@ -296,7 +301,7 @@ docker run --rm \
   alpine \
   sh -c 'cd /volume && tar xzf /backup/supertokens-postgres.tgz'
 
-./compass start
+COMPASS_HEALTH_URL=http://localhost:13000/api/health ./compass start
 curl -f http://localhost:13000/api/health
 ./compass status
 ```

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -164,6 +164,6 @@ The repo has the code paths for Google watches and repair. The self-host Docker 
 
 ## What to read next
 
-If you are using local development, use [Run Compass without the installer](./advanced-manual.md). If you need public Google watch notifications, continue with [Server hosting guide](./server-guide.md).
+If you need public Google watch notifications, continue with [Server hosting guide](./server-guide.md).
 
 Have an idea on how we can make self-hosting easier? Let us know in [this GitHub Discussion](https://github.com/SwitchbackTech/compass/discussions/1694).

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -2,7 +2,7 @@
 
 This guide describes the recommended first server setup for one person hosting Compass on a small VPS. One public domain, Compass on `127.0.0.1`, Caddy in front for HTTPS.
 
-If you only want Compass on your own computer, use the normal Bun-based local setup instead of this self-hosting guide. See [Run Compass without the installer](./advanced-manual.md).
+If you only want Compass on your own computer, use the normal Bun-based local setup instead of this self-hosting guide.
 
 ## Before you start
 

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -17,7 +17,6 @@ The compose stack binds the web and backend containers to `127.0.0.1`; the serve
 - Back up before updating: [Backups and restore](../docs/Self-Hosting/backup-and-restore.md)
 - Missing `compass.yaml` with old Docker volumes: [Backups and restore](../docs/Self-Hosting/backup-and-restore.md#if-compassyaml-is-missing-but-old-volumes-exist)
 - Google setup or no-Google mode: [Google Calendar](../docs/self-hosting/google-calendar.md)
-- Manual Bun setup: [Run Compass without the installer](../docs/self-hosting/advanced-manual.md)
 
 ## Files in this folder
 


### PR DESCRIPTION
## What changed

- Verified `docs/self-hosting/backup-and-restore.md` against the live simulated self-host at `selfhosted.compasscalendar.com`.
- Fixed the optional same-server restore rehearsal so it changes only the temporary Compose host binding for the backend (`127.0.0.1:13000->3000`) while leaving `backend.port` at `3000` for the backend process and in-container healthcheck.
- Added a short note explaining why `backend.port` must stay at `3000` during the rehearsal.

## Live verification

- Created backup at `/root/compass-backups/20260520-010926` with `compass.yaml`, Mongo data/config archives, SuperTokens Postgres archive, and manifest.
- Verified archive contents with `tar tzf` and non-empty file checks.
- Restored that backup over the simulated production volumes.
- Confirmed local and public backend health checks after backup, restore, and restart.
- Confirmed browser login worked, a smoke event survived the restore, then edit/delete persisted after `./compass restart`.
- Ran the corrected same-server rehearsal and confirmed the temporary stack health check passed on `http://localhost:13000/api/health`; cleanup removed the temporary project and volumes.

## Validation

- `git diff --check` passed.
- `bun lint` currently fails on an unrelated pre-existing import-order issue in `packages/web/src/views/Week/interaction/WeekPointerCaptureBoundary.tsx`.