### PR TITLE
test(web): strengthen shortcuts overlay assertions

### DIFF
--- a/packages/web/src/components/PlannerSidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx
@@ -26,13 +26,16 @@ describe("ShortcutsOverlay", () => {
     const overlay = screen.getByRole("dialog", { name: "Keyboard shortcuts" });
 
     expect(overlay.firstElementChild?.className).toContain("translate-x-0");
-    expect(screen.getByText("Shortcuts")).toBeTruthy();
-    expect(screen.getByText("Day")).toBeTruthy();
-    expect(screen.getByText("Previous day")).toBeTruthy();
-    expect(screen.queryByText("Empty")).toBeNull();
+    expect(screen.getByText("Shortcuts")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keyboard shortcuts for Day view"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Day")).toBeInTheDocument();
+    expect(screen.getByText("Previous day")).toBeInTheDocument();
+    expect(screen.queryByText("Empty")).not.toBeInTheDocument();
   });
 
-  it("returns focus to the planner sidebar when closed with Escape", () => {
+  it("calls onClose when closed with Escape", () => {
     const onClose = mock();
 
     render(


### PR DESCRIPTION
### Motivation

- Make the `ShortcutsOverlay` unit test more robust and expressive by using `jest-dom` matchers instead of truthy/null checks. 
- Cover the computed subtitle text for the Day view and clarify the Escape-key test name to match the asserted behavior.

### Description

- Replaced loose assertions (`toBeTruthy()` / `toBeNull()`) with `jest-dom` assertions (`toBeInTheDocument()` / `not.toBeInTheDocument()`).
- Added an assertion for the generated subtitle string `"Keyboard shortcuts for Day view"`.
- Renamed the second test from `returns focus to the planner sidebar when closed with Escape` to `calls onClose when closed with Escape` to reflect the actual behavior asserted.
- Modified file: `packages/web/src/components/PlannerSidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx`.

### Testing

- Ran `bun test --cwd packages/web src/components/PlannerSidebar/ShortcutsOverlay/ShortcutsOverlay.test.tsx` which errored because `jsdom` is missing (dependencies not installed).
- Ran `bun install` which failed due to registry `403` responses, so dependencies and tooling (e.g. `biome`) could not be installed; therefore linting and full test verification could not be completed.
- Ran `npx -y react-doctor@latest . --verbose --diff` which was blocked by an npm TypeScript override conflict.
- Performed local diff checks to validate formatting/changes (no code-style errors reported by `git diff --check`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3ac8a7c08331b06acf19a4f329c8)