### PR TITLE
feat(web): persist week view position across refresh via /week/:dateString

### DIFF
--- a/e2e/navigation/week-view-switch.spec.ts
+++ b/e2e/navigation/week-view-switch.spec.ts
@@ -81,7 +81,7 @@ test.describe("View dropdown", () => {
     await page.keyboard.press("Escape");
 
     await expect(page.getByTestId("view-select-dropdown")).toHaveCount(0);
-    await expect(page).toHaveURL(/\/week$/);
+    await expect(page).toHaveURL(/\/week\/\d{4}-\d{2}-\d{2}$/);
     await expect(viewButton(page, "week")).toBeVisible();
   });
 
@@ -94,7 +94,7 @@ test.describe("View dropdown", () => {
     await viewOption(page, "week").click();
 
     await expect(page.getByTestId("view-select-dropdown")).toHaveCount(0);
-    await expect(page).toHaveURL(/\/week$/);
+    await expect(page).toHaveURL(/\/week\/\d{4}-\d{2}-\d{2}$/);
     await expect(viewButton(page, "week")).toBeVisible();
   });
 

--- a/e2e/oauth/google-auth-callback.spec.ts
+++ b/e2e/oauth/google-auth-callback.spec.ts
@@ -227,7 +227,7 @@ test.describe("Google auth callback", () => {
 
     delayedSignIn.resolve();
 
-    await expect(page).toHaveURL(/\/week$/);
+    await expect(page).toHaveURL(/\/week\/\d{4}-\d{2}-\d{2}$/);
     expect(apiMocks.loginOrSignup).toHaveLength(1);
     expect(apiMocks.connectGoogle).toHaveLength(0);
     expect(apiMocks.loginOrSignup[0]?.headers.rid).toBe("thirdparty");
@@ -256,7 +256,7 @@ test.describe("Google auth callback", () => {
 
     await page.goto(getCallbackUrl(state));
 
-    await expect(page).toHaveURL(/\/week$/);
+    await expect(page).toHaveURL(/\/week\/\d{4}-\d{2}-\d{2}$/);
     expect(apiMocks.loginOrSignup).toHaveLength(0);
     expect(apiMocks.connectGoogle).toHaveLength(1);
     expectGoogleAuthRequestBody(apiMocks.connectGoogle[0], state);
@@ -277,7 +277,7 @@ test.describe("Google auth callback", () => {
 
     await page.goto(getCallbackUrl(state));
 
-    await expect(page).toHaveURL(/\/week$/);
+    await expect(page).toHaveURL(/\/week\/\d{4}-\d{2}-\d{2}$/);
     expect(apiMocks.connectGoogle).toHaveLength(0);
     expect(apiMocks.loginOrSignup).toHaveLength(1);
     expect(apiMocks.loginOrSignup[0]?.headers.rid).toBe("thirdparty");
@@ -299,7 +299,7 @@ test.describe("Google auth callback", () => {
 
     await page.goto(getCallbackUrl(state, REQUIRED_SCOPES[0] ?? ""));
 
-    await expect(page).toHaveURL(/\/week$/);
+    await expect(page).toHaveURL(/\/week\/\d{4}-\d{2}-\d{2}$/);
     await expect(
       page.getByText(
         "Missing Google Calendar permissions. Please grant all requested permissions.",

--- a/e2e/utils/event-test-utils.ts
+++ b/e2e/utils/event-test-utils.ts
@@ -143,7 +143,9 @@ const ensureWeekView = async (page: Page) => {
   await viewButton.waitFor({ state: "visible", timeout: 5000 });
   await viewButton.click();
   await page.getByRole("option", { name: "Week" }).click();
-  await page.waitForURL((url) => url.pathname === "/week", { timeout: 10000 });
+  await page.waitForURL((url) => url.pathname.startsWith("/week"), {
+    timeout: 10000,
+  });
 
   // Verify we actually switched to Week view
   await weekViewButton.waitFor({ state: "visible", timeout: 5000 });

--- a/packages/web/src/__tests__/utils/state/draft.test.util.tsx
+++ b/packages/web/src/__tests__/utils/state/draft.test.util.tsx
@@ -1,4 +1,5 @@
 import { act } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import { renderHook } from "@web/__tests__/__mocks__/mock.render";
 import { type Schema_WebEvent } from "@web/common/types/web.event.types";
@@ -28,7 +29,10 @@ export function setupDraftState(event: Schema_WebEvent) {
     },
   };
 
-  const weekHook = renderHook(() => useWeek(useToday().today), { state });
+  const weekHook = renderHook(() => useWeek(useToday().today), {
+    state,
+    wrapper: MemoryRouter,
+  });
   const weekProps = weekHook.result.current;
 
   const gridHook = renderHook(() => useGridLayout(), {

--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -5,6 +5,7 @@ export const ROOT_ROUTES = {
   LIFE: "/life",
   ROOT: "/",
   WEEK: "/week",
+  WEEK_DATE: "/week/:dateString",
   DAY: "/day",
   DAY_DATE: "/day/:dateString",
 };

--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -1,6 +1,12 @@
 import { type LoaderFunctionArgs } from "react-router-dom";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
-import { loadDayData, loadRootData, loadTodayData } from "@web/routers/loaders";
+import {
+  loadDayData,
+  loadRootData,
+  loadSpecificWeekData,
+  loadTodayData,
+  loadWeekData,
+} from "@web/routers/loaders";
 
 function createLoaderArgs(url: string): LoaderFunctionArgs<unknown> {
   return {
@@ -57,5 +63,57 @@ describe("loadDayData", () => {
     expect(response.headers.get("Location")).toBe(
       `${ROOT_ROUTES.DAY}/${dateString}?auth=verify&token=abc`,
     );
+  });
+});
+
+describe("loadWeekData", () => {
+  it("redirects the bare week route to today's dated week route", async () => {
+    const { dateString } = loadTodayData();
+    const response = await loadWeekData(
+      createLoaderArgs("http://localhost/week"),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      `${ROOT_ROUTES.WEEK}/${dateString}`,
+    );
+  });
+
+  it("preserves auth query params when redirecting to the dated week route", async () => {
+    const { dateString } = loadTodayData();
+    const response = await loadWeekData(
+      createLoaderArgs("http://localhost/week?auth=login"),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      `${ROOT_ROUTES.WEEK}/${dateString}?auth=login`,
+    );
+  });
+});
+
+describe("loadSpecificWeekData", () => {
+  it("returns the parsed date for a valid dateString param", async () => {
+    const result = await loadSpecificWeekData({
+      request: new Request("http://localhost/week/2026-05-20"),
+      params: { dateString: "2026-05-20" },
+      context: undefined,
+    });
+
+    expect(result).not.toBeInstanceOf(Response);
+    expect(result).toMatchObject({ dateString: "2026-05-20" });
+  });
+
+  it("redirects to the bare week route for an invalid dateString param", async () => {
+    const result = await loadSpecificWeekData({
+      request: new Request("http://localhost/week/not-a-date"),
+      params: { dateString: "not-a-date" },
+      context: undefined,
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(ROOT_ROUTES.WEEK);
   });
 });

--- a/packages/web/src/routers/loaders.ts
+++ b/packages/web/src/routers/loaders.ts
@@ -30,33 +30,52 @@ export function loadTodayData(): DayLoaderData {
   return { dateInView, dateString: dateInView.format(dateFormat) };
 }
 
-function buildTodayRedirectUrl(request: Request): string {
+function buildTodayRedirectUrl(request: Request, baseRoute: string): string {
   const { dateString } = loadTodayData();
   const url = new URL(request.url);
 
-  return `${ROOT_ROUTES.DAY}/${dateString}${url.search}`;
+  return `${baseRoute}/${dateString}${url.search}`;
 }
 
 export function loadDayData({
   request,
 }: LoaderFunctionArgs<unknown>): Response {
-  return redirect(buildTodayRedirectUrl(request));
+  return redirect(buildTodayRedirectUrl(request, ROOT_ROUTES.DAY));
 }
 
 export function loadRootData(args: LoaderFunctionArgs<unknown>): Response {
   return loadDayData(args);
 }
 
-export async function loadSpecificDayData({
-  params,
-}: LoaderFunctionArgs<unknown>): Promise<DayLoaderData | Response> {
+export function loadWeekData({
+  request,
+}: LoaderFunctionArgs<unknown>): Response {
+  return redirect(buildTodayRedirectUrl(request, ROOT_ROUTES.WEEK));
+}
+
+function loadSpecificDateData(
+  params: LoaderFunctionArgs<unknown>["params"],
+  baseRoute: string,
+): DayLoaderData | Response {
   const parsedDate = zYearMonthDayString.safeParse(params.dateString);
   const { success, data: dateString } = parsedDate;
 
-  if (!success) return redirect(ROOT_ROUTES.DAY);
+  if (!success) return redirect(baseRoute);
 
-  return Promise.resolve({
+  return {
     dateString,
     dateInView: dayjs(dateString, dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT),
-  });
+  };
+}
+
+export function loadSpecificDayData({
+  params,
+}: LoaderFunctionArgs<unknown>): DayLoaderData | Response {
+  return loadSpecificDateData(params, ROOT_ROUTES.DAY);
+}
+
+export function loadSpecificWeekData({
+  params,
+}: LoaderFunctionArgs<unknown>): DayLoaderData | Response {
+  return loadSpecificDateData(params, ROOT_ROUTES.WEEK);
 }

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -6,6 +6,8 @@ import {
   loadDayData,
   loadRootData,
   loadSpecificDayData,
+  loadSpecificWeekData,
+  loadWeekData,
 } from "@web/routers/loaders";
 
 const devOnlyRoutes: RouteObject[] = IS_DEV
@@ -65,12 +67,21 @@ export const routeObjects: RouteObject[] = [
       },
       {
         path: ROOT_ROUTES.WEEK,
-        lazy: async () =>
-          import(
-            /* webpackChunkName: "week" */ "@web/views/Week/WeekView"
-          ).then((module) => ({
-            Component: module.WeekView,
-          })),
+        children: [
+          {
+            path: ROOT_ROUTES.WEEK_DATE,
+            id: ROOT_ROUTES.WEEK_DATE,
+            loader: loadSpecificWeekData,
+            lazy: async () =>
+              import(
+                /* webpackChunkName: "week" */ "@web/views/Week/WeekView"
+              ).then((module) => ({ Component: module.WeekView })),
+          },
+          {
+            index: true,
+            loader: loadWeekData,
+          },
+        ],
       },
       {
         path: ROOT_ROUTES.ROOT,

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
@@ -194,4 +194,19 @@ describe("useGlobalShortcuts", () => {
       unmount();
     });
   });
+
+  it("does not navigate when pressing W while already on a dated week route", () => {
+    mockPathname.value = "/week/2026-05-20";
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    act(() => {
+      pressKey("w");
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
+  });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
@@ -55,7 +55,7 @@ export function useGlobalShortcuts() {
   });
 
   useAppHotkeyUp(weekHotkey, () => {
-    if (location.pathname !== VIEW_SHORTCUTS.week.route) {
+    if (!location.pathname.startsWith(VIEW_SHORTCUTS.week.route)) {
       navigate(VIEW_SHORTCUTS.week.route);
     }
   });

--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -1,0 +1,130 @@
+import { act } from "react";
+import dayjs from "@core/util/date/dayjs";
+import { renderHook } from "@web/__tests__/__mocks__/mock.render";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const DATE_FORMAT = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+const mockNavigate = mock();
+const mockParams: { dateString?: string } = {};
+
+// react-router-dom's useNavigate/useParams are mocked directly (rather than
+// relying on a real MemoryRouter) because Bun's `mock.module` is process-wide:
+// another test file mocking "react-router-dom" can otherwise silently replace
+// these hooks for every file that runs afterward in the same test run. See
+// useGlobalShortcuts.test.tsx for the same pattern.
+const actualReactRouterDom = await import("react-router-dom");
+
+mock.module("react-router-dom", () => ({
+  ...actualReactRouterDom,
+  useNavigate: () => mockNavigate,
+  useParams: () => mockParams,
+}));
+
+const { useWeek } = await import("./useWeek");
+
+describe("useWeek", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockParams.dateString = undefined;
+  });
+
+  it("derives the anchor and week days from the URL date, not today", () => {
+    mockParams.dateString = "2026-05-20";
+    const today = dayjs("2026-07-07", DATE_FORMAT);
+
+    const { result } = renderHook(() => useWeek(today));
+
+    expect(result.current.component.startOfView.format(DATE_FORMAT)).toBe(
+      dayjs("2026-05-20", DATE_FORMAT).startOf("week").format(DATE_FORMAT),
+    );
+    expect(result.current.component.isCurrentWeek).toBe(false);
+    expect(
+      result.current.component.weekDays.map((d) => d.format(DATE_FORMAT)),
+    ).not.toContain(today.format(DATE_FORMAT));
+  });
+
+  it("falls back to today when no dateString param is present", () => {
+    const today = dayjs("2026-07-07", DATE_FORMAT);
+
+    const { result } = renderHook(() => useWeek(today));
+
+    expect(result.current.component.isCurrentWeek).toBe(true);
+  });
+
+  it("navigates to the incremented week on incrementWeek", () => {
+    mockParams.dateString = "2026-05-20";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { result } = renderHook(() => useWeek(today));
+
+    act(() => {
+      result.current.util.incrementWeek();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/week/2026-05-27");
+  });
+
+  it("navigates to the decremented week on decrementWeek", () => {
+    mockParams.dateString = "2026-05-20";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { result } = renderHook(() => useWeek(today));
+
+    act(() => {
+      result.current.util.decrementWeek();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/week/2026-05-13");
+  });
+
+  it("navigates to the given date on goToDate", () => {
+    mockParams.dateString = "2026-05-20";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { result } = renderHook(() => useWeek(today));
+
+    act(() => {
+      result.current.state.goToDate(dayjs("2026-08-01", DATE_FORMAT));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/week/2026-08-01");
+  });
+
+  it("navigates to today on goToToday", () => {
+    mockParams.dateString = "2026-01-01";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { result } = renderHook(() => useWeek(today));
+
+    act(() => {
+      result.current.util.goToToday();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/week/2026-05-20");
+  });
+
+  it("does not navigate on goToToday when already viewing today's week", () => {
+    mockParams.dateString = "2026-05-20";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { result } = renderHook(() => useWeek(today));
+
+    act(() => {
+      result.current.util.goToToday();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("pages within a narrower visible window before crossing the week edge", () => {
+    // 2026-05-20 (Wed) sits at window offset 2 in a 3-day window (Tue/Wed/Thu
+    // of the Sun-start week). Paging forward by 3 days lands inside the same
+    // week (offset clamps to maxOffset 4) rather than crossing into the next
+    // one — that edge-crossing behavior is covered by the full-week test above.
+    mockParams.dateString = "2026-05-20";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { result } = renderHook(() => useWeek(today, 3));
+
+    act(() => {
+      result.current.util.incrementWeek();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/week/2026-05-22");
+  });
+});

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -1,5 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { type Dayjs } from "@core/util/date/dayjs";
+import { useEffect, useMemo, useRef } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjacentEvents";
@@ -15,14 +17,28 @@ import { type Category_View } from "@web/views/Week/week-view.types";
 
 export type WeekNavigationSource = "manual" | "drag-to-edge";
 
+const DATE_FORMAT = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
 export const useWeek = (
   today: Dayjs,
   visibleDayCount: number = WEEK_DAY_COUNT,
 ) => {
   // The anchor is the day the visible window centers on. The week range and
   // the window offset both derive from it, so a day-count change re-windows
-  // around the anchor without extra state.
-  const [anchor, setAnchor] = useState(today);
+  // around the anchor without extra state. The anchor itself lives in the
+  // URL (rather than useState) so a refresh restores the same week; it is
+  // memoized on the date *string* because `today` is a fresh Dayjs every
+  // render, and memoizing on the Dayjs instance would re-derive start/end
+  // (and re-fire the updateDates effect below) on every render.
+  const navigate = useNavigate();
+  const { dateString } = useParams();
+  const anchorDateString = dateString ?? today.format(DATE_FORMAT);
+  const anchor = useMemo(
+    () => dayjs(anchorDateString, DATE_FORMAT),
+    [anchorDateString],
+  );
+  const setAnchor = (date: Dayjs) =>
+    navigate(`${ROOT_ROUTES.WEEK}/${date.format(DATE_FORMAT)}`);
   const navigationSourceRef = useRef<WeekNavigationSource>("manual");
 
   const start = useMemo(() => anchor.startOf("week"), [anchor]);


### PR DESCRIPTION
## Summary
- Refreshing the week view used to reset to the current week because the anchor lived in `useState`. This mirrors the day view's `/day/:dateString` pattern: the week anchor now lives in the URL (`/week/:dateString`), so a refresh restores the exact week (and, on narrow viewports, the exact visible day window).
- Bare `/week` redirects to today's dated route; an invalid `:dateString` redirects back to bare `/week`; navigating `/week/A` → `/week/B` stays on the same route so scroll position, drag state, etc. survive (no remount).
- Fixed a related bug: the `W` shortcut guard compared `location.pathname` for exact equality against `/week`, so pressing `W` while already on a dated week route (`/week/2026-05-20`) would navigate back to bare `/week` and silently reset the just-persisted week. Now uses `startsWith`, matching the existing day-view guard.

## Manual Testing Steps
- [ ] Go to `/week` — URL becomes `/week/<today's date>` and the current week renders.
- [ ] Click "Previous week" a couple of times to move to a past week, then reload the page (full navigation, not client-side) — the URL and the exact same week (day labels) are restored instead of resetting to today.
- [ ] Click the "go to today" control — URL becomes `/week/<today's date>` again.
- [ ] While on a dated week route (e.g. `/week/2026-07-07`), press `W` — nothing happens (URL and view stay put).
- [ ] Press `D` then `W` — still switches Day ↔ Week view correctly.
- [ ] Visit `/week/not-a-date` — redirects to `/week/<today's date>`.
- [ ] Narrow the browser window so fewer than 7 day columns show, page forward/back, then reload — the same visible days come back (resizing alone never changes the URL; paging does).

## Test plan
- [x] `bun run test:web` — 1118 pass, 0 fail
- [x] `bun run type-check` — clean (core, web app, web tests)
- [x] `bun run lint` — clean on all touched files (16 pre-existing warnings elsewhere, unrelated to this change)
- [x] Manual verification in real Chrome (claude-in-chrome) against a local dev server: bare `/week` redirect, prev/next navigation updating the URL, full-page reload preserving the exact week, "go to today", the `W` guard fix, `D`/`W` view switching, and the invalid-date redirect — all confirmed with no console or network errors.