### PR TITLE
fix: stop auto-subscribing new users, make it opt-in

### DIFF
--- a/packages/backend/src/auth/services/google/google.auth.service.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.test.ts
@@ -11,7 +11,6 @@ import type * as GoogleAuthUtilModule from "@backend/auth/services/google/util/g
 import { determineGoogleAuthMode } from "@backend/auth/services/google/util/google.auth.util";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import mongoService from "@backend/common/services/mongo.service";
-import EmailService from "@backend/email/email.service";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
@@ -599,9 +598,6 @@ describe("googleAuthService", () => {
         picture: faker.image.url(),
       } as TokenPayload;
       const refreshToken = faker.string.uuid();
-      const tagNewUserSpy = jest
-        .spyOn(EmailService, "tagNewUserIfEnabled")
-        .mockResolvedValue();
       const restartSpy = jest
         .spyOn(googleCalendarSyncService, "startGoogleCalendarSyncIfNeeded")
         .mockResolvedValue();
@@ -613,10 +609,8 @@ describe("googleAuthService", () => {
       );
 
       expect(result.cUserId).toBe(recipeUserId);
-      expect(tagNewUserSpy).toHaveBeenCalled();
       expect(restartSpy).toHaveBeenCalledWith(recipeUserId);
 
-      tagNewUserSpy.mockRestore();
       restartSpy.mockRestore();
     });
 
@@ -638,9 +632,6 @@ describe("googleAuthService", () => {
       const restartSpy = jest
         .spyOn(googleCalendarSyncService, "startGoogleCalendarSyncIfNeeded")
         .mockResolvedValue();
-      const tagNewUserSpy = jest
-        .spyOn(EmailService, "tagNewUserIfEnabled")
-        .mockResolvedValue();
 
       const result = await googleAuthService.googleSignup(
         providerUser,
@@ -660,7 +651,6 @@ describe("googleAuthService", () => {
       expect(restartSpy).toHaveBeenCalledWith(existingUser._id.toString());
 
       restartSpy.mockRestore();
-      tagNewUserSpy.mockRestore();
     });
   });
 });

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -14,7 +14,6 @@ import { SyncError } from "@backend/common/errors/sync/sync.errors";
 import { UserError } from "@backend/common/errors/user/user.errors";
 import { normalizeEmail } from "@backend/common/helpers/email.util";
 import mongoService from "@backend/common/services/mongo.service";
-import EmailService from "@backend/email/email.service";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 import userService from "@backend/user/services/user.service";
@@ -173,8 +172,6 @@ async function googleSignup(
         sync: { importGCal: "RESTART", incrementalGCalSync: "RESTART" },
       },
     });
-
-    await EmailService.tagNewUserIfEnabled(cUser.user, cUser.isNewUser);
 
     return { cUserId: cUser.user.userId };
   });

--- a/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
@@ -15,7 +15,6 @@ import {
   getFormFieldValue,
   maybeReplaceEmailPasswordSession,
 } from "@backend/common/middleware/supertokens.middleware.util";
-import EmailService from "@backend/email/email.service";
 import userService from "@backend/user/services/user.service";
 import {
   type CreateGoogleSignInResponse,
@@ -176,7 +175,7 @@ export async function handleEmailPasswordSignUp(
     const userId = response.session.getUserId();
 
     if (email) {
-      const { user, isNewUser } = await userService.upsertUserFromAuth({
+      const { user } = await userService.upsertUserFromAuth({
         userId,
         email,
         name,
@@ -187,7 +186,6 @@ export async function handleEmailPasswordSignUp(
         user.userId,
         replaceSessionWithCompassUser,
       );
-      await EmailService.tagNewUserIfEnabled(user, isNewUser);
       return remappedResponse;
     }
   }

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -20,7 +20,6 @@ import {
   ensureExternalUserIdMapping,
   getFormFieldValue,
 } from "@backend/common/middleware/supertokens.middleware.util";
-import EmailService from "@backend/email/email.service";
 import userService from "@backend/user/services/user.service";
 
 jest.mock("cors", () => ({
@@ -527,9 +526,6 @@ describe("supertokens.middleware", () => {
     });
 
     it("replaces the EmailPassword sign-up session with the canonical Compass user", async () => {
-      jest
-        .spyOn(EmailService, "tagNewUserIfEnabled")
-        .mockResolvedValue(undefined);
       (userService.upsertUserFromAuth as jest.Mock).mockResolvedValue({
         user: { userId: "compass-user-id" },
         isNewUser: false,

--- a/packages/backend/src/email/email.service.ts
+++ b/packages/backend/src/email/email.service.ts
@@ -71,10 +71,7 @@ class EmailService {
     }
   }
 
-  static async tagNewUserIfEnabled(
-    user: Schema_User,
-    isNewUser: boolean,
-  ): Promise<void> {
+  static async tagSubscribedUser(user: Schema_User): Promise<void> {
     const isMissingValue =
       !CONFIG.EMAILER_SECRET || !CONFIG.EMAILER_USER_TAG_ID;
     if (isMissingValue) {
@@ -84,7 +81,6 @@ class EmailService {
       return;
     }
 
-    if (!isNewUser) return;
     const subscriber = mapCompassUserToEmailSubscriber(user);
     await EmailService.addTagToSubscriber(
       subscriber,

--- a/packages/backend/src/user/services/user-metadata.service.test.ts
+++ b/packages/backend/src/user/services/user-metadata.service.test.ts
@@ -1,3 +1,4 @@
+import { EmailDriver } from "@backend/__tests__/drivers/email.driver";
 import { GoogleWatchDriver } from "@backend/__tests__/drivers/google-watch.driver";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { UserMetadataServiceDriver } from "@backend/__tests__/drivers/user-metadata.service.driver";
@@ -40,6 +41,57 @@ describe("UserMetadataService", () => {
       const persisted = await driver.fetchUserMetadata(userId);
 
       expect(persisted.sync?.importGCal).toBe("RESTART");
+    });
+
+    it("tags the user in Kit on first opt-in to updates", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const { addTagToSubscriber } = EmailDriver.mockEmailServiceResponse();
+
+      const metadata = await driver.updateUserMetadata({
+        userId,
+        data: { subscribeToUpdates: true },
+      });
+
+      expect(metadata.subscribeToUpdates).toBe(true);
+      expect(addTagToSubscriber).toHaveBeenCalledTimes(1);
+
+      addTagToSubscriber.mockRestore();
+    });
+
+    it("does not re-tag the user in Kit on a repeat opt-in", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const { addTagToSubscriber } = EmailDriver.mockEmailServiceResponse();
+
+      await driver.updateUserMetadata({
+        userId,
+        data: { subscribeToUpdates: true },
+      });
+      await driver.updateUserMetadata({
+        userId,
+        data: { subscribeToUpdates: true },
+      });
+
+      expect(addTagToSubscriber).toHaveBeenCalledTimes(1);
+
+      addTagToSubscriber.mockRestore();
+    });
+
+    it("does not tag the user in Kit when not opting in", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const { addTagToSubscriber } = EmailDriver.mockEmailServiceResponse();
+
+      const metadata = await driver.updateUserMetadata({
+        userId,
+        data: { sync: { importGCal: "RESTART" } },
+      });
+
+      expect(metadata.subscribeToUpdates).toBeUndefined();
+      expect(addTagToSubscriber).not.toHaveBeenCalled();
+
+      addTagToSubscriber.mockRestore();
     });
   });
 

--- a/packages/backend/src/user/services/user-metadata.service.ts
+++ b/packages/backend/src/user/services/user-metadata.service.ts
@@ -6,6 +6,7 @@ import {
   type GoogleConnectionState,
   type UserMetadata,
 } from "@core/types/user.types";
+import EmailService from "@backend/email/email.service";
 import { isGoogleCalendarSyncHealthy } from "@backend/sync/services/google-sync/google-sync.health";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 import { type GetUserMetadataResponse } from "@backend/user/types/user.types";
@@ -81,6 +82,12 @@ class UserMetadataService {
     data: Partial<UserMetadata>;
   }): Promise<UserMetadata> => {
     const value = await this.getStoredUserMetadata(userId);
+
+    if (data.subscribeToUpdates === true && !value.subscribeToUpdates) {
+      const user = await findCompassUserBy("_id", userId);
+      if (user) await EmailService.tagSubscribedUser(user);
+    }
+
     const update = mergeWith(value, data) as UserMetadata;
 
     const result = (await SupertokensUserMetadata.updateUserMetadata(

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -38,6 +38,7 @@ export interface UserMetadata extends SupertokensUserMetadata.JSONObject {
   google?: {
     connectionState?: GoogleConnectionState;
   };
+  subscribeToUpdates?: boolean;
 }
 
 export interface UserProfile

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -6,6 +6,7 @@ export const GOOGLE_REVOKED_TOAST_ID: Id = "google-revoked-api";
 export const GOOGLE_REPAIR_FAILED_TOAST_ID: Id = "google-repair-failed";
 export const TASK_DELETED_TOAST_ID: Id = "task-deleted";
 export const TASK_MIGRATION_TOAST_ID: Id = "task-migration";
+export const SUBSCRIBE_TO_UPDATES_TOAST_ID: Id = "subscribe-to-updates";
 
 export const toastDefaultOptions: ToastOptions = {
   autoClose: 5000,

--- a/packages/web/src/common/hooks/useSubscribeCmdItems.test.ts
+++ b/packages/web/src/common/hooks/useSubscribeCmdItems.test.ts
@@ -1,0 +1,106 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act, type MouseEvent } from "react";
+import {
+  userMetadataActions,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockUseSession = mock();
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+const mockUpdateMetadata = mock();
+mock.module("@web/common/apis/user.api", () => ({
+  UserApi: { updateMetadata: mockUpdateMetadata },
+}));
+
+const toast = Object.assign(mock(), {
+  error: mock(),
+  update: mock(),
+  isActive: mock(() => false),
+});
+mock.module("react-toastify", () => ({
+  ToastContainer: () => null,
+  toast,
+}));
+
+const { useSubscribeCmdItems } =
+  require("./useSubscribeCmdItems") as typeof import("./useSubscribeCmdItems");
+
+describe("useSubscribeCmdItems", () => {
+  beforeEach(() => {
+    mockUseSession.mockClear();
+    mockUpdateMetadata.mockClear();
+    toast.mockClear();
+    toast.error.mockClear();
+    toast.update.mockClear();
+    userMetadataActions.clear();
+
+    mockUseSession.mockReturnValue({ authenticated: true });
+  });
+
+  it("returns no items when unauthenticated", () => {
+    mockUseSession.mockReturnValue({ authenticated: false });
+
+    const { result } = renderHook(() => useSubscribeCmdItems());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no items when already subscribed", () => {
+    userMetadataActions.set({ subscribeToUpdates: true });
+
+    const { result } = renderHook(() => useSubscribeCmdItems());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("shows a success toast and updates the store after subscribing", async () => {
+    mockUpdateMetadata.mockResolvedValue({ subscribeToUpdates: true });
+
+    const { result } = renderHook(() => useSubscribeCmdItems());
+    const item = result.current.find(
+      (item) => item.id === "subscribe-to-updates",
+    );
+
+    const mockEvent = {} as MouseEvent<HTMLButtonElement>;
+    await act(async () => {
+      item?.onClick?.(mockEvent);
+    });
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        "Subscribed to updates",
+        expect.objectContaining({ toastId: "subscribe-to-updates" }),
+      );
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(useUserMetadataStore.getState().current).toEqual({
+      subscribeToUpdates: true,
+    });
+  });
+
+  it("shows an error toast when subscribing fails", async () => {
+    mockUpdateMetadata.mockRejectedValue(new Error("network error"));
+
+    const { result } = renderHook(() => useSubscribeCmdItems());
+    const item = result.current.find(
+      (item) => item.id === "subscribe-to-updates",
+    );
+
+    const mockEvent = {} as MouseEvent<HTMLButtonElement>;
+    await act(async () => {
+      item?.onClick?.(mockEvent);
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't subscribe to updates. Please try again.",
+        expect.objectContaining({ toastId: "subscribe-to-updates" }),
+      );
+    });
+    expect(toast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/common/hooks/useSubscribeCmdItems.ts
+++ b/packages/web/src/common/hooks/useSubscribeCmdItems.ts
@@ -1,0 +1,37 @@
+import { type JsonStructureItem } from "react-cmdk";
+import { useSession } from "@web/auth/compass/session/useSession";
+import {
+  selectUserMetadata,
+  userMetadataActions,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+import { UserApi } from "@web/common/apis/user.api";
+
+/**
+ * Returns a command palette item to opt in to email updates.
+ * One-way: hidden once subscribed. Unsubscribing happens via the
+ * email's own footer link, not from within Compass.
+ */
+export const useSubscribeCmdItems = (): JsonStructureItem[] => {
+  const { authenticated } = useSession();
+  const subscribed = useUserMetadataStore(
+    (state) => selectUserMetadata(state)?.subscribeToUpdates ?? false,
+  );
+
+  if (!authenticated || subscribed) {
+    return [];
+  }
+
+  return [
+    {
+      id: "subscribe-to-updates",
+      children: "Subscribe to Updates",
+      icon: "BellIcon",
+      onClick: () => {
+        void UserApi.updateMetadata({ subscribeToUpdates: true }).then(
+          userMetadataActions.set,
+        );
+      },
+    },
+  ];
+};

--- a/packages/web/src/common/hooks/useSubscribeCmdItems.ts
+++ b/packages/web/src/common/hooks/useSubscribeCmdItems.ts
@@ -6,6 +6,9 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { UserApi } from "@web/common/apis/user.api";
+import { SUBSCRIBE_TO_UPDATES_TOAST_ID } from "@web/common/constants/toast.constants";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 
 /**
  * Returns a command palette item to opt in to email updates.
@@ -28,9 +31,19 @@ export const useSubscribeCmdItems = (): JsonStructureItem[] => {
       children: "Subscribe to Updates",
       icon: "BellIcon",
       onClick: () => {
-        void UserApi.updateMetadata({ subscribeToUpdates: true }).then(
-          userMetadataActions.set,
-        );
+        UserApi.updateMetadata({ subscribeToUpdates: true })
+          .then((metadata) => {
+            userMetadataActions.set(metadata);
+            showStatusToast(
+              SUBSCRIBE_TO_UPDATES_TOAST_ID,
+              "Subscribed to updates",
+            );
+          })
+          .catch(() => {
+            showErrorToast("Couldn't subscribe to updates. Please try again.", {
+              toastId: SUBSCRIBE_TO_UPDATES_TOAST_ID,
+            });
+          });
       },
     },
   ];

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -62,6 +62,11 @@ mock.module("@web/auth/compass/hooks/useCompleteAuthentication", () => ({
   useCompleteAuthentication: () => mockCompleteAuthentication,
 }));
 
+const mockUpdateMetadata = mock();
+mock.module("@web/common/apis/user.api", () => ({
+  UserApi: { updateMetadata: mockUpdateMetadata },
+}));
+
 const mockEmailPassword = {
   getResetPasswordTokenFromURL: mock(),
   sendPasswordResetEmail: mock(),
@@ -254,6 +259,8 @@ describe("AuthModal", () => {
     mockEmailPassword.sendPasswordResetEmail.mockClear();
     mockEmailPassword.getResetPasswordTokenFromURL.mockClear();
     mockEmailPassword.submitNewPassword.mockClear();
+    mockUpdateMetadata.mockClear();
+    mockUpdateMetadata.mockResolvedValue({ subscribeToUpdates: true });
     mockUseSession.mockReturnValue({
       authenticated: false,
       setAuthenticated: mock(),
@@ -631,6 +638,40 @@ describe("AuthModal", () => {
           { id: "email", value: "test@example.com" },
           { id: "password", value: "password123" },
         ],
+      });
+      expect(mockUpdateMetadata).not.toHaveBeenCalled();
+    });
+
+    it("subscribes to updates after sign-up when the checkbox is checked", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<ModalTrigger />);
+
+      await user.click(screen.getByRole("button", { name: /open modal/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^sign up$/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText(/name/i), "Alex");
+      await user.type(screen.getByLabelText(/email/i), "test@example.com");
+      await user.type(screen.getByLabelText(/password/i), "password123");
+      await user.click(
+        screen.getByRole("checkbox", { name: /subscribe to updates/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateMetadata).toHaveBeenCalledWith({
+          subscribeToUpdates: true,
+        });
       });
     });
 

--- a/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
@@ -1,15 +1,20 @@
-import { type ChangeEvent, type FC, useCallback } from "react";
+import { type ChangeEvent, type FC, useCallback, useState } from "react";
 import {
   type SignUpFormData,
   SignUpSchema,
 } from "@web/auth/compass/schemas/auth.schemas";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import { AuthButton } from "../components/AuthButton";
 import { AuthInput } from "../components/AuthInput";
 import { useZodForm } from "../hooks/useZodForm";
 
+export type SignUpSubmitData = SignUpFormData & {
+  subscribeToUpdates: boolean;
+};
+
 interface SignUpFormProps {
   /** Callback when form is submitted with valid data */
-  onSubmit: (data: SignUpFormData) => void | Promise<void>;
+  onSubmit: (data: SignUpSubmitData) => void | Promise<void>;
   /** Callback when name field changes (for dynamic greeting) */
   onNameChange?: (name: string) => void;
   /** Whether form submission is in progress */
@@ -26,10 +31,12 @@ export const SignUpForm: FC<SignUpFormProps> = ({
   onNameChange,
   isSubmitting,
 }) => {
+  const [subscribeToUpdates, setSubscribeToUpdates] = useState(false);
+
   const form = useZodForm({
     schema: SignUpSchema,
     initialValues: { name: "", email: "", password: "" },
-    onSubmit,
+    onSubmit: (data) => onSubmit({ ...data, subscribeToUpdates }),
   });
 
   const handleNameChange = useCallback(
@@ -77,6 +84,18 @@ export const SignUpForm: FC<SignUpFormProps> = ({
         hasError={!!form.touched.password && !!form.errors.password}
         autoComplete="new-password"
       />
+
+      <TooltipWrapper description="Once a month. Unsubscribe anytime.">
+        <label className="flex w-fit items-center gap-2 text-sm text-text-lighter">
+          <input
+            type="checkbox"
+            checked={subscribeToUpdates}
+            onChange={(e) => setSubscribeToUpdates(e.target.checked)}
+            className="h-4 w-4 rounded-full border-border-primary accent-accent-primary"
+          />
+          Subscribe to updates
+        </label>
+      </TooltipWrapper>
 
       <AuthButton
         type="submit"

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -6,8 +6,9 @@ import {
   type ForgotPasswordFormData,
   type LogInFormData,
   type ResetPasswordFormData,
-  type SignUpFormData,
 } from "@web/auth/compass/schemas/auth.schemas";
+import { UserApi } from "@web/common/apis/user.api";
+import { type SignUpSubmitData } from "../forms/SignUpForm";
 import { getAuthSubmitErrorMessage } from "./useAuthFormHandlers.util";
 import { type AuthView } from "./useAuthModal";
 
@@ -46,7 +47,7 @@ interface UseAuthFormHandlersOptions {
 export interface UseAuthFormHandlersResult {
   isSubmitting: boolean;
   submitError: string | null;
-  handleSignUp: (data: SignUpFormData) => Promise<void>;
+  handleSignUp: (data: SignUpSubmitData) => Promise<void>;
   handleLogin: (data: LogInFormData) => Promise<void>;
   handleForgotPassword: (data: ForgotPasswordFormData) => Promise<void>;
   handleResetPassword: (data: ResetPasswordFormData) => Promise<void>;
@@ -76,7 +77,7 @@ export function useAuthFormHandlers({
   }, [currentView]);
 
   const handleSignUp = useCallback(
-    async (data: SignUpFormData) => {
+    async (data: SignUpSubmitData) => {
       setIsSubmitting(true);
       setSubmitError(null);
 
@@ -94,6 +95,11 @@ export function useAuthFormHandlers({
             await completeAuthentication({
               email: response.user.emails[0] ?? data.email,
             });
+            if (data.subscribeToUpdates) {
+              void UserApi.updateMetadata({ subscribeToUpdates: true }).catch(
+                () => {},
+              );
+            }
             closeModal();
             return;
           case "FIELD_ERROR":

--- a/packages/web/src/views/CmdPalette/CmdPalette.tsx
+++ b/packages/web/src/views/CmdPalette/CmdPalette.tsx
@@ -14,6 +14,7 @@ import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
 import { useAuthCmdItems } from "@web/common/hooks/useAuthCmdItems";
 import { useGoogleCmdItems } from "@web/common/hooks/useGoogleCmdItems";
 import { useLogoutCmdItems } from "@web/common/hooks/useLogoutCmdItems";
+import { useSubscribeCmdItems } from "@web/common/hooks/useSubscribeCmdItems";
 import { onEventTargetVisibility } from "@web/common/utils/dom/event-target-visibility.util";
 import {
   createAlldayDraft,
@@ -62,6 +63,7 @@ const CmdPalette = ({
   const authCmdItems = useAuthCmdItems();
   const googleCmdItems = useGoogleCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
+  const subscribeCmdItems = useSubscribeCmdItems();
 
   const handleCreateSomedayDraft = async (
     category: Categories_Event.SOMEDAY_WEEK | Categories_Event.SOMEDAY_MONTH,
@@ -152,7 +154,12 @@ const CmdPalette = ({
       {
         heading: "Settings",
         id: "settings",
-        items: [...googleCmdItems, ...authCmdItems, ...logoutCmdItems],
+        items: [
+          ...googleCmdItems,
+          ...subscribeCmdItems,
+          ...authCmdItems,
+          ...logoutCmdItems,
+        ],
       },
       ...moreCommandPaletteItems,
     ],

--- a/packages/web/src/views/Day/components/DayCmdPalette.tsx
+++ b/packages/web/src/views/Day/components/DayCmdPalette.tsx
@@ -9,6 +9,7 @@ import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
 import { useAuthCmdItems } from "@web/common/hooks/useAuthCmdItems";
 import { useGoogleCmdItems } from "@web/common/hooks/useGoogleCmdItems";
 import { useLogoutCmdItems } from "@web/common/hooks/useLogoutCmdItems";
+import { useSubscribeCmdItems } from "@web/common/hooks/useSubscribeCmdItems";
 import {
   CompassDOMEvents,
   compassEventEmitter,
@@ -39,6 +40,7 @@ export const DayCmdPalette = ({ onGoToToday }: DayCmdPaletteProps) => {
   const authCmdItems = useAuthCmdItems();
   const googleCmdItems = useGoogleCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
+  const subscribeCmdItems = useSubscribeCmdItems();
 
   const filteredItems = filterItems(
     [
@@ -86,7 +88,12 @@ export const DayCmdPalette = ({ onGoToToday }: DayCmdPaletteProps) => {
       {
         heading: "Settings",
         id: "settings",
-        items: [...googleCmdItems, ...authCmdItems, ...logoutCmdItems],
+        items: [
+          ...googleCmdItems,
+          ...subscribeCmdItems,
+          ...authCmdItems,
+          ...logoutCmdItems,
+        ],
       },
       ...moreCommandPaletteItems,
     ],

--- a/packages/web/src/views/Week/components/Dedication/Dedication.tsx
+++ b/packages/web/src/views/Week/components/Dedication/Dedication.tsx
@@ -73,7 +73,7 @@ export const Dedication = () => {
             </button>
           </div>
           <p className="text-l">
-            This app is dedicated to Derek John Benton (1993-2014).
+            Compass Calendar is dedicated to Derek John Benton (1993-2014).
           </p>
           <div className="flex flex-row items-center justify-center">
             <blockquote className="mr-5">


### PR DESCRIPTION
## Summary
- Compass auto-tagged every new user (email/password and Google sign-up) in Kit for email updates, with no consent step — some users ended up getting emails they never agreed to.
- Removed the unconditional `EmailService.tagNewUserIfEnabled` calls from both sign-up paths. Users are now opted out by default, and only get tagged in Kit when they explicitly opt in.
- Added a `subscribeToUpdates` preference to `UserMetadata`, gated behind the existing `POST /api/user/metadata` endpoint so opting in works the same way whether it happens at sign-up or later.
- Sign-up form: added a "Subscribe to updates" checkbox (unchecked by default) with a tooltip reading "Once a month. Unsubscribe anytime."
- Command palette: added a one-way "Subscribe to Updates" command (Settings section) for users who skip the checkbox at sign-up or sign up via Google. It disappears once subscribed — there's no in-app unsubscribe, since that's meant to happen via the email's own footer link.
- The command palette action shows a success toast ("Subscribed to updates") or an error toast ("Couldn't subscribe to updates. Please try again.") using the app's existing toast styling. The sign-up checkbox intentionally stays silent — no toast there, since the account-creation flow already gives its own feedback.

## Manual Testing Steps
I validated most of this against a real local Chrome + backend, but hit an intermittent browser-automation tooling failure (`Cannot access a chrome-extension:// URL of different extension`, likely from two Chrome extension connections on the same account) partway through, before I could complete a full click-to-submit round trip. Confirmed before that:
- [ ] Open the app while logged out and click "Sign up" (or navigate to `/day?auth=signup`). Confirm a "Subscribe to updates" checkbox appears below the password field, unchecked by default.
- [ ] Hover the checkbox label. Confirm a tooltip reads "Once a month. Unsubscribe anytime."
- [ ] Fill in the sign-up form, leave the checkbox unchecked, submit. Confirm the account is created with no toast/notification about email updates.
- [ ] Fill in the sign-up form, check the checkbox, submit. Open the Network tab and confirm a `POST /api/user/metadata` request fires with `{"subscribeToUpdates": true}`.
- [ ] As a signed-in user who did **not** check the box at sign-up, open the command palette (Cmd+K) and confirm "Subscribe to Updates" appears under Settings.
- [ ] Click "Subscribe to Updates". Confirm a "Subscribed to updates" toast appears, and the command disappears from the palette on next open.
- [ ] Edge case: temporarily break the metadata request (e.g. via devtools request blocking) and click "Subscribe to Updates" again. Confirm an error toast reads "Couldn't subscribe to updates. Please try again."

## Test plan
- [x] `bun run test:core` — 145 pass, 0 fail
- [x] `bun run test:web` — 1110 pass, 0 fail (includes new tests: sign-up checkbox wiring in `AuthModal.test.tsx`, and `useSubscribeCmdItems.test.ts` covering hidden/visible states and success/error toasts)
- [x] `bun run type-check` — clean across core, backend, web app, and web tests
- [x] Targeted `bunx biome check` on every touched file — clean
- [x] Added backend test cases in `user-metadata.service.test.ts` (tag-once-on-opt-in, no-retag-on-repeat, no-tag-when-not-opting-in) and updated `google.auth.service.test.ts` / `supertokens.middleware.test.ts` for the removed auto-tag calls. Could not run these locally — this sandbox's in-memory MongoDB fails to start for any backend test, a pre-existing environment limitation unrelated to this change (confirmed by running an unrelated backend test file, which fails identically). Will confirm via CI.