### PR TITLE
[codex] add bug capture skill

### DIFF
--- a/.agents/skills/bug-capture/SKILL.md
+++ b/.agents/skills/bug-capture/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: bug-capture
+description: Capture a reported bug as a high-context GitHub issue after targeted diagnosis. Use when a user reports a bug, shares reproduction steps or screenshots, and wants the issue tracker to contain enough context for a later agent to fix it quickly.
+---
+
+# Bug Capture
+
+Capture a real bug as a GitHub issue with enough evidence for a later agent to
+fix it quickly: workflow, screenshot evidence, diagnosis, likely fix, and
+verification path.
+
+## Rules
+
+- Investigate, but do not fix: no product-code edits, branches, commits, or
+  leftover temporary files.
+- Do not overstate certainty. Say when a bug was reproduced, when it was not
+  reproduced, and how confident you are in the diagnosis.
+- Spend tokens on evidence that changes the issue. Summarize long logs, files,
+  and screenshots instead of pasting them.
+
+## Process
+
+### 1. Gather
+
+Use existing context first: reporter description, screen/route/feature,
+workflow, actual result, expected result, environment/account state, screenshot,
+logs, and issue links.
+
+For screenshots:
+
+- Inspect attached screenshots and summarize what matters.
+- Use `[screenshot]` in the issue unless the reporter provides a real URL or
+  safe path to reference.
+- Keep image observations in the summary or diagnosis, not in a long screenshot
+  section.
+
+### 2. Investigate
+
+Inspect before asking questions.
+
+- Read only relevant domain docs (`CONTEXT.md`, feature docs, ADRs).
+- Search for the reported screen, route, component, API, event, or error text.
+- Check nearby tests and recent local patterns.
+- Reproduce or run the narrowest practical UI/API/test flow when available.
+- Use sub-agents only for independent questions; ask each for concise findings.
+
+Record concrete evidence: whether you reproduced it, commands/run results,
+browser observations, likely affected files/modules, and confidence.
+
+### 3. Clarify
+
+Ask questions only after investigation, only for facts you cannot infer.
+
+- Ask one question at a time.
+- Ask at most 3 questions total.
+- Include your recommended/default answer.
+- Focus on missing screen/step, reproducibility, expected behavior, or relevant
+  account/auth/Google/self-hosted state.
+
+If key facts are still missing, publish a useful issue with an information-needed
+label.
+
+### 4. Prepare GitHub
+
+- Use GitHub Issues through `gh`, inferred from the current repo remote.
+- Ensure a `bug` label exists; create it if missing.
+- Normal capture: apply `bug` and `needs-triage`.
+- Incomplete capture: apply `bug` and `needs-info`. If an obvious equivalent
+  already exists, such as `needs more info`, use it instead of creating a
+  duplicate.
+- Never apply `ready-for-agent` automatically.
+
+### 5. Dedupe
+
+Search open issues with screen, route, workflow, error, and symptom keywords.
+
+- Strong duplicate: comment on it with the new workflow, screenshot placeholder,
+  diagnosis, likely fix, and verification path.
+- Weak match: create a new issue and mention the possible relation.
+- No match: create a new issue.
+
+### 6. Publish
+
+Use title format:
+
+```text
+<area>: <observable broken behavior>
+```
+
+Use this body:
+
+```md
+## Bug report
+
+Short summary of what is broken and who is affected.
+
+## Where it happened
+
+Route, screen, feature, environment, or account state.
+
+## Workflow
+
+1. Reporter step.
+2. Reporter step.
+3. What happened.
+
+## Expected outcome
+
+What should have happened.
+
+## Screenshot
+
+[screenshot]
+
+## Diagnosis
+
+Reproduction status, strongest evidence, likely affected files/modules,
+confidence, and related issue if any.
+
+## Likely fix
+
+Concrete handoff prompt for the fixing agent: where to start and what behavior
+to preserve.
+
+## Verification
+
+Shortest practical flow, test, or command proving the fix.
+```
+
+If publishing fails, report the failure and provide the draft body.
+
+### 7. Report
+
+Return the issue URL, whether it was new or a duplicate comment, any missing
+information, and a short plain-English diagnosis/likely-fix summary.

--- a/.agents/skills/bug-capture/agents/openai.yaml
+++ b/.agents/skills/bug-capture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bug Capture"
+  short_description: "Capture bugs as rich GitHub issues"
+  default_prompt: "Use $bug-capture to investigate this bug report and create a GitHub issue."


### PR DESCRIPTION
## Summary

Adds a new `bug-capture` agent skill for turning a bug report into a high-context GitHub issue. The skill is intentionally standalone and token-conscious: it tells the agent to investigate only what changes the issue, ask at most three targeted follow-up questions, and avoid fixing product code during capture.

This also adds `agents/openai.yaml` metadata so the skill is easier to identify in Codex.

## How to use `bug-capture`

1. In Codex, invoke `$bug-capture` and describe the bug: where Tyler found it, the workflow he followed, what happened, and what should have happened instead.
2. Attach the screenshot in the chat when available.
3. The agent inspects the report, screenshot, relevant docs, and code before asking questions.
4. If anything important is still unclear, the agent asks one question at a time, with a maximum of three questions.
5. The agent searches open GitHub issues for likely duplicates.
6. If it finds a strong duplicate, it comments there with the new evidence. Otherwise it creates a new issue.
7. The issue gets `bug` plus `needs-triage` for normal captures, or an information-needed label if the report is still too incomplete.

The screenshot flow is deliberately lightweight: if Codex can inspect the screenshot but cannot upload it to GitHub, the issue uses `[screenshot]` as the placeholder and summarizes the visual evidence in the issue text.

## Issue shape

The skill creates or comments with these sections:

- Bug report
- Where it happened
- Workflow
- Expected outcome
- Screenshot
- Diagnosis
- Likely fix
- Verification

## Validation

- Ran the skill-creator validator against `.agents/skills/bug-capture`
- Ran `bun lint`
- Checked for whitespace/non-ASCII issues
- Checked for secret-shaped strings in the new skill files
