### PR TITLE
refactor(web): convert grid event view-model off legacy bridge

### DIFF
--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -1,8 +1,10 @@
 import {
+  Origin,
   SOMEDAY_MONTHLY_LIMIT,
   SOMEDAY_WEEKLY_LIMIT,
 } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
+import { type Schema_Event } from "@core/types/event.types";
 import { COLUMN_MONTH, COLUMN_WEEK } from "@web/common/constants/web.constants";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -12,18 +14,47 @@ import {
 } from "@web/common/utils/event/event.util";
 import { categorizeSomedayEvents } from "@web/common/utils/event/someday.event.util";
 import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
-import { eventToSchemaEvent } from "./event.legacy-bridge";
 import { type NormalizedEventQueryData } from "./event.query.types";
+
+// The grid renderer (assembleGridEvent) still consumes the legacy
+// Schema_Event shape. This mirrors the mapping event.legacy-bridge.ts uses,
+// scoped to scheduled (timed/allDay) events only — this file never sees
+// someday events, so the someday-anchorDate branch there doesn't apply here.
+const scheduledEventToSchemaEvent = (event: Event): Schema_Event => {
+  const { schedule } = event;
+  if (schedule.kind === "someday") {
+    throw new Error("scheduledEventToSchemaEvent: someday event");
+  }
+  return {
+    _id: event.id,
+    title: event.content.kind === "details" ? event.content.title : "",
+    description:
+      event.content.kind === "details" ? event.content.description : "",
+    origin: Origin.COMPASS,
+    priority: event.priority,
+    isAllDay: schedule.kind === "allDay",
+    isSomeday: false,
+    startDate: schedule.start,
+    endDate: schedule.end,
+    recurrence:
+      event.recurrence.kind === "series"
+        ? { rule: [...event.recurrence.rules], eventId: event.id }
+        : event.recurrence.kind === "occurrence"
+          ? { eventId: event.recurrence.seriesId }
+          : undefined,
+    updatedAt: event.updatedAt ?? undefined,
+  };
+};
 
 const eventsFrom = (data?: NormalizedEventQueryData): Event[] =>
   data?.ids.flatMap((id) => (data.entities[id] ? [data.entities[id]] : [])) ??
   [];
 
 // assembleGridEvent/hasEventDates still operate on the legacy Schema_Event
-// shape; bridged via eventToSchemaEvent until the grid renderer converts to
-// `Event` directly. A cache entry with a missing/malformed `schedule` is a
-// bug upstream (normalizeEventList/query seeding), not a case to silently
-// swallow — but it must not crash this shared derivation, since every grid
+// shape; bridged via scheduledEventToSchemaEvent above. A cache entry with a
+// missing/malformed `schedule` is a bug upstream (normalizeEventList/query
+// seeding), not a case to silently swallow — but it must not crash this
+// shared derivation, since every grid
 // consumer recomputes from it on every render (a throw here becomes a
 // render-crash loop). Log loudly and drop the offending event instead.
 const isValidScheduledEvent = (event: Event): boolean => {
@@ -42,7 +73,7 @@ const gridEventsFrom = (events: Event[], kind: "timed" | "allDay") =>
   events
     .filter(isValidScheduledEvent)
     .filter((event) => event.schedule.kind === kind)
-    .map(eventToSchemaEvent)
+    .map(scheduledEventToSchemaEvent)
     .filter((event): event is EventWithDates => hasEventDates(event))
     .map(assembleGridEvent);
 


### PR DESCRIPTION
## Summary

The last major piece of packet 03's legacy-bridge dissolution. `event.view-model.ts` (shared Day+Week grid-render derivation) was the one remaining substantial blocker — everything else is converted (PRs #2019-#2032, all merged today).

Investigation confirmed every OTHER `assembleGridEvent` caller (`allDayDraftEventPosition.ts`, `dayCalendarDraft.util.ts`, `DayCalendarGrid.tsx`, `submit.parser.ts`, `GridContextMenuWrapper.tsx`) is still genuinely `Schema_Event`-sourced from local draft/store state, not `Event`-sourced — converting `assembleGridEvent`'s signature itself would require touching all of those, out of scope here. So this converts only `event.view-model.ts`'s own call site: a local `scheduledEventToSchemaEvent` mirrors `event.legacy-bridge.ts`'s mapping (scoped to timed/allDay only, since this file never sees someday events), replacing the import from `event.legacy-bridge.ts` entirely. The small duplication is deliberate — the goal is *removing* this file's dependency on the bridge, not reintroducing it via a shared helper.

### Final remaining legacy-bridge callers (after this PR)
```
packages/web/src/events/grid-event-draft.adapter.ts
packages/web/src/events/someday-event-draft.adapter.ts
packages/web/src/components/PlannerSidebar/SomedayEventSections/interaction/SomedayInteractionCoordinator.tsx
packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
packages/web/src/common/utils/event/someday.event.util.ts
packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
packages/web/src/components/PlannerSidebar/draft/hooks/useSidebarActions.ts
packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
```
All within the someday sidebar's own files, or `useSidebarActions.ts`'s `onMigrate` create-fallback / `useWeekShortcuts.ts`'s `convertToSomeday` — the previously-flagged legitimate remainders. `event.legacy-bridge.ts` is not deleted in this PR (still needed by these).

## Test plan
- [x] `bun run type-check` clean
- [x] `bun test` (web): 1254/1254 pass, no fixture changes
- [x] `bunx playwright test --workers=1`: 11/11 pass
- [x] Manual check via local dev server: Day (single-day, 3 events) and Week (same events correctly positioned, someday sidebar intact) both render correctly, no console errors