### PR TITLE
fix(web): restore day draft form opening after drag

### DIFF
--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -457,6 +457,9 @@ describe("DayCalendarGrid", () => {
     });
 
     expect(screen.queryByRole("dialog", { name: "Event form" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /timed event: untitled event/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("dismisses the event form when pressing outside the calendar", async () => {
@@ -489,40 +492,91 @@ describe("DayCalendarGrid", () => {
   });
 
   it("opens the form for a new all-day draft", async () => {
-    renderDayCalendarGrid();
+    const { user } = renderDayCalendarGrid();
 
-    const allDayRegion = getAllDayRegion();
-
-    fireEvent.mouseDown(allDayRegion, {
-      button: 0,
-      clientX: 100,
-      clientY: 1,
+    await user.pointer({
+      coords: { clientX: 100, clientY: 1 },
+      keys: "[MouseLeft>]",
+      target: getAllDayRegion(),
     });
 
     await waitFor(() => {
-      expect(getDraft()?.isAllDay).toBe(true);
+      expect(
+        screen.getByRole("button", {
+          name: /all-day event: untitled event/i,
+        }),
+      ).toBeVisible();
       expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
     });
+
+    await user.pointer({ keys: "[/MouseLeft]" });
   });
 
-  it("dismisses an open draft when clicking empty Day all-day calendar space", () => {
-    const existingDraft = createTimedEvent({
-      _id: "open-all-day-draft",
+  it("dismisses an open form when pressing empty Day all-day calendar space", async () => {
+    const event = createTimedEvent({
+      _id: "open-from-all-day-grid",
       endDate: "2026-05-20T10:00:00.000",
       startDate: "2026-05-20T09:00:00.000",
-      title: "Open all-day draft",
+      title: "Open from all-day grid",
     });
 
-    setDraftEvent(existingDraft);
-    renderDayCalendarGrid();
+    setDayEvents([event]);
+    const { user } = renderDayCalendarGrid();
+    await user.click(
+      screen.getByRole("button", {
+        name: /timed event: open from all-day grid/i,
+      }),
+    );
+    expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
 
-    fireEvent.mouseDown(getAllDayRegion(), {
-      button: 0,
-      clientX: 100,
-      clientY: 20,
+    await user.pointer([
+      {
+        coords: { clientX: 100, clientY: 20 },
+        keys: "[MouseLeft>]",
+        target: getAllDayRegion(),
+      },
+      {
+        coords: { clientX: 100, clientY: 20 },
+        keys: "[/MouseLeft]",
+        target: getAllDayRegion(),
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Event form" }),
+      ).not.toBeInTheDocument();
     });
+    expect(
+      screen.queryByRole("button", {
+        name: /all-day event: untitled event/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
 
-    expect(getDraft()).toBeNull();
+  it("opens the form for a new timed draft", async () => {
+    const { user } = renderDayCalendarGrid();
+    const emptySlot = getTimedSlot(3);
+
+    await user.pointer([
+      {
+        coords: { clientX: 100, clientY: 120 },
+        keys: "[MouseLeft>]",
+        target: emptySlot,
+      },
+      {
+        coords: { clientX: 100, clientY: 120 },
+        keys: "[/MouseLeft]",
+        target: emptySlot,
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /timed event: untitled event/i }),
+      ).toBeVisible();
+      expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
+    });
   });
 
   it("places a new all-day draft below existing all-day events", async () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -86,20 +86,13 @@ mock.module("@web/common/calendar-grid/hooks/useCalendarGridLayout", () => ({
   },
 }));
 
-const floatingUi =
-  require("@floating-ui/react") as typeof import("@floating-ui/react");
-const useDismissMock = mock(floatingUi.useDismiss);
 let latestEventForm: EventFormProps | null = null;
-
-mock.module("@floating-ui/react", () => ({
-  ...floatingUi,
-  useDismiss: useDismissMock,
-}));
 
 mock.module("@web/components/FloatingEventForm/FloatingEventForm", () => ({
   FloatingEventForm: ({ form }: { form: EventFormProps }) => {
     latestEventForm = form;
-    return null;
+
+    return getIsFormOpen() ? <dialog aria-label="Event form" open /> : null;
   },
 }));
 
@@ -109,9 +102,12 @@ const { DayCalendarGrid } =
 const renderDayCalendarGrid = () => ({
   user: userEvent.setup(),
   ...render(
-    <Provider store={store}>
-      <DayCalendarGrid />
-    </Provider>,
+    <>
+      <Provider store={store}>
+        <DayCalendarGrid />
+      </Provider>
+      <button type="button">Outside calendar</button>
+    </>,
   ),
 });
 
@@ -180,18 +176,6 @@ const setDraftEvent = (event: Schema_Event) => {
   store.dispatch(draftSlice.actions.startGridClick(event));
 };
 
-const getDismissOptions = () => {
-  const [, options] = useDismissMock.mock.calls.at(-1) ?? [];
-
-  expect(options).toBeDefined();
-
-  return options as {
-    enabled: boolean;
-    outsidePress?: (event: MouseEvent) => boolean;
-    outsidePressEvent: string;
-  };
-};
-
 const expectFormAnchoredTo = (card: HTMLElement, cardRect: DOMRect) => {
   const positionReference = latestEventForm?.refs.reference.current;
   const domReference = latestEventForm?.refs.domReference.current;
@@ -210,7 +194,6 @@ const expectFormAnchoredTo = (card: HTMLElement, cardRect: DOMRect) => {
 beforeEach(() => {
   store = createStoreWithEvents([]);
   latestEventForm = null;
-  useDismissMock.mockClear();
 });
 
 afterEach(() => {
@@ -460,52 +443,33 @@ describe("DayCalendarGrid", () => {
     expect(getDraft()).toBeNull();
   });
 
-  it("dismisses on click after empty agenda handlers run", () => {
-    renderDayCalendarGrid();
-
-    expect(getDismissOptions()).toEqual(
-      expect.objectContaining({
-        enabled: true,
-        outsidePress: expect.any(Function),
-        outsidePressEvent: "click",
-      }),
-    );
-  });
-
-  it("keeps the form open when pointer capture retargets the opening click", async () => {
+  it("dismisses the event form when pressing outside the calendar", async () => {
     const event = createTimedEvent({
-      _id: "retargeted-opening-click",
+      _id: "outside-press",
       endDate: "2026-05-20T10:00:00.000",
       startDate: "2026-05-20T09:00:00.000",
-      title: "Retargeted opening click",
+      title: "Outside press",
     });
 
     setDayEvents([event]);
     const { user } = renderDayCalendarGrid();
+    await user.click(
+      screen.getByRole("button", { name: /timed event: outside press/i }),
+    );
+    expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
 
-    const card = screen.getByRole("button", {
-      name: /retargeted opening click/i,
+    await user.pointer({
+      keys: "[MouseLeft>]",
+      target: screen.getByRole("button", { name: "Outside calendar" }),
     });
-    card.getBoundingClientRect = () => new DOMRect(20, 40, 160, 60);
-
-    card.focus();
-    await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(getDraft()?._id).toBe(event._id);
+      expect(
+        screen.queryByRole("dialog", { name: "Event form" }),
+      ).not.toBeInTheDocument();
     });
 
-    const openingClick = new MouseEvent("click", {
-      bubbles: true,
-      clientX: 100,
-      clientY: 70,
-    });
-    Object.defineProperty(openingClick, "target", {
-      configurable: true,
-      value: screen.getByLabelText("Calendar agenda"),
-    });
-
-    expect(getDismissOptions().outsidePress?.(openingClick)).toBe(false);
+    await user.pointer({ keys: "[/MouseLeft]" });
   });
 
   it("opens the form for a new all-day draft", async () => {
@@ -521,18 +485,8 @@ describe("DayCalendarGrid", () => {
 
     await waitFor(() => {
       expect(getDraft()?.isAllDay).toBe(true);
-      expect(getIsFormOpen()).toBe(true);
+      expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
     });
-
-    const outsidePress = getDismissOptions().outsidePress;
-    const openingClick = new MouseEvent("click", { bubbles: true });
-    Object.defineProperty(openingClick, "target", {
-      configurable: true,
-      value: allDayRegion,
-    });
-
-    expect(outsidePress?.(openingClick)).toBe(false);
-    expect(outsidePress?.(openingClick)).toBe(true);
   });
 
   it("dismisses an open draft when clicking empty Day all-day calendar space", () => {
@@ -640,7 +594,7 @@ describe("DayCalendarGrid", () => {
       expect(draft).not.toBeNull();
       expect(dayjs(draft?.startDate).format("HH:mm")).toBe("02:00");
       expect(dayjs(draft?.endDate).format("HH:mm")).toBe("05:00");
-      expect(getIsFormOpen()).toBe(true);
+      expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
     });
   });
 
@@ -676,46 +630,5 @@ describe("DayCalendarGrid", () => {
       expect(dayjs(draft?.endDate).format("HH:mm")).toBe("05:00");
       expect(getIsFormOpen()).toBe(true);
     });
-  });
-
-  it("keeps the timed draft form open for the opening click after a drag create", async () => {
-    renderDayCalendarGrid();
-
-    const timedGrid = getTimedGrid();
-    const timedSlot = getTimedSlot(3);
-
-    fireEvent.mouseDown(timedSlot, {
-      button: 0,
-      clientX: 100,
-      clientY: 120,
-    });
-    fireEvent.mouseMove(window, {
-      buttons: 1,
-      clientX: 100,
-      clientY: 300,
-    });
-    fireEvent.mouseUp(window, {
-      button: 0,
-      clientX: 100,
-      clientY: 300,
-    });
-
-    await waitFor(() => {
-      expect(getIsFormOpen()).toBe(true);
-    });
-
-    const outsidePress = getDismissOptions().outsidePress;
-    const openingClick = new MouseEvent("click", {
-      bubbles: true,
-      clientX: 100,
-      clientY: 300,
-    });
-    Object.defineProperty(openingClick, "target", {
-      configurable: true,
-      value: timedGrid,
-    });
-
-    expect(outsidePress?.(openingClick)).toBe(false);
-    expect(outsidePress?.(openingClick)).toBe(true);
   });
 });

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -423,24 +424,39 @@ describe("DayCalendarGrid", () => {
     expect(screen.queryByText("Delete Event")).not.toBeInTheDocument();
   });
 
-  it("dismisses an open draft when clicking empty Day timed calendar space", () => {
-    const existingDraft = createTimedEvent({
+  it("dismisses an open form when pressing empty Day timed calendar space", async () => {
+    const event = createTimedEvent({
       _id: "open-draft",
       endDate: "2026-05-20T10:00:00.000",
       startDate: "2026-05-20T09:00:00.000",
       title: "Open draft",
     });
 
-    setDraftEvent(existingDraft);
-    renderDayCalendarGrid();
+    setDayEvents([event]);
+    const { user } = renderDayCalendarGrid();
+    await user.click(
+      screen.getByRole("button", { name: /timed event: open draft/i }),
+    );
+    expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
 
-    fireEvent.mouseDown(getTimedSlot(3), {
-      button: 0,
-      clientX: 100,
-      clientY: 120,
+    const emptySlot = getTimedSlot(3);
+    await user.pointer([
+      {
+        coords: { clientX: 100, clientY: 120 },
+        keys: "[MouseLeft>]",
+        target: emptySlot,
+      },
+      {
+        coords: { clientX: 100, clientY: 120 },
+        keys: "[/MouseLeft]",
+        target: emptySlot,
+      },
+    ]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(getDraft()).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Event form" })).toBeNull();
   });
 
   it("dismisses the event form when pressing outside the calendar", async () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -6,13 +6,17 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { createStoreWithEvents } from "@web/__tests__/utils/state/store.test.util";
 import { CALENDAR_TIMED_EVENT_FAN_INDENT } from "@web/common/calendar-grid/calendarGrid.constants";
 import { type CalendarGridMeasurements } from "@web/common/calendar-grid/types/calendarGrid.types";
-import { ZIndex } from "@web/common/constants/web.constants";
+import {
+  DATA_CALENDAR_TIMED_GRID_ROW,
+  ZIndex,
+} from "@web/common/constants/web.constants";
 import {
   CompassDOMEvents,
   compassEventEmitter,
@@ -102,12 +106,14 @@ mock.module("@web/components/FloatingEventForm/FloatingEventForm", () => ({
 const { DayCalendarGrid } =
   require("./DayCalendarGrid") as typeof import("./DayCalendarGrid");
 
-const renderDayCalendarGrid = () =>
-  render(
+const renderDayCalendarGrid = () => ({
+  user: userEvent.setup(),
+  ...render(
     <Provider store={store}>
       <DayCalendarGrid />
     </Provider>,
-  );
+  ),
+});
 
 const createTimedEvent = (
   overrides: Partial<Schema_Event> & {
@@ -151,6 +157,24 @@ const getIsFormOpen = () => selectIsEventFormOpen(store.getState());
 const resetDraft = () => {
   store.dispatch(draftSlice.actions.discard(undefined));
 };
+
+const getTimedGrid = () =>
+  screen.getByRole("region", {
+    name: "Timed events grid",
+  });
+
+const getTimedSlot = (index = 0) => {
+  const slot = getTimedGrid().querySelectorAll<HTMLElement>(
+    `[${DATA_CALENDAR_TIMED_GRID_ROW}='true']`,
+  )[index];
+
+  expect(slot).toBeDefined();
+
+  return slot;
+};
+
+const getAllDayRegion = () =>
+  screen.getByRole("region", { name: "All-day events" });
 
 const setDraftEvent = (event: Schema_Event) => {
   store.dispatch(draftSlice.actions.startGridClick(event));
@@ -203,18 +227,14 @@ describe("DayCalendarGrid", () => {
   it("renders one timed column", () => {
     renderDayCalendarGrid();
 
-    const timedGrid = screen.getByRole("region", {
-      name: "Timed events grid",
-    });
+    const timedGrid = getTimedGrid();
     expect(within(timedGrid).getAllByRole("columnheader")).toHaveLength(1);
   });
 
   it("renders all-day and timed regions without rendering tasks", () => {
     renderDayCalendarGrid();
 
-    expect(
-      screen.getByRole("region", { name: "All-day events" }),
-    ).toBeInTheDocument();
+    expect(getAllDayRegion()).toBeInTheDocument();
     expect(
       screen.queryByRole("list", { name: "Task list" }),
     ).not.toBeInTheDocument();
@@ -283,10 +303,10 @@ describe("DayCalendarGrid", () => {
 
     expect(initialBackZIndex).toBeLessThan(ZIndex.MAX);
 
-    fireEvent.focus(back);
+    back.focus();
     expect(Number(back.style.zIndex)).toBe(initialBackZIndex);
 
-    fireEvent.blur(back);
+    back.blur();
     expect(Number(back.style.zIndex)).toBe(initialBackZIndex);
   });
 
@@ -305,8 +325,7 @@ describe("DayCalendarGrid", () => {
         title: "Front overlap",
       }),
     ]);
-
-    renderDayCalendarGrid();
+    const { user } = renderDayCalendarGrid();
 
     const back = screen.getByRole("button", { name: /back overlap/i });
     const front = screen.getByRole("button", { name: /front overlap/i });
@@ -317,19 +336,7 @@ describe("DayCalendarGrid", () => {
     expect(initialBackWidth).toBe(frontWidth);
     expect(initialBackZIndex).toBeLessThan(ZIndex.MAX);
 
-    fireEvent.pointerDown(back, {
-      button: 0,
-      clientX: 100,
-      clientY: 120,
-      isPrimary: true,
-      pointerId: 1,
-    });
-    fireEvent.pointerUp(window, {
-      button: 0,
-      clientX: 100,
-      clientY: 120,
-      pointerId: 1,
-    });
+    await user.click(back);
 
     await waitFor(() => {
       expect(getDraft()?._id).toBe("back");
@@ -368,12 +375,13 @@ describe("DayCalendarGrid", () => {
     const cardRect = new DOMRect(20, 40, 160, 60);
 
     setDayEvents([event]);
-    renderDayCalendarGrid();
+    const { user } = renderDayCalendarGrid();
 
     const card = screen.getByRole("button", { name: /virtual reference/i });
     card.getBoundingClientRect = () => cardRect;
 
-    fireEvent.keyDown(card, { key: "Enter" });
+    card.focus();
+    await user.keyboard("{Enter}");
 
     await waitFor(() => {
       expect(getDraft()?._id).toBe(event._id);
@@ -392,24 +400,12 @@ describe("DayCalendarGrid", () => {
     const cardRect = new DOMRect(20, 40, 160, 60);
 
     setDayEvents([event]);
-    renderDayCalendarGrid();
+    const { user } = renderDayCalendarGrid();
 
     const card = screen.getByRole("button", { name: /pointer reference/i });
     card.getBoundingClientRect = () => cardRect;
 
-    fireEvent.pointerDown(card, {
-      button: 0,
-      clientX: 100,
-      clientY: 120,
-      isPrimary: true,
-      pointerId: 1,
-    });
-    fireEvent.pointerUp(window, {
-      button: 0,
-      clientX: 100,
-      clientY: 120,
-      pointerId: 1,
-    });
+    await user.click(card);
 
     await waitFor(() => {
       expect(getDraft()?._id).toBe(event._id);
@@ -427,16 +423,14 @@ describe("DayCalendarGrid", () => {
         title: "Right click event",
       }),
     ]);
-
-    renderDayCalendarGrid();
-
-    fireEvent.contextMenu(
-      screen.getByRole("button", { name: /right click event/i }),
+    const { user } = renderDayCalendarGrid();
+    await user.pointer([
       {
-        clientX: 100,
-        clientY: 120,
+        keys: "[MouseRight>]",
+        target: screen.getByRole("button", { name: /right click event/i }),
       },
-    );
+      { keys: "[/MouseRight]" },
+    ]);
 
     await waitFor(() => {
       expect(screen.getByText("Edit")).toBeInTheDocument();
@@ -457,16 +451,7 @@ describe("DayCalendarGrid", () => {
     setDraftEvent(existingDraft);
     renderDayCalendarGrid();
 
-    const timedGrid = screen.getByRole("region", {
-      name: "Timed events grid",
-    });
-    const timedGridRow = timedGrid.querySelector(
-      "[data-calendar-timed-grid-row='true']",
-    );
-
-    expect(timedGridRow).toBeInstanceOf(HTMLElement);
-
-    fireEvent.mouseDown(timedGridRow!, {
+    fireEvent.mouseDown(getTimedSlot(3), {
       button: 0,
       clientX: 100,
       clientY: 120,
@@ -496,14 +481,15 @@ describe("DayCalendarGrid", () => {
     });
 
     setDayEvents([event]);
-    renderDayCalendarGrid();
+    const { user } = renderDayCalendarGrid();
 
     const card = screen.getByRole("button", {
       name: /retargeted opening click/i,
     });
     card.getBoundingClientRect = () => new DOMRect(20, 40, 160, 60);
 
-    fireEvent.keyDown(card, { key: "Enter" });
+    card.focus();
+    await user.keyboard("{Enter}");
 
     await waitFor(() => {
       expect(getDraft()?._id).toBe(event._id);
@@ -525,7 +511,7 @@ describe("DayCalendarGrid", () => {
   it("opens the form for a new all-day draft", async () => {
     renderDayCalendarGrid();
 
-    const allDayRegion = screen.getByRole("region", { name: "All-day events" });
+    const allDayRegion = getAllDayRegion();
 
     fireEvent.mouseDown(allDayRegion, {
       button: 0,
@@ -560,14 +546,11 @@ describe("DayCalendarGrid", () => {
     setDraftEvent(existingDraft);
     renderDayCalendarGrid();
 
-    fireEvent.mouseDown(
-      screen.getByRole("region", { name: "All-day events" }),
-      {
-        button: 0,
-        clientX: 100,
-        clientY: 20,
-      },
-    );
+    fireEvent.mouseDown(getAllDayRegion(), {
+      button: 0,
+      clientX: 100,
+      clientY: 20,
+    });
 
     expect(getDraft()).toBeNull();
   });
@@ -589,14 +572,11 @@ describe("DayCalendarGrid", () => {
     ]);
     renderDayCalendarGrid();
 
-    fireEvent.mouseDown(
-      screen.getByRole("region", { name: "All-day events" }),
-      {
-        button: 0,
-        clientX: 100,
-        clientY: 80,
-      },
-    );
+    fireEvent.mouseDown(getAllDayRegion(), {
+      button: 0,
+      clientX: 100,
+      clientY: 80,
+    });
 
     await waitFor(() => {
       const draft = screen.getByRole("button", {
@@ -638,16 +618,7 @@ describe("DayCalendarGrid", () => {
   it("creates the selected timed range when dragging from an empty timed slot", async () => {
     renderDayCalendarGrid();
 
-    const timedGrid = screen.getByRole("region", {
-      name: "Timed events grid",
-    });
-    const timedGridRow = timedGrid.querySelector(
-      "[data-calendar-timed-grid-row='true']",
-    );
-
-    expect(timedGridRow).toBeInstanceOf(HTMLElement);
-
-    fireEvent.mouseDown(timedGridRow!, {
+    fireEvent.mouseDown(getTimedSlot(3), {
       button: 0,
       clientX: 100,
       clientY: 120,
@@ -676,16 +647,7 @@ describe("DayCalendarGrid", () => {
   it("opens the timed draft form after stray zero-button mousemove events", async () => {
     renderDayCalendarGrid();
 
-    const timedGrid = screen.getByRole("region", {
-      name: "Timed events grid",
-    });
-    const timedGridRow = timedGrid.querySelector(
-      "[data-calendar-timed-grid-row='true']",
-    );
-
-    expect(timedGridRow).toBeInstanceOf(HTMLElement);
-
-    fireEvent.mouseDown(timedGridRow!, {
+    fireEvent.mouseDown(getTimedSlot(3), {
       button: 0,
       clientX: 100,
       clientY: 120,
@@ -719,16 +681,10 @@ describe("DayCalendarGrid", () => {
   it("keeps the timed draft form open for the opening click after a drag create", async () => {
     renderDayCalendarGrid();
 
-    const timedGrid = screen.getByRole("region", {
-      name: "Timed events grid",
-    });
-    const timedGridRow = timedGrid.querySelector(
-      "[data-calendar-timed-grid-row='true']",
-    );
+    const timedGrid = getTimedGrid();
+    const timedSlot = getTimedSlot(3);
 
-    expect(timedGridRow).toBeInstanceOf(HTMLElement);
-
-    fireEvent.mouseDown(timedGridRow!, {
+    fireEvent.mouseDown(timedSlot, {
       button: 0,
       clientX: 100,
       clientY: 120,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -669,6 +669,97 @@ describe("DayCalendarGrid", () => {
       expect(draft).not.toBeNull();
       expect(dayjs(draft?.startDate).format("HH:mm")).toBe("02:00");
       expect(dayjs(draft?.endDate).format("HH:mm")).toBe("05:00");
+      expect(getIsFormOpen()).toBe(true);
     });
+  });
+
+  it("opens the timed draft form after stray zero-button mousemove events", async () => {
+    renderDayCalendarGrid();
+
+    const timedGrid = screen.getByRole("region", {
+      name: "Timed events grid",
+    });
+    const timedGridRow = timedGrid.querySelector(
+      "[data-calendar-timed-grid-row='true']",
+    );
+
+    expect(timedGridRow).toBeInstanceOf(HTMLElement);
+
+    fireEvent.mouseDown(timedGridRow!, {
+      button: 0,
+      clientX: 100,
+      clientY: 120,
+    });
+    fireEvent.mouseMove(window, {
+      buttons: 1,
+      clientX: 100,
+      clientY: 300,
+    });
+    fireEvent.mouseMove(window, {
+      buttons: 0,
+      clientX: 20,
+      clientY: 20,
+    });
+    fireEvent.mouseUp(window, {
+      button: 0,
+      clientX: 100,
+      clientY: 300,
+    });
+
+    await waitFor(() => {
+      const draft = getDraft();
+
+      expect(draft).not.toBeNull();
+      expect(dayjs(draft?.startDate).format("HH:mm")).toBe("02:00");
+      expect(dayjs(draft?.endDate).format("HH:mm")).toBe("05:00");
+      expect(getIsFormOpen()).toBe(true);
+    });
+  });
+
+  it("keeps the timed draft form open for the opening click after a drag create", async () => {
+    renderDayCalendarGrid();
+
+    const timedGrid = screen.getByRole("region", {
+      name: "Timed events grid",
+    });
+    const timedGridRow = timedGrid.querySelector(
+      "[data-calendar-timed-grid-row='true']",
+    );
+
+    expect(timedGridRow).toBeInstanceOf(HTMLElement);
+
+    fireEvent.mouseDown(timedGridRow!, {
+      button: 0,
+      clientX: 100,
+      clientY: 120,
+    });
+    fireEvent.mouseMove(window, {
+      buttons: 1,
+      clientX: 100,
+      clientY: 300,
+    });
+    fireEvent.mouseUp(window, {
+      button: 0,
+      clientX: 100,
+      clientY: 300,
+    });
+
+    await waitFor(() => {
+      expect(getIsFormOpen()).toBe(true);
+    });
+
+    const outsidePress = getDismissOptions().outsidePress;
+    const openingClick = new MouseEvent("click", {
+      bubbles: true,
+      clientX: 100,
+      clientY: 300,
+    });
+    Object.defineProperty(openingClick, "target", {
+      configurable: true,
+      value: timedGrid,
+    });
+
+    expect(outsidePress?.(openingClick)).toBe(false);
+    expect(outsidePress?.(openingClick)).toBe(true);
   });
 });

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -109,8 +109,14 @@ export function DayCalendarGrid() {
     ? Categories_Event.ALLDAY
     : Categories_Event.TIMED;
   const allDayCreationPressTargetRef = useRef<HTMLElement | null>(null);
+  const shouldIgnoreNextOutsidePressRef = useRef(false);
   const shouldDismissEventForm = useCallback(
     (event: MouseEvent) => {
+      if (shouldIgnoreNextOutsidePressRef.current) {
+        shouldIgnoreNextOutsidePressRef.current = false;
+        return false;
+      }
+
       const eventElement = draft?._id
         ? getCalendarEventElementFromGrid(draft._id)
         : null;
@@ -218,10 +224,16 @@ export function DayCalendarGrid() {
   }, []);
 
   const openEventFormForEvent = useCallback(
-    (event: Schema_GridEvent) => {
+    (
+      event: Schema_GridEvent,
+      options?: { ignoreNextOutsidePress?: boolean },
+    ) => {
       if (!event._id) {
         return;
       }
+
+      shouldIgnoreNextOutsidePressRef.current =
+        options?.ignoreNextOutsidePress ?? false;
 
       const eventElement = getCalendarEventElementFromGrid(event._id);
       setFormReference(eventElement);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -66,19 +66,6 @@ const createEventFormAnchor = (eventId: string): VirtualElement => {
   };
 };
 
-const isPointInsideElement = (event: MouseEvent, element: Element) => {
-  const rect = element.getBoundingClientRect();
-
-  return (
-    rect.width > 0 &&
-    rect.height > 0 &&
-    event.clientX >= rect.left &&
-    event.clientX <= rect.right &&
-    event.clientY >= rect.top &&
-    event.clientY <= rect.bottom
-  );
-};
-
 export function DayCalendarGrid() {
   const dispatch = useAppDispatch();
   const dateInView = useDateInView();
@@ -108,39 +95,6 @@ export function DayCalendarGrid() {
   const draftCategory = draft?.isAllDay
     ? Categories_Event.ALLDAY
     : Categories_Event.TIMED;
-  const allDayCreationPressTargetRef = useRef<HTMLElement | null>(null);
-  const shouldIgnoreNextOutsidePressRef = useRef(false);
-  const shouldDismissEventForm = useCallback(
-    (event: MouseEvent) => {
-      if (shouldIgnoreNextOutsidePressRef.current) {
-        shouldIgnoreNextOutsidePressRef.current = false;
-        return false;
-      }
-
-      const eventElement = draft?._id
-        ? getCalendarEventElementFromGrid(draft._id)
-        : null;
-
-      if (eventElement && isPointInsideElement(event, eventElement)) {
-        return false;
-      }
-
-      const allDayCreationPressTarget = allDayCreationPressTargetRef.current;
-
-      if (!allDayCreationPressTarget) {
-        return true;
-      }
-
-      allDayCreationPressTargetRef.current = null;
-
-      const target = event.target;
-
-      return !(
-        target instanceof Node && allDayCreationPressTarget.contains(target)
-      );
-    },
-    [draft?._id],
-  );
   const handleFormOpenChange = useCallback(
     (open: boolean, _event: Event, reason?: OpenChangeReason) => {
       const dismissed = reason === "escape-key" || reason === "outside-press";
@@ -155,13 +109,6 @@ export function DayCalendarGrid() {
     draftCategory,
     isFormOpen,
     handleFormOpenChange,
-    {
-      dismiss: {
-        enabled: true,
-        outsidePress: shouldDismissEventForm,
-        outsidePressEvent: "click",
-      },
-    },
   );
   const setFormPositionReference = form.refs.setPositionReference;
   const setFormReference = form.refs.setReference;
@@ -224,16 +171,10 @@ export function DayCalendarGrid() {
   }, []);
 
   const openEventFormForEvent = useCallback(
-    (
-      event: Schema_GridEvent,
-      options?: { ignoreNextOutsidePress?: boolean },
-    ) => {
+    (event: Schema_GridEvent) => {
       if (!event._id) {
         return;
       }
-
-      shouldIgnoreNextOutsidePressRef.current =
-        options?.ignoreNextOutsidePress ?? false;
 
       const eventElement = getCalendarEventElementFromGrid(event._id);
       setFormReference(eventElement);
@@ -268,10 +209,7 @@ export function DayCalendarGrid() {
         return;
       }
 
-      const allDayCreationPressTarget = event.currentTarget;
-
       if (draft) {
-        allDayCreationPressTargetRef.current = null;
         dispatch(draftSlice.actions.discard(undefined));
         return;
       }
@@ -287,7 +225,6 @@ export function DayCalendarGrid() {
         endDate,
       );
 
-      allDayCreationPressTargetRef.current = allDayCreationPressTarget;
       openEventFormForEvent(
         addId(assembleGridEvent(draftEvent as EventWithDates)),
       );

--- a/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
@@ -32,10 +32,7 @@ export const useDayTimedDraftCreation = ({
 }: {
   dateCalcs: CalendarDateCalcs;
   draft: Schema_Event | null;
-  onOpenEvent: (
-    event: Schema_GridEvent,
-    options?: { ignoreNextOutsidePress?: boolean },
-  ) => void;
+  onOpenEvent: (event: Schema_GridEvent) => void;
 }) => {
   const dispatch = useAppDispatch();
   const timedDraftCreationGestureRef = useRef<TimedDraftCreationGesture | null>(
@@ -141,7 +138,7 @@ export const useDayTimedDraftCreation = ({
               return;
             }
 
-            onOpenEvent(nextEvent, { ignoreNextOutsidePress: true });
+            onOpenEvent(nextEvent);
           },
         );
       };

--- a/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
@@ -32,7 +32,10 @@ export const useDayTimedDraftCreation = ({
 }: {
   dateCalcs: CalendarDateCalcs;
   draft: Schema_Event | null;
-  onOpenEvent: (event: Schema_GridEvent) => void;
+  onOpenEvent: (
+    event: Schema_GridEvent,
+    options?: { ignoreNextOutsidePress?: boolean },
+  ) => void;
 }) => {
   const dispatch = useAppDispatch();
   const timedDraftCreationGestureRef = useRef<TimedDraftCreationGesture | null>(
@@ -138,7 +141,7 @@ export const useDayTimedDraftCreation = ({
               return;
             }
 
-            onOpenEvent(nextEvent);
+            onOpenEvent(nextEvent, { ignoreNextOutsidePress: true });
           },
         );
       };
@@ -174,7 +177,6 @@ export const useDayTimedDraftCreation = ({
         }
 
         if (mouseEvent.buttons !== 1) {
-          finish(mouseEvent);
           return;
         }
 

--- a/packages/web/src/views/Forms/hooks/useEventForm.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useEventForm.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Categories_Event } from "@core/types/event.types";
+import { afterEach, describe, expect, it } from "bun:test";
+import "@testing-library/jest-dom";
+import { useEventForm } from "./useEventForm";
+
+afterEach(cleanup);
+
+const EventFormHarness = ({ interactions }: { interactions: string[] }) => {
+  const form = useEventForm(
+    Categories_Event.TIMED,
+    true,
+    (_isOpen, _event, reason) => {
+      if (reason === "outside-press") {
+        interactions.push("dismiss form");
+      }
+    },
+  );
+
+  return (
+    <>
+      <dialog
+        {...form.getFloatingProps()}
+        aria-label="Event form"
+        open
+        ref={form.refs.setFloating}
+      />
+      <button
+        onMouseDown={() => interactions.push("handle outside target")}
+        type="button"
+      >
+        Outside target
+      </button>
+    </>
+  );
+};
+
+describe("useEventForm", () => {
+  it("lets an outside target handle mousedown before dismissing the form", async () => {
+    const interactions: string[] = [];
+
+    const user = userEvent.setup();
+    render(<EventFormHarness interactions={interactions} />);
+
+    await user.pointer({
+      keys: "[MouseLeft>]",
+      target: screen.getByRole("button", { name: "Outside target" }),
+    });
+
+    expect(interactions).toEqual(["handle outside target", "dismiss form"]);
+
+    await user.pointer({ keys: "[/MouseLeft]" });
+  });
+});

--- a/packages/web/src/views/Forms/hooks/useEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEventForm.ts
@@ -109,6 +109,7 @@ export const useEventForm = (
   });
 
   const dismiss = useDismiss(context, {
+    capture: { outsidePress: false },
     outsidePressEvent: "mousedown",
     ...options?.dismiss,
   });

--- a/packages/web/src/views/Forms/hooks/useEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useEventForm.ts
@@ -108,7 +108,10 @@ export const useEventForm = (
     },
   });
 
-  const dismiss = useDismiss(context, options?.dismiss);
+  const dismiss = useDismiss(context, {
+    outsidePressEvent: "mousedown",
+    ...options?.dismiss,
+  });
   const { getReferenceProps, getFloatingProps } = useInteractions([dismiss]);
 
   return {


### PR DESCRIPTION
## What changed
- configure shared Floating UI outside-press dismissal to use `mousedown` in bubble phase
- preserve explicit `useEventForm` dismissal overrides without adding refs, snapshots, DOM markers, or view-specific props
- add interaction coverage for event ordering and user-visible Day timed/all-day dismissal, click-create, and drag-create behavior

## Why
Floating UI captured the outside `mousedown` before the calendar grid's React handler. It discarded the existing draft first, so the same grid press then looked like a new-event action and created a replacement draft.

Bubble-phase dismissal lets the grid handler make the intent decision first. With an open draft, the handler discards and returns; without one, normal event creation proceeds. Floating UI then performs its shared outside-press dismissal.

## Impact
Clicking empty Day or Week grid space closes an existing form without creating another event. Clicking empty space with no form still creates a draft, and timed drag creation still renders its placeholder and opens the form on release.

## Validation
- `useEventForm.test.tsx`: 1 pass, 0 fail
- `DayCalendarGrid.test.tsx`: 18 pass, 0 fail
- clean pushed-commit `MainGrid.test.tsx`: 16 pass, 0 fail
- `bun type-check`
- focused `bunx biome check`
- React Doctor changed-file scan: 100/100, no findings
- Chrome hard reload and Computer Use verification:
  - open form + empty timed-grid click closes the form without creating a draft
  - empty timed-grid click with no form creates a draft and opens the form
  - timed drag renders the placeholder and opens the form on release

## Notes
- repo-wide `bun lint` is blocked before scanning by an unrelated nested Biome root config under `.worktrees/refactor-unify-floating-event-forms/`
