### PR TITLE
fix(web): keep now description escape local

### DIFF
--- a/packages/web/src/views/Now/components/TaskDescription/TaskDescription.tsx
+++ b/packages/web/src/views/Now/components/TaskDescription/TaskDescription.tsx
@@ -1,6 +1,13 @@
 import { FloppyDisk, Pencil } from "@phosphor-icons/react";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { flushSync } from "react-dom";
 import styled from "styled-components";
 import {
   CompassDOMEvents,
@@ -163,7 +170,7 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({
     originalValueRef.current = description;
   }, [description]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isEditing && textareaRef.current) {
       const length = textareaRef.current.value.length;
 
@@ -175,7 +182,9 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({
   useEffect(() => {
     if (isEditing) return;
 
-    const handler = () => setIsEditing(true);
+    const handler = () => {
+      flushSync(() => setIsEditing(true));
+    };
 
     compassEventEmitter.on(CompassDOMEvents.FOCUS_TASK_DESCRIPTION, handler);
 

--- a/packages/web/src/views/Now/shortcuts/useNowShortcuts.test.tsx
+++ b/packages/web/src/views/Now/shortcuts/useNowShortcuts.test.tsx
@@ -1,12 +1,21 @@
 import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
-import { renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { type PropsWithChildren } from "react";
 import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider } from "styled-components";
+import { theme } from "@web/common/styles/theme";
 import {
   CompassDOMEvents,
   compassEventEmitter,
   pressKey,
 } from "@web/common/utils/dom/event-emitter.util";
+import { TaskDescription } from "../components/TaskDescription/TaskDescription";
 import { useNowShortcuts } from "./useNowShortcuts";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -19,6 +28,16 @@ function wrapper({ children }: PropsWithChildren) {
         {children}
       </MemoryRouter>
     </HotkeysProvider>
+  );
+}
+
+function NowDescriptionHarness({ onEscape }: { onEscape: () => void }) {
+  useNowShortcuts({ onEscape });
+
+  return (
+    <ThemeProvider theme={theme}>
+      <TaskDescription description="Notes" onSave={mock()} />
+    </ThemeProvider>
   );
 }
 
@@ -44,6 +63,22 @@ describe("useNowShortcuts", () => {
     await waitFor(() => {
       expect(onFocusDescription).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("does not run the global Escape shortcut when Escape follows E D", async () => {
+    const onEscape = mock();
+    render(<NowDescriptionHarness onEscape={onEscape} />, { wrapper });
+
+    act(() => {
+      pressKey("e");
+      pressKey("d");
+      pressKey("Escape", {}, document.activeElement ?? document);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Notes")).toBeTruthy();
+    });
+    expect(onEscape).not.toHaveBeenCalled();
   });
 
   it("does not focus description when pressing D alone", async () => {


### PR DESCRIPTION
## Summary
- Keep the Now description editor mounted and focused synchronously when `E D` opens it.
- Add regression coverage for pressing `E`, `D`, then `Escape` quickly so the global Escape shortcut does not run.

## Evidence
- Scan window started after the last automation run at `2026-05-23T14:01:13.101Z`.
- `origin/main` advanced to `3771d243b4cd7f3eb43cf741b2e66eabecacb7a1` from PR #1807, which changed Now description editing to the `E D` shortcut and added a global Escape path back to Day.
- A local regression test reproduced the bug against the current merged code: the fast `E D Escape` sequence called the global Escape handler once.
- Root cause: the description editor was opened through an async state update, so a fast following Escape could be handled before the textarea was mounted and focused.

## Validation
- `bun test --cwd packages/web src/views/Now/shortcuts/useNowShortcuts.test.tsx src/views/Now/components/TaskDescription/TaskDescription.test.tsx`
- `bun test:web`
- `bun type-check`
- `bun lint`
- `git diff --check`
