### PR TITLE
fix(day): migrate task when the reorder handle is focused

### DIFF
--- a/packages/web/src/views/Day/components/Task/DraggableTask.tsx
+++ b/packages/web/src/views/Day/components/Task/DraggableTask.tsx
@@ -59,6 +59,7 @@ export function DraggableTask({
           {...attributes}
           {...listeners}
           ref={setActivatorNodeRef}
+          data-task-id={task._id}
           aria-label={
             isDragging
               ? `Reordering ${task.title}. Use arrow keys to move, space to drop.`

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.test.tsx
@@ -20,6 +20,15 @@ const focusTaskCheckbox = () => {
   return checkbox;
 };
 
+const focusReorderHandle = () => {
+  const handle = document.createElement("button");
+  handle.setAttribute("aria-label", "Reorder My task");
+  handle.dataset.taskId = TASK_ID;
+  document.body.appendChild(handle);
+  handle.focus();
+  return handle;
+};
+
 const pressMigrate = (key: "ArrowRight" | "ArrowLeft") =>
   pressKey(key, {
     keyDownInit: { shiftKey: true },
@@ -87,6 +96,18 @@ describe("useDayViewShortcuts migration", () => {
 
     await waitFor(() => {
       expect(onMigrateTask).toHaveBeenCalledWith(TASK_ID, "backward");
+    });
+  });
+
+  it("migrates when the drag/reorder handle is focused", async () => {
+    const onMigrateTask = mock();
+    focusReorderHandle();
+
+    renderHook(() => useDayViewShortcuts({ onMigrateTask }), { wrapper });
+    pressMigrate("ArrowRight");
+
+    await waitFor(() => {
+      expect(onMigrateTask).toHaveBeenCalledWith(TASK_ID, "forward");
     });
   });
 

--- a/packages/web/src/views/Day/util/day.shortcut.util.ts
+++ b/packages/web/src/views/Day/util/day.shortcut.util.ts
@@ -40,6 +40,15 @@ export const isFocusedWithinTask = () => {
     return true;
   }
 
+  // Check if focused on the drag/reorder handle. It carries its own
+  // data-task-id because it sits outside the task's data-task-id container.
+  if (
+    activeElement.tagName === "BUTTON" &&
+    activeElement.getAttribute("aria-label")?.startsWith("Reorder")
+  ) {
+    return true;
+  }
+
   return false;
 };
 
@@ -78,6 +87,15 @@ export const getFocusedTaskId = () => {
       "[data-task-id]",
     ) as HTMLElement;
     return taskContainer?.dataset?.taskId || null;
+  }
+
+  // Reorder/drag handle carries its own data-task-id (it lives outside the
+  // task's data-task-id container, so closest() can't find it).
+  if (
+    activeElement.tagName === "BUTTON" &&
+    activeElement.getAttribute("aria-label")?.startsWith("Reorder")
+  ) {
+    return activeElement.dataset?.taskId ?? null;
   }
 
   return null;


### PR DESCRIPTION
## What

Fix Day-view task migration so it works when the **reorder/drag handle** (the "thumb" to the left of a task) has keyboard focus. Previously `Shift+ArrowLeft/Right` did nothing in that state.

## Why

From the 2026-07-09 daily spec: a keyboard user who has focused the reorder handle expects the migrate hotkey to still move the task, so they can trust that keyboard migration always works.

## Root cause

The reorder handle is rendered as a sibling of the task's inner element, **outside** the element carrying `data-task-id`. The migration focus helpers (`isFocusedWithinTask` / `getFocusedTaskId` in `day.shortcut.util.ts`) only recognized the checkbox, the title input, and the arrow buttons — so with the handle focused, `isFocusedWithinTask()` returned `false` and migration never fired.

## Changes

- `DraggableTask.tsx`: give the reorder handle its own `data-task-id` (mirrors the checkbox/input).
- `day.shortcut.util.ts`: recognize the reorder handle (a `<button>` whose `aria-label` starts with "Reorder") in both `isFocusedWithinTask` and `getFocusedTaskId`.
- `useDayViewShortcuts.test.tsx`: new regression test — migration fires when the handle is focused.

> Note: the binding is `Shift+Arrow` (not `cmd+ctrl+arrow`, which the spec described). Flag if a different binding was intended.

## Manual testing steps

1. Open the Day view with 2+ tasks (the handle only shows when reorder is possible).
2. Tab/focus the reorder handle (⋮⋮) to the left of a task.
3. Press `Shift+ArrowRight` → task migrates to the next day; `Shift+ArrowLeft` → previous day.

## Verification

- `bun run test:web src/views/Day/hooks/shortcuts/useDayViewShortcuts.test.tsx` — 7/7 pass (incl. new test)
- Day suite `bun run test:web src/views/Day` — 70/70; `bun run type-check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)