### PR TITLE
refactor(web): route someday same-column reorder through strict mutations

### DIFF
--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.test.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.test.ts
@@ -78,6 +78,50 @@ const createState = (): State_Sidebar =>
     somedayWeekIds: [somedayEvent._id!],
   }) as State_Sidebar;
 
+const SECOND_SOMEDAY_EVENT_ID = "664e21f9a6b3f0b1c2d3e4f6";
+
+const secondSomedayEventContract = createMockEvent({
+  id: EventIdSchema.parse(SECOND_SOMEDAY_EVENT_ID),
+  content: { kind: "details", title: "Second someday event", description: "" },
+  schedule: EventScheduleSchema.parse({
+    kind: "someday",
+    period: "week",
+    anchorDate: "2024-01-15",
+    sortOrder: 1,
+  }),
+});
+
+const createTwoEventWeekState = (): State_Sidebar =>
+  ({
+    blockedSomedayDropColumn: null,
+    draft: null,
+    isDrafting: false,
+    isDraftingExisting: false,
+    isDraftingNew: false,
+    isDragging: true,
+    isSomedayFormOpen: false,
+    somedayEvents: {
+      columnOrder: [COLUMN_WEEK, COLUMN_MONTH],
+      columns: {
+        [COLUMN_MONTH]: {
+          id: COLUMN_MONTH,
+          eventIds: [],
+        },
+        [COLUMN_WEEK]: {
+          id: COLUMN_WEEK,
+          eventIds: [somedayEvent._id!, SECOND_SOMEDAY_EVENT_ID],
+        },
+      },
+      events: {
+        [somedayEvent._id!]: somedayEventContract,
+        [SECOND_SOMEDAY_EVENT_ID]: secondSomedayEventContract,
+      },
+    },
+    somedayIds: [somedayEvent._id!, SECOND_SOMEDAY_EVENT_ID],
+    somedayMonthIds: [],
+    somedayWeekIds: [somedayEvent._id!, SECOND_SOMEDAY_EVENT_ID],
+  }) as State_Sidebar;
+
 const createSetters = (): Setters_Sidebar =>
   ({
     setBlockedSomedayDropColumn: mock(),
@@ -163,5 +207,88 @@ describe("useSidebarActions", () => {
     });
     // Scheduling a someday drop must not start a grid draft.
     expect(useDraftStore.getState().status?.isDrafting).toBe(false);
+  });
+
+  it("reorders within the same someday column via the strict reorderSomeday mutation", async () => {
+    await getOfflineDataStore().putEvent({
+      version: 2,
+      id: somedayEventContract.id,
+      event: somedayEventContract,
+      isDemo: false,
+    });
+    await getOfflineDataStore().putEvent({
+      version: 2,
+      id: secondSomedayEventContract.id,
+      event: secondSomedayEventContract,
+      isDemo: false,
+    });
+
+    const state = createTwoEventWeekState();
+    const { queryClient, wrapper } = createStoreWrapper(currentState, {
+      events: [somedayEventContract, secondSomedayEventContract],
+    });
+    const setSomedayEvents = mock();
+    const setters = { ...createSetters(), setSomedayEvents };
+
+    const { result } = renderHook(
+      () =>
+        useSidebarActions(
+          {
+            onGoToDate: mock(),
+            viewEnd: dayjs("2024-01-21"),
+            viewStart: dayjs("2024-01-15"),
+          },
+          state,
+          setters,
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(["calendars"])).toBeDefined();
+    });
+
+    // Swap the two week-column events: second event moves from index 1 to 0.
+    result.current.commitSomedayInteraction({
+      destination: { droppableId: COLUMN_WEEK, index: 0 },
+      eventId: SECOND_SOMEDAY_EVENT_ID,
+      source: { droppableId: COLUMN_WEEK, index: 1 },
+      type: "sidebarDrop",
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient
+          .getMutationCache()
+          .getAll()
+          .some((mutation) => {
+            if (mutation.options.mutationKey?.[2] !== "reorder-someday") {
+              return false;
+            }
+            const input = mutation.state.variables as {
+              period?: string;
+              items?: { eventId: string; sortOrder: number }[];
+            };
+            return (
+              input.period === "week" &&
+              input.items?.[0]?.eventId === SECOND_SOMEDAY_EVENT_ID &&
+              input.items?.[0]?.sortOrder === 0 &&
+              input.items?.[1]?.eventId === SOMEDAY_EVENT_ID &&
+              input.items?.[1]?.sortOrder === 1
+            );
+          }),
+      ).toBe(true);
+    });
+
+    // Local optimistic reorder is applied before the mutation fires.
+    expect(setSomedayEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: expect.objectContaining({
+          [COLUMN_WEEK]: expect.objectContaining({
+            eventIds: [SECOND_SOMEDAY_EVENT_ID, SOMEDAY_EVENT_ID],
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
@@ -14,6 +14,7 @@ import {
   RecurringEventUpdateScope,
   type Schema_Event,
 } from "@core/types/event.types";
+import { type ReorderEventsInput } from "@core/types/event-command.contracts";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { getUserId } from "@web/auth/compass/session/session.util";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
@@ -934,11 +935,19 @@ export const useSidebarActions = (
 
     setSomedayEvents(newState);
 
-    const newOrder = newEventIds.map((_id, index) => ({
-      _id,
-      order: index,
-    }));
-    eventMutations.reorderSomeday(newOrder);
+    const period = newColumn.id === COLUMN_WEEK ? "week" : "month";
+    const items = newEventIds.reduce<ReorderEventsInput["items"]>(
+      (acc, eventId, sortOrder) => {
+        const id = EventIdSchema.safeParse(eventId);
+        if (id.success) acc.push({ eventId: id.data, sortOrder });
+        return acc;
+      },
+      [],
+    );
+
+    if (items.length > 0) {
+      mutations.reorderSomeday({ period, items });
+    }
   };
 
   const reorderSomedayEvent = (result: SomedayReorderResult) => {


### PR DESCRIPTION
## Summary

Phase E of the someday sidebar conversion (packet 03). Builds on Phase A-D (#2022-#2025), all merged. Leaves `event.legacy-bridge.ts`'s `createLegacyEventMutationsAdapter` in place — still used by `handleCrossColumnDragging` (Phase F, the last remaining piece).

- `handleSameColumnReordering` in `useSidebarActions.ts` now builds a strict `ReorderEventsInput` (`{period, items: [{eventId, sortOrder}]}`) and calls `mutations.reorderSomeday(input)` directly, instead of a legacy `{_id, order}[]` array through the adapter. `period` is derived from the column being reordered.
- The optimistic `setSomedayEvents` update stays unconditional and unchanged, ordered before the mutation call exactly as before.

### Bug found and fixed
`createLegacyEventMutationsAdapter` was constructed without its third `somedayPeriod` argument, so it silently defaulted to `"week"` for every reorder — **month-column same-column reorders were persisting with `period: "week"` on the wire**, regardless of which column the user actually reordered. This didn't affect the local optimistic array math (`applySomedayColumnOrder`, untouched by this phase), only what got sent to the backend. Fixed by deriving the real period per-column in the strict conversion.

Added a unit test (`useSidebarActions.test.ts`) that specifically exercises this: swaps two events in the week column and asserts both the mutation's `period`/`items` shape and the local optimistic reorder, since this is exactly the kind of thing that's easy to get subtly wrong without a test catching it (per the bug above, and the two prior timezone bugs Phases C/D found).

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1253/1253 pass (1252 baseline + 1 new test), no deletions
- [x] `bunx playwright test`: 11/11 pass