### PR TITLE
refactor(web): replace raw tailwind colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev:ports": "bun packages/scripts/src/commands/dev-ports.ts",
     "dev:update": "git checkout main && git pull &&bun install",
     "dev:web": "bun run dev:ports && cd packages/web &&bun run dev.ts",
-    "lint": "biome check .",
+    "lint": "bun packages/scripts/src/testing/check-semantic-colors.ts && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/packages/scripts/src/testing/check-semantic-colors.ts
+++ b/packages/scripts/src/testing/check-semantic-colors.ts
@@ -1,0 +1,39 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const webSource = join(import.meta.dir, "../../../web/src");
+const sourceExtensions = new Set([".css", ".ts", ".tsx"]);
+const rawColorUtility =
+  /(?:bg|text|border|ring|outline|placeholder|divide|from|to|via)-(?:(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|black|white)(?:-\d{2,3})?(?:\/\d{1,3})?|darkBlue-\d{2,3})/g;
+const rawColorTheme =
+  /--color-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|black|white)(?:-\d{2,3})?/g;
+
+function getSourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return getSourceFiles(path);
+    return sourceExtensions.has(entry.name.slice(entry.name.lastIndexOf(".")))
+      ? [path]
+      : [];
+  });
+}
+
+const violations = getSourceFiles(webSource).flatMap((path) => {
+  const source = readFileSync(path, "utf8");
+  const matches = [
+    ...source.matchAll(rawColorUtility),
+    ...source.matchAll(rawColorTheme),
+  ];
+  return matches.map((match) => {
+    const line = source.slice(0, match.index).split("\n").length;
+    return `${relative(process.cwd(), path)}:${line} uses ${match[0]}`;
+  });
+});
+
+if (violations.length > 0) {
+  console.error(
+    "Raw Tailwind colors are not allowed. Use semantic Compass colors:",
+  );
+  console.error(violations.join("\n"));
+  process.exit(1);
+}

--- a/packages/web/src/common/utils/toast/session-expired.toast.tsx
+++ b/packages/web/src/common/utils/toast/session-expired.toast.tsx
@@ -36,7 +36,7 @@ export const SessionExpiredToast = ({ toastId }: SessionExpiredToastProps) => {
 
   return (
     <div className="flex w-full flex-col gap-2">
-      <p className="text-sm text-white">
+      <p className="text-sm text-text-lighter">
         You've been signed out. Please sign in again.
       </p>
       <button

--- a/packages/web/src/components/AuthModal/components/AuthButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AuthButton.tsx
@@ -36,7 +36,7 @@ export const AuthButton: FC<AuthButtonProps> = ({
         isDisabled ? "cursor-not-allowed" : "cursor-pointer",
         {
           // Primary variant
-          "h-10 w-full bg-accent-primary px-4 text-white focus:ring-accent-primary":
+          "h-10 w-full bg-accent-primary px-4 text-text-lighter focus:ring-accent-primary":
             variant === "primary",
           "c-button-elevated": variant === "primary" && !isDisabled,
           "hover:brightness-110": variant === "primary" && !isDisabled,
@@ -48,7 +48,7 @@ export const AuthButton: FC<AuthButtonProps> = ({
           "hover:bg-bg-tertiary": variant === "secondary" && !isDisabled,
 
           // Outline variant (white/black, matches Google button)
-          "h-10 w-full border border-[#1f1f1f] bg-white px-4 text-[#1f1f1f]":
+          "h-10 w-full border border-[#1f1f1f] bg-text-lighter px-4 text-[#1f1f1f]":
             variant === "outline",
           "hover:border-[#151515] hover:bg-[#f0f0f0]":
             variant === "outline" && !isDisabled,

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -51,7 +51,7 @@ export const GoogleButton = ({
       disabled={disabled}
       aria-label={label}
       className={clsx(
-        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-white px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-text-lighter px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
         disabled
           ? "cursor-not-allowed opacity-60"
           : "c-button-elevated cursor-pointer hover:bg-[#f8f8f8]",

--- a/packages/web/src/components/Button/ArrowButton.tsx
+++ b/packages/web/src/components/Button/ArrowButton.tsx
@@ -12,12 +12,12 @@ export const ArrowButton = ({
   tabIndex?: number;
   onClick: () => void;
 }) => {
-  const hoverColor = "bg-white/20";
+  const hoverColor = "bg-text-lighter/20";
 
   return (
     <button
       type="button"
-      className={`flex h-6 w-6 items-center justify-center rounded-full text-white transition-colors hover:${hoverColor} focus:${hoverColor} focus:outline-none focus:ring-2 focus:ring-white/50`}
+      className={`flex h-6 w-6 items-center justify-center rounded-full text-text-lighter transition-colors hover:${hoverColor} focus:${hoverColor} focus:outline-none focus:ring-2 focus:ring-text-lighter/50`}
       aria-label={label}
       onClick={onClick}
       tabIndex={tabIndex}

--- a/packages/web/src/components/MobileGate/MobileGate.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.tsx
@@ -10,7 +10,7 @@ export const MobileGate: React.FC = () => {
   return (
     <div className="flex min-h-dvh items-center justify-center bg-bg-primary p-4">
       <div className="flex w-[400px] max-w-[90vw] flex-col items-center rounded border border-border-primary bg-bg-secondary p-8 text-center">
-        <h1 className="mb-6 font-medium font-sans text-2xl text-white">
+        <h1 className="mb-6 font-medium font-sans text-2xl text-text-lighter">
           Compass isn&apos;t built for mobile yet
         </h1>
         <p className="mb-8 font-sans text-base text-text-light-inactive leading-relaxed">
@@ -20,7 +20,7 @@ export const MobileGate: React.FC = () => {
         <button
           type="button"
           onClick={handleJoinWaitlist}
-          className="min-h-[44px] cursor-pointer rounded border-none bg-accent-primary px-8 py-2 font-medium font-sans text-base text-white transition-opacity duration-300 hover:opacity-90 focus:outline focus:outline-2 focus:outline-accent-primary focus:outline-offset-2"
+          className="min-h-[44px] cursor-pointer rounded border-none bg-accent-primary px-8 py-2 font-medium font-sans text-base text-text-lighter transition-opacity duration-300 hover:opacity-90 focus:outline focus:outline-2 focus:outline-accent-primary focus:outline-offset-2"
         >
           Join Mobile Waitlist
         </button>

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -111,7 +111,7 @@ export const SelectView = ({
         {...getReferenceProps()}
         className={
           buttonClassName ??
-          "flex items-center gap-2 rounded px-3 py-1.5 text-sm text-white/90 transition-colors hover:bg-white/10"
+          "flex items-center gap-2 rounded px-3 py-1.5 text-sm text-text-lighter/90 transition-colors hover:bg-text-lighter/10"
         }
         aria-expanded={isOpen}
         aria-haspopup="listbox"
@@ -179,7 +179,7 @@ export const SelectView = ({
                 className={classNames(
                   "flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
                   isSelected ? "text-accent-primary" : "text-text-light",
-                  isActive ? "bg-white/10" : "hover:bg-white/10",
+                  isActive ? "bg-text-lighter/10" : "hover:bg-text-lighter/10",
                 )}
               >
                 <span>{option.label}</span>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -9,6 +9,7 @@
  */
 :root {
   --compass-color-accent-primary: hsl(202 100 67);
+  --compass-color-accent-secondary: hsl(196 60 59);
   --compass-color-accent-primary-shadow: hsl(202 100 42);
   --compass-color-bg-primary: hsl(222 28 7);
   --compass-color-bg-secondary: hsl(218 24 9);
@@ -29,6 +30,7 @@
   --compass-color-menu-tooltip-bg: hsl(0 0 20);
   --compass-color-menu-tooltip-text: hsl(0 0 100);
   --compass-color-not-found-gradient-highlight: hsl(218 27 8);
+  --compass-color-overlay-backdrop: hsl(0 0 0 / 80%);
   --compass-color-panel-badge-bg: hsl(0 0 100 / 7%);
   --compass-color-panel-bg: hsl(219 8 46 / 20%);
   --compass-color-panel-scrollbar: hsl(219 8 46 / 20%);
@@ -59,6 +61,7 @@
 @theme inline {
   --color-accent-primary: var(--compass-color-accent-primary);
   --color-accent-primary-shadow: var(--compass-color-accent-primary-shadow);
+  --color-accent-secondary: var(--compass-color-accent-secondary);
   --color-bg-primary: var(--compass-color-bg-primary);
   --color-bg-secondary: var(--compass-color-bg-secondary);
   --color-border-primary: var(--compass-color-border-primary);
@@ -88,6 +91,7 @@
   --color-not-found-gradient-highlight: var(
     --compass-color-not-found-gradient-highlight
   );
+  --color-overlay-backdrop: var(--compass-color-overlay-backdrop);
   --color-panel-badge-bg: var(--compass-color-panel-badge-bg);
   --color-panel-bg: var(--compass-color-panel-bg);
   --color-panel-scrollbar: var(--compass-color-panel-scrollbar);
@@ -136,22 +140,6 @@
 
   /* Border radius */
   --radius-default: 4px;
-
-  /**
-   * Raw colors
-   * Do NOT use these anymore - use the semantic colors instead
-   * https://github.com/SwitchbackTech/compass/issues/1265
-   */
-  --color-blue-200: hsl(196 60 59);
-  --color-gray-900: hsl(0 0 0 / 50.2%);
-  --color-gray-800: hsl(219 18 34 / 20%);
-  --color-gray-700: hsl(219 18 34 / 25.1%);
-  --color-gray-600: hsl(219 8 46 / 20%);
-  --color-gray-500: hsl(219 8 46 / 20%);
-  --color-gray-400: hsl(221 9 37);
-  --color-gray-300: hsl(219 8 46 / 90.2%);
-  --color-gray-200: hsl(208 13 71 / 54.9%);
-  --color-white-100: hsl(0 0 100);
 
   /* Animations */
   --animate-progress-slide: progressSlide 2s ease-out infinite;
@@ -401,7 +389,7 @@
 }
 
 @utility c-loader-spinner {
-  @apply relative my-15 h-[10em] w-[10em] animate-loader-spin rounded-full border-[1.1em] border-white/20 border-l-text-lighter text-[4px] -indent-[9999em];
+  @apply relative my-15 h-[10em] w-[10em] animate-loader-spin rounded-full border-[1.1em] border-text-lighter/20 border-l-text-lighter text-[4px] -indent-[9999em];
   transform: translateZ(0);
 }
 

--- a/packages/web/src/views/Cleanup/Cleanup.tsx
+++ b/packages/web/src/views/Cleanup/Cleanup.tsx
@@ -61,7 +61,7 @@ export const CleanupView = () => {
           <button
             type="button"
             onClick={handleRedirect}
-            className="rounded-sm bg-accent-primary px-6 py-3 text-white transition-colors hover:bg-accent-primary/90"
+            className="rounded-sm bg-accent-primary px-6 py-3 text-text-lighter transition-colors hover:bg-accent-primary/90"
           >
             Continue to Home
           </button>

--- a/packages/web/src/views/Day/components/AddTask/AddTaskActiveButton.tsx
+++ b/packages/web/src/views/Day/components/AddTask/AddTaskActiveButton.tsx
@@ -20,14 +20,14 @@ export function AddTaskActiveButton({
   onBlur,
 }: AddTaskActiveButtonProps) {
   return (
-    <div className="flex items-start gap-3 rounded border border-blue-200/30 bg-blue-200/5 p-2">
+    <div className="flex items-start gap-3 rounded border border-accent-secondary/30 bg-accent-secondary/5 p-2">
       <button
         type="button"
         onClick={onAddTask}
         aria-label="Create task"
         className="mt-1"
       >
-        <PlusIcon className="h-4 w-4 text-blue-200" />
+        <PlusIcon className="h-4 w-4 text-accent-secondary" />
       </button>
       <div className="flex-1">
         <input
@@ -41,7 +41,7 @@ export function AddTaskActiveButton({
           onBlur={onBlur}
           placeholder="Enter task title..."
           aria-label="Task title"
-          className="w-full bg-transparent text-sm text-white-100 placeholder-gray-200 outline-none"
+          className="w-full bg-transparent text-sm text-text-lighter placeholder-text-light-inactive outline-none"
         />
       </div>
     </div>

--- a/packages/web/src/views/Day/components/AddTask/AddTaskPreviewButton.tsx
+++ b/packages/web/src/views/Day/components/AddTask/AddTaskPreviewButton.tsx
@@ -19,18 +19,18 @@ export function AddTaskPreviewButton({
     <button
       id={ID_ADD_TASK_BUTTON}
       type="button"
-      className="group flex w-full cursor-pointer items-start gap-3 rounded border border-gray-400/30 bg-gray-400/5 p-2 text-left transition-colors hover:border-blue-200/30 hover:bg-blue-200/5 focus:border-blue-200/50 focus:bg-blue-200/10 focus:outline-none focus:ring-2 focus:ring-blue-200/30"
+      className="group flex w-full cursor-pointer items-start gap-3 rounded border border-panel-scrollbar-active/30 bg-panel-scrollbar-active/5 p-2 text-left transition-colors hover:border-accent-secondary/30 hover:bg-accent-secondary/5 focus:border-accent-secondary/50 focus:outline-none focus:ring-2 focus:ring-accent-secondary/30"
       onClick={onBeginAddingTask}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       aria-label="Create new task"
     >
       <PlusIcon
-        className="h-4 w-4 text-gray-200 transition-colors group-hover:text-blue-200 group-focus:text-blue-200"
+        className="h-4 w-4 text-text-light-inactive transition-colors group-hover:text-accent-secondary group-focus:text-accent-secondary"
         aria-hidden={true}
       />
       <div className="flex flex-1 items-center justify-between">
-        <span className="text-gray-200 text-sm transition-colors group-hover:text-white-100 group-focus:text-white-100">
+        <span className="text-sm text-text-light-inactive transition-colors group-hover:text-text-lighter group-focus:text-text-lighter">
           Create task
         </span>
         {isHoveringAddBlock && (

--- a/packages/web/src/views/Day/components/ContextMenu/BaseContextMenu.tsx
+++ b/packages/web/src/views/Day/components/ContextMenu/BaseContextMenu.tsx
@@ -45,7 +45,7 @@ export const BaseContextMenu = forwardRef<HTMLUListElement, Props>(
       ...getFloatingProps(props),
       className: classNames(
         "bg-bg-secondary absolute z-30 min-w-[160px] list-none rounded",
-        "border border-gray-600 shadow-md",
+        "border border-panel-bg shadow-md",
       ),
       style: props.style,
       ref,

--- a/packages/web/src/views/Day/components/Icons/TaskCircleIcon.tsx
+++ b/packages/web/src/views/Day/components/Icons/TaskCircleIcon.tsx
@@ -7,7 +7,7 @@ export const TaskCircleIcon = ({
     <>
       {status === "completed" ? (
         <svg
-          className="h-4 w-4 text-green"
+          className="h-4 w-4 text-status-success"
           fill="currentColor"
           viewBox="0 0 20 20"
           aria-hidden="true"
@@ -20,7 +20,7 @@ export const TaskCircleIcon = ({
         </svg>
       ) : (
         <svg
-          className="h-4 w-4 text-gray-200 opacity-80 transition-opacity group-hover:opacity-100"
+          className="h-4 w-4 text-text-light-inactive opacity-80 transition-opacity group-hover:opacity-100"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/packages/web/src/views/Day/components/Task/DraggableTask.tsx
+++ b/packages/web/src/views/Day/components/Task/DraggableTask.tsx
@@ -73,13 +73,13 @@ export function DraggableTask({
             "hover:cursor-grab hover:bg-border-primary",
             "rounded-xs py-2 transition-colors",
             "hover:opacity-100 focus-visible:opacity-100 group-hover:opacity-100",
-            "text-white",
-            "focus-visible:bg-white/20 focus-visible:ring-2 focus-visible:ring-white/50",
+            "text-text-lighter",
+            "focus-visible:bg-text-lighter/20 focus-visible:ring-2 focus-visible:ring-text-lighter/50",
             "focus:outline-none",
             {
               // A distinct accent (vs. the white focus ring) so keyboard users
               // can see the grab actually registered, not just that it's focused.
-              "cursor-grabbing bg-blue-200/20 opacity-100 ring-2 ring-blue-200":
+              "cursor-grabbing bg-accent-secondary/20 opacity-100 ring-2 ring-accent-secondary":
                 isDragging,
             },
           )}

--- a/packages/web/src/views/Day/components/Task/Task.tsx
+++ b/packages/web/src/views/Day/components/Task/Task.tsx
@@ -51,7 +51,7 @@ export const Task = ({
       key={task._id}
       {...{ [DATA_TASK_ELEMENT_ID]: task._id }}
       data-testid={task._id}
-      className={`group flex items-start gap-3 rounded border p-2 transition-colors duration-200 focus-within:border-blue-200/50 focus-within:ring-1 focus-within:ring-blue-200/30 ${task.status === "completed" ? "opacity-50" : ""}`}
+      className={`group flex items-start gap-3 rounded border p-2 transition-colors duration-200 focus-within:border-accent-secondary/50 focus-within:ring-1 focus-within:ring-accent-secondary/30 ${task.status === "completed" ? "opacity-50" : ""}`}
     >
       {/* biome-ignore lint/a11y/useSemanticElements: This custom checkbox button keeps the existing task keyboard flow and icon state. */}
       <button
@@ -67,7 +67,7 @@ export const Task = ({
         }}
         onKeyDown={(e) => onCheckboxKeyDown(e, task._id, task.title)}
         onClick={() => onStatusToggle(task._id)}
-        className="mt-1 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-200"
+        className="mt-1 rounded-full focus:outline-none focus:ring-2 focus:ring-accent-secondary"
       >
         <TaskCircleIcon status={task.status} />
       </button>
@@ -79,9 +79,9 @@ export const Task = ({
           id={`task-input-${task._id}`}
           name={`task-title-${task._id}`}
           className={classNames(
-            "w-full text-sm text-white-100 outline-none",
+            "w-full text-sm text-text-lighter outline-none",
             "border-transparent border-b bg-transparent",
-            { "border-white/20": isEditing },
+            { "border-text-lighter/20": isEditing },
           )}
           type="text"
           value={title}

--- a/packages/web/src/views/Day/components/TaskList/TaskList.tsx
+++ b/packages/web/src/views/Day/components/TaskList/TaskList.tsx
@@ -56,7 +56,7 @@ export function TaskList({ width }: { width: number }) {
     <section
       aria-label="daily-tasks"
       style={{ width }}
-      className="flex h-full shrink-0 flex-col bg-darkBlue-400 text-white"
+      className="flex h-full shrink-0 flex-col bg-bg-primary text-text-lighter"
     >
       <div className="flex flex-1 flex-col gap-2 overflow-hidden p-4">
         <TaskContextMenuWrapper>

--- a/packages/web/src/views/Week/components/Dedication/Dedication.tsx
+++ b/packages/web/src/views/Week/components/Dedication/Dedication.tsx
@@ -39,7 +39,7 @@ export const Dedication = () => {
   return (
     <dialog
       ref={dialogRef}
-      className={`max-h-none max-w-none bg-transparent p-0 transition-[opacity,overlay,display] duration-300 ease-out backdrop:bg-black/80 backdrop:transition-opacity backdrop:duration-300 ${
+      className={`max-h-none max-w-none bg-transparent p-0 transition-[opacity,overlay,display] duration-300 ease-out backdrop:bg-overlay-backdrop backdrop:transition-opacity backdrop:duration-300 ${
         isVisible
           ? "opacity-100 backdrop:opacity-100"
           : "opacity-0 backdrop:opacity-0"

--- a/packages/web/src/views/Week/components/TodayButton/TodayButton.tsx
+++ b/packages/web/src/views/Week/components/TodayButton/TodayButton.tsx
@@ -20,7 +20,7 @@ export const TodayButton = ({
       >
         <button
           type="button"
-          className="flex h-6 w-6 items-center justify-center rounded-full text-white transition-colors hover:bg-white/20 focus:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
+          className="flex h-6 w-6 items-center justify-center rounded-full text-text-lighter transition-colors hover:bg-text-lighter/20 focus:bg-text-lighter/20 focus:outline-none focus:ring-2 focus:ring-text-lighter/50"
           aria-label="Go to today"
         >
           <CircleIcon />


### PR DESCRIPTION
## Summary

- replace raw Tailwind palette utilities with semantic Compass theme tokens
- remove legacy raw color theme variables
- add a lint gate that prevents raw Tailwind palette colors from returning

## Validation

- `bun test:web` (1254 passed)
- web TypeScript check
- semantic color check
- changed-file Biome checks

Full repository lint still reports an unrelated pre-existing error in `packages/web/src/components/CommandPalette/CommandPalette.tsx`.