### PR TITLE
refactor(web): convert event forms cluster to GridEventDraft

### DIFF
--- a/packages/web/src/components/FloatingEventForm/FloatingEventForm.test.tsx
+++ b/packages/web/src/components/FloatingEventForm/FloatingEventForm.test.tsx
@@ -1,7 +1,7 @@
 import { HotkeyManager } from "@tanstack/react-hotkeys";
 import { EventIdSchema } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { Categories_Event } from "@core/types/event.types";
 import {
   cleanup,
   fireEvent,
@@ -13,26 +13,18 @@ import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-tes
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { FloatingEventForm } from "@web/components/FloatingEventForm/FloatingEventForm";
+import {
+  createGridEventDraft,
+  editGridEventDraft,
+} from "@web/events/grid-event-draft.adapter";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { draftActions } from "@web/events/stores/draft.store";
 import { useEventForm } from "@web/views/Forms/hooks/useEventForm";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
 
-// draft.store.ts still holds the legacy Schema_Event shape (see its own
-// TODO); these ids are also used to seed the strict-contract `Event` query
-// cache below, so they must satisfy EventIdSchema (real ObjectId shape).
 const EXISTING_EVENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
 const RECURRING_EVENT_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
-
-const draft: Schema_Event = {
-  endDate: "2026-05-21",
-  isAllDay: true,
-  isSomeday: false,
-  startDate: "2026-05-20",
-  title: "",
-  user: "user",
-};
 
 beforeEach(() => {
   HotkeyManager.resetInstance();
@@ -45,7 +37,12 @@ afterEach(() => {
 
 describe("FloatingEventForm", () => {
   it("focuses the title when the form opens", async () => {
-    draftActions.startGridClick(draft);
+    const draft = createGridEventDraft({
+      kind: "allDay",
+      start: new Date("2026-05-20"),
+      end: new Date("2026-05-21"),
+    });
+    draftActions.startGridDraft({ activity: "gridClick", draft });
     draftActions.setFormOpen(true);
 
     const Harness = () => {
@@ -69,15 +66,20 @@ describe("FloatingEventForm", () => {
   });
 
   it("deletes an already-saved event on Delete instead of just closing the form", async () => {
-    const existingEvent: Schema_Event = {
-      _id: EXISTING_EVENT_ID,
-      endDate: "2026-05-20T15:00:00.000Z",
-      isAllDay: false,
-      isSomeday: false,
-      startDate: "2026-05-20T14:00:00.000Z",
-      title: "Existing Event",
-      user: "user",
-    };
+    const existingEvent = createMockEvent({
+      id: EventIdSchema.parse(EXISTING_EVENT_ID),
+      content: {
+        kind: "details",
+        title: "Existing Event",
+        description: "",
+      },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
 
     const queryClient = createCompassQueryClient();
     queryClient.setQueryData(
@@ -86,29 +88,12 @@ describe("FloatingEventForm", () => {
         start: "2026-05-20T00:00:00.000Z",
         end: "2026-05-21T00:00:00.000Z",
       }),
-      toNormalizedEventQueryData([
-        createMockEvent({
-          id: EventIdSchema.parse(EXISTING_EVENT_ID),
-          content: {
-            kind: "details",
-            title: "Existing Event",
-            description: "",
-          },
-          schedule: EventScheduleSchema.parse({
-            kind: "timed",
-            start: "2026-05-20T14:00:00.000Z",
-            end: "2026-05-20T15:00:00.000Z",
-            timeZone: "UTC",
-          }),
-        }),
-      ]),
+      toNormalizedEventQueryData([existingEvent]),
     );
 
-    draftActions.start({
-      activity: "keyboardEdit",
-      event: existingEvent,
-      eventType: Categories_Event.TIMED,
-    });
+    const draft = editGridEventDraft(existingEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
     draftActions.setFormOpen(true);
 
     const Harness = () => {
@@ -160,19 +145,21 @@ describe("FloatingEventForm", () => {
   });
 
   it("asks for a recurrence scope before deleting a recurring day event", async () => {
-    const recurringEvent: Schema_Event = {
-      _id: RECURRING_EVENT_ID,
-      endDate: "2026-05-20T15:00:00.000Z",
-      isAllDay: false,
-      isSomeday: false,
-      recurrence: {
-        eventId: RECURRING_EVENT_ID,
-        rule: ["RRULE:FREQ=WEEKLY"],
+    const recurringEvent = createMockEvent({
+      id: EventIdSchema.parse(RECURRING_EVENT_ID),
+      content: {
+        kind: "details",
+        title: "Recurring Event",
+        description: "",
       },
-      startDate: "2026-05-20T14:00:00.000Z",
-      title: "Recurring Event",
-      user: "user",
-    };
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
     const queryClient = createCompassQueryClient();
     queryClient.setQueryData(
       eventQueryKeys.day({
@@ -180,29 +167,12 @@ describe("FloatingEventForm", () => {
         start: "2026-05-20T00:00:00.000Z",
         end: "2026-05-21T00:00:00.000Z",
       }),
-      toNormalizedEventQueryData([
-        createMockEvent({
-          id: EventIdSchema.parse(RECURRING_EVENT_ID),
-          content: {
-            kind: "details",
-            title: "Recurring Event",
-            description: "",
-          },
-          recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
-          schedule: EventScheduleSchema.parse({
-            kind: "timed",
-            start: "2026-05-20T14:00:00.000Z",
-            end: "2026-05-20T15:00:00.000Z",
-            timeZone: "UTC",
-          }),
-        }),
-      ]),
+      toNormalizedEventQueryData([recurringEvent]),
     );
-    draftActions.start({
-      activity: "keyboardEdit",
-      event: recurringEvent,
-      eventType: Categories_Event.TIMED,
-    });
+
+    const draft = editGridEventDraft(recurringEvent);
+    if (!draft) throw new Error("expected an edit draft");
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
     draftActions.setFormOpen(true);
 
     const Harness = () => {

--- a/packages/web/src/components/FloatingEventForm/FloatingEventForm.tsx
+++ b/packages/web/src/components/FloatingEventForm/FloatingEventForm.tsx
@@ -1,20 +1,18 @@
 import { FloatingFocusManager, FloatingPortal } from "@floating-ui/react";
-import { useCallback, useState } from "react";
-import {
-  type RecurringEventUpdateScope,
-  type Schema_Event,
-} from "@core/types/event.types";
+import { type Dispatch, type SetStateAction, useCallback, useState } from "react";
+import { type RecurringEventUpdateScope } from "@core/types/event.types";
 import {
   Z_INDEX_FLOATING_FORM,
   ZIndex,
 } from "@web/common/constants/web.constants";
 import { useGridMaxZIndex } from "@web/common/hooks/useGridMaxZIndex";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { useEventById } from "@web/events/queries/useEventById";
 import { toRecurrenceScope } from "@web/events/recurrence/recurrence-scope";
 import {
   draftActions,
-  selectDraft,
+  selectGridDraft,
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
@@ -31,15 +29,15 @@ export function FloatingEventForm({
 }: {
   form: ReturnType<typeof useEventForm>;
 }) {
-  const draft = useDraftStore(selectDraft);
+  const draft = useDraftStore(selectGridDraft);
   const isFormOpen = useDraftStore(selectIsEventFormOpen);
-  const _id = draft?._id;
+  const _id = draft?.kind === "edit" ? draft.source.id : undefined;
   const [pendingAction, setPendingAction] = useState<
-    { event: Schema_Event; type: "save" } | { type: "delete" } | null
+    { draft: GridEventDraft; type: "save" } | { type: "delete" } | null
   >(null);
   const onSave = useSaveEventForm();
-  const onDelete = useDeleteEvent(draft?._id as string);
-  const onDuplicate = useDuplicateEvent(draft?._id as string);
+  const onDelete = useDeleteEvent(_id as string);
+  const onDuplicate = useDuplicateEvent(_id as string);
   const onClose = useCloseEventForm();
   const maxZIndex = useGridMaxZIndex();
   const formZIndex = Math.max(
@@ -49,43 +47,36 @@ export function FloatingEventForm({
   const open = isFormOpen && !!draft;
   const existingEvent = useEventById(_id);
   const existing = Boolean(existingEvent);
-  // TODO(packet-03-phase-3c): existingEvent is now the new `Event` contract
-  // (recurrence.kind "single" | "series" | "occurrence"); this form still
-  // targets the legacy Schema_Event draft shape.
   const needsRecurrenceScope = Boolean(
     existingEvent && existingEvent.recurrence.kind !== "single",
   );
 
-  const setEvent = useCallback(
-    (
-      cb:
-        | ((event: Schema_Event | null) => Schema_Event | null)
-        | Schema_Event
-        | null,
-    ) => {
-      const update = typeof cb === "function" ? cb(draft) : cb;
-      draftActions.setEvent(update);
-    },
-    [draft],
-  );
+  const setDraft: Dispatch<SetStateAction<GridEventDraft | null>> =
+    useCallback(
+      (next) => {
+        const resolved = typeof next === "function" ? next(draft) : next;
+        draftActions.setGridDraft(resolved);
+      },
+      [draft],
+    );
 
-  if (!open) return null;
+  if (!open || !draft) return null;
 
   const closeScopeDialog = () => setPendingAction(null);
   const submitWithScope = (applyTo: RecurringEventUpdateScope) => {
     if (pendingAction?.type === "save") {
-      onSave(pendingAction.event, applyTo);
+      onSave(pendingAction.draft, applyTo);
     } else if (pendingAction?.type === "delete") {
       onDelete(toRecurrenceScope(applyTo));
     }
     setPendingAction(null);
   };
-  const submit = (event: Schema_Event | null) => {
-    if (event && needsRecurrenceScope) {
-      setPendingAction({ event, type: "save" });
+  const submit = (nextDraft: GridEventDraft | null) => {
+    if (nextDraft && needsRecurrenceScope) {
+      setPendingAction({ draft: nextDraft, type: "save" });
       return;
     }
-    onSave(event);
+    onSave(nextDraft);
   };
   const deleteEvent = () => {
     if (needsRecurrenceScope) {
@@ -115,23 +106,23 @@ export function FloatingEventForm({
           }}
         >
           <EventForm
-            event={draft}
+            draft={draft}
             isDraft={!existing}
             isExistingEvent={existing}
             onClose={onClose}
             onDelete={deleteEvent}
             onDuplicate={onDuplicate}
             onSubmit={submit}
-            setEvent={setEvent}
+            setDraft={setDraft}
           />
         </div>
       </FloatingFocusManager>
       {pendingAction && (
         <RecurringEventUpdateScopeDialogContent
           draft={
-            (pendingAction.type === "save"
-              ? pendingAction.event
-              : draft) as Schema_GridEvent | null
+            pendingAction.type === "save"
+              ? gridEventDraftToSchemaEvent(pendingAction.draft)
+              : gridEventDraftToSchemaEvent(draft)
           }
           onUpdateScopeChange={submitWithScope}
           setRecurrenceUpdateScopeDialogOpen={(isOpen) => {

--- a/packages/web/src/events/stores/draft.store.ts
+++ b/packages/web/src/events/stores/draft.store.ts
@@ -230,6 +230,29 @@ export const draftActions = {
       { type: "startGridDraft" },
     ),
 
+  // Writes the canonical draft directly, keeping the legacy `event`
+  // projection in sync for the remaining consumers (Day's grid-layer
+  // rendering) that still read it via `selectDraft`.
+  setGridDraft: (draft: GridEventDraft | null) =>
+    useDraftStore.setState(
+      (state) => ({
+        gridDraft: draft,
+        event: draft ? gridEventDraftToSchemaEvent(draft) : null,
+        status: draft
+          ? {
+              ...(state.status ?? initialDraftStatus),
+              eventType:
+                draft.values.schedule.kind === "allDay"
+                  ? Categories_Event.ALLDAY
+                  : Categories_Event.TIMED,
+              isDrafting: true,
+            }
+          : initialDraftStatus,
+      }),
+      false,
+      { type: "setGridDraft" },
+    ),
+
   setFormOpen: (isFormOpen: boolean) =>
     useDraftStore.setState(
       (state) => ({

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection.tsx
@@ -1,6 +1,7 @@
-import { type FC, type SetStateAction } from "react";
-import { Categories_Event, type Schema_Event } from "@core/types/event.types";
+import { type FC } from "react";
+import { Categories_Event } from "@core/types/event.types";
 import { type SelectOption } from "@web/common/types/component.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
 import { DatePickers } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers";
 import { TimePickers } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers";
 import { type SetEventFormField } from "@web/views/Forms/EventForm/types";
@@ -9,7 +10,7 @@ export interface Props {
   bgColor: string;
   category: Categories_Event;
   displayEndDate: Date;
-  event: Schema_Event;
+  draft: GridEventDraft;
   endTime: SelectOption<string>;
   inputColor?: string;
   isEndDatePickerOpen: boolean;
@@ -18,13 +19,13 @@ export interface Props {
   selectedEndDate: Date;
   selectedStartDate: Date;
   setDisplayEndDate: (value: Date) => void;
+  setDraft: (draft: GridEventDraft) => void;
   setEndTime: (value: SelectOption<string>) => void;
   setIsEndDatePickerOpen: (arg0: boolean) => void;
   setIsStartDatePickerOpen: (arg0: boolean) => void;
   setSelectedEndDate: (value: Date) => void;
   setSelectedStartDate: (value: Date) => void;
   setStartTime: (value: SelectOption<string>) => void;
-  setEvent: (event: SetStateAction<Schema_Event | null>) => void;
   startTime: SelectOption<string>;
 }
 
@@ -32,7 +33,7 @@ export const DateTimeSection: FC<Props> = ({
   bgColor,
   category,
   displayEndDate,
-  event,
+  draft,
   inputColor,
   isEndDatePickerOpen,
   isStartDatePickerOpen,
@@ -46,7 +47,7 @@ export const DateTimeSection: FC<Props> = ({
   setEndTime,
   setSelectedEndDate,
   setSelectedStartDate,
-  setEvent,
+  setDraft,
   startTime,
   endTime,
 }) => {
@@ -73,11 +74,11 @@ export const DateTimeSection: FC<Props> = ({
       {category === Categories_Event.TIMED && (
         <TimePickers
           bgColor={bgColor}
+          draft={draft}
           endTime={endTime}
-          event={event}
           setStartTime={setStartTime}
           setEndTime={setEndTime}
-          setEvent={setEvent}
+          setDraft={setDraft}
           startTime={startTime}
           selectedEndDate={selectedEndDate}
           selectedStartDate={selectedStartDate}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -1,5 +1,5 @@
-import { type FC, type SetStateAction, useState } from "react";
-import { type Schema_Event } from "@core/types/event.types";
+import { type FC, useState } from "react";
+import dayjs from "@core/util/date/dayjs";
 import { type SelectOption } from "@web/common/types/component.types";
 import { type Option_Time } from "@web/common/types/util.types";
 import {
@@ -8,28 +8,30 @@ import {
   mapToBackend,
 } from "@web/common/utils/datetime/web.date.util";
 import { shouldAdjustComplimentTime } from "@web/common/utils/datetime/web.datetime.util";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { replaceGridDraftSchedule } from "@web/events/grid-event-draft.adapter";
 import { TimePicker } from "./TimePicker";
 
 interface Props {
   bgColor: string;
-  event: Schema_Event;
+  draft: GridEventDraft;
   endTime: SelectOption<string>;
   selectedEndDate: Date;
   selectedStartDate: Date;
+  setDraft: (draft: GridEventDraft) => void;
   setEndTime: (value: SelectOption<string>) => void;
-  setEvent: (event: SetStateAction<Schema_Event | null>) => void;
   setStartTime: (value: SelectOption<string>) => void;
   startTime: SelectOption<string>;
 }
 
 export const TimePickers: FC<Props> = ({
   bgColor,
+  draft,
   endTime,
-  event,
   selectedEndDate,
   selectedStartDate,
+  setDraft,
   setEndTime,
-  setEvent,
   setStartTime,
   startTime,
 }) => {
@@ -79,8 +81,6 @@ export const TimePickers: FC<Props> = ({
     const correctedStart = adjustComplimentTimeIfNeeded("end", option.value);
 
     if (endTime.value && endTime.value !== option.value) {
-      // TODO(packet-03-phase-3c): mapToBackend now returns an EventSchedule;
-      // this component still operates on legacy Schema_Event startDate/endDate.
       const schedule = mapToBackend({
         startDate: selectedStartDate,
         endDate: selectedEndDate,
@@ -89,13 +89,16 @@ export const TimePickers: FC<Props> = ({
         isAllDay: false,
       });
 
-      const _event = {
-        ...event,
-        startDate: schedule.start,
-        endDate: schedule.end,
-      };
+      if (schedule.kind !== "timed") return; // TS guard: isAllDay: false above always yields "timed"
 
-      setEvent(_event);
+      setDraft(
+        replaceGridDraftSchedule(draft, {
+          kind: "timed",
+          start: dayjs(schedule.start).toDate(),
+          end: dayjs(schedule.end).toDate(),
+          timeZone: schedule.timeZone,
+        }),
+      );
     }
     setIsEndMenuOpen(false);
   };
@@ -105,8 +108,6 @@ export const TimePickers: FC<Props> = ({
     const correctedEnd = adjustComplimentTimeIfNeeded("start", option.value);
 
     if (startTime.value && startTime.value !== option.value) {
-      // TODO(packet-03-phase-3c): mapToBackend now returns an EventSchedule;
-      // this component still operates on legacy Schema_Event startDate/endDate.
       const schedule = mapToBackend({
         startDate: selectedStartDate,
         endDate: selectedEndDate,
@@ -115,13 +116,16 @@ export const TimePickers: FC<Props> = ({
         isAllDay: false,
       });
 
-      const _event = {
-        ...event,
-        startDate: schedule.start,
-        endDate: schedule.end,
-      };
+      if (schedule.kind !== "timed") return; // TS guard: isAllDay: false above always yields "timed"
 
-      setEvent(_event);
+      setDraft(
+        replaceGridDraftSchedule(draft, {
+          kind: "timed",
+          start: dayjs(schedule.start).toDate(),
+          end: dayjs(schedule.end).toDate(),
+          timeZone: schedule.timeZone,
+        }),
+      );
       setIsStartMenuOpen(false);
     }
   };

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -2,9 +2,16 @@ import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef, type SetStateAction, useState } from "react";
-import { Origin, Priorities } from "@core/constants/core.constants";
-import { type Schema_Event } from "@core/types/event.types";
+import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  createGridEventDraft,
+  editGridEventDraft,
+  replaceGridDraftSchedule,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
 import { type Props as DateTimeSectionProps } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -94,19 +101,61 @@ function dispatchDelete(target: HTMLElement) {
   return event;
 }
 
-const createEvent = (overrides: Partial<Schema_Event> = {}): Schema_Event => ({
-  _id: "event-1",
-  description: "",
-  endDate: "2026-04-24T15:00:00.000Z",
-  isAllDay: false,
-  isSomeday: false,
-  origin: Origin.COMPASS,
-  priority: Priorities.UNASSIGNED,
-  startDate: "2026-04-24T14:00:00.000Z",
-  title: "Keyboard duplicate event",
-  user: "user-1",
-  ...overrides,
-});
+// An "edit" GridEventDraft for an already-saved event, built from the strict
+// `Event` contract via the same editGridEventDraft adapter production code
+// uses (DayCalendarGrid.tsx, GridDraft.tsx).
+const createEditDraft = (
+  overrides: {
+    description?: string;
+    endDate?: string;
+    startDate?: string;
+    title?: string;
+  } = {},
+): GridEventDraft => {
+  const {
+    description = "",
+    endDate = "2026-04-24T15:00:00.000Z",
+    startDate = "2026-04-24T14:00:00.000Z",
+    title = "Keyboard duplicate event",
+  } = overrides;
+
+  const event = createMockEvent({
+    content: { kind: "details", title, description },
+    schedule: EventScheduleSchema.parse({
+      kind: "timed",
+      start: startDate,
+      end: endDate,
+      timeZone: "UTC",
+    }),
+  });
+
+  const draft = editGridEventDraft(event);
+  if (!draft) throw new Error("expected an edit draft");
+
+  return draft;
+};
+
+// A "create" GridEventDraft for a not-yet-saved draft (no source event).
+const createNewDraft = (
+  overrides: {
+    endDate?: string;
+    startDate?: string;
+    title?: string;
+  } = {},
+): GridEventDraft => {
+  const {
+    endDate = "2026-04-24T15:00:00.000Z",
+    startDate = "2026-04-24T14:00:00.000Z",
+    title = "Unsaved draft",
+  } = overrides;
+
+  const draft = createGridEventDraft(
+    timedGridSchedule(new Date(startDate), new Date(endDate)),
+  );
+  if (draft.kind !== "create") throw new Error("expected a create draft");
+
+  return { ...draft, values: { ...draft.values, title } };
+};
 
 describe("EventForm", () => {
   beforeEach(() => {
@@ -118,14 +167,14 @@ describe("EventForm", () => {
   it("renders the title before the actions on the same row", () => {
     render(
       <EventForm
-        event={createEvent({ description: "Plan the launch" })}
+        draft={createEditDraft({ description: "Plan the launch" })}
         isDraft={false}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -142,19 +191,19 @@ describe("EventForm", () => {
   });
 
   it("duplicates the event with Mod+D while the title field is focused", async () => {
-    const event = createEvent();
+    const draft = createEditDraft();
     const onDuplicate = mock();
 
     render(
       <EventForm
-        event={event}
+        draft={draft}
         isDraft={false}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={onDuplicate}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -166,7 +215,7 @@ describe("EventForm", () => {
     await waitFor(() => {
       expect(onDuplicate).toHaveBeenCalledTimes(1);
     });
-    expect(onDuplicate).toHaveBeenCalledWith(event);
+    expect(onDuplicate).toHaveBeenCalledWith(draft);
   });
 
   it("closes a draft event immediately when deleting from the menu", async () => {
@@ -176,14 +225,14 @@ describe("EventForm", () => {
 
     render(
       <EventForm
-        event={createEvent({ _id: undefined, title: "Unsaved draft" })}
+        draft={createNewDraft({ title: "Unsaved draft" })}
         isDraft={true}
         isExistingEvent={false}
         onClose={onClose}
         onDelete={onDelete}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -199,14 +248,14 @@ describe("EventForm", () => {
 
     render(
       <EventForm
-        event={createEvent()}
+        draft={createEditDraft()}
         isDraft={false}
         isExistingEvent={true}
         onClose={onClose}
         onDelete={onDelete}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -226,14 +275,14 @@ describe("EventForm", () => {
 
     render(
       <EventForm
-        event={createEvent({ description: "Plan the launch" })}
+        draft={createEditDraft({ description: "Plan the launch" })}
         isDraft={false}
         isExistingEvent={true}
         onClose={onClose}
         onDelete={onDelete}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -253,14 +302,14 @@ describe("EventForm", () => {
 
     render(
       <EventForm
-        event={createEvent()}
+        draft={createEditDraft()}
         isDraft={false}
         isExistingEvent={true}
         onClose={onClose}
         onDelete={onDelete}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -277,40 +326,44 @@ describe("EventForm", () => {
   });
 
   it("rebases date and time controls during render when event dates change", () => {
-    const event = createEvent();
-    const nextEvent = {
-      ...event,
-      endDate: "2026-04-27T17:30:00.000Z",
-      startDate: "2026-04-25T16:30:00.000Z",
-    };
+    const draft = createEditDraft();
+    const nextDraft = replaceGridDraftSchedule(draft, {
+      kind: "timed",
+      start: new Date("2026-04-25T16:30:00.000Z"),
+      end: new Date("2026-04-27T17:30:00.000Z"),
+      timeZone: "UTC",
+    });
 
     const { rerender } = render(
       <EventForm
-        event={event}
+        draft={draft}
         isDraft={false}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
     rerender(
       <EventForm
-        event={nextEvent}
+        draft={nextDraft}
         isDraft={false}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
-    const expected = getFormDates(nextEvent.startDate, nextEvent.endDate);
+    const expected = getFormDates(
+      "2026-04-25T16:30:00.000Z",
+      "2026-04-27T17:30:00.000Z",
+    );
     const props = capturedDateControlsSectionProps?.dateTimeSectionProps;
 
     expect(props?.startTime).toEqual(expected.startTime);
@@ -323,18 +376,18 @@ describe("EventForm", () => {
   });
 
   it("lets an untouched empty draft title keep normal arrow-key behavior", () => {
-    const event = { ...createEvent(), title: "" };
+    const draft = createNewDraft({ title: "" });
 
     render(
       <EventForm
-        event={event}
+        draft={draft}
         isDraft={true}
         isExistingEvent={false}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -345,18 +398,18 @@ describe("EventForm", () => {
   });
 
   it("lets an untouched existing event title keep normal arrow-key behavior", () => {
-    const event = { ...createEvent(), title: "Planning" };
+    const draft = createEditDraft({ title: "Planning" });
 
     render(
       <EventForm
-        event={event}
+        draft={draft}
         isDraft={false}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -369,14 +422,14 @@ describe("EventForm", () => {
   it("lets the description field keep normal arrow-key behavior", () => {
     render(
       <EventForm
-        event={createEvent({ description: "Plan the launch" })}
+        draft={createEditDraft({ description: "Plan the launch" })}
         isDraft={false}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -387,18 +440,18 @@ describe("EventForm", () => {
   });
 
   it("lets directly edited existing event titles keep normal arrow-key behavior", () => {
-    const event = { ...createEvent(), title: "Planning" };
+    const draft = createEditDraft({ title: "Planning" });
 
     render(
       <EventForm
-        event={event}
+        draft={draft}
         isDraft={false}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -414,32 +467,32 @@ describe("EventForm", () => {
     const onSubmit = mock();
 
     function Harness() {
-      const [event, setEvent] = useState<Schema_Event>(
-        createEvent({ _id: undefined, title: "" }),
+      const [draft, setDraftState] = useState<GridEventDraft>(
+        createNewDraft({ title: "" }),
       );
-      const setEventFromForm = (
-        nextEvent: SetStateAction<Schema_Event | null>,
+      const setDraftFromForm = (
+        nextDraft: SetStateAction<GridEventDraft | null>,
       ) => {
-        setEvent((currentEvent) => {
-          const resolvedEvent =
-            typeof nextEvent === "function"
-              ? nextEvent(currentEvent)
-              : nextEvent;
+        setDraftState((currentDraft) => {
+          const resolvedDraft =
+            typeof nextDraft === "function"
+              ? nextDraft(currentDraft)
+              : nextDraft;
 
-          return resolvedEvent ?? currentEvent;
+          return resolvedDraft ?? currentDraft;
         });
       };
 
       return (
         <EventForm
-          event={event}
+          draft={draft}
           isDraft={true}
           isExistingEvent={false}
           onClose={mock()}
           onDelete={mock()}
           onDuplicate={mock()}
           onSubmit={onSubmit}
-          setEvent={setEventFromForm}
+          setDraft={setDraftFromForm}
         />
       );
     }
@@ -454,7 +507,9 @@ describe("EventForm", () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Plan" }),
+      expect.objectContaining({
+        values: expect.objectContaining({ title: "Plan" }),
+      }),
     );
   });
 
@@ -464,14 +519,14 @@ describe("EventForm", () => {
 
     render(
       <EventForm
-        event={createEvent()}
+        draft={createEditDraft()}
         isDraft={true}
         isExistingEvent={true}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={onSubmit}
-        setEvent={mock()}
+        setDraft={mock()}
       />,
     );
 
@@ -491,14 +546,14 @@ describe("EventForm", () => {
       <>
         <button type="button">Draft block</button>
         <EventForm
-          event={createEvent()}
+          draft={createEditDraft()}
           isDraft={true}
           isExistingEvent={false}
           onClose={mock()}
           onDelete={mock()}
           onDuplicate={mock()}
           onSubmit={onSubmit}
-          setEvent={mock()}
+          setDraft={mock()}
         />
       </>,
     );
@@ -515,14 +570,14 @@ describe("EventForm", () => {
 
     render(
       <EventForm
-        event={createEvent()}
+        draft={createEditDraft()}
         isDraft={true}
         isExistingEvent={false}
         onClose={mock()}
         onDelete={mock()}
         onDuplicate={mock()}
         onSubmit={mock()}
-        setEvent={mock()}
+        setDraft={mock()}
         titleInputRef={titleInputRef}
       />,
     );

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -3,6 +3,7 @@ import fastDeepEqual from "fast-deep-equal/react";
 import type React from "react";
 import {
   type KeyboardEvent,
+  type SetStateAction,
   memo,
   useCallback,
   useEffect,
@@ -11,6 +12,7 @@ import {
   useState,
 } from "react";
 import { Priorities } from "@core/constants/core.constants";
+import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
 import { darken } from "@web/common/styles/color.utils";
@@ -20,7 +22,6 @@ import {
 } from "@web/common/styles/theme.util";
 import { type SelectOption } from "@web/common/types/component.types";
 import { mapToBackend } from "@web/common/utils/datetime/web.date.util";
-import { getCategory } from "@web/common/utils/event/event.util";
 import {
   isComboboxInteraction,
   isDeleteTextEditingTarget,
@@ -31,6 +32,12 @@ import {
   INPUT_RESET_CLASSNAME,
 } from "@web/components/Focusable/Focusable";
 import { Textarea } from "@web/components/Textarea/Textarea";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  applySchemaEventPatchToGridDraft,
+  gridEventDraftToSchemaEvent,
+  replaceGridDraftSchedule,
+} from "@web/events/grid-event-draft.adapter";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
@@ -40,7 +47,7 @@ import { PrioritySection } from "@web/views/Forms/EventForm/PrioritySection";
 import { SaveSection } from "@web/views/Forms/EventForm/SaveSection";
 import { TitleActionsRow } from "@web/views/Forms/EventForm/TitleActionsRow";
 import {
-  type FormProps,
+  type GridEventFormProps,
   type SetEventFormField,
 } from "@web/views/Forms/EventForm/types";
 import { EventFormShell } from "@web/views/Forms/EventFormShell";
@@ -109,25 +116,33 @@ const handleEventFormDelete = ({
   onDelete();
 };
 
-export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
+export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
   ({
-    event,
+    draft,
     onClose: _onClose,
     onConvert,
     onDelete,
     onSubmit,
     onDuplicate,
-    setEvent,
+    setDraft,
     titleInputRef,
     isDraft,
     isExistingEvent,
     ...props
   }) => {
-    const { title } = event || {};
+    // Schema_Event-shaped projection of the canonical draft, for the
+    // still-unconverted DatePickers/PrioritySection field-patch API and
+    // RecurrenceSection's Schema_Event contract — see
+    // grid-event-draft.adapter.ts's gridEventDraftToSchemaEvent doc comment.
+    const event = useMemo(() => gridEventDraftToSchemaEvent(draft), [draft]);
+    const { title } = event;
     const priority = event.priority || Priorities.UNASSIGNED;
     const priorityColor = colorByPriority[priority];
-    const category = getCategory(event);
-    const latestEventRef = useRef(event);
+    const category =
+      draft.values.schedule.kind === "allDay"
+        ? Categories_Event.ALLDAY
+        : Categories_Event.TIMED;
+    const latestDraftRef = useRef(draft);
     const eventStartDate = event.startDate as string;
     const eventEndDate = event.endDate as string;
 
@@ -203,25 +218,49 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
       [updateDateTimeState],
     );
 
-    const setLatestEvent = useCallback(
-      (nextEvent: Parameters<typeof setEvent>[0]) => {
-        const resolvedEvent =
-          typeof nextEvent === "function"
-            ? nextEvent(latestEventRef.current)
-            : nextEvent;
+    const setLatestDraft = useCallback(
+      (nextDraft: SetStateAction<GridEventDraft | null>) => {
+        const resolvedDraft =
+          typeof nextDraft === "function"
+            ? nextDraft(latestDraftRef.current)
+            : nextDraft;
 
-        if (resolvedEvent) {
-          latestEventRef.current = resolvedEvent;
+        if (resolvedDraft) {
+          latestDraftRef.current = resolvedDraft;
         }
 
-        setEvent(resolvedEvent);
+        setDraft(resolvedDraft);
       },
-      [setEvent],
+      [setDraft],
+    );
+
+    // Schema_Event-shaped writer for the still-unconverted DatePickers/
+    // PrioritySection field-patch API and RecurrenceSection's setEvent
+    // contract: merges the patch onto the current draft's Schema_Event
+    // projection, then reapplies it onto the canonical GridEventDraft.
+    const setLatestEvent = useCallback(
+      (nextEvent: SetStateAction<Schema_Event | null>) => {
+        const currentEvent = gridEventDraftToSchemaEvent(latestDraftRef.current);
+        const resolvedEvent =
+          typeof nextEvent === "function"
+            ? nextEvent(currentEvent)
+            : nextEvent;
+
+        if (!resolvedEvent) return;
+
+        setLatestDraft(
+          applySchemaEventPatchToGridDraft(
+            latestDraftRef.current,
+            resolvedEvent,
+          ),
+        );
+      },
+      [setLatestDraft],
     );
 
     useEffect(() => {
-      latestEventRef.current = event;
-    }, [event]);
+      latestDraftRef.current = draft;
+    }, [draft]);
 
     /***********
      * Handlers
@@ -245,9 +284,9 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
     }, [isDraft, onClose, onDelete]);
 
     const onDuplicateEvent = useCallback(() => {
-      onDuplicate?.(event);
+      onDuplicate?.(draft);
       onClose();
-    }, [onDuplicate, onClose, event]);
+    }, [onDuplicate, onClose, draft]);
 
     const handleIgnoredKeys = (e: KeyboardEvent) => {
       // Ignores certain keys and key combinations to prevent default behavior.
@@ -289,46 +328,56 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
     };
 
     const onSubmitForm = () => {
-      const eventToSubmit = latestEventRef.current;
+      const draftToSubmit = latestDraftRef.current;
+      const isAllDay = draftToSubmit.values.schedule.kind === "allDay";
       const selectedDateTimes = {
         startDate: selectedStartDate,
         startTime,
         endDate: selectedEndDate,
         endTime,
-        isAllDay: eventToSubmit.isAllDay || false,
+        isAllDay,
       };
 
-      // TODO(packet-03-phase-3c): mapToBackend now returns an EventSchedule;
-      // this component still operates on legacy Schema_Event startDate/endDate.
       const schedule = mapToBackend(selectedDateTimes);
-      const startDate = schedule.start;
-      const endDate = schedule.end;
+      const start = dayjs(schedule.start).toDate();
+      const end = dayjs(schedule.end).toDate();
 
-      if (dayjs(startDate).isAfter(dayjs(endDate))) {
+      if (dayjs(start).isAfter(dayjs(end))) {
         showErrorToast(
           "uff-dah, looks like you got the start & end times mixed up",
         );
         return;
       }
 
-      const finalEvent = {
-        ...eventToSubmit,
-        priority: eventToSubmit.priority || Priorities.UNASSIGNED,
-        startDate,
-        endDate,
-      };
+      const withSchedule = replaceGridDraftSchedule(
+        draftToSubmit,
+        schedule.kind === "allDay"
+          ? { kind: "allDay", start, end }
+          : { kind: "timed", start, end, timeZone: schedule.timeZone },
+      );
 
-      onSubmit(finalEvent);
+      const finalDraft: GridEventDraft = {
+        ...withSchedule,
+        values: {
+          ...withSchedule.values,
+          priority: withSchedule.values.priority || Priorities.UNASSIGNED,
+        },
+      } as GridEventDraft;
+
+      onSubmit(finalDraft);
     };
 
     const onSetEventField: SetEventFormField = (field) => {
-      setLatestEvent({ ...latestEventRef.current, ...field });
+      setLatestEvent({
+        ...gridEventDraftToSchemaEvent(latestDraftRef.current),
+        ...field,
+      });
     };
 
     const dateTimeSectionProps = {
       bgColor: priorityColor,
       displayEndDate,
-      event,
+      draft,
       category,
       endTime,
       inputColor: hoverColorByPriority[priority],
@@ -345,7 +394,7 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
       setDisplayEndDate,
       setIsEndDatePickerOpen,
       setIsStartDatePickerOpen,
-      setEvent: setLatestEvent,
+      setDraft: setLatestDraft,
     };
 
     const recurrenceSectionProps = {
@@ -389,7 +438,7 @@ export const EventForm: React.FC<Omit<FormProps, "category">> = memo(
       (keyboardEvent) => {
         keyboardEvent.preventDefault();
         keyboardEvent.stopPropagation();
-        onDuplicate?.(event);
+        onDuplicate?.(draft);
       },
       EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
     );

--- a/packages/web/src/views/Forms/EventForm/types.ts
+++ b/packages/web/src/views/Forms/EventForm/types.ts
@@ -1,11 +1,14 @@
-import { type Ref, type SetStateAction } from "react";
+import { type Dispatch, type Ref, type SetStateAction } from "react";
 import { type Priority } from "@core/constants/core.constants";
 import {
   type Categories_Event,
   type Direction_Migrate,
   type Schema_Event,
 } from "@core/types/event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
 
+// Still used by SomedayEventForm, which remains on the legacy Schema_Event
+// draft shape (out of scope for the grid forms' GridEventDraft conversion).
 export interface FormProps {
   event: Schema_Event;
   category: Categories_Event;
@@ -25,6 +28,24 @@ export interface FormProps {
   onSubmitEventForm?: (event: Schema_Event) => void;
   priority?: Priority;
   setEvent: (event: SetStateAction<Schema_Event | null>) => void;
+  titleInputRef?: Ref<HTMLInputElement>;
+}
+
+// EventForm's props: the grid draft forms (Day + Week) both converge on the
+// canonical GridEventDraft. Does not include onMigrate/onSubmitEventForm —
+// those are Someday-only concerns EventForm never used.
+export interface GridEventFormProps {
+  draft: GridEventDraft;
+  category: Categories_Event;
+  isDraft: boolean;
+  isExistingEvent: boolean;
+  onClose: () => void;
+  onConvert?: () => void;
+  onDelete: () => void;
+  onDuplicate?: (draft: GridEventDraft) => void;
+  onSubmit: (draft: GridEventDraft | null) => void;
+  priority?: Priority;
+  setDraft: Dispatch<SetStateAction<GridEventDraft | null>>;
   titleInputRef?: Ref<HTMLInputElement>;
 }
 

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
@@ -1,73 +1,52 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import {
-  RecurringEventUpdateScope,
-  type Schema_Event,
-} from "@core/types/event.types";
+import { RecurringEventUpdateScope } from "@core/types/event.types";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
-import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { parseGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
-import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
-import { schemaEventToCreateInput } from "@web/events/queries/event.legacy-bridge";
-import { findEventInCache } from "@web/events/queries/event.query.cache";
+import { toRecurrenceScope } from "@web/events/recurrence/recurrence-scope";
 import { useCloseEventForm } from "@web/views/Forms/hooks/useCloseEventForm";
-import { OnSubmitParser } from "@web/views/Week/components/Draft/hooks/actions/submit.parser";
 
-// TODO(packet-03-phase-3c): OnSubmitParser still produces a legacy
-// Schema_Event; bridged onto CreateEventInput via schemaEventToCreateInput
-// until the EventForm submits an EventDraft directly (event-draft.parser.ts).
 export function useSaveEventForm() {
   const closeEventForm = useCloseEventForm();
-  const queryClient = useQueryClient();
-  const updateEvent = useUpdateEvent();
-  const { create } = useEventMutations();
+  const { create, replace } = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
-
-  const onCreate = useCallback(
-    (draft: Schema_GridEvent) => {
-      const event = new OnSubmitParser(draft).parse();
-      const calendarId = getDefaultTargetCalendar(calendars ?? [])?.id;
-      if (!calendarId) return;
-      const input = schemaEventToCreateInput(event, calendarId);
-      if (!input) return;
-      create(input);
-    },
-    [create, calendars],
-  );
-
-  const onEdit = useCallback(
-    (
-      draft: Schema_GridEvent,
-      applyTo: RecurringEventUpdateScope = RecurringEventUpdateScope.THIS_EVENT,
-    ) => {
-      const event = new OnSubmitParser(draft).parse();
-
-      updateEvent({ event, applyTo });
-    },
-    [updateEvent],
-  );
 
   const saveEventForm = useCallback(
     (
-      draft: Schema_Event | null,
+      draft: GridEventDraft | null,
       applyTo: RecurringEventUpdateScope = RecurringEventUpdateScope.THIS_EVENT,
     ) => {
       if (!draft) return closeEventForm();
 
-      const existing = Boolean(
-        draft._id && findEventInCache(queryClient, draft._id),
-      );
+      if (draft.kind === "create") {
+        const calendarId = getDefaultTargetCalendar(calendars ?? [])?.id;
+        if (!calendarId) return closeEventForm();
 
-      if (existing) {
-        onEdit(draft as Schema_GridEvent, applyTo);
+        const parsed = parseGridEventDraft({
+          ...draft,
+          values: { ...draft.values, calendarId },
+        });
+
+        if (parsed.ok && parsed.mode === "create") {
+          create(parsed.input);
+        }
       } else {
-        onCreate(draft as Schema_GridEvent);
+        const scope = toRecurrenceScope(applyTo);
+        const parsed = parseGridEventDraft({
+          ...draft,
+          values: { ...draft.values, scope },
+        });
+
+        if (parsed.ok && parsed.mode === "edit") {
+          replace({ id: parsed.eventId, input: parsed.input });
+        }
       }
 
       closeEventForm();
     },
-    [closeEventForm, onEdit, onCreate, queryClient],
+    [calendars, closeEventForm, create, replace],
   );
 
   return saveEventForm;

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -2,7 +2,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type PropsWithChildren, type Ref, useState } from "react";
 import { Origin, Priorities } from "@core/constants/core.constants";
-import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
@@ -40,12 +39,12 @@ mock.module("@floating-ui/react", () => ({
 
 mock.module("@web/views/Forms/EventForm/EventForm", () => ({
   EventForm: ({
-    event: draftEvent,
+    draft: formDraft,
     onSubmit,
     titleInputRef,
   }: {
-    event: Schema_Event;
-    onSubmit?: (event: Schema_Event) => void;
+    draft: GridEventDraft;
+    onSubmit?: (draft: GridEventDraft) => void;
     titleInputRef?: Ref<HTMLInputElement>;
   }) => (
     <>
@@ -54,7 +53,7 @@ mock.module("@web/views/Forms/EventForm/EventForm", () => ({
         onKeyDown={(event) => {
           if (event.key === "Enter") {
             event.preventDefault();
-            onSubmit?.(draftEvent);
+            onSubmit?.(formDraft);
           }
         }}
         ref={titleInputRef}

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -9,10 +9,7 @@ import {
   getEventDragOffset,
   gridEventDefaultPosition,
 } from "@web/common/utils/event/event.util";
-import {
-  applySchemaEventPatchToGridDraft,
-  gridEventDraftToSchemaEvent,
-} from "@web/events/grid-event-draft.adapter";
+import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { type CalendarTimedDeckLayout } from "@web/layout/calendar-grid/layout/calendarTimedDeckLayout";
 import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { FloatingFormContainer } from "@web/views/Forms/SomedayEventForm/FloatingFormContainer";
@@ -185,33 +182,17 @@ export const GridDraft: FC<Props> = ({
             {...getFloatingProps()}
           >
             <EventForm
-              event={draftSchemaEvent as Schema_Event}
+              draft={draft}
               onClose={discard}
               onConvert={onConvert}
               onDelete={onDelete}
               onDuplicate={duplicateEvent}
               isDraft={draft.kind === "create"}
               isExistingEvent={draft.kind === "edit"}
-              onSubmit={(event) => {
-                if (event && draft) {
-                  void onSubmit(applySchemaEventPatchToGridDraft(draft, event));
-                }
+              onSubmit={(nextDraft) => {
+                if (nextDraft) void onSubmit(nextDraft);
               }}
-              setEvent={(nextEvent) => {
-                if (!draft) return;
-
-                const patch =
-                  typeof nextEvent === "function"
-                    ? nextEvent(draftSchemaEvent)
-                    : nextEvent;
-
-                if (!patch) {
-                  setDraft(null);
-                  return;
-                }
-
-                setDraft(applySchemaEventPatchToGridDraft(draft, patch));
-              }}
+              setDraft={setDraft}
               titleInputRef={titleInputRef}
             />
           </FloatingFormContainer>


### PR DESCRIPTION
## Summary

Phase D — the event forms cluster (`EventForm.tsx`, `FloatingEventForm.tsx`, `TimePickers.tsx`/`DateTimeSection.tsx`, `useSaveEventForm.ts`). Unblocked by Phase C (#2030), which converted Week's local draft state so both Day and Week now feed `EventForm` the same `GridEventDraft`-shaped data. This is the exact file cluster a prior big-bang attempt broke with 118 type errors (5328eb137/7cbbb74e6, reverted by a91434684/a1d23ea7b) — that attempt tried this together with Week's draft-state conversion in one pass; doing Week's state first (Phase C) is what made this phase tractable.

- `EventForm.tsx`'s public contract is now `draft: GridEventDraft` / `setDraft` / `onSubmit: (draft: GridEventDraft | null) => void` — the shape both `FloatingEventForm` (Day) and `GridDraft.tsx` (Week) now hand it directly.
- `RecurrenceSection`/`DatePickers`/`PrioritySection` (confirmed independent, out of scope, not rewritten) still consume/produce `Schema_Event`-shaped `event`/`setEvent` — kept working via a small interop shim inside `EventForm.tsx` itself: derives a `Schema_Event` projection via `gridEventDraftToSchemaEvent(draft)`, and a writer that reapplies patches via `applySchemaEventPatchToGridDraft` before calling `setDraft`. Same pattern Phase C proved at the `GridDraft.tsx` boundary, moved one level deeper.
- `TimePickers.tsx` bypasses that shim entirely and calls `replaceGridDraftSchedule` directly on the draft.
- `FloatingEventForm.tsx` (Day) now reads `selectGridDraft`/writes via a new `draftActions.setGridDraft` store action (keeps the legacy `event` projection in sync for Day's still-unconverted grid-layer rendering).
- `useSaveEventForm.ts` rewritten to build `CreateEventInput`/`ReplaceEventInput` via `parseGridEventDraft` and call `mutations.create`/`mutations.replace` directly, dropping `OnSubmitParser`/`schemaEventToCreateInput`. Branches on the draft's own `kind` discriminant (create vs. edit) instead of the old cache-lookup heuristic — more robust, not just a mechanical port.

### Bug found (flagged separately, not fixed here — out of this phase's scope)
Day view's all-day row doesn't render any all-day event — confirmed pre-existing via `git stash` reproduction on unmodified `main`, alongside a React key-prop warning in `DayCalendarAllDayEventsLayer`. The event persists correctly to IndexedDB; this is a rendering-pipeline bug unrelated to the forms cluster. Week's all-day rendering is unaffected (the all-day e2e spec passes). Filed as its own follow-up.

## Test plan
- [x] `bun run type-check` clean (checked after every chunk of work, given this cluster's history)
- [x] `bun test` (web): 1254/1254 pass, no coverage deleted — updated `EventForm.test.tsx`, `FloatingEventForm.test.tsx`, `GridDraft.test.tsx`
- [x] `bunx playwright test`: 11/11 pass
- [x] Manual verification against a local dev server (Day view, which has no e2e coverage): timed event create, title edit + save, Cmd+Z undo (restored old title), delete — confirmed via DOM/IndexedDB inspection