### PR TITLE
fix(web): context menu color reflects event priority

### DIFF
--- a/packages/web/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenu.tsx
@@ -6,6 +6,8 @@ import {
   useRole,
 } from "@floating-ui/react";
 import React from "react";
+import { Priorities } from "@core/constants/core.constants";
+import { hoverColorByPriority } from "@web/common/styles/theme.util";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
   ContextMenuItems,
@@ -40,11 +42,13 @@ export const ContextMenu = React.forwardRef<HTMLUListElement, ContextMenuProps>(
 
     if (!event) return null;
 
+    const priority = event.priority || Priorities.UNASSIGNED;
+
     return (
       <ul
         className="c-context-menu"
         ref={ref}
-        style={style}
+        style={{ ...style, backgroundColor: hoverColorByPriority[priority] }}
         {...getFloatingProps()}
       >
         {actions ? (


### PR DESCRIPTION
## Summary

The event context menu (right-click an event → priority circles + Edit/Duplicate/Delete) always rendered with the fixed near-white `menu-bg` token, regardless of the event's priority. This was inconsistent with the event form, which tints its panel by priority.

This tints the context menu background using the **same source of truth the form uses** — `hoverColorByPriority[priority]` (the map `EventFormShell` reads) — so the two surfaces stay visually consistent as priorities/colors evolve. Priority is derived as `event.priority || Priorities.UNASSIGNED`, mirroring `EventForm`.

The Task context menu is intentionally left unchanged: tasks have no priority (delete-only), so a priority tint doesn't apply there.

## Simplicity

Net-neutral complexity: +5 lines in one file, no new abstractions and no new hooks (`useEffect`/`useRef`/`useState` count unchanged). It reuses the existing `hoverColorByPriority` color map rather than introducing a parallel color path, and applies the tint via an inline `backgroundColor` (which reliably wins over `.c-context-menu`'s own `bg-menu-bg`, avoiding CSS source-order ambiguity). The `priority` intermediate variable is kept for legibility and to match how `EventForm` names the same value. No simplification opportunities found beyond that.

## Manual Testing Steps

- [ ] Open the app and land on the Day view with at least two events of different priorities (e.g. a Relations event and a Work event).
- [ ] Right-click the Relations (teal) event — the context menu that appears should have a mint/teal tinted background matching that event, not white.
- [ ] Right-click the Work (blue-gray) event — the context menu should have a light-blue tinted background, distinct from the Relations one.
- [ ] Confirm the menu's text (Edit, Duplicate, Delete) and the priority circles remain clearly legible on the tinted background.
- [ ] Confirm the menu color matches the color the event form shows when you open that same event for editing.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bun test packages/web/src/components/ContextMenu/` — 7 pass, 0 fail
- [x] `bunx @biomejs/biome check` on the changed file — no issues
- [x] Local browser (Day view): verified menu background computed to `rgb(159,233,212)` (teal) on a Relations event and `rgb(149,189,219)` (blue) on a Work event
