### PR TITLE
fix(web): add SEO metadata to improve search and social previews

### DIFF
--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -3,8 +3,58 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Compass</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Compass Calendar — simple, keyboard-first weekly planning</title>
+    <meta
+      name="description"
+      content="Compass is a small but mighty calendar and to-do app for busy minimalists — a simple, keyboard-first way to plan your week around what matters."
+    />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://www.compasscalendar.com/" />
+
+    <!-- Open Graph (social sharing) -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Compass Calendar" />
+    <meta
+      property="og:title"
+      content="Compass Calendar — simple, keyboard-first weekly planning"
+    />
+    <meta
+      property="og:description"
+      content="A small but mighty calendar and to-do app for busy minimalists. Plan your week around what matters — simply."
+    />
+    <meta property="og:url" content="https://www.compasscalendar.com/" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary" />
+    <meta
+      name="twitter:title"
+      content="Compass Calendar — simple, keyboard-first weekly planning"
+    />
+    <meta
+      name="twitter:description"
+      content="A small but mighty calendar and to-do app for busy minimalists. Plan your week around what matters — simply."
+    />
+
+    <!-- Structured data for rich search results -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Compass Calendar",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Web",
+        "url": "https://www.compasscalendar.com/",
+        "description": "Compass is a small but mighty calendar and to-do app for busy minimalists — a simple, keyboard-first way to plan your week around what matters.",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
+    </script>
+
     <link rel="icon" href="./favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

Fixes #1876. Googling "Compass Calendar" surfaced only the URL and the bare name "Compass" — the app's `index.html` shipped `<title>Compass</title>` and **zero** descriptive metadata, so search engines and link unfurlers had nothing to show.

This adds static `<head>` metadata (Compass is an SPA — the server returns one `index.html` and JS builds the page, so crawlers and social unfurlers that read only raw HTML need the metadata to be static, not React-injected):

- A descriptive `<title>` and `<meta name="description">` (product voice matched to the in-app welcome copy).
- `<link rel="canonical">` and `<meta name="robots" content="index, follow">`.
- Open Graph tags (`og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`).
- Twitter Card (`summary`).
- `SoftwareApplication` JSON-LD for rich search results.

**Deliberately not included:** an `og:image`/`twitter:image`. `Bun.build` content-hashes every asset referenced from `index.html` (the favicon builds to `/favicon-<hash>.ico`), and the only image assets are the favicon and the mascot — there's no stable social-preview image URL to point at, and a broken image ref is worse than none. A designed 1200×630 OG image on a stable path is a worthwhile follow-up (noted for the PO).

## Simplicity

No simplification opportunities — this is purely additive static markup in `index.html` with no logic, no components, and no React hooks. The JSON-LD is a single inline `<script type="application/ld+json">` block.

## Manual Testing Steps

- [ ] View source (or the network response) of the app's root HTML and confirm the `<head>` contains a `<title>`, `<meta name="description">`, `<link rel="canonical">`, `og:*` tags, `twitter:card`, and an `application/ld+json` block.
- [ ] Paste the deployed URL into a link-unfurling surface (e.g. Slack) and confirm it shows the title + description rather than a bare URL.
- [ ] Validate the JSON-LD at https://validator.schema.org/ (or Google's Rich Results Test) — it should parse as a `SoftwareApplication` with no errors.
- [ ] Confirm the canonical/`og:url` domain (`https://www.compasscalendar.com/`) matches the intended production URL for the app — adjust if the app is served from a different host.

## Test plan

- [x] `bun run build:web` — succeeds; the built (minified) `build/web/index.html` retains the title, description, canonical, OG, Twitter, and JSON-LD tags.
- [x] JSON-LD block parses (`JSON.parse` of the `ld+json` script → `@type: SoftwareApplication`).
- [x] Local dev server (`GET /`) serves all the new `<head>` tags.
- [x] `bun run type-check` — clean (no TS surface, but confirms nothing else regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)