### PR TITLE
fix(web): delete draft events immediately

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -7,7 +7,7 @@ import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { type Props as DateTimeSectionProps } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 type CapturedDateTimeSectionProps = Pick<
   DateTimeSectionProps,
@@ -36,7 +36,14 @@ mock.module(
 );
 
 mock.module("@web/views/Forms/EventForm/EventActionMenu", () => ({
-  EventActionMenu: () => <button type="button">Event actions</button>,
+  EventActionMenu: ({ onDelete }: { onDelete: () => void }) => (
+    <>
+      <button type="button">Event actions</button>
+      <button type="button" onClick={onDelete}>
+        Delete event
+      </button>
+    </>
+  ),
 }));
 
 mock.module("@web/views/Forms/EventForm/PrioritySection", () => ({
@@ -91,10 +98,16 @@ const createEvent = (overrides: Partial<Schema_Event> = {}): Schema_Event => ({
 });
 
 describe("EventForm", () => {
+  const originalConfirm = window.confirm;
+
   beforeEach(() => {
     HotkeyManager.resetInstance();
     capturedDateControlsSectionProps = null;
     document.body.removeAttribute("data-app-locked");
+  });
+
+  afterEach(() => {
+    window.confirm = originalConfirm;
   });
 
   it("renders the title before the actions on the same row", () => {
@@ -183,6 +196,33 @@ describe("EventForm", () => {
 
     expect(onDraftTitleArrowKey).not.toHaveBeenCalled();
     expect(afterTyping.defaultPrevented).toBe(false);
+  });
+
+  it("closes a draft event immediately when deleting from the menu", async () => {
+    const user = userEvent.setup();
+    const onClose = mock();
+    const onDelete = mock();
+    const confirm = mock(() => true);
+    window.confirm = confirm;
+
+    render(
+      <EventForm
+        event={createEvent({ _id: undefined, title: "Unsaved draft" })}
+        isDraft={true}
+        isExistingEvent={false}
+        onClose={onClose}
+        onDelete={onDelete}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setEvent={mock()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete event" }));
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("resets title editing state when an unsaved draft session changes", async () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -97,6 +97,23 @@ const resolveDateTimeState = (
   return createDateTimeState(sourceStartDate, sourceEndDate);
 };
 
+const handleEventFormDelete = ({
+  isDraft,
+  onClose,
+  onDelete,
+}: {
+  isDraft: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+}) => {
+  if (isDraft) {
+    onClose();
+    return;
+  }
+
+  onDelete();
+};
+
 export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
   ({
     event,
@@ -262,6 +279,10 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
       }, 1);
     }, [_onClose]);
 
+    const onDeleteEvent = useCallback(() => {
+      handleEventFormDelete({ isDraft, onClose, onDelete });
+    }, [isDraft, onClose, onDelete]);
+
     const onDuplicateEvent = useCallback(() => {
       onDuplicate?.(event);
       onClose();
@@ -389,18 +410,7 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
       setEvent: setLatestEvent,
     };
 
-    useAppHotkey(
-      "Delete",
-      () => {
-        if (isDraft) {
-          onClose();
-          return;
-        }
-
-        onDelete();
-      },
-      EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
-    );
+    useAppHotkey("Delete", onDeleteEvent, EVENT_FORM_PLAIN_HOTKEY_OPTIONS);
 
     useAppHotkey(
       "Enter",
@@ -498,7 +508,7 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
                 onConvert?.();
               }}
               onDuplicate={onDuplicateEvent}
-              onDelete={onDelete}
+              onDelete={onDeleteEvent}
             />
           }
         />

--- a/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.test.tsx
+++ b/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.test.tsx
@@ -17,8 +17,17 @@ mock.module(
 );
 
 mock.module("@web/views/Forms/SomedayEventForm/SomedayEventActionMenu", () => ({
-  SomedayEventActionMenu: () => (
-    <button type="button">Someday event actions</button>
+  SomedayEventActionMenu: ({
+    onDeleteClick,
+  }: {
+    onDeleteClick: () => void;
+  }) => (
+    <>
+      <button type="button">Someday event actions</button>
+      <button type="button" onClick={onDeleteClick}>
+        Delete someday event
+      </button>
+    </>
   ),
 }));
 
@@ -71,5 +80,29 @@ describe("SomedayEventForm", () => {
     expect(actions.parentElement).toHaveClass("shrink-0");
     expect(row?.firstElementChild?.contains(title)).toBe(true);
     expect(row?.lastElementChild?.contains(actions)).toBe(true);
+  });
+
+  it("closes a someday draft immediately when deleting from the menu", () => {
+    const onClose = mock();
+    const onDelete = mock();
+
+    render(
+      <SomedayEventForm
+        category={Categories_Event.SOMEDAY_WEEK}
+        event={{ ...event, _id: undefined, title: "Someday draft" }}
+        isDraft={true}
+        isExistingEvent={false}
+        onClose={onClose}
+        onDelete={onDelete}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setEvent={mock()}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Delete someday event" }).click();
+
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
+++ b/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
@@ -31,7 +31,7 @@ import { useSomedayFormShortcuts } from "@web/views/Forms/SomedayEventForm/useSo
 export const SomedayEventForm: React.FC<FormProps> = ({
   event,
   category,
-  isDraft: _isDraft,
+  isDraft,
   isExistingEvent: _isExistingEvent,
   onClose,
   onMigrate,
@@ -128,9 +128,14 @@ export const SomedayEventForm: React.FC<FormProps> = ({
     };
 
   const onDelete = useCallback(() => {
+    if (isDraft) {
+      onClose();
+      return;
+    }
+
     onDeleteEvent();
     onClose();
-  }, [onDeleteEvent, onClose]);
+  }, [isDraft, onDeleteEvent, onClose]);
 
   const onKeyDown = (e: KeyboardEvent<HTMLFormElement>) => {
     if (e.key === "Backspace") {


### PR DESCRIPTION
What changed

Draft events in the EventForm now close immediately when deleted, instead of flowing through the confirmation alert. The delete hotkey and the action menu both share the same draft-aware delete path.

Why

Drafts are unsaved state. They should discard directly rather than asking for a confirmation that only applies to persisted events.

Impact

Deleting a draft event now behaves like a discard action, which removes an unnecessary confirmation step and matches the user expectation for unsaved work.

Validation

- `TZ=Etc/UTC bun run type-check:web-tests`
- `TZ=Etc/UTC bun run test:web`
- `TZ=Etc/UTC bun run lint`

Closes #1879 