### PR TITLE
fix(web): prevent day agenda replacement form

### DIFF
--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -82,6 +82,15 @@ mock.module("@web/common/calendar-grid/hooks/useCalendarGridLayout", () => ({
   },
 }));
 
+const floatingUi =
+  require("@floating-ui/react") as typeof import("@floating-ui/react");
+const useDismissMock = mock(floatingUi.useDismiss);
+
+mock.module("@floating-ui/react", () => ({
+  ...floatingUi,
+  useDismiss: useDismissMock,
+}));
+
 mock.module("@web/components/FloatingEventForm/FloatingEventForm", () => ({
   FloatingEventForm: () => null,
 }));
@@ -130,6 +139,7 @@ const setDraftEvent = (event: Schema_Event) => {
 
 beforeEach(() => {
   store = createStoreWithEvents([]);
+  useDismissMock.mockClear();
 });
 
 afterEach(() => {
@@ -354,6 +364,18 @@ describe("DayCalendarGrid", () => {
     });
 
     expect(getDraft()).toBeNull();
+  });
+
+  it("dismisses the floating form after empty agenda mouse handlers run", () => {
+    renderDayCalendarGrid();
+
+    expect(useDismissMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        enabled: true,
+        outsidePressEvent: "click",
+      }),
+    );
   });
 
   it("dismisses an open draft when clicking empty Day all-day calendar space", () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -57,6 +57,10 @@ import {
 import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
 
 const isDayInteractionMotionActive = () => false;
+const DAY_EVENT_FORM_DISMISS_OPTIONS = {
+  enabled: true,
+  outsidePressEvent: "click",
+} as const;
 
 export function DayCalendarGrid() {
   const dispatch = useAppDispatch();
@@ -90,7 +94,7 @@ export function DayCalendarGrid() {
       dispatch(draftSlice.actions.discard(undefined));
     }
   });
-  const dismiss = useDismiss(floating.context, { enabled: true });
+  const dismiss = useDismiss(floating.context, DAY_EVENT_FORM_DISMISS_OPTIONS);
   const interactions = useInteractions([dismiss]);
 
   const getDayInteractionLayoutSources = useCallback(


### PR DESCRIPTION
## What changed
- Delays Day event-form outside-click dismissal until the normal click event.
- Keeps the existing empty-agenda mouse handlers in charge of closing an open form, so the same click cannot also create a replacement form.
- Adds regression coverage for the Day agenda dismissal timing.

## Why
Clicking empty Day agenda space while an event form was open closed the current form too early, then the agenda handled the same click as a fresh event creation. This made a replacement form appear when the user was only trying to dismiss the current one.

Closes #1828.

## Verification
- `bun test src/views/Day/components/Calendar/DayCalendarGrid.test.tsx`
- `bun lint`
- `bun type-check`
- Browser smoke on `http://localhost:9080/day/2026-05-30`: empty timed space opens the form, the next empty click closes it, and another empty click opens it again; all-day empty space also closes cleanly.