### PR TITLE
style(web): move auth modal sign up/log in toggle to top-right

### DIFF
--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -8,7 +8,6 @@ import {
 } from "@web/common/utils/toast/error-toast.util";
 import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
-import { AuthButton } from "./components/AuthButton";
 import { ForgotPasswordForm } from "./forms/ForgotPasswordForm";
 import { LogInForm } from "./forms/LogInForm";
 import { ResetPasswordForm } from "./forms/ResetPasswordForm";
@@ -129,7 +128,22 @@ export const AuthModal: FC = () => {
           : "Hey, welcome back";
 
   return (
-    <OverlayPanel title={title} onDismiss={closeModal} variant="modal">
+    <OverlayPanel
+      title={title}
+      titleAction={
+        showAuthSwitch ? (
+          <button
+            type="button"
+            onClick={handleSwitchAuth}
+            className="shrink-0 rounded-3xl border border-[#1f1f1f] bg-white px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#f0f0f0]"
+          >
+            {isLoginView ? "Sign up" : "Log in"}
+          </button>
+        ) : null
+      }
+      onDismiss={closeModal}
+      variant="modal"
+    >
       <div className="flex w-full flex-col gap-6">
         {/* Form based on current view */}
         {currentView === "signUp" && (
@@ -171,23 +185,6 @@ export const AuthModal: FC = () => {
             {submitError}
           </p>
         ) : null}
-        {/* Auth switch (Sign In / Sign Up) - only for signIn and signUp views */}
-        {showAuthSwitch && (
-          <>
-            <div className="flex items-center gap-3">
-              <div className="h-px flex-1 bg-border-primary" />
-              <span className="text-sm text-text-light">or</span>
-              <div className="h-px flex-1 bg-border-primary" />
-            </div>
-            <AuthButton
-              type="button"
-              variant="outline"
-              onClick={handleSwitchAuth}
-            >
-              {isLoginView ? "Sign up" : "Log in"}
-            </AuthButton>
-          </>
-        )}
         {/* Google Sign In - at bottom */}
         {showGoogleAuth ? (
           <>


### PR DESCRIPTION
## Summary
- Moves the "Sign up" / "Log in" toggle button from a divider block at the bottom of the auth modal form into the top-right corner next to the title, via `OverlayPanel`'s existing `titleAction` prop.
- Removes the now-redundant "or" divider that used to precede that toggle (the Google OAuth section keeps its own separate divider).
- Matches the reference design: switching to the "wrong" form is now discoverable next to the title instead of buried below the form fields.

Apple sign-in from the reference mockup was intentionally left out — this codebase has no Apple OAuth integration. The subscribe-to-updates checkbox's position and behavior are unchanged.

## Manual Testing Steps
- [ ] Go to the app and trigger the "Log in" dialog. Confirm the title reads "Hey, welcome back" with a "Sign up" pill button in the top-right corner (no toggle button or extra divider at the bottom of the form anymore).
- [ ] Click the top-right "Sign up" pill. Confirm the dialog switches to "Nice to meet you" with a "Log in" pill now in the top-right, and the Name/Email/Password fields plus "Subscribe to updates" checkbox appear.
- [ ] Click the top-right "Log in" pill. Confirm it switches back to the "Hey, welcome back" login view.
- [ ] From the login view, click "Forgot password?" Confirm the "Reset Password" view shows no toggle pill next to its title (matches prior behavior).
- [ ] Confirm the "Continue with Google" button still appears below the form with a single "or" divider above it, and Terms/Privacy links still render at the bottom.

## Test plan
- [x] `bun run test:web -- AuthModal.test.tsx` — 36/36 pass
- [x] `bunx biome check packages/web/src/components/AuthModal/AuthModal.tsx` — clean
- [x] Manually verified in the user's real Chrome (via claude-in-chrome): login to sign up to back to login to forgot password, confirmed toggle placement/visibility at each step and no console or network errors during the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
