### PR TITLE
fix(web): honor manual scroll on timed drag commit

### DIFF
--- a/packages/web/src/common/calendar-grid/interaction/math/allDayResize.ts
+++ b/packages/web/src/common/calendar-grid/interaction/math/allDayResize.ts
@@ -31,9 +31,9 @@ export const createAllDayResizeVisual = ({
   sourceRect,
   startDayIndex,
 }: CreateAllDayResizeVisualInput): AllDayResizeVisual => ({
-  activeEdge: edge,
   endDayIndex,
   eventId,
+  initialEdge: edge,
   initialEndDayIndex: endDayIndex,
   initialStartDayIndex: startDayIndex,
   pointerStart,
@@ -51,7 +51,7 @@ export const updateAllDayResizeVisual = (
   const pointerColumn = getNearestDayColumn(layout.dayColumns, pointer.x);
   const pointerDayIndex = pointerColumn?.index ?? visual.initialStartDayIndex;
   const nextRange =
-    visual.activeEdge === "startDate"
+    visual.initialEdge === "startDate"
       ? resizeFromStart(visual, pointerDayIndex)
       : resizeFromEnd(visual, pointerDayIndex);
   const initialStartColumn = getColumn(
@@ -73,7 +73,6 @@ export const updateAllDayResizeVisual = (
 
   return {
     ...visual,
-    activeEdge: nextRange.activeEdge,
     endDayIndex: nextRange.endDayIndex,
     startDayIndex: nextRange.startDayIndex,
     transform: {
@@ -90,14 +89,12 @@ const resizeFromStart = (
 ) => {
   if (pointerDayIndex <= visual.initialEndDayIndex) {
     return {
-      activeEdge: "startDate" as const,
       endDayIndex: visual.initialEndDayIndex,
       startDayIndex: pointerDayIndex,
     };
   }
 
   return {
-    activeEdge: "endDate" as const,
     endDayIndex: pointerDayIndex,
     startDayIndex: visual.initialEndDayIndex,
   };
@@ -106,14 +103,12 @@ const resizeFromStart = (
 const resizeFromEnd = (visual: AllDayResizeVisual, pointerDayIndex: number) => {
   if (pointerDayIndex >= visual.initialStartDayIndex) {
     return {
-      activeEdge: "endDate" as const,
       endDayIndex: pointerDayIndex,
       startDayIndex: visual.initialStartDayIndex,
     };
   }
 
   return {
-    activeEdge: "startDate" as const,
     endDayIndex: visual.initialStartDayIndex,
     startDayIndex: pointerDayIndex,
   };

--- a/packages/web/src/common/calendar-grid/interaction/math/timedResize.ts
+++ b/packages/web/src/common/calendar-grid/interaction/math/timedResize.ts
@@ -20,6 +20,7 @@ interface CreateTimedResizeVisualInput {
 interface UpdateTimedResizeVisualInput {
   layout: CalendarLayoutCache;
   pointer: VisualPoint;
+  scrollDeltaPx?: number;
 }
 
 export const createTimedResizeVisual = ({
@@ -46,11 +47,11 @@ export const createTimedResizeVisual = ({
 
 export const updateTimedResizeVisual = (
   visual: TimedResizeVisual,
-  { layout, pointer }: UpdateTimedResizeVisualInput,
+  { layout, pointer, scrollDeltaPx = 0 }: UpdateTimedResizeVisualInput,
 ): TimedResizeVisual => {
   const deltaY = pointer.y - visual.pointerStart.y;
   const deltaMinutes = snapToStep(
-    deltaY / layout.pixelsPerMinute,
+    (deltaY + scrollDeltaPx) / layout.pixelsPerMinute,
     layout.snapMinutes,
   );
   const nextTimes = getNextResizeTimes(
@@ -73,7 +74,8 @@ export const updateTimedResizeVisual = (
       x: 0,
       y:
         (nextTimes.startMinutes - visual.initialStartMinutes) *
-        layout.pixelsPerMinute,
+          layout.pixelsPerMinute -
+        scrollDeltaPx,
     },
   };
 };

--- a/packages/web/src/common/calendar-grid/interaction/model/AllDayResizeVisual.ts
+++ b/packages/web/src/common/calendar-grid/interaction/model/AllDayResizeVisual.ts
@@ -3,9 +3,9 @@ import { type VisualPoint, type VisualRect } from "./TimedDragVisual";
 export type AllDayResizeEdge = "endDate" | "startDate";
 
 export interface AllDayResizeVisual {
-  activeEdge: AllDayResizeEdge;
   endDayIndex: number;
   eventId: string;
+  initialEdge: AllDayResizeEdge;
   initialEndDayIndex: number;
   initialStartDayIndex: number;
   pointerStart: VisualPoint;

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
@@ -34,6 +34,8 @@ export interface CalendarInteractionAdapter<TTarget, TVisual, TResult> {
     target: TTarget;
     visual: TVisual;
   }): FloatingInteractionOverlayMount;
+  // Must be idempotent for a given pointer: the engine re-invokes this at
+  // pointerup with the same pointer to recompute the visual before commit.
   updateVisual(input: {
     pointer: CalendarInteractionPoint;
     target: TTarget;

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
@@ -190,7 +190,9 @@ describe("CalendarInteractionEngine", () => {
       true,
     );
 
-    const result = engine.handlePointerUp(makePointerEvent("pointerup"));
+    const result = engine.handlePointerUp(
+      makePointerEvent("pointerup", { x: 35, y: 45 }),
+    );
 
     expect(result).toEqual({ target, type: "click" });
     expect(commit).not.toHaveBeenCalled();
@@ -299,7 +301,9 @@ describe("CalendarInteractionEngine", () => {
     engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
     flushFrame(16);
 
-    const result = engine.handlePointerUp(makePointerEvent("pointerup"));
+    const result = engine.handlePointerUp(
+      makePointerEvent("pointerup", { x: 35, y: 45 }),
+    );
 
     expect(result).toMatchObject({ type: "commit" });
     expect(commit).toHaveBeenCalledWith(
@@ -320,6 +324,27 @@ describe("CalendarInteractionEngine", () => {
       active: false,
       phase: "commit",
     });
+  });
+
+  it("recomputes the visual from the release pointer before commit", () => {
+    const { commit, engine, flushFrame } = createHarness();
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+
+    engine.handlePointerUp(makePointerEvent("pointerup", { x: 55, y: 65 }));
+
+    expect(commit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        visual: expect.objectContaining({
+          transform: {
+            x: 50,
+            y: 60,
+          },
+        }),
+      }),
+    );
   });
 
   it("cancels cleanly on blur and can be cancelled repeatedly", () => {

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
@@ -46,8 +46,10 @@ const makePointerEvent = (
 const SOURCE_ELEMENT_INTERACTION_ATTRIBUTE = "data-calendar-interaction-source";
 
 const createHarness = ({
+  scrollableAncestor,
   sourceOverlayMode,
 }: {
+  scrollableAncestor?: { clientHeight: number; scrollHeight: number };
   sourceOverlayMode?: SourceElementOverlayMode;
 } = {}) => {
   document.body.innerHTML = "";
@@ -64,7 +66,24 @@ const createHarness = ({
   source.style.visibility = "visible";
   source.style.height = "40px";
   source.style.width = "120px";
-  document.body.append(source);
+
+  let scrollContainer: HTMLDivElement | null = null;
+
+  if (scrollableAncestor) {
+    scrollContainer = document.createElement("div");
+    Object.defineProperty(scrollContainer, "clientHeight", {
+      configurable: true,
+      value: scrollableAncestor.clientHeight,
+    });
+    Object.defineProperty(scrollContainer, "scrollHeight", {
+      configurable: true,
+      value: scrollableAncestor.scrollHeight,
+    });
+    document.body.append(scrollContainer);
+    scrollContainer.append(source);
+  } else {
+    document.body.append(source);
+  }
 
   const target = {
     id: "target-id",
@@ -172,6 +191,7 @@ const createHarness = ({
     fireHoldTimer,
     flushFrame,
     frameCallbacks,
+    scrollContainer,
     source,
     target,
     timerCallbacks,
@@ -403,6 +423,67 @@ describe("CalendarInteractionEngine", () => {
     flushFrame(32);
 
     expect(engine.getMetrics().frameGaps).toEqual([16]);
+  });
+
+  it("re-syncs the visual when the source element's scrollable ancestor scrolls during motion", () => {
+    const { adapter, engine, flushFrame, scrollContainer } = createHarness({
+      scrollableAncestor: { clientHeight: 500, scrollHeight: 1000 },
+    });
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+
+    expect(adapter.updateVisual).toHaveBeenCalledTimes(1);
+
+    scrollContainer?.dispatchEvent(new Event("scroll"));
+    flushFrame(32);
+
+    expect(adapter.updateVisual).toHaveBeenCalledTimes(2);
+    expect(adapter.updateVisual).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pointer: { x: 35, y: 45 } }),
+    );
+  });
+
+  it("ignores scroll events on the scrollable ancestor outside of an active motion session", () => {
+    const { engine, frameCallbacks, scrollContainer } = createHarness({
+      scrollableAncestor: { clientHeight: 500, scrollHeight: 1000 },
+    });
+
+    scrollContainer?.dispatchEvent(new Event("scroll"));
+
+    expect(frameCallbacks.size).toBe(0);
+  });
+
+  it("stops listening to the scrollable ancestor after commit", () => {
+    const { engine, flushFrame, frameCallbacks, scrollContainer } =
+      createHarness({
+        scrollableAncestor: { clientHeight: 500, scrollHeight: 1000 },
+      });
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+    engine.handlePointerUp(makePointerEvent("pointerup", { x: 35, y: 45 }));
+
+    scrollContainer?.dispatchEvent(new Event("scroll"));
+
+    expect(frameCallbacks.size).toBe(0);
+  });
+
+  it("does not treat a non-scrollable ancestor as a scroll sync target", () => {
+    const { engine, flushFrame, frameCallbacks, scrollContainer } =
+      createHarness({
+        scrollableAncestor: { clientHeight: 500, scrollHeight: 500 },
+      });
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+
+    scrollContainer?.dispatchEvent(new Event("scroll"));
+
+    expect(frameCallbacks.size).toBe(0);
   });
 });
 

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -57,6 +57,7 @@ export interface CalendarInteractionEngine<TTarget, TVisual, TResult> {
     event: PointerEvent,
   ): CalendarInteractionPointerUpResult<TTarget, TResult>;
   ownsPointer(event: Pick<PointerEvent, "pointerId">): boolean;
+  syncVisual(): void;
 }
 
 const defaultOptions = {
@@ -205,6 +206,14 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     session = { phase: "idle" };
 
     return { result, type: "commit" };
+  }
+
+  function syncVisual() {
+    if (session.phase !== "motion") {
+      return;
+    }
+
+    scheduleFrame();
   }
 
   function handlePointerCancel(event: PointerEvent) {
@@ -436,6 +445,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     handlePointerMove,
     handlePointerUp,
     ownsPointer,
+    syncVisual,
   };
 };
 

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -57,7 +57,6 @@ export interface CalendarInteractionEngine<TTarget, TVisual, TResult> {
     event: PointerEvent,
   ): CalendarInteractionPointerUpResult<TTarget, TResult>;
   ownsPointer(event: Pick<PointerEvent, "pointerId">): boolean;
-  syncVisual(): void;
 }
 
 const defaultOptions = {
@@ -91,6 +90,8 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
   let preparedSource: PreparedSourceElement | null = null;
   let previousFrameTimestamp: number | null = null;
   let rafId: unknown = null;
+  let scrollSync: { element: EventTarget; handleScroll: () => void } | null =
+    null;
   let session: CalendarInteractionSession<TTarget, TVisual> = {
     phase: "idle",
   };
@@ -208,14 +209,6 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     return { result, type: "commit" };
   }
 
-  function syncVisual() {
-    if (session.phase !== "motion") {
-      return;
-    }
-
-    scheduleFrame();
-  }
-
   function handlePointerCancel(event: PointerEvent) {
     if (session.phase === "idle" || event.pointerId !== session.pointerId) {
       return;
@@ -319,6 +312,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
         pendingSession.target,
       ),
     );
+    attachScrollSync(getNearestScrollableAncestor(pendingSession.sourceElement));
     activatedAt = resolvedOptions.now();
     latestPointer = pendingSession.startPoint;
     metrics.active = true;
@@ -333,6 +327,30 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       visual,
     };
     scheduleFrame();
+  }
+
+  function attachScrollSync(element: EventTarget | null) {
+    if (!element) {
+      return;
+    }
+
+    const handleScroll = () => {
+      if (session.phase === "motion") {
+        scheduleFrame();
+      }
+    };
+
+    element.addEventListener("scroll", handleScroll, { passive: true });
+    scrollSync = { element, handleScroll };
+  }
+
+  function detachScrollSync() {
+    if (!scrollSync) {
+      return;
+    }
+
+    scrollSync.element.removeEventListener("scroll", scrollSync.handleScroll);
+    scrollSync = null;
   }
 
   function mountOverlay(mount: FloatingInteractionOverlayMount) {
@@ -413,6 +431,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
 
     overlay?.unmount();
     overlay = null;
+    detachScrollSync();
 
     if (preparedSource) {
       restoreSourceElement(preparedSource);
@@ -445,7 +464,6 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     handlePointerMove,
     handlePointerUp,
     ownsPointer,
-    syncVisual,
   };
 };
 
@@ -453,3 +471,22 @@ const getPointerPoint = (event: PointerEvent): CalendarInteractionPoint => ({
   x: event.clientX,
   y: event.clientY,
 });
+
+// The overlay tracks the dragged element visually, so it needs to re-sync
+// whenever its nearest scrollable ancestor scrolls — regardless of what kind
+// of element is being dragged.
+const getNearestScrollableAncestor = (
+  element: HTMLElement,
+): HTMLElement | null => {
+  let node = element.parentElement;
+
+  while (node) {
+    if (node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+
+    node = node.parentElement;
+  }
+
+  return null;
+};

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -190,9 +190,21 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     }
 
     const motionSession = session;
+    const finalUpdate = resolvedOptions.adapter.updateVisual({
+      pointer: getPointerPoint(event),
+      target: motionSession.target,
+      timestamp: resolvedOptions.now(),
+      visual: motionSession.visual,
+    });
+
+    if (finalUpdate.overlay) {
+      overlay?.update(finalUpdate.overlay);
+      metrics.styleWritesDuringMotion += 1;
+    }
+
     const result = resolvedOptions.adapter.commit({
       target: motionSession.target,
-      visual: motionSession.visual,
+      visual: finalUpdate.visual,
     });
     teardownActiveSession("commit");
     session = { phase: "idle" };

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -197,11 +197,6 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       visual: motionSession.visual,
     });
 
-    if (finalUpdate.overlay) {
-      overlay?.update(finalUpdate.overlay);
-      metrics.styleWritesDuringMotion += 1;
-    }
-
     const result = resolvedOptions.adapter.commit({
       target: motionSession.target,
       visual: finalUpdate.visual,

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts
@@ -337,6 +337,16 @@ const activateAllDayEventWithoutMoving = () => {
   return result.current;
 };
 
+const createTimedResizeHandle = (edge: "startDate" | "endDate") => {
+  const { source } = registerEvent(timedEvent, "timed");
+  const handle = document.createElement("span");
+
+  handle.setAttribute("data-calendar-event-resize-handle", edge);
+  source.append(handle);
+
+  return handle;
+};
+
 afterEach(() => {
   document.body.innerHTML = "";
   dayCalendarEventRegistry.clear();
@@ -473,5 +483,74 @@ describe("DayInteractionAdapter", () => {
     expect(result.hasMoved).toBe(false);
     expect(result.event.startDate).toBe(multiDayAllDayEvent.startDate);
     expect(result.event.endDate).toBe(multiDayAllDayEvent.endDate);
+  });
+
+  it("continues timed smart scroll in the RAF loop while resizing toward the grid edge", () => {
+    const result: { current?: DayTimedResizeCommitResult } = {};
+    const handle = createTimedResizeHandle("endDate");
+    const { adapter, flushFrame, mainGridElement } = createAdapter({
+      onTimedResize: (nextResult) => {
+        result.current = nextResult;
+      },
+    });
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: handle, x: 160, y: 160 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: handle, x: 160, y: 220 }),
+    );
+
+    flushFrame(16);
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: handle, x: 160, y: 700 }),
+    );
+    flushFrame(32);
+    flushFrame(48);
+
+    expect(mainGridElement.scrollTop).toBe(20);
+
+    adapter.handlePointerUp(
+      makePointerEvent("pointerup", { target: handle, x: 160, y: 700 }),
+    );
+
+    expect(result.current).toMatchObject({
+      event: expect.objectContaining({
+        endDate: expect.stringContaining("19:30"),
+        startDate: expect.stringContaining("09:00"),
+      }),
+    });
+  });
+
+  it("uses the latest timed grid scroll position when it changes before timed resize commit", () => {
+    const result: { current?: DayTimedResizeCommitResult } = {};
+    const handle = createTimedResizeHandle("endDate");
+    const { adapter, flushFrame, mainGridElement } = createAdapter({
+      onTimedResize: (nextResult) => {
+        result.current = nextResult;
+      },
+    });
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: handle, x: 160, y: 160 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: handle, x: 160, y: 220 }),
+    );
+
+    flushFrame();
+
+    mainGridElement.scrollTop = 120;
+
+    adapter.handlePointerUp(
+      makePointerEvent("pointerup", { target: handle, x: 160, y: 220 }),
+    );
+
+    expect(result.current).toMatchObject({
+      event: expect.objectContaining({
+        endDate: expect.stringContaining("13:00"),
+        startDate: expect.stringContaining("09:00"),
+      }),
+    });
   });
 });

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts
@@ -389,6 +389,39 @@ describe("DayInteractionAdapter", () => {
     expect(timeLabel?.textContent).not.toBe("");
   });
 
+  it("uses the latest timed grid scroll position when it changes before timed drag commit", () => {
+    const result: { current?: DayTimedDragCommitResult } = {};
+    const { child } = registerEvent(timedEvent, "timed");
+    const { adapter, flushFrame, mainGridElement } = createAdapter({
+      onTimedDrag: (nextResult) => {
+        result.current = nextResult;
+      },
+    });
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: child, x: 160, y: 160 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: child, x: 160, y: 220 }),
+    );
+    flushFrame();
+
+    mainGridElement.scrollTop = 120;
+
+    adapter.handlePointerUp(
+      makePointerEvent("pointerup", { target: child, x: 160, y: 220 }),
+    );
+
+    expect(result.current).toMatchObject({
+      event: expect.objectContaining({
+        endDate: expect.stringContaining("13:00"),
+        startDate: expect.stringContaining("12:00"),
+      }),
+      hasMoved: true,
+      type: "timedDragEnd",
+    });
+  });
+
   it("continues timed smart scroll while dragging a saved timed event", () => {
     const result: { current?: DayTimedDragCommitResult } = {};
     const { child } = registerEvent(timedEvent, "timed");

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
@@ -105,6 +105,7 @@ export const createDayInteractionAdapter = ({
 }: DayInteractionAdapterOptions = {}): DayInteractionAdapter => {
   let layout: CalendarLayoutCache | null = null;
   let scrollTop: number | null = null;
+  let detachScrollSync: (() => void) | null = null;
 
   const engine: CalendarInteractionEngine<
     DayInteractionTarget,
@@ -226,6 +227,8 @@ export const createDayInteractionAdapter = ({
       cancel: () => {
         layout = null;
         scrollTop = null;
+        detachScrollSync?.();
+        detachScrollSync = null;
       },
       commit: ({ target, visual }) => {
         let result: DayInteractionCommitResult;
@@ -251,6 +254,8 @@ export const createDayInteractionAdapter = ({
 
         layout = null;
         scrollTop = null;
+        detachScrollSync?.();
+        detachScrollSync = null;
 
         return result;
       },
@@ -268,6 +273,25 @@ export const createDayInteractionAdapter = ({
 
         layout = nextLayout;
         scrollTop = nextLayout.smartScroll?.initialScrollTop ?? null;
+
+        detachScrollSync?.();
+        detachScrollSync = null;
+
+        const scrollElement = nextLayout.smartScroll?.element;
+
+        if (scrollElement) {
+          const handleScroll = () => {
+            engine.syncVisual();
+          };
+
+          scrollElement.addEventListener("scroll", handleScroll, {
+            passive: true,
+          });
+          detachScrollSync = () => {
+            scrollElement.removeEventListener("scroll", handleScroll);
+          };
+        }
+
         runtime().onMotionActivation?.(target);
 
         if (target.type === "allDayDrag") {

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
@@ -105,7 +105,6 @@ export const createDayInteractionAdapter = ({
 }: DayInteractionAdapterOptions = {}): DayInteractionAdapter => {
   let layout: CalendarLayoutCache | null = null;
   let scrollTop: number | null = null;
-  let detachScrollSync: (() => void) | null = null;
 
   const engine: CalendarInteractionEngine<
     DayInteractionTarget,
@@ -227,8 +226,6 @@ export const createDayInteractionAdapter = ({
       cancel: () => {
         layout = null;
         scrollTop = null;
-        detachScrollSync?.();
-        detachScrollSync = null;
       },
       commit: ({ target, visual }) => {
         let result: DayInteractionCommitResult;
@@ -254,8 +251,6 @@ export const createDayInteractionAdapter = ({
 
         layout = null;
         scrollTop = null;
-        detachScrollSync?.();
-        detachScrollSync = null;
 
         return result;
       },
@@ -273,25 +268,6 @@ export const createDayInteractionAdapter = ({
 
         layout = nextLayout;
         scrollTop = nextLayout.smartScroll?.initialScrollTop ?? null;
-
-        detachScrollSync?.();
-        detachScrollSync = null;
-
-        const scrollElement = nextLayout.smartScroll?.element;
-
-        if (scrollElement) {
-          const handleScroll = () => {
-            engine.syncVisual();
-          };
-
-          scrollElement.addEventListener("scroll", handleScroll, {
-            passive: true,
-          });
-          detachScrollSync = () => {
-            scrollElement.removeEventListener("scroll", handleScroll);
-          };
-        }
-
         runtime().onMotionActivation?.(target);
 
         if (target.type === "allDayDrag") {

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
@@ -361,9 +361,11 @@ export const createDayInteractionAdapter = ({
             throw new Error("Mismatched Day interaction target");
           }
 
+          const smartScroll = applySmartScroll(pointer);
           const nextVisual = updateTimedResizeVisual(visual, {
             layout,
             pointer,
+            scrollDeltaPx: smartScroll.scrollDeltaPx,
           });
           const nextEvent = timedResizeVisualToDayGridEvent(
             target.event,
@@ -377,6 +379,7 @@ export const createDayInteractionAdapter = ({
               mutate: (node) => updateCalendarOverlayTimeLabel(node, nextEvent),
               transform: nextVisual.transform,
             },
+            shouldContinue: smartScroll.isScrolling,
             visual: nextVisual,
           };
         }

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
@@ -414,6 +414,8 @@ export const createDayInteractionAdapter = ({
       return { isScrolling: false, scrollDeltaPx: 0 };
     }
 
+    scrollTop = layout.smartScroll.element.scrollTop;
+
     const frame = getSmartScrollFrame({
       cache: layout.smartScroll,
       pointerY: pointer.y,

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
@@ -444,6 +444,35 @@ describe("WeekInteractionAdapter timed drag", () => {
     );
   });
 
+  it("uses the latest timed grid scroll position when it changes before timed drag commit", () => {
+    const { adapter, child, flushFrame, mainGrid, onCommitTimedDrag } =
+      createHarness();
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: child, x: 320, y: 1020 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: child, x: 320, y: 1120 }),
+    );
+
+    flushFrame();
+
+    mainGrid.scrollTop = 120;
+
+    adapter.handlePointerUp(
+      makePointerEvent("pointerup", { target: child, x: 320, y: 1120 }),
+    );
+
+    expect(onCommitTimedDrag).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          endDate: expect.stringContaining("12:15"),
+          startDate: expect.stringContaining("11:15"),
+        }),
+      }),
+    );
+  });
+
   it("continues timed smart scroll in the RAF loop and feeds scroll delta into commit time", () => {
     const { adapter, child, flushFrame, mainGrid, onCommitTimedDrag } =
       createHarness();

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
@@ -77,7 +77,13 @@ const makePointerEvent = (
   return event;
 };
 
-const createHarness = ({ isPending = false }: { isPending?: boolean } = {}) => {
+const createHarness = ({
+  isPending = false,
+  mainGridScrollTop = 0,
+}: {
+  isPending?: boolean;
+  mainGridScrollTop?: number;
+} = {}) => {
   document.body.innerHTML = "";
   weekEventRegistry.clear();
 
@@ -106,7 +112,7 @@ const createHarness = ({ isPending = false }: { isPending?: boolean } = {}) => {
   document.body.append(mainGrid);
   Object.defineProperty(mainGrid, "clientHeight", { value: 1300 });
   Object.defineProperty(mainGrid, "scrollHeight", { value: 2600 });
-  mainGrid.scrollTop = 0;
+  mainGrid.scrollTop = mainGridScrollTop;
 
   setRect(mainGrid, {
     height: 1300,
@@ -193,6 +199,7 @@ const createHarness = ({ isPending = false }: { isPending?: boolean } = {}) => {
     event,
     fireHoldTimer,
     flushFrame,
+    mainGrid,
     onClickTimedEvent,
     onCommitTimedDrag,
     onCommitTimedResize,
@@ -435,6 +442,69 @@ describe("WeekInteractionAdapter timed resize", () => {
         eventId: event._id,
         hasMoved: false,
         type: "timedResizeEnd",
+      }),
+    );
+  });
+
+  it("continues timed smart scroll in the RAF loop while resizing toward the grid edge", () => {
+    const { adapter, endHandle, flushFrame, mainGrid, onCommitTimedResize } =
+      createHarness();
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: endHandle, x: 320, y: 1100 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: endHandle, x: 320, y: 1150 }),
+    );
+
+    flushFrame(16);
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: endHandle, x: 320, y: 1290 }),
+    );
+    flushFrame(32);
+    flushFrame(48);
+
+    expect(mainGrid.scrollTop).toBe(20);
+
+    adapter.handlePointerUp(
+      makePointerEvent("pointerup", { target: endHandle, x: 320, y: 1290 }),
+    );
+
+    expect(onCommitTimedResize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          endDate: expect.stringContaining("12:15"),
+          startDate: expect.stringContaining("09:00"),
+        }),
+      }),
+    );
+  });
+
+  it("uses the latest timed grid scroll position when it changes before timed resize commit", () => {
+    const { adapter, endHandle, flushFrame, mainGrid, onCommitTimedResize } =
+      createHarness();
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: endHandle, x: 320, y: 1100 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: endHandle, x: 320, y: 1200 }),
+    );
+
+    flushFrame();
+
+    mainGrid.scrollTop = 120;
+
+    adapter.handlePointerUp(
+      makePointerEvent("pointerup", { target: endHandle, x: 320, y: 1200 }),
+    );
+
+    expect(onCommitTimedResize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          endDate: expect.stringContaining("12:15"),
+          startDate: expect.stringContaining("09:00"),
+        }),
       }),
     );
   });

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
@@ -480,6 +480,32 @@ describe("WeekInteractionAdapter timed resize", () => {
     );
   });
 
+  it("re-syncs the overlay position when the grid scrolls without further pointer movement", () => {
+    const { adapter, endHandle, flushFrame, mainGrid } = createHarness();
+
+    adapter.handlePointerDown(
+      makePointerEvent("pointerdown", { target: endHandle, x: 320, y: 1100 }),
+    );
+    adapter.handlePointerMove(
+      makePointerEvent("pointermove", { target: endHandle, x: 320, y: 1150 }),
+    );
+    flushFrame();
+
+    const overlay = document.body.querySelector(
+      "[data-calendar-interaction-overlay]",
+    ) as HTMLElement | null;
+
+    expect(overlay?.style.transform).toBe("translate3d(0px, 0px, 0)");
+    expect(overlay?.style.height).toBe("150px");
+
+    mainGrid.scrollTop = 100;
+    mainGrid.dispatchEvent(new Event("scroll"));
+    flushFrame();
+
+    expect(overlay?.style.transform).toBe("translate3d(0px, -100px, 0)");
+    expect(overlay?.style.height).toBe("250px");
+  });
+
   it("uses the latest timed grid scroll position when it changes before timed resize commit", () => {
     const { adapter, endHandle, flushFrame, mainGrid, onCommitTimedResize } =
       createHarness();

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -607,6 +607,8 @@ export const createWeekInteractionAdapter = ({
       return { isScrolling: false, scrollDeltaPx: 0 };
     }
 
+    scrollTop = layout.smartScroll.element.scrollTop;
+
     const frame = getSmartScrollFrame({
       cache: layout.smartScroll,
       pointerY: pointer.y,

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -99,6 +99,7 @@ export const createWeekInteractionAdapter = ({
   let isLayoutRebuildPending = false;
   let layout: WeekLayoutCache | null = null;
   let scrollTop: number | null = null;
+  let detachScrollSync: (() => void) | null = null;
 
   const engine: CalendarInteractionEngine<
     WeekInteractionTarget,
@@ -694,11 +695,31 @@ export const createWeekInteractionAdapter = ({
     scrollTop = null;
     resetEdgeNavigation();
     isLayoutRebuildPending = false;
+    detachScrollSync?.();
+    detachScrollSync = null;
   }
 
   function setLayout(nextLayout: WeekLayoutCache) {
     layout = nextLayout;
     scrollTop = nextLayout.smartScroll?.initialScrollTop ?? null;
+
+    detachScrollSync?.();
+    detachScrollSync = null;
+
+    const scrollElement = nextLayout.smartScroll?.element;
+
+    if (scrollElement) {
+      const handleScroll = () => {
+        engine.syncVisual();
+      };
+
+      scrollElement.addEventListener("scroll", handleScroll, {
+        passive: true,
+      });
+      detachScrollSync = () => {
+        scrollElement.removeEventListener("scroll", handleScroll);
+      };
+    }
   }
 
   return {

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -386,9 +386,11 @@ export const createWeekInteractionAdapter = ({
             throw new Error("Mismatched Week interaction target");
           }
 
+          const smartScroll = applySmartScroll(pointer);
           const next = updateTimedResizeInteractionVisual({
             layout,
             pointer,
+            scrollDeltaPx: smartScroll.scrollDeltaPx,
             target,
             visual,
           });
@@ -400,6 +402,7 @@ export const createWeekInteractionAdapter = ({
                 updateCalendarOverlayTimeLabel(node, next.event),
               transform: next.visual.transform,
             },
+            shouldContinue: smartScroll.isScrolling,
             visual: next.visual,
           };
         }

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -99,7 +99,6 @@ export const createWeekInteractionAdapter = ({
   let isLayoutRebuildPending = false;
   let layout: WeekLayoutCache | null = null;
   let scrollTop: number | null = null;
-  let detachScrollSync: (() => void) | null = null;
 
   const engine: CalendarInteractionEngine<
     WeekInteractionTarget,
@@ -695,31 +694,11 @@ export const createWeekInteractionAdapter = ({
     scrollTop = null;
     resetEdgeNavigation();
     isLayoutRebuildPending = false;
-    detachScrollSync?.();
-    detachScrollSync = null;
   }
 
   function setLayout(nextLayout: WeekLayoutCache) {
     layout = nextLayout;
     scrollTop = nextLayout.smartScroll?.initialScrollTop ?? null;
-
-    detachScrollSync?.();
-    detachScrollSync = null;
-
-    const scrollElement = nextLayout.smartScroll?.element;
-
-    if (scrollElement) {
-      const handleScroll = () => {
-        engine.syncVisual();
-      };
-
-      scrollElement.addEventListener("scroll", handleScroll, {
-        passive: true,
-      });
-      detachScrollSync = () => {
-        scrollElement.removeEventListener("scroll", handleScroll);
-      };
-    }
   }
 
   return {

--- a/packages/web/src/views/Week/interaction/adapter/interactions/timedEventResizeInteraction.ts
+++ b/packages/web/src/views/Week/interaction/adapter/interactions/timedEventResizeInteraction.ts
@@ -40,17 +40,20 @@ export const createTimedResizeInteractionVisual = ({
 export const updateTimedResizeInteractionVisual = ({
   layout,
   pointer,
+  scrollDeltaPx,
   target,
   visual,
 }: {
   layout: WeekLayoutCache;
   pointer: VisualPoint;
+  scrollDeltaPx?: number;
   target: WeekTimedResizeTarget;
   visual: TimedResizeVisual;
 }) => {
   const nextVisual = updateTimedResizeVisual(visual, {
     layout,
     pointer,
+    scrollDeltaPx,
   });
 
   return {


### PR DESCRIPTION
## What changed

Closes #1897 
This fixes timed drag commits in Day and Week so the final committed time reflects the latest timed-grid scroll position, including manual scroll changes that happen while the pointer is still down.

It also adds focused regressions around the engine commit path and timed drag behavior in both views.

## Why it changed

Issue #1895 reported that a timed drag could land on the wrong slot if the user scrolled the timed grid during the drag and then released without another pointer-driven update.

## Impact

Timed events dropped in Day and Week now commit to the slot the user is actually looking at when they release, instead of committing against stale scroll state.

## Root cause

Two things were stale at commit time:

1. The interaction engine committed the last stored visual instead of recomputing from the actual `pointerup` position.
2. The Day and Week timed-drag smart-scroll helpers cached `scrollTop`, so manual scroll changes could be missed if they happened between the last motion frame and commit.

## Validation

- `bun test --cwd packages/web src/common/calendar-interaction/CalendarInteractionEngine.test.ts`
- `bun test --cwd packages/web src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts`
- `bun test --cwd packages/web src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts`
- `bunx biome check packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts`

`bun lint` currently fails in this checkout because Biome traverses an unrelated nested config under `.worktrees/refactor-unify-floating-event-forms/biome.json`. The touched files themselves pass Biome directly.