### PR TITLE
fix(web): ignore right-click resize starts

### DIFF
--- a/packages/web/src/components/DND/Resizable.test.tsx
+++ b/packages/web/src/components/DND/Resizable.test.tsx
@@ -11,7 +11,7 @@ mock.module("@web/common/hooks/usePointerPosition", () => ({
 type MockResizeStart = (
   event: ReactMouseEvent<HTMLButtonElement>,
   direction: "right",
-  element: null,
+  element: HTMLElement,
 ) => void;
 
 type MockResizeStop = (
@@ -35,7 +35,7 @@ mock.module("re-resizable", () => ({
       <button
         type="button"
         data-testid="resize-start"
-        onClick={(e) => onResizeStart?.(e, "right", null)}
+        onMouseDown={(e) => onResizeStart?.(e, "right", e.currentTarget)}
       >
         Start
       </button>
@@ -71,8 +71,26 @@ describe("Resizable", () => {
       </Resizable>,
     );
 
-    fireEvent.click(getByTestId("resize-start"));
+    fireEvent.mouseDown(getByTestId("resize-start"));
     expect(mockTogglePointerMovementTracking).toHaveBeenCalledWith(true);
+  });
+
+  it("does not start resizing from right click", () => {
+    const mockOnResizeStart = mock();
+    const { getByTestId } = render(
+      <Resizable
+        id="test-id"
+        defaultSize={{ width: 100, height: 100 }}
+        onResizeStart={mockOnResizeStart}
+      >
+        <div>Content</div>
+      </Resizable>,
+    );
+
+    fireEvent.mouseDown(getByTestId("resize-start"), { button: 2 });
+
+    expect(mockTogglePointerMovementTracking).not.toHaveBeenCalled();
+    expect(mockOnResizeStart).not.toHaveBeenCalled();
   });
 
   it("calls togglePointerMovementTracking with false on resize stop", () => {

--- a/packages/web/src/components/DND/Resizable.tsx
+++ b/packages/web/src/components/DND/Resizable.tsx
@@ -34,6 +34,10 @@ export function Resizable({
 
   const handleResizeStart = useCallback<ResizeStartCallback>(
     (e, direction, ref) => {
+      if ("button" in e && e.button !== 0) {
+        return false;
+      }
+
       togglePointerMovementTracking(true);
       resizing$.next(true);
       resizeId$.next(id);


### PR DESCRIPTION
## Summary
- Prevent right-clicks from starting event resizing in the shared resize wrapper used by Day view.
- Add a regression test that verifies right-click resize starts are ignored.

Closes #1815.

## Root cause
Day view resize handles started resizing for any mouse button. Holding the right mouse button on a resize edge and moving the pointer could therefore resize the event while the user was trying to use the context menu.

## Validation
- `cd packages/web && bun test src/components/DND/Resizable.test.tsx`
- Reproduced the Day-view right-click-hold-and-move bug locally, then confirmed the event height stayed unchanged after the fix.
- `bun run type-check`
- `bun lint`

Note: `bun run test:web` is blocked by a repeatable Bun 1.2.3 crash in the unrelated `src/common/hooks/useLogoutCmdItems.test.ts` file.