### PR TITLE
test(web): enable real dexie + fake-indexeddb round trips in web tests

### DIFF
--- a/packages/web/src/__tests__/utils/storage/indexeddb.test.util.ts
+++ b/packages/web/src/__tests__/utils/storage/indexeddb.test.util.ts
@@ -1,29 +1,10 @@
-import { DEMO_DATA_SEED_FLAG_KEY } from "@web/common/storage/migrations/external/demo-data-seed";
-import {
-  initializeOfflineDataStore,
-  resetOfflineDataStoreAsync,
-} from "@web/common/storage/offline-data/offline-data.store.registry";
-
 const COMPASS_LOCAL_DB_NAME = "compass-local";
 
-export async function clearCompassLocalDb(): Promise<void> {
-  await resetOfflineDataStoreAsync();
+export async function deleteCompassLocalDb(): Promise<void> {
   await new Promise<void>((resolve) => {
     const request = indexedDB.deleteDatabase(COMPASS_LOCAL_DB_NAME);
     request.onsuccess = () => resolve();
     request.onerror = () => resolve();
     request.onblocked = () => resolve();
   });
-}
-
-/**
- * Prepares empty storage for tests that expect no data.
- * Clears localStorage and IndexedDB, then sets the demo-data-seed migration
- * flag so it won't seed when storage initializes.
- */
-export async function prepareEmptyStorageForTests(): Promise<void> {
-  localStorage.clear();
-  await clearCompassLocalDb();
-  localStorage.setItem(DEMO_DATA_SEED_FLAG_KEY, "completed");
-  await initializeOfflineDataStore();
 }

--- a/packages/web/src/__tests__/web.preload.ts
+++ b/packages/web/src/__tests__/web.preload.ts
@@ -99,6 +99,14 @@ globalThis.Event = window.Event;
 globalThis.CustomEvent = window.CustomEvent;
 globalThis.MouseEvent = window.MouseEvent;
 globalThis.KeyboardEvent = window.KeyboardEvent;
+// Bun's native globalThis.dispatchEvent/addEventListener operate on Bun's own
+// Event realm. Dexie constructs `new CustomEvent(...)` against the jsdom
+// Event class above, so dispatching through Bun's native EventTarget throws
+// "must be an instance of Event" (cross-realm brand check). Rebind these to
+// jsdom's window so the whole event pipeline stays in one realm.
+globalThis.dispatchEvent = window.dispatchEvent.bind(window);
+globalThis.addEventListener = window.addEventListener.bind(window);
+globalThis.removeEventListener = window.removeEventListener.bind(window);
 globalThis.self = window;
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -262,6 +270,23 @@ window.HTMLCanvasElement.prototype.getContext = function (
 };
 
 await import("fake-indexeddb/auto");
+// fake-indexeddb/auto attaches indexedDB (and friends) to `typeof window
+// !== "undefined" ? window : ...`, which resolves to the jsdom window set
+// above. Dexie reads `globalThis.indexedDB`/`globalThis.IDBKeyRange`
+// directly, so mirror them onto globalThis or `new Dexie(...).open()`
+// throws MissingAPIError.
+globalThis.indexedDB = window.indexedDB;
+globalThis.IDBKeyRange = window.IDBKeyRange;
+globalThis.IDBCursor = window.IDBCursor;
+globalThis.IDBCursorWithValue = window.IDBCursorWithValue;
+globalThis.IDBDatabase = window.IDBDatabase;
+globalThis.IDBFactory = window.IDBFactory;
+globalThis.IDBIndex = window.IDBIndex;
+globalThis.IDBObjectStore = window.IDBObjectStore;
+globalThis.IDBOpenDBRequest = window.IDBOpenDBRequest;
+globalThis.IDBRequest = window.IDBRequest;
+globalThis.IDBTransaction = window.IDBTransaction;
+globalThis.IDBVersionChangeEvent = window.IDBVersionChangeEvent;
 
 if (typeof globalThis.structuredClone === "undefined") {
   globalThis.structuredClone = (obj: unknown) => {

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.reorder.test.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.reorder.test.ts
@@ -1,0 +1,80 @@
+import { Origin, Priorities } from "@core/constants/core.constants";
+import { type Event_Core } from "@core/types/event.types";
+import { deleteCompassLocalDb } from "@web/__tests__/utils/storage/indexeddb.test.util";
+import { IndexedDbOfflineDataStore } from "@web/common/storage/offline-data/indexeddb-offline-data.store";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const makeEvent = (overrides: Partial<Event_Core> = {}): Event_Core => ({
+  _id: "event-1",
+  title: "Someday task",
+  startDate: "2026-05-05T09:00:00.000Z",
+  endDate: "2026-05-05T10:00:00.000Z",
+  origin: Origin.COMPASS,
+  priority: Priorities.UNASSIGNED,
+  isSomeday: true,
+  user: "unauthenticated",
+  ...overrides,
+});
+
+/**
+ * Regression coverage for #1946: a stale reorder write used to overwrite an
+ * event's dates because it round-tripped the whole record through
+ * getAllEvents()/putEvent(). This exercises the real Dexie + fake-indexeddb
+ * store directly (bypassing the offline-data.store.registry mock other test
+ * files install) via the exact store methods LocalEventRepository.edit()
+ * and .reorder() delegate to.
+ */
+describe("IndexedDbOfflineDataStore reorder/edit interaction", () => {
+  let store: IndexedDbOfflineDataStore;
+
+  beforeEach(async () => {
+    store = new IndexedDbOfflineDataStore();
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    store.close();
+    await deleteCompassLocalDb();
+  });
+
+  it("keeps an edited event's new dates after a reorder lands afterward", async () => {
+    await store.putEvent(makeEvent({ order: 0 }));
+
+    // Simulate a month → week drag: the date edit commits first, then a
+    // reorder (queued for the destination view) lands after it.
+    await store.putEvent(
+      makeEvent({
+        startDate: "2026-05-12T09:00:00.000Z",
+        endDate: "2026-05-12T10:00:00.000Z",
+      }),
+    );
+    await store.updateEventOrders([{ _id: "event-1", order: 7 }]);
+
+    const [stored] = await store.getAllEvents();
+
+    expect(stored.startDate).toBe("2026-05-12T09:00:00.000Z");
+    expect(stored.endDate).toBe("2026-05-12T10:00:00.000Z");
+    expect(stored.order).toBe(7);
+  });
+
+  it("never reverts an in-flight date edit when reorder and edit race", async () => {
+    await store.putEvent(makeEvent({ order: 0 }));
+
+    await Promise.all([
+      store.updateEventOrders([{ _id: "event-1", order: 3 }]),
+      store.putEvent(
+        makeEvent({
+          startDate: "2026-05-19T09:00:00.000Z",
+          endDate: "2026-05-19T10:00:00.000Z",
+        }),
+      ),
+    ]);
+
+    const [stored] = await store.getAllEvents();
+
+    // Regardless of which write lands last, reorder only ever patches the
+    // `order` field, so the edited dates must always survive.
+    expect(stored.startDate).toBe("2026-05-19T09:00:00.000Z");
+    expect(stored.endDate).toBe("2026-05-19T10:00:00.000Z");
+  });
+});

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.reorder.test.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.reorder.test.ts
@@ -1,10 +1,12 @@
 import { Origin, Priorities } from "@core/constants/core.constants";
-import { type Event_Core } from "@core/types/event.types";
 import { deleteCompassLocalDb } from "@web/__tests__/utils/storage/indexeddb.test.util";
 import { IndexedDbOfflineDataStore } from "@web/common/storage/offline-data/indexeddb-offline-data.store";
+import { type LocalStoredEvent } from "@web/common/storage/types/local-event.types";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-const makeEvent = (overrides: Partial<Event_Core> = {}): Event_Core => ({
+const makeEvent = (
+  overrides: Partial<LocalStoredEvent> = {},
+): LocalStoredEvent => ({
   _id: "event-1",
   title: "Someday task",
   startDate: "2026-05-05T09:00:00.000Z",

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
@@ -1,0 +1,35 @@
+import { deleteCompassLocalDb } from "@web/__tests__/utils/storage/indexeddb.test.util";
+import { IndexedDbOfflineDataStore } from "./indexeddb-offline-data.store";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
+  afterEach(async () => {
+    await deleteCompassLocalDb();
+  });
+
+  it("persists and reads back a task through a real IndexedDB round trip", async () => {
+    const store = new IndexedDbOfflineDataStore();
+    await store.initialize();
+
+    expect(store.isReady()).toBe(true);
+
+    await store.putTask("2026-07-07", {
+      _id: "task-1",
+      title: "Write a real Dexie test",
+      status: "todo",
+      order: 0,
+      createdAt: "2026-07-07T00:00:00.000Z",
+    });
+
+    const tasks = await store.getTasks("2026-07-07");
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      _id: "task-1",
+      title: "Write a real Dexie test",
+      status: "todo",
+    });
+
+    store.close();
+  });
+});


### PR DESCRIPTION
## Summary
- `packages/web/src/__tests__/web.preload.ts` never actually made real IndexedDB usable in tests: `fake-indexeddb/auto` attaches `indexedDB` to `window`, but Dexie reads `globalThis.indexedDB` directly, so `new Dexie(...).open()` threw `MissingAPIError`. Mirrored `indexedDB` and the `IDB*` constructors from `window` onto `globalThis` right after the `fake-indexeddb/auto` import.
- Even with that fixed, opening a Dexie db threw `TypeError: Argument 1 ('event') to EventTarget.dispatchEvent must be an instance of Event` — Bun's native `dispatchEvent`/`addEventListener` stayed on `globalThis` (the preload's "copy if missing" loop skips them since Bun already defines them), so Dexie's `new CustomEvent(...)` (built against jsdom's `Event` class) got dispatched through Bun's own `Event` realm, tripping a cross-realm brand check. Rebound `dispatchEvent`/`addEventListener`/`removeEventListener` to jsdom's `window` so the whole event pipeline stays in one realm.
- Every storage test in this repo previously exercised the mock offline-data store only. Added a smoke test (`indexeddb-offline-data.store.test.ts`) that does a real `initialize()` → `putTask()` → `getTasks()` round trip against the actual Dexie/fake-indexeddb stack.
- Added a regression test (`indexeddb-offline-data.store.reorder.test.ts`) for #1946 (`8386e95d6`), which fixed a stale-reorder write clobbering an event's dates. The new test proves `updateEventOrders` never touches `startDate`/`endDate`, both sequentially (edit then reorder) and under a `Promise.all` race.
- Deleted the two dead, never-imported exports in `indexeddb.test.util.ts` (`clearCompassLocalDb`, `prepareEmptyStorageForTests`) and replaced them with the one helper (`deleteCompassLocalDb`) both new test files actually use — avoids duplicating the same 6-line IndexedDB-delete promise in two files.

## Manual Testing Steps
This is a test-infrastructure-only change with no browser-observable surface (no product code changed). Equivalent verification, runnable by a reviewer:
- [ ] Run `bun run test:web -- src/common/storage/offline-data` from the repo root — expect 3 passing tests across 2 files, including "persists and reads back a task through a real IndexedDB round trip" and the two reorder/edit regression tests.
- [ ] Run `bun run test:web` — expect the full web suite (1104 tests / 173 files) to pass with no failures.
- [ ] Run `bun run lint` — expect 0 errors (16 pre-existing, unrelated warnings are fine).

## Test plan
- [x] `bun run test:web -- src/common/storage/offline-data` — 3 pass, 0 fail
- [x] `bun run test:web` (full web suite) — 1104 pass, 0 fail, across 173 files
- [x] `bun run lint` — 0 errors, 16 pre-existing warnings unrelated to this change