### PR TITLE
fix(web): prevent event release flash

### DIFF
--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
@@ -182,12 +182,26 @@ const createHarness = ({
     timerCallbacks.delete(timerId);
     callback();
   };
+  // After a commit the engine holds the overlay until the source element
+  // reflows or this deadline fires; jsdom rects never change, so tests use
+  // the deadline to reach the restored state.
+  const fireCommitTeardownDeadline = () => {
+    const [[timerId, callback]] = timerCallbacks;
+
+    if (!callback) {
+      throw new Error("Expected a commit teardown deadline to be scheduled");
+    }
+
+    timerCallbacks.delete(timerId);
+    callback();
+  };
 
   return {
     adapter,
     cancel,
     commit,
     engine,
+    fireCommitTeardownDeadline,
     fireHoldTimer,
     flushFrame,
     frameCallbacks,
@@ -276,9 +290,10 @@ describe("CalendarInteractionEngine", () => {
   });
 
   it("can keep the source visible as a dimmed placeholder during motion", () => {
-    const { engine, flushFrame, source } = createHarness({
-      sourceOverlayMode: "dim-source",
-    });
+    const { engine, fireCommitTeardownDeadline, flushFrame, source } =
+      createHarness({
+        sourceOverlayMode: "dim-source",
+      });
 
     engine.handlePointerDown(makePointerEvent("pointerdown", { x: 10, y: 10 }));
     engine.handlePointerMove(makePointerEvent("pointermove", { x: 36, y: 10 }));
@@ -290,6 +305,7 @@ describe("CalendarInteractionEngine", () => {
 
     flushFrame();
     engine.handlePointerUp(makePointerEvent("pointerup"));
+    fireCommitTeardownDeadline();
 
     expect(source.style.visibility).toBe("visible");
     expect(source.style.opacity).toBe("");
@@ -298,7 +314,8 @@ describe("CalendarInteractionEngine", () => {
   });
 
   it("restores only the styles changed by the source overlay mode", () => {
-    const { engine, flushFrame, source } = createHarness();
+    const { engine, fireCommitTeardownDeadline, flushFrame, source } =
+      createHarness();
 
     engine.handlePointerDown(makePointerEvent("pointerdown", { x: 10, y: 10 }));
     engine.handlePointerMove(makePointerEvent("pointermove", { x: 36, y: 10 }));
@@ -308,6 +325,7 @@ describe("CalendarInteractionEngine", () => {
 
     flushFrame();
     engine.handlePointerUp(makePointerEvent("pointerup"));
+    fireCommitTeardownDeadline();
 
     expect(source.style.visibility).toBe("visible");
     expect(source.style.opacity).toBe("0.25");
@@ -315,7 +333,8 @@ describe("CalendarInteractionEngine", () => {
   });
 
   it("commits the current visual and restores the source on pointer up", () => {
-    const { commit, engine, flushFrame, source } = createHarness();
+    const { commit, engine, fireCommitTeardownDeadline, flushFrame, source } =
+      createHarness();
 
     engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
     engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
@@ -336,6 +355,9 @@ describe("CalendarInteractionEngine", () => {
         }),
       }),
     );
+
+    fireCommitTeardownDeadline();
+
     expect(source.style.visibility).toBe("visible");
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),
@@ -344,6 +366,102 @@ describe("CalendarInteractionEngine", () => {
       active: false,
       phase: "commit",
     });
+  });
+
+  it("holds the overlay and source state after commit until the source reflows", () => {
+    const { engine, flushFrame, frameCallbacks, source, timerCallbacks } =
+      createHarness();
+    const rect = { height: 0, left: 0, top: 0, width: 0 };
+
+    source.getBoundingClientRect = () => ({ ...rect }) as DOMRect;
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+    engine.handlePointerUp(makePointerEvent("pointerup", { x: 35, y: 45 }));
+
+    // Still held: React hasn't applied the committed geometry yet.
+    expect(source.style.visibility).toBe("hidden");
+    expect(
+      document.body.querySelector("[data-calendar-interaction-overlay]"),
+    ).toBeTruthy();
+
+    flushFrame(32);
+
+    expect(source.style.visibility).toBe("hidden");
+
+    rect.top = 50;
+    flushFrame(48);
+
+    expect(source.style.visibility).toBe("visible");
+    expect(
+      document.body.querySelector("[data-calendar-interaction-overlay]"),
+    ).toBeNull();
+    expect(frameCallbacks.size).toBe(0);
+    expect(timerCallbacks.size).toBe(0);
+  });
+
+  it("restores at the deadline when the committed geometry never changes", () => {
+    const {
+      engine,
+      fireCommitTeardownDeadline,
+      flushFrame,
+      frameCallbacks,
+      source,
+    } = createHarness();
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+    engine.handlePointerUp(makePointerEvent("pointerup", { x: 35, y: 45 }));
+
+    expect(source.style.visibility).toBe("hidden");
+
+    fireCommitTeardownDeadline();
+
+    expect(source.style.visibility).toBe("visible");
+    expect(
+      document.body.querySelector("[data-calendar-interaction-overlay]"),
+    ).toBeNull();
+    expect(frameCallbacks.size).toBe(0);
+  });
+
+  it("tears down a held commit when the source element leaves the DOM", () => {
+    const { engine, flushFrame, source } = createHarness();
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+    engine.handlePointerUp(makePointerEvent("pointerup", { x: 35, y: 45 }));
+
+    source.remove();
+    flushFrame(32);
+
+    expect(source.style.visibility).toBe("visible");
+    expect(
+      document.body.querySelector("[data-calendar-interaction-overlay]"),
+    ).toBeNull();
+  });
+
+  it("flushes a held commit teardown when a new interaction starts", () => {
+    const { engine, flushFrame, source } = createHarness();
+
+    engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
+    engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
+    flushFrame(16);
+    engine.handlePointerUp(makePointerEvent("pointerup", { x: 35, y: 45 }));
+
+    expect(source.style.visibility).toBe("hidden");
+
+    expect(
+      engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 })),
+    ).toBe(true);
+
+    expect(source.style.visibility).toBe("visible");
+    expect(
+      document.body.querySelector("[data-calendar-interaction-overlay]"),
+    ).toBeNull();
+    expect(engine.getSession()).toMatchObject({ phase: "pending" });
   });
 
   it("recomputes the visual from the release pointer before commit", () => {
@@ -446,7 +564,7 @@ describe("CalendarInteractionEngine", () => {
   });
 
   it("ignores scroll events on the scrollable ancestor outside of an active motion session", () => {
-    const { engine, frameCallbacks, scrollContainer } = createHarness({
+    const { frameCallbacks, scrollContainer } = createHarness({
       scrollableAncestor: { clientHeight: 500, scrollHeight: 1000 },
     });
 
@@ -456,15 +574,21 @@ describe("CalendarInteractionEngine", () => {
   });
 
   it("stops listening to the scrollable ancestor after commit", () => {
-    const { engine, flushFrame, frameCallbacks, scrollContainer } =
-      createHarness({
-        scrollableAncestor: { clientHeight: 500, scrollHeight: 1000 },
-      });
+    const {
+      engine,
+      fireCommitTeardownDeadline,
+      flushFrame,
+      frameCallbacks,
+      scrollContainer,
+    } = createHarness({
+      scrollableAncestor: { clientHeight: 500, scrollHeight: 1000 },
+    });
 
     engine.handlePointerDown(makePointerEvent("pointerdown", { x: 5, y: 5 }));
     engine.handlePointerMove(makePointerEvent("pointermove", { x: 35, y: 45 }));
     flushFrame(16);
     engine.handlePointerUp(makePointerEvent("pointerup", { x: 35, y: 45 }));
+    fireCommitTeardownDeadline();
 
     scrollContainer?.dispatchEvent(new Event("scroll"));
 

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -37,6 +37,7 @@ export interface CalendarInteractionCancellationTargets {
 interface CalendarInteractionEngineOptions<TTarget, TVisual, TResult>
   extends CalendarInteractionEngineSchedulerOptions {
   adapter: CalendarInteractionAdapter<TTarget, TVisual, TResult>;
+  commitTeardownDeadlineMs?: number;
   createMetrics?: () => CalendarInteractionMetrics;
   createOverlay?: () => FloatingInteractionOverlay;
   holdDelayMs?: number;
@@ -66,6 +67,7 @@ const defaultOptions = {
   clearTimer: (timer: unknown) => {
     clearTimeout(timer as ReturnType<typeof setTimeout>);
   },
+  commitTeardownDeadlineMs: 250,
   createMetrics: createCalendarInteractionMetrics,
   createOverlay: () => new FloatingInteractionOverlay(),
   holdDelayMs: 750,
@@ -87,6 +89,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
   let latestPointer: CalendarInteractionPoint | null = null;
   let metrics = resolvedOptions.createMetrics();
   let overlay: FloatingInteractionOverlay | null = null;
+  let pendingCommitTeardown: { frame: unknown; timer: unknown } | null = null;
   let preparedSource: PreparedSourceElement | null = null;
   let previousFrameTimestamp: number | null = null;
   let rafId: unknown = null;
@@ -112,6 +115,10 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     if (session.phase !== "idle") {
       return false;
     }
+
+    // A new press must never coexist with a held commit overlay or a
+    // still-prepared source element from the previous interaction.
+    finishPendingCommitTeardown();
 
     const target = resolvedOptions.adapter.getTarget(event);
 
@@ -203,7 +210,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       target: motionSession.target,
       visual: finalUpdate.visual,
     });
-    teardownActiveSession("commit");
+    deferCommitTeardown();
     session = { phase: "idle" };
 
     return { result, type: "commit" };
@@ -261,6 +268,8 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
   }
 
   function cancel() {
+    finishPendingCommitTeardown();
+
     if (session.phase === "idle") {
       return;
     }
@@ -423,6 +432,69 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     if (next.shouldContinue) {
       scheduleFrame();
     }
+  }
+
+  // Committing hands rendering back to React, which paints the moved event a
+  // few scheduler tasks after pointerup. Tearing down immediately would show
+  // the restored source element at its pre-interaction geometry until that
+  // render lands — a visible flash on release. So the overlay clone stays
+  // mounted (and the source stays hidden/dimmed) until the source element
+  // reflows to its committed geometry, leaves the DOM, or the deadline passes
+  // (commits that change nothing never reflow).
+  function deferCommitTeardown() {
+    const element = preparedSource?.element;
+
+    if (!element) {
+      teardownActiveSession("commit");
+      return;
+    }
+
+    const initialRect = element.getBoundingClientRect();
+    const checkFrame = () => {
+      if (!pendingCommitTeardown) {
+        return;
+      }
+
+      pendingCommitTeardown.frame = null;
+
+      const rect = element.getBoundingClientRect();
+      const hasReflowed =
+        !element.isConnected ||
+        rect.top !== initialRect.top ||
+        rect.left !== initialRect.left ||
+        rect.width !== initialRect.width ||
+        rect.height !== initialRect.height;
+
+      if (hasReflowed) {
+        finishPendingCommitTeardown();
+        return;
+      }
+
+      pendingCommitTeardown.frame = resolvedOptions.requestFrame(checkFrame);
+    };
+
+    pendingCommitTeardown = {
+      frame: null,
+      timer: resolvedOptions.setTimer(
+        finishPendingCommitTeardown,
+        resolvedOptions.commitTeardownDeadlineMs,
+      ),
+    };
+    pendingCommitTeardown.frame = resolvedOptions.requestFrame(checkFrame);
+  }
+
+  function finishPendingCommitTeardown() {
+    if (!pendingCommitTeardown) {
+      return;
+    }
+
+    if (pendingCommitTeardown.frame !== null) {
+      resolvedOptions.cancelFrame(pendingCommitTeardown.frame);
+    }
+
+    resolvedOptions.clearTimer(pendingCommitTeardown.timer);
+    pendingCommitTeardown = null;
+    teardownActiveSession("commit");
   }
 
   function teardownActiveSession(phase: "cancelled" | "commit") {

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -457,15 +457,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
 
       pendingCommitTeardown.frame = null;
 
-      const rect = element.getBoundingClientRect();
-      const hasReflowed =
-        !element.isConnected ||
-        rect.top !== initialRect.top ||
-        rect.left !== initialRect.left ||
-        rect.width !== initialRect.width ||
-        rect.height !== initialRect.height;
-
-      if (hasReflowed) {
+      if (hasSourceReflowed(element, initialRect)) {
         finishPendingCommitTeardown();
         return;
       }
@@ -495,6 +487,18 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     resolvedOptions.clearTimer(pendingCommitTeardown.timer);
     pendingCommitTeardown = null;
     teardownActiveSession("commit");
+  }
+
+  function hasSourceReflowed(element: Element, initialRect: DOMRect) {
+    const rect = element.getBoundingClientRect();
+
+    return (
+      !element.isConnected ||
+      rect.top !== initialRect.top ||
+      rect.left !== initialRect.left ||
+      rect.width !== initialRect.width ||
+      rect.height !== initialRect.height
+    );
   }
 
   function teardownActiveSession(phase: "cancelled" | "commit") {

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
@@ -213,10 +213,22 @@ const createHarness = ({
     callback(timestamp);
   };
 
+  const fireCommitTeardownDeadline = () => {
+    const [[timerId, callback]] = timerCallbacks;
+
+    if (!callback) {
+      throw new Error("Expected a commit teardown deadline to be scheduled");
+    }
+
+    timerCallbacks.delete(timerId);
+    callback();
+  };
+
   return {
     adapter,
     child,
     event,
+    fireCommitTeardownDeadline,
     flushFrame,
     onClickAllDayEvent,
     onCommitAllDayDrag,
@@ -327,6 +339,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
     const {
       adapter,
       child,
+      fireCommitTeardownDeadline,
       flushFrame,
       onCommitAllDayDrag,
       onMotionActivation,
@@ -368,6 +381,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
         type: "allDayDragEnd",
       }),
     );
+    fireCommitTeardownDeadline();
     expectSourceRestored(source);
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayResize.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayResize.test.ts
@@ -185,10 +185,22 @@ const createHarness = ({
     callback(timestamp);
   };
 
+  const fireCommitTeardownDeadline = () => {
+    const [[timerId, callback]] = timerCallbacks;
+
+    if (!callback) {
+      throw new Error("Expected a commit teardown deadline to be scheduled");
+    }
+
+    timerCallbacks.delete(timerId);
+    callback();
+  };
+
   return {
     adapter,
     endHandle,
     event,
+    fireCommitTeardownDeadline,
     flushFrame,
     onClickAllDayEvent,
     onCommitAllDayResize,
@@ -261,6 +273,7 @@ describe("WeekInteractionAdapter all-day resize", () => {
     const {
       adapter,
       endHandle,
+      fireCommitTeardownDeadline,
       flushFrame,
       onCommitAllDayResize,
       onMotionActivation,
@@ -302,6 +315,7 @@ describe("WeekInteractionAdapter all-day resize", () => {
         type: "allDayResizeEnd",
       }),
     );
+    fireCommitTeardownDeadline();
     expect(source.style.visibility).toBe("visible");
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
@@ -241,10 +241,22 @@ const createHarness = ({
     callback();
   };
 
+  const fireCommitTeardownDeadline = () => {
+    const [[timerId, callback]] = timerCallbacks;
+
+    if (!callback) {
+      throw new Error("Expected a commit teardown deadline to be scheduled");
+    }
+
+    timerCallbacks.delete(timerId);
+    callback();
+  };
+
   return {
     adapter,
     child,
     event,
+    fireCommitTeardownDeadline,
     fireHoldTimer,
     flushFrame,
     frameCallbacks,
@@ -373,6 +385,7 @@ describe("WeekInteractionAdapter timed drag", () => {
       adapter,
       child,
       event,
+      fireCommitTeardownDeadline,
       flushFrame,
       onCommitTimedDrag,
       onMotionActivation,
@@ -417,6 +430,7 @@ describe("WeekInteractionAdapter timed drag", () => {
         hasMoved: true,
       }),
     );
+    fireCommitTeardownDeadline();
     expectSourceRestored(source);
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
@@ -199,10 +199,22 @@ const createHarness = ({
     callback();
   };
 
+  const fireCommitTeardownDeadline = () => {
+    const [[timerId, callback]] = timerCallbacks;
+
+    if (!callback) {
+      throw new Error("Expected a commit teardown deadline to be scheduled");
+    }
+
+    timerCallbacks.delete(timerId);
+    callback();
+  };
+
   return {
     adapter,
     endHandle,
     event,
+    fireCommitTeardownDeadline,
     fireHoldTimer,
     flushFrame,
     mainGrid,
@@ -258,6 +270,7 @@ describe("WeekInteractionAdapter timed resize", () => {
     const {
       adapter,
       endHandle,
+      fireCommitTeardownDeadline,
       flushFrame,
       onCommitTimedResize,
       onMotionActivation,
@@ -299,6 +312,7 @@ describe("WeekInteractionAdapter timed resize", () => {
         type: "timedResizeEnd",
       }),
     );
+    fireCommitTeardownDeadline();
     expect(source.style.visibility).toBe("visible");
     expect(
       document.body.querySelector("[data-calendar-interaction-overlay]"),


### PR DESCRIPTION
## Summary

Keep the calendar interaction overlay mounted briefly after a drag or resize commit until the source event reflows, disconnects, or the teardown deadline expires. This prevents the original event from flashing at its old geometry while React paints the committed position or duration.

## Simplicity

The implementation adds one bounded teardown path and the simplify pass extracted the source reflow predicate into a named helper (`refactor(web): simplify commit reflow check`) so the frame loop stays readable. React hook usage stayed flat: this diff adds no `useEffect`, `useRef`, or `useState`.

## Manual Testing Steps

- [ ] Open `http://localhost:9086/day/2026-07-08` with `bun dev:web` running and confirm the Day view shows temporary-account timed events.
- [ ] Drag the visible `Exercise` event from 12-1 PM down to 2-3 PM and confirm it appears once in the new slot after release, with no flash back to the original slot.
- [ ] Drag the bottom edge of `Exercise` from 2-3 PM down to 4 PM and confirm it becomes 2-4 PM after release, with no stale duplicate or release flash.
- [ ] Repeat a second drag/resize immediately after the first and confirm the next interaction starts normally.
- [ ] Check the browser console/network panel; in frontend-only mode, backend refresh failures to `localhost:3006` are expected, but no calendar interaction errors should appear.

## Test plan

- [x] `bun test:web -- CalendarInteractionEngine` — 20 pass, 0 fail. The existing jsdom Tailwind CSS parse warning still prints before the passing results.
- [x] `bun test:web -- WeekInteractionAdapter` — 39 pass, 0 fail.
- [x] `bun test:web` — 1166 pass, 0 fail.
- [x] `bunx biome check packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts` — passes.
- [x] `bunx biome check packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayResize.test.ts` — passes.
- [x] `bun lint` — exits 0 with existing warnings outside this PR scope in calendar grid accessibility, command palette class sorting, form test unused imports, and week scroll area accessibility.
- [x] Local browser walkthrough on `http://localhost:9086/day/2026-07-08` — drag moved `Exercise` from 12-1 PM to 2-3 PM with one rendered event and zero overlays after release; resize changed it from 2-3 PM to 2-4 PM with one rendered event and zero overlays after release.