### PR TITLE
refactor(web): commit Week saved-event drag/resize through strict mutations

### DIFF
--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -1,7 +1,15 @@
 import { type FC, type PropsWithChildren, useMemo, useRef } from "react";
 import { type Event } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
-import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { type GridScheduleDraft } from "@web/events/event-draft.types";
+import {
+  editGridEventDraft,
+  parseGridEventDraft,
+  replaceGridDraftSchedule,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import { draftActions } from "@web/events/stores/draft.store";
 import { CalendarInteractionPointerCaptureBoundary } from "@web/interaction/react/CalendarInteractionPointerCaptureBoundary";
@@ -33,6 +41,7 @@ export const WeekInteractionCoordinator: FC<Props> = ({
     endOfView: weekProps.component.endOfView,
   });
   const { actions, confirmation, setters, state } = useDraftContext();
+  const mutations = useEventMutations();
   const layoutSourcesRef = useRef(getLayoutSources);
   const timedEventsById = useMemo(() => {
     return mapEventsById(timedEvents);
@@ -81,6 +90,37 @@ export const WeekInteractionCoordinator: FC<Props> = ({
 
   const openAllDayEvent = openClickedGridEvent;
 
+  // Non-recurring saved events skip the Draft confirmation flow entirely and
+  // commit straight through the strict mutation. Recurring events (source
+  // event carries `recurrence`) still need the scope-confirmation dialog,
+  // which lives in useDraftConfirmation (out of scope here) — those keep
+  // going through the legacy confirmation.onSubmit path below.
+  const commitStrictSavedMutation = (event: Schema_GridEvent) => {
+    const sourceEvent = event._id ? eventsById.get(event._id) : undefined;
+    const draft = sourceEvent ? editGridEventDraft(sourceEvent, "this") : null;
+
+    if (!draft) return;
+
+    const schedule: GridScheduleDraft = event.isAllDay
+      ? {
+          kind: "allDay",
+          start: dayjs(event.startDate).toDate(),
+          end: dayjs(event.endDate).toDate(),
+        }
+      : timedGridSchedule(
+          dayjs(event.startDate).toDate(),
+          dayjs(event.endDate).toDate(),
+        );
+
+    const parsed = parseGridEventDraft(
+      replaceGridDraftSchedule(draft, schedule),
+    );
+
+    if (parsed.ok && parsed.mode === "edit") {
+      mutations.replace({ id: parsed.eventId, input: parsed.input });
+    }
+  };
+
   const commitSavedMutation = (
     result:
       | WeekAllDayDragCommitResult
@@ -103,7 +143,12 @@ export const WeekInteractionCoordinator: FC<Props> = ({
       return;
     }
 
-    void confirmation.onSubmit(result.event);
+    if (result.event.recurrence) {
+      void confirmation.onSubmit(result.event);
+      return;
+    }
+
+    commitStrictSavedMutation(result.event);
   };
 
   runtimeRef.current = {


### PR DESCRIPTION
## Summary

Phase A of migrating Week's local drag-geometry state off the legacy bridge (packet 03). A read-only investigation found Week actually has two separate drag/resize systems: a modern pointer-capture engine driving saved, not-yet-opened event drag/resize (isolated, low-risk to convert independently), and a legacy local-state system driving the currently-open draft/form card (Phase C, much larger, not touched here).

- New `commitStrictSavedMutation` in `WeekInteractionCoordinator.tsx`: looks up the strict source `Event`, builds a `GridEventDraft` via `editGridEventDraft` + `replaceGridDraftSchedule` (dates derived via `dayjs(...).toDate()`, not `new Date(dateString)`, per the timezone bug class every prior phase in this effort found), parses via `parseGridEventDraft`, and calls `mutations.replace` directly.
- `commitSavedMutation`'s direct-submit branch (form not open) now branches on whether the dragged event carries `recurrence`: non-recurring events take the new strict path; recurring events keep the exact legacy `confirmation.onSubmit` path unchanged, since the scope-confirmation dialog for recurring events lives in `useDraftConfirmation`/`views/Week/components/Draft/`, out of this phase's scope.
- `timedDragVisualToGridEvent.ts`/its all-day sibling are untouched — still produce `Schema_GridEvent`; only the consumer at the commit call site changed.

Day's equivalent (`DayInteractionCoordinator.commitSavedMutation`, still on the legacy `useUpdateEvent`) and everything under `views/Week/components/Draft/` are untouched — separate, later phases.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1254/1254 pass, no fixture changes, no deletions
- [x] `bunx playwright test`: 11/11 pass, including `e2e/timed/move-event-reduced-days.spec.ts` (drags a saved, non-recurring, form-closed event — exercises exactly this path) and `e2e/timed/event-smoke.spec.ts`