### PR TITLE
feat(backend): centralize google request context and retry policy

### DIFF
--- a/packages/backend/src/__tests__/drivers/event.driver.ts
+++ b/packages/backend/src/__tests__/drivers/event.driver.ts
@@ -5,8 +5,8 @@ import { Origin, Priorities } from "@core/constants/core.constants";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { mockGcalEvents } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import calendarService from "@backend/calendar/services/calendar.service";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 
 export class EventDriver {
   static async generateV0Data(count = 3) {
@@ -20,7 +20,7 @@ export class EventDriver {
       users.map(async (user) =>
         calendarService.initializeGoogleCalendars(
           user._id,
-          await getGcalClient(user._id.toString()),
+          await createGoogleRequestContext(user._id.toString()),
         ),
       ),
     );

--- a/packages/backend/src/__tests__/drivers/google-sync.driver.ts
+++ b/packages/backend/src/__tests__/drivers/google-sync.driver.ts
@@ -4,8 +4,8 @@ import { Resource_Sync, type Schema_Sync } from "@core/types/sync.types";
 import { type Schema_User } from "@core/types/user.types";
 import dayjs from "@core/util/date/dayjs";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 
@@ -15,7 +15,7 @@ export class GoogleSyncDriver {
     defaultUser = false,
   ): Promise<void> {
     const gCalendarId = defaultUser ? "test-calendar" : faker.string.uuid();
-    const gcal = await getGcalClient(user._id.toString());
+    const context = await createGoogleRequestContext(user._id.toString());
 
     // Avoid racing multiple upserts for the same user's sync document in tests.
     await updateSync(Resource_Sync.CALENDAR, user._id.toString(), gCalendarId, {
@@ -27,7 +27,7 @@ export class GoogleSyncDriver {
     await googleWatchService.startGoogleWatches(
       user._id.toString(),
       [{ gCalendarId }, { gCalendarId: Resource_Sync.CALENDAR }], // Watch all selected calendars and calendar list
-      gcal,
+      context,
     );
   }
 

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -13,6 +13,7 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 import { SyncError } from "@backend/common/errors/sync/sync.errors";
 import { UserError } from "@backend/common/errors/user/user.errors";
 import { normalizeEmail } from "@backend/common/helpers/email.util";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
@@ -278,11 +279,17 @@ async function googleSignin(
   const googleOAuthClient = new GoogleOAuthClient();
   googleOAuthClient.oauthClient.setCredentials(oAuthTokens);
 
+  // Wrap the just-authenticated client directly instead of building a
+  // context via createGoogleRequestContext(cUserId): the refresh token may
+  // not be persisted to Mongo yet at this point in the OAuth callback, so
+  // re-fetching by userId here could fail.
+  const freshContext: GoogleRequestContext = {
+    gcal: googleOAuthClient.getGcalClient(),
+    quotaUser: cUserId,
+  };
+
   googleCalendarSyncService
-    .importLatestGoogleCalendarChanges(
-      cUserId,
-      googleOAuthClient.getGcalClient(),
-    )
+    .importLatestGoogleCalendarChanges(cUserId, freshContext)
     .catch(async (err) => {
       if (
         err instanceof Error &&

--- a/packages/backend/src/calendar/services/calendar.service.test.ts
+++ b/packages/backend/src/calendar/services/calendar.service.test.ts
@@ -7,8 +7,8 @@ import {
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import calendarService from "@backend/calendar/services/calendar.service";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 
 describe("CalendarService", () => {
   beforeEach(setupTestDb);
@@ -40,11 +40,11 @@ describe("CalendarService", () => {
     it("upserts the user's Google calendars as CalendarRecords", async () => {
       const { user } = await UtilDriver.setupTestUser();
       const userId = user._id.toString();
-      const gcal = await getGcalClient(userId);
+      const context = await createGoogleRequestContext(userId);
 
       const result = await calendarService.initializeGoogleCalendars(
         userId,
-        gcal,
+        context,
       );
 
       expect(result.acknowledged).toBe(true);
@@ -62,9 +62,9 @@ describe("CalendarService", () => {
     it("is idempotent: re-running preserves the record id and user-set visibility", async () => {
       const { user } = await UtilDriver.setupTestUser();
       const userId = user._id.toString();
-      const gcal = await getGcalClient(userId);
+      const context = await createGoogleRequestContext(userId);
 
-      await calendarService.initializeGoogleCalendars(userId, gcal);
+      await calendarService.initializeGoogleCalendars(userId, context);
       const [before] = await mongoService.calendar
         .find({ userId: user._id, "source.provider": "google" })
         .toArray();
@@ -73,7 +73,7 @@ describe("CalendarService", () => {
         { calendarId: before!._id.toHexString(), isVisible: false },
       ]);
 
-      await calendarService.initializeGoogleCalendars(userId, gcal);
+      await calendarService.initializeGoogleCalendars(userId, context);
       const [after] = await mongoService.calendar
         .find({ userId: user._id, "source.provider": "google" })
         .toArray();
@@ -87,9 +87,9 @@ describe("CalendarService", () => {
     it("returns every calendar owned by the user", async () => {
       const { user } = await UtilDriver.setupTestUser();
       const userId = user._id.toString();
-      const gcal = await getGcalClient(userId);
+      const context = await createGoogleRequestContext(userId);
 
-      await calendarService.initializeGoogleCalendars(userId, gcal);
+      await calendarService.initializeGoogleCalendars(userId, context);
       await seedLocalCalendar(user._id);
 
       const calendars = await calendarService.list(userId);
@@ -132,9 +132,9 @@ describe("CalendarService", () => {
     it("returns the active primary Google calendar", async () => {
       const { user } = await UtilDriver.setupTestUser();
       const userId = user._id.toString();
-      const gcal = await getGcalClient(userId);
+      const context = await createGoogleRequestContext(userId);
 
-      await calendarService.initializeGoogleCalendars(userId, gcal);
+      await calendarService.initializeGoogleCalendars(userId, context);
 
       const primary = await calendarService.getPrimaryGoogleCalendar(userId);
 

--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -3,11 +3,11 @@ import {
   type ClientSession,
   type ObjectId,
 } from "mongodb";
-import { type gCalendar } from "@core/types/gcal";
 import { Resource_Sync } from "@core/types/sync.types";
 import { zObjectId } from "@core/types/type.utils";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { mapGoogleCalendar } from "@backend/calendar/calendar.record.mapper";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
 import { getCalendarsToSync } from "@backend/sync/services/init/google-sync-init";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
@@ -23,12 +23,12 @@ class CalendarService {
    */
   async initializeGoogleCalendars(
     userId: ObjectId | string,
-    gcal: gCalendar,
+    context: GoogleRequestContext,
     session?: ClientSession,
   ) {
     const userObjectId = zObjectId.parse(userId);
 
-    const googleCalendarResult = await getCalendarsToSync(gcal);
+    const googleCalendarResult = await getCalendarsToSync(context);
     const {
       calendars: googleCalendars,
       nextPageToken,

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -16,7 +16,7 @@ const logger = Logger("app:constants");
 const ConfigSchema = z
   .object({
     BASEURL: z.string().nonempty(),
-    CHANNEL_EXPIRATION_MIN: z.string().nonempty().default("10"),
+    CHANNEL_EXPIRATION_MIN: z.string().nonempty().default("10080"),
     GOOGLE_CLIENT_ID: z.string().nonempty().optional(),
     GOOGLE_CLIENT_SECRET: z.string().nonempty().optional(),
     DB: z.string().nonempty(),
@@ -85,7 +85,8 @@ function parseRawConfig(config: CompassConfig): Config {
 
   return ConfigSchema.parse({
     BASEURL: config.backend.apiUrl,
-    CHANNEL_EXPIRATION_MIN: toStr(config.google?.channelExpirationMin) ?? "10",
+    CHANNEL_EXPIRATION_MIN:
+      toStr(config.google?.channelExpirationMin) ?? "10080",
     GOOGLE_CLIENT_ID: nonEmpty(config.google?.clientId),
     GOOGLE_CLIENT_SECRET: nonEmpty(config.google?.clientSecret),
     DB: isDev(nodeEnv) ? "dev_calendar" : "prod_calendar",

--- a/packages/backend/src/common/services/gcal/gcal.context.ts
+++ b/packages/backend/src/common/services/gcal/gcal.context.ts
@@ -1,0 +1,27 @@
+import { type gCalendar } from "@core/types/gcal";
+import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
+
+/**
+ * Everything a Google Calendar API call needs: the authenticated client and
+ * the stable per-user `quotaUser` used for Google's quota accounting. Every
+ * call for a given user must reuse the same `quotaUser` (the Compass user
+ * id) rather than generating a fresh one per request.
+ */
+export interface GoogleRequestContext {
+  gcal: gCalendar;
+  quotaUser: string;
+}
+
+/**
+ * Builds a GoogleRequestContext for `userId`, fetching a gCalendar client
+ * for them. Callers that already hold a `gCalendar` obtained some other way
+ * should build the context object directly (`{ gcal, quotaUser: userId }`)
+ * instead of calling this, to avoid a redundant network/DB round trip.
+ */
+export const createGoogleRequestContext = async (
+  userId: string,
+): Promise<GoogleRequestContext> => {
+  const gcal = await getGcalClient(userId);
+
+  return { gcal, quotaUser: userId };
+};

--- a/packages/backend/src/common/services/gcal/gcal.retry.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.retry.test.ts
@@ -1,0 +1,183 @@
+import { GaxiosError, type GaxiosResponse } from "gaxios";
+import {
+  computeBackoffDelayMs,
+  isRetryableGoogleError,
+  withGoogleRetry,
+} from "@backend/common/services/gcal/gcal.retry";
+
+const makeGaxiosError = ({
+  status,
+  reasons,
+  noResponse = false,
+}: {
+  status?: number;
+  reasons?: string[];
+  noResponse?: boolean;
+}): GaxiosError => {
+  const err = new GaxiosError(
+    "Gcal request failed",
+    { headers: new Headers(), url: new URL("https://example.com") },
+    noResponse
+      ? undefined
+      : ({
+          status,
+          statusText: "",
+          headers: new Headers(),
+          config: {
+            headers: new Headers(),
+            url: new URL("https://example.com"),
+          },
+          // GaxiosError's constructor only preserves `data` when the
+          // response looks like it came from a real fetch Response (i.e.
+          // `bodyUsed` is truthy) — otherwise it discards it via
+          // translateData(responseType, undefined).
+          bodyUsed: true,
+          data: {
+            error: {
+              errors: (reasons ?? []).map((reason) => ({ reason })),
+            },
+          },
+        } as unknown as GaxiosResponse),
+  );
+
+  return err;
+};
+
+describe("isRetryableGoogleError", () => {
+  it("retries on 429", () => {
+    expect(isRetryableGoogleError(makeGaxiosError({ status: 429 }))).toBe(true);
+  });
+
+  it.each([
+    "rateLimitExceeded",
+    "userRateLimitExceeded",
+    "quotaExceeded",
+    "dailyLimitExceeded",
+  ])("retries on 403 with reason %s", (reason) => {
+    expect(
+      isRetryableGoogleError(
+        makeGaxiosError({ status: 403, reasons: [reason] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not retry on 403 with an unrelated reason", () => {
+    expect(
+      isRetryableGoogleError(
+        makeGaxiosError({ status: 403, reasons: ["forbidden"] }),
+      ),
+    ).toBe(false);
+  });
+
+  it.each([500, 502, 503, 504])("retries on %d", (status) => {
+    expect(isRetryableGoogleError(makeGaxiosError({ status }))).toBe(true);
+  });
+
+  it.each([400, 401, 404, 410])("does not retry on %d", (status) => {
+    expect(isRetryableGoogleError(makeGaxiosError({ status }))).toBe(false);
+  });
+
+  it("retries when there is no response at all (network-level failure)", () => {
+    expect(isRetryableGoogleError(makeGaxiosError({ noResponse: true }))).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    "ECONNRESET",
+    "ETIMEDOUT",
+    "ECONNREFUSED",
+    "ENOTFOUND",
+    "EAI_AGAIN",
+  ])("retries plain network errors with code %s", (code) => {
+    expect(
+      isRetryableGoogleError(Object.assign(new Error("boom"), { code })),
+    ).toBe(true);
+  });
+
+  it("does not retry a plain validation error", () => {
+    expect(isRetryableGoogleError(new Error("Invalid Value"))).toBe(false);
+  });
+
+  it("does not retry undefined/null", () => {
+    expect(isRetryableGoogleError(undefined)).toBe(false);
+    expect(isRetryableGoogleError(null)).toBe(false);
+  });
+});
+
+describe("computeBackoffDelayMs", () => {
+  it("produces increasing caps that saturate at maxDelayMs", () => {
+    const randomSpy = jest.spyOn(Math, "random").mockReturnValue(1);
+
+    const delays = [0, 1, 2, 3, 4, 5, 6, 10].map((attempt) =>
+      computeBackoffDelayMs(attempt, { baseDelayMs: 500, maxDelayMs: 30_000 }),
+    );
+
+    expect(delays).toEqual([500, 1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+
+    randomSpy.mockRestore();
+  });
+
+  it("jitters within [0, cap]", () => {
+    const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const delay = computeBackoffDelayMs(2, {
+      baseDelayMs: 500,
+      maxDelayMs: 30_000,
+    });
+
+    expect(delay).toBe(1000);
+
+    randomSpy.mockRestore();
+  });
+});
+
+describe("withGoogleRetry", () => {
+  const noopSleep = async () => undefined;
+
+  it("resolves immediately on success without sleeping", async () => {
+    const sleep = jest.fn(noopSleep);
+    const fn = jest.fn().mockResolvedValue("ok");
+
+    await expect(withGoogleRetry(fn, { sleep })).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries a retryable failure and resolves once it succeeds", async () => {
+    const sleep = jest.fn(noopSleep);
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(makeGaxiosError({ status: 429 }))
+      .mockRejectedValueOnce(makeGaxiosError({ status: 500 }))
+      .mockResolvedValueOnce("ok");
+
+    await expect(withGoogleRetry(fn, { sleep, maxAttempts: 5 })).resolves.toBe(
+      "ok",
+    );
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws immediately on a non-retryable error without sleeping", async () => {
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({ status: 404 });
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(withGoogleRetry(fn, { sleep })).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("throws the original error once maxAttempts is exhausted", async () => {
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({ status: 429 });
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(withGoogleRetry(fn, { sleep, maxAttempts: 3 })).rejects.toBe(
+      err,
+    );
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/common/services/gcal/gcal.retry.ts
+++ b/packages/backend/src/common/services/gcal/gcal.retry.ts
@@ -1,0 +1,142 @@
+import { GaxiosError } from "gaxios";
+import { Logger } from "@core/logger/winston.logger";
+
+const logger = Logger("app:gcal.retry");
+
+/** 403 reasons Google returns for quota/rate-limit rejections (retryable). */
+const RETRYABLE_403_REASONS = new Set([
+  "rateLimitExceeded",
+  "userRateLimitExceeded",
+  "quotaExceeded",
+  "dailyLimitExceeded",
+]);
+
+/** Node network error codes that indicate a transient, retryable failure. */
+const RETRYABLE_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EPIPE",
+]);
+
+const get403Reasons = (err: GaxiosError): string[] => {
+  const data = err.response?.data as
+    | { error?: { errors?: Array<{ reason?: string }> } }
+    | undefined;
+
+  return (data?.error?.errors ?? [])
+    .map(({ reason }) => reason)
+    .filter((reason): reason is string => Boolean(reason));
+};
+
+/**
+ * Classifies whether a Google API failure is worth retrying: rate limits
+ * (429, or 403 with a quota/rate-limit reason), 5xx server errors, and
+ * network-level failures (no response, or a transient connection error
+ * code). Everything else (400, 401, 404, 410, other 403 reasons, etc.) is
+ * treated as a real failure and should surface immediately.
+ */
+export const isRetryableGoogleError = (err: unknown): boolean => {
+  if (err instanceof GaxiosError) {
+    const status = err.response?.status;
+
+    // No response at all means the request never completed (network-level
+    // failure), which is inherently transient.
+    if (!err.response) return true;
+
+    if (status === 429) return true;
+    if (typeof status === "number" && status >= 500) return true;
+
+    if (status === 403) {
+      return get403Reasons(err).some((reason) =>
+        RETRYABLE_403_REASONS.has(reason),
+      );
+    }
+
+    return false;
+  }
+
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+
+  return typeof code === "string" && RETRYABLE_NETWORK_CODES.has(code);
+};
+
+export interface WithGoogleRetryOptions {
+  /** Total attempts, including the first. Defaults to 5. */
+  maxAttempts?: number;
+  /** Base delay in ms before the first retry. Defaults to 500. */
+  baseDelayMs?: number;
+  /** Upper bound for the backoff delay, before jitter. Defaults to 30s. */
+  maxDelayMs?: number;
+  /** Injectable for tests so retries don't actually sleep. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_BASE_DELAY_MS = 500;
+const DEFAULT_MAX_DELAY_MS = 30_000;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Truncated exponential backoff with full jitter: the delay is a uniform
+ * random value in [0, min(baseDelayMs * 2^attempt, maxDelayMs)].
+ */
+export const computeBackoffDelayMs = (
+  attempt: number,
+  {
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+  }: Pick<WithGoogleRetryOptions, "baseDelayMs" | "maxDelayMs"> = {},
+): number => {
+  const cap = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+
+  return Math.random() * cap;
+};
+
+/**
+ * Runs `fn`, retrying with truncated exponential backoff (full jitter) on
+ * retryable Google API failures (see `isRetryableGoogleError`). Non-retryable
+ * errors and the final attempt's error are rethrown as-is.
+ */
+export const withGoogleRetry = async <T>(
+  fn: () => Promise<T>,
+  opts: WithGoogleRetryOptions = {},
+): Promise<T> => {
+  const {
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    sleep = defaultSleep,
+  } = opts;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const isLastAttempt = attempt === maxAttempts - 1;
+
+      if (!isRetryableGoogleError(err) || isLastAttempt) {
+        throw err;
+      }
+
+      const delayMs = computeBackoffDelayMs(attempt, {
+        baseDelayMs,
+        maxDelayMs,
+      });
+
+      logger.warn(
+        `Retrying Google API call after retryable error (attempt ${attempt + 1}/${maxAttempts}), waiting ${Math.round(delayMs)}ms`,
+        err,
+      );
+
+      await sleep(delayMs);
+    }
+  }
+
+  // Unreachable: the loop always either returns or throws.
+  throw new Error("withGoogleRetry: exhausted attempts without a result");
+};

--- a/packages/backend/src/common/services/gcal/gcal.service.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.test.ts
@@ -6,7 +6,9 @@ jest.mock("@backend/sync/services/watch/google-watch-token", () => ({
   encodeChannelToken: jest.fn(() => "encoded-token"),
 }));
 
+import { GaxiosError, type GaxiosResponse } from "gaxios";
 import { GCAL_NOTIFICATION_ENDPOINT } from "@core/constants/core.constants";
+import { type GoogleRequestContext } from "./gcal.context";
 import gcalService from "./gcal.service";
 
 describe("gcal.service watch callbacks", () => {
@@ -15,16 +17,21 @@ describe("gcal.service watch callbacks", () => {
       status: 200,
       data: { id: "507f1f77bcf86cd799439011", resourceId: "resource-id" },
     });
+    const context = {
+      gcal: { events: { watch } },
+      quotaUser: "user-1",
+    } as unknown as GoogleRequestContext;
 
-    await gcalService.watchEvents({ events: { watch } } as never, {
+    await gcalService.watchEvents(context, {
       channelId: "507f1f77bcf86cd799439011",
-      expiration: new Date("2030-01-01T00:00:00.000Z"),
+      expiration: new Date("2030-01-01T00:00:00.000Z").toISOString(),
       gCalendarId: "primary",
     });
 
     expect(watch).toHaveBeenCalledWith(
       expect.objectContaining({
         calendarId: "primary",
+        quotaUser: "user-1",
         requestBody: expect.objectContaining({
           address:
             "https://example.trycloudflare.com/api" +
@@ -40,14 +47,19 @@ describe("gcal.service watch callbacks", () => {
       status: 200,
       data: { id: "507f1f77bcf86cd799439011", resourceId: "resource-id" },
     });
+    const context = {
+      gcal: { calendarList: { watch } },
+      quotaUser: "user-1",
+    } as unknown as GoogleRequestContext;
 
-    await gcalService.watchCalendars({ calendarList: { watch } } as never, {
+    await gcalService.watchCalendars(context, {
       channelId: "507f1f77bcf86cd799439011",
-      expiration: new Date("2030-01-01T00:00:00.000Z"),
+      expiration: new Date("2030-01-01T00:00:00.000Z").toISOString(),
     });
 
     expect(watch).toHaveBeenCalledWith(
       expect.objectContaining({
+        quotaUser: "user-1",
         requestBody: expect.objectContaining({
           address:
             "https://example.trycloudflare.com/api" +
@@ -56,5 +68,58 @@ describe("gcal.service watch callbacks", () => {
         }),
       }),
     );
+  });
+
+  it("forwards quotaUser into the underlying googleapis call", async () => {
+    const list = jest.fn().mockResolvedValue({
+      status: 200,
+      data: { items: [] },
+    });
+    const context = {
+      gcal: { events: { list } },
+      quotaUser: "stable-user-id",
+    } as unknown as GoogleRequestContext;
+
+    await gcalService.getEvents(context, { calendarId: "primary" });
+
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        calendarId: "primary",
+        quotaUser: "stable-user-id",
+      }),
+    );
+  });
+
+  it("retries a retryable failure via withGoogleRetry and eventually succeeds", async () => {
+    const rateLimitError = new GaxiosError(
+      "rate limited",
+      { headers: new Headers(), url: new URL("https://example.com") },
+      {
+        status: 429,
+        statusText: "",
+        headers: new Headers(),
+        config: {
+          headers: new Headers(),
+          url: new URL("https://example.com"),
+        },
+        data: {},
+      } as unknown as GaxiosResponse,
+    );
+
+    const list = jest
+      .fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce({ status: 200, data: { items: [] } });
+    const context = {
+      gcal: { events: { list } },
+      quotaUser: "user-1",
+    } as unknown as GoogleRequestContext;
+
+    const result = await gcalService.getEvents(context, {
+      calendarId: "primary",
+    });
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(result.data).toEqual({ items: [] });
   });
 });

--- a/packages/backend/src/common/services/gcal/gcal.service.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.ts
@@ -1,7 +1,6 @@
 import { type GaxiosResponse } from "gaxios";
 import { GCAL_NOTIFICATION_ENDPOINT } from "@core/constants/core.constants";
 import {
-  type gCalendar,
   type gParamsEventsList,
   type gSchema$Event,
   type gSchema$Events,
@@ -16,6 +15,8 @@ import { GCAL_PRIMARY } from "@backend/common/constants/backend.constants";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { GcalError } from "@backend/common/errors/integration/gcal/gcal.errors";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
+import { withGoogleRetry } from "@backend/common/services/gcal/gcal.retry";
 import { encodeChannelToken } from "@backend/sync/services/watch/google-watch-token";
 
 const getGcalNotificationAddress = () =>
@@ -34,43 +35,48 @@ class GCalService {
   }
 
   async getEvent(
-    gcal: gCalendar,
+    { gcal, quotaUser }: GoogleRequestContext,
     gcalEventId: string,
     calendarId = GCAL_PRIMARY,
   ): Promise<gSchema$Event> {
-    const response = await gcal.events.get({
-      calendarId,
-      eventId: gcalEventId,
-    });
+    const response = await withGoogleRetry(() =>
+      gcal.events.get({ calendarId, eventId: gcalEventId, quotaUser }),
+    );
 
     return this.validateGCalResponse(response).data;
   }
 
   async createEvent(
-    gcal: gCalendar,
+    { gcal, quotaUser }: GoogleRequestContext,
     calendarId: string,
     event: gSchema$Event,
   ): Promise<gSchema$Event> {
-    const response = await gcal.events.insert({
-      calendarId,
-      requestBody: event,
-    });
+    const response = await withGoogleRetry(() =>
+      gcal.events.insert({ calendarId, quotaUser, requestBody: event }),
+    );
 
     return this.validateGCalResponse(response).data;
   }
 
-  async deleteEvent(gcal: gCalendar, calendarId: string, gcalEventId: string) {
-    const response = await gcal.events.delete({
-      calendarId,
-      eventId: gcalEventId,
-      sendUpdates: "all",
-    });
+  async deleteEvent(
+    { gcal, quotaUser }: GoogleRequestContext,
+    calendarId: string,
+    gcalEventId: string,
+  ) {
+    const response = await withGoogleRetry(() =>
+      gcal.events.delete({
+        calendarId,
+        eventId: gcalEventId,
+        quotaUser,
+        sendUpdates: "all",
+      }),
+    );
 
     return response;
   }
 
   private async getEventInstances(
-    gcal: gCalendar,
+    { gcal, quotaUser }: GoogleRequestContext,
     calendarId: string,
     eventId: string,
     timeMin?: string,
@@ -78,26 +84,31 @@ class GCalService {
     pageToken?: string,
     maxResults?: number,
   ) {
-    const response = await gcal.events.instances({
-      calendarId,
-      eventId,
-      timeMin,
-      timeMax,
-      pageToken,
-      maxResults,
-    });
+    const response = await withGoogleRetry(() =>
+      gcal.events.instances({
+        calendarId,
+        eventId,
+        timeMin,
+        timeMax,
+        pageToken,
+        maxResults,
+        quotaUser,
+      }),
+    );
 
     return this.validateGCalResponse(response);
   }
 
-  async getEvents(gcal: gCalendar, params: gParamsEventsList) {
-    const response = await gcal.events.list(params);
+  async getEvents(context: GoogleRequestContext, params: gParamsEventsList) {
+    const response = await withGoogleRetry(() =>
+      context.gcal.events.list({ ...params, quotaUser: context.quotaUser }),
+    );
 
     return this.validateGCalResponse(response);
   }
 
   async *getBaseRecurringEventInstances({
-    gCal,
+    context,
     calendarId,
     eventId,
     maxResults = 1000,
@@ -105,7 +116,7 @@ class GCalService {
     timeMax,
     pageToken,
   }: {
-    gCal: gCalendar;
+    context: GoogleRequestContext;
     calendarId: string;
     eventId: string;
     maxResults?: number;
@@ -119,7 +130,7 @@ class GCalService {
 
     do {
       const { data = {} } = await this.getEventInstances(
-        gCal,
+        context,
         calendarId,
         eventId,
         timeMin,
@@ -149,14 +160,14 @@ class GCalService {
    * generator function to list all google calendar events
    */
   async *getAllEvents({
-    gCal,
+    context,
     calendarId,
     maxResults = 1000,
     singleEvents = false,
     pageToken,
     syncToken,
   }: {
-    gCal: gCalendar;
+    context: GoogleRequestContext;
     calendarId: string;
     maxResults?: number;
     singleEvents?: boolean;
@@ -169,7 +180,7 @@ class GCalService {
     let isLastPage = true;
 
     do {
-      const { data = {} } = await this.getEvents(gCal, {
+      const { data = {} } = await this.getEvents(context, {
         calendarId,
         singleEvents,
         maxResults,
@@ -195,13 +206,15 @@ class GCalService {
   }
 
   async getCalendarlist(
-    gcal: gCalendar,
+    { gcal, quotaUser }: GoogleRequestContext,
     {
       nextSyncToken: syncToken,
       nextPageToken: pageToken,
     }: Partial<Pick<SyncDetails, "nextSyncToken" | "nextPageToken">> = {},
   ) {
-    const response = await gcal.calendarList.list({ syncToken, pageToken });
+    const response = await withGoogleRetry(() =>
+      gcal.calendarList.list({ syncToken, pageToken, quotaUser }),
+    );
 
     if (!response.data.nextSyncToken) {
       throw error(
@@ -222,72 +235,81 @@ class GCalService {
    * events.update, which replaces the whole resource.
    */
   async patchEvent(
-    gcal: gCalendar,
+    { gcal, quotaUser }: GoogleRequestContext,
     calendarId: string,
     gEventId: string,
     event: gSchema$Event,
   ) {
-    const response = await gcal.events.patch({
-      calendarId,
-      eventId: gEventId,
-      requestBody: event,
-    });
+    const response = await withGoogleRetry(() =>
+      gcal.events.patch({
+        calendarId,
+        eventId: gEventId,
+        quotaUser,
+        requestBody: event,
+      }),
+    );
 
     return this.validateGCalResponse(response).data;
   }
 
   watchCalendars = async (
-    gcal: gCalendar,
+    { gcal, quotaUser }: GoogleRequestContext,
     params: Omit<Params_WatchEvents, "gCalendarId" | "resourceId">,
   ) => {
-    const response = await gcal.calendarList.watch({
-      quotaUser: params.quotaUser,
-      requestBody: {
-        // reminder: address always needs to be HTTPS
-        address: getGcalNotificationAddress(),
-        expiration: params.expiration,
-        id: IDSchemaV4.parse(params.channelId),
-        token: encodeChannelToken({ resource: Resource_Sync.CALENDAR }),
-        type: "web_hook",
-      },
-    });
+    const response = await withGoogleRetry(() =>
+      gcal.calendarList.watch({
+        quotaUser,
+        requestBody: {
+          // reminder: address always needs to be HTTPS
+          address: getGcalNotificationAddress(),
+          expiration: params.expiration,
+          id: IDSchemaV4.parse(params.channelId),
+          token: encodeChannelToken({ resource: Resource_Sync.CALENDAR }),
+          type: "web_hook",
+        },
+      }),
+    );
 
     return { watch: this.validateGCalResponse(response).data };
   };
 
   watchEvents = async (
-    gcal: gCalendar,
+    { gcal, quotaUser }: GoogleRequestContext,
     params: Omit<Params_WatchEvents, "resourceId">,
   ) => {
-    const response = await gcal.events.watch({
-      calendarId: params.gCalendarId,
-      quotaUser: params.quotaUser,
-      requestBody: {
-        // reminder: address always needs to be HTTPS
-        address: getGcalNotificationAddress(),
-        expiration: params.expiration,
-        id: IDSchemaV4.parse(params.channelId),
-        token: encodeChannelToken({ resource: Resource_Sync.EVENTS }),
-        type: "web_hook",
-      },
-    });
+    const response = await withGoogleRetry(() =>
+      gcal.events.watch({
+        calendarId: params.gCalendarId,
+        quotaUser,
+        requestBody: {
+          // reminder: address always needs to be HTTPS
+          address: getGcalNotificationAddress(),
+          expiration: params.expiration,
+          id: IDSchemaV4.parse(params.channelId),
+          token: encodeChannelToken({ resource: Resource_Sync.EVENTS }),
+          type: "web_hook",
+        },
+      }),
+    );
 
     return { watch: this.validateGCalResponse(response).data };
   };
 
   stopWatch = async (
-    gcal: gCalendar,
-    params: Pick<Params_WatchEvents, "channelId" | "quotaUser"> & {
+    { gcal, quotaUser }: GoogleRequestContext,
+    params: Pick<Params_WatchEvents, "channelId"> & {
       resourceId: string;
     },
   ) => {
-    const response = await gcal.channels.stop({
-      quotaUser: params.quotaUser,
-      requestBody: {
-        id: params.channelId,
-        resourceId: params.resourceId,
-      },
-    });
+    const response = await withGoogleRetry(() =>
+      gcal.channels.stop({
+        quotaUser,
+        requestBody: {
+          id: params.channelId,
+          resourceId: params.resourceId,
+        },
+      }),
+    );
 
     return this.validateGCalResponse(response);
   };

--- a/packages/backend/src/event/google-event-sync.service.ts
+++ b/packages/backend/src/event/google-event-sync.service.ts
@@ -1,6 +1,7 @@
 import { type ClientSession, type ObjectId } from "mongodb";
-import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
+import { type gSchema$Event } from "@core/types/gcal";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import { eventRepository } from "@backend/event/event.repository";
 import { mapGoogleEvent } from "@backend/event/google-event.adapter";
@@ -58,7 +59,7 @@ export class GoogleEventSync {
   private readonly gCalendarId: string;
 
   constructor(
-    private readonly gcal: gCalendar,
+    private readonly context: GoogleRequestContext,
     private readonly calendar: CalendarRecord,
   ) {
     if (calendar.source.provider !== "google") {
@@ -197,7 +198,7 @@ export class GoogleEventSync {
   ): Promise<gSchema$Event[]> {
     const instances: gSchema$Event[] = [];
     const response = gcalService.getBaseRecurringEventInstances({
-      gCal: this.gcal,
+      context: this.context,
       calendarId: this.gCalendarId,
       eventId: gEventId,
       maxResults: perPage,

--- a/packages/backend/src/sync/controllers/sync.debug.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.debug.controller.ts
@@ -3,12 +3,12 @@ import { type SessionRequest } from "supertokens-node/framework/express";
 import { type BaseError } from "@core/errors/errors.base";
 import { type CalendarId } from "@core/types/domain-primitives";
 import calendarService from "@backend/calendar/services/calendar.service";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import {
   type Res_Promise,
   type SReqBody,
 } from "@backend/common/types/express.types";
 import { sseServer } from "@backend/servers/sse/sse.server";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { getSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
@@ -110,14 +110,14 @@ class SyncDebugController {
     try {
       const userId = req.session?.getUserId() as string;
       const calendarId = req.body.calendarId;
-      const gcal = await getGcalClient(userId);
+      const context = await createGoogleRequestContext(userId);
 
       const watchResult = await googleWatchService.startEventWatch(
         userId,
         {
           gCalendarId: calendarId,
         },
-        gcal,
+        context,
       );
 
       res.promise(watchResult);

--- a/packages/backend/src/sync/services/event-propagation/__tests__/google-to-compass.event-propagation.test.ts
+++ b/packages/backend/src/sync/services/event-propagation/__tests__/google-to-compass.event-propagation.test.ts
@@ -10,6 +10,7 @@ import {
   mockRegularGcalEvent,
 } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { GoogleToCompassEventPropagation } from "@backend/sync/services/event-propagation/google-to-compass/google-to-compass.event-propagation";
@@ -38,6 +39,7 @@ const asAsyncPage = async function* (items: gSchema$Event[]) {
 describe("GoogleToCompassEventPropagation", () => {
   let calendar: CalendarRecord;
   const gcal = {} as gCalendar;
+  const context: GoogleRequestContext = { gcal, quotaUser: "user-1" };
 
   beforeAll(setupTestDb);
   beforeEach(cleanupCollections);
@@ -66,7 +68,7 @@ describe("GoogleToCompassEventPropagation", () => {
 
   it("creates a standalone event", async () => {
     const gEvent = mockRegularGcalEvent();
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
 
     const result = await propagation.processEvents([gEvent]);
 
@@ -83,7 +85,7 @@ describe("GoogleToCompassEventPropagation", () => {
 
   it("updates the matching event by (calendarId, externalReference.eventId)", async () => {
     const gEvent = mockRegularGcalEvent();
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
     await propagation.processEvents([gEvent]);
 
     const result = await propagation.processEvents([
@@ -102,7 +104,7 @@ describe("GoogleToCompassEventPropagation", () => {
 
   it("deletes the matching event when Google reports it cancelled", async () => {
     const gEvent = mockRegularGcalEvent();
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
     await propagation.processEvents([gEvent]);
 
     const result = await propagation.processEvents([
@@ -122,7 +124,7 @@ describe("GoogleToCompassEventPropagation", () => {
     (gcalService.getBaseRecurringEventInstances as jest.Mock).mockReturnValue(
       asAsyncPage(instances),
     );
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
 
     const result = await propagation.processEvents([base]);
 
@@ -153,7 +155,7 @@ describe("GoogleToCompassEventPropagation", () => {
     (gcalService.getBaseRecurringEventInstances as jest.Mock).mockReturnValue(
       asAsyncPage(instances),
     );
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
     await propagation.processEvents([base]);
 
     const cancellations = [
@@ -171,7 +173,7 @@ describe("GoogleToCompassEventPropagation", () => {
     (gcalService.getBaseRecurringEventInstances as jest.Mock).mockReturnValue(
       asAsyncPage(instances),
     );
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
     await propagation.processEvents([base]);
 
     const [firstInstance] = instances;
@@ -191,7 +193,7 @@ describe("GoogleToCompassEventPropagation", () => {
     (
       gcalService.getBaseRecurringEventInstances as jest.Mock
     ).mockReturnValueOnce(asAsyncPage(instances));
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
     await propagation.processEvents([base]);
 
     const { base: splitBase, instances: splitInstances } =
@@ -209,7 +211,7 @@ describe("GoogleToCompassEventPropagation", () => {
 
   it("ignores unsupported event types without dropping them silently", async () => {
     const gEvent = mockRegularGcalEvent({ eventType: "outOfOffice" });
-    const propagation = new GoogleToCompassEventPropagation(gcal, calendar);
+    const propagation = new GoogleToCompassEventPropagation(context, calendar);
 
     const result = await propagation.processEvents([gEvent]);
 

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google-backfill.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google-backfill.ts
@@ -1,11 +1,11 @@
 import { Logger } from "@core/logger/winston.logger";
 import calendarService from "@backend/calendar/services/calendar.service";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { eventRepository } from "@backend/event/event.repository";
 import { mapEventRecordToGoogle } from "@backend/event/google-event.adapter";
 import { isWritableToGoogle } from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 
 const logger = Logger("app:compass-to-google-backfill");
 
@@ -39,7 +39,7 @@ export const syncCompassEventsToGoogle = async (
 
   if (candidates.length === 0) return 0;
 
-  const gcal = await getGcalClient(userId);
+  const context = await createGoogleRequestContext(userId);
   let syncedCount = 0;
 
   for (const record of candidates) {
@@ -51,7 +51,7 @@ export const syncCompassEventsToGoogle = async (
     try {
       const body = mapEventRecordToGoogle(record);
       const created = await gcalService.createEvent(
-        gcal,
+        context,
         calendar.source.calendarId,
         body,
       );

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
@@ -1,13 +1,13 @@
 import { ObjectId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { eventMutationError } from "@backend/event/event.error";
 import { type EventRecord } from "@backend/event/event.record";
 import { eventRepository } from "@backend/event/event.repository";
 import { mapEventRecordToGoogle } from "@backend/event/google-event.adapter";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
 
 const logger = Logger("app:compass-to-google.event-propagation");
@@ -101,9 +101,9 @@ export class CompassToGoogleEventPropagation {
     if (!calendar || calendar.source.provider !== "google") return;
     if (!record.externalReference) return;
 
-    const gcal = await getGcalClient(userId);
+    const context = await createGoogleRequestContext(userId);
     await gcalService.deleteEvent(
-      gcal,
+      context,
       calendar.source.calendarId,
       record.externalReference.eventId,
     );
@@ -117,12 +117,12 @@ export class CompassToGoogleEventPropagation {
     if (!calendar || calendar.source.provider !== "google") return;
     if (!isWritableToGoogle(record)) return;
 
-    const gcal = await getGcalClient(userId);
+    const context = await createGoogleRequestContext(userId);
     const body = mapEventRecordToGoogle(record);
 
     if (record.externalReference) {
       await gcalService.patchEvent(
-        gcal,
+        context,
         calendar.source.calendarId,
         record.externalReference.eventId,
         body,
@@ -131,7 +131,7 @@ export class CompassToGoogleEventPropagation {
     }
 
     const created = await gcalService.createEvent(
-      gcal,
+      context,
       calendar.source.calendarId,
       body,
     );

--- a/packages/backend/src/sync/services/event-propagation/google-to-compass/google-to-compass.event-propagation.ts
+++ b/packages/backend/src/sync/services/event-propagation/google-to-compass/google-to-compass.event-propagation.ts
@@ -1,6 +1,7 @@
 import { Logger } from "@core/logger/winston.logger";
-import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
+import { type gSchema$Event } from "@core/types/gcal";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
 import {
   GoogleEventSync,
@@ -17,7 +18,7 @@ const logger = Logger("app:google-to-compass.event-propagation");
  */
 export class GoogleToCompassEventPropagation {
   constructor(
-    private gcal: gCalendar,
+    private context: GoogleRequestContext,
     private calendar: CalendarRecord,
   ) {}
 
@@ -36,7 +37,7 @@ export class GoogleToCompassEventPropagation {
       // a second webhook fired by rapid saves), and without the retry that
       // transient conflict surfaced as a 500.
       return await session.withTransaction(async (session) => {
-        const sync = new GoogleEventSync(this.gcal, this.calendar);
+        const sync = new GoogleEventSync(this.context, this.calendar);
         return sync.apply(events, 1000, session);
       });
     } finally {

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.ts
@@ -1,6 +1,5 @@
 import { Logger } from "@core/logger/winston.logger";
 import { type CalendarId } from "@core/types/domain-primitives";
-import { type gCalendar } from "@core/types/gcal";
 import { Resource_Sync } from "@core/types/sync.types";
 import {
   shouldDoIncrementalGCalSync,
@@ -9,11 +8,14 @@ import {
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { getGoogleRepairErrorMessage } from "@backend/common/errors/integration/gcal/gcal.errors";
+import {
+  createGoogleRequestContext,
+  type GoogleRequestContext,
+} from "@backend/common/services/gcal/gcal.context";
 import { isInvalidGoogleToken } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import compassToGoogleBackfill from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google-backfill";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import {
   createSyncImport,
   type SyncImport,
@@ -97,7 +99,7 @@ async function importFull(
 
 async function importLatestGoogleCalendarChanges(
   userId: string,
-  gcal?: gCalendar,
+  context?: GoogleRequestContext,
   perPage = 1000,
 ) {
   logger.info(`Starting incremental Google Calendar sync for user: ${userId}`);
@@ -147,8 +149,8 @@ async function importLatestGoogleCalendarChanges(
       return;
     }
 
-    const syncImport = gcal
-      ? await createSyncImport(gcal)
+    const syncImport = context
+      ? await createSyncImport(context)
       : await createSyncImport(userId);
 
     const result = await syncImport.importLatestEvents(
@@ -325,9 +327,9 @@ async function runGoogleCalendarSyncSetup(
 async function initializeGoogleCalendarSync(
   user: string,
 ): Promise<{ eventsCount: number; calendarsCount: number }> {
-  const gcal = await getGcalClient(user);
+  const context = await createGoogleRequestContext(user);
 
-  await calendarService.initializeGoogleCalendars(user, gcal);
+  await calendarService.initializeGoogleCalendars(user, context);
 
   const calendar = await calendarService.getPrimaryGoogleCalendar(user);
 
@@ -336,7 +338,7 @@ async function initializeGoogleCalendarSync(
     return { eventsCount: 0, calendarsCount: 0 };
   }
 
-  const syncImport = await createSyncImport(gcal);
+  const syncImport = await createSyncImport(context);
   const importResult = await importFull(syncImport, calendar, user);
 
   if (isUsingGcalWebhookHttps()) {
@@ -346,7 +348,7 @@ async function initializeGoogleCalendarSync(
         { gCalendarId: Resource_Sync.CALENDAR },
         { gCalendarId: calendar.source.calendarId },
       ],
-      gcal,
+      context,
     );
   }
 

--- a/packages/backend/src/sync/services/import/google-import.service.test.ts
+++ b/packages/backend/src/sync/services/import/google-import.service.test.ts
@@ -11,6 +11,7 @@ import {
   mockRegularGcalEvent,
 } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { SyncImport } from "@backend/sync/services/import/google-import.service";
@@ -64,6 +65,7 @@ describe("SyncImport", () => {
   let calendar: CalendarRecord;
   let userId: string;
   const gcal = {} as gCalendar;
+  const context: GoogleRequestContext = { gcal, quotaUser: "user-1" };
 
   beforeAll(setupTestDb);
   beforeEach(cleanupCollections);
@@ -94,7 +96,7 @@ describe("SyncImport", () => {
         asInstancePage(instances),
       );
 
-      const syncImport = new SyncImport(gcal);
+      const syncImport = new SyncImport(context);
       const result = await syncImport.importAllEvents(userId, calendar, 1000);
 
       expect(result.totalSaved).toBe(1 + instances.length);
@@ -121,7 +123,7 @@ describe("SyncImport", () => {
           asPages({ items: [gEvent], nextSyncToken: "sync-token-2" }),
         );
 
-      const syncImport = new SyncImport(gcal);
+      const syncImport = new SyncImport(context);
       await syncImport.importAllEvents(userId, calendar, 1000);
       await syncImport.importAllEvents(userId, calendar, 1000);
 
@@ -137,7 +139,7 @@ describe("SyncImport", () => {
         asPages({ items: [gEvent], nextSyncToken: "sync-token-1" }),
       );
 
-      const syncImport = new SyncImport(gcal);
+      const syncImport = new SyncImport(context);
       const result = await syncImport.importAllEvents(userId, calendar, 1000);
 
       expect(result.totalSaved).toBe(0);
@@ -161,7 +163,7 @@ describe("SyncImport", () => {
         asPages({ items: [gEvent], nextSyncToken: "sync-token-1" }),
       );
 
-      const syncImport = new SyncImport(gcal);
+      const syncImport = new SyncImport(context);
       const pageToken = await getGCalEventsSyncPageToken(
         userId,
         calendar.source.provider === "google" ? calendar.source.calendarId : "",
@@ -190,7 +192,7 @@ describe("SyncImport", () => {
         data: { items: [gEvent], nextSyncToken: "next-sync-token" },
       });
 
-      const syncImport = new SyncImport(gcal);
+      const syncImport = new SyncImport(context);
       const result = await syncImport.importLatestEvents(
         userId,
         calendar,
@@ -199,7 +201,7 @@ describe("SyncImport", () => {
 
       expect(result.totalSaved).toBe(1);
       expect(gcalService.getEvents).toHaveBeenCalledWith(
-        gcal,
+        context,
         expect.objectContaining({ syncToken: "existing-sync-token" }),
       );
 
@@ -215,7 +217,7 @@ describe("SyncImport", () => {
     });
 
     it("returns empty stats when no sync token is known yet", async () => {
-      const syncImport = new SyncImport(gcal);
+      const syncImport = new SyncImport(context);
       const result = await syncImport.importLatestEvents(
         userId,
         calendar,
@@ -232,7 +234,7 @@ describe("SyncImport", () => {
         data: { items: [gEvent], nextSyncToken: "sync-token-1" },
       });
 
-      const syncImport = new SyncImport(gcal);
+      const syncImport = new SyncImport(context);
       await syncImport.importEventsByCalendar(
         userId,
         calendar,

--- a/packages/backend/src/sync/services/import/google-import.service.ts
+++ b/packages/backend/src/sync/services/import/google-import.service.ts
@@ -1,14 +1,16 @@
 import { type ClientSession } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
-import { type gCalendar } from "@core/types/gcal";
 import { Resource_Sync } from "@core/types/sync.types";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { GcalError } from "@backend/common/errors/integration/gcal/gcal.errors";
 import { SyncError } from "@backend/common/errors/sync/sync.errors";
+import {
+  createGoogleRequestContext,
+  type GoogleRequestContext,
+} from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import { GoogleEventSync } from "@backend/event/google-event-sync.service";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import {
   getGCalEventsSyncPageToken,
   getSync,
@@ -57,10 +59,10 @@ const addStats = (
  * pass it in.
  */
 export class SyncImport {
-  private gcal: gCalendar;
+  private context: GoogleRequestContext;
 
-  constructor(gcal: gCalendar) {
-    this.gcal = gcal;
+  constructor(context: GoogleRequestContext) {
+    this.context = context;
   }
 
   /**
@@ -85,7 +87,7 @@ export class SyncImport {
     );
 
     const startTime = performance.now();
-    const sync = new GoogleEventSync(this.gcal, calendar);
+    const sync = new GoogleEventSync(this.context, calendar);
 
     let stats = emptyStats();
     let syncToken: string | undefined;
@@ -97,7 +99,7 @@ export class SyncImport {
     );
 
     const gCalResponse = gcalService.getAllEvents({
-      gCal: this.gcal,
+      context: this.context,
       calendarId: calendar.source.calendarId,
       maxResults: perPage,
       pageToken: pageToken ?? undefined,
@@ -196,7 +198,7 @@ export class SyncImport {
       );
     }
 
-    const sync = new GoogleEventSync(this.gcal, calendar);
+    const sync = new GoogleEventSync(this.context, calendar);
 
     let stats = emptyStats();
     let syncToken: string | undefined = initialSyncToken;
@@ -211,7 +213,7 @@ export class SyncImport {
         );
       }
 
-      const response = await gcalService.getEvents(this.gcal, {
+      const response = await gcalService.getEvents(this.context, {
         calendarId: calendar.source.calendarId,
         ...(pageToken ? { pageToken } : { syncToken: token }),
         maxResults: perPage,
@@ -243,7 +245,13 @@ export class SyncImport {
   }
 }
 
-export const createSyncImport = async (id: string | gCalendar) => {
-  const gcal = typeof id === "string" ? await getGcalClient(id) : id;
-  return new SyncImport(gcal);
+export const createSyncImport = async (
+  idOrContext: string | GoogleRequestContext,
+) => {
+  const context =
+    typeof idOrContext === "string"
+      ? await createGoogleRequestContext(idOrContext)
+      : idOrContext;
+
+  return new SyncImport(context);
 };

--- a/packages/backend/src/sync/services/init/google-sync-init.test.ts
+++ b/packages/backend/src/sync/services/init/google-sync-init.test.ts
@@ -1,5 +1,4 @@
 import { GoogleCalendarMetadataSchema } from "@core/types/calendar.types";
-import { type gCalendar } from "@core/types/gcal";
 import { StringV4Schema } from "@core/types/type.utils";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
@@ -7,8 +6,8 @@ import {
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import { getCalendarsToSync } from "@backend/sync/services/init/google-sync-init";
 
 describe("getCalendarsToSync", () => {
@@ -18,8 +17,8 @@ describe("getCalendarsToSync", () => {
 
   it("returns calendars to sync for a user", async () => {
     const { user } = await UtilDriver.setupTestUser();
-    const gcal = await getGcalClient(user._id.toString());
-    const result = await getCalendarsToSync(gcal);
+    const context = await createGoogleRequestContext(user._id.toString());
+    const result = await getCalendarsToSync(context);
 
     expect(result.gCalendarIds).toEqual(
       expect.arrayContaining(result.calendars.map((c) => c.id)),
@@ -46,18 +45,18 @@ describe("getCalendarsToSync", () => {
 
   it("throws when nextSyncToken is invalid", async () => {
     const { user } = await UtilDriver.setupTestUser();
-    const gcal = await getGcalClient(user._id.toString());
+    const context = await createGoogleRequestContext(user._id.toString());
     const getCalendarlist = gcalService.getCalendarlist.bind(gcalService);
     const getCalendarlistSpy = jest.spyOn(gcalService, "getCalendarlist");
 
-    getCalendarlistSpy.mockImplementation(async (gcal: gCalendar) =>
-      getCalendarlist(gcal).then((res) => ({
+    getCalendarlistSpy.mockImplementation(async (context) =>
+      getCalendarlist(context).then((res) => ({
         ...res,
         nextSyncToken: "",
       })),
     );
 
-    await expect(getCalendarsToSync(gcal)).rejects.toThrow(
+    await expect(getCalendarsToSync(context)).rejects.toThrow(
       /Failed to get Calendar\(list\)s to sync/,
     );
   });

--- a/packages/backend/src/sync/services/init/google-sync-init.ts
+++ b/packages/backend/src/sync/services/init/google-sync-init.ts
@@ -1,9 +1,9 @@
-import { type gCalendar } from "@core/types/gcal";
 import { StringV4Schema } from "@core/types/type.utils";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 
-export const getCalendarsToSync = async (gcal: gCalendar) => {
-  const calendarListResponse = await gcalService.getCalendarlist(gcal);
+export const getCalendarsToSync = async (context: GoogleRequestContext) => {
+  const calendarListResponse = await gcalService.getCalendarlist(context);
   const { items = [], nextPageToken } = calendarListResponse;
 
   const nextSyncToken = StringV4Schema.parse(

--- a/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.test.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { mockRegularGcalEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { GCalNotificationHandler } from "@backend/sync/services/notify/handler/gcal.notification.handler";
@@ -24,6 +25,7 @@ jest.mock("@backend/common/services/gcal/gcal.service", () => ({
 describe("GCalNotificationHandler", () => {
   let handler: GCalNotificationHandler;
   let mockGcal: gCalendar;
+  let mockContext: GoogleRequestContext;
   let mockUserId: string;
   let mockCalendarId: string;
   let mockSyncToken: string;
@@ -69,9 +71,10 @@ describe("GCalNotificationHandler", () => {
         instances: jest.fn(),
       },
     } as unknown as gCalendar;
+    mockContext = { gcal: mockGcal, quotaUser: mockUserId };
 
     handler = new GCalNotificationHandler(
-      mockGcal,
+      mockContext,
       Resource_Sync.EVENTS,
       mockUserId,
       mockCalendarId,
@@ -98,7 +101,7 @@ describe("GCalNotificationHandler", () => {
       const result = await handler.handleNotification();
 
       // Verify
-      expect(gcalService.getEvents).toHaveBeenCalledWith(mockGcal, {
+      expect(gcalService.getEvents).toHaveBeenCalledWith(mockContext, {
         calendarId: mockCalendarId,
         syncToken: "test-sync-token",
       });
@@ -120,7 +123,7 @@ describe("GCalNotificationHandler", () => {
 
     it("should return IGNORED if resource is not EVENTS", async () => {
       handler = new GCalNotificationHandler(
-        mockGcal,
+        mockContext,
         Resource_Sync.SETTINGS, // Not EVENTS
         mockUserId,
         mockCalendarId,
@@ -145,7 +148,7 @@ describe("GCalNotificationHandler", () => {
 
     it("should return IGNORED when no owning calendar is found for the user", async () => {
       handler = new GCalNotificationHandler(
-        mockGcal,
+        mockContext,
         Resource_Sync.EVENTS,
         new ObjectId().toString(),
         mockCalendarId,

--- a/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
-import { type gCalendar } from "@core/types/gcal";
 import { Resource_Sync } from "@core/types/sync.types";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { GoogleToCompassEventPropagation } from "@backend/sync/services/event-propagation/google-to-compass/google-to-compass.event-propagation";
@@ -17,7 +17,7 @@ export type NotificationSummary = {
 
 export class GCalNotificationHandler {
   constructor(
-    private gcal: gCalendar,
+    private context: GoogleRequestContext,
     private resource: Resource_Sync,
     private userId: string,
     private gCalendarId: string,
@@ -53,7 +53,10 @@ export class GCalNotificationHandler {
       return { summary: "IGNORED", calendarId: null, eventIds: [] };
     }
 
-    const processor = new GoogleToCompassEventPropagation(this.gcal, calendar);
+    const processor = new GoogleToCompassEventPropagation(
+      this.context,
+      calendar,
+    );
     const result = await processor.processEvents(changes);
 
     logger.info(
@@ -71,7 +74,7 @@ export class GCalNotificationHandler {
    * Get the latest changes from Google Calendar using a sync token
    */
   private async getLatestChanges() {
-    const response = await gcalService.getEvents(this.gcal, {
+    const response = await gcalService.getEvents(this.context, {
       calendarId: this.gCalendarId,
       syncToken: this.nextSyncToken,
     });

--- a/packages/backend/src/sync/services/watch/google-watch-maintenance.planner.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-maintenance.planner.ts
@@ -3,12 +3,12 @@ import { Logger } from "@core/logger/winston.logger";
 import { type Result_Watch_Stop } from "@core/types/sync.types";
 import { type Schema_Watch } from "@core/types/watch.types";
 import dayjs from "@core/util/date/dayjs";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import {
   isFullSyncRequired,
   isInvalidGoogleToken,
 } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { hasUpdatedCompassEventRecently } from "@backend/sync/services/watch/google-watch-activity";
@@ -72,8 +72,7 @@ export const pruneSync = async (
     let deletedUserData = false;
     let stopped: Result_Watch_Stop = [];
 
-    const quotaUser = new ObjectId().toString();
-    const gcal = await getGcalClient(user);
+    const context = await createGoogleRequestContext(user);
 
     try {
       const results = await Promise.all(
@@ -82,8 +81,7 @@ export const pruneSync = async (
             user,
             _id.toString(),
             resourceId,
-            gcal,
-            quotaUser,
+            context,
           ),
         ),
       );
@@ -118,7 +116,7 @@ export const refreshWatch = async (
     let resynced = false;
 
     try {
-      const gcal = await getGcalClient(r.user);
+      const context = await createGoogleRequestContext(r.user);
 
       const refreshesByUser = await Promise.all(
         r.payload.map(async ({ _id, user, expiration, ...syncPayload }) => {
@@ -129,7 +127,7 @@ export const refreshWatch = async (
               channelId: _id.toString(),
               expiration: expiration.getTime().toString(),
             },
-            gcal,
+            context,
           );
 
           return {

--- a/packages/backend/src/sync/services/watch/google-watch.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.ts
@@ -1,7 +1,6 @@
 import { type ClientSession, ObjectId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
-import { type gCalendar } from "@core/types/gcal";
 import {
   type Params_WatchEvents,
   type Payload_Sync_Notif,
@@ -16,6 +15,10 @@ import { GcalError } from "@backend/common/errors/integration/gcal/gcal.errors";
 import { SyncError } from "@backend/common/errors/sync/sync.errors";
 import { WatchError } from "@backend/common/errors/sync/watch.errors";
 import { UserError } from "@backend/common/errors/user/user.errors";
+import {
+  createGoogleRequestContext,
+  type GoogleRequestContext,
+} from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import {
   getGoogleErrorStatus,
@@ -23,7 +26,6 @@ import {
 } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
 import { GCalNotificationHandler } from "@backend/sync/services/notify/handler/gcal.notification.handler";
 import { getSync } from "@backend/sync/services/records/sync-records.repository";
@@ -52,15 +54,15 @@ async function deleteWatchesByUser(
 
 async function prepareStopWatches(
   user: string,
-  gcal?: gCalendar,
+  context?: GoogleRequestContext,
   session?: ClientSession,
 ) {
   const watches = await mongoService.watch
     .find({ user }, { session })
     .toArray();
 
-  if (watches.length === 0 || gcal) {
-    return { watches, gcal };
+  if (watches.length === 0 || context) {
+    return { watches, context };
   }
 
   const compassUser = await findCompassUserBy("_id", user);
@@ -76,12 +78,12 @@ async function prepareStopWatches(
       "Google refresh token is missing. Corresponding watch records deleted",
     );
 
-    return { watches: [], gcal };
+    return { watches: [], context };
   }
 
   return {
     watches,
-    gcal: await getGcalClient(user),
+    context: await createGoogleRequestContext(user),
   };
 }
 
@@ -182,9 +184,9 @@ async function handleGoogleWatchNotification(payload: Payload_Sync_Notif) {
     );
   }
 
-  const gcal = await getGcalClient(userId);
+  const context = await createGoogleRequestContext(userId);
   const handler = new GCalNotificationHandler(
-    gcal,
+    context,
     resource,
     userId,
     watch.gCalendarId,
@@ -213,9 +215,9 @@ async function handleGoogleWatchNotification(payload: Payload_Sync_Notif) {
 async function refreshWatch(
   userId: string,
   payload: Params_WatchEvents,
-  gcal?: gCalendar,
+  context?: GoogleRequestContext,
 ) {
-  if (!gcal) gcal = await getGcalClient(userId);
+  if (!context) context = await createGoogleRequestContext(userId);
 
   const watchExists = payload.channelId && payload.resourceId;
 
@@ -224,14 +226,14 @@ async function refreshWatch(
       userId,
       payload.channelId,
       payload.resourceId,
-      gcal,
+      context,
     );
   }
 
   const watchResult = await googleWatchService.startGoogleWatches(
     userId,
-    [{ gCalendarId: payload.gCalendarId, quotaUser: payload.quotaUser }],
-    gcal,
+    [{ gCalendarId: payload.gCalendarId }],
+    context,
   );
 
   return watchResult[0];
@@ -239,8 +241,7 @@ async function refreshWatch(
 
 async function startCalendarListWatch(
   user: string,
-  params: Pick<Params_WatchEvents, "quotaUser">,
-  gcal: gCalendar,
+  context: GoogleRequestContext,
 ): Promise<{ acknowledged: boolean; insertedId?: ObjectId }> {
   try {
     const alreadyWatching = await isWatchingGoogleResource(
@@ -261,8 +262,7 @@ async function startCalendarListWatch(
     const _id = new ObjectId();
     const channelId = _id.toString();
 
-    const { watch: gcalWatch } = await gcalService.watchCalendars(gcal, {
-      ...params,
+    const { watch: gcalWatch } = await gcalService.watchCalendars(context, {
       channelId,
       expiration,
     });
@@ -287,7 +287,12 @@ async function startCalendarListWatch(
         }),
       )
       .catch(async (error) => {
-        await googleWatchService.stopWatch(user, channelId, resourceId, gcal);
+        await googleWatchService.stopWatch(
+          user,
+          channelId,
+          resourceId,
+          context,
+        );
 
         throw error;
       });
@@ -302,8 +307,8 @@ async function startCalendarListWatch(
 
 async function startEventWatch(
   user: string,
-  params: Pick<Params_WatchEvents, "gCalendarId" | "quotaUser">,
-  gcal: gCalendar,
+  params: Pick<Params_WatchEvents, "gCalendarId">,
+  context: GoogleRequestContext,
 ): Promise<{ acknowledged: boolean; insertedId?: ObjectId }> {
   try {
     const alreadyWatching = await isWatchingGoogleResource(
@@ -324,7 +329,7 @@ async function startEventWatch(
     const _id = new ObjectId();
     const channelId = _id.toString();
 
-    const { watch: gcalWatch } = await gcalService.watchEvents(gcal, {
+    const { watch: gcalWatch } = await gcalService.watchEvents(context, {
       ...params,
       channelId,
       expiration,
@@ -347,7 +352,12 @@ async function startEventWatch(
         }),
       )
       .catch(async (error) => {
-        await googleWatchService.stopWatch(user, channelId, resourceId, gcal);
+        await googleWatchService.stopWatch(
+          user,
+          channelId,
+          resourceId,
+          context,
+        );
 
         throw error;
       });
@@ -362,8 +372,8 @@ async function startEventWatch(
 
 async function startGoogleWatches(
   userId: string,
-  watchParams: Pick<Params_WatchEvents, "gCalendarId" | "quotaUser">[],
-  gcal: gCalendar,
+  watchParams: Pick<Params_WatchEvents, "gCalendarId">[],
+  context: GoogleRequestContext,
 ) {
   if (!isUsingGcalWebhookHttps()) {
     return [];
@@ -372,10 +382,10 @@ async function startGoogleWatches(
   return Promise.all(
     watchParams.map(async (params) => {
       if (params.gCalendarId === (Resource_Sync.CALENDAR as string)) {
-        return googleWatchService.startCalendarListWatch(userId, params, gcal);
+        return googleWatchService.startCalendarListWatch(userId, context);
       }
 
-      return googleWatchService.startEventWatch(userId, params, gcal);
+      return googleWatchService.startEventWatch(userId, params, context);
     }),
   ).then((results) => results.filter((r) => r !== undefined));
 }
@@ -384,17 +394,15 @@ async function stopWatch(
   user: string,
   channelId: string,
   resourceId: string,
-  gcal?: gCalendar,
-  quotaUser?: string,
+  context?: GoogleRequestContext,
   session?: ClientSession,
 ) {
   const filter = { user, _id: new ObjectId(channelId), resourceId };
 
   try {
-    if (!gcal) gcal = await getGcalClient(user);
+    if (!context) context = await createGoogleRequestContext(user);
 
-    await gcalService.stopWatch(gcal, {
-      quotaUser,
+    await gcalService.stopWatch(context, {
       channelId,
       resourceId,
     });
@@ -441,11 +449,10 @@ async function stopWatch(
 
 async function stopWatches(
   user: string,
-  gcal?: gCalendar,
-  quotaUser?: string,
+  context?: GoogleRequestContext,
   session?: ClientSession,
 ): Promise<Result_Watch_Stop> {
-  const prepared = await prepareStopWatches(user, gcal, session);
+  const prepared = await prepareStopWatches(user, context, session);
 
   if (prepared.watches.length === 0) {
     return [];
@@ -457,14 +464,7 @@ async function stopWatches(
   const result = await Promise.all(
     prepared.watches.map(async ({ _id, resourceId }) =>
       googleWatchService
-        .stopWatch(
-          user,
-          _id.toString(),
-          resourceId,
-          prepared.gcal,
-          quotaUser,
-          session,
-        )
+        .stopWatch(user, _id.toString(), resourceId, prepared.context, session)
         .catch((error) => {
           logger.error(
             `Error stopping watch for user: ${user}, channelId: ${_id.toString()}`,

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -202,7 +202,6 @@ class UserService {
         const watches = await googleWatchService.stopWatches(
           userId,
           undefined,
-          new ObjectId().toString(),
           session,
         );
         summary.eventWatches = watches.length;

--- a/packages/core/src/types/sync.types.ts
+++ b/packages/core/src/types/sync.types.ts
@@ -14,7 +14,6 @@ export interface Params_WatchEvents {
   channelId: string; // use a valid mongo object id string
   resourceId: string;
   expiration: string;
-  quotaUser?: string; // added to aid gcal API quota calculations
 }
 
 export interface SyncDetails {

--- a/packages/scripts/src/migrations/2025.10.13T14.22.21.migrate-sync-watch-data.ts
+++ b/packages/scripts/src/migrations/2025.10.13T14.22.21.migrate-sync-watch-data.ts
@@ -6,9 +6,9 @@ import { Resource_Sync } from "@core/types/sync.types";
 import { ExpirationDateSchema } from "@core/types/type.utils";
 import { type Schema_Watch, WatchSchema } from "@core/types/watch.types";
 import { MONGO_BATCH_SIZE } from "@backend/common/constants/backend.constants";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
-import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { getChannelExpiration } from "@backend/sync/services/watch/google-watch-timing";
 
@@ -61,30 +61,30 @@ export default class Migration implements RunnableMigration<MigrationContext> {
         return [parsed.data];
       });
 
-      const gcal = await getGcalClient(syncDoc.user).catch((err: unknown) => {
-        logger.error(
-          `Failed to get gcal client for user ${syncDoc.user}: ${err}`,
-        );
+      const context = await createGoogleRequestContext(syncDoc.user).catch(
+        (err: unknown) => {
+          logger.error(
+            `Failed to get gcal client for user ${syncDoc.user}: ${err}`,
+          );
 
-        return null;
-      });
+          return null;
+        },
+      );
 
-      if (!gcal) continue;
+      if (!context) continue;
 
       const expiration = getChannelExpiration();
-      const quotaUser = new ObjectId().toString();
 
       await Promise.allSettled([
         ...syncDocs.map(async (s) => {
           await googleWatchService
-            .stopWatch(syncDoc.user, s.channelId, s.resourceId, gcal, quotaUser)
+            .stopWatch(syncDoc.user, s.channelId, s.resourceId, context)
             .catch(logger.error);
 
-          const { watch } = await gcalService.watchEvents(gcal, {
+          const { watch } = await gcalService.watchEvents(context, {
             channelId: new ObjectId().toString(),
             expiration,
             gCalendarId: s.gCalendarId,
-            quotaUser,
           });
 
           if (!watch.id) return;
@@ -101,10 +101,9 @@ export default class Migration implements RunnableMigration<MigrationContext> {
           );
         }),
         gcalService
-          .watchCalendars(gcal, {
+          .watchCalendars(context, {
             channelId: new ObjectId().toString(),
             expiration,
-            quotaUser,
           })
           .then(({ watch }) => {
             if (!watch.id) return;


### PR DESCRIPTION
## Summary
- Introduces `GoogleRequestContext` (`{ gcal, quotaUser }`) and requires it in every `GCalService` method instead of a raw `gCalendar`, so `quotaUser` (the stable Compass user id, per A14/A33) is always forwarded to Google.
- Adds `withGoogleRetry`/`isRetryableGoogleError` (`gcal.retry.ts`): truncated exponential backoff with full jitter around every Google network call, retrying 429s, quota-flavored 403s, 5xx, and network-level failures; everything else surfaces immediately.
- Raises the default `CHANNEL_EXPIRATION_MIN` from 10 minutes to 7 days (10080), keeping the existing short test override untouched.
- Fixes two latent bugs surfaced while threading the context through every call site: `google-watch-maintenance.planner.ts` and `user.service.ts` were both generating a *fresh random* `quotaUser` per request instead of reusing the stable per-user id, defeating Google's quota accounting.

This is step 0 of [handoff/someday/04-initial-multi-calendar-import.md](handoff/someday/04-initial-multi-calendar-import.md) (pulled forward from packet 07 per decision A30) — a prerequisite for the multi-calendar import fan-out landing in follow-up PRs. Steps 1-9 (pagination, calendar reconciliation, per-calendar import, bounded concurrency, resumability, watch fan-out) are intentionally out of scope here.

## Test plan
- [x] `bun run type-check` — clean
- [x] Focused backend suites (`gcal`, `watch`, `import`, `event-propagation`, `notify`, `init`, `google-sync`, `sync.debug.controller`, `calendar.service`, `user.service`) via `jest --selectProjects backend` — 27 suites / 206 tests passing
- [x] `bun run lint` — 0 errors (15 pre-existing warnings, unrelated web files)
- [x] `/simplify` pass — reviewed, nothing to change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>