### PR TITLE
feat(web): persist sidebar open state across refreshes

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Ship the current branch end-to-end - validate the change in a local Chrome preview, open a non-draft PR with a lower-case conventional-commit title, watch CI and push fixes for any failures, squash-merge once green, then watch the post-merge GitHub Actions on main (release tag, docker publish, staging deploy, health check). Use this whenever the user says "ship this", "ship it", "ship the branch", or asks to take the current work from local changes all the way to a merged, deployed PR instead of doing each step manually.
+description: Ship the current branch end-to-end - validate the change in a local Chrome preview, simplify the diff for quality before committing, open a non-draft PR with a lower-case conventional-commit title, watch CI and push fixes for any failures, squash-merge once green, then watch the post-merge GitHub Actions on main (release tag, docker publish, staging deploy, health check). Use this whenever the user says "ship this", "ship it", "ship the branch", or asks to take the current work from local changes all the way to a merged, deployed PR instead of doing each step manually.
 ---
 
 # Ship
@@ -15,7 +15,7 @@ steps with one supervised run, not to rubber-stamp a merge.
 - Confirm the current branch is not `main`. If it is, stop and tell
   the user — there's nothing to ship from main itself.
 - `git status` / `git diff` to see what's actually changed. If there are
-  uncommitted changes, they need a commit before anything else (see step 2
+  uncommitted changes, they need a commit before anything else (see step 3
   for message format).
 - If the diff touches `packages/core`, remember per this repo's CLAUDE.md
   that core/schema changes usually need coverage across core, web, backend,
@@ -54,7 +54,7 @@ real one.
    view you were on, what you clicked/typed, and what rendered or happened
    as a result. No internal function/variable/file names — describe it the
    way a user would see it. This log becomes the PR's Manual Testing Steps
-   section in step 2, so capture it while it's fresh instead of
+   section in step 3, so capture it while it's fresh instead of
    reconstructing it from memory afterward.
 7. Check `read_console_messages` and `read_network_requests` for errors the
    UI wouldn't otherwise surface.
@@ -68,7 +68,24 @@ real one.
    commands a reviewer can run themselves (e.g., a script invocation and
    its expected output) rather than clicks. Never skip the record itself.
 
-## 2. Commit, push, and open the PR
+## 2. Simplify before committing
+
+Run the `simplify` skill (`.claude/skills/simplify/SKILL.md`) scoped to the
+current diff so the code that ships is the clean version, not the
+first-draft one. It's quality-only — reuse, duplication, legibility — and
+won't second-guess the correctness you just validated in step 1.
+
+1. Invoke `simplify` with its default scope (the current diff against the
+   base branch). Don't widen the scope to the whole package.
+2. If it changes anything, run the focused test/type-check commands its own
+   Verify section calls for on the packages touched, plus `bun run lint`.
+3. If a simplify change touches behavior a user could see (not a pure
+   internal refactor), redo the relevant slice of step 1's Chrome
+   walkthrough rather than assuming the refactor is behavior-preserving.
+4. There's no separate "simplify commit" — fold the result into the same
+   diff you commit in step 3.
+
+## 3. Commit, push, and open the PR
 
 **Commit message and PR title are the same string**, lower-case
 Conventional Commits, matching this repo's actual history (check `git log
@@ -115,7 +132,7 @@ Steps:
      automated counterpart to Manual Testing Steps, not a restatement of
      it — don't blur the two together.
 
-## 3. Watch CI, fix what breaks
+## 4. Watch CI, fix what breaks
 
 This repo's PR checks are: `type-check` and a `unit` matrix
 (core/web/backend/scripts) from the `Test` workflow, plus `e2e` (Playwright)
@@ -124,7 +141,7 @@ these names as the only source of truth, though — always read the live
 check list, since workflows can change.
 
 1. `gh pr checks <pr-number> --watch` blocks until every check finishes.
-2. If everything passes, move to step 4.
+2. If everything passes, move to step 5.
 3. If something fails, pull the failure detail rather than guessing:
    `gh run view <run-id> --log-failed`. Reproduce locally with the matching
    focused command from this repo's defaults (`bun run test:web`,
@@ -134,14 +151,14 @@ check list, since workflows can change.
 4. Fix the root cause, not the symptom. Commit the fix with its own
    lower-case conventional message (it'll be squashed into the final PR
    commit, so it doesn't need to match the PR title) and push.
-5. Go back to step 3.1 and watch again. Repeat until green.
+5. Go back to step 4.1 and watch again. Repeat until green.
 6. If a failure isn't something you can fix confidently (flaky
    infrastructure, an ambiguous product decision, a failure outside the
    diff's blast radius), stop and surface it to the user instead of forcing
    a fix. Guessing at a fix for something you don't understand just trades
    one CI failure for a worse one later.
 
-## 4. Merge
+## 5. Merge
 
 Only merge once CI is fully green and you're actually confident in the
 change — "confident" means you understand every fix you made along the way,
@@ -153,16 +170,16 @@ so the default squash subject already matches what you need:
 gh pr merge <pr-number> --squash --delete-branch
 ```
 
-If you're not confident — the fix in step 3 felt like a guess, or CI is
+If you're not confident — the fix in step 4 felt like a guess, or CI is
 green but something about the Chrome validation still nagged at you — say
 so and let the user decide whether to merge. This gate is about your own
 confidence in the change, not about whether a human has re-run the PR's
 `## Manual Testing Steps` checkboxes — those are for reviewers to use after
 merge review, not a pre-merge blocker for `ship` itself. A merge to `main`
-in this repo immediately kicks off a real deploy pipeline (see step 5), so
+in this repo immediately kicks off a real deploy pipeline (see step 6), so
 this is not a reversible-for-free action.
 
-## 5. Watch what happens after merge
+## 6. Watch what happens after merge
 
 Merging to `main` triggers `release-on-main.yml`: it tags a new patch
 release, publishes Docker images, deploys to staging, then runs a staging

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -4,15 +4,17 @@ export const StorageKeySchema = z.enum([
   "compass.auth",
   "compass.onboarding.has-seen-welcome",
   "compass.day.task-list-width",
+  "compass.view.sidebar-open",
 ]);
 
 export type StorageKey = z.infer<typeof StorageKeySchema>;
 
 export const STORAGE_KEYS: Record<
-  "AUTH" | "HAS_SEEN_WELCOME" | "DAY_TASK_LIST_WIDTH",
+  "AUTH" | "HAS_SEEN_WELCOME" | "DAY_TASK_LIST_WIDTH" | "SIDEBAR_OPEN",
   StorageKey
 > = {
   AUTH: "compass.auth",
   HAS_SEEN_WELCOME: "compass.onboarding.has-seen-welcome",
   DAY_TASK_LIST_WIDTH: "compass.day.task-list-width",
+  SIDEBAR_OPEN: "compass.view.sidebar-open",
 } as const;

--- a/packages/web/src/common/hooks/useResponsiveLayout.test.ts
+++ b/packages/web/src/common/hooks/useResponsiveLayout.test.ts
@@ -3,6 +3,7 @@ import {
   SIDEBAR_AUTO_COLLAPSE_BREAKPOINT,
   TASK_LIST_AUTO_COLLAPSE_BREAKPOINT,
 } from "@web/common/constants/responsive.constants";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   selectIsSidebarOpen,
   selectIsTaskListOpen,
@@ -152,6 +153,42 @@ describe("useResponsiveLayout sidebar", () => {
     });
     act(() => {
       sidebarQuery._triggerChange(false);
+    });
+
+    expect(getIsSidebarOpen()).toBe(false);
+  });
+
+  it("should respect a saved closed preference on mount when screen is wide", () => {
+    localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "false");
+    setupMatchMedia({ sidebarMatches: true, taskListMatches: true });
+
+    renderHook(() => useResponsiveLayout());
+
+    expect(getIsSidebarOpen()).toBe(false);
+  });
+
+  it("should ignore a saved open preference on mount when screen is narrow", () => {
+    localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "true");
+    setupMatchMedia({ sidebarMatches: false, taskListMatches: true });
+
+    renderHook(() => useResponsiveLayout());
+
+    expect(getIsSidebarOpen()).toBe(false);
+  });
+
+  it("should restore a saved closed preference when crossing back to wide", () => {
+    localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "false");
+    const { sidebarQuery } = setupMatchMedia({
+      sidebarMatches: false,
+      taskListMatches: true,
+    });
+
+    renderHook(() => useResponsiveLayout());
+
+    expect(getIsSidebarOpen()).toBe(false);
+
+    act(() => {
+      sidebarQuery._triggerChange(true);
     });
 
     expect(getIsSidebarOpen()).toBe(false);

--- a/packages/web/src/common/hooks/useResponsiveLayout.ts
+++ b/packages/web/src/common/hooks/useResponsiveLayout.ts
@@ -3,13 +3,16 @@ import {
   SIDEBAR_AUTO_COLLAPSE_BREAKPOINT,
   TASK_LIST_AUTO_COLLAPSE_BREAKPOINT,
 } from "@web/common/constants/responsive.constants";
+import { readSidebarOpen } from "@web/common/storage/sidebar-open.storage";
 import { viewActions } from "@web/events/stores/view.store";
 
 /**
  * Syncs panel visibility in the view store with the window size. Panels
- * auto-collapse/reopen only when a breakpoint is crossed, so a manual toggle
- * sticks until the next crossing. Mount once per app (AuthenticatedLayout) so
- * overrides survive view switches.
+ * auto-collapse below their breakpoint regardless of any saved preference,
+ * but reopening above it restores the user's last manual choice (persisted
+ * via toggleSidebar), so a breakpoint crossing never overrides a preference
+ * a refresh would otherwise honor. Mount once per app (AuthenticatedLayout)
+ * so overrides survive view switches.
  */
 export function useResponsiveLayout() {
   useLayoutEffect(() => {
@@ -18,7 +21,8 @@ export function useResponsiveLayout() {
         query: window.matchMedia(
           `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
         ),
-        setOpen: viewActions.setSidebarOpen,
+        setOpen: (matches: boolean) =>
+          viewActions.setSidebarOpen(matches && readSidebarOpen()),
       },
       {
         query: window.matchMedia(

--- a/packages/web/src/common/storage/sidebar-open.storage.test.ts
+++ b/packages/web/src/common/storage/sidebar-open.storage.test.ts
@@ -1,0 +1,30 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import {
+  readSidebarOpen,
+  writeSidebarOpen,
+} from "@web/common/storage/sidebar-open.storage";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("sidebar open storage", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults to open when nothing is stored", () => {
+    expect(readSidebarOpen()).toBe(true);
+  });
+
+  it("defaults to open for invalid stored values", () => {
+    localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "not-a-boolean");
+
+    expect(readSidebarOpen()).toBe(true);
+  });
+
+  it("writes and reads back through the storage abstraction", () => {
+    writeSidebarOpen(false);
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("false");
+    expect(readSidebarOpen()).toBe(false);
+
+    writeSidebarOpen(true);
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("true");
+    expect(readSidebarOpen()).toBe(true);
+  });
+});

--- a/packages/web/src/common/storage/sidebar-open.storage.ts
+++ b/packages/web/src/common/storage/sidebar-open.storage.ts
@@ -1,0 +1,10 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+export function readSidebarOpen(): boolean {
+  return persistentBrowserStore.get(STORAGE_KEYS.SIDEBAR_OPEN) !== "false";
+}
+
+export function writeSidebarOpen(isOpen: boolean): void {
+  persistentBrowserStore.set(STORAGE_KEYS.SIDEBAR_OPEN, String(isOpen));
+}

--- a/packages/web/src/events/stores/view.store.ts
+++ b/packages/web/src/events/stores/view.store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import dayjs from "@core/util/date/dayjs";
 import { IS_DEV } from "@web/common/constants/env.constants";
+import { writeSidebarOpen } from "@web/common/storage/sidebar-open.storage";
 
 interface ViewState {
   dates: {
@@ -41,7 +42,11 @@ export const viewActions = {
     }),
   toggleSidebar: () =>
     useViewStore.setState(
-      (state) => ({ sidebar: { isOpen: !state.sidebar.isOpen } }),
+      (state) => {
+        const isOpen = !state.sidebar.isOpen;
+        writeSidebarOpen(isOpen);
+        return { sidebar: { isOpen } };
+      },
       false,
       { type: "toggleSidebar" },
     ),


### PR DESCRIPTION
## Summary
- Persist the sidebar's open/closed state to localStorage (`compass.view.sidebar-open`) whenever the user manually toggles it via the header icon or the `[` shortcut, so the preference survives a page refresh.
- The viewport-driven auto-collapse (`useResponsiveLayout`) still forces the sidebar closed below the 1280px breakpoint regardless of the saved preference, and now restores the saved preference when crossing back above it (previously it always reopened unconditionally on that crossing).
- Updates the `ship` skill (`.claude/skills/ship/SKILL.md`) to run `/simplify` on the diff as a new step before committing.

## Manual Testing Steps
- [ ] Open the app, start an anonymous session ("Start Now"), switch to Week view.
- [ ] Click the sidebar toggle icon in the top-left corner to close the sidebar.
- [ ] Refresh the page — the sidebar stays closed.
- [ ] Press the `[` keyboard shortcut — the sidebar reopens.
- [ ] Refresh the page — the sidebar stays open.
- [ ] Shrink the browser window to under ~1280px wide — the sidebar force-closes regardless of the saved preference. Widen the window back — the saved preference is restored.

## Test plan
- [x] `bun run test:web -- useResponsiveLayout sidebar-open` — 16 pass, 0 fail
- [x] `bun run type-check` — clean (core, web app, web tests)
- [x] `bunx biome check` scoped to the changed files — clean (full `bun run lint` currently aborts on a stale nested `.worktrees/*/biome.json` root config unrelated to this change)