### PR TITLE
feat(core): allow events to have empty title

### DIFF
--- a/packages/core/src/mappers/map.event.to-compass.test.ts
+++ b/packages/core/src/mappers/map.event.to-compass.test.ts
@@ -112,6 +112,39 @@ describe("toCompass", () => {
     });
   });
 
+  describe("title", () => {
+    const baseGEvent: gSchema$Event = {
+      kind: "calendar#event",
+      id: "empty-title-event",
+      status: "confirmed",
+      start: { dateTime: "2025-04-03T07:00:00-05:00", timeZone: "UTC" },
+      end: { dateTime: "2025-04-03T08:00:00-05:00", timeZone: "UTC" },
+    };
+
+    it("maps a titleless Google event to an empty string, not 'untitled'", () => {
+      // Google omits `summary` entirely for events with no title.
+      const cEvent = MapEvent.toCompass("user1", [baseGEvent], Origin.GOOGLE)[0];
+      if (!cEvent) {
+        throw new Error("Failed to map event");
+      }
+
+      expect(cEvent.title).toBe("");
+    });
+
+    it("preserves a Google event's title when present", () => {
+      const cEvent = MapEvent.toCompass(
+        "user1",
+        [{ ...baseGEvent, summary: "Real title" }],
+        Origin.GOOGLE,
+      )[0];
+      if (!cEvent) {
+        throw new Error("Failed to map event");
+      }
+
+      expect(cEvent.title).toBe("Real title");
+    });
+  });
+
   describe("recurrence", () => {
     it("does not include gRecurringEventId for regular events", () => {
       const regularGEvent = timed[0] as gSchema$Event;

--- a/packages/core/src/mappers/map.event.ts
+++ b/packages/core/src/mappers/map.event.ts
@@ -166,7 +166,9 @@ export namespace MapEvent {
 }
 
 const gEventDefaults = {
-  summary: "untitled",
+  // Untitled Google events omit `summary` entirely; default to an empty
+  // string (not "untitled") so a titleless event stays titleless (#1871).
+  summary: "",
   description: "",
   start: {
     dateTime: "1990-01-01T00:00:00-10:00",

--- a/packages/core/src/types/event_new.types.ts
+++ b/packages/core/src/types/event_new.types.ts
@@ -46,7 +46,9 @@ const RecurrenceSchema = z.union([
 export const EventSchema = z.object({
   _id: zObjectId,
   calendar: zObjectId,
-  title: StringV4Schema,
+  // Own schema (not the shared, non-empty StringV4Schema) so titleless
+  // events are allowed — an empty title is valid in Compass (#1871).
+  title: z.string(),
   description: z.string().default(""),
   isSomeday: z.boolean().default(false),
   startDate: z.date(),


### PR DESCRIPTION
## Summary

Titleless Google Calendar events omit the `summary` field entirely, but the gcal→compass mapper's `gEventDefaults` defaulted `summary` to `"untitled"` — so a user who left an event unnamed got "untitled" written into Compass. This defaults the missing summary to an empty string instead, so a titleless event stays titleless end-to-end.

Two changes in `packages/core`:
- `map.event.ts`: `gEventDefaults.summary` `"untitled"` → `""`.
- `event_new.types.ts`: the v4 `EventSchema` `title` gets its own `z.string()` instead of the shared, non-empty `StringV4Schema`, so `""` is a valid title (the shared schema stays strict for `gEventId`, recurrence rules, etc.).

Existing events already stored as "untitled" in Google are intentionally left as-is (they carry a real `summary`); they clear when the user next edits them. No inbound "(No title)"/"untitled" string-matching, per product decision. Outbound (compass→gcal) already omits `summary` for an empty title, and the Google write is a `PUT` (`events.update`), so clearing a title propagates correctly with no change needed.

Closes #1871

## Simplicity

Net-neutral on line count and strictly simpler in intent: the fix removes a magic default ("untitled") rather than adding branching, and scopes the schema relaxation to the one field that needs it instead of loosening the shared `StringV4Schema`. No React hooks are involved (core package) — no simplification opportunities found in the diff.

## Manual Testing Steps

The changed code path is only exercised by a real Google Calendar sync, so these steps require a staging/authed account (they can't be reproduced in a local anonymous session):

- [ ] In Compass, create an event and leave the title blank; save it. It should save without error and render as a blank colored block (no "untitled" text).
- [ ] Open the same event again — the title field should be empty (showing only the "Title" placeholder), not "untitled".
- [ ] Confirm the event appears in the connected Google Calendar as "(No title)".
- [ ] In Google Calendar, move that event's time by 15 minutes. Back in Compass, after sync the title should still be blank (not repopulated to "untitled").
- [ ] Create a normally-titled event and confirm its title is unchanged (regression check).

## Test plan

- [x] `bun run test:core` → 147 pass, 0 fail (includes two new `toCompass > title` cases: absent Google summary → `""`; real summary preserved)
- [x] `bun run type-check` → clean
- [ ] `test:web` / `test:backend` — run on CI (blocked locally by an unrelated stale nested worktree colliding jest's haste-map; clean on CI's fresh checkout)