### PR TITLE
fix(web): show visual feedback when keyboard-lifting a day task

### DIFF
--- a/packages/web/src/views/Day/components/Task/DraggableTask.tsx
+++ b/packages/web/src/views/Day/components/Task/DraggableTask.tsx
@@ -59,7 +59,11 @@ export function DraggableTask({
           {...attributes}
           {...listeners}
           ref={setActivatorNodeRef}
-          aria-label={`Reorder ${task.title}`}
+          aria-label={
+            isDragging
+              ? `Reordering ${task.title}. Use arrow keys to move, space to drop.`
+              : `Reorder ${task.title}`
+          }
           onFocus={() => setSelectedTaskIndex(index)}
           className={classNames(
             // Floats in the DropZone's pl-8 gutter so it reserves no row space
@@ -72,7 +76,10 @@ export function DraggableTask({
             "focus-visible:bg-white/20 focus-visible:ring-2 focus-visible:ring-white/50",
             "focus:outline-none",
             {
-              "cursor-grabbing opacity-100": isDragging,
+              // A distinct accent (vs. the white focus ring) so keyboard users
+              // can see the grab actually registered, not just that it's focused.
+              "cursor-grabbing bg-blue-200/20 opacity-100 ring-2 ring-blue-200":
+                isDragging,
             },
           )}
         >

--- a/packages/web/src/views/Day/components/Tasks/Tasks.test.tsx
+++ b/packages/web/src/views/Day/components/Tasks/Tasks.test.tsx
@@ -138,6 +138,21 @@ describe("Tasks drag and drop", () => {
     expect(reorderTasks).toHaveBeenCalledWith(0, 1);
   });
 
+  it("marks the handle as actively dragging once lifted", async () => {
+    renderTaskList();
+
+    const before = screen.getByRole("button", { name: "Reorder Task 1" });
+
+    expect(before).toHaveAttribute("aria-label", "Reorder Task 1");
+
+    const handle = await liftTask("Task 1");
+
+    expect(handle).toHaveAttribute(
+      "aria-label",
+      "Reordering Task 1. Use arrow keys to move, space to drop.",
+    );
+  });
+
   it("announces the drag lifecycle for screen readers", async () => {
     renderTaskList();
 


### PR DESCRIPTION
## Summary
- When a keyboard user focuses a task's reorder handle in Day view and presses Space to lift it, nothing visually changed — the handle already showed its resting focus ring (white, from `:focus-visible`), and the `isDragging` classes (`cursor-grabbing opacity-100`) were redundant with that resting state, so there was no way to tell "it worked."
- The reorder handle now switches to a distinct blue ring/background (`ring-blue-200 bg-blue-200/20`, matching the accent color already used elsewhere in this component family) while actively lifted, and its `aria-label` changes from `"Reorder {title}"` to `"Reordering {title}. Use arrow keys to move, space to drop."`.
- Screen-reader announcements for drag start/move/cancel were already wired up separately in `Tasks.tsx`; this change closes the gap for sighted keyboard users who don't use a screen reader.

## Manual Testing Steps
- [ ] Go to Day view with 2+ tasks in the task list.
- [ ] Tab to a task's drag handle (the six-dot icon that appears to the left of a task when focused).
- [ ] Confirm it shows a white focus ring (unchanged resting behavior).
- [ ] Press Space to lift the task.
- [ ] Confirm the ring/background switches to blue, giving a clear "picked up" signal.
- [ ] Press an arrow key to move the task, then Space again to drop it, and confirm the task reordered and the ring returns to white (or clears on blur).
- [ ] Press Escape mid-drag on a fresh lift and confirm the task returns to its original position with no lasting style change.

## Test plan
- [x] `bun run test:web -- --run Tasks` — 14 pass, 0 fail (includes new test `marks the handle as actively dragging once lifted`, plus all pre-existing keyboard drag/announcement tests).
- [x] `bun run lint` — clean (only pre-existing warnings in unrelated files).