### PR TITLE
refactor(day): extract shared reorder-handle focus check

### DIFF
--- a/packages/web/src/views/Day/util/day.shortcut.util.ts
+++ b/packages/web/src/views/Day/util/day.shortcut.util.ts
@@ -1,6 +1,13 @@
 import { StringV4Schema } from "@core/types/type.utils";
 import { ID_ADD_TASK_BUTTON } from "@web/common/constants/web.constants";
 
+// The drag/reorder handle is a "Reorder …" button that carries its own
+// data-task-id, because it sits outside the task's data-task-id container
+// (so closest("[data-task-id]") can't reach it — read the id off the handle).
+const isReorderHandle = (el: HTMLElement) =>
+  el.tagName === "BUTTON" &&
+  (el.getAttribute("aria-label")?.startsWith("Reorder") ?? false);
+
 export const isFocusedOnTaskCheckbox = () => {
   // Check if we're focused on a task checkbox
   const activeElement = document.activeElement as HTMLElement | null;
@@ -40,12 +47,8 @@ export const isFocusedWithinTask = () => {
     return true;
   }
 
-  // Check if focused on the drag/reorder handle. It carries its own
-  // data-task-id because it sits outside the task's data-task-id container.
-  if (
-    activeElement.tagName === "BUTTON" &&
-    activeElement.getAttribute("aria-label")?.startsWith("Reorder")
-  ) {
+  // Check if focused on the drag/reorder handle.
+  if (isReorderHandle(activeElement)) {
     return true;
   }
 
@@ -89,12 +92,8 @@ export const getFocusedTaskId = () => {
     return taskContainer?.dataset?.taskId || null;
   }
 
-  // Reorder/drag handle carries its own data-task-id (it lives outside the
-  // task's data-task-id container, so closest() can't find it).
-  if (
-    activeElement.tagName === "BUTTON" &&
-    activeElement.getAttribute("aria-label")?.startsWith("Reorder")
-  ) {
+  // The reorder handle carries its own data-task-id (see isReorderHandle).
+  if (isReorderHandle(activeElement)) {
     return activeElement.dataset?.taskId ?? null;
   }
 


### PR DESCRIPTION
## Summary

`isFocusedWithinTask` and `getFocusedTaskId` in `day.shortcut.util.ts` each
carried a verbatim copy of the drag/reorder-handle check — a `"Reorder …"`
button whose `data-task-id` lives on the handle itself (it sits outside the
task's `data-task-id` container). #1976 added that block to both functions.

This extracts a single `isReorderHandle(el)` predicate so the two stay in
sync, and collapses the two near-duplicate comments into one. Pure
quality/legibility cleanup — no behavior change.

## Simplicity

Net complexity down: one shared 3-line predicate replaces two verbatim
condition blocks plus their duplicated comments (11 insertions, 12
deletions). The helper is used in exactly two places with a one-parameter,
stable API — a real DRY extraction, not speculative abstraction. The wider
parallel structure between the two functions is pre-existing and left
untouched to keep the diff behavior-preserving. No `useEffect`/`useRef`/
`useState` involved (plain DOM-reading utils).

## Manual Testing Steps

- [ ] Open the Day view with at least two tasks in the list.
- [ ] Tab to a task's drag/reorder handle (the grip control), then press
      **Shift+ArrowRight** — the task migrates to the next day.
- [ ] With the same handle focused, press **Shift+ArrowLeft** — the task
      migrates to the previous day.
- [ ] Focus a task's checkbox (not the handle) and confirm Shift+Arrow still
      migrates that task as before.
- [ ] Click into a task's title input and press Shift+ArrowRight — the
      caret/selection moves within the text; the task does **not** migrate.

## Test plan

- [x] `bun run type-check` — passes
- [x] `bun test --cwd packages/web src/views/Day/hooks/shortcuts/useDayViewShortcuts.test.tsx src/views/Day/util` — 15 pass, 0 fail (incl. "migrates when the drag/reorder handle is focused")
- [x] `bunx @biomejs/biome check` on the touched file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)