### PR TITLE
feat(day): default task list width to 600

### DIFF
--- a/packages/web/src/views/Day/storage/task-list-width.constants.ts
+++ b/packages/web/src/views/Day/storage/task-list-width.constants.ts
@@ -1,4 +1,4 @@
-export const TASK_LIST_DEFAULT_WIDTH = 360;
+export const TASK_LIST_DEFAULT_WIDTH = 600;
 export const TASK_LIST_MIN_WIDTH = 240;
 export const TASK_LIST_MAX_WIDTH = 600;
 // Matches the resize-handle column's w-8 (2rem) in DayViewContent.


### PR DESCRIPTION
## What

Change the day-view task list's default width from 360px to 600px (the current `TASK_LIST_MAX_WIDTH`), so the list opens at full supported width.

## Why

From the 2026-07-09 daily spec. Gives the task list more room by default.

## Changes

- `TASK_LIST_DEFAULT_WIDTH`: 360 → 600 in `packages/web/src/views/Day/storage/task-list-width.constants.ts`

The value stays within the existing clamp range (min 240, max 600); stored user widths are unaffected.

## Manual testing steps

1. Clear `localStorage` (or use a fresh profile) and open the Day view.
2. The task list should open at 600px wide (full width, flush to the resize handle).
3. Existing users with a stored width keep their width.

## Verification

- `bun run test:web src/views/Day/storage/task-list-width.storage.test.ts` — 3/3 pass
- `bun run type-check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)