### PR TITLE
refactor(web): read someday sidebar events as strict Event

### DIFF
--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -1,8 +1,6 @@
 import { z } from "zod";
-import {
-  CompassCoreEventSchema,
-  type Schema_Event,
-} from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
+import { CompassCoreEventSchema } from "@core/types/event.types";
 import { IDSchema } from "@core/types/type.utils";
 import { type SelectOption } from "@web/common/types/component.types";
 
@@ -58,7 +56,7 @@ export interface Schema_SelectedDates {
   endTime: SelectOption<string>;
   isAllDay: boolean;
 }
-export interface Schema_SomedayEventsColumn {
+export interface Someday_EventsColumn {
   columns: {
     [key: string]: {
       id: string;
@@ -67,7 +65,7 @@ export interface Schema_SomedayEventsColumn {
   };
   columnOrder: string[];
   events: {
-    [key: string]: Schema_Event;
+    [key: string]: Event;
   };
 }
 

--- a/packages/web/src/common/utils/event/someday.event.util.test.ts
+++ b/packages/web/src/common/utils/event/someday.event.util.test.ts
@@ -75,14 +75,14 @@ describe("categorizeSomedayEvents", () => {
     expect(result.columnOrder).toEqual([COLUMN_WEEK, COLUMN_MONTH]);
   });
 
-  it("bridges each event into the legacy Schema_Event shape for the sidebar renderer", () => {
+  it("returns each event as the strict Event contract for the sidebar renderer", () => {
     const event = someday({ period: "week" });
     const result = categorizeSomedayEvents(normalized([event]), undefined);
 
-    expect(result.events[event.id]).toMatchObject({
-      _id: event.id,
-      isSomeday: true,
-      order: 0,
+    expect(result.events[event.id]).toBe(event);
+    expect(result.events[event.id]?.schedule).toMatchObject({
+      kind: "someday",
+      sortOrder: 0,
     });
   });
 });

--- a/packages/web/src/common/utils/event/someday.event.util.ts
+++ b/packages/web/src/common/utils/event/someday.event.util.ts
@@ -1,3 +1,6 @@
+import { Priorities } from "@core/constants/core.constants";
+import { type DateOnly } from "@core/types/domain-primitives";
+import { type Event } from "@core/types/event.contracts";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import {
@@ -6,11 +9,11 @@ import {
   ID_SOMEDAY_EVENT_ACTION_MENU,
 } from "@web/common/constants/web.constants";
 import {
-  type Schema_SomedayEventsColumn,
   type Schema_WebEvent,
+  type Someday_EventsColumn,
 } from "@web/common/types/web.event.types";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { type Payload_ConvertEvent } from "@web/events/event.types";
-import { eventToSchemaEvent } from "@web/events/queries/event.legacy-bridge";
 import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
 import { parseSomedayEventBeforeSubmit } from "@web/views/Week/components/Draft/hooks/actions/submit.parser";
 
@@ -87,16 +90,13 @@ export const getSomedayEventCategory = (
  * contract's required field (no more client backfill for a missing legacy
  * `order`).
  *
- * Returns the legacy `Schema_SomedayEventsColumn` shape (bridged via
- * eventToSchemaEvent) so the sidebar components consuming it don't need to
- * change in this phase.
- * TODO(packet-03-phase-3c): return `Event`-shaped columns once the sidebar
- * renderer is converted, and drop the bridge.
+ * Returns `Event`-shaped columns directly — the sidebar renderer consumes
+ * the strict contract, no legacy `Schema_Event` bridge involved.
  */
 export const categorizeSomedayEvents = (
   weekData: NormalizedEventQueryData | undefined,
   monthData: NormalizedEventQueryData | undefined,
-): Schema_SomedayEventsColumn => {
+): Someday_EventsColumn => {
   const bySortOrder = (data: NormalizedEventQueryData | undefined) =>
     data
       ? [...data.ids]
@@ -113,9 +113,9 @@ export const categorizeSomedayEvents = (
   const weekEvents = bySortOrder(weekData);
   const monthEvents = bySortOrder(monthData);
 
-  const events: Schema_SomedayEventsColumn["events"] = {};
+  const events: Someday_EventsColumn["events"] = {};
   for (const event of [...weekEvents, ...monthEvents]) {
-    events[event.id] = eventToSchemaEvent(event);
+    events[event.id] = event;
   }
 
   return {
@@ -133,6 +133,98 @@ export const categorizeSomedayEvents = (
     events,
   };
 };
+
+// The sidebar's local draft/preview state holds strict `Event` objects, but
+// the someday create/edit form and its supporting utils (submit.parser,
+// web.date.util, event.util) still speak the legacy `Schema_Event` shape —
+// see event.legacy-bridge.ts's own TODO. These two helpers are the reverse
+// direction of `eventToSchemaEvent`: they build a best-effort `Event` from a
+// `Schema_Event` at the specific points the sidebar needs to hand a
+// Schema_Event-shaped draft/edit back into Event-typed local state
+// (freshly-created events, drag-computed date ranges). Never sent to a
+// mutation — those still submit the `Schema_Event`-shaped draft directly via
+// the legacy adapter.
+const someEventScheduleFromLegacy = (
+  event: Schema_Event,
+): Event["schedule"] => ({
+  kind: "someday",
+  period:
+    dayjs(event.endDate).diff(dayjs(event.startDate), "day") > 7
+      ? "month"
+      : "week",
+  // A brand-new draft has no startDate yet (assigned at submit time from the
+  // target category/view range, see useSidebarActions.ts's onSubmit) --
+  // anchor on today rather than an empty string, which downstream date
+  // parsing (parseCompassEventDate) throws on.
+  anchorDate: (event.startDate || dayjs().toYearMonthDayString()).slice(
+    0,
+    10,
+  ) as DateOnly,
+  sortOrder: event.order ?? 0,
+});
+
+const someEventRecurrenceFromLegacy = (
+  event: Schema_Event,
+): Event["recurrence"] => {
+  const rule = event.recurrence?.rule;
+
+  if (Array.isArray(rule) && rule.length > 0) {
+    return { kind: "series", rules: rule };
+  }
+
+  if (event.recurrence?.eventId) {
+    return {
+      kind: "occurrence",
+      seriesId: event.recurrence.eventId as Event["id"],
+    };
+  }
+
+  return { kind: "single" };
+};
+
+/**
+ * Reapplies a legacy `Schema_Event`'s user-editable fields (title,
+ * description, dates, recurrence, priority) onto an existing local `Event`,
+ * keeping `id`/`calendarId` from `base` unless the schema event carries a
+ * (real, already-persisted) id of its own.
+ */
+export const applySchemaEventToLocalEvent = (
+  base: Event,
+  schemaEvent: Schema_Event,
+): Event => ({
+  ...base,
+  id: (schemaEvent._id ?? base.id) as Event["id"],
+  content: {
+    kind: "details",
+    title: schemaEvent.title ?? "",
+    description: schemaEvent.description ?? "",
+  },
+  schedule: someEventScheduleFromLegacy(schemaEvent),
+  recurrence: someEventRecurrenceFromLegacy(schemaEvent),
+  priority: schemaEvent.priority ?? base.priority,
+});
+
+/**
+ * Builds a full local `Event` from a legacy `Schema_Event`, generating an id
+ * if the schema event doesn't have one yet (a brand-new, unsaved draft).
+ */
+export const schemaEventToLocalEvent = (
+  schemaEvent: Schema_Event,
+  calendarId: string,
+): Event => ({
+  id: (schemaEvent._id ?? createObjectIdString()) as Event["id"],
+  calendarId: calendarId as Event["calendarId"],
+  content: {
+    kind: "details",
+    title: schemaEvent.title ?? "",
+    description: schemaEvent.description ?? "",
+  },
+  schedule: someEventScheduleFromLegacy(schemaEvent),
+  recurrence: someEventRecurrenceFromLegacy(schemaEvent),
+  priority: schemaEvent.priority ?? Priorities.UNASSIGNED,
+  createdAt: dayjs().toISOString() as Event["createdAt"],
+  updatedAt: null,
+});
 
 export const isSomedayEventActionMenuOpen = () => {
   const actionMenu = document.getElementById(ID_SOMEDAY_EVENT_ACTION_MENU);

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEventSections.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEventSections.tsx
@@ -1,5 +1,5 @@
 import { type FC } from "react";
-import { type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
 import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
 import { type State_Sidebar } from "@web/components/PlannerSidebar/draft/hooks/useSidebarState";
@@ -17,9 +17,9 @@ interface Props {
 const getSectionEvents = (
   columnName: typeof COLUMN_WEEK | typeof COLUMN_MONTH,
   somedayEvents: State_Sidebar["somedayEvents"],
-): Schema_Event[] =>
-  somedayEvents.columns[columnName].eventIds.map(
-    (eventId) => somedayEvents.events[eventId],
+): Event[] =>
+  somedayEvents.columns[columnName].eventIds.flatMap((eventId) =>
+    somedayEvents.events[eventId] ? [somedayEvents.events[eventId]] : [],
   );
 
 export const SomedayEventSections: FC<Props> = ({

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
@@ -1,16 +1,17 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { Priorities } from "@core/constants/core.constants";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type Props_DraftForm } from "@web/views/Week/components/Draft/hooks/state/useDraftForm";
 import { SomedayEvent } from "./SomedayEvent";
 import { describe, expect, it, mock } from "bun:test";
 
-const createEvent = (): Schema_Event =>
-  ({
-    _id: "event-1",
+const createEvent = (): Event =>
+  createMockEvent({
     priority: Priorities.WORK,
-    title: "Plan launch",
-  }) as Schema_Event;
+    content: { kind: "details", title: "Plan launch", description: "" },
+  });
 
 const formProps = {
   getReferenceProps: () => ({}),

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
@@ -1,6 +1,6 @@
 import { type KeyboardEvent, type Ref } from "react";
 import { type Priorities } from "@core/constants/core.constants";
-import { type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import { colorByPriority } from "@web/common/styles/theme.util";
@@ -15,7 +15,7 @@ import {
 
 interface Props {
   category: SomedayInteractionCategory;
-  event: Schema_Event;
+  event: Event;
   status: {
     isDrafting: boolean;
     isDragging: boolean;
@@ -57,7 +57,7 @@ export const SomedayEvent = ({
   const tint = (percent: number) =>
     `color-mix(in srgb, ${colorByPriority[priority]} ${percent}%, transparent)`;
   const somedayEventProps = {
-    [DATA_EVENT_ELEMENT_ID]: event._id,
+    [DATA_EVENT_ELEMENT_ID]: event.id,
     "aria-hidden": isDragging || undefined,
     onBlur,
     onClick,

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
@@ -2,6 +2,7 @@ import { FloatingFocusManager, FloatingPortal } from "@floating-ui/react";
 import { type Ref, useRef } from "react";
 import { toast } from "react-toastify";
 import { Priorities } from "@core/constants/core.constants";
+import { type Event } from "@core/types/event.contracts";
 import {
   Categories_Event,
   RecurringEventUpdateScope,
@@ -13,12 +14,16 @@ import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 import { computeCurrentEventDateRange } from "@web/common/utils/datetime/web.date.util";
 import { getDraftTimes } from "@web/common/utils/draft/draft.util";
 import { refocusEventElement } from "@web/common/utils/event/event.util";
+import { schemaEventToLocalEvent } from "@web/common/utils/event/someday.event.util";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
 import { type Setters_Sidebar } from "@web/components/PlannerSidebar/draft/hooks/useSidebarState";
 import { type SomedayInteractionCategory } from "@web/components/PlannerSidebar/SomedayEventSections/interaction/registry/somedayEventRegistry";
 import { SomedayEvent } from "@web/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
-import { createLegacyEventMutationsAdapter } from "@web/events/queries/event.legacy-bridge";
+import {
+  createLegacyEventMutationsAdapter,
+  eventToSchemaEvent,
+} from "@web/events/queries/event.legacy-bridge";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { FloatingFormContainer } from "@web/views/Forms/SomedayEventForm/FloatingFormContainer";
 import { SomedayEventForm } from "@web/views/Forms/SomedayEventForm/SomedayEventForm";
@@ -27,7 +32,7 @@ import { getSidebarOpenWidth } from "@web/views/Week/layout.constants";
 
 export interface Props {
   category: SomedayInteractionCategory;
-  event: Schema_Event;
+  event: Event;
   isDrafting: boolean;
   isDragging: boolean;
   onSubmit: (event: Schema_Event | null) => void;
@@ -65,7 +70,7 @@ export const SomedayEventContainer = ({
 
   const formProps = useDraftForm(
     category,
-    state.isSomedayFormOpen && state.draft?._id === event._id,
+    state.isSomedayFormOpen && state.draft?.id === event.id,
     actions.discard,
     actions.reset,
     setters.setIsSomedayFormOpen,
@@ -75,12 +80,11 @@ export const SomedayEventContainer = ({
 
   useAppShortcut("Enter", () => {
     if (!isFocusedRef.current) return;
-    actions.onDraft(event, category);
+    actions.onDraft(eventToSchemaEvent(event), category);
   });
 
   const migrateEvent = (direction: "up" | "down") => {
-    const canMigrate =
-      !event.recurrence?.rule || event.recurrence?.rule.length === 0;
+    const canMigrate = event.recurrence.kind === "single";
     if (!canMigrate) {
       toast.error("Can't migrate recurring events");
       return;
@@ -91,16 +95,16 @@ export const SomedayEventContainer = ({
         : (["month", Categories_Event.SOMEDAY_MONTH] as const);
     void actions.onSubmit(
       targetCategory,
-      computeCurrentEventDateRange({ duration }, event, weekViewRange),
+      computeCurrentEventDateRange(
+        { duration },
+        eventToSchemaEvent(event),
+        weekViewRange,
+      ),
     );
-    if (event._id) {
-      refocusEventElement(event._id);
-    }
+    refocusEventElement(event.id);
   };
 
   const scheduleEvent = () => {
-    if (!event._id) return;
-
     const isCurrentWeek = dayjs().isBetween(
       weekViewRange.startDate,
       weekViewRange.endDate,
@@ -114,14 +118,14 @@ export const SomedayEventContainer = ({
 
     convertToCalendar({
       event: {
-        _id: event._id,
+        _id: event.id,
         startDate,
         endDate,
         isAllDay: false,
         isSomeday: false,
       },
     });
-    refocusEventElement(event._id);
+    refocusEventElement(event.id);
   };
 
   const whenFocused =
@@ -141,9 +145,24 @@ export const SomedayEventContainer = ({
   );
   useAppShortcut("Shift+ArrowRight", whenFocused(scheduleEvent));
 
-  const isDraftingThisEvent =
-    state.isDrafting && state.draft?._id === event._id;
-  const formEvent = isDraftingThisEvent && state.draft ? state.draft : event;
+  const isDraftingThisEvent = state.isDrafting && state.draft?.id === event.id;
+  // A brand-new draft's `state.draft.id`/dates are client-synthesized
+  // placeholders (schemaEventToLocalEvent invents an id and anchors the
+  // schedule on today to satisfy Event's required fields, since this local
+  // cache always holds full Event bodies). Neither must read back as real:
+  // a synthesized `_id` makes onSubmit's edit/create branch pick "edit" for
+  // an id nothing in the repository has, silently dropping the create; a
+  // synthesized `startDate`/`endDate` short-circuits onSubmit's own
+  // getDatesByCategory computation, persisting today's date instead of the
+  // target column's actual (week-start-normalized) range.
+  const formEvent = {
+    ...eventToSchemaEvent(
+      isDraftingThisEvent && state.draft ? state.draft : event,
+    ),
+    ...(state.isDraftingNew
+      ? { _id: undefined, startDate: undefined, endDate: undefined }
+      : {}),
+  };
 
   return (
     <>
@@ -158,7 +177,7 @@ export const SomedayEventContainer = ({
           isFocusedRef.current = false;
         }}
         onClick={() => {
-          actions.onDraft(event, category);
+          actions.onDraft(eventToSchemaEvent(event), category);
         }}
         onFocus={() => {
           isFocusedRef.current = true;
@@ -189,9 +208,7 @@ export const SomedayEventContainer = ({
                 }}
                 onDelete={() => {
                   // For recurring someday events, delete the entire series
-                  const isRecurring =
-                    Array.isArray(event.recurrence?.rule) ||
-                    typeof event.recurrence?.eventId === "string";
+                  const isRecurring = event.recurrence.kind !== "single";
                   const deleteScope = isRecurring
                     ? RecurringEventUpdateScope.ALL_EVENTS
                     : RecurringEventUpdateScope.THIS_EVENT;
@@ -200,7 +217,18 @@ export const SomedayEventContainer = ({
                 onDuplicate={duplicateEvent}
                 onMigrate={actions.onMigrate}
                 onSubmit={onSubmit}
-                setEvent={setEvent}
+                setEvent={(next) =>
+                  setEvent((previous) => {
+                    const resolved =
+                      typeof next === "function"
+                        ? next(previous ? eventToSchemaEvent(previous) : null)
+                        : next;
+
+                    return resolved
+                      ? schemaEventToLocalEvent(resolved, event.calendarId)
+                      : null;
+                  })
+                }
               />
             </FloatingFormContainer>
           </FloatingFocusManager>

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type Props_DraftForm } from "@web/views/Week/components/Draft/context/DraftContext";
 import { describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
@@ -13,15 +15,19 @@ const formProps = {
   getReferenceProps: () => ({}),
 } as unknown as Props_DraftForm;
 
-const createEvent = (overrides: Partial<Schema_Event> = {}): Schema_Event =>
-  ({
-    _id: "someday-1",
-    isSomeday: true,
-    title: "Read a book",
+const createEvent = (overrides: Partial<Event> = {}): Event =>
+  createMockEvent({
+    content: { kind: "details", title: "Read a book", description: "" },
+    schedule: EventScheduleSchema.parse({
+      kind: "someday",
+      period: "week",
+      anchorDate: "2026-05-17",
+      sortOrder: 0,
+    }),
     ...overrides,
-  }) as Schema_Event;
+  });
 
-const renderRectangle = (event: Schema_Event) =>
+const renderRectangle = (event: Event) =>
   render(
     <SomedayEventRectangle
       category={Categories_Event.SOMEDAY_WEEK}
@@ -46,7 +52,9 @@ describe("SomedayEventRectangle", () => {
 
   it("shows a passive repeat indicator instead of a migrate control for a recurring event", () => {
     renderRectangle(
-      createEvent({ recurrence: { rule: ["RRULE:FREQ=WEEKLY"] } }),
+      createEvent({
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      }),
     );
 
     // The recurrence is announced, but there is no interactive migrate/warning

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
@@ -1,8 +1,9 @@
 import { CaretLeft, CaretRight, DotsSixVertical } from "@phosphor-icons/react";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
-import { isRecurringEvent } from "@core/util/event/event.util";
+import { type Event } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
 import { RepeatIcon } from "@web/components/Icons/Repeat";
 import { type Actions_Sidebar } from "@web/components/PlannerSidebar/draft/hooks/useSidebarActions";
+import { eventToSchemaEvent } from "@web/events/queries/event.legacy-bridge";
 import { type Props_DraftForm } from "@web/views/Week/components/Draft/context/DraftContext";
 
 const ACTIONS_CLASS_NAME =
@@ -13,7 +14,7 @@ const ACTION_BUTTON_CLASS_NAME =
 
 interface Props {
   category: Categories_Event;
-  event: Schema_Event;
+  event: Event;
   onMigrate: Actions_Sidebar["onMigrate"];
   formProps: Props_DraftForm;
 }
@@ -25,7 +26,8 @@ export const SomedayEventRectangle = ({
   onMigrate,
 }: Props) => {
   const target = category === Categories_Event.SOMEDAY_WEEK ? "week" : "month";
-  const canMigrate = !isRecurringEvent(event);
+  const canMigrate = event.recurrence.kind === "single";
+  const title = event.content.kind === "details" ? event.content.title : "";
 
   return (
     <div
@@ -49,7 +51,7 @@ export const SomedayEventRectangle = ({
             className="relative min-w-0 truncate text-m"
             style={{ lineHeight: "16px" }}
           >
-            {event.title}
+            {title}
           </span>
         </div>
 
@@ -63,7 +65,7 @@ export const SomedayEventRectangle = ({
               className={ACTION_BUTTON_CLASS_NAME}
               onClick={(e) => {
                 e.stopPropagation();
-                onMigrate(event, category, "back");
+                onMigrate(eventToSchemaEvent(event), category, "back");
               }}
               title={`Migrate to previous ${target}`}
               type="button"
@@ -75,7 +77,7 @@ export const SomedayEventRectangle = ({
               className={ACTION_BUTTON_CLASS_NAME}
               onClick={(e) => {
                 e.stopPropagation();
-                onMigrate(event, category, "forward");
+                onMigrate(eventToSchemaEvent(event), category, "forward");
               }}
               title={`Migrate to next ${target}`}
               type="button"

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventItem/SomedayEventItem.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventItem/SomedayEventItem.tsx
@@ -1,5 +1,5 @@
 import { type FC, useLayoutEffect, useRef } from "react";
-import { type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
 import {
   type SomedayInteractionCategory,
@@ -14,7 +14,7 @@ const SOMEDAY_SORT_ANIMATION_EASING = "cubic-bezier(0.2, 0, 0, 1)";
 export interface Props {
   category: SomedayInteractionCategory;
   draftId: string;
-  event: Schema_Event;
+  event: Event;
   index: number;
   isDrafting: boolean;
   animateEnter?: boolean;
@@ -116,19 +116,17 @@ export const SomedayEventItem: FC<Props> = ({
   index,
   animateEnter = false,
 }) => {
-  const isDraftingThisEvent =
-    isDrafting && (draftId === event._id || !event._id);
+  const isDraftingThisEvent = isDrafting && (draftId === event.id || !event.id);
   const enterAnimationRef = useRef(animateEnter);
   const layoutAnimationRef = useSomedayRowLayoutAnimation();
   const { actions, setters, state } = useSidebarContext();
   const { start, end } = useViewStore(selectDatesInView);
-  const isDraggingThisEvent =
-    state.isDragging && state.draft?._id === event._id;
+  const isDraggingThisEvent = state.isDragging && state.draft?.id === event.id;
   const interactionRef = useSomedayEventRegistrationRef({
     category,
-    eventId: event._id,
+    eventId: event.id,
     index,
-    isEnabled: Boolean(event._id),
+    isEnabled: Boolean(event.id),
   });
 
   return (

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvents.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvents.tsx
@@ -1,5 +1,5 @@
 import { type FC } from "react";
-import { type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
 import { type SomedayInteractionCategory } from "@web/components/PlannerSidebar/SomedayEventSections/interaction/registry/somedayEventRegistry";
 import { SomedayEventsContainer } from "@web/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventsContainer/SomedayEventsContainer";
@@ -10,7 +10,7 @@ import {
 
 interface Props {
   category: SomedayInteractionCategory;
-  events: Schema_Event[];
+  events: Event[];
 }
 export const SomedayEvents: FC<Props> = ({ category, events }) => {
   const { state } = useSidebarContext();

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventsContainer/SomedayEventsContainer.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventsContainer/SomedayEventsContainer.tsx
@@ -4,7 +4,8 @@ import {
   SOMEDAY_MONTHLY_LIMIT,
   SOMEDAY_WEEKLY_LIMIT,
 } from "@core/constants/core.constants";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
 import {
   COLUMN_MONTH,
   COLUMN_WEEK,
@@ -51,7 +52,7 @@ const getActiveDropZoneHeight = (
 
 export interface Props {
   category: SomedayInteractionCategory;
-  events: Schema_Event[];
+  events: Event[];
   isDraftingNew: boolean;
 }
 
@@ -104,11 +105,11 @@ export const SomedayEventsContainer: FC<Props> = ({
           <SomedayEventItem
             animateEnter={shouldAnimateRowEntrance}
             category={category}
-            draftId={state.draft?._id || ID_SOMEDAY_DRAFT}
+            draftId={state.draft?.id || ID_SOMEDAY_DRAFT}
             event={event}
             index={index}
-            isDrafting={state.draft?._id === event._id}
-            key={event?._id || "draft"}
+            isDrafting={state.draft?.id === event.id}
+            key={event?.id || "draft"}
           />
         ))}
       </div>

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayMonthSection/SomedayMonthSection.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayMonthSection/SomedayMonthSection.tsx
@@ -1,12 +1,13 @@
 import { type FC } from "react";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
 import { SomedaySectionHeader } from "@web/components/PlannerSidebar/SomedayEventSections/SomedaySectionHeader/SomedaySectionHeader";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { SomedayEvents } from "../SomedayEvents/SomedayEvents";
 import { useMonthLabel } from "./useMonthLabel";
 
 interface Props {
-  events: Schema_Event[];
+  events: Event[];
   monthDate: WeekProps["component"]["startOfView"];
 }
 

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayWeekSection/SomedayWeekSection.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayWeekSection/SomedayWeekSection.tsx
@@ -1,10 +1,11 @@
 import { type FC } from "react";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
 import { SomedaySectionHeader } from "@web/components/PlannerSidebar/SomedayEventSections/SomedaySectionHeader/SomedaySectionHeader";
 import { SomedayEvents } from "../SomedayEvents/SomedayEvents";
 
 interface Props {
-  events: Schema_Event[];
+  events: Event[];
   weekLabel: string;
 }
 

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/SomedayInteractionCoordinator.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/SomedayInteractionCoordinator.tsx
@@ -1,5 +1,6 @@
 import { type FC, type PropsWithChildren, useMemo, useRef } from "react";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
+import { eventToSchemaEvent } from "@web/events/queries/event.legacy-bridge";
 import { CalendarInteractionPointerCaptureBoundary } from "@web/interaction/react/CalendarInteractionPointerCaptureBoundary";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { type WeekLayoutCacheSources } from "@web/views/Week/interaction/adapter/geometry/weekLayoutCache";
@@ -46,7 +47,8 @@ export const SomedayInteractionCoordinator: FC<Props> = ({
     getVisibleDays: () => visibleDayKeys,
     isSidebarDropAllowed: actions.isSomedaySidebarDropAllowed,
     onCancelInteraction: actions.cancelSomedayInteraction,
-    onClickSomedayEvent: actions.onDraft,
+    onClickSomedayEvent: (event, category) =>
+      actions.onDraft(eventToSchemaEvent(event), category),
     onCommitSomedayInteraction: (result) => {
       // Mark before dispatching so the freshly rendered GridEvent /
       // AllDayEvent picks up the acknowledgment on its first paint.
@@ -57,7 +59,7 @@ export const SomedayInteractionCoordinator: FC<Props> = ({
       actions.commitSomedayInteraction(result);
     },
     onMotionActivation: (target) => {
-      actions.startSomedayInteraction(target.event._id);
+      actions.startSomedayInteraction(target.event.id);
     },
     onPreviewSomedaySidebarDrop: (result) => {
       if (!result) {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.test.ts
@@ -1,6 +1,9 @@
 import { Priorities } from "@core/constants/core.constants";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type EventId } from "@core/types/domain-primitives";
+import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import {
   ID_ALLDAY_COLUMNS,
   ID_GRID_COLUMNS_TIMED,
@@ -14,17 +17,18 @@ import { somedayEventRegistry } from "@web/components/PlannerSidebar/SomedayEven
 import { resetWeekInteractionEdgeNavigationState } from "@web/views/Week/interaction/state/weekInteractionEdgeNavigationState";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
-const createSomedayEvent = (
-  overrides: Partial<Schema_Event> = {},
-): Schema_Event => ({
-  _id: "someday-event",
-  endDate: "2026-05-23",
-  isSomeday: true,
-  order: 0,
-  startDate: "2026-05-17",
-  title: "Someday event",
-  ...overrides,
-});
+const createSomedayEvent = (overrides: Partial<Event> = {}): Event =>
+  createMockEvent({
+    id: "someday-event" as EventId,
+    content: { kind: "details", title: "Someday event", description: "" },
+    schedule: EventScheduleSchema.parse({
+      kind: "someday",
+      period: "week",
+      anchorDate: "2026-05-17",
+      sortOrder: 0,
+    }),
+    ...overrides,
+  });
 
 const setRect = (
   element: HTMLElement,
@@ -195,7 +199,7 @@ const createHarness = ({
   somedayEventRegistry.register({
     category: Categories_Event.SOMEDAY_WEEK,
     element: source,
-    eventId: event._id!,
+    eventId: event.id,
     index: 0,
   });
 
@@ -226,7 +230,7 @@ const createHarness = ({
       timedColumnsElement: timedColumns,
     }),
     runtime: () => ({
-      getSomedayEventById: (eventId) => (eventId === event._id ? event : null),
+      getSomedayEventById: (eventId) => (eventId === event.id ? event : null),
       getVisibleDays: () => currentVisibleDays,
       onCancelInteraction,
       onClickSomedayEvent,

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.ts
@@ -1,6 +1,7 @@
 import { Priorities } from "@core/constants/core.constants";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
+import { Categories_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
 import { theme } from "@web/common/styles/theme";
@@ -252,7 +253,7 @@ export const createSomedayInteractionAdapter = ({
 
         return {
           drop: null,
-          eventId: target.event._id!,
+          eventId: target.event.id,
           pointerStart,
           sourceIndex: target.registered.index,
           sourceRect,
@@ -338,7 +339,7 @@ export const createSomedayInteractionAdapter = ({
     const currentRuntime = runtime();
     const somedayEvent = currentRuntime.getSomedayEventById(registered.eventId);
 
-    if (!somedayEvent?._id) {
+    if (!somedayEvent?.id) {
       return null;
     }
 
@@ -491,7 +492,7 @@ export const createSomedayInteractionAdapter = ({
   ): SomedayInteractionCommitResult {
     const drop = visual.drop;
 
-    if (!drop || !target.event._id) {
+    if (!drop || !target.event.id) {
       return { type: "noop" };
     }
 
@@ -508,7 +509,7 @@ export const createSomedayInteractionAdapter = ({
           endDate: start.add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
           startDate: start.format(YEAR_MONTH_DAY_FORMAT),
         },
-        eventId: target.event._id!,
+        eventId: target.event.id,
         isAllDay: true,
         type: "schedule",
       };
@@ -523,7 +524,7 @@ export const createSomedayInteractionAdapter = ({
         endDate: start.add(ONE_HOUR_MINUTES, "minutes").format(),
         startDate: start.format(),
       },
-      eventId: target.event._id!,
+      eventId: target.event.id,
       isAllDay: false,
       type: "schedule",
     };
@@ -539,7 +540,7 @@ export const createSomedayInteractionAdapter = ({
         droppableId: getColumnName(drop.category),
         index: drop.index,
       },
-      eventId: target.event._id!,
+      eventId: target.event.id,
       source: {
         droppableId: getColumnName(target.category),
         index: visual.sourceIndex,
@@ -555,7 +556,7 @@ export const createSomedayInteractionAdapter = ({
   ) {
     const currentRuntime = runtime();
 
-    if (drop?.type !== "sidebar" || !target.event._id) {
+    if (drop?.type !== "sidebar" || !target.event.id) {
       clearSidebarPreview(currentRuntime);
       return;
     }
@@ -702,10 +703,7 @@ export const createSomedayInteractionAdapter = ({
   };
 };
 
-const createSomedayDraftEventClone = (
-  source: HTMLElement,
-  event: Schema_Event,
-) => {
+const createSomedayDraftEventClone = (source: HTMLElement, event: Event) => {
   const clone = createDraftEventClone(source);
 
   clone.style.zIndex = "25";
@@ -730,7 +728,7 @@ const createSomedayDraftEventClone = (
 const mutateDraftEvent = (
   node: HTMLElement,
   drop: SomedayInteractionDrop | null,
-  event: Schema_Event,
+  event: Event,
 ) => {
   node.style.overflow = "hidden";
 

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types.ts
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types.ts
@@ -1,4 +1,4 @@
-import { type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
 import {
   type CalendarInteractionCancellationTargets,
   type CalendarInteractionEngineSchedulerOptions,
@@ -21,7 +21,7 @@ export interface SomedayInteractionAdapterOptions {
 }
 
 export interface SomedayInteractionRuntime {
-  getSomedayEventById(eventId: string): Schema_Event | null;
+  getSomedayEventById(eventId: string): Event | null;
   /**
    * Local YYYY-MM-DD dates of the rendered day columns, in window order.
    * Sourced from the same React render that painted the columns so drop
@@ -30,10 +30,7 @@ export interface SomedayInteractionRuntime {
   getVisibleDays(): string[];
   isSidebarDropAllowed?: (result: SomedaySidebarCommitResult) => boolean;
   onCancelInteraction?: () => void;
-  onClickSomedayEvent(
-    event: Schema_Event,
-    category: SomedayInteractionCategory,
-  ): void;
+  onClickSomedayEvent(event: Event, category: SomedayInteractionCategory): void;
   onCommitSomedayInteraction(result: SomedayInteractionCommitResult): void;
   onMotionActivation?: (target: SomedayInteractionTarget) => void;
   onPreviewSomedaySidebarDrop?: (
@@ -44,7 +41,7 @@ export interface SomedayInteractionRuntime {
 
 export interface SomedayInteractionTarget {
   category: SomedayInteractionCategory;
-  event: Schema_Event;
+  event: Event;
   registered: SomedayInteractionRegisteredEvent;
 }
 

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.test.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.test.ts
@@ -20,10 +20,10 @@ const { useSidebarActions } =
 
 const SOMEDAY_EVENT_ID = "664e21f9a6b3f0b1c2d3e4f5";
 
-// draft.store.ts/useSidebarState still hold the legacy Schema_Event shape
-// (see draft.store.ts's own TODO); `somedayEvent` drives those, while
-// `somedayEventContract` (below) seeds the strict-contract `Event` query
-// cache and the local repository the transition mutation reads through.
+// draft.store.ts still holds the legacy Schema_Event shape (see its own
+// TODO); `somedayEvent` seeds that, while `somedayEventContract` (below)
+// seeds the strict-contract `Event` sidebar cache/query and the local
+// repository the transition mutation reads through.
 const somedayEvent: Schema_Event = {
   _id: SOMEDAY_EVENT_ID,
   endDate: "2024-01-21",
@@ -51,7 +51,7 @@ const somedayEventContract = createMockEvent({
 const createState = (): State_Sidebar =>
   ({
     blockedSomedayDropColumn: null,
-    draft: somedayEvent,
+    draft: somedayEventContract,
     isDrafting: true,
     isDraftingExisting: true,
     isDraftingNew: false,
@@ -70,7 +70,7 @@ const createState = (): State_Sidebar =>
         },
       },
       events: {
-        [somedayEvent._id!]: somedayEvent,
+        [somedayEvent._id!]: somedayEventContract,
       },
     },
     somedayIds: [somedayEvent._id!],

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
@@ -7,6 +7,7 @@ import {
   SOMEDAY_WEEKLY_LIMIT,
 } from "@core/constants/core.constants";
 import { MapEvent } from "@core/mappers/map.event";
+import { type Event } from "@core/types/event.contracts";
 import {
   Categories_Event,
   type Direction_Migrate,
@@ -28,6 +29,10 @@ import {
   assembleWebEvent,
   hasEventDates,
 } from "@web/common/utils/event/event.util";
+import {
+  applySchemaEventToLocalEvent,
+  schemaEventToLocalEvent,
+} from "@web/common/utils/event/someday.event.util";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { DirtyParser } from "@web/common/utils/parse/dirty.parser";
@@ -42,7 +47,10 @@ import {
   type SomedaySidebarCommitResult,
 } from "@web/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
-import { createLegacyEventMutationsAdapter } from "@web/events/queries/event.legacy-bridge";
+import {
+  createLegacyEventMutationsAdapter,
+  eventToSchemaEvent,
+} from "@web/events/queries/event.legacy-bridge";
 import { useSomedayEventViewModel } from "@web/events/queries/useSomedayEventsQuery";
 import {
   type Activity_DraftEvent,
@@ -99,9 +107,11 @@ const getNextSomedayOrder = (
   const columnName = getSomedayColumnName(category);
   const events = somedayEvents.columns[columnName].eventIds
     .map((eventId) => somedayEvents.events[eventId])
-    .filter(Boolean);
+    .filter((event): event is Event => Boolean(event));
   const orders = events
-    .map((event) => event.order)
+    .map((event) =>
+      event.schedule.kind === "someday" ? event.schedule.sortOrder : undefined,
+    )
     .filter(
       (order): order is number =>
         typeof order === "number" && !Number.isNaN(order),
@@ -186,13 +196,13 @@ const applySomedayColumnOrder = ({
   const orderUpdates = eventIds.flatMap((eventId, order) => {
     const event = orderedEvents[eventId];
 
-    if (!event) {
+    if (!event || event.schedule.kind !== "someday") {
       return [];
     }
 
     orderedEvents[eventId] = {
       ...event,
-      order,
+      schedule: { ...event.schedule, sortOrder: order },
     };
 
     return [{ _id: eventId, order }];
@@ -211,15 +221,12 @@ export const useSidebarActions = (
 ) => {
   const mutations = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
+  const calendarId = getDefaultTargetCalendar(calendars ?? [])?.id;
   // TODO(packet-03-phase-3c): legacy-shaped facade until this file's
   // Schema_Event-based drag/drop state is converted to the new contracts.
   const eventMutations = useMemo(
-    () =>
-      createLegacyEventMutationsAdapter(
-        mutations,
-        () => getDefaultTargetCalendar(calendars ?? [])?.id,
-      ),
-    [mutations, calendars],
+    () => createLegacyEventMutationsAdapter(mutations, () => calendarId),
+    [mutations, calendarId],
   );
   const interactionPreviewKeyRef = useRef<string | null>(null);
   const interactionSnapshotRef = useRef<State_Sidebar["somedayEvents"] | null>(
@@ -271,10 +278,10 @@ export const useSidebarActions = (
   }, [setIsSomedayFormOpen]);
 
   const create = useCallback(() => {
-    setDraft(draft);
+    setDraft(draft ? schemaEventToLocalEvent(draft, calendarId ?? "") : null);
     setIsDrafting(true);
     openForm();
-  }, [openForm, draft, setDraft, setIsDrafting]);
+  }, [openForm, draft, calendarId, setDraft, setIsDrafting]);
 
   const discard = useCallback(() => {
     if (state.draft) {
@@ -302,10 +309,12 @@ export const useSidebarActions = (
   // NOT converted to GridEventDraft/editGridEventDraft: onDraft only opens
   // someday events (see SomedayEventContainer/SomedayInteractionCoordinator
   // call sites), and editGridEventDraft explicitly rejects "someday"
-  // schedules. See packet-03-phase-3c scoping note.
+  // schedules. See packet-03-phase-3c scoping note. Kept Schema_Event-typed:
+  // ContextMenuItems.tsx (the grid right-click menu) also calls this with a
+  // Schema_GridEvent, outside this packet's someday-sidebar file set.
   const onDraft = (event: Schema_Event, category: Categories_Event) => {
     setIsDrafting(true);
-    setDraft(event);
+    setDraft(schemaEventToLocalEvent(event, calendarId ?? ""));
     setIsSomedayFormOpen(true);
 
     draftActions.start({
@@ -471,17 +480,19 @@ export const useSidebarActions = (
     applyTo: RecurringEventUpdateScope = RecurringEventUpdateScope.THIS_EVENT,
   ) => {
     // No confirmation prompt: deletes are undoable via Cmd/Ctrl+Z
-    const eventToDelete = state.draft ?? draft;
+    const eventIdToDelete = state.draft?.id ?? draft?._id;
 
-    if (eventToDelete?._id) {
-      eventMutations.deleteSomeday({ _id: eventToDelete._id, applyTo });
+    if (eventIdToDelete) {
+      eventMutations.deleteSomeday({ _id: eventIdToDelete, applyTo });
     }
 
     close();
   };
 
   const duplicateSomedayEvent = () => {
-    const eventToDuplicate = state.draft ?? draft;
+    const eventToDuplicate = state.draft
+      ? eventToSchemaEvent(state.draft)
+      : draft;
     if (!eventToDuplicate) return;
 
     const { _id: _duplicatedEventId, ...duplicateEvent } =
@@ -596,14 +607,16 @@ export const useSidebarActions = (
       return;
     }
 
-    setDraft(event);
+    setDraft(schemaEventToLocalEvent(event, calendarId ?? ""));
     setIsSomedayFormOpen(true);
     setIsDrafting(true);
   };
 
   const onSubmit = async (
     category: Categories_Event,
-    event: Schema_Event | null = state.draft,
+    event: Schema_Event | null = state.draft
+      ? eventToSchemaEvent(state.draft)
+      : null,
   ) => {
     if (!event) return;
 
@@ -670,7 +683,7 @@ export const useSidebarActions = (
         },
         events: {
           ...state.somedayEvents.events,
-          [eventId]: eventWithOrder,
+          [eventId]: schemaEventToLocalEvent(eventWithOrder, calendarId ?? ""),
         },
       });
 
@@ -718,7 +731,9 @@ export const useSidebarActions = (
       events: sourceOrder.events,
     });
 
-    let draggedEvent = destOrder.events[draggableId];
+    const draggedEvent = destOrder.events[draggableId];
+
+    if (!draggedEvent) return;
 
     const draggedToMonthColumn = destColumn.id === COLUMN_MONTH;
 
@@ -726,25 +741,17 @@ export const useSidebarActions = (
       startDate: viewStart.format(),
       endDate: viewEnd.format(),
     };
-    if (draggedToMonthColumn) {
-      draggedEvent = computeCurrentEventDateRange(
-        { duration: "month" },
-        draggedEvent,
-        weekViewRange,
-      );
-    } else {
-      draggedEvent = computeCurrentEventDateRange(
-        { duration: "week" },
-        draggedEvent,
-        weekViewRange,
-      );
-    }
+    const draggedSchemaEvent = computeCurrentEventDateRange(
+      { duration: draggedToMonthColumn ? "month" : "week" },
+      eventToSchemaEvent(draggedEvent),
+      weekViewRange,
+    );
 
-    if (!draggedEvent?._id) return;
+    if (!draggedSchemaEvent._id) return;
 
-    const draggedEventId = draggedEvent._id;
+    const draggedEventId = draggedSchemaEvent._id;
 
-    if (!hasEventDates(draggedEvent)) return;
+    if (!hasEventDates(draggedSchemaEvent)) return;
 
     const orderUpdates = [
       ...sourceOrder.orderUpdates,
@@ -766,7 +773,10 @@ export const useSidebarActions = (
       },
       events: {
         ...destOrder.events,
-        [draggableId]: draggedEvent,
+        [draggableId]: applySchemaEventToLocalEvent(
+          draggedEvent,
+          draggedSchemaEvent,
+        ),
       },
     };
     setSomedayEvents(newState);
@@ -774,7 +784,7 @@ export const useSidebarActions = (
 
     eventMutations.edit({
       _id: draggedEventId,
-      event: assembleWebEvent(draggedEvent),
+      event: assembleWebEvent(draggedSchemaEvent),
     });
   };
 

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarState.test.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarState.test.ts
@@ -1,6 +1,6 @@
 import { act } from "@testing-library/react";
-import { type Schema_Event } from "@core/types/event.types";
 import { renderHookWithStore } from "@web/__tests__/render-with-store";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createInitialState } from "@web/__tests__/utils/state/store.test.util";
 import { beforeEach, describe, expect, it } from "bun:test";
 
@@ -9,10 +9,9 @@ let isDNDing = false;
 const { useSidebarState } =
   require("./useSidebarState") as typeof import("./useSidebarState");
 
-const draftEvent = {
-  _id: "draft-event-id",
-  title: "Draft",
-} as Schema_Event;
+const draftEvent = createMockEvent({
+  content: { kind: "details", title: "Draft", description: "" },
+});
 
 const createSidebarState = () => {
   if (!isDNDing) {

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarState.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarState.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { type Schema_Event } from "@core/types/event.types";
+import { type Event } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
 import { useSomedayEventViewModel } from "@web/events/queries/useSomedayEventsQuery";
@@ -16,19 +16,24 @@ export const useSidebarState = () => {
     dayjs(dates.start),
     dayjs(dates.end),
   );
+  const isDNDing = useDraftStore(selectIsDNDing);
   const [somedayEvents, setSomedayEventsState] = useState(categorizedEvents);
 
+  // Only resync from the query's derived view while no sidebar drag is in
+  // flight. A live reorder preview (and a just-submitted create) sets this
+  // state directly with its own already-correct value; letting a query
+  // refetch overwrite it mid-drag would blow away the preview out from
+  // under the pointer.
   useEffect(() => {
+    if (isDNDing) return;
     setSomedayEventsState(categorizedEvents);
-  }, [categorizedEvents]);
+  }, [categorizedEvents, isDNDing]);
 
   const setSomedayEvents = useCallback((nextEvents: SidebarSomedayEvents) => {
     setSomedayEventsState(nextEvents);
   }, []);
 
-  const isDNDing = useDraftStore(selectIsDNDing);
-
-  const [draft, setDraft] = useState<Schema_Event | null>(null);
+  const [draft, setDraft] = useState<Event | null>(null);
   const [isDrafting, setIsDrafting] = useState(false);
   const [isDraftingExisting, setIsDraftingExisting] = useState(false);
   const [blockedSomedayDropColumn, setBlockedSomedayDropColumn] = useState<
@@ -45,7 +50,7 @@ export const useSidebarState = () => {
   const isDraftingNew =
     isDrafting &&
     !isDraftingExisting &&
-    !somedayIds.includes(draft?._id as string);
+    !somedayIds.includes(draft?.id as string);
 
   const state = {
     draft,

--- a/packages/web/src/events/queries/event.view-model.test.ts
+++ b/packages/web/src/events/queries/event.view-model.test.ts
@@ -59,7 +59,7 @@ describe("Event query view models", () => {
       undefined,
     );
 
-    expect(result.orderedEvents.map(({ _id }) => _id)).toEqual([
+    expect(result.orderedEvents.map(({ id }) => id)).toEqual([
       first.id,
       second.id,
     ]);


### PR DESCRIPTION
## Summary

Phase A of the someday sidebar conversion (packet 03, `handoff/someday/03-event-runtime-cutover.md`). A prior read-only investigation mapped this subsystem and proposed a 6-phase plan (A-F); this is Phase A only — the read path.

- `categorizeSomedayEvents` now returns `Event`-shaped columns directly (previously bridged through `eventToSchemaEvent`).
- `useSidebarState.ts`'s `somedayEvents`/`draft` are `Event`-typed. Its query-resync effect now skips while a sidebar drag is in flight (`isDNDing`) — a live reorder preview or just-submitted create already holds its own correct value, and a mid-drag query refetch would otherwise clobber it out from under the pointer.
- The full `SomedayEvent*`/`SomedayInteractionAdapter*` component/adapter tree is converted to `Event` props.
- Mutation logic in `useSidebarActions.ts` (`onSubmit`/`onMigrate`/delete/duplicate/reorder) is **behaviorally untouched** — same `eventMutations.*` calls via the legacy adapter, same payloads. Two new reverse-bridge helpers (`schemaEventToLocalEvent`/`applySchemaEventToLocalEvent` in `someday.event.util.ts`) build/update local `Event` state from the `Schema_Event`-shaped values the someday form still produces, used only to update local state, never sent to a mutation.

`event.legacy-bridge.ts` and `draft.store.ts` are untouched.

### Two bugs found and fixed along the way
Both surfaced by Playwright while verifying this conversion, not introduced by it in a new way — they were latent in how a fresh draft's placeholder fields got constructed:
1. A fresh draft's synthesized placeholder `id` was reading back as a persisted `_id`, causing `onSubmit` to silently misroute a create into a no-op edit.
2. The placeholder's synthesized anchor date leaked into the submitted payload, bypassing `onSubmit`'s own `getDatesByCategory` computation and persisting the wrong date.

Both fixed in `SomedayEventContainer.tsx` by stripping the synthesized `_id`/`startDate`/`endDate` for the `state.isDraftingNew` case before building the form's event.

### Scope note
`onDraft` stays `Schema_Event`-typed rather than `Event`-typed: the grid's right-click context menu also calls it with a `Schema_GridEvent`, which is outside this phase's file set. Converting it is Phase B+.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1252/1252 pass (one fixture updated in `someday.event.util.test.ts` to assert the strict `Event` contract instead of the legacy shape; no tests deleted)
- [x] `bunx playwright test`: 11/11 pass, including the someday-specific specs, confirmed stable across repeated runs