### PR TITLE
fix(web): render recurring "all events" time edits immediately

### DIFF
--- a/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
@@ -3,6 +3,7 @@ import {
   RecurringEventUpdateScope,
   type Schema_Event,
 } from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
 import { projectRecurringEdit } from "./projectRecurringEdit";
 import { describe, expect, test } from "bun:test";
 
@@ -32,9 +33,58 @@ describe("projectRecurringEdit", () => {
       { _id: "one", title: "Updated" },
       { _id: "two", title: "Updated" },
     ]);
-    expect(result.upserts.map(({ startDate }) => startDate)).toEqual(
-      events.map(({ startDate }) => startDate),
-    );
+    // A title-only edit has no time delta, so every occurrence keeps its time.
+    expect(
+      result.upserts.map(({ startDate }) => dayjs(startDate).toISOString()),
+    ).toEqual(events.map(({ startDate }) => dayjs(startDate).toISOString()));
+  });
+
+  test("shifts every occurrence when an all-events edit moves the time", () => {
+    const events = [
+      occurrence("one", 1),
+      occurrence("two", 2),
+      occurrence("three", 3),
+    ];
+    // Drag the second instance two hours later (and lengthen it by 30 min).
+    const original = events[1];
+    const edited = {
+      ...original,
+      startDate: "2026-07-02T18:00:00.000Z",
+      endDate: "2026-07-02T19:30:00.000Z",
+    };
+
+    const result = projectRecurringEdit({
+      applyTo: RecurringEventUpdateScope.ALL_EVENTS,
+      edited,
+      original,
+      seriesEvents: events,
+    });
+
+    // Every instance — including ones before the dragged one — moves by the
+    // same delta, so the whole series re-renders at the new time immediately.
+    expect(
+      result.upserts.map(({ _id, startDate, endDate }) => ({
+        _id,
+        startDate,
+        endDate,
+      })),
+    ).toEqual([
+      {
+        _id: "one",
+        startDate: "2026-07-01T18:00:00+00:00",
+        endDate: "2026-07-01T19:30:00+00:00",
+      },
+      {
+        _id: "two",
+        startDate: "2026-07-02T18:00:00+00:00",
+        endDate: "2026-07-02T19:30:00+00:00",
+      },
+      {
+        _id: "three",
+        startDate: "2026-07-03T18:00:00+00:00",
+        endDate: "2026-07-03T19:30:00+00:00",
+      },
+    ]);
   });
 
   test("patches and shifts only the cutoff and future occurrences", () => {

--- a/packages/web/src/events/recurrence/projectRecurringEdit.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.ts
@@ -90,12 +90,15 @@ export function projectRecurringEdit({
     };
   }
 
-  const upserts = affected.map((event) => {
-    const patched = seriesPatch(event, edited);
-    return applyTo === RecurringEventUpdateScope.ALL_EVENTS
-      ? patched
-      : shiftEvent(patched, original, edited);
-  });
+  // Shift every affected instance by the drag's delta so the change renders
+  // optimistically. Both scopes shift by the same delta; they differ only in
+  // which instances are affected (all vs. only those at/after the cutoff),
+  // computed above. Each instance shifts relative to its own time, and the
+  // dragged instance — still at its old time in the cache here — lands on the
+  // edited time because (old + (edited - original)) === edited.
+  const upserts = affected.map((event) =>
+    shiftEvent(seriesPatch(event, edited), original, edited),
+  );
 
   return { removeIds: new Set(), upserts };
 }


### PR DESCRIPTION
## Summary

Dragging one instance of a recurring event to a new time and choosing **All Events** did nothing visible — the event and its instances stayed put. The API call succeeded (204), but the optimistic update only patched each occurrence's *metadata* (title, priority, recurrence) and never shifted its start/end, so the series looked unchanged until (and unless) a later refetch reconciled it.

The `ALL_EVENTS` scope now shifts every affected instance by the drag's delta, exactly like the existing `THIS_AND_FOLLOWING` scope already did. Both scopes shift by the same delta; they differ only in *which* instances they touch (all instances vs. only those at/after the dragged one). The dragged instance — still at its old time in the cache at projection time — lands on the edited time because `old + (edited − original) === edited`, so no special-casing is needed. The whole series re-renders at the new time immediately.

## Simplicity

Net simpler: the change collapses a two-branch conditional (`ALL_EVENTS ? patched : shiftEvent(...)`) into a single shared code path, since the only real difference between the scopes is the `affected` set computed just above. No new hooks, no new abstractions.

## Manual Testing Steps

_(Requires a signed-in, calendar-synced account — recurring events aren't available anonymously.)_

- [ ] Create a daily recurring event and confirm it loads on every day of the week view.
- [ ] Drag one instance to a different time. When prompted, choose **Apply to All Events**.
- [ ] Confirm every instance of the series moves to the new time immediately (no manual refresh needed).
- [ ] Reload the page and confirm the new times persisted (server agrees with the optimistic render).
- [ ] Repeat with **This and Following** and confirm only the dragged instance and later ones move (unchanged behavior).
- [ ] Edit only the title via **All Events** and confirm titles update and times stay put.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bunx biome check` on changed files — clean
- [x] `bun run test:web` on the recurrence projection suite — 4 pass, 0 fail, including a new test proving an all-events *time* edit shifts every occurrence by the same delta (previously the test asserted times stayed unchanged — the bug, now corrected).
- Note: the end-to-end drag→204→re-render flow needs a synced account and can't be exercised anonymously (IndexedDB, not network, in anon mode) — deferred to staging QA. The projection logic is proven by the unit test.