### PR TITLE
docs(someday): check off packet 03 exit criteria and master-doc box

### DIFF
--- a/handoff/someday/03-event-runtime-cutover.md
+++ b/handoff/someday/03-event-runtime-cutover.md
@@ -269,11 +269,9 @@ provider id or reintroduce `event.user` for convenient queries.
       Verified 2026-07-11 on the final state: `bun run type-check` clean,
       `bun test` (web) 1254/1254, `bunx playwright test --workers=1` 11/11,
       `bun run lint` exits 0 (15 pre-existing a11y warnings, no errors).
-- [ ] Every runtime requirement archived from #1138 and #1135 has matching
-      code and test evidence in this packet. Not independently audited in
-      this session — needs a human (or a session with GitHub issue access)
-      to cross-reference the archived requirements list against this
-      packet's actual PRs before this box is checked.
+- [x] Every runtime requirement archived from #1138 and #1135 has matching
+      code and test evidence in this packet. Cross-referenced by the PO
+      2026-07-11 — confirmed satisfied.
 
 Suggested commit boundaries:
 

--- a/handoff/someday/master-doc.md
+++ b/handoff/someday/master-doc.md
@@ -57,7 +57,7 @@ unfinished.
 - [x] 02. [Safe event data migration](./02-safe-event-data-migration.md) — build and
       verify the non-destructive v2 backfill plus the calendar-collection
       migration (A32).
-- [ ] 03. [Event runtime cutover](./03-event-runtime-cutover.md) — move the codebase
+- [x] 03. [Event runtime cutover](./03-event-runtime-cutover.md) — move the codebase
       from the legacy user-owned event shape to calendar-owned storage.
 - [ ] 04. [Initial multi-calendar import](./04-initial-multi-calendar-import.md) —
       import all eligible Google calendars and events; starts with the request


### PR DESCRIPTION
Docs-only. PO cross-referenced #1138/#1135 and confirmed the archived requirements are satisfied — checks off the last remaining exit criterion in \`03-event-runtime-cutover.md\` and the packet 03 checkbox in \`master-doc.md\`. All 6 exit criteria now checked; packet 03 is complete.