### PR TITLE
fix(web): coalesce rapid event edits into a single write

### DIFF
--- a/packages/web/src/events/mutations/event.mutation.runtime.ts
+++ b/packages/web/src/events/mutations/event.mutation.runtime.ts
@@ -122,3 +122,32 @@ export async function waitForPrecedingEventWrites(
     delete: lastStatus(["delete", "delete-someday"]),
   };
 }
+
+/**
+ * True when a later edit to the same event is already queued. Writes serialize
+ * by `mutationId`, so by the time an edit reaches its turn a rapid burst (held
+ * arrow-key nudge, drag) may have enqueued newer edits for the same event. The
+ * older edits' PUTs are then redundant — the newest edit persists the final
+ * position — so callers skip them, collapsing the burst to a single network
+ * write instead of one per keystroke (which otherwise drains one-at-a-time
+ * after the user stops). Optimistic cache writes already ran per keystroke, so
+ * the on-screen event is unaffected.
+ */
+export function isSupersededByLaterEditWrite(
+  queryClient: QueryClient,
+  eventId: string,
+  ownVariables: unknown,
+): boolean {
+  const mutations = queryClient.getMutationCache().getAll() as AnyMutation[];
+  const self = mutations.find(
+    (mutation) => mutation.state.variables === ownVariables,
+  );
+  if (!self) return false;
+  return mutations.some(
+    (mutation) =>
+      mutation.state.status === "pending" &&
+      mutation.mutationId > self.mutationId &&
+      operationOf(mutation) === "edit" &&
+      variablesEventId(mutation) === eventId,
+  );
+}

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -302,6 +302,59 @@ describe("useEventMutations", () => {
     context.pending.resolve();
   });
 
+  test("coalesces a burst of edits to one event into a single write of the final state", async () => {
+    const context = setup();
+    context.queryClient.setQueryData(calendarKey, normalized(event()));
+    const editEvent = (title: string) =>
+      context.hook.result.current.mutations.edit({
+        _id: "event-1",
+        event: event({ title }) as Schema_WebEvent,
+        applyTo: RecurringEventUpdateScope.THIS_EVENT,
+      });
+
+    // A held-key nudge (or drag) fires many edits before any write lands. Each
+    // earlier edit sees a newer edit already queued and skips its network write,
+    // so only the final position is actually persisted — no per-keystroke PUT,
+    // no trailing "replay" as the serialized queue drains after the user stops.
+    act(() => {
+      editEvent("First");
+      editEvent("Second");
+      editEvent("Third");
+    });
+
+    // Optimistic UI still reflects every step, ending on the final title.
+    await waitFor(() => {
+      expect(
+        context.queryClient.getQueryData<ReturnType<typeof normalized>>(
+          calendarKey,
+        )?.entities["event-1"].title,
+      ).toBe("Third");
+    });
+
+    // Exactly one repository write, carrying the final state.
+    await waitFor(() => {
+      expect(
+        context.calls.filter(({ method }) => method === "edit"),
+      ).toHaveLength(1);
+    });
+    const edits = context.calls.filter(({ method }) => method === "edit");
+    expect((edits[0].value as { event: Schema_Event }).event.title).toBe(
+      "Third",
+    );
+
+    context.pending.resolve();
+
+    // Every edit still marks a write (anon-change tracking) even though two
+    // skipped the network.
+    await waitFor(() => {
+      expect(context.markedWrites).toHaveLength(3);
+      expect(context.hook.result.current.hasPending).toBe(false);
+    });
+    expect(
+      context.calls.filter(({ method }) => method === "edit"),
+    ).toHaveLength(1);
+  });
+
   test("a failed edit leaves a concurrent edit to another event untouched", async () => {
     const context = setup();
     const other = event({ _id: "event-2", title: "Other" });

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -30,6 +30,7 @@ import {
   eventMutationKeys,
 } from "./event.mutation.keys";
 import {
+  isSupersededByLaterEditWrite,
   markAnonymousEventWrite,
   type PrecedingEventWrites,
   precedingCreateOk,
@@ -124,12 +125,23 @@ export function useEventMutations(
     variables: unknown,
     canWrite: (preceding: PrecedingEventWrites) => boolean,
     write: () => Promise<unknown>,
+    { coalesce = false }: { coalesce?: boolean } = {},
   ) => {
     const preceding = await waitForPrecedingEventWrites(
       queryClient,
       eventId,
       variables,
     );
+    // A newer edit for this event is already queued and will persist the final
+    // state, so this write is redundant — skip the network call but still mark
+    // the write (anon-change tracking) so a burst collapses to one request.
+    if (
+      coalesce &&
+      isSupersededByLaterEditWrite(queryClient, eventId, variables)
+    ) {
+      await markWrite();
+      return;
+    }
     if (canWrite(preceding)) await write();
     await markWrite();
   };
@@ -171,8 +183,12 @@ export function useEventMutations(
       "edit",
       async (variables) => {
         const { _id, event, applyTo } = variables;
-        await writeAfterPreceding(_id, variables, precedingCreateOk, () =>
-          repository.edit(_id, event, { applyTo }),
+        await writeAfterPreceding(
+          _id,
+          variables,
+          precedingCreateOk,
+          () => repository.edit(_id, event, { applyTo }),
+          { coalesce: true },
         );
       },
       ({ _id, event, shouldRemove }) => {


### PR DESCRIPTION
## Summary

Fixes the lag and "replay" when nudging an event repeatedly (e.g. holding Shift+Arrow, or moving a someday event onto the grid and then nudging it around). Spec item 3.

**Root cause:** every keystroke fired an optimistic cache write *and* a network PUT. The PUTs are serialized per-event (to avoid backend write-conflict 500s) with no coalescing, so a burst enqueued N requests that drained one-at-a-time *after* the user stopped — the visible lag, the trailing "replay", and the errors under load.

**Fix:** when an edit reaches its turn to write and a **newer edit for the same event is already queued**, it skips its network write — the newer edit will persist the final position. A burst collapses to a **single** request. The per-keystroke optimistic cache writes are untouched, so the on-screen event still moves instantly. This reuses the existing per-event serialization rather than adding a debounce timer or new machinery.

I deliberately chose this queue-coalescing approach over a call-site debounce (the plan's first option): the optimistic write and network write are welded inside one `useMutation`, so a call-site debounce would have to replicate the optimistic write or reroute through the draft store — more moving parts (a debounce util, flush-on-blur/unmount, changes at multiple call sites) for a worse result. Coalescing is ~15 lines, needs no new utility, changes no call sites, and also covers fast drags.

## Simplicity

Net simpler than the alternatives. One new pure helper (`isSupersededByLaterEditWrite`) and one guarded branch in the existing write path; no new hooks, no debounce utility, no call-site changes. `simplify` found nothing to reduce.

## Manual Testing Steps

- [ ] In Week view, focus a timed event and **hold Shift+Arrow** to nudge it across several slots — it moves smoothly and, on release, only **one** save request is sent (not one per step). Check the network tab: a single PUT with the final time.
- [ ] Move a **someday** event onto the grid (Shift+Right) and then nudge it around — the preview appears immediately and, when you stop, there's no trailing sequence of moves replaying one at a time.
- [ ] Nudge once (a single Shift+Arrow) and confirm the change still persists (reload — the event stays at the new time).
- [ ] Undo/redo an edit still works (Cmd+Z / the command palette Undo row).

## Test plan

- [x] `bun test` (web) — `src/events` suite (mutations incl. new coalescing test, serialization, undo/redo, query cache): **57 pass, 0 fail**
- [x] New test: "coalesces a burst of edits to one event into a single write of the final state" — 3 rapid edits → 1 repository write carrying the final state, all 3 marked
- [x] Existing "serializes rapid edits… writes never overlap" still passes (unaffected — it awaits each write landing before the next edit)
- [x] `type-check` (web, tsc) — pass
- [x] `biome check` — clean

## Notes for PO
- Observed (separate, pre-existing): a React "two children with the same key" console warning fires during Shift+Arrow nudges — a transient duplicate `_id` in a keyed list from optimistic churn. It's console-only and unrelated to request volume; left out of this focused change. Flagging as a follow-up.
