### PR TITLE
[codex] update Playwright e2e runner and improve speed to completion

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,13 +7,26 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      # Keep this tag aligned with the Playwright version in bun.lock.
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      options: --ipc=host
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Install Bun setup prerequisites
+        run: apt-get update && apt-get install -y --no-install-recommends unzip
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -36,10 +49,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+      - name: Verify Playwright browser install
+        timeout-minutes: 3
+        run: bunx playwright install chromium
 
       - name: Run e2e tests
+        timeout-minutes: 8
         env:
           TZ: Etc/UTC
           GOOGLE_CLIENT_ID: test-client-id

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.0",
         "@biomejs/biome": "^2.4.12",
-        "@playwright/test": "^1.56.0",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^22.13.10",
         "@types/node-fetch": "^2.6.13",
         "jest": "^29.0.3",
@@ -616,7 +616,7 @@
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
-    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
@@ -1792,9 +1792,9 @@
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
-    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
-    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "pony-cause": ["pony-cause@2.1.11", "", {}, "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.0",
     "@biomejs/biome": "^2.4.12",
-    "@playwright/test": "^1.56.0",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22.13.10",
     "@types/node-fetch": "^2.6.13",
     "jest": "^29.0.3",


### PR DESCRIPTION
## Summary

This PR updates the e2e runner to the latest Playwright release and keeps the GitHub Actions browser environment aligned with it.

It also makes the PR e2e workflow less likely to block indefinitely by canceling stale runs, adding job/step time limits, and running inside the official Playwright container instead of installing Linux browser dependencies on every run.

## Why

Recent PR e2e runs were sometimes getting stuck before tests started, specifically during the Playwright browser setup step. Moving to the Playwright container and adding explicit limits should make normal runs faster to start and prevent stuck setup from consuming hours.

The first containerized CI run exposed one extra environment prerequisite: `oven-sh/setup-bun` needs `unzip`, which the Playwright image does not include by default. This PR now installs that small prerequisite before setting up Bun.

## Changes

- Upgrade `@playwright/test` to `1.60.0` in `package.json` and `bun.lock`.
- Update the e2e workflow to use `mcr.microsoft.com/playwright:v1.60.0-noble`.
- Add PR-run concurrency so newer commits cancel older e2e runs for the same PR.
- Add a 15-minute job timeout, a 3-minute browser verification timeout, and an 8-minute e2e step timeout.
- Install `unzip` before `oven-sh/setup-bun` inside the Playwright container.
- Replace `playwright install --with-deps chromium` with a short browser verification step, since the container already includes the browser dependencies.

## Validation

- `npm view @playwright/test dist-tags.latest version` confirmed `1.60.0`.
- Verified the `mcr.microsoft.com/playwright:v1.60.0-noble` image exists for Linux runners.
- `bun install --frozen-lockfile`
- `bunx playwright --version` -> `1.60.0`
- `bunx playwright install chromium`
- `bunx playwright test --list` -> `44 tests`
- TanStack hotkey tests: `40 passed`
- `bun run type-check`
- `CI=1 bun run test:e2e` -> `41 passed, 3 skipped`
- `bun lint`
- `git diff --check`
- GitHub Actions e2e run after the container prerequisite fix: passed
