### PR TITLE
style(web): move the repeat icon bottom-right and color it by priority

### DIFF
--- a/packages/web/src/common/calendar-grid/components/CalendarEventCard.test.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarEventCard.test.tsx
@@ -159,6 +159,44 @@ describe("CalendarEventCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("places the repeat indicator bottom-right and colors it by priority", () => {
+    const renderRecurring = (priority: Priorities) =>
+      render(
+        <CalendarTimedEventCard
+          displayMode="saved"
+          event={createEvent({
+            priority,
+            recurrence: { eventId: "series-1", rule: ["RRULE:FREQ=WEEKLY"] },
+          })}
+          motionMode="idle"
+          position={position}
+        />,
+      );
+
+    const { container: workContainer, unmount } = renderRecurring(
+      Priorities.WORK,
+    );
+    const workIcon = workContainer.querySelector('svg[class*="right-1"]');
+
+    // Positioned bottom-right (not the old bottom-left), and no longer the
+    // hardcoded white fg color.
+    expect(workIcon).not.toBeNull();
+    const workClass = workIcon?.getAttribute("class") ?? "";
+    expect(workClass).not.toContain("left-1");
+    expect(workClass).not.toContain("fg-primary");
+    const workMarkup = workIcon?.outerHTML;
+    unmount();
+
+    // A different priority yields a different (priority-derived) icon color.
+    const { container: relationsContainer } = renderRecurring(
+      Priorities.RELATIONS,
+    );
+    const relationsIcon = relationsContainer.querySelector(
+      'svg[class*="right-1"]',
+    );
+    expect(relationsIcon?.outerHTML).not.toBe(workMarkup);
+  });
+
   it("renders all-day event details, interaction attributes, acknowledgement animation, and resize handles", () => {
     const onEventMouseDown = mock();
     const onScalerMouseDown = mock();

--- a/packages/web/src/common/calendar-grid/components/CalendarTimedEventCard.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarTimedEventCard.tsx
@@ -108,6 +108,9 @@ const CalendarTimedEventCardBase = (
   const baseColor = gridColorByPriority[priority];
   const draftColor = darken(baseColor, 18);
   const hoverColor = gridHoverColorByPriority[priority];
+  // Tie the repeat indicator to the event's priority: a darker shade of the
+  // card color complements it on every priority instead of a loud, fixed white.
+  const repeatIconColor = darken(baseColor, 30);
   const selectedBoxShadow = "0 0 0 1px rgba(255,255,255,0.55)";
 
   const bgColor = (() => {
@@ -276,7 +279,8 @@ const CalendarTimedEventCardBase = (
       {showRepeatIcon && (
         <RepeatIcon
           aria-hidden="true"
-          className="pointer-events-none absolute bottom-0.5 left-1 text-fg-primary"
+          className="pointer-events-none absolute right-1 bottom-0.5"
+          color={repeatIconColor}
           size={10}
           weight="bold"
         />


### PR DESCRIPTION
## Summary

The repeat indicator added to recurring events (bottom-left, fixed light `text-fg-primary`) had two problems the PO flagged:

- **Position:** bottom-**left** competes with the title and time labels (also on the left) and overlaps the text on short (~15-min) events.
- **Color:** a fixed white was too visually loud and didn't relate to the event.

This moves the icon to the bottom-**right** and derives its color from the event's priority — `darken(gridColorByPriority[priority], 30)`, a darker shade of the card's own color (the same darken-based convention the event forms and gradients use). Nothing is hard-coded, so the icon always complements the event whatever its priority.

## Simplicity

Tiny, self-contained change to one component: one derived value (`repeatIconColor`) reusing the `baseColor` the card already computes, a `left-1 text-fg-primary` → `right-1` + `color={…}` swap on the existing `RepeatIcon`. No new hooks, no new abstractions.

## Manual Testing Steps

- [ ] Create (or open) a **recurring** timed event large enough to show the small repeat/loop icon.
- [ ] Confirm the icon now sits in the **bottom-right** corner, clear of the title and time labels on the left.
- [ ] Confirm its color is a darker shade of the event's own color (not white), and check this across events of different priorities (unassigned / work / relations / self) — each icon should complement its card.
- [ ] Check a short (~15-minute) recurring event: the icon should no longer overlap the title/time text.

> Note: the icon only renders for recurring events above a minimum size; the exact shade is a visual judgment best confirmed on real events in staging.

## Test plan

- [x] `CalendarEventCard.test.tsx` — new case asserts the repeat icon is placed bottom-right (`right-1`, not `left-1`), no longer uses the hard-coded `fg-primary` color, and renders a **different** color for a different priority (proving it's priority-derived). Existing recurring-announcement tests still pass.
- [x] `bun run test:web` — 1216/1216 pass.
- [x] `bun run type-check` + `bunx biome check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)