### PR TITLE
docs: capture debugging gotchas, add ship correctness-review gate

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Ship the current branch end-to-end - validate the change in a local Chrome preview, commit it, run the simplify skill for a distinct follow-up commit, open a non-draft PR with a lower-case conventional-commit title, watch CI and push fixes for any failures, squash-merge once green, then watch the post-merge GitHub Actions on main (release tag, docker publish, staging deploy, health check). Use this whenever the user says "ship this", "ship it", "ship the branch", or asks to take the current work from local changes all the way to a merged, deployed PR instead of doing each step manually.
+description: Ship the current branch end-to-end - validate the change in a local Chrome preview, run a correctness-focused code review and fix what it confirms, commit it, run the simplify skill for a distinct follow-up commit, open a non-draft PR with a lower-case conventional-commit title, watch CI and push fixes for any failures, squash-merge once green, then watch the post-merge GitHub Actions on main (release tag, docker publish, staging deploy, health check). Use this whenever the user says "ship this", "ship it", "ship the branch", or asks to take the current work from local changes all the way to a merged, deployed PR instead of doing each step manually.
 ---
 
 # Ship
@@ -15,7 +15,7 @@ steps with one supervised run, not to rubber-stamp a merge.
 - Confirm the current branch is not `main`. If it is, stop and tell
   the user — there's nothing to ship from main itself.
 - `git status` / `git diff` to see what's actually changed. If there are
-  uncommitted changes, they need a commit before anything else (see step 2
+  uncommitted changes, they need a commit before anything else (see step 3
   for message format).
 - If the diff touches `packages/core`, remember per this repo's CLAUDE.md
   that core/schema changes usually need coverage across core, web, backend,
@@ -54,7 +54,7 @@ real one.
    view you were on, what you clicked/typed, and what rendered or happened
    as a result. No internal function/variable/file names — describe it the
    way a user would see it. This log becomes the PR's Manual Testing Steps
-   section in step 4, so capture it while it's fresh instead of
+   section in step 5, so capture it while it's fresh instead of
    reconstructing it from memory afterward.
 7. Check `read_console_messages` and `read_network_requests` for errors the
    UI wouldn't otherwise surface.
@@ -68,7 +68,34 @@ real one.
    commands a reviewer can run themselves (e.g., a script invocation and
    its expected output) rather than clicks. Never skip the record itself.
 
-## 2. Commit the implementation
+## 2. Correctness review
+
+Browser validation catches behavior that's wrong when exercised; it won't
+catch a bug on a path you didn't happen to click, or a race/edge case that
+only shows up under different data. Run a review pass now, on the still-
+uncommitted diff, so a fix folds into the implementation commit in step 3
+instead of surfacing later as a CI failure, a review comment, or a follow-up
+PR — all slower to close than catching it here.
+
+1. Invoke the `code-review` skill at medium effort against the working-tree
+   diff (the default scope — do not widen it to the whole package). Medium
+   trades broader coverage for fewer, higher-confidence findings, which is
+   the right tradeoff for a routine ship; reserve `high`/`max`/`ultra` for
+   changes you already suspect are risky.
+2. This skill also flags reuse/simplification findings — leave those alone
+   here. Step 4 (`simplify`) owns quality/legibility; acting on them in both
+   places just produces duplicate work. Only correctness findings are this
+   step's job.
+3. For each correctness finding you're confident is real, fix it. If the fix
+   changes user-visible behavior, redo the relevant slice of step 1's Chrome
+   walkthrough rather than assuming the fix is safe.
+4. If a finding is plausible but you're not confident, surface it to the
+   user rather than guessing at a fix or silently dropping it.
+5. If nothing surfaced, say so plainly — "no correctness issues found" is a
+   valid, non-padded result, same as simplify's "nothing to change" case in
+   step 4.
+
+## 3. Commit the implementation
 
 Commit before running simplify, not after — simplify now creates its own
 follow-up commit (see `.claude/skills/simplify/SKILL.md`), and a follow-up
@@ -94,18 +121,19 @@ query`.
 `git add` the relevant files (never `-A`/`.` blindly — check what you're
 staging), commit with the message above.
 
-## 3. Simplify
+## 4. Simplify
 
 Run the `simplify` skill (`.claude/skills/simplify/SKILL.md`) scoped to the
 current diff so the code that ships is the clean version, not the
 first-draft one. It's quality-only — reuse, duplication, legibility — and
-won't second-guess the correctness you just validated in step 1.
+won't second-guess the correctness you already validated in step 1 and
+reviewed in step 2.
 
 1. Invoke `simplify` with its default scope (the current diff against the
    base branch). Don't widen the scope to the whole package.
 2. `simplify` runs its own focused verify commands and, if it changed
    anything, creates its own commit — you don't need to re-run tests or
-   commit again on top of it. Because step 2 already committed the
+   commit again on top of it. Because step 3 already committed the
    implementation, that lands as a distinct follow-up commit; don't fold it
    back into the implementation commit or ask simplify to skip committing.
 3. If a simplify change touches behavior a user could see (not a pure
@@ -113,15 +141,15 @@ won't second-guess the correctness you just validated in step 1.
    walkthrough rather than assuming the refactor is behavior-preserving.
 4. If simplify found nothing to change, there's no second commit — that's
    expected, not an error.
-5. Note the result for the PR body's `## Simplicity` section (step 4): did
+5. Note the result for the PR body's `## Simplicity` section (step 5): did
    `useEffect`/`useRef`/`useState` usage in the diff go down, stay flat, or
    go up, and if any remain, pull their one-line justifications straight
    from simplify's own commit body (per its Commit section) rather than
    re-deriving them.
 
-## 4. Push and open the PR
+## 5. Push and open the PR
 
-The PR title is the same string as the implementation commit from step 2 —
+The PR title is the same string as the implementation commit from step 3 —
 simplify's follow-up commit (if any) keeps its own message and doesn't
 change the PR title.
 
@@ -134,7 +162,7 @@ change the PR title.
    - `## Simplicity` — one short paragraph on whether this change net-reduced
      or net-increased complexity, and how. Always name any `useEffect`,
      `useRef`, or `useState` that's new or was kept in the diff, with the
-     one-line justification from step 3.5 — that's the part reviewers can't
+     one-line justification from step 4.5 — that's the part reviewers can't
      get from the diff alone (a hook's presence is visible; whether it was
      considered and rejected as unnecessary is not). If simplify found
      nothing to change and no hooks are in play, say so plainly — "no
@@ -157,7 +185,7 @@ change the PR title.
      automated counterpart to Manual Testing Steps, not a restatement of
      it — don't blur the two together.
 
-## 5. Watch CI, fix what breaks
+## 6. Watch CI, fix what breaks
 
 This repo's PR checks are: `type-check` and a `unit` matrix
 (core/web/backend/scripts) from the `Test` workflow, plus `e2e` (Playwright)
@@ -166,7 +194,7 @@ these names as the only source of truth, though — always read the live
 check list, since workflows can change.
 
 1. `gh pr checks <pr-number> --watch` blocks until every check finishes.
-2. If everything passes, move to step 6.
+2. If everything passes, move to step 7.
 3. If something fails, pull the failure detail rather than guessing:
    `gh run view <run-id> --log-failed`. Reproduce locally with the matching
    focused command from this repo's defaults (`bun run test:web`,
@@ -176,14 +204,14 @@ check list, since workflows can change.
 4. Fix the root cause, not the symptom. Commit the fix with its own
    lower-case conventional message (it'll be squashed into the final PR
    commit, so it doesn't need to match the PR title) and push.
-5. Go back to step 5.1 and watch again. Repeat until green.
+5. Go back to step 6.1 and watch again. Repeat until green.
 6. If a failure isn't something you can fix confidently (flaky
    infrastructure, an ambiguous product decision, a failure outside the
    diff's blast radius), stop and surface it to the user instead of forcing
    a fix. Guessing at a fix for something you don't understand just trades
    one CI failure for a worse one later.
 
-## 6. Merge
+## 7. Merge
 
 Only merge once CI is fully green and you're actually confident in the
 change — "confident" means you understand every fix you made along the way,
@@ -195,16 +223,16 @@ so the default squash subject already matches what you need:
 gh pr merge <pr-number> --squash --delete-branch
 ```
 
-If you're not confident — the fix in step 5 felt like a guess, or CI is
+If you're not confident — the fix in step 6 felt like a guess, or CI is
 green but something about the Chrome validation still nagged at you — say
 so and let the user decide whether to merge. This gate is about your own
 confidence in the change, not about whether a human has re-run the PR's
 `## Manual Testing Steps` checkboxes — those are for reviewers to use after
 merge review, not a pre-merge blocker for `ship` itself. A merge to `main`
-in this repo immediately kicks off a real deploy pipeline (see step 7), so
+in this repo immediately kicks off a real deploy pipeline (see step 8), so
 this is not a reversible-for-free action.
 
-## 7. Watch what happens after merge
+## 8. Watch what happens after merge
 
 Merging to `main` triggers `release-on-main.yml`: it tags a new patch
 release, publishes Docker images, deploys to staging, then runs a staging

--- a/docs/development/common-change-recipes.md
+++ b/docs/development/common-change-recipes.md
@@ -123,6 +123,35 @@ For web local-data migrations:
 2. Confirm startup behavior still works in the intended dev mode.
 3. Document any new required variables.
 
+## Type A Hook That Accepts A `queryOptions`-Builder Function
+
+Some web hooks take a TanStack Query `queryOptions(...)`-returning function as
+a parameter (for example `usePrefetchAdjacentEvents`, which takes either
+`weekEventsQueryOptions` or `dayEventsQueryOptions` in
+`packages/web/src/events/queries/usePrefetchAdjacentEvents.ts`) so the same
+hook works for either view. Two approaches that look reasonable both fail to
+type-check:
+
+1. A named function-type alias with a fixed return shape (e.g.
+   `(args) => FetchQueryOptions<never, Error, never>`) — `never`/`unknown`
+   erase the concrete `queryKey` tuple type each call site actually returns,
+   producing `'queryKey' requires 3 elements but source may have fewer`
+   errors.
+2. A union of the concrete function types
+   (`typeof weekEventsQueryOptions | typeof dayEventsQueryOptions`) — calling
+   a union of functions collapses the return type in a way that fails to
+   unify with the consumer's own generic inference for one of the two shapes.
+
+What works: make the *consuming hook itself* generic with the same type
+parameters `prefetchQuery`/`useQuery` use
+(`TQueryFnData, TError, TData, TQueryKey extends readonly unknown[]`), and
+type the parameter as
+`(args: EventsQueryArgs) => FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>`.
+Each call site then independently instantiates the generic via inference —
+no union collapsing, no erased tuple type. TanStack's generic surface is
+designed for per-call-site inference; piggyback on that instead of fighting
+it with a shared named type.
+
 ## Add A New CLI Command
 
 1. Register the command in `packages/scripts/src/cli.ts`.

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -29,7 +29,7 @@ Unit workflow (`test-unit.yml`):
 - runs a matrix across `core`, `web`, `backend`, and `scripts`
 - uses `fail-fast: false`, so one failing lane does not cancel the others
 - runs `bun run test:<project>` in each lane after dependency install
-- passes timezone through `TZ: ${{ vars.TZ }}`
+- runs every lane with `TZ: Etc/UTC` set
 
 Local parity commands:
 
@@ -123,6 +123,9 @@ Isolation rules:
 - If a test replaces globals (`fetch`, `document.getElementById`, storage, timers, console methods), restore the original value in teardown.
 - Prefer `renderWithStore`, `createStoreWrapper`, or a focused provider harness over mocking `@web/store` or `store.hooks`.
 - `bun test --cwd packages/web` is the acceptance check for web test isolation. A focused test can pass while still leaking into the direct suite.
+- `mock.module` is process-global, not per-file: the preload's `afterAll(() => mock.restore())` (`packages/web/src/__tests__/web.preload.ts`) runs once at the very end of the whole run, so a `mock.module(...)` in one test file replaces that module for every file that imports it afterward — an order-dependent failure. Only mock a module if it has a single importer with no dedicated test of its own; if it has a dedicated test elsewhere, mocking it here will break that test instead.
+- To focus an element on mount in this jsdom setup, use React's `autoFocus` prop or a stable callback ref (`ref={useCallback(n => n?.focus(), [])}`) — both fire in the commit phase. A `useEffect(() => ref.current?.focus())` does **not** make the element `document.activeElement` in tests. `autoFocus` trips biome's `lint/a11y/noAutofocus` (error) and a JSX-attribute `biome-ignore` comment breaks the formatter, so prefer the callback ref.
+- `FloatingFocusManager` fights virtual-focus combobox palettes: for a component that keeps real focus in one input while using `useListNavigation({ virtual: true })` + `aria-activedescendant` (a command-palette style pattern), `FloatingFocusManager` asynchronously grabs focus to the panel container and steals it back from the input. Drop it — `useDismiss` still handles Escape/outside-press without it. It belongs on anchored forms with a real reference element instead (e.g. `FloatingEventForm`).
 
 ### Web Jest Harness Defaults (MSW + Globals)
 
@@ -205,6 +208,44 @@ Assertions to prefer:
   - user interaction (header toggle button)
   - keyboard interaction (`[` shortcut via view shortcut hooks)
 
+### Seeding Event Data And Client State
+
+Persisted events live in TanStack Query; transient client state lives in
+per-domain Zustand stores (see
+[Frontend Runtime Flow](../frontend/frontend-runtime-flow.md#state-systems)).
+Seed both explicitly rather than reaching into module internals:
+
+- The render harnesses (`mock.render.tsx`'s `render`/`renderHook`, and
+  `render-with-store.tsx`'s `createStoreWrapper`/`renderWithStore`/
+  `renderHookWithStore`) take an `events` option that calls
+  `seedEventQueries(queryClient, events)`
+  (`@web/__tests__/utils/event-query-test-data.ts`).
+- They take a `state` option (shape mirrors the old Redux `RootState`:
+  `{ events: { draft }, view, settings, userMetadata }`), routed through
+  `seedStoresFromState()` (`@web/__tests__/utils/state/seed-stores.ts`) into
+  the real Zustand stores.
+- Zustand stores are module singletons; isolation comes from
+  `resetAllStores()`, registered in a global `afterEach` in `web.preload.ts`.
+  A new store must be added to both the reset registry
+  (`@web/__tests__/utils/state/reset-stores.ts`) and the seeder, or it leaks
+  state across tests silently.
+
+Two gotchas that produce confusing failures far from their actual cause:
+
+- **Someday view-model seeding:** any component/hook rendering
+  `useSomedayEventViewModel` Zod-parses every entity in the someday query via
+  `validateSomedayEvents`. A test that seeds minimal grid fixtures with a
+  broad `setQueryDefaults(["events"], ...)` will have the someday query
+  inherit them, and the derive throws mid-render. Also seed
+  `setQueryDefaults(["events", "someday"], { initialData: toNormalizedEventQueryData([]) })`
+  (see `useWeekShortcuts.test.tsx` for a working example).
+- **Pending-mutation seeding:** a pending event is derived from an in-flight
+  mutation whose `mutationKey` is a full 3-segment
+  `eventMutationKeys.operation("edit" | "create" | ...)`. A bare
+  `["events", "mutation"]` key is not recognized. Convert payloads nest the
+  id under `variables.event._id`; a reorder mutation marks no events pending
+  by design.
+
 ### Route-Aware Component Tests
 
 For components that depend on routing context (`Outlet`, nested routes, route transitions), prefer the shared memory-router helper:
@@ -244,6 +285,8 @@ Preferred style:
 - mock only external services, not internal business logic
 
 **Do not import `mongoService` (or other persistence implementations) directly in tests.** Use test drivers instead (e.g. `UserDriver`, `GoogleWatchDriver` in `packages/backend/src/__tests__/drivers/`). Drivers encapsulate persistence so that switching away from Mongo (or another store) in the future does not require changing test code.
+
+CI runs every lane with `TZ: Etc/UTC` (see CI Unit Test Workflow above). If a backend test only fails locally, match that explicitly rather than relying on your machine's default timezone: `TZ=UTC ./node_modules/.bin/jest --selectProjects backend`.
 
 Useful anchors:
 
@@ -288,6 +331,34 @@ or on a rerun of just the failed job. `playwright.config.ts` now runs a
 single worker in CI (`workers: process.env.CI ? 1 : 2`) specifically to
 remove this contention; if it recurs, treat it as environmental before
 assuming a spec regressed, and do not "fix" it by deleting the test.
+
+A test that fails **deterministically** isn't automatically a real product
+bug either — it can be the harness racing a CSS transition. One
+`create-event-mouse` spec failed 100% of the time in reduced-day-count mode
+(narrow viewport + sidebar open): `ensureSidebarOpen`
+(`e2e/utils/event-test-utils.ts`) waited for the sidebar to become *visible*
+but not for its `transition-[width]` to finish, so the test measured column
+positions mid-animation and then dragged after the grid had reflowed to a
+different column count. Fixed by `waitForMainGridWidthToSettle` (polls
+`#mainGrid`'s measured width until two consecutive reads match), called from
+the just-opened branch of `ensureSidebarOpen` — this benefits any spec that
+opens the sidebar and then immediately depends on grid geometry. Verify
+empirically (a throwaway debug spec dumping live `getBoundingClientRect()`s)
+before concluding either way: "flaky = environment" and "deterministic = app
+regression" are both assumptions, not defaults.
+
+### CI-Only Flakiness From Branch Divergence
+
+A web unit test that times out only on GitHub Actions and never locally
+(even when replaying CI's exact file execution order or running
+`--rerun-each=25`) is not always pure environmental flake. If the failing
+test lives in shortcut or view-store code, first check whether the PR branch
+is behind `main` on those exact files — merging/rebasing main in has
+resolved this class of failure before, because divergent shortcut/store code
+interacting with CI's file ordering was the real contributor, not the
+environment. Only treat it as a genuine flake
+(`gh run rerun <run-id> --failed`) once the branch is confirmed current and
+the diff doesn't touch the failing area.
 
 ## Testing Realtime And Sync Changes
 

--- a/docs/frontend/responsive-layout.md
+++ b/docs/frontend/responsive-layout.md
@@ -1,0 +1,78 @@
+# Responsive Layout
+
+How the app adapts to window width: panel auto-collapse and the week grid's
+shrinking day window.
+
+## Panel Auto-Collapse
+
+Files:
+
+- `packages/web/src/common/hooks/useResponsiveLayout.ts` (mounted once in the
+  authenticated layout)
+- `packages/web/src/common/constants/responsive.constants.ts`
+
+Breakpoints:
+
+- `SIDEBAR_AUTO_COLLAPSE_BREAKPOINT` = 1280px (Tailwind `xl`)
+- `TASK_LIST_AUTO_COLLAPSE_BREAKPOINT` = 720px (task list + divider + a
+  minimum-usable calendar no longer fit side by side below this width)
+
+The hook only reacts to `matchMedia` `change` events — a breakpoint crossing,
+not a continuous width readout. This means a manual toggle (`[` for the
+sidebar, `]` for the day-view task list) sticks until the next crossing; it
+does not get silently re-opened or re-closed by unrelated re-renders.
+
+## Week Grid Day Window
+
+The week view renders a *window* of 1–7 day columns, not always the full
+week. Two pieces derive that window from the measured grid width:
+
+- `packages/web/src/views/Week/hooks/grid/useVisibleDayCount.ts` — a
+  `ResizeObserver` on the grid track computes `visibleDayCount` via
+  `computeVisibleDayCount(trackWidth)`
+  (`packages/web/src/views/Week/util/week-window.util.ts`). Updates freeze
+  while a drag interaction is in flight (`isWeekInteractionMotionActive()`)
+  so the window never re-derives mid-gesture. Defaults to the full week
+  (`WEEK_DAY_COUNT = 7`) until a real measurement lands — jsdom never
+  measures, so tests default to a full week unless they explicitly mock the
+  observer.
+- `packages/web/src/views/Week/hooks/useWeek.ts` — holds a single **anchor
+  date** in the URL (not `useState`, so a refresh restores the same week),
+  memoized on the date *string* rather than the `Dayjs` instance (`today` is a
+  fresh `Dayjs` every render; memoizing on the instance would re-derive
+  `start`/`end` — and re-fire dependent effects — on every render). `start`,
+  `end`, and `windowOffset` (`computeVisibleWindowOffset`, which centers the
+  window on the anchor and clamps to the week's boundaries) all derive from
+  the anchor plus the current `visibleDayCount`. A day-count change therefore
+  needs no extra state — the window just re-centers on the same anchor.
+
+Paging (`incrementWeek`/`decrementWeek`, both thin wrappers around
+`pageWindow`) is two different moves depending on position: within the
+current week it shifts `windowOffset` by `visibleDayCount`, clamped to the
+week's boundaries; at the boundary it instead crosses into the adjacent
+week, entering from that week's near side (offset `0` going forward, or the
+max offset going back). Neither branch is a flat ±7-day jump —
+`anchorDateForWindowOffset` re-derives the anchor from whichever
+`weekStart`/`windowOffset` pair the branch computed.
+
+## Memo Comparator Trap
+
+`GridEventMemo` (`.../Event/Grid/GridEvent/GridEvent.tsx`) and
+`AllDayEventMemo` (`.../Grid/AllDayRow/AllDayEvent.tsx`) skip re-render unless
+their custom comparator says something relevant changed. Both comparators
+must include `weekDays` (or `weekProps.component.weekDays`) in that
+comparison. If a future edit drops it: the day window can move (paging,
+resize-driven `visibleDayCount` change) without any event's own data or
+measurements changing, and events silently keep rendering at their *previous*
+window position instead of the new one.
+
+## Mobile Gate
+
+Below-desktop-width behavior above is distinct from mobile-OS gating —
+`isMobileOS()` blocks phones/tablets entirely (see
+[Frontend Runtime Flow](./frontend-runtime-flow.md#root-view-responsibilities)).
+`useIsMobile` (768px) is unrelated to this window-width system; it is used
+only by LifeView layout.
+
+Related: [Week Drag Interaction](./week-drag-interaction.md) — the drag
+geometry model that reads the same `weekDays` window this doc describes.

--- a/docs/frontend/week-drag-interaction.md
+++ b/docs/frontend/week-drag-interaction.md
@@ -12,7 +12,7 @@ dates can never disagree with what is on screen, even mid-gesture.
 ## Why this exists
 
 The week view renders a *window* of 1–7 day columns (not always the full
-week — see [Responsive Layout](../architecture/repo-architecture.md)).
+week — see [Responsive Layout](./responsive-layout.md)).
 Column **index** is window-relative (`0..N-1`), but earlier code seeded a
 drag's starting day from `event.startDate.getDay()` — a week-absolute value
 (`0=Sun..6=Sat`). The two only agreed when 7 columns rendered starting
@@ -82,6 +82,28 @@ sequenceDiagram
     Cache-->>Adapter: fresh columns + dates
     Adapter->>Adapter: commit using visual.dayDate
 ```
+
+## updateVisual Must Be Idempotent
+
+`CalendarInteractionEngine.handlePointerUp`
+(`packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts`)
+recomputes the visual by calling `adapter.updateVisual` with the release
+pointer, then commits *that* result — it does not commit whatever the last
+`requestAnimationFrame` produced. In effect, `updateVisual` runs once during
+the final RAF frame and once more at pointerup, fed the first call's own
+`visual` output as its input for the second call. So for a fixed release
+pointer, feeding a math function's own output back into itself must produce
+the same result again — the function must be idempotent under repeated
+application with an unchanged pointer.
+
+Any flip/branch logic inside an `updateVisual` math function must branch on
+an **immutable** field captured at grab time (e.g. `initialEdge` in
+`packages/web/src/common/calendar-grid/interaction/math/timedResize.ts` and
+`allDayResize.ts`) — never on a field the function itself overwrites (e.g. a
+mutated `activeEdge`). Branching on a mutated field diverges on the second
+pass: the first call flips the edge and updates the field, so the second call
+sees the *new* value and can flip again or compute a different result,
+producing a wrong committed range specifically on edge-flip drags.
 
 ## Pitfall
 


### PR DESCRIPTION
## Summary
- Writes durable, re-verified debugging knowledge out of an agent's private cross-session memory and into checked-in repo docs, so it benefits any future session or teammate instead of only continuations with one user. New `docs/frontend/responsive-layout.md`; additions to `week-drag-interaction.md`, `testing-playbook.md`, and `common-change-recipes.md`. Fixes a dead cross-doc link found along the way.
- Adds a "Correctness review" step to the `ship` skill, between browser validation and commit, so a confirmed correctness bug folds into the implementation commit instead of surfacing later as a CI failure, a review comment, or a follow-up PR.

## Simplicity
No simplification opportunities found — the diff is entirely documentation and a skill-process file; there's no application code, React hooks, or duplicated logic in scope for `simplify` to act on.

## Manual Testing Steps
- [ ] Open `docs/frontend/responsive-layout.md` and confirm it reads coherently and its "Related"/"Mobile Gate" links resolve to real files/sections.
- [ ] Run `grep -oE 'step [0-9]+' .claude/skills/ship/SKILL.md | sort -u` and confirm every referenced step number has a matching `## N.` heading in the same file.
- [ ] Run `grep -n "TZ" .github/workflows/test-unit.yml` and confirm it matches the `testing-playbook.md` claim that CI sets `TZ: Etc/UTC`.

## Test plan
- [x] Verified every new/changed technical claim against current source (grep/read) before writing it — 3 of the underlying memories turned out stale (a removed cursor-lock utility, a renamed test, a fix already completed on a different unmerged branch) and were corrected in memory rather than published as fact.
- [x] Confirmed `ship/SKILL.md` step headings are sequential 0–8 and every internal "step N" cross-reference resolves.
- [x] Confirmed all new/linked doc paths exist (`docs/frontend/responsive-layout.md`, `frontend-runtime-flow.md#state-systems`, etc.).
- No unit/e2e run — change touches no application code (`bun run test:*` / `type-check` not applicable).