### PR TITLE
fix(web): keep shortcut-list keys unique for repeated combos

### DIFF
--- a/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
@@ -9,7 +9,7 @@ describe("ShortcutList", () => {
   // those collide, firing React's "two children with the same key" warning and
   // risking omitted rows. Both rows must render, warning-free.
   it("renders duplicate key combos with distinct labels and no key collision", () => {
-    const consoleError = mock(() => {});
+    const consoleError = mock((..._args: unknown[]) => {});
     const originalError = console.error;
     console.error = consoleError;
 

--- a/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
@@ -1,8 +1,41 @@
 import { render, screen } from "@testing-library/react";
 import { ShortcutList } from "./ShortcutList";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 
 describe("ShortcutList", () => {
+  // A single key combo can legitimately appear more than once in a section
+  // (e.g. Shift+ArrowRight moves a calendar event to the next day AND schedules
+  // a Someday event, depending on focus). Keying rows on the combo alone made
+  // those collide, firing React's "two children with the same key" warning and
+  // risking omitted rows. Both rows must render, warning-free.
+  it("renders duplicate key combos with distinct labels and no key collision", () => {
+    const consoleError = mock(() => {});
+    const originalError = console.error;
+    console.error = consoleError;
+
+    try {
+      render(
+        <ShortcutList
+          shortcuts={[
+            { keys: ["Shift", "ArrowRight"], label: "Move event to next day" },
+            { keys: ["Shift", "ArrowRight"], label: "Schedule someday event" },
+          ]}
+        />,
+      );
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(screen.getByText("Move event to next day")).toBeInTheDocument();
+    expect(screen.getByText("Schedule someday event")).toBeInTheDocument();
+    expect(
+      consoleError.mock.calls.some((call) =>
+        String(call[0]).includes("same key"),
+      ),
+    ).toBe(false);
+  });
+
+
   it("renders each key of a combo as its own keycap chip", () => {
     render(
       <ShortcutList

--- a/packages/web/src/components/Shortcuts/ShortcutList.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutList.tsx
@@ -7,8 +7,12 @@ export const ShortcutList = ({ shortcuts }: { shortcuts: Shortcut[] }) => {
   return (
     <ul className="space-y-1.5">
       {shortcuts.map((it) => (
+        // Key on combo + label: one key combo legitimately appears more than
+        // once in a section (e.g. Shift+Arrow does one thing to a calendar
+        // event and another to a Someday event), so the combo alone is not
+        // unique and collides as a React key.
         <li
-          key={it.keys.join("-")}
+          key={`${it.keys.join("-")}-${it.label}`}
           className="flex min-h-9 items-center justify-between gap-4 rounded-default py-1.5 text-[13px] text-text-lighter leading-tight"
         >
           <span className="min-w-0 flex-1 break-words">{it.label}</span>


### PR DESCRIPTION
## Summary

The keyboard-shortcuts help list (`ShortcutList`) keyed each row on its combo string (`it.keys.join("-")`). A single combo legitimately appears more than once within a section — in Week view, `Shift+ArrowRight`/`ArrowUp`/`ArrowDown` each map to **both** a calendar-event action and a Someday-event action:

- `Shift+ArrowRight` → "Move event to next day" **and** "Schedule someday event"
- `Shift+ArrowUp` → "Move event 15 min earlier" **and** "Move someday event to week list"
- `Shift+ArrowDown` → "Move event 15 min later" **and** "Move someday event to month list"

Those rows collided on the same React key, firing `Encountered two children with the same key` every time the list rendered. This is what surfaced while nudging timed events with Shift+Arrow in Week view — the warning came from the shortcuts help list in the sidebar, not from the calendar grid or the event query cache.

The fix keys each row on **combo + label**; labels are unique within a section, so every row gets a distinct, stable key.

It's a console-only warning, but React may omit or duplicate children when keys collide, so it's worth closing.

## Simplicity

Net-neutral on complexity: a one-line change to the `key` expression plus a regression test. No new hooks — the diff contains no `useEffect`, `useRef`, or `useState`. No abstractions added; the fix is the smallest change that makes the keys unique.

## Manual Testing Steps

- [ ] Open the app in **Week** view (`/week/...`).
- [ ] Open your browser devtools console.
- [ ] Confirm there is **no** `Encountered two children with the same key` warning on load (before this change, three appeared: `Shift-ArrowRight`, `Shift-ArrowUp`, `Shift-ArrowDown`).
- [ ] Create a timed event, click it once to focus it, then press `Shift`+`ArrowDown`/`ArrowUp`/`ArrowRight` several times to nudge it. Confirm the event moves and the console stays clean.
- [ ] Press `?` to toggle the keyboard-shortcuts help; confirm the Edit section still lists all the Shift+Arrow shortcuts (both the calendar-event and Someday-event actions) and nothing is missing.

## Test plan

- [x] Added `ShortcutList` regression test: renders two shortcuts sharing a combo with distinct labels, asserts both rows render and no "same key" warning is emitted. Verified it **fails** with the old key and **passes** with the fix.
- [x] `bun test src/components/Shortcuts/` → 10 pass, 0 fail.
- [x] Biome clean on changed files.
- [x] Manually verified in local Chrome: 0 dup-key warnings on load and after ~50 rapid Shift+Arrow nudges (down/up/right); calendar grid never warned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)