### PR TITLE
fix(web): clear stale email from sidebar after sign-out

### DIFF
--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
@@ -1,4 +1,6 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { type UserProfile } from "@core/types/user.types";
+import { type UseLoadProfileResult } from "@web/auth/compass/user/hooks/useLoadProfile";
 import {
   afterEach,
   beforeEach,
@@ -13,6 +15,18 @@ const getLastKnownEmail = mock(() => "person@example.com");
 const markUserAsAuthenticated = mock();
 const showSessionExpiredToast = mock();
 const getProfile = mock();
+
+const mockProfile: UserProfile = {
+  firstName: "Person",
+  lastName: "One",
+  name: "Person One",
+  email: "person@example.com",
+  locale: "en-US",
+  picture: "",
+  userId: "user-1",
+};
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 mock.module("@web/auth/compass/state/auth.state.util", () => ({
   getLastKnownEmail,
@@ -36,6 +50,16 @@ async function importHook() {
   );
 
   return import(moduleUrl.href);
+}
+
+function renderToggleableAuth(
+  useLoadProfile: (hasAuthenticatedBefore: boolean) => UseLoadProfileResult,
+) {
+  return renderHook(
+    ({ hasAuthenticatedBefore }: { hasAuthenticatedBefore: boolean }) =>
+      useLoadProfile(hasAuthenticatedBefore),
+    { initialProps: { hasAuthenticatedBefore: true } },
+  );
 }
 
 describe("useLoadProfile", () => {
@@ -66,5 +90,48 @@ describe("useLoadProfile", () => {
     });
     expect(getProfile).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears the profile and email once the user signs out", async () => {
+    getProfile.mockResolvedValue(mockProfile);
+    const { useLoadProfile } = await importHook();
+
+    const { result, rerender } = renderToggleableAuth(useLoadProfile);
+
+    await waitFor(() => {
+      expect(result.current.email).toBe(mockProfile.email);
+    });
+
+    rerender({ hasAuthenticatedBefore: false });
+
+    expect(result.current.email).toBeNull();
+    expect(result.current.profile).toBeNull();
+  });
+
+  it("drops a profile response that resolves after the user has already signed out", async () => {
+    let resolveProfile!: (profile: UserProfile) => void;
+    getProfile.mockImplementation(
+      () =>
+        new Promise<UserProfile>((resolve) => {
+          resolveProfile = resolve;
+        }),
+    );
+    const { useLoadProfile } = await importHook();
+
+    const { result, rerender } = renderToggleableAuth(useLoadProfile);
+
+    expect(getProfile).toHaveBeenCalledTimes(1);
+
+    rerender({ hasAuthenticatedBefore: false });
+    expect(result.current.email).toBeNull();
+
+    await act(async () => {
+      resolveProfile(mockProfile);
+      await flushPromises();
+    });
+
+    expect(result.current.email).toBeNull();
+    expect(result.current.profile).toBeNull();
+    expect(markUserAsAuthenticated).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
@@ -26,6 +26,8 @@ export function useLoadProfile(
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [isLoadingUser, setIsLoadingUser] = useState(hasAuthenticatedBefore);
   const profileRequest = useRef<Promise<void> | null>(null);
+  const isAuthenticatedRef = useRef(hasAuthenticatedBefore);
+  isAuthenticatedRef.current = hasAuthenticatedBefore;
   const userId = profile?.userId ?? null;
   const profileEmail = profile?.email ?? null;
   const email =
@@ -41,6 +43,8 @@ export function useLoadProfile(
 
     profileRequest.current = UserApi.getProfile()
       .then((userProfile) => {
+        // Signed out while this request was in flight — drop the stale response.
+        if (!isAuthenticatedRef.current) return;
         setProfile(userProfile);
         markUserAsAuthenticated(userProfile.email);
       })
@@ -70,12 +74,13 @@ export function useLoadProfile(
   }, []);
 
   useLayoutEffect(() => {
-    if (profile) return;
-
     if (!hasAuthenticatedBefore) {
+      setProfile(null);
       setIsLoadingUser(false);
       return;
     }
+
+    if (profile) return;
 
     void loadProfile();
   }, [hasAuthenticatedBefore, loadProfile, profile]);


### PR DESCRIPTION
## Summary
- After signing out via the command palette's `Log Out [z]` command, the account label at the bottom of the sidebar kept showing the previous user's email instead of falling back to "Temporary account."
- Root cause: `useLoadProfile` fetched the profile into React state but never reset it when auth flipped back to unauthenticated — the stale `profile` object (and its email) lived on until a full page reload.
- Fix: the hook's effect now explicitly clears `profile` when `hasAuthenticatedBefore` becomes false, and a ref-based guard drops any in-flight profile fetch that resolves after sign-out (otherwise it would resurrect both the stale email and the "has authenticated" storage flag).

## Manual Testing Steps
This worktree has no local `compass.yaml`/backend config, so the dev server can't be started here to click through it live, and this environment has no real Google OAuth credentials to exercise a real sign-in either. The change was instead verified via the CLI commands below, which exercise the exact state transition that caused the bug:
- [ ] Run `bun run test:web -- src/auth/compass/user/hooks/useLoadProfile.test.ts` as part of the full `bun run test:web` suite — confirm the two new cases pass: `useLoadProfile > clears the profile and email once the user signs out` and `useLoadProfile > drops a profile response that resolves after the user has already signed out`.
- [ ] In a real dev environment: sign in, confirm the sidebar shows your email at the bottom, open the command palette (`cmd+k`), run `Log Out [z]`, confirm the dialog, and confirm the sidebar immediately shows "Temporary account" with no page reload needed.

## Test plan
- [x] `bun run test:web` — 1112 pass, 0 fail (full suite, including the 2 new tests added for this fix)
- [x] `bunx biome check` on the two changed files — clean
- [x] `bun run type-check` (app + test tsconfigs) — clean