### PR TITLE
style(week): render the now line only on the current day's column

### DIFF
--- a/packages/web/src/common/calendar-grid/components/CalendarTimedGrid.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarTimedGrid.tsx
@@ -49,7 +49,7 @@ export const CalendarTimedGrid: FC<CalendarTimedGridProps> = ({
   today,
   visibleDates,
 }) => {
-  const isTodayVisible = visibleDates.some(({ date }) =>
+  const todayColumnIndex = visibleDates.findIndex(({ date }) =>
     date.isSame(today, "day"),
   );
 
@@ -76,7 +76,12 @@ export const CalendarTimedGrid: FC<CalendarTimedGridProps> = ({
           } as CSSVariables
         }
       >
-        {isTodayVisible ? <CalendarNowLine /> : null}
+        {todayColumnIndex >= 0 ? (
+          <CalendarNowLine
+            columnCount={visibleDates.length}
+            columnIndex={todayColumnIndex}
+          />
+        ) : null}
         {visibleDates.map(({ date, key }) => (
           <div
             className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-grid-line-primary border-l data-[past=true]:bg-bg-secondary"
@@ -151,7 +156,13 @@ const CalendarTimeColumn = () => {
   );
 };
 
-const CalendarNowLine = () => {
+const CalendarNowLine = ({
+  columnCount,
+  columnIndex,
+}: {
+  columnCount: number;
+  columnIndex: number;
+}) => {
   const [percentOfDay, setPercentOfDay] = useState(() =>
     getCurrentPercentOfDay(),
   );
@@ -166,12 +177,14 @@ const CalendarNowLine = () => {
 
   return (
     <div
-      className="absolute h-px w-full"
+      className="absolute h-px"
       role="separator"
       title="now line"
       style={{
         background: blueGradient,
         top: `${percentOfDay}%`,
+        left: `calc(${columnIndex} * 100% / ${columnCount})`,
+        width: `calc(100% / ${columnCount})`,
         zIndex: ZIndex.LAYER_2,
       }}
     />


### PR DESCRIPTION
## Summary

Reduces visual noise in the week grid by rendering the current-time "now line" **only under today's column**, instead of stretching it across all seven days. Spec item 4.

- The line's `left`/`width` are now derived from today's column index and the visible-day count (`left: index × 100%/count`, `width: 100%/count`), so it sits under exactly one column.
- The existing guard already hides the line when today isn't in the visible week — kept as-is (now expressed as `todayColumnIndex >= 0`).
- Day view is unchanged in effect: with one column, the line spans full width as before.

## Simplicity

Small, self-contained change to one component. Reused the existing today-visibility check (swapped `.some()` for `.findIndex()` to get the column index in the same pass — no extra iteration). **No new hooks**; the component keeps its existing `useState` + `useEffect` minute-tick, which legitimately syncs React with wall-clock time via `setInterval` (a non-React system). `simplify` found nothing to reduce.

## Manual Testing Steps

- [ ] Open **Week** view on the current week — the now line appears **only under today's column**, not across the whole grid.
- [ ] Navigate to a **different week** (Next/Previous week) — the now line disappears entirely.
- [ ] Switch to **Day** view — the now line spans the single day column as before.
- [ ] Leave the week view open across a minute boundary — the line still advances vertically (minute tick intact).

## Test plan

- [x] `type-check` (web, tsc) — pass
- [x] Local preview (Week view, current week July 5–11, today = Thu Jul 9): now line computed `left: calc(57.1429%)` (col 4 of 7) and `width: calc(14.2857%)` (1/7) — confirmed under Thursday only
- [x] Local preview (Day view): `left: calc(0%)`, `width: calc(100%)` — spans the single column
- [x] Local preview (next week, July 12–18): now-line element absent from DOM
- [x] No now-line-specific unit tests exist; change is a positioning-only edit to one component
