### PR TITLE
feat(web): Warm the event cache for instant week/day navigation

### DIFF
--- a/docs/frontend/event-caching.md
+++ b/docs/frontend/event-caching.md
@@ -102,6 +102,26 @@ sides call the **same** predicate:
 - **Auth / source transitions** — refresh the repository source store and drop
   stale entries (e.g. Google revoked → fall back to `local`).
 
+## Navigation: placeholder data + prefetch
+
+Two small TanStack features make prev/next navigation feel instant:
+
+- **Someday keeps the previous month's list visible** while a new month
+  fetches (`placeholderData: keepPreviousData` on `somedayEventsQueryOptions`).
+  Deliberately *not* applied to day/week: the calendar grid gates its entire
+  render on `query.isPending` and positions events by absolute date, so
+  keeping stale data visible there would transiently render the previous
+  range's events in the new range's grid columns. Extending this to the grid
+  needs those consumers rewired to treat `isPlaceholderData` as still-loading.
+- **The adjacent day/week is prefetched** as soon as the current one renders
+  (`usePrefetchAdjacentEvents`, wired into `useWeek`/`useDayEvents`). It calls
+  `queryClient.prefetchQuery` with the *same* options builder and date
+  formatting the real read hook uses, so the warmed entry lands under the
+  exact key a subsequent read looks up. `prefetchQuery` is a no-op for
+  entries that are already cached and fresh, so this adds no extra fetches on
+  repeat renders of the same range — only the next click resolves from cache
+  instead of paying a fetch.
+
 ## What the cache is *not*
 
 - **Not Redux.** Redux owns only the in-progress draft and calendar interaction

--- a/packages/web/src/ducks/events/queries/event.query.options.ts
+++ b/packages/web/src/ducks/events/queries/event.query.options.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions } from "@tanstack/react-query";
 import { type EventRepositorySource } from "@web/common/repositories/event/event.repository.factory";
 import { getEventRepositoryBySource } from "@web/common/repositories/event/event.repository.util";
 import { fetchDayEvents } from "./day.event.query";
@@ -77,5 +77,17 @@ export function somedayEventsQueryOptions({
         getEventRepositoryBySource(source),
       ),
     ...EVENT_QUERY_CACHE_OPTIONS,
+    // Keep the previous month's Someday list visible while a new month range
+    // fetches, instead of a momentary empty list. Safe here because the
+    // sidebar renders straight from the derived list with no isPending gate.
+    //
+    // Deliberately NOT applied to day/week options: the calendar grid gates
+    // its entire render on `query.isPending` and positions events by absolute
+    // date (see MainGridEvents/AllDayEvents/DayCalendarGrid), so keeping stale
+    // data visible there would transiently render the previous range's events
+    // in the new range's grid columns. Extending this to the grid needs those
+    // consumers rewired to treat `isPlaceholderData` as still-loading — a
+    // separate, larger change.
+    placeholderData: keepPreviousData,
   });
 }

--- a/packages/web/src/ducks/events/queries/event.query.options.ts
+++ b/packages/web/src/ducks/events/queries/event.query.options.ts
@@ -18,7 +18,7 @@ const EVENT_QUERY_CACHE_OPTIONS = {
   refetchOnWindowFocus: false,
 } as const;
 
-type EventsQueryArgs = {
+export type EventsQueryArgs = {
   source: EventRepositorySource;
   startDate: string;
   endDate: string;

--- a/packages/web/src/ducks/events/queries/usePrefetchAdjacentEvents.test.ts
+++ b/packages/web/src/ducks/events/queries/usePrefetchAdjacentEvents.test.ts
@@ -1,0 +1,118 @@
+import { waitFor } from "@testing-library/react";
+import dayjs from "@core/util/date/dayjs";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const fetchWeekEvents = mock(async () => ({
+  ids: ["week-neighbor"],
+  entities: {
+    "week-neighbor": {
+      _id: "week-neighbor",
+      title: "Neighbor week event",
+      startDate: "2025-11-03T09:00:00",
+      endDate: "2025-11-03T10:00:00",
+    },
+  },
+}));
+
+mock.module("@web/ducks/events/queries/week.event.query", () => ({
+  fetchWeekEvents,
+}));
+
+const { renderHook } =
+  require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");
+const { createCompassQueryClient } =
+  require("@web/common/query/query-client") as typeof import("@web/common/query/query-client");
+const { createCompassStore } =
+  require("@web/store") as typeof import("@web/store");
+const { eventQueryKeys } =
+  require("@web/ducks/events/queries/event.query.keys") as typeof import("@web/ducks/events/queries/event.query.keys");
+const { weekEventsQueryOptions } =
+  require("@web/ducks/events/queries/event.query.options") as typeof import("@web/ducks/events/queries/event.query.options");
+const { usePrefetchAdjacentEvents } =
+  require("@web/ducks/events/queries/usePrefetchAdjacentEvents") as typeof import("@web/ducks/events/queries/usePrefetchAdjacentEvents");
+
+const currentStart = dayjs.utc("2025-11-10T00:00:00Z");
+const previousStart = currentStart.subtract(7, "day");
+const nextStart = currentStart.add(7, "day");
+
+const previous = {
+  startDate: previousStart.format(),
+  endDate: previousStart.endOf("week").format(),
+};
+const next = {
+  startDate: nextStart.format(),
+  endDate: nextStart.endOf("week").format(),
+};
+
+const previousKey = eventQueryKeys.list({
+  source: "local",
+  scope: "week",
+  params: { ...previous, someday: false },
+});
+const nextKey = eventQueryKeys.list({
+  source: "local",
+  scope: "week",
+  params: { ...next, someday: false },
+});
+const currentKey = eventQueryKeys.list({
+  source: "local",
+  scope: "week",
+  params: {
+    startDate: currentStart.format(),
+    endDate: currentStart.endOf("week").format(),
+    someday: false,
+  },
+});
+
+describe("usePrefetchAdjacentEvents", () => {
+  beforeEach(() => {
+    fetchWeekEvents.mockClear();
+  });
+
+  it("populates the cache for the previous and next range under the read hook's own keys", async () => {
+    const queryClient = createCompassQueryClient();
+    const store = createCompassStore({ queryClient });
+
+    renderHook(
+      () => usePrefetchAdjacentEvents(weekEventsQueryOptions, previous, next),
+      { queryClient, store },
+    );
+
+    type CachedWeekData = { ids: string[]; entities: Record<string, unknown> };
+    await waitFor(() => {
+      expect(queryClient.getQueryData<CachedWeekData>(previousKey)).toEqual({
+        ids: ["week-neighbor"],
+        entities: expect.any(Object),
+      });
+      expect(queryClient.getQueryData<CachedWeekData>(nextKey)).toEqual({
+        ids: ["week-neighbor"],
+        entities: expect.any(Object),
+      });
+    });
+    expect(queryClient.getQueryData(currentKey)).toBeUndefined();
+    expect(fetchWeekEvents.mock.calls.length).toBe(2);
+  });
+
+  it("does not refetch an already-cached, fresh adjacent range", async () => {
+    const queryClient = createCompassQueryClient();
+    const store = createCompassStore({ queryClient });
+
+    const first = renderHook(
+      () => usePrefetchAdjacentEvents(weekEventsQueryOptions, previous, next),
+      { queryClient, store },
+    );
+    await waitFor(() => {
+      expect(fetchWeekEvents.mock.calls.length).toBe(2);
+    });
+    first.unmount();
+
+    renderHook(
+      () => usePrefetchAdjacentEvents(weekEventsQueryOptions, previous, next),
+      { queryClient, store },
+    );
+
+    // Give the effect a tick to (not) fire additional fetches.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fetchWeekEvents.mock.calls.length).toBe(2);
+  });
+});

--- a/packages/web/src/ducks/events/queries/usePrefetchAdjacentEvents.ts
+++ b/packages/web/src/ducks/events/queries/usePrefetchAdjacentEvents.ts
@@ -1,0 +1,52 @@
+import { type FetchQueryOptions, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useEventRepositorySource } from "@web/common/repositories/event/event.repository.source.store";
+import { type EventsQueryArgs } from "./event.query.options";
+
+type AdjacentRange = Omit<EventsQueryArgs, "source">;
+
+/**
+ * Warms the cache for the ranges adjacent to the one currently being read, so
+ * the next prev/next navigation resolves from cache instead of paying a fresh
+ * fetch. `queryOptionsFn` must be the same options builder (and `previous`/
+ * `next` the same date-formatting) the corresponding read hook uses for the
+ * current range, so the prefetched entries land under the exact keys a
+ * subsequent read would look up — a mismatched format prefetches a phantom
+ * entry the real read never finds.
+ *
+ * `prefetchQuery` is a no-op for entries that are already cached and fresh
+ * (within `staleTime`), so re-running this on every render is safe.
+ */
+export function usePrefetchAdjacentEvents<
+  TQueryFnData,
+  TError,
+  TData,
+  TQueryKey extends readonly unknown[],
+>(
+  queryOptionsFn: (
+    args: EventsQueryArgs,
+  ) => FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  previous: AdjacentRange,
+  next: AdjacentRange,
+) {
+  const queryClient = useQueryClient();
+  const source = useEventRepositorySource();
+
+  // Depends on the primitive startDate/endDate fields rather than the
+  // previous/next objects themselves, which are recreated on every render at
+  // the call sites; depending on the object reference would re-run (and
+  // re-prefetch) every render instead of only when the actual range changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above.
+  useEffect(() => {
+    void queryClient.prefetchQuery(queryOptionsFn({ source, ...previous }));
+    void queryClient.prefetchQuery(queryOptionsFn({ source, ...next }));
+  }, [
+    queryClient,
+    queryOptionsFn,
+    source,
+    previous.startDate,
+    previous.endDate,
+    next.startDate,
+    next.endDate,
+  ]);
+}

--- a/packages/web/src/ducks/events/queries/useSomedayEventsQuery.test.ts
+++ b/packages/web/src/ducks/events/queries/useSomedayEventsQuery.test.ts
@@ -1,31 +1,35 @@
 import { waitFor } from "@testing-library/react";
-import dayjs from "@core/util/date/dayjs";
+import { Origin, Priorities } from "@core/constants/core.constants";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { type SomedayEventQueryData } from "./event.query.types";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
-const fetchSomedayEvents = mock(async () => ({
-  ids: ["664e21f9a6b3f0b1c2d3e4f5"],
-  entities: {
-    "664e21f9a6b3f0b1c2d3e4f5": {
-      _id: "664e21f9a6b3f0b1c2d3e4f5",
-      title: "Read a book",
-      isSomeday: true,
-      startDate: "2025-11-10",
-      endDate: "2025-11-12",
-      origin: "compass",
-      priority: "unassigned",
-      user: "user-1",
-      order: 0,
-      updatedAt: new Date("2025-11-01T00:00:00Z"),
+const fetchSomedayEvents = mock(
+  async (): Promise<SomedayEventQueryData> => ({
+    ids: ["664e21f9a6b3f0b1c2d3e4f5"],
+    entities: {
+      "664e21f9a6b3f0b1c2d3e4f5": {
+        _id: "664e21f9a6b3f0b1c2d3e4f5",
+        title: "Read a book",
+        isSomeday: true,
+        startDate: "2025-11-10",
+        endDate: "2025-11-12",
+        origin: Origin.COMPASS,
+        priority: Priorities.UNASSIGNED,
+        user: "user-1",
+        order: 0,
+        updatedAt: new Date("2025-11-01T00:00:00Z"),
+      },
     },
-  },
-  pagination: {
-    data: [],
-    count: 1,
-    page: 1,
-    pageSize: 1,
-    offset: 0,
-  },
-}));
+    pagination: {
+      data: [],
+      count: 1,
+      page: 1,
+      pageSize: 1,
+      offset: 0,
+    },
+  }),
+);
 
 mock.module("@web/ducks/events/queries/someday.event.query", () => ({
   fetchSomedayEvents,
@@ -61,6 +65,65 @@ describe("useSomedayEventsQuery", () => {
       ]);
     });
     expect(result.result.current.data?.pagination.count).toBe(1);
+  });
+
+  it("keeps the previous month's list visible while the next month fetches", async () => {
+    const someday = (id: string, title: string): SomedayEventQueryData => ({
+      ids: [id],
+      entities: {
+        [id]: {
+          _id: id,
+          title,
+          isSomeday: true,
+          startDate: "2025-11-10",
+          endDate: "2025-11-12",
+          origin: Origin.COMPASS,
+          priority: Priorities.UNASSIGNED,
+          user: "user-1",
+          order: 0,
+          updatedAt: new Date("2025-11-01T00:00:00Z"),
+        },
+      },
+      pagination: { data: [], count: 1, page: 1, pageSize: 1, offset: 0 },
+    });
+    const monthA = someday("monthA-event", "November task");
+    const monthB = someday("monthB-event", "December task");
+    let resolveMonthB!: (value: SomedayEventQueryData) => void;
+    const monthBPromise = new Promise<SomedayEventQueryData>((resolve) => {
+      resolveMonthB = resolve;
+    });
+
+    fetchSomedayEvents.mockImplementationOnce(async () => monthA);
+    const queryClient = createCompassQueryClient();
+    const store = createCompassStore({ queryClient });
+
+    const { rerender, result } = renderHook(
+      ({ start }: { start: Dayjs }) => useSomedayEventsQuery(start),
+      {
+        initialProps: { start: dayjs.utc("2025-11-10T00:00:00Z") },
+        queryClient,
+        store,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.ids).toEqual(["monthA-event"]);
+    });
+
+    fetchSomedayEvents.mockImplementationOnce(() => monthBPromise);
+    rerender({ start: dayjs.utc("2025-12-10T00:00:00Z") });
+
+    await waitFor(() => {
+      expect(result.current.isPlaceholderData).toBe(true);
+      expect(result.current.data?.ids).toEqual(["monthA-event"]);
+    });
+
+    resolveMonthB(monthB);
+
+    await waitFor(() => {
+      expect(result.current.isPlaceholderData).toBe(false);
+      expect(result.current.data?.ids).toEqual(["monthB-event"]);
+    });
   });
 
   it("returns query error without reporting it globally", async () => {

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -1,7 +1,9 @@
 import { configureStore } from "@reduxjs/toolkit";
+import { type QueryClient } from "@tanstack/react-query";
 import { waitFor } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
 import { createInitialState } from "@web/__tests__/utils/state/store.test.util";
+import { eventQueryKeys } from "@web/ducks/events/queries/event.query.keys";
 import { reducers } from "@web/store/reducers";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -39,6 +41,26 @@ describe("useDayEvents", () => {
     fetchDayEvents.mockClear();
   });
 
+  // Source-agnostic: the active repository source can be "local" or "remote"
+  // depending on process-wide auth state, so match cache entries by their
+  // date-range metadata (like the read hooks' own keys do) rather than
+  // asserting a specific source.
+  const findDayEntry = (queryClient: QueryClient, date: dayjs.Dayjs) => {
+    const startDate = date.startOf("day").utc(true).format();
+    const endDate = date.endOf("day").utc(true).format();
+    const match = queryClient
+      .getQueriesData({ queryKey: eventQueryKeys.scope("day") })
+      .find(([key]) => {
+        const metadata = key[2] as
+          | { startDate?: string; endDate?: string }
+          | undefined;
+        return (
+          metadata?.startDate === startDate && metadata?.endDate === endDate
+        );
+      });
+    return match?.[1];
+  };
+
   it("fetches day events into the query cache", async () => {
     const queryClient = createCompassQueryClient();
     const store = createStore();
@@ -47,11 +69,19 @@ describe("useDayEvents", () => {
     renderHook(() => useDayEvents(date), { queryClient, store });
 
     await waitFor(() => {
-      expect(fetchDayEvents).toHaveBeenCalledTimes(1);
+      expect(findDayEntry(queryClient, date)).toEqual(
+        expect.objectContaining({ ids: ["event-1"] }),
+      );
     });
-    expect(
-      queryClient.getQueriesData({ queryKey: ["events", "day"] })[0]?.[1],
-    ).toEqual(expect.objectContaining({ ids: ["event-1"] }));
+    // Also prefetches the adjacent days (see usePrefetchAdjacentEvents).
+    await waitFor(() => {
+      expect(findDayEntry(queryClient, date.subtract(1, "day"))).toEqual(
+        expect.objectContaining({ ids: ["event-1"] }),
+      );
+      expect(findDayEntry(queryClient, date.add(1, "day"))).toEqual(
+        expect.objectContaining({ ids: ["event-1"] }),
+      );
+    });
   });
 
   it("re-fetches with a new key when the date changes", async () => {
@@ -66,14 +96,16 @@ describe("useDayEvents", () => {
     });
 
     await waitFor(() => {
-      expect(fetchDayEvents).toHaveBeenCalledTimes(1);
+      expect(findDayEntry(queryClient, initialDate)).toBeDefined();
     });
-    const callsAfterFirst = fetchDayEvents.mock.calls.length;
 
-    rerender({ date: initialDate.add(1, "day") });
+    const nextDate = initialDate.add(1, "day");
+    rerender({ date: nextDate });
 
     await waitFor(() => {
-      expect(fetchDayEvents.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+      expect(findDayEntry(queryClient, nextDate)).toEqual(
+        expect.objectContaining({ ids: ["event-1"] }),
+      );
     });
   });
 });

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.ts
@@ -1,14 +1,33 @@
 import { useMemo } from "react";
 import type dayjs from "@core/util/date/dayjs";
+import { dayEventsQueryOptions } from "@web/ducks/events/queries/event.query.options";
 import { useDayEventsQuery } from "@web/ducks/events/queries/useDayEventsQuery";
+import { usePrefetchAdjacentEvents } from "@web/ducks/events/queries/usePrefetchAdjacentEvents";
+
+const dayRange = (date: dayjs.Dayjs) => ({
+  startDate: date.startOf("day").utc(true).format(),
+  endDate: date.endOf("day").utc(true).format(),
+});
 
 export function useDayEvents(dateInView: dayjs.Dayjs) {
-  const { startDateUtc, endDateUtc } = useMemo(() => {
-    return {
+  const { startDateUtc, endDateUtc } = useMemo(
+    () => ({
       startDateUtc: dateInView.startOf("day").utc(true).format(),
       endDateUtc: dateInView.endOf("day").utc(true).format(),
-    };
-  }, [dateInView]);
+    }),
+    [dateInView],
+  );
 
   useDayEventsQuery({ startDate: startDateUtc, endDate: endDateUtc });
+
+  // Warm the previous/next day so the next prev/next click resolves from
+  // cache. Uses the same start/end-of-day UTC formatting as the read above,
+  // so the prefetched entries land under the exact keys a subsequent read
+  // looks up.
+  const previous = useMemo(
+    () => dayRange(dateInView.subtract(1, "day")),
+    [dateInView],
+  );
+  const next = useMemo(() => dayRange(dateInView.add(1, "day")), [dateInView]);
+  usePrefetchAdjacentEvents(dayEventsQueryOptions, previous, next);
 }

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { weekEventsQueryOptions } from "@web/ducks/events/queries/event.query.options";
+import { usePrefetchAdjacentEvents } from "@web/ducks/events/queries/usePrefetchAdjacentEvents";
 import { useSomedayEventsQuery } from "@web/ducks/events/queries/useSomedayEventsQuery";
 import { useWeekEventsQuery } from "@web/ducks/events/queries/useWeekEventsQuery";
 import { updateDates } from "@web/ducks/events/slices/view.slice";
@@ -29,6 +32,24 @@ export const useWeek = (today: Dayjs) => {
   // revisits). Redux stays the render source of truth via the hooks' sync.
   useWeekEventsQuery({ startOfView: start, endOfView: end });
   useSomedayEventsQuery(start);
+
+  // Warm the previous/next week so the next prev/next click resolves from
+  // cache. Uses the same toUTCOffset formatting useWeekEventsQuery uses for
+  // the current range, so the prefetched entries land under the exact keys a
+  // subsequent read looks up.
+  const previousStart = useMemo(() => start.subtract(7, "day"), [start]);
+  const nextStart = useMemo(() => start.add(7, "day"), [start]);
+  usePrefetchAdjacentEvents(
+    weekEventsQueryOptions,
+    {
+      startDate: toUTCOffset(previousStart),
+      endDate: toUTCOffset(previousStart.endOf("week")),
+    },
+    {
+      startDate: toUTCOffset(nextStart),
+      endDate: toUTCOffset(nextStart.endOf("week")),
+    },
+  );
 
   useEffect(() => {
     dispatch(


### PR DESCRIPTION
## Why

PR #1924 hardened the query-owned event mutation layer and cleaned up the last redux-saga/Redux remnants. What was still missing: TanStack Query's caching wasn't being used to make **view navigation** itself feel instant — every first visit to a range paid a full fetch, and range changes could show a loading/empty state before data arrived.

Implements `docs/superpowers/plans/2026-07-03-event-query-navigation-enhancements.md`.

## What changed

- **`placeholderData: keepPreviousData` on the Someday query only.** Navigating to a new month keeps the previous month's list visible while the fetch resolves, instead of a momentary empty list. Safe there because the sidebar renders straight from the derived list with no `isPending` gate, and there's an existing reserve-height mechanism built for exactly this smoothing.

  **Deliberately not applied to day/week.** The calendar grid gates its entire render on `query.isPending` and positions events by absolute date (`MainGridEvents`/`AllDayEvents`/`DayCalendarGrid`). Keeping stale data visible there during a range change would transiently render the *previous* range's events in the *new* range's grid columns — a real correctness bug, not just a UX nicety. Extending this to the grid needs those consumers rewired to treat `isPlaceholderData` as still-loading; that's a separate, larger change.

- **`usePrefetchAdjacentEvents`, wired into `useWeek` and `useDayEvents`.** Warms the previous/next range as soon as the current one renders, using the *same* query-options builder and date-formatting the real read hook uses for the current range — so the prefetched entry lands under the exact key a subsequent read looks up (a mismatched format would prefetch a phantom entry the real read never finds). `prefetchQuery` is a no-op for entries that are already cached and fresh, so this adds no extra fetches on repeat renders of the same range.

- **Dropped the optional retry-tuning task.** `createCompassQueryClient` already sets `retry: false` globally for all queries, so there was nothing to make source-aware — the premise (3 retries) didn't hold in this codebase.

- **Docs:** added a "Navigation: placeholder data + prefetch" section to `docs/frontend/event-caching.md`.

## Testing

- `bun run test:web` → **1067 pass / 0 fail**
- `bun run type-check` → clean
- Focused Biome on all 7 changed files → clean
- **Manual acceptance against the running app** (not just unit tests): temporarily exposed the query client on `window` to inspect the live cache during navigation, then reverted before committing. Confirmed:
  - Day view: cache held exactly `{prev, current, next}` after load; navigating to the already-prefetched next day required **zero new fetch**, and the new neighbor was immediately prefetched.
  - Week view: same pattern (current/previous/next all cached after one navigation).
  - Someday: month-boundary navigation retained both months' data with no console errors.

## Notes for reviewers

- The core design constraint: a prefetch hook that's generic over the query-options builder function needed the *hook itself* generic with TanStack's own type parameters (`TQueryFnData, TError, TData, TQueryKey`) rather than a named function-type alias — a union or an erased return type both fail to type-check against `prefetchQuery`'s per-call-site inference.
- `usePrefetchAdjacentEvents.ts` has a documented `biome-ignore` for `useExhaustiveDependencies`: it intentionally depends on the primitive `startDate`/`endDate` fields rather than the `previous`/`next` objects, which are recreated fresh on every render at the call sites — depending on the object reference would re-prefetch on every render instead of only when the range actually changes.
- `useDayEvents.test.ts` needed its existing assertions updated: they previously counted raw `fetchDayEvents` calls, which now legitimately fire 3x (current + prefetch × 2). Rewrote them to match cache entries by date-range metadata instead, which is both more precise and robust to whichever repository source resolves in a given test run (a pre-existing, unrelated test-isolation quirk in the source-resolution singleton).

🤖 Generated with [Claude Code](https://claude.com/claude-code)