### PR TITLE
style(forms): give the event form shell one standard width

### DIFF
--- a/packages/web/src/views/Forms/EventFormShell.tsx
+++ b/packages/web/src/views/Forms/EventFormShell.tsx
@@ -11,10 +11,13 @@ interface EventFormShellProps extends ComponentPropsWithoutRef<"form"> {
 
 /**
  * Shared outer `<form>` for the timed and someday event forms. It owns the
- * panel's layout — padding, background, shadow, rounding, transition, and the
- * priority-tinted `--event-form-bg` — so the two forms stay consistent and
- * can't drift apart. Content-agnostic: callers pass their fields as children
- * and any form-specific props (`name`, mouse handlers, an extra `className`).
+ * panel's layout — a fixed width, padding, background, shadow, rounding,
+ * transition, and the priority-tinted `--event-form-bg` — so the two forms
+ * stay consistent and can't drift apart. The fixed width is the single source
+ * of the form's size: without it each form shrink-wrapped to its own content,
+ * which left the someday form noticeably wider than the timed one.
+ * Content-agnostic: callers pass their fields as children and any form-specific
+ * props (`name`, mouse handlers, an extra `className`).
  */
 export const EventFormShell = ({
   priority,
@@ -28,7 +31,7 @@ export const EventFormShell = ({
     // biome-ignore lint/a11y/noRedundantRoles: <form> only gets its implicit "form" role when it has an accessible name, which this one doesn't; e2e tests rely on getByRole("form").
     role="form"
     className={classNames(
-      "z-1 rounded-sm bg-(--event-form-bg) px-5 py-4.5 shadow-[0_5px_5px_var(--color-shadow-default)] transition-all duration-300",
+      "z-1 w-96 rounded-sm bg-(--event-form-bg) px-5 py-4.5 shadow-[0_5px_5px_var(--color-shadow-default)] transition-all duration-300",
       className,
     )}
     style={


### PR DESCRIPTION
## Summary

The timed (grid) event form and the someday event form both shrink-wrapped to their own content, so the someday form — larger title type, no time-picker row — rendered noticeably wider than the timed one (see spec's `form-someday-event-width-too-wide.png` vs `form-event-width-good.png`).

This hoists a single fixed width (`w-96` = 384px, the timed form's natural width) onto the shared `EventFormShell` that both forms already use. Now the width is one source of truth on the shell, and content can no longer make the two forms drift apart. This also nudges the shell toward fully owning form layout (width + padding + chrome) vs. content, which is the direction needed for the future "move the form into the sidebar" work.

## Simplicity

Net simpler: removes an entire class of "the two forms are different widths" drift by making width a single shell-level constant instead of an emergent property of each form's content. One className token added, no logic. No `useEffect`/`useRef`/`useState` involved (this is a presentational shell). Ran the simplify pass — nothing further to change.

## Manual Testing Steps

- [ ] Open the app in Week view. In the left sidebar's Someday section, click a someday event to open its form. Confirm the form is the same compact width as a timed event's form (not noticeably wider).
- [ ] Click an empty spot on the timed calendar grid to open a new timed event form. Confirm its width looks unchanged from before, and the two time pickers (start – end) still sit side by side on one row without wrapping or clipping.
- [ ] In the timed form, type a long title and confirm it doesn't stretch the form wider.
- [ ] In the someday form, type a long title and confirm the form width stays fixed.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bunx biome check` on the changed file — clean
- [x] `bun run test:web` — 1222 pass, 0 fail
- [x] Verified in local Chrome preview: timed Event Form = 384px (no horizontal overflow, time row fits); Someday Event Form = 384px (no overflow) — both now identical where the someday form was previously wider.