### PR TITLE
test(web): stabilize week registry clock

### DIFF
--- a/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
+++ b/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
@@ -32,7 +32,15 @@ import {
   type WeekInteractionEventType,
   weekEventRegistry,
 } from "./weekEventRegistry";
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
 
 const startOfView = dayjs("2026-05-17T00:00:00.000Z");
 const endOfView = startOfView.add(7, "day");
@@ -227,7 +235,12 @@ const RegisteredAllDayEventHarness = ({
   );
 };
 
+beforeEach(() => {
+  setSystemTime(new Date("2026-05-19T00:00:00.000Z"));
+});
+
 afterEach(() => {
+  setSystemTime();
   act(() => {
     __resetSomedayCommitAcknowledgementState();
   });


### PR DESCRIPTION
## Summary
- Freeze the Week event registry test clock so its May 2026 past/future examples stay stable.
- Restore real time after each test.

## Evidence
- GitHub Actions Test run 26301965222 failed in unit (web), job 77429129727, at packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx:411.
- Local reproduction on ac02269af335 failed the same test because the event ending 2026-05-22 was treated as past on 2026-05-23.

## Verification
- bun test --cwd packages/web src/views/Week/interaction/registry/weekEventRegistry.test.tsx
- bun test:web
- bun type-check
- bun lint
