### PR TITLE
refactor(web): clean up post-migration comment/copy debt and dead code

### DIFF
--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -40,8 +40,7 @@ interface CommandPaletteProps {
 
 /**
  * Case-insensitive substring filter on each item's label. Sections with no
- * surviving items are dropped so their heading disappears too. Behaviour
- * matches react-cmdk's `filterItems` on the old `children` field.
+ * surviving items are dropped so their heading disappears too.
  */
 export function filterSections(
   sections: CommandSection[],
@@ -158,7 +157,7 @@ export const CommandPalette = ({
       >
         {/* No FloatingFocusManager: virtual list navigation keeps real focus in
             the search input, so a focus trap would only fight it. We focus the
-            input on open via the effect above. */}
+            input on open via the focusInputOnMount callback ref above. */}
         <div
           ref={refs.setFloating}
           className="mt-[15vh] h-fit w-[640px] max-w-[90vw] overflow-hidden rounded-xl border border-border-primary bg-bg-secondary shadow-[0_16px_48px_var(--color-shadow-default)]"

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -86,9 +86,6 @@ export const DayViewContent = memo(() => {
   const toggleSidebar = useCallback(() => {
     viewActions.toggleSidebar();
   }, []);
-  const toggleTaskList = useCallback(() => {
-    viewActions.toggleTaskList();
-  }, []);
   // Task-focused shortcuts imply the user wants the list visible; reopen it
   // first and defer focus a frame so the list exists in the DOM.
   const withTaskListOpen = useCallback((focusTask: () => void) => {
@@ -196,7 +193,7 @@ export const DayViewContent = memo(() => {
         onGoToToday={handleGoToToday}
         onShowShortcuts={toggleShortcuts}
         commonTasks={getDayCmdTasks()}
-        placeholder="Try: 'week', 'today', 'bug', or 'code'"
+        placeholder="Try: 'week', 'today', 'bug', or 'feedback'"
       />
       <Dedication />
 

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -118,7 +118,7 @@ export const WeekView = () => {
         onGoToToday={goToTodayViaCmd}
         onShowShortcuts={toggleShortcuts}
         commonTasks={weekCmdTasks}
-        placeholder="Try: 'create', 'bug', or 'code'"
+        placeholder="Try: 'create', 'bug', or 'feedback'"
       />
       <Dedication />
 


### PR DESCRIPTION
## What

A small cleanup pass over the changes that merged today, focused on comment/copy debt and dead code left by the two big refactors (react-router-dom → TanStack Router in #1952, react-cmdk → native `CommandPalette` in #1953).

- **CommandPalette comments** — removed the now-meaningless `filterSections` note that said its behaviour "matches react-cmdk's `filterItems`" (react-cmdk no longer exists in the tree to compare against), and corrected the focus comment that referred to a callback ref as "the effect above" (there is no effect; it's the `focusInputOnMount` callback ref).
- **Dead code** — removed the unused `toggleTaskList` `useCallback` in `DayViewContent` (orphaned since #1935; Biome flags it as `noUnusedVariables`, a non-blocking warning so it slipped through CI). The underlying `viewActions.toggleTaskList` store action is left in place — it's still part of the view-store API and exercised by a test.
- **Misleading palette hint** — the command palette placeholder suggested searching `'code'`, but no command label contains "code", so that hint returned "No results". Swapped `'code'` → `'feedback'` (matches "Share Feedback") in both the day and week placeholders. This copy predated today but is genuinely broken UX.

## Why not bigger

Today's PRs were unusually clean (ship/simplify workflow), so there was little to remove — no leftover `react-cmdk`/`react-router-dom` imports, no orphaned files, no debug leftovers. This PR is deliberately small and low-risk.

## Testing

- `bun run type-check` — passes
- `bun test --cwd packages/web` for CommandPalette + Day view/Tasks — 27 pass, 0 fail
- `bunx biome check` on touched files — clean (dead-code warning resolved)
- Manual: no behavioral change beyond the two placeholder strings; the removed callback was never wired to any handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)