### PR TITLE
docs(web): document floating-ui positioning conventions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 - Event shape or recurrence behavior: [Event And Task Domain Model](./architecture/event-and-task-domain-model.md), [Recurrence Handling](./features/recurring-events-handling.md)
 - Event caching, reads, or optimistic writes: [Event Caching](./frontend/event-caching.md)
 - Dragging/resizing events on the week grid: [Week Drag Interaction](./frontend/week-drag-interaction.md)
+- Tooltips, popovers, menus, or any floating/anchored UI: [UI Positioning Conventions](./frontend/ui-positioning.md)
 - Local-first or storage behavior: [Offline Storage And Migrations](./features/offline-storage-and-migrations.md)
 - Backend routes and API behavior: [Backend Route Map](./backend/README.md), [Backend Request Flow](./backend/backend-request-flow.md), [Backend Error Handling](./backend/backend-error-handling.md)
 - Event writes, sync transactions, or a new calendar integration: [Event Propagation Transactions](./backend/event-propagation-transactions.md)

--- a/docs/frontend/ui-positioning.md
+++ b/docs/frontend/ui-positioning.md
@@ -1,0 +1,58 @@
+# UI Positioning Conventions
+
+How Compass positions floating and anchored UI. Follow this when adding tooltips,
+popovers, menus, or any element that floats next to an anchor.
+
+## Default: `@floating-ui/react`
+
+Use [`@floating-ui/react`](https://floating-ui.com/docs/react) (already a dependency) for
+all anchored/floating UI. **Do not hand-roll positioning** with `getBoundingClientRect` +
+`position: absolute/fixed` math — floating-ui already handles flipping, shifting,
+collision, and auto-updates, and hand-rolled versions drift out of sync.
+
+Use it for:
+
+- Tooltips
+- Popovers
+- Select menus, comboboxes, dropdown menus
+- Context menus (anchor to a virtual element at the cursor)
+- Floating forms / anchored panels
+
+The codebase is already fully on floating-ui — study these before writing new positioning:
+
+- Tooltips: `packages/web/src/components/Tooltip/useTooltip.ts`, `Tooltip.tsx`
+- Context menus (virtual-element-at-cursor): `packages/web/src/components/ContextMenu/`
+- View switcher select: `packages/web/src/components/SelectView/SelectView.tsx`
+- Sophisticated floating forms (conditional offset/flip/shift/hide):
+  `packages/web/src/views/Forms/hooks/useEventForm.ts`
+- List-navigable menus: `packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx`
+- Command palette (`FloatingOverlay`/`FloatingPortal`): `packages/web/src/components/CommandPalette/CommandPalette.tsx`
+
+Shared conventions:
+
+- Render floating content through `FloatingPortal` for correct stacking.
+- Wrap forms/menus that own focus in `FloatingFocusManager`.
+- Take z-index from `packages/web/src/common/constants/web.constants.ts`
+  (`Z_INDEX_TOOLTIP`, `Z_INDEX_FLOATING_MENU`, `Z_INDEX_FLOATING_FORM`, `Z_INDEX_MODAL`),
+  not ad-hoc values.
+
+## Exceptions — libraries that own their positioning
+
+Do **not** wrap these in floating-ui; they ship their own popper:
+
+- `react-datepicker` (date pickers, month pickers)
+- `react-select` (recurrence/time selects)
+- `react-toastify` (toasts)
+
+## Centered modals/dialogs
+
+Modals and dialogs are centered overlays, not anchored UI — they do not need floating-ui.
+Use the existing `OverlayPanel` pattern (`packages/web/src/components/OverlayPanel/`).
+
+## Testing
+
+Components that rely on floating-ui refs/styles need the shared test setup — see the
+"Floating UI-Dependent Tests" section in
+[Testing Playbook](../development/testing-playbook.md). Do not mock `@floating-ui/react`
+in broad component tests; a mock that helps one file can break unrelated tests in the same
+Bun process.


### PR DESCRIPTION
## What

Add `docs/frontend/ui-positioning.md` documenting how Compass positions floating/anchored UI, and link it from the docs index.

## Why

From the 2026-07-09 daily spec (the "refactor to floating-ui" item). Investigation showed the codebase is **already fully on `@floating-ui/react`** — tooltips, context menus, selects/dropdowns, floating forms, and the command palette all use it. So the valuable, non-redundant work is to capture the convention so it's followed going forward, rather than re-refactor already-migrated code or add speculative abstractions.

## Changes

- New `docs/frontend/ui-positioning.md`: use `@floating-ui/react` for anchored UI (with pointers to canonical implementations and shared conventions — `FloatingPortal`, `FloatingFocusManager`, z-index constants); documented exceptions (react-datepicker / react-select / react-toastify own their positioning; centered modals use `OverlayPanel`); testing note.
- `docs/README.md`: index entry under Common Change Paths.

## Verification

Docs-only. Links resolve to existing files/sections; new doc path is lowercase `docs/frontend/` to match the tracked directory (case-sensitive CI safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)