### PR TITLE
docs(claude): forbid task chips in the handoff window

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -52,6 +52,11 @@ Per `HANDOFF.md` → Daily implementation and `agent-operating-rules.md`:
   push-notify, not a workaround.
 - **Blocked or need a PO-only decision:** send a mobile push notification, log it under
   the summary's PO follow-ups, and move to other workable spec items — never idle.
+- **Own your follow-up decisions.** Incidental findings (a stray warning, dead code, a
+  tangential cleanup) are yours to decide — do them if worthwhile and in scope, or drop
+  them. **Never spawn a background task chip (`spawn_task`)** or otherwise hand the PO a
+  context-free choice; you have the context, they don't. See
+  `agent-operating-rules.md` → "I own follow-up decisions."
 - QA: CI is the always-on gate. Do real-browser QA (`preview_*`, `/qa-staging`) while the
   screen is present/unlocked; sequence it for then if the PO has walked away.
 


### PR DESCRIPTION
## Summary

Codifies PO feedback from the 2026-07-09 handoff run: spawning a background task chip (`spawn_task`) during the autonomous implementation window offloads a judgment call onto the PO, who has none of the context the agent does. That's the opposite of the workflow's "own the code, decide yourself" intent.

- `.claude/skills/handoff/SKILL.md` (this PR): adds an "own your follow-up decisions" bullet to the implementation-window section — decide incidental findings yourself (do or drop), never `spawn_task` or manufacture a PO decision point.
- `handoff/agent-operating-rules.md` (gitignored local doc, updated alongside): the fuller rule — "I own follow-up decisions — never hand the PO a context-free choice."

## Manual Testing Steps

- [ ] Read `.claude/skills/handoff/SKILL.md` §2 — the new bullet forbids `spawn_task` and directs the agent to own follow-up decisions, pointing at `agent-operating-rules.md`.

## Test plan

- [x] Docs-only change (skill markdown); no code paths touched. CI (type-check/lint/unit/e2e) runs but is unaffected by this file.