### PR TITLE
fix(web): delete existing events via FloatingEventForm; fix flaky keyboard-delete e2e spec

### DIFF
--- a/e2e/timed/delete-event-keyboard.spec.ts
+++ b/e2e/timed/delete-event-keyboard.spec.ts
@@ -11,10 +11,6 @@ import {
 } from "../utils/event-test-utils";
 
 test.skip(({ isMobile }) => isMobile, "Keyboard shortcuts are desktop-only.");
-test.fixme(
-  Boolean(process.env.CI),
-  "Flaky in GitHub Actions while waiting for saved timed events to re-render.",
-);
 
 test("should delete a timed event using keyboard interaction", async ({
   page,

--- a/e2e/utils/event-test-utils.ts
+++ b/e2e/utils/event-test-utils.ts
@@ -450,6 +450,11 @@ export const deleteEventWithMouse = async (page: Page) => {
 
 export const deleteEventWithKeyboard = async (page: Page) => {
   await getFormTitleInput(page).waitFor({ timeout: FORM_TIMEOUT });
+  // The title input autofocuses when the form opens. The app treats Delete
+  // as a text-edit key while focus is in an editable field (so typing can
+  // use Backspace/Delete normally), so focus must move off the input first
+  // for Delete to trigger the event-deletion shortcut instead.
+  await blurActiveElement(page);
   page.once("dialog", (dialog) => dialog.accept());
   await page.keyboard.press("Delete");
 };

--- a/packages/web/src/components/FloatingEventForm/FloatingEventForm.test.tsx
+++ b/packages/web/src/components/FloatingEventForm/FloatingEventForm.test.tsx
@@ -1,14 +1,19 @@
+import { HotkeyManager } from "@tanstack/react-hotkeys";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import {
   cleanup,
+  fireEvent,
   render,
   screen,
   waitFor,
 } from "@web/__tests__/__mocks__/mock.render";
+import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
+import { createCompassQueryClient } from "@web/common/query/query-client";
 import { FloatingEventForm } from "@web/components/FloatingEventForm/FloatingEventForm";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { draftActions } from "@web/events/stores/draft.store";
 import { useEventForm } from "@web/views/Forms/hooks/useEventForm";
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
 
 const draft: Schema_Event = {
@@ -20,7 +25,17 @@ const draft: Schema_Event = {
   user: "user",
 };
 
-afterEach(cleanup);
+const originalConfirm = window.confirm;
+
+beforeEach(() => {
+  HotkeyManager.resetInstance();
+  draftActions.discard();
+});
+
+afterEach(() => {
+  cleanup();
+  window.confirm = originalConfirm;
+});
 
 describe("FloatingEventForm", () => {
   it("focuses the title when the form opens", async () => {
@@ -45,5 +60,71 @@ describe("FloatingEventForm", () => {
     await waitFor(() =>
       expect(screen.getByPlaceholderText("Title")).toHaveFocus(),
     );
+  });
+
+  it("deletes an already-saved event on Delete instead of just closing the form", async () => {
+    const existingEvent: Schema_Event = {
+      _id: "existing-event-id",
+      endDate: "2026-05-20T15:00:00.000Z",
+      isAllDay: false,
+      isSomeday: false,
+      startDate: "2026-05-20T14:00:00.000Z",
+      title: "Existing Event",
+      user: "user",
+    };
+
+    const queryClient = createCompassQueryClient();
+    queryClient.setQueryData(
+      eventQueryKeys.day({
+        source: "local",
+        startDate: "2026-05-20T00:00:00.000Z",
+        endDate: "2026-05-21T00:00:00.000Z",
+      }),
+      toNormalizedEventQueryData([existingEvent]),
+    );
+
+    const confirm = mock(() => true);
+    window.confirm = confirm;
+
+    draftActions.start({
+      activity: "keyboardEdit",
+      event: existingEvent,
+      eventType: Categories_Event.TIMED,
+    });
+    draftActions.setFormOpen(true);
+
+    const Harness = () => {
+      const form = useEventForm(Categories_Event.TIMED, true, () => undefined);
+
+      return (
+        <>
+          <button ref={form.refs.setReference} type="button">
+            Existing event
+          </button>
+          <FloatingEventForm form={form} />
+        </>
+      );
+    };
+
+    render(<Harness />, { queryClient });
+
+    const titleField = await screen.findByPlaceholderText("Title");
+    await waitFor(() => expect(titleField).toHaveFocus());
+
+    // A real keyboard user moves focus off the title text field before
+    // Delete deletes the event, rather than editing the title text.
+    titleField.blur();
+
+    fireEvent.keyDown(screen.getByRole("form"), {
+      bubbles: true,
+      cancelable: true,
+      key: "Delete",
+    });
+
+    // window.confirm only fires on the real-delete branch (`handleEventFormDelete`
+    // calling `onDelete`), never on the draft-close branch (`onClose` only) —
+    // so this pins FloatingEventForm computing isDraft from whether the event
+    // already exists, not hardcoding it to true for every opened event.
+    await waitFor(() => expect(confirm).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/web/src/components/FloatingEventForm/FloatingEventForm.tsx
+++ b/packages/web/src/components/FloatingEventForm/FloatingEventForm.tsx
@@ -76,7 +76,7 @@ export function FloatingEventForm({
         >
           <EventForm
             event={draft}
-            isDraft={true}
+            isDraft={!existing}
             isExistingEvent={existing}
             onClose={onClose}
             onDelete={onDelete}


### PR DESCRIPTION
## Summary
- `e2e/timed/delete-event-keyboard.spec.ts` failed deterministically (not just in CI) because the event form's title input autofocuses on open, and the app intentionally ignores Delete while focus is in a text field (so Backspace/Delete edit the title normally). `deleteEventWithKeyboard` pressed Delete without moving focus off the input first, so it never reached the real delete handler. Fixed by blurring the focused element before pressing Delete, and removed the now-incorrect CI-only `test.fixme` gate.
- While diagnosing that, found `FloatingEventForm` hardcoded `isDraft={true}` for every event it renders (new or already-saved). `handleEventFormDelete` treats `isDraft` as "just close, don't delete," so Delete (and the actions-menu Delete button) silently did nothing for existing events opened through the Day view's floating form — it also hid the "Move to sidebar" menu item and disabled Enter-to-submit/Convert for those events. Fixed by computing `isDraft={!existing}`, matching the Week view's `GridDraft` semantics. Added a regression test that seeds a real persisted event and confirms Delete triggers the actual confirm-and-delete flow (verified it fails without the fix, passes with it).
- Confirmed the someday keyboard-delete spec (`e2e/someday/delete-someday-event-keyboard.spec.ts`) was a suspected false positive from the same root cause — the shared `deleteEventWithKeyboard` fix resolves it too; no separate code change needed there.

## Test plan
- [x] `bun test --cwd packages/web` — 1068 pass, 0 fail
- [x] `bunx playwright test e2e/timed/ e2e/someday/ e2e/allday/` — 20 pass, 0 fail
- [x] Re-ran `e2e/timed/delete-event-keyboard.spec.ts` and `e2e/someday/delete-someday-event-keyboard.spec.ts` 3x each for stability (no flakiness)
- [x] Confirmed both fixes actually catch the regression by reverting each change locally and re-running (fails without fix, passes with fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)