### PR TITLE
feat(web): preview recurring draft occurrences across the week

### DIFF
--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -13,6 +13,7 @@ import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { useDraftContext } from "./context/useDraftContext";
 import { getActiveTimedDraftDeckLayout } from "./grid/activeTimedDraftDeckLayout";
 import { GridDraft } from "./grid/GridDraft";
+import { getRecurringDraftPreviews } from "./grid/getRecurringDraftPreviews";
 import { useGridMouseMove } from "./grid/hooks/useGridMouseMove";
 import { useGridMouseUp } from "./grid/hooks/useGridMouseUp";
 
@@ -44,6 +45,15 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
     () => getActiveTimedDraftDeckLayout(draft, timedEvents),
     [draft, timedEvents],
   );
+  const recurringPreviews = useMemo(
+    () =>
+      getRecurringDraftPreviews(
+        draft,
+        weekProps.component.startOfView,
+        weekProps.component.endOfView,
+      ),
+    [draft, weekProps.component.startOfView, weekProps.component.endOfView],
+  );
 
   if (draft?.isAllDay === undefined) {
     return null;
@@ -62,6 +72,7 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
         activeAllDayDraftEvent={activeAllDayDraftEvent}
         deckLayout={deckLayout}
         measurements={measurements}
+        recurringPreviews={recurringPreviews}
         weekProps={weekProps}
       />
     ),

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -116,10 +116,12 @@ const renderGridDraft = ({
   activeAllDayDraftEvent = null,
   deckLayout = null,
   draft = createDraft(),
+  recurringPreviews = [],
 }: {
   activeAllDayDraftEvent?: Schema_GridEvent | null;
   deckLayout?: { groupSize: number; order: number } | null;
   draft?: Schema_GridEvent;
+  recurringPreviews?: Schema_GridEvent[];
 } = {}) => {
   const repositionDraftByKeyboard = mock(() => true);
   const onSubmit = mock();
@@ -160,6 +162,7 @@ const renderGridDraft = ({
           hourHeight: 48,
           mainGrid: null,
         }}
+        recurringPreviews={recurringPreviews}
         weekProps={createWeekProps()}
       />
     </DraftContext.Provider>,
@@ -248,6 +251,28 @@ describe("GridDraft keyboard focus", () => {
 
     expect(draftBlock.style.width).toBe(`${CALENDAR_DECK_MIN_WIDTH}px`);
     expect(Number(draftBlock.style.zIndex)).toBe(deckLayout.order + 1);
+  });
+
+  it("renders a read-only card for each recurring preview occurrence", () => {
+    renderGridDraft({
+      recurringPreviews: [
+        createDraft({
+          _id: undefined,
+          endDate: "2026-05-27T15:00:00.000Z",
+          startDate: "2026-05-27T14:00:00.000Z",
+        }),
+        createDraft({
+          _id: undefined,
+          endDate: "2026-05-28T15:00:00.000Z",
+          startDate: "2026-05-28T14:00:00.000Z",
+        }),
+      ],
+    });
+
+    // The interactive draft plus one card per preview occurrence.
+    expect(
+      screen.getAllByRole("button", { name: /Timed event: Planning/ }),
+    ).toHaveLength(3);
   });
 
   it("submits the draft from title Enter without focusing the draft block", async () => {

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -19,6 +19,7 @@ interface Props {
   activeAllDayDraftEvent?: Schema_GridEvent | null;
   deckLayout?: CalendarTimedDeckLayout | null;
   measurements: Measurements_Grid;
+  recurringPreviews?: readonly Schema_GridEvent[];
   weekProps: WeekProps;
 }
 
@@ -28,6 +29,7 @@ export const GridDraft: FC<Props> = ({
   activeAllDayDraftEvent = null,
   deckLayout = null,
   measurements,
+  recurringPreviews = [],
   weekProps,
 }) => {
   const titleInputRef = useRef<HTMLInputElement>(null);
@@ -83,6 +85,19 @@ export const GridDraft: FC<Props> = ({
 
   return (
     <>
+      {/* Read-only previews of the other recurrence occurrences in view. They
+          take no handlers, so CalendarTimedEventCard swallows clicks — only the
+          canonical draft below is interactive. */}
+      {recurringPreviews.map((preview) => (
+        <GridEvent
+          displayMode="draft"
+          event={preview}
+          key={`draft-preview-${preview.startDate}`}
+          measurements={measurements}
+          weekProps={weekProps}
+        />
+      ))}
+
       {draft.isAllDay ? (
         <AllDayEventMemo
           event={allDayDraftEvent}

--- a/packages/web/src/views/Week/components/Draft/grid/getRecurringDraftPreviews.test.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/getRecurringDraftPreviews.test.ts
@@ -1,0 +1,91 @@
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import dayjs from "@core/util/date/dayjs";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { getRecurringDraftPreviews } from "./getRecurringDraftPreviews";
+import { describe, expect, test } from "bun:test";
+
+const startOfView = dayjs("2026-07-05T00:00:00.000Z"); // Sun
+const endOfView = dayjs("2026-07-11T23:59:59.999Z"); // Sat
+
+const timedDraft = (
+  overrides: Partial<Schema_GridEvent> = {},
+): Schema_GridEvent =>
+  ({
+    isAllDay: false,
+    // Wednesday 10:00–11:00
+    startDate: "2026-07-08T10:00:00.000Z",
+    endDate: "2026-07-08T11:00:00.000Z",
+    title: "Standup",
+    ...overrides,
+  }) as Schema_GridEvent;
+
+const dayKey = (date?: string) => dayjs(date).format(YEAR_MONTH_DAY_FORMAT);
+
+describe("getRecurringDraftPreviews", () => {
+  test("returns [] for a non-recurring draft", () => {
+    expect(
+      getRecurringDraftPreviews(timedDraft(), startOfView, endOfView),
+    ).toEqual([]);
+  });
+
+  test("returns [] for a null draft", () => {
+    expect(getRecurringDraftPreviews(null, startOfView, endOfView)).toEqual([]);
+  });
+
+  test("returns [] for an all-day recurring draft", () => {
+    const draft = timedDraft({
+      isAllDay: true,
+      recurrence: { rule: ["RRULE:FREQ=DAILY"] },
+    });
+
+    expect(getRecurringDraftPreviews(draft, startOfView, endOfView)).toEqual(
+      [],
+    );
+  });
+
+  test("expands a daily draft to the remaining days of the view, excluding its own day", () => {
+    const draft = timedDraft({ recurrence: { rule: ["RRULE:FREQ=DAILY"] } });
+
+    const previews = getRecurringDraftPreviews(draft, startOfView, endOfView);
+
+    // Wed is the interactive draft; Thu/Fri/Sat are previews (Sun next week is
+    // past the view).
+    const previewDays = previews.map((p) => dayKey(p.startDate));
+    expect(previewDays).toEqual(["2026-07-09", "2026-07-10", "2026-07-11"]);
+    // None coincide with the draft's own day.
+    expect(previewDays).not.toContain(dayKey(draft.startDate));
+  });
+
+  test("keeps the draft's time-of-day and duration on each occurrence", () => {
+    const draft = timedDraft({ recurrence: { rule: ["RRULE:FREQ=DAILY"] } });
+
+    const previews = getRecurringDraftPreviews(draft, startOfView, endOfView);
+
+    for (const preview of previews) {
+      const durationMs = dayjs(preview.endDate).diff(preview.startDate);
+      expect(durationMs).toBe(60 * 60 * 1000); // 1 hour, same as the draft
+    }
+  });
+
+  test("previews carry no id so they stay inert", () => {
+    const draft = timedDraft({
+      _id: "draft-1",
+      recurrence: { rule: ["RRULE:FREQ=DAILY"] },
+    });
+
+    const previews = getRecurringDraftPreviews(draft, startOfView, endOfView);
+
+    expect(previews.length).toBeGreaterThan(0);
+    expect(previews.every((p) => p._id === undefined)).toBe(true);
+  });
+
+  test("expands a weekly draft to only its matching weekday in view", () => {
+    const draft = timedDraft({ recurrence: { rule: ["RRULE:FREQ=WEEKLY"] } });
+
+    // The next weekly occurrence (2026-07-15) is outside this view, so there
+    // are no other-day previews within the visible week.
+    expect(getRecurringDraftPreviews(draft, startOfView, endOfView)).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/web/src/views/Week/components/Draft/grid/getRecurringDraftPreviews.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/getRecurringDraftPreviews.ts
@@ -1,0 +1,86 @@
+import { ObjectId } from "bson";
+import { GCAL_MAX_RECURRENCES } from "@core/constants/core.constants";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { CompassEventRRule } from "@core/util/event/compass.event.rrule";
+import { getCompassEventDateFormat } from "@core/util/event/event.util";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+
+/**
+ * Expand a recurring timed draft into read-only preview occurrences that fall
+ * within the visible week, so the user sees the full effect of the recurrence
+ * before saving. The interactive draft still renders its own occurrence; these
+ * are the *other* days.
+ *
+ * Occurrences run forward from the draft's start (the series' first instance)
+ * through the end of the view — the same instances the saved event would have.
+ * We deliberately don't backfill days before the draft's start, because the
+ * saved series wouldn't exist there either; the preview reflects that reality.
+ *
+ * Derived from the draft on every render (no stored state), so discarding the
+ * draft clears the previews for free and dragging/editing it updates them.
+ * Returns [] for non-recurring drafts and for all-day drafts (previewed
+ * separately by the all-day row).
+ */
+export const getRecurringDraftPreviews = (
+  draft: Schema_GridEvent | null,
+  startOfView: Dayjs,
+  endOfView: Dayjs,
+): Schema_GridEvent[] => {
+  const rule = draft?.recurrence?.rule;
+
+  if (
+    !draft ||
+    draft.isAllDay ||
+    !draft.startDate ||
+    !draft.endDate ||
+    !Array.isArray(rule) ||
+    rule.length === 0
+  ) {
+    return [];
+  }
+
+  try {
+    const rrule = new CompassEventRRule({
+      _id: new ObjectId(),
+      startDate: draft.startDate,
+      endDate: draft.endDate,
+      recurrence: { rule },
+    });
+
+    const format = getCompassEventDateFormat(draft.startDate);
+    const durationMs = dayjs(draft.endDate).diff(
+      draft.startDate,
+      "milliseconds",
+    );
+    const endBoundary = endOfView.endOf("day");
+    const startBoundary = startOfView.startOf("day");
+    const draftDayKey = dayjs(draft.startDate).format(YEAR_MONTH_DAY_FORMAT);
+
+    return rrule
+      .all(
+        (date, index) =>
+          index < GCAL_MAX_RECURRENCES && dayjs(date).isBefore(endBoundary),
+      )
+      .filter((date) => {
+        const occurrence = dayjs(date);
+        return (
+          !occurrence.isBefore(startBoundary) &&
+          occurrence.format(YEAR_MONTH_DAY_FORMAT) !== draftDayKey
+        );
+      })
+      .map((date) => {
+        const start = dayjs(date);
+        return {
+          ...draft,
+          // No id: these are inert previews, not events, and must not be
+          // hover-tracked or keyed off the draft.
+          _id: undefined,
+          startDate: start.format(format),
+          endDate: start.add(durationMs, "milliseconds").format(format),
+        };
+      });
+  } catch {
+    return [];
+  }
+};


### PR DESCRIPTION
## Summary

When a user drafts a recurring event, the draft now previews its other occurrences on the days they'd fall within the visible week — so the draft reflects the full future reality of the event before it's saved (spec item: "render recurrence changes optimistically"). Create a daily 8–9am draft on a 7-day week and every remaining day shows a preview block; press ESC and they all vanish with no server request.

### How it works

- A pure helper, `getRecurringDraftPreviews`, expands the draft's recurrence rule (via the existing `CompassEventRRule`) into the occurrences that fall within the visible week, offset to each day at the draft's time and duration.
- The previews are **derived from the draft on every render** (a `useMemo` in `Draft.tsx`), not stored anywhere. That's what makes discard/ESC free — there's no extra state to reset — and makes the previews follow the draft as it's dragged or edited.
- The previews render as read-only `GridEvent` cards with no handlers, so `CalendarTimedEventCard` swallows their clicks — only the canonical draft stays interactive and owns the form.
- Occurrences run **forward from the draft's start** through the end of the view — the same instances the saved series would actually have. We deliberately don't backfill days before the draft's start, because the saved event wouldn't exist there either. This matches the spec's own principle that the draft should represent the event's future reality.

## Simplicity

The core is one pure function plus a `.map()` in the render — no new store state, no cross-component wiring. It adds exactly one `useMemo` (`recurringPreviews` in `Draft.tsx`), which is justified: it derives previews from the draft and view bounds, mirroring the existing `deckLayout`/all-day-draft memos in the same component, and avoids re-expanding the rule on unrelated renders. No `useState`/`useRef` added. Deriving-from-source rather than storing a second copy is the simplest design that can't drift out of sync with the draft.

## Manual Testing Steps

_(Requires a signed-in account — recurring events are disabled for anonymous sessions.)_

- [ ] In Week view (7 days), start drafting a timed event and set it to repeat daily. Confirm a preview block appears on each remaining day of the week at the same time.
- [ ] Drag the draft to a new time and confirm the previews follow to the new time on every day.
- [ ] Press ESC (or cancel the draft) and confirm all previews disappear immediately, with no network request (check the Network tab).
- [ ] Confirm you can only interact with (click/drag) the original draft, not the preview blocks.
- [ ] Set the repeat to weekly and confirm previews only appear on the matching weekday(s) within the view.
- [ ] Confirm a non-recurring draft shows no extra previews.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bunx biome check` — clean
- [x] `bun run test:web` — 1237 pass, 0 fail. New coverage: `getRecurringDraftPreviews` unit tests (daily expansion excluding the draft's own day, time/duration preserved on each occurrence, weekly-outside-view yields none, non-recurring/all-day/null yield none, previews carry no id) — verified tz-stable across UTC/MDT/America-New_York; and a `GridDraft` render test proving one read-only card renders per preview occurrence plus the interactive draft.
- Note: the end-to-end authed flow (toggling repeat in the form → previews) can't be exercised anonymously since recurrence is sign-in gated — deferred to staging QA. The derivation and rendering are proven by the tests above.