### PR TITLE
refactor(web): convert Week draft state to GridEventDraft

### DIFF
--- a/packages/web/src/common/utils/parse/dirty.parser.ts
+++ b/packages/web/src/common/utils/parse/dirty.parser.ts
@@ -1,4 +1,6 @@
 import { type Schema_Event } from "@core/types/event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 
 /**
  * Parser for determining if an event has been modified (is dirty)
@@ -78,5 +80,40 @@ export class DirtyParser {
         ? DirtyParser.recurrenceChanged(curr, orig)
         : current !== original;
     });
+  }
+
+  /**
+   * GridEventDraft-comparable dirty check for an in-progress edit: rebuilds
+   * the pristine draft the edit started from (via editGridEventDraft on the
+   * same source/scope) and compares against it field-by-field, rather than
+   * against Schema_Event fields. Recurrence is compared by kind only (not by
+   * rule-array equality like isEventDirty does) — an edit draft's recurrence
+   * starts at "preserve" and only ever changes kind when the user explicitly
+   * toggles it, so a kind mismatch is a reliable-enough dirty signal for
+   * this narrower comparison.
+   */
+  static isGridDraftDirty(
+    draft: Extract<GridEventDraft, { kind: "edit" }>,
+  ): boolean {
+    const pristine = editGridEventDraft(draft.source, draft.values.scope);
+    if (!pristine) return true;
+
+    const { values } = draft;
+    const orig = pristine.values;
+
+    if (values.title !== orig.title) return true;
+    if (values.description !== orig.description) return true;
+    if (values.priority !== orig.priority) return true;
+    if (values.calendarId !== orig.calendarId) return true;
+    if (values.schedule.kind !== orig.schedule.kind) return true;
+    if (values.schedule.start.getTime() !== orig.schedule.start.getTime()) {
+      return true;
+    }
+    if (values.schedule.end.getTime() !== orig.schedule.end.getTime()) {
+      return true;
+    }
+    if (values.recurrence.kind !== orig.recurrence.kind) return true;
+
+    return false;
   }
 }

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
@@ -4,8 +4,11 @@ import { type ReactElement } from "react";
 import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import { render, screen } from "@web/__tests__/__mocks__/mock.render";
 import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { useDraftStore } from "@web/events/stores/draft.store";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -32,6 +35,22 @@ const createMockGridEvent = (
     position: gridEventDefaultPosition,
     ...overrides,
   } as Schema_GridEvent;
+};
+
+// GridContextMenuWrapper.tsx (the real right-click flow, unconverted here)
+// already pushes a GridEventDraft into the store's `gridDraft` field before
+// ContextMenuItems mounts; seed the same field directly so edit/editPriority
+// have a canonical draft to read.
+const seedGridDraftForEvent = (event: Schema_GridEvent) => {
+  const strictEvent = createMockEvent({
+    content: {
+      kind: "details",
+      title: event.title ?? "",
+      description: event.description ?? "",
+    },
+  });
+  const draft = editGridEventDraft(strictEvent);
+  useDraftStore.setState({ gridDraft: draft });
 };
 
 const { ContextMenuItems } =
@@ -77,6 +96,7 @@ describe("ContextMenuItems", () => {
     mockSetDraft.mockClear();
     mockSubmit.mockClear();
     mockOnDelete.mockClear();
+    useDraftStore.setState({ gridDraft: null });
   });
 
   it("should render menu items", () => {
@@ -98,6 +118,7 @@ describe("ContextMenuItems", () => {
       _id: "event-1",
       title: "Test Event",
     });
+    seedGridDraftForEvent(event);
 
     renderWithTheme(<ContextMenuItems event={event} close={mockClose} />);
 
@@ -134,6 +155,7 @@ describe("ContextMenuItems", () => {
       _id: "pending-event-1",
       title: "Pending Event",
     });
+    seedGridDraftForEvent(event);
 
     renderWithTheme(<ContextMenuItems event={event} close={mockClose} />, {
       pendingEventIds: ["pending-event-1"],
@@ -186,6 +208,7 @@ describe("ContextMenuItems", () => {
       _id: "event-1",
       title: "Normal Event",
     });
+    seedGridDraftForEvent(event);
 
     renderWithTheme(<ContextMenuItems event={event} close={mockClose} />);
 
@@ -194,7 +217,9 @@ describe("ContextMenuItems", () => {
     );
 
     expect(mockSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({ priority: "work" }),
+      expect.objectContaining({
+        values: expect.objectContaining({ priority: "work" }),
+      }),
     );
     expect(mockClose).toHaveBeenCalled();
   });

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -5,9 +5,10 @@ import { ID_CONTEXT_MENU_ITEMS } from "@web/common/constants/web.constants";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import { colorByPriority } from "@web/common/styles/theme.util";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
-import { assembleGridEvent } from "@web/common/utils/event/event.util";
 import { getSomedayEventCategory } from "@web/common/utils/event/someday.event.util";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
 export interface ContextMenuAction {
@@ -133,6 +134,11 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
   const { actions, setters, confirmation } = useDraftContext();
   const { openForm, duplicateEvent, submit } = actions;
   const { setDraft } = setters;
+  // The right-click flow (GridContextMenuWrapper.tsx) already builds a
+  // GridEventDraft via editGridEventDraft and pushes it into the store, so
+  // this reads that canonical draft rather than re-deriving one from
+  // `event` (a Schema_GridEvent render projection with no strict source).
+  const gridDraft = useDraftStore(selectGridDraft);
 
   const sidebarContext = useSidebarContext(true);
 
@@ -141,7 +147,7 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
     duplicate: duplicateEvent,
     edit: () => {
       if (!event.isSomeday) {
-        setDraft(assembleGridEvent(event));
+        if (gridDraft) setDraft(gridDraft);
         openForm();
         return;
       }
@@ -151,7 +157,16 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
       const category = getSomedayEventCategory(event);
       sidebarActions.onDraft(event, category);
     },
-    editPriority: (priority) => submit({ ...event, priority }),
+    editPriority: (priority) => {
+      if (!gridDraft) return;
+
+      const updated: GridEventDraft = {
+        ...gridDraft,
+        values: { ...gridDraft.values, priority },
+      } as GridEventDraft;
+
+      void submit(updated);
+    },
   };
 
   return (

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -144,6 +144,34 @@ export function timedGridSchedule(start: Date, end: Date): GridScheduleDraft {
   return { kind: "timed", start, end, timeZone: getBrowserTimeZone() };
 }
 
+// Reflects the draft's *live* recurrence edit (e.g. from RecurrenceSection's
+// toggle, mid-form), not just the source event's original recurrence — a
+// user editing recurrence on an existing draft must see that edit echoed
+// back through the Schema_Event projection the form renders from.
+function legacyRecurrenceFromDraft(
+  draft: GridEventDraft,
+): Schema_Event["recurrence"] {
+  const { recurrence } = draft.values;
+
+  if (draft.kind === "edit" && recurrence.kind === "preserve") {
+    return legacyRecurrenceFromEvent(draft.source);
+  }
+
+  if (recurrence.kind === "series") {
+    const eventId =
+      draft.kind === "edit" && draft.source.recurrence.kind === "occurrence"
+        ? draft.source.recurrence.seriesId
+        : undefined;
+
+    return { rule: [...recurrence.rules], ...(eventId ? { eventId } : {}) };
+  }
+
+  // "single": explicitly no recurrence. `rule: null` (not undefined)
+  // mirrors useRecurrence.ts's toggleRecurrence-off shape so `hasRecurrence`
+  // reads false rather than falling through to a stale truthy rule.
+  return { rule: null as unknown as string[] };
+}
+
 // TODO(packet-03-phase-3c): remove once remaining grid consumers no longer
 // require Schema_Event. Keeping this projection beside the GridEventDraft
 // adapter lets the draft store expose one canonical grid draft without a
@@ -163,15 +191,81 @@ export function gridEventDraftToSchemaEvent(
     isAllDay: schedule.kind === "allDay",
     isSomeday: false,
     priority: draft.values.priority ?? Priorities.UNASSIGNED,
-    recurrence:
-      draft.kind === "edit"
-        ? legacyRecurrenceFromEvent(draft.source)
-        : undefined,
+    recurrence: legacyRecurrenceFromDraft(draft),
     startDate:
       schedule.kind === "allDay"
         ? toDateOnlyString(schedule.start)
         : dayjs(schedule.start).format(),
     title: draft.values.title,
+  };
+}
+
+// The reverse direction of gridEventDraftToSchemaEvent, scoped to the one
+// boundary that needs it: EventForm/RecurrenceSection write back into a
+// legacy Schema_Event-shaped `setEvent`, which this reapplies onto the
+// canonical GridEventDraft (preserving `kind`/`source`/`clientId`, which a
+// Schema_Event patch has no way to express).
+export function applySchemaEventPatchToGridDraft(
+  current: GridEventDraft,
+  patch: Schema_Event,
+): GridEventDraft {
+  const rule = patch.recurrence?.rule;
+  const recurrence =
+    Array.isArray(rule) && rule.length > 0
+      ? ({ kind: "series", rules: rule } as const)
+      : current.kind === "edit"
+        ? ({ kind: "preserve" } as const)
+        : ({ kind: "single" } as const);
+
+  const scheduleDates: GridScheduleDraft =
+    current.values.schedule.kind === "allDay"
+      ? {
+          kind: "allDay",
+          start: patch.startDate
+            ? dayjs(patch.startDate).toDate()
+            : current.values.schedule.start,
+          end: patch.endDate
+            ? dayjs(patch.endDate).toDate()
+            : current.values.schedule.end,
+        }
+      : {
+          kind: "timed",
+          start: patch.startDate
+            ? dayjs(patch.startDate).toDate()
+            : current.values.schedule.start,
+          end: patch.endDate
+            ? dayjs(patch.endDate).toDate()
+            : current.values.schedule.end,
+          timeZone: current.values.schedule.timeZone,
+        };
+
+  const sharedValues = {
+    title: patch.title ?? "",
+    description: patch.description ?? "",
+    schedule: scheduleDates,
+    priority: patch.priority ?? current.values.priority,
+  };
+
+  if (current.kind === "create") {
+    return {
+      ...current,
+      values: {
+        ...sharedValues,
+        calendarId: current.values.calendarId,
+        recurrence:
+          recurrence.kind === "preserve" ? { kind: "single" } : recurrence,
+      },
+    };
+  }
+
+  return {
+    ...current,
+    values: {
+      ...sharedValues,
+      calendarId: current.values.calendarId,
+      recurrence,
+      scope: current.values.scope,
+    },
   };
 }
 

--- a/packages/web/src/events/stores/draft.store.ts
+++ b/packages/web/src/events/stores/draft.store.ts
@@ -201,7 +201,11 @@ export const draftActions = {
   }: {
     activity: Extract<
       Activity_DraftEvent,
-      "createShortcut" | "eventRightClick" | "gridClick" | "resizing"
+      | "createShortcut"
+      | "eventRightClick"
+      | "gridClick"
+      | "keyboardEdit"
+      | "resizing"
     >;
     dateToResize?: "startDate" | "endDate" | null;
     draft: GridEventDraft;

--- a/packages/web/src/views/Forms/EventForm/ConvertToStandaloneDialog.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/ConvertToStandaloneDialog.test.tsx
@@ -1,7 +1,8 @@
 import userEvent from "@testing-library/user-event";
 import { type ReactElement } from "react";
 import { render, screen } from "@web/__tests__/__mocks__/mock.render";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { ConvertToStandaloneDialog } from "@web/views/Forms/EventForm/ConvertToStandaloneDialog";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { describe, expect, it, mock } from "bun:test";
@@ -9,7 +10,19 @@ import { describe, expect, it, mock } from "bun:test";
 const onConfirm = mock();
 const onCancel = mock();
 
-const renderDialog = (standaloneDraft: Schema_GridEvent | null) => {
+const draftWithTitle = (title: string): GridEventDraft => {
+  const draft = createGridEventDraft({
+    kind: "timed",
+    start: new Date("2026-05-31T10:00:00.000Z"),
+    end: new Date("2026-05-31T11:00:00.000Z"),
+    timeZone: "UTC",
+  });
+  if (draft.kind !== "create") throw new Error("Expected a create draft");
+
+  return { ...draft, values: { ...draft.values, title } };
+};
+
+const renderDialog = (standaloneDraft: GridEventDraft | null) => {
   const ui: ReactElement = (
     <DraftContext.Provider
       value={
@@ -39,7 +52,7 @@ describe("ConvertToStandaloneDialog", () => {
   });
 
   it("shows the event name when a draft is pending", () => {
-    renderDialog({ title: "Gym" } as Schema_GridEvent);
+    renderDialog(draftWithTitle("Gym"));
 
     expect(
       screen.getByText("Convert to standalone event?"),
@@ -50,7 +63,7 @@ describe("ConvertToStandaloneDialog", () => {
   });
 
   it("falls back to a generic name for an untitled draft", () => {
-    renderDialog({ title: "" } as Schema_GridEvent);
+    renderDialog(draftWithTitle(""));
 
     expect(
       screen.getByText(
@@ -61,7 +74,7 @@ describe("ConvertToStandaloneDialog", () => {
 
   it("confirms and cancels via the action buttons", async () => {
     const user = userEvent.setup();
-    renderDialog({ title: "Gym" } as Schema_GridEvent);
+    renderDialog(draftWithTitle("Gym"));
 
     await user.click(screen.getByRole("button", { name: "Convert" }));
     expect(onConfirm).toHaveBeenCalledTimes(1);

--- a/packages/web/src/views/Forms/EventForm/ConvertToStandaloneDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/ConvertToStandaloneDialog.tsx
@@ -15,7 +15,7 @@ export function ConvertToStandaloneDialog() {
 
   if (!standaloneDraft) return null;
 
-  const eventName = standaloneDraft.title || "this event";
+  const eventName = standaloneDraft.values.title || "this event";
 
   return (
     <OverlayPanel

--- a/packages/web/src/views/Forms/EventForm/RecurrenceScopeDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/RecurrenceScopeDialog.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useState } from "react";
-import { RecurringEventUpdateScope } from "@core/types/event.types";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import {
+  RecurringEventUpdateScope,
+  type Schema_Event,
+} from "@core/types/event.types";
 import { DirtyParser } from "@web/common/utils/parse/dirty.parser";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
+import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { selectDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
@@ -43,7 +46,7 @@ export function RecurrenceScopeDialog() {
 
   return (
     <RecurringEventUpdateScopeDialogContent
-      draft={draft}
+      draft={draft ? gridEventDraftToSchemaEvent(draft) : null}
       onUpdateScopeChange={onUpdateScopeChange}
       setRecurrenceUpdateScopeDialogOpen={setRecurrenceUpdateScopeDialogOpen}
     />
@@ -51,7 +54,7 @@ export function RecurrenceScopeDialog() {
 }
 
 interface RecurringEventUpdateScopeDialogContentProps {
-  draft: Schema_GridEvent | null;
+  draft: Schema_Event | null;
   onUpdateScopeChange: (applyTo: RecurringEventUpdateScope) => void;
   recurrenceChanged?: boolean;
   setRecurrenceUpdateScopeDialogOpen: (isOpen: boolean) => void;

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -1,7 +1,11 @@
 import { type FC, useMemo } from "react";
 import { createPortal } from "react-dom";
+import { Origin } from "@core/constants/core.constants";
 import { Categories_Event } from "@core/types/event.types";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { getDraftContainer } from "@web/common/utils/draft/draft.util";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import {
   selectDraftCategory,
@@ -33,29 +37,51 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   });
   const { state } = useDraftContext();
   const { draft } = state;
+  // Schema_GridEvent-shaped projection of the canonical GridEventDraft, for
+  // the still-unconverted grid-layout helpers below (deck layout, all-day
+  // positioning, recurrence previews) — see grid-event-draft.adapter.ts's
+  // gridEventDraftToSchemaEvent doc comment. `position` is a placeholder
+  // default: these helpers never read it, only startDate/endDate/isAllDay/
+  // recurrence/_id.
+  const draftSchemaEvent: Schema_GridEvent | null = useMemo(
+    () =>
+      draft
+        ? ({
+            ...gridEventDraftToSchemaEvent(draft),
+            origin: Origin.COMPASS,
+            user: "",
+            position: gridEventDefaultPosition,
+          } as Schema_GridEvent)
+        : null,
+    [draft],
+  );
   const activeAllDayDraftEvent = useMemo(
     () =>
       positionAllDayDraftEvent({
-        draft,
+        draft: draftSchemaEvent,
         events: allDayEvents,
       }).activeDraftEvent,
-    [allDayEvents, draft],
+    [allDayEvents, draftSchemaEvent],
   );
   const deckLayout = useMemo(
-    () => getActiveTimedDraftDeckLayout(draft, timedEvents),
-    [draft, timedEvents],
+    () => getActiveTimedDraftDeckLayout(draftSchemaEvent, timedEvents),
+    [draftSchemaEvent, timedEvents],
   );
   const recurringPreviews = useMemo(
     () =>
       getRecurringDraftPreviews(
-        draft,
+        draftSchemaEvent,
         weekProps.component.startOfView,
         weekProps.component.endOfView,
       ),
-    [draft, weekProps.component.startOfView, weekProps.component.endOfView],
+    [
+      draftSchemaEvent,
+      weekProps.component.startOfView,
+      weekProps.component.endOfView,
+    ],
   );
 
-  if (draft?.isAllDay === undefined) {
+  if (!draft) {
     return null;
   }
   if (!category) return null;

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -2,9 +2,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type PropsWithChildren, type Ref, useState } from "react";
 import { Origin, Priorities } from "@core/constants/core.constants";
+import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { CALENDAR_DECK_MIN_WIDTH } from "@web/layout/calendar-grid/calendarGrid.constants";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -41,8 +44,8 @@ mock.module("@web/views/Forms/EventForm/EventForm", () => ({
     onSubmit,
     titleInputRef,
   }: {
-    event: Schema_GridEvent;
-    onSubmit?: (event: Schema_GridEvent) => void;
+    event: Schema_Event;
+    onSubmit?: (event: Schema_Event) => void;
     titleInputRef?: Ref<HTMLInputElement>;
   }) => (
     <>
@@ -65,7 +68,44 @@ mock.module("@web/views/Forms/EventForm/EventForm", () => ({
 
 const { GridDraft } = require("./GridDraft") as typeof import("./GridDraft");
 
+// The interactive draft GridDraft.tsx reads from context — always a
+// not-yet-saved "create" GridEventDraft in these fixtures (none of these
+// tests exercise editing an existing event).
 const createDraft = (
+  overrides: {
+    endDate?: string;
+    isAllDay?: boolean;
+    startDate?: string;
+    title?: string;
+  } = {},
+): GridEventDraft => {
+  const {
+    endDate = "2026-05-26T15:00:00.000Z",
+    isAllDay = false,
+    startDate = "2026-05-26T14:00:00.000Z",
+    title = "Planning",
+  } = overrides;
+
+  const draft = createGridEventDraft(
+    isAllDay
+      ? { kind: "allDay", start: new Date(startDate), end: new Date(endDate) }
+      : {
+          kind: "timed",
+          start: new Date(startDate),
+          end: new Date(endDate),
+          timeZone: "UTC",
+        },
+  );
+  if (draft.kind !== "create") throw new Error("Expected a create draft");
+
+  return { ...draft, values: { ...draft.values, title } };
+};
+
+// activeAllDayDraftEvent/recurringPreviews are still Schema_GridEvent-shaped
+// props (out of this phase's scope — the wider grid *renderer* conversion),
+// so they need their own Schema_GridEvent-shaped fixture, independent of the
+// interactive GridEventDraft above.
+const createSchemaGridEvent = (
   overrides: Partial<Schema_GridEvent> = {},
 ): Schema_GridEvent => ({
   description: "",
@@ -120,7 +160,7 @@ const renderGridDraft = ({
 }: {
   activeAllDayDraftEvent?: Schema_GridEvent | null;
   deckLayout?: { groupSize: number; order: number } | null;
-  draft?: Schema_GridEvent;
+  draft?: GridEventDraft;
   recurringPreviews?: Schema_GridEvent[];
 } = {}) => {
   const repositionDraftByKeyboard = mock(() => true);
@@ -140,10 +180,12 @@ const renderGridDraft = ({
     setters: {
       setDateBeingChanged: mock(),
       setDraft: mock(),
+      setDragOffset: mock(),
       setIsResizing: mock(),
     },
     state: {
       draft,
+      dragOffset: { x: 0, y: 0 },
       formProps: createFormProps(),
       isDragging: false,
       isFormOpen: true,
@@ -181,7 +223,6 @@ describe("GridDraft keyboard focus", () => {
       draft: createDraft({
         endDate: "2026-05-27T00:00:00.000Z",
         isAllDay: true,
-        position: undefined,
         startDate: "2026-05-26T00:00:00.000Z",
       }),
     });
@@ -200,13 +241,16 @@ describe("GridDraft keyboard focus", () => {
     const draft = createDraft({
       endDate: "2026-05-27T00:00:00.000Z",
       isAllDay: true,
-      position: undefined,
       startDate: "2026-05-26T00:00:00.000Z",
     });
 
     renderGridDraft({
       activeAllDayDraftEvent: {
-        ...draft,
+        ...createSchemaGridEvent({
+          endDate: "2026-05-27T00:00:00.000Z",
+          isAllDay: true,
+          startDate: "2026-05-26T00:00:00.000Z",
+        }),
         row: 3,
       },
       draft,
@@ -256,12 +300,12 @@ describe("GridDraft keyboard focus", () => {
   it("renders a read-only card for each recurring preview occurrence", () => {
     renderGridDraft({
       recurringPreviews: [
-        createDraft({
+        createSchemaGridEvent({
           _id: undefined,
           endDate: "2026-05-27T15:00:00.000Z",
           startDate: "2026-05-27T14:00:00.000Z",
         }),
-        createDraft({
+        createSchemaGridEvent({
           _id: undefined,
           endDate: "2026-05-28T15:00:00.000Z",
           startDate: "2026-05-28T14:00:00.000Z",
@@ -290,7 +334,9 @@ describe("GridDraft keyboard focus", () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({ title: "Planning" }),
+      expect.objectContaining({
+        values: expect.objectContaining({ title: "Planning" }),
+      }),
     );
     expect(document.activeElement).not.toBe(draftBlock);
   });

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -1,10 +1,18 @@
 import { FloatingFocusManager } from "@floating-ui/react";
 import { type FC, type MouseEvent, useRef } from "react";
+import { Origin } from "@core/constants/core.constants";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
-import { getEventDragOffset } from "@web/common/utils/event/event.util";
+import {
+  getEventDragOffset,
+  gridEventDefaultPosition,
+} from "@web/common/utils/event/event.util";
+import {
+  applySchemaEventPatchToGridDraft,
+  gridEventDraftToSchemaEvent,
+} from "@web/events/grid-event-draft.adapter";
 import { type CalendarTimedDeckLayout } from "@web/layout/calendar-grid/layout/calendarTimedDeckLayout";
 import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { FloatingFormContainer } from "@web/views/Forms/SomedayEventForm/FloatingFormContainer";
@@ -35,8 +43,10 @@ export const GridDraft: FC<Props> = ({
   const titleInputRef = useRef<HTMLInputElement>(null);
   const { actions, setters, state, confirmation } = useDraftContext();
   const { discard, duplicateEvent, startDragging } = actions;
-  const { setDraft, setDateBeingChanged, setIsResizing } = setters;
-  const { draft, isDragging, formProps, isFormOpen, isResizing } = state;
+  const { setDraft, setDragOffset, setDateBeingChanged, setIsResizing } =
+    setters;
+  const { draft, dragOffset, isDragging, formProps, isFormOpen, isResizing } =
+    state;
   const { context, getReferenceProps, getFloatingProps, x, y, refs, strategy } =
     formProps;
 
@@ -51,20 +61,26 @@ export const GridDraft: FC<Props> = ({
     titleInputRef.current?.focus();
   };
 
+  // Schema_GridEvent-shaped projection of the canonical GridEventDraft, for
+  // the still-unconverted renderer components (GridEvent/AllDayEventMemo)
+  // and the forms cluster (EventForm/RecurrenceSection) — see
+  // grid-event-draft.adapter.ts's gridEventDraftToSchemaEvent doc comment.
+  const draftSchemaEvent: Schema_Event | null = draft
+    ? gridEventDraftToSchemaEvent(draft)
+    : null;
+  const draftAsGridEvent: Schema_GridEvent | null = draftSchemaEvent
+    ? ({
+        ...draftSchemaEvent,
+        origin: draftSchemaEvent.origin ?? Origin.COMPASS,
+        user: draftSchemaEvent.user ?? "",
+        position: { ...gridEventDefaultPosition, dragOffset },
+      } as Schema_GridEvent)
+    : null;
+
   const handleDrag = (_: Schema_GridEvent, moveEvent: PartialMouseEvent) => {
     if (!draft) return; // TS Guard
 
-    const newDraft = {
-      ...draft,
-      position: {
-        ...draft.position,
-        dragOffset: getEventDragOffset(draft, moveEvent),
-        initialX: moveEvent.clientX,
-        initialY: moveEvent.clientY,
-      },
-    };
-
-    setDraft(newDraft);
+    setDragOffset(getEventDragOffset(draftAsGridEvent ?? undefined, moveEvent));
     startDragging();
   };
 
@@ -72,16 +88,19 @@ export const GridDraft: FC<Props> = ({
   const motionMode = isResizing ? "resizing" : isDragging ? "dragging" : "idle";
 
   const { onMouseDown } = useGridEventMouseDown(
-    draft?.isAllDay ? Categories_Event.ALLDAY : Categories_Event.TIMED,
+    draft?.values.schedule.kind === "allDay"
+      ? Categories_Event.ALLDAY
+      : Categories_Event.TIMED,
     handleGridDraftClick,
     handleDrag,
   );
 
-  if (!draft) return null;
+  if (!draft || !draftAsGridEvent) return null;
 
-  const allDayDraftEvent = draft.isAllDay
-    ? (activeAllDayDraftEvent ?? draft)
-    : draft;
+  const isAllDay = draft.values.schedule.kind === "allDay";
+  const allDayDraftEvent = isAllDay
+    ? (activeAllDayDraftEvent ?? draftAsGridEvent)
+    : draftAsGridEvent;
 
   return (
     <>
@@ -98,11 +117,11 @@ export const GridDraft: FC<Props> = ({
         />
       ))}
 
-      {draft.isAllDay ? (
+      {isAllDay ? (
         <AllDayEventMemo
           event={allDayDraftEvent}
           isPlaceholder={false}
-          key={`draft-${draft?._id}`}
+          key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}
           onKeyDown={focusTitleInput}
           onMouseDown={(e: MouseEvent, event: Schema_GridEvent) => {
@@ -127,8 +146,8 @@ export const GridDraft: FC<Props> = ({
         <GridEvent
           deckLayout={deckLayout}
           displayMode="draft"
-          event={draft}
-          key={`draft-${draft?._id}`}
+          event={draftAsGridEvent}
+          key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}
           motionMode={motionMode}
           onEventMouseDown={(event: Schema_GridEvent, e: MouseEvent) => {
@@ -166,22 +185,32 @@ export const GridDraft: FC<Props> = ({
             {...getFloatingProps()}
           >
             <EventForm
-              event={draft as Schema_Event}
+              event={draftSchemaEvent as Schema_Event}
               onClose={discard}
               onConvert={onConvert}
               onDelete={onDelete}
               onDuplicate={duplicateEvent}
-              isDraft={!draft._id}
-              isExistingEvent={!!draft._id}
+              isDraft={draft.kind === "create"}
+              isExistingEvent={draft.kind === "edit"}
               onSubmit={(event) => {
-                if (event) void onSubmit(event as Schema_GridEvent);
+                if (event && draft) {
+                  void onSubmit(applySchemaEventPatchToGridDraft(draft, event));
+                }
               }}
               setEvent={(nextEvent) => {
-                const event =
+                if (!draft) return;
+
+                const patch =
                   typeof nextEvent === "function"
-                    ? nextEvent(draft)
+                    ? nextEvent(draftSchemaEvent)
                     : nextEvent;
-                setDraft(event as Schema_GridEvent | null);
+
+                if (!patch) {
+                  setDraft(null);
+                  return;
+                }
+
+                setDraft(applySchemaEventPatchToGridDraft(draft, patch));
               }}
               titleInputRef={titleInputRef}
             />

--- a/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
@@ -21,22 +21,22 @@ export const useGridMouseUp = () => {
     (category: Categories_Event) => {
       let shouldSubmit = false;
       let hasMoved = false;
-      const isNew = !draft?._id;
+      const isNew = draft?.kind !== "edit";
 
       if (category === Categories_Event.TIMED) {
         hasMoved = resizeStatus?.hasMoved || dragStatus?.hasMoved || false;
-        shouldSubmit = !draft?.isOpen;
+        shouldSubmit = true;
       } else if (category === Categories_Event.ALLDAY) {
         hasMoved = dragStatus?.hasMoved || resizeStatus?.hasMoved || false;
         shouldSubmit = hasMoved;
       }
 
       const clickedOnExisting = !isNew && !hasMoved;
-      const shouldOpenForm = (isNew || clickedOnExisting) && !draft?.isOpen;
+      const shouldOpenForm = isNew || clickedOnExisting;
 
       return { shouldOpenForm, shouldSubmit };
     },
-    [draft?._id, draft?.isOpen, dragStatus?.hasMoved, resizeStatus?.hasMoved],
+    [draft?.kind, dragStatus?.hasMoved, resizeStatus?.hasMoved],
   );
 
   const stopMotion = useCallback(() => {
@@ -115,12 +115,12 @@ export const useGridMouseUp = () => {
       if (
         isDrafting &&
         draftType === Categories_Event.SOMEDAY_WEEK &&
-        !draft?.isAllDay
+        draft?.values.schedule.kind !== "allDay"
       ) {
         e.stopPropagation();
       }
 
-      if (draft?.isAllDay) {
+      if (draft?.values.schedule.kind === "allDay") {
         handleAllDayRowMouseUp();
       } else {
         handleMainGridMouseUp();

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/drag-duration.util.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/drag-duration.util.ts
@@ -1,13 +1,13 @@
 import dayjs from "@core/util/date/dayjs";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { type GridScheduleDraft } from "@web/events/event-draft.types";
 import { type Status_Drag } from "@web/views/Week/components/Draft/hooks/state/useDraftState";
 
 export const getDragDurationMinutes = (
-  draft: Schema_GridEvent,
+  schedule: GridScheduleDraft,
   dragStatus: Status_Drag | null,
 ) => {
   return (
     dragStatus?.durationMin ??
-    dayjs(draft.endDate).diff(draft.startDate, "minutes")
+    dayjs(schedule.end).diff(schedule.start, "minutes")
   );
 };

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -1,11 +1,17 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { act } from "react";
-import { Origin, Priorities } from "@core/constants/core.constants";
+import { Priorities } from "@core/constants/core.constants";
+import { type Event } from "@core/types/event.contracts";
 import { Categories_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createInitialState } from "@web/__tests__/utils/state/store.test.util";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  createGridEventDraft,
+  editGridEventDraft,
+  gridEventDraftToSchemaEvent,
+} from "@web/events/grid-event-draft.adapter";
 import { type Activity_DraftEvent } from "@web/events/stores/draft.store";
 import {
   type Setters_Draft,
@@ -21,38 +27,95 @@ let currentState = createInitialState();
 const { useDraftActions } =
   require("./useDraftActions") as typeof import("./useDraftActions");
 
-const createDraft = (
-  overrides: Partial<Schema_GridEvent> = {},
-): Schema_GridEvent => ({
-  _id: "event-1",
-  title: "Seed event",
-  startDate: "2024-01-15T10:00:00.000Z",
-  endDate: "2024-01-15T11:30:00.000Z",
-  isAllDay: false,
-  isSomeday: false,
-  origin: Origin.COMPASS,
-  priority: Priorities.UNASSIGNED,
-  user: "user-1",
-  position: {
-    isOverlapping: false,
-    totalEventsInGroup: 1,
-    widthMultiplier: 1,
-    horizontalOrder: 1,
-    dragOffset: { x: 0, y: 0 },
-    initialX: null,
-    initialY: null,
+const sourceEvent: Event = {
+  id: "0123456789abcdef01234567",
+  calendarId: "0123456789abcdef76543210",
+  content: { kind: "details", title: "Seed event", description: "" },
+  schedule: {
+    kind: "timed",
+    start: "2024-01-15T10:00:00.000Z",
+    end: "2024-01-15T11:30:00.000Z",
+    timeZone: "UTC",
   },
-  ...overrides,
-});
+  recurrence: { kind: "single" },
+  priority: Priorities.UNASSIGNED,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: null,
+} as unknown as Event;
+
+const createEditDraft = (
+  scheduleOverrides: Partial<{
+    start: string;
+    end: string;
+    isAllDay: boolean;
+  }> = {},
+): GridEventDraft => {
+  const draft = editGridEventDraft(sourceEvent);
+  if (!draft || draft.kind !== "edit")
+    throw new Error("Expected an edit draft");
+
+  const { isAllDay, start, end } = scheduleOverrides;
+
+  return {
+    ...draft,
+    values: {
+      ...draft.values,
+      schedule: isAllDay
+        ? {
+            kind: "allDay",
+            start: new Date(start ?? "2024-01-16T00:00:00.000Z"),
+            end: new Date(end ?? "2024-01-17T00:00:00.000Z"),
+          }
+        : {
+            kind: "timed",
+            start: new Date(start ?? "2024-01-16T10:00:00.000Z"),
+            end: new Date(end ?? "2024-01-16T11:00:00.000Z"),
+            timeZone: "UTC",
+          },
+    },
+  };
+};
+
+const createNewDraft = (
+  scheduleOverrides: Partial<{
+    start: string;
+    end: string;
+    isAllDay: boolean;
+  }> = {},
+): GridEventDraft => {
+  const { isAllDay, start, end } = scheduleOverrides;
+
+  return createGridEventDraft(
+    isAllDay
+      ? {
+          kind: "allDay",
+          start: new Date(start ?? "2024-01-16T00:00:00.000Z"),
+          end: new Date(end ?? "2024-01-17T00:00:00.000Z"),
+        }
+      : {
+          kind: "timed",
+          start: new Date(start ?? "2024-01-16T10:00:00.000Z"),
+          end: new Date(end ?? "2024-01-16T11:00:00.000Z"),
+          timeZone: "UTC",
+        },
+  );
+};
 
 describe("getDragDurationMinutes", () => {
+  const schedule = {
+    kind: "timed" as const,
+    start: new Date("2024-01-15T10:00:00.000Z"),
+    end: new Date("2024-01-15T11:30:00.000Z"),
+    timeZone: "UTC",
+  };
+
   it("uses the draft duration before drag status is ready", () => {
-    expect(getDragDurationMinutes(createDraft(), null)).toBe(90);
+    expect(getDragDurationMinutes(schedule, null)).toBe(90);
   });
 
   it("uses the tracked duration once available", () => {
     expect(
-      getDragDurationMinutes(createDraft(), {
+      getDragDurationMinutes(schedule, {
         durationMin: 45,
       }),
     ).toBe(45);
@@ -63,8 +126,9 @@ const createState = (
   overrides: Partial<State_Draft_Local> = {},
 ): State_Draft_Local => ({
   dateBeingChanged: "endDate",
-  draft: createDraft(),
+  draft: createEditDraft(),
   draftSessionKey: 0,
+  dragOffset: { x: 0, y: 0 },
   dragStatus: null,
   isDragging: false,
   isFormOpen: true,
@@ -79,6 +143,7 @@ const createSetters = (
 ): Setters_Draft => ({
   setDateBeingChanged: mock(),
   setDraft: mock(),
+  setDragOffset: mock(),
   setDraftSessionKey: mock(),
   setDragStatus: mock(),
   setIsDragging: mock(),
@@ -116,15 +181,18 @@ const setDraftActivity = (
   };
 };
 
-const renderDraftActions = (draftOverrides: Partial<Schema_GridEvent>) => {
+const renderDraftActions = (draft: GridEventDraft) => {
   const setDraft = mock();
+  currentState.events!.draft = {
+    ...currentState.events!.draft,
+    gridDraft: draft,
+    event: gridEventDraftToSchemaEvent(draft),
+  };
   const { wrapper } = createStoreWrapper(currentState);
   const { result } = renderHook(
     () =>
       useDraftActions(
-        createState({
-          draft: createDraft(draftOverrides),
-        }),
+        createState({ draft }),
         createSetters({ setDraft }),
         dateCalcs,
         weekProps,
@@ -142,18 +210,19 @@ const expectDraftRange = (
   startDate: string,
   endDate: string,
 ) => {
-  const nextDraft = setDraft.mock.calls[0]?.[0] as Schema_GridEvent;
+  const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
 
-  expect(dayjs(nextDraft.startDate).isSame(startDate)).toBe(true);
-  expect(dayjs(nextDraft.endDate).isSame(endDate)).toBe(true);
+  expect(dayjs(nextDraft.values.schedule.start).isSame(startDate)).toBe(true);
+  expect(dayjs(nextDraft.values.schedule.end).isSame(endDate)).toBe(true);
 };
 
 describe("useDraftActions", () => {
   beforeEach(() => {
-    const draft = createDraft();
+    const draft = createEditDraft();
     currentState = createInitialState();
     currentState.events!.draft = {
-      event: draft,
+      gridDraft: draft,
+      event: gridEventDraftToSchemaEvent(draft),
       status: {
         activity: "eventRightClick",
         dateToResize: null,
@@ -200,11 +269,12 @@ describe("useDraftActions", () => {
 
   it("moves a shortcut-created timed draft by keyboard while preserving duration", () => {
     setDraftActivity("createShortcut");
-    const { result, setDraft } = renderDraftActions({
-      _id: undefined,
-      startDate: "2024-01-16T10:00:00.000Z",
-      endDate: "2024-01-16T11:00:00.000Z",
-    });
+    const { result, setDraft } = renderDraftActions(
+      createNewDraft({
+        start: "2024-01-16T10:00:00.000Z",
+        end: "2024-01-16T11:00:00.000Z",
+      }),
+    );
 
     result.current.repositionDraftByKeyboard("ArrowDown");
 
@@ -217,11 +287,12 @@ describe("useDraftActions", () => {
 
   it("moves a mouse-created timed draft by keyboard while preserving duration", () => {
     setDraftActivity("gridClick");
-    const { result, setDraft } = renderDraftActions({
-      _id: undefined,
-      startDate: "2024-01-16T10:00:00.000Z",
-      endDate: "2024-01-16T11:00:00.000Z",
-    });
+    const { result, setDraft } = renderDraftActions(
+      createNewDraft({
+        start: "2024-01-16T10:00:00.000Z",
+        end: "2024-01-16T11:00:00.000Z",
+      }),
+    );
 
     result.current.repositionDraftByKeyboard("ArrowDown");
 
@@ -234,11 +305,12 @@ describe("useDraftActions", () => {
 
   it("moves a clicked existing timed event draft by keyboard", () => {
     setDraftActivity("gridClick");
-    const { result, setDraft } = renderDraftActions({
-      _id: "event-1",
-      startDate: "2024-01-16T10:00:00.000Z",
-      endDate: "2024-01-16T11:00:00.000Z",
-    });
+    const { result, setDraft } = renderDraftActions(
+      createEditDraft({
+        start: "2024-01-16T10:00:00.000Z",
+        end: "2024-01-16T11:00:00.000Z",
+      }),
+    );
 
     result.current.repositionDraftByKeyboard("ArrowLeft");
 
@@ -251,11 +323,12 @@ describe("useDraftActions", () => {
 
   it("moves a keyboard-opened existing timed event draft by keyboard", () => {
     setDraftActivity("keyboardEdit");
-    const { result, setDraft } = renderDraftActions({
-      _id: "event-1",
-      startDate: "2024-01-16T10:00:00.000Z",
-      endDate: "2024-01-16T11:00:00.000Z",
-    });
+    const { result, setDraft } = renderDraftActions(
+      createEditDraft({
+        start: "2024-01-16T10:00:00.000Z",
+        end: "2024-01-16T11:00:00.000Z",
+      }),
+    );
 
     result.current.repositionDraftByKeyboard("ArrowRight");
 
@@ -268,11 +341,12 @@ describe("useDraftActions", () => {
 
   it("does not move a timed draft past midnight", () => {
     setDraftActivity("createShortcut");
-    const { result, setDraft } = renderDraftActions({
-      _id: undefined,
-      startDate: "2024-01-16T23:00:00.000Z",
-      endDate: "2024-01-17T00:00:00.000Z",
-    });
+    const { result, setDraft } = renderDraftActions(
+      createNewDraft({
+        start: "2024-01-16T23:00:00.000Z",
+        end: "2024-01-17T00:00:00.000Z",
+      }),
+    );
 
     result.current.repositionDraftByKeyboard("ArrowDown");
 
@@ -281,12 +355,13 @@ describe("useDraftActions", () => {
 
   it("moves a clicked existing all-day event draft horizontally and ignores vertical arrows", () => {
     setDraftActivity("gridClick", Categories_Event.ALLDAY);
-    const { result, setDraft } = renderDraftActions({
-      _id: "event-1",
-      isAllDay: true,
-      startDate: "2024-01-16T00:00:00.000Z",
-      endDate: "2024-01-17T00:00:00.000Z",
-    });
+    const { result, setDraft } = renderDraftActions(
+      createEditDraft({
+        isAllDay: true,
+        start: "2024-01-16T00:00:00.000Z",
+        end: "2024-01-17T00:00:00.000Z",
+      }),
+    );
 
     result.current.repositionDraftByKeyboard("ArrowRight");
 
@@ -304,12 +379,13 @@ describe("useDraftActions", () => {
 
   it("moves a shortcut-created all-day draft horizontally and ignores vertical arrows", () => {
     setDraftActivity("createShortcut", Categories_Event.ALLDAY);
-    const { result, setDraft } = renderDraftActions({
-      _id: undefined,
-      isAllDay: true,
-      startDate: "2024-01-16T00:00:00.000Z",
-      endDate: "2024-01-17T00:00:00.000Z",
-    });
+    const { result, setDraft } = renderDraftActions(
+      createNewDraft({
+        isAllDay: true,
+        start: "2024-01-16T00:00:00.000Z",
+        end: "2024-01-17T00:00:00.000Z",
+      }),
+    );
 
     result.current.repositionDraftByKeyboard("ArrowRight");
 

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -5,12 +5,10 @@ import {
   SOMEDAY_WEEK_LIMIT_MSG,
 } from "@core/constants/core.constants";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
-import { MapEvent } from "@core/mappers/map.event";
 import { DateOnlySchema, EventIdSchema } from "@core/types/domain-primitives";
 import {
   Categories_Event,
   RecurringEventUpdateScope,
-  type Schema_Event,
 } from "@core/types/event.types";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import { devAlert } from "@core/util/app.util";
@@ -18,8 +16,7 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
-import { assembleDefaultEvent } from "@web/common/utils/event/event.util";
+import { assembleWebEvent } from "@web/common/utils/event/event.util";
 import {
   getArrowKeyMovement,
   isTimedEventInsideOneDay,
@@ -30,16 +27,25 @@ import {
 } from "@web/common/utils/event/someday.event.util";
 import { DirtyParser } from "@web/common/utils/parse/dirty.parser";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
-import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import {
-  schemaEventToCreateInput,
-  schemaEventToReplaceInput,
-} from "@web/events/queries/event.legacy-bridge";
+  type GridEventDraft,
+  type GridScheduleDraft,
+} from "@web/events/event-draft.types";
+import {
+  createGridEventDraft,
+  duplicateGridEventDraft,
+  gridEventDraftToSchemaEvent,
+  parseGridEventDraft,
+  replaceGridDraftSchedule,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import { useSomedayEventViewModel } from "@web/events/queries/useSomedayEventsQuery";
 import {
   draftActions,
   selectDraft,
   selectDraftStatus,
+  selectGridDraft,
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { useDraftEffects } from "@web/views/Week/components/Draft/hooks/effects/useDraftEffects";
@@ -81,6 +87,7 @@ export const useDraftActions = (
       weekProps.component.endOfView,
     );
   const draftFromStore = useDraftStore(selectDraft);
+  const gridDraftFromStore = useDraftStore(selectGridDraft);
 
   const { activity, dateToResize, eventType, isDrafting } =
     useDraftStore(selectDraftStatus)!;
@@ -88,6 +95,7 @@ export const useDraftActions = (
   const {
     dateBeingChanged,
     draft,
+    dragOffset,
     dragStatus,
     isDragging,
     isResizing,
@@ -178,13 +186,14 @@ export const useDraftActions = (
       applyTo: RecurringEventUpdateScope = RecurringEventUpdateScope.THIS_EVENT,
     ) => {
       // No confirmation prompt: deletes are undoable via Cmd/Ctrl+Z
-      const eventToDelete = draft ?? draftFromStore;
-      const id = eventToDelete?._id
-        ? EventIdSchema.safeParse(eventToDelete._id)
+      const draftId = draft?.kind === "edit" ? draft.source.id : undefined;
+      const storeId = draftFromStore?._id
+        ? EventIdSchema.safeParse(draftFromStore._id)
         : undefined;
+      const id = draftId ?? (storeId?.success ? storeId.data : undefined);
 
-      if (id?.success) {
-        mutations.delete({ id: id.data, scope: scopeFromApplyTo(applyTo) });
+      if (id) {
+        mutations.delete({ id, scope: scopeFromApplyTo(applyTo) });
       }
       discard();
     },
@@ -198,31 +207,40 @@ export const useDraftActions = (
         return;
       }
 
-      const somedayEvent = buildConvertToSomedayEvent(
-        draft!,
-        { startDate: start, endDate: end },
-        somedayWeekCount,
-      );
-      const id = EventIdSchema.safeParse(somedayEvent._id);
-
-      if (id.success) {
-        const category = getSomedayEventCategory(somedayEvent);
-
-        mutations.transition({
-          id: id.data,
-          input: {
-            kind: "unschedule",
-            schedule: {
-              kind: "someday",
-              period:
-                category === Categories_Event.SOMEDAY_MONTH ? "month" : "week",
-              anchorDate: DateOnlySchema.parse(
-                somedayEvent.startDate!.slice(0, 10),
-              ),
-              sortOrder: somedayEvent.order ?? 0,
-            },
-          },
+      if (draft) {
+        const schemaEvent = assembleWebEvent({
+          ...gridEventDraftToSchemaEvent(draft),
+          startDate: dayjs(draft.values.schedule.start).format(),
+          endDate: dayjs(draft.values.schedule.end).format(),
         });
+        const somedayEvent = buildConvertToSomedayEvent(
+          schemaEvent,
+          { startDate: start, endDate: end },
+          somedayWeekCount,
+        );
+        const id = EventIdSchema.safeParse(somedayEvent._id);
+
+        if (id.success) {
+          const category = getSomedayEventCategory(somedayEvent);
+
+          mutations.transition({
+            id: id.data,
+            input: {
+              kind: "unschedule",
+              schedule: {
+                kind: "someday",
+                period:
+                  category === Categories_Event.SOMEDAY_MONTH
+                    ? "month"
+                    : "week",
+                anchorDate: DateOnlySchema.parse(
+                  somedayEvent.startDate!.slice(0, 10),
+                ),
+                sortOrder: somedayEvent.order ?? 0,
+              },
+            },
+          });
+        }
       }
 
       discard();
@@ -235,30 +253,27 @@ export const useDraftActions = (
   }, [setIsFormOpen]);
 
   const determineSubmitAction = useCallback(
-    (draft: Schema_GridEvent) => {
-      const isExisting = !!draft._id;
-      if (!isExisting) return "CREATE";
+    (draft: GridEventDraft) => {
+      if (draft.kind !== "edit") return "CREATE";
 
-      if (isExisting) {
-        if (isFormOpenBeforeDragging) {
-          return "OPEN_FORM";
-        }
-        const isSame = draftFromStore
-          ? !DirtyParser.isEventDirty(draft, draftFromStore)
-          : false;
-        if (isSame) {
-          // no need to make HTTP request
-          return "DISCARD";
-        }
+      if (isFormOpenBeforeDragging) {
+        return "OPEN_FORM";
       }
+
+      const isSame = !DirtyParser.isGridDraftDirty(draft);
+      if (isSame) {
+        // no need to make HTTP request
+        return "DISCARD";
+      }
+
       return "UPDATE";
     },
-    [draftFromStore, isFormOpenBeforeDragging],
+    [isFormOpenBeforeDragging],
   );
 
   const submit = useCallback(
     async (
-      draft: Schema_GridEvent,
+      draft: GridEventDraft,
       applyTo: RecurringEventUpdateScope = RecurringEventUpdateScope.THIS_EVENT,
     ) => {
       const action = determineSubmitAction(draft);
@@ -270,25 +285,36 @@ export const useDraftActions = (
           discard();
           return;
         case "CREATE": {
+          if (draft.kind !== "create") return;
+
           const calendarId = getDefaultTargetCalendar(calendars ?? [])?.id;
           if (!calendarId) return;
 
-          const input = schemaEventToCreateInput(draft, calendarId);
-          if (input) mutations.create(input);
+          const parsed = parseGridEventDraft({
+            ...draft,
+            values: { ...draft.values, calendarId },
+          });
+
+          if (parsed.ok && parsed.mode === "create") {
+            mutations.create(parsed.input);
+          }
           return;
         }
         case "UPDATE": {
-          const id = draft._id ? EventIdSchema.safeParse(draft._id) : undefined;
-          if (!id?.success) {
+          if (draft.kind !== "edit") {
             discard();
             return;
           }
 
-          const input = schemaEventToReplaceInput(
-            draft,
-            scopeFromApplyTo(applyTo),
-          );
-          if (input) mutations.replace({ id: id.data, input });
+          const scope = scopeFromApplyTo(applyTo);
+          const parsed = parseGridEventDraft({
+            ...draft,
+            values: { ...draft.values, scope },
+          });
+
+          if (parsed.ok && parsed.mode === "edit") {
+            mutations.replace({ id: parsed.eventId, input: parsed.input });
+          }
 
           if (isFormOpenBeforeDragging) {
             openForm();
@@ -312,14 +338,53 @@ export const useDraftActions = (
   );
 
   const duplicateEvent = useCallback(() => {
-    const draft = MapEvent.removeProviderData({
-      ...(draftFromStore as Schema_Event),
-    }) as Schema_GridEvent;
-    const { _id: _duplicatedEventId, ...duplicateDraft } = draft;
+    if (!gridDraftFromStore) {
+      discard();
+      return;
+    }
 
-    submit(duplicateDraft);
+    if (gridDraftFromStore.kind !== "edit") {
+      // In-progress, not-yet-saved draft: duplicate its current form values.
+      void submit({
+        kind: "create",
+        source: null,
+        values: { ...gridDraftFromStore.values },
+      });
+      discard();
+      return;
+    }
+
+    const duplicate = duplicateGridEventDraft(gridDraftFromStore.source);
+    if (!duplicate) {
+      discard();
+      return;
+    }
+
+    // duplicateGridEventDraft always drops recurrence (built for Day, which
+    // has no recurring-series duplication UX). Week must preserve a
+    // series-base event's rule on duplicate — matching the legacy
+    // MapEvent.removeProviderData behavior this replaces, which kept
+    // `recurrence.rule` for a series but dropped an occurrence's `eventId`
+    // link (an occurrence's duplicate becomes standalone, since it carries
+    // no rule of its own).
+    const sourceRecurrence = gridDraftFromStore.source.recurrence;
+    const withRecurrence: GridEventDraft =
+      sourceRecurrence.kind === "series" && duplicate.kind === "create"
+        ? {
+            ...duplicate,
+            values: {
+              ...duplicate.values,
+              recurrence: {
+                kind: "series",
+                rules: [...sourceRecurrence.rules],
+              },
+            },
+          }
+        : duplicate;
+
+    void submit(withRecurrence);
     discard();
-  }, [draftFromStore, submit, discard]);
+  }, [gridDraftFromStore, submit, discard]);
 
   const isInsideVisibleWeek = useCallback(
     (start: Dayjs) => {
@@ -337,11 +402,12 @@ export const useDraftActions = (
     (key: string) => {
       if (!canRepositionDraftByKeyboard(activity) || !draft) return false;
 
-      const movement = getArrowKeyMovement(key, Boolean(draft.isAllDay));
+      const isAllDay = draft.values.schedule.kind === "allDay";
+      const movement = getArrowKeyMovement(key, isAllDay);
       if (!movement) return false;
 
-      const start = dayjs(draft.startDate);
-      const end = dayjs(draft.endDate);
+      const start = dayjs(draft.values.schedule.start);
+      const end = dayjs(draft.values.schedule.end);
       const nextStart = start
         .add(movement.days, "day")
         .add(movement.minutes, "minutes");
@@ -351,15 +417,19 @@ export const useDraftActions = (
 
       if (!isInsideVisibleWeek(nextStart)) return false;
 
-      if (!draft.isAllDay && !isTimedEventInsideOneDay(nextStart, nextEnd)) {
+      if (!isAllDay && !isTimedEventInsideOneDay(nextStart, nextEnd)) {
         return false;
       }
 
-      setDraft({
-        ...draft,
-        startDate: nextStart.format(),
-        endDate: nextEnd.format(),
-      });
+      const schedule: GridScheduleDraft = isAllDay
+        ? { kind: "allDay", start: nextStart.toDate(), end: nextEnd.toDate() }
+        : {
+            ...draft.values.schedule,
+            start: nextStart.toDate(),
+            end: nextEnd.toDate(),
+          };
+
+      setDraft(replaceGridDraftSchedule(draft, schedule));
 
       return true;
     },
@@ -373,11 +443,15 @@ export const useDraftActions = (
       ) => {
         if (!draft) return;
 
+        const isAllDay = draft.values.schedule.kind === "allDay";
         const rawX = e.clientX;
-        const x = draft.isAllDay ? rawX - draft.position.dragOffset.x : rawX;
-        const startEndDurationMin = getDragDurationMinutes(draft, dragStatus);
+        const x = isAllDay ? rawX - dragOffset.x : rawX;
+        const startEndDurationMin = getDragDurationMinutes(
+          draft.values.schedule,
+          dragStatus,
+        );
 
-        const y = e.clientY - draft.position.dragOffset.y;
+        const y = e.clientY - dragOffset.y;
 
         let eventStart = dateCalcs.getDateByXY(
           x,
@@ -387,7 +461,7 @@ export const useDraftActions = (
 
         let eventEnd = eventStart.add(startEndDurationMin, "minutes");
 
-        if (!draft.isAllDay) {
+        if (!isAllDay) {
           // Edge case: timed events' end times can overflow past midnight at the bottom of the grid.
           // Below logic prevents that from occurring.
           if (eventEnd.date() !== eventStart.date()) {
@@ -396,18 +470,27 @@ export const useDraftActions = (
           }
         }
 
-        const _draft: Schema_GridEvent = {
-          ...draft,
-          startDate: draft.isAllDay
-            ? eventStart.format(YEAR_MONTH_DAY_FORMAT)
-            : eventStart.format(),
-          endDate: draft.isAllDay
-            ? eventEnd.format(YEAR_MONTH_DAY_FORMAT)
-            : eventEnd.format(),
-          priority: draft.priority || Priorities.UNASSIGNED,
-        };
+        const schedule: GridScheduleDraft = isAllDay
+          ? {
+              kind: "allDay",
+              start: eventStart.toDate(),
+              end: eventEnd.toDate(),
+            }
+          : {
+              ...draft.values.schedule,
+              start: eventStart.toDate(),
+              end: eventEnd.toDate(),
+            };
 
-        setDraft(_draft);
+        const nextDraft = replaceGridDraftSchedule(draft, schedule);
+
+        setDraft({
+          ...nextDraft,
+          values: {
+            ...nextDraft.values,
+            priority: nextDraft.values.priority || Priorities.UNASSIGNED,
+          },
+        } as GridEventDraft);
       };
       if (!isDragging) {
         devAlert("not dragging (anymore?)");
@@ -419,7 +502,10 @@ export const useDraftActions = (
         e.clientY,
         weekProps.component.startOfView,
       );
-      const hasMoved = currTime !== draft?.startDate;
+      const draftStartStr = draft
+        ? dayjs(draft.values.schedule.start).format()
+        : undefined;
+      const hasMoved = currTime !== draftStartStr;
 
       if (!dragStatus?.hasMoved && hasMoved) {
         setDragStatus(
@@ -437,6 +523,7 @@ export const useDraftActions = (
       dateCalcs,
       weekProps.component.startOfView,
       draft,
+      dragOffset,
       dragStatus,
       setDraft,
       setDragStatus,
@@ -447,19 +534,26 @@ export const useDraftActions = (
     (currTime: dayjs.Dayjs) => {
       if (!draft || !dateBeingChanged) return false;
 
-      if (draft.isAllDay) {
+      const isAllDay = draft.values.schedule.kind === "allDay";
+      if (isAllDay) {
         return true;
       }
 
+      const draftDate =
+        dateBeingChanged === "startDate"
+          ? draft.values.schedule.start
+          : draft.values.schedule.end;
       const _currTime = currTime.format();
-      const noChange = draft[dateBeingChanged] === _currTime;
+      const noChange = dayjs(draftDate).format() === _currTime;
 
       if (noChange) return false;
 
-      const diffDay = currTime.day() !== dayjs(draft.startDate).day();
+      const diffDay =
+        currTime.day() !== dayjs(draft.values.schedule.start).day();
       if (diffDay) return false;
 
-      const sameStart = currTime.format() === draft.startDate;
+      const sameStart =
+        _currTime === dayjs(draft.values.schedule.start).format();
       if (sameStart) return false;
 
       return true;
@@ -471,24 +565,40 @@ export const useDraftActions = (
     (e: MouseEvent) => {
       if (!draft || !draftFromStore) return; // TS Guard
 
+      const isAllDay = draft.values.schedule.kind === "allDay";
       const _dateBeingChanged = dateBeingChanged as "startDate" | "endDate";
       const oppositeKey =
         _dateBeingChanged === "startDate" ? "endDate" : "startDate";
 
+      // String mirrors of the draft's live schedule, formatted exactly as
+      // the legacy Schema_GridEvent draft stored them (all-day: day-only
+      // YEAR_MONTH_DAY_FORMAT strings; timed: full offset strings). The flip
+      // math below is unchanged dayjs-string arithmetic ported verbatim from
+      // before the GridEventDraft conversion, reading/writing through this
+      // mirror instead of native Schema_GridEvent fields.
+      const formatDraftDate = (date: Date) =>
+        isAllDay
+          ? dayjs(date).format(YEAR_MONTH_DAY_FORMAT)
+          : dayjs(date).format();
+      const draftDates: Record<"startDate" | "endDate", string> = {
+        startDate: formatDraftDate(draft.values.schedule.start),
+        endDate: formatDraftDate(draft.values.schedule.end),
+      };
+
       const flipIfNeeded = (currTime: Dayjs) => {
-        let startDate = draft?.startDate;
-        let endDate = draft?.endDate;
+        let startDate = draftDates.startDate;
+        let endDate = draftDates.endDate;
 
         let justFlipped = false;
         let dateKey = dateBeingChanged;
-        const opposite = dayjs(draft?.[oppositeKey]);
+        const opposite = dayjs(draftDates[oppositeKey]);
         const comparisonKeyword =
           dateBeingChanged === "startDate" ? "after" : "before";
 
         if (comparisonKeyword === "after") {
           if (currTime.isAfter(opposite)) {
             dateKey = oppositeKey;
-            startDate = draft?.endDate;
+            startDate = draftDates.endDate;
             setDateBeingChanged(dateKey);
 
             justFlipped = true;
@@ -496,7 +606,7 @@ export const useDraftActions = (
         } else if (comparisonKeyword === "before") {
           if (currTime.isBefore(opposite)) {
             setDateBeingChanged(oppositeKey);
-            if (draft?.isAllDay) {
+            if (isAllDay) {
               // For all-day events, move by day
               startDate = dayjs(startDate)
                 .subtract(1, "day")
@@ -519,15 +629,31 @@ export const useDraftActions = (
         }
 
         closeForm();
-        setDraft((_draft): Schema_GridEvent => {
+
+        const schedule: GridScheduleDraft = isAllDay
+          ? {
+              kind: "allDay",
+              start: dayjs(startDate).toDate(),
+              end: dayjs(endDate).toDate(),
+            }
+          : {
+              ...draft.values.schedule,
+              start: dayjs(startDate).toDate(),
+              end: dayjs(endDate).toDate(),
+            };
+
+        setDraft((_draft) => {
+          if (!_draft) return _draft;
+
+          const withSchedule = replaceGridDraftSchedule(_draft, schedule);
+
           return {
-            ..._draft!,
-            _id: _draft!._id,
-            hasFlipped: justFlipped,
-            endDate: endDate,
-            startDate: startDate,
-            priority: draft.priority,
-          };
+            ...withSchedule,
+            values: {
+              ...withSchedule.values,
+              priority: draft.values.priority,
+            },
+          } as GridEventDraft;
         });
 
         return justFlipped;
@@ -539,7 +665,7 @@ export const useDraftActions = (
       if (!isResizing) return;
 
       // For all-day events, use a fixed Y coordinate (0) because Y positioning is irrelevant:
-      const y = draft.isAllDay ? 0 : e.clientY;
+      const y = isAllDay ? 0 : e.clientY;
       const currTime = dateCalcs.getDateByXY(
         e.clientX,
         y,
@@ -558,7 +684,7 @@ export const useDraftActions = (
       let updatedTime: string;
       let hasMoved: boolean;
 
-      if (draft?.isAllDay) {
+      if (isAllDay) {
         // For all-day events, work with day differences
         const diffDays = currTime.diff(origTime, "day", true);
         updatedTime = currTime
@@ -576,11 +702,17 @@ export const useDraftActions = (
         setResizeStatus({ hasMoved: true });
       }
 
-      setDraft((_draft): Schema_GridEvent => {
-        return {
-          ..._draft!,
-          ...(dateChanged ? { [dateChanged]: updatedTime } : {}),
-        };
+      setDraft((_draft) => {
+        if (!_draft) return _draft;
+
+        const nextSchedule: GridScheduleDraft = {
+          ..._draft.values.schedule,
+          ...(dateChanged === "startDate"
+            ? { start: dayjs(updatedTime).toDate() }
+            : { end: dayjs(updatedTime).toDate() }),
+        } as GridScheduleDraft;
+
+        return replaceGridDraftSchedule(_draft, nextSchedule);
       });
     },
     [
@@ -602,23 +734,42 @@ export const useDraftActions = (
   const create = useCallback(async () => {
     setDraftSessionKey((key) => key + 1);
 
-    if (draftFromStore !== null) {
-      setDraft(draftFromStore as Schema_GridEvent);
+    if (gridDraftFromStore) {
+      setDraft(gridDraftFromStore);
     } else {
-      const { startDate, endDate } = draftFromStore ?? {
-        startDate: undefined,
-        endDate: undefined,
-      };
+      // Rare fallback: a "gridClick" activity started via
+      // draftActions.startGridClick (a source event not yet in the query
+      // cache), which has no GridEventDraft to hand off. Build a default
+      // from the legacy Schema_Event mirror's dates instead.
+      const startDate = draftFromStore?.startDate;
+      const endDate = draftFromStore?.endDate;
+      const isAllDay = eventType === Categories_Event.ALLDAY;
 
-      const defaultDraft = (await assembleDefaultEvent(
-        eventType,
-        startDate,
-        endDate,
-      )) as Schema_GridEvent;
-      setDraft(defaultDraft);
+      const schedule: GridScheduleDraft = isAllDay
+        ? {
+            kind: "allDay",
+            start: startDate ? dayjs(startDate).toDate() : dayjs().toDate(),
+            end: endDate
+              ? dayjs(endDate).toDate()
+              : dayjs().add(1, "day").toDate(),
+          }
+        : timedGridSchedule(
+            startDate ? dayjs(startDate).toDate() : dayjs().toDate(),
+            endDate ? dayjs(endDate).toDate() : dayjs().add(1, "hour").toDate(),
+          );
+
+      setDraft(createGridEventDraft(schedule));
     }
+
     openForm();
-  }, [openForm, draftFromStore, eventType, setDraft, setDraftSessionKey]);
+  }, [
+    openForm,
+    gridDraftFromStore,
+    draftFromStore,
+    eventType,
+    setDraft,
+    setDraftSessionKey,
+  ]);
 
   const handleChange = useCallback(async () => {
     const isSomeday =
@@ -630,7 +781,7 @@ export const useDraftActions = (
     }
     if (!isSomeday && activity === "keyboardEdit") {
       setDraftSessionKey((key) => key + 1);
-      setDraft(draftFromStore as Schema_GridEvent);
+      if (gridDraftFromStore) setDraft(gridDraftFromStore);
       openForm();
       return;
     }
@@ -643,7 +794,7 @@ export const useDraftActions = (
     }
     if (activity === "resizing") {
       setDraftSessionKey((key) => key + 1);
-      setDraft(draftFromStore as Schema_GridEvent);
+      if (gridDraftFromStore) setDraft(gridDraftFromStore);
       startResizing();
     }
   }, [
@@ -653,7 +804,7 @@ export const useDraftActions = (
     create,
     setDraft,
     setDraftSessionKey,
-    draftFromStore,
+    gridDraftFromStore,
     startResizing,
     openForm,
   ]);

--- a/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { Origin, Priorities } from "@core/constants/core.constants";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { Priorities } from "@core/constants/core.constants";
+import { type Event } from "@core/types/event.contracts";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import {
   type Setters_Draft,
   type State_Draft_Local,
@@ -10,29 +12,27 @@ import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { useDraftEffects } from "./useDraftEffects";
 import { describe, expect, it, mock } from "bun:test";
 
-const createDraft = (
-  overrides: Partial<Schema_GridEvent> = {},
-): Schema_GridEvent => ({
-  _id: "event-1",
-  title: "Moved event",
-  startDate: "2024-01-15T10:00:00.000Z",
-  endDate: "2024-01-15T11:00:00.000Z",
-  isAllDay: false,
-  isSomeday: false,
-  origin: Origin.COMPASS,
-  priority: Priorities.UNASSIGNED,
-  user: "user-1",
-  position: {
-    isOverlapping: false,
-    totalEventsInGroup: 1,
-    widthMultiplier: 1,
-    horizontalOrder: 1,
-    dragOffset: { x: 0, y: 0 },
-    initialX: null,
-    initialY: null,
+const sourceEvent: Event = {
+  id: "0123456789abcdef01234567",
+  calendarId: "0123456789abcdef76543210",
+  content: { kind: "details", title: "Moved event", description: "" },
+  schedule: {
+    kind: "timed",
+    start: "2024-01-15T10:00:00.000Z",
+    end: "2024-01-15T11:00:00.000Z",
+    timeZone: "UTC",
   },
-  ...overrides,
-});
+  recurrence: { kind: "single" },
+  priority: Priorities.UNASSIGNED,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: null,
+} as unknown as Event;
+
+const createDraft = (): GridEventDraft => {
+  const draft = editGridEventDraft(sourceEvent);
+  if (!draft) throw new Error("Expected an edit draft");
+  return draft;
+};
 
 const createState = (
   overrides: Partial<State_Draft_Local> = {},
@@ -40,6 +40,7 @@ const createState = (
   dateBeingChanged: "endDate",
   draft: createDraft(),
   draftSessionKey: 0,
+  dragOffset: { x: 0, y: 0 },
   dragStatus: { durationMin: 60, hasMoved: true },
   isDragging: true,
   isFormOpen: false,
@@ -54,6 +55,7 @@ const createSetters = (
 ): Setters_Draft => ({
   setDateBeingChanged: mock(),
   setDraft: mock(),
+  setDragOffset: mock(),
   setDraftSessionKey: mock(),
   setDragStatus: mock(),
   setIsDragging: mock(),

--- a/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
@@ -85,12 +85,19 @@ export const useDraftEffects = (
   useEffect(() => {
     if (isDragging && draft) {
       setIsFormOpen(false);
-      const durationMin = dayjs(draft.endDate).diff(draft.startDate, "minutes");
+      const { start, end } = draft.values.schedule;
+      const durationMin = dayjs(end).diff(start, "minutes");
 
       setDragStatus((dragStatus) => ({
         durationMin,
         hasMoved: dragStatus?.hasMoved,
       }));
     }
-  }, [isDragging, setDragStatus, draft?.endDate, draft, setIsFormOpen]);
+  }, [
+    isDragging,
+    setDragStatus,
+    draft?.values.schedule.end,
+    draft,
+    setIsFormOpen,
+  ]);
 };

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.test.tsx
@@ -2,86 +2,85 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
 import { ObjectId } from "bson";
 import { type PropsWithChildren } from "react";
-import { Origin, Priorities } from "@core/constants/core.constants";
 import { EventIdSchema } from "@core/types/domain-primitives";
 import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
-import {
-  RecurringEventUpdateScope,
-  type Schema_Event,
-} from "@core/types/event.types";
+import { RecurringEventUpdateScope } from "@core/types/event.types";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import {
+  type EditEventRecurrenceDraft,
+  type GridEventDraft,
+  type NewEventRecurrenceDraft,
+} from "@web/events/event-draft.types";
+import {
+  createGridEventDraft,
+  editGridEventDraft,
+} from "@web/events/grid-event-draft.adapter";
 import { normalizeEventList } from "@web/events/queries/event.query.normalize";
 import { useDraftConfirmation } from "./useDraftConfirmation";
 import { describe, expect, it, mock } from "bun:test";
 
-const createDraft = (
-  overrides: Partial<Schema_GridEvent> = {},
-): Schema_GridEvent => ({
-  _id: "event-1",
-  title: "Seed event",
-  startDate: "2026-05-31T10:00:00.000Z",
-  endDate: "2026-05-31T11:00:00.000Z",
-  isAllDay: false,
-  isSomeday: false,
-  origin: Origin.COMPASS,
-  priority: Priorities.UNASSIGNED,
-  user: "user-1",
-  position: {
-    isOverlapping: false,
-    totalEventsInGroup: 1,
-    widthMultiplier: 1,
-    horizontalOrder: 1,
-    dragOffset: { x: 0, y: 0 },
-    initialX: null,
-    initialY: null,
-  },
-  ...overrides,
+const SCHEDULE = EventScheduleSchema.parse({
+  kind: "timed",
+  start: "2026-05-31T10:00:00.000Z",
+  end: "2026-05-31T11:00:00.000Z",
+  timeZone: "UTC",
 });
 
-// The query cache requires strict-contract `Event`s (unlike the draft
-// itself, which is still legacy Schema_GridEvent-shaped per draft.store.ts's
-// own TODO).
-const toStrictEvent = (event: Schema_Event): Event =>
-  createMockEvent({
-    id: EventIdSchema.parse(event._id!),
-    content: {
-      kind: "details",
-      title: event.title ?? "",
-      description: event.description ?? "",
-    },
-    recurrence:
-      Array.isArray(event.recurrence?.rule) && event.recurrence.rule.length > 0
-        ? { kind: "series", rules: event.recurrence.rule }
-        : { kind: "single" },
-    schedule: EventScheduleSchema.parse({
-      kind: "timed",
-      start: event.startDate!,
-      end: event.endDate!,
-      timeZone: "UTC",
-    }),
+const buildCreateDraft = (
+  recurrence: NewEventRecurrenceDraft = { kind: "single" },
+): GridEventDraft => {
+  const draft = createGridEventDraft({
+    kind: "timed",
+    start: new Date("2026-05-31T10:00:00.000Z"),
+    end: new Date("2026-05-31T11:00:00.000Z"),
+    timeZone: "UTC",
   });
+  if (draft.kind !== "create") throw new Error("Expected a create draft");
+
+  return { ...draft, values: { ...draft.values, recurrence } };
+};
+
+const buildEditDraft = ({
+  id = "0123456789abcdef01234567",
+  recurrence = { kind: "single" },
+  liveRecurrence = { kind: "preserve" },
+}: {
+  id?: string;
+  recurrence?: Event["recurrence"];
+  liveRecurrence?: EditEventRecurrenceDraft;
+} = {}): GridEventDraft => {
+  const source = createMockEvent({
+    id: EventIdSchema.parse(id),
+    recurrence,
+    schedule: SCHEDULE,
+  });
+  const draft = editGridEventDraft(source);
+  if (!draft || draft.kind !== "edit")
+    throw new Error("Expected an edit draft");
+
+  return { ...draft, values: { ...draft.values, recurrence: liveRecurrence } };
+};
 
 const renderDraftConfirmation = ({
-  draft = createDraft(),
-  events = [],
+  draft,
+  seriesEvents = [],
   isInstance = false,
   isRecurrence = false,
   isSomeday = false,
 }: {
-  draft?: Schema_GridEvent;
-  events?: Schema_Event[];
+  draft: GridEventDraft;
+  seriesEvents?: Event[];
   isInstance?: boolean;
   isRecurrence?: boolean;
   isSomeday?: boolean;
-} = {}) => {
+}) => {
   const discard = mock();
   const deleteEvent = mock();
   const submit = mock();
   const queryClient = new QueryClient();
   queryClient.setQueryData(
     ["events", "week", { source: "local" }],
-    normalizeEventList(events.map(toStrictEvent)),
+    normalizeEventList(seriesEvents),
   );
   const wrapper = ({ children }: PropsWithChildren) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -110,11 +109,9 @@ const renderDraftConfirmation = ({
 
 describe("useDraftConfirmation", () => {
   it("submits a new recurring draft without opening the update scope dialog", async () => {
-    const draft = createDraft({
-      _id: undefined,
-      recurrence: {
-        rule: ["FREQ=WEEKLY;COUNT=4"],
-      },
+    const draft = buildCreateDraft({
+      kind: "series",
+      rules: ["FREQ=WEEKLY;COUNT=4"],
     });
     const { discard, result, submit } = renderDraftConfirmation({ draft });
 
@@ -134,20 +131,20 @@ describe("useDraftConfirmation", () => {
 
   it("opens the update scope dialog for existing multi-occurrence recurring instances", async () => {
     const baseEventId = new ObjectId().toString();
-    const baseEvent = createDraft({
-      _id: baseEventId,
-      recurrence: {
-        rule: ["FREQ=WEEKLY;COUNT=4"],
-      },
+    const baseEvent = createMockEvent({
+      id: EventIdSchema.parse(baseEventId),
+      recurrence: { kind: "series", rules: ["FREQ=WEEKLY;COUNT=4"] },
+      schedule: SCHEDULE,
     });
-    const draft = createDraft({
+    const draft = buildEditDraft({
       recurrence: {
-        eventId: baseEventId,
+        kind: "occurrence",
+        seriesId: EventIdSchema.parse(baseEventId),
       },
     });
     const { discard, result, submit } = renderDraftConfirmation({
       draft,
-      events: [baseEvent],
+      seriesEvents: [baseEvent],
     });
 
     await act(async () => {
@@ -161,10 +158,9 @@ describe("useDraftConfirmation", () => {
   });
 
   it("submits an existing standalone draft made recurring without opening the update scope dialog", async () => {
-    const draft = createDraft({
-      recurrence: {
-        rule: ["FREQ=WEEKLY;COUNT=4"],
-      },
+    const draft = buildEditDraft({
+      recurrence: { kind: "single" },
+      liveRecurrence: { kind: "series", rules: ["FREQ=WEEKLY;COUNT=4"] },
     });
     const { discard, result, submit } = renderDraftConfirmation({ draft });
 
@@ -184,20 +180,20 @@ describe("useDraftConfirmation", () => {
 
   it("submits a single-occurrence recurring instance without opening the update scope dialog", async () => {
     const baseEventId = new ObjectId().toString();
-    const baseEvent = createDraft({
-      _id: baseEventId,
-      recurrence: {
-        rule: ["RRULE:FREQ=WEEKLY;COUNT=1"],
-      },
+    const baseEvent = createMockEvent({
+      id: EventIdSchema.parse(baseEventId),
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=1"] },
+      schedule: SCHEDULE,
     });
-    const draft = createDraft({
+    const draft = buildEditDraft({
       recurrence: {
-        eventId: baseEventId,
+        kind: "occurrence",
+        seriesId: EventIdSchema.parse(baseEventId),
       },
     });
     const { discard, result, submit } = renderDraftConfirmation({
       draft,
-      events: [baseEvent],
+      seriesEvents: [baseEvent],
     });
 
     await act(async () => {
@@ -215,10 +211,8 @@ describe("useDraftConfirmation", () => {
   });
 
   it("opens the update scope dialog before deleting recurring timed drafts", async () => {
-    const draft = createDraft({
-      recurrence: {
-        rule: ["RRULE:FREQ=WEEKLY;COUNT=4"],
-      },
+    const draft = buildEditDraft({
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=4"] },
     });
     const { deleteEvent, discard, result } = renderDraftConfirmation({
       draft,

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.ts
@@ -2,13 +2,16 @@ import { ObjectId } from "bson";
 import { useCallback, useState } from "react";
 import { type Event } from "@core/types/event.contracts";
 import { RecurringEventUpdateScope } from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
 import { CompassEventRRule } from "@core/util/event/compass.event.rrule";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
 import { useEventById } from "@web/events/queries/useEventById";
 import { type useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
+type EditGridEventDraft = Extract<GridEventDraft, { kind: "edit" }>;
+
 const hasMultipleRecurrenceOccurrences = (
-  event: Schema_GridEvent,
+  schedule: { start: Date; end: Date },
   rule: string[] | null | undefined,
 ): boolean => {
   if (!Array.isArray(rule) || rule.length === 0) {
@@ -18,8 +21,8 @@ const hasMultipleRecurrenceOccurrences = (
   try {
     const recurrence = new CompassEventRRule({
       _id: new ObjectId(),
-      startDate: event.startDate,
-      endDate: event.endDate,
+      startDate: dayjs(schedule.start).format(),
+      endDate: dayjs(schedule.end).format(),
       recurrence: { rule },
     });
 
@@ -29,22 +32,31 @@ const hasMultipleRecurrenceOccurrences = (
   }
 };
 
+// Returns the recurrence rule that should decide the update-scope prompt:
+// an explicit "series"/"single" choice on the draft (the user toggled
+// recurrence in the form) always wins; otherwise ("preserve") falls back to
+// the source event's own rule, or — for an occurrence with no rule of its
+// own — the loaded series base's rule.
 const getScopeDecisionRecurrenceRule = (
-  event: Schema_GridEvent,
+  draft: EditGridEventDraft,
   baseEvent: Event | null | undefined,
 ): string[] | null | undefined => {
-  const rule = event.recurrence?.rule;
-  if (Array.isArray(rule) || rule === null) {
-    return rule;
+  const recurrence = draft.values.recurrence;
+
+  if (recurrence.kind === "series") return recurrence.rules;
+  if (recurrence.kind === "single") return null;
+
+  if (draft.source.recurrence.kind === "series") {
+    return [...draft.source.recurrence.rules];
   }
 
-  if (!event.recurrence?.eventId || !baseEvent) {
-    return undefined;
+  if (draft.source.recurrence.kind === "occurrence") {
+    return baseEvent?.recurrence.kind === "series"
+      ? [...baseEvent.recurrence.rules]
+      : undefined;
   }
 
-  return baseEvent.recurrence.kind === "series"
-    ? [...baseEvent.recurrence.rules]
-    : undefined;
+  return undefined;
 };
 
 export const useDraftConfirmation = ({
@@ -55,7 +67,10 @@ export const useDraftConfirmation = ({
   const { isInstance, isRecurrence } = actions;
   const { draft } = state;
   const isSomeday = actions.isSomeday();
-  const baseEventId = draft?.recurrence?.eventId;
+  const baseEventId =
+    draft?.kind === "edit" && draft.source.recurrence.kind === "occurrence"
+      ? draft.source.recurrence.seriesId
+      : undefined;
   const baseEvent = useEventById(baseEventId);
 
   const [
@@ -63,10 +78,11 @@ export const useDraftConfirmation = ({
     setRecurrenceUpdateScopeDialogOpen,
   ] = useState<boolean>(false);
 
-  const [finalDraft, setFinalDraft] = useState<Schema_GridEvent | null>(null);
+  const [finalDraft, setFinalDraft] = useState<GridEventDraft | null>(null);
 
-  const [standaloneDraft, setStandaloneDraft] =
-    useState<Schema_GridEvent | null>(null);
+  const [standaloneDraft, setStandaloneDraft] = useState<GridEventDraft | null>(
+    null,
+  );
 
   const onConfirmConvertToStandalone = useCallback(() => {
     if (standaloneDraft) {
@@ -97,20 +113,20 @@ export const useDraftConfirmation = ({
   );
 
   const onSubmit = useCallback(
-    async (_draft: Schema_GridEvent) => {
-      const rule = getScopeDecisionRecurrenceRule(_draft, baseEvent);
-      const draftIsInstance = ObjectId.isValid(
-        _draft.recurrence?.eventId ?? "",
-      );
-      const isExistingDraft = Boolean(_draft._id) || draftIsInstance;
+    async (_draft: GridEventDraft) => {
+      const isEditDraft = _draft.kind === "edit";
+      const rule = isEditDraft
+        ? getScopeDecisionRecurrenceRule(_draft, baseEvent)
+        : undefined;
+      const draftIsInstance =
+        isEditDraft && _draft.source.recurrence.kind === "occurrence";
       const isRecurringEvent =
-        isExistingDraft && (isRecurrence() || draftIsInstance);
+        isEditDraft && (isRecurrence() || draftIsInstance);
       const instanceEvent = isInstance() || draftIsInstance;
       const toStandAlone = instanceEvent && rule === null;
-      const hasMultipleOccurrences = hasMultipleRecurrenceOccurrences(
-        _draft,
-        rule,
-      );
+      const hasMultipleOccurrences = isEditDraft
+        ? hasMultipleRecurrenceOccurrences(_draft.values.schedule, rule)
+        : true;
       const isSingleOccurrenceInstance =
         isRecurringEvent && instanceEvent && !hasMultipleOccurrences;
       const shouldAskForUpdateScope =

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction, useState } from "react";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
 
 export interface Status_Drag {
   durationMin: number;
@@ -10,10 +10,16 @@ export interface Status_Resize {
   hasMoved: boolean;
 }
 
+export interface DragOffset {
+  x: number;
+  y: number;
+}
+
 export interface State_Draft_Local {
   dateBeingChanged: "startDate" | "endDate" | null;
-  draft: Schema_GridEvent | null;
+  draft: GridEventDraft | null;
   draftSessionKey: number;
+  dragOffset: DragOffset;
   dragStatus: Status_Drag | null;
   isDragging: boolean;
   isResizing: boolean;
@@ -25,7 +31,8 @@ export interface State_Draft_Local {
 export interface Setters_Draft {
   setIsDragging: (value: boolean) => void;
   setIsResizing: (value: boolean) => void;
-  setDraft: Dispatch<SetStateAction<Schema_GridEvent | null>>;
+  setDraft: Dispatch<SetStateAction<GridEventDraft | null>>;
+  setDragOffset: Dispatch<SetStateAction<DragOffset>>;
   setDragStatus: Dispatch<SetStateAction<Status_Drag | null>>;
   setResizeStatus: (value: Status_Resize | null) => void;
   setDateBeingChanged: (value: "startDate" | "endDate" | null) => void;
@@ -34,10 +41,18 @@ export interface Setters_Draft {
   setIsFormOpenBeforeDragging: (value: boolean | null) => void;
 }
 
+const ZERO_DRAG_OFFSET: DragOffset = { x: 0, y: 0 };
+
 export const useDraftState = () => {
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
-  const [draft, setDraft] = useState<Schema_GridEvent | null>(null);
+  const [draft, setDraft] = useState<GridEventDraft | null>(null);
+  // Mid-drag cursor-offset (pixels between the pointer and the dragged
+  // event's origin), populated only while a mouse-drag is active. Kept as a
+  // sibling to `draft` rather than folded into it: `GridEventDraft` is the
+  // persisted-shape contract (dates + form fields) and has no grid-layout
+  // concept of a cursor offset.
+  const [dragOffset, setDragOffset] = useState<DragOffset>(ZERO_DRAG_OFFSET);
   const [draftSessionKey, setDraftSessionKey] = useState(0);
   const [dragStatus, setDragStatus] = useState<Status_Drag | null>(null);
   const [resizeStatus, setResizeStatus] = useState<Status_Resize | null>(null);
@@ -52,6 +67,7 @@ export const useDraftState = () => {
   const state: State_Draft_Local = {
     draft,
     draftSessionKey,
+    dragOffset,
     dragStatus,
     isDragging,
     isFormOpen,
@@ -65,6 +81,7 @@ export const useDraftState = () => {
     setIsDragging,
     setIsResizing,
     setDraft,
+    setDragOffset,
     setDragStatus,
     setResizeStatus,
     setDateBeingChanged,

--- a/packages/web/src/views/Week/hooks/grid/useDragEventSmartScroll.ts
+++ b/packages/web/src/views/Week/hooks/grid/useDragEventSmartScroll.ts
@@ -13,7 +13,7 @@ export const useDragEventSmartScroll = (
 
   useEffect(() => {
     if (!state.isDragging) return;
-    if (state.draft?.isAllDay !== false) return;
+    if (state.draft?.values.schedule.kind !== "timed") return;
 
     const updateMousePosition = (event: MouseEvent) => {
       setMousePosition({ x: event.clientX, y: event.clientY });
@@ -24,7 +24,7 @@ export const useDragEventSmartScroll = (
     return () => {
       window.removeEventListener("mousemove", updateMousePosition);
     };
-  }, [state.draft?.isAllDay, state.isDragging]);
+  }, [state.draft?.values.schedule.kind, state.isDragging]);
 
   useEffect(() => {
     if (!mainGridRef.current) return;
@@ -33,7 +33,7 @@ export const useDragEventSmartScroll = (
     const scrollIfNeeded = () => {
       if (!state.isDragging) return;
       if (!container) return;
-      if (state.draft?.isAllDay !== false) return;
+      if (state.draft?.values.schedule.kind !== "timed") return;
 
       const containerRect = container.getBoundingClientRect();
       const { top, bottom } = {
@@ -76,7 +76,7 @@ export const useDragEventSmartScroll = (
     state.isDragging,
     mousePosition.x,
     mousePosition.y,
-    state.draft?.isAllDay,
+    state.draft?.values.schedule.kind,
     mousePosition,
     mainGridRef.current,
   ]);

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -19,6 +19,7 @@ import {
 } from "@web/common/constants/web.constants";
 import { getOfflineDataStore } from "@web/common/storage/offline-data/offline-data.store.registry";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
+import { type GridEventDraft } from "@web/events/event-draft.types";
 import { useDraftStore } from "@web/events/stores/draft.store";
 import { initialViewState, useViewStore } from "@web/events/stores/view.store";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
@@ -201,7 +202,12 @@ describe("useWeekShortcuts calendar event targeting", () => {
       expect(useDraftStore.getState().status?.activity).toBe("keyboardEdit");
     });
     expect(useDraftStore.getState().event?._id).toBe(EVENT_1_ID);
-    expect(useDraftStore.getState().event).toHaveProperty("position");
+    // The canonical GridEventDraft must be populated too — this is what
+    // lets a subsequent drag continue the keyboard-opened edit (the
+    // "M"-then-drag gap this conversion closes).
+    const gridDraft = useDraftStore.getState().gridDraft;
+    expect(gridDraft?.kind).toBe("edit");
+    expect(gridDraft?.kind === "edit" && gridDraft.source.id).toBe(EVENT_1_ID);
   });
 
   it("edits the prepared all-day calendar event with M", async () => {
@@ -215,7 +221,11 @@ describe("useWeekShortcuts calendar event targeting", () => {
       expect(useDraftStore.getState().status?.activity).toBe("keyboardEdit");
     });
     expect(useDraftStore.getState().event?._id).toBe(ALL_DAY_EVENT_1_ID);
-    expect(useDraftStore.getState().event).toHaveProperty("position");
+    const gridDraft = useDraftStore.getState().gridDraft;
+    expect(gridDraft?.kind).toBe("edit");
+    expect(gridDraft?.kind === "edit" && gridDraft.source.id).toBe(
+      ALL_DAY_EVENT_1_ID,
+    );
   });
 
   it("edits the hovered calendar event with M when no event is focused", async () => {
@@ -435,14 +445,11 @@ describe("useWeekShortcuts shift+arrow event moves", () => {
     await waitFor(() => {
       expect(confirmationOnSubmit).toHaveBeenCalledTimes(1);
     });
-    const submitted = confirmationOnSubmit.mock.calls[0]?.[0] as {
-      startDate: string;
-      endDate: string;
-    };
-    expect(submitted.startDate).toBe(
+    const submitted = confirmationOnSubmit.mock.calls[0]?.[0] as GridEventDraft;
+    expect(dayjs(submitted.values.schedule.start).format()).toBe(
       dayjs("2026-05-20T09:00:00.000Z").add(1, "day").format(),
     );
-    expect(submitted.endDate).toBe(
+    expect(dayjs(submitted.values.schedule.end).format()).toBe(
       dayjs("2026-05-20T10:00:00.000Z").add(1, "day").format(),
     );
   });
@@ -457,10 +464,8 @@ describe("useWeekShortcuts shift+arrow event moves", () => {
     await waitFor(() => {
       expect(confirmationOnSubmit).toHaveBeenCalledTimes(1);
     });
-    const movedUp = confirmationOnSubmit.mock.calls[0]?.[0] as {
-      startDate: string;
-    };
-    expect(movedUp.startDate).toBe(
+    const movedUp = confirmationOnSubmit.mock.calls[0]?.[0] as GridEventDraft;
+    expect(dayjs(movedUp.values.schedule.start).format()).toBe(
       dayjs("2026-05-20T09:00:00.000Z").subtract(15, "minutes").format(),
     );
 
@@ -469,10 +474,8 @@ describe("useWeekShortcuts shift+arrow event moves", () => {
     await waitFor(() => {
       expect(confirmationOnSubmit).toHaveBeenCalledTimes(2);
     });
-    const movedDown = confirmationOnSubmit.mock.calls[1]?.[0] as {
-      startDate: string;
-    };
-    expect(movedDown.startDate).toBe(
+    const movedDown = confirmationOnSubmit.mock.calls[1]?.[0] as GridEventDraft;
+    expect(dayjs(movedDown.values.schedule.start).format()).toBe(
       dayjs("2026-05-20T09:00:00.000Z").add(15, "minutes").format(),
     );
   });

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { SOMEDAY_WEEK_LIMIT_MSG } from "@core/constants/core.constants";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type EventId } from "@core/types/domain-primitives";
 import { Categories_Event } from "@core/types/event.types";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
@@ -24,6 +25,12 @@ import {
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
 import { focusFirstSomedaySidebarItem } from "@web/components/PlannerSidebar/util/sidebarFocus.util";
+import { type GridScheduleDraft } from "@web/events/event-draft.types";
+import {
+  editGridEventDraft,
+  replaceGridDraftSchedule,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import { createLegacyEventMutationsAdapter } from "@web/events/queries/event.legacy-bridge";
 import { useSomedayEventViewModel } from "@web/events/queries/useSomedayEventsQuery";
@@ -92,7 +99,7 @@ export const useWeekShortcuts = ({
     useSomedayEventViewModel(startOfView, endOfView);
 
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
-  const { allDayEvents, timedEvents } = useWeekEventViewModel({
+  const { allDayEvents, entities, timedEvents } = useWeekEventViewModel({
     startOfView,
     endOfView,
   });
@@ -208,22 +215,19 @@ export const useWeekShortcuts = ({
     const resolvedTarget = getTargetedCalendarEvent();
     if (!resolvedTarget) return;
 
-    const { event, target } = resolvedTarget;
+    const { event } = resolvedTarget;
 
-    // NOT converted to GridEventDraft/editGridEventDraft: useDraftActions.ts
-    // reads `draft.position.dragOffset` off this store's `event` field when
-    // the keyboard-opened draft is subsequently dragged, and
-    // gridEventDraftToSchemaEvent has no grid-layout `position` to give it.
-    // See packet-03-phase-3c scoping note.
-    draftActions.start({
-      activity: "keyboardEdit",
-      event,
-      eventType:
-        target.eventType === "all-day"
-          ? Categories_Event.ALLDAY
-          : Categories_Event.TIMED,
-    });
-  }, [getTargetedCalendarEvent]);
+    const sourceEvent = event._id ? entities[event._id as EventId] : undefined;
+    const draft = sourceEvent ? editGridEventDraft(sourceEvent) : null;
+
+    if (!draft) return;
+
+    // dragOffset (the cursor-to-event pixel offset a subsequent drag needs)
+    // lives in useDraftState's sibling state, populated by
+    // GridDraft.tsx's handleDrag the moment a drag actually starts — the
+    // "M"-then-drag continuation this closes needs no position data here.
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+  }, [entities, getTargetedCalendarEvent]);
 
   const deleteTargetedCalendarEvent = useCallback(
     (keyboardEvent: KeyboardEvent) => {
@@ -322,14 +326,34 @@ export const useWeekShortcuts = ({
       nudgeEventFromKeyboard({
         event,
         keyboardEvent,
-        onNudge: (event) => {
-          void confirmation.onSubmit(event);
+        onNudge: (nudgedEvent) => {
+          const sourceEvent = nudgedEvent._id
+            ? entities[nudgedEvent._id as EventId]
+            : undefined;
+          const draft = sourceEvent
+            ? editGridEventDraft(sourceEvent, "this")
+            : null;
+          if (!draft) return;
+
+          const schedule: GridScheduleDraft = nudgedEvent.isAllDay
+            ? {
+                kind: "allDay",
+                start: dayjs(nudgedEvent.startDate).toDate(),
+                end: dayjs(nudgedEvent.endDate).toDate(),
+              }
+            : timedGridSchedule(
+                dayjs(nudgedEvent.startDate).toDate(),
+                dayjs(nudgedEvent.endDate).toDate(),
+              );
+
+          void confirmation.onSubmit(replaceGridDraftSchedule(draft, schedule));
         },
       });
     },
     [
       confirmation,
       convertFocusedEventToSomeday,
+      entities,
       findCalendarEventForTarget,
       weekDays,
     ],

--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -90,16 +90,16 @@ export const WeekInteractionCoordinator: FC<Props> = ({
 
   const openAllDayEvent = openClickedGridEvent;
 
-  // Non-recurring saved events skip the Draft confirmation flow entirely and
-  // commit straight through the strict mutation. Recurring events (source
-  // event carries `recurrence`) still need the scope-confirmation dialog,
-  // which lives in useDraftConfirmation (out of scope here) — those keep
-  // going through the legacy confirmation.onSubmit path below.
-  const commitStrictSavedMutation = (event: Schema_GridEvent) => {
+  // Rebuilds the GridEventDraft for a saved event after the modern
+  // pointer-capture engine (WeekInteractionAdapter) commits a drag/resize —
+  // it operates on Schema_GridEvent geometry, so this re-derives the strict
+  // draft from the query cache's source Event plus the engine's resulting
+  // dates.
+  const gridEventDraftFromSavedResult = (event: Schema_GridEvent) => {
     const sourceEvent = event._id ? eventsById.get(event._id) : undefined;
     const draft = sourceEvent ? editGridEventDraft(sourceEvent, "this") : null;
 
-    if (!draft) return;
+    if (!draft) return null;
 
     const schedule: GridScheduleDraft = event.isAllDay
       ? {
@@ -112,9 +112,19 @@ export const WeekInteractionCoordinator: FC<Props> = ({
           dayjs(event.endDate).toDate(),
         );
 
-    const parsed = parseGridEventDraft(
-      replaceGridDraftSchedule(draft, schedule),
-    );
+    return replaceGridDraftSchedule(draft, schedule);
+  };
+
+  // Non-recurring saved events skip the Draft confirmation flow entirely and
+  // commit straight through the strict mutation. Recurring events (source
+  // event carries `recurrence`) still need the scope-confirmation dialog,
+  // which lives in useDraftConfirmation (out of scope here) — those keep
+  // going through the legacy confirmation.onSubmit path below.
+  const commitStrictSavedMutation = (event: Schema_GridEvent) => {
+    const draft = gridEventDraftFromSavedResult(event);
+    if (!draft) return;
+
+    const parsed = parseGridEventDraft(draft);
 
     if (parsed.ok && parsed.mode === "edit") {
       mutations.replace({ id: parsed.eventId, input: parsed.input });
@@ -138,13 +148,16 @@ export const WeekInteractionCoordinator: FC<Props> = ({
     }
 
     if (result.hadFormOpenBeforeInteraction) {
-      setters.setDraft(result.event);
+      const draft = gridEventDraftFromSavedResult(result.event);
+      if (draft) setters.setDraft(draft);
+
       actions.openForm();
       return;
     }
 
     if (result.event.recurrence) {
-      void confirmation.onSubmit(result.event);
+      const draft = gridEventDraftFromSavedResult(result.event);
+      if (draft) void confirmation.onSubmit(draft);
       return;
     }
 


### PR DESCRIPTION
## Summary

Phase C of migrating Week's local drag-geometry state off the legacy bridge (packet 03) — the highest-risk phase in this multi-week effort, since a prior big-bang attempt at converting exactly this area (Week's local draft state + the forms cluster in one pass) caused 118 type errors and needed two full reverts (5328eb137/7cbbb74e6, reverted by a91434684/a1d23ea7b). This phase stayed scoped to Week's local state only, leaving the forms cluster's own conversion for a follow-on phase.

`useDraftState.ts`'s local `draft` is now `GridEventDraft | null` (read/write the same way Day already reads/writes the store's `gridDraft`), plus one narrow sibling `dragOffset: {x,y}` field — the only `Schema_GridEvent`-only field that's read past initial assignment (pure gesture-scoped cursor math, never sent to the backend).

- `useDraftActions.ts` (~700 lines): `create`/`drag`/`resize`/`repositionDraftByKeyboard`/`duplicateEvent`/`convert`/`submit`/`determineSubmitAction`/`handleChange` all rewritten against `GridEventDraft`. `resize()`'s flip logic (the trickiest function) is a near-literal port of the original string-based dayjs math, minimizing risk in the highest-scrutiny function.
- `useWeekShortcuts.ts`'s "M" shortcut and `MainGridEvents.tsx`/`AllDayEvents.tsx`'s `handleKeyDown` now open keyboard-edit drafts via `draftActions.startGridDraft({ activity: "keyboardEdit", draft: editGridEventDraft(...) })` — closing the exact gap ("keyboard-edit drag continuation") flagged from the very start of this packet.
- `dirty.parser.ts`: new `DirtyParser.isGridDraftDirty` (rebuilds the pristine draft and diffs field-by-field) replaces the `Schema_Event`-based no-op-edit check.
- `grid-event-draft.adapter.ts`: new `legacyRecurrenceFromDraft` (reflects *live* recurrence edits, not just the source's original) and `applySchemaEventPatchToGridDraft` (the reverse-direction boundary shim for the still-unconverted `EventForm`/`RecurrenceSection`, which still speak `Schema_Event`).

### Bugs found and fixed
1. `duplicateGridEventDraft` (built for Day, no recurring-duplication UX there) dropped recurrence unconditionally — Week's Cmd+D must preserve a series-base event's rule on duplicate. Added a Week-local override.
2. `gridEventDraftToSchemaEvent` only reflected the source event's *original* recurrence, not live in-progress edits — would have silently reverted a user's recurrence toggle while a draft's form was open. Fixed via `legacyRecurrenceFromDraft`.

### Not touched (by design)
The forms cluster (`EventForm.tsx`/`FloatingEventForm.tsx`/`TimePickers.tsx`/`useSaveEventForm.ts`), `RecurrenceSection.tsx`/`useRecurrence.ts` (confirmed independent), Day's files, the someday sidebar, `event.legacy-bridge.ts` (still has other callers). Where the still-unconverted forms cluster needs to keep receiving `Schema_Event`-shaped data at its existing boundary, a small shim (`applySchemaEventPatchToGridDraft`) bridges it rather than forcing that conversion in this phase.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1254/1254 pass (matches baseline exactly), no coverage deleted — updated fixtures in `useDraftActions.test.ts`, `useDraftEffects.test.ts`, `useDraftConfirmation.test.tsx`, `GridDraft.test.tsx`, `ContextMenuItems.test.tsx`, `ConvertToStandaloneDialog.test.tsx`, `useWeekShortcuts.test.tsx` to build `GridEventDraft` fixtures instead of raw `Schema_GridEvent` object literals
- [x] `bunx playwright test`: 11/11 pass
- [x] Manual/temp Playwright verification (written, run, deleted, not committed): confirmed drag-to-move, resize, and — the actual target behavior — **keyboard-edit-then-drag works end-to-end**: "M" opens the strict edit draft, dragging updates its schedule live, saving persists the dragged position to IndexedDB. Also verified duplicate and convert-to-someday from a keyboard-opened draft.