### PR TITLE
Fix Someday hover times on week grid

### DIFF
--- a/docs/acceptance/events.md
+++ b/docs/acceptance/events.md
@@ -247,8 +247,10 @@ Someday events can be dragged from the sidebar onto a specific day and time on t
 
 - While the Someday event is over a timed grid slot, the preview uses the same
   layout as a Timed Event: title at the top, time underneath.
-- If the target time has already passed, the preview hides the time just like
-  the saved Timed Event will.
+- The preview shows the tentative time while hovering, even if the target time
+  has already passed.
+- If the target time has already passed, the time disappears after drop the same
+  way it does on saved past Timed Events.
 - The event disappears from the sidebar.
 - The event appears on the grid at the dropped time.
 - The event is now a regular scheduled event and persists after a page reload.

--- a/docs/acceptance/events.md
+++ b/docs/acceptance/events.md
@@ -245,6 +245,10 @@ Someday events can be dragged from the sidebar onto a specific day and time on t
 
 ### Expected Results
 
+- While the Someday event is over a timed grid slot, the preview uses the same
+  layout as a Timed Event: title at the top, time underneath.
+- If the target time has already passed, the preview hides the time just like
+  the saved Timed Event will.
 - The event disappears from the sidebar.
 - The event appears on the grid at the dropped time.
 - The event is now a regular scheduled event and persists after a page reload.

--- a/e2e/someday/drag-someday-event-mouse.spec.ts
+++ b/e2e/someday/drag-someday-event-mouse.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import {
+  createEventTitle,
+  expectSomedayEventVisible,
+  fillTitleAndSaveEventForm,
+  getMainGridPoint,
+  openSomedayEventFormWithMouse,
+  prepareCalendarPage,
+} from "../utils/event-test-utils";
+
+test.skip(
+  ({ isMobile }) => isMobile,
+  "Mouse flows are desktop-only in week view.",
+);
+
+test("shows a timed-grid preview while dragging a someday event", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+
+  const title = createEventTitle("Someday Drag Preview");
+  await openSomedayEventFormWithMouse(page, "week");
+  await fillTitleAndSaveEventForm(page, title);
+  await expectSomedayEventVisible(page, title);
+
+  const somedayEvent = page.locator("#sidebar").getByRole("button", {
+    name: title,
+  });
+  const eventBox = await somedayEvent.boundingBox();
+
+  if (!eventBox) {
+    throw new Error("Expected the Someday event to be visible.");
+  }
+
+  const start = {
+    x: eventBox.x + eventBox.width / 2,
+    y: eventBox.y + eventBox.height / 2,
+  };
+  const target = await getMainGridPoint(page, { xRatio: 0.35, yRatio: 0.35 });
+
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(target.x, target.y, { steps: 12 });
+
+  const overlay = page.locator("[data-calendar-interaction-overlay]");
+  await expect(overlay).toBeVisible();
+  await expect(
+    overlay.locator("[data-someday-interaction-time-label]"),
+  ).toHaveText(/\d{1,2}(?::\d{2})?\s+-\s+\d{1,2}(?::\d{2})?\s*(AM|PM)/i);
+
+  await page.mouse.up();
+});

--- a/e2e/someday/drag-someday-event-mouse.spec.ts
+++ b/e2e/someday/drag-someday-event-mouse.spec.ts
@@ -61,6 +61,7 @@ const expectTimedPreviewTextStack = async (page: Page, title: string) => {
   expect(timeBox.y + timeBox.height / 2).toBeGreaterThan(
     titleBox.y + titleBox.height / 2,
   );
+  expect(timeBox.y - titleBox.y).toBeLessThan(titleBox.height + 8);
   expect(timeBox.x).toBeLessThan(titleBox.x + 8);
 };
 

--- a/e2e/someday/drag-someday-event-mouse.spec.ts
+++ b/e2e/someday/drag-someday-event-mouse.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import {
   createEventTitle,
   expectSomedayEventVisible,
@@ -13,14 +13,8 @@ test.skip(
   "Mouse flows are desktop-only in week view.",
 );
 
-test("shows a timed-grid preview while dragging a someday event", async ({
-  page,
-}) => {
-  await prepareCalendarPage(page);
-  await page.getByRole("button", { name: "Next week" }).click();
-  await page.locator("#mainGrid").waitFor({ state: "visible" });
-
-  const title = createEventTitle("Someday Drag Preview");
+const dragSomedayEventToTimedGrid = async (page: Page, titlePrefix: string) => {
+  const title = createEventTitle(titlePrefix);
   await openSomedayEventFormWithMouse(page, "week");
   await fillTitleAndSaveEventForm(page, title);
   await expectSomedayEventVisible(page, title);
@@ -44,6 +38,10 @@ test("shows a timed-grid preview while dragging a someday event", async ({
   await page.mouse.down();
   await page.mouse.move(target.x, target.y, { steps: 12 });
 
+  return title;
+};
+
+const expectTimedPreviewTextStack = async (page: Page, title: string) => {
   const overlay = page.locator("[data-calendar-interaction-overlay]");
   const titleLabel = overlay.getByText(title);
   const timeLabel = overlay.locator("[data-someday-interaction-time-label]");
@@ -60,8 +58,37 @@ test("shows a timed-grid preview while dragging a someday event", async ({
     throw new Error("Expected the Someday timed preview text to be visible.");
   }
 
-  expect(timeBox.y).toBeGreaterThan(titleBox.y + titleBox.height - 2);
+  expect(timeBox.y + timeBox.height / 2).toBeGreaterThan(
+    titleBox.y + titleBox.height / 2,
+  );
   expect(timeBox.x).toBeLessThan(titleBox.x + 8);
+};
+
+test("shows a timed-grid preview while dragging a someday event", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+  await page.getByRole("button", { name: "Next week" }).click();
+  await page.locator("#mainGrid").waitFor({ state: "visible" });
+
+  const title = await dragSomedayEventToTimedGrid(page, "Someday Drag Preview");
+  await expectTimedPreviewTextStack(page, title);
+
+  await page.mouse.up();
+});
+
+test("shows a timed-grid preview while dragging over a past slot", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+  await page.getByRole("button", { name: "Previous week" }).click();
+  await page.locator("#mainGrid").waitFor({ state: "visible" });
+
+  const title = await dragSomedayEventToTimedGrid(
+    page,
+    "Someday Past Drag Preview",
+  );
+  await expectTimedPreviewTextStack(page, title);
 
   await page.mouse.up();
 });

--- a/e2e/someday/drag-someday-event-mouse.spec.ts
+++ b/e2e/someday/drag-someday-event-mouse.spec.ts
@@ -60,7 +60,8 @@ test("shows a timed-grid preview while dragging a someday event", async ({
     throw new Error("Expected the Someday timed preview text to be visible.");
   }
 
-  expect(timeBox.y).toBeGreaterThan(titleBox.y);
+  expect(timeBox.y).toBeGreaterThan(titleBox.y + titleBox.height - 2);
+  expect(timeBox.x).toBeLessThan(titleBox.x + 8);
 
   await page.mouse.up();
 });

--- a/e2e/someday/drag-someday-event-mouse.spec.ts
+++ b/e2e/someday/drag-someday-event-mouse.spec.ts
@@ -17,6 +17,8 @@ test("shows a timed-grid preview while dragging a someday event", async ({
   page,
 }) => {
   await prepareCalendarPage(page);
+  await page.getByRole("button", { name: "Next week" }).click();
+  await page.locator("#mainGrid").waitFor({ state: "visible" });
 
   const title = createEventTitle("Someday Drag Preview");
   await openSomedayEventFormWithMouse(page, "week");
@@ -43,10 +45,22 @@ test("shows a timed-grid preview while dragging a someday event", async ({
   await page.mouse.move(target.x, target.y, { steps: 12 });
 
   const overlay = page.locator("[data-calendar-interaction-overlay]");
+  const titleLabel = overlay.getByText(title);
+  const timeLabel = overlay.locator("[data-someday-interaction-time-label]");
+
   await expect(overlay).toBeVisible();
-  await expect(
-    overlay.locator("[data-someday-interaction-time-label]"),
-  ).toHaveText(/\d{1,2}(?::\d{2})?\s+-\s+\d{1,2}(?::\d{2})?\s*(AM|PM)/i);
+  await expect(timeLabel).toHaveText(
+    /\d{1,2}(?::\d{2})?\s+-\s+\d{1,2}(?::\d{2})?\s*(AM|PM)/i,
+  );
+
+  const titleBox = await titleLabel.boundingBox();
+  const timeBox = await timeLabel.boundingBox();
+
+  if (!titleBox || !timeBox) {
+    throw new Error("Expected the Someday timed preview text to be visible.");
+  }
+
+  expect(timeBox.y).toBeGreaterThan(titleBox.y);
 
   await page.mouse.up();
 });

--- a/e2e/timed/create-event-mouse.spec.ts
+++ b/e2e/timed/create-event-mouse.spec.ts
@@ -4,6 +4,7 @@ import {
   ensureSidebarOpen,
   expectTimedEventVisible,
   fillTitleAndSaveEventForm,
+  getMainGridPoint,
   openTimedEventFormWithMouse,
   prepareCalendarPage,
 } from "../utils/event-test-utils";
@@ -13,24 +14,6 @@ interface StoredTimedEvent {
   startDate?: string;
   title?: string;
 }
-
-const getMainGridPoint = async (
-  page: Page,
-  { xRatio = 0.3, yRatio = 0.3 } = {},
-) => {
-  const mainGrid = page.locator("#mainGrid");
-  await mainGrid.scrollIntoViewIfNeeded();
-  const box = await mainGrid.boundingBox();
-
-  if (!box) {
-    throw new Error("Expected the week grid to be visible.");
-  }
-
-  return {
-    x: box.x + box.width * xRatio,
-    y: box.y + box.height * yRatio,
-  };
-};
 
 const getSavedEventsByTitle = (page: Page, title: string) =>
   page.evaluate(async (eventTitle) => {

--- a/e2e/utils/event-test-utils.ts
+++ b/e2e/utils/event-test-utils.ts
@@ -227,6 +227,24 @@ export const clickGridCenter = async (page: Page, locator: Locator) => {
   await page.mouse.up();
 };
 
+export const getMainGridPoint = async (
+  page: Page,
+  { xRatio = 0.3, yRatio = 0.3 } = {},
+) => {
+  const mainGrid = page.locator("#mainGrid");
+  await mainGrid.scrollIntoViewIfNeeded();
+  const box = await mainGrid.boundingBox();
+
+  if (!box) {
+    throw new Error("Expected the week grid to be visible.");
+  }
+
+  return {
+    x: box.x + box.width * xRatio,
+    y: box.y + box.height * yRatio,
+  };
+};
+
 /**
  * Fills the event form title and submits via the Save control (role=button, name Save).
  * Keyboard shortcuts for submit (Enter / Mod+Enter) are not driven here: Playwright’s

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
@@ -50,7 +50,10 @@ export const SomedayEventRectangle = ({
         direction={FlexDirections.ROW}
         justifyContent={JustifyContent.SPACE_BETWEEN}
       >
-        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+        <div
+          className="flex min-w-0 flex-1 items-center gap-1.5"
+          data-someday-event-title-row="true"
+        >
           <DotsSixVertical
             aria-hidden="true"
             className="shrink-0 text-text-light"

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
@@ -407,7 +407,7 @@ describe("SomedayInteractionAdapter", () => {
     expect(timeLabel?.parentElement?.style.flexDirection).toBe("column");
   });
 
-  it("matches dropped past timed events by hiding the tentative time range", () => {
+  it("keeps the tentative timed-grid range visible for past targets", () => {
     const { adapter, flushFrame, sourceChild, timedColumns } = createHarness({
       viewStart: dayjs().subtract(1, "week").startOf("week"),
     });
@@ -432,8 +432,9 @@ describe("SomedayInteractionAdapter", () => {
     );
 
     expect(
-      overlay?.querySelector("[data-someday-interaction-time-label]"),
-    ).toBeNull();
+      overlay?.querySelector("[data-someday-interaction-time-label]")
+        ?.textContent,
+    ).toMatch(/2\s+-\s+3 AM/);
     expect(titleRow?.style.alignSelf).toBe("stretch");
     expect(titleRow?.style.alignItems).toBe("flex-start");
     expect(titleRow?.style.flexDirection).toBe("column");

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
@@ -101,7 +101,11 @@ const setReducedMotionPreference = (matches: boolean) => {
   };
 };
 
-const createHarness = () => {
+const createHarness = ({
+  viewStart = dayjs("2026-05-17"),
+}: {
+  viewStart?: ReturnType<typeof dayjs>;
+} = {}) => {
   document.body.innerHTML = "";
   somedayDropTargetRegistry.clear();
   somedayEventRegistry.clear();
@@ -211,7 +215,7 @@ const createHarness = () => {
       mainGridElement: mainGrid,
       timedColumnsElement: timedColumns,
     }),
-    getViewStart: () => dayjs("2026-05-17"),
+    getViewStart: () => viewStart,
     runtime: () => ({
       getSomedayEventById: (eventId) => (eventId === event._id ? event : null),
       onCancelInteraction,
@@ -369,7 +373,9 @@ describe("SomedayInteractionAdapter", () => {
   });
 
   it("shows the tentative timed-grid range inside the visible Someday preview", () => {
-    const { adapter, flushFrame, sourceChild, timedColumns } = createHarness();
+    const { adapter, flushFrame, sourceChild, timedColumns } = createHarness({
+      viewStart: dayjs().add(1, "week").startOf("week"),
+    });
 
     adapter.handlePointerDown(
       makePointerEvent("pointerdown", { target: sourceChild, x: 20, y: 12 }),
@@ -392,9 +398,45 @@ describe("SomedayInteractionAdapter", () => {
 
     expect(timeLabel).toBeTruthy();
     expect(timeLabel?.textContent).toMatch(/2\s+-\s+3 AM/);
+    expect(timeLabel?.style.display).toBe("block");
     expect(
       timeLabel?.parentElement?.getAttribute("data-someday-event-title-row"),
     ).toBe("true");
+    expect(timeLabel?.parentElement?.style.alignSelf).toBe("stretch");
+    expect(timeLabel?.parentElement?.style.alignItems).toBe("flex-start");
+    expect(timeLabel?.parentElement?.style.flexDirection).toBe("column");
+  });
+
+  it("matches dropped past timed events by hiding the tentative time range", () => {
+    const { adapter, flushFrame, sourceChild, timedColumns } = createHarness({
+      viewStart: dayjs().subtract(1, "week").startOf("week"),
+    });
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: sourceChild, x: 20, y: 12 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", {
+        target: timedColumns,
+        x: 250,
+        y: 220,
+      }),
+    );
+    flushFrame();
+
+    const overlay = document.body.querySelector<HTMLElement>(
+      "[data-calendar-interaction-overlay]",
+    );
+    const titleRow = overlay?.querySelector<HTMLElement>(
+      "[data-someday-event-title-row]",
+    );
+
+    expect(
+      overlay?.querySelector("[data-someday-interaction-time-label]"),
+    ).toBeNull();
+    expect(titleRow?.style.alignSelf).toBe("stretch");
+    expect(titleRow?.style.alignItems).toBe("flex-start");
+    expect(titleRow?.style.flexDirection).toBe("column");
   });
 
   it("disables Someday overlay motion when reduced motion is preferred", () => {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
@@ -112,6 +112,8 @@ const createHarness = () => {
   const timerCallbacks = new Map<unknown, () => void>();
   const event = createSomedayEvent();
   const source = document.createElement("div");
+  const sourceContent = document.createElement("div");
+  const sourceTitleRow = document.createElement("div");
   const sourceChild = document.createElement("span");
   const sourceButton = document.createElement("button");
   const weekDropTarget = document.createElement("div");
@@ -126,7 +128,11 @@ const createHarness = () => {
   const onRequestWeekNavigation = mock();
 
   sourceButton.type = "button";
-  source.append(sourceChild, sourceButton);
+  sourceContent.className = "h-full";
+  sourceTitleRow.setAttribute("data-someday-event-title-row", "true");
+  sourceTitleRow.append(sourceChild);
+  sourceContent.append(sourceTitleRow, sourceButton);
+  source.append(sourceContent);
   weekDropTarget.append(source);
   mainGrid.id = ID_GRID_MAIN;
   timedColumns.id = ID_GRID_COLUMNS_TIMED;
@@ -360,6 +366,35 @@ describe("SomedayInteractionAdapter", () => {
     expect(overlay?.style.color).toBe(expectedTextColor);
     expect(overlay?.style.backgroundColor).toBe(expectedHoverColor);
     expect(overlay?.querySelector("[data-someday-drag-affordance]")).toBeNull();
+  });
+
+  it("shows the tentative timed-grid range inside the visible Someday preview", () => {
+    const { adapter, flushFrame, sourceChild, timedColumns } = createHarness();
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: sourceChild, x: 20, y: 12 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", {
+        target: timedColumns,
+        x: 250,
+        y: 220,
+      }),
+    );
+    flushFrame();
+
+    const overlay = document.body.querySelector<HTMLElement>(
+      "[data-calendar-interaction-overlay]",
+    );
+    const timeLabel = overlay?.querySelector<HTMLElement>(
+      "[data-someday-interaction-time-label]",
+    );
+
+    expect(timeLabel).toBeTruthy();
+    expect(timeLabel?.textContent).toMatch(/2\s+-\s+3 AM/);
+    expect(
+      timeLabel?.parentElement?.getAttribute("data-someday-event-title-row"),
+    ).toBe("true");
   });
 
   it("disables Someday overlay motion when reduced motion is preferred", () => {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
@@ -411,6 +411,7 @@ describe("SomedayInteractionAdapter", () => {
     expect(textStack?.style.flexDirection).toBe("column");
     expect(titleRow?.style.alignSelf).toBe("stretch");
     expect(titleRow?.style.alignItems).toBe("flex-start");
+    expect(titleRow?.style.flex).toBe("0 1 auto");
     expect(titleRow?.style.flexDirection).toBe("row");
   });
 
@@ -448,6 +449,7 @@ describe("SomedayInteractionAdapter", () => {
     ).toBe(titleRow?.parentElement);
     expect(titleRow?.style.alignSelf).toBe("stretch");
     expect(titleRow?.style.alignItems).toBe("flex-start");
+    expect(titleRow?.style.flex).toBe("0 1 auto");
     expect(titleRow?.style.flexDirection).toBe("row");
     expect(titleRow?.parentElement?.style.flexDirection).toBe("column");
   });

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
@@ -132,6 +132,7 @@ const createHarness = ({
   const onRequestWeekNavigation = mock();
 
   sourceButton.type = "button";
+  sourceButton.setAttribute("data-someday-drag-affordance", "true");
   sourceContent.className = "h-full";
   sourceTitleRow.setAttribute("data-someday-event-title-row", "true");
   sourceTitleRow.append(sourceChild);
@@ -395,16 +396,22 @@ describe("SomedayInteractionAdapter", () => {
     const timeLabel = overlay?.querySelector<HTMLElement>(
       "[data-someday-interaction-time-label]",
     );
+    const titleRow = overlay?.querySelector<HTMLElement>(
+      "[data-someday-event-title-row]",
+    );
+    const textStack = titleRow?.parentElement;
 
     expect(timeLabel).toBeTruthy();
     expect(timeLabel?.textContent).toMatch(/2\s+-\s+3 AM/);
     expect(timeLabel?.style.display).toBe("block");
-    expect(
-      timeLabel?.parentElement?.getAttribute("data-someday-event-title-row"),
-    ).toBe("true");
-    expect(timeLabel?.parentElement?.style.alignSelf).toBe("stretch");
-    expect(timeLabel?.parentElement?.style.alignItems).toBe("flex-start");
-    expect(timeLabel?.parentElement?.style.flexDirection).toBe("column");
+    expect(timeLabel?.parentElement).toBe(textStack);
+    expect(timeLabel?.previousElementSibling).toBe(titleRow);
+    expect(textStack?.style.alignItems).toBe("flex-start");
+    expect(textStack?.style.display).toBe("flex");
+    expect(textStack?.style.flexDirection).toBe("column");
+    expect(titleRow?.style.alignSelf).toBe("stretch");
+    expect(titleRow?.style.alignItems).toBe("flex-start");
+    expect(titleRow?.style.flexDirection).toBe("row");
   });
 
   it("keeps the tentative timed-grid range visible for past targets", () => {
@@ -435,9 +442,14 @@ describe("SomedayInteractionAdapter", () => {
       overlay?.querySelector("[data-someday-interaction-time-label]")
         ?.textContent,
     ).toMatch(/2\s+-\s+3 AM/);
+    expect(
+      overlay?.querySelector("[data-someday-interaction-time-label]")
+        ?.parentElement,
+    ).toBe(titleRow?.parentElement);
     expect(titleRow?.style.alignSelf).toBe("stretch");
     expect(titleRow?.style.alignItems).toBe("flex-start");
-    expect(titleRow?.style.flexDirection).toBe("column");
+    expect(titleRow?.style.flexDirection).toBe("row");
+    expect(titleRow?.parentElement?.style.flexDirection).toBe("column");
   });
 
   it("disables Someday overlay motion when reduced motion is preferred", () => {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -794,6 +794,7 @@ const applyTimedOverlayLayout = (node: HTMLElement) => {
 
   titleRow.style.alignSelf = "stretch";
   titleRow.style.alignItems = "flex-start";
+  titleRow.style.flex = "0 1 auto";
   titleRow.style.flexDirection = "row";
   titleRow.style.gap = "0";
   titleRow.style.justifyContent = "flex-start";
@@ -821,6 +822,7 @@ const resetTimedOverlayLayout = (node: HTMLElement) => {
 
   titleRow.style.alignSelf = "";
   titleRow.style.alignItems = "";
+  titleRow.style.flex = "";
   titleRow.style.flexDirection = "";
   titleRow.style.gap = "";
   titleRow.style.justifyContent = "";

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -37,6 +37,8 @@ import { setWeekInteractionMotionActive } from "@web/views/Week/interaction/stat
 import {
   EVENT_ALLDAY_HEIGHT,
   EVENT_PADDING_RIGHT,
+  GRID_EVENT_TIME_LABEL_FONT_SIZE,
+  GRID_EVENT_TIME_LABEL_OPACITY,
   GRID_TIME_STEP,
   TIMED_EVENT_COLUMN_INSET,
 } from "@web/views/Week/layout.constants";
@@ -855,9 +857,9 @@ const getOrCreateOverlayTimeLabel = (
   const label = document.createElement("span");
 
   label.setAttribute("data-someday-interaction-time-label", "true");
-  label.style.fontSize = "11px";
+  label.style.fontSize = GRID_EVENT_TIME_LABEL_FONT_SIZE;
   label.style.marginLeft = "0";
-  label.style.opacity = "0.78";
+  label.style.opacity = GRID_EVENT_TIME_LABEL_OPACITY;
   label.style.alignSelf = "flex-start";
   label.style.flexShrink = "0";
   label.style.whiteSpace = "nowrap";

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -86,6 +86,10 @@ const SOMEDAY_OVERLAY_TRANSITION_ANCHORED =
   `transform ${SOMEDAY_OVERLAY_ANCHOR_MS}ms ${SOMEDAY_OVERLAY_EASING}`;
 const SOMEDAY_OVERLAY_SHADOW_LIFTED = `0 12px 28px color-mix(in srgb, ${theme.color.shadow.default} 22%, transparent)`;
 const SOMEDAY_OVERLAY_SHADOW_SETTLED = `0 6px 14px color-mix(in srgb, ${theme.color.shadow.default} 14%, transparent)`;
+const SOMEDAY_EVENT_TITLE_ROW_SELECTOR =
+  '[data-someday-event-title-row="true"]';
+const SOMEDAY_TIME_LABEL_SELECTOR =
+  '[data-someday-interaction-time-label="true"]';
 
 const inertRuntime: SomedayInteractionRuntime = {
   getSomedayEventById: () => null,
@@ -744,15 +748,14 @@ const mutateOverlay = (
     ? theme.color.text.dark
     : theme.color.text.lighter;
 
-  const timeLabel = getOrCreateOverlayTimeLabel(node);
-
   if (drop?.type !== "timed") {
-    timeLabel.remove();
+    node.querySelector<HTMLElement>(SOMEDAY_TIME_LABEL_SELECTOR)?.remove();
     return;
   }
 
   const start = dayjs().startOf("day").add(drop.startMinutes, "minutes");
   const end = start.add(ONE_HOUR_MINUTES, "minutes");
+  const timeLabel = getOrCreateOverlayTimeLabel(node);
 
   timeLabel.textContent = getTimesLabel(start.format(), end.format());
   timeLabel.style.display = event.title ? "inline" : "block";
@@ -764,21 +767,23 @@ const isReducedMotionPreferred = () =>
   window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 const getOrCreateOverlayTimeLabel = (node: HTMLElement) => {
-  const existing = node.querySelector<HTMLElement>(
-    "[data-someday-interaction-time-label]",
-  );
+  const existing = node.querySelector<HTMLElement>(SOMEDAY_TIME_LABEL_SELECTOR);
 
   if (existing) {
     return existing;
   }
 
+  const parent =
+    node.querySelector<HTMLElement>(SOMEDAY_EVENT_TITLE_ROW_SELECTOR) ?? node;
   const label = document.createElement("span");
 
   label.setAttribute("data-someday-interaction-time-label", "true");
   label.style.fontSize = "11px";
-  label.style.marginLeft = "4px";
+  label.style.marginLeft = parent === node ? "4px" : "0";
   label.style.opacity = "0.78";
-  node.append(label);
+  label.style.flexShrink = "0";
+  label.style.whiteSpace = "nowrap";
+  parent.append(label);
 
   return label;
 };

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -785,14 +785,20 @@ const getTimedDropDateRange = (
 
 const applyTimedOverlayLayout = (node: HTMLElement) => {
   const titleRow = getOverlayTitleRow(node);
+  const textStack = getOverlayTextStack(titleRow);
+
+  textStack.style.alignItems = "flex-start";
+  textStack.style.display = "flex";
+  textStack.style.flexDirection = "column";
+  textStack.style.justifyContent = "flex-start";
 
   titleRow.style.alignSelf = "stretch";
   titleRow.style.alignItems = "flex-start";
-  titleRow.style.flexDirection = "column";
+  titleRow.style.flexDirection = "row";
   titleRow.style.gap = "0";
   titleRow.style.justifyContent = "flex-start";
 
-  return titleRow;
+  return textStack;
 };
 
 const resetTimedOverlayLayout = (node: HTMLElement) => {
@@ -805,6 +811,13 @@ const resetTimedOverlayLayout = (node: HTMLElement) => {
   if (!titleRow) {
     return;
   }
+
+  const textStack = getOverlayTextStack(titleRow);
+
+  textStack.style.alignItems = "";
+  textStack.style.display = "";
+  textStack.style.flexDirection = "";
+  textStack.style.justifyContent = "";
 
   titleRow.style.alignSelf = "";
   titleRow.style.alignItems = "";
@@ -820,6 +833,9 @@ const removeOverlayTimeLabel = (node: HTMLElement) => {
 const getOverlayTitleRow = (node: HTMLElement) =>
   node.querySelector<HTMLElement>(SOMEDAY_EVENT_TITLE_ROW_SELECTOR) ?? node;
 
+const getOverlayTextStack = (titleRow: HTMLElement) =>
+  titleRow.parentElement ?? titleRow;
+
 const getOrCreateOverlayTimeLabel = (
   node: HTMLElement,
   parent: HTMLElement,
@@ -827,6 +843,10 @@ const getOrCreateOverlayTimeLabel = (
   const existing = node.querySelector<HTMLElement>(SOMEDAY_TIME_LABEL_SELECTOR);
 
   if (existing) {
+    if (existing.parentElement !== parent) {
+      parent.append(existing);
+    }
+
     return existing;
   }
 
@@ -836,6 +856,7 @@ const getOrCreateOverlayTimeLabel = (
   label.style.fontSize = "11px";
   label.style.marginLeft = "0";
   label.style.opacity = "0.78";
+  label.style.alignSelf = "flex-start";
   label.style.flexShrink = "0";
   label.style.whiteSpace = "nowrap";
   parent.append(label);

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -1,7 +1,6 @@
 import { Priorities } from "@core/constants/core.constants";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
-import dayjs from "@core/util/date/dayjs";
 import { type CalendarInteractionAdapter } from "@web/common/calendar-interaction/CalendarInteractionAdapter";
 import {
   type CalendarInteractionCancellationTargets,
@@ -39,7 +38,6 @@ import {
   EVENT_ALLDAY_HEIGHT,
   EVENT_PADDING_RIGHT,
   GRID_TIME_STEP,
-  MIN_EVENT_HEIGHT_FOR_TIME_LABEL,
   TIMED_EVENT_COLUMN_INSET,
 } from "@web/views/Week/layout.constants";
 import { somedayDropTargetRegistry } from "../registry/somedayDropTargetRegistry";
@@ -759,11 +757,6 @@ const mutateOverlay = (
   const titleRow = applyTimedOverlayLayout(node);
   const { end, start } = getTimedDropDateRange(drop, visual);
 
-  if (dayjs().isAfter(end) || !isOverlayTallEnoughForTimeLabel(node)) {
-    removeOverlayTimeLabel(node);
-    return;
-  }
-
   const timeLabel = getOrCreateOverlayTimeLabel(node, titleRow);
 
   timeLabel.textContent = getTimesLabel(start.format(), end.format());
@@ -826,12 +819,6 @@ const removeOverlayTimeLabel = (node: HTMLElement) => {
 
 const getOverlayTitleRow = (node: HTMLElement) =>
   node.querySelector<HTMLElement>(SOMEDAY_EVENT_TITLE_ROW_SELECTOR) ?? node;
-
-const isOverlayTallEnoughForTimeLabel = (node: HTMLElement) => {
-  const height = Number.parseFloat(node.style.height);
-
-  return Number.isNaN(height) || height >= MIN_EVENT_HEIGHT_FOR_TIME_LABEL;
-};
 
 const getOrCreateOverlayTimeLabel = (
   node: HTMLElement,

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -39,6 +39,7 @@ import {
   EVENT_ALLDAY_HEIGHT,
   EVENT_PADDING_RIGHT,
   GRID_TIME_STEP,
+  MIN_EVENT_HEIGHT_FOR_TIME_LABEL,
   TIMED_EVENT_COLUMN_INSET,
 } from "@web/views/Week/layout.constants";
 import { somedayDropTargetRegistry } from "../registry/somedayDropTargetRegistry";
@@ -299,7 +300,8 @@ export const createSomedayInteractionAdapter = ({
         return {
           overlay: {
             height: overlayRect?.height,
-            mutate: (node) => mutateOverlay(node, nextDrop, target.event),
+            mutate: (node) =>
+              mutateOverlay(node, nextDrop, target.event, nextVisual),
             transform: nextVisual.transform,
             width: overlayRect?.width,
           },
@@ -696,6 +698,7 @@ const mutateOverlay = (
   node: HTMLElement,
   drop: SomedayInteractionDrop | null,
   event: Schema_Event,
+  visual: SomedayInteractionVisual,
 ) => {
   node.style.overflow = "hidden";
 
@@ -749,16 +752,22 @@ const mutateOverlay = (
     : theme.color.text.lighter;
 
   if (drop?.type !== "timed") {
-    node.querySelector<HTMLElement>(SOMEDAY_TIME_LABEL_SELECTOR)?.remove();
+    resetTimedOverlayLayout(node);
     return;
   }
 
-  const start = dayjs().startOf("day").add(drop.startMinutes, "minutes");
-  const end = start.add(ONE_HOUR_MINUTES, "minutes");
-  const timeLabel = getOrCreateOverlayTimeLabel(node);
+  const titleRow = applyTimedOverlayLayout(node);
+  const { end, start } = getTimedDropDateRange(drop, visual);
+
+  if (dayjs().isAfter(end) || !isOverlayTallEnoughForTimeLabel(node)) {
+    removeOverlayTimeLabel(node);
+    return;
+  }
+
+  const timeLabel = getOrCreateOverlayTimeLabel(node, titleRow);
 
   timeLabel.textContent = getTimesLabel(start.format(), end.format());
-  timeLabel.style.display = event.title ? "inline" : "block";
+  timeLabel.style.display = "block";
 };
 
 const isReducedMotionPreferred = () =>
@@ -766,20 +775,79 @@ const isReducedMotionPreferred = () =>
   typeof window.matchMedia === "function" &&
   window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-const getOrCreateOverlayTimeLabel = (node: HTMLElement) => {
+const getTimedDropDateRange = (
+  drop: SomedayTimedDrop,
+  visual: SomedayInteractionVisual,
+) => {
+  const start = visual.initialViewStart
+    .add(visual.weekOffsetDays + drop.dayIndex, "day")
+    .startOf("day")
+    .add(drop.startMinutes, "minutes");
+
+  return {
+    end: start.add(ONE_HOUR_MINUTES, "minutes"),
+    start,
+  };
+};
+
+const applyTimedOverlayLayout = (node: HTMLElement) => {
+  const titleRow = getOverlayTitleRow(node);
+
+  titleRow.style.alignSelf = "stretch";
+  titleRow.style.alignItems = "flex-start";
+  titleRow.style.flexDirection = "column";
+  titleRow.style.gap = "0";
+  titleRow.style.justifyContent = "flex-start";
+
+  return titleRow;
+};
+
+const resetTimedOverlayLayout = (node: HTMLElement) => {
+  removeOverlayTimeLabel(node);
+
+  const titleRow = node.querySelector<HTMLElement>(
+    SOMEDAY_EVENT_TITLE_ROW_SELECTOR,
+  );
+
+  if (!titleRow) {
+    return;
+  }
+
+  titleRow.style.alignSelf = "";
+  titleRow.style.alignItems = "";
+  titleRow.style.flexDirection = "";
+  titleRow.style.gap = "";
+  titleRow.style.justifyContent = "";
+};
+
+const removeOverlayTimeLabel = (node: HTMLElement) => {
+  node.querySelector<HTMLElement>(SOMEDAY_TIME_LABEL_SELECTOR)?.remove();
+};
+
+const getOverlayTitleRow = (node: HTMLElement) =>
+  node.querySelector<HTMLElement>(SOMEDAY_EVENT_TITLE_ROW_SELECTOR) ?? node;
+
+const isOverlayTallEnoughForTimeLabel = (node: HTMLElement) => {
+  const height = Number.parseFloat(node.style.height);
+
+  return Number.isNaN(height) || height >= MIN_EVENT_HEIGHT_FOR_TIME_LABEL;
+};
+
+const getOrCreateOverlayTimeLabel = (
+  node: HTMLElement,
+  parent: HTMLElement,
+) => {
   const existing = node.querySelector<HTMLElement>(SOMEDAY_TIME_LABEL_SELECTOR);
 
   if (existing) {
     return existing;
   }
 
-  const parent =
-    node.querySelector<HTMLElement>(SOMEDAY_EVENT_TITLE_ROW_SELECTOR) ?? node;
   const label = document.createElement("span");
 
   label.setAttribute("data-someday-interaction-time-label", "true");
   label.style.fontSize = "11px";
-  label.style.marginLeft = parent === node ? "4px" : "0";
+  label.style.marginLeft = "0";
   label.style.opacity = "0.78";
   label.style.flexShrink = "0";
   label.style.whiteSpace = "nowrap";

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -81,6 +81,8 @@
   --animate-sync-dot-pulse: syncDotPulse 2.4s ease-in-out infinite;
   --animate-someday-commit-acknowledge: somedayCommitAcknowledge 260ms
     cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-someday-commit-time-exit: somedayCommitTimeExit 260ms
+    cubic-bezier(0.16, 1, 0.3, 1) both;
 
   @keyframes progressSlide {
     0% {
@@ -112,11 +114,23 @@
       scale: 1;
     }
   }
+
+  @keyframes somedayCommitTimeExit {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   :root {
     --animate-someday-commit-acknowledge: none;
+    --animate-someday-commit-time-exit: none;
   }
 }
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -81,14 +81,6 @@
   --animate-sync-dot-pulse: syncDotPulse 2.4s ease-in-out infinite;
   --animate-someday-commit-acknowledge: somedayCommitAcknowledge 260ms
     cubic-bezier(0.16, 1, 0.3, 1) both;
-  /* Someday-to-timed-grid drop choreography: the title moves from the overlay's
-     centered resting position to its natural top-aligned position, then the
-     time row fades in beneath it. Triggers only when the event is tall enough
-     to read both phases (handled in GridEvent). */
-  --animate-someday-commit-title-rise: somedayCommitTitleRise 280ms
-    cubic-bezier(0.16, 1, 0.3, 1) both;
-  --animate-someday-commit-time-fade: somedayCommitTimeFade 200ms
-    cubic-bezier(0.16, 1, 0.3, 1) 180ms both;
 
   @keyframes progressSlide {
     0% {
@@ -120,31 +112,11 @@
       scale: 1;
     }
   }
-
-  @keyframes somedayCommitTitleRise {
-    from {
-      transform: translateY(18px);
-    }
-    to {
-      transform: translateY(0);
-    }
-  }
-
-  @keyframes somedayCommitTimeFade {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   :root {
     --animate-someday-commit-acknowledge: none;
-    --animate-someday-commit-title-rise: none;
-    --animate-someday-commit-time-fade: none;
   }
 }
 

--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -37,12 +37,6 @@ import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { isWeekInteractionMotionActive } from "@web/views/Week/interaction/state/weekInteractionMotionState";
 import { MIN_EVENT_HEIGHT_FOR_TIME_LABEL } from "@web/views/Week/layout.constants";
 
-// Minimum event height for the layered title-rise + time-fade choreography
-// to read meaningfully. Below this, the block-level acknowledgment plays
-// alone (degraded case) because the title has no vertical headroom to rise
-// from and the time row would arrive in the same frame as the title.
-const MIN_EVENT_HEIGHT_FOR_COMMIT_CHOREOGRAPHY = 40;
-
 interface Props {
   displayMode: GridEventDisplayMode;
   event: Schema_GridEvent;
@@ -104,15 +98,6 @@ const GridEventBase = (
     isDraft,
   );
 
-  // Layered title-rise + time-fade choreography runs alongside the
-  // block-level acknowledgment on commit, but only when the event is a
-  // timed event with enough vertical room to stage the rise and the
-  // following time-row fade. AllDayEvent and short timed events fall back
-  // to the block-level settle alone.
-  const shouldChoreographCommit =
-    shouldAcknowledgeCommit &&
-    !event.isAllDay &&
-    position.height >= MIN_EVENT_HEIGHT_FOR_COMMIT_CHOREOGRAPHY;
   const lineClamp = useMemo(
     () => getLineClamp(position.height),
     [position.height],
@@ -241,22 +226,12 @@ const GridEventBase = (
         direction={FlexDirections.COLUMN}
         flexWrap={FlexWrap.WRAP}
       >
-        <span
-          className={cn({
-            "animate-someday-commit-title-rise": shouldChoreographCommit,
-          })}
-          style={titleStyle}
-        >
-          {event.title}
-        </span>
+        <span style={titleStyle}>{event.title}</span>
         {!event.isAllDay && (
           <>
             {(isDraft || !isInPast) &&
               position.height >= MIN_EVENT_HEIGHT_FOR_TIME_LABEL && (
                 <Text
-                  className={cn({
-                    "animate-someday-commit-time-fade": shouldChoreographCommit,
-                  })}
                   data-week-event-time-label="true"
                   size="xs"
                   zIndex={ZIndex.LAYER_3}

--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -35,7 +35,12 @@ import { Text } from "@web/components/Text";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { isWeekInteractionMotionActive } from "@web/views/Week/interaction/state/weekInteractionMotionState";
-import { MIN_EVENT_HEIGHT_FOR_TIME_LABEL } from "@web/views/Week/layout.constants";
+import {
+  GRID_EVENT_TIME_LABEL_FONT_SIZE,
+  GRID_EVENT_TIME_LABEL_OPACITY,
+  GRID_EVENT_TITLE_LINE_HEIGHT,
+  MIN_EVENT_HEIGHT_FOR_TIME_LABEL,
+} from "@web/views/Week/layout.constants";
 
 interface Props {
   displayMode: GridEventDisplayMode;
@@ -153,7 +158,7 @@ const GridEventBase = (
 
   const titleStyle: CSSProperties = {
     fontSize: position.height <= 15 ? "10px" : "13px",
-    lineHeight: position.height <= 15 ? "1.1" : undefined,
+    lineHeight: position.height <= 15 ? "1.1" : GRID_EVENT_TITLE_LINE_HEIGHT,
     minHeight: "3px",
     display: "-webkit-box",
     overflow: "hidden",
@@ -161,6 +166,12 @@ const GridEventBase = (
     wordBreak: "break-all",
     WebkitBoxOrient: "vertical",
     WebkitLineClamp: lineClamp,
+  };
+
+  const timeLabelStyle: CSSProperties = {
+    fontSize: GRID_EVENT_TIME_LABEL_FONT_SIZE,
+    opacity: GRID_EVENT_TIME_LABEL_OPACITY,
+    whiteSpace: "nowrap",
   };
 
   const showResizeCursor =
@@ -242,7 +253,7 @@ const GridEventBase = (
                       shouldAnimatePastCommitTimeOut,
                   })}
                   data-week-event-time-label="true"
-                  size="xs"
+                  style={timeLabelStyle}
                   zIndex={ZIndex.LAYER_3}
                 >
                   {event.startDate &&

--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -102,6 +102,10 @@ const GridEventBase = (
     () => getLineClamp(position.height),
     [position.height],
   );
+  const isTallEnoughForTimeLabel =
+    position.height >= MIN_EVENT_HEIGHT_FOR_TIME_LABEL;
+  const shouldAnimatePastCommitTimeOut =
+    shouldAcknowledgeCommit && isInPast && !isDraft && isTallEnoughForTimeLabel;
 
   const priority = event.priority || Priorities.UNASSIGNED;
   const baseColor = gridColorByPriority[priority];
@@ -229,9 +233,14 @@ const GridEventBase = (
         <span style={titleStyle}>{event.title}</span>
         {!event.isAllDay && (
           <>
-            {(isDraft || !isInPast) &&
-              position.height >= MIN_EVENT_HEIGHT_FOR_TIME_LABEL && (
+            {(isDraft || !isInPast || shouldAnimatePastCommitTimeOut) &&
+              isTallEnoughForTimeLabel && (
                 <Text
+                  aria-hidden={shouldAnimatePastCommitTimeOut || undefined}
+                  className={cn({
+                    "animate-someday-commit-time-exit opacity-0":
+                      shouldAnimatePastCommitTimeOut,
+                  })}
                   data-week-event-time-label="true"
                   size="xs"
                   zIndex={ZIndex.LAYER_3}

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
@@ -418,6 +418,32 @@ describe("WeekInteractionAdapter timed drag", () => {
     ).toBeNull();
   });
 
+  it("adds a temporary time label while dragging a saved timed event that did not render one", () => {
+    const { adapter, child, flushFrame } = createHarness();
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: child, x: 320, y: 1020 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: child, x: 320, y: 1120 }),
+    );
+
+    flushFrame();
+
+    const overlay = document.body.querySelector<HTMLElement>(
+      "[data-calendar-interaction-overlay]",
+    );
+    const timeLabel = overlay?.querySelector<HTMLElement>(
+      "[data-week-event-time-label='true']",
+    );
+
+    expect(timeLabel).toBeTruthy();
+    expect(timeLabel?.textContent).toMatch(/10\s+-\s+11 AM/);
+    expect(timeLabel?.previousElementSibling).toBe(
+      overlay?.querySelector("span"),
+    );
+  });
+
   it("continues timed smart scroll in the RAF loop and feeds scroll delta into commit time", () => {
     const { adapter, child, flushFrame, mainGrid, onCommitTimedDrag } =
       createHarness();

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -80,6 +80,7 @@ const inertRuntime: WeekInteractionRuntime = {
 };
 
 const WEEK_EVENT_RESIZE_HANDLE_ATTRIBUTE = "data-week-event-resize-handle";
+const WEEK_EVENT_TIME_LABEL_SELECTOR = "[data-week-event-time-label='true']";
 const activeEdgeNavigationIndicatorState = {
   currentEdge: null,
   isDragging: true,
@@ -776,13 +777,61 @@ const readElementRect = (element: HTMLElement): VisualRect => {
 };
 
 const updateOverlayTimeLabel = (node: HTMLElement, event: Schema_GridEvent) => {
-  const timeLabel = node.querySelector<HTMLElement>(
-    "[data-week-event-time-label='true']",
-  );
-
-  if (!timeLabel || !event.startDate || !event.endDate) {
+  if (!event.startDate || !event.endDate) {
     return;
   }
 
+  const timeLabel = getOrCreateOverlayTimeLabel(node);
+
+  timeLabel.removeAttribute("aria-hidden");
+  timeLabel.classList.remove("animate-someday-commit-time-exit", "opacity-0");
+  timeLabel.style.display = "block";
   timeLabel.textContent = getTimesLabel(event.startDate, event.endDate);
+};
+
+const getOrCreateOverlayTimeLabel = (node: HTMLElement) => {
+  const existing = node.querySelector<HTMLElement>(
+    WEEK_EVENT_TIME_LABEL_SELECTOR,
+  );
+
+  if (existing) {
+    return existing;
+  }
+
+  const label = document.createElement("span");
+
+  label.setAttribute("data-week-event-time-label", "true");
+  label.style.fontSize = "0.563rem";
+  label.style.position = "relative";
+  label.style.zIndex = "3";
+
+  const parent = getOverlayTimeLabelParent(node);
+  const resizeHandle = getFirstDirectResizeHandle(parent);
+
+  parent.insertBefore(label, resizeHandle);
+
+  return label;
+};
+
+const getOverlayTimeLabelParent = (node: HTMLElement) => {
+  const firstChild = node.firstElementChild;
+
+  if (firstChild instanceof HTMLElement && firstChild.tagName !== "SPAN") {
+    return firstChild;
+  }
+
+  return node;
+};
+
+const getFirstDirectResizeHandle = (node: HTMLElement) => {
+  for (const child of node.children) {
+    if (
+      child instanceof HTMLElement &&
+      child.hasAttribute(WEEK_EVENT_RESIZE_HANDLE_ATTRIBUTE)
+    ) {
+      return child;
+    }
+  }
+
+  return null;
 };

--- a/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
+++ b/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
@@ -359,7 +359,7 @@ describe("weekEventRegistry", () => {
     expect(weekEventRegistry.resolve("pending-event", "timed")).toBeNull();
   });
 
-  it("acknowledges a dropped timed event with block and text choreography", () => {
+  it("acknowledges a dropped timed event without moving the text", () => {
     const event = createTimedEvent({
       endDate: "2026-05-22T10:00:00.000Z",
       startDate: "2026-05-22T09:00:00.000Z",
@@ -374,8 +374,8 @@ describe("weekEventRegistry", () => {
 
     expect(element).toHaveClass("animate-someday-commit-acknowledge");
     expectEventBgToUseHoverColor(element);
-    expect(title).toHaveClass("animate-someday-commit-title-rise");
-    expect(timeLabel).toHaveClass("animate-someday-commit-time-fade");
+    expect(title).not.toHaveClass("animate-someday-commit-title-rise");
+    expect(timeLabel).not.toHaveClass("animate-someday-commit-time-fade");
   });
 
   it("settles short dropped timed events without text choreography", () => {

--- a/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
+++ b/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
@@ -394,6 +394,21 @@ describe("weekEventRegistry", () => {
     expect(title).not.toHaveClass("animate-someday-commit-title-rise");
   });
 
+  it("slides the time out when a dropped timed event lands in the past", () => {
+    const event = createTimedEvent({
+      endDate: "2026-05-18T10:00:00.000Z",
+      startDate: "2026-05-18T09:00:00.000Z",
+    });
+
+    markSomedayCommitAcknowledgement(event._id!);
+    renderWithStore(<RegisteredTimedEventHarness event={event} />);
+
+    const timeLabel = screen.getByText(/9\s+-\s+10 AM/);
+
+    expect(timeLabel).toHaveAttribute("aria-hidden", "true");
+    expect(timeLabel).toHaveClass("animate-someday-commit-time-exit");
+  });
+
   it("settles dropped all-day events without text choreography", () => {
     const event = createAllDayEvent();
 

--- a/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
+++ b/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
@@ -16,6 +16,11 @@ import { GridEvent } from "@web/views/Week/components/Event/Grid/GridEvent/GridE
 import { AllDayEventMemo } from "@web/views/Week/components/Grid/AllDayRow/AllDayEvent";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
+import {
+  GRID_EVENT_TIME_LABEL_FONT_SIZE,
+  GRID_EVENT_TIME_LABEL_OPACITY,
+  GRID_EVENT_TITLE_LINE_HEIGHT,
+} from "@web/views/Week/layout.constants";
 import { createWeekInteractionEventOverlayMount } from "../adapter/dom/cloneWeekInteractionEventElement";
 import {
   createWeekEventRegistry,
@@ -392,6 +397,23 @@ describe("weekEventRegistry", () => {
     expect(element).toHaveClass("animate-someday-commit-acknowledge");
     expectEventBgToUseHoverColor(element);
     expect(title).not.toHaveClass("animate-someday-commit-title-rise");
+  });
+
+  it("renders a saved timed event with the Someday preview text style", () => {
+    const event = createTimedEvent({
+      endDate: "2026-05-22T10:00:00.000Z",
+      startDate: "2026-05-22T09:00:00.000Z",
+    });
+
+    renderWithStore(<RegisteredTimedEventHarness event={event} />);
+
+    const title = screen.getByText("Timed event");
+    const timeLabel = screen.getByText(/9\s+-\s+10 AM/);
+
+    expect(title.style.lineHeight).toBe(GRID_EVENT_TITLE_LINE_HEIGHT);
+    expect(timeLabel.style.fontSize).toBe(GRID_EVENT_TIME_LABEL_FONT_SIZE);
+    expect(timeLabel.style.opacity).toBe(GRID_EVENT_TIME_LABEL_OPACITY);
+    expect(timeLabel.previousElementSibling).toBe(title);
   });
 
   it("slides the time out when a dropped timed event lands in the past", () => {

--- a/packages/web/src/views/Week/layout.constants.ts
+++ b/packages/web/src/views/Week/layout.constants.ts
@@ -14,6 +14,9 @@ export const EVENT_ALLDAY_GAP = 3;
 export const EVENT_ALLDAY_ROW_HEIGHT = EVENT_ALLDAY_HEIGHT + EVENT_ALLDAY_GAP;
 export const EVENT_PADDING_RIGHT = 10;
 export const TIMED_EVENT_COLUMN_INSET = 5;
+export const GRID_EVENT_TIME_LABEL_FONT_SIZE = "11px";
+export const GRID_EVENT_TIME_LABEL_OPACITY = "0.78";
+export const GRID_EVENT_TITLE_LINE_HEIGHT = "16px";
 /** Minimum rendered event height (px) to show the time label below the title.
  *  Below this the label is suppressed to prevent overflow on short events.
  *  At typical hourHeight (~65px/hr): 30-min ≈ 33px (hidden), 45-min ≈ 49px (shown). */


### PR DESCRIPTION
## Summary

Fixes #1801.

When a Someday event is dragged from the sidebar onto the Timed Grid, the hover preview now uses the same visual structure as a Timed Event: the title starts at the top and the time appears underneath it.

The preview always shows the tentative time while the event is hovering over the grid, including when the target time is already in the past. That gives the user constant feedback about the slot they are aiming for while dragging.

The saved Timed Event now shares the same title/time text treatment as the Someday preview, so the handoff after drop does not visually change the typography or spacing. Future events keep the time visible. Past events hide the time after drop, and Someday drops into past slots animate the time up and out so the transition feels intentional instead of abrupt.

This also covers the related saved timed-event drag path: if a past saved Timed Event starts from a final state that does not render a time label, its drag clone creates a temporary time label while moving so the user can still place it accurately.

The acceptance runbook documents the split between hover-preview behavior and final saved-event behavior.

## Verification

- `bun test src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts src/views/Week/interaction/registry/weekEventRegistry.test.tsx`
- `bunx playwright test e2e/someday/drag-someday-event-mouse.spec.ts --project=chromium-desktop`
- `bun type-check`
- `bun lint`
- `bunx react-doctor@latest . --verbose --diff`
