### PR TITLE
fix(web): humanize user-facing copy

### DIFF
--- a/packages/web/src/auth/google/authorization/google-authorization.constants.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.constants.ts
@@ -12,6 +12,6 @@ export const GOOGLE_AUTH_SCOPES_REQUIRED = [
 ];
 
 export const GOOGLE_AUTHORIZATION_ERROR_MESSAGE =
-  "Google authorization could not be completed. Please try again.";
+  "We couldn't connect your Google account. Please try again.";
 export const MISSING_GOOGLE_SCOPES_ERROR_MESSAGE =
-  "Missing Google Calendar permissions. Please grant all requested permissions.";
+  "Compass needs all the requested permissions to sync your calendar. Please allow them and try again.";

--- a/packages/web/src/auth/google/authorization/google-authorization.test.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.test.ts
@@ -160,7 +160,7 @@ describe("completeGoogleAuthorization", () => {
     ).resolves.toEqual({
       status: "failed",
       message:
-        "Missing Google Calendar permissions. Please grant all requested permissions.",
+        "Compass needs all the requested permissions to sync your calendar. Please allow them and try again.",
       returnPath: "/week",
     });
 
@@ -180,7 +180,7 @@ describe("completeGoogleAuthorization", () => {
       }),
     ).resolves.toEqual({
       status: "failed",
-      message: "Google authorization could not be completed. Please try again.",
+      message: "We couldn't connect your Google account. Please try again.",
       returnPath: "/day",
     });
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -75,9 +75,12 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
           return;
         }
 
-        showErrorToast("Google Calendar sync failed. Please try again.", {
-          toastId: GOOGLE_REPAIR_FAILED_TOAST_ID,
-        });
+        showErrorToast(
+          "We couldn't sync your Google Calendar. Please try again.",
+          {
+            toastId: GOOGLE_REPAIR_FAILED_TOAST_ID,
+          },
+        );
       }
     };
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -26,7 +26,7 @@ describe("getGoogleAccountSummaryStatus", () => {
   ] as const)("returns syncing copy for %s", (state) => {
     expect(getGoogleAccountSummaryStatus(state, callbacks)).toEqual({
       variant: "syncing",
-      tooltip: "Syncing...",
+      tooltip: "Syncing…",
     });
   });
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -12,9 +12,9 @@ const SYNCING_COMMAND_LABEL: Record<
   "checking" | "repairing" | "IMPORTING",
   string
 > = {
-  checking: "Checking Google Calendar…",
-  repairing: "Syncing Google Calendar…",
-  IMPORTING: "Syncing Google Calendar…",
+  checking: "Checking your Google Calendar…",
+  repairing: "Syncing your Google Calendar…",
+  IMPORTING: "Syncing your Google Calendar…",
 };
 
 export const getGoogleConnectionConfig = (
@@ -89,12 +89,12 @@ export const getGoogleAccountSummaryStatus = (
     case "checking":
       return {
         variant: "syncing",
-        tooltip: "Syncing...",
+        tooltip: "Syncing…",
       };
     case "ATTENTION":
       return {
         variant: "warning",
-        tooltip: "Google Calendar needs a sync",
+        tooltip: "Your Google Calendar is out of date",
         action: { label: "Sync now", onClick: onRepairGoogle },
       };
     case "RECONNECT_REQUIRED":

--- a/packages/web/src/auth/google/util/google.auth.util.factory.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.factory.ts
@@ -13,9 +13,9 @@ export interface SyncLocalEventsResult {
 }
 
 export const LOCAL_EVENTS_SYNC_ERROR_MESSAGE =
-  "We could not sync your local events. Your changes are still saved on this device.";
+  "We couldn't save your events to the cloud. Your changes are still safe on this device.";
 export const LOCAL_EVENTS_SYNC_SESSION_EXPIRED_MESSAGE =
-  "Your session expired before Compass could save your local events. Sign in again to continue. Your changes are still saved on this device.";
+  "You were signed out before Compass could save your events to the cloud. Sign in again to finish — your changes are still safe on this device.";
 
 type GoogleAuthUtilDependencies = {
   clearUserMetadata: () => void;

--- a/packages/web/src/common/utils/app-init.util.test.ts
+++ b/packages/web/src/common/utils/app-init.util.test.ts
@@ -120,7 +120,7 @@ describe("app-init.util", () => {
 
       // Now toast should be called
       expect(mockToastError).toHaveBeenCalledWith(
-        "Offline storage unavailable: Storage quota exceeded. Your data will not be saved locally.",
+        "Compass can't use offline storage right now: Storage quota exceeded. Your changes won't be saved on this device.",
         {
           autoClose: false,
           position: "bottom-right",
@@ -170,7 +170,7 @@ describe("app-init.util", () => {
         runToastTimeout();
 
         expect(mockToastError).toHaveBeenCalledWith(
-          "Offline storage unavailable: Failed to initialize IndexedDB after 3 attempts. Your data will not be saved locally.",
+          "Compass can't use offline storage right now: Failed to initialize IndexedDB after 3 attempts. Your changes won't be saved on this device.",
           expect.objectContaining({
             autoClose: false,
             position: "bottom-right",

--- a/packages/web/src/common/utils/app-init.util.ts
+++ b/packages/web/src/common/utils/app-init.util.ts
@@ -40,7 +40,7 @@ export function showDbInitErrorToast(dbInitError: DatabaseInitError): void {
   // Use setTimeout to ensure toast container is mounted
   setTimeout(() => {
     toast.error(
-      `Offline storage unavailable: ${dbInitError.message}. Your data will not be saved locally.`,
+      `Compass can't use offline storage right now: ${dbInitError.message}. Your changes won't be saved on this device.`,
       {
         autoClose: false,
         position: "bottom-right",

--- a/packages/web/src/common/utils/storage/db-errors.util.ts
+++ b/packages/web/src/common/utils/storage/db-errors.util.ts
@@ -58,7 +58,7 @@ export function handleDatabaseError(
   // Handle Dexie-specific errors
   if (error instanceof Dexie.QuotaExceededError) {
     throw new DatabaseOperationError(
-      "Storage quota exceeded. Please free up space in your browser.",
+      "Your browser is out of storage space. Please free some up and try again.",
       operation,
       error,
     );
@@ -66,7 +66,7 @@ export function handleDatabaseError(
 
   if (error instanceof Dexie.VersionError) {
     throw new DatabaseOperationError(
-      "Database version mismatch. Please reload the page.",
+      "Compass needs a quick refresh. Please reload the page.",
       operation,
       error,
     );
@@ -74,7 +74,7 @@ export function handleDatabaseError(
 
   if (error instanceof Dexie.DatabaseClosedError) {
     throw new DatabaseOperationError(
-      "Database was closed unexpectedly. The operation will be retried.",
+      "Compass briefly lost its local storage. We'll try that again.",
       operation,
       error,
     );

--- a/packages/web/src/common/utils/toast/session-expired.toast.tsx
+++ b/packages/web/src/common/utils/toast/session-expired.toast.tsx
@@ -37,7 +37,7 @@ export const SessionExpiredToast = ({ toastId }: SessionExpiredToastProps) => {
   return (
     <div className="flex w-full flex-col gap-2">
       <p className="text-sm text-white">
-        Session expired. Please sign in again.
+        You've been signed out. Please sign in again.
       </p>
       <button
         className="w-full rounded bg-fg-primary-dark px-3 py-2 font-medium text-sm text-text-lighter transition-colors hover:bg-[color-mix(in_srgb,var(--color-fg-primary-dark)_90%,white)]"

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.test.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.test.ts
@@ -7,7 +7,7 @@ describe("getAuthSubmitErrorMessage", () => {
     error.name = "ApiError";
 
     expect(getAuthSubmitErrorMessage(error, "Unable to log in")).toBe(
-      "Unable to reach the Compass server. Check that your backend is running and try again.",
+      "We can't reach Compass right now. Please check your connection and try again.",
     );
   });
 
@@ -18,7 +18,7 @@ describe("getAuthSubmitErrorMessage", () => {
         "Unable to log in",
       ),
     ).toBe(
-      "Unable to reach the Compass server. Check that your backend is running and try again.",
+      "We can't reach Compass right now. Please check your connection and try again.",
     );
   });
 });

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.util.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.util.ts
@@ -6,7 +6,7 @@ export function getAuthSubmitErrorMessage(
 ): string {
   if (error instanceof Error) {
     if (isBackendUnavailableError(error)) {
-      return "Unable to reach the Compass server. Check that your backend is running and try again.";
+      return "We can't reach Compass right now. Please check your connection and try again.";
     }
 
     return error.message;

--- a/packages/web/src/components/PlannerSidebar/PlannerAccountSummary/PlannerAccountSummary.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerAccountSummary/PlannerAccountSummary.test.tsx
@@ -158,7 +158,7 @@ describe("PlannerAccountSummary", () => {
     "IMPORTING",
     "repairing",
     "checking",
-  ] as const)("shows the wave shimmer class and 'Syncing...' copy for %s", async (state) => {
+  ] as const)("shows the wave shimmer class and 'Syncing…' copy for %s", async (state) => {
     const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";
     mockGoogleState = state;
@@ -170,7 +170,7 @@ describe("PlannerAccountSummary", () => {
 
     await user.hover(email);
     await waitFor(() => {
-      expect(screen.getByRole("tooltip")).toHaveTextContent("Syncing...");
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Syncing…");
     });
   });
 
@@ -260,7 +260,7 @@ describe("PlannerAccountSummary", () => {
 
     renderSummary({ pendingEventIds: ["event-1"] });
 
-    expect(screen.getByText("Syncing...")).toBeTruthy();
+    expect(screen.getByText("Syncing…")).toBeTruthy();
     expect(screen.queryByText("Syncing changes…")).toBeNull();
   });
 });

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
@@ -112,7 +112,7 @@ describe("completeGoogleAuthCallback", () => {
     expect(mockConnectGoogle).not.toHaveBeenCalled();
     expect(completeAuthentication).not.toHaveBeenCalled();
     expect(mockShowErrorToast).toHaveBeenCalledWith(
-      "Missing Google Calendar permissions. Please grant all requested permissions.",
+      "Compass needs all the requested permissions to sync your calendar. Please allow them and try again.",
     );
     expect(navigate).toHaveBeenCalledWith("/week", { replace: true });
   });
@@ -128,7 +128,7 @@ describe("completeGoogleAuthCallback", () => {
     expect(mockConnectGoogle).not.toHaveBeenCalled();
     expect(completeAuthentication).not.toHaveBeenCalled();
     expect(mockShowErrorToast).toHaveBeenCalledWith(
-      "Google authorization could not be completed. Please try again.",
+      "We couldn't connect your Google account. Please try again.",
     );
     expect(navigate).toHaveBeenCalledWith("/day", { replace: true });
   });

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
@@ -62,7 +62,7 @@ export function GoogleAuthCallbackView() {
 
   return (
     <OverlayPanel
-      title="Completing Google authorization..."
+      title="Just finishing up …"
       message="Returning you to Compass."
       role="status"
       variant="status"


### PR DESCRIPTION
## Summary

Replaces developer-focused wording across loaders, toasts, and error messages with plain, colloquial language — while keeping every message *functional* (each error still tells the user what to do next). Spec item 2.

Highlights:
- **Post-OAuth spinner:** "Completing Google authorization…" → **"Just finishing up …"** (the specific complaint — users don't know what "authorization" means).
- **Google connection labels/tooltips:** "Checking Google Calendar…" → "Checking your Google Calendar…"; "Syncing..." → "Syncing…"; "Google Calendar needs a sync" → "Your Google Calendar is out of date".
- **Errors de-jargoned, instructions kept:** storage "quota exceeded" → "Your browser is out of storage space. Please free some up and try again."; "Database version mismatch. Please reload the page." → "Compass needs a quick refresh. Please reload the page."; "Unable to reach the Compass server… backend is running" → "We can't reach Compass right now. Please check your connection and try again."; session-expiry and local-sync-failure messages reworded to be warmer but still clear about what happened and what to do.

Left already-friendly copy alone (e.g. the "uff-dah…" date warning, "Login required, cuz security 😇", the login loader messages).

## Simplicity

Pure string edits — no logic, control flow, or component structure changed, and **no `useState`/`useEffect`/`useRef`** touched. `simplify` found nothing to reduce. Net complexity unchanged.

## Manual Testing Steps

- [ ] Complete a Google sign-in; while returning to Compass, the spinner reads **"Just finishing up …"**.
- [ ] Open the command palette and view the Google connection row — labels read "Checking your Google Calendar…" / "Syncing your Google Calendar…" depending on state.
- [ ] Trigger a Google sync failure (e.g. revoke access mid-session) — the toast reads "We couldn't sync your Google Calendar. Please try again."
- [ ] Force a session expiry (let the session lapse, then act) — the toast reads "You've been signed out. Please sign in again."
- [ ] (Hard to reproduce without fault injection) Storage-quota / DB-version / offline-storage errors now read in plain language with a clear next step.

## Test plan

- [x] `bun test` (web) — GoogleAuthCallback, useConnectGoogle.util, google-authorization, app-init, useAuthFormHandlers, PlannerAccountSummary: **44 pass, 0 fail** (assertions updated to the new copy)
- [x] `type-check` (web, tsc) — pass
- [x] `biome check` on changed files — clean (reformatted one call that exceeded line length)
- [x] Repo-wide grep confirmed no remaining occurrences of the old strings
