### PR TITLE
fix(web): align logout dialog and drop stale logout keycap

### DIFF
--- a/packages/web/src/common/hooks/useLogoutCmdItems.ts
+++ b/packages/web/src/common/hooks/useLogoutCmdItems.ts
@@ -16,7 +16,6 @@ export const useLogoutCmdItems = (): CommandItem[] => {
       id: "log-out",
       label: "Log Out",
       icon: SignOutIcon,
-      shortcut: "z",
       onClick: openLogoutConfirmation,
     },
   ];

--- a/packages/web/src/components/LogoutConfirmation/LogoutConfirmationDialog.tsx
+++ b/packages/web/src/components/LogoutConfirmation/LogoutConfirmationDialog.tsx
@@ -22,14 +22,15 @@ export function LogoutConfirmationDialog({
       title="Log out?"
       message="You'll lose access to your calendar data."
       onDismiss={onCancel}
+      align="start"
       variant="modal"
     >
-      <OverlayPanelActions>
-        <OverlayPanelActionButton onClick={onCancel}>
-          Cancel
-        </OverlayPanelActionButton>
+      <OverlayPanelActions align="start">
         <OverlayPanelActionButton variant="primary" onClick={onConfirm}>
           Log out
+        </OverlayPanelActionButton>
+        <OverlayPanelActionButton onClick={onCancel}>
+          Cancel
         </OverlayPanelActionButton>
       </OverlayPanelActions>
     </OverlayPanel>

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -26,6 +26,8 @@ interface Props {
   onDismiss?: () => void;
   /** ARIA role for the panel (default: "dialog") */
   role?: "dialog" | "status" | "alert";
+  /** Cross-axis alignment of the title/message/children (default: "center") */
+  align?: "center" | "start";
   /** Panel style variant */
   variant?: "modal" | "status";
   /** Tailwind width class for the modal variant (default: "w-[400px]") */
@@ -40,6 +42,7 @@ export const OverlayPanel = ({
   children,
   onDismiss,
   role = "dialog",
+  align = "center",
   variant = "modal",
   widthClassName = "w-[400px]",
 }: Props) => {
@@ -62,7 +65,8 @@ export const OverlayPanel = ({
   );
 
   const panelClasses = clsx(
-    "flex flex-col items-center",
+    "flex flex-col",
+    align === "start" ? "items-start" : "items-center",
     variant === "modal" && [
       widthClassName,
       "max-w-[90vw] gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]",
@@ -157,10 +161,22 @@ export const OverlayPanel = ({
 
 interface OverlayPanelActionsProps {
   children: ReactNode;
+  /** Horizontal alignment of the action buttons (default: "end") */
+  align?: "start" | "end";
 }
 
-export const OverlayPanelActions = ({ children }: OverlayPanelActionsProps) => (
-  <div className="flex w-full justify-end gap-3">{children}</div>
+export const OverlayPanelActions = ({
+  children,
+  align = "end",
+}: OverlayPanelActionsProps) => (
+  <div
+    className={clsx(
+      "flex w-full gap-3",
+      align === "start" ? "justify-start" : "justify-end",
+    )}
+  >
+    {children}
+  </div>
 );
 
 interface OverlayPanelActionButtonProps


### PR DESCRIPTION
## Summary

Cleans up the logout confirmation dialog and its command-palette entry (spec item 1):

- **Left-align the dialog.** The header ("Log out?"), message, and action buttons now share the same left edge, instead of the header being left while the message/buttons drifted center/right. Implemented with opt-in `align` props on `OverlayPanel` / `OverlayPanelActions` that **default to the current behavior** (`center` panel, `end` actions), so every other consumer — AuthModal, RecurrenceScopeDialog, LifeAboutDialog, and the auth status spinner — renders exactly as before. Only the logout dialog opts into `align="start"`.
- **Reorder buttons** to `Log out` (primary) then `Cancel`.
- **Remove the stale `z` keycap** from the command-palette "Log Out" item — that keyboard binding no longer exists, so the keycap was misleading. The palette already renders `item.shortcut` conditionally, so dropping the field removes the chip.

**Behavior note for reviewers:** because DOM order now matches the visual order (Log out, then Cancel), `OverlayPanel`'s mount-focus lands on "Log out" rather than "Cancel". I kept DOM order == visual order deliberately (decoupling via CSS `order` would make screen readers announce a different sequence than sighted users see). Logout is recoverable, and the dialog is itself the confirmation gate — flagging in case you'd prefer initial focus on Cancel.

## Simplicity

Net-neutral-to-simpler. The change is a button reorder, one deleted line, and two default-preserving `align` props expressed as idiomatic `clsx` ternaries — no new abstraction, no duplication introduced. **No `useState`/`useEffect`/`useRef`** added or touched. `simplify` found nothing further to reduce.

## Manual Testing Steps

- [ ] As a signed-in user, open the command palette and locate **Log Out** — confirm there is **no** keyboard-shortcut keycap chip beside it (compare: shortcut items like "Go to Week" still show their keycap).
- [ ] Click **Log Out** — the confirmation dialog's header, message, and buttons are all left-aligned, and the buttons read **Log out** then **Cancel** (left to right).
- [ ] Click **Cancel** — dialog closes, you stay signed in.
- [ ] Reopen and click **Log out** — you are signed out.
- [ ] Press **Esc** and separately click the backdrop — each dismisses the dialog; focus is trapped inside the dialog while Tabbing.
- [ ] Regression check on the shared panel: open the **sign-in modal** and the **"apply to which events?" dialog** (edit a recurring event, then save) — their content is still centered and their buttons still right-aligned (unchanged).

## Test plan

- [x] `bun test` (web) — LogoutConfirmationDialog, OverlayPanel, CommandPalette, useLogoutCmdItems: **20 pass, 0 fail**
- [x] `type-check` (web, tsc) — pass
- [x] `biome check` on changed files — clean
- [x] Local preview smoke: app renders with no console errors; command-palette items without a shortcut (Log In, Sign Up) render no keycap, confirming Log Out now behaves identically. Full authed logout-dialog visual deferred to staging (anon/temp session doesn't expose Log Out).
