### PR TITLE
refactor(web): convert Day drag-create preview to GridEventDraft

### DIFF
--- a/handoff/someday/03-event-runtime-cutover.md
+++ b/handoff/someday/03-event-runtime-cutover.md
@@ -45,10 +45,19 @@ remaining ~13 files, in addition to what's converted:
   dragged; `GridEventDraft` carries no grid-layout position data. Needs
   either a position field added to the draft or the keyboard-edit path
   routed differently.
-- **Day drag-preview client id**: `useDayTimedDraftCreation.ts`'s in-progress
-  drag preview carries a client-assigned `_id` that `dayCalendarDraft.util.ts`
-  matches against; `GridEventDraft`'s `"create"` kind has no field for a
-  pre-assigned id.
+- ~~**Day drag-preview client id**~~ — closed on `refactor/web-event-legacy-bridge-2`:
+  added an optional `clientId` to `GridEventDraft`'s `"create"` kind so
+  `useDayTimedDraftCreation.ts`'s in-progress drag preview can carry the
+  same client-assigned id `dayCalendarDraft.util.ts`'s
+  `isDraftOnlyEvent`/`isActiveDraftEvent` match against. Note this gap was
+  Day-specific: Week's equivalent (`useTimedGridDraftCreation.ts`) never
+  needed an id because Week overlays the draft separately rather than
+  merging it into the persisted-events array by `_id`. `DayCalendarGrid.tsx`
+  still has its own separate remaining marker — `getDayEventById` bridges to
+  `assembleGridEvent`, which still expects `Schema_Event`; that's the grid
+  *renderer* (not draft-opening) and is part of the wider
+  `Schema_GridEvent`/`web.event.types.ts` renderer conversion referenced in
+  this packet's step 2, not this gap.
 
 `useUpdateEvent.ts`'s live drag/resize position updates and the local
 `Schema_GridEvent` drag-geometry state in `useDraftState.ts` (10+ consumers:

--- a/packages/web/src/events/event-draft.types.ts
+++ b/packages/web/src/events/event-draft.types.ts
@@ -99,6 +99,13 @@ export type GridEventDraft =
   | {
       kind: "create";
       source: null;
+      /**
+       * Optional client-assigned id for a not-yet-saved draft. Lets
+       * placeholder-matching code (e.g. dayCalendarDraft.util.ts) recognize
+       * the same in-progress draft across re-renders before it has a
+       * server-issued id.
+       */
+      clientId?: EventId;
       values: GridDraftValues<NewEventFormValues>;
     }
   | {

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -1,4 +1,5 @@
 import { Priorities } from "@core/constants/core.constants";
+import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { type Schema_Event } from "@core/types/event.types";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
@@ -40,10 +41,12 @@ function gridScheduleFromEvent(event: Event): GridScheduleDraft | null {
 
 export function createGridEventDraft(
   schedule: GridScheduleDraft,
+  clientId?: EventId,
 ): GridEventDraft {
   return {
     kind: "create",
     source: null,
+    clientId,
     values: {
       title: "",
       description: "",
@@ -151,7 +154,7 @@ export function gridEventDraftToSchemaEvent(
   const { schedule } = draft.values;
 
   return {
-    _id: draft.kind === "edit" ? draft.source.id : undefined,
+    _id: draft.kind === "edit" ? draft.source.id : draft.clientId,
     description: draft.values.description,
     endDate:
       schedule.kind === "allDay"

--- a/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
@@ -4,12 +4,17 @@ import {
   useEffect,
   useRef,
 } from "react";
+import { type EventId } from "@core/types/domain-primitives";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
   addId,
   assembleDefaultEvent,
 } from "@web/common/utils/event/event.util";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
 import {
   hasExceededCalendarInteractionMoveThreshold,
@@ -124,15 +129,19 @@ export const useDayTimedDraftCreation = ({
               return;
             }
 
-            // NOT converted to GridEventDraft/createGridEventDraft: nextEvent
-            // carries a client-assigned `_id` (via addId) that
+            // GridEventDraft's clientId keeps the same client-assigned id
+            // (from addId, below) across preview updates so
             // dayCalendarDraft.util.ts's isPlaceholder/isActiveDraft matching
-            // depends on. GridEventDraft's "create" kind has no field for a
-            // pre-assigned id (source is null), so routing this through
-            // startGridDraft would drop the id and break placeholder
-            // matching during drag-preview. See packet-03-phase-3c scoping
-            // note.
-            draftActions.startGridClick(nextEvent);
+            // can recognize this draft before it has a server-issued id.
+            const draft = createGridEventDraft(
+              timedGridSchedule(
+                new Date(nextEvent.startDate),
+                new Date(nextEvent.endDate),
+              ),
+              nextEvent._id as EventId,
+            );
+
+            draftActions.startGridDraft({ activity: "gridClick", draft });
           },
         );
       };


### PR DESCRIPTION
## Summary

Continues packet 03 (`handoff/someday/03-event-runtime-cutover.md`). A prior phase (#2019) documented three structural gaps blocking the rest of the legacy-bridge dissolution; this closes the smallest one.

- Added an optional `clientId` field to `GridEventDraft`'s `"create"` kind, so a not-yet-saved draft can carry a stable client-assigned id across preview updates.
- `useDayTimedDraftCreation.ts`'s drag-create preview now builds a `GridEventDraft` (reusing the existing `addId`-assigned client id) and writes it via `draftActions.startGridDraft`, instead of the legacy `startGridClick`.

This gap was Day-specific: `dayCalendarDraft.util.ts`'s `isDraftOnlyEvent`/`isActiveDraftEvent` match the draft against the persisted-events array by `_id`. Week's equivalent (`useTimedGridDraftCreation.ts`, already converted) never needed this because Week overlays the draft separately rather than merging it into the persisted-events array by id — confirmed by inspection before writing this, so the fix targets the actual constraint rather than copying Week's pattern.

`DayCalendarGrid.tsx` keeps its own separate TODO marker (`getDayEventById` bridges to `assembleGridEvent`, which still expects `Schema_Event`) — that's the grid *renderer*, a different, wider piece of this packet (see the packet doc's step 2), not this gap.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1252/1252 pass
- [x] `bunx playwright test`: 11/11 pass
- [x] Manually exercised the Day-view drag-create flow against a local dev server (mouse drag + synthetic event dispatch) — no console errors, no thrown exceptions