### PR TITLE
refactor(core): define strict event contracts

### DIFF
--- a/docs/architecture/event-and-task-domain-model.md
+++ b/docs/architecture/event-and-task-domain-model.md
@@ -2,6 +2,37 @@
 
 The event domain is the most cross-cutting part of Compass. Read this before changing event shape, recurrence logic, sync behavior, or local persistence.
 
+## Target Contracts (sub-calendar v1, pre-cutover)
+
+Strict calendar-owned contracts exist alongside the legacy model and become the
+runtime shape at the sub-calendar v1 cutover. Until then the legacy sections
+below describe live behavior; the contracts describe where every consumer is
+headed.
+
+- `packages/core/src/types/domain-primitives.ts` — branded ids, `DateOnly`,
+  `DateTime` (RFC 3339 with offset), `TimeZone`, `SortOrder`, `RRule`.
+- `packages/core/src/types/event.contracts.ts` — canonical `Event`: required
+  `calendarId`, discriminated `content` (`details` | `busy`), `schedule`
+  (`timed` | `allDay` | `someday`, exclusive all-day ends), `recurrence`
+  (`single` | `series` | `occurrence`), plus `BusyPeriod` for free/busy-only
+  calendars.
+- `packages/core/src/types/event-command.contracts.ts` — create (optional
+  client id), full-replace, delete, someday reorder, the someday↔scheduled
+  transition (the only command that changes an event's calendar), list and
+  availability queries.
+- `packages/core/src/types/calendar.contracts.ts` — `Calendar` read model with
+  provider/access and derived capabilities (`getCalendarCapabilities`).
+- `packages/core/src/types/server-message.contracts.ts` — the discriminated
+  SSE union every backend publish site must emit.
+- `packages/backend/src/calendar/calendar.record.ts`,
+  `packages/backend/src/event/event.record.ts` — Mongo record shapes
+  (ObjectIds/BSON dates, single nullable `externalReference`, no `origin`).
+- `packages/backend/src/event/google-event.adapter.ts` — Google↔record
+  mapping; provider writes are `events.patch` bodies.
+- `packages/web/src/events/event-draft.types.ts` + `event-draft.parser.ts` —
+  the only intentionally incomplete event shape and the single parser that can
+  turn it into a command.
+
 ## Core Event Schema
 
 Primary source:

--- a/packages/backend/src/calendar/calendar.record.mapper.test.ts
+++ b/packages/backend/src/calendar/calendar.record.mapper.test.ts
@@ -1,0 +1,170 @@
+import { type calendar_v3 } from "@googleapis/calendar";
+import { ObjectId } from "mongodb";
+import {
+  CalendarSchema,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import {
+  mapCalendarRecord,
+  mapGoogleCalendar,
+} from "@backend/calendar/calendar.record.mapper";
+
+const fullEntry = (): calendar_v3.Schema$CalendarListEntry => ({
+  id: "gcal-1",
+  etag: "etag-1",
+  summary: "Work",
+  summaryOverride: "My Work",
+  description: "Company schedule",
+  timeZone: "America/Denver",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#5b6cff",
+  accessRole: "writer",
+  primary: false,
+  selected: true,
+});
+
+describe("mapGoogleCalendar", () => {
+  const userId = new ObjectId();
+
+  it("maps a full entry", () => {
+    const record = mapGoogleCalendar(fullEntry(), { userId });
+    expect(record.name).toBe("My Work");
+    expect(record.description).toBe("Company schedule");
+    expect(record.timeZone).toBe("America/Denver");
+    expect(record.foregroundColor).toBe("#ffffff");
+    expect(record.backgroundColor).toBe("#5b6cff");
+    expect(record.access).toBe("writer");
+    expect(record.isPrimary).toBe(false);
+    expect(record.isVisible).toBe(true);
+    expect(record.isActive).toBe(true);
+    expect(record.userId).toBe(userId);
+    expect(record.source).toEqual({
+      provider: "google",
+      calendarId: "gcal-1",
+      etag: "etag-1",
+    });
+  });
+
+  it("prefers summaryOverride over summary", () => {
+    const record = mapGoogleCalendar(
+      { ...fullEntry(), summaryOverride: "Custom name" },
+      { userId },
+    );
+    expect(record.name).toBe("Custom name");
+  });
+
+  it("falls back to summary when summaryOverride is absent", () => {
+    const entry = fullEntry();
+    delete entry.summaryOverride;
+    const record = mapGoogleCalendar(entry, { userId });
+    expect(record.name).toBe("Work");
+  });
+
+  it("defaults missing colors", () => {
+    const entry = fullEntry();
+    delete entry.foregroundColor;
+    delete entry.backgroundColor;
+    const record = mapGoogleCalendar(entry, { userId });
+    expect(record.backgroundColor).toBe("#9e9e9e");
+    expect(record.foregroundColor).toBe("#000000");
+  });
+
+  it("seeds isVisible from selected only when there is no existing record", () => {
+    const record = mapGoogleCalendar(
+      { ...fullEntry(), selected: false },
+      { userId },
+    );
+    expect(record.isVisible).toBe(false);
+  });
+
+  it("preserves _id and isVisible from an existing record", () => {
+    const existingId = new ObjectId();
+    const record = mapGoogleCalendar(
+      { ...fullEntry(), selected: false },
+      { userId, existing: { _id: existingId, isVisible: true } },
+    );
+    expect(record._id).toBe(existingId);
+    expect(record.isVisible).toBe(true);
+  });
+
+  it("maps reader and freeBusyReader access roles", () => {
+    const reader = mapGoogleCalendar(
+      { ...fullEntry(), accessRole: "reader" },
+      { userId },
+    );
+    expect(reader.access).toBe("reader");
+
+    const freeBusyReader = mapGoogleCalendar(
+      { ...fullEntry(), accessRole: "freeBusyReader" },
+      { userId },
+    );
+    expect(freeBusyReader.access).toBe("freeBusyReader");
+  });
+
+  it("throws when id is missing", () => {
+    const entry = fullEntry();
+    delete entry.id;
+    expect(() => mapGoogleCalendar(entry, { userId })).toThrow();
+  });
+
+  it("throws when etag is missing", () => {
+    const entry = fullEntry();
+    delete entry.etag;
+    expect(() => mapGoogleCalendar(entry, { userId })).toThrow();
+  });
+
+  it("throws when accessRole is invalid", () => {
+    const entry = { ...fullEntry(), accessRole: "bogus" };
+    expect(() => mapGoogleCalendar(entry, { userId })).toThrow();
+  });
+});
+
+describe("mapCalendarRecord", () => {
+  const buildRecord = (
+    overrides: Partial<CalendarRecord> = {},
+  ): CalendarRecord => ({
+    _id: new ObjectId(),
+    userId: new ObjectId(),
+    name: "Work",
+    description: "",
+    timeZone: "America/Denver",
+    foregroundColor: "#ffffff",
+    backgroundColor: "#5b6cff",
+    access: "writer",
+    isPrimary: false,
+    isVisible: true,
+    isActive: true,
+    source: { provider: "google", calendarId: "gcal-1", etag: "etag-1" },
+    createdAt: new Date(),
+    updatedAt: null,
+    ...overrides,
+  });
+
+  it("produces output that parses with CalendarSchema", () => {
+    const record = buildRecord();
+    const calendar = mapCalendarRecord(record);
+    expect(() => CalendarSchema.parse(calendar)).not.toThrow();
+    expect(calendar.id).toBe(record._id.toHexString());
+    expect(calendar.provider).toBe("google");
+  });
+
+  it("derives capabilities from the access role", () => {
+    const record = buildRecord({ access: "freeBusyReader" });
+    const calendar = mapCalendarRecord(record);
+    expect(calendar.capabilities).toEqual(
+      getCalendarCapabilities("freeBusyReader"),
+    );
+  });
+
+  it("does not leak provider ids, etags, or userId", () => {
+    const record = buildRecord();
+    const calendar = mapCalendarRecord(record) as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(calendar).not.toHaveProperty("userId");
+    expect(calendar).not.toHaveProperty("source");
+    expect(calendar).not.toHaveProperty("etag");
+  });
+});

--- a/packages/backend/src/calendar/calendar.record.mapper.ts
+++ b/packages/backend/src/calendar/calendar.record.mapper.ts
@@ -1,0 +1,70 @@
+import { type calendar_v3 } from "@googleapis/calendar";
+import { ObjectId } from "mongodb";
+import {
+  type Calendar,
+  CalendarAccessSchema,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { type CalendarId, type TimeZone } from "@core/types/domain-primitives";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+
+export const mapGoogleCalendar = (
+  entry: calendar_v3.Schema$CalendarListEntry,
+  context: {
+    userId: ObjectId;
+    existing?: Pick<CalendarRecord, "_id" | "isVisible">;
+  },
+): CalendarRecord => {
+  if (!entry.id) {
+    throw new Error("Google calendar entry is missing an id");
+  }
+  if (!entry.etag) {
+    throw new Error("Google calendar entry is missing an etag");
+  }
+
+  const accessResult = CalendarAccessSchema.safeParse(entry.accessRole);
+  if (!accessResult.success) {
+    throw new Error(
+      `Google calendar entry has an invalid accessRole: ${String(entry.accessRole)}`,
+    );
+  }
+
+  return {
+    _id: context.existing?._id ?? new ObjectId(),
+    userId: context.userId,
+    name: entry.summaryOverride ?? entry.summary ?? "",
+    description: entry.description ?? "",
+    timeZone: (entry.timeZone ?? null) as TimeZone | null,
+    // Match the legacy Google calendar mapper's defaults (map.calendar.ts).
+    backgroundColor: entry.backgroundColor ?? "#9e9e9e",
+    foregroundColor: entry.foregroundColor ?? "#000000",
+    access: accessResult.data,
+    isPrimary: entry.primary ?? false,
+    // Google's `selected` only seeds visibility on first insert; an existing
+    // record's user-controlled visibility must never be overwritten by sync.
+    isVisible: context.existing?.isVisible ?? entry.selected ?? true,
+    isActive: true,
+    source: {
+      provider: "google",
+      calendarId: entry.id,
+      etag: entry.etag,
+    },
+    createdAt: new Date(),
+    updatedAt: null,
+  };
+};
+
+export const mapCalendarRecord = (record: CalendarRecord): Calendar => ({
+  id: record._id.toHexString() as CalendarId,
+  name: record.name,
+  description: record.description,
+  timeZone: record.timeZone,
+  foregroundColor: record.foregroundColor,
+  backgroundColor: record.backgroundColor,
+  provider: record.source.provider,
+  access: record.access,
+  capabilities: getCalendarCapabilities(record.access),
+  isPrimary: record.isPrimary,
+  isVisible: record.isVisible,
+  isActive: record.isActive,
+});

--- a/packages/backend/src/calendar/calendar.record.test.ts
+++ b/packages/backend/src/calendar/calendar.record.test.ts
@@ -1,0 +1,110 @@
+import { ObjectId as BsonObjectId } from "bson";
+import { ObjectId } from "mongodb";
+import {
+  CalendarRecordSchema,
+  CalendarSourceRecordSchema,
+  GoogleCalendarSourceRecordSchema,
+  LocalCalendarSourceRecordSchema,
+} from "@backend/calendar/calendar.record";
+
+const baseRecord = () => ({
+  _id: new ObjectId(),
+  userId: new ObjectId(),
+  name: "Work",
+  description: "",
+  timeZone: "America/Denver",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#5b6cff",
+  access: "owner" as const,
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  source: { provider: "local" as const },
+  createdAt: new Date(),
+  updatedAt: null,
+});
+
+describe("CalendarSourceRecordSchema", () => {
+  it("parses a local source", () => {
+    const result = LocalCalendarSourceRecordSchema.safeParse({
+      provider: "local",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parses a google source", () => {
+    const result = GoogleCalendarSourceRecordSchema.safeParse({
+      provider: "google",
+      calendarId: "gcal-1",
+      etag: "etag-1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown keys", () => {
+    const result = CalendarSourceRecordSchema.safeParse({
+      provider: "local",
+      extra: true,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("CalendarRecordSchema", () => {
+  it("parses a valid local calendar record", () => {
+    const result = CalendarRecordSchema.safeParse(baseRecord());
+    expect(result.success).toBe(true);
+  });
+
+  it("parses a valid google calendar record", () => {
+    const result = CalendarRecordSchema.safeParse({
+      ...baseRecord(),
+      access: "writer",
+      source: {
+        provider: "google",
+        calendarId: "gcal-1",
+        etag: "etag-1",
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a local-source calendar with non-owner access", () => {
+    const result = CalendarRecordSchema.safeParse({
+      ...baseRecord(),
+      access: "writer",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(["access"]);
+    }
+  });
+
+  it("rejects unknown keys", () => {
+    const result = CalendarRecordSchema.safeParse({
+      ...baseRecord(),
+      extra: "nope",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("transforms a 24-hex string _id into an ObjectId instance", () => {
+    const hex = new ObjectId().toHexString();
+    const result = CalendarRecordSchema.safeParse({
+      ...baseRecord(),
+      _id: hex,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data._id).toBeInstanceOf(BsonObjectId);
+    }
+  });
+
+  it("accepts an ObjectId instance directly for _id", () => {
+    const result = CalendarRecordSchema.safeParse(baseRecord());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data._id).toBeInstanceOf(BsonObjectId);
+    }
+  });
+});

--- a/packages/backend/src/calendar/calendar.record.ts
+++ b/packages/backend/src/calendar/calendar.record.ts
@@ -1,0 +1,53 @@
+import { z } from "zod/v4";
+import { CalendarAccessSchema } from "@core/types/calendar.contracts";
+import { HexColorSchema, TimeZoneSchema } from "@core/types/domain-primitives";
+import { zObjectId } from "@core/types/type.utils";
+
+// Reuse the zObjectId sentinel, never z.instanceof(ObjectId):
+// zod-to-mongo-schema.ts maps zObjectId to bsonType "objectId" by reference,
+// while a raw instanceof degrades to an unvalidated {} in the $jsonSchema.
+const ObjectIdSchema = zObjectId;
+
+export const LocalCalendarSourceRecordSchema = z.strictObject({
+  provider: z.literal("local"),
+});
+
+export const GoogleCalendarSourceRecordSchema = z.strictObject({
+  provider: z.literal("google"),
+  calendarId: z.string().min(1),
+  etag: z.string().min(1),
+});
+
+export const CalendarSourceRecordSchema = z.discriminatedUnion("provider", [
+  LocalCalendarSourceRecordSchema,
+  GoogleCalendarSourceRecordSchema,
+]);
+export type CalendarSourceRecord = z.infer<typeof CalendarSourceRecordSchema>;
+
+export const CalendarRecordSchema = z
+  .strictObject({
+    _id: ObjectIdSchema,
+    userId: ObjectIdSchema,
+    name: z.string(),
+    description: z.string(),
+    timeZone: TimeZoneSchema.nullable(),
+    foregroundColor: HexColorSchema,
+    backgroundColor: HexColorSchema,
+    access: CalendarAccessSchema,
+    isPrimary: z.boolean(),
+    isVisible: z.boolean(),
+    isActive: z.boolean(),
+    source: CalendarSourceRecordSchema,
+    createdAt: z.date(),
+    updatedAt: z.date().nullable(),
+  })
+  .superRefine(({ access, source }, context) => {
+    if (source.provider === "local" && access !== "owner") {
+      context.addIssue({
+        code: "custom",
+        message: "Local calendars must have owner access",
+        path: ["access"],
+      });
+    }
+  });
+export type CalendarRecord = z.infer<typeof CalendarRecordSchema>;

--- a/packages/backend/src/event/event.record.mapper.test.ts
+++ b/packages/backend/src/event/event.record.mapper.test.ts
@@ -1,0 +1,153 @@
+import { ObjectId } from "mongodb";
+import { EventSchema } from "@core/types/event.contracts";
+import { CreateEventInputSchema } from "@core/types/event-command.contracts";
+import { type EventRecord } from "@backend/event/event.record";
+import {
+  mapCreateInput,
+  mapEventRecord,
+} from "@backend/event/event.record.mapper";
+
+const buildRecord = (overrides: Partial<EventRecord> = {}): EventRecord => ({
+  _id: new ObjectId(),
+  calendarId: new ObjectId(),
+  content: { kind: "details", title: "Design review", description: "" },
+  schedule: {
+    kind: "timed",
+    start: new Date("2026-07-14T15:00:00.000Z"),
+    end: new Date("2026-07-14T16:00:00.000Z"),
+    timeZone: "America/Denver",
+  },
+  recurrence: { kind: "single" },
+  priority: "unassigned",
+  externalReference: null,
+  createdAt: new Date("2026-07-10T18:00:00.000Z"),
+  updatedAt: null,
+  ...overrides,
+});
+
+describe("mapEventRecord", () => {
+  it("maps a timed event and produces output that passes EventSchema", () => {
+    const record = buildRecord();
+    const event = mapEventRecord(record);
+    expect(() => EventSchema.parse(event)).not.toThrow();
+    expect(event.id).toBe(record._id.toHexString());
+    expect(event.calendarId).toBe(record.calendarId.toHexString());
+    if (event.schedule.kind === "timed") {
+      expect(event.schedule.start).toBe(record.schedule.start.toISOString());
+      expect(event.schedule.end).toBe(record.schedule.end.toISOString());
+    } else {
+      throw new Error("expected timed schedule");
+    }
+    expect(event.createdAt).toBe(record.createdAt.toISOString());
+    expect(event.updatedAt).toBeNull();
+  });
+
+  it("maps an all-day event unchanged", () => {
+    const record = buildRecord({
+      schedule: { kind: "allDay", start: "2026-08-03", end: "2026-08-06" },
+    });
+    const event = mapEventRecord(record);
+    expect(() => EventSchema.parse(event)).not.toThrow();
+    expect(event.schedule).toEqual({
+      kind: "allDay",
+      start: "2026-08-03",
+      end: "2026-08-06",
+    });
+  });
+
+  it("maps an occurrence recurrence seriesId to a hex string", () => {
+    const seriesId = new ObjectId();
+    const record = buildRecord({
+      recurrence: { kind: "occurrence", seriesId },
+    });
+    const event = mapEventRecord(record);
+    expect(() => EventSchema.parse(event)).not.toThrow();
+    expect(event.recurrence).toEqual({
+      kind: "occurrence",
+      seriesId: seriesId.toHexString(),
+    });
+  });
+
+  it("maps a non-null updatedAt", () => {
+    const updatedAt = new Date("2026-07-11T00:00:00.000Z");
+    const record = buildRecord({ updatedAt });
+    const event = mapEventRecord(record);
+    expect(event.updatedAt).toBe(updatedAt.toISOString());
+  });
+});
+
+describe("mapCreateInput / mapEventRecord round trip", () => {
+  const now = new Date("2026-07-10T18:00:00.000Z");
+
+  it("round-trips a timed create input into an Event that passes EventSchema", () => {
+    const input = CreateEventInputSchema.parse({
+      calendarId: new ObjectId().toHexString(),
+      content: { kind: "details", title: "Design review", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T09:00:00-06:00",
+        end: "2026-07-14T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      priority: "work",
+    });
+
+    const record = mapCreateInput(input, { now });
+    const event = mapEventRecord(record);
+    expect(() => EventSchema.parse(event)).not.toThrow();
+    expect(event.calendarId).toBe(input.calendarId);
+    expect(event.createdAt).toBe(now.toISOString());
+    if (event.schedule.kind === "timed" && input.schedule.kind === "timed") {
+      expect(new Date(event.schedule.start).getTime()).toBe(
+        new Date(input.schedule.start).getTime(),
+      );
+      expect(new Date(event.schedule.end).getTime()).toBe(
+        new Date(input.schedule.end).getTime(),
+      );
+    } else {
+      throw new Error("expected timed schedule");
+    }
+  });
+
+  it("echoes a client-supplied id", () => {
+    const clientId = new ObjectId().toHexString();
+    const input = CreateEventInputSchema.parse({
+      id: clientId,
+      calendarId: new ObjectId().toHexString(),
+      content: { kind: "details", title: "Offline note", description: "" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    const record = mapCreateInput(input, { now });
+    expect(record._id.toHexString()).toBe(clientId);
+
+    const event = mapEventRecord(record);
+    expect(event.id).toBe(clientId);
+  });
+
+  it("generates a new id when the client does not supply one", () => {
+    const input = CreateEventInputSchema.parse({
+      calendarId: new ObjectId().toHexString(),
+      content: { kind: "details", title: "Offline note", description: "" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    const record = mapCreateInput(input, { now });
+    expect(record._id).toBeInstanceOf(ObjectId);
+  });
+});

--- a/packages/backend/src/event/event.record.mapper.ts
+++ b/packages/backend/src/event/event.record.mapper.ts
@@ -1,0 +1,78 @@
+import { ObjectId } from "mongodb";
+import {
+  type CalendarId,
+  type DateTime,
+  type EventId,
+} from "@core/types/domain-primitives";
+import { type Event, type EventSchedule } from "@core/types/event.contracts";
+import { type CreateEventInput } from "@core/types/event-command.contracts";
+import {
+  type EventRecord,
+  type EventScheduleRecord,
+} from "@backend/event/event.record";
+
+const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
+
+const mapScheduleRecordToSchedule = (
+  schedule: EventScheduleRecord,
+): EventSchedule => {
+  if (schedule.kind !== "timed") return schedule;
+
+  return {
+    kind: "timed",
+    // BSON Dates serialize with a "Z" offset, which satisfies the
+    // DateTimeSchema RFC 3339 offset requirement.
+    start: schedule.start.toISOString() as DateTime,
+    end: schedule.end.toISOString() as DateTime,
+    timeZone: schedule.timeZone,
+  };
+};
+
+export const mapEventRecord = (record: EventRecord): Event => ({
+  id: record._id.toHexString() as EventId,
+  calendarId: record.calendarId.toHexString() as CalendarId,
+  content: record.content,
+  schedule: mapScheduleRecordToSchedule(record.schedule),
+  recurrence:
+    record.recurrence.kind === "occurrence"
+      ? {
+          kind: "occurrence",
+          seriesId: record.recurrence.seriesId.toHexString() as EventId,
+        }
+      : record.recurrence,
+  priority: record.priority,
+  createdAt: record.createdAt.toISOString() as DateTime,
+  updatedAt: record.updatedAt
+    ? (record.updatedAt.toISOString() as DateTime)
+    : null,
+});
+
+export const mapCreateInput = (
+  input: CreateEventInput,
+  context: { now: Date },
+): EventRecord => {
+  const schedule: EventScheduleRecord =
+    input.schedule.kind === "timed"
+      ? {
+          kind: "timed",
+          start: new Date(input.schedule.start),
+          end: new Date(input.schedule.end),
+          timeZone: input.schedule.timeZone,
+        }
+      : input.schedule;
+
+  return {
+    _id:
+      input.id && OBJECT_ID_PATTERN.test(input.id)
+        ? new ObjectId(input.id)
+        : new ObjectId(),
+    calendarId: new ObjectId(input.calendarId),
+    content: input.content,
+    schedule,
+    recurrence: input.recurrence,
+    priority: input.priority,
+    externalReference: null,
+    createdAt: context.now,
+    updatedAt: null,
+  };
+};

--- a/packages/backend/src/event/event.record.test.ts
+++ b/packages/backend/src/event/event.record.test.ts
@@ -1,0 +1,141 @@
+import { ObjectId as BsonObjectId } from "bson";
+import { ObjectId } from "mongodb";
+import { EventRecordSchema } from "@backend/event/event.record";
+
+const baseFields = () => ({
+  _id: new ObjectId(),
+  calendarId: new ObjectId(),
+  priority: "unassigned" as const,
+  externalReference: null,
+  createdAt: new Date(),
+  updatedAt: null,
+});
+
+describe("EventRecordSchema", () => {
+  it("parses a timed single event", () => {
+    const result = EventRecordSchema.safeParse({
+      ...baseFields(),
+      content: { kind: "details", title: "Design review", description: "" },
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-14T15:00:00.000Z"),
+        end: new Date("2026-07-14T16:00:00.000Z"),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parses an all-day series event", () => {
+    const result = EventRecordSchema.safeParse({
+      ...baseFields(),
+      content: { kind: "details", title: "Retreat", description: "" },
+      schedule: { kind: "allDay", start: "2026-08-03", end: "2026-08-06" },
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parses a someday occurrence event with a busy content", () => {
+    const result = EventRecordSchema.safeParse({
+      ...baseFields(),
+      content: { kind: "busy" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "occurrence", seriesId: new ObjectId() },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown keys", () => {
+    const result = EventRecordSchema.safeParse({
+      ...baseFields(),
+      content: { kind: "busy" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+      extra: "nope",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a timed schedule where end is not after start", () => {
+    const result = EventRecordSchema.safeParse({
+      ...baseFields(),
+      content: { kind: "busy" },
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-14T16:00:00.000Z"),
+        end: new Date("2026-07-14T15:00:00.000Z"),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("transforms 24-hex string ObjectId fields into ObjectId instances", () => {
+    const hex = new ObjectId().toHexString();
+    const result = EventRecordSchema.safeParse({
+      ...baseFields(),
+      _id: hex,
+      calendarId: hex,
+      content: { kind: "busy" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data._id).toBeInstanceOf(BsonObjectId);
+      expect(result.data.calendarId).toBeInstanceOf(BsonObjectId);
+    }
+  });
+
+  it("parses a valid external reference and rejects an invalid one", () => {
+    const valid = EventRecordSchema.safeParse({
+      ...baseFields(),
+      content: { kind: "busy" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+      externalReference: {
+        provider: "google",
+        eventId: "gevent-1",
+        recurringEventId: null,
+      },
+    });
+    expect(valid.success).toBe(true);
+
+    const invalid = EventRecordSchema.safeParse({
+      ...baseFields(),
+      content: { kind: "busy" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+      externalReference: { provider: "google", eventId: "" },
+    });
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/packages/backend/src/event/event.record.ts
+++ b/packages/backend/src/event/event.record.ts
@@ -1,0 +1,88 @@
+import { z } from "zod/v4";
+import {
+  DateOnlySchema,
+  PrioritySchema,
+  RRuleSchema,
+  SortOrderSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+import { EventContentSchema } from "@core/types/event.contracts";
+import { zObjectId } from "@core/types/type.utils";
+
+// See calendar.record.ts: zObjectId, not z.instanceof(ObjectId), so the
+// derived $jsonSchema keeps bsonType "objectId". Refinements (end > start) do
+// not survive into $jsonSchema either; the Mongo validator enforces structure
+// only, and cross-field ordering stays an application-level parse.
+const ObjectIdSchema = zObjectId;
+
+const TimedScheduleRecordSchema = z
+  .strictObject({
+    kind: z.literal("timed"),
+    start: z.date(),
+    end: z.date(),
+    timeZone: TimeZoneSchema,
+  })
+  .refine(({ start, end }) => end.getTime() > start.getTime(), {
+    message: "Timed event end must be after start",
+    path: ["end"],
+  });
+
+const AllDayScheduleRecordSchema = z
+  .strictObject({
+    kind: z.literal("allDay"),
+    start: DateOnlySchema,
+    end: DateOnlySchema,
+  })
+  .refine(({ start, end }) => end > start, {
+    message: "All-day event end is exclusive and must be after start",
+    path: ["end"],
+  });
+
+const SomedayScheduleRecordSchema = z.strictObject({
+  kind: z.literal("someday"),
+  period: z.enum(["week", "month"]),
+  anchorDate: DateOnlySchema,
+  sortOrder: SortOrderSchema,
+});
+
+export const EventScheduleRecordSchema = z.discriminatedUnion("kind", [
+  TimedScheduleRecordSchema,
+  AllDayScheduleRecordSchema,
+  SomedayScheduleRecordSchema,
+]);
+export type EventScheduleRecord = z.infer<typeof EventScheduleRecordSchema>;
+
+export const EventRecurrenceRecordSchema = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("single") }),
+  z.strictObject({ kind: z.literal("series"), rules: RRuleSchema }),
+  z.strictObject({
+    kind: z.literal("occurrence"),
+    seriesId: ObjectIdSchema,
+  }),
+]);
+export type EventRecurrenceRecord = z.infer<typeof EventRecurrenceRecordSchema>;
+
+export const GoogleEventReferenceSchema = z.strictObject({
+  provider: z.literal("google"),
+  eventId: z.string().min(1),
+  recurringEventId: z.string().min(1).nullable(),
+});
+export type GoogleEventReference = z.infer<typeof GoogleEventReferenceSchema>;
+
+export const ExternalEventReferenceSchema = GoogleEventReferenceSchema;
+export type ExternalEventReference = z.infer<
+  typeof ExternalEventReferenceSchema
+>;
+
+export const EventRecordSchema = z.strictObject({
+  _id: ObjectIdSchema,
+  calendarId: ObjectIdSchema,
+  content: EventContentSchema,
+  schedule: EventScheduleRecordSchema,
+  recurrence: EventRecurrenceRecordSchema,
+  priority: PrioritySchema,
+  externalReference: ExternalEventReferenceSchema.nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date().nullable(),
+});
+export type EventRecord = z.infer<typeof EventRecordSchema>;

--- a/packages/backend/src/event/google-event-adapter.types.ts
+++ b/packages/backend/src/event/google-event-adapter.types.ts
@@ -1,0 +1,26 @@
+import { type calendar_v3 } from "@googleapis/calendar";
+import { type EventRecord } from "@backend/event/event.record";
+
+export type GoogleCalendarListEntryInput = calendar_v3.Schema$CalendarListEntry;
+export type GoogleEventInput = calendar_v3.Schema$Event;
+
+export type GoogleEventMapResult =
+  | { kind: "mapped"; event: EventRecord }
+  | {
+      kind: "cancelled";
+      providerEventId: string;
+      providerRecurringEventId: string | null;
+    }
+  | { kind: "ignored"; reason: "unsupportedType" | "outsideRange" }
+  | {
+      kind: "invalid";
+      reason: "missingId" | "missingDates" | "invalidRecurrence";
+    };
+
+// events.patch body (A28). Never events.update: update replaces the whole
+// resource, clearing attendees, location, reminders, and every other field
+// Compass does not model.
+export type GoogleEventWriteInput = Pick<
+  calendar_v3.Schema$Event,
+  "summary" | "description" | "start" | "end" | "recurrence"
+>;

--- a/packages/backend/src/event/google-event.adapter.test.ts
+++ b/packages/backend/src/event/google-event.adapter.test.ts
@@ -1,0 +1,382 @@
+import { type calendar_v3 } from "@googleapis/calendar";
+import { ObjectId } from "mongodb";
+import {
+  type EventRecord,
+  EventRecordSchema,
+} from "@backend/event/event.record";
+import {
+  mapEventRecordToGoogle,
+  mapGoogleEvent,
+} from "@backend/event/google-event.adapter";
+
+const calendarId = new ObjectId();
+
+const baseContext = (
+  overrides: Partial<{
+    calendarTimeZone: string | null;
+    resolveSeriesObjectId: (id: string) => ObjectId | undefined;
+    now: Date;
+  }> = {},
+) => ({
+  calendarId,
+  calendarTimeZone: null,
+  resolveSeriesObjectId: () => undefined,
+  now: new Date("2026-07-10T18:00:00.000Z"),
+  ...overrides,
+});
+
+const timedEvent = (
+  overrides: Partial<calendar_v3.Schema$Event> = {},
+): calendar_v3.Schema$Event => ({
+  id: "gevent-1",
+  summary: "Design review",
+  description: "",
+  creator: { email: "owner@example.com" },
+  start: { dateTime: "2026-07-14T09:00:00-06:00", timeZone: "America/Denver" },
+  end: { dateTime: "2026-07-14T10:00:00-06:00", timeZone: "America/Denver" },
+  ...overrides,
+});
+
+describe("mapGoogleEvent", () => {
+  it("maps a normal timed event with an offset dateTime and explicit timeZone", () => {
+    const result = mapGoogleEvent(timedEvent(), baseContext());
+    expect(result.kind).toBe("mapped");
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.schedule).toMatchObject({
+      kind: "timed",
+      timeZone: "America/Denver",
+    });
+    expect(() => EventRecordSchema.parse(result.event)).not.toThrow();
+  });
+
+  it("falls back through the timeZone ladder: event tz, then calendar tz, then UTC", () => {
+    const noEventTz = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        start: { dateTime: "2026-07-14T09:00:00-06:00" },
+        end: { dateTime: "2026-07-14T10:00:00-06:00" },
+      },
+      baseContext({ calendarTimeZone: "America/New_York" }),
+    );
+    if (noEventTz.kind !== "mapped") throw new Error("expected mapped");
+    expect(noEventTz.event.schedule).toMatchObject({
+      timeZone: "America/New_York",
+    });
+
+    const noTzAtAll = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        start: { dateTime: "2026-07-14T09:00:00-06:00" },
+        end: { dateTime: "2026-07-14T10:00:00-06:00" },
+      },
+      baseContext({ calendarTimeZone: null }),
+    );
+    if (noTzAtAll.kind !== "mapped") throw new Error("expected mapped");
+    expect(noTzAtAll.event.schedule).toMatchObject({ timeZone: "UTC" });
+  });
+
+  it("maps a single-day all-day event with an exclusive end", () => {
+    const result = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        start: { date: "2026-08-03" },
+        end: { date: "2026-08-04" },
+      },
+      baseContext(),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.schedule).toEqual({
+      kind: "allDay",
+      start: "2026-08-03",
+      end: "2026-08-04",
+    });
+  });
+
+  it("normalizes a multi-day all-day event and preserves the exclusive end", () => {
+    const result = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        start: { date: "2026-08-03" },
+        end: { date: "2026-08-06" },
+      },
+      baseContext(),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.schedule).toEqual({
+      kind: "allDay",
+      start: "2026-08-03",
+      end: "2026-08-06",
+    });
+  });
+
+  it("normalizes an all-day event whose end equals start to a one-day span", () => {
+    const result = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        start: { date: "2026-08-03" },
+        end: { date: "2026-08-03" },
+      },
+      baseContext(),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.schedule).toEqual({
+      kind: "allDay",
+      start: "2026-08-03",
+      end: "2026-08-04",
+    });
+  });
+
+  it("normalizes a missing all-day end to a one-day span", () => {
+    const result = mapGoogleEvent(
+      { ...timedEvent(), start: { date: "2026-08-03" }, end: undefined },
+      baseContext(),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.schedule).toEqual({
+      kind: "allDay",
+      start: "2026-08-03",
+      end: "2026-08-04",
+    });
+  });
+
+  it("maps to busy content when both summary and creator are absent", () => {
+    const event = timedEvent();
+    delete event.summary;
+    delete event.creator;
+    const result = mapGoogleEvent(event, baseContext());
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.content).toEqual({ kind: "busy" });
+  });
+
+  it("maps to empty-title details when summary is empty but creator is present", () => {
+    const result = mapGoogleEvent(
+      { ...timedEvent(), summary: "" },
+      baseContext(),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.content).toEqual({
+      kind: "details",
+      title: "",
+      description: "",
+    });
+  });
+
+  it("maps a cancelled event to a tombstone with its recurringEventId", () => {
+    const result = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        status: "cancelled",
+        recurringEventId: "gevent-series-1",
+      },
+      baseContext(),
+    );
+    expect(result).toEqual({
+      kind: "cancelled",
+      providerEventId: "gevent-1",
+      providerRecurringEventId: "gevent-series-1",
+    });
+  });
+
+  it("maps a cancelled event with no recurringEventId to a null pointer", () => {
+    const result = mapGoogleEvent(
+      { ...timedEvent(), status: "cancelled" },
+      baseContext(),
+    );
+    expect(result).toEqual({
+      kind: "cancelled",
+      providerEventId: "gevent-1",
+      providerRecurringEventId: null,
+    });
+  });
+
+  it("ignores an unsupported eventType", () => {
+    const result = mapGoogleEvent(
+      { ...timedEvent(), eventType: "outOfOffice" },
+      baseContext(),
+    );
+    expect(result).toEqual({ kind: "ignored", reason: "unsupportedType" });
+  });
+
+  it("maps default eventType normally", () => {
+    const result = mapGoogleEvent(
+      { ...timedEvent(), eventType: "default" },
+      baseContext(),
+    );
+    expect(result.kind).toBe("mapped");
+  });
+
+  it("is invalid with missingId when id is absent", () => {
+    const event = timedEvent();
+    delete event.id;
+    const result = mapGoogleEvent(event, baseContext());
+    expect(result).toEqual({ kind: "invalid", reason: "missingId" });
+  });
+
+  it("is invalid with missingDates when neither date nor dateTime is present", () => {
+    const result = mapGoogleEvent(
+      { ...timedEvent(), start: {}, end: {} },
+      baseContext(),
+    );
+    expect(result).toEqual({ kind: "invalid", reason: "missingDates" });
+  });
+
+  it("is invalid with missingDates when the timed end is missing", () => {
+    const result = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        start: { dateTime: "2026-07-14T09:00:00-06:00" },
+        end: {},
+      },
+      baseContext(),
+    );
+    expect(result).toEqual({ kind: "invalid", reason: "missingDates" });
+  });
+
+  it("maps a series recurrence, copying the rules", () => {
+    const rules = ["RRULE:FREQ=WEEKLY;COUNT=12;BYDAY=MO"];
+    const result = mapGoogleEvent(
+      { ...timedEvent(), recurrence: rules },
+      baseContext(),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.recurrence).toEqual({ kind: "series", rules });
+  });
+
+  it("resolves an occurrence via the resolver", () => {
+    const seriesId = new ObjectId();
+    const result = mapGoogleEvent(
+      { ...timedEvent(), recurringEventId: "gevent-series-1" },
+      baseContext({ resolveSeriesObjectId: () => seriesId }),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.recurrence).toEqual({ kind: "occurrence", seriesId });
+  });
+
+  it("is invalid with invalidRecurrence when the occurrence cannot be resolved", () => {
+    const result = mapGoogleEvent(
+      { ...timedEvent(), recurringEventId: "gevent-series-1" },
+      baseContext({ resolveSeriesObjectId: () => undefined }),
+    );
+    expect(result).toEqual({ kind: "invalid", reason: "invalidRecurrence" });
+  });
+
+  it("is invalid with invalidRecurrence when both rules and recurringEventId are present", () => {
+    const result = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        recurrence: ["RRULE:FREQ=WEEKLY"],
+        recurringEventId: "gevent-series-1",
+      },
+      baseContext({ resolveSeriesObjectId: () => new ObjectId() }),
+    );
+    expect(result).toEqual({ kind: "invalid", reason: "invalidRecurrence" });
+  });
+
+  it("maps single recurrence when neither rules nor recurringEventId are present", () => {
+    const result = mapGoogleEvent(timedEvent(), baseContext());
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.recurrence).toEqual({ kind: "single" });
+  });
+
+  it("sets priority to unassigned and derives createdAt/updatedAt from the payload", () => {
+    const result = mapGoogleEvent(
+      {
+        ...timedEvent(),
+        created: "2026-07-01T00:00:00.000Z",
+        updated: "2026-07-02T00:00:00.000Z",
+      },
+      baseContext(),
+    );
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.priority).toBe("unassigned");
+    expect(result.event.createdAt).toEqual(
+      new Date("2026-07-01T00:00:00.000Z"),
+    );
+    expect(result.event.updatedAt).toEqual(
+      new Date("2026-07-02T00:00:00.000Z"),
+    );
+  });
+
+  it("falls back to context.now for createdAt and null for updatedAt when absent", () => {
+    const now = new Date("2026-07-10T18:00:00.000Z");
+    const result = mapGoogleEvent(timedEvent(), baseContext({ now }));
+    if (result.kind !== "mapped") throw new Error("expected mapped");
+    expect(result.event.createdAt).toEqual(now);
+    expect(result.event.updatedAt).toBeNull();
+  });
+});
+
+describe("mapEventRecordToGoogle", () => {
+  const buildRecord = (overrides: Partial<EventRecord> = {}): EventRecord => ({
+    _id: new ObjectId(),
+    calendarId: new ObjectId(),
+    content: { kind: "details", title: "Design review", description: "notes" },
+    schedule: {
+      kind: "timed",
+      start: new Date("2026-07-14T15:00:00.000Z"),
+      end: new Date("2026-07-14T16:00:00.000Z"),
+      timeZone: "America/Denver",
+    },
+    recurrence: { kind: "single" },
+    priority: "work",
+    externalReference: null,
+    createdAt: new Date(),
+    updatedAt: null,
+    ...overrides,
+  });
+
+  it("produces a timed patch body", () => {
+    const record = buildRecord();
+    const patch = mapEventRecordToGoogle(record);
+    expect(patch).toEqual({
+      summary: "Design review",
+      description: "notes",
+      start: {
+        dateTime: "2026-07-14T15:00:00.000Z",
+        timeZone: "America/Denver",
+      },
+      end: { dateTime: "2026-07-14T16:00:00.000Z", timeZone: "America/Denver" },
+      recurrence: null,
+    });
+  });
+
+  it("produces an all-day patch body", () => {
+    const record = buildRecord({
+      schedule: { kind: "allDay", start: "2026-08-03", end: "2026-08-06" },
+    });
+    const patch = mapEventRecordToGoogle(record);
+    expect(patch.start).toEqual({ date: "2026-08-03" });
+    expect(patch.end).toEqual({ date: "2026-08-06" });
+    expect(patch.recurrence).toBeNull();
+  });
+
+  it("includes recurrence rules for a series event", () => {
+    const rules = ["RRULE:FREQ=WEEKLY;COUNT=12;BYDAY=MO"];
+    const record = buildRecord({ recurrence: { kind: "series", rules } });
+    const patch = mapEventRecordToGoogle(record);
+    expect(patch.recurrence).toEqual(rules);
+  });
+
+  it("sends recurrence: null for a single event so a series edit clears Google's rules", () => {
+    const record = buildRecord({ recurrence: { kind: "single" } });
+    const patch = mapEventRecordToGoogle(record);
+    expect(patch.recurrence).toBeNull();
+  });
+
+  it("throws for busy content", () => {
+    const record = buildRecord({ content: { kind: "busy" } });
+    expect(() => mapEventRecordToGoogle(record)).toThrow();
+  });
+
+  it("throws for a someday schedule", () => {
+    const record = buildRecord({
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+    });
+    expect(() => mapEventRecordToGoogle(record)).toThrow();
+  });
+});

--- a/packages/backend/src/event/google-event.adapter.ts
+++ b/packages/backend/src/event/google-event.adapter.ts
@@ -1,0 +1,219 @@
+import { ObjectId } from "mongodb";
+import { Priorities } from "@core/constants/core.constants";
+import { type DateOnly, type TimeZone } from "@core/types/domain-primitives";
+import { type EventContent } from "@core/types/event.contracts";
+import {
+  type EventRecord,
+  type EventRecurrenceRecord,
+  type EventScheduleRecord,
+} from "@backend/event/event.record";
+import {
+  type GoogleEventInput,
+  type GoogleEventMapResult,
+  type GoogleEventWriteInput,
+} from "@backend/event/google-event-adapter.types";
+
+const parseDateOnly = (value: string | null | undefined): string | null => {
+  if (!value) return null;
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : null;
+};
+
+const addOneDay = (dateOnly: string): string => {
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString().slice(0, 10);
+};
+
+const parseInstant = (value: string | null | undefined): Date | null => {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+type ScheduleMapResult =
+  | { kind: "ok"; schedule: EventScheduleRecord }
+  | { kind: "invalid" };
+
+const mapSchedule = (
+  event: GoogleEventInput,
+  calendarTimeZone: string | null,
+): ScheduleMapResult => {
+  const startDateOnly = parseDateOnly(event.start?.date);
+  if (startDateOnly) {
+    const endDateOnlyRaw = parseDateOnly(event.end?.date);
+    // Google's end.date is already exclusive; a missing or same-day end
+    // means a one-day event, so advance it to the next day ourselves.
+    const endDateOnly =
+      !endDateOnlyRaw || endDateOnlyRaw === startDateOnly
+        ? addOneDay(startDateOnly)
+        : endDateOnlyRaw;
+    return {
+      kind: "ok",
+      schedule: {
+        kind: "allDay",
+        start: startDateOnly as DateOnly,
+        end: endDateOnly as DateOnly,
+      },
+    };
+  }
+
+  const startInstant = parseInstant(event.start?.dateTime);
+  if (startInstant) {
+    const endInstant = parseInstant(event.end?.dateTime);
+    if (!endInstant) return { kind: "invalid" };
+
+    const timeZone = event.start?.timeZone ?? calendarTimeZone ?? "UTC";
+    return {
+      kind: "ok",
+      schedule: {
+        kind: "timed",
+        start: startInstant,
+        end: endInstant,
+        timeZone: timeZone as TimeZone,
+      },
+    };
+  }
+
+  return { kind: "invalid" };
+};
+
+type RecurrenceMapResult =
+  | { kind: "ok"; recurrence: EventRecurrenceRecord }
+  | { kind: "invalid" };
+
+const mapRecurrence = (
+  event: GoogleEventInput,
+  resolveSeriesObjectId: (gRecurringEventId: string) => ObjectId | undefined,
+): RecurrenceMapResult => {
+  const hasRules =
+    Array.isArray(event.recurrence) && event.recurrence.length > 0;
+  const hasRecurringEventId = Boolean(event.recurringEventId);
+
+  if (hasRules && hasRecurringEventId) return { kind: "invalid" };
+
+  if (hasRules) {
+    return {
+      kind: "ok",
+      recurrence: { kind: "series", rules: event.recurrence as string[] },
+    };
+  }
+
+  if (hasRecurringEventId) {
+    const seriesId = resolveSeriesObjectId(event.recurringEventId as string);
+    if (!seriesId) return { kind: "invalid" };
+    return { kind: "ok", recurrence: { kind: "occurrence", seriesId } };
+  }
+
+  return { kind: "ok", recurrence: { kind: "single" } };
+};
+
+const mapContent = (event: GoogleEventInput): EventContent => {
+  // Google omits `summary` and `creator` entirely (not just leaves them
+  // undefined) on events whose private details are withheld from a reader;
+  // that specific combination is the only reliable "busy" signal.
+  if (!("summary" in event) && !("creator" in event)) {
+    return { kind: "busy" };
+  }
+  return {
+    kind: "details",
+    title: event.summary ?? "",
+    description: event.description ?? "",
+  };
+};
+
+export const mapGoogleEvent = (
+  event: GoogleEventInput,
+  context: {
+    calendarId: ObjectId;
+    calendarTimeZone: string | null;
+    resolveSeriesObjectId: (gRecurringEventId: string) => ObjectId | undefined;
+    now: Date;
+  },
+): GoogleEventMapResult => {
+  if (!event.id) {
+    return { kind: "invalid", reason: "missingId" };
+  }
+
+  if (event.status === "cancelled") {
+    return {
+      kind: "cancelled",
+      providerEventId: event.id,
+      providerRecurringEventId: event.recurringEventId ?? null,
+    };
+  }
+
+  if (event.eventType && event.eventType !== "default") {
+    return { kind: "ignored", reason: "unsupportedType" };
+  }
+
+  const scheduleResult = mapSchedule(event, context.calendarTimeZone);
+  if (scheduleResult.kind === "invalid") {
+    return { kind: "invalid", reason: "missingDates" };
+  }
+
+  const recurrenceResult = mapRecurrence(event, context.resolveSeriesObjectId);
+  if (recurrenceResult.kind === "invalid") {
+    return { kind: "invalid", reason: "invalidRecurrence" };
+  }
+
+  const record: EventRecord = {
+    _id: new ObjectId(),
+    calendarId: context.calendarId,
+    content: mapContent(event),
+    schedule: scheduleResult.schedule,
+    recurrence: recurrenceResult.recurrence,
+    priority: Priorities.UNASSIGNED,
+    externalReference: {
+      provider: "google",
+      eventId: event.id,
+      recurringEventId: event.recurringEventId ?? null,
+    },
+    createdAt: event.created ? new Date(event.created) : context.now,
+    updatedAt: event.updated ? new Date(event.updated) : null,
+  };
+
+  return { kind: "mapped", event: record };
+};
+
+export const mapEventRecordToGoogle = (
+  record: EventRecord,
+): GoogleEventWriteInput => {
+  if (record.content.kind !== "details") {
+    // Programmer error: busy content is a reader-only privacy placeholder
+    // and is never written back to Google.
+    throw new Error("Cannot write busy-content event to Google");
+  }
+  if (record.schedule.kind === "someday") {
+    // Programmer error: someday events live on the Compass-local calendar
+    // and never reach a Google-backed calendar's write path.
+    throw new Error("Cannot write a someday-scheduled event to Google");
+  }
+
+  const scheduleFields: Pick<GoogleEventWriteInput, "start" | "end"> =
+    record.schedule.kind === "timed"
+      ? {
+          start: {
+            dateTime: record.schedule.start.toISOString(),
+            timeZone: record.schedule.timeZone,
+          },
+          end: {
+            dateTime: record.schedule.end.toISOString(),
+            timeZone: record.schedule.timeZone,
+          },
+        }
+      : {
+          start: { date: record.schedule.start },
+          end: { date: record.schedule.end },
+        };
+
+  return {
+    summary: record.content.title,
+    description: record.content.description,
+    ...scheduleFields,
+    // events.patch merges by key: an omitted key is left unchanged on
+    // Google, while an explicit null clears it. A series-to-single edit
+    // must send `recurrence: null` to clear the stale rules on Google.
+    recurrence:
+      record.recurrence.kind === "series" ? [...record.recurrence.rules] : null,
+  };
+};

--- a/packages/core/src/types/calendar.contracts.test.ts
+++ b/packages/core/src/types/calendar.contracts.test.ts
@@ -1,0 +1,155 @@
+import { faker } from "@faker-js/faker";
+import {
+  type CalendarAccess,
+  CalendarListResponseSchema,
+  CalendarSchema,
+  getCalendarCapabilities,
+  SetCalendarVisibilityInputSchema,
+} from "@core/types/calendar.contracts";
+
+const validCalendar = {
+  id: faker.database.mongodbObjectId(),
+  name: "Personal",
+  description: "",
+  timeZone: "America/Denver",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#000000",
+  provider: "local",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+};
+
+describe("Calendar Contracts", () => {
+  describe("CalendarSchema", () => {
+    it("parses a fully valid calendar", () => {
+      expect(CalendarSchema.safeParse(validCalendar).success).toBe(true);
+    });
+
+    it("rejects an unknown key", () => {
+      const result = CalendarSchema.safeParse({
+        ...validCalendar,
+        extra: true,
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a null timeZone", () => {
+      const result = CalendarSchema.safeParse({
+        ...validCalendar,
+        timeZone: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getCalendarCapabilities", () => {
+    it("returns full capabilities for an owner", () => {
+      expect(getCalendarCapabilities("owner")).toEqual({
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: true,
+        canManage: true,
+        canWatchEvents: true,
+      });
+    });
+
+    it("returns write-but-not-manage capabilities for a writer", () => {
+      expect(getCalendarCapabilities("writer")).toEqual({
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: true,
+        canManage: false,
+        canWatchEvents: true,
+      });
+    });
+
+    it("returns read-only capabilities for a reader", () => {
+      expect(getCalendarCapabilities("reader")).toEqual({
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: true,
+      });
+    });
+
+    it("returns availability-only capabilities for a freeBusyReader", () => {
+      expect(getCalendarCapabilities("freeBusyReader")).toEqual({
+        canReadAvailability: true,
+        canReadDetails: false,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: false,
+      });
+    });
+
+    it("covers every access role with no leftovers", () => {
+      const roles: CalendarAccess[] = [
+        "owner",
+        "writer",
+        "reader",
+        "freeBusyReader",
+      ];
+
+      for (const role of roles) {
+        expect(() => getCalendarCapabilities(role)).not.toThrow();
+      }
+    });
+  });
+
+  describe("CalendarListResponseSchema", () => {
+    it("parses a list of calendars", () => {
+      const result = CalendarListResponseSchema.safeParse({
+        calendars: [validCalendar],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects unknown keys", () => {
+      const result = CalendarListResponseSchema.safeParse({
+        calendars: [],
+        nextCursor: null,
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("SetCalendarVisibilityInputSchema", () => {
+    it("accepts a single-element array", () => {
+      const input = [
+        { calendarId: faker.database.mongodbObjectId(), isVisible: true },
+      ];
+
+      expect(SetCalendarVisibilityInputSchema.safeParse(input).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an empty array", () => {
+      expect(SetCalendarVisibilityInputSchema.safeParse([]).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects unknown keys on an item", () => {
+      const input = [
+        {
+          calendarId: faker.database.mongodbObjectId(),
+          isVisible: true,
+          extra: 1,
+        },
+      ];
+
+      expect(SetCalendarVisibilityInputSchema.safeParse(input).success).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/packages/core/src/types/calendar.contracts.ts
+++ b/packages/core/src/types/calendar.contracts.ts
@@ -1,0 +1,94 @@
+import { z } from "zod/v4";
+import {
+  CalendarIdSchema,
+  HexColorSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+
+export const CalendarProviderSchema = z.enum(["local", "google"]);
+export type CalendarProvider = z.infer<typeof CalendarProviderSchema>;
+
+export const CalendarAccessSchema = z.enum([
+  "owner",
+  "writer",
+  "reader",
+  "freeBusyReader",
+]);
+export type CalendarAccess = z.infer<typeof CalendarAccessSchema>;
+
+export const CalendarCapabilitiesSchema = z.strictObject({
+  canReadAvailability: z.boolean(),
+  canReadDetails: z.boolean(),
+  canWrite: z.boolean(),
+  canManage: z.boolean(),
+  canWatchEvents: z.boolean(),
+});
+export type CalendarCapabilities = z.infer<typeof CalendarCapabilitiesSchema>;
+
+export const CalendarSchema = z.strictObject({
+  id: CalendarIdSchema,
+  name: z.string(),
+  description: z.string(),
+  timeZone: TimeZoneSchema.nullable(),
+  foregroundColor: HexColorSchema,
+  backgroundColor: HexColorSchema,
+  provider: CalendarProviderSchema,
+  access: CalendarAccessSchema,
+  capabilities: CalendarCapabilitiesSchema,
+  isPrimary: z.boolean(),
+  isVisible: z.boolean(),
+  isActive: z.boolean(),
+});
+export type Calendar = z.infer<typeof CalendarSchema>;
+
+export const CalendarListResponseSchema = z.strictObject({
+  calendars: z.array(CalendarSchema),
+});
+export type CalendarListResponse = z.infer<typeof CalendarListResponseSchema>;
+
+export const SetCalendarVisibilityInputSchema = z
+  .array(
+    z.strictObject({
+      calendarId: CalendarIdSchema,
+      isVisible: z.boolean(),
+    }),
+  )
+  .nonempty();
+export type SetCalendarVisibilityInput = z.infer<
+  typeof SetCalendarVisibilityInputSchema
+>;
+
+export const CAPABILITIES_BY_ACCESS = {
+  owner: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: true,
+    canWatchEvents: true,
+  },
+  writer: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: false,
+    canWatchEvents: true,
+  },
+  reader: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: false,
+    canManage: false,
+    canWatchEvents: true,
+  },
+  freeBusyReader: {
+    canReadAvailability: true,
+    canReadDetails: false,
+    canWrite: false,
+    canManage: false,
+    canWatchEvents: false,
+  },
+} as const satisfies Record<CalendarAccess, CalendarCapabilities>;
+
+export const getCalendarCapabilities = (
+  access: CalendarAccess,
+): CalendarCapabilities => CAPABILITIES_BY_ACCESS[access];

--- a/packages/core/src/types/domain-primitives.test.ts
+++ b/packages/core/src/types/domain-primitives.test.ts
@@ -1,0 +1,139 @@
+import { faker } from "@faker-js/faker";
+import { Priorities } from "@core/constants/core.constants";
+import {
+  CalendarIdSchema,
+  DateOnlySchema,
+  DateTimeSchema,
+  EventIdSchema,
+  PrioritySchema,
+  RRuleSchema,
+  SortOrderSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+
+describe("Domain Primitives", () => {
+  describe("EventIdSchema", () => {
+    it("accepts a 24-character hex id", () => {
+      expect(
+        EventIdSchema.safeParse(faker.database.mongodbObjectId()).success,
+      ).toBe(true);
+    });
+
+    it("rejects a short id", () => {
+      expect(EventIdSchema.safeParse("abc123").success).toBe(false);
+    });
+
+    it("rejects a non-hex id", () => {
+      expect(EventIdSchema.safeParse("g".repeat(24)).success).toBe(false);
+    });
+  });
+
+  describe("CalendarIdSchema", () => {
+    it("accepts a 24-character hex id", () => {
+      expect(
+        CalendarIdSchema.safeParse(faker.database.mongodbObjectId()).success,
+      ).toBe(true);
+    });
+
+    it("rejects a short id", () => {
+      expect(CalendarIdSchema.safeParse("abc123").success).toBe(false);
+    });
+
+    it("rejects a non-hex id", () => {
+      expect(CalendarIdSchema.safeParse("g".repeat(24)).success).toBe(false);
+    });
+  });
+
+  describe("DateOnlySchema", () => {
+    it("accepts a valid calendar date", () => {
+      expect(DateOnlySchema.safeParse("2026-07-14").success).toBe(true);
+    });
+
+    it("accepts a leap day", () => {
+      expect(DateOnlySchema.safeParse("2024-02-29").success).toBe(true);
+    });
+
+    it("rejects a rollover day (Feb 30)", () => {
+      expect(DateOnlySchema.safeParse("2026-02-30").success).toBe(false);
+    });
+
+    it("rejects a rollover month (month 13)", () => {
+      expect(DateOnlySchema.safeParse("2026-13-01").success).toBe(false);
+    });
+
+    it("rejects a non-zero-padded date", () => {
+      expect(DateOnlySchema.safeParse("2026-7-4").success).toBe(false);
+    });
+  });
+
+  describe("DateTimeSchema", () => {
+    it("accepts a Z-offset timestamp", () => {
+      expect(DateTimeSchema.safeParse("2026-07-14T10:00:00Z").success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a numeric-offset timestamp", () => {
+      expect(
+        DateTimeSchema.safeParse("2026-07-14T10:00:00-06:00").success,
+      ).toBe(true);
+    });
+
+    it("rejects a timestamp with no offset", () => {
+      expect(DateTimeSchema.safeParse("2026-07-14T10:00:00").success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("TimeZoneSchema", () => {
+    it("accepts a valid IANA time zone", () => {
+      expect(TimeZoneSchema.safeParse("America/Denver").success).toBe(true);
+    });
+
+    it("rejects an invalid time zone", () => {
+      expect(TimeZoneSchema.safeParse("Not/AZone").success).toBe(false);
+    });
+  });
+
+  describe("SortOrderSchema", () => {
+    it("accepts a non-negative integer", () => {
+      expect(SortOrderSchema.safeParse(0).success).toBe(true);
+      expect(SortOrderSchema.safeParse(5).success).toBe(true);
+    });
+
+    it("rejects a negative number", () => {
+      expect(SortOrderSchema.safeParse(-1).success).toBe(false);
+    });
+
+    it("rejects a float", () => {
+      expect(SortOrderSchema.safeParse(1.5).success).toBe(false);
+    });
+  });
+
+  describe("RRuleSchema", () => {
+    it("rejects an empty array", () => {
+      expect(RRuleSchema.safeParse([]).success).toBe(false);
+    });
+
+    it("rejects an array containing an empty string", () => {
+      expect(RRuleSchema.safeParse([""]).success).toBe(false);
+    });
+
+    it("accepts a non-empty array of rule lines", () => {
+      expect(RRuleSchema.safeParse(["RRULE:FREQ=WEEKLY"]).success).toBe(true);
+    });
+  });
+
+  describe("PrioritySchema", () => {
+    it("accepts every priority enum value", () => {
+      for (const priority of Object.values(Priorities)) {
+        expect(PrioritySchema.safeParse(priority).success).toBe(true);
+      }
+    });
+
+    it("rejects an unrecognized priority", () => {
+      expect(PrioritySchema.safeParse("other").success).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/types/domain-primitives.ts
+++ b/packages/core/src/types/domain-primitives.ts
@@ -1,0 +1,44 @@
+import { z } from "zod/v4";
+import { Priorities } from "@core/constants/core.constants";
+import {
+  RGBHexSchema,
+  TimezoneSchema,
+  zYearMonthDayString,
+} from "@core/types/type.utils";
+
+const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
+
+export const EventIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"EventId">();
+export type EventId = z.infer<typeof EventIdSchema>;
+
+export const CalendarIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"CalendarId">();
+export type CalendarId = z.infer<typeof CalendarIdSchema>;
+
+export const DateOnlySchema = zYearMonthDayString.brand<"DateOnly">();
+export type DateOnly = z.infer<typeof DateOnlySchema>;
+
+export const DateTimeSchema = z.iso
+  .datetime({ offset: true })
+  .brand<"DateTime">();
+export type DateTime = z.infer<typeof DateTimeSchema>;
+
+export const TimeZoneSchema = TimezoneSchema.brand<"TimeZone">();
+export type TimeZone = z.infer<typeof TimeZoneSchema>;
+
+export const HexColorSchema = RGBHexSchema;
+export type HexColor = z.infer<typeof HexColorSchema>;
+
+export const SortOrderSchema = z.number().int().nonnegative().finite();
+export type SortOrder = z.infer<typeof SortOrderSchema>;
+
+export const PrioritySchema = z.enum(Priorities);
+export type Priority = z.infer<typeof PrioritySchema>;
+
+export const RRuleSchema = z.array(z.string().trim().min(1)).min(1).readonly();
+export type RRule = z.infer<typeof RRuleSchema>;

--- a/packages/core/src/types/event-command.contracts.test.ts
+++ b/packages/core/src/types/event-command.contracts.test.ts
@@ -1,0 +1,373 @@
+import { faker } from "@faker-js/faker";
+import { Priorities } from "@core/constants/core.constants";
+import {
+  AvailabilityQuerySchema,
+  CreateEventInputSchema,
+  DeleteEventInputSchema,
+  EventListQuerySchema,
+  EventListResponseSchema,
+  EventMutationErrorSchema,
+  ReorderEventsInputSchema,
+  ReplaceEventInputSchema,
+  TransitionEventInputSchema,
+} from "@core/types/event-command.contracts";
+
+const calendarId = () => faker.database.mongodbObjectId();
+const eventId = () => faker.database.mongodbObjectId();
+
+const content = { kind: "details", title: "Standup", description: "" };
+const timedSchedule = {
+  kind: "timed",
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const allDaySchedule = {
+  kind: "allDay",
+  start: "2026-07-14",
+  end: "2026-07-15",
+};
+const somedaySchedule = {
+  kind: "someday",
+  period: "week",
+  anchorDate: "2026-07-14",
+  sortOrder: 0,
+};
+
+describe("Event Command Contracts", () => {
+  describe("CreateEventInputSchema", () => {
+    const base = () => ({
+      calendarId: calendarId(),
+      content,
+      schedule: timedSchedule,
+      recurrence: { kind: "single" },
+      priority: Priorities.UNASSIGNED,
+    });
+
+    it("parses without an id", () => {
+      expect(CreateEventInputSchema.safeParse(base()).success).toBe(true);
+    });
+
+    it("parses with an optional client-generated id", () => {
+      const input = { ...base(), id: eventId() };
+
+      expect(CreateEventInputSchema.safeParse(input).success).toBe(true);
+    });
+
+    it("rejects an occurrence recurrence", () => {
+      const input = {
+        ...base(),
+        recurrence: { kind: "occurrence", seriesId: eventId() },
+      };
+
+      expect(CreateEventInputSchema.safeParse(input).success).toBe(false);
+    });
+
+    it("rejects provider fields", () => {
+      const input = {
+        ...base(),
+        externalReference: {
+          provider: "google",
+          eventId: "abc",
+          recurringEventId: null,
+        },
+      };
+
+      expect(CreateEventInputSchema.safeParse(input).success).toBe(false);
+    });
+
+    it("rejects unknown keys", () => {
+      const input = { ...base(), extra: true };
+
+      expect(CreateEventInputSchema.safeParse(input).success).toBe(false);
+    });
+  });
+
+  describe("ReplaceEventInputSchema", () => {
+    const base = (overrides: Record<string, unknown> = {}) => ({
+      content,
+      schedule: timedSchedule,
+      recurrence: { kind: "preserve" },
+      priority: Priorities.WORK,
+      scope: "this",
+      ...overrides,
+    });
+
+    it("accepts a preserve recurrence edit", () => {
+      expect(ReplaceEventInputSchema.safeParse(base()).success).toBe(true);
+    });
+
+    it("accepts a single recurrence edit", () => {
+      const input = base({ recurrence: { kind: "single" } });
+
+      expect(ReplaceEventInputSchema.safeParse(input).success).toBe(true);
+    });
+
+    it("accepts a series recurrence edit", () => {
+      const input = base({
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      });
+
+      expect(ReplaceEventInputSchema.safeParse(input).success).toBe(true);
+    });
+
+    it("accepts every recurrence scope value", () => {
+      for (const scope of ["this", "thisAndFollowing", "all"] as const) {
+        expect(ReplaceEventInputSchema.safeParse(base({ scope })).success).toBe(
+          true,
+        );
+      }
+    });
+
+    it("rejects an unknown scope", () => {
+      const input = base({ scope: "future" });
+
+      expect(ReplaceEventInputSchema.safeParse(input).success).toBe(false);
+    });
+  });
+
+  describe("DeleteEventInputSchema", () => {
+    it("accepts a valid scope", () => {
+      expect(DeleteEventInputSchema.safeParse({ scope: "all" }).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an unknown scope", () => {
+      expect(
+        DeleteEventInputSchema.safeParse({ scope: "future" }).success,
+      ).toBe(false);
+    });
+
+    it("rejects unknown keys", () => {
+      const result = DeleteEventInputSchema.safeParse({
+        scope: "all",
+        extra: 1,
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("ReorderEventsInputSchema", () => {
+    it("accepts unique ordered items", () => {
+      const input = {
+        period: "week",
+        items: [
+          { eventId: eventId(), sortOrder: 0 },
+          { eventId: eventId(), sortOrder: 1 },
+        ],
+      };
+
+      expect(ReorderEventsInputSchema.safeParse(input).success).toBe(true);
+    });
+
+    it("rejects duplicate event ids", () => {
+      const id = eventId();
+      const input = {
+        period: "week",
+        items: [
+          { eventId: id, sortOrder: 0 },
+          { eventId: id, sortOrder: 1 },
+        ],
+      };
+
+      expect(ReorderEventsInputSchema.safeParse(input).success).toBe(false);
+    });
+
+    it("rejects an empty items array", () => {
+      const input = { period: "week", items: [] };
+
+      expect(ReorderEventsInputSchema.safeParse(input).success).toBe(false);
+    });
+  });
+
+  describe("TransitionEventInputSchema", () => {
+    it("parses a schedule transition onto a timed target", () => {
+      const input = {
+        kind: "schedule",
+        targetCalendarId: calendarId(),
+        schedule: timedSchedule,
+      };
+
+      expect(TransitionEventInputSchema.safeParse(input).success).toBe(true);
+    });
+
+    it("parses a schedule transition onto an allDay target", () => {
+      const input = {
+        kind: "schedule",
+        targetCalendarId: calendarId(),
+        schedule: allDaySchedule,
+      };
+
+      expect(TransitionEventInputSchema.safeParse(input).success).toBe(true);
+    });
+
+    it("rejects a someday schedule on the schedule branch", () => {
+      const input = {
+        kind: "schedule",
+        targetCalendarId: calendarId(),
+        schedule: somedaySchedule,
+      };
+
+      expect(TransitionEventInputSchema.safeParse(input).success).toBe(false);
+    });
+
+    it("parses an unschedule transition with a someday schedule", () => {
+      const input = { kind: "unschedule", schedule: somedaySchedule };
+
+      expect(TransitionEventInputSchema.safeParse(input).success).toBe(true);
+    });
+
+    it("rejects unknown keys", () => {
+      const input = {
+        kind: "unschedule",
+        schedule: somedaySchedule,
+        extra: 1,
+      };
+
+      expect(TransitionEventInputSchema.safeParse(input).success).toBe(false);
+    });
+  });
+
+  describe("EventListQuerySchema", () => {
+    it("parses a range query", () => {
+      const query = {
+        kind: "range",
+        start: "2026-07-14T00:00:00Z",
+        end: "2026-07-21T00:00:00Z",
+        priorities: [Priorities.WORK],
+      };
+
+      expect(EventListQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("accepts an empty priorities array (means all priorities)", () => {
+      const query = {
+        kind: "range",
+        start: "2026-07-14T00:00:00Z",
+        end: "2026-07-21T00:00:00Z",
+        priorities: [],
+      };
+
+      expect(EventListQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("rejects a range end before start", () => {
+      const query = {
+        kind: "range",
+        start: "2026-07-21T00:00:00Z",
+        end: "2026-07-14T00:00:00Z",
+        priorities: [],
+      };
+
+      expect(EventListQuerySchema.safeParse(query).success).toBe(false);
+    });
+
+    it("parses a someday query with only period and anchorDate", () => {
+      const query = {
+        kind: "someday",
+        period: "month",
+        anchorDate: "2026-07-01",
+      };
+
+      expect(EventListQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("rejects a someday query with a cursor/limit-like key", () => {
+      const query = {
+        kind: "someday",
+        period: "month",
+        anchorDate: "2026-07-01",
+        limit: 9,
+      };
+
+      expect(EventListQuerySchema.safeParse(query).success).toBe(false);
+    });
+  });
+
+  describe("EventListResponseSchema", () => {
+    it("accepts an events-only payload", () => {
+      expect(EventListResponseSchema.safeParse({ events: [] }).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects unknown keys alongside events", () => {
+      const result = EventListResponseSchema.safeParse({
+        events: [],
+        nextCursor: null,
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("AvailabilityQuerySchema", () => {
+    it("accepts unique calendar ids with end after start", () => {
+      const query = {
+        calendarIds: [calendarId(), calendarId()],
+        start: "2026-07-14T00:00:00Z",
+        end: "2026-07-14T01:00:00Z",
+      };
+
+      expect(AvailabilityQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("rejects duplicate calendar ids", () => {
+      const id = calendarId();
+      const query = {
+        calendarIds: [id, id],
+        start: "2026-07-14T00:00:00Z",
+        end: "2026-07-14T01:00:00Z",
+      };
+
+      expect(AvailabilityQuerySchema.safeParse(query).success).toBe(false);
+    });
+
+    it("rejects end before or equal to start", () => {
+      const query = {
+        calendarIds: [calendarId()],
+        start: "2026-07-14T01:00:00Z",
+        end: "2026-07-14T00:00:00Z",
+      };
+
+      expect(AvailabilityQuerySchema.safeParse(query).success).toBe(false);
+    });
+  });
+
+  describe("EventMutationErrorSchema", () => {
+    it("accepts every mutation error code", () => {
+      const codes = [
+        "EVENT_NOT_FOUND",
+        "CALENDAR_NOT_FOUND",
+        "CALENDAR_READ_ONLY",
+        "RECURRENCE_CONFLICT",
+        "INVALID_SCHEDULE",
+        "PROVIDER_FAILURE",
+      ] as const;
+
+      for (const code of codes) {
+        const error = { code, message: "failed", retryable: false };
+
+        expect(EventMutationErrorSchema.safeParse(error).success).toBe(true);
+      }
+    });
+
+    it("rejects an unrecognized code", () => {
+      const error = { code: "WAT", message: "failed", retryable: false };
+
+      expect(EventMutationErrorSchema.safeParse(error).success).toBe(false);
+    });
+
+    it("rejects an empty message", () => {
+      const error = {
+        code: "EVENT_NOT_FOUND",
+        message: "",
+        retryable: false,
+      };
+
+      expect(EventMutationErrorSchema.safeParse(error).success).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -1,0 +1,170 @@
+import { z } from "zod/v4";
+import {
+  CalendarIdSchema,
+  DateOnlySchema,
+  DateTimeSchema,
+  EventIdSchema,
+  PrioritySchema,
+  RRuleSchema,
+  SortOrderSchema,
+} from "@core/types/domain-primitives";
+import {
+  BusyPeriodSchema,
+  EditableRecurrenceSchema,
+  EventScheduleSchema,
+  EventSchema,
+  ScheduledScheduleSchema,
+  SomedayScheduleSchema,
+} from "@core/types/event.contracts";
+
+const EditableContentSchema = z.strictObject({
+  kind: z.literal("details"),
+  title: z.string(),
+  description: z.string(),
+});
+
+export const RecurrenceScopeSchema = z.enum([
+  "this",
+  "thisAndFollowing",
+  "all",
+]);
+export type RecurrenceScope = z.infer<typeof RecurrenceScopeSchema>;
+
+export const RecurrenceEditSchema = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("preserve") }),
+  z.strictObject({ kind: z.literal("single") }),
+  z.strictObject({ kind: z.literal("series"), rules: RRuleSchema }),
+]);
+export type RecurrenceEdit = z.infer<typeof RecurrenceEditSchema>;
+
+export const CreateEventInputSchema = z.strictObject({
+  // Optional client-generated id (A25): preserves optimistic creation and
+  // undo-of-delete, which restores an event under its original id. The server
+  // enforces uniqueness and rejects an id that already exists.
+  id: EventIdSchema.optional(),
+  calendarId: CalendarIdSchema,
+  content: EditableContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: EditableRecurrenceSchema,
+  priority: PrioritySchema,
+});
+export type CreateEventInput = z.infer<typeof CreateEventInputSchema>;
+
+export const ReplaceEventInputSchema = z.strictObject({
+  content: EditableContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: RecurrenceEditSchema,
+  priority: PrioritySchema,
+  scope: RecurrenceScopeSchema,
+});
+export type ReplaceEventInput = z.infer<typeof ReplaceEventInputSchema>;
+
+// The only command that changes an event's calendar (A24). "schedule" moves a
+// someday event onto a writable calendar; "unschedule" moves a scheduled event
+// to the Compass-local calendar and deletes any provider copy. Occurrences are
+// rejected; a series transitions whole.
+export const TransitionEventInputSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("schedule"),
+    targetCalendarId: CalendarIdSchema,
+    schedule: ScheduledScheduleSchema,
+  }),
+  z.strictObject({
+    kind: z.literal("unschedule"),
+    schedule: SomedayScheduleSchema,
+  }),
+]);
+export type TransitionEventInput = z.infer<typeof TransitionEventInputSchema>;
+
+export const DeleteEventInputSchema = z.strictObject({
+  scope: RecurrenceScopeSchema,
+});
+export type DeleteEventInput = z.infer<typeof DeleteEventInputSchema>;
+
+const EventOrderSchema = z.strictObject({
+  eventId: EventIdSchema,
+  sortOrder: SortOrderSchema,
+});
+
+export const ReorderEventsInputSchema = z
+  .strictObject({
+    period: z.enum(["week", "month"]),
+    items: z.array(EventOrderSchema).min(1),
+  })
+  .refine(
+    ({ items }) =>
+      new Set(items.map(({ eventId }) => eventId)).size === items.length,
+    { message: "Event ids must be unique", path: ["items"] },
+  );
+export type ReorderEventsInput = z.infer<typeof ReorderEventsInputSchema>;
+
+const RangeEventListQuerySchema = z
+  .strictObject({
+    kind: z.literal("range"),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    priorities: z.array(PrioritySchema),
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Range end must be after start",
+    path: ["end"],
+  });
+
+// No cursor or limit: the product caps someday lists at 9 per period (A35),
+// so the whole period is one bounded read.
+const SomedayEventListQuerySchema = z.strictObject({
+  kind: z.literal("someday"),
+  period: z.enum(["week", "month"]),
+  anchorDate: DateOnlySchema,
+});
+
+export const EventListQuerySchema = z.discriminatedUnion("kind", [
+  RangeEventListQuerySchema,
+  SomedayEventListQuerySchema,
+]);
+export type EventListQuery = z.infer<typeof EventListQuerySchema>;
+
+export const EventResponseSchema = z.strictObject({ event: EventSchema });
+export type EventResponse = z.infer<typeof EventResponseSchema>;
+
+export const EventListResponseSchema = z.strictObject({
+  events: z.array(EventSchema),
+});
+export type EventListResponse = z.infer<typeof EventListResponseSchema>;
+
+export const AvailabilityQuerySchema = z
+  .strictObject({
+    calendarIds: z.array(CalendarIdSchema).min(1),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Availability end must be after start",
+    path: ["end"],
+  })
+  .refine(
+    ({ calendarIds }) => new Set(calendarIds).size === calendarIds.length,
+    { message: "Calendar ids must be unique", path: ["calendarIds"] },
+  );
+export type AvailabilityQuery = z.infer<typeof AvailabilityQuerySchema>;
+
+export const AvailabilityResponseSchema = z.strictObject({
+  busyPeriods: z.array(BusyPeriodSchema),
+});
+export type AvailabilityResponse = z.infer<typeof AvailabilityResponseSchema>;
+
+export const EventMutationErrorCodeSchema = z.enum([
+  "EVENT_NOT_FOUND",
+  "CALENDAR_NOT_FOUND",
+  "CALENDAR_READ_ONLY",
+  "RECURRENCE_CONFLICT",
+  "INVALID_SCHEDULE",
+  "PROVIDER_FAILURE",
+]);
+
+export const EventMutationErrorSchema = z.strictObject({
+  code: EventMutationErrorCodeSchema,
+  message: z.string().min(1),
+  retryable: z.boolean(),
+});
+export type EventMutationError = z.infer<typeof EventMutationErrorSchema>;

--- a/packages/core/src/types/event.contracts.test.ts
+++ b/packages/core/src/types/event.contracts.test.ts
@@ -1,0 +1,289 @@
+import { faker } from "@faker-js/faker";
+import { Priorities } from "@core/constants/core.constants";
+import {
+  BusyPeriodSchema,
+  EditableRecurrenceSchema,
+  EventContentSchema,
+  EventRecurrenceSchema,
+  EventScheduleSchema,
+  EventSchema,
+} from "@core/types/event.contracts";
+
+const timedSchedule = {
+  kind: "timed",
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const allDaySchedule = {
+  kind: "allDay",
+  start: "2026-07-14",
+  end: "2026-07-15",
+};
+const somedaySchedule = {
+  kind: "someday",
+  period: "week",
+  anchorDate: "2026-07-14",
+  sortOrder: 0,
+};
+
+const singleRecurrence = { kind: "single" };
+const seriesRecurrence = { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] };
+
+const baseEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: faker.database.mongodbObjectId(),
+  calendarId: faker.database.mongodbObjectId(),
+  content: { kind: "details", title: "Standup", description: "Daily sync" },
+  schedule: timedSchedule,
+  recurrence: singleRecurrence,
+  priority: Priorities.UNASSIGNED,
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: null,
+  ...overrides,
+});
+
+describe("Event Contracts", () => {
+  describe("EventContentSchema", () => {
+    it("rejects unknown keys on details content", () => {
+      const result = EventContentSchema.safeParse({
+        kind: "details",
+        title: "x",
+        description: "y",
+        extra: 1,
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects unknown keys on busy content", () => {
+      const result = EventContentSchema.safeParse({ kind: "busy", extra: 1 });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("EventScheduleSchema (timed)", () => {
+    it("rejects end equal to start", () => {
+      const schedule = { ...timedSchedule, end: timedSchedule.start };
+      const result = EventScheduleSchema.safeParse(schedule);
+
+      expect(result.success).toBe(false);
+      expect(result.success ? null : result.error.issues[0]?.path).toEqual([
+        "end",
+      ]);
+    });
+
+    it("rejects end before start", () => {
+      const schedule = {
+        ...timedSchedule,
+        start: "2026-07-14T10:00:00-06:00",
+        end: "2026-07-14T09:00:00-06:00",
+      };
+
+      expect(EventScheduleSchema.safeParse(schedule).success).toBe(false);
+    });
+
+    it("rejects unknown keys", () => {
+      const schedule = { ...timedSchedule, extra: 1 };
+
+      expect(EventScheduleSchema.safeParse(schedule).success).toBe(false);
+    });
+  });
+
+  describe("EventScheduleSchema (allDay)", () => {
+    it("rejects end equal to start (exclusive end)", () => {
+      const schedule = {
+        kind: "allDay",
+        start: "2026-07-14",
+        end: "2026-07-14",
+      };
+      const result = EventScheduleSchema.safeParse(schedule);
+
+      expect(result.success).toBe(false);
+      expect(result.success ? null : result.error.issues[0]?.path).toEqual([
+        "end",
+      ]);
+    });
+
+    it("accepts end one day after start", () => {
+      expect(EventScheduleSchema.safeParse(allDaySchedule).success).toBe(true);
+    });
+
+    it("accepts a multi-day span", () => {
+      const schedule = {
+        kind: "allDay",
+        start: "2026-07-14",
+        end: "2026-07-20",
+      };
+
+      expect(EventScheduleSchema.safeParse(schedule).success).toBe(true);
+    });
+
+    it("rejects an instant string in place of a date-only value", () => {
+      const schedule = {
+        kind: "allDay",
+        start: "2026-07-14T00:00:00Z",
+        end: "2026-07-15",
+      };
+
+      expect(EventScheduleSchema.safeParse(schedule).success).toBe(false);
+    });
+
+    it("rejects unknown keys", () => {
+      const schedule = { ...allDaySchedule, extra: 1 };
+
+      expect(EventScheduleSchema.safeParse(schedule).success).toBe(false);
+    });
+  });
+
+  describe("EventScheduleSchema (someday)", () => {
+    it("rejects a missing sortOrder", () => {
+      const schedule = {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-14",
+      };
+
+      expect(EventScheduleSchema.safeParse(schedule).success).toBe(false);
+    });
+
+    it("accepts a valid someday schedule", () => {
+      expect(EventScheduleSchema.safeParse(somedaySchedule).success).toBe(true);
+    });
+
+    it("rejects unknown keys", () => {
+      const schedule = { ...somedaySchedule, extra: 1 };
+
+      expect(EventScheduleSchema.safeParse(schedule).success).toBe(false);
+    });
+  });
+
+  describe("EventRecurrenceSchema", () => {
+    it("rejects a series with an empty rules array", () => {
+      const recurrence = { kind: "series", rules: [] };
+
+      expect(EventRecurrenceSchema.safeParse(recurrence).success).toBe(false);
+    });
+
+    it("rejects an occurrence with an invalid seriesId", () => {
+      const recurrence = { kind: "occurrence", seriesId: "not-an-id" };
+
+      expect(EventRecurrenceSchema.safeParse(recurrence).success).toBe(false);
+    });
+
+    it("accepts an occurrence with a valid seriesId", () => {
+      const recurrence = {
+        kind: "occurrence",
+        seriesId: faker.database.mongodbObjectId(),
+      };
+
+      expect(EventRecurrenceSchema.safeParse(recurrence).success).toBe(true);
+    });
+
+    it("rejects unknown keys on a single recurrence", () => {
+      expect(
+        EventRecurrenceSchema.safeParse({ kind: "single", extra: 1 }).success,
+      ).toBe(false);
+    });
+
+    it("rejects unknown keys on a series recurrence", () => {
+      const recurrence = { ...seriesRecurrence, extra: 1 };
+
+      expect(EventRecurrenceSchema.safeParse(recurrence).success).toBe(false);
+    });
+  });
+
+  describe("EditableRecurrenceSchema", () => {
+    it("rejects an occurrence (create/replace never submit a seriesId)", () => {
+      const recurrence = {
+        kind: "occurrence",
+        seriesId: faker.database.mongodbObjectId(),
+      };
+
+      expect(EditableRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("EventSchema", () => {
+    const contents: [string, unknown][] = [
+      [
+        "details",
+        { kind: "details", title: "Standup", description: "Daily sync" },
+      ],
+      ["busy", { kind: "busy" }],
+    ];
+    const schedules: [string, unknown][] = [
+      ["timed", timedSchedule],
+      ["allDay", allDaySchedule],
+      ["someday", somedaySchedule],
+    ];
+    const recurrences: [string, unknown][] = [
+      ["single", singleRecurrence],
+      ["series", seriesRecurrence],
+      [
+        "occurrence",
+        { kind: "occurrence", seriesId: faker.database.mongodbObjectId() },
+      ],
+    ];
+
+    for (const [contentName, content] of contents) {
+      for (const [scheduleName, schedule] of schedules) {
+        for (const [recurrenceName, recurrence] of recurrences) {
+          it(`parses content=${contentName} schedule=${scheduleName} recurrence=${recurrenceName}`, () => {
+            const event = baseEvent({ content, schedule, recurrence });
+
+            expect(EventSchema.safeParse(event).success).toBe(true);
+          });
+        }
+      }
+    }
+
+    it("accepts an empty title and description for details content", () => {
+      const event = baseEvent({
+        content: { kind: "details", title: "", description: "" },
+      });
+
+      expect(EventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("accepts a null updatedAt", () => {
+      expect(
+        EventSchema.safeParse(baseEvent({ updatedAt: null })).success,
+      ).toBe(true);
+    });
+
+    it("rejects unknown keys on the event itself", () => {
+      const event = baseEvent({ extra: true });
+
+      expect(EventSchema.safeParse(event).success).toBe(false);
+    });
+  });
+
+  describe("BusyPeriodSchema", () => {
+    it("accepts a valid busy period", () => {
+      const period = {
+        calendarId: faker.database.mongodbObjectId(),
+        start: "2026-07-14T09:00:00Z",
+        end: "2026-07-14T10:00:00Z",
+      };
+
+      expect(BusyPeriodSchema.safeParse(period).success).toBe(true);
+    });
+
+    it("rejects end equal to start", () => {
+      const period = {
+        calendarId: faker.database.mongodbObjectId(),
+        start: "2026-07-14T09:00:00Z",
+        end: "2026-07-14T09:00:00Z",
+      };
+      const result = BusyPeriodSchema.safeParse(period);
+
+      expect(result.success).toBe(false);
+      expect(result.success ? null : result.error.issues[0]?.path).toEqual([
+        "end",
+      ]);
+    });
+  });
+});

--- a/packages/core/src/types/event.contracts.ts
+++ b/packages/core/src/types/event.contracts.ts
@@ -1,0 +1,116 @@
+import { z } from "zod/v4";
+import {
+  CalendarIdSchema,
+  DateOnlySchema,
+  DateTimeSchema,
+  EventIdSchema,
+  PrioritySchema,
+  RRuleSchema,
+  SortOrderSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+
+export const EventContentSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("details"),
+    title: z.string(),
+    description: z.string(),
+  }),
+  z.strictObject({ kind: z.literal("busy") }),
+]);
+export type EventContent = z.infer<typeof EventContentSchema>;
+
+const TimedScheduleSchema = z
+  .strictObject({
+    kind: z.literal("timed"),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    timeZone: TimeZoneSchema,
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Timed event end must be after start",
+    path: ["end"],
+  });
+
+const AllDayScheduleSchema = z
+  .strictObject({
+    kind: z.literal("allDay"),
+    start: DateOnlySchema,
+    end: DateOnlySchema,
+  })
+  .refine(({ start, end }) => end > start, {
+    message: "All-day event end is exclusive and must be after start",
+    path: ["end"],
+  });
+
+export const SomedayScheduleSchema = z.strictObject({
+  kind: z.literal("someday"),
+  period: z.enum(["week", "month"]),
+  anchorDate: DateOnlySchema,
+  sortOrder: SortOrderSchema,
+});
+export type SomedaySchedule = z.infer<typeof SomedayScheduleSchema>;
+
+export const ScheduledScheduleSchema = z.discriminatedUnion("kind", [
+  TimedScheduleSchema,
+  AllDayScheduleSchema,
+]);
+export type ScheduledSchedule = z.infer<typeof ScheduledScheduleSchema>;
+
+export const EventScheduleSchema = z.discriminatedUnion("kind", [
+  TimedScheduleSchema,
+  AllDayScheduleSchema,
+  SomedayScheduleSchema,
+]);
+export type EventSchedule = z.infer<typeof EventScheduleSchema>;
+
+const SingleRecurrenceSchema = z.strictObject({
+  kind: z.literal("single"),
+});
+
+const SeriesRecurrenceSchema = z.strictObject({
+  kind: z.literal("series"),
+  rules: RRuleSchema,
+});
+
+const OccurrenceRecurrenceSchema = z.strictObject({
+  kind: z.literal("occurrence"),
+  seriesId: EventIdSchema,
+});
+
+export const EditableRecurrenceSchema = z.discriminatedUnion("kind", [
+  SingleRecurrenceSchema,
+  SeriesRecurrenceSchema,
+]);
+export type EditableRecurrence = z.infer<typeof EditableRecurrenceSchema>;
+
+export const EventRecurrenceSchema = z.discriminatedUnion("kind", [
+  SingleRecurrenceSchema,
+  SeriesRecurrenceSchema,
+  OccurrenceRecurrenceSchema,
+]);
+export type EventRecurrence = z.infer<typeof EventRecurrenceSchema>;
+
+export const EventSchema = z.strictObject({
+  id: EventIdSchema,
+  calendarId: CalendarIdSchema,
+  content: EventContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: EventRecurrenceSchema,
+  priority: PrioritySchema,
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema.nullable(),
+});
+export type Event = z.infer<typeof EventSchema>;
+
+export const BusyPeriodSchema = z
+  .strictObject({
+    calendarId: CalendarIdSchema,
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Busy period end must be after start",
+    path: ["end"],
+  });
+export type BusyPeriod = z.infer<typeof BusyPeriodSchema>;

--- a/packages/core/src/types/server-message.contracts.test.ts
+++ b/packages/core/src/types/server-message.contracts.test.ts
@@ -1,0 +1,173 @@
+import { faker } from "@faker-js/faker";
+import {
+  CalendarChangeMessageSchema,
+  EventChangeMessageSchema,
+  ImportResultMessageSchema,
+  ServerMessageSchema,
+  SyncStatusMessageSchema,
+  UserMetadataMessageSchema,
+} from "@core/types/server-message.contracts";
+
+const calendarId = () => faker.database.mongodbObjectId();
+const eventId = () => faker.database.mongodbObjectId();
+
+describe("Server Message Contracts", () => {
+  describe("EventChangeMessageSchema", () => {
+    it("parses a realistic eventsChanged message", () => {
+      const message = {
+        type: "eventsChanged",
+        calendarId: calendarId(),
+        eventIds: [eventId(), eventId()],
+        reason: "updated",
+      };
+
+      expect(EventChangeMessageSchema.safeParse(message).success).toBe(true);
+    });
+
+    it("accepts an empty eventIds array (invalidate the whole calendar)", () => {
+      const message = {
+        type: "eventsChanged",
+        calendarId: calendarId(),
+        eventIds: [],
+        reason: "reconciled",
+      };
+
+      expect(EventChangeMessageSchema.safeParse(message).success).toBe(true);
+    });
+
+    it("rejects an unrecognized reason", () => {
+      const message = {
+        type: "eventsChanged",
+        calendarId: calendarId(),
+        eventIds: [],
+        reason: "renamed",
+      };
+
+      expect(EventChangeMessageSchema.safeParse(message).success).toBe(false);
+    });
+  });
+
+  describe("CalendarChangeMessageSchema", () => {
+    it("parses a realistic calendarsChanged message", () => {
+      const message = { type: "calendarsChanged", calendarIds: [calendarId()] };
+
+      expect(CalendarChangeMessageSchema.safeParse(message).success).toBe(true);
+    });
+  });
+
+  describe("SyncStatusMessageSchema", () => {
+    it("parses a syncing status", () => {
+      const message = {
+        type: "syncStatusChanged",
+        sync: { status: "syncing" },
+      };
+
+      expect(SyncStatusMessageSchema.safeParse(message).success).toBe(true);
+    });
+
+    it("parses a healthy status", () => {
+      const message = {
+        type: "syncStatusChanged",
+        sync: { status: "healthy" },
+      };
+
+      expect(SyncStatusMessageSchema.safeParse(message).success).toBe(true);
+    });
+
+    it("parses an attention status with code and retryable", () => {
+      const message = {
+        type: "syncStatusChanged",
+        sync: { status: "attention", code: "GOOGLE_REVOKED", retryable: false },
+      };
+
+      expect(SyncStatusMessageSchema.safeParse(message).success).toBe(true);
+    });
+
+    it("rejects an attention status missing code and retryable", () => {
+      const message = {
+        type: "syncStatusChanged",
+        sync: { status: "attention" },
+      };
+
+      expect(SyncStatusMessageSchema.safeParse(message).success).toBe(false);
+    });
+  });
+
+  describe("ImportResultMessageSchema", () => {
+    it("parses a realistic importCompleted message", () => {
+      const message = {
+        type: "importCompleted",
+        operation: "full",
+        eventsCount: 120,
+        calendarsCount: 3,
+      };
+
+      expect(ImportResultMessageSchema.safeParse(message).success).toBe(true);
+    });
+
+    it("rejects a negative eventsCount", () => {
+      const message = {
+        type: "importCompleted",
+        operation: "incremental",
+        eventsCount: -1,
+        calendarsCount: 0,
+      };
+
+      expect(ImportResultMessageSchema.safeParse(message).success).toBe(false);
+    });
+
+    it("rejects a non-integer calendarsCount", () => {
+      const message = {
+        type: "importCompleted",
+        operation: "repair",
+        eventsCount: 0,
+        calendarsCount: 1.5,
+      };
+
+      expect(ImportResultMessageSchema.safeParse(message).success).toBe(false);
+    });
+  });
+
+  describe("UserMetadataMessageSchema", () => {
+    it("parses a realistic userMetadataChanged message", () => {
+      const message = {
+        type: "userMetadataChanged",
+        metadata: { syncEnabled: true, plan: "free" },
+      };
+
+      expect(UserMetadataMessageSchema.safeParse(message).success).toBe(true);
+    });
+  });
+
+  describe("ServerMessageSchema", () => {
+    it("rejects an unknown message type", () => {
+      const message = { type: "somethingElse" };
+
+      expect(ServerMessageSchema.safeParse(message).success).toBe(false);
+    });
+
+    it("parses every union member from a realistic payload", () => {
+      const messages = [
+        {
+          type: "eventsChanged",
+          calendarId: calendarId(),
+          eventIds: [],
+          reason: "created",
+        },
+        { type: "calendarsChanged", calendarIds: [calendarId()] },
+        { type: "syncStatusChanged", sync: { status: "healthy" } },
+        {
+          type: "importCompleted",
+          operation: "full",
+          eventsCount: 0,
+          calendarsCount: 0,
+        },
+        { type: "userMetadataChanged", metadata: {} },
+      ];
+
+      for (const message of messages) {
+        expect(ServerMessageSchema.safeParse(message).success).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/core/src/types/server-message.contracts.ts
+++ b/packages/core/src/types/server-message.contracts.ts
@@ -1,0 +1,63 @@
+import { z } from "zod/v4";
+import { CalendarIdSchema, EventIdSchema } from "@core/types/domain-primitives";
+
+export const EventChangeMessageSchema = z.strictObject({
+  type: z.literal("eventsChanged"),
+  calendarId: CalendarIdSchema,
+  eventIds: z.array(EventIdSchema),
+  reason: z.enum(["created", "updated", "deleted", "reconciled"]),
+});
+export type EventChangeMessage = z.infer<typeof EventChangeMessageSchema>;
+
+export const CalendarChangeMessageSchema = z.strictObject({
+  type: z.literal("calendarsChanged"),
+  calendarIds: z.array(CalendarIdSchema),
+});
+export type CalendarChangeMessage = z.infer<typeof CalendarChangeMessageSchema>;
+
+const SyncStateSchema = z.discriminatedUnion("status", [
+  z.strictObject({ status: z.literal("syncing") }),
+  z.strictObject({ status: z.literal("healthy") }),
+  z.strictObject({
+    status: z.literal("attention"),
+    code: z.enum(["GOOGLE_REVOKED", "IMPORT_FAILED", "WATCH_REPAIR_FAILED"]),
+    retryable: z.boolean(),
+  }),
+]);
+
+export const SyncStatusMessageSchema = z.strictObject({
+  type: z.literal("syncStatusChanged"),
+  sync: SyncStateSchema,
+});
+export type SyncStatusMessage = z.infer<typeof SyncStatusMessageSchema>;
+
+export const ImportResultMessageSchema = z.strictObject({
+  type: z.literal("importCompleted"),
+  operation: z.enum(["full", "incremental", "repair"]),
+  eventsCount: z.number().int().nonnegative(),
+  calendarsCount: z.number().int().nonnegative(),
+});
+export type ImportResultMessage = z.infer<typeof ImportResultMessageSchema>;
+
+// Wraps the user-metadata payload the backend already replays on SSE connect;
+// the account summary consumes it. The legacy UserMetadata is a plain TS
+// interface with no Zod schema, so implementation should model only the fields
+// the web actually reads and validate those.
+export const UserMetadataMessageSchema = z.strictObject({
+  type: z.literal("userMetadataChanged"),
+  metadata: z.record(z.string(), z.unknown()),
+});
+export type UserMetadataMessage = z.infer<typeof UserMetadataMessageSchema>;
+
+// Completeness rule (A27): every backend publish site emits a member of this
+// union. The six current SSE names (EVENT_CHANGED, SOMEDAY_EVENT_CHANGED,
+// IMPORT_GCAL_START, IMPORT_GCAL_END, GOOGLE_REVOKED, USER_METADATA) each map
+// to a member or are explicitly retired; a contract test enforces the mapping.
+export const ServerMessageSchema = z.discriminatedUnion("type", [
+  EventChangeMessageSchema,
+  CalendarChangeMessageSchema,
+  SyncStatusMessageSchema,
+  ImportResultMessageSchema,
+  UserMetadataMessageSchema,
+]);
+export type ServerMessage = z.infer<typeof ServerMessageSchema>;

--- a/packages/web/src/common/storage/types/local-event.record.test.ts
+++ b/packages/web/src/common/storage/types/local-event.record.test.ts
@@ -1,0 +1,89 @@
+import { faker } from "@faker-js/faker";
+import { Priorities } from "@core/constants/core.constants";
+import { EventSchema } from "@core/types/event.contracts";
+import { LocalEventRecordSchema } from "@web/common/storage/types/local-event.record";
+
+const validEvent = () => {
+  const id = faker.database.mongodbObjectId();
+
+  return EventSchema.parse({
+    id,
+    calendarId: faker.database.mongodbObjectId(),
+    content: { kind: "details", title: "Standup", description: "" },
+    schedule: {
+      kind: "timed",
+      start: "2026-07-14T09:00:00-06:00",
+      end: "2026-07-14T10:00:00-06:00",
+      timeZone: "America/Denver",
+    },
+    recurrence: { kind: "single" },
+    priority: Priorities.UNASSIGNED,
+    createdAt: "2026-07-14T09:00:00-06:00",
+    updatedAt: null,
+  });
+};
+
+describe("LocalEventRecordSchema", () => {
+  it("parses a valid record", () => {
+    const event = validEvent();
+    const result = LocalEventRecordSchema.safeParse({
+      version: 2,
+      id: event.id,
+      event,
+      isDemo: false,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects version 1", () => {
+    const event = validEvent();
+    const result = LocalEventRecordSchema.safeParse({
+      version: 1,
+      id: event.id,
+      event,
+      isDemo: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a top-level id that doesn't match event.id", () => {
+    const event = validEvent();
+    const otherEvent = validEvent();
+    const result = LocalEventRecordSchema.safeParse({
+      version: 2,
+      id: otherEvent.id,
+      event,
+      isDemo: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys", () => {
+    const event = validEvent();
+    const result = LocalEventRecordSchema.safeParse({
+      version: 2,
+      id: event.id,
+      event,
+      isDemo: false,
+      extra: "nope",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a syncState key", () => {
+    const event = validEvent();
+    const result = LocalEventRecordSchema.safeParse({
+      version: 2,
+      id: event.id,
+      event,
+      isDemo: false,
+      syncState: { status: "synced" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/web/src/common/storage/types/local-event.record.ts
+++ b/packages/web/src/common/storage/types/local-event.record.ts
@@ -1,0 +1,19 @@
+import { z } from "zod/v4";
+import { EventSchema } from "@core/types/event.contracts";
+
+// There is no syncState field (A35): local sync is push-all-then-clear on
+// connect, so a per-record state machine models a queue that does not exist.
+export const LocalEventRecordSchema = z
+  .strictObject({
+    version: z.literal(2),
+    id: EventSchema.shape.id,
+    event: EventSchema,
+    isDemo: z.boolean(),
+  })
+  // IndexedDB keys on the duplicated top-level id, so it must always match
+  // the nested event's own id.
+  .refine(({ id, event }) => id === event.id, {
+    message: "Top-level id must match event.id",
+    path: ["id"],
+  });
+export type LocalEventRecord = z.infer<typeof LocalEventRecordSchema>;

--- a/packages/web/src/events/event-draft.parser.test.ts
+++ b/packages/web/src/events/event-draft.parser.test.ts
@@ -1,0 +1,307 @@
+import { faker } from "@faker-js/faker";
+import { Priorities } from "@core/constants/core.constants";
+import {
+  type CalendarId,
+  CalendarIdSchema,
+  type EventId,
+  EventIdSchema,
+} from "@core/types/domain-primitives";
+import { CreateEventInputSchema } from "@core/types/event-command.contracts";
+import { parseEventDraft } from "@web/events/event-draft.parser";
+import {
+  type EditEventDraft,
+  type EditEventFormValues,
+  type EventScheduleDraft,
+  type NewEventDraft,
+  type NewEventFormValues,
+} from "@web/events/event-draft.types";
+
+const calendarId = (): CalendarId =>
+  CalendarIdSchema.parse(faker.database.mongodbObjectId());
+const eventId = (): EventId =>
+  EventIdSchema.parse(faker.database.mongodbObjectId());
+
+const timedSchedule = (
+  overrides: Partial<Extract<EventScheduleDraft, { kind: "timed" }>> = {},
+): EventScheduleDraft => ({
+  kind: "timed",
+  start: new Date("2026-07-14T09:00:00-06:00"),
+  end: new Date("2026-07-14T10:00:00-06:00"),
+  timeZone: "America/Denver",
+  ...overrides,
+});
+
+const allDaySchedule = (
+  overrides: Partial<Extract<EventScheduleDraft, { kind: "allDay" }>> = {},
+): EventScheduleDraft => ({
+  kind: "allDay",
+  start: new Date(2026, 6, 14),
+  end: new Date(2026, 6, 14),
+  ...overrides,
+});
+
+const somedaySchedule = (
+  overrides: Partial<Extract<EventScheduleDraft, { kind: "someday" }>> = {},
+): EventScheduleDraft => ({
+  kind: "someday",
+  period: "week",
+  anchorDate: new Date(2026, 6, 14),
+  sortOrder: 0,
+  ...overrides,
+});
+
+const newFormValues = (
+  overrides: Partial<NewEventFormValues> = {},
+): NewEventFormValues => ({
+  title: "Standup",
+  description: "",
+  schedule: timedSchedule(),
+  priority: Priorities.UNASSIGNED,
+  calendarId: calendarId(),
+  recurrence: { kind: "single" },
+  ...overrides,
+});
+
+const newDraft = (
+  overrides: Partial<NewEventFormValues> = {},
+): NewEventDraft => ({
+  mode: "create",
+  values: newFormValues(overrides),
+  isDirty: true,
+  submitError: null,
+});
+
+const editFormValues = (
+  overrides: Partial<EditEventFormValues> = {},
+): EditEventFormValues => ({
+  title: "Standup",
+  description: "",
+  schedule: timedSchedule(),
+  priority: Priorities.UNASSIGNED,
+  calendarId: calendarId(),
+  recurrence: { kind: "preserve" },
+  scope: "this",
+  ...overrides,
+});
+
+const editDraft = (
+  overrides: Partial<EditEventFormValues> = {},
+  draftOverrides: Partial<Omit<EditEventDraft, "values" | "mode">> = {},
+): EditEventDraft => ({
+  mode: "edit",
+  values: editFormValues(overrides),
+  isDirty: true,
+  submitError: null,
+  eventId: eventId(),
+  originalCalendarId: calendarId(),
+  ...draftOverrides,
+});
+
+describe("parseEventDraft", () => {
+  describe("happy paths", () => {
+    it("parses a timed create draft with the offset for the draft's time zone", () => {
+      const result = parseEventDraft(newDraft());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || result.mode !== "create")
+        throw new Error("expected create");
+
+      expect(result.input.schedule.kind).toBe("timed");
+      if (result.input.schedule.kind !== "timed")
+        throw new Error("expected timed");
+      expect(result.input.schedule.start).toContain("-06:00");
+      expect(result.input.schedule.end).toContain("-06:00");
+      expect(CreateEventInputSchema.parse(result.input)).toBeTruthy();
+    });
+
+    it("normalizes a same-day all-day selection to an exclusive end", () => {
+      const result = parseEventDraft(newDraft({ schedule: allDaySchedule() }));
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || result.mode !== "create")
+        throw new Error("expected create");
+      expect(result.input.schedule).toEqual({
+        kind: "allDay",
+        start: "2026-07-14",
+        end: "2026-07-15",
+      });
+      expect(CreateEventInputSchema.parse(result.input)).toBeTruthy();
+    });
+
+    it("passes a multi-day all-day selection through unchanged", () => {
+      const schedule = allDaySchedule({ end: new Date(2026, 6, 16) });
+      const result = parseEventDraft(newDraft({ schedule }));
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || result.mode !== "create")
+        throw new Error("expected create");
+      expect(result.input.schedule).toEqual({
+        kind: "allDay",
+        start: "2026-07-14",
+        end: "2026-07-16",
+      });
+    });
+
+    it("parses a someday create draft", () => {
+      const result = parseEventDraft(newDraft({ schedule: somedaySchedule() }));
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || result.mode !== "create")
+        throw new Error("expected create");
+      expect(result.input.schedule).toEqual({
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-14",
+        sortOrder: 0,
+      });
+    });
+
+    it("parses an edit draft that preserves recurrence and scope", () => {
+      const draft = editDraft({ scope: "this" });
+      const result = parseEventDraft(draft);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || result.mode !== "edit")
+        throw new Error("expected edit");
+      expect(result.input.recurrence).toEqual({ kind: "preserve" });
+      expect(result.input.scope).toBe("this");
+      expect(result.eventId).toBe(draft.eventId);
+    });
+
+    it("parses an edit draft that switches to series rules", () => {
+      const draft = editDraft({
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY"] },
+      });
+      const result = parseEventDraft(draft);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || result.mode !== "edit")
+        throw new Error("expected edit");
+      expect(result.input.recurrence).toEqual({
+        kind: "series",
+        rules: ["RRULE:FREQ=DAILY"],
+      });
+    });
+
+    it("parses a create draft with series recurrence", () => {
+      const draft = newDraft({
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      });
+      const result = parseEventDraft(draft);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok || result.mode !== "create")
+        throw new Error("expected create");
+      expect(result.input.recurrence).toEqual({
+        kind: "series",
+        rules: ["RRULE:FREQ=WEEKLY"],
+      });
+      expect(CreateEventInputSchema.parse(result.input)).toBeTruthy();
+    });
+  });
+
+  describe("failures", () => {
+    it("reports a null start", () => {
+      const result = parseEventDraft(
+        newDraft({ schedule: timedSchedule({ start: null }) }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.start).toBeDefined();
+    });
+
+    it("reports a null time zone", () => {
+      const result = parseEventDraft(
+        newDraft({ schedule: timedSchedule({ timeZone: null }) }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.timeZone).toBeDefined();
+    });
+
+    it("reports a timed end before start", () => {
+      const result = parseEventDraft(
+        newDraft({
+          schedule: timedSchedule({
+            start: new Date("2026-07-14T10:00:00-06:00"),
+            end: new Date("2026-07-14T09:00:00-06:00"),
+          }),
+        }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.end).toBeDefined();
+    });
+
+    it("reports an all-day end before start", () => {
+      const result = parseEventDraft(
+        newDraft({
+          schedule: allDaySchedule({
+            start: new Date(2026, 6, 14),
+            end: new Date(2026, 6, 13),
+          }),
+        }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.end).toBeDefined();
+    });
+
+    it("reports a null priority", () => {
+      const result = parseEventDraft(newDraft({ priority: null }));
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.priority).toBeDefined();
+    });
+
+    it("reports a null calendarId on create", () => {
+      const result = parseEventDraft(newDraft({ calendarId: null }));
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.calendarId).toBeDefined();
+    });
+
+    it("reports blank series rules", () => {
+      const result = parseEventDraft(
+        newDraft({ recurrence: { kind: "series", rules: [""] } }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.recurrence).toBeDefined();
+    });
+
+    it("reports a missing someday sortOrder", () => {
+      const result = parseEventDraft(
+        newDraft({ schedule: somedaySchedule({ sortOrder: null }) }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.sortOrder).toBeDefined();
+    });
+
+    it("reports every simultaneous error in one result", () => {
+      const result = parseEventDraft(
+        newDraft({
+          calendarId: null,
+          priority: null,
+          schedule: timedSchedule({ start: null, timeZone: null }),
+        }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected failure");
+      expect(result.fieldErrors.calendarId).toBeDefined();
+      expect(result.fieldErrors.priority).toBeDefined();
+      expect(result.fieldErrors.start).toBeDefined();
+      expect(result.fieldErrors.timeZone).toBeDefined();
+    });
+  });
+});

--- a/packages/web/src/events/event-draft.parser.ts
+++ b/packages/web/src/events/event-draft.parser.ts
@@ -1,0 +1,275 @@
+import { type z } from "zod/v4";
+import { type EventId } from "@core/types/domain-primitives";
+import {
+  type CreateEventInput,
+  CreateEventInputSchema,
+  type ReplaceEventInput,
+  ReplaceEventInputSchema,
+} from "@core/types/event-command.contracts";
+import dayjs from "@core/util/date/dayjs";
+import {
+  type EditEventDraft,
+  type EditEventRecurrenceDraft,
+  type EventDraft,
+  type EventScheduleDraft,
+  type NewEventRecurrenceDraft,
+} from "@web/events/event-draft.types";
+
+export type ParseEventDraftResult =
+  | { ok: true; mode: "create"; input: CreateEventInput }
+  | { ok: true; mode: "edit"; eventId: EventId; input: ReplaceEventInput }
+  | { ok: false; fieldErrors: Record<string, string> };
+
+// Candidate shapes are plain, unbranded data. CreateEventInputSchema /
+// ReplaceEventInputSchema.safeParse is the only place that brands/validates
+// them into a real command, so an incomplete or malformed draft can never
+// produce one.
+type TimedScheduleCandidate = {
+  kind: "timed";
+  start: string;
+  end: string;
+  timeZone: string;
+};
+
+type AllDayScheduleCandidate = {
+  kind: "allDay";
+  start: string;
+  end: string;
+};
+
+type SomedayScheduleCandidate = {
+  kind: "someday";
+  period: "week" | "month";
+  anchorDate: string;
+  sortOrder: number;
+};
+
+type ScheduleCandidate =
+  | TimedScheduleCandidate
+  | AllDayScheduleCandidate
+  | SomedayScheduleCandidate;
+
+type RecurrenceCandidate =
+  | { kind: "preserve" }
+  | { kind: "single" }
+  | { kind: "series"; rules: string[] };
+
+function isValidTimeZone(timeZone: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new Intl.DateTimeFormat("en-US", { timeZone });
+    return true;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (_error) {
+    return false;
+  }
+}
+
+function toDateOnlyString(date: Date): string {
+  return dayjs(date).toYearMonthDayString();
+}
+
+// Formats the instant in the draft's own time zone so the offset matches the
+// event's zone (not the browser's), mirroring toRFC3339OffsetString usage
+// elsewhere in the app.
+function toOffsetDateTimeString(date: Date, timeZone: string): string {
+  return dayjs.tz(date, timeZone).format();
+}
+
+function buildSchedule(
+  schedule: EventScheduleDraft,
+  fieldErrors: Record<string, string>,
+): ScheduleCandidate | null {
+  if (schedule.kind === "timed") {
+    const { start, end, timeZone } = schedule;
+
+    if (start === null) fieldErrors.start = "Start is required";
+    if (end === null) fieldErrors.end = "End is required";
+
+    if (timeZone === null) {
+      fieldErrors.timeZone = "Time zone is required";
+    } else if (!isValidTimeZone(timeZone)) {
+      fieldErrors.timeZone = "Invalid time zone";
+    }
+
+    if (
+      start !== null &&
+      end !== null &&
+      end.getTime() <= start.getTime() &&
+      !fieldErrors.end
+    ) {
+      fieldErrors.end = "End must be after start";
+    }
+
+    if (
+      start === null ||
+      end === null ||
+      timeZone === null ||
+      fieldErrors.end ||
+      fieldErrors.timeZone
+    ) {
+      return null;
+    }
+
+    return {
+      kind: "timed",
+      start: toOffsetDateTimeString(start, timeZone),
+      end: toOffsetDateTimeString(end, timeZone),
+      timeZone,
+    };
+  }
+
+  if (schedule.kind === "allDay") {
+    const { start, end } = schedule;
+
+    if (start === null) fieldErrors.start = "Start is required";
+    if (end === null) fieldErrors.end = "End is required";
+
+    if (start === null || end === null) return null;
+
+    const startStr = toDateOnlyString(start);
+    let endStr = toDateOnlyString(end);
+
+    if (endStr < startStr) {
+      fieldErrors.end = "End must not be before start";
+      return null;
+    }
+
+    // A same-day selection is valid input; normalize to an exclusive end by
+    // adding one day, mirroring the legacy mapToBackend behavior. A
+    // multi-day selection's end already represents an exclusive day and
+    // passes through unchanged.
+    if (endStr === startStr) {
+      endStr = dayjs(endStr).add(1, "day").toYearMonthDayString();
+    }
+
+    return { kind: "allDay", start: startStr, end: endStr };
+  }
+
+  // someday
+  const { period, anchorDate, sortOrder } = schedule;
+
+  if (anchorDate === null) fieldErrors.anchorDate = "Anchor date is required";
+  if (sortOrder === null) fieldErrors.sortOrder = "Sort order is required";
+
+  if (anchorDate === null || sortOrder === null) return null;
+
+  return {
+    kind: "someday",
+    period,
+    anchorDate: toDateOnlyString(anchorDate),
+    sortOrder,
+  };
+}
+
+function buildRecurrenceRules(
+  draft: NewEventRecurrenceDraft,
+  fieldErrors: Record<string, string>,
+): RecurrenceCandidate | null {
+  if (draft.kind === "single") return { kind: "single" };
+
+  const hasBlankRule = draft.rules.some((rule) => rule.trim() === "");
+
+  if (draft.rules.length === 0 || hasBlankRule) {
+    fieldErrors.recurrence = "Recurrence rules cannot be empty";
+    return null;
+  }
+
+  return { kind: "series", rules: draft.rules };
+}
+
+function buildEditRecurrence(
+  draft: EditEventRecurrenceDraft,
+  fieldErrors: Record<string, string>,
+): RecurrenceCandidate | null {
+  if (draft.kind === "preserve") return { kind: "preserve" };
+
+  return buildRecurrenceRules(draft, fieldErrors);
+}
+
+function toFieldErrors(error: z.ZodError): Record<string, string> {
+  const fieldErrors: Record<string, string> = {};
+
+  for (const issue of error.issues) {
+    const key = issue.path.length > 0 ? issue.path.join(".") : "root";
+
+    if (!(key in fieldErrors)) fieldErrors[key] = issue.message;
+  }
+
+  return fieldErrors;
+}
+
+export function parseEventDraft(draft: EventDraft): ParseEventDraftResult {
+  const fieldErrors: Record<string, string> = {};
+
+  if (draft.values.priority === null) {
+    fieldErrors.priority = "Priority is required";
+  }
+
+  if (draft.mode === "create" && draft.values.calendarId === null) {
+    fieldErrors.calendarId = "Calendar is required";
+  }
+
+  const schedule = buildSchedule(draft.values.schedule, fieldErrors);
+
+  const recurrence =
+    draft.mode === "create"
+      ? buildRecurrenceRules(draft.values.recurrence, fieldErrors)
+      : buildEditRecurrence(draft.values.recurrence, fieldErrors);
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return { ok: false, fieldErrors };
+  }
+
+  // Local validation above guarantees these are non-null; the checks stay
+  // here so control flow, not a cast, proves it to the type checker.
+  if (schedule === null || recurrence === null) {
+    return { ok: false, fieldErrors };
+  }
+
+  const content = {
+    kind: "details" as const,
+    title: draft.values.title,
+    description: draft.values.description,
+  };
+
+  if (draft.mode === "create") {
+    const candidate = {
+      calendarId: draft.values.calendarId,
+      content,
+      schedule,
+      recurrence,
+      priority: draft.values.priority,
+    };
+
+    const parsed = CreateEventInputSchema.safeParse(candidate);
+
+    if (!parsed.success) {
+      return { ok: false, fieldErrors: toFieldErrors(parsed.error) };
+    }
+
+    return { ok: true, mode: "create", input: parsed.data };
+  }
+
+  const editDraft: EditEventDraft = draft;
+  const candidate = {
+    content,
+    schedule,
+    recurrence,
+    priority: editDraft.values.priority,
+    scope: editDraft.values.scope,
+  };
+
+  const parsed = ReplaceEventInputSchema.safeParse(candidate);
+
+  if (!parsed.success) {
+    return { ok: false, fieldErrors: toFieldErrors(parsed.error) };
+  }
+
+  return {
+    ok: true,
+    mode: "edit",
+    eventId: editDraft.eventId,
+    input: parsed.data,
+  };
+}

--- a/packages/web/src/events/event-draft.types.ts
+++ b/packages/web/src/events/event-draft.types.ts
@@ -1,0 +1,80 @@
+import {
+  type CalendarId,
+  type EventId,
+  type Priority,
+} from "@core/types/domain-primitives";
+import { type RecurrenceScope } from "@core/types/event-command.contracts";
+
+// Drafts use required keys with nullable incomplete values. This confines
+// form checks to one place without recreating the optional-property problem.
+export type EventScheduleDraft =
+  | {
+      kind: "timed";
+      start: Date | null;
+      end: Date | null;
+      timeZone: string | null;
+    }
+  | {
+      kind: "allDay";
+      start: Date | null;
+      end: Date | null;
+    }
+  | {
+      kind: "someday";
+      period: "week" | "month";
+      anchorDate: Date | null;
+      sortOrder: number | null;
+    };
+
+export type NewEventRecurrenceDraft =
+  | { kind: "single" }
+  | { kind: "series"; rules: string[] };
+
+export type EditEventRecurrenceDraft =
+  | { kind: "preserve" }
+  | NewEventRecurrenceDraft;
+
+type SharedEventFormValues = {
+  title: string;
+  description: string;
+  schedule: EventScheduleDraft;
+  priority: Priority | null;
+};
+
+// A new draft can only use "single" or "series" and has no irrelevant
+// recurrence scope.
+export type NewEventFormValues = SharedEventFormValues & {
+  calendarId: CalendarId | null;
+  recurrence: NewEventRecurrenceDraft;
+};
+
+// An edit starts with "preserve", so the backend retains the stored
+// single/series/occurrence identity unless the user explicitly changes
+// recurrence. The client never submits a seriesId.
+export type EditEventFormValues = SharedEventFormValues & {
+  calendarId: CalendarId;
+  recurrence: EditEventRecurrenceDraft;
+  scope: RecurrenceScope;
+};
+
+export type EventFormValues = NewEventFormValues | EditEventFormValues;
+
+type DraftState<TValues extends EventFormValues> = {
+  values: TValues;
+  isDirty: boolean;
+  submitError: string | null;
+};
+
+export type NewEventDraft = DraftState<NewEventFormValues> & {
+  mode: "create";
+};
+
+// originalCalendarId is displayed but never included in ReplaceEventInput,
+// so an edit cannot move an existing event between calendars.
+export type EditEventDraft = DraftState<EditEventFormValues> & {
+  mode: "edit";
+  eventId: EventId;
+  originalCalendarId: CalendarId;
+};
+
+export type EventDraft = NewEventDraft | EditEventDraft;

--- a/packages/web/src/events/event-view.types.ts
+++ b/packages/web/src/events/event-view.types.ts
@@ -1,0 +1,52 @@
+import { type CalendarId, type EventId } from "@core/types/domain-primitives";
+import { type BusyPeriod, type Event } from "@core/types/event.contracts";
+
+export type EventEntityMap = Record<EventId, Event>;
+
+export type NormalizedEvents = {
+  ids: EventId[];
+  entities: EventEntityMap;
+};
+
+export type OptimisticEvent = {
+  event: Event;
+  mutation: {
+    id: string;
+    state: "creating" | "updating" | "deleting" | "failed";
+  };
+};
+
+// Layout code consumes GridCalendarItem; mutation code narrows
+// CalendarItem.kind === "event" before exposing actions.
+export type CalendarItem =
+  | { kind: "event"; event: Event }
+  | { kind: "busyPeriod"; busyPeriod: BusyPeriod };
+
+export type GridEventLayout = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  zIndex: number;
+  isOverlapping: boolean;
+  dragOffset: { x: number; y: number };
+};
+
+export type GridCalendarItem = {
+  item: CalendarItem;
+  layout: GridEventLayout;
+};
+
+export type SelectedDateRange = {
+  start: Date;
+  end: Date;
+  kind: "timed" | "allDay";
+};
+
+export type SomedayColumnView = {
+  period: "week" | "month";
+  anchorDate: string;
+  eventIds: EventId[];
+};
+
+export type CalendarEventIndex = Record<CalendarId, EventId[]>;


### PR DESCRIPTION
## Summary

Implements plan packet **01 — domain contracts** from the sub-calendar v1 roadmap (#2012). Purely additive: the strict calendar-owned contracts land alongside the legacy model; no runtime path changes until packet 03's cutover.

- **core** (`packages/core/src/types/`): branded domain primitives (`EventId`, `CalendarId`, `DateOnly`, `DateTime`, `TimeZone`, `SortOrder`, `RRule`); discriminated `Event` (`content` details|busy, `schedule` timed|allDay|someday with exclusive all-day ends, `recurrence` single|series|occurrence); `BusyPeriod`; `Calendar` with derived capabilities; command contracts including the optional client create id (A25) and the someday↔scheduled `TransitionEventInput` (A24); strict SSE `ServerMessage` union covering import results and user metadata (A27)
- **backend**: `CalendarRecord`/`EventRecord` Mongo schemas (`zObjectId` sentinel so `$jsonSchema` derivation keeps `bsonType: objectId`; single nullable `externalReference`; no `origin` per A34); Google CalendarList/Event adapters with the reader-withheld busy-content heuristic, timezone fallback ladder (A26), exclusive-end normalization, and `events.patch` write bodies (A28)
- **web**: `EventDraft`/view types, `LocalEventRecord` (version 2, `isDemo`, no `syncState` per A35), and `parseEventDraft` — every draft is gated through the core input schemas before it can become a command
- **docs**: target-contract section added to the architecture domain model

## Validation

- `bun test:core` 265 pass (+127), `bun test:web` 1260 pass (+21), `bun test:backend` 74/74 suites / 543 pass (+67), `bun test:scripts` 64 pass
- `bun run type-check` clean; `bun lint` clean on all new files (repo-wide pre-existing diagnostics untouched)
- Note for local runs: the backend jest suite requires `TZ=UTC` in the environment (`ConfigSchema` rejects anything else)

## Notes

- Decision references (A24–A35) are the dated rows in `handoff/someday/master-doc.md` on #2012
- `migrateLocalEvent` (legacy IndexedDB conversion) is deferred to packet 02's shared transform, per the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)