### PR TITLE
feat(backend): log health checks at debug level so they're hidden by default

### DIFF
--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -14,7 +14,7 @@ Examples:
 | `runtime.version` | Self-host | Docker image tag used by the self-host compose stack. Defaults to `latest`. Pin this for reproducible installs. |
 | `runtime.nodeEnv` | Yes | Runtime mode. Use `production` for self-hosted and staging; `development` for local dev. |
 | `runtime.timezone` | Yes | Backend timezone. Only `Etc/UTC` and `UTC` are accepted. |
-| `runtime.logLevel` | No | Winston log level. Defaults to `info`. |
+| `runtime.logLevel` | No | Winston log level. Defaults to `info`. Set to `debug` to include health-check requests (`GET /api/health`) in the logs, which are otherwise hidden. |
 
 ## Web
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -280,6 +280,17 @@ cd ~/compass
 ./compass logs backend
 ```
 
+Health-check requests (`GET /api/health`) fire every few seconds and are hidden
+from the tail by default so they don't drown out real traffic. To see them,
+raise the log level to `debug` — either set `runtime.logLevel: debug` in
+`compass.yaml`, or start the backend with `LOG_LEVEL=debug`:
+
+```bash
+cd ~/compass
+LOG_LEVEL=debug docker compose up -d backend
+./compass logs backend
+```
+
 For a final server-side check, run:
 
 ```bash

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -139,9 +139,17 @@ const isTestWithoutConfig =
 let parsedConfig: Config;
 
 try {
-  parsedConfig = isTestWithoutConfig
-    ? parseConfigFromEnv(process.env)
-    : parseRawConfig(loadCompassConfig());
+  if (isTestWithoutConfig) {
+    parsedConfig = parseConfigFromEnv(process.env);
+  } else {
+    const rawConfig = loadCompassConfig();
+    // Honor runtime.logLevel from the config file. Winston and the request
+    // logger read LOG_LEVEL from the environment, so surface it there.
+    if (rawConfig.runtime.logLevel) {
+      process.env["LOG_LEVEL"] = rawConfig.runtime.logLevel;
+    }
+    parsedConfig = parseRawConfig(rawConfig);
+  }
 } catch (error) {
   logger.error(
     "Exiting because a critical config value is missing or invalid:",

--- a/packages/backend/src/common/middleware/http.logger.middleware.test.ts
+++ b/packages/backend/src/common/middleware/http.logger.middleware.test.ts
@@ -5,32 +5,60 @@ const { httpLoggingMiddleware } = jest.requireActual<
   typeof import("@backend/common/middleware/http.logger.middleware")
 >("@backend/common/middleware/http.logger.middleware");
 
+const makeRequest = (originalUrl: string): Request =>
+  ({
+    method: "GET",
+    originalUrl,
+    get ip() {
+      throw new Error("request IP should not be read");
+    },
+  }) as unknown as Request;
+
+const runMiddleware = (req: Request) => {
+  const res = Object.assign(new EventEmitter(), {
+    statusCode: 200,
+  }) as unknown as Response;
+  const next = jest.fn();
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+  httpLoggingMiddleware(req, res, next);
+  res.emit("finish");
+
+  return { next, logSpy };
+};
+
 describe("httpLoggingMiddleware", () => {
+  const originalLogLevel = process.env["LOG_LEVEL"];
+
+  afterEach(() => {
+    process.env["LOG_LEVEL"] = originalLogLevel;
+    jest.restoreAllMocks();
+  });
+
   it("logs completed requests without reading the request IP address", () => {
-    const req = {
-      method: "GET",
-      originalUrl: "/api/health",
-      get ip() {
-        throw new Error("request IP should not be read");
-      },
-    } as unknown as Request;
-    const res = Object.assign(new EventEmitter(), {
-      statusCode: 200,
-    }) as unknown as Response;
-    const next = jest.fn();
-    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    delete process.env["LOG_LEVEL"];
 
-    try {
-      httpLoggingMiddleware(req, res, next);
-      res.emit("finish");
+    const { next, logSpy } = runMiddleware(makeRequest("/api/event"));
 
-      expect(next).toHaveBeenCalledTimes(1);
-      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("GET"));
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining("/api/health"),
-      );
-    } finally {
-      logSpy.mockRestore();
-    }
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("GET"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("/api/event"));
+  });
+
+  it("does not log health checks at the default log level", () => {
+    delete process.env["LOG_LEVEL"];
+
+    const { next, logSpy } = runMiddleware(makeRequest("/api/health"));
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs health checks when LOG_LEVEL is debug", () => {
+    process.env["LOG_LEVEL"] = "debug";
+
+    const { logSpy } = runMiddleware(makeRequest("/api/health?foo=bar"));
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("/api/health"));
   });
 });

--- a/packages/backend/src/common/middleware/http.logger.middleware.ts
+++ b/packages/backend/src/common/middleware/http.logger.middleware.ts
@@ -3,6 +3,11 @@ import { styleText } from "node:util";
 
 type HttpLogColor = "cyanBright" | "yellow" | "red" | "magentaBright";
 
+// The load balancer / Docker health check hits this every ~10s, which floods
+// the logs when tailing staging/prod. We log it at debug level so it stays out
+// of the default (info) tail; set LOG_LEVEL=debug to see health checks again.
+const HEALTH_CHECK_PATH = "/api/health";
+
 const getStatusColor = (status: string): HttpLogColor => {
   switch (status[0]) {
     case "1":
@@ -31,6 +36,9 @@ export const httpLoggingMiddleware: RequestHandler = (req, res, next) => {
     const statusColor = getStatusColor(status);
     const method = req.method || "unknown";
     const url = req.originalUrl || req.url || "unknown";
+
+    const isHealthCheck = url.split("?")[0] === HEALTH_CHECK_PATH;
+    if (isHealthCheck && process.env["LOG_LEVEL"] !== "debug") return;
 
     console.log(
       [

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -26,6 +26,10 @@ services:
     image: switchbacktech/compass-backend:${COMPASS_VERSION:-latest}
     environment:
       COMPASS_CONFIG_FILE: /app/compass.yaml
+      # Default to info so health-check requests stay out of the tail. Reveal
+      # them with `LOG_LEVEL=debug docker compose up -d backend`. A logLevel in
+      # compass.yaml takes precedence over this default.
+      LOG_LEVEL: ${LOG_LEVEL:-info}
     ports:
       - *backend-port
     read_only: true


### PR DESCRIPTION
## Summary

Health-check requests (`GET /api/health`) are hit every ~10s by the load balancer / Docker healthcheck and flooded the logs when tailing staging/prod. They now log at **debug** level, so the default (`info`) tail stays readable while the endpoint and its logging are fully preserved.

The noise came from `httpLoggingMiddleware`, which wrote every request with a raw `console.log` that bypassed the leveled logger entirely. Separately, there was **no working way to raise the log level in a deployed container** — `runtime.logLevel` was documented but never wired to winston, and the compose backend service never passed `LOG_LEVEL`. Both are fixed, so admins have two ways to reveal health checks when they want them:

- **`LOG_LEVEL=debug`** — now passed through the compose backend service (default `info`): `LOG_LEVEL=debug docker compose up -d backend`
- **`runtime.logLevel: debug`** in `compass.yaml` — now surfaced into `LOG_LEVEL` (previously silently ignored)

One intentional consequence: local dev now honors the root `compass.yaml`'s `logLevel: debug`, so devs finally get their intended debug output.

## Simplicity

Net-neutral-to-simpler. The change is a two-line guard clause in the request logger plus a small config-load restructure (ternary → if/else so config loads once and sets the env before parsing). No new abstraction was introduced — a "level is debug" check is a one-off inline comparison, clearer than a helper. No React hooks are involved (backend-only). `simplify` found nothing to change.

## Manual Testing Steps

This is a backend logging change with no browser surface, so these are CLI steps a reviewer can run.

- [ ] Start the backend (or use staging). Tail the logs: `./compass logs backend` (or `docker compose logs -f backend`). Repeatedly `curl -f http://localhost:3000/api/health` (or the staging URL). Confirm **no** log line appears for the health checks.
- [ ] Confirm normal requests still log: hit any other endpoint (e.g. load the app) and confirm the usual colorized `GET /api/... 200 ...ms` line still appears.
- [ ] Reveal health checks via env: restart the backend with `LOG_LEVEL=debug docker compose up -d backend`, tail again, `curl` the health endpoint, and confirm the health-check line **now appears**.
- [ ] Reveal via config: set `runtime.logLevel: debug` in `compass.yaml`, restart, and confirm health checks appear (verifies the previously-dead config now controls the level).
- [ ] Confirm `curl -f .../api/health` still returns `{"status":"ok",...}` — the endpoint behavior is unchanged.

## Test plan

- [x] `bun run type-check` — pass
- [x] Biome lint on changed files — clean
- [x] Middleware behavior exercised directly (bun), 6/6 cases: `/api/health` hidden at unset/`info`/with query string, shown at `debug`; non-health requests always logged
- [x] `self-host/compose.yaml` parses; backend env resolves to `LOG_LEVEL: ${LOG_LEVEL:-info}`
- [x] Updated jest unit test `http.logger.middleware.test.ts` (hidden by default, shown at debug, normal requests logged) — runs in CI (local jest unavailable in this nested worktree)
