### PR TITLE
refactor: clean up july 8 merge debt

### DIFF
--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -66,7 +66,7 @@ Both `google.clientId` and `google.clientSecret` must be real values for Google 
 | `google.webhookUrl` | No | Public HTTPS API URL for Google Calendar push notifications. When omitted, Compass uses `backend.apiUrl`. |
 | `google.notificationToken` | Required for HTTPS Google webhooks | Token used to verify Google Calendar webhook requests. |
 
-See [Google Calendar](./google-calendar.md) for full setup instructions.
+See [Google Calendar](../self-hosting/google-calendar.md) for full setup instructions.
 
 ## Optional Integrations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,9 +45,9 @@ Markdown files in this `docs/` directory are automatically mirrored to [docs.com
 - [Self-Hosting](./self-hosting/README.md)
 - [Testing Playbook](./development/testing-playbook.md)
 - [Types And Validation](./development/types-and-validation.md)
-- [CI/CD](./ci-cd/README.md)
-- [CLI And Maintenance Commands](./ci-cd/cli-and-maintenance-commands.md)
-- [Versioning](./ci-cd/versioning.md)
+- [CI/CD Workflows](./CI-CD/workflows.md)
+- [CLI And Maintenance Commands](./development/cli.md)
+- [Versioning](./CI-CD/versioning.md)
 
 ## Feature Deep Dives
 

--- a/docs/development/hosting-modes.md
+++ b/docs/development/hosting-modes.md
@@ -88,6 +88,6 @@ A few things that trip up new contributors:
 - [Password Auth Flow](../features/password-auth-flow.md)
 - [Offline Storage And Migrations](../features/offline-storage-and-migrations.md)
 - [Local Development](./local-development.md)
-- [Deploy](./deploy.md)
+- [Self-Hosting](../self-hosting/README.md)
 - [Google Sync And SSE Flow](../features/google-sync-and-sse-flow.md)
 - [Backend Route Map](../backend/README.md)

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -133,8 +133,12 @@ checkout; if its ports are already claimed by another worktree's
 `compass.yaml`, it rewrites `web.port`, `web.url`, `backend.port`,
 `backend.apiUrl`, and the localhost `originsAllowed` entries to the next free
 pair (9081/3001, 9082/3002, ...). Comments and secrets in the file are
-preserved, and reruns are no-ops. `.claude/launch.json`'s `Backend`/`Web`
-preview-tooling ports are kept in sync the same way.
+preserved, and reruns are no-ops.
+
+The preflight only mutates gitignored local config. It does not rewrite tracked
+tooling files such as `.claude/launch.json`; see
+[issue #1969](https://github.com/SwitchbackTech/compass-calendar/issues/1969)
+for the cleanup that removed that behavior.
 
 Notes:
 

--- a/docs/development/troubleshoot.md
+++ b/docs/development/troubleshoot.md
@@ -73,7 +73,7 @@ bun run cli delete -u <email>
 
 The delete flow removes both Compass data and SuperTokens auth state. The browser cleanup screen only clears local browser storage after the server-side purge is complete.
 
-See [CLI And Maintenance Commands](../ci-cd/cli-and-maintenance-commands.md) for the current delete flow.
+See [CLI And Maintenance Commands](./cli.md) for the current delete flow.
 
 ### Invalid domain name
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -2,7 +2,7 @@
 
 This guide explains how to setup Compass on your own infrastructure.
 
-If you'd rather have a local development setup or use the binaries, see the [developer's quickstart](../Development/quickstart.md).
+If you'd rather have a local development setup or use the binaries, see the [developer's quickstart](../development/quickstart.md).
 
 ## Before you start
 

--- a/packages/scripts/src/commands/dev-ports.test.ts
+++ b/packages/scripts/src/commands/dev-ports.test.ts
@@ -1,8 +1,4 @@
-import {
-  readPorts,
-  reassignPorts,
-  syncLaunchConfig,
-} from "@scripts/commands/dev-ports";
+import { readPorts, reassignPorts } from "@scripts/commands/dev-ports";
 
 const SAMPLE_YAML = `# Compass Config
 # hand-written setup notes live here
@@ -88,61 +84,5 @@ describe("reassignPorts", () => {
       "url: https://compass.example.com",
     );
     expect(reassignPorts(customized, next)).toBeNull();
-  });
-});
-
-describe("syncLaunchConfig", () => {
-  const SAMPLE_LAUNCH = `{
-  "version": "0.0.1",
-  "configurations": [
-    {
-      "name": "Backend",
-      "runtimeExecutable": "/opt/homebrew/bin/bun",
-      "runtimeArgs": ["dev:backend"],
-      "port": 3000
-    },
-    {
-      "name": "Web",
-      "runtimeExecutable": "/opt/homebrew/bin/bun",
-      "runtimeArgs": ["run", "dev:web"],
-      "port": 9080
-    },
-    {
-      "name": "Debug Web",
-      "runtimeExecutable": "/opt/homebrew/bin/bun",
-      "runtimeArgs": ["run", "debug:web"],
-      "port": 8080
-    }
-  ]
-}
-`;
-
-  it("replaces only the port digits, leaving every other line untouched", () => {
-    const result = syncLaunchConfig(SAMPLE_LAUNCH, {
-      web: 9081,
-      backend: 3001,
-    });
-
-    expect(result).toContain(
-      '"runtimeArgs": ["dev:backend"],\n      "port": 3001',
-    );
-    expect(result).toContain(
-      '"runtimeArgs": ["run", "dev:web"],\n      "port": 9081',
-    );
-    expect(result).toContain('"port": 8080'); // Debug Web untouched
-    expect(JSON.parse(result as string)).toEqual(
-      JSON.parse(
-        SAMPLE_LAUNCH.replace('"port": 3000', '"port": 3001').replace(
-          '"port": 9080',
-          '"port": 9081',
-        ),
-      ),
-    );
-  });
-
-  it("returns null when ports already match (no-op)", () => {
-    expect(
-      syncLaunchConfig(SAMPLE_LAUNCH, { web: 9080, backend: 3000 }),
-    ).toBeNull();
   });
 });

--- a/packages/scripts/src/commands/dev-ports.ts
+++ b/packages/scripts/src/commands/dev-ports.ts
@@ -128,55 +128,6 @@ function ensureConfigExists(root: string, configPath: string): void {
   console.log(`[dev-ports] created compass.yaml from ${source}`);
 }
 
-// .claude/launch.json (checked into git, used by preview tooling) hardcodes
-// the same default ports as compass.yaml. Keep its Backend/Web entries in
-// sync so preview tooling watches the port this worktree actually uses —
-// "Debug Web" (8080, a static http-server, not compass-config-driven) is
-// left alone. Replaces just the "port" digits per named entry via regex
-// (rather than JSON.parse + stringify) so a reformat of the whole file isn't
-// forced on every unrelated line just to change two numbers.
-export function syncLaunchConfig(
-  launchJson: string,
-  ports: DevPorts,
-): string | null {
-  const portByName: Record<string, number> = {
-    Backend: ports.backend,
-    Web: ports.web,
-  };
-
-  let result = launchJson;
-  let changed = false;
-
-  for (const [name, port] of Object.entries(portByName)) {
-    const pattern = new RegExp(
-      `("name":\\s*"${name}"[\\s\\S]*?"port":\\s*)(\\d+)`,
-    );
-    result = result.replace(
-      pattern,
-      (match, prefix: string, oldPort: string) => {
-        if (Number(oldPort) === port) return match;
-        changed = true;
-        return `${prefix}${port}`;
-      },
-    );
-  }
-
-  return changed ? result : null;
-}
-
-function applyLaunchConfigSync(root: string, ports: DevPorts): void {
-  const launchPath = path.join(root, ".claude", "launch.json");
-  if (!existsSync(launchPath)) return;
-
-  const rewritten = syncLaunchConfig(readFileSync(launchPath, "utf8"), ports);
-  if (rewritten === null) return;
-
-  writeFileSync(launchPath, rewritten);
-  console.log(
-    `[dev-ports] synced .claude/launch.json to web ${ports.web}, backend ${ports.backend}`,
-  );
-}
-
 function isPortsClaimed(ports: DevPorts, claimed: DevPorts[]): boolean {
   return claimed.some(
     (c) => c.web === ports.web || c.backend === ports.backend,
@@ -219,7 +170,6 @@ async function main(): Promise<void> {
 
   const claimed = readSiblingPorts(root);
   if (!isPortsClaimed(current, claimed)) {
-    applyLaunchConfigSync(root, current); // catches drift from manual edits
     return;
   }
 
@@ -237,7 +187,6 @@ async function main(): Promise<void> {
   }
 
   writeFileSync(configPath, rewritten);
-  applyLaunchConfigSync(root, next);
   console.log(
     `[dev-ports] ports ${current.web}/${current.backend} are claimed by ` +
       `another worktree — reassigned to web ${next.web}, backend ${next.backend}`,

--- a/packages/web/src/common/utils/event/event-nudge-shortcut.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge-shortcut.util.ts
@@ -1,0 +1,35 @@
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { refocusEventElement } from "@web/common/utils/event/event.util";
+import {
+  getArrowKeyMovement,
+  nudgeEventDates,
+} from "@web/common/utils/event/event-nudge.util";
+
+export function nudgeEventFromKeyboard({
+  afterNudge,
+  event,
+  keyboardEvent,
+  onNudge,
+}: {
+  afterNudge?: () => void;
+  event: Schema_GridEvent;
+  keyboardEvent: KeyboardEvent;
+  onNudge: (event: Schema_GridEvent) => void;
+}): boolean {
+  if (!event._id) return false;
+
+  const movement = getArrowKeyMovement(
+    keyboardEvent.key,
+    Boolean(event.isAllDay),
+  );
+  if (!movement) return false;
+
+  const dates = nudgeEventDates(event, movement);
+  if (!dates) return false;
+
+  keyboardEvent.preventDefault();
+  onNudge({ ...event, ...dates });
+  afterNudge?.();
+  refocusEventElement(event._id);
+  return true;
+}

--- a/packages/web/src/events/mutations/event.mutation-history.ts
+++ b/packages/web/src/events/mutations/event.mutation-history.ts
@@ -1,0 +1,108 @@
+import { type QueryClient } from "@tanstack/react-query";
+import {
+  RecurringEventUpdateScope,
+  type Schema_Event,
+} from "@core/types/event.types";
+import { type EventRepositorySource } from "@web/common/repositories/event/event.repository.factory";
+import { showDeletedToast } from "@web/common/utils/toast/deleted-toast.util";
+import {
+  type Payload_ConvertEvent,
+  type Payload_DeleteEvent,
+  type Payload_EditEvent,
+} from "@web/events/event.types";
+import { findEventInCache } from "@web/events/queries/event.query.cache";
+import {
+  isRestoringHistory,
+  undoHistoryActions,
+} from "@web/events/stores/undo.store";
+
+// Recurring events are excluded from undo history entirely: series-wide ops
+// can't be restored from a client snapshot (the server rewrites the series),
+// undoing a deleted instance via `create` would spawn a duplicate standalone
+// event instead of clearing the exdate, and even a THIS_EVENT instance edit
+// confirms the instance server-side, so its pre-edit snapshot is stale by
+// the time an undo would replay it.
+const isRecurring = (event: Schema_Event) =>
+  Boolean(event.recurrence?.eventId || event.recurrence?.rule?.length);
+
+const isThisEventScope = (applyTo?: RecurringEventUpdateScope) =>
+  !applyTo || applyTo === RecurringEventUpdateScope.THIS_EVENT;
+
+export function recordEventEditHistory({
+  payload,
+  queryClient,
+  source,
+}: {
+  payload: Payload_EditEvent;
+  queryClient: QueryClient;
+  source: EventRepositorySource;
+}): void {
+  if (isRestoringHistory() || !isThisEventScope(payload.applyTo)) return;
+
+  const before = findEventInCache(queryClient, payload._id, source);
+  if (
+    !before ||
+    isRecurring(before) ||
+    isRecurring(payload.event as Schema_Event)
+  ) {
+    return;
+  }
+
+  undoHistoryActions.record({
+    kind: "edit",
+    _id: payload._id,
+    before,
+    // Merge over `before` so fields the payload dropped (e.g. provider ids)
+    // survive a redo replay.
+    after: { ...before, ...payload.event, _id: payload._id },
+  });
+}
+
+export function recordEventDeleteHistory({
+  kind,
+  payload,
+  queryClient,
+  source,
+}: {
+  kind: "delete" | "delete-someday";
+  payload: Payload_DeleteEvent;
+  queryClient: QueryClient;
+  source: EventRepositorySource;
+}): Schema_Event | null {
+  const existing = findEventInCache(queryClient, payload._id, source);
+  if (isRestoringHistory()) return existing;
+
+  const undoable =
+    !!existing && !isRecurring(existing) && isThisEventScope(payload.applyTo);
+  if (undoable) undoHistoryActions.record({ kind, event: existing });
+  showDeletedToast(undoable);
+  return existing;
+}
+
+export function recordEventConvertHistory({
+  event,
+  converted,
+  existing,
+  isSomeday,
+}: {
+  event: Payload_ConvertEvent["event"];
+  converted: Schema_Event | null;
+  existing: Schema_Event | null;
+  isSomeday: boolean;
+}): void {
+  if (
+    isRestoringHistory() ||
+    !existing ||
+    !converted ||
+    isRecurring(existing)
+  ) {
+    return;
+  }
+
+  undoHistoryActions.record({
+    kind: isSomeday ? "convert-to-someday" : "convert-to-calendar",
+    _id: event._id,
+    before: existing,
+    after: converted,
+  });
+}

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -11,7 +11,6 @@ import { type EventRepository } from "@web/common/repositories/event/event.repos
 import { getEventRepositoryBySource } from "@web/common/repositories/event/event.repository.util";
 import { handleError } from "@web/common/utils/event/event.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
-import { showDeletedToast } from "@web/common/utils/toast/deleted-toast.util";
 import {
   type Payload_ConvertEvent,
   type Payload_DeleteEvent,
@@ -27,10 +26,6 @@ import {
 } from "@web/events/queries/event.query.cache";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import {
-  isRestoringHistory,
-  undoHistoryActions,
-} from "@web/events/stores/undo.store";
-import {
   type EventMutationOperation,
   eventMutationKeys,
 } from "./event.mutation.keys";
@@ -41,6 +36,11 @@ import {
   precedingDeleteOk,
   waitForPrecedingEventWrites,
 } from "./event.mutation.runtime";
+import {
+  recordEventConvertHistory,
+  recordEventDeleteHistory,
+  recordEventEditHistory,
+} from "./event.mutation-history";
 
 // Convert mutations capture the fully-resolved converted event at the
 // `.mutate()` boundary (see wrappers below) so `onMutate` and the async
@@ -55,18 +55,6 @@ type ConvertVariables = {
 // absent from the cache (nothing to delete server-side); the optimistic
 // removal still runs but no repository write is issued.
 type DeleteSomedayVariables = Payload_DeleteEvent & { skipRepository: boolean };
-
-// Recurring events are excluded from undo history entirely: series-wide ops
-// can't be restored from a client snapshot (the server rewrites the series),
-// undoing a deleted instance via `create` would spawn a duplicate standalone
-// event instead of clearing the exdate, and even a THIS_EVENT instance edit
-// confirms the instance server-side, so its pre-edit snapshot is stale by
-// the time an undo would replay it.
-const isRecurring = (event: Schema_Event) =>
-  Boolean(event.recurrence?.eventId || event.recurrence?.rule?.length);
-
-const isThisEventScope = (applyTo?: RecurringEventUpdateScope) =>
-  !applyTo || applyTo === RecurringEventUpdateScope.THIS_EVENT;
 
 export type EventMutations = {
   create: (event: Schema_Event) => void;
@@ -301,45 +289,17 @@ export function useEventMutations(
   // pre-mutation event. Replays from useUndoRedo set the restoring flag so
   // they don't record themselves.
   return useMemo(() => {
-    // Shared by delete/deleteSomeday: record the pre-removal snapshot when
-    // undoable and show the "Deleted" toast (keycap hint only if recorded).
-    // Returns the snapshot so deleteSomeday can derive skipRepository.
     const recordDelete = (
       payload: Payload_DeleteEvent,
       kind: "delete" | "delete-someday",
-    ) => {
-      const existing = findEventInCache(queryClient, payload._id, source);
-      if (isRestoringHistory()) return existing;
+    ) => recordEventDeleteHistory({ payload, kind, queryClient, source });
 
-      const undoable =
-        !!existing &&
-        !isRecurring(existing) &&
-        isThisEventScope(payload.applyTo);
-      if (undoable) undoHistoryActions.record({ kind, event: existing });
-      showDeletedToast(undoable);
-      return existing;
-    };
-
-    // Shared by both converts: resolve the merged event and record the
-    // before/after pair unless replaying or recurring.
     const recordConvert = (
       event: Payload_ConvertEvent["event"],
       isSomeday: boolean,
     ) => {
       const { existing, converted } = convertedEvent(event, isSomeday);
-      if (
-        !isRestoringHistory() &&
-        existing &&
-        converted &&
-        !isRecurring(existing)
-      ) {
-        undoHistoryActions.record({
-          kind: isSomeday ? "convert-to-someday" : "convert-to-calendar",
-          _id: event._id,
-          before: existing,
-          after: converted,
-        });
-      }
+      recordEventConvertHistory({ event, existing, converted, isSomeday });
       return converted;
     };
 
@@ -350,26 +310,7 @@ export function useEventMutations(
           _id: event._id ?? createObjectIdString(),
         }),
       edit: (payload: Payload_EditEvent) => {
-        if (!isRestoringHistory() && isThisEventScope(payload.applyTo)) {
-          const before = findEventInCache(queryClient, payload._id, source);
-          // Recurring events are excluded even at THIS_EVENT scope (see the
-          // isRecurring note); check the payload too so an edit that *adds*
-          // recurrence isn't recorded either.
-          if (
-            before &&
-            !isRecurring(before) &&
-            !isRecurring(payload.event as Schema_Event)
-          ) {
-            undoHistoryActions.record({
-              kind: "edit",
-              _id: payload._id,
-              before,
-              // Merge over `before` so fields the payload dropped (e.g.
-              // provider ids) survive a redo replay.
-              after: { ...before, ...payload.event, _id: payload._id },
-            });
-          }
-        }
+        recordEventEditHistory({ payload, queryClient, source });
         editMutation.mutate(payload);
       },
       delete: (payload: Payload_DeleteEvent) => {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -1,11 +1,7 @@
 import { useUpdateEvent } from "@web/common/hooks/useUpdateEvent";
 import { useAppHotkey } from "@web/common/hotkeys/useAppHotkey";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
-import { refocusEventElement } from "@web/common/utils/event/event.util";
-import {
-  getArrowKeyMovement,
-  nudgeEventDates,
-} from "@web/common/utils/event/event-nudge.util";
+import { nudgeEventFromKeyboard } from "@web/common/utils/event/event-nudge-shortcut.util";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { draftActions } from "@web/events/stores/draft.store";
 import { getFocusedDayCalendarEventTarget } from "@web/views/Day/interaction/targeting/dayCalendarEventTargeting";
@@ -34,16 +30,12 @@ export function useDayEventNudgeShortcuts({
     );
     if (!event?._id) return;
 
-    const movement = getArrowKeyMovement(keyboardEvent.key, false);
-    if (!movement) return;
-
-    const dates = nudgeEventDates(event, movement);
-    if (!dates) return;
-
-    keyboardEvent.preventDefault();
-    updateEvent({ event: { ...event, ...dates } }, true);
-    draftActions.discard();
-    refocusEventElement(event._id);
+    nudgeEventFromKeyboard({
+      event,
+      keyboardEvent,
+      onNudge: (event) => updateEvent({ event }, true),
+      afterNudge: () => draftActions.discard(),
+    });
   };
 
   useAppHotkey("Shift+ArrowUp", nudgeFocusedEvent);

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -11,10 +11,8 @@ import {
   createTimedDraft,
 } from "@web/common/utils/draft/draft.util";
 import { refocusEventElement } from "@web/common/utils/event/event.util";
-import {
-  getArrowKeyMovement,
-  nudgeEventDates,
-} from "@web/common/utils/event/event-nudge.util";
+import { getArrowKeyMovement } from "@web/common/utils/event/event-nudge.util";
+import { nudgeEventFromKeyboard } from "@web/common/utils/event/event-nudge-shortcut.util";
 import { buildConvertToSomedayEvent } from "@web/common/utils/event/someday.event.util";
 import {
   isDeleteTextEditingTarget,
@@ -300,12 +298,13 @@ export const useWeekShortcuts = ({
         return;
       }
 
-      const dates = nudgeEventDates(event, movement);
-      if (!dates) return;
-
-      keyboardEvent.preventDefault();
-      void confirmation.onSubmit({ ...event, ...dates });
-      refocusEventElement(event._id);
+      nudgeEventFromKeyboard({
+        event,
+        keyboardEvent,
+        onNudge: (event) => {
+          void confirmation.onSubmit(event);
+        },
+      });
     },
     [
       confirmation,


### PR DESCRIPTION
## Summary

Cleanup pass over the PRs merged on 2026-07-08 UTC:

- #1956 test(e2e): fix ci worker-contention flakiness, restore specs
- #1957 refactor(web): clean up post-migration comment/copy debt and dead code
- #1958 feat(web): move events with shift+arrow keyboard shortcuts
- #1959 chore: add qa-staging skill for post-merge staging QA sweeps
- #1960 fix: remove auth params during oauth
- #1961 feat(web): undo/redo event changes with cmd/ctrl+z
- #1962 style: sidebar and cleanup deprecated configs/comments
- #1963 feat(dev): assign per-worktree dev ports via preflight script
- #1964 fix(web): make undo/redo reliable under rapid replay
- #1965 fix(backend): retry transient write conflicts in event sync transactions
- #1967 docs: capture debugging gotchas, add ship correctness-review gate

## Changes

- Moves undo history recording policy out of `useEventMutations` into a focused mutation-history helper while keeping the mutation hook interface unchanged.
- Extracts shared keyboard event nudge execution for Day/Week shortcuts while leaving view-specific targeting and Week edge behavior in place.
- Fixes #1969 by removing dev-port preflight writes to tracked `.claude/launch.json`; the preflight now only mutates gitignored local config.
- Fixes stale docs links in the docs index, config docs, development docs, and self-hosting guide.

## Verification

Passed:

- `bun type-check`
- `bun test:web` (1188 pass, 0 fail)
- `bun test packages/scripts/src/commands/dev-ports.test.ts` (7 pass, 0 fail)
- `bun lint` (exit 0; existing warnings remain in unrelated files)
- docs link sanity check (`MISSING_COUNT=0`)
- `git diff --check`

Attempted but blocked by local test environment/state:

- `bun test:scripts`: Jest initially scanned local nested worktrees for duplicate mocks; rerun with `.worktrees` ignored and `COMPASS_CONFIG_FILE=compass.yaml` reached tests but migration integration tests failed against existing persistent `dev_calendar` state / missing Google config from local config.
- `bun test:backend`: same Jest/local Mongo setup issue; one run also collided with the scripts run on `mongodb-memory-server` port `14307` before rerunning sequentially.

Issue: fixes #1969.
