### PR TITLE
style(forms): extract a shared EventFormShell

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -15,7 +15,6 @@ import { darken } from "@core/util/color.utils";
 import dayjs from "@core/util/date/dayjs";
 import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
 import { useAppHotkey } from "@web/common/hotkeys/useAppHotkey";
-import { type CSSVariables } from "@web/common/styles/css.types";
 import {
   colorByPriority,
   hoverColorByPriority,
@@ -43,6 +42,7 @@ import {
   type FormProps,
   type SetEventFormField,
 } from "@web/views/Forms/EventForm/types";
+import { EventFormShell } from "@web/views/Forms/EventFormShell";
 
 const EVENT_FORM_PLAIN_HOTKEY_OPTIONS = {
   enabled: true,
@@ -399,11 +399,9 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
     );
 
     return (
-      <form
+      <EventFormShell
         {...props}
-        // biome-ignore lint/a11y/noRedundantRoles: <form> only gets its implicit "form" role when it has an accessible name, which this one doesn't; e2e tests rely on getByRole("form").
-        role="form"
-        className="z-1 rounded-sm bg-(--event-form-bg) px-5 py-4.5 shadow-[0_5px_5px_var(--color-shadow-default)] transition-all duration-300"
+        priority={priority}
         name={ID_EVENT_FORM}
         onMouseUp={() => {
           if (isStartDatePickerOpen) {
@@ -417,9 +415,6 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
         onMouseDown={(e) => {
           e.stopPropagation();
         }}
-        style={
-          { "--event-form-bg": hoverColorByPriority[priority] } as CSSVariables
-        }
       >
         <TitleActionsRow
           title={
@@ -477,7 +472,7 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
         />
 
         <SaveSection priority={priority} onSubmit={onSubmitForm} />
-      </form>
+      </EventFormShell>
     );
   },
   fastDeepEqual,

--- a/packages/web/src/views/Forms/EventFormShell.tsx
+++ b/packages/web/src/views/Forms/EventFormShell.tsx
@@ -1,0 +1,43 @@
+import classNames from "classnames";
+import { type ComponentPropsWithoutRef, type ReactNode } from "react";
+import { type Priorities } from "@core/constants/core.constants";
+import { type CSSVariables } from "@web/common/styles/css.types";
+import { hoverColorByPriority } from "@web/common/styles/theme.util";
+
+interface EventFormShellProps extends ComponentPropsWithoutRef<"form"> {
+  priority: Priorities;
+  children: ReactNode;
+}
+
+/**
+ * Shared outer `<form>` for the timed and someday event forms. It owns the
+ * panel's layout — padding, background, shadow, rounding, transition, and the
+ * priority-tinted `--event-form-bg` — so the two forms stay consistent and
+ * can't drift apart. Content-agnostic: callers pass their fields as children
+ * and any form-specific props (`name`, mouse handlers, an extra `className`).
+ */
+export const EventFormShell = ({
+  priority,
+  className,
+  style,
+  children,
+  ...props
+}: EventFormShellProps) => (
+  <form
+    {...props}
+    // biome-ignore lint/a11y/noRedundantRoles: <form> only gets its implicit "form" role when it has an accessible name, which this one doesn't; e2e tests rely on getByRole("form").
+    role="form"
+    className={classNames(
+      "z-1 rounded-sm bg-(--event-form-bg) px-5 py-4.5 shadow-[0_5px_5px_var(--color-shadow-default)] transition-all duration-300",
+      className,
+    )}
+    style={
+      {
+        ...style,
+        "--event-form-bg": hoverColorByPriority[priority],
+      } as CSSVariables
+    }
+  >
+    {children}
+  </form>
+);

--- a/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
+++ b/packages/web/src/views/Forms/SomedayEventForm/SomedayEventForm.tsx
@@ -10,11 +10,7 @@ import { Priorities } from "@core/constants/core.constants";
 import { Categories_Event } from "@core/types/event.types";
 import { darken } from "@core/util/color.utils";
 import { ID_SOMEDAY_EVENT_FORM } from "@web/common/constants/web.constants";
-import { type CSSVariables } from "@web/common/styles/css.types";
-import {
-  colorByPriority,
-  hoverColorByPriority,
-} from "@web/common/styles/theme.util";
+import { colorByPriority } from "@web/common/styles/theme.util";
 import {
   isComboboxInteraction,
   isDeleteTextEditingTarget,
@@ -31,6 +27,7 @@ import {
   type FormProps,
   type SetEventFormField,
 } from "@web/views/Forms/EventForm/types";
+import { EventFormShell } from "@web/views/Forms/EventFormShell";
 import { SomedayEventActionMenu } from "@web/views/Forms/SomedayEventForm/SomedayEventActionMenu";
 import { SomedayRecurrenceSection } from "@web/views/Forms/SomedayEventForm/SomedayRecurrenceSection/SomedayRecurrenceSection";
 import { useSomedayFormShortcuts } from "@web/views/Forms/SomedayEventForm/useSomedayFormShortcuts";
@@ -174,11 +171,10 @@ export const SomedayEventForm: React.FC<FormProps> = ({
   };
 
   return (
-    <form
+    <EventFormShell
       {...props}
-      // biome-ignore lint/a11y/noRedundantRoles: <form> only gets its implicit "form" role when it has an accessible name, which this one doesn't; e2e tests rely on getByRole("form").
-      role="form"
-      className="z-1 rounded-sm bg-(--event-form-bg) px-5 py-4.5 text-xl shadow-[0_5px_5px_var(--color-shadow-default)] transition-all duration-300"
+      priority={priority}
+      className="text-xl"
       name={ID_SOMEDAY_EVENT_FORM}
       onClick={stopPropagation}
       onKeyDown={onKeyDown}
@@ -186,9 +182,6 @@ export const SomedayEventForm: React.FC<FormProps> = ({
       onMouseUp={(e) => {
         e.stopPropagation();
       }}
-      style={
-        { "--event-form-bg": hoverColorByPriority[priority] } as CSSVariables
-      }
     >
       <TitleActionsRow
         title={
@@ -248,6 +241,6 @@ export const SomedayEventForm: React.FC<FormProps> = ({
       />
 
       <SaveSection priority={priority} onSubmit={_onSubmit} />
-    </form>
+    </EventFormShell>
   );
 };


### PR DESCRIPTION
## Summary

Consolidates the event-form styling (spec item 5). The timed event form and the someday event form each hand-rolled the **same** outer `<form>` — identical padding, background, shadow, rounding, transition, priority-tinted `--event-form-bg`, and `role="form"`. This extracts that into one content-agnostic `EventFormShell` so the two forms stay consistent and can't drift apart.

- New `packages/web/src/views/Forms/EventFormShell.tsx` owns the shared container styling; callers pass their fields as `children` and any form-specific props (`name`, mouse/key handlers, an extra `className`).
- Both forms now render their existing sections inside `<EventFormShell>`; removed the now-dead style imports.
- The someday form keeps its intentionally larger text by passing `className="text-xl"`, which the shell merges — so this change is **visually identical** to before.

Deliberately **not** unifying the floating wrappers (`FloatingEventForm` vs `FloatingFormContainer`): they anchor to genuinely different things (a grid event vs the sidebar), so merging them would couple unrelated behavior. That matches the "shared form shell only" scope agreed at planning.

## Simplicity

Net **reduction** in duplication: one shared component replaces two copies of the same `<form>` styling, and three now-unused imports were removed. No `useState`/`useEffect`/`useRef` involved. This is itself a simplification, so `simplify` had nothing to add.

## Manual Testing Steps

- [ ] Open a **timed** event (click one on the grid) — the form shows the usual padding, rounded corners, drop shadow, and priority-tinted background; title, priority, date/time, repeat, description, and Save all work.
- [ ] Open a **someday** event (from the sidebar "This Week"/"This Month" list) — same panel styling, and its text is still the larger size it was before.
- [ ] Confirm both forms still save, close on Escape, and don't close when you click inside them.

## Test plan

- [x] `bun test` (web) — `src/views/Forms` suite (EventForm, SomedayEventForm, hooks, recurrence): **48 pass, 0 fail**
- [x] `type-check` (web, tsc) — pass
- [x] `biome check` — clean (no unused imports)
- [x] Local preview: timed Event Form renders via the shell with the exact expected classes (`z-1 rounded-sm bg-(--event-form-bg) px-5 py-4.5 shadow-… transition-all duration-300`, no `text-xl`); no console errors

## Note for PO
- I preserved the someday form's larger text (`text-xl`) rather than unifying font size, since that looked intentional. If you'd prefer the two forms to share one text scale, that's a quick follow-up.
