### PR TITLE
fix: update auth state immediately on sign out

### DIFF
--- a/packages/web/src/auth/compass/session/SessionProvider.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.tsx
@@ -54,7 +54,7 @@ SuperTokens.init({
 
 export const SessionContext = createContext<CompassSession>({
   authenticated: false,
-  setAuthenticated: () => {},
+  setAuthenticated: () => { },
 });
 
 const authenticated$ = new BehaviorSubject(false);
@@ -131,7 +131,8 @@ export function sessionInit() {
         sse.openStream();
         break;
       case "SIGN_OUT":
-        store.dispatch(userMetadataSlice.actions.clear(undefined));
+        authenticated$.next(false);
+        handleSessionMissing();
         sse.closeStream();
         break;
     }


### PR DESCRIPTION
## Summary

Fixes the command palette showing both "Log In" and "Log Out" actions after signing out.

Closes #1809

## Changes Made

* Updated the `SIGN_OUT` session event handling to immediately set the authentication state to logged out instead of waiting for the async session check to complete.
* Added `handleSessionMissing()` during sign out to ensure auth-related state is cleared consistently across the app.

## Result

After logging out, the session state now updates instantly, so the command palette correctly shows only the relevant authentication actions.
