### PR TITLE
Improve welcome modal styling and focus states

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,9 +5,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx biome format --write --changed --since=main --no-errors-on-unmatched >/dev/null",
+            "command": "bunx biome check --write --assist-enabled=true --changed --since=main --no-errors-on-unmatched >/dev/null",
             "timeout": 60,
-            "statusMessage": "Formatting branch changes"
+            "statusMessage": "Applying Biome fixes to branch changes"
           }
         ]
       }

--- a/packages/web/src/auth/compass/session/SessionProvider.test.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.test.tsx
@@ -103,7 +103,9 @@ const { session } = require("@web/common/classes/Session") as {
   };
 };
 
-const { SessionContext, SessionProvider, sessionInit } =
+const { SessionContext } =
+  require("./session.context") as typeof import("./session.context");
+const { SessionProvider, sessionInit } =
   require("./SessionProvider") as typeof import("./SessionProvider");
 
 describe("SessionProvider sessionInit", () => {

--- a/packages/web/src/auth/compass/session/SessionProvider.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.tsx
@@ -1,19 +1,7 @@
-import { type PropsWithChildren, useEffect, useState } from "react";
-import { BehaviorSubject } from "rxjs";
-import {
-  distinctUntilChanged,
-  distinctUntilKeyChanged,
-  skip,
-} from "rxjs/operators";
-import SuperTokens from "supertokens-web-js";
-import EmailPassword from "supertokens-web-js/recipe/emailpassword";
-import EmailVerification from "supertokens-web-js/recipe/emailverification";
-import Session from "supertokens-web-js/recipe/session";
-import ThirdParty from "supertokens-web-js/recipe/thirdparty";
 import { APP_NAME } from "@core/constants/core.constants";
 import {
-  getLastKnownEmail,
-  markUserAsAuthenticated,
+	getLastKnownEmail,
+	markUserAsAuthenticated,
 } from "@web/auth/compass/state/auth.state.util";
 import { session } from "@web/common/classes/Session";
 import { ENV_WEB } from "@web/common/constants/env.constants";
@@ -22,31 +10,40 @@ import { authSlice } from "@web/ducks/auth/slices/auth.slice";
 import { userMetadataSlice } from "@web/ducks/auth/slices/user-metadata.slice";
 import * as sse from "@web/sse/provider/SSEProvider";
 import { store } from "@web/store";
+import { type PropsWithChildren, useEffect, useState } from "react";
+import { BehaviorSubject } from "rxjs";
+import {
+	distinctUntilChanged,
+	distinctUntilKeyChanged,
+	skip,
+} from "rxjs/operators";
+import SuperTokens from "supertokens-web-js";
+import EmailPassword from "supertokens-web-js/recipe/emailpassword";
+import EmailVerification from "supertokens-web-js/recipe/emailverification";
+import Session from "supertokens-web-js/recipe/session";
+import ThirdParty from "supertokens-web-js/recipe/thirdparty";
 import { clearGoogleSyncIndicatorOverride } from "../../google/state/google.sync.state";
 import { refreshUserMetadata } from "../user/util/user-metadata.util";
-import { SessionContext } from "./session.context";
-
-export { SessionContext } from "./session.context";
 
 SuperTokens.init({
-  appInfo: {
-    appName: APP_NAME,
-    apiDomain: ENV_WEB.API_BASEURL,
-    apiBasePath: ROOT_ROUTES.API,
-  },
-  recipeList: [
-    ThirdParty.init(),
-    EmailPassword.init(),
-    EmailVerification.init(),
-    Session.init({
-      postAPIHook: async (context) => {
-        session.emit(context.action, context);
-      },
-      onHandleEvent: (event) => {
-        session.emit(event.action, event);
-      },
-    }),
-  ],
+	appInfo: {
+		appName: APP_NAME,
+		apiDomain: ENV_WEB.API_BASEURL,
+		apiBasePath: ROOT_ROUTES.API,
+	},
+	recipeList: [
+		ThirdParty.init(),
+		EmailPassword.init(),
+		EmailVerification.init(),
+		Session.init({
+			postAPIHook: async (context) => {
+				session.emit(context.action, context);
+			},
+			onHandleEvent: (event) => {
+				session.emit(event.action, event);
+			},
+		}),
+	],
 });
 
 const authenticated$ = new BehaviorSubject(false);
@@ -57,119 +54,119 @@ let sessionEventVersion = 0;
 const $authenticated = authenticated$.pipe(skip(1), distinctUntilChanged());
 
 const handleAuthenticatedSession = () => {
-  authenticated$.next(true);
-  markUserAsAuthenticated(getLastKnownEmail());
-  void refreshUserMetadata();
+	authenticated$.next(true);
+	markUserAsAuthenticated(getLastKnownEmail());
+	void refreshUserMetadata();
 };
 
 const handleSessionExists = () => {
-  handleAuthenticatedSession();
-  if (!sse.getStream()) {
-    sse.openStream();
-  }
+	handleAuthenticatedSession();
+	if (!sse.getStream()) {
+		sse.openStream();
+	}
 };
 
 const handleSessionMissing = () => {
-  authenticated$.next(false);
-  store.dispatch(authSlice.actions.resetAuth());
-  store.dispatch(userMetadataSlice.actions.clear(undefined));
-  clearGoogleSyncIndicatorOverride();
+	authenticated$.next(false);
+	store.dispatch(authSlice.actions.resetAuth());
+	store.dispatch(userMetadataSlice.actions.clear(undefined));
+	clearGoogleSyncIndicatorOverride();
 };
 
 async function checkIfSessionExists(): Promise<boolean> {
-  // Skip real session check in e2e tests — tests control auth state via Redux dispatch.
-  // Running SuperTokens session checks races against those dispatches and resets state.
-  if (typeof window !== "undefined" && window.__COMPASS_E2E_TEST__) {
-    return false;
-  }
+	// Skip real session check in e2e tests — tests control auth state via Redux dispatch.
+	// Running SuperTokens session checks races against those dispatches and resets state.
+	if (typeof window !== "undefined" && window.__COMPASS_E2E_TEST__) {
+		return false;
+	}
 
-  if (isCheckingSession) return authenticated$.value;
+	if (isCheckingSession) return authenticated$.value;
 
-  isCheckingSession = true;
-  const eventVersionAtCheckStart = sessionEventVersion;
+	isCheckingSession = true;
+	const eventVersionAtCheckStart = sessionEventVersion;
 
-  try {
-    const exists = await session.doesSessionExist();
+	try {
+		const exists = await session.doesSessionExist();
 
-    if (sessionEventVersion !== eventVersionAtCheckStart) {
-      return authenticated$.value;
-    }
+		if (sessionEventVersion !== eventVersionAtCheckStart) {
+			return authenticated$.value;
+		}
 
-    if (exists) {
-      handleSessionExists();
-    } else {
-      handleSessionMissing();
-    }
+		if (exists) {
+			handleSessionExists();
+		} else {
+			handleSessionMissing();
+		}
 
-    return exists;
-  } catch (error) {
-    console.error("Error checking auth status:", error);
-    authenticated$.next(false);
-    return false;
-  } finally {
-    isCheckingSession = false;
-  }
+		return exists;
+	} catch (error) {
+		console.error("Error checking auth status:", error);
+		authenticated$.next(false);
+		return false;
+	} finally {
+		isCheckingSession = false;
+	}
 }
 
 export function sessionInit() {
-  if (isSessionInitialized) {
-    return;
-  }
+	if (isSessionInitialized) {
+		return;
+	}
 
-  isSessionInitialized = true;
-  void checkIfSessionExists();
+	isSessionInitialized = true;
+	void checkIfSessionExists();
 
-  // No need to unsubscribe as this runs for the lifetime of the app
-  session.events.pipe(distinctUntilKeyChanged("action")).subscribe((e) => {
-    switch (e.action) {
-      case "REFRESH_SESSION":
-      case "SESSION_CREATED":
-        sessionEventVersion += 1;
-        // Mark user as authenticated when session is created or refreshed
-        // This ensures the flag is set even if markUserAsAuthenticated wasn't called during OAuth
-        handleAuthenticatedSession();
-        sse.closeStream();
-        sse.openStream();
-        break;
-      case "SIGN_OUT":
-        sessionEventVersion += 1;
-        handleSessionMissing();
-        sse.closeStream();
-        break;
-      default:
-        void checkIfSessionExists();
-    }
-  });
+	// No need to unsubscribe as this runs for the lifetime of the app
+	session.events.pipe(distinctUntilKeyChanged("action")).subscribe((e) => {
+		switch (e.action) {
+			case "REFRESH_SESSION":
+			case "SESSION_CREATED":
+				sessionEventVersion += 1;
+				// Mark user as authenticated when session is created or refreshed
+				// This ensures the flag is set even if markUserAsAuthenticated wasn't called during OAuth
+				handleAuthenticatedSession();
+				sse.closeStream();
+				sse.openStream();
+				break;
+			case "SIGN_OUT":
+				sessionEventVersion += 1;
+				handleSessionMissing();
+				sse.closeStream();
+				break;
+			default:
+				void checkIfSessionExists();
+		}
+	});
 }
 
 export function SessionProvider({ children }: PropsWithChildren<object>) {
-  const [authenticated, setAuthenticated] = useState(authenticated$.value);
+	const [authenticated, setAuthenticated] = useState(authenticated$.value);
 
-  useEffect(() => {
-    const authSub = $authenticated.subscribe(setAuthenticated);
+	useEffect(() => {
+		const authSub = $authenticated.subscribe(setAuthenticated);
 
-    return () => {
-      authSub.unsubscribe();
-    };
-  }, []);
+		return () => {
+			authSub.unsubscribe();
+		};
+	}, []);
 
-  // Expose test hooks for e2e testing
-  useEffect(() => {
-    if (typeof window !== "undefined" && window.__COMPASS_E2E_TEST__) {
-      window.__COMPASS_E2E_HOOKS__ = {
-        setAuthenticated: (value: boolean) => authenticated$.next(value),
-      };
-    }
-  }, []);
+	// Expose test hooks for e2e testing
+	useEffect(() => {
+		if (typeof window !== "undefined" && window.__COMPASS_E2E_TEST__) {
+			window.__COMPASS_E2E_HOOKS__ = {
+				setAuthenticated: (value: boolean) => authenticated$.next(value),
+			};
+		}
+	}, []);
 
-  return (
-    <SessionContext.Provider
-      value={{
-        authenticated,
-        setAuthenticated: (value: boolean) => authenticated$.next(value),
-      }}
-    >
-      {children}
-    </SessionContext.Provider>
-  );
+	return (
+		<SessionContext.Provider
+			value={{
+				authenticated,
+				setAuthenticated: (value: boolean) => authenticated$.next(value),
+			}}
+		>
+			{children}
+		</SessionContext.Provider>
+	);
 }

--- a/packages/web/src/auth/compass/session/SessionProvider.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.tsx
@@ -23,8 +23,8 @@ import EmailVerification from "supertokens-web-js/recipe/emailverification";
 import Session from "supertokens-web-js/recipe/session";
 import ThirdParty from "supertokens-web-js/recipe/thirdparty";
 import { clearGoogleSyncIndicatorOverride } from "../../google/state/google.sync.state";
-import { SessionContext } from "./session.context";
 import { refreshUserMetadata } from "../user/util/user-metadata.util";
+import { SessionContext } from "./session.context";
 
 SuperTokens.init({
 	appInfo: {

--- a/packages/web/src/auth/compass/session/SessionProvider.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.tsx
@@ -26,8 +26,6 @@ import { clearGoogleSyncIndicatorOverride } from "../../google/state/google.sync
 import { SessionContext } from "./session.context";
 import { refreshUserMetadata } from "../user/util/user-metadata.util";
 
-export { SessionContext } from "./session.context";
-
 SuperTokens.init({
 	appInfo: {
 		appName: APP_NAME,

--- a/packages/web/src/auth/compass/session/SessionProvider.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.tsx
@@ -23,7 +23,10 @@ import EmailVerification from "supertokens-web-js/recipe/emailverification";
 import Session from "supertokens-web-js/recipe/session";
 import ThirdParty from "supertokens-web-js/recipe/thirdparty";
 import { clearGoogleSyncIndicatorOverride } from "../../google/state/google.sync.state";
+import { SessionContext } from "./session.context";
 import { refreshUserMetadata } from "../user/util/user-metadata.util";
+
+export { SessionContext } from "./session.context";
 
 SuperTokens.init({
 	appInfo: {

--- a/packages/web/src/auth/compass/session/session.context.ts
+++ b/packages/web/src/auth/compass/session/session.context.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
-import { type CompassSession } from "./session.types";
+import type { CompassSession } from "./session.types";
 
 export const SessionContext = createContext<CompassSession>({
-  authenticated: false,
-  setAuthenticated: () => {},
+	authenticated: false,
+	setAuthenticated: () => {},
 });

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -1,10 +1,18 @@
 import { z } from "zod";
 
-export const StorageKeySchema = z.enum(["compass.reminder", "compass.auth"]);
+export const StorageKeySchema = z.enum([
+  "compass.reminder",
+  "compass.auth",
+  "compass.onboarding.has-seen-welcome",
+]);
 
 export type StorageKey = z.infer<typeof StorageKeySchema>;
 
-export const STORAGE_KEYS: Record<"REMINDER" | "AUTH", StorageKey> = {
+export const STORAGE_KEYS: Record<
+  "REMINDER" | "AUTH" | "HAS_SEEN_WELCOME",
+  StorageKey
+> = {
   REMINDER: "compass.reminder",
   AUTH: "compass.auth",
+  HAS_SEEN_WELCOME: "compass.onboarding.has-seen-welcome",
 } as const;

--- a/packages/web/src/common/types/react-inert.d.ts
+++ b/packages/web/src/common/types/react-inert.d.ts
@@ -1,0 +1,7 @@
+import "react";
+
+declare module "react" {
+  interface HTMLAttributes<T> {
+    inert?: "" | undefined;
+  }
+}

--- a/packages/web/src/common/types/react-inert.d.ts
+++ b/packages/web/src/common/types/react-inert.d.ts
@@ -1,7 +1,0 @@
-import "react";
-
-declare module "react" {
-  interface HTMLAttributes<T> {
-    inert?: "" | undefined;
-  }
-}

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, type ReactNode, useLayoutEffect } from "react";
+import { act, type ReactElement, type ReactNode, useLayoutEffect } from "react";
 import {
   createMemoryRouter,
   MemoryRouter,
@@ -337,7 +337,9 @@ describe("AuthModal", () => {
 
       // Focus the backdrop so it can receive keyboard events
       const backdrop = screen.getByRole("presentation");
-      backdrop.focus();
+      await act(async () => {
+        backdrop.focus();
+      });
 
       await user.keyboard("{Escape}");
       await flushEffects();

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -1,136 +1,104 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { CompassSession } from "@web/auth/compass/session/session.types";
 import { act, createContext } from "react";
-import { type CompassSession } from "@web/auth/compass/session/session.types";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockOpenModal = mock();
 const SessionContext = createContext<CompassSession>({
-  authenticated: false,
-  setAuthenticated: mock(),
+	authenticated: false,
+	setAuthenticated: mock(),
 });
 
 mock.module("@web/auth/compass/session/session.context", () => ({
-  SessionContext,
+	SessionContext,
 }));
 
 mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
-  useAuthModal: () => ({
-    openModal: mockOpenModal,
-  }),
+	useAuthModal: () => ({
+		openModal: mockOpenModal,
+	}),
 }));
 
 const { WelcomeModal, STORAGE_KEY } =
-  require("./WelcomeModal") as typeof import("./WelcomeModal");
+	require("./WelcomeModal") as typeof import("./WelcomeModal");
 
 describe("WelcomeModal", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    mockOpenModal.mockClear();
-  });
+	beforeEach(() => {
+		localStorage.clear();
+		mockOpenModal.mockClear();
+	});
 
-  it("closes when the backdrop is clicked", async () => {
-    const user = userEvent.setup();
+	it("closes when the backdrop is clicked", async () => {
+		const user = userEvent.setup();
 
-    render(<WelcomeModal />);
+		render(<WelcomeModal />);
 
-    expect(
-      screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
-    ).toBeTruthy();
+		expect(
+			screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+		).toBeTruthy();
 
-    await user.click(screen.getByRole("presentation"));
+		await user.click(screen.getByRole("presentation"));
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
-      ).toBeNull();
-    });
-    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
-  });
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+			).toBeNull();
+		});
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+	});
 
-  it("closes when Escape is pressed", async () => {
-    const user = userEvent.setup();
+	it("closes when Escape is pressed", async () => {
+		const user = userEvent.setup();
 
-    render(<WelcomeModal />);
+		render(<WelcomeModal />);
 
-    const backdrop = screen.getByRole("presentation");
-    await act(async () => {
-      backdrop.focus();
-    });
+		const backdrop = screen.getByRole("presentation");
+		await act(async () => {
+			backdrop.focus();
+		});
 
-    await user.keyboard("{Escape}");
+		await user.keyboard("{Escape}");
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
-      ).toBeNull();
-    });
-    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
-  });
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+			).toBeNull();
+		});
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+	});
 
-  it("expands and collapses FAQ answers", async () => {
-    const user = userEvent.setup();
+	it("expands and collapses FAQ answers", async () => {
+		const user = userEvent.setup();
 
-    render(<WelcomeModal />);
+		render(<WelcomeModal />);
 
-    const questionButton = screen.getByRole("button", {
-      name: "Who is Compass for?",
-    });
-    const answerId = questionButton.getAttribute("aria-controls");
-    expect(answerId).toBeTruthy();
+		const questionButton = screen.getByRole("button", {
+			name: "Who is Compass for?",
+		});
+		const answerId = questionButton.getAttribute("aria-controls");
+		expect(answerId).toBeTruthy();
 
-    const answer = document.getElementById(answerId as string);
-    expect(questionButton).toHaveAttribute("aria-expanded", "false");
-    expect(answer).toHaveAttribute("aria-hidden", "true");
-    expect(answer).toHaveAttribute("data-state", "closed");
+		const answer = document.getElementById(answerId as string);
+		expect(questionButton).toHaveAttribute("aria-expanded", "false");
+		expect(answer).toHaveAttribute("aria-hidden", "true");
+		expect(answer).toHaveAttribute("data-state", "closed");
 
-    await user.click(questionButton);
+		await user.click(questionButton);
 
-    expect(questionButton).toHaveAttribute("aria-expanded", "true");
-    expect(answer).toHaveAttribute("aria-hidden", "false");
-    expect(answer).toHaveAttribute("data-state", "open");
-    expect(
-      screen.getByText(
-        /Compass is designed for minimalists who value efficiency/,
-      ),
-    ).toBeTruthy();
+		expect(questionButton).toHaveAttribute("aria-expanded", "true");
+		expect(answer).toHaveAttribute("aria-hidden", "false");
+		expect(answer).toHaveAttribute("data-state", "open");
+		expect(
+			screen.getByText(
+				/Compass is designed for minimalists who value efficiency/,
+			),
+		).toBeTruthy();
 
-    await user.click(questionButton);
+		await user.click(questionButton);
 
-    expect(questionButton).toHaveAttribute("aria-expanded", "false");
-    expect(answer).toHaveAttribute("aria-hidden", "true");
-    expect(answer).toHaveAttribute("data-state", "closed");
-  });
-
-  it("uses the shared focus ring on modal links and FAQ triggers", async () => {
-    const user = userEvent.setup();
-
-    render(<WelcomeModal />);
-
-    const openSourceQuestion = screen.getByRole("button", {
-      name: "How much of the code is open-source?",
-    });
-    expect(openSourceQuestion).toHaveClass("c-focus-ring");
-
-    await user.click(openSourceQuestion);
-
-    expect(
-      screen.getByRole("link", { name: "self-hosting guide" }),
-    ).toHaveClass("c-focus-ring");
-    expect(screen.getByRole("link", { name: "X (Twitter)" })).toHaveClass(
-      "c-focus-ring",
-    );
-    expect(screen.getByRole("link", { name: "LinkedIn" })).toHaveClass(
-      "c-focus-ring",
-    );
-    expect(screen.getByRole("link", { name: "GitHub" })).toHaveClass(
-      "c-focus-ring",
-    );
-    expect(screen.getByRole("link", { name: "Privacy" })).toHaveClass(
-      "c-focus-ring",
-    );
-    expect(screen.getByRole("link", { name: "Terms" })).toHaveClass(
-      "c-focus-ring",
-    );
-  });
+		expect(questionButton).toHaveAttribute("aria-expanded", "false");
+		expect(answer).toHaveAttribute("aria-hidden", "true");
+		expect(answer).toHaveAttribute("data-state", "closed");
+	});
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -20,8 +20,10 @@ mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
 	}),
 }));
 
-const { WelcomeModal, STORAGE_KEY } =
+const { WelcomeModal } =
 	require("./WelcomeModal") as typeof import("./WelcomeModal");
+const { STORAGE_KEYS } =
+	require("@web/common/constants/storage.constants") as typeof import("@web/common/constants/storage.constants");
 
 describe("WelcomeModal", () => {
 	beforeEach(() => {
@@ -45,7 +47,7 @@ describe("WelcomeModal", () => {
 				screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
 			).toBeNull();
 		});
-		expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+		expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe("true");
 	});
 
 	it("closes when Escape is pressed", async () => {
@@ -65,7 +67,7 @@ describe("WelcomeModal", () => {
 				screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
 			).toBeNull();
 		});
-		expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+		expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe("true");
 	});
 
 	it("expands and collapses FAQ answers", async () => {
@@ -100,37 +102,5 @@ describe("WelcomeModal", () => {
 		expect(questionButton).toHaveAttribute("aria-expanded", "false");
 		expect(answer).toHaveAttribute("aria-hidden", "true");
 		expect(answer).toHaveAttribute("data-state", "closed");
-	});
-
-	it("uses the shared focus ring on modal links and FAQ triggers", async () => {
-		const user = userEvent.setup();
-
-		render(<WelcomeModal />);
-
-		const openSourceQuestion = screen.getByRole("button", {
-			name: "How much of the code is open-source?",
-		});
-		expect(openSourceQuestion).toHaveClass("c-focus-ring");
-
-		await user.click(openSourceQuestion);
-
-		expect(
-			screen.getByRole("link", { name: "self-hosting guide" }),
-		).toHaveClass("c-focus-ring");
-		expect(screen.getByRole("link", { name: "X (Twitter)" })).toHaveClass(
-			"c-focus-ring",
-		);
-		expect(screen.getByRole("link", { name: "LinkedIn" })).toHaveClass(
-			"c-focus-ring",
-		);
-		expect(screen.getByRole("link", { name: "GitHub" })).toHaveClass(
-			"c-focus-ring",
-		);
-		expect(screen.getByRole("link", { name: "Privacy" })).toHaveClass(
-			"c-focus-ring",
-		);
-		expect(screen.getByRole("link", { name: "Terms" })).toHaveClass(
-			"c-focus-ring",
-		);
 	});
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -67,4 +67,38 @@ describe("WelcomeModal", () => {
     });
     expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
   });
+
+  it("expands and collapses FAQ answers", async () => {
+    const user = userEvent.setup();
+
+    render(<WelcomeModal />);
+
+    const questionButton = screen.getByRole("button", {
+      name: "Who is Compass for?",
+    });
+    const answerId = questionButton.getAttribute("aria-controls");
+    expect(answerId).toBeTruthy();
+
+    const answer = document.getElementById(answerId as string);
+    expect(questionButton).toHaveAttribute("aria-expanded", "false");
+    expect(answer).toHaveAttribute("aria-hidden", "true");
+    expect(answer).toHaveAttribute("data-state", "closed");
+
+    await user.click(questionButton);
+
+    expect(questionButton).toHaveAttribute("aria-expanded", "true");
+    expect(answer).toHaveAttribute("aria-hidden", "false");
+    expect(answer).toHaveAttribute("data-state", "open");
+    expect(
+      screen.getByText(
+        /Compass is designed for minimalists who value efficiency/,
+      ),
+    ).toBeTruthy();
+
+    await user.click(questionButton);
+
+    expect(questionButton).toHaveAttribute("aria-expanded", "false");
+    expect(answer).toHaveAttribute("aria-hidden", "true");
+    expect(answer).toHaveAttribute("data-state", "closed");
+  });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -1,127 +1,104 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { CompassSession } from "@web/auth/compass/session/session.types";
 import { act, createContext } from "react";
-import { type CompassSession } from "@web/auth/compass/session/session.types";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockOpenModal = mock();
 const SessionContext = createContext<CompassSession>({
-  authenticated: false,
-  setAuthenticated: mock(),
+	authenticated: false,
+	setAuthenticated: mock(),
 });
 
 mock.module("@web/auth/compass/session/SessionProvider", () => ({
-  SessionContext,
+	SessionContext,
 }));
 
 mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
-  useAuthModal: () => ({
-    openModal: mockOpenModal,
-  }),
+	useAuthModal: () => ({
+		openModal: mockOpenModal,
+	}),
 }));
 
 const { WelcomeModal, STORAGE_KEY } =
-  require("./WelcomeModal") as typeof import("./WelcomeModal");
+	require("./WelcomeModal") as typeof import("./WelcomeModal");
 
 describe("WelcomeModal", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    mockOpenModal.mockClear();
-  });
+	beforeEach(() => {
+		localStorage.clear();
+		mockOpenModal.mockClear();
+	});
 
-  it("closes when the backdrop is clicked", async () => {
-    const user = userEvent.setup();
+	it("closes when the backdrop is clicked", async () => {
+		const user = userEvent.setup();
 
-    render(<WelcomeModal />);
+		render(<WelcomeModal />);
 
-    expect(
-      screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
-    ).toBeTruthy();
+		expect(
+			screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+		).toBeTruthy();
 
-    await user.click(screen.getByRole("presentation"));
+		await user.click(screen.getByRole("presentation"));
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
-      ).toBeNull();
-    });
-    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
-  });
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+			).toBeNull();
+		});
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+	});
 
-  it("closes when Escape is pressed", async () => {
-    const user = userEvent.setup();
+	it("closes when Escape is pressed", async () => {
+		const user = userEvent.setup();
 
-    render(<WelcomeModal />);
+		render(<WelcomeModal />);
 
-    const backdrop = screen.getByRole("presentation");
-    await act(async () => {
-      backdrop.focus();
-    });
+		const backdrop = screen.getByRole("presentation");
+		await act(async () => {
+			backdrop.focus();
+		});
 
-    await user.keyboard("{Escape}");
+		await user.keyboard("{Escape}");
 
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
-      ).toBeNull();
-    });
-    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
-  });
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+			).toBeNull();
+		});
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+	});
 
-  it("expands and collapses FAQ answers", async () => {
-    const user = userEvent.setup();
+	it("expands and collapses FAQ answers", async () => {
+		const user = userEvent.setup();
 
-    render(<WelcomeModal />);
+		render(<WelcomeModal />);
 
-    const questionButton = screen.getByRole("button", {
-      name: "Who is Compass for?",
-    });
-    const answerId = questionButton.getAttribute("aria-controls");
-    expect(answerId).toBeTruthy();
+		const questionButton = screen.getByRole("button", {
+			name: "Who is Compass for?",
+		});
+		const answerId = questionButton.getAttribute("aria-controls");
+		expect(answerId).toBeTruthy();
 
-    const answer = document.getElementById(answerId as string);
-    expect(questionButton).toHaveAttribute("aria-expanded", "false");
-    expect(answer).toHaveAttribute("aria-hidden", "true");
-    expect(answer).toHaveAttribute("data-state", "closed");
+		const answer = document.getElementById(answerId as string);
+		expect(questionButton).toHaveAttribute("aria-expanded", "false");
+		expect(answer).toHaveAttribute("aria-hidden", "true");
+		expect(answer).toHaveAttribute("data-state", "closed");
 
-    await user.click(questionButton);
+		await user.click(questionButton);
 
-    expect(questionButton).toHaveAttribute("aria-expanded", "true");
-    expect(answer).toHaveAttribute("aria-hidden", "false");
-    expect(answer).toHaveAttribute("data-state", "open");
-    expect(
-      screen.getByText(
-        /Compass is designed for minimalists who value efficiency/,
-      ),
-    ).toBeTruthy();
+		expect(questionButton).toHaveAttribute("aria-expanded", "true");
+		expect(answer).toHaveAttribute("aria-hidden", "false");
+		expect(answer).toHaveAttribute("data-state", "open");
+		expect(
+			screen.getByText(
+				/Compass is designed for minimalists who value efficiency/,
+			),
+		).toBeTruthy();
 
-    await user.click(questionButton);
+		await user.click(questionButton);
 
-    expect(questionButton).toHaveAttribute("aria-expanded", "false");
-    expect(answer).toHaveAttribute("aria-hidden", "true");
-    expect(answer).toHaveAttribute("data-state", "closed");
-  });
-
-  it("uses the shared focus ring on modal links and FAQ triggers", async () => {
-    const user = userEvent.setup();
-
-    render(<WelcomeModal />);
-
-    const openSourceQuestion = screen.getByRole("button", {
-      name: "How much of the code is open-source?",
-    });
-    expect(openSourceQuestion).toHaveClass("c-focus-ring");
-
-    await user.click(openSourceQuestion);
-
-    expect(
-      screen.getByRole("link", { name: "self-hosting guide" }),
-    ).toHaveClass("c-focus-ring");
-    expect(screen.getByRole("link", { name: "Privacy" })).toHaveClass(
-      "c-focus-ring",
-    );
-    expect(screen.getByRole("link", { name: "Terms" })).toHaveClass(
-      "c-focus-ring",
-    );
-  });
+		expect(questionButton).toHaveAttribute("aria-expanded", "false");
+		expect(answer).toHaveAttribute("aria-hidden", "true");
+		expect(answer).toHaveAttribute("data-state", "closed");
+	});
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -83,14 +83,12 @@ describe("WelcomeModal", () => {
 		expect(questionButton).toHaveAttribute("aria-expanded", "false");
 		expect(answer).toHaveAttribute("aria-hidden", "true");
 		expect(answer).toHaveAttribute("data-state", "closed");
-		expect(answer).toHaveAttribute("inert");
 
 		await user.click(questionButton);
 
 		expect(questionButton).toHaveAttribute("aria-expanded", "true");
 		expect(answer).toHaveAttribute("aria-hidden", "false");
 		expect(answer).toHaveAttribute("data-state", "open");
-		expect(answer).not.toHaveAttribute("inert");
 		expect(
 			screen.getByText(
 				/Compass is designed for minimalists who value efficiency/,
@@ -102,7 +100,6 @@ describe("WelcomeModal", () => {
 		expect(questionButton).toHaveAttribute("aria-expanded", "false");
 		expect(answer).toHaveAttribute("aria-hidden", "true");
 		expect(answer).toHaveAttribute("data-state", "closed");
-		expect(answer).toHaveAttribute("inert");
 	});
 
 	it("uses the shared focus ring on modal links and FAQ triggers", async () => {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -83,12 +83,14 @@ describe("WelcomeModal", () => {
 		expect(questionButton).toHaveAttribute("aria-expanded", "false");
 		expect(answer).toHaveAttribute("aria-hidden", "true");
 		expect(answer).toHaveAttribute("data-state", "closed");
+		expect(answer).toHaveAttribute("inert");
 
 		await user.click(questionButton);
 
 		expect(questionButton).toHaveAttribute("aria-expanded", "true");
 		expect(answer).toHaveAttribute("aria-hidden", "false");
 		expect(answer).toHaveAttribute("data-state", "open");
+		expect(answer).not.toHaveAttribute("inert");
 		expect(
 			screen.getByText(
 				/Compass is designed for minimalists who value efficiency/,
@@ -100,5 +102,38 @@ describe("WelcomeModal", () => {
 		expect(questionButton).toHaveAttribute("aria-expanded", "false");
 		expect(answer).toHaveAttribute("aria-hidden", "true");
 		expect(answer).toHaveAttribute("data-state", "closed");
+		expect(answer).toHaveAttribute("inert");
+	});
+
+	it("uses the shared focus ring on modal links and FAQ triggers", async () => {
+		const user = userEvent.setup();
+
+		render(<WelcomeModal />);
+
+		const openSourceQuestion = screen.getByRole("button", {
+			name: "How much of the code is open-source?",
+		});
+		expect(openSourceQuestion).toHaveClass("c-focus-ring");
+
+		await user.click(openSourceQuestion);
+
+		expect(
+			screen.getByRole("link", { name: "self-hosting guide" }),
+		).toHaveClass("c-focus-ring");
+		expect(screen.getByRole("link", { name: "X (Twitter)" })).toHaveClass(
+			"c-focus-ring",
+		);
+		expect(screen.getByRole("link", { name: "LinkedIn" })).toHaveClass(
+			"c-focus-ring",
+		);
+		expect(screen.getByRole("link", { name: "GitHub" })).toHaveClass(
+			"c-focus-ring",
+		);
+		expect(screen.getByRole("link", { name: "Privacy" })).toHaveClass(
+			"c-focus-ring",
+		);
+		expect(screen.getByRole("link", { name: "Terms" })).toHaveClass(
+			"c-focus-ring",
+		);
 	});
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -101,4 +101,27 @@ describe("WelcomeModal", () => {
     expect(answer).toHaveAttribute("aria-hidden", "true");
     expect(answer).toHaveAttribute("data-state", "closed");
   });
+
+  it("uses the shared focus ring on modal links and FAQ triggers", async () => {
+    const user = userEvent.setup();
+
+    render(<WelcomeModal />);
+
+    const openSourceQuestion = screen.getByRole("button", {
+      name: "How much of the code is open-source?",
+    });
+    expect(openSourceQuestion).toHaveClass("c-focus-ring");
+
+    await user.click(openSourceQuestion);
+
+    expect(
+      screen.getByRole("link", { name: "self-hosting guide" }),
+    ).toHaveClass("c-focus-ring");
+    expect(screen.getByRole("link", { name: "Privacy" })).toHaveClass(
+      "c-focus-ring",
+    );
+    expect(screen.getByRole("link", { name: "Terms" })).toHaveClass(
+      "c-focus-ring",
+    );
+  });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -4,8 +4,6 @@ import { act, createContext } from "react";
 import { type CompassSession } from "@web/auth/compass/session/session.types";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
-const STORAGE_KEY = "compass.onboarding.has-seen-welcome";
-
 const mockOpenModal = mock();
 const SessionContext = createContext<CompassSession>({
   authenticated: false,
@@ -22,7 +20,7 @@ mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
   }),
 }));
 
-const { WelcomeModal } =
+const { WelcomeModal, STORAGE_KEY } =
   require("./WelcomeModal") as typeof import("./WelcomeModal");
 
 describe("WelcomeModal", () => {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act, createContext } from "react";
+import { type CompassSession } from "@web/auth/compass/session/session.types";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const STORAGE_KEY = "compass.onboarding.has-seen-welcome";
+
+const mockOpenModal = mock();
+const SessionContext = createContext<CompassSession>({
+  authenticated: false,
+  setAuthenticated: mock(),
+});
+
+mock.module("@web/auth/compass/session/SessionProvider", () => ({
+  SessionContext,
+}));
+
+mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
+  useAuthModal: () => ({
+    openModal: mockOpenModal,
+  }),
+}));
+
+const { WelcomeModal } =
+  require("./WelcomeModal") as typeof import("./WelcomeModal");
+
+describe("WelcomeModal", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockOpenModal.mockClear();
+  });
+
+  it("closes when the backdrop is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<WelcomeModal />);
+
+    expect(
+      screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+    ).toBeTruthy();
+
+    await user.click(screen.getByRole("presentation"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+      ).toBeNull();
+    });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("closes when Escape is pressed", async () => {
+    const user = userEvent.setup();
+
+    render(<WelcomeModal />);
+
+    const backdrop = screen.getByRole("presentation");
+    await act(async () => {
+      backdrop.focus();
+    });
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
+      ).toBeNull();
+    });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+});

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -1,5 +1,10 @@
 import { LinkedinLogo, XLogo } from "@phosphor-icons/react";
-import { useContext, useState } from "react";
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useContext,
+  useState,
+} from "react";
 import { SessionContext } from "@web/auth/compass/session/SessionProvider";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
@@ -39,14 +44,17 @@ const FAQ_ITEMS = [
   },
   {
     question: "What makes Compass different from other calendars?",
-    answer: "It's simpler and faster. Instead of doing everything, we do a few things well.",
+    answer:
+      "It's simpler and faster. Instead of doing everything, we do a few things well.",
   },
 ];
 
 export function WelcomeModal() {
   const { authenticated } = useContext(SessionContext);
   const { openModal } = useAuthModal();
-  const [isOpen, setIsOpen] = useState(() => !authenticated && !hasSeenWelcome());
+  const [isOpen, setIsOpen] = useState(
+    () => !authenticated && !hasSeenWelcome(),
+  );
 
   if (!isOpen) return null;
 
@@ -60,25 +68,42 @@ export function WelcomeModal() {
     openModal("login");
   };
 
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      dismiss();
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      dismiss();
+    }
+  };
+
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome modal.
     <div
-      className="fixed inset-0 flex items-center justify-center bg-bg-primary/85 backdrop-blur-sm overflow-y-auto py-8"
+      className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-bg-primary/85 py-8 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
       role="presentation"
       style={{ zIndex: Z_INDEX_MODAL }}
+      tabIndex={-1}
     >
       <div
         role="dialog"
         aria-modal
         aria-label="Welcome to Compass Calendar"
-        className="w-[560px] max-w-[90vw] flex flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
+        className="flex w-[560px] max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
       >
         {/* Header */}
         <div className="flex flex-col gap-2">
-          <h2 className="m-0 text-2xl font-bold text-text-lighter">
+          <h2 className="m-0 font-bold text-2xl text-text-lighter">
             Ahoy! You found a simple, fast calendar.
           </h2>
           <p className="m-0 text-base text-text-light">
-            We&apos;re making Compass Calendar the best place to manage your week.
+            We&apos;re making Compass Calendar the best place to manage your
+            week.
           </p>
         </div>
 
@@ -87,7 +112,7 @@ export function WelcomeModal() {
           <button
             type="button"
             onClick={dismiss}
-            className="h-11 flex-1 rounded bg-accent-primary px-4 text-sm font-medium text-text-dark transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
+            className="h-11 flex-1 rounded bg-accent-primary px-4 font-medium text-sm text-text-dark transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
           >
             Start Now
           </button>
@@ -104,7 +129,7 @@ export function WelcomeModal() {
         <div className="flex flex-col divide-y divide-border-primary">
           {FAQ_ITEMS.map((item) => (
             <details key={item.question} className="group py-3">
-              <summary className="cursor-pointer list-none text-sm font-medium text-text-lighter select-none hover:text-text-lightest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary rounded">
+              <summary className="cursor-pointer select-none list-none rounded font-medium text-sm text-text-lighter hover:text-text-lightest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary">
                 {item.question}
               </summary>
               <div className="mt-2 text-sm text-text-light leading-relaxed">
@@ -112,16 +137,18 @@ export function WelcomeModal() {
                   item.answer
                 ) : (
                   <>
-                    All of it! Compass is a monorepo that includes the API, frontend, CLI, and
-                    more. You can run it yourself too; read the{" "}
+                    All of it! Compass is a monorepo that includes the API,
+                    frontend, CLI, and more. You can run it yourself too; read
+                    the{" "}
                     <a
                       href="/blog/self-host"
                       className="font-medium text-accent-primary underline-offset-4 hover:underline"
                     >
                       self-hosting guide
                     </a>{" "}
-                    to set up your own instance. It&apos;s all available on GitHub (link in
-                    footer), and we&apos;re always looking for contributors :]
+                    to set up your own instance. It&apos;s all available on
+                    GitHub (link in footer), and we&apos;re always looking for
+                    contributors :]
                   </>
                 )}
               </div>
@@ -130,14 +157,14 @@ export function WelcomeModal() {
         </div>
 
         {/* Footer: social + legal */}
-        <div className="flex items-center justify-between border-t border-border-primary pt-4">
+        <div className="flex items-center justify-between border-border-primary border-t pt-4">
           <div className="flex items-center gap-3">
             <a
               href="https://x.com/CompassCalendar"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="X (Twitter)"
-              className="text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary rounded"
+              className="rounded text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
             >
               <XLogo size={18} weight="bold" />
             </a>
@@ -146,17 +173,17 @@ export function WelcomeModal() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn"
-              className="text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary rounded"
+              className="rounded text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
             >
               <LinkedinLogo size={18} weight="bold" />
             </a>
           </div>
-          <div className="flex items-center gap-4 text-xs text-text-light">
+          <div className="flex items-center gap-4 text-text-light text-xs">
             <a
               href="https://compasscalendar.com/privacy"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-text-lighter hover:underline underline-offset-4"
+              className="underline-offset-4 hover:text-text-lighter hover:underline"
             >
               Privacy
             </a>
@@ -164,7 +191,7 @@ export function WelcomeModal() {
               href="https://compasscalendar.com/terms"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-text-lighter hover:underline underline-offset-4"
+              className="underline-offset-4 hover:text-text-lighter hover:underline"
             >
               Terms
             </a>

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -1,261 +1,261 @@
 import {
-  GithubLogoIcon,
-  LinkedinLogoIcon,
-  XLogoIcon,
+	GithubLogoIcon,
+	LinkedinLogoIcon,
+	XLogoIcon,
 } from "@phosphor-icons/react";
-import {
-  type KeyboardEvent,
-  type MouseEvent,
-  useContext,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
+import {
+	type KeyboardEvent,
+	type MouseEvent,
+	useContext,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+} from "react";
 
 export const STORAGE_KEY = "compass.onboarding.has-seen-welcome";
 
 function hasSeenWelcome(): boolean {
-  try {
-    return localStorage.getItem(STORAGE_KEY) === "true";
-  } catch {
-    return true;
-  }
+	try {
+		return localStorage.getItem(STORAGE_KEY) === "true";
+	} catch {
+		return true;
+	}
 }
 
 function markWelcomeSeen(): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, "true");
-  } catch {
-    // Silently fail if localStorage is unavailable
-  }
+	try {
+		localStorage.setItem(STORAGE_KEY, "true");
+	} catch {
+		// Silently fail if localStorage is unavailable
+	}
 }
 
 const FAQ_ITEMS = [
-  {
-    question: "Who is Compass for?",
-    answer:
-      "Compass is designed for minimalists who value efficiency, keyboard shortcuts, and open-source software. We are focused on helping people do more with less.",
-  },
-  {
-    question: "Does Compass use AI?",
-    answer:
-      "Not currently. Compass gives you the tools to make your own decisions about how to spend your time, without algorithmic suggestions you'll ignore anyway.",
-  },
-  {
-    question: "How much of the code is open-source?",
-    answer: null, // rendered separately
-  },
-  {
-    question: "What makes Compass different from other calendars?",
-    answer:
-      "It's simpler and faster. Instead of doing everything, we do a few things well.",
-  },
+	{
+		question: "Who is Compass for?",
+		answer:
+			"Compass is designed for minimalists who value efficiency, keyboard shortcuts, and open-source software. We are focused on helping people do more with less.",
+	},
+	{
+		question: "Does Compass use AI?",
+		answer:
+			"Not currently. Compass gives you the tools to make your own decisions about how to spend your time, without algorithmic suggestions you'll ignore anyway.",
+	},
+	{
+		question: "How much of the code is open-source?",
+		answer: null, // rendered separately
+	},
+	{
+		question: "What makes Compass different from other calendars?",
+		answer:
+			"It's simpler and faster. Instead of doing everything, we do a few things well.",
+	},
 ];
 
 export function WelcomeModal() {
-  const { authenticated } = useContext(SessionContext);
-  const { openModal } = useAuthModal();
-  const disclosureIdPrefix = useId();
-  const [isOpen, setIsOpen] = useState(
-    () => !authenticated && !hasSeenWelcome(),
-  );
-  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const backdropRef = useRef<HTMLDivElement>(null);
+	const { authenticated } = useContext(SessionContext);
+	const { openModal } = useAuthModal();
+	const disclosureIdPrefix = useId();
+	const [isOpen, setIsOpen] = useState(
+		() => !authenticated && !hasSeenWelcome(),
+	);
+	const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const backdropRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    backdropRef.current?.focus();
-  }, []);
+	useEffect(() => {
+		backdropRef.current?.focus();
+	}, []);
 
-  if (!isOpen) return null;
+	if (!isOpen) return null;
 
-  const dismiss = () => {
-    markWelcomeSeen();
-    setIsOpen(false);
-  };
+	const dismiss = () => {
+		markWelcomeSeen();
+		setIsOpen(false);
+	};
 
-  const handleLogIn = () => {
-    dismiss();
-    openModal("login");
-  };
+	const handleLogIn = () => {
+		dismiss();
+		openModal("login");
+	};
 
-  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      dismiss();
-    }
-  };
+	const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+		if (event.target === event.currentTarget) {
+			dismiss();
+		}
+	};
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      dismiss();
-    }
-  };
+	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (event.key === "Escape") {
+			dismiss();
+		}
+	};
 
-  const toggleFaq = (question: string) => {
-    setExpandedFaqs((currentFaqs) => {
-      const nextFaqs = new Set(currentFaqs);
+	const toggleFaq = (question: string) => {
+		setExpandedFaqs((currentFaqs) => {
+			const nextFaqs = new Set(currentFaqs);
 
-      if (nextFaqs.has(question)) {
-        nextFaqs.delete(question);
-      } else {
-        nextFaqs.add(question);
-      }
+			if (nextFaqs.has(question)) {
+				nextFaqs.delete(question);
+			} else {
+				nextFaqs.add(question);
+			}
 
-      return nextFaqs;
-    });
-  };
+			return nextFaqs;
+		});
+	};
 
-  return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome modal.
-    <div
-      className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-bg-primary/85 py-8 backdrop-blur-sm"
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
-      ref={backdropRef}
-      role="presentation"
-      style={{ zIndex: Z_INDEX_MODAL }}
-      tabIndex={-1}
-    >
-      <div
-        role="dialog"
-        aria-modal
-        aria-label="Welcome to Compass Calendar"
-        className="flex w-140 max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
-      >
-        {/* Header */}
-        <div className="flex flex-col gap-2">
-          <h2 className="font-bold text-2xl text-text-lighter">Ahoy!</h2>
-          <p className="text-text-lighter">
-            You found a simple, fast calendar.
-          </p>
-        </div>
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome modal.
+		<div
+			className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-bg-primary/85 py-8 backdrop-blur-sm"
+			onClick={handleBackdropClick}
+			onKeyDown={handleKeyDown}
+			ref={backdropRef}
+			role="presentation"
+			style={{ zIndex: Z_INDEX_MODAL }}
+			tabIndex={-1}
+		>
+			<div
+				role="dialog"
+				aria-modal
+				aria-label="Welcome to Compass Calendar"
+				className="flex w-140 max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
+			>
+				{/* Header */}
+				<div className="flex flex-col gap-2">
+					<h2 className="font-bold text-2xl text-text-lighter">Ahoy!</h2>
+					<p className="text-text-lighter">
+						You found a simple, fast calendar.
+					</p>
+				</div>
 
-        {/* Action buttons */}
-        <div className="flex gap-3">
-          <button
-            type="button"
-            onClick={dismiss}
-            className="c-button c-button-primary flex-1"
-          >
-            Start Now
-          </button>
-          <button
-            type="button"
-            onClick={handleLogIn}
-            className="c-button c-button-secondary flex-1"
-          >
-            Log In
-          </button>
-        </div>
+				{/* Action buttons */}
+				<div className="flex gap-3">
+					<button
+						type="button"
+						onClick={dismiss}
+						className="c-button c-button-primary flex-1"
+					>
+						Start Now
+					</button>
+					<button
+						type="button"
+						onClick={handleLogIn}
+						className="c-button c-button-secondary flex-1"
+					>
+						Log In
+					</button>
+				</div>
 
-        {/* FAQ */}
-        <div className="flex flex-col divide-y divide-border-primary">
-          {FAQ_ITEMS.map((item, index) => {
-            const isExpanded = expandedFaqs.has(item.question);
-            const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
-            const state = isExpanded ? "open" : "closed";
+				{/* FAQ */}
+				<div className="flex flex-col divide-y divide-border-primary">
+					{FAQ_ITEMS.map((item, index) => {
+						const isExpanded = expandedFaqs.has(item.question);
+						const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
+						const state = isExpanded ? "open" : "closed";
 
-            return (
-              <div key={item.question} className="py-3">
-                <button
-                  type="button"
-                  aria-controls={answerId}
-                  aria-expanded={isExpanded}
-                  className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text-lighter transition-colors hover:text-text-lightest"
-                  onClick={() => toggleFaq(item.question)}
-                >
-                  {item.question}
-                </button>
-                <div
-                  id={answerId}
-                  aria-hidden={!isExpanded}
-                  className="c-disclosure-content"
-                  data-state={state}
-                >
-                  <div>
-                    <div className="mt-2 text-sm text-text-light leading-relaxed">
-                      {item.answer !== null ? (
-                        item.answer
-                      ) : (
-                        <>
-                          All of it! Compass is a monorepo that includes the
-                          API, frontend, CLI, and more. You can run it yourself
-                          too; read the{" "}
-                          <a
-                            href="/blog/self-host"
-                            className="c-focus-ring font-medium text-accent-primary underline-offset-4 hover:underline"
-                          >
-                            self-hosting guide
-                          </a>{" "}
-                          to set up your own instance. It&apos;s all available
-                          on GitHub (link in footer), and we&apos;re always
-                          looking for contributors :]
-                        </>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+						return (
+							<div key={item.question} className="py-3">
+								<button
+									type="button"
+									aria-controls={answerId}
+									aria-expanded={isExpanded}
+									className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text-lighter transition-colors hover:text-text-lightest"
+									onClick={() => toggleFaq(item.question)}
+								>
+									{item.question}
+								</button>
+								<div
+									id={answerId}
+									aria-hidden={!isExpanded}
+									className="c-disclosure-content"
+									data-state={state}
+								>
+									<div>
+										<div className="mt-2 text-sm text-text-light leading-relaxed">
+											{item.answer !== null ? (
+												item.answer
+											) : (
+												<>
+													All of it! Compass is a monorepo that includes the
+													API, frontend, CLI, and more. You can run it yourself
+													too; read the{" "}
+													<a
+														href="/blog/self-host"
+														className="c-focus-ring font-medium text-accent-primary underline-offset-4 hover:underline"
+													>
+														self-hosting guide
+													</a>{" "}
+													to set up your own instance. It&apos;s all available
+													on GitHub (link in footer), and we&apos;re always
+													looking for contributors :]
+												</>
+											)}
+										</div>
+									</div>
+								</div>
+							</div>
+						);
+					})}
+				</div>
 
-        {/* Footer: social + legal */}
-        <div className="flex items-center justify-between border-border-primary border-t pt-4">
-          <div className="flex items-center gap-3">
-            <a
-              href="https://x.com/CompassCalendar"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="X (Twitter)"
-              className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
-            >
-              <XLogoIcon size={18} weight="bold" />
-            </a>
-            <a
-              href="https://www.linkedin.com/company/compass-calendar"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn"
-              className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
-            >
-              <LinkedinLogoIcon size={18} weight="bold" />
-            </a>
-            <a
-              href="https://www.github.com/SwitchbackTech/compass-calendar"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="GitHub"
-              className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
-            >
-              <GithubLogoIcon size={18} weight="bold" />
-            </a>
-          </div>
-          <div className="flex items-center gap-4 text-text-light text-xs">
-            <a
-              href="https://compasscalendar.com/privacy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
-            >
-              Privacy
-            </a>
-            <a
-              href="https://compasscalendar.com/terms"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
-            >
-              Terms
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+				{/* Footer: social + legal */}
+				<div className="flex items-center justify-between border-border-primary border-t pt-4">
+					<div className="flex items-center gap-3">
+						<a
+							href="https://x.com/CompassCalendar"
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="X (Twitter)"
+							className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
+						>
+							<XLogoIcon size={18} weight="bold" />
+						</a>
+						<a
+							href="https://www.linkedin.com/company/compass-calendar"
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="LinkedIn"
+							className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
+						>
+							<LinkedinLogoIcon size={18} weight="bold" />
+						</a>
+						<a
+							href="https://www.github.com/SwitchbackTech/compass-calendar"
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="GitHub"
+							className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
+						>
+							<GithubLogoIcon size={18} weight="bold" />
+						</a>
+					</div>
+					<div className="flex items-center gap-4 text-text-light text-xs">
+						<a
+							href="https://compasscalendar.com/privacy"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
+						>
+							Privacy
+						</a>
+						<a
+							href="https://compasscalendar.com/terms"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
+						>
+							Terms
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -3,6 +3,8 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   useContext,
+  useEffect,
+  useRef,
   useState,
 } from "react";
 import { SessionContext } from "@web/auth/compass/session/SessionProvider";
@@ -55,6 +57,11 @@ export function WelcomeModal() {
   const [isOpen, setIsOpen] = useState(
     () => !authenticated && !hasSeenWelcome(),
   );
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    backdropRef.current?.focus();
+  }, []);
 
   if (!isOpen) return null;
 
@@ -86,6 +93,7 @@ export function WelcomeModal() {
       className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-bg-primary/85 py-8 backdrop-blur-sm"
       onClick={handleBackdropClick}
       onKeyDown={handleKeyDown}
+      ref={backdropRef}
       role="presentation"
       style={{ zIndex: Z_INDEX_MODAL }}
       tabIndex={-1}

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -9,7 +9,7 @@ import { SessionContext } from "@web/auth/compass/session/SessionProvider";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 
-const STORAGE_KEY = "compass.onboarding.has-seen-welcome";
+export const STORAGE_KEY = "compass.onboarding.has-seen-welcome";
 
 function hasSeenWelcome(): boolean {
   try {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -176,6 +176,7 @@ export function WelcomeModal() {
 									aria-hidden={!isExpanded}
 									className="c-disclosure-content"
 									data-state={state}
+									inert={isExpanded ? undefined : ""}
 								>
 									<div>
 										<div className="mt-2 text-sm text-text-light leading-relaxed">

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -15,46 +15,8 @@ import {
 	useRef,
 	useState,
 } from "react";
-
-export const STORAGE_KEY = "compass.onboarding.has-seen-welcome";
-
-function hasSeenWelcome(): boolean {
-	try {
-		return localStorage.getItem(STORAGE_KEY) === "true";
-	} catch {
-		return true;
-	}
-}
-
-function markWelcomeSeen(): void {
-	try {
-		localStorage.setItem(STORAGE_KEY, "true");
-	} catch {
-		// Silently fail if localStorage is unavailable
-	}
-}
-
-const FAQ_ITEMS = [
-	{
-		question: "Who is Compass for?",
-		answer:
-			"Compass is designed for minimalists who value efficiency, keyboard shortcuts, and open-source software. We are focused on helping people do more with less.",
-	},
-	{
-		question: "Does Compass use AI?",
-		answer:
-			"Not currently. Compass gives you the tools to make your own decisions about how to spend your time, without algorithmic suggestions you'll ignore anyway.",
-	},
-	{
-		question: "How much of the code is open-source?",
-		answer: null, // rendered separately
-	},
-	{
-		question: "What makes Compass different from other calendars?",
-		answer:
-			"It's simpler and faster. Instead of doing everything, we do a few things well.",
-	},
-];
+import { FAQ_ITEMS } from "./faq";
+import { hasSeenWelcome, markWelcomeSeen } from "./welcome.modal.util";
 
 export function WelcomeModal() {
 	const { authenticated } = useContext(SessionContext);
@@ -183,18 +145,15 @@ export function WelcomeModal() {
 												item.answer
 											) : (
 												<>
-													All of it! Compass is a monorepo that includes the
-													API, frontend, CLI, and more. You can run it yourself
-													too; read the{" "}
+													Yes! The repo includes the API, frontend, CLI, and
+													more. You can run it yourself too; read the{" "}
 													<a
 														href="/blog/self-host"
 														className="c-focus-ring font-medium text-accent-primary underline-offset-4 hover:underline"
 													>
 														self-hosting guide
 													</a>{" "}
-													to set up your own instance. It&apos;s all available
-													on GitHub (link in footer), and we&apos;re always
-													looking for contributors :]
+													to set up your own instance.
 												</>
 											)}
 										</div>

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -176,7 +176,6 @@ export function WelcomeModal() {
 									aria-hidden={!isExpanded}
 									className="c-disclosure-content"
 									data-state={state}
-									inert={isExpanded ? undefined : ""}
 								>
 									<div>
 										<div className="mt-2 text-sm text-text-light leading-relaxed">

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -1,250 +1,248 @@
 import { LinkedinLogoIcon, XLogoIcon } from "@phosphor-icons/react";
-import {
-  type KeyboardEvent,
-  type MouseEvent,
-  useContext,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
 import { SessionContext } from "@web/auth/compass/session/SessionProvider";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
+import {
+	type KeyboardEvent,
+	type MouseEvent,
+	useContext,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+} from "react";
 
 export const STORAGE_KEY = "compass.onboarding.has-seen-welcome";
 
 function hasSeenWelcome(): boolean {
-  try {
-    return localStorage.getItem(STORAGE_KEY) === "true";
-  } catch {
-    return true;
-  }
+	try {
+		return localStorage.getItem(STORAGE_KEY) === "true";
+	} catch {
+		return true;
+	}
 }
 
 function markWelcomeSeen(): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, "true");
-  } catch {
-    // Silently fail if localStorage is unavailable
-  }
+	try {
+		localStorage.setItem(STORAGE_KEY, "true");
+	} catch {
+		// Silently fail if localStorage is unavailable
+	}
 }
 
 const FAQ_ITEMS = [
-  {
-    question: "Who is Compass for?",
-    answer:
-      "Compass is designed for minimalists who value efficiency, keyboard shortcuts, and open-source software. We are focused on helping people do more with less.",
-  },
-  {
-    question: "Does Compass use AI?",
-    answer:
-      "Not currently. Compass gives you the tools to make your own decisions about how to spend your time, without algorithmic suggestions you'll ignore anyway.",
-  },
-  {
-    question: "How much of the code is open-source?",
-    answer: null, // rendered separately
-  },
-  {
-    question: "What makes Compass different from other calendars?",
-    answer:
-      "It's simpler and faster. Instead of doing everything, we do a few things well.",
-  },
+	{
+		question: "Who is Compass for?",
+		answer:
+			"Compass is designed for minimalists who value efficiency, keyboard shortcuts, and open-source software. We are focused on helping people do more with less.",
+	},
+	{
+		question: "Does Compass use AI?",
+		answer:
+			"Not currently. Compass gives you the tools to make your own decisions about how to spend your time, without algorithmic suggestions you'll ignore anyway.",
+	},
+	{
+		question: "How much of the code is open-source?",
+		answer: null, // rendered separately
+	},
+	{
+		question: "What makes Compass different from other calendars?",
+		answer:
+			"It's simpler and faster. Instead of doing everything, we do a few things well.",
+	},
 ];
 
 export function WelcomeModal() {
-  const { authenticated } = useContext(SessionContext);
-  const { openModal } = useAuthModal();
-  const disclosureIdPrefix = useId();
-  const [isOpen, setIsOpen] = useState(
-    () => !authenticated && !hasSeenWelcome(),
-  );
-  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const backdropRef = useRef<HTMLDivElement>(null);
+	const { authenticated } = useContext(SessionContext);
+	const { openModal } = useAuthModal();
+	const disclosureIdPrefix = useId();
+	const [isOpen, setIsOpen] = useState(
+		() => !authenticated && !hasSeenWelcome(),
+	);
+	const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const backdropRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    backdropRef.current?.focus();
-  }, []);
+	useEffect(() => {
+		backdropRef.current?.focus();
+	}, []);
 
-  if (!isOpen) return null;
+	if (!isOpen) return null;
 
-  const dismiss = () => {
-    markWelcomeSeen();
-    setIsOpen(false);
-  };
+	const dismiss = () => {
+		markWelcomeSeen();
+		setIsOpen(false);
+	};
 
-  const handleLogIn = () => {
-    dismiss();
-    openModal("login");
-  };
+	const handleLogIn = () => {
+		dismiss();
+		openModal("login");
+	};
 
-  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      dismiss();
-    }
-  };
+	const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+		if (event.target === event.currentTarget) {
+			dismiss();
+		}
+	};
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      dismiss();
-    }
-  };
+	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (event.key === "Escape") {
+			dismiss();
+		}
+	};
 
-  const toggleFaq = (question: string) => {
-    setExpandedFaqs((currentFaqs) => {
-      const nextFaqs = new Set(currentFaqs);
+	const toggleFaq = (question: string) => {
+		setExpandedFaqs((currentFaqs) => {
+			const nextFaqs = new Set(currentFaqs);
 
-      if (nextFaqs.has(question)) {
-        nextFaqs.delete(question);
-      } else {
-        nextFaqs.add(question);
-      }
+			if (nextFaqs.has(question)) {
+				nextFaqs.delete(question);
+			} else {
+				nextFaqs.add(question);
+			}
 
-      return nextFaqs;
-    });
-  };
+			return nextFaqs;
+		});
+	};
 
-  return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome modal.
-    <div
-      className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-bg-primary/85 py-8 backdrop-blur-sm"
-      onClick={handleBackdropClick}
-      onKeyDown={handleKeyDown}
-      ref={backdropRef}
-      role="presentation"
-      style={{ zIndex: Z_INDEX_MODAL }}
-      tabIndex={-1}
-    >
-      <div
-        role="dialog"
-        aria-modal
-        aria-label="Welcome to Compass Calendar"
-        className="flex w-140 max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
-      >
-        {/* Header */}
-        <div className="flex flex-col gap-2">
-          <h2 className="m-0 font-bold text-2xl text-text-lighter">
-            Ahoy! You found a simple, fast calendar.
-          </h2>
-          <p className="m-0 text-base text-text-light">
-            Compass Calendar is the best place to manage your week.
-          </p>
-        </div>
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome modal.
+		<div
+			className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-bg-primary/85 py-8 backdrop-blur-sm"
+			onClick={handleBackdropClick}
+			onKeyDown={handleKeyDown}
+			ref={backdropRef}
+			role="presentation"
+			style={{ zIndex: Z_INDEX_MODAL }}
+			tabIndex={-1}
+		>
+			<div
+				role="dialog"
+				aria-modal
+				aria-label="Welcome to Compass Calendar"
+				className="flex w-140 max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
+			>
+				{/* Header */}
+				<div className="flex flex-col gap-2">
+					<h2 className="font-bold text-2xl text-text-lighter">Ahoy!</h2>
+					<p className="text-text-lighter">
+						You found a simple, fast calendar.
+					</p>
+				</div>
 
-        {/* Action buttons */}
-        <div className="flex gap-3">
-          <button
-            type="button"
-            onClick={dismiss}
-            className="c-button c-button-primary flex-1"
-          >
-            Start Now
-          </button>
-          <button
-            type="button"
-            onClick={handleLogIn}
-            className="c-button c-button-secondary flex-1"
-          >
-            Log In
-          </button>
-        </div>
+				{/* Action buttons */}
+				<div className="flex gap-3">
+					<button
+						type="button"
+						onClick={dismiss}
+						className="c-button c-button-primary flex-1"
+					>
+						Start Now
+					</button>
+					<button
+						type="button"
+						onClick={handleLogIn}
+						className="c-button c-button-secondary flex-1"
+					>
+						Log In
+					</button>
+				</div>
 
-        {/* FAQ */}
-        <div className="flex flex-col divide-y divide-border-primary">
-          {FAQ_ITEMS.map((item, index) => {
-            const isExpanded = expandedFaqs.has(item.question);
-            const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
-            const state = isExpanded ? "open" : "closed";
+				{/* FAQ */}
+				<div className="flex flex-col divide-y divide-border-primary">
+					{FAQ_ITEMS.map((item, index) => {
+						const isExpanded = expandedFaqs.has(item.question);
+						const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
+						const state = isExpanded ? "open" : "closed";
 
-            return (
-              <div key={item.question} className="py-3">
-                <button
-                  type="button"
-                  aria-controls={answerId}
-                  aria-expanded={isExpanded}
-                  className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text-lighter transition-colors hover:text-text-lightest"
-                  onClick={() => toggleFaq(item.question)}
-                >
-                  {item.question}
-                </button>
-                <div
-                  id={answerId}
-                  aria-hidden={!isExpanded}
-                  className="c-disclosure-content"
-                  data-state={state}
-                >
-                  <div>
-                    <div className="mt-2 text-sm text-text-light leading-relaxed">
-                      {item.answer !== null ? (
-                        item.answer
-                      ) : (
-                        <>
-                          All of it! Compass is a monorepo that includes the
-                          API, frontend, CLI, and more. You can run it yourself
-                          too; read the{" "}
-                          <a
-                            href="/blog/self-host"
-                            className="c-focus-ring font-medium text-accent-primary underline-offset-4 hover:underline"
-                          >
-                            self-hosting guide
-                          </a>{" "}
-                          to set up your own instance. It&apos;s all available
-                          on GitHub (link in footer), and we&apos;re always
-                          looking for contributors :]
-                        </>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+						return (
+							<div key={item.question} className="py-3">
+								<button
+									type="button"
+									aria-controls={answerId}
+									aria-expanded={isExpanded}
+									className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text-lighter transition-colors hover:text-text-lightest"
+									onClick={() => toggleFaq(item.question)}
+								>
+									{item.question}
+								</button>
+								<div
+									id={answerId}
+									aria-hidden={!isExpanded}
+									className="c-disclosure-content"
+									data-state={state}
+								>
+									<div>
+										<div className="mt-2 text-sm text-text-light leading-relaxed">
+											{item.answer !== null ? (
+												item.answer
+											) : (
+												<>
+													All of it! Compass is a monorepo that includes the
+													API, frontend, CLI, and more. You can run it yourself
+													too; read the{" "}
+													<a
+														href="/blog/self-host"
+														className="c-focus-ring font-medium text-accent-primary underline-offset-4 hover:underline"
+													>
+														self-hosting guide
+													</a>{" "}
+													to set up your own instance. It&apos;s all available
+													on GitHub (link in footer), and we&apos;re always
+													looking for contributors :]
+												</>
+											)}
+										</div>
+									</div>
+								</div>
+							</div>
+						);
+					})}
+				</div>
 
-        {/* Footer: social + legal */}
-        <div className="flex items-center justify-between border-border-primary border-t pt-4">
-          <div className="flex items-center gap-3">
-            <a
-              href="https://x.com/CompassCalendar"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="X (Twitter)"
-              className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
-            >
-              <XLogoIcon size={18} weight="bold" />
-            </a>
-            <a
-              href="https://www.linkedin.com/company/compass-calendar"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn"
-              className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
-            >
-              <LinkedinLogoIcon size={18} weight="bold" />
-            </a>
-          </div>
-          <div className="flex items-center gap-4 text-text-light text-xs">
-            <a
-              href="https://compasscalendar.com/privacy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
-            >
-              Privacy
-            </a>
-            <a
-              href="https://compasscalendar.com/terms"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
-            >
-              Terms
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+				{/* Footer: social + legal */}
+				<div className="flex items-center justify-between border-border-primary border-t pt-4">
+					<div className="flex items-center gap-3">
+						<a
+							href="https://x.com/CompassCalendar"
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="X (Twitter)"
+							className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
+						>
+							<XLogoIcon size={18} weight="bold" />
+						</a>
+						<a
+							href="https://www.linkedin.com/company/compass-calendar"
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="LinkedIn"
+							className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
+						>
+							<LinkedinLogoIcon size={18} weight="bold" />
+						</a>
+					</div>
+					<div className="flex items-center gap-4 text-text-light text-xs">
+						<a
+							href="https://compasscalendar.com/privacy"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
+						>
+							Privacy
+						</a>
+						<a
+							href="https://compasscalendar.com/terms"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
+						>
+							Terms
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -1,9 +1,10 @@
-import { LinkedinLogo, XLogo } from "@phosphor-icons/react";
+import { LinkedinLogoIcon, XLogoIcon } from "@phosphor-icons/react";
 import {
   type KeyboardEvent,
   type MouseEvent,
   useContext,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
@@ -54,8 +55,12 @@ const FAQ_ITEMS = [
 export function WelcomeModal() {
   const { authenticated } = useContext(SessionContext);
   const { openModal } = useAuthModal();
+  const disclosureIdPrefix = useId();
   const [isOpen, setIsOpen] = useState(
     () => !authenticated && !hasSeenWelcome(),
+  );
+  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
+    () => new Set(),
   );
   const backdropRef = useRef<HTMLDivElement>(null);
 
@@ -87,6 +92,20 @@ export function WelcomeModal() {
     }
   };
 
+  const toggleFaq = (question: string) => {
+    setExpandedFaqs((currentFaqs) => {
+      const nextFaqs = new Set(currentFaqs);
+
+      if (nextFaqs.has(question)) {
+        nextFaqs.delete(question);
+      } else {
+        nextFaqs.add(question);
+      }
+
+      return nextFaqs;
+    });
+  };
+
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome modal.
     <div
@@ -102,7 +121,7 @@ export function WelcomeModal() {
         role="dialog"
         aria-modal
         aria-label="Welcome to Compass Calendar"
-        className="flex w-[560px] max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
+        className="flex w-140 max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]"
       >
         {/* Header */}
         <div className="flex flex-col gap-2">
@@ -110,8 +129,7 @@ export function WelcomeModal() {
             Ahoy! You found a simple, fast calendar.
           </h2>
           <p className="m-0 text-base text-text-light">
-            We&apos;re making Compass Calendar the best place to manage your
-            week.
+            Compass Calendar is the best place to manage your week.
           </p>
         </div>
 
@@ -120,14 +138,14 @@ export function WelcomeModal() {
           <button
             type="button"
             onClick={dismiss}
-            className="h-11 flex-1 rounded bg-accent-primary px-4 font-medium text-sm text-text-dark transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
+            className="c-button c-button-primary flex-1"
           >
             Start Now
           </button>
           <button
             type="button"
             onClick={handleLogIn}
-            className="h-11 flex-1 rounded border border-border-primary bg-panel-badge-bg px-4 text-sm text-text-lighter transition-colors hover:bg-panel-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg"
+            className="c-button c-button-secondary flex-1"
           >
             Log In
           </button>
@@ -135,33 +153,54 @@ export function WelcomeModal() {
 
         {/* FAQ */}
         <div className="flex flex-col divide-y divide-border-primary">
-          {FAQ_ITEMS.map((item) => (
-            <details key={item.question} className="group py-3">
-              <summary className="cursor-pointer select-none list-none rounded font-medium text-sm text-text-lighter hover:text-text-lightest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary">
-                {item.question}
-              </summary>
-              <div className="mt-2 text-sm text-text-light leading-relaxed">
-                {item.answer !== null ? (
-                  item.answer
-                ) : (
-                  <>
-                    All of it! Compass is a monorepo that includes the API,
-                    frontend, CLI, and more. You can run it yourself too; read
-                    the{" "}
-                    <a
-                      href="/blog/self-host"
-                      className="font-medium text-accent-primary underline-offset-4 hover:underline"
-                    >
-                      self-hosting guide
-                    </a>{" "}
-                    to set up your own instance. It&apos;s all available on
-                    GitHub (link in footer), and we&apos;re always looking for
-                    contributors :]
-                  </>
-                )}
+          {FAQ_ITEMS.map((item, index) => {
+            const isExpanded = expandedFaqs.has(item.question);
+            const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
+            const state = isExpanded ? "open" : "closed";
+
+            return (
+              <div key={item.question} className="py-3">
+                <button
+                  type="button"
+                  aria-controls={answerId}
+                  aria-expanded={isExpanded}
+                  className="w-full cursor-pointer select-none rounded text-left font-medium text-sm text-text-lighter transition-colors hover:text-text-lightest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+                  onClick={() => toggleFaq(item.question)}
+                >
+                  {item.question}
+                </button>
+                <div
+                  id={answerId}
+                  aria-hidden={!isExpanded}
+                  className="c-disclosure-content"
+                  data-state={state}
+                >
+                  <div>
+                    <div className="mt-2 text-sm text-text-light leading-relaxed">
+                      {item.answer !== null ? (
+                        item.answer
+                      ) : (
+                        <>
+                          All of it! Compass is a monorepo that includes the
+                          API, frontend, CLI, and more. You can run it yourself
+                          too; read the{" "}
+                          <a
+                            href="/blog/self-host"
+                            className="font-medium text-accent-primary underline-offset-4 hover:underline"
+                          >
+                            self-hosting guide
+                          </a>{" "}
+                          to set up your own instance. It&apos;s all available
+                          on GitHub (link in footer), and we&apos;re always
+                          looking for contributors :]
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
               </div>
-            </details>
-          ))}
+            );
+          })}
         </div>
 
         {/* Footer: social + legal */}
@@ -174,7 +213,7 @@ export function WelcomeModal() {
               aria-label="X (Twitter)"
               className="rounded text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
             >
-              <XLogo size={18} weight="bold" />
+              <XLogoIcon size={18} weight="bold" />
             </a>
             <a
               href="https://www.linkedin.com/company/compass-calendar"
@@ -183,7 +222,7 @@ export function WelcomeModal() {
               aria-label="LinkedIn"
               className="rounded text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
             >
-              <LinkedinLogo size={18} weight="bold" />
+              <LinkedinLogoIcon size={18} weight="bold" />
             </a>
           </div>
           <div className="flex items-center gap-4 text-text-light text-xs">

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -164,7 +164,7 @@ export function WelcomeModal() {
                   type="button"
                   aria-controls={answerId}
                   aria-expanded={isExpanded}
-                  className="w-full cursor-pointer select-none rounded text-left font-medium text-sm text-text-lighter transition-colors hover:text-text-lightest focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+                  className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text-lighter transition-colors hover:text-text-lightest"
                   onClick={() => toggleFaq(item.question)}
                 >
                   {item.question}
@@ -186,7 +186,7 @@ export function WelcomeModal() {
                           too; read the{" "}
                           <a
                             href="/blog/self-host"
-                            className="font-medium text-accent-primary underline-offset-4 hover:underline"
+                            className="c-focus-ring font-medium text-accent-primary underline-offset-4 hover:underline"
                           >
                             self-hosting guide
                           </a>{" "}
@@ -211,7 +211,7 @@ export function WelcomeModal() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="X (Twitter)"
-              className="rounded text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+              className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
             >
               <XLogoIcon size={18} weight="bold" />
             </a>
@@ -220,7 +220,7 @@ export function WelcomeModal() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="LinkedIn"
-              className="rounded text-text-light transition-colors hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
+              className="c-focus-ring text-text-light transition-colors hover:text-text-lighter"
             >
               <LinkedinLogoIcon size={18} weight="bold" />
             </a>
@@ -230,7 +230,7 @@ export function WelcomeModal() {
               href="https://compasscalendar.com/privacy"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline-offset-4 hover:text-text-lighter hover:underline"
+              className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
             >
               Privacy
             </a>
@@ -238,7 +238,7 @@ export function WelcomeModal() {
               href="https://compasscalendar.com/terms"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline-offset-4 hover:text-text-lighter hover:underline"
+              className="c-focus-ring underline-offset-4 hover:text-text-lighter hover:underline"
             >
               Terms
             </a>

--- a/packages/web/src/components/WelcomeModal/faq.ts
+++ b/packages/web/src/components/WelcomeModal/faq.ts
@@ -1,0 +1,21 @@
+export const FAQ_ITEMS = [
+	{
+		question: "Who is Compass for?",
+		answer:
+			"Compass is designed for minimalists who value efficiency, keyboard shortcuts, and open-source software. We are focused on helping people do more with less.",
+	},
+	{
+		question: "Does Compass use AI?",
+		answer:
+			"Not currently. Compass gives you the tools to make your own decisions about how to spend your time, without algorithmic suggestions you'll ignore anyway.",
+	},
+	{
+		question: "Is it open-source?",
+		answer: null, // rendered separately
+	},
+	{
+		question: "What makes Compass different from other calendars?",
+		answer:
+			"It's simpler and faster. Instead of doing everything, we do a few things well.",
+	},
+];

--- a/packages/web/src/components/WelcomeModal/welcome.modal.util.ts
+++ b/packages/web/src/components/WelcomeModal/welcome.modal.util.ts
@@ -1,0 +1,17 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+
+export function hasSeenWelcome(): boolean {
+	try {
+		return localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME) === "true";
+	} catch {
+		return true;
+	}
+}
+
+export function markWelcomeSeen(): void {
+	try {
+		localStorage.setItem(STORAGE_KEYS.HAS_SEEN_WELCOME, "true");
+	} catch {
+		// Silently fail if localStorage is unavailable
+	}
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -227,14 +227,15 @@
 }
 
 @utility c-disclosure-content {
-  @apply grid grid-rows-[0fr] overflow-hidden opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none;
+  @apply invisible grid grid-rows-[0fr] overflow-hidden opacity-0 transition-[grid-template-rows,opacity,visibility] duration-200 ease-out motion-reduce:transition-none;
+  transition-behavior: allow-discrete;
 
   & > * {
     min-height: 0;
   }
 
   &[data-state="open"] {
-    @apply grid-rows-[1fr] opacity-100;
+    @apply visible grid-rows-[1fr] opacity-100;
   }
 }
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -192,8 +192,12 @@
   }
 }
 
+@utility c-focus-ring {
+  @apply rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg;
+}
+
 @utility c-button {
-  @apply inline-flex h-11 items-center justify-center rounded px-4 font-medium text-sm transition-[background-color,border-color,box-shadow,filter,transform] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg disabled:pointer-events-none disabled:opacity-60;
+  @apply c-focus-ring inline-flex h-11 items-center justify-center px-4 font-medium text-sm transition-[background-color,border-color,box-shadow,filter,transform] duration-150 ease-out disabled:pointer-events-none disabled:opacity-60;
 
   box-shadow:
     0 10px 18px -10px var(--color-shadow-default),

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -227,37 +227,14 @@
 }
 
 @utility c-disclosure-content {
-  display: grid;
-  grid-template-rows: 0fr;
-  opacity: 0;
-  transform: translateY(-2px);
-  visibility: hidden;
-  transition:
-    grid-template-rows 180ms cubic-bezier(0.16, 1, 0.3, 1),
-    opacity 160ms ease-out,
-    transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
-    visibility 0s linear 180ms;
+  @apply grid grid-rows-[0fr] overflow-hidden opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none;
 
   & > * {
     min-height: 0;
-    overflow: hidden;
   }
 
   &[data-state="open"] {
-    grid-template-rows: 1fr;
-    opacity: 1;
-    transform: translateY(0);
-    visibility: visible;
-    transition:
-      grid-template-rows 180ms cubic-bezier(0.16, 1, 0.3, 1),
-      opacity 160ms ease-out,
-      transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
-      visibility 0s;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    transition: none;
-    transform: none;
+    @apply grid-rows-[1fr] opacity-100;
   }
 }
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -193,7 +193,7 @@
 }
 
 @utility c-focus-ring {
-  @apply rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg;
+  @apply rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-primary focus-visible:ring-offset-1 focus-visible:ring-offset-panel-bg;
 }
 
 @utility c-button {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -192,6 +192,71 @@
   }
 }
 
+@utility c-button {
+  @apply inline-flex h-11 items-center justify-center rounded px-4 font-medium text-sm transition-[background-color,border-color,box-shadow,filter,transform] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary focus-visible:ring-offset-2 focus-visible:ring-offset-panel-bg disabled:pointer-events-none disabled:opacity-60;
+
+  box-shadow:
+    0 10px 18px -10px var(--color-shadow-default),
+    0 4px 8px -6px var(--color-shadow-default);
+
+  &:hover {
+    box-shadow:
+      0 16px 24px -12px var(--color-shadow-default),
+      0 8px 12px -8px var(--color-shadow-default);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    box-shadow:
+      0 6px 12px -10px var(--color-shadow-default),
+      0 2px 6px -6px var(--color-shadow-default);
+    transform: translateY(0);
+  }
+}
+
+@utility c-button-primary {
+  @apply bg-accent-primary text-text-dark hover:brightness-110;
+}
+
+@utility c-button-secondary {
+  @apply border border-border-primary bg-panel-badge-bg text-text-lighter hover:bg-panel-bg;
+}
+
+@utility c-disclosure-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transform: translateY(-2px);
+  visibility: hidden;
+  transition:
+    grid-template-rows 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 160ms ease-out,
+    transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    visibility 0s linear 180ms;
+
+  & > * {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &[data-state="open"] {
+    grid-template-rows: 1fr;
+    opacity: 1;
+    transform: translateY(0);
+    visibility: visible;
+    transition:
+      grid-template-rows 180ms cubic-bezier(0.16, 1, 0.3, 1),
+      opacity 160ms ease-out,
+      transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
+      visibility 0s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+    transform: none;
+  }
+}
+
 @utility compass-scroll {
   @layer components {
     :focus-visible {

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from "@testing-library/react";
+import { act } from "react";
 import { Origin, Priorities } from "@core/constants/core.constants";
 import { Categories_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
@@ -186,7 +187,9 @@ describe("useDraftActions", () => {
       { wrapper },
     );
 
-    result.current.duplicateEvent();
+    act(() => {
+      result.current.duplicateEvent();
+    });
 
     const createAction = dispatchSpy.mock.calls.find(
       ([action]) => action.type === createEventSlice.actionNames.request,


### PR DESCRIPTION
## Summary
- add reusable c-prefixed Tailwind utilities for lifted buttons, disclosure animation, and focus rings
- update WelcomeModal buttons and FAQ disclosures to use the centralized utilities
- apply consistent accent focus styling to all modal controls and links

## Tests
- bunx biome check packages/web/src/components/WelcomeModal/WelcomeModal.tsx packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx packages/web/src/index.css
- bun test src/components/WelcomeModal/WelcomeModal.test.tsx
- bunx typescript@6.0.3 -p packages/web/tsconfig.app.json --noEmit
- bunx typescript@6.0.3 -p packages/web/tsconfig.test.json --noEmit
- bun run build.ts