### PR TITLE
fix(web): make [ sidebar shortcut global and stop flash on refresh

### DIFF
--- a/e2e/navigation/responsive-layout.spec.ts
+++ b/e2e/navigation/responsive-layout.spec.ts
@@ -36,6 +36,33 @@ test.describe("Responsive sidebar", () => {
     await page.locator("#timedColumns").waitFor();
     await expect(page.locator("#sidebar")).toHaveCount(0);
   });
+
+  test("toggles with [ from the day view", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/day");
+    await expect(page.locator("#sidebar")).toBeVisible();
+
+    await page.keyboard.press("[");
+    await expect(page.locator("#sidebar")).toHaveCount(0);
+
+    await page.keyboard.press("[");
+    await expect(page.locator("#sidebar")).toBeVisible();
+  });
+
+  test("never mounts on refresh when collapsed", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/week");
+    await expect(page.locator("#sidebar")).toBeVisible();
+
+    await page.keyboard.press("[");
+    await expect(page.locator("#sidebar")).toHaveCount(0);
+
+    // The store seeds from the persisted preference, so the sidebar must be
+    // absent as soon as the grid renders — not collapse after a first paint.
+    await page.reload();
+    await page.locator("#timedColumns").waitFor();
+    await expect(page.locator("#sidebar")).toHaveCount(0);
+  });
 });
 
 test.describe("Responsive day view task list", () => {

--- a/packages/web/src/events/stores/view.store.ts
+++ b/packages/web/src/events/stores/view.store.ts
@@ -2,7 +2,10 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import dayjs from "@core/util/date/dayjs";
 import { IS_DEV } from "@web/common/constants/env.constants";
-import { writeSidebarOpen } from "@web/common/storage/sidebar-open.storage";
+import {
+  readSidebarOpen,
+  writeSidebarOpen,
+} from "@web/common/storage/sidebar-open.storage";
 
 interface ViewState {
   dates: {
@@ -22,7 +25,9 @@ export const initialViewState: ViewState = {
     start: dayjs().startOf("week").format(),
     end: dayjs().endOf("week").format(),
   },
-  sidebar: { isOpen: true },
+  // Seed from the persisted preference so a collapsed sidebar never mounts
+  // (and animates closed) on the first render after a refresh.
+  sidebar: { isOpen: readSidebarOpen() },
   taskList: { isOpen: true },
 };
 

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
@@ -1,7 +1,12 @@
 import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren } from "react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
+import {
+  selectIsSidebarOpen,
+  useViewStore,
+} from "@web/events/stores/view.store";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const logout = mock();
@@ -140,6 +145,34 @@ describe("useGlobalShortcuts", () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("toggles and persists the sidebar when pressing [", async () => {
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+
+    act(() => {
+      pressKey("[");
+    });
+
+    await waitFor(() => {
+      expect(selectIsSidebarOpen(useViewStore.getState())).toBe(false);
+    });
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("false");
+
+    act(() => {
+      pressKey("[");
+    });
+
+    await waitFor(() => {
+      expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+    });
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("true");
 
     act(() => {
       unmount();

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
@@ -6,6 +6,7 @@ import { VIEW_SHORTCUTS } from "@web/common/constants/shortcuts.constants";
 import { useAppHotkey, useAppHotkeyUp } from "@web/common/hotkeys/useAppHotkey";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { useLogoutConfirmation } from "@web/components/LogoutConfirmation/hooks/useLogoutConfirmation";
+import { viewActions } from "@web/events/stores/view.store";
 import { settingsActions } from "@web/settings/settings.store";
 
 /**
@@ -58,6 +59,8 @@ export function useGlobalShortcuts() {
       navigate(VIEW_SHORTCUTS.week.route);
     }
   });
+
+  useAppHotkeyUp("[", () => viewActions.toggleSidebar());
 
   useAppHotkeyUp("Z", () => {
     if (authenticated) {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -112,8 +112,6 @@ export const useWeekShortcuts = ({
     incrementWeek();
   }, [incrementWeek, _discardDraft]);
 
-  const openSidebar = useCallback(() => viewActions.toggleSidebar(), []);
-
   const createAllDayDraftEvent = useCallback(() => {
     void createAlldayDraft(startOfView, endOfView, "createShortcut");
   }, [startOfView, endOfView]);
@@ -226,7 +224,6 @@ export const useWeekShortcuts = ({
     [repositionDraftByKeyboard],
   );
 
-  useAppHotkeyUp("[", openSidebar);
   useAppHotkeyUp("J", goToPreviousWeek);
   useAppHotkeyUp("K", goToNextWeek);
   useAppHotkeyUp("T", toToday);


### PR DESCRIPTION
## Summary

Two sidebar UX bugs:

- The `[` shortcut only toggled the sidebar from the week view. Its registration lived in the week view's shortcut hook (the day view's copy was removed in #1935), even though the shortcut help menu and header tooltip advertise it everywhere. The registration now lives in the global shortcuts hook, which mounts once for both calendar views, and the week-only registration is removed so the key isn't handled twice.
- After #1941, refreshing with the sidebar collapsed briefly showed the sidebar before it animated closed. The store's initial state hard-coded the sidebar open and the persisted preference was only applied after mount. The store now seeds its initial sidebar state from the persisted preference, so a collapsed sidebar never mounts on refresh.

## Manual Testing Steps

- [ ] Open `/week` in a wide window and press `[` — the sidebar slides closed and an open-sidebar icon appears at the top left of the header. Press `[` again — it reopens.
- [ ] Collapse the sidebar, then refresh — the sidebar must not appear at all, not even briefly, while the calendar renders.
- [ ] Switch to the Day view and press `[` — the sidebar opens; press again — it closes. (This was the broken case.)
- [ ] With the sidebar closed, click the sidebar icon at the top left of the header — it opens, and the choice survives a refresh.
- [ ] Refresh with the sidebar open — it renders open immediately, and narrowing the window below ~1280px still auto-collapses it.

## Test plan

- [x] `bun run test:web` — 1128 pass, 0 fail (includes new `[` toggle-and-persist case in `useGlobalShortcuts.test.tsx`)
- [x] `bunx playwright test e2e/navigation/responsive-layout.spec.ts` — 6 pass (2 new: day-view `[` toggle; sidebar absent immediately after reload when collapsed)
- [x] `bun run lint` — clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)