### PR TITLE
[codex] fix standalone recurrence scope prompt

### DIFF
--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.test.tsx
@@ -151,6 +151,28 @@ describe("useDraftConfirmation", () => {
     expect(discard).not.toHaveBeenCalled();
   });
 
+  it("submits an existing standalone draft made recurring without opening the update scope dialog", async () => {
+    const draft = createDraft({
+      recurrence: {
+        rule: ["FREQ=WEEKLY;COUNT=4"],
+      },
+    });
+    const { discard, result, submit } = renderDraftConfirmation({ draft });
+
+    await act(async () => {
+      await result.current.onSubmit(draft);
+    });
+
+    expect(result.current.isRecurrenceUpdateScopeDialogOpen).toBe(false);
+    expect(result.current.finalDraft).toBeNull();
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith(
+      draft,
+      RecurringEventUpdateScope.THIS_EVENT,
+    );
+    expect(discard).toHaveBeenCalledTimes(1);
+  });
+
   it("submits a single-occurrence recurring instance without opening the update scope dialog", async () => {
     const baseEventId = new ObjectId().toString();
     const baseEvent = createDraft({

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.ts
@@ -85,10 +85,9 @@ export const useDraftConfirmation = ({
       const draftIsInstance = ObjectId.isValid(
         _draft.recurrence?.eventId ?? "",
       );
-      const draftIsRecurring = Array.isArray(rule) || draftIsInstance;
       const isExistingDraft = Boolean(_draft._id) || draftIsInstance;
       const isRecurringEvent =
-        isExistingDraft && (isRecurrence() || draftIsRecurring);
+        isExistingDraft && (isRecurrence() || draftIsInstance);
       const instanceEvent = isInstance() || draftIsInstance;
       const toStandAlone = instanceEvent && rule === null;
       const hasMultipleOccurrences = hasMultipleRecurrenceOccurrences(


### PR DESCRIPTION
## Summary
- Prevent the Week edit flow from showing the recurring update-scope dialog when a standalone event is first made recurring.
- Add regression coverage for saving an existing standalone draft after enabling repeat.

## Validation
- Not run at user request; PR checks will validate this branch.