### PR TITLE
style(web): keep datepicker arrows fixed and cap its width in the sidebar

### DIFF
--- a/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const plannerMonthPickerClassName =
-  "[&_.calendar]:!w-full [&_.calendar]:!bg-transparent [&_.calendar]:!shadow-none [&_.react-datepicker]:!border-0 [&_.react-datepicker]:!bg-transparent [&_.react-datepicker]:!shadow-none [&_.react-datepicker\\_\\_day-names]:!mb-0 [&_.react-datepicker\\_\\_header.react-datepicker\\_\\_header]:!px-0 [&_.react-datepicker\\_\\_month-container.react-datepicker\\_\\_month-container]:!bg-transparent [&_.react-datepicker\\_\\_month-container.react-datepicker\\_\\_month-container]:!px-0";
+  "[&_.calendar]:!block [&_.calendar]:!w-full [&_.calendar]:!max-w-80 [&_.calendar]:!mx-auto [&_.calendar]:!bg-transparent [&_.calendar]:!shadow-none [&_.react-datepicker]:!border-0 [&_.react-datepicker]:!bg-transparent [&_.react-datepicker]:!shadow-none [&_.react-datepicker\\_\\_day-names]:!mb-0 [&_.react-datepicker\\_\\_header.react-datepicker\\_\\_header]:!px-0 [&_.react-datepicker\\_\\_month-container.react-datepicker\\_\\_month-container]:!bg-transparent [&_.react-datepicker\\_\\_month-container.react-datepicker\\_\\_month-container]:!px-0";
 
 const headerActionsClassName = "!ml-2.5";
 
@@ -76,7 +76,7 @@ export const PlannerMonthPicker: FC<Props> = ({
         headerClassName="!relative !justify-start !px-0 !pb-3"
         inline
         isOpen={true}
-        monthContainerClassName="!w-auto"
+        monthContainerClassName="!w-32"
         monthTextClassName="text-[14px] font-medium"
         monthsShown={monthsShown}
         onChange={(date) => {


### PR DESCRIPTION
## Summary

Two fixes to the sidebar mini month-picker (`PlannerMonthPicker`):

1. **Arrows no longer drift across months.** The month-title box was auto-width, so a longer month name ("September") pushed the prev/next arrows sideways relative to a shorter one ("May") — a dead-click hazard when paging months. It now has a fixed width sized for the longest full month name, so the arrows stay put.
2. **The calendar no longer stretches when the sidebar widens.** With the sidebar now resizable (#1999), the calendar filled the full width, spreading the day cells apart at wider sizes. It now caps at its natural width (320px) and centers, leaving empty space at the sides.

## Simplicity

Net-neutral in size (two className strings), net-positive in behavior predictability. No `useEffect`/`useRef`/`useState` added or touched. No simplification opportunities — the change is purely CSS utility classes on the existing markup, no logic or hooks involved.

## Manual Testing Steps

- [ ] Open the app. In the left sidebar's month calendar, click the next/prev arrows to page through several months (e.g. May → September → December). Confirm the arrows stay in the same horizontal position the whole time instead of shifting with the month name's length.
- [ ] Confirm the currently-selected/today date and day grid still render correctly, and clicking a day still selects it.
- [ ] Drag the sidebar's resize handle to widen the sidebar substantially. Confirm the calendar stays at a fixed size and centers (empty space appears on both sides) rather than stretching and spreading the day cells apart.
- [ ] Narrow the sidebar back to its minimum. Confirm the calendar and its arrows still fit without overflowing or clipping.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bunx biome check` on the changed file — clean
- [x] Verified in local Chrome preview with computed-style measurements: prev-arrow left constant at 154px across all months; longest month name ("September") = 106px fits inside the 128px title box; calendar caps at 320px with equal 51px side gaps (centered) when sidebar widened to 460px; no overflow at the 240px minimum sidebar width; no day-grid regression from the display change.