### PR TITLE
fix(web): stop grid drafts from displaying in UTC instead of local time

### DIFF
--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -3,6 +3,7 @@ import { type Event } from "@core/types/event.contracts";
 import {
   createGridEventDraft,
   editGridEventDraft,
+  gridEventDraftToSchemaEvent,
   parseGridEventDraft,
   replaceGridDraftSchedule,
 } from "./grid-event-draft.adapter";
@@ -76,6 +77,23 @@ test("replaces only the draft schedule during a drag or resize", () => {
 
   expect(updated.values.schedule.start).toEqual(new Date("2026-07-12"));
   expect(updated.values.calendarId).toBeNull();
+});
+
+test("keeps the schedule's own UTC offset instead of forcing Z", () => {
+  // _getTimeLabel (web.date.util.ts) reads the offset embedded in
+  // Schema_Event.startDate/endDate to decide what time to display - it does
+  // not localize to the browser's timezone. Date#toISOString() always
+  // produces a "Z" (UTC) suffix, which made every grid-created/dragged event
+  // display in UTC instead of local time for any non-UTC browser. dayjs's
+  // default format() preserves the local offset instead, matching every
+  // other Schema_Event producer (draft.util.ts, someday.draft.util.ts, etc).
+  const draft = editGridEventDraft(timedEvent);
+  if (!draft) throw new Error("Expected scheduled event draft");
+
+  const schemaEvent = gridEventDraftToSchemaEvent(draft);
+
+  expect(schemaEvent.startDate).not.toMatch(/Z$/);
+  expect(schemaEvent.endDate).not.toMatch(/Z$/);
 });
 
 test("parses an edit draft into a replace command", () => {

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -2,6 +2,7 @@ import { Priorities } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
 import { type Schema_Event } from "@core/types/event.types";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import {
   type ParseEventDraftResult,
@@ -155,7 +156,7 @@ export function gridEventDraftToSchemaEvent(
     endDate:
       schedule.kind === "allDay"
         ? toDateOnlyString(schedule.end)
-        : schedule.end.toISOString(),
+        : dayjs(schedule.end).format(),
     isAllDay: schedule.kind === "allDay",
     isSomeday: false,
     priority: draft.values.priority ?? Priorities.UNASSIGNED,
@@ -166,7 +167,7 @@ export function gridEventDraftToSchemaEvent(
     startDate:
       schedule.kind === "allDay"
         ? toDateOnlyString(schedule.start)
-        : schedule.start.toISOString(),
+        : dayjs(schedule.start).format(),
     title: draft.values.title,
   };
 }


### PR DESCRIPTION
## Summary

Found while running `/qa-staging` right after PR #2019 merged: creating or dragging an event on the grid rendered/announced its time 6 hours off (in `America/Denver`, UTC-6) once it round-tripped through a reload.

`gridEventDraftToSchemaEvent` (added in #2019) serialized dates with `Date#toISOString()`, which always emits a `Z` (UTC) suffix. `_getTimeLabel` in `web.date.util.ts` reads the UTC offset embedded in `Schema_Event.startDate`/`endDate` directly rather than localizing to the browser's timezone - that's the existing, intentional convention every other `Schema_Event` producer in the app follows (`draft.util.ts`, `someday.draft.util.ts`, etc. all use dayjs's default `.format()`, which preserves the local offset). `#2019`'s new code broke that convention for the grid draft pipeline it converted.

CI's unit suite runs with `TZ=UTC`, where `toISOString()` and `.format()` produce visually different but numerically equivalent output (`Z` vs `+00:00`), so nothing failed - it only surfaces for non-UTC browsers.

## Fix
- `gridEventDraftToSchemaEvent` now uses `dayjs(...).format()` for timed schedules, matching the rest of the codebase.
- Added a regression test that asserts the offset suffix directly (not `Z`) rather than comparing wall-clock output, so it fails under `TZ=UTC` too.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1252/1252 pass
- [x] New regression test verified failing before the fix and passing after, under both `TZ=UTC` and `TZ=America/Denver`
- [x] Reproduced live on staging before the fix (created + dragged an event, saw it announced/labeled 6h off after reload), will re-verify on staging after this deploys

## Manual Testing Steps
1. Go to staging (or set your OS timezone to something other than UTC) and create a timed event by clicking an empty grid slot
2. Reload the page
3. Confirm the event's displayed and announced (hover/accessible name) time matches what you actually clicked, not a UTC-shifted time