### PR TITLE
fix(web): stop someday DnD month→week drop from clobbering new dates

### DIFF
--- a/packages/web/src/__tests__/utils/storage/mock-offline-data-store.util.ts
+++ b/packages/web/src/__tests__/utils/storage/mock-offline-data-store.util.ts
@@ -31,6 +31,7 @@ export function createMockOfflineDataStore(): MockedOfflineDataStore {
     putEvent: mock().mockResolvedValue(undefined),
     putEvents: mock().mockResolvedValue(undefined),
     deleteEvent: mock().mockResolvedValue(undefined),
+    updateEventOrders: mock().mockResolvedValue(undefined),
     clearAllEvents: mock().mockResolvedValue(undefined),
     getMigrationRecords: mock().mockResolvedValue([]),
     setMigrationRecord: mock().mockResolvedValue(undefined),

--- a/packages/web/src/common/repositories/event/local.event.repository.test.ts
+++ b/packages/web/src/common/repositories/event/local.event.repository.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const putEvent = mock();
 const getAllEvents = mock();
+const updateEventOrders = mock();
 
 mock.module(
   "@web/common/storage/offline-data/offline-data.store.registry",
@@ -17,6 +18,7 @@ mock.module(
     getOfflineDataStore: () => ({
       putEvent,
       getAllEvents,
+      updateEventOrders,
     }),
     initializeOfflineDataStore: mock().mockResolvedValue(undefined),
     isOfflineDataStoreReady: mock().mockReturnValue(true),
@@ -40,6 +42,7 @@ describe("LocalEventRepository", () => {
   beforeEach(() => {
     putEvent.mockClear();
     getAllEvents.mockClear();
+    updateEventOrders.mockClear();
   });
 
   it("preserves the demo marker when editing a seeded demo event", async () => {
@@ -53,5 +56,18 @@ describe("LocalEventRepository", () => {
     );
 
     expect(isLocalDemoEvent(putEvent.mock.calls[0][0])).toBe(true);
+  });
+
+  it("delegates reorder to the store without reading or rewriting whole events", async () => {
+    const order = [
+      { _id: "event-1", order: 0 },
+      { _id: "event-2", order: 1 },
+    ];
+
+    await new LocalEventRepository().reorder(order);
+
+    expect(updateEventOrders).toHaveBeenCalledWith(order);
+    expect(getAllEvents).not.toHaveBeenCalled();
+    expect(putEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/common/repositories/event/local.event.repository.ts
+++ b/packages/web/src/common/repositories/event/local.event.repository.ts
@@ -88,29 +88,6 @@ export class LocalEventRepository implements EventRepository {
   }
 
   async reorder(order: Payload_Order[]): Promise<void> {
-    const allEvents = await this.store.getAllEvents();
-    const orderMap = new Map(order.map((o) => [o._id, o.order]));
-
-    // Track errors for individual event saves
-    const errors: Array<{ eventId: string; error: unknown }> = [];
-
-    for (const event of allEvents) {
-      const eventId = event._id;
-      if (eventId && orderMap.has(eventId)) {
-        // Cast to Schema_Event which includes order property
-        const eventWithOrder = event as unknown as Schema_Event;
-        eventWithOrder.order = orderMap.get(eventId);
-        try {
-          await this.store.putEvent(event);
-        } catch (error) {
-          errors.push({ eventId, error });
-        }
-      }
-    }
-
-    // If any saves failed, throw aggregate error
-    if (errors.length > 0) {
-      throw new Error(`Failed to reorder ${errors.length} events`);
-    }
+    await this.store.updateEventOrders(order);
   }
 }

--- a/packages/web/src/common/storage/migrations/data/task-id-to-underscore-id.test.ts
+++ b/packages/web/src/common/storage/migrations/data/task-id-to-underscore-id.test.ts
@@ -23,6 +23,7 @@ function createMockStore(): MockedOfflineDataStore {
     putEvent: mock().mockResolvedValue(undefined),
     putEvents: mock().mockResolvedValue(undefined),
     deleteEvent: mock().mockResolvedValue(undefined),
+    updateEventOrders: mock().mockResolvedValue(undefined),
     clearAllEvents: mock().mockResolvedValue(undefined),
     getMigrationRecords: mock().mockResolvedValue([]),
     setMigrationRecord: mock().mockResolvedValue(undefined),

--- a/packages/web/src/common/storage/migrations/external/localstorage-tasks.test.ts
+++ b/packages/web/src/common/storage/migrations/external/localstorage-tasks.test.ts
@@ -51,6 +51,7 @@ function createMockStore(): MockedOfflineDataStore {
     putEvent: mock().mockResolvedValue(undefined),
     putEvents: mock().mockResolvedValue(undefined),
     deleteEvent: mock().mockResolvedValue(undefined),
+    updateEventOrders: mock().mockResolvedValue(undefined),
     clearAllEvents: mock().mockResolvedValue(undefined),
     getMigrationRecords: mock().mockResolvedValue([]),
     setMigrationRecord: mock().mockResolvedValue(undefined),

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
@@ -1,4 +1,5 @@
 import Dexie, { type Table } from "dexie";
+import { type Payload_Order } from "@core/types/event.types";
 import { isDateRangeOverlapping } from "@core/util/date/date.util";
 import { type LocalStoredEvent } from "@web/common/storage/types/local-event.types";
 import {
@@ -233,6 +234,14 @@ export class IndexedDbOfflineDataStore implements OfflineDataStore {
 
   async deleteEvent(eventId: string): Promise<void> {
     await this.db.events.delete(eventId);
+  }
+
+  async updateEventOrders(order: Payload_Order[]): Promise<void> {
+    await this.db.transaction("rw", this.db.events, async () => {
+      for (const { _id, order: nextOrder } of order) {
+        await this.db.events.update(_id, { order: nextOrder });
+      }
+    });
   }
 
   async clearAllEvents(): Promise<void> {

--- a/packages/web/src/common/storage/offline-data/offline-data.store.ts
+++ b/packages/web/src/common/storage/offline-data/offline-data.store.ts
@@ -1,3 +1,4 @@
+import { type Payload_Order } from "@core/types/event.types";
 import { type LocalStoredEvent } from "@web/common/storage/types/local-event.types";
 import { type Task } from "@web/common/types/task.types";
 
@@ -111,6 +112,12 @@ export interface OfflineDataStore {
    * Delete an event by ID.
    */
   deleteEvent(eventId: string): Promise<void>;
+
+  /**
+   * Patch the `order` field on the given events, leaving every other field
+   * untouched. Ids not present in storage are ignored.
+   */
+  updateEventOrders(order: Payload_Order[]): Promise<void>;
 
   /**
    * Clear all events from storage.

--- a/packages/web/src/common/storage/types/local-event.types.ts
+++ b/packages/web/src/common/storage/types/local-event.types.ts
@@ -4,6 +4,7 @@ export const LOCAL_DEMO_EVENT_FIELD = "__compassDemoEvent";
 
 export type LocalStoredEvent = Event_Core & {
   [LOCAL_DEMO_EVENT_FIELD]?: true;
+  order?: number;
 };
 
 export function markLocalDemoEvent<T extends Event_Core>(


### PR DESCRIPTION
## Summary
- Dragging a someday event from **This Month** to **This Week** in the sidebar would appear to move, then snap back to This Month. The reverse (week → month) worked fine.
- Root cause: `LocalEventRepository.reorder` read a stale snapshot of every event and wrote each back whole (old dates included), racing the concurrent `edit` mutation that carried the dragged event's new dates. Whichever write landed last won — Dexie's primary-key iteration order made month→week drags lose that race while week→month happened to win.
- Fix: added `updateEventOrders` to the offline data store, implemented with Dexie's atomic `Table.update`, so `reorder` only ever patches the `order` field and can no longer clobber a concurrent edit's dates.

## Test plan
- [x] `bun run test:web` (1120 pass)
- [x] `bun run lint`
- [x] `bun run type-check`
- [x] Manual verification in browser preview: anonymous session, week view, dragged 'Review quarterly goals' month→week and 'Learn a new shortcut' week→month, reloaded after each — both persisted correctly (verified against the DOM/event registry, not just the optimistic UI).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>