### PR TITLE
refactor(web): convert Day grid renderer off legacy bridge

### DIFF
--- a/packages/web/src/events/mutations/useUpdateEvent.ts
+++ b/packages/web/src/events/mutations/useUpdateEvent.ts
@@ -1,15 +1,14 @@
 import { useQueryClient } from "@tanstack/react-query";
 import fastDeepEqual from "fast-deep-equal/es6";
 import { useCallback } from "react";
-import { Priorities } from "@core/constants/core.constants";
-import { EventIdSchema } from "@core/types/domain-primitives";
-import { ScheduledScheduleSchema } from "@core/types/event.contracts";
+import { type RecurringEventUpdateScope } from "@core/types/event.types";
+import dayjs from "@core/util/date/dayjs";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
-import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import {
-  type Payload_EditEvent,
-  type SliceStateContext,
-} from "@web/events/event.types";
+  editGridEventDraft,
+  parseGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import {
   findEventInCache,
@@ -18,75 +17,80 @@ import {
 import { toRecurrenceScope } from "@web/events/recurrence/recurrence-scope";
 import { draftActions } from "@web/events/stores/draft.store";
 
-// TODO(packet-03-phase-3c): bridges the legacy Schema_WebEvent grid-edit
-// payload onto ReplaceEventInput until the draft store + inline-edit call
-// sites (Week grid drag/resize) are converted to build EventDraft/
-// ReplaceEventInput directly. Preserves recurrence (recurrence.kind
-// "preserve") and maps the legacy applyTo scope via
-// legacyScopeToRecurrenceScope.
+// The persisted-write half builds a GridEventDraft from the cached strict
+// `Event` plus the incoming Schema_GridEvent's changed fields (schedule/
+// priority/title/description), matching
+// WeekInteractionCoordinator.commitStrictSavedMutation (#2029), instead of
+// hand-rolling a ReplaceEventInput via zod. Recurrence always stays
+// "preserve" here — this hook only ever moves/resizes/re-prioritizes an
+// existing event, never edits its recurrence rule.
+//
+// draftActions.setEvent still writes into the draft store's legacy
+// `event: Schema_Event` projection: Day's grid rendering layers read the
+// in-progress drag/resize position via `selectDraft`, and GridEventDraft has
+// no field for that live pixel geometry (packet-03-phase-3c's documented
+// out-of-scope local drag-geometry state).
 export function useUpdateEvent() {
   const queryClient = useQueryClient();
   const { replace } = useEventMutations();
 
   const update = useCallback(
     (
-      payload: Omit<Payload_EditEvent & SliceStateContext, "_id">,
+      payload: {
+        event: Schema_GridEvent;
+        shouldRemove?: boolean;
+        applyTo?: RecurringEventUpdateScope;
+      },
       saveImmediate = true,
     ) => {
       const { event, shouldRemove, applyTo } = payload;
 
       if (!event._id) return;
 
-      // NOT converted to GridEventDraft/startGridDraft: `payload.event` is a
-      // Schema_GridEvent carrying live drag/resize geometry (`position`)
-      // that GridEventDraft has no field for. This is the local
-      // drag-geometry state called out as out of scope in the
-      // packet-03-phase-3c scoping note.
-      draftActions.setEvent(payload.event);
+      draftActions.setEvent(event);
 
       if (!saveImmediate) return;
-
-      const original = findEventInCache(queryClient, event._id) ?? {};
-      const position = (event as Schema_GridEvent).position;
-      const recurrence = event.recurrence;
-      const equal = fastDeepEqual(event, { position, recurrence, ...original });
-
-      if (equal) return;
 
       if (shouldRemove) {
         removeEventFromQueries(queryClient, event._id);
         return;
       }
 
-      const id = EventIdSchema.safeParse(event._id);
-      if (!id.success) return;
+      const sourceEvent = findEventInCache(queryClient, event._id);
+      if (!sourceEvent) return;
 
-      const schedule = ScheduledScheduleSchema.safeParse(
-        event.isAllDay
-          ? { kind: "allDay", start: event.startDate, end: event.endDate }
-          : {
-              kind: "timed",
-              start: event.startDate,
-              end: event.endDate,
-              timeZone: getBrowserTimeZone(),
-            },
+      const sourceDraft = editGridEventDraft(
+        sourceEvent,
+        toRecurrenceScope(applyTo),
       );
-      if (!schedule.success) return;
+      if (!sourceDraft || sourceDraft.kind !== "edit") return;
 
-      replace({
-        id: id.data,
-        input: {
-          content: {
-            kind: "details",
-            title: event.title ?? "",
-            description: event.description ?? "",
-          },
-          schedule: schedule.data,
-          recurrence: { kind: "preserve" },
-          priority: event.priority ?? Priorities.UNASSIGNED,
-          scope: toRecurrenceScope(applyTo),
+      const patchedDraft = {
+        ...sourceDraft,
+        values: {
+          ...sourceDraft.values,
+          title: event.title ?? sourceDraft.values.title,
+          description: event.description ?? sourceDraft.values.description,
+          schedule: event.isAllDay
+            ? {
+                kind: "allDay" as const,
+                start: dayjs(event.startDate).toDate(),
+                end: dayjs(event.endDate).toDate(),
+              }
+            : timedGridSchedule(
+                dayjs(event.startDate).toDate(),
+                dayjs(event.endDate).toDate(),
+              ),
+          priority: event.priority ?? sourceDraft.values.priority,
         },
-      });
+      };
+
+      if (fastDeepEqual(patchedDraft.values, sourceDraft.values)) return;
+
+      const parsed = parseGridEventDraft(patchedDraft);
+      if (parsed.ok && parsed.mode === "edit") {
+        replace({ id: parsed.eventId, input: parsed.input });
+      }
     },
     [replace, queryClient],
   );

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -22,7 +22,6 @@ import {
   editGridEventDraft,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
-import { eventToSchemaEvent } from "@web/events/queries/event.legacy-bridge";
 import { useDayEventViewModel } from "@web/events/queries/useDayEventsQuery";
 import {
   draftActions,
@@ -211,22 +210,22 @@ export function DayCalendarGrid() {
     [dayEvents, setFormPositionReference, setFormReference],
   );
 
-  // TODO(packet-03-phase-3c): dayEvents is now `Event[]` (new contract);
-  // bridged to the legacy Schema_Event shape assembleGridEvent still expects
-  // until the grid renderer is converted.
+  // timedEvents/allDayEvents are the same Schema_GridEvent objects the grid
+  // layers render from (assembled once in event.view-model.ts), so the
+  // context menu/right-click lookup reuses them directly instead of
+  // re-deriving a fresh Schema_GridEvent from `dayEvents` (Event[]).
+  const dayGridEventsById = useMemo(() => {
+    const map = new Map<string, Schema_GridEvent>();
+    for (const gridEvent of [...timedEvents, ...allDayEvents]) {
+      if (gridEvent._id) map.set(gridEvent._id, gridEvent);
+    }
+    return map;
+  }, [timedEvents, allDayEvents]);
+
   const getDayEventById = useCallback(
-    (eventId: string): Schema_GridEvent | null => {
-      const event = dayEvents.find((dayEvent) => dayEvent.id === eventId);
-      if (!event) return null;
-
-      const schemaEvent = eventToSchemaEvent(event);
-      if (!hasEventDates(schemaEvent)) {
-        return null;
-      }
-
-      return assembleGridEvent(schemaEvent);
-    },
-    [dayEvents],
+    (eventId: string): Schema_GridEvent | null =>
+      dayGridEventsById.get(eventId) ?? null,
+    [dayGridEventsById],
   );
 
   const { contextMenu, handleContextMenu } = useDayCalendarContextMenu({

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -2,17 +2,20 @@ import { HotkeyManager } from "@tanstack/react-hotkeys";
 import { Origin, Priorities } from "@core/constants/core.constants";
 import { EventIdSchema } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
-import dayjs from "@core/util/date/dayjs";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   cleanup,
   renderHook,
   waitFor,
 } from "@web/__tests__/__mocks__/mock.render";
+import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import { pressKey } from "@web/common/utils/dom/event-emitter.util";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { dayCalendarEventRegistry } from "@web/views/Day/interaction/registry/dayCalendarEventRegistry";
 import { useDayEventNudgeShortcuts } from "./useDayEventNudgeShortcuts";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -64,12 +67,31 @@ const focusCalendarTarget = (eventType: "all-day" | "timed") => {
 
 const renderNudgeShortcuts = () => {
   const queryClient = createCompassQueryClient();
+  // useUpdateEvent now reads the source `Event` straight from the query
+  // cache (editGridEventDraft needs it), rather than the seeded-events
+  // `initialData` default this harness normally relies on — that default
+  // only applies once a real query mounts, and this hook mounts none of its
+  // own. Register a real cache entry so `findEventInCache` can see it.
+  queryClient.setQueryData(
+    eventQueryKeys.day({
+      source: "local",
+      start: "2026-05-20T00:00:00.000Z",
+      end: "2026-05-21T00:00:00.000Z",
+    }),
+    toNormalizedEventQueryData([timedEventContract]),
+  );
   renderHook(() => useDayEventNudgeShortcuts({ timedEvents: [timedEvent] }), {
     events: [timedEventContract],
     queryClient,
   });
   return { queryClient };
 };
+
+// The mutation's write path formats the moved instant in the browser's own
+// time zone (matching every other GridEventDraft-based submit path), not
+// dayjs's default local-offset `.format()`.
+const offsetString = (date: Dayjs) =>
+  dayjs.tz(date.toDate(), getBrowserTimeZone()).format();
 
 const getEditMutation = (
   queryClient: ReturnType<typeof createCompassQueryClient>,
@@ -103,10 +125,10 @@ describe("useDayEventNudgeShortcuts", () => {
       input: { schedule: { start: string; end: string } };
     };
     expect(input.schedule.start).toBe(
-      dayjs(timedEvent.startDate).subtract(15, "minutes").format(),
+      offsetString(dayjs(timedEvent.startDate).subtract(15, "minutes")),
     );
     expect(input.schedule.end).toBe(
-      dayjs(timedEvent.endDate).subtract(15, "minutes").format(),
+      offsetString(dayjs(timedEvent.endDate).subtract(15, "minutes")),
     );
   });
 
@@ -123,7 +145,7 @@ describe("useDayEventNudgeShortcuts", () => {
       input: { schedule: { start: string } };
     };
     expect(input.schedule.start).toBe(
-      dayjs(timedEvent.startDate).add(15, "minutes").format(),
+      offsetString(dayjs(timedEvent.startDate).add(15, "minutes")),
     );
   });
 


### PR DESCRIPTION
## Summary

Second-to-last piece of packet 03's legacy-bridge dissolution. Everything else is converted: the grid draft pipeline, the someday sidebar, Week's local draft/drag state, and the event forms cluster (PRs #2019-#2031).

Narrower than the old TODO comment suggested:

- `DayCalendarGrid.tsx`'s `getDayEventById` was independently re-running the same `eventToSchemaEvent` + `assembleGridEvent` conversion `event.view-model.ts` already performs to build `timedEvents`/`allDayEvents`. Fixed by looking up the already-assembled objects in a map instead of re-deriving them — a real simplification (removes duplicate work), not just a type change. `assembleGridEvent` itself is untouched: it has ~8 callers across Day and Week, most still `Schema_Event`-sourced, so narrowing its signature here would just move the bridge rather than shrink it.
- `useUpdateEvent.ts` (live drag/resize position updates) wasn't actually round-tripping through `eventToSchemaEvent` as the old comment implied — its real legacy dependency was hand-rolled zod construction instead of the shared `GridEventDraft` pipeline. Converted to match `WeekInteractionCoordinator.commitStrictSavedMutation`'s established pattern (#2029): `findEventInCache` → `editGridEventDraft` → patch changed fields → `parseGridEventDraft` → `replace`. `draftActions.setEvent` still writes the legacy `event: Schema_Event` store projection, since Day's grid layers read live drag/resize position via `selectDraft` and `GridEventDraft` structurally has no field for that pixel geometry — the documented, still out-of-scope local drag-geometry state.

### Remaining legacy-bridge callers after this change
- `event.view-model.ts` (shared Day+Week grid-render derivation — the wider renderer conversion, out of scope for this packet)
- `grid-event-draft.adapter.ts`/`someday-event-draft.adapter.ts` (internal, adapter-owned)
- The someday sidebar's remaining internal uses (out of scope, explicitly excluded)
- `useSidebarActions.ts`'s `onMigrate` create-fallback and `useWeekShortcuts.ts`'s `convertToSomeday` — the two previously-flagged legitimate remainders

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1254/1254 pass, no deletions
- [x] `bunx playwright test --workers=1`: 11/11 pass (one flaky failure under 2-worker contention on an unrelated someday spec, passed cleanly in isolation and on rerun — matches this repo's documented worker-contention flakiness, not a regression)