### PR TITLE
fix(backend): remove legacy saslprep dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,6 @@
         "lodash.mergewith": "^4.6.2",
         "mongodb": "^7.2.0",
         "rrule": "^2.7.2",
-        "saslprep": "^1.0.3",
         "supertokens-node": "^23.0.1",
         "tslib": "^2.4.0",
       },
@@ -1803,8 +1802,6 @@
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "saslprep": ["saslprep@1.0.3", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag=="],
 
     "sass": ["sass@1.99.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.1.5", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,7 +14,6 @@
     "lodash.mergewith": "^4.6.2",
     "mongodb": "^7.2.0",
     "rrule": "^2.7.2",
-    "saslprep": "^1.0.3",
     "supertokens-node": "^23.0.1",
     "tslib": "^2.4.0"
   },

--- a/packages/scripts/src/commands/build.backend.ts
+++ b/packages/scripts/src/commands/build.backend.ts
@@ -3,7 +3,7 @@
  *
  * Bundles the Express app into a single Bun-native file.
  * All JS/TS dependencies (including @compass/core) are inlined.
- * Only native C/Rust modules are kept external and installed separately.
+ * All dependencies are inlined.
  *
  * Usage:
  *   bun run build:backend
@@ -33,7 +33,6 @@ await $`rm -rf ${BACKEND_BUILD}`.quiet();
 log.success("Removed old backend build");
 
 // 2. Bundle — full bundle so @compass/core and all JS/TS deps are inlined.
-//    Native modules (C/Rust binaries) must stay external and be installed below.
 log.info("Bundling backend ...");
 const result = await Bun.build({
   entrypoints: [path.join(COMPASS_ROOT_DEV, "packages/backend/src/app.ts")],
@@ -41,9 +40,6 @@ const result = await Bun.build({
   target: "bun",
   sourcemap: "inline",
   minify: false,
-  external: [
-    "saslprep", // MongoDB optional C binding
-  ],
 });
 
 if (!result.success) {
@@ -65,27 +61,14 @@ if (await Bun.file(configPath).exists()) {
   log.warning(`Compass config file not found: ${configPath}`);
 }
 
-// 4. Write a minimal package.json for the external native modules only.
-//    Everything else is inlined in app.js — no full workspace needed.
-const backendPkg = JSON.parse(
-  await Bun.file(
-    path.join(COMPASS_ROOT_DEV, "packages/backend/package.json"),
-  ).text(),
-) as { dependencies?: Record<string, string> };
-
-const externalVersions: Record<string, string> = {};
-for (const name of ["saslprep"]) {
-  const version = backendPkg.dependencies?.[name];
-  if (version) externalVersions[name] = version;
-}
-
+// 4. Write a minimal package.json. Everything is inlined in app.js.
 await Bun.write(
   path.join(BACKEND_BUILD, "package.json"),
-  JSON.stringify({ dependencies: externalVersions }, null, 2),
+  JSON.stringify({ dependencies: {} }, null, 2),
 );
 
-// 5. Install only the external native modules
-log.info("Installing native module dependencies ...");
+// 5. Install an empty production dependency tree so Bun writes its runtime files.
+log.info("Installing production dependency metadata ...");
 const install = Bun.spawnSync({
   cmd: ["bun", "install", "--production", "--ignore-scripts", "--no-progress"],
   cwd: BACKEND_BUILD,


### PR DESCRIPTION
## Summary

- remove the legacy direct `saslprep` dependency from the backend package
- remove the backend build special case that externalized and installed `saslprep`
- keep MongoDB-owned `@mongodb-js/saslprep` as the transitive dependency provided by `mongodb`

## Validation

- `bun install`
- `bun run build:backend`
- `bun run type-check`

## Notes

- `bun test:backend` was attempted but could not complete in this worktree because `compass.yaml` is missing and backend config parsing exits before tests run.
