### PR TITLE
fix(web): toast responds to undo

### DIFF
--- a/packages/web/src/common/utils/toast/deleted-toast.util.test.tsx
+++ b/packages/web/src/common/utils/toast/deleted-toast.util.test.tsx
@@ -1,0 +1,42 @@
+import { EVENT_DELETED_TOAST_ID } from "@web/common/constants/toast.constants";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const toast = Object.assign(mock(), {
+  update: mock(),
+});
+
+mock.module("react-toastify", () => ({
+  ToastContainer: () => null,
+  toast,
+}));
+
+const { showRestoredToast } =
+  require("@web/common/utils/toast/deleted-toast.util") as typeof import("@web/common/utils/toast/deleted-toast.util");
+
+describe("showRestoredToast", () => {
+  beforeEach(() => {
+    toast.mockClear();
+    toast.update.mockClear();
+  });
+
+  it('updates the "Deleted" toast in place to "Restored"', () => {
+    showRestoredToast();
+
+    expect(toast.update).toHaveBeenCalledWith(
+      EVENT_DELETED_TOAST_ID,
+      expect.objectContaining({
+        render: "Restored",
+        autoClose: expect.any(Number),
+      }),
+    );
+  });
+
+  it("never creates a new toast, so it's a no-op once the toast is gone", () => {
+    // `toast.update` on a dismissed id is a no-op in react-toastify; we must not
+    // fall back to `toast(...)`, which would stack a fresh "Restored" toast even
+    // after the "Deleted" toast disappeared.
+    showRestoredToast();
+
+    expect(toast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/common/utils/toast/deleted-toast.util.tsx
+++ b/packages/web/src/common/utils/toast/deleted-toast.util.tsx
@@ -1,4 +1,8 @@
-import { EVENT_DELETED_TOAST_ID } from "@web/common/constants/toast.constants";
+import { toast } from "react-toastify";
+import {
+  EVENT_DELETED_TOAST_ID,
+  toastDefaultOptions,
+} from "@web/common/constants/toast.constants";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 
@@ -19,4 +23,18 @@ export function showDeletedToast(withUndoHint: boolean): void {
       "Deleted"
     ),
   );
+}
+
+/**
+ * Flip the "Deleted" toast to "Restored" when the user undoes the delete.
+ * `toast.update` only touches a live toast, so once the "Deleted" toast has
+ * auto-dismissed this is a no-op — restoring after it's gone shows nothing,
+ * which is what we want. It shares `EVENT_DELETED_TOAST_ID` so it updates the
+ * existing toast in place rather than stacking a second one.
+ */
+export function showRestoredToast(): void {
+  toast.update(EVENT_DELETED_TOAST_ID, {
+    render: "Restored",
+    autoClose: toastDefaultOptions.autoClose,
+  });
 }

--- a/packages/web/src/events/mutations/useUndoRedo.ts
+++ b/packages/web/src/events/mutations/useUndoRedo.ts
@@ -7,6 +7,7 @@ import {
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { useEventRepositorySource } from "@web/common/repositories/event/event.repository.source.store";
 import { type Schema_WebEvent } from "@web/common/types/web.event.types";
+import { showRestoredToast } from "@web/common/utils/toast/deleted-toast.util";
 import {
   type EventMutationDependencies,
   useEventMutations,
@@ -94,6 +95,9 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
         replaySnapshot(entry._id, entry.before);
       }
     });
+    // A delete surfaced a "Deleted" toast; if it's still up, flip it to
+    // "Restored" so it can't keep claiming the event is gone.
+    if (isDeleteEntry(entry)) showRestoredToast();
     refocusAfterReplay(entryEventId(entry));
   }, [mutations, replaySnapshot]);
 


### PR DESCRIPTION
## Problem
Deleting an event shows a self-dismissing "Deleted" status toast (with a `Mod+Z` undo hint). If the user then undoes the delete (`Cmd+Z`) while that toast is still on screen, the event is correctly restored — but the toast keeps saying **"Deleted"**, falsely claiming the event is gone.

## Fix
Add `showRestoredToast()` and call it from `useUndoRedo.undo` when the popped history entry is a delete (the only undo path that restores a deleted event). It calls `toast.update` on the shared `EVENT_DELETED_TOAST_ID`, flipping the text to **"Restored"**.

Because `toast.update` is a no-op once the toast has auto-dismissed, this only rewrites the message *if the toast is still visible* — a late undo (after the 5s auto-close) shows nothing rather than resurrecting a stale toast. This reuses the exact fixed-id + `toast.update` mechanism already relied on by `status-toast.util`, so no new toast state or timers are introduced.

Redo (re-delete) is intentionally left silent: it runs inside `runHistoryRestore`, so `recordEventDeleteHistory` returns before `showDeletedToast` — pre-existing behavior, out of scope.

## Tests
- New `deleted-toast.util.test.tsx`: `showRestoredToast` updates the `EVENT_DELETED_TOAST_ID` toast to "Restored", and never calls bare `toast(...)` (so it stays a no-op once the toast is gone).
- Existing `useUndoRedo.test.tsx` (delete-undo path) still green with the real, unmocked toast — proving the new call is harmless in the restore path.
- Type-check + biome clean.

## Manual Testing Steps
1. Create/sync an event on the week grid.
2. Delete it — a "Deleted  ⌘Z" toast appears bottom-left.
3. Immediately press `Cmd+Z` (while the toast is still showing).
4. **Expected:** the event reappears **and** the toast text flips to "Restored".
5. Delete another event, wait ~5s for the toast to auto-dismiss, then `Cmd+Z`.
6. **Expected:** event reappears, no toast shown (nothing stale to correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)