### PR TITLE
style(web): keep header nav controls in a fixed position

### DIFF
--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -60,7 +60,6 @@ export const CalendarHeader: FC<Props> = ({
       </h1>
 
       <div className="z-2 ml-auto flex items-center gap-3 pr-5">
-        <SelectView />
         <TodayButton navigateToToday={onToday} isToday={isToday} />
         <TooltipWrapper shortcut="J">
           <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
@@ -68,6 +67,7 @@ export const CalendarHeader: FC<Props> = ({
         <TooltipWrapper shortcut="K">
           <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
         </TooltipWrapper>
+        <SelectView />
       </div>
     </div>
   );

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -116,7 +116,9 @@ export const SelectView = ({
         aria-controls={isOpen ? dropdownId : undefined}
         aria-label={`Select view, currently ${currentView}`}
       >
-        <span>{buttonLabel}</span>
+        {/* min-width fits the widest label ("Week") so the nav arrows to the
+            left of this button don't shift when the view changes */}
+        <span className="min-w-10 text-left">{buttonLabel}</span>
         <svg
           className="h-4 w-4"
           fill="none"


### PR DESCRIPTION
## Summary
Reorders the calendar header's right-aligned control cluster from **view select · today dot · < · >** to **today dot · < · > · view select**, and gives the view-select label a fixed min-width.

Why: the cluster is right-anchored, so a control only stays put if nothing to its right changes size. The today dot conditionally disappears when viewing today, and the view-select label swaps between "Day" and "Week" (different widths). With the dot leftmost and the view select width fixed, the arrows and view select never move — users can park their mouse on an arrow and click repeatedly across days/weeks/views without re-aiming.

## Manual Testing Steps
- [ ] Open the app (lands on Day view for today): the header's top-right shows `<` `>` `Day ⌄` with no dot (you're on today)
- [ ] Click `>` (next day): a dot appears to the **left** of the arrows; the arrows and "Day" selector do not move — your cursor is still on `>`
- [ ] Click the dot: you return to today, the dot disappears, and the arrows/selector again do not move
- [ ] Click `Day ⌄` and choose **Week**: the view switches, and the arrows/view select stay in exactly the same spot despite the wider "Week" label
- [ ] In Week view, click `>` (next week): the dot appears far-left; nothing else shifts

## Test plan
- [x] `bun run test:web` — 1118 pass, 0 fail (172 files)
- [x] `bunx biome check` on both changed files — clean (`bun run lint` currently fails on a clean tree due to a pre-existing biome migrate config error, unrelated to this PR)
- [x] Manual walkthrough of all steps above in Chrome against the local dev server, verifying bounding-box positions are pixel-identical across all states

🤖 Generated with [Claude Code](https://claude.com/claude-code)