### PR TITLE
fix(web): tint context menu hover and drop dividers by priority

### DIFF
--- a/packages/web/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenu.tsx
@@ -7,6 +7,8 @@ import {
 } from "@floating-ui/react";
 import React from "react";
 import { Priorities } from "@core/constants/core.constants";
+import { darken } from "@web/common/styles/color.utils";
+import { type CSSVariables } from "@web/common/styles/css.types";
 import { hoverColorByPriority } from "@web/common/styles/theme.util";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -43,12 +45,19 @@ export const ContextMenu = React.forwardRef<HTMLUListElement, ContextMenuProps>(
     if (!event) return null;
 
     const priority = event.priority || Priorities.UNASSIGNED;
+    const bgColor = hoverColorByPriority[priority];
 
     return (
       <ul
         className="c-context-menu"
         ref={ref}
-        style={{ ...style, backgroundColor: hoverColorByPriority[priority] }}
+        style={
+          {
+            ...style,
+            backgroundColor: bgColor,
+            "--menu-item-hover": darken(bgColor, 8),
+          } as CSSVariables
+        }
         {...getFloatingProps()}
       >
         {actions ? (

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -445,7 +445,7 @@
 }
 
 @utility c-context-menu-item {
-  @apply flex w-full cursor-pointer appearance-none items-center gap-2 whitespace-nowrap border-0 border-menu-border border-b bg-transparent px-3 py-2.5 text-left text-[14px] text-menu-text select-none last:border-b-0 hover:bg-menu-hover disabled:cursor-wait disabled:opacity-50;
+  @apply flex w-full cursor-pointer appearance-none items-center gap-2 whitespace-nowrap border-0 bg-transparent px-3 py-2.5 text-left text-[14px] text-menu-text select-none hover:bg-(--menu-item-hover) disabled:cursor-wait disabled:opacity-50;
 }
 
 @utility c-not-found {


### PR DESCRIPTION
## Summary

Follow-up to #2008, which tinted the event context menu panel by priority but left two elements still keyed off fixed near-white tokens that clashed with the tint:

- **Item hover** used `menu-hover` (near-white), so hovering Edit/Duplicate/Delete flashed a white band over the tinted panel.
- **Dividers** between items used `menu-border` (near-white), drawing white lines across the tint.

This derives a per-priority hover shade — `darken(panelTint, 8)` — exposed as the `--menu-item-hover` CSS variable and consumed by `.c-context-menu-item`'s `hover:` state, and removes the dividers so the menu reads as a single priority-tinted surface. This matches the event form's own action menu, which separates items by spacing and hover rather than lines.

## Simplicity

Net-neutral-to-simpler: the CSS utility lost three border classes (`border-menu-border`, `border-b`, `last:border-b-0`) and swapped one fixed hover token for a variable; the component added a single `bgColor` const (used twice — as the panel background and as the `darken` input, so it also removes a duplicate map lookup). No new `useEffect`/`useRef`/`useState` — the hover value is derived during render and passed as a CSS variable, so styling stays in the stylesheet rather than inline on each button.

## Manual Testing Steps

- [ ] Open the app on the Day view with events of at least two different priorities (e.g. a Relations/teal event and a Work/blue event).
- [ ] Right-click the Relations event to open its context menu — the panel should be teal.
- [ ] Hover over Edit, Duplicate, and Delete in turn — the hover highlight should be a slightly darker teal, not white.
- [ ] Confirm there are no white horizontal lines between Edit/Duplicate/Delete; the menu should read as one continuous tinted surface.
- [ ] Right-click the Work event and repeat — the panel and the hover highlight should both be shades of blue (hover slightly darker), again with no white dividers.
- [ ] Confirm the menu text and priority circles remain legible throughout.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bun test packages/web/src/components/ContextMenu/` — 7 pass, 0 fail
- [x] `bunx @biomejs/biome check` on the changed files — no issues
- [x] Local browser (Day view, Relations event): verified `--menu-item-hover` computed to `hsl(163 63% 69%)` (darker teal) and menu-item `border-bottom-width` is `0px`; hovering an item shows the darker-teal band with no white lines
