### PR TITLE
chore: simplify labels

### DIFF
--- a/.agents/config/triage-labels.md
+++ b/.agents/config/triage-labels.md
@@ -1,14 +1,11 @@
 # Triage Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those
+The skills speak in terms of canonical triage roles. This file maps those
 roles to the actual label strings used in this repo's issue tracker.
 
 | Label in mattpocock/skills | Label in our tracker | Meaning                                  |
 | -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
-| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
-| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
-| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `needs-info`               | `needs more info`    | Waiting on more information              |
 | `wontfix`                  | `wontfix`            | Will not be actioned                     |
 
 When a skill mentions a role, use the corresponding label string from this

--- a/.agents/skills/bug-capture/SKILL.md
+++ b/.agents/skills/bug-capture/SKILL.md
@@ -65,10 +65,8 @@ label.
 - Use GitHub Issues through `gh`, inferred from the current repo remote.
 - Ensure a `bug` label exists; create it if missing.
 - Normal capture: apply `bug` and `needs-triage`.
-- Incomplete capture: apply `bug` and `needs-info`. If an obvious equivalent
-  already exists, such as `needs more info`, use it instead of creating a
-  duplicate.
-- Never apply `ready-for-agent` automatically.
+- Incomplete capture: apply `bug` and `needs more info`. If an obvious equivalent
+  already exists use it instead of creating a  duplicate.
 
 ### 5. Dedupe
 


### PR DESCRIPTION
FYI @Uarmagan. We already have `needs more info`, so no need to overcomplicate with `needs-triage` and these other labels. 