### PR TITLE
refactor(web): route someday cross-column reorder through strict mutations

### DIFF
--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.test.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.test.ts
@@ -122,6 +122,55 @@ const createTwoEventWeekState = (): State_Sidebar =>
     somedayWeekIds: [somedayEvent._id!, SECOND_SOMEDAY_EVENT_ID],
   }) as State_Sidebar;
 
+const THIRD_SOMEDAY_EVENT_ID = "664e21f9a6b3f0b1c2d3e4f7";
+
+const thirdSomedayEventContract = createMockEvent({
+  id: EventIdSchema.parse(THIRD_SOMEDAY_EVENT_ID),
+  content: { kind: "details", title: "Third someday event", description: "" },
+  schedule: EventScheduleSchema.parse({
+    kind: "someday",
+    period: "month",
+    anchorDate: "2024-01-01",
+    sortOrder: 0,
+  }),
+});
+
+const createCrossColumnState = (): State_Sidebar =>
+  ({
+    blockedSomedayDropColumn: null,
+    draft: null,
+    isDrafting: false,
+    isDraftingExisting: false,
+    isDraftingNew: false,
+    isDragging: true,
+    isSomedayFormOpen: false,
+    somedayEvents: {
+      columnOrder: [COLUMN_WEEK, COLUMN_MONTH],
+      columns: {
+        [COLUMN_MONTH]: {
+          id: COLUMN_MONTH,
+          eventIds: [THIRD_SOMEDAY_EVENT_ID],
+        },
+        [COLUMN_WEEK]: {
+          id: COLUMN_WEEK,
+          eventIds: [somedayEvent._id!, SECOND_SOMEDAY_EVENT_ID],
+        },
+      },
+      events: {
+        [somedayEvent._id!]: somedayEventContract,
+        [SECOND_SOMEDAY_EVENT_ID]: secondSomedayEventContract,
+        [THIRD_SOMEDAY_EVENT_ID]: thirdSomedayEventContract,
+      },
+    },
+    somedayIds: [
+      somedayEvent._id!,
+      SECOND_SOMEDAY_EVENT_ID,
+      THIRD_SOMEDAY_EVENT_ID,
+    ],
+    somedayMonthIds: [THIRD_SOMEDAY_EVENT_ID],
+    somedayWeekIds: [somedayEvent._id!, SECOND_SOMEDAY_EVENT_ID],
+  }) as State_Sidebar;
+
 const createSetters = (): Setters_Sidebar =>
   ({
     setBlockedSomedayDropColumn: mock(),
@@ -286,6 +335,136 @@ describe("useSidebarActions", () => {
         columns: expect.objectContaining({
           [COLUMN_WEEK]: expect.objectContaining({
             eventIds: [SECOND_SOMEDAY_EVENT_ID, SOMEDAY_EVENT_ID],
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("moves a Someday event across columns via reorderSomeday + replace mutations", async () => {
+    await getOfflineDataStore().putEvent({
+      version: 2,
+      id: somedayEventContract.id,
+      event: somedayEventContract,
+      isDemo: false,
+    });
+    await getOfflineDataStore().putEvent({
+      version: 2,
+      id: secondSomedayEventContract.id,
+      event: secondSomedayEventContract,
+      isDemo: false,
+    });
+    await getOfflineDataStore().putEvent({
+      version: 2,
+      id: thirdSomedayEventContract.id,
+      event: thirdSomedayEventContract,
+      isDemo: false,
+    });
+
+    const state = createCrossColumnState();
+    const { queryClient, wrapper } = createStoreWrapper(currentState, {
+      events: [
+        somedayEventContract,
+        secondSomedayEventContract,
+        thirdSomedayEventContract,
+      ],
+    });
+    const setSomedayEvents = mock();
+    const setters = { ...createSetters(), setSomedayEvents };
+
+    const { result } = renderHook(
+      () =>
+        useSidebarActions(
+          {
+            onGoToDate: mock(),
+            viewEnd: dayjs("2024-01-21"),
+            viewStart: dayjs("2024-01-15"),
+          },
+          state,
+          setters,
+        ),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(["calendars"])).toBeDefined();
+    });
+
+    // Move the first week event into the month column, ahead of the
+    // existing month event.
+    result.current.commitSomedayInteraction({
+      destination: { droppableId: COLUMN_MONTH, index: 0 },
+      eventId: SOMEDAY_EVENT_ID,
+      source: { droppableId: COLUMN_WEEK, index: 0 },
+      type: "sidebarDrop",
+    });
+
+    await waitFor(() => {
+      const mutations = queryClient.getMutationCache().getAll();
+
+      // The dragged event's own period/sortOrder move via `replace`.
+      const replaced = mutations.some((mutation) => {
+        if (mutation.options.mutationKey?.[2] !== "replace") return false;
+        const variables = mutation.state.variables as {
+          id?: string;
+          input?: { schedule?: { period?: string; sortOrder?: number } };
+        };
+        return (
+          variables.id === SOMEDAY_EVENT_ID &&
+          variables.input?.schedule?.period === "month" &&
+          variables.input?.schedule?.sortOrder === 0
+        );
+      });
+
+      // The remaining week-column sibling is reordered under "week".
+      const weekReordered = mutations.some((mutation) => {
+        if (mutation.options.mutationKey?.[2] !== "reorder-someday") {
+          return false;
+        }
+        const input = mutation.state.variables as {
+          period?: string;
+          items?: { eventId: string; sortOrder: number }[];
+        };
+        return (
+          input.period === "week" &&
+          input.items?.length === 1 &&
+          input.items?.[0]?.eventId === SECOND_SOMEDAY_EVENT_ID &&
+          input.items?.[0]?.sortOrder === 0
+        );
+      });
+
+      // The existing month-column sibling is reordered under "month",
+      // without the dragged event mixed in (it moved via `replace` above).
+      const monthReordered = mutations.some((mutation) => {
+        if (mutation.options.mutationKey?.[2] !== "reorder-someday") {
+          return false;
+        }
+        const input = mutation.state.variables as {
+          period?: string;
+          items?: { eventId: string; sortOrder: number }[];
+        };
+        return (
+          input.period === "month" &&
+          input.items?.length === 1 &&
+          input.items?.[0]?.eventId === THIRD_SOMEDAY_EVENT_ID &&
+          input.items?.[0]?.sortOrder === 1
+        );
+      });
+
+      expect(replaced).toBe(true);
+      expect(weekReordered).toBe(true);
+      expect(monthReordered).toBe(true);
+    });
+
+    // Local optimistic move is applied before the mutations fire.
+    expect(setSomedayEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: expect.objectContaining({
+          [COLUMN_WEEK]: expect.objectContaining({
+            eventIds: [SECOND_SOMEDAY_EVENT_ID],
+          }),
+          [COLUMN_MONTH]: expect.objectContaining({
+            eventIds: [SOMEDAY_EVENT_ID, THIRD_SOMEDAY_EVENT_ID],
           }),
         }),
       }),

--- a/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
+++ b/packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
@@ -27,13 +27,9 @@ import {
 } from "@web/common/utils/datetime/web.date.util";
 import {
   assembleDefaultEvent,
-  assembleWebEvent,
   hasEventDates,
 } from "@web/common/utils/event/event.util";
-import {
-  applySchemaEventToLocalEvent,
-  schemaEventToLocalEvent,
-} from "@web/common/utils/event/someday.event.util";
+import { schemaEventToLocalEvent } from "@web/common/utils/event/someday.event.util";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { DirtyParser } from "@web/common/utils/parse/dirty.parser";
@@ -835,6 +831,10 @@ export const useSidebarActions = (
       return;
     }
 
+    const draggedEvent = baseEvents.events[draggableId];
+
+    if (!draggedEvent || draggedEvent.schedule.kind !== "someday") return;
+
     // Remove from source column
     const sourceEventIds = Array.from(sourceColumn.eventIds);
     sourceEventIds.splice(source.index, 1);
@@ -852,32 +852,38 @@ export const useSidebarActions = (
       events: sourceOrder.events,
     });
 
-    const draggedEvent = destOrder.events[draggableId];
+    const draggedSortOrder = destOrder.orderUpdates.find(
+      ({ _id }) => _id === draggableId,
+    )?.order;
 
-    if (!draggedEvent) return;
+    if (draggedSortOrder === undefined) return;
 
-    const draggedToMonthColumn = destColumn.id === COLUMN_MONTH;
+    const editDraft = editSomedayEventDraft(draggedEvent);
 
-    const weekViewRange = {
-      startDate: viewStart.format(),
-      endDate: viewEnd.format(),
+    if (!editDraft) return;
+
+    const destPeriod = destColumn.id === COLUMN_MONTH ? "month" : "week";
+    // viewStart is already a local-zone Dayjs; deriving anchorDate from it
+    // directly (rather than round-tripping through a formatted string and
+    // reparsing) sidesteps the UTC-midnight parsing bug prior phases hit.
+    const anchorDate =
+      destPeriod === "month"
+        ? viewStart.startOf("month").toDate()
+        : viewStart.toDate();
+
+    const retargeted = retargetSomedayEventDraft(editDraft, {
+      period: destPeriod,
+      anchorDate,
+      sortOrder: draggedSortOrder,
+    });
+    const result = parseEventDraft(retargeted);
+
+    if (!result.ok || result.mode !== "edit") return;
+
+    const updatedDraggedEvent: Event = {
+      ...draggedEvent,
+      schedule: result.input.schedule,
     };
-    const draggedSchemaEvent = computeCurrentEventDateRange(
-      { duration: draggedToMonthColumn ? "month" : "week" },
-      eventToSchemaEvent(draggedEvent),
-      weekViewRange,
-    );
-
-    if (!draggedSchemaEvent._id) return;
-
-    const draggedEventId = draggedSchemaEvent._id;
-
-    if (!hasEventDates(draggedSchemaEvent)) return;
-
-    const orderUpdates = [
-      ...sourceOrder.orderUpdates,
-      ...destOrder.orderUpdates,
-    ];
 
     const newState = {
       ...baseEvents,
@@ -894,19 +900,36 @@ export const useSidebarActions = (
       },
       events: {
         ...destOrder.events,
-        [draggableId]: applySchemaEventToLocalEvent(
-          draggedEvent,
-          draggedSchemaEvent,
-        ),
+        [draggableId]: updatedDraggedEvent,
       },
     };
     setSomedayEvents(newState);
-    eventMutations.reorderSomeday(orderUpdates);
 
-    eventMutations.edit({
-      _id: draggedEventId,
-      event: assembleWebEvent(draggedSchemaEvent),
-    });
+    // The dragged event's own period/anchorDate/sortOrder move through the
+    // replace call below, not a reorder call: its someday.period is still
+    // the old value server-side until that replace lands, and reorderSomeday
+    // isn't sequenced against other mutations, so folding it into either
+    // column's reorder items here could race the backend's per-item
+    // period-match check. Excluding it keeps every reorder item's period
+    // already correct server-side, independent of call order.
+    const sourcePeriod = sourceColumn.id === COLUMN_MONTH ? "month" : "week";
+    const sourceItems = sourceOrder.orderUpdates.map(({ _id, order }) => ({
+      eventId: _id as EventId,
+      sortOrder: order,
+    }));
+    const destItems = destOrder.orderUpdates
+      .filter(({ _id }) => _id !== draggableId)
+      .map(({ _id, order }) => ({ eventId: _id as EventId, sortOrder: order }));
+
+    if (sourceItems.length > 0) {
+      mutations.reorderSomeday({ period: sourcePeriod, items: sourceItems });
+    }
+
+    if (destItems.length > 0) {
+      mutations.reorderSomeday({ period: destPeriod, items: destItems });
+    }
+
+    mutations.replace({ id: result.eventId, input: result.input });
   };
 
   const handleSameColumnReordering = (


### PR DESCRIPTION
## Summary

Phase F — the last phase of the someday sidebar conversion (packet 03). Builds on Phase A-E (#2022-#2026), all merged.

`handleCrossColumnDragging` was the last someday-sidebar call site still using `createLegacyEventMutationsAdapter`. Converted to:

- The dragged event's own `period`/`anchorDate`/`sortOrder` move through a single `mutations.replace({id, input})` call, built via `editSomedayEventDraft` → `retargetSomedayEventDraft` → `parseEventDraft`. `anchorDate` is derived directly from the already-local `viewStart` Dayjs, sidestepping the UTC-midnight date-construction bug class prior phases hit.
- The two sibling columns each get a separate `mutations.reorderSomeday({period, items})` call with the correct `"week"`/`"month"` period, **excluding the dragged event's id** from both: its `someday.period` is still stale server-side until the `replace` lands, and `reorderSomeday` isn't sequenced against other mutations, so folding it into a reorder call could race the backend's per-item period-match validation. Excluding it means every remaining reorder item's period is already correct server-side regardless of call order.
- `isSomedaySidebarDropAllowed`/`previewSomedaySidebarDrop`/`previewBlockedSomedaySidebarDrop` needed no changes — confirmed they already operate correctly on the `Event`-typed local state from Phase A.

### Bug found and fixed
The old combined single-call reorder always sent `period: "week"` (same missing-arg pattern Phase E found and fixed for same-column reorder). Beyond persisting the wrong period, this would have **failed backend validation entirely** whenever the destination column already had a resident sibling, since the backend's `reorder` command requires every item's server-side `schedule.period` to match the input's `period`.

### Remaining `createLegacyEventMutationsAdapter` callers (repo-wide)
- `useSidebarActions.ts`'s `onMigrate` create-fallback branch (out of this packet's phase scope — Phase C only converted the edit branches)
- `useWeekShortcuts.ts`'s `convertToSomeday` (a different flow entirely — the grid's someday-conversion keyboard shortcut, not part of the sidebar)

`event.legacy-bridge.ts` still has live callers and was not touched or deleted.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1254/1254 pass (1253 baseline + 1 new test covering the cross-column move, asserting the `replace` mutation's schedule + both `reorderSomeday` calls' period/items), no deletions
- [x] `bunx playwright test`: 11/11 pass