### PR TITLE
fix(web): select an all-day date on the first click

### DIFF
--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -94,17 +94,11 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
       formatWeekDay={(day) => day[0]}
       open={isOpen}
       {...props}
-      onCalendarOpen={() => {
-        datePickerProps.onCalendarOpen?.();
-      }}
-      onCalendarClose={() => {
-        datePickerProps.onCalendarClose?.();
-      }}
+      // Close the picker when the user clicks away (react-datepicker has no
+      // onCalendarClose for outside-clicks). onCalendarOpen/onCalendarClose/
+      // onSelect flow straight through {...props}.
       onClickOutside={() => {
         datePickerProps.onCalendarClose?.();
-      }}
-      onSelect={(date, event: React.SyntheticEvent<Event> | undefined) => {
-        datePickerProps.onSelect?.(date, event);
       }}
       portalId={portalId}
       showPopperArrow={false}

--- a/packages/web/src/components/Focusable/Focusable.test.tsx
+++ b/packages/web/src/components/Focusable/Focusable.test.tsx
@@ -1,0 +1,47 @@
+import userEvent from "@testing-library/user-event";
+import { render } from "@web/__tests__/__mocks__/mock.render";
+import { Focusable } from "@web/components/Focusable/Focusable";
+import { describe, expect, it } from "bun:test";
+
+// The underline is a decorative 2px Divider with no accessible role, so it's
+// matched by its stable height class. The point of these tests is the fix for
+// the date-picker double-click bug: the underline must stay mounted whether or
+// not the input is focused, so focusing/blurring never reflows the layout (which
+// previously moved a hovered day out from under the cursor between mousedown and
+// mouseup, swallowing the first click).
+const underline = (container: HTMLElement) =>
+  container.querySelector(".h-0\\.5");
+
+describe("Focusable", () => {
+  it("renders the underline even while unfocused when withUnderline is set", () => {
+    const { container } = render(
+      <Focusable Component="input" withUnderline placeholder="Title" />,
+    );
+
+    expect(document.activeElement).not.toBe(container.querySelector("input"));
+    expect(underline(container)).not.toBeNull();
+  });
+
+  it("keeps the underline mounted across focus and blur", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Focusable Component="input" withUnderline placeholder="Title" />,
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+
+    await user.click(input);
+    expect(document.activeElement).toBe(input);
+    expect(underline(container)).not.toBeNull();
+
+    input.blur();
+    expect(underline(container)).not.toBeNull();
+  });
+
+  it("renders no underline when withUnderline is not set", () => {
+    const { container } = render(
+      <Focusable Component="input" placeholder="Title" />,
+    );
+
+    expect(underline(container)).toBeNull();
+  });
+});

--- a/packages/web/src/components/Focusable/Focusable.tsx
+++ b/packages/web/src/components/Focusable/Focusable.tsx
@@ -64,7 +64,17 @@ export const Focusable = forwardRef<HTMLElement, Props>(
           autoFocus={autoFocus}
           ref={ref}
         />
-        {!!withUnderline && isFocused && <Divider color={underlineColor} />}
+        {/*
+          Keep the underline mounted whenever `withUnderline` and toggle its
+          visible width via focus, instead of mounting/unmounting it on blur.
+          The Divider always reserves 2px of height while mounted, so
+          unmounting it on blur shifted layout — which, in the date picker,
+          moved the hovered day out from under the cursor between mousedown and
+          mouseup and swallowed the first click. A stable layout fixes that.
+        */}
+        {!!withUnderline && (
+          <Divider color={underlineColor} toggled={isFocused} />
+        )}
       </>
     );
   },


### PR DESCRIPTION
## Summary

The all-day event date picker required **two clicks** to pick a date: the first click on a day appeared to do nothing (the hover highlight showed, but the date didn't change), and only the second click selected it.

**Root cause (layout reflow, not event wiring):** the date input is a `Focusable` with `withUnderline`, and its 2px underline (`Divider`) was rendered **only while focused** (`isFocused && <Divider/>`). The first click's `mousedown` blurs the input → the underline unmounts → the input shrinks 2px → everything below reflows up → the day cell under the cursor moves → `mouseup` lands on a different element, so no `click` fires and the date never updates. The second click works because focus is already gone and the layout is stable.

**Fix:** keep the underline mounted whenever `withUnderline` and drive its *visible width* from focus (via the `Divider`'s existing `toggled` prop) instead of mounting/unmounting it. The input now has a constant height, so the first click registers. This also removes the small vertical "jump" every `Focusable` input made when focused.

Also folds in a small cleanup the datepicker code invited (as its own commit): removed three date-picker handlers that were re-wrapped after the props spread only to call the same prop back (`onCalendarOpen`/`onCalendarClose`/`onSelect`) — they flow straight through `{...props}`.

## Simplicity

Net simpler. The fix removes the conditional-mount branch in `Focusable`; the follow-up commit deletes 9 lines of pass-through indirection in `DatePicker`. No new hooks. The existing `useState(isFocused)` and its `useCallback` focus/blur handlers are unchanged — they hold genuine local UI state and stabilize the handlers when the parent's are stable.

## Manual Testing Steps

- [ ] Create an all-day event so the event form opens with **start** and **end** date inputs.
- [ ] Click the start-date input — the calendar opens.
- [ ] Hover a **different** day, then click it **once** — the date should update to that day and the calendar should close **on the first click** (previously it took two).
- [ ] Repeat for the end-date input.
- [ ] Confirm the calendar still opens on input click, selects a day, closes on select, and closes when you click outside it.
- [ ] Glance at the event form's title/description inputs and the timed-event time pickers — focusing an input should no longer nudge the fields below it by ~2px.

> Note for reviewers: the bug is a real-mouse `mousedown`→reflow→`mouseup` interaction and does **not** reproduce with scripted/synthetic clicks (or in jsdom), so it needs a human with a mouse to confirm the one-click behavior. The automated checks below verify the mechanism (stable layout) and no regressions.

## Test plan

- [x] New `Focusable.test.tsx` — asserts the underline is mounted while unfocused, stays mounted across focus/blur, and is absent without `withUnderline` (guards against reverting to the unmount-on-blur behavior). 3/3 pass.
- [x] Browser-verified on the local dev server: the all-day date input's container height is a stable 36px whether unfocused, focused, or blurred (previously 34→36 on focus — that reflow was the bug); the underline `<div>` is present while unfocused; the calendar opens on input click, selects day 15 on a click (input → `7-15-2026`), and closes; no console errors.
- [x] `bun run test:web` — 1218/1218 pass (Focusable is widely used; full suite run to catch consumer regressions).
- [x] `bun run type-check` + `bunx biome check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)