### PR TITLE
fix(web): open sidebar for command palette event creation, add shortcuts + keycaps

### DIFF
--- a/e2e/auth/logout-confirmation.spec.ts
+++ b/e2e/auth/logout-confirmation.spec.ts
@@ -34,9 +34,9 @@ const markPageAuthenticated = async (page: Page) => {
 
 const waitForLogoutCommand = async (page: Page) => {
   await page.getByRole("button", { name: "Open command palette" }).click();
-  await expect(page.getByText("Log Out [z]")).toBeVisible();
+  await expect(page.getByText("Log Out")).toBeVisible();
   await page.keyboard.press("Escape");
-  await expect(page.getByText("Log Out [z]")).toHaveCount(0);
+  await expect(page.getByText("Log Out")).toHaveCount(0);
 };
 
 const pressLogoutShortcut = async (page: Page) => {

--- a/packages/web/src/common/constants/navigation.cmd.constants.test.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.test.ts
@@ -11,27 +11,31 @@ describe("getNavigationCommandItems", () => {
       currentView,
       onGoToToday: () => {},
       onNavigateToView: () => {},
+      onShowShortcuts: () => {},
       today,
     }).map((item) => item.label);
   }
 
-  it("returns the other views and today for the week palette", () => {
+  it("returns the other views, today, and shortcuts for the week palette", () => {
     expect(getItemLabels("week")).toEqual([
-      "Go to Day [d]",
-      "Go to Today (Thursday, May 28) [t]",
+      "Go to Day",
+      "Go to Today (Thursday, May 28)",
+      "Show Shortcuts",
     ]);
   });
 
-  it("returns the other views and today for the day palette", () => {
+  it("returns the other views, today, and shortcuts for the day palette", () => {
     expect(getItemLabels("day")).toEqual([
-      "Go to Week [w]",
-      "Go to Today (Thursday, May 28) [t]",
+      "Go to Week",
+      "Go to Today (Thursday, May 28)",
+      "Show Shortcuts",
     ]);
   });
 
   it("runs the matching navigation callbacks", () => {
     const navigatedViews: ViewName[] = [];
     let didGoToToday = false;
+    let didShowShortcuts = false;
     const items = getNavigationCommandItems({
       currentView: "day",
       onGoToToday: () => {
@@ -40,13 +44,18 @@ describe("getNavigationCommandItems", () => {
       onNavigateToView: (viewName) => {
         navigatedViews.push(viewName);
       },
+      onShowShortcuts: () => {
+        didShowShortcuts = true;
+      },
       today,
     });
 
     items.find((item) => item.id === "go-to-week")?.onClick?.({} as never);
     items.find((item) => item.id === "today")?.onClick?.({} as never);
+    items.find((item) => item.id === "show-shortcuts")?.onClick?.({} as never);
 
     expect(navigatedViews).toEqual(["week"]);
     expect(didGoToToday).toBe(true);
+    expect(didShowShortcuts).toBe(true);
   });
 });

--- a/packages/web/src/common/constants/navigation.cmd.constants.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.ts
@@ -3,6 +3,7 @@ import {
   CalendarDotsIcon,
   CalendarIcon,
   type Icon,
+  KeyboardIcon,
 } from "@phosphor-icons/react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import {
@@ -15,6 +16,7 @@ interface GetNavigationCommandItemsArgs {
   currentView: ViewName;
   onGoToToday: () => void;
   onNavigateToView: (viewName: ViewName) => void;
+  onShowShortcuts: () => void;
   today: Dayjs;
 }
 
@@ -29,20 +31,30 @@ export const getNavigationCommandItems = ({
   currentView,
   onGoToToday,
   onNavigateToView,
+  onShowShortcuts,
   today,
 }: GetNavigationCommandItemsArgs): CommandItem[] => [
   ...navigationViewOrder
     .filter((viewName) => viewName !== currentView)
     .map((viewName) => ({
       id: `go-to-${viewName}`,
-      label: `Go to ${VIEW_SHORTCUTS[viewName].label} [${VIEW_SHORTCUTS[viewName].key}]`,
+      label: `Go to ${VIEW_SHORTCUTS[viewName].label}`,
       icon: viewIcons[viewName],
+      shortcut: VIEW_SHORTCUTS[viewName].key,
       onClick: () => onNavigateToView(viewName),
     })),
   {
     id: "today",
-    label: `Go to Today (${today.format("dddd, MMMM D")}) [t]`,
+    label: `Go to Today (${today.format("dddd, MMMM D")})`,
     icon: ArrowUDownLeftIcon,
+    shortcut: "t",
     onClick: onGoToToday,
+  },
+  {
+    id: "show-shortcuts",
+    label: "Show Shortcuts",
+    icon: KeyboardIcon,
+    shortcut: "?",
+    onClick: onShowShortcuts,
   },
 ];

--- a/packages/web/src/common/hooks/useLogoutCmdItems.ts
+++ b/packages/web/src/common/hooks/useLogoutCmdItems.ts
@@ -14,8 +14,9 @@ export const useLogoutCmdItems = (): CommandItem[] => {
   return [
     {
       id: "log-out",
-      label: "Log Out [z]",
+      label: "Log Out",
       icon: SignOutIcon,
+      shortcut: "z",
       onClick: openLogoutConfirmation,
     },
   ];

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -207,8 +207,11 @@ describe("CommandPalette", () => {
   it("renders a keycap chip for the shortcut and runs onShowShortcuts on click", () => {
     renderPalette();
 
+    // `[aria-hidden='true']` (not `.c-keycap`) because SelectView.test.tsx
+    // mocks ShortcutHint process-wide (bun's mock.module leaks across
+    // files); its stub keeps aria-hidden but drops the real class.
     const row = screen.getByText("Show Shortcuts").closest("button");
-    expect(row?.querySelector(".c-keycap")?.textContent).toBe("?");
+    expect(row?.querySelector("[aria-hidden='true']")?.textContent).toBe("?");
 
     fireEvent.click(row as HTMLButtonElement);
     expect(onShowShortcuts).toHaveBeenCalledTimes(1);

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -39,6 +39,7 @@ mock.module("@web/common/hooks/useGoogleCmdItems", () => ({
 const { CommandPalette, filterSections } = await import("./CommandPalette");
 
 const onGoToToday = mock();
+const onShowShortcuts = mock();
 const taskAlphaClick = mock();
 const taskDisabledClick = mock();
 
@@ -65,6 +66,7 @@ const renderPalette = () =>
       currentView="week"
       today={dayjs("2026-07-07")}
       onGoToToday={onGoToToday}
+      onShowShortcuts={onShowShortcuts}
       commonTasks={buildTasks()}
       placeholder="Try: 'create', 'bug', or 'code'"
     />,
@@ -76,9 +78,11 @@ const getInput = () =>
 
 // The active row is the one the component paints with the active token; this
 // is driven by our own activeIndex, which is exactly what we want to assert.
+// Scoped to the label span (not the row's full textContent) so it isn't
+// polluted by the row's keycap chip text (e.g. "Go to DayD").
 const activeRowText = (container: HTMLElement) =>
-  container.ownerDocument.querySelector(".bg-panel-badge-bg")?.textContent ??
-  null;
+  container.ownerDocument.querySelector(".bg-panel-badge-bg > span")
+    ?.textContent ?? null;
 
 const isOpen = () => selectIsCmdPaletteOpen(useSettingsStore.getState());
 
@@ -86,6 +90,7 @@ describe("CommandPalette", () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     onGoToToday.mockClear();
+    onShowShortcuts.mockClear();
     taskAlphaClick.mockClear();
     taskDisabledClick.mockClear();
   });
@@ -99,7 +104,7 @@ describe("CommandPalette", () => {
     expect(screen.getByText("More")).toBeInTheDocument();
 
     // Week view hides its own nav item and surfaces the Day + Today entries.
-    expect(screen.getByText("Go to Day [d]")).toBeInTheDocument();
+    expect(screen.getByText("Go to Day")).toBeInTheDocument();
     expect(screen.getByText(/Go to Today/)).toBeInTheDocument();
     expect(screen.getByText("Task Alpha")).toBeInTheDocument();
     // Settings surfaces the (stubbed) Google item.
@@ -108,7 +113,7 @@ describe("CommandPalette", () => {
 
     expect(getInput()).toHaveFocus();
     // First option is active by default.
-    expect(activeRowText(container)).toBe("Go to Day [d]");
+    expect(activeRowText(container)).toBe("Go to Day");
   });
 
   it("filters case-insensitively, dropping empty sections, and shows a no-results row", () => {
@@ -135,15 +140,16 @@ describe("CommandPalette", () => {
     expect(screen.getByText("Task Disabled").closest("button")).toBeDisabled();
 
     // First option active by default; ArrowUp wraps to the last (Version) row.
-    expect(activeRowText(container)).toBe("Go to Day [d]");
+    expect(activeRowText(container)).toBe("Go to Day");
     fireEvent.keyDown(input, { key: "ArrowUp" });
     expect(activeRowText(container)).toMatch(/Version/);
     // ArrowDown from the last option wraps back to the first.
     fireEvent.keyDown(input, { key: "ArrowDown" });
-    expect(activeRowText(container)).toBe("Go to Day [d]");
+    expect(activeRowText(container)).toBe("Go to Day");
 
     // Walk down to Task Alpha, then the next ArrowDown skips the disabled row.
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Today
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // Show Shortcuts
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Task Alpha
     expect(activeRowText(container)).toBe("Task Alpha");
     fireEvent.keyDown(input, { key: "ArrowDown" }); // skips Task Disabled
@@ -170,7 +176,7 @@ describe("CommandPalette", () => {
     expect(activeRowText(container)).toMatch(/Go to Today/);
 
     fireEvent.change(input, { target: { value: "go" } });
-    expect(activeRowText(container)).toBe("Go to Day [d]");
+    expect(activeRowText(container)).toBe("Go to Day");
   });
 
   it("closes on Escape", () => {
@@ -196,6 +202,17 @@ describe("CommandPalette", () => {
     );
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders a keycap chip for the shortcut and runs onShowShortcuts on click", () => {
+    renderPalette();
+
+    const row = screen.getByText("Show Shortcuts").closest("button");
+    expect(row?.querySelector(".c-keycap")?.textContent).toBe("?");
+
+    fireEvent.click(row as HTMLButtonElement);
+    expect(onShowShortcuts).toHaveBeenCalledTimes(1);
+    expect(isOpen()).toBe(false);
   });
 });
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -21,6 +21,7 @@ import { useAuthCmdItems } from "@web/common/hooks/useAuthCmdItems";
 import { useGoogleCmdItems } from "@web/common/hooks/useGoogleCmdItems";
 import { useLogoutCmdItems } from "@web/common/hooks/useLogoutCmdItems";
 import { useSubscribeCmdItems } from "@web/common/hooks/useSubscribeCmdItems";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   selectIsCmdPaletteOpen,
   settingsActions,
@@ -32,6 +33,7 @@ interface CommandPaletteProps {
   currentView: ViewName;
   today: Dayjs;
   onGoToToday: () => void;
+  onShowShortcuts: () => void;
   commonTasks: CommandItem[];
   placeholder: string;
 }
@@ -62,6 +64,7 @@ export const CommandPalette = ({
   currentView,
   today,
   onGoToToday,
+  onShowShortcuts,
   commonTasks,
   placeholder,
 }: CommandPaletteProps) => {
@@ -101,6 +104,7 @@ export const CommandPalette = ({
         onGoToToday,
         onNavigateToView: (viewName) =>
           navigate({ to: VIEW_SHORTCUTS[viewName].route }),
+        onShowShortcuts,
         today,
       }),
     },
@@ -215,7 +219,15 @@ export const CommandPalette = ({
                     const content = (
                       <>
                         <item.icon size={18} />
-                        <span>{item.label}</span>
+                        <span className="min-w-0 flex-1 truncate">
+                          {item.label}
+                        </span>
+                        {item.shortcut && (
+                          <ShortcutKeys
+                            className="ml-auto shrink-0"
+                            keys={item.shortcut}
+                          />
+                        )}
                       </>
                     );
 

--- a/packages/web/src/components/CommandPalette/command-palette.types.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.types.ts
@@ -14,6 +14,8 @@ export interface CommandItem {
   href?: string;
   target?: "_blank";
   disabled?: boolean;
+  /** A single key (`"?"`) or one key per combo entry (`["Shift", "W"]`), rendered as keycap chips. */
+  shortcut?: string | string[];
 }
 
 export interface CommandSection {

--- a/packages/web/src/views/Day/getDayCmdTasks.ts
+++ b/packages/web/src/views/Day/getDayCmdTasks.ts
@@ -23,8 +23,9 @@ export const getDayCmdTasks = (): CommandItem[] => [
   },
   {
     id: "create-allday-event",
-    label: "Create all-day event [a]",
+    label: "Create all-day event",
     icon: PlusIcon,
+    shortcut: "a",
     onClick: () =>
       queueMicrotask(() =>
         compassEventEmitter.emit(CompassDOMEvents.CREATE_ALLDAY_DRAFT),
@@ -32,8 +33,9 @@ export const getDayCmdTasks = (): CommandItem[] => [
   },
   {
     id: "edit-event",
-    label: "Edit event [m]",
+    label: "Edit event",
     icon: NotePencilIcon,
+    shortcut: "m",
     onClick: () => queueMicrotask(openEventFormEditEvent),
   },
 ];

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -194,6 +194,7 @@ export const DayViewContent = memo(() => {
         currentView="day"
         today={dayjs()}
         onGoToToday={handleGoToToday}
+        onShowShortcuts={toggleShortcuts}
         commonTasks={getDayCmdTasks()}
         placeholder="Try: 'week', 'today', 'bug', or 'code'"
       />

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -116,6 +116,7 @@ export const WeekView = () => {
         currentView="week"
         today={today}
         onGoToToday={goToTodayViaCmd}
+        onShowShortcuts={toggleShortcuts}
         commonTasks={weekCmdTasks}
         placeholder="Try: 'create', 'bug', or 'code'"
       />

--- a/packages/web/src/views/Week/hooks/useWeekCmdTasks.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeekCmdTasks.test.tsx
@@ -1,6 +1,5 @@
 import { act } from "@testing-library/react";
 import { type SyntheticEvent } from "react";
-import { Categories_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { renderHookWithStore } from "@web/__tests__/render-with-store";
 import {
@@ -77,8 +76,8 @@ const getItem = (items: ReturnType<typeof useWeekCmdTasks>, id: string) => {
 
 describe("useWeekCmdTasks", () => {
   it.each([
-    ["create-someday-week-event", Categories_Event.SOMEDAY_WEEK],
-    ["create-someday-month-event", Categories_Event.SOMEDAY_MONTH],
+    "create-someday-week-event",
+    "create-someday-month-event",
   ])("opens the sidebar when creating a %s while it's closed", async (id) => {
     viewActions.setSidebarOpen(false);
     const { result } = renderWeekCmdTasks();

--- a/packages/web/src/views/Week/hooks/useWeekCmdTasks.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeekCmdTasks.test.tsx
@@ -1,0 +1,101 @@
+import { act } from "@testing-library/react";
+import { type SyntheticEvent } from "react";
+import { Categories_Event } from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
+import { renderHookWithStore } from "@web/__tests__/render-with-store";
+import {
+  initialViewState,
+  selectIsSidebarOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("@web/auth/compass/session/session.util", () => ({
+  getUserId: mock().mockResolvedValue("mock-user"),
+}));
+
+const { useWeekCmdTasks } =
+  require("./useWeekCmdTasks") as typeof import("./useWeekCmdTasks");
+
+// `onEventTargetVisibility` (wrapping every command's onClick) defers its
+// callback until the row's IntersectionObserver reports non-intersecting.
+// The global test env's mock observer never fires that callback, so each
+// test captures it here and flushes it manually, mirroring
+// event-target-visibility.util.test.ts.
+let observerCallback:
+  | ((entries: Array<{ isIntersecting: boolean }>) => void)
+  | undefined;
+const mockObserve = mock();
+const mockDisconnect = mock();
+
+const fireClick = async (
+  onClick: ((event: SyntheticEvent<HTMLElement>) => void) | undefined,
+) => {
+  await act(async () => {
+    onClick?.({
+      currentTarget: document.createElement("button"),
+    } as unknown as SyntheticEvent<HTMLElement>);
+    observerCallback?.([{ isIntersecting: false }]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+};
+
+beforeEach(() => {
+  observerCallback = undefined;
+  mockObserve.mockClear();
+  mockDisconnect.mockClear();
+  global.IntersectionObserver = mock((callback) => {
+    observerCallback = callback;
+    return {
+      disconnect: mockDisconnect,
+      observe: mockObserve,
+      takeRecords: mock(),
+      unobserve: mock(),
+    };
+  }) as unknown as typeof IntersectionObserver;
+});
+
+afterEach(() => {
+  useViewStore.setState(initialViewState);
+});
+
+const renderWeekCmdTasks = () => {
+  const startOfView = dayjs("2026-07-05"); // Sunday
+  const endOfView = startOfView.add(6, "days");
+
+  return renderHookWithStore(() =>
+    useWeekCmdTasks({ endOfView, isCurrentWeek: true, startOfView }),
+  );
+};
+
+const getItem = (items: ReturnType<typeof useWeekCmdTasks>, id: string) => {
+  const item = items.find((candidate) => candidate.id === id);
+  if (!item) throw new Error(`Missing command item: ${id}`);
+  return item;
+};
+
+describe("useWeekCmdTasks", () => {
+  it.each([
+    ["create-someday-week-event", Categories_Event.SOMEDAY_WEEK],
+    ["create-someday-month-event", Categories_Event.SOMEDAY_MONTH],
+  ])("opens the sidebar when creating a %s while it's closed", async (id) => {
+    viewActions.setSidebarOpen(false);
+    const { result } = renderWeekCmdTasks();
+
+    await fireClick(getItem(result.current, id).onClick);
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+  });
+
+  it("leaves the sidebar open (does not re-toggle) when already open", async () => {
+    viewActions.setSidebarOpen(true);
+    const { result } = renderWeekCmdTasks();
+
+    await fireClick(
+      getItem(result.current, "create-someday-week-event").onClick,
+    );
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+  });
+});

--- a/packages/web/src/views/Week/hooks/useWeekCmdTasks.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeekCmdTasks.test.tsx
@@ -1,5 +1,5 @@
 import { act } from "@testing-library/react";
-import { type SyntheticEvent } from "react";
+import { type MouseEvent } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { renderHookWithStore } from "@web/__tests__/render-with-store";
 import {
@@ -29,12 +29,12 @@ const mockObserve = mock();
 const mockDisconnect = mock();
 
 const fireClick = async (
-  onClick: ((event: SyntheticEvent<HTMLElement>) => void) | undefined,
+  onClick: ((event: MouseEvent<HTMLElement>) => void) | undefined,
 ) => {
   await act(async () => {
     onClick?.({
       currentTarget: document.createElement("button"),
-    } as unknown as SyntheticEvent<HTMLElement>);
+    } as unknown as MouseEvent<HTMLElement>);
     observerCallback?.([{ isIntersecting: false }]);
     await new Promise((resolve) => setTimeout(resolve, 0));
   });

--- a/packages/web/src/views/Week/hooks/useWeekCmdTasks.ts
+++ b/packages/web/src/views/Week/hooks/useWeekCmdTasks.ts
@@ -13,6 +13,11 @@ import {
 import { createSomedayDraft } from "@web/common/utils/draft/someday.draft.util";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 import { useSomedayEventViewModel } from "@web/events/queries/useSomedayEventsQuery";
+import {
+  selectIsSidebarOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
 
 interface UseWeekCmdTasksArgs {
   isCurrentWeek: boolean;
@@ -35,6 +40,7 @@ export const useWeekCmdTasks = ({
     startOfView,
     endOfView,
   );
+  const isSidebarOpen = useViewStore(selectIsSidebarOpen);
 
   const handleCreateSomedayDraft = async (
     category: Categories_Event.SOMEDAY_WEEK | Categories_Event.SOMEDAY_MONTH,
@@ -54,37 +60,45 @@ export const useWeekCmdTasks = ({
       endOfView,
       "createShortcut",
     );
+
+    if (!isSidebarOpen) {
+      viewActions.toggleSidebar();
+    }
   };
 
   return [
     {
       id: "create-event",
-      label: "Create Event [c]",
+      label: "Create Event",
       icon: PlusIcon,
+      shortcut: "c",
       onClick: onEventTargetVisibility(() => {
         void createTimedDraft(isCurrentWeek, startOfView, "createShortcut");
       }),
     },
     {
       id: "create-allday-event",
-      label: "Create All-Day Event [a]",
+      label: "Create All-Day Event",
       icon: PlusIcon,
+      shortcut: "a",
       onClick: onEventTargetVisibility(() => {
         void createAlldayDraft(startOfView, endOfView, "createShortcut");
       }),
     },
     {
       id: "create-someday-week-event",
-      label: "Create Week Event [Shift+W]",
+      label: "Create Week Event",
       icon: PlusIcon,
+      shortcut: ["Shift", "W"],
       onClick: onEventTargetVisibility(() => {
         void handleCreateSomedayDraft(Categories_Event.SOMEDAY_WEEK);
       }),
     },
     {
       id: "create-someday-month-event",
-      label: "Create Month Event [Shift+M]",
+      label: "Create Month Event",
       icon: PlusIcon,
+      shortcut: ["Shift", "M"],
       onClick: onEventTargetVisibility(() => {
         void handleCreateSomedayDraft(Categories_Event.SOMEDAY_MONTH);
       }),


### PR DESCRIPTION
## Summary
- Fixes a bug where selecting "Create Month Event" / "Create Week Event" from the command palette while the sidebar was closed set draft state but never opened the sidebar, so the someday event form never actually rendered (`CollapsiblePanel` unmounts its children when closed).
- Adds a "Show Shortcuts" ('?') entry to the command palette (Week and Day views), reusing the existing sidebar-opening `toggleShortcuts` handler.
- Restyles command palette rows: shortcut hints move from bracketed label text (`"Go to Day [d]"`) into a new `CommandItem.shortcut` field, rendered as keycap chips via the existing `ShortcutKeys` component — matching the styling already used in the shortcuts sidebar.

## Test plan
- [x] `bun test --cwd packages/web src/components/CommandPalette/CommandPalette.test.tsx src/views/Week/hooks/useWeekCmdTasks.test.tsx` — 16/16 pass
- [x] `bun run lint` — clean (no new errors)
- [x] Manually verified in browser preview: closed the sidebar, ran "Create Week Event" / "Create Month Event" from `Mod+K` — sidebar reopened with the event form rendered in both cases
- [x] Manually verified "Show Shortcuts" opens the sidebar directly into the shortcuts overlay when closed, in both Week and Day views
- [x] Visually confirmed keycap chips render for all shortcut-bearing rows in both views, and rows without a shortcut (e.g. Day's "Create event") render no chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)