### PR TITLE
fix(web): show the repeat icon on 15-minute recurring events

### DIFF
--- a/packages/web/src/common/calendar-grid/components/CalendarEventCard.test.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarEventCard.test.tsx
@@ -197,6 +197,62 @@ describe("CalendarEventCard", () => {
     expect(relationsIcon?.outerHTML).not.toBe(workMarkup);
   });
 
+  it("shows the repeat indicator on a 15-minute recurring event despite its small rendered height", () => {
+    // A true 15-minute event lays out shorter than a taller one resized down to
+    // 15 minutes; the icon used to be gated on rendered pixel height, so the two
+    // disagreed. Gating on duration makes any 15-minute recurring event qualify.
+    const { container } = render(
+      <CalendarTimedEventCard
+        displayMode="saved"
+        event={createEvent({
+          endDate: "2024-01-15T09:15:00.000Z",
+          recurrence: { eventId: "series-1", rule: ["RRULE:FREQ=WEEKLY"] },
+          startDate: "2024-01-15T09:00:00.000Z",
+        })}
+        motionMode="idle"
+        // A short height that fell below the old pixel-height threshold.
+        position={{ ...position, height: 18 }}
+      />,
+    );
+
+    expect(container.querySelector('svg[class*="right-1"]')).not.toBeNull();
+  });
+
+  it("shows the repeat indicator on a recurring draft preview", () => {
+    // The draft preview should reflect the future reality: once a draft has a
+    // recurrence rule, its card renders the repeat icon immediately (drafts are
+    // not placeholders, so they are not excluded from the indicator).
+    const { container } = render(
+      <CalendarTimedEventCard
+        displayMode="draft"
+        event={createEvent({
+          _id: undefined,
+          recurrence: { rule: ["RRULE:FREQ=WEEKLY"] },
+        })}
+        motionMode="idle"
+        position={position}
+      />,
+    );
+
+    expect(container.querySelector('svg[class*="right-1"]')).not.toBeNull();
+  });
+
+  it("hides the repeat indicator on a too-narrow event", () => {
+    const { container } = render(
+      <CalendarTimedEventCard
+        displayMode="saved"
+        event={createEvent({
+          recurrence: { eventId: "series-1", rule: ["RRULE:FREQ=WEEKLY"] },
+        })}
+        motionMode="idle"
+        // Below the width gate: too cramped to place the icon without crowding.
+        position={{ ...position, width: 30 }}
+      />,
+    );
+
+    expect(container.querySelector('svg[class*="right-1"]')).toBeNull();
+  });
+
   it("renders all-day event details, interaction attributes, acknowledgement animation, and resize handles", () => {
     const onEventMouseDown = mock();
     const onScalerMouseDown = mock();

--- a/packages/web/src/common/calendar-grid/components/CalendarTimedEventCard.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarTimedEventCard.tsx
@@ -36,7 +36,13 @@ import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 import { getLineClamp } from "@web/common/utils/grid/grid.util";
 import { RepeatIcon } from "@web/components/Icons/Repeat";
 
-const REPEAT_ICON_MIN_HEIGHT = 30;
+// Gate the repeat indicator on the event's duration, not its rendered pixel
+// height: a true 15-minute event and one resized down to 15 minutes are laid
+// out through different height paths that straddle a pixel threshold, so the
+// same 15-minute event would show the icon in one case and hide it in the
+// other. Duration is the same regardless of render path. 15 min is the minimum
+// event length, so every recurring timed event qualifies.
+const REPEAT_ICON_MIN_DURATION_MINUTES = 15;
 const REPEAT_ICON_MIN_WIDTH = 40;
 
 interface CalendarTimedEventCardProps {
@@ -87,10 +93,14 @@ const CalendarTimedEventCardBase = (
   const isResizing = motionMode === "resizing";
   const isInPast = dayjs().isAfter(dayjs(event.endDate));
   const isRecurring = isRecurringEvent(event);
+  const durationMinutes = dayjs(event.endDate).diff(
+    dayjs(event.startDate),
+    "minute",
+  );
   const showRepeatIcon =
     isRecurring &&
     !isPlaceholder &&
-    position.height >= REPEAT_ICON_MIN_HEIGHT &&
+    durationMinutes >= REPEAT_ICON_MIN_DURATION_MINUTES &&
     position.width >= REPEAT_ICON_MIN_WIDTH;
 
   const lineClamp = useMemo(


### PR DESCRIPTION
## Summary

The repeat indicator on timed events was gated on the event's *rendered pixel height* (`position.height >= 30`). A true 15-minute event and one resized down to 15 minutes are laid out through two different height-computation paths that straddle that threshold, so the same 15-minute recurring event would show the icon in one case and hide it in the other (spec problem 1).

This gates the icon on the event's **duration** instead (start→end minutes), which is the same regardless of how the event was rendered. 15 minutes is the minimum event length, so every recurring timed event now shows the icon consistently. This also covers a freshly-drafted recurring event's preview — as soon as a draft has a recurrence rule, its card renders the icon (spec problem 2), since the draft already flows its `recurrence` into the same card and drafts aren't excluded like placeholders are.

## Simplicity

Net-neutral size, net-positive correctness. Swaps a brittle pixel-height proxy for the semantic value it was standing in for (duration). The duration is computed inline with `dayjs().diff`, matching the file's existing inline-derivation style — no memo (a cheap date diff) and no new `useEffect`/`useRef`/`useState`. The width gate is unchanged.

## Manual Testing Steps

_(Requires a signed-in account — recurring events are disabled for anonymous sessions.)_

- [ ] Create a recurring event and resize/create it so it is 15 minutes long. Confirm the repeat icon shows in its bottom-right corner.
- [ ] Confirm a 15-minute recurring event that was *never* longer (created directly at 15 min) shows the icon the same as one resized down from 30+ minutes — no inconsistency between the two.
- [ ] Confirm longer recurring events (30 min, 1 hour) still show the icon as before.
- [ ] Start drafting a new event and set it to repeat in the form. Confirm the repeat icon appears on the draft preview immediately (before saving).
- [ ] Confirm a very narrow event still hides the icon (no crowding).

## Test plan

- [x] `bun run type-check` — clean
- [x] `bunx biome check` on changed files — clean
- [x] `bun run test:web` on the event-card suite — 11 pass, 0 fail, including three new tests: a 15-minute recurring event with a small rendered height shows the icon (would fail under the old pixel-height gate), a recurring draft preview shows the icon, and a too-narrow event still hides it.
- [x] Confirmed in local Chrome preview that a 15-minute timed draft renders (6:00–6:15 PM). Note: the authed repeat-on-draft flow can't be exercised anonymously (recurrence requires sign-in) — deferred to staging.