### PR TITLE
refactor(web): simplify day event listener tests and clean listener payload

### DIFF
--- a/packages/web/src/ducks/events/listeners/day.event.listener.test.ts
+++ b/packages/web/src/ducks/events/listeners/day.event.listener.test.ts
@@ -23,6 +23,23 @@ const createMockRepository = (): any => ({
 const mockLocalEventRepository = createMockRepository();
 const mockRemoteEventRepository = createMockRepository();
 
+const eventResponse = (data: unknown, startDate = "", endDate = "") => {
+  const count = Array.isArray(data) ? data.length : 0;
+
+  return {
+    data,
+    count,
+    page: 1,
+    pageSize: count,
+    offset: 0,
+    startDate,
+    endDate,
+  };
+};
+
+const waitForEffects = (ms = 100) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 const mockGetEventRepository = mock((sessionExists: boolean) =>
   sessionExists ? mockRemoteEventRepository : mockLocalEventRepository,
 );
@@ -123,6 +140,14 @@ describe("day.event.listener", () => {
   let queryClient: ReturnType<typeof createCompassQueryClient>;
   const startDate = "2025-01-01";
   const endDate = "2025-01-31";
+  const requestDayEvents = (reason = "DAY_VIEW_CHANGE") =>
+    store.dispatch(
+      getDayEventsSlice.actions.request({
+        startDate,
+        endDate,
+        __context: { reason },
+      }),
+    );
 
   beforeEach(() => {
     queryClient = createCompassQueryClient();
@@ -155,26 +180,14 @@ describe("day.event.listener", () => {
 
       mockGetSessionExists.mockResolvedValueOnce(true);
       mockGetEventRepositorySource.mockReturnValueOnce("remote");
-      mockRemoteEventRepository.get.mockResolvedValueOnce({
-        data: [event1, event2],
-        count: 2,
-        page: 1,
-        pageSize: 2,
-        offset: 0,
-        startDate,
-        endDate,
-      });
-
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
+      mockRemoteEventRepository.get.mockResolvedValueOnce(
+        eventResponse([event1, event2], startDate, endDate),
       );
 
+      requestDayEvents();
+
       // Wait for async effects to settle
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForEffects();
 
       const state = store.getState();
       const dayEventsSlice = state.events.getDayEvents;
@@ -202,25 +215,13 @@ describe("day.event.listener", () => {
 
       mockGetSessionExists.mockResolvedValueOnce(true);
       mockGetEventRepositorySource.mockReturnValueOnce("remote");
-      mockRemoteEventRepository.get.mockResolvedValueOnce({
-        data: [inRangeEvent, outOfRangeEvent],
-        count: 2,
-        page: 1,
-        pageSize: 2,
-        offset: 0,
-        startDate,
-        endDate,
-      });
-
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
+      mockRemoteEventRepository.get.mockResolvedValueOnce(
+        eventResponse([inRangeEvent, outOfRangeEvent], startDate, endDate),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      requestDayEvents();
+
+      await waitForEffects();
 
       const state = store.getState();
       // Out-of-range event should be filtered out before normalization
@@ -238,15 +239,9 @@ describe("day.event.listener", () => {
       mockGetEventRepositorySource.mockReturnValueOnce("local");
       mockLocalEventRepository.get.mockRejectedValueOnce(testError);
 
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
-      );
+      requestDayEvents();
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForEffects();
 
       const state = store.getState();
       expect(state.events.getDayEvents.isSuccess).toBe(false);
@@ -256,25 +251,13 @@ describe("day.event.listener", () => {
     it("handles malformed response (data is null)", async () => {
       mockGetSessionExists.mockResolvedValueOnce(true);
       mockGetEventRepositorySource.mockReturnValueOnce("remote");
-      mockRemoteEventRepository.get.mockResolvedValueOnce({
-        data: null,
-        count: 0,
-        page: 1,
-        pageSize: 0,
-        offset: 0,
-        startDate,
-        endDate,
-      });
-
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
+      mockRemoteEventRepository.get.mockResolvedValueOnce(
+        eventResponse(null, startDate, endDate),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      requestDayEvents();
+
+      await waitForEffects();
 
       const state = store.getState();
       expect(state.events.getDayEvents.isSuccess).toBe(false);
@@ -284,25 +267,13 @@ describe("day.event.listener", () => {
     it("handles malformed response (data is not an array)", async () => {
       mockGetSessionExists.mockResolvedValueOnce(true);
       mockGetEventRepositorySource.mockReturnValueOnce("remote");
-      mockRemoteEventRepository.get.mockResolvedValueOnce({
-        data: { invalid: "object" },
-        count: 0,
-        page: 1,
-        pageSize: 0,
-        offset: 0,
-        startDate,
-        endDate,
-      });
-
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
+      mockRemoteEventRepository.get.mockResolvedValueOnce(
+        eventResponse({ invalid: "object" }, startDate, endDate),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      requestDayEvents();
+
+      await waitForEffects();
 
       const state = store.getState();
       expect(state.events.getDayEvents.isSuccess).toBe(false);
@@ -314,25 +285,13 @@ describe("day.event.listener", () => {
     it("uses local repository when session does not exist", async () => {
       mockGetSessionExists.mockResolvedValueOnce(false);
       mockGetEventRepositorySource.mockReturnValueOnce("local");
-      mockLocalEventRepository.get.mockResolvedValueOnce({
-        data: [],
-        count: 0,
-        page: 1,
-        pageSize: 0,
-        offset: 0,
-        startDate,
-        endDate,
-      });
-
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
+      mockLocalEventRepository.get.mockResolvedValueOnce(
+        eventResponse([], startDate, endDate),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      requestDayEvents();
+
+      await waitForEffects();
 
       expect(mockLocalEventRepository.get).toHaveBeenCalled();
       expect(mockRemoteEventRepository.get).not.toHaveBeenCalled();
@@ -341,25 +300,13 @@ describe("day.event.listener", () => {
     it("uses remote repository when session exists", async () => {
       mockGetSessionExists.mockResolvedValueOnce(true);
       mockGetEventRepositorySource.mockReturnValueOnce("remote");
-      mockRemoteEventRepository.get.mockResolvedValueOnce({
-        data: [],
-        count: 0,
-        page: 1,
-        pageSize: 0,
-        offset: 0,
-        startDate,
-        endDate,
-      });
-
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
+      mockRemoteEventRepository.get.mockResolvedValueOnce(
+        eventResponse([], startDate, endDate),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      requestDayEvents();
+
+      await waitForEffects();
 
       expect(mockRemoteEventRepository.get).toHaveBeenCalled();
       expect(mockLocalEventRepository.get).not.toHaveBeenCalled();
@@ -382,48 +329,20 @@ describe("day.event.listener", () => {
         // First call: slow
         // Second call: fast
         if (currentCall === 1) {
-          await new Promise((resolve) => setTimeout(resolve, 150));
-          return {
-            data: [event1],
-            count: 1,
-            page: 1,
-            pageSize: 1,
-            offset: 0,
-            startDate,
-            endDate,
-          };
-        } else {
-          return {
-            data: [event2],
-            count: 1,
-            page: 1,
-            pageSize: 1,
-            offset: 0,
-            startDate,
-            endDate,
-          };
+          await waitForEffects(150);
+          return eventResponse([event1], startDate, endDate);
         }
+
+        return eventResponse([event2], startDate, endDate);
       });
 
       // Dispatch two rapid requests
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
-      );
+      requestDayEvents();
 
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
-      );
+      requestDayEvents();
 
       // Wait for both to settle
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      await waitForEffects(300);
 
       const state = store.getState();
       // With takeLatest and dedup, should have used the second request's result
@@ -439,34 +358,16 @@ describe("day.event.listener", () => {
 
       mockGetSessionExists.mockResolvedValue(true);
       mockGetEventRepositorySource.mockReturnValue("remote");
-      mockRemoteEventRepository.get.mockResolvedValue({
-        data: [event],
-        count: 1,
-        page: 1,
-        pageSize: 1,
-        offset: 0,
-        startDate,
-        endDate,
-      });
+      mockRemoteEventRepository.get.mockResolvedValue(
+        eventResponse([event], startDate, endDate),
+      );
 
       // Dispatch identical payload twice
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
-      );
+      requestDayEvents();
 
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
-      );
+      requestDayEvents();
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForEffects();
 
       // Repository.get should only be called once due to dedup
       expect(mockRemoteEventRepository.get).toHaveBeenCalledTimes(1);
@@ -479,39 +380,21 @@ describe("day.event.listener", () => {
 
       mockGetSessionExists.mockResolvedValue(true);
       mockGetEventRepositorySource.mockReturnValue("remote");
-      mockRemoteEventRepository.get.mockResolvedValue({
-        data: [event],
-        count: 1,
-        page: 1,
-        pageSize: 1,
-        offset: 0,
-        startDate,
-        endDate,
-      });
-
-      // First dispatch
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "DAY_VIEW_CHANGE" },
-        }),
+      mockRemoteEventRepository.get.mockResolvedValue(
+        eventResponse([event], startDate, endDate),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // First dispatch
+      requestDayEvents();
+
+      await waitForEffects();
 
       mockRemoteEventRepository.get.mockClear();
 
       // Second dispatch same payload (e.g., SSE refetch)
-      store.dispatch(
-        getDayEventsSlice.actions.request({
-          startDate,
-          endDate,
-          __context: { reason: "SYNC" },
-        }),
-      );
+      requestDayEvents("SYNC");
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForEffects();
 
       // Should refetch, not use cache (staleTime: 0)
       expect(mockRemoteEventRepository.get).toHaveBeenCalledTimes(1);

--- a/packages/web/src/ducks/events/listeners/day.event.listener.ts
+++ b/packages/web/src/ducks/events/listeners/day.event.listener.ts
@@ -5,7 +5,6 @@ import {
   getEventRepositorySource,
 } from "@web/common/repositories/event/event.repository.util";
 import { type CompassStartListening } from "@web/common/store/listener-middleware";
-import { type Payload_NormalizedAsyncAction } from "@web/common/types/entity.types";
 import { handleError } from "@web/common/utils/event/event.util";
 import { fetchDayEvents } from "@web/ducks/events/queries/day.event.query";
 import { eventQueryKeys } from "@web/ducks/events/queries/event.query.keys";
@@ -33,6 +32,7 @@ export async function registerDayEventQueryListeners(
         );
         const source = getEventRepositorySource(sessionExists);
         const repository = getEventRepository(sessionExists);
+        const { startDate, endDate } = action.payload;
 
         // Guard: abort if superseded before fetchQuery
         if (listenerApi.signal.aborted) return;
@@ -42,8 +42,8 @@ export async function registerDayEventQueryListeners(
           listenerApi.extra.queryClient.fetchQuery({
             queryKey: eventQueryKeys.day({
               source,
-              startDate: action.payload.startDate,
-              endDate: action.payload.endDate,
+              startDate,
+              endDate,
             }),
             queryFn: () => fetchDayEvents(action.payload, repository),
             staleTime: 0, // always refetch settled entries (SSE re-dispatch refetches)
@@ -60,13 +60,13 @@ export async function registerDayEventQueryListeners(
         );
         listenerApi.dispatch(
           getDayEventsSlice.actions.success({
-            data: result.ids as Payload_NormalizedAsyncAction,
+            data: result.ids,
             count: result.ids.length,
             pageSize: result.ids.length,
             page: 1,
             offset: 0,
-            startDate: action.payload.startDate,
-            endDate: action.payload.endDate,
+            startDate,
+            endDate,
             priorities: [],
           }),
         );


### PR DESCRIPTION
### Motivation
- Reduce duplicated test boilerplate and make day-events listener tests easier to read and maintain.
- Avoid repeated paginated response objects and ad-hoc timeouts across tests.
- Simplify the listener implementation by reusing the request payload values and removing an unnecessary normalized-type cast.

### Description
- Added `eventResponse(data, startDate, endDate)` helper to the test to produce a consistent paginated response object and replaced many inline response literals with it.
- Added `waitForEffects(ms)` and `requestDayEvents(reason)` test helpers to replace repeated `setTimeout` waits and identical `getDayEventsSlice.actions.request` dispatches.
- Simplified the listener by destructuring `startDate`/`endDate` from `action.payload` and reusing them in the query key and success payload, and removed the unused `Payload_NormalizedAsyncAction` import and cast.
- Replaced multiple manual `setTimeout` waits in tests with `waitForEffects` and unified response shaping for clearer, smaller tests.

### Testing
- Ran `git diff --check` which completed without reported diff errors.
- Attempted `bun test packages/web/src/ducks/events/listeners/day.event.listener.test.ts` but it errored with `Cannot find module '@reduxjs/toolkit'` because dependencies are not installed in this environment.
- Attempted `bun install` to run test/lint but dependency downloads failed with registry HTTP 403 responses, preventing test execution.
- Attempted `bun lint` but lint/runtime tooling (`biome`) was unavailable due to missing dependencies, so lint could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46de7ecb3483318d6f3e28db61d1c0)