### PR TITLE
refactor(web): route someday create/delete/duplicate through strict mutations

### DIFF
--- a/packages/web/src/common/utils/event/someday.event.util.ts
+++ b/packages/web/src/common/utils/event/someday.event.util.ts
@@ -152,14 +152,17 @@ const someEventScheduleFromLegacy = (
     dayjs(event.endDate).diff(dayjs(event.startDate), "day") > 7
       ? "month"
       : "week",
-  // A brand-new draft has no startDate yet (assigned at submit time from the
-  // target category/view range, see useSidebarActions.ts's onSubmit) --
-  // anchor on today rather than an empty string, which downstream date
-  // parsing (parseCompassEventDate) throws on.
-  anchorDate: (event.startDate || dayjs().toYearMonthDayString()).slice(
-    0,
-    10,
-  ) as DateOnly,
+  // A brand-new draft has no startDate yet: leave anchorDate empty (not
+  // today's date) so onSubmit's `!_event.startDate` check still detects
+  // "not yet dated" and assigns the real target-category/view-range dates
+  // via getDatesByCategory. Defaulting to today here would look plausible
+  // but silently commits every new someday item to today's date instead of
+  // the week/month bucket the user actually picked (verified via
+  // `DEBUG insertEventIntoQueries`: with the today-default, a newly created
+  // someday-week item's schedule.anchorDate never matched the visible
+  // week-bucket query, so it silently never landed in the cache the sidebar
+  // reads from).
+  anchorDate: (event.startDate ?? "").slice(0, 10) as DateOnly,
   sortOrder: event.order ?? 0,
 });
 

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
@@ -6,7 +6,7 @@ import {
   SOMEDAY_WEEK_LIMIT_MSG,
   SOMEDAY_WEEKLY_LIMIT,
 } from "@core/constants/core.constants";
-import { MapEvent } from "@core/mappers/map.event";
+import { type EventId, EventIdSchema } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import {
   Categories_Event,
@@ -46,12 +46,18 @@ import {
   type SomedayInteractionCommitResult,
   type SomedaySidebarCommitResult,
 } from "@web/components/PlannerSidebar/SomedayEventSections/interaction/adapter/SomedayInteractionAdapter.types";
+import { parseEventDraft } from "@web/events/event-draft.parser";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import {
   createLegacyEventMutationsAdapter,
   eventToSchemaEvent,
 } from "@web/events/queries/event.legacy-bridge";
 import { useSomedayEventViewModel } from "@web/events/queries/useSomedayEventsQuery";
+import { toRecurrenceScope } from "@web/events/recurrence/recurrence-scope";
+import {
+  createSomedayEventDraft,
+  duplicateSomedayEventDraft,
+} from "@web/events/someday-event-draft.adapter";
 import {
   type Activity_DraftEvent,
   draftActions,
@@ -481,24 +487,38 @@ export const useSidebarActions = (
   ) => {
     // No confirmation prompt: deletes are undoable via Cmd/Ctrl+Z
     const eventIdToDelete = state.draft?.id ?? draft?._id;
+    const id = eventIdToDelete
+      ? EventIdSchema.safeParse(eventIdToDelete)
+      : null;
 
-    if (eventIdToDelete) {
-      eventMutations.deleteSomeday({ _id: eventIdToDelete, applyTo });
+    if (id?.success) {
+      mutations.delete({ id: id.data, scope: toRecurrenceScope(applyTo) });
     }
 
     close();
   };
 
   const duplicateSomedayEvent = () => {
-    const eventToDuplicate = state.draft
-      ? eventToSchemaEvent(state.draft)
-      : draft;
-    if (!eventToDuplicate) return;
+    const eventToDuplicate: Event | null = state.draft
+      ? state.draft
+      : draft
+        ? schemaEventToLocalEvent(draft, calendarId ?? "")
+        : null;
 
-    const { _id: _duplicatedEventId, ...duplicateEvent } =
-      MapEvent.removeProviderData(eventToDuplicate);
+    if (!eventToDuplicate || !calendarId) return;
 
-    eventMutations.create(duplicateEvent);
+    const somedayDraft = duplicateSomedayEventDraft(eventToDuplicate);
+    if (!somedayDraft) return;
+
+    const result = parseEventDraft({
+      ...somedayDraft,
+      values: { ...somedayDraft.values, calendarId },
+    });
+
+    if (result.ok && result.mode === "create") {
+      mutations.create(result.input);
+    }
+
     close();
   };
 
@@ -663,7 +683,7 @@ export const useSidebarActions = (
     } else {
       const columnName = getSomedayColumnName(category);
       const column = state.somedayEvents.columns[columnName];
-      const eventId = createObjectIdString();
+      const eventId = createObjectIdString() as EventId;
       const order = getNextSomedayOrder(category, state.somedayEvents);
 
       const eventWithOrder = {
@@ -687,7 +707,28 @@ export const useSidebarActions = (
         },
       });
 
-      eventMutations.create(eventWithOrder);
+      if (calendarId) {
+        const somedayDraft = createSomedayEventDraft(
+          category === Categories_Event.SOMEDAY_WEEK ? "week" : "month",
+          dayjs(parsedEvent.startDate).toDate(),
+          order,
+        );
+
+        const result = parseEventDraft({
+          ...somedayDraft,
+          values: {
+            ...somedayDraft.values,
+            title: parsedEvent.title ?? "",
+            description: parsedEvent.description ?? "",
+            priority: parsedEvent.priority,
+            calendarId,
+          },
+        });
+
+        if (result.ok && result.mode === "create") {
+          mutations.create({ ...result.input, id: eventId });
+        }
+      }
     }
 
     close();

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
@@ -505,18 +505,20 @@ export const useSidebarActions = (
         ? schemaEventToLocalEvent(draft, calendarId ?? "")
         : null;
 
-    if (!eventToDuplicate || !calendarId) return;
+    const somedayDraft =
+      eventToDuplicate && calendarId
+        ? duplicateSomedayEventDraft(eventToDuplicate)
+        : null;
 
-    const somedayDraft = duplicateSomedayEventDraft(eventToDuplicate);
-    if (!somedayDraft) return;
+    if (somedayDraft && calendarId) {
+      const result = parseEventDraft({
+        ...somedayDraft,
+        values: { ...somedayDraft.values, calendarId },
+      });
 
-    const result = parseEventDraft({
-      ...somedayDraft,
-      values: { ...somedayDraft.values, calendarId },
-    });
-
-    if (result.ok && result.mode === "create") {
-      mutations.create(result.input);
+      if (result.ok && result.mode === "create") {
+        mutations.create(result.input);
+      }
     }
 
     close();

--- a/packages/web/src/events/someday-event-draft.adapter.ts
+++ b/packages/web/src/events/someday-event-draft.adapter.ts
@@ -1,0 +1,58 @@
+import { Priorities } from "@core/constants/core.constants";
+import { type Event } from "@core/types/event.contracts";
+import { type NewEventDraft } from "@web/events/event-draft.types";
+
+// Mirrors grid-event-draft.adapter.ts's createGridEventDraft/
+// duplicateGridEventDraft, but for someday drafts, which use the generic
+// EventDraft/EventScheduleDraft ("someday" is a variant GridScheduleDraft
+// deliberately excludes). calendarId starts null: someday events aren't
+// calendar-scoped by the user until the call site resolves a default target
+// calendar, mirroring how a blank grid draft starts with no calendar picked.
+export function createSomedayEventDraft(
+  category: "week" | "month",
+  anchorDate: Date,
+  sortOrder: number,
+): NewEventDraft {
+  return {
+    mode: "create",
+    isDirty: true,
+    submitError: null,
+    values: {
+      title: "",
+      description: "",
+      schedule: { kind: "someday", period: category, anchorDate, sortOrder },
+      priority: Priorities.UNASSIGNED,
+      calendarId: null,
+      recurrence: { kind: "single" },
+    },
+  };
+}
+
+// A duplicate is a brand-new, standalone event: it starts from the source
+// event's fields but is never linked back to it (mode "create"), so
+// editing/deleting the duplicate never touches the original. Returns null for
+// a non-someday source, mirroring duplicateGridEventDraft's null-return guard.
+export function duplicateSomedayEventDraft(event: Event): NewEventDraft | null {
+  const { schedule } = event;
+  if (schedule.kind !== "someday") return null;
+
+  return {
+    mode: "create",
+    isDirty: true,
+    submitError: null,
+    values: {
+      title: event.content.kind === "details" ? event.content.title : "",
+      description:
+        event.content.kind === "details" ? event.content.description : "",
+      schedule: {
+        kind: "someday",
+        period: schedule.period,
+        anchorDate: new Date(schedule.anchorDate),
+        sortOrder: schedule.sortOrder,
+      },
+      priority: event.priority,
+      calendarId: null,
+      recurrence: { kind: "single" },
+    },
+  };
+}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
@@ -64,8 +64,11 @@ export const useRecurrence = (
   },
 ) => {
   const { recurrence, endDate: _endDate, isSomeday } = event ?? {};
-  const startDate = event?.startDate ?? dayjs().toRFC3339OffsetString();
-  const endDate = _endDate ?? dayjs().add(1, "hour").toRFC3339OffsetString();
+  // `||`, not `??`: an undated someday draft-in-progress can carry
+  // `startDate: ""` (not yet assigned a real date), which `??` wouldn't
+  // catch and `parseCompassEventDate` throws on below.
+  const startDate = event?.startDate || dayjs().toRFC3339OffsetString();
+  const endDate = _endDate || dayjs().add(1, "hour").toRFC3339OffsetString();
   const _startDate = parseCompassEventDate(startDate);
   const hasRecurrence = (event?.recurrence?.rule?.length ?? 0) > 0;
   const currentRule = event?.recurrence?.rule;


### PR DESCRIPTION
## Summary

Phase B of the someday sidebar conversion (packet 03). Builds on Phase A (#2022, merged) and includes a real regression fix that Phase A introduced (found via Playwright, not by inspection alone).

### Bug fix (found before Phase B's own changes)
Phase A's placeholder-`Event` builder (`schemaEventToLocalEvent`) defaulted a new draft's `schedule.anchorDate` to today when `startDate` was empty, to avoid a crash in `useRecurrence.ts`'s date parsing. That default silently defeated `onSubmit`'s `!_event.startDate` "not yet dated" check — every new/edited someday item got created anchored to today instead of the picked week/month bucket, so it never matched the visible query's cache entry and the sidebar list never re-rendered the change. Verified via a `DEBUG insertEventIntoQueries` trace (`matched: 0` for the new event's own week bucket) and reproduced/fixed in an isolated worktree. Fixed by leaving `anchorDate` empty for an undated draft (restoring `onSubmit`'s detection) and fixing the actual crash at its source in `useRecurrence.ts` (`||` instead of `??`, since `??` doesn't catch an empty string).

### Phase B: create, delete, duplicate
- New `packages/web/src/events/someday-event-draft.adapter.ts` — mirrors `grid-event-draft.adapter.ts`'s `createGridEventDraft`/`duplicateGridEventDraft` pattern, but for the generic `EventDraft`/`EventScheduleDraft` contracts (`GridScheduleDraft` deliberately excludes `"someday"`, so the grid adapter can't be reused here).
- `onSubmit`'s create branch, `deleteSomedayEvent`, and `duplicateSomedayEvent` in `useSidebarActions.ts` now call `useEventMutations()`'s strict `create`/`delete` directly, bypassing `createLegacyEventMutationsAdapter` for these three call sites.
- `onSubmit`'s edit branch, `onMigrate`, `commitSomedayInteraction`, and both reorder/drag handlers are untouched — still route through the legacy adapter (Phase C/D/E/F).
- No new `draft.store.ts` field: `state.draft` already gives create/delete/duplicate what they need locally. A store-level someday draft field is deferred to whichever later phase needs to open/edit a draft the way grid editing does.
- Fixed one more small behavior gap during review: `duplicateSomedayEvent` returned early (skipping `close()`) when there was no resolvable default calendar, unlike the original (and `onSubmit`/`deleteSomedayEvent`), which always call `close()` after attempting the mutation regardless of a silent no-op.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1252/1252 pass, no test deletions
- [x] `bunx playwright test`: 11/11 pass, including `e2e/someday/event-smoke.spec.ts`'s create/edit/delete flow and both drag-preview specs