### PR TITLE
refactor(web): route someday-to-scheduled conversion through strict mutations

### DIFF
--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
@@ -20,10 +20,8 @@ import { type Setters_Sidebar } from "@web/components/PlannerSidebar/draft/hooks
 import { type SomedayInteractionCategory } from "@web/components/PlannerSidebar/SomedayEventSections/interaction/registry/somedayEventRegistry";
 import { SomedayEvent } from "@web/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
-import {
-  createLegacyEventMutationsAdapter,
-  eventToSchemaEvent,
-} from "@web/events/queries/event.legacy-bridge";
+import { eventToSchemaEvent } from "@web/events/queries/event.legacy-bridge";
+import { scheduleSomedayEventTransition } from "@web/events/someday-event-draft.adapter";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { FloatingFormContainer } from "@web/views/Forms/SomedayEventForm/FloatingFormContainer";
 import { SomedayEventForm } from "@web/views/Forms/SomedayEventForm/SomedayEventForm";
@@ -61,12 +59,6 @@ export const SomedayEventContainer = ({
   const { state, actions, setters } = useSidebarContext();
   const mutations = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
-  // TODO(packet-03-phase-3c): legacy-shaped facade until this component's
-  // Schema_Event-based props are converted to the new contracts.
-  const { convertToCalendar } = createLegacyEventMutationsAdapter(
-    mutations,
-    () => getDefaultTargetCalendar(calendars ?? [])?.id,
-  );
 
   const formProps = useDraftForm(
     category,
@@ -116,15 +108,18 @@ export const SomedayEventContainer = ({
       dayjs(weekViewRange.startDate),
     );
 
-    convertToCalendar({
-      event: {
-        _id: event.id,
-        startDate,
-        endDate,
-        isAllDay: false,
-        isSomeday: false,
-      },
-    });
+    const calendarId = getDefaultTargetCalendar(calendars ?? [])?.id;
+    const input = calendarId
+      ? scheduleSomedayEventTransition(
+          { startDate, endDate },
+          false,
+          calendarId,
+        )
+      : null;
+
+    if (input) {
+      mutations.transition({ id: event.id, input });
+    }
     refocusEventElement(event.id);
   };
 

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
@@ -59,6 +59,7 @@ import {
   duplicateSomedayEventDraft,
   editSomedayEventDraft,
   retargetSomedayEventDraft,
+  scheduleSomedayEventTransition,
 } from "@web/events/someday-event-draft.adapter";
 import {
   type Activity_DraftEvent,
@@ -449,14 +450,20 @@ export const useSidebarActions = (
   const commitSomedayInteraction = (result: SomedayInteractionCommitResult) => {
     if (result.type === "schedule") {
       clearSomedayInteractionPreview({ shouldRestore: true });
-      eventMutations.convertToCalendar({
-        event: {
-          ...result.dates,
-          _id: result.eventId,
-          isAllDay: result.isAllDay,
-          isSomeday: false,
-        },
-      });
+
+      const id = EventIdSchema.safeParse(result.eventId);
+      const input = calendarId
+        ? scheduleSomedayEventTransition(
+            result.dates,
+            result.isAllDay,
+            calendarId,
+          )
+        : null;
+
+      if (id.success && input) {
+        mutations.transition({ id: id.data, input });
+      }
+
       discardSomedayInteraction();
       return;
     }

--- a/packages/web/src/events/someday-event-draft.adapter.ts
+++ b/packages/web/src/events/someday-event-draft.adapter.ts
@@ -1,7 +1,13 @@
 import { Priorities } from "@core/constants/core.constants";
+import { type CalendarId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
-import { type RecurrenceScope } from "@core/types/event-command.contracts";
+import {
+  type RecurrenceScope,
+  type TransitionEventInput,
+  TransitionEventInputSchema,
+} from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import {
   type EditEventDraft,
   type NewEventDraft,
@@ -119,4 +125,34 @@ export function retargetSomedayEventDraft(
     ...draft,
     values: { ...draft.values, schedule: { kind: "someday", ...schedule } },
   };
+}
+
+// Builds the TransitionEventInput for dragging/shortcutting a someday event
+// onto the calendar grid. Mirrors schemaEventToCreateInput/
+// schemaEventToReplaceInput's safeParse-and-return-null-on-failure shape
+// (event.legacy-bridge.ts) so a malformed drop never reaches the mutation
+// layer. `dates` are already local-zone strings from the drop/shortcut call
+// site (YYYY-MM-DD for all-day, full offset-ISO for timed) - see
+// SomedayInteractionAdapter's schedule-drop construction.
+export function scheduleSomedayEventTransition(
+  dates: { startDate: string; endDate: string },
+  isAllDay: boolean,
+  targetCalendarId: CalendarId,
+): TransitionEventInput | null {
+  const schedule = isAllDay
+    ? { kind: "allDay" as const, start: dates.startDate, end: dates.endDate }
+    : {
+        kind: "timed" as const,
+        start: dates.startDate,
+        end: dates.endDate,
+        timeZone: getBrowserTimeZone(),
+      };
+
+  const parsed = TransitionEventInputSchema.safeParse({
+    kind: "schedule",
+    targetCalendarId,
+    schedule,
+  });
+
+  return parsed.success ? parsed.data : null;
 }


### PR DESCRIPTION
## Summary

Phase D of the someday sidebar conversion (packet 03). Builds on Phase A/B/C (#2022-#2024), all merged.

- New `scheduleSomedayEventTransition(dates, isAllDay, targetCalendarId)` in `packages/web/src/events/someday-event-draft.adapter.ts` — builds and validates a `TransitionEventInput` (timed or all-day schedule), mirroring `event.legacy-bridge.ts`'s safeParse-and-return-null-on-failure pattern.
- `commitSomedayInteraction`'s `result.type === "schedule"` branch (drag-to-grid commit) in `useSidebarActions.ts` now calls `mutations.transition` directly instead of `eventMutations.convertToCalendar`.
- `SomedayEventContainer.tsx`'s `scheduleEvent` (the `Shift+ArrowRight` keyboard shortcut) — same conversion, and its `createLegacyEventMutationsAdapter` instance is removed entirely (no longer needed by this component).
- No new `draft.store.ts` field needed.

`handleSameColumnReordering`/`handleCrossColumnDragging`/reorder are untouched (Phase E/F). `event.legacy-bridge.ts` itself is untouched — still exported and used by the reorder/legacy-adapter paths those later phases will convert.

## Verification
Undo-of-conversion (Cmd/Ctrl+Z) was specifically checked, not assumed: confirmed `mutations.transition` records undo history at the same `.mutate()` boundary every other mutation uses (read `useEventMutations.ts`'s `recordEventTransitionHistory` call), then verified live end-to-end with a temporary Playwright spec (written, run, then deleted — not part of this diff): dragged a someday event onto the grid, confirmed the IndexedDB record's `schedule.kind` flipped `someday` → `timed` and it rendered on the grid, then Cmd/Ctrl+Z'd and confirmed it flipped back and reappeared in the sidebar.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1252/1252 pass, no test deletions
- [x] `bunx playwright test`: 11/11 pass, including `e2e/someday/drag-someday-event-mouse.spec.ts`