### PR TITLE
refactor(web): route someday edit/migrate through strict mutations

### DIFF
--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
@@ -57,6 +57,8 @@ import { toRecurrenceScope } from "@web/events/recurrence/recurrence-scope";
 import {
   createSomedayEventDraft,
   duplicateSomedayEventDraft,
+  editSomedayEventDraft,
+  retargetSomedayEventDraft,
 } from "@web/events/someday-event-draft.adapter";
 import {
   type Activity_DraftEvent,
@@ -574,11 +576,35 @@ export const useSidebarActions = (
     if (_event._id) {
       if (!hasEventDates(_event)) return;
 
-      const eventId = _event._id;
-      eventMutations.edit({
-        _id: eventId,
-        event: assembleWebEvent(_event),
-      });
+      const idResult = EventIdSchema.safeParse(_event._id);
+      const existingEvent = idResult.success
+        ? state.somedayEvents.events[idResult.data]
+        : undefined;
+
+      if (idResult.success && existingEvent?.schedule.kind === "someday") {
+        const editDraft = editSomedayEventDraft(existingEvent);
+        const period =
+          direction === "up"
+            ? "week"
+            : direction === "down"
+              ? "month"
+              : category === Categories_Event.SOMEDAY_WEEK
+                ? "week"
+                : "month";
+
+        if (editDraft) {
+          const retargeted = retargetSomedayEventDraft(editDraft, {
+            period,
+            anchorDate: dayjs(_event.startDate).toDate(),
+            sortOrder: existingEvent.schedule.sortOrder,
+          });
+          const result = parseEventDraft(retargeted);
+
+          if (result.ok && result.mode === "edit") {
+            mutations.replace({ id: result.eventId, input: result.input });
+          }
+        }
+      }
     } else {
       eventMutations.create(_event);
     }
@@ -681,7 +707,51 @@ export const useSidebarActions = (
           ? RecurringEventUpdateScope.ALL_EVENTS
           : RecurringEventUpdateScope.THIS_EVENT;
 
-      eventMutations.edit({ _id: eventId, event: parsedEvent, applyTo });
+      const idResult = EventIdSchema.safeParse(eventId);
+      const existingEvent = idResult.success
+        ? state.somedayEvents.events[idResult.data]
+        : undefined;
+      const existingSchedule = existingEvent?.schedule;
+      const editDraft =
+        existingEvent && existingSchedule?.kind === "someday"
+          ? editSomedayEventDraft(existingEvent, toRecurrenceScope(applyTo))
+          : null;
+
+      if (editDraft && existingSchedule?.kind === "someday") {
+        const rule = parsedEvent.recurrence?.rule;
+        const recurrence =
+          Array.isArray(rule) && rule.length > 0
+            ? { kind: "series" as const, rules: rule }
+            : { kind: "single" as const };
+
+        const result = parseEventDraft({
+          ...editDraft,
+          values: {
+            ...editDraft.values,
+            title: parsedEvent.title ?? "",
+            description: parsedEvent.description ?? "",
+            priority: parsedEvent.priority ?? editDraft.values.priority,
+            schedule: {
+              kind: "someday",
+              period: existingSchedule.period,
+              // dayjs (not `new Date`) parses a bare "YYYY-MM-DD" string as
+              // local midnight; `new Date` parses it as UTC midnight, which
+              // reads back as the previous local day in a negative-offset
+              // zone once parseEventDraft reformats it — silently dropping
+              // the edited event into the prior week/month's bucket.
+              anchorDate: parsedEvent.startDate
+                ? dayjs(parsedEvent.startDate).toDate()
+                : dayjs(existingSchedule.anchorDate).toDate(),
+              sortOrder: parsedEvent.order ?? existingSchedule.sortOrder,
+            },
+            recurrence,
+          },
+        });
+
+        if (result.ok && result.mode === "edit") {
+          mutations.replace({ id: result.eventId, input: result.input });
+        }
+      }
     } else {
       const columnName = getSomedayColumnName(category);
       const column = state.somedayEvents.columns[columnName];

--- a/packages/web/src/events/someday-event-draft.adapter.ts
+++ b/packages/web/src/events/someday-event-draft.adapter.ts
@@ -52,7 +52,11 @@ export function duplicateSomedayEventDraft(event: Event): NewEventDraft | null {
       schedule: {
         kind: "someday",
         period: schedule.period,
-        anchorDate: new Date(schedule.anchorDate),
+        // dayjs(...), not new Date(...): a bare "YYYY-MM-DD" string parses
+        // as UTC midnight via the Date constructor, which reads back as the
+        // previous local day in a negative-UTC-offset zone once
+        // parseEventDraft reformats it - see editSomedayEventDraft's note.
+        anchorDate: dayjs(schedule.anchorDate).toDate(),
         sortOrder: schedule.sortOrder,
       },
       priority: event.priority,

--- a/packages/web/src/events/someday-event-draft.adapter.ts
+++ b/packages/web/src/events/someday-event-draft.adapter.ts
@@ -1,6 +1,11 @@
 import { Priorities } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
-import { type NewEventDraft } from "@web/events/event-draft.types";
+import { type RecurrenceScope } from "@core/types/event-command.contracts";
+import dayjs from "@core/util/date/dayjs";
+import {
+  type EditEventDraft,
+  type NewEventDraft,
+} from "@web/events/event-draft.types";
 
 // Mirrors grid-event-draft.adapter.ts's createGridEventDraft/
 // duplicateGridEventDraft, but for someday drafts, which use the generic
@@ -54,5 +59,60 @@ export function duplicateSomedayEventDraft(event: Event): NewEventDraft | null {
       calendarId: null,
       recurrence: { kind: "single" },
     },
+  };
+}
+
+// Mirrors editGridEventDraft, but for someday drafts. "preserve" is the
+// baseline recurrence (matches editGridEventDraft's default); call sites
+// that submit an explicit recurrence change (e.g. the someday form's rule
+// editor) overwrite `values.recurrence` before parsing. Returns null for a
+// non-someday source, mirroring editGridEventDraft's null-return guard.
+export function editSomedayEventDraft(
+  event: Event,
+  scope: RecurrenceScope = "this",
+): EditEventDraft | null {
+  const { schedule } = event;
+  if (schedule.kind !== "someday") return null;
+
+  return {
+    mode: "edit",
+    eventId: event.id,
+    originalCalendarId: event.calendarId,
+    isDirty: true,
+    submitError: null,
+    values: {
+      title: event.content.kind === "details" ? event.content.title : "",
+      description:
+        event.content.kind === "details" ? event.content.description : "",
+      schedule: {
+        kind: "someday",
+        period: schedule.period,
+        // `new Date("YYYY-MM-DD")` parses as UTC midnight; in a negative
+        // UTC-offset zone that reads back as the previous local day once
+        // parseEventDraft's toDateOnlyString reformats it, silently shifting
+        // the event into the prior week/month's bucket. dayjs(...) parses a
+        // bare date-only string as local midnight instead.
+        anchorDate: dayjs(schedule.anchorDate).toDate(),
+        sortOrder: schedule.sortOrder,
+      },
+      priority: event.priority,
+      calendarId: event.calendarId,
+      recurrence: { kind: "preserve" },
+      scope,
+    },
+  };
+}
+
+// Shifts an existing edit draft's someday schedule (period/anchorDate/
+// sortOrder) for the migrate forward/back/up/down flows, keeping every other
+// field (title, description, recurrence, scope) untouched. Mirrors
+// replaceGridDraftSchedule's spread-and-override shape.
+export function retargetSomedayEventDraft(
+  draft: EditEventDraft,
+  schedule: { period: "week" | "month"; anchorDate: Date; sortOrder: number },
+): EditEventDraft {
+  return {
+    ...draft,
+    values: { ...draft.values, schedule: { kind: "someday", ...schedule } },
   };
 }


### PR DESCRIPTION
## Summary

Phase C of the someday sidebar conversion (packet 03). Builds on Phase A (#2022) and Phase B (#2023), both merged.

- New `editSomedayEventDraft`/`retargetSomedayEventDraft` in `packages/web/src/events/someday-event-draft.adapter.ts`, mirroring `editGridEventDraft`/`replaceGridDraftSchedule`.
- `onSubmit`'s edit branch now builds an `EditEventDraft` from the pre-edit strict `Event`, overlays the form's changes, and calls `mutations.replace` directly, instead of `eventMutations.edit`. Recurrence scope logic (`isInstance`/`recurrenceChanged`/always-`THIS_EVENT`-for-someday) unchanged, just converted to the strict `RecurrenceScope` type.
- `onMigrate` (forward/back/up/down between week/month columns): kept the existing `Schema_Event`-typed date math (`computeRelativeEventDateRange`/`computeCurrentEventDateRange`) since those functions aren't someday-specific and retyping them would expand scope beyond this phase — only the submission boundary changed, building an edit draft via the new adapter functions before calling `mutations.replace`.
- `SomedayEventContainer.tsx`'s `migrateEvent` needed no changes — it already routes through the edit path above.
- No new `draft.store.ts` field — `state.somedayEvents.events` already gives the lookup this phase needs.

### Bugs found and fixed
1. `editSomedayEventDraft`'s (and, on review, Phase B's `duplicateSomedayEventDraft`'s) `anchorDate` construction used `new Date("YYYY-MM-DD")`, which parses as UTC midnight — in a negative-UTC-offset zone this reads back as the *previous* local day once `parseEventDraft` reformats it, silently dropping the edited/migrated/duplicated event into the prior week/month's bucket. Both fixed to use `dayjs(dateString).toDate()` instead, which parses a bare date-only string as local midnight. Caught by Playwright during development (not by type-check or unit tests), confirming the mandatory behavioral gate is pulling its weight on this packet.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1252/1252 pass, no test deletions
- [x] `bunx playwright test`: 11/11 pass, including `e2e/someday/event-smoke.spec.ts`'s edit flow
- [x] Manual verification against a local dev server in `America/Denver`: edited an existing someday item's title (persisted, correct column, verified via IndexedDB); migrated a someday-month item forward (anchorDate moved cleanly, correct migration toast)