### PR TITLE
fix(ci): add production kit email config

### DIFF
--- a/.github/docker/Dockerfile.web
+++ b/.github/docker/Dockerfile.web
@@ -5,6 +5,8 @@ COPY . .
 
 ARG BASEURL=http://localhost:3000/api
 ARG GOOGLE_CLIENT_ID=
+ARG POSTHOG_KEY=
+ARG POSTHOG_HOST=
 ARG COMPASS_BUILD_REF=self-host
 
 ENV COMPASS_BUILD_REF=${COMPASS_BUILD_REF}
@@ -28,6 +30,14 @@ RUN printf '%s\n' \
   'google:' \
   "  clientId: ${GOOGLE_CLIENT_ID}" \
   > compass.yaml
+
+RUN if [ -n "$POSTHOG_KEY" ] && [ -n "$POSTHOG_HOST" ]; then \
+  printf '%s\n' \
+    'posthog:' \
+    "  key: ${POSTHOG_KEY}" \
+    "  host: ${POSTHOG_HOST}" \
+    >> compass.yaml; \
+  fi
 
 RUN bun install --frozen-lockfile
 RUN cd packages/web && bun run build.ts

--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: self-host/Dockerfile.web
+          file: .github/docker/Dockerfile.web
           push: true
           build-args: |
             BASEURL=${{ vars.BACKEND_API_URL }}
@@ -67,6 +67,7 @@ jobs:
           GCAL_NOTIFICATION_EXPIRATION_MIN: ${{ vars.GCAL_NOTIFICATION_EXPIRATION_MIN }}
           GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
           IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          KIT_USER_TAG_ID: ${{ inputs.environment == 'production' && vars.KIT_USER_TAG_ID || '' }}
           POSTHOG_KEY: ${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_KEY || '' }}
           POSTHOG_HOST: ${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_HOST || '' }}
           RELEASE_TAG: ${{ inputs.tag }}
@@ -77,6 +78,7 @@ jobs:
           COMPASS_SYNC_TOKEN: ${{ secrets.COMPASS_SYNC_TOKEN }}
           GCAL_NOTIFICATION_TOKEN: ${{ secrets.GCAL_NOTIFICATION_TOKEN }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          KIT_API_SECRET: ${{ inputs.environment == 'production' && secrets.KIT_API_SECRET || '' }}
           MONGO_PASSWORD: ${{ secrets.MONGO_PASSWORD }}
           MONGO_REPLICA_SET_KEY: ${{ secrets.MONGO_REPLICA_SET_KEY }}
           MONGO_URI: ${{ secrets.MONGO_URI }}
@@ -86,6 +88,12 @@ jobs:
           SUPERTOKENS_URI: ${{ secrets.SUPERTOKENS_URI }}
         run: |
           echo "Deploying Compass ${RELEASE_TAG} (image version: ${IMAGE_VERSION}) to ${{ inputs.environment }}"
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            if [ -z "$KIT_API_SECRET" ] || [ -z "$KIT_USER_TAG_ID" ]; then
+              echo "Production deploy requires KIT_API_SECRET and KIT_USER_TAG_ID." >&2
+              exit 1
+            fi
+          fi
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
@@ -128,6 +136,12 @@ jobs:
                 'posthog:' \
                 "  key: \"${POSTHOG_KEY}\"" \
                 "  host: \"${POSTHOG_HOST}\""
+            fi
+            if [ -n "$KIT_API_SECRET" ] && [ -n "$KIT_USER_TAG_ID" ]; then
+              printf '%s\n' \
+                'email:' \
+                "  kitApiSecret: \"${KIT_API_SECRET}\"" \
+                "  kitUserTagId: \"${KIT_USER_TAG_ID}\""
             fi
           } | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"

--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -52,6 +52,8 @@ jobs:
           build-args: |
             BASEURL=${{ vars.BACKEND_API_URL }}
             GOOGLE_CLIENT_ID=${{ vars.GOOGLE_CLIENT_ID }}
+            POSTHOG_KEY=${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_KEY || '' }}
+            POSTHOG_HOST=${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_HOST || '' }}
             COMPASS_BUILD_REF=${{ steps.version.outputs.image_version }}
           tags: switchbacktech/compass-web:${{ inputs.environment }}-${{ steps.version.outputs.image_version }}
 
@@ -65,6 +67,8 @@ jobs:
           GCAL_NOTIFICATION_EXPIRATION_MIN: ${{ vars.GCAL_NOTIFICATION_EXPIRATION_MIN }}
           GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
           IMAGE_VERSION: ${{ steps.version.outputs.image_version }}
+          POSTHOG_KEY: ${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_KEY || '' }}
+          POSTHOG_HOST: ${{ (inputs.environment == 'production' || inputs.environment == 'staging-cloud') && vars.POSTHOG_HOST || '' }}
           RELEASE_TAG: ${{ inputs.tag }}
           SSH_HOST: ${{ vars.SSH_HOST }}
           SSH_USER: ${{ vars.SSH_USER }}
@@ -86,39 +90,46 @@ jobs:
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
-          printf '%s\n' \
-            'runtime:' \
-            "  version: \"${IMAGE_VERSION}\"" \
-            '  nodeEnv: production' \
-            '  timezone: Etc/UTC' \
-            'web:' \
-            '  port: 9080' \
-            "  url: \"${FRONTEND_URL}\"" \
-            "  image: \"${WEB_IMAGE}\"" \
-            'backend:' \
-            '  port: 3000' \
-            "  apiUrl: \"${BACKEND_API_URL}\"" \
-            '  originsAllowed:' \
-            "    - \"${FRONTEND_URL}\"" \
-            "  compassToken: \"${COMPASS_SYNC_TOKEN}\"" \
-            'mongo:' \
-            '  username: compass' \
-            "  password: \"${MONGO_PASSWORD}\"" \
-            ${MONGO_REPLICA_SET_KEY:+"  replicaSetKey: \"${MONGO_REPLICA_SET_KEY}\""} \
-            "  uri: \"${MONGO_URI}\"" \
-            'supertokens:' \
-            "  uri: \"${SUPERTOKENS_URI}\"" \
-            "  key: \"${SUPERTOKENS_KEY}\"" \
-            ${SUPERTOKENS_POSTGRES_PASSWORD:+'  postgres:'} \
-            ${SUPERTOKENS_POSTGRES_PASSWORD:+'    user: supertokens'} \
-            ${SUPERTOKENS_POSTGRES_PASSWORD:+"    password: \"${SUPERTOKENS_POSTGRES_PASSWORD}\""} \
-            ${SUPERTOKENS_POSTGRES_PASSWORD:+'    database: supertokens'} \
-            'google:' \
-            "  clientId: \"${GOOGLE_CLIENT_ID}\"" \
-            "  clientSecret: \"${GOOGLE_CLIENT_SECRET}\"" \
-            "  notificationToken: \"${GCAL_NOTIFICATION_TOKEN}\"" \
-            ${GCAL_NOTIFICATION_EXPIRATION_MIN:+"  channelExpirationMin: ${GCAL_NOTIFICATION_EXPIRATION_MIN}"} \
-            | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
+          {
+            printf '%s\n' \
+              'runtime:' \
+              "  version: \"${IMAGE_VERSION}\"" \
+              '  nodeEnv: production' \
+              '  timezone: Etc/UTC' \
+              'web:' \
+              '  port: 9080' \
+              "  url: \"${FRONTEND_URL}\"" \
+              "  image: \"${WEB_IMAGE}\"" \
+              'backend:' \
+              '  port: 3000' \
+              "  apiUrl: \"${BACKEND_API_URL}\"" \
+              '  originsAllowed:' \
+              "    - \"${FRONTEND_URL}\"" \
+              "  compassToken: \"${COMPASS_SYNC_TOKEN}\"" \
+              'mongo:' \
+              '  username: compass' \
+              "  password: \"${MONGO_PASSWORD}\"" \
+              ${MONGO_REPLICA_SET_KEY:+"  replicaSetKey: \"${MONGO_REPLICA_SET_KEY}\""} \
+              "  uri: \"${MONGO_URI}\"" \
+              'supertokens:' \
+              "  uri: \"${SUPERTOKENS_URI}\"" \
+              "  key: \"${SUPERTOKENS_KEY}\"" \
+              ${SUPERTOKENS_POSTGRES_PASSWORD:+'  postgres:'} \
+              ${SUPERTOKENS_POSTGRES_PASSWORD:+'    user: supertokens'} \
+              ${SUPERTOKENS_POSTGRES_PASSWORD:+"    password: \"${SUPERTOKENS_POSTGRES_PASSWORD}\""} \
+              ${SUPERTOKENS_POSTGRES_PASSWORD:+'    database: supertokens'} \
+              'google:' \
+              "  clientId: \"${GOOGLE_CLIENT_ID}\"" \
+              "  clientSecret: \"${GOOGLE_CLIENT_SECRET}\"" \
+              "  notificationToken: \"${GCAL_NOTIFICATION_TOKEN}\"" \
+              ${GCAL_NOTIFICATION_EXPIRATION_MIN:+"  channelExpirationMin: ${GCAL_NOTIFICATION_EXPIRATION_MIN}"}
+            if [ -n "$POSTHOG_KEY" ] && [ -n "$POSTHOG_HOST" ]; then
+              printf '%s\n' \
+                'posthog:' \
+                "  key: \"${POSTHOG_KEY}\"" \
+                "  host: \"${POSTHOG_HOST}\""
+            fi
+          } | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"
           COMPOSE_GIT_REF="${COMPOSE_GIT_REF:-${RELEASE_TAG}}"
           compose_url="https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.yaml"

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -144,3 +144,8 @@ The workflow deploys to the GitHub `production` environment through
 `switchbacktech/compass-web:production-<version>`, then runs
 `deploy-health-check.yml` with the `cloud` profile. Production is expected to use
 external MongoDB and SuperTokens Cloud rather than self-hosted data services.
+
+For cloud web image builds, `_deploy-environment.yml` uses
+`.github/docker/Dockerfile.web` so frontend-only cloud config, such as PostHog,
+is baked into the bundle without adding cloud-only settings to the self-host
+Dockerfile.

--- a/self-host/Dockerfile.web
+++ b/self-host/Dockerfile.web
@@ -5,6 +5,8 @@ COPY . .
 
 ARG BASEURL=http://localhost:3000/api
 ARG GOOGLE_CLIENT_ID=
+ARG POSTHOG_KEY=
+ARG POSTHOG_HOST=
 ARG COMPASS_BUILD_REF=self-host
 
 ENV COMPASS_BUILD_REF=${COMPASS_BUILD_REF}
@@ -28,6 +30,14 @@ RUN printf '%s\n' \
   'google:' \
   "  clientId: ${GOOGLE_CLIENT_ID}" \
   > compass.yaml
+
+RUN if [ -n "$POSTHOG_KEY" ] && [ -n "$POSTHOG_HOST" ]; then \
+  printf '%s\n' \
+    'posthog:' \
+    "  key: ${POSTHOG_KEY}" \
+    "  host: ${POSTHOG_HOST}" \
+    >> compass.yaml; \
+  fi
 
 RUN bun install --frozen-lockfile
 RUN cd packages/web && bun run build.ts

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -85,6 +85,14 @@ describe("self-host docker compose", () => {
     expect(dockerfile).not.toContain("--environment");
   });
 
+  it("keeps PostHog out of the self-host web image", () => {
+    const dockerfile = readRepoFile("self-host/Dockerfile.web");
+
+    expect(dockerfile).not.toContain("COMPASS_WEB_BUILD_CONFIG_B64");
+    expect(dockerfile).not.toContain("POSTHOG_");
+    expect(dockerfile).not.toContain("posthog:");
+  });
+
   it("mounts compass.yaml into the backend container", () => {
     const compose = readFileSync(join(import.meta.dir, "compose.yaml"), {
       encoding: "utf8",
@@ -165,6 +173,51 @@ describe("staging deploy workflow", () => {
     );
     expect(workflow).toContain(
       'notificationToken: \\"$'.concat('{GCAL_NOTIFICATION_TOKEN}\\"'),
+    );
+  });
+
+  it("builds cloud deploy web images from a GitHub-only Dockerfile with PostHog config", () => {
+    const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
+    const dockerfile = readRepoFile(".github/docker/Dockerfile.web");
+
+    expect(workflow).toContain("file: .github/docker/Dockerfile.web");
+    expect(workflow).toContain("POSTHOG_KEY=$");
+    expect(workflow).toContain("POSTHOG_HOST=$");
+    expect(workflow).not.toContain("COMPASS_WEB_BUILD_CONFIG_B64");
+    expect(workflow).not.toContain("base64");
+    expect(dockerfile).toContain("ARG POSTHOG_KEY=");
+    expect(dockerfile).toContain("ARG POSTHOG_HOST=");
+    expect(dockerfile).toContain("'posthog:'");
+  });
+
+  it("writes Kit email config only for production deploys", () => {
+    const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
+
+    expect(workflow).toContain(
+      "KIT_USER_TAG_ID: $".concat(
+        "{{ inputs.environment == 'production' && vars.KIT_USER_TAG_ID || '' }}",
+      ),
+    );
+    expect(workflow).toContain(
+      "KIT_API_SECRET: $".concat(
+        "{{ inputs.environment == 'production' && secrets.KIT_API_SECRET || '' }}",
+      ),
+    );
+    expect(workflow).toContain(
+      'if [ "$'.concat('{{ inputs.environment }}" = "production" ]; then'),
+    );
+    expect(workflow).toContain(
+      "Production deploy requires KIT_API_SECRET and KIT_USER_TAG_ID",
+    );
+    expect(workflow).toContain(
+      'if [ -n "$KIT_API_SECRET" ] && [ -n "$KIT_USER_TAG_ID" ]; then',
+    );
+    expect(workflow).toContain("'email:'");
+    expect(workflow).toContain(
+      'kitApiSecret: \\"$'.concat('{KIT_API_SECRET}\\"'),
+    );
+    expect(workflow).toContain(
+      'kitUserTagId: \\"$'.concat('{KIT_USER_TAG_ID}\\"'),
     );
   });
 


### PR DESCRIPTION
## Summary
- add production-only Kit email config to deploy-generated `compass.yaml`
- fail production deploys early when `KIT_API_SECRET` or `KIT_USER_TAG_ID` is missing
- add focused workflow regression coverage for the production-only Kit wiring

## Why
Production signups were skipping `EmailService.tagNewUserIfEnabled()` because deployed `compass.yaml` did not include the existing `email.kitApiSecret` and `email.kitUserTagId` config values.

## Validation
- `bun test self-host/docker-compose.test.ts` passes: 20 pass, 0 fail
- direct Biome check on changed files passes
- `bun lint` still fails on existing unrelated repo issues: Biome schema version mismatch, import order in `packages/web/src/__tests__/patched-jest.d.ts`, and two redundant boolean casts

## Deploy note
Before production deploy, set these on the GitHub production environment:
- secret: `KIT_API_SECRET`
- variable: `KIT_USER_TAG_ID`
