### PR TITLE
refactor(web): rename interaction overlay to draft event

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,25 +95,22 @@ An unscheduled event stored in the sidebar instead of the calendar grid.
 _Avoid_: Someday task
 
 **Draft Event**:
-A temporary event shape used while the user edits, drags, resizes, or
-repositions before saving.
-
-**Interaction Overlay**:
-The temporary moving visual shown while a user drags or resizes an Event.
+A temporary event shape or visual used while the user edits, drags, resizes,
+or repositions before saving.
 
 **Source Event Element**:
 The original rendered Event element that an interaction starts from. During an
-**Interaction Overlay**, the source can either stay visible as a dimmed
-placeholder or be hidden while the overlay moves.
+active **Draft Event** drag or resize, the source can either stay visible as a
+dimmed placeholder or be hidden while the draft event moves.
 
-**Source Element Overlay Mode**:
-The interaction choice for the **Source Event Element** while an
-**Interaction Overlay** is active. `dim-source` means keep the original Event
+**Source Element Draft Event Mode**:
+The interaction choice for the **Source Event Element** during a
+**Draft Event** drag or resize. `dim-source` means keep the original Event
 visible, faded, and non-interactive so the user can still see where it came
-from. `hide-source` means hide the original Event while the overlay is moving.
-Use `dim-source` for drag interactions where the original slot should remain
-visible; use `hide-source` only when showing both the source and overlay would
-make the resize or motion state confusing.
+from. `hide-source` means hide the original Event while the draft event is
+moving. Use `dim-source` for drag interactions where the original slot should
+remain visible; use `hide-source` only when showing both the source and draft
+event would make the resize or motion state confusing.
 
 **Base Event**:
 A recurring event that owns the series recurrence rule.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -167,7 +167,7 @@ The scale is a fixed rem ramp (product UI, not fluid display type). Steps: `xs 0
 
 ## 4. Elevation
 
-Depth is conveyed two ways, in order of priority. **First, tonal layering:** surfaces stack by stepping lightness within the near-black blue band (`bg-primary #0d1017` → `bg-secondary #11151c` → translucent panel fills like `panel-bg hsl(219 8 46 / 20%)`). A higher surface is a slightly lighter blue, not a boxed-and-shadowed card. **Second, shadow reserved for state and floating layers:** drop shadows are not a resting decoration; they appear when an element leaves the plane, hover, focus, an active drag/resize Interaction Overlay, or a menu/overlay panel that floats above the grid. The default shadow is a soft `hsla(0 0 0 / 25%)`.
+Depth is conveyed two ways, in order of priority. **First, tonal layering:** surfaces stack by stepping lightness within the near-black blue band (`bg-primary #0d1017` → `bg-secondary #11151c` → translucent panel fills like `panel-bg hsl(219 8 46 / 20%)`). A higher surface is a slightly lighter blue, not a boxed-and-shadowed card. **Second, shadow reserved for state and floating layers:** drop shadows are not a resting decoration; they appear when an element leaves the plane, hover, focus, an active drag/resize Draft Event, or a menu/overlay panel that floats above the grid. The default shadow is a soft `hsla(0 0 0 / 25%)`.
 
 ### Shadow Vocabulary
 
@@ -210,7 +210,7 @@ Controls are quiet, borderless, and hover-revealing: they sit flush on their sur
 ### Calendar Grid (signature surface)
 
 - **Grid lines:** `grid-line-primary` hairlines (`hsl(219 18 34 / 20%)`) structure the Timed Grid without visual weight.
-- **Events:** Priority-colored blocks are the brightest content on the canvas. A selected event uses `event-selected` (`#abb9c4`). During drag/resize, an Interaction Overlay carries a state shadow while the source element either dims (`dim-source`) or hides (`hide-source`).
+- **Events:** Priority-colored blocks are the brightest content on the canvas. A selected event uses `event-selected` (`#abb9c4`). During drag/resize, a Draft Event carries a state shadow while the source element either dims (`dim-source`) or hides (`hide-source`).
 
 ### Command Palette
 

--- a/e2e/someday/drag-someday-event-mouse.spec.ts
+++ b/e2e/someday/drag-someday-event-mouse.spec.ts
@@ -42,11 +42,11 @@ const dragSomedayEventToTimedGrid = async (page: Page, titlePrefix: string) => {
 };
 
 const expectTimedPreviewTextStack = async (page: Page, title: string) => {
-  const overlay = page.locator("[data-calendar-interaction-overlay]");
-  const titleLabel = overlay.getByText(title);
-  const timeLabel = overlay.locator("[data-someday-interaction-time-label]");
+  const draftEvent = page.locator("[data-calendar-draft-event]");
+  const titleLabel = draftEvent.getByText(title);
+  const timeLabel = draftEvent.locator("[data-someday-interaction-time-label]");
 
-  await expect(overlay).toBeVisible();
+  await expect(draftEvent).toBeVisible();
   await expect(timeLabel).toHaveText(
     /\d{1,2}(?::\d{2})?\s*(AM|PM)?\s+-\s+\d{1,2}(?::\d{2})?\s*(AM|PM)/i,
   );

--- a/e2e/timed/move-event-reduced-days.spec.ts
+++ b/e2e/timed/move-event-reduced-days.spec.ts
@@ -64,19 +64,19 @@ test("aligns the mid-drag visual and drops on the hovered day at a reduced day c
   // Let the interaction engine paint the moved visual
   await page.waitForTimeout(150);
 
-  // While the mouse is still down, the interaction overlay (the moving
+  // While the mouse is still down, the draft event (the moving
   // visual) must sit centered inside the target column, not between two
   // columns
-  const overlay = page.locator("[data-calendar-interaction-overlay]");
-  await expect(overlay).toBeVisible();
-  const overlayBox = await overlay.boundingBox();
-  if (!overlayBox) {
-    throw new Error("Expected the drag overlay to be visible.");
+  const draftEvent = page.locator("[data-calendar-draft-event]");
+  await expect(draftEvent).toBeVisible();
+  const draftEventBox = await draftEvent.boundingBox();
+  if (!draftEventBox) {
+    throw new Error("Expected the drag draft event to be visible.");
   }
 
-  const overlayCenterX = overlayBox.x + overlayBox.width / 2;
+  const draftEventCenterX = draftEventBox.x + draftEventBox.width / 2;
   const targetCenterX = (targetColumn.left + targetColumn.right) / 2;
-  expect(Math.abs(overlayCenterX - targetCenterX)).toBeLessThanOrEqual(5);
+  expect(Math.abs(draftEventCenterX - targetCenterX)).toBeLessThanOrEqual(5);
 
   await page.mouse.up();
 

--- a/packages/web/src/common/calendar-grid/interaction/calendarInteractionDom.ts
+++ b/packages/web/src/common/calendar-grid/interaction/calendarInteractionDom.ts
@@ -1,5 +1,5 @@
-import { type FloatingInteractionOverlayMount } from "@web/common/calendar-interaction/CalendarInteractionAdapter";
-import { createInteractionClone } from "@web/common/calendar-interaction/dom/clone/createInteractionClone";
+import { type FloatingDraftEventMount } from "@web/common/calendar-interaction/CalendarInteractionAdapter";
+import { createDraftEventClone } from "@web/common/calendar-interaction/dom/clone/createDraftEventClone";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 
@@ -23,7 +23,7 @@ export const getCalendarResizeHandleEdge = (
   return isCalendarResizeEdge(edge) ? edge : null;
 };
 
-export const updateCalendarOverlayTimeLabel = (
+export const updateCalendarDraftEventTimeLabel = (
   node: HTMLElement,
   event: Schema_GridEvent,
 ) => {
@@ -31,7 +31,7 @@ export const updateCalendarOverlayTimeLabel = (
     return;
   }
 
-  const timeLabel = getOrCreateCalendarOverlayTimeLabel(node);
+  const timeLabel = getOrCreateCalendarDraftEventTimeLabel(node);
 
   timeLabel.removeAttribute("aria-hidden");
   timeLabel.classList.remove("animate-someday-commit-time-exit", "opacity-0");
@@ -39,13 +39,13 @@ export const updateCalendarOverlayTimeLabel = (
   timeLabel.textContent = getTimesLabel(event.startDate, event.endDate);
 };
 
-export const createCalendarInteractionEventOverlayMount = ({
+export const createCalendarInteractionDraftEventMount = ({
   source,
 }: {
   source: HTMLElement;
-}): FloatingInteractionOverlayMount => {
+}): FloatingDraftEventMount => {
   const rect = source.getBoundingClientRect();
-  const clone = createInteractionClone(source);
+  const clone = createDraftEventClone(source);
 
   for (const element of [clone, ...clone.querySelectorAll<HTMLElement>("*")]) {
     element.removeAttribute("data-day-interaction-event-id");
@@ -67,7 +67,7 @@ export const createCalendarInteractionEventOverlayMount = ({
   };
 };
 
-const getOrCreateCalendarOverlayTimeLabel = (node: HTMLElement) => {
+const getOrCreateCalendarDraftEventTimeLabel = (node: HTMLElement) => {
   const existing = node.querySelector<HTMLElement>(
     CALENDAR_EVENT_TIME_LABEL_SELECTOR,
   );
@@ -83,7 +83,7 @@ const getOrCreateCalendarOverlayTimeLabel = (node: HTMLElement) => {
   label.style.position = "relative";
   label.style.zIndex = "3";
 
-  const parent = getOverlayTimeLabelParent(node);
+  const parent = getDraftEventTimeLabelParent(node);
   const resizeHandle = getFirstDirectResizeHandle(parent);
 
   parent.insertBefore(label, resizeHandle);
@@ -91,7 +91,7 @@ const getOrCreateCalendarOverlayTimeLabel = (node: HTMLElement) => {
   return label;
 };
 
-const getOverlayTimeLabelParent = (node: HTMLElement) => {
+const getDraftEventTimeLabelParent = (node: HTMLElement) => {
   const firstChild = node.firstElementChild;
 
   if (firstChild instanceof HTMLElement && firstChild.tagName !== "SPAN") {

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionAdapter.ts
@@ -1,6 +1,6 @@
 import { type CalendarInteractionPoint } from "./CalendarInteractionSession";
 
-export interface FloatingInteractionOverlayMount {
+export interface FloatingDraftEventMount {
   clone: HTMLElement;
   cursor?: string;
   rect: {
@@ -11,29 +11,29 @@ export interface FloatingInteractionOverlayMount {
   };
 }
 
-export type FloatingInteractionOverlayUpdate = {
+export type FloatingDraftEventUpdate = {
   height?: number;
   mutate?: (node: HTMLElement) => void;
   transform: CalendarInteractionPoint;
   width?: number;
 } | null;
 
-export type SourceElementOverlayMode = "hide-source" | "dim-source";
+export type SourceElementDraftEventMode = "hide-source" | "dim-source";
 
 export interface CalendarInteractionAdapter<TTarget, TVisual, TResult> {
   getTarget(event: PointerEvent): TTarget | null;
   getSourceElement(target: TTarget): HTMLElement;
-  getSourceElementOverlayMode?(target: TTarget): SourceElementOverlayMode;
+  getSourceElementDraftEventMode?(target: TTarget): SourceElementDraftEventMode;
   createVisual(input: {
     pointerStart: CalendarInteractionPoint;
     sourceElement: HTMLElement;
     target: TTarget;
   }): TVisual | null;
-  getOverlayMount(input: {
+  getDraftEventMount(input: {
     sourceElement: HTMLElement;
     target: TTarget;
     visual: TVisual;
-  }): FloatingInteractionOverlayMount;
+  }): FloatingDraftEventMount;
   // Must be idempotent for a given pointer: the engine re-invokes this at
   // pointerup with the same pointer to recompute the visual before commit.
   updateVisual(input: {
@@ -42,7 +42,7 @@ export interface CalendarInteractionAdapter<TTarget, TVisual, TResult> {
     timestamp: number;
     visual: TVisual;
   }): {
-    overlay: FloatingInteractionOverlayUpdate;
+    draftEvent: FloatingDraftEventUpdate;
     shouldContinue?: boolean;
     visual: TVisual;
   };

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.test.ts
@@ -1,12 +1,12 @@
 import { ZIndex } from "@web/common/constants/web.constants";
 import {
   type CalendarInteractionAdapter,
-  type FloatingInteractionOverlayMount,
-  type SourceElementOverlayMode,
+  type FloatingDraftEventMount,
+  type SourceElementDraftEventMode,
 } from "./CalendarInteractionAdapter";
 import { createCalendarInteractionEngine } from "./CalendarInteractionEngine";
-import { createInteractionClone } from "./dom/clone/createInteractionClone";
-import { FloatingInteractionOverlay } from "./dom/overlay/FloatingInteractionOverlay";
+import { createDraftEventClone } from "./dom/clone/createDraftEventClone";
+import { FloatingDraftEvent } from "./dom/draft-event/FloatingDraftEvent";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 interface TestTarget {
@@ -47,10 +47,10 @@ const SOURCE_ELEMENT_INTERACTION_ATTRIBUTE = "data-calendar-interaction-source";
 
 const createHarness = ({
   scrollableAncestor,
-  sourceOverlayMode,
+  sourceDraftEventMode,
 }: {
   scrollableAncestor?: { clientHeight: number; scrollHeight: number };
-  sourceOverlayMode?: SourceElementOverlayMode;
+  sourceDraftEventMode?: SourceElementDraftEventMode;
 } = {}) => {
   document.body.innerHTML = "";
 
@@ -104,28 +104,26 @@ const createHarness = ({
         y: 0,
       },
     })),
-    getOverlayMount: mock(
-      ({ sourceElement }): FloatingInteractionOverlayMount => {
-        const clone = createInteractionClone(sourceElement);
+    getDraftEventMount: mock(({ sourceElement }): FloatingDraftEventMount => {
+      const clone = createDraftEventClone(sourceElement);
 
-        return {
-          clone,
-          rect: {
-            height: 40,
-            left: 10,
-            top: 20,
-            width: 120,
-          },
-        };
-      },
-    ),
+      return {
+        clone,
+        rect: {
+          height: 40,
+          left: 10,
+          top: 20,
+          width: 120,
+        },
+      };
+    }),
     getSourceElement: mock((resolvedTarget) => resolvedTarget.source),
-    ...(sourceOverlayMode
-      ? { getSourceElementOverlayMode: mock(() => sourceOverlayMode) }
+    ...(sourceDraftEventMode
+      ? { getSourceElementDraftEventMode: mock(() => sourceDraftEventMode) }
       : {}),
     getTarget: mock(() => target),
     updateVisual: mock(({ pointer, visual }) => ({
-      overlay: {
+      draftEvent: {
         transform: {
           x: pointer.x - visual.start.x,
           y: pointer.y - visual.start.y,
@@ -182,7 +180,7 @@ const createHarness = ({
     timerCallbacks.delete(timerId);
     callback();
   };
-  // After a commit the engine holds the overlay until the source element
+  // After a commit the engine holds the draft event until the source element
   // reflows or this deadline fires; jsdom rects never change, so tests use
   // the deadline to reach the restored state.
   const fireCommitTeardownDeadline = () => {
@@ -251,7 +249,7 @@ describe("CalendarInteractionEngine", () => {
     });
     expect(source.style.visibility).toBe("hidden");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeTruthy();
 
     flushFrame();
@@ -292,7 +290,7 @@ describe("CalendarInteractionEngine", () => {
   it("can keep the source visible as a dimmed placeholder during motion", () => {
     const { engine, fireCommitTeardownDeadline, flushFrame, source } =
       createHarness({
-        sourceOverlayMode: "dim-source",
+        sourceDraftEventMode: "dim-source",
       });
 
     engine.handlePointerDown(makePointerEvent("pointerdown", { x: 10, y: 10 }));
@@ -313,7 +311,7 @@ describe("CalendarInteractionEngine", () => {
     expect(source).not.toHaveAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
   });
 
-  it("restores only the styles changed by the source overlay mode", () => {
+  it("restores only the styles changed by the source draft event mode", () => {
     const { engine, fireCommitTeardownDeadline, flushFrame, source } =
       createHarness();
 
@@ -360,7 +358,7 @@ describe("CalendarInteractionEngine", () => {
 
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
     expect(engine.getMetrics()).toMatchObject({
       active: false,
@@ -368,7 +366,7 @@ describe("CalendarInteractionEngine", () => {
     });
   });
 
-  it("holds the overlay and source state after commit until the source reflows", () => {
+  it("holds the draft event and source state after commit until the source reflows", () => {
     const { engine, flushFrame, frameCallbacks, source, timerCallbacks } =
       createHarness();
     const rect = { height: 0, left: 0, top: 0, width: 0 };
@@ -383,7 +381,7 @@ describe("CalendarInteractionEngine", () => {
     // Still held: React hasn't applied the committed geometry yet.
     expect(source.style.visibility).toBe("hidden");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeTruthy();
 
     flushFrame(32);
@@ -395,7 +393,7 @@ describe("CalendarInteractionEngine", () => {
 
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
     expect(frameCallbacks.size).toBe(0);
     expect(timerCallbacks.size).toBe(0);
@@ -421,7 +419,7 @@ describe("CalendarInteractionEngine", () => {
 
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
     expect(frameCallbacks.size).toBe(0);
   });
@@ -439,7 +437,7 @@ describe("CalendarInteractionEngine", () => {
 
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
   });
 
@@ -459,7 +457,7 @@ describe("CalendarInteractionEngine", () => {
 
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
     expect(engine.getSession()).toMatchObject({ phase: "pending" });
   });
@@ -499,7 +497,7 @@ describe("CalendarInteractionEngine", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
     expect(engine.getSession()).toEqual({ phase: "idle" });
     expect(engine.getMetrics()).toMatchObject({
@@ -611,12 +609,12 @@ describe("CalendarInteractionEngine", () => {
   });
 });
 
-describe("FloatingInteractionOverlay", () => {
+describe("FloatingDraftEvent", () => {
   it("mounts a body-level clone and applies immediate transform updates", () => {
     const clone = document.createElement("div");
-    const overlay = new FloatingInteractionOverlay();
+    const draftEvent = new FloatingDraftEvent();
 
-    overlay.mount({
+    draftEvent.mount({
       clone,
       rect: {
         height: 20,
@@ -625,7 +623,7 @@ describe("FloatingInteractionOverlay", () => {
         width: 60,
       },
     });
-    overlay.update({
+    draftEvent.update({
       height: 24,
       transform: {
         x: 7,
@@ -634,7 +632,7 @@ describe("FloatingInteractionOverlay", () => {
       width: 70,
     });
 
-    expect(overlay.getNode()).toBe(clone);
+    expect(draftEvent.getNode()).toBe(clone);
     expect(clone.parentElement).toBe(document.body);
     expect(clone.style.position).toBe("fixed");
     expect(clone.style.transition).toBe("none");
@@ -643,13 +641,13 @@ describe("FloatingInteractionOverlay", () => {
     expect(clone.style.width).toBe("70px");
     expect(clone.style.zIndex).toBe(`${ZIndex.MAX}`);
 
-    overlay.unmount();
+    draftEvent.unmount();
 
     expect(clone.parentElement).toBeNull();
   });
 });
 
-describe("createInteractionClone", () => {
+describe("createDraftEventClone", () => {
   it("removes interaction-hostile attributes from the clone tree", () => {
     const source = document.createElement("div");
     const child = document.createElement("button");
@@ -662,14 +660,14 @@ describe("createInteractionClone", () => {
     child.setAttribute("aria-describedby", "description");
     source.append(child);
 
-    const clone = createInteractionClone(source);
+    const clone = createDraftEventClone(source);
     const clonedChild = clone.querySelector("button");
 
     expect(clone.id).toBe("");
     expect(clone.getAttribute("tabindex")).toBeNull();
     expect(clone.getAttribute("aria-controls")).toBeNull();
     expect(clone).toHaveAttribute("aria-hidden", "true");
-    expect(clone).toHaveAttribute("data-calendar-interaction-overlay", "true");
+    expect(clone).toHaveAttribute("data-calendar-draft-event", "true");
     expect(clone.style.margin).toBe("0px");
     expect(clone.style.pointerEvents).toBe("none");
     expect(clonedChild?.id).toBe("");

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionEngine.ts
@@ -1,6 +1,6 @@
 import {
   type CalendarInteractionAdapter,
-  type FloatingInteractionOverlayMount,
+  type FloatingDraftEventMount,
 } from "./CalendarInteractionAdapter";
 import {
   type CalendarInteractionMetrics,
@@ -14,7 +14,7 @@ import {
   type PendingCalendarInteractionSession,
 } from "./CalendarInteractionSession";
 import { hasExceededCalendarInteractionMoveThreshold } from "./calendarInteractionPointer";
-import { FloatingInteractionOverlay } from "./dom/overlay/FloatingInteractionOverlay";
+import { FloatingDraftEvent } from "./dom/draft-event/FloatingDraftEvent";
 import {
   type PreparedSourceElement,
   prepareSourceElementForInteraction,
@@ -39,7 +39,7 @@ interface CalendarInteractionEngineOptions<TTarget, TVisual, TResult>
   adapter: CalendarInteractionAdapter<TTarget, TVisual, TResult>;
   commitTeardownDeadlineMs?: number;
   createMetrics?: () => CalendarInteractionMetrics;
-  createOverlay?: () => FloatingInteractionOverlay;
+  createDraftEvent?: () => FloatingDraftEvent;
   holdDelayMs?: number;
   moveThresholdPx?: number;
 }
@@ -69,7 +69,7 @@ const defaultOptions = {
   },
   commitTeardownDeadlineMs: 250,
   createMetrics: createCalendarInteractionMetrics,
-  createOverlay: () => new FloatingInteractionOverlay(),
+  createDraftEvent: () => new FloatingDraftEvent(),
   holdDelayMs: 750,
   moveThresholdPx: 25,
   now: () => performance.now(),
@@ -88,7 +88,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
   let activatedAt: number | null = null;
   let latestPointer: CalendarInteractionPoint | null = null;
   let metrics = resolvedOptions.createMetrics();
-  let overlay: FloatingInteractionOverlay | null = null;
+  let draftEvent: FloatingDraftEvent | null = null;
   let pendingCommitTeardown: { frame: unknown; timer: unknown } | null = null;
   let preparedSource: PreparedSourceElement | null = null;
   let previousFrameTimestamp: number | null = null;
@@ -116,7 +116,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       return false;
     }
 
-    // A new press must never coexist with a held commit overlay or a
+    // A new press must never coexist with a held commit draft event or a
     // still-prepared source element from the previous interaction.
     finishPendingCommitTeardown();
 
@@ -309,15 +309,15 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       return;
     }
 
-    const overlayMount = resolvedOptions.adapter.getOverlayMount({
+    const draftEventMount = resolvedOptions.adapter.getDraftEventMount({
       sourceElement: pendingSession.sourceElement,
       target: pendingSession.target,
       visual,
     });
-    mountOverlay(overlayMount);
+    mountDraftEvent(draftEventMount);
     preparedSource = prepareSourceElementForInteraction(
       pendingSession.sourceElement,
-      resolvedOptions.adapter.getSourceElementOverlayMode?.(
+      resolvedOptions.adapter.getSourceElementDraftEventMode?.(
         pendingSession.target,
       ),
     );
@@ -364,12 +364,12 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
     scrollSync = null;
   }
 
-  function mountOverlay(mount: FloatingInteractionOverlayMount) {
-    const overlayMountStart = resolvedOptions.now();
-    const nextOverlay = resolvedOptions.createOverlay();
-    nextOverlay.mount(mount);
-    metrics.overlayMountMs = resolvedOptions.now() - overlayMountStart;
-    overlay = nextOverlay;
+  function mountDraftEvent(mount: FloatingDraftEventMount) {
+    const draftEventMountStart = resolvedOptions.now();
+    const nextDraftEvent = resolvedOptions.createDraftEvent();
+    nextDraftEvent.mount(mount);
+    metrics.draftEventMountMs = resolvedOptions.now() - draftEventMountStart;
+    draftEvent = nextDraftEvent;
   }
 
   function clearPendingTimer(
@@ -390,7 +390,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
   }
 
   function runFrame(timestamp: number) {
-    if (session.phase !== "motion" || !latestPointer || !overlay) {
+    if (session.phase !== "motion" || !latestPointer || !draftEvent) {
       return;
     }
 
@@ -406,8 +406,8 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       visual: next.visual,
     } satisfies MotionCalendarInteractionSession<TTarget, TVisual>;
 
-    if (next.overlay) {
-      overlay.update(next.overlay);
+    if (next.draftEvent) {
+      draftEvent.update(next.draftEvent);
       metrics.styleWritesDuringMotion += 1;
     }
 
@@ -437,7 +437,7 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
   // Committing hands rendering back to React, which paints the moved event a
   // few scheduler tasks after pointerup. Tearing down immediately would show
   // the restored source element at its pre-interaction geometry until that
-  // render lands — a visible flash on release. So the overlay clone stays
+  // render lands — a visible flash on release. So the draft event clone stays
   // mounted (and the source stays hidden/dimmed) until the source element
   // reflows to its committed geometry, leaves the DOM, or the deadline passes
   // (commits that change nothing never reflow).
@@ -507,8 +507,8 @@ export const createCalendarInteractionEngine = <TTarget, TVisual, TResult>(
       rafId = null;
     }
 
-    overlay?.unmount();
-    overlay = null;
+    draftEvent?.unmount();
+    draftEvent = null;
     detachScrollSync();
 
     if (preparedSource) {
@@ -550,7 +550,7 @@ const getPointerPoint = (event: PointerEvent): CalendarInteractionPoint => ({
   y: event.clientY,
 });
 
-// The overlay tracks the dragged element visually, so it needs to re-sync
+// The draft event tracks the dragged element visually, so it needs to re-sync
 // whenever its nearest scrollable ancestor scrolls — regardless of what kind
 // of element is being dragged.
 const getNearestScrollableAncestor = (

--- a/packages/web/src/common/calendar-interaction/CalendarInteractionMetrics.ts
+++ b/packages/web/src/common/calendar-interaction/CalendarInteractionMetrics.ts
@@ -6,7 +6,7 @@ export interface CalendarInteractionMetrics {
   firstFrameLatencyMs: number | null;
   frameGaps: number[];
   layoutReadsDuringMotion: number;
-  overlayMountMs: number | null;
+  draftEventMountMs: number | null;
   phase: CalendarInteractionPhase;
   pointerMoveCount: number;
   rafCount: number;
@@ -22,7 +22,7 @@ export const createCalendarInteractionMetrics =
     firstFrameLatencyMs: null,
     frameGaps: [],
     layoutReadsDuringMotion: 0,
-    overlayMountMs: null,
+    draftEventMountMs: null,
     phase: "idle",
     pointerMoveCount: 0,
     rafCount: 0,

--- a/packages/web/src/common/calendar-interaction/dom/clone/createDraftEventClone.ts
+++ b/packages/web/src/common/calendar-interaction/dom/clone/createDraftEventClone.ts
@@ -1,4 +1,4 @@
-export const createInteractionClone = (source: HTMLElement) => {
+export const createDraftEventClone = (source: HTMLElement) => {
   const clone = source.cloneNode(true) as HTMLElement;
 
   for (const element of [clone, ...clone.querySelectorAll<HTMLElement>("*")]) {
@@ -10,7 +10,7 @@ export const createInteractionClone = (source: HTMLElement) => {
   }
 
   clone.setAttribute("aria-hidden", "true");
-  clone.setAttribute("data-calendar-interaction-overlay", "true");
+  clone.setAttribute("data-calendar-draft-event", "true");
   clone.style.margin = "0";
   clone.style.pointerEvents = "none";
 

--- a/packages/web/src/common/calendar-interaction/dom/draft-event/FloatingDraftEvent.ts
+++ b/packages/web/src/common/calendar-interaction/dom/draft-event/FloatingDraftEvent.ts
@@ -1,7 +1,7 @@
 import { ZIndex } from "@web/common/constants/web.constants";
 import { type CalendarInteractionPoint } from "../../CalendarInteractionSession";
 
-export class FloatingInteractionOverlay {
+export class FloatingDraftEvent {
   #node: HTMLElement | null = null;
 
   mount({

--- a/packages/web/src/common/calendar-interaction/dom/source/sourceElementVisibility.ts
+++ b/packages/web/src/common/calendar-interaction/dom/source/sourceElementVisibility.ts
@@ -1,15 +1,15 @@
-import { type SourceElementOverlayMode } from "../../CalendarInteractionAdapter";
+import { type SourceElementDraftEventMode } from "../../CalendarInteractionAdapter";
 
 interface HiddenSourceElement {
+  draftEventMode: "hide-source";
   element: HTMLElement;
-  overlayMode: "hide-source";
   visibility: string;
 }
 
 interface DimmedSourceElement {
+  draftEventMode: "dim-source";
   element: HTMLElement;
   opacity: string;
-  overlayMode: "dim-source";
   pointerEvents: string;
 }
 
@@ -19,15 +19,15 @@ const SOURCE_ELEMENT_INTERACTION_ATTRIBUTE = "data-calendar-interaction-source";
 
 export const prepareSourceElementForInteraction = (
   element: HTMLElement,
-  overlayMode: SourceElementOverlayMode = "hide-source",
+  draftEventMode: SourceElementDraftEventMode = "hide-source",
 ): PreparedSourceElement => {
   element.setAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE, "true");
 
-  if (overlayMode === "dim-source") {
+  if (draftEventMode === "dim-source") {
     const source = {
+      draftEventMode,
       element,
       opacity: element.style.opacity,
-      overlayMode,
       pointerEvents: element.style.pointerEvents,
     };
 
@@ -38,8 +38,8 @@ export const prepareSourceElementForInteraction = (
   }
 
   const source = {
+    draftEventMode,
     element,
-    overlayMode,
     visibility: element.style.visibility,
   };
 
@@ -51,7 +51,7 @@ export const prepareSourceElementForInteraction = (
 export const restoreSourceElement = (source: PreparedSourceElement) => {
   source.element.removeAttribute(SOURCE_ELEMENT_INTERACTION_ATTRIBUTE);
 
-  if (source.overlayMode === "dim-source") {
+  if (source.draftEventMode === "dim-source") {
     source.element.style.opacity = source.opacity;
     source.element.style.pointerEvents = source.pointerEvents;
 

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
@@ -496,18 +496,20 @@ describe("SomedayInteractionAdapter", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector<HTMLElement>(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector<HTMLElement>(
+      "[data-calendar-draft-event]",
     );
     const expectedTextColor = normalizeCssColor(theme.color.text.dark);
     const expectedHoverColor = normalizeCssColor(
       gridHoverColorByPriority[Priorities.UNASSIGNED],
     );
 
-    expect(overlay).toBeTruthy();
-    expect(overlay?.style.color).toBe(expectedTextColor);
-    expect(overlay?.style.backgroundColor).toBe(expectedHoverColor);
-    expect(overlay?.querySelector("[data-someday-drag-affordance]")).toBeNull();
+    expect(draftEvent).toBeTruthy();
+    expect(draftEvent?.style.color).toBe(expectedTextColor);
+    expect(draftEvent?.style.backgroundColor).toBe(expectedHoverColor);
+    expect(
+      draftEvent?.querySelector("[data-someday-drag-affordance]"),
+    ).toBeNull();
   });
 
   it("shows the tentative timed-grid range inside the visible Someday preview", () => {
@@ -527,13 +529,13 @@ describe("SomedayInteractionAdapter", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector<HTMLElement>(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector<HTMLElement>(
+      "[data-calendar-draft-event]",
     );
-    const timeLabel = overlay?.querySelector<HTMLElement>(
+    const timeLabel = draftEvent?.querySelector<HTMLElement>(
       "[data-someday-interaction-time-label]",
     );
-    const titleRow = overlay?.querySelector<HTMLElement>(
+    const titleRow = draftEvent?.querySelector<HTMLElement>(
       "[data-someday-event-title-row]",
     );
     const textStack = titleRow?.parentElement;
@@ -569,19 +571,19 @@ describe("SomedayInteractionAdapter", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector<HTMLElement>(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector<HTMLElement>(
+      "[data-calendar-draft-event]",
     );
-    const titleRow = overlay?.querySelector<HTMLElement>(
+    const titleRow = draftEvent?.querySelector<HTMLElement>(
       "[data-someday-event-title-row]",
     );
 
     expect(
-      overlay?.querySelector("[data-someday-interaction-time-label]")
+      draftEvent?.querySelector("[data-someday-interaction-time-label]")
         ?.textContent,
     ).toMatch(/2\s+-\s+3 AM/);
     expect(
-      overlay?.querySelector("[data-someday-interaction-time-label]")
+      draftEvent?.querySelector("[data-someday-interaction-time-label]")
         ?.parentElement,
     ).toBe(titleRow?.parentElement);
     expect(titleRow?.style.alignSelf).toBe("stretch");
@@ -591,7 +593,7 @@ describe("SomedayInteractionAdapter", () => {
     expect(titleRow?.parentElement?.style.flexDirection).toBe("column");
   });
 
-  it("disables Someday overlay motion when reduced motion is preferred", () => {
+  it("disables Someday draft event motion when reduced motion is preferred", () => {
     const restoreMatchMedia = setReducedMotionPreference(true);
     const { adapter, flushFrame, sourceChild, timedColumns } = createHarness();
 
@@ -608,13 +610,13 @@ describe("SomedayInteractionAdapter", () => {
       );
       flushFrame();
 
-      const overlay = document.body.querySelector<HTMLElement>(
-        "[data-calendar-interaction-overlay]",
+      const draftEvent = document.body.querySelector<HTMLElement>(
+        "[data-calendar-draft-event]",
       );
 
-      expect(overlay).toBeTruthy();
-      expect(overlay?.style.transition).toBe("none");
-      expect(overlay?.style.scale).toBe("1");
+      expect(draftEvent).toBeTruthy();
+      expect(draftEvent?.style.transition).toBe("none");
+      expect(draftEvent?.style.scale).toBe("1");
     } finally {
       restoreMatchMedia();
     }
@@ -690,8 +692,8 @@ describe("SomedayInteractionAdapter", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector<HTMLElement>(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector<HTMLElement>(
+      "[data-calendar-draft-event]",
     );
     const expectedHoverColor = normalizeCssColor(
       gridHoverColorByPriority[Priorities.UNASSIGNED],
@@ -699,8 +701,8 @@ describe("SomedayInteractionAdapter", () => {
 
     // Anchored (grid-hover) styling proves the preview snapped to a valid
     // slot rather than floating under the cursor in the header.
-    expect(overlay?.style.backgroundColor).toBe(expectedHoverColor);
-    expect(overlay?.style.scale).toBe("1");
+    expect(draftEvent?.style.backgroundColor).toBe(expectedHoverColor);
+    expect(draftEvent?.style.scale).toBe("1");
   });
 
   it("clamps drags in the gap between the all-day row and the timed grid", () => {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -10,7 +10,7 @@ import {
 } from "@web/common/calendar-interaction/CalendarInteractionEngine";
 import { type CalendarInteractionPoint } from "@web/common/calendar-interaction/CalendarInteractionSession";
 import { isEligibleCalendarInteractionPointerDown } from "@web/common/calendar-interaction/calendarInteractionPointer";
-import { createInteractionClone } from "@web/common/calendar-interaction/dom/clone/createInteractionClone";
+import { createDraftEventClone } from "@web/common/calendar-interaction/dom/clone/createDraftEventClone";
 import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
 import { theme } from "@web/common/styles/theme";
 import {
@@ -66,28 +66,28 @@ const ONE_HOUR_MINUTES = 60;
 // Matches the "settle" curve used by GridEvent for visual coherence with the
 // landed event. The reshape duration (240ms) is short enough to track the
 // cursor without feeling instant; the transform duration (110ms) is only
-// applied while the overlay is anchored to a grid slot, so cursor-follow in
+// applied while the draft event is anchored to a grid slot, so cursor-follow in
 // the sidebar stays 1:1 with the pointer.
-const SOMEDAY_OVERLAY_EASING = "cubic-bezier(0.16, 1, 0.3, 1)";
-const SOMEDAY_OVERLAY_RESHAPE_MS = 240;
-const SOMEDAY_OVERLAY_ANCHOR_MS = 110;
-const SOMEDAY_OVERLAY_LIFT_MS = 160;
-// Subtle lift while the overlay is floating (in the sidebar / between
+const SOMEDAY_DRAFT_EVENT_EASING = "cubic-bezier(0.16, 1, 0.3, 1)";
+const SOMEDAY_DRAFT_EVENT_RESHAPE_MS = 240;
+const SOMEDAY_DRAFT_EVENT_ANCHOR_MS = 110;
+const SOMEDAY_DRAFT_EVENT_LIFT_MS = 160;
+// Subtle lift while the draft event is floating (in the sidebar / between
 // targets). Settles back to 1 once anchored to a slot so the preview matches
 // the resting size of the real event.
-const SOMEDAY_OVERLAY_LIFT_SCALE = "1.04";
-const SOMEDAY_OVERLAY_SETTLED_SCALE = "1";
-const SOMEDAY_OVERLAY_TRANSITION_BASE =
-  `height ${SOMEDAY_OVERLAY_RESHAPE_MS}ms ${SOMEDAY_OVERLAY_EASING}, ` +
-  `width ${SOMEDAY_OVERLAY_RESHAPE_MS}ms ${SOMEDAY_OVERLAY_EASING}, ` +
-  `color ${SOMEDAY_OVERLAY_RESHAPE_MS}ms ${SOMEDAY_OVERLAY_EASING}, ` +
-  `scale ${SOMEDAY_OVERLAY_LIFT_MS}ms ${SOMEDAY_OVERLAY_EASING}, ` +
-  `box-shadow ${SOMEDAY_OVERLAY_LIFT_MS}ms ${SOMEDAY_OVERLAY_EASING}`;
-const SOMEDAY_OVERLAY_TRANSITION_ANCHORED =
-  `${SOMEDAY_OVERLAY_TRANSITION_BASE}, ` +
-  `transform ${SOMEDAY_OVERLAY_ANCHOR_MS}ms ${SOMEDAY_OVERLAY_EASING}`;
-const SOMEDAY_OVERLAY_SHADOW_LIFTED = `0 12px 28px color-mix(in srgb, ${theme.color.shadow.default} 22%, transparent)`;
-const SOMEDAY_OVERLAY_SHADOW_SETTLED = `0 6px 14px color-mix(in srgb, ${theme.color.shadow.default} 14%, transparent)`;
+const SOMEDAY_DRAFT_EVENT_LIFT_SCALE = "1.04";
+const SOMEDAY_DRAFT_EVENT_SETTLED_SCALE = "1";
+const SOMEDAY_DRAFT_EVENT_TRANSITION_BASE =
+  `height ${SOMEDAY_DRAFT_EVENT_RESHAPE_MS}ms ${SOMEDAY_DRAFT_EVENT_EASING}, ` +
+  `width ${SOMEDAY_DRAFT_EVENT_RESHAPE_MS}ms ${SOMEDAY_DRAFT_EVENT_EASING}, ` +
+  `color ${SOMEDAY_DRAFT_EVENT_RESHAPE_MS}ms ${SOMEDAY_DRAFT_EVENT_EASING}, ` +
+  `scale ${SOMEDAY_DRAFT_EVENT_LIFT_MS}ms ${SOMEDAY_DRAFT_EVENT_EASING}, ` +
+  `box-shadow ${SOMEDAY_DRAFT_EVENT_LIFT_MS}ms ${SOMEDAY_DRAFT_EVENT_EASING}`;
+const SOMEDAY_DRAFT_EVENT_TRANSITION_ANCHORED =
+  `${SOMEDAY_DRAFT_EVENT_TRANSITION_BASE}, ` +
+  `transform ${SOMEDAY_DRAFT_EVENT_ANCHOR_MS}ms ${SOMEDAY_DRAFT_EVENT_EASING}`;
+const SOMEDAY_DRAFT_EVENT_SHADOW_LIFTED = `0 12px 28px color-mix(in srgb, ${theme.color.shadow.default} 22%, transparent)`;
+const SOMEDAY_DRAFT_EVENT_SHADOW_SETTLED = `0 6px 14px color-mix(in srgb, ${theme.color.shadow.default} 14%, transparent)`;
 const SOMEDAY_EVENT_TITLE_ROW_SELECTOR =
   '[data-someday-event-title-row="true"]';
 const SOMEDAY_TIME_LABEL_SELECTOR =
@@ -259,8 +259,8 @@ export const createSomedayInteractionAdapter = ({
           transform: { x: 0, y: 0 },
         };
       },
-      getOverlayMount: ({ sourceElement, target }) => ({
-        clone: createSomedayOverlayClone(sourceElement, target.event),
+      getDraftEventMount: ({ sourceElement, target }) => ({
+        clone: createSomedayDraftEventClone(sourceElement, target.event),
         cursor: "move",
         rect: readElementRect(sourceElement),
       }),
@@ -279,7 +279,7 @@ export const createSomedayInteractionAdapter = ({
         );
         // Edge navigation reads the raw pointer (it only engages inside grid
         // layouts). Drop resolution and the floating preview use the clamped
-        // pointer so the overlay can't wander into dead zones like the week
+        // pointer so the draft event can't wander into dead zones like the week
         // header — it slides along the nearest valid drop zone instead.
         const clampedPointer = clampPointToZones(pointer, getClampZones());
         const nextDrop = resolveDrop(
@@ -287,16 +287,18 @@ export const createSomedayInteractionAdapter = ({
           edgeNavigationUpdate.visual,
         );
         previewSidebarDrop(target, edgeNavigationUpdate.visual, nextDrop);
-        const overlayRect = getCalendarOverlayRect(nextDrop);
+        const draftEventRect = getCalendarDraftEventRect(nextDrop);
         const nextVisual = {
           ...edgeNavigationUpdate.visual,
           drop: nextDrop,
-          transform: overlayRect
+          transform: draftEventRect
             ? {
                 x:
-                  overlayRect.left -
+                  draftEventRect.left -
                   edgeNavigationUpdate.visual.sourceRect.left,
-                y: overlayRect.top - edgeNavigationUpdate.visual.sourceRect.top,
+                y:
+                  draftEventRect.top -
+                  edgeNavigationUpdate.visual.sourceRect.top,
               }
             : {
                 x:
@@ -307,11 +309,11 @@ export const createSomedayInteractionAdapter = ({
         };
 
         return {
-          overlay: {
-            height: overlayRect?.height,
-            mutate: (node) => mutateOverlay(node, nextDrop, target.event),
+          draftEvent: {
+            height: draftEventRect?.height,
+            mutate: (node) => mutateDraftEvent(node, nextDrop, target.event),
             transform: nextVisual.transform,
-            width: overlayRect?.width,
+            width: draftEventRect?.width,
           },
           shouldContinue: edgeNavigationUpdate.isDwellActive,
           visual: nextVisual,
@@ -649,7 +651,7 @@ export const createSomedayInteractionAdapter = ({
     isLayoutRebuildPending = false;
   }
 
-  function getCalendarOverlayRect(drop: SomedayInteractionDrop | null) {
+  function getCalendarDraftEventRect(drop: SomedayInteractionDrop | null) {
     if (!drop || drop.type === "sidebar") {
       return null;
     }
@@ -700,17 +702,17 @@ export const createSomedayInteractionAdapter = ({
   };
 };
 
-const createSomedayOverlayClone = (
+const createSomedayDraftEventClone = (
   source: HTMLElement,
   event: Schema_Event,
 ) => {
-  const clone = createInteractionClone(source);
+  const clone = createDraftEventClone(source);
 
   clone.style.zIndex = "25";
 
   // SomedayEvent renders with a translucent priority tint (15% color-mix),
   // which looks faded once it leaves the sidebar background. Repaint the
-  // floating overlay with the solid grid color so the preview reads as the
+  // floating draft event with the solid grid color so the preview reads as the
   // GridEvent / AllDayEvent it's about to become.
   const priority = event.priority ?? Priorities.UNASSIGNED;
   clone.style.background = gridColorByPriority[priority];
@@ -725,7 +727,7 @@ const createSomedayOverlayClone = (
   return clone;
 };
 
-const mutateOverlay = (
+const mutateDraftEvent = (
   node: HTMLElement,
   drop: SomedayInteractionDrop | null,
   event: Schema_Event,
@@ -733,7 +735,7 @@ const mutateOverlay = (
   node.style.overflow = "hidden";
 
   const isReducedMotion = isReducedMotionPreferred();
-  // Only smooth `transform` while the overlay is anchored to a grid slot.
+  // Only smooth `transform` while the draft event is anchored to a grid slot.
   // In the sidebar (or with no drop target) transform must remain instant so
   // the clone tracks the pointer 1:1.
   const isGridAnchored = drop?.type === "allDay" || drop?.type === "timed";
@@ -749,20 +751,20 @@ const mutateOverlay = (
   const nextTransition = isReducedMotion
     ? "none"
     : isGridAnchored
-      ? SOMEDAY_OVERLAY_TRANSITION_ANCHORED
-      : SOMEDAY_OVERLAY_TRANSITION_BASE;
+      ? SOMEDAY_DRAFT_EVENT_TRANSITION_ANCHORED
+      : SOMEDAY_DRAFT_EVENT_TRANSITION_BASE;
 
   if (node.style.transition !== nextTransition) {
     node.style.transition = nextTransition;
   }
 
-  // Lift the overlay while it's floating so pickup reads as a physical "I've
+  // Lift the draft event while it's floating so pickup reads as a physical "I've
   // grabbed this." Settle to 1 once anchored to a slot so the preview matches
   // the real event's resting size; shadow tightens in tandem.
   const nextScale =
     isReducedMotion || isGridAnchored
-      ? SOMEDAY_OVERLAY_SETTLED_SCALE
-      : SOMEDAY_OVERLAY_LIFT_SCALE;
+      ? SOMEDAY_DRAFT_EVENT_SETTLED_SCALE
+      : SOMEDAY_DRAFT_EVENT_LIFT_SCALE;
 
   if (node.style.scale !== nextScale) {
     node.style.scale = nextScale;
@@ -770,8 +772,8 @@ const mutateOverlay = (
 
   const nextShadow =
     isReducedMotion || isGridAnchored
-      ? SOMEDAY_OVERLAY_SHADOW_SETTLED
-      : SOMEDAY_OVERLAY_SHADOW_LIFTED;
+      ? SOMEDAY_DRAFT_EVENT_SHADOW_SETTLED
+      : SOMEDAY_DRAFT_EVENT_SHADOW_LIFTED;
 
   if (node.style.boxShadow !== nextShadow) {
     node.style.boxShadow = nextShadow;
@@ -782,14 +784,14 @@ const mutateOverlay = (
     : theme.color.text.lighter;
 
   if (drop?.type !== "timed") {
-    resetTimedOverlayLayout(node);
+    resetTimedDraftEventLayout(node);
     return;
   }
 
-  const titleRow = applyTimedOverlayLayout(node);
+  const titleRow = applyTimedDraftEventLayout(node);
   const { end, start } = getTimedDropDateRange(drop);
 
-  const timeLabel = getOrCreateOverlayTimeLabel(node, titleRow);
+  const timeLabel = getOrCreateDraftEventTimeLabel(node, titleRow);
 
   timeLabel.textContent = getTimesLabel(start.format(), end.format());
   timeLabel.style.display = "block";
@@ -811,9 +813,9 @@ const getTimedDropDateRange = (drop: SomedayTimedDrop) => {
   };
 };
 
-const applyTimedOverlayLayout = (node: HTMLElement) => {
-  const titleRow = getOverlayTitleRow(node);
-  const textStack = getOverlayTextStack(titleRow);
+const applyTimedDraftEventLayout = (node: HTMLElement) => {
+  const titleRow = getDraftEventTitleRow(node);
+  const textStack = getDraftEventTextStack(titleRow);
 
   textStack.style.alignItems = "flex-start";
   textStack.style.display = "flex";
@@ -830,8 +832,8 @@ const applyTimedOverlayLayout = (node: HTMLElement) => {
   return textStack;
 };
 
-const resetTimedOverlayLayout = (node: HTMLElement) => {
-  removeOverlayTimeLabel(node);
+const resetTimedDraftEventLayout = (node: HTMLElement) => {
+  removeDraftEventTimeLabel(node);
 
   const titleRow = node.querySelector<HTMLElement>(
     SOMEDAY_EVENT_TITLE_ROW_SELECTOR,
@@ -841,7 +843,7 @@ const resetTimedOverlayLayout = (node: HTMLElement) => {
     return;
   }
 
-  const textStack = getOverlayTextStack(titleRow);
+  const textStack = getDraftEventTextStack(titleRow);
 
   textStack.style.alignItems = "";
   textStack.style.display = "";
@@ -856,17 +858,17 @@ const resetTimedOverlayLayout = (node: HTMLElement) => {
   titleRow.style.justifyContent = "";
 };
 
-const removeOverlayTimeLabel = (node: HTMLElement) => {
+const removeDraftEventTimeLabel = (node: HTMLElement) => {
   node.querySelector<HTMLElement>(SOMEDAY_TIME_LABEL_SELECTOR)?.remove();
 };
 
-const getOverlayTitleRow = (node: HTMLElement) =>
+const getDraftEventTitleRow = (node: HTMLElement) =>
   node.querySelector<HTMLElement>(SOMEDAY_EVENT_TITLE_ROW_SELECTOR) ?? node;
 
-const getOverlayTextStack = (titleRow: HTMLElement) =>
+const getDraftEventTextStack = (titleRow: HTMLElement) =>
   titleRow.parentElement ?? titleRow;
 
-const getOrCreateOverlayTimeLabel = (
+const getOrCreateDraftEventTimeLabel = (
   node: HTMLElement,
   parent: HTMLElement,
 ) => {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types.ts
@@ -57,7 +57,7 @@ export interface SomedaySidebarDrop {
 export interface SomedayTimedDrop {
   /** Local YYYY-MM-DD date of the drop column. */
   date: string;
-  /** Window-relative column index; used for overlay geometry only. */
+  /** Window-relative column index; used for draftEvent geometry only. */
   dayIndex: number;
   endMinutes: number;
   startMinutes: number;
@@ -67,7 +67,7 @@ export interface SomedayTimedDrop {
 export interface SomedayAllDayDrop {
   /** Local YYYY-MM-DD date of the drop column. */
   date: string;
-  /** Window-relative column index; used for overlay geometry only. */
+  /** Window-relative column index; used for draftEvent geometry only. */
   dayIndex: number;
   type: "allDay";
 }

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types.ts
@@ -57,7 +57,7 @@ export interface SomedaySidebarDrop {
 export interface SomedayTimedDrop {
   /** Local YYYY-MM-DD date of the drop column. */
   date: string;
-  /** Window-relative column index; used for draftEvent geometry only. */
+  /** Window-relative column index; used for draft event geometry only. */
   dayIndex: number;
   endMinutes: number;
   startMinutes: number;
@@ -67,7 +67,7 @@ export interface SomedayTimedDrop {
 export interface SomedayAllDayDrop {
   /** Local YYYY-MM-DD date of the drop column. */
   date: string;
-  /** Window-relative column index; used for draftEvent geometry only. */
+  /** Window-relative column index; used for draft event geometry only. */
   dayIndex: number;
   type: "allDay";
 }

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/state/somedayCommitAcknowledgementState.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/state/somedayCommitAcknowledgementState.ts
@@ -3,7 +3,7 @@ import { useSyncExternalStore } from "react";
 /**
  * Tracks event ids that were just committed from a Someday-to-calendar drop.
  *
- * The floating overlay and the freshly mounted GridEvent / AllDayEvent are
+ * The floating draft event and the freshly mounted GridEvent / AllDayEvent are
  * two separate DOM nodes that hand off in a single frame; without an
  * entrance animation the drop reads as a swap. This module lets the
  * calendar event components opt into a one-shot acknowledgment animation

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.test.ts
@@ -371,7 +371,7 @@ describe("DayInteractionAdapter", () => {
     expect(dayjs(result.event.startDate).isSame(visibleDate, "day")).toBe(true);
   });
 
-  it("creates an overlay time label when dragging a short timed event without one", () => {
+  it("creates a draft event time label when dragging a short timed event without one", () => {
     const { child, source } = registerEvent(timedEvent, "timed");
     const { adapter, flushFrame } = createAdapter();
 
@@ -387,10 +387,10 @@ describe("DayInteractionAdapter", () => {
     );
     flushFrame();
 
-    const overlay = document.querySelector(
-      "[data-calendar-interaction-overlay='true']",
+    const draftEvent = document.querySelector(
+      "[data-calendar-draft-event='true']",
     );
-    const timeLabel = overlay?.querySelector(
+    const timeLabel = draftEvent?.querySelector(
       "[data-calendar-event-time-label='true']",
     );
 

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
@@ -6,9 +6,9 @@ import {
 } from "@web/common/calendar-grid/calendarGrid.constants";
 import { getLocalMinutes } from "@web/common/calendar-grid/interaction/calendarInteractionDate";
 import {
-  createCalendarInteractionEventOverlayMount,
+  createCalendarInteractionDraftEventMount,
   getCalendarResizeHandleEdge,
-  updateCalendarOverlayTimeLabel,
+  updateCalendarDraftEventTimeLabel,
 } from "@web/common/calendar-grid/interaction/calendarInteractionDom";
 import {
   buildAllDayCalendarLayoutCache,
@@ -312,18 +312,18 @@ export const createDayInteractionAdapter = ({
           startMinutes: getLocalMinutes(target.event.startDate),
         });
       },
-      getOverlayMount: ({ sourceElement }) =>
-        createCalendarInteractionEventOverlayMount({
+      getDraftEventMount: ({ sourceElement }) =>
+        createCalendarInteractionDraftEventMount({
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
-      getSourceElementOverlayMode: (target) =>
+      getSourceElementDraftEventMode: (target) =>
         isDragTarget(target) ? "dim-source" : "hide-source",
       getTarget: (event) => getInteractionTarget(event),
       updateVisual: ({ pointer, target, visual }) => {
         if (!layout) {
           return {
-            overlay: null,
+            draftEvent: null,
             visual,
           };
         }
@@ -335,7 +335,7 @@ export const createDayInteractionAdapter = ({
           });
 
           return {
-            overlay: {
+            draftEvent: {
               transform: nextVisual.transform,
             },
             visual: nextVisual,
@@ -349,7 +349,7 @@ export const createDayInteractionAdapter = ({
           });
 
           return {
-            overlay: {
+            draftEvent: {
               height: nextVisual.sourceRect.height,
               transform: nextVisual.transform,
               width: nextVisual.width,
@@ -376,9 +376,10 @@ export const createDayInteractionAdapter = ({
           );
 
           return {
-            overlay: {
+            draftEvent: {
               height: nextVisual.height,
-              mutate: (node) => updateCalendarOverlayTimeLabel(node, nextEvent),
+              mutate: (node) =>
+                updateCalendarDraftEventTimeLabel(node, nextEvent),
               transform: nextVisual.transform,
             },
             shouldContinue: smartScroll.isScrolling,
@@ -403,8 +404,9 @@ export const createDayInteractionAdapter = ({
         );
 
         return {
-          overlay: {
-            mutate: (node) => updateCalendarOverlayTimeLabel(node, nextEvent),
+          draftEvent: {
+            mutate: (node) =>
+              updateCalendarDraftEventTimeLabel(node, nextEvent),
             transform: nextVisual.transform,
           },
           shouldContinue: smartScroll.isScrolling,

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayDrag.test.ts
@@ -358,13 +358,13 @@ describe("WeekInteractionAdapter all-day drag", () => {
 
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay).toBeTruthy();
-    expect(overlay?.style.transition).toBe("none");
-    expect(overlay?.style.transform).toBe("translate3d(100px, 0px, 0)");
+    expect(draftEvent).toBeTruthy();
+    expect(draftEvent?.style.transition).toBe("none");
+    expect(draftEvent?.style.transform).toBe("translate3d(100px, 0px, 0)");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: child, x: 430, y: 30 }),
@@ -384,7 +384,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
     fireCommitTeardownDeadline();
     expectSourceRestored(source);
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
   });
 
@@ -425,7 +425,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
     expect(onRequestWeekNavigation).not.toHaveBeenCalled();
   });
 
-  it("restores the source element and overlay when all-day drag is cancelled", () => {
+  it("restores the source element and draft event when all-day drag is cancelled", () => {
     const { adapter, child, flushFrame, onCommitAllDayDrag, source } =
       createHarness();
 
@@ -439,7 +439,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
 
     expectSourceDimmed(source);
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeTruthy();
 
     adapter.handlePointerCancel(
@@ -448,7 +448,7 @@ describe("WeekInteractionAdapter all-day drag", () => {
 
     expectSourceRestored(source);
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
     expect(onCommitAllDayDrag).not.toHaveBeenCalled();
   });

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayResize.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.allDayResize.test.ts
@@ -292,13 +292,13 @@ describe("WeekInteractionAdapter all-day resize", () => {
 
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transition).toBe("none");
-    expect(overlay?.style.transform).toBe("translate3d(0px, 0px, 0)");
-    expect(overlay?.style.width).toBe("290px");
+    expect(draftEvent?.style.transition).toBe("none");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, 0px, 0)");
+    expect(draftEvent?.style.width).toBe("290px");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: endHandle, x: 655, y: 30 }),
@@ -318,7 +318,7 @@ describe("WeekInteractionAdapter all-day resize", () => {
     fireCommitTeardownDeadline();
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
   });
 
@@ -334,12 +334,12 @@ describe("WeekInteractionAdapter all-day resize", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transform).toBe("translate3d(100px, 0px, 0)");
-    expect(overlay?.style.width).toBe("190px");
+    expect(draftEvent?.style.transform).toBe("translate3d(100px, 0px, 0)");
+    expect(draftEvent?.style.width).toBe("190px");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: startHandle, x: 655, y: 30 }),
@@ -393,7 +393,7 @@ describe("WeekInteractionAdapter all-day resize", () => {
     );
   });
 
-  it("restores the source element and overlay when all-day resize is cancelled", () => {
+  it("restores the source element and draft event when all-day resize is cancelled", () => {
     const { adapter, endHandle, flushFrame, onCommitAllDayResize, source } =
       createHarness();
 
@@ -407,7 +407,7 @@ describe("WeekInteractionAdapter all-day resize", () => {
 
     expect(source.style.visibility).toBe("hidden");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeTruthy();
 
     adapter.handlePointerCancel(
@@ -416,7 +416,7 @@ describe("WeekInteractionAdapter all-day resize", () => {
 
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
     expect(onCommitAllDayResize).not.toHaveBeenCalled();
   });

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedDrag.test.ts
@@ -406,13 +406,13 @@ describe("WeekInteractionAdapter timed drag", () => {
 
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay).toBeTruthy();
-    expect(overlay?.style.transition).toBe("none");
-    expect(overlay?.style.transform).toBe("translate3d(0px, 100px, 0)");
+    expect(draftEvent).toBeTruthy();
+    expect(draftEvent?.style.transition).toBe("none");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, 100px, 0)");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: child, x: 320, y: 1120 }),
@@ -433,7 +433,7 @@ describe("WeekInteractionAdapter timed drag", () => {
     fireCommitTeardownDeadline();
     expectSourceRestored(source);
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
   });
 
@@ -449,17 +449,17 @@ describe("WeekInteractionAdapter timed drag", () => {
 
     flushFrame();
 
-    const overlay = document.body.querySelector<HTMLElement>(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector<HTMLElement>(
+      "[data-calendar-draft-event]",
     );
-    const timeLabel = overlay?.querySelector<HTMLElement>(
+    const timeLabel = draftEvent?.querySelector<HTMLElement>(
       "[data-calendar-event-time-label='true']",
     );
 
     expect(timeLabel).toBeTruthy();
     expect(timeLabel?.textContent).toMatch(/10\s+-\s+11 AM/);
     expect(timeLabel?.previousElementSibling).toBe(
-      overlay?.querySelector("span"),
+      draftEvent?.querySelector("span"),
     );
   });
 
@@ -545,11 +545,11 @@ describe("WeekInteractionAdapter timed drag", () => {
 
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transform).toBe("translate3d(0px, -600px, 0)");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, -600px, 0)");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: child, x: 320, y: 20 }),
@@ -577,11 +577,11 @@ describe("WeekInteractionAdapter timed drag", () => {
 
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transform).toBe("translate3d(0px, 300px, 0)");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, 300px, 0)");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: child, x: 320, y: 2200 }),

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.timedResize.test.ts
@@ -289,13 +289,13 @@ describe("WeekInteractionAdapter timed resize", () => {
 
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transition).toBe("none");
-    expect(overlay?.style.transform).toBe("translate3d(0px, 0px, 0)");
-    expect(overlay?.style.height).toBe("150px");
+    expect(draftEvent?.style.transition).toBe("none");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, 0px, 0)");
+    expect(draftEvent?.style.height).toBe("150px");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: endHandle, x: 320, y: 1150 }),
@@ -315,7 +315,7 @@ describe("WeekInteractionAdapter timed resize", () => {
     fireCommitTeardownDeadline();
     expect(source.style.visibility).toBe("visible");
     expect(
-      document.body.querySelector("[data-calendar-interaction-overlay]"),
+      document.body.querySelector("[data-calendar-draft-event]"),
     ).toBeNull();
   });
 
@@ -358,13 +358,13 @@ describe("WeekInteractionAdapter timed resize", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transition).toBe("none");
-    expect(overlay?.style.transform).toBe("translate3d(0px, -50px, 0)");
-    expect(overlay?.style.height).toBe("150px");
+    expect(draftEvent?.style.transition).toBe("none");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, -50px, 0)");
+    expect(draftEvent?.style.height).toBe("150px");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: startHandle, x: 320, y: 950 }),
@@ -394,12 +394,12 @@ describe("WeekInteractionAdapter timed resize", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transform).toBe("translate3d(0px, -25px, 0)");
-    expect(overlay?.style.height).toBe("25px");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, -25px, 0)");
+    expect(draftEvent?.style.height).toBe("25px");
 
     adapter.handlePointerUp(
       makePointerEvent("pointerup", { target: endHandle, x: 320, y: 980 }),
@@ -483,7 +483,7 @@ describe("WeekInteractionAdapter timed resize", () => {
     );
   });
 
-  it("re-syncs the overlay position when the grid scrolls without further pointer movement", () => {
+  it("re-syncs the draft event position when the grid scrolls without further pointer movement", () => {
     const { adapter, endHandle, flushFrame, mainGrid } = createHarness();
 
     adapter.handlePointerDown(
@@ -494,19 +494,19 @@ describe("WeekInteractionAdapter timed resize", () => {
     );
     flushFrame();
 
-    const overlay = document.body.querySelector(
-      "[data-calendar-interaction-overlay]",
+    const draftEvent = document.body.querySelector(
+      "[data-calendar-draft-event]",
     ) as HTMLElement | null;
 
-    expect(overlay?.style.transform).toBe("translate3d(0px, 0px, 0)");
-    expect(overlay?.style.height).toBe("150px");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, 0px, 0)");
+    expect(draftEvent?.style.height).toBe("150px");
 
     mainGrid.scrollTop = 100;
     mainGrid.dispatchEvent(new Event("scroll"));
     flushFrame();
 
-    expect(overlay?.style.transform).toBe("translate3d(0px, -100px, 0)");
-    expect(overlay?.style.height).toBe("250px");
+    expect(draftEvent?.style.transform).toBe("translate3d(0px, -100px, 0)");
+    expect(draftEvent?.style.height).toBe("250px");
   });
 
   it("uses the latest timed grid scroll position when it changes before timed resize commit", () => {

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -1,7 +1,7 @@
 import {
-  createCalendarInteractionEventOverlayMount,
+  createCalendarInteractionDraftEventMount,
   getCalendarResizeHandleEdge,
-  updateCalendarOverlayTimeLabel,
+  updateCalendarDraftEventTimeLabel,
 } from "@web/common/calendar-grid/interaction/calendarInteractionDom";
 import { getSmartScrollFrame } from "@web/common/calendar-grid/interaction/math/smartScroll";
 import {
@@ -314,12 +314,12 @@ export const createWeekInteractionAdapter = ({
           target,
         });
       },
-      getOverlayMount: ({ sourceElement }) =>
-        createCalendarInteractionEventOverlayMount({
+      getDraftEventMount: ({ sourceElement }) =>
+        createCalendarInteractionDraftEventMount({
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
-      getSourceElementOverlayMode: (target) =>
+      getSourceElementDraftEventMode: (target) =>
         isDragTarget(target) ? "dim-source" : "hide-source",
       getTarget: (event) => getInteractionTarget(event),
       updateVisual: ({ pointer, target, timestamp, visual }) => {
@@ -328,7 +328,7 @@ export const createWeekInteractionAdapter = ({
         if (!layout || scrollTop === null) {
           if (visual.type !== "allDayDrag" && visual.type !== "allDayResize") {
             return {
-              overlay: null,
+              draftEvent: null,
               visual,
             };
           }
@@ -336,7 +336,7 @@ export const createWeekInteractionAdapter = ({
 
         if (!layout) {
           return {
-            overlay: null,
+            draftEvent: null,
             visual,
           };
         }
@@ -354,7 +354,7 @@ export const createWeekInteractionAdapter = ({
           });
 
           return {
-            overlay: {
+            draftEvent: {
               transform: nextVisual.transform,
             },
             shouldContinue: nextEdgeNavigation.isDwellActive,
@@ -370,7 +370,7 @@ export const createWeekInteractionAdapter = ({
           });
 
           return {
-            overlay: {
+            draftEvent: {
               height: nextVisual.sourceRect.height,
               transform: nextVisual.transform,
               width: nextVisual.width,
@@ -394,10 +394,10 @@ export const createWeekInteractionAdapter = ({
           });
 
           return {
-            overlay: {
+            draftEvent: {
               height: next.visual.height,
               mutate: (node) =>
-                updateCalendarOverlayTimeLabel(node, next.event),
+                updateCalendarDraftEventTimeLabel(node, next.event),
               transform: next.visual.transform,
             },
             shouldContinue: smartScroll.isScrolling,
@@ -424,8 +424,9 @@ export const createWeekInteractionAdapter = ({
         });
 
         return {
-          overlay: {
-            mutate: (node) => updateCalendarOverlayTimeLabel(node, next.event),
+          draftEvent: {
+            mutate: (node) =>
+              updateCalendarDraftEventTimeLabel(node, next.event),
             transform: next.visual.transform,
           },
           shouldContinue:

--- a/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
+++ b/packages/web/src/views/Week/interaction/registry/weekEventRegistry.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from "@testing-library/react";
 import { act } from "react";
 import { Priorities } from "@core/constants/core.constants";
 import dayjs from "@core/util/date/dayjs";
-import { createCalendarInteractionEventOverlayMount } from "@web/common/calendar-grid/interaction/calendarInteractionDom";
-import { FloatingInteractionOverlay } from "@web/common/calendar-interaction/dom/overlay/FloatingInteractionOverlay";
+import { createCalendarInteractionDraftEventMount } from "@web/common/calendar-grid/interaction/calendarInteractionDom";
+import { FloatingDraftEvent } from "@web/common/calendar-interaction/dom/draft-event/FloatingDraftEvent";
 import { gridHoverColorByPriority } from "@web/common/styles/theme.util";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -467,8 +467,8 @@ describe("weekEventRegistry", () => {
   });
 });
 
-describe("createCalendarInteractionEventOverlayMount", () => {
-  it("clones a Week event for overlay use without duplicate interactive attributes", () => {
+describe("createCalendarInteractionDraftEventMount", () => {
+  it("clones a Week event for draft event use without duplicate interactive attributes", () => {
     const source = document.createElement("div");
     const child = document.createElement("button");
 
@@ -489,13 +489,13 @@ describe("createCalendarInteractionEventOverlayMount", () => {
     child.style.transition = "opacity 150ms ease";
     source.append(child);
 
-    const mount = createCalendarInteractionEventOverlayMount({
+    const mount = createCalendarInteractionDraftEventMount({
       source,
     });
     const clonedChild = mount.clone.querySelector("button");
-    const overlay = new FloatingInteractionOverlay();
+    const draftEvent = new FloatingDraftEvent();
 
-    overlay.mount(mount);
+    draftEvent.mount(mount);
 
     expect(mount.rect).toEqual({
       height: 44,
@@ -512,9 +512,9 @@ describe("createCalendarInteractionEventOverlayMount", () => {
     expect(clonedChild?.id).toBe("");
     expect(clonedChild?.getAttribute("aria-controls")).toBeNull();
     expect(clonedChild?.style.transition).toBe("none");
-    expect(overlay.getNode()?.style.width).toBe("140px");
-    expect(overlay.getNode()?.style.height).toBe("44px");
+    expect(draftEvent.getNode()?.style.width).toBe("140px");
+    expect(draftEvent.getNode()?.style.height).toBe("44px");
 
-    overlay.unmount();
+    draftEvent.unmount();
   });
 });


### PR DESCRIPTION
## Summary
- Rename the calendar drag/resize interaction overlay concept to Draft Event across adapter APIs, DOM helpers, selectors, metrics, tests, and docs.
- Move the DOM implementation to draft-event naming and rename the private selector to `data-calendar-draft-event`.
- Keep unrelated overlay language for shortcuts, command palette, menus, loading, and dialog/backdrop layers unchanged.

## Simplicity
- Kept this as a direct terminology refactor with no compatibility aliases for old exported names or selectors.
- No hook churn: no new or changed `useEffect`, `useRef`, `useState`, `useMemo`, or `useCallback` usage.
- Follow-up simplify pass only adjusted one comment from identifier-style wording to domain wording.

## Manual testing steps
- [ ] Open `http://localhost:9084` in Chrome and confirm the signed-in Day calendar renders.
- [ ] Drag a timed event in the calendar and confirm the moving draft event visual follows the target slot until release.
- [ ] Drag a Someday event into the timed grid and confirm the draft event preview shows the title and tentative time range.
- [ ] Drag a Someday event over a past timed slot and confirm the draft event preview still shows the title and tentative time range.

## Test plan
- [x] `bun test:web -- CalendarInteractionEngine` — 20 pass, 0 fail
- [x] `bun test:web -- WeekInteractionAdapter` — 39 pass, 0 fail
- [x] `bun test:web -- DayInteractionAdapter` — 9 pass, 0 fail
- [x] `bun test:web -- SomedayInteractionAdapter` — 17 pass, 0 fail
- [x] `bun type-check`
- [x] `bun lint` — exits 0; reports existing unrelated warnings
- [x] `bunx playwright test e2e/timed/move-event-reduced-days.spec.ts e2e/someday/drag-someday-event-mouse.spec.ts --workers=1` — 3 pass, 0 fail
