### PR TITLE
fix(web): stop Cmd+D from also navigating to Day view

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -432,6 +432,7 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
       "Mod+D",
       (keyboardEvent) => {
         keyboardEvent.preventDefault();
+        keyboardEvent.stopPropagation();
         onDuplicate?.(event);
       },
       EVENT_FORM_PLAIN_HOTKEY_OPTIONS,

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
@@ -3,7 +3,7 @@ import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren } from "react";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { createInitialState } from "@web/__tests__/utils/state/store.test.util";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
 import { reducers } from "@web/store/reducers";
@@ -45,6 +45,13 @@ mock.module(
 
 const { useGlobalShortcuts } = await import("./useGlobalShortcuts");
 
+const currentPathname = { value: "" };
+
+function LocationSpy() {
+  currentPathname.value = useLocation().pathname;
+  return null;
+}
+
 function wrapper({ children }: PropsWithChildren) {
   const store = createStore();
 
@@ -55,6 +62,7 @@ function wrapper({ children }: PropsWithChildren) {
           initialEntries={["/week"]}
           future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
         >
+          <LocationSpy />
           {children}
         </MemoryRouter>
       </Provider>
@@ -79,6 +87,7 @@ describe("useGlobalShortcuts", () => {
       authenticated: true,
       setAuthenticated: mock(),
     });
+    currentPathname.value = "";
   });
 
   it("opens logout confirmation when authenticated users press Z", async () => {
@@ -105,5 +114,58 @@ describe("useGlobalShortcuts", () => {
       expect(mockOpenModal).toHaveBeenCalledWith("login");
     });
     expect(mockOpenLogoutConfirmation).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate to Day view when a held-Cmd D keyup is replayed after a Mod+D press", async () => {
+    renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    await waitFor(() => {
+      expect(currentPathname.value).toBe("/week");
+    });
+
+    // Mod+D pressed (e.g. Event Form duplicate shortcut). The test platform
+    // resolves "Mod" to Control, so use ctrlKey here to match. Dispatched
+    // directly (rather than via the paired `pressKey` helper) so the
+    // modifier-swallowed keyup below isn't preceded by an extra, unwanted
+    // unmodified keyup.
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "d",
+        ctrlKey: true,
+      }),
+    );
+
+    // macOS swallows the "d" keyup while the modifier is held, then replays
+    // it once the modifier is released — by then the modifier flag is
+    // already false, matching the bare "D" Day-view shortcut unless
+    // explicitly suppressed.
+    document.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        bubbles: true,
+        cancelable: true,
+        key: "d",
+        ctrlKey: false,
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(currentPathname.value).toBe("/week");
+  });
+
+  it("still navigates to Day view for a plain D press", async () => {
+    renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    await waitFor(() => {
+      expect(currentPathname.value).toBe("/week");
+    });
+
+    pressKey("d");
+
+    await waitFor(() => {
+      expect(currentPathname.value).toBe("/day");
+    });
   });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
@@ -1,9 +1,8 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren } from "react";
 import { Provider } from "react-redux";
-import { MemoryRouter, useLocation } from "react-router-dom";
 import { createInitialState } from "@web/__tests__/utils/state/store.test.util";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
 import { reducers } from "@web/store/reducers";
@@ -15,6 +14,8 @@ const mockOpenLogoutConfirmation = mock();
 const mockUseAuthModal = mock();
 const mockUseLogoutConfirmation = mock();
 const mockUseSession = mock();
+const mockNavigate = mock();
+const mockPathname = { value: "/week" };
 
 const createStore = () =>
   configureStore({
@@ -43,29 +44,26 @@ mock.module(
   }),
 );
 
+// react-router-dom's useNavigate/useLocation are mocked directly (rather than
+// relying on a real MemoryRouter) because Bun's `mock.module` is process-wide:
+// another test file mocking "react-router-dom" can otherwise silently replace
+// `useNavigate` for every file that runs afterward in the same test run.
+const actualReactRouterDom = await import("react-router-dom");
+
+mock.module("react-router-dom", () => ({
+  ...actualReactRouterDom,
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: mockPathname.value }),
+}));
+
 const { useGlobalShortcuts } = await import("./useGlobalShortcuts");
-
-const currentPathname = { value: "" };
-
-function LocationSpy() {
-  currentPathname.value = useLocation().pathname;
-  return null;
-}
 
 function wrapper({ children }: PropsWithChildren) {
   const store = createStore();
 
   return (
     <HotkeysProvider>
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={["/week"]}
-          future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
-        >
-          <LocationSpy />
-          {children}
-        </MemoryRouter>
-      </Provider>
+      <Provider store={store}>{children}</Provider>
     </HotkeysProvider>
   );
 }
@@ -79,6 +77,7 @@ describe("useGlobalShortcuts", () => {
     mockUseAuthModal.mockReset();
     mockUseLogoutConfirmation.mockReset();
     mockUseSession.mockReset();
+    mockNavigate.mockClear();
     mockUseAuthModal.mockReturnValue({ openModal: mockOpenModal });
     mockUseLogoutConfirmation.mockReturnValue({
       openLogoutConfirmation: mockOpenLogoutConfirmation,
@@ -87,18 +86,24 @@ describe("useGlobalShortcuts", () => {
       authenticated: true,
       setAuthenticated: mock(),
     });
-    currentPathname.value = "";
+    mockPathname.value = "/week";
   });
 
   it("opens logout confirmation when authenticated users press Z", async () => {
-    renderHook(() => useGlobalShortcuts(), { wrapper });
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
 
-    pressKey("z");
+    act(() => {
+      pressKey("z");
+    });
 
     await waitFor(() => {
       expect(mockOpenLogoutConfirmation).toHaveBeenCalledTimes(1);
     });
     expect(mockOpenModal).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
   });
 
   it("opens login when logged-out users press Z", async () => {
@@ -106,66 +111,76 @@ describe("useGlobalShortcuts", () => {
       authenticated: false,
       setAuthenticated: mock(),
     });
-    renderHook(() => useGlobalShortcuts(), { wrapper });
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
 
-    pressKey("z");
+    act(() => {
+      pressKey("z");
+    });
 
     await waitFor(() => {
       expect(mockOpenModal).toHaveBeenCalledWith("login");
     });
     expect(mockOpenLogoutConfirmation).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
   });
 
   it("does not navigate to Day view when a held-Cmd D keyup is replayed after a Mod+D press", async () => {
-    renderHook(() => useGlobalShortcuts(), { wrapper });
-
-    await waitFor(() => {
-      expect(currentPathname.value).toBe("/week");
-    });
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
 
     // Mod+D pressed (e.g. Event Form duplicate shortcut). The test platform
     // resolves "Mod" to Control, so use ctrlKey here to match. Dispatched
     // directly (rather than via the paired `pressKey` helper) so the
     // modifier-swallowed keyup below isn't preceded by an extra, unwanted
     // unmodified keyup.
-    document.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        bubbles: true,
-        cancelable: true,
-        key: "d",
-        ctrlKey: true,
-      }),
-    );
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "d",
+          ctrlKey: true,
+        }),
+      );
+    });
 
     // macOS swallows the "d" keyup while the modifier is held, then replays
     // it once the modifier is released — by then the modifier flag is
     // already false, matching the bare "D" Day-view shortcut unless
     // explicitly suppressed.
-    document.dispatchEvent(
-      new KeyboardEvent("keyup", {
-        bubbles: true,
-        cancelable: true,
-        key: "d",
-        ctrlKey: false,
-      }),
-    );
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keyup", {
+          bubbles: true,
+          cancelable: true,
+          key: "d",
+          ctrlKey: false,
+        }),
+      );
+    });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockNavigate).not.toHaveBeenCalled();
 
-    expect(currentPathname.value).toBe("/week");
+    act(() => {
+      unmount();
+    });
   });
 
   it("still navigates to Day view for a plain D press", async () => {
-    renderHook(() => useGlobalShortcuts(), { wrapper });
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
 
-    await waitFor(() => {
-      expect(currentPathname.value).toBe("/week");
+    act(() => {
+      pressKey("d");
     });
 
-    pressKey("d");
-
     await waitFor(() => {
-      expect(currentPathname.value).toBe("/day");
+      expect(mockNavigate).toHaveBeenCalledWith("/day");
+    });
+
+    act(() => {
+      unmount();
     });
   });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
@@ -26,25 +26,15 @@ export function useGlobalShortcuts() {
 
   // macOS swallows the keyup for a letter held with Cmd until Cmd itself is
   // released, then replays it with metaKey already false — which matches the
-  // bare "D" view shortcut below and incorrectly navigates to Day view after
-  // a Cmd+D (duplicate event) press. Suppress that replayed keyup.
-  const suppressDayShortcutRef = useRef(false);
-  const suppressDayShortcutTimeoutRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
+  // bare "D" view shortcut below and incorrectly navigates to Day view right
+  // after a Cmd+D (duplicate event) press. Ignore the Day shortcut for a
+  // short window after Mod+D fires to filter out that replayed keyup.
+  const suppressDayShortcutUntilRef = useRef(0);
 
   useAppHotkey(
     "Mod+D",
     () => {
-      suppressDayShortcutRef.current = true;
-
-      if (suppressDayShortcutTimeoutRef.current) {
-        clearTimeout(suppressDayShortcutTimeoutRef.current);
-      }
-
-      suppressDayShortcutTimeoutRef.current = setTimeout(() => {
-        suppressDayShortcutRef.current = false;
-      }, 1000);
+      suppressDayShortcutUntilRef.current = Date.now() + 1000;
     },
     {
       ignoreInputs: false,
@@ -55,14 +45,8 @@ export function useGlobalShortcuts() {
   );
 
   useAppHotkeyUp(dayHotkey, () => {
-    if (suppressDayShortcutRef.current) {
-      suppressDayShortcutRef.current = false;
-
-      if (suppressDayShortcutTimeoutRef.current) {
-        clearTimeout(suppressDayShortcutTimeoutRef.current);
-        suppressDayShortcutTimeoutRef.current = null;
-      }
-
+    if (Date.now() < suppressDayShortcutUntilRef.current) {
+      suppressDayShortcutUntilRef.current = 0;
       return;
     }
 

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
@@ -1,4 +1,5 @@
 import { type RegisterableHotkey } from "@tanstack/react-hotkeys";
+import { useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
@@ -23,7 +24,48 @@ export function useGlobalShortcuts() {
   const weekHotkey =
     VIEW_SHORTCUTS.week.key.toUpperCase() as RegisterableHotkey;
 
+  // macOS swallows the keyup for a letter held with Cmd until Cmd itself is
+  // released, then replays it with metaKey already false — which matches the
+  // bare "D" view shortcut below and incorrectly navigates to Day view after
+  // a Cmd+D (duplicate event) press. Suppress that replayed keyup.
+  const suppressDayShortcutRef = useRef(false);
+  const suppressDayShortcutTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+
+  useAppHotkey(
+    "Mod+D",
+    () => {
+      suppressDayShortcutRef.current = true;
+
+      if (suppressDayShortcutTimeoutRef.current) {
+        clearTimeout(suppressDayShortcutTimeoutRef.current);
+      }
+
+      suppressDayShortcutTimeoutRef.current = setTimeout(() => {
+        suppressDayShortcutRef.current = false;
+      }, 1000);
+    },
+    {
+      ignoreInputs: false,
+      preventDefault: false,
+      stopPropagation: false,
+      conflictBehavior: "allow",
+    },
+  );
+
   useAppHotkeyUp(dayHotkey, () => {
+    if (suppressDayShortcutRef.current) {
+      suppressDayShortcutRef.current = false;
+
+      if (suppressDayShortcutTimeoutRef.current) {
+        clearTimeout(suppressDayShortcutTimeoutRef.current);
+        suppressDayShortcutTimeoutRef.current = null;
+      }
+
+      return;
+    }
+
     if (!location.pathname.startsWith(VIEW_SHORTCUTS.day.route)) {
       navigate(VIEW_SHORTCUTS.day.route);
     }


### PR DESCRIPTION
## Summary

Fixes #1842.

- `EventForm`'s `Mod+D` handler now calls `stopPropagation()` in addition to `preventDefault()`, matching the existing pattern in `SomedayEventForm`'s `useSomedayFormShortcuts`.
- The actual root cause of the Day-view navigation bug was not propagation — `@tanstack/react-hotkeys` routes all registrations for a target through one shared listener, so `stopPropagation()` on a keydown event has no effect on a separate keyup registration. The real cause is a documented macOS quirk (see the comment in `@tanstack/hotkeys`'s `key-state-tracker.ts`): the OS swallows the `keyup` for a letter key held with Cmd/Ctrl until the modifier itself is released, then replays it afterward with the modifier flag already `false`. Since the global Day-view shortcut listens for a bare `D` keyup, that replayed event spuriously matched it and triggered navigation right after a Cmd+D duplicate action.
- `useGlobalShortcuts` now tracks a short-lived "Mod+D was just pressed" flag (auto-clearing after 1s as a safety net) and skips the Day-view navigation when the replayed keyup fires shortly after.
- The tooltip z-index half of the original issue (Cmd+D tooltip rendering behind the Event Form) was already fixed by #1880 and is present on this branch — no changes needed there.

## Test plan

- [x] `bun run test:web -- useGlobalShortcuts` — added regression tests: one simulating the swallowed/replayed keyup after Mod+D (asserts no navigation), one confirming a plain `D` press still navigates to Day view.
- [x] `bun run test:web -- EventForm` — existing suite still passes.
- [x] `bunx typescript@6.0.3 -p packages/web/tsconfig.app.json --noEmit` and `tsconfig.test.json --noEmit` — clean.
- [x] `biome check` on touched files — clean (pre-existing unrelated warning in `EventForm.tsx` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)