### PR TITLE
fix(web): close actions menu on blur

### DIFF
--- a/packages/web/src/components/FloatingEventForm/FloatingEventForm.tsx
+++ b/packages/web/src/components/FloatingEventForm/FloatingEventForm.tsx
@@ -62,6 +62,10 @@ export function FloatingEventForm({
     <FloatingPortal>
       <FloatingFocusManager
         context={form.context}
+        // Must stay false: this form hosts nested floating trees (e.g.
+        // ActionsMenu) with their own focus managers, so the default
+        // close-on-blur here would close the form while focus is still
+        // moving within a child menu's separate floating tree.
         closeOnFocusOut={false}
         order={["reference"]}
       >

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.test.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.test.tsx
@@ -53,7 +53,7 @@ describe("ActionsMenu", () => {
     expect(screen.getByText("Delete Event")).toBeInTheDocument();
   });
 
-  it("closes the menu when focus leaves the menu tree", async () => {
+  it("closes the menu when focus leaves the menu tree without stealing focus back", async () => {
     const user = userEvent.setup();
 
     renderMenu(
@@ -68,6 +68,9 @@ describe("ActionsMenu", () => {
     const menuItem = screen.getByRole("menuitem", { name: "Delete Event" });
     const priorityButton = screen.getByRole("button", { name: "Priority" });
 
+    // jsdom doesn't perform the browser's native Tab-key focus transfer, so
+    // we move focus to the next element ourselves to simulate it, then
+    // assert the menu doesn't fight that transfer by refocusing the trigger.
     await act(async () => {
       fireEvent.focus(menuItem);
       fireEvent.blur(menuItem, { relatedTarget: priorityButton });

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.test.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { type ReactElement } from "react";
+import userEvent from "@testing-library/user-event";
+import { act, type ReactElement } from "react";
 import { ActionsMenu, useMenuContext } from "./ActionsMenu";
 import { describe, expect, it } from "bun:test";
 
@@ -17,7 +18,9 @@ const TestMenuItem = () => {
 };
 
 describe("ActionsMenu", () => {
-  it("keeps mouse hover from stealing focus from the editor action trigger", () => {
+  it("keeps mouse hover from stealing focus from the editor action trigger", async () => {
+    const user = userEvent.setup();
+
     renderMenu(
       <ActionsMenu bgColor="#fff">{() => <TestMenuItem />}</ActionsMenu>,
     );
@@ -25,20 +28,54 @@ describe("ActionsMenu", () => {
     const trigger = screen.getByLabelText("Open actions menu");
     trigger.focus();
 
-    fireEvent.click(trigger);
-    fireEvent.mouseMove(screen.getByText("Delete Event"));
+    await user.click(trigger);
+
+    act(() => {
+      fireEvent.mouseMove(screen.getByText("Delete Event"));
+    });
 
     expect(document.activeElement).toBe(trigger);
   });
 
-  it("keeps the menu mounted when focus moves inside it", () => {
+  it("keeps the menu mounted when focus moves inside it", async () => {
+    const user = userEvent.setup();
+
     renderMenu(
       <ActionsMenu bgColor="#fff">{() => <TestMenuItem />}</ActionsMenu>,
     );
 
-    fireEvent.click(screen.getByLabelText("Open actions menu"));
-    fireEvent.focus(screen.getByText("Delete Event"));
+    await user.click(screen.getByLabelText("Open actions menu"));
+
+    act(() => {
+      fireEvent.focus(screen.getByText("Delete Event"));
+    });
 
     expect(screen.getByText("Delete Event")).toBeInTheDocument();
+  });
+
+  it("closes the menu when focus leaves the menu tree", async () => {
+    const user = userEvent.setup();
+
+    renderMenu(
+      <div>
+        <ActionsMenu bgColor="#fff">{() => <TestMenuItem />}</ActionsMenu>
+        <button type="button">Priority</button>
+      </div>,
+    );
+
+    await user.click(screen.getByLabelText("Open actions menu"));
+
+    const menuItem = screen.getByRole("menuitem", { name: "Delete Event" });
+    const priorityButton = screen.getByRole("button", { name: "Priority" });
+
+    await act(async () => {
+      fireEvent.focus(menuItem);
+      fireEvent.blur(menuItem, { relatedTarget: priorityButton });
+      priorityButton.focus();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(priorityButton).toHaveFocus();
   });
 });

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
@@ -16,7 +16,6 @@ import { DotsThreeVerticalIcon } from "@phosphor-icons/react";
 import type React from "react";
 import {
   createContext,
-  type FocusEvent,
   type MouseEvent,
   useContext,
   useEffect,
@@ -139,28 +138,6 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
     [click, dismiss, role, listNavigation],
   );
 
-  const referenceElement =
-    refs.reference.current instanceof HTMLElement
-      ? refs.reference.current
-      : null;
-
-  const isFocusWithinMenuTree = (nextFocused: EventTarget | null) => {
-    if (!(nextFocused instanceof HTMLElement)) {
-      return false;
-    }
-
-    return Boolean(
-      referenceElement?.contains(nextFocused) ||
-        refs.floating.current?.contains(nextFocused),
-    );
-  };
-
-  const closeOnBlurOutsideMenuTree = (event: FocusEvent<HTMLElement>) => {
-    if (!isFocusWithinMenuTree(event.relatedTarget)) {
-      setOpen(false);
-    }
-  };
-
   const closeMenu = () => {
     setOpen(false);
     // Return focus to trigger when menu closes
@@ -176,7 +153,6 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
         className="inline-flex"
         ref={refs.setReference}
         {...getReferenceProps({
-          onBlur: closeOnBlurOutsideMenuTree,
           onClick: (e: MouseEvent<HTMLDivElement>) => {
             // Prevent default behaviour (like focusing inputs) and stop bubbling to parent form
             e.preventDefault();
@@ -205,16 +181,14 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
             returnFocus={false}
           >
             <div
-              className="flex flex-col gap-2 rounded-sm bg-[var(--actions-menu-bg)] p-2 shadow-[0_4px_8px_rgb(0_0_0/10%)]"
+              className="flex flex-col gap-2 rounded-sm bg-(--actions-menu-bg) p-2 shadow-[0_4px_8px_rgb(0_0_0/10%)]"
               ref={refs.setFloating}
               style={{
                 ...context.floatingStyles,
                 backgroundColor: bgColor,
                 zIndex: menuZIndex,
               }}
-              {...getFloatingProps({
-                onBlur: closeOnBlurOutsideMenuTree,
-              })}
+              {...getFloatingProps()}
               id={menuId}
               role="menu"
               aria-labelledby={triggerId}

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
@@ -16,6 +16,7 @@ import { DotsThreeVerticalIcon } from "@phosphor-icons/react";
 import type React from "react";
 import {
   createContext,
+  type FocusEvent,
   type MouseEvent,
   useContext,
   useEffect,
@@ -138,6 +139,28 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
     [click, dismiss, role, listNavigation],
   );
 
+  const referenceElement =
+    refs.reference.current instanceof HTMLElement
+      ? refs.reference.current
+      : null;
+
+  const isFocusWithinMenuTree = (nextFocused: EventTarget | null) => {
+    if (!(nextFocused instanceof HTMLElement)) {
+      return false;
+    }
+
+    return Boolean(
+      referenceElement?.contains(nextFocused) ||
+        refs.floating.current?.contains(nextFocused),
+    );
+  };
+
+  const closeOnBlurOutsideMenuTree = (event: FocusEvent<HTMLElement>) => {
+    if (!isFocusWithinMenuTree(event.relatedTarget)) {
+      setOpen(false);
+    }
+  };
+
   const closeMenu = () => {
     setOpen(false);
     // Return focus to trigger when menu closes
@@ -153,6 +176,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
         className="inline-flex"
         ref={refs.setReference}
         {...getReferenceProps({
+          onBlur: closeOnBlurOutsideMenuTree,
           onClick: (e: MouseEvent<HTMLDivElement>) => {
             // Prevent default behaviour (like focusing inputs) and stop bubbling to parent form
             e.preventDefault();
@@ -177,7 +201,6 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
           <FloatingFocusManager
             context={context}
             modal={false}
-            closeOnFocusOut={false}
             initialFocus={openedByMouseRef.current ? -1 : 0}
             returnFocus={false}
           >
@@ -189,7 +212,9 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
                 backgroundColor: bgColor,
                 zIndex: menuZIndex,
               }}
-              {...getFloatingProps()}
+              {...getFloatingProps({
+                onBlur: closeOnBlurOutsideMenuTree,
+              })}
               id={menuId}
               role="menu"
               aria-labelledby={triggerId}


### PR DESCRIPTION
## What changed
- close the event-form actions menu when focus leaves the trigger/menu tree
- keep the menu open when focus moves within the menu itself
- add a regression test that covers blur to the next form control

## Why
The actions menu stayed open after the user moved focus away from it, which blocked the normal tab flow through the rest of the event form.

## Root cause
`ActionsMenu` explicitly disabled focus-out closing and had no replacement blur handling for the trigger/menu tree.

## Validation
- `bun test --cwd packages/web src/views/Forms/ActionsMenu/ActionsMenu.test.tsx`
- `bun type-check`
- `bunx @biomejs/biome check packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx packages/web/src/views/Forms/ActionsMenu/ActionsMenu.test.tsx --config-path ./biome.json`
- Chrome validation on `http://localhost:9080/day/2026-06-30`: opened an event form, opened the actions menu, pressed `Tab`, and confirmed the menu closed

## Notes
- `bun lint` is currently blocked by an unrelated nested Biome root configuration under `.worktrees/refactor-unify-floating-event-forms`.
