### PR TITLE
fix(web): keep all-day drafts visible

### DIFF
--- a/packages/web/src/common/calendar-grid/layout/allDayDraftEventPosition.test.ts
+++ b/packages/web/src/common/calendar-grid/layout/allDayDraftEventPosition.test.ts
@@ -1,0 +1,70 @@
+import { Origin, Priorities } from "@core/constants/core.constants";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { positionAllDayDraftEvent } from "./allDayDraftEventPosition";
+import { describe, expect, it } from "bun:test";
+
+const createAllDayEvent = (
+  overrides: Partial<Schema_GridEvent> = {},
+): Schema_GridEvent => ({
+  _id: "event-1",
+  endDate: "2026-05-26",
+  isAllDay: true,
+  isSomeday: false,
+  origin: Origin.COMPASS,
+  position: gridEventDefaultPosition,
+  priority: Priorities.UNASSIGNED,
+  startDate: "2026-05-25",
+  title: "All-day event",
+  user: "user-1",
+  ...overrides,
+});
+
+describe("positionAllDayDraftEvent", () => {
+  it("places a new all-day draft after existing same-day all-day events", () => {
+    const draft = createAllDayEvent({
+      _id: undefined,
+      title: "Draft",
+    });
+
+    const { activeDraftEvent } = positionAllDayDraftEvent({
+      draft,
+      events: [
+        createAllDayEvent({
+          _id: "first",
+          title: "First",
+        }),
+        createAllDayEvent({
+          _id: "second",
+          title: "Second",
+        }),
+      ],
+    });
+
+    expect(activeDraftEvent?.row).toBe(3);
+  });
+
+  it("replaces an existing all-day event draft before assigning rows", () => {
+    const draft = createAllDayEvent({
+      _id: "second",
+      title: "Editing second",
+    });
+
+    const { activeDraftEvent } = positionAllDayDraftEvent({
+      draft,
+      events: [
+        createAllDayEvent({
+          _id: "first",
+          title: "First",
+        }),
+        createAllDayEvent({
+          _id: "second",
+          title: "Second",
+        }),
+      ],
+    });
+
+    expect(activeDraftEvent?.row).toBe(2);
+    expect(activeDraftEvent?.title).toBe("Editing second");
+  });
+});

--- a/packages/web/src/common/calendar-grid/layout/allDayDraftEventPosition.ts
+++ b/packages/web/src/common/calendar-grid/layout/allDayDraftEventPosition.ts
@@ -1,0 +1,49 @@
+import { type Schema_Event } from "@core/types/event.types";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import {
+  assembleGridEvent,
+  hasEventDates,
+} from "@web/common/utils/event/event.util";
+import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
+
+export const positionAllDayDraftEvent = ({
+  draft,
+  events,
+}: {
+  draft: Schema_Event | null;
+  events: Schema_GridEvent[];
+}): {
+  activeDraftEvent: Schema_GridEvent | null;
+  events: Schema_GridEvent[];
+} => {
+  if (!draft?.isAllDay || !hasEventDates(draft)) {
+    return { activeDraftEvent: null, events };
+  }
+
+  const draftEvent = assembleGridEvent(draft);
+  const existingIndex = draftEvent._id
+    ? events.findIndex((event) => event._id === draftEvent._id)
+    : -1;
+  const eventForRows =
+    existingIndex === -1
+      ? draftEvent
+      : {
+          ...draftEvent,
+          position: events[existingIndex].position,
+          row: events[existingIndex].row,
+        };
+  const eventsWithDraft =
+    existingIndex === -1
+      ? [...events, eventForRows]
+      : events.map((event, index) =>
+          index === existingIndex ? eventForRows : event,
+        );
+  const positionedEvents = assignEventsToRow(eventsWithDraft).allDayEvents;
+  const activeDraftIndex =
+    existingIndex === -1 ? positionedEvents.length - 1 : existingIndex;
+
+  return {
+    activeDraftEvent: positionedEvents[activeDraftIndex] ?? null,
+    events: positionedEvents,
+  };
+};

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -68,7 +68,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
 
   return (
     <ReactDatePicker
-      popperClassName="!z-20"
+      popperClassName="!z-22"
       calendarClassName={classNames("calendar", calendarClassName, {
         "calendar--open": isOpen,
         "calendar--animation": animationOnToggle,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -123,6 +123,22 @@ const createTimedEvent = (
     ...overrides,
   }) as Schema_Event;
 
+const createAllDayEvent = (
+  overrides: Partial<Schema_Event> & {
+    _id: string;
+    startDate: string;
+    endDate: string;
+  },
+): Schema_Event =>
+  ({
+    isAllDay: true,
+    isSomeday: false,
+    recurrence: undefined,
+    title: overrides._id,
+    user: "user",
+    ...overrides,
+  }) as Schema_Event;
+
 const setDayEvents = (events: Schema_Event[]) => {
   store = createStoreWithEvents(events);
 };
@@ -135,6 +151,18 @@ const resetDraft = () => {
 
 const setDraftEvent = (event: Schema_Event) => {
   store.dispatch(draftSlice.actions.startGridClick(event));
+};
+
+const getDismissOptions = () => {
+  const [, options] = useDismissMock.mock.calls.at(-1) ?? [];
+
+  expect(options).toBeDefined();
+
+  return options as {
+    enabled: boolean;
+    outsidePress?: (event: MouseEvent) => boolean;
+    outsidePressEvent: string;
+  };
 };
 
 beforeEach(() => {
@@ -369,13 +397,41 @@ describe("DayCalendarGrid", () => {
   it("dismisses the floating form after empty agenda mouse handlers run", () => {
     renderDayCalendarGrid();
 
-    expect(useDismissMock).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(getDismissOptions()).toEqual(
       expect.objectContaining({
         enabled: true,
+        outsidePress: expect.any(Function),
         outsidePressEvent: "click",
       }),
     );
+  });
+
+  it("does not dismiss a new all-day draft from the click that created it", async () => {
+    renderDayCalendarGrid();
+
+    const allDayRegion = screen.getByRole("region", { name: "All-day events" });
+
+    fireEvent.mouseDown(allDayRegion, {
+      button: 0,
+      clientX: 100,
+      clientY: 1,
+    });
+
+    await waitFor(() => {
+      expect(getDraft()?.isAllDay).toBe(true);
+    });
+
+    const outsidePress = getDismissOptions().outsidePress;
+    expect(outsidePress).toBeDefined();
+
+    const creationClick = new MouseEvent("click", { bubbles: true });
+    Object.defineProperty(creationClick, "target", {
+      configurable: true,
+      value: allDayRegion,
+    });
+
+    expect(outsidePress?.(creationClick)).toBe(false);
+    expect(outsidePress?.(creationClick)).toBe(true);
   });
 
   it("dismisses an open draft when clicking empty Day all-day calendar space", () => {
@@ -399,6 +455,52 @@ describe("DayCalendarGrid", () => {
     );
 
     expect(getDraft()).toBeNull();
+  });
+
+  it("places a new all-day draft below existing all-day events", async () => {
+    setDayEvents([
+      createAllDayEvent({
+        _id: "first-all-day",
+        endDate: "2026-05-21",
+        startDate: "2026-05-20",
+        title: "First all-day",
+      }),
+      createAllDayEvent({
+        _id: "second-all-day",
+        endDate: "2026-05-21",
+        startDate: "2026-05-20",
+        title: "Second all-day",
+      }),
+    ]);
+    renderDayCalendarGrid();
+
+    fireEvent.mouseDown(
+      screen.getByRole("region", { name: "All-day events" }),
+      {
+        button: 0,
+        clientX: 100,
+        clientY: 80,
+      },
+    );
+
+    await waitFor(() => {
+      const draft = screen.getByRole("button", {
+        name: /all-day event: untitled event/i,
+      });
+      const first = screen.getByRole("button", {
+        name: /all-day event: first all-day/i,
+      });
+      const second = screen.getByRole("button", {
+        name: /all-day event: second all-day/i,
+      });
+
+      expect(parseFloat(draft.style.top)).toBeGreaterThan(
+        parseFloat(first.style.top),
+      );
+      expect(parseFloat(draft.style.top)).toBeGreaterThan(
+        parseFloat(second.style.top),
+      );
+    });
   });
 
   it("scrolls the Day timed grid to now when the Day view requests it", () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -57,10 +57,6 @@ import {
 import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
 
 const isDayInteractionMotionActive = () => false;
-const DAY_EVENT_FORM_DISMISS_OPTIONS = {
-  enabled: true,
-  outsidePressEvent: "click",
-} as const;
 
 export function DayCalendarGrid() {
   const dispatch = useAppDispatch();
@@ -87,6 +83,7 @@ export function DayCalendarGrid() {
   const dayEvents = useAppSelector(selectDayEvents);
   const allDayRowsCount = useAppSelector(selectDayRowCount);
   const draft = useAppSelector(selectDraft);
+  const allDayCreationPressTargetRef = useRef<HTMLElement | null>(null);
   const floating = useFloatingAtCursor((open, _event, reason) => {
     const dismissed = reason === "escape-key" || reason === "outside-press";
 
@@ -94,7 +91,26 @@ export function DayCalendarGrid() {
       dispatch(draftSlice.actions.discard(undefined));
     }
   });
-  const dismiss = useDismiss(floating.context, DAY_EVENT_FORM_DISMISS_OPTIONS);
+  const shouldDismissEventForm = useCallback((event: MouseEvent) => {
+    const allDayCreationPressTarget = allDayCreationPressTargetRef.current;
+
+    if (!allDayCreationPressTarget) {
+      return true;
+    }
+
+    allDayCreationPressTargetRef.current = null;
+
+    const target = event.target;
+
+    return !(
+      target instanceof Node && allDayCreationPressTarget.contains(target)
+    );
+  }, []);
+  const dismiss = useDismiss(floating.context, {
+    enabled: true,
+    outsidePress: shouldDismissEventForm,
+    outsidePressEvent: "click",
+  });
   const interactions = useInteractions([dismiss]);
 
   const getDayInteractionLayoutSources = useCallback(
@@ -205,7 +221,10 @@ export function DayCalendarGrid() {
         return;
       }
 
+      const allDayCreationPressTarget = event.currentTarget;
+
       if (draft) {
+        allDayCreationPressTargetRef.current = null;
         dispatch(draftSlice.actions.discard(undefined));
         closeFloatingAtCursor();
         return;
@@ -222,6 +241,7 @@ export function DayCalendarGrid() {
         endDate,
       );
 
+      allDayCreationPressTargetRef.current = allDayCreationPressTarget;
       openEventFormForEvent(
         addId(assembleGridEvent(draftEvent as EventWithDates)),
       );
@@ -267,7 +287,7 @@ export function DayCalendarGrid() {
   return (
     <section
       aria-label="Calendar agenda"
-      className="flex h-full min-w-xs flex-1 flex-col bg-bg-primary p-0.5"
+      className="flex h-full min-w-xs flex-1 flex-col bg-bg-primary px-0.5 pb-0.5"
       onContextMenu={handleContextMenu}
     >
       {anchorElement}

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
@@ -1,5 +1,6 @@
 import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
+import { positionAllDayDraftEvent } from "@web/common/calendar-grid/layout/allDayDraftEventPosition";
 import { type CalendarGridVisibleDate } from "@web/common/calendar-grid/types/calendarGrid.types";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -26,6 +27,10 @@ export const addVisibleDraftEvent = ({
     !isDraftVisibleOnDate(draft, visibleDates)
   ) {
     return events;
+  }
+
+  if (isAllDay) {
+    return positionAllDayDraftEvent({ draft, events }).events;
   }
 
   const draftEvent = assembleGridEvent(draft);

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -1,9 +1,13 @@
 import { type FC, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { Categories_Event } from "@core/types/event.types";
+import { positionAllDayDraftEvent } from "@web/common/calendar-grid/layout/allDayDraftEventPosition";
 import { getDraftContainer } from "@web/common/utils/draft/draft.util";
 import { selectDraftCategory } from "@web/ducks/events/selectors/draft.selectors";
-import { selectGridEvents } from "@web/ducks/events/selectors/event.selectors";
+import {
+  selectAllDayEvents,
+  selectGridEvents,
+} from "@web/ducks/events/selectors/event.selectors";
 import { useAppSelector } from "@web/store/store.hooks";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -23,9 +27,18 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   useGridMouseMove();
 
   const category = useAppSelector(selectDraftCategory);
+  const allDayEvents = useAppSelector(selectAllDayEvents);
   const timedEvents = useAppSelector(selectGridEvents);
   const { state } = useDraftContext();
   const { draft } = state;
+  const activeAllDayDraftEvent = useMemo(
+    () =>
+      positionAllDayDraftEvent({
+        draft,
+        events: allDayEvents,
+      }).activeDraftEvent,
+    [allDayEvents, draft],
+  );
   const deckLayout = useMemo(
     () => getActiveTimedDraftDeckLayout(draft, timedEvents),
     [draft, timedEvents],
@@ -45,6 +58,7 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   return createPortal(
     isGridDraft && (
       <GridDraft
+        activeAllDayDraftEvent={activeAllDayDraftEvent}
         deckLayout={deckLayout}
         measurements={measurements}
         weekProps={weekProps}

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -117,9 +117,11 @@ const createFormProps = () => {
 };
 
 const renderGridDraft = ({
+  activeAllDayDraftEvent = null,
   deckLayout = null,
   draft = createDraft(),
 }: {
+  activeAllDayDraftEvent?: Schema_GridEvent | null;
   deckLayout?: { groupSize: number; order: number } | null;
   draft?: Schema_GridEvent;
 } = {}) => {
@@ -154,6 +156,7 @@ const renderGridDraft = ({
   const result = render(
     <DraftContext.Provider value={value}>
       <GridDraft
+        activeAllDayDraftEvent={activeAllDayDraftEvent}
         deckLayout={deckLayout}
         measurements={{
           allDayRow: null,
@@ -191,6 +194,29 @@ describe("GridDraft keyboard focus", () => {
       left: "200px",
       top: "23px",
       width: "90px",
+    });
+  });
+
+  it("uses the positioned all-day draft row when one is provided", () => {
+    const draft = createDraft({
+      endDate: "2026-05-27T00:00:00.000Z",
+      isAllDay: true,
+      position: undefined,
+      startDate: "2026-05-26T00:00:00.000Z",
+    });
+
+    renderGridDraft({
+      activeAllDayDraftEvent: {
+        ...draft,
+        row: 3,
+      },
+      draft,
+    });
+
+    expect(
+      screen.getByRole("button", { name: /All-day event: Planning/ }),
+    ).toHaveStyle({
+      top: "69px",
     });
   });
 

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -16,12 +16,16 @@ import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 
 interface Props {
+  activeAllDayDraftEvent?: Schema_GridEvent | null;
   deckLayout?: CalendarTimedDeckLayout | null;
   measurements: Measurements_Grid;
   weekProps: WeekProps;
 }
 
+const handleGridDraftClick = () => {};
+
 export const GridDraft: FC<Props> = ({
+  activeAllDayDraftEvent = null,
   deckLayout = null,
   measurements,
   weekProps,
@@ -42,7 +46,6 @@ export const GridDraft: FC<Props> = ({
     actions.convert(start, end);
   };
 
-  const handleClick = () => {};
   const focusTitleInput = () => {
     titleInputRef.current?.focus();
   };
@@ -69,18 +72,22 @@ export const GridDraft: FC<Props> = ({
 
   const { onMouseDown } = useGridEventMouseDown(
     draft?.isAllDay ? Categories_Event.ALLDAY : Categories_Event.TIMED,
-    handleClick,
+    handleGridDraftClick,
     handleDrag,
   );
 
   if (!draft) return null;
+
+  const allDayDraftEvent = draft.isAllDay
+    ? (activeAllDayDraftEvent ?? draft)
+    : draft;
 
   return (
     <>
       {draft.isAllDay ? (
         <AllDayEventMemo
           endOfView={weekProps.component.endOfView}
-          event={draft}
+          event={allDayDraftEvent}
           isPlaceholder={false}
           key={`draft-${draft?._id}`}
           measurements={measurements}


### PR DESCRIPTION
## Summary
- Fix Day all-day draft creation so the same click that creates the draft does not immediately close the floating form.
- Make Day and Week use the same all-day draft placement helper, so a new draft lands after existing all-day events instead of covering the first row.
- Raise the event-form date picker above the floating event form.

Closes #1841

## What was going wrong
- Day all-day creation could flash and disappear because the creating click was also being treated like an outside click after the draft/form opened.
- Week all-day drafts were rendered without being folded back through the all-day row assignment, so the draft could overlap the first saved all-day event.
- The date picker popover was lower than the floating form layer, so it appeared behind the draft form.

## Main files
- `packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx`
- `packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts`
- `packages/web/src/common/calendar-grid/layout/allDayDraftEventPosition.ts`
- `packages/web/src/views/Week/components/Draft/Draft.tsx`
- `packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx`
- `packages/web/src/components/DatePicker/DatePicker.tsx`

## Validation
- Browser: Day top-band all-day click opens the draft and the form stays open at http://localhost:9080/day/2026-05-31
- Browser: event-form date picker renders above the floating form (datepicker z-index 22, form z-index 21)
- `bun run test:web`
- `bun test --cwd packages/web src/components/PlannerSidebar/SomedayEventSections/SomedayEventSections.test.tsx`
- `bun test --cwd packages/web src/common/calendar-grid/layout/allDayDraftEventPosition.test.ts src/views/Day/components/Calendar/DayCalendarGrid.test.tsx src/views/Week/components/Draft/grid/GridDraft.test.tsx`
- `bun lint`
- `bun run type-check`
- `bun run build:web`
- `git diff --check`
- `react-doctor --diff`: 100/100, with one pre-existing DatePicker customInput warning left unchanged

## CI
- GitHub checks are green on the rebased branch: e2e, web unit, type-check, backend/core/scripts unit tests, and CodeQL.