### PR TITLE
fix(web): make repeat icons consistent across event types

### DIFF
--- a/packages/web/src/common/calendar-grid/components/CalendarAllDayEventCard.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarAllDayEventCard.tsx
@@ -15,14 +15,13 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { darken } from "@web/common/styles/color.utils";
 import {
   gridColorByPriority,
   gridHoverColorByPriority,
 } from "@web/common/styles/theme.util";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
-import { RepeatIcon } from "@web/components/Icons/Repeat";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
+import { GridEventRepeatIcon } from "./GridEventRepeatIcon";
 
 const REPEAT_ICON_MIN_WIDTH = 60;
 
@@ -65,9 +64,6 @@ const CalendarAllDayEventCardBase = (
   const isRecurring = isRecurringEvent(event);
   const showRepeatIcon =
     isRecurring && !isPlaceholder && position.width >= REPEAT_ICON_MIN_WIDTH;
-  // Match the timed card: tie the indicator to the event's priority (a darker
-  // shade of the card color) instead of a loud, fixed white.
-  const repeatIconColor = darken(baseColor, 30);
   const hoverBgColor = !isPlaceholder ? hoverColor : baseColor;
 
   const eventStyle = {
@@ -145,15 +141,7 @@ const CalendarAllDayEventCardBase = (
           <SpaceCharacter />
         </span>
       </div>
-      {showRepeatIcon && (
-        <RepeatIcon
-          aria-hidden="true"
-          className="pointer-events-none absolute right-1 bottom-0.5"
-          color={repeatIconColor}
-          size={10}
-          weight="bold"
-        />
-      )}
+      {showRepeatIcon && <GridEventRepeatIcon baseColor={baseColor} />}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Resize handles are pointer-only drag targets hidden from assistive tech. */}
       <div
         aria-hidden="true"

--- a/packages/web/src/common/calendar-grid/components/CalendarAllDayEventCard.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarAllDayEventCard.tsx
@@ -15,6 +15,7 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
+import { darken } from "@web/common/styles/color.utils";
 import {
   gridColorByPriority,
   gridHoverColorByPriority,
@@ -64,6 +65,9 @@ const CalendarAllDayEventCardBase = (
   const isRecurring = isRecurringEvent(event);
   const showRepeatIcon =
     isRecurring && !isPlaceholder && position.width >= REPEAT_ICON_MIN_WIDTH;
+  // Match the timed card: tie the indicator to the event's priority (a darker
+  // shade of the card color) instead of a loud, fixed white.
+  const repeatIconColor = darken(baseColor, 30);
   const hoverBgColor = !isPlaceholder ? hoverColor : baseColor;
 
   const eventStyle = {
@@ -130,20 +134,26 @@ const CalendarAllDayEventCardBase = (
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <div className="flex min-w-0 items-center gap-0.5">
-        {showRepeatIcon && (
-          <RepeatIcon
-            aria-hidden="true"
-            className="pointer-events-none shrink-0 text-fg-primary"
-            size={10}
-            weight="bold"
-          />
-        )}
+      <div
+        className={cn("flex min-w-0 items-center", {
+          // Reserve room so a long title truncates before the bottom-right icon.
+          "pr-3.5": showRepeatIcon,
+        })}
+      >
         <span className="relative min-w-0 truncate text-xs">
           {event.title}
           <SpaceCharacter />
         </span>
       </div>
+      {showRepeatIcon && (
+        <RepeatIcon
+          aria-hidden="true"
+          className="pointer-events-none absolute right-1 bottom-0.5"
+          color={repeatIconColor}
+          size={10}
+          weight="bold"
+        />
+      )}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Resize handles are pointer-only drag targets hidden from assistive tech. */}
       <div
         aria-hidden="true"

--- a/packages/web/src/common/calendar-grid/components/CalendarEventCard.test.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarEventCard.test.tsx
@@ -329,6 +329,44 @@ describe("CalendarEventCard", () => {
     expect(onParentKeyDown).not.toHaveBeenCalled();
   });
 
+  it("places the all-day repeat indicator bottom-right and colors it by priority", () => {
+    const renderRecurring = (priority: Priorities) =>
+      render(
+        <CalendarAllDayEventCard
+          event={createEvent({
+            isAllDay: true,
+            priority,
+            recurrence: { eventId: "series-1", rule: ["RRULE:FREQ=WEEKLY"] },
+          })}
+          isPlaceholder={false}
+          position={position}
+        />,
+      );
+
+    const { container: workContainer, unmount } = renderRecurring(
+      Priorities.WORK,
+    );
+    const workIcon = workContainer.querySelector('svg[class*="right-1"]');
+
+    // Matches the timed card: bottom-right, and no longer the fixed white fg
+    // color on the left.
+    expect(workIcon).not.toBeNull();
+    const workClass = workIcon?.getAttribute("class") ?? "";
+    expect(workClass).toContain("bottom-0.5");
+    expect(workClass).not.toContain("fg-primary");
+    const workMarkup = workIcon?.outerHTML;
+    unmount();
+
+    // A different priority yields a different (priority-derived) icon color.
+    const { container: relationsContainer } = renderRecurring(
+      Priorities.RELATIONS,
+    );
+    const relationsIcon = relationsContainer.querySelector(
+      'svg[class*="right-1"]',
+    );
+    expect(relationsIcon?.outerHTML).not.toBe(workMarkup);
+  });
+
   it("announces recurring all-day events", () => {
     render(
       <CalendarAllDayEventCard

--- a/packages/web/src/common/calendar-grid/components/CalendarTimedEventCard.tsx
+++ b/packages/web/src/common/calendar-grid/components/CalendarTimedEventCard.tsx
@@ -34,7 +34,7 @@ import {
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 import { getLineClamp } from "@web/common/utils/grid/grid.util";
-import { RepeatIcon } from "@web/components/Icons/Repeat";
+import { GridEventRepeatIcon } from "./GridEventRepeatIcon";
 
 // Gate the repeat indicator on the event's duration, not its rendered pixel
 // height: a true 15-minute event and one resized down to 15 minutes are laid
@@ -118,9 +118,6 @@ const CalendarTimedEventCardBase = (
   const baseColor = gridColorByPriority[priority];
   const draftColor = darken(baseColor, 18);
   const hoverColor = gridHoverColorByPriority[priority];
-  // Tie the repeat indicator to the event's priority: a darker shade of the
-  // card color complements it on every priority instead of a loud, fixed white.
-  const repeatIconColor = darken(baseColor, 30);
   const selectedBoxShadow = "0 0 0 1px rgba(255,255,255,0.55)";
 
   const bgColor = (() => {
@@ -286,15 +283,7 @@ const CalendarTimedEventCardBase = (
           </>
         )}
       </div>
-      {showRepeatIcon && (
-        <RepeatIcon
-          aria-hidden="true"
-          className="pointer-events-none absolute right-1 bottom-0.5"
-          color={repeatIconColor}
-          size={10}
-          weight="bold"
-        />
-      )}
+      {showRepeatIcon && <GridEventRepeatIcon baseColor={baseColor} />}
     </div>
   );
 };

--- a/packages/web/src/common/calendar-grid/components/GridEventRepeatIcon.tsx
+++ b/packages/web/src/common/calendar-grid/components/GridEventRepeatIcon.tsx
@@ -1,0 +1,23 @@
+import { darken } from "@web/common/styles/color.utils";
+import { RepeatIcon } from "@web/components/Icons/Repeat";
+
+interface Props {
+  baseColor: string;
+}
+
+/**
+ * The recurrence indicator shared by the timed and all-day grid cards: a small
+ * repeat glyph pinned to the card's bottom-right, tinted a darker shade of the
+ * event's priority color so it complements the card instead of a loud fixed
+ * white. Keeping it in one place stops the two cards from drifting apart.
+ * Decorative — the recurring state is announced via each card's aria-label.
+ */
+export const GridEventRepeatIcon = ({ baseColor }: Props) => (
+  <RepeatIcon
+    aria-hidden="true"
+    className="pointer-events-none absolute right-1 bottom-0.5"
+    color={darken(baseColor, 30)}
+    size={10}
+    weight="bold"
+  />
+);

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type Props_DraftForm } from "@web/views/Week/components/Draft/context/DraftContext";
+import { describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+
+import { SomedayEventRectangle } from "./SomedayEventRectangle";
+
+// The component only reaches for the reference ref and reference props from the
+// floating-ui form hook, so a minimal stub is enough to render it in isolation.
+const formProps = {
+  refs: { setReference: () => {} },
+  getReferenceProps: () => ({}),
+} as unknown as Props_DraftForm;
+
+const createEvent = (overrides: Partial<Schema_Event> = {}): Schema_Event =>
+  ({
+    _id: "someday-1",
+    isSomeday: true,
+    title: "Read a book",
+    ...overrides,
+  }) as Schema_Event;
+
+const renderRectangle = (event: Schema_Event) =>
+  render(
+    <SomedayEventRectangle
+      category={Categories_Event.SOMEDAY_WEEK}
+      event={event}
+      formProps={formProps}
+      onMigrate={mock()}
+    />,
+  );
+
+describe("SomedayEventRectangle", () => {
+  it("shows migrate controls for a non-recurring someday event", () => {
+    renderRectangle(createEvent());
+
+    expect(
+      screen.getByRole("button", { name: "Migrate to previous week" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Migrate to next week" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Recurring event")).not.toBeInTheDocument();
+  });
+
+  it("shows a passive repeat indicator instead of a migrate control for a recurring event", () => {
+    renderRectangle(
+      createEvent({ recurrence: { rule: ["RRULE:FREQ=WEEKLY"] } }),
+    );
+
+    // The recurrence is announced, but there is no interactive migrate/warning
+    // control and no "Can't migrate" affordance.
+    expect(screen.getByLabelText("Recurring event")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /migrate/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/can't migrate recurring events/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
@@ -1,11 +1,7 @@
-import {
-  ArrowCounterClockwise,
-  CaretLeft,
-  CaretRight,
-  DotsSixVertical,
-} from "@phosphor-icons/react";
+import { CaretLeft, CaretRight, DotsSixVertical } from "@phosphor-icons/react";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
-import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { isRecurringEvent } from "@core/util/event/event.util";
+import { RepeatIcon } from "@web/components/Icons/Repeat";
 import { type Actions_Sidebar } from "@web/components/PlannerSidebar/draft/hooks/useSidebarActions";
 import { type Props_DraftForm } from "@web/views/Week/components/Draft/context/DraftContext";
 
@@ -29,8 +25,7 @@ export const SomedayEventRectangle = ({
   onMigrate,
 }: Props) => {
   const target = category === Categories_Event.SOMEDAY_WEEK ? "week" : "month";
-  const canMigrate =
-    !event.recurrence?.rule || event.recurrence?.rule.length === 0;
+  const canMigrate = !isRecurringEvent(event);
 
   return (
     <div
@@ -89,27 +84,16 @@ export const SomedayEventRectangle = ({
             </button>
           </div>
         ) : (
-          <div
-            className={ACTIONS_CLASS_NAME}
-            data-someday-drag-affordance="true"
-          >
-            <button
-              aria-label="Recurring events cannot be migrated"
-              className={ACTION_BUTTON_CLASS_NAME}
-              onClick={(e) => {
-                e.stopPropagation();
-                showErrorToast("Can't migrate recurring events");
-              }}
-              title="Can't migrate recurring events"
-              type="button"
-            >
-              <ArrowCounterClockwise
-                aria-hidden="true"
-                size={14}
-                weight="bold"
-              />
-            </button>
-          </div>
+          // Recurring someday events can't be migrated; instead of a disabled
+          // migrate control with a hover warning, show a passive, muted repeat
+          // indicator so the user can see the event repeats.
+          <RepeatIcon
+            aria-label="Recurring event"
+            className="mr-1 shrink-0 text-text-light"
+            role="img"
+            size={14}
+            weight="bold"
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Unifies the recurrence indicator across the three event surfaces so a repeating event looks the same everywhere (see spec's `repeat-icon-inconsistent.png`):

- **All-day events** showed the repeat icon on the *left* in a fixed white. It now sits bottom-right and is colored by priority (a darker shade of the card color), matching the timed grid cards from #1998.
- **Recurring someday events** showed a disabled migrate control with a hover "Can't migrate recurring events" warning. That proactive warning is replaced by a passive, muted repeat indicator (announced to assistive tech via `role="img"`) so the user can simply see the event repeats. Non-recurring someday events keep their working migrate controls.

## Simplicity

Net simpler despite adding a file. The timed and all-day cards were rendering a byte-identical bottom-right repeat icon; the follow-up `refactor` commit extracts that into a shared `GridEventRepeatIcon` (one prop, `baseColor`) so the two cards can't drift apart — which is the whole point of a "make them consistent" change. The someday change *removes* an interactive control (button + click handler + toast) in favor of a static icon, and uses the canonical `isRecurringEvent` predicate instead of an inline `recurrence?.rule` check (also more correct — it covers the `recurrence.eventId` case). No `useEffect`/`useRef`/`useState` involved anywhere in the diff.

## Manual Testing Steps

_(Recurring events require a signed-in account — they can't be created in an anonymous session.)_

- [ ] In Week view, find or create a recurring **all-day** event. Confirm its repeat icon is in the bottom-right corner (not the left) and is a subtle darker shade of the event's color (not bright white).
- [ ] Confirm the all-day repeat icon's color matches the treatment on a recurring **timed** event (same darker-by-priority look).
- [ ] Confirm a long all-day event title truncates before the icon rather than running under it.
- [ ] In the sidebar's Someday section, find or create a recurring someday event. Confirm it shows a small muted repeat icon on the right, always visible, and that hovering it shows **no** "Can't migrate recurring events" warning and clicking it does nothing (it's passive).
- [ ] Confirm a **non-recurring** someday event still shows its migrate (‹ ›) controls on hover and they still work.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bunx biome check` on changed files — clean
- [x] `bun run test:web` — 1228 pass, 0 fail. New tests: all-day repeat indicator is bottom-right + priority-colored; recurring someday shows a passive announced repeat icon with no migrate/warning control; non-recurring someday shows migrate controls.
- [x] Confirmed in local Chrome preview: non-recurring all-day and someday events render with no regression from the restructure. Recurring visual states can't be created anonymously (recurrence is sign-in gated) — deferred to staging QA; component behavior is locked by the unit tests above.