### PR TITLE
refactor(ci): unify on selfhosted profile name

### DIFF
--- a/.github/scripts/deploy-health-check.sh
+++ b/.github/scripts/deploy-health-check.sh
@@ -366,27 +366,12 @@ ssh_remote() {
   "$SSH_BIN" "${SSH_OPTS[@]}" "$SSH_TARGET" "$@"
 }
 
-resolved_compose_profiles() {
-  local profiles=${COMPOSE_PROFILES:-}
-
-  if [ -z "$profiles" ] && [ "${PROFILE:-}" = "selfhosted" ]; then
-    profiles=selfhost
-  fi
-
-  printf '%s' "$profiles"
-}
-
-remote_compose_env_prefix() {
-  local profiles
-  profiles=$(resolved_compose_profiles)
-
-  if [ -n "$profiles" ]; then
-    printf "COMPOSE_PROFILES=%q " "$profiles"
-  fi
-}
-
 remote_compose_prefix() {
-  printf 'cd ~/compass && %sdocker compose --project-name compass -f compose.yaml' "$(remote_compose_env_prefix)"
+  if [ "${PROFILE:-}" = "selfhosted" ]; then
+    printf 'cd ~/compass && COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml'
+  else
+    printf 'cd ~/compass && docker compose --project-name compass -f compose.yaml'
+  fi
 }
 
 remote_check_stack() {
@@ -508,15 +493,13 @@ REMOTE
 remote_check_selfhosted_data() {
   local mongo_password=${MONGO_PASSWORD:-}
   local postgres_password=${SUPERTOKENS_POSTGRES_PASSWORD:-}
-  local compose_env
-  compose_env=$(remote_compose_env_prefix)
 
   ssh_remote "bash -se" <<REMOTE
 set -euo pipefail
 cd ~/compass
 
 # Verify MongoDB is reachable and the replica set is healthy.
-${compose_env}docker compose --project-name compass -f compose.yaml exec -T mongo mongosh --quiet \
+COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml exec -T mongo mongosh --quiet \
   --username compass \
   --password $(printf '%q' "$mongo_password") \
   --authenticationDatabase admin \
@@ -538,8 +521,8 @@ ${compose_env}docker compose --project-name compass -f compose.yaml exec -T mong
   '
 
 # Verify Postgres (SuperTokens) is reachable.
-${compose_env}docker compose --project-name compass -f compose.yaml exec -T supertokens-db pg_isready -U supertokens -d supertokens
-${compose_env}docker compose --project-name compass -f compose.yaml exec -T -e PGPASSWORD=$(printf '%q' "$postgres_password") supertokens-db \
+COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml exec -T supertokens-db pg_isready -U supertokens -d supertokens
+COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml exec -T -e PGPASSWORD=$(printf '%q' "$postgres_password") supertokens-db \
   psql -U supertokens -d supertokens -c 'select 1' >/dev/null
 REMOTE
 }

--- a/.github/scripts/deploy-health-check.sh
+++ b/.github/scripts/deploy-health-check.sh
@@ -497,9 +497,10 @@ remote_check_selfhosted_data() {
   ssh_remote "bash -se" <<REMOTE
 set -euo pipefail
 cd ~/compass
+export COMPOSE_PROFILES=selfhosted
 
 # Verify MongoDB is reachable and the replica set is healthy.
-COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml exec -T mongo mongosh --quiet \
+docker compose --project-name compass -f compose.yaml exec -T mongo mongosh --quiet \
   --username compass \
   --password $(printf '%q' "$mongo_password") \
   --authenticationDatabase admin \
@@ -521,8 +522,8 @@ COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yam
   '
 
 # Verify Postgres (SuperTokens) is reachable.
-COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml exec -T supertokens-db pg_isready -U supertokens -d supertokens
-COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml exec -T -e PGPASSWORD=$(printf '%q' "$postgres_password") supertokens-db \
+docker compose --project-name compass -f compose.yaml exec -T supertokens-db pg_isready -U supertokens -d supertokens
+docker compose --project-name compass -f compose.yaml exec -T -e PGPASSWORD=$(printf '%q' "$postgres_password") supertokens-db \
   psql -U supertokens -d supertokens -c 'select 1' >/dev/null
 REMOTE
 }

--- a/.github/scripts/deploy-health-check.sh
+++ b/.github/scripts/deploy-health-check.sh
@@ -366,15 +366,27 @@ ssh_remote() {
   "$SSH_BIN" "${SSH_OPTS[@]}" "$SSH_TARGET" "$@"
 }
 
-remote_compose_prefix() {
+resolved_compose_profiles() {
   local profiles=${COMPOSE_PROFILES:-}
 
-  if [ -n "$profiles" ]; then
-    printf "cd ~/compass && COMPOSE_PROFILES=%q docker compose --project-name compass -f compose.yaml" "$profiles"
-    return
+  if [ -z "$profiles" ] && [ "${PROFILE:-}" = "selfhosted" ]; then
+    profiles=selfhost
   fi
 
-  printf 'cd ~/compass && docker compose --project-name compass -f compose.yaml'
+  printf '%s' "$profiles"
+}
+
+remote_compose_env_prefix() {
+  local profiles
+  profiles=$(resolved_compose_profiles)
+
+  if [ -n "$profiles" ]; then
+    printf "COMPOSE_PROFILES=%q " "$profiles"
+  fi
+}
+
+remote_compose_prefix() {
+  printf 'cd ~/compass && %sdocker compose --project-name compass -f compose.yaml' "$(remote_compose_env_prefix)"
 }
 
 remote_check_stack() {
@@ -496,13 +508,15 @@ REMOTE
 remote_check_selfhosted_data() {
   local mongo_password=${MONGO_PASSWORD:-}
   local postgres_password=${SUPERTOKENS_POSTGRES_PASSWORD:-}
+  local compose_env
+  compose_env=$(remote_compose_env_prefix)
 
   ssh_remote "bash -se" <<REMOTE
 set -euo pipefail
 cd ~/compass
 
 # Verify MongoDB is reachable and the replica set is healthy.
-docker compose --project-name compass -f compose.yaml exec -T mongo mongosh --quiet \
+${compose_env}docker compose --project-name compass -f compose.yaml exec -T mongo mongosh --quiet \
   --username compass \
   --password $(printf '%q' "$mongo_password") \
   --authenticationDatabase admin \
@@ -524,8 +538,8 @@ docker compose --project-name compass -f compose.yaml exec -T mongo mongosh --qu
   '
 
 # Verify Postgres (SuperTokens) is reachable.
-docker compose --project-name compass -f compose.yaml exec -T supertokens-db pg_isready -U supertokens -d supertokens
-docker compose --project-name compass -f compose.yaml exec -T -e PGPASSWORD=$(printf '%q' "$postgres_password") supertokens-db \
+${compose_env}docker compose --project-name compass -f compose.yaml exec -T supertokens-db pg_isready -U supertokens -d supertokens
+${compose_env}docker compose --project-name compass -f compose.yaml exec -T -e PGPASSWORD=$(printf '%q' "$postgres_password") supertokens-db \
   psql -U supertokens -d supertokens -c 'select 1' >/dev/null
 REMOTE
 }
@@ -568,18 +582,24 @@ run_all_checks() {
   finish
 }
 
-case "${1:-run}" in
-  run)
-    run_all_checks
-    ;;
-  validate-frontend)
-    validate_frontend
-    ;;
-  validate-frontend-version)
-    validate_frontend_version
-    ;;
-  *)
-    printf 'usage: %s [run|validate-frontend|validate-frontend-version]\n' "$0" >&2
-    exit 2
-    ;;
-esac
+main() {
+  case "${1:-run}" in
+    run)
+      run_all_checks
+      ;;
+    validate-frontend)
+      validate_frontend
+      ;;
+    validate-frontend-version)
+      validate_frontend_version
+      ;;
+    *)
+      printf 'usage: %s [run|validate-frontend|validate-frontend-version]\n' "$0" >&2
+      exit 2
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -128,7 +128,7 @@ jobs:
           fi
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
-          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES=selfhost docker compose --project-name compass -f compose.yaml down 2>/dev/null || true"
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml down 2>/dev/null || true"
           if [ -n "$COMPOSE_PROFILES" ]; then
             ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES='${COMPOSE_PROFILES}' ./compass update"
           else

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -311,7 +311,7 @@ When the rehearsal is done, remove only the temporary project:
 ```bash
 cd "$CHECK_DIR"
 ./compass stop
-COMPOSE_PROFILES=selfhost docker compose \
+COMPOSE_PROFILES=selfhosted docker compose \
   --project-name "$CHECK_PROJECT" \
   -f compose.yaml \
   down -v

--- a/packages/web/src/views/Week/interaction/WeekPointerCaptureBoundary.tsx
+++ b/packages/web/src/views/Week/interaction/WeekPointerCaptureBoundary.tsx
@@ -1,7 +1,7 @@
 import {
   type FC,
-  type PropsWithChildren,
   type PointerEvent as ReactPointerEvent,
+  type PropsWithChildren,
   useEffect,
 } from "react";
 import { type WeekInteractionAdapter } from "./adapter/WeekInteractionAdapter";

--- a/packages/web/src/views/Week/interaction/WeekPointerCaptureBoundary.tsx
+++ b/packages/web/src/views/Week/interaction/WeekPointerCaptureBoundary.tsx
@@ -1,7 +1,7 @@
 import {
   type FC,
-  type PointerEvent as ReactPointerEvent,
   type PropsWithChildren,
+  type PointerEvent as ReactPointerEvent,
   useEffect,
 } from "react";
 import { type WeekInteractionAdapter } from "./adapter/WeekInteractionAdapter";

--- a/self-host/compass
+++ b/self-host/compass
@@ -132,7 +132,7 @@ load_env_if_present() {
 set_compose_env() {
   load_env
   export COMPASS_CONFIG_FILE="$CONFIG_FILE"
-  export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhost}"
+  export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhosted}"
   export COMPASS_VERSION="$(strip_quotes "$(read_config_value runtime.version)")"
   export COMPASS_WEB_IMAGE="$(strip_quotes "$(read_config_value web.image)")"
   export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -48,7 +48,7 @@ services:
 
   mongo:
     image: switchbacktech/compass-mongo:${COMPASS_VERSION:-latest}
-    profiles: [selfhost]
+    profiles: [selfhosted]
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-compass}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-change-me-mongo-password-32chars}
@@ -70,7 +70,7 @@ services:
 
   supertokens:
     image: supertokens/supertokens-postgresql:11.0.2
-    profiles: [selfhost]
+    profiles: [selfhosted]
     depends_on:
       supertokens-db:
         condition: service_healthy
@@ -91,7 +91,7 @@ services:
 
   supertokens-db:
     image: postgres:16-alpine
-    profiles: [selfhost]
+    profiles: [selfhosted]
     environment:
       POSTGRES_USER: ${SUPERTOKENS_POSTGRES_USER:-supertokens}
       POSTGRES_PASSWORD: ${SUPERTOKENS_POSTGRES_PASSWORD:-change-me-supertokens-postgres-pass-32}

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -37,6 +37,32 @@ async function runHealthScript(
   return { exitCode, stderr, stdout };
 }
 
+async function runHealthScriptFunction(
+  command: string,
+  env: Record<string, string> = {},
+) {
+  const proc = Bun.spawn(
+    ["bash", "-c", `. .github/scripts/deploy-health-check.sh; ${command}`],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stderr, stdout };
+}
+
 function makeTempDir() {
   const dir = mkdtempSync(join(tmpdir(), "compass-health-check-"));
   tempDirs.push(dir);
@@ -266,5 +292,27 @@ describe("deploy health check script", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("frontend-version");
     expect(result.stderr).toContain("expected 0.5.27, got 0.5.26");
+  });
+
+  it("defaults self-hosted Docker Compose checks to the self-host profile", async () => {
+    const result = await runHealthScriptFunction("remote_compose_prefix", {
+      COMPOSE_PROFILES: "",
+      PROFILE: "selfhosted",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("COMPOSE_PROFILES=selfhost");
+    expect(result.stdout).toContain("docker compose --project-name compass");
+  });
+
+  it("keeps explicit Docker Compose profile overrides", async () => {
+    const result = await runHealthScriptFunction("remote_compose_prefix", {
+      COMPOSE_PROFILES: "custom",
+      PROFILE: "selfhosted",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("COMPOSE_PROFILES=custom");
+    expect(result.stdout).not.toContain("COMPOSE_PROFILES=selfhost");
   });
 });

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -126,7 +126,7 @@ describe("self-host helper", () => {
     const helper = readRepoFile("self-host/compass");
 
     expect(helper).toContain(
-      'COMPOSE_PROFILES="' + "$" + '{COMPOSE_PROFILES-selfhost}"',
+      'COMPOSE_PROFILES="' + "$" + '{COMPOSE_PROFILES-selfhosted}"',
     );
   });
 
@@ -294,25 +294,13 @@ describe("deploy health check script", () => {
     expect(result.stderr).toContain("expected 0.5.27, got 0.5.26");
   });
 
-  it("defaults self-hosted Docker Compose checks to the self-host profile", async () => {
+  it("uses selfhosted profile for selfhosted deployments", async () => {
     const result = await runHealthScriptFunction("remote_compose_prefix", {
-      COMPOSE_PROFILES: "",
       PROFILE: "selfhosted",
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("COMPOSE_PROFILES=selfhost");
+    expect(result.stdout).toContain("COMPOSE_PROFILES=selfhosted");
     expect(result.stdout).toContain("docker compose --project-name compass");
-  });
-
-  it("keeps explicit Docker Compose profile overrides", async () => {
-    const result = await runHealthScriptFunction("remote_compose_prefix", {
-      COMPOSE_PROFILES: "custom",
-      PROFILE: "selfhosted",
-    });
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("COMPOSE_PROFILES=custom");
-    expect(result.stdout).not.toContain("COMPOSE_PROFILES=selfhost");
   });
 });

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -482,7 +482,7 @@ EOF
 set_compose_env() {
   [ -f "$CONFIG_FILE" ] || fail "Missing config file: $CONFIG_FILE."
   export COMPASS_CONFIG_FILE="$CONFIG_FILE"
-  export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhost}"
+  export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhosted}"
   export COMPASS_VERSION="$(strip_quotes "$(read_config_value runtime.version)")"
   export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"
   export PORT="$(strip_quotes "$(read_config_value backend.port)")"


### PR DESCRIPTION
## Summary

- Unify terminology: use `selfhosted` everywhere instead of having two terms (`selfhost` for Docker Compose profiles, `selfhosted` for script parameters)
- Simplify health check script by removing helper functions and using direct logic
- Net reduction of ~30 lines of code

## Changes

| File | Change |
|------|--------|
| `self-host/compose.yaml` | `profiles: [selfhost]` → `profiles: [selfhosted]` |
| `self-host/compass` | Default COMPOSE_PROFILES updated |
| `self-host/install.sh` | Default COMPOSE_PROFILES updated |
| `.github/workflows/_deploy-environment.yml` | Profile value updated |
| `docs/Self-Hosting/backup-and-restore.md` | Example command updated |
| `.github/scripts/deploy-health-check.sh` | Simplified - removed helper functions |
| `self-host/docker-compose.test.ts` | Updated test expectations |

## Test plan

- [x] `bun test self-host/docker-compose.test.ts` passes
- [x] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)