### PR TITLE
feat(backend): paginate and widen calendarlist eligibility

### DIFF
--- a/handoff/someday/04-initial-multi-calendar-import.md
+++ b/handoff/someday/04-initial-multi-calendar-import.md
@@ -28,8 +28,8 @@ Depends on: `03-event-runtime-cutover.md`.
 
 ## Implementation steps
 
-0. Prerequisite pulled forward from `07` (A30), because a 25-calendar fan-out
-   without it hits rate limits and 10-minute channels cannot survive
+0. [x] Prerequisite pulled forward from `07` (A30), because a 25-calendar
+   fan-out without it hits rate limits and 10-minute channels cannot survive
    multi-calendar renewal churn:
    - introduce the small Google request context (authenticated client, stable
      Compass user id as `quotaUser`, retry policy) and require it in every
@@ -39,6 +39,8 @@ Depends on: `03-event-runtime-cutover.md`.
    - request seven-day channel expirations, persist Google's returned
      expiration, and keep short expirations a dev/test override.
      `07` then owns only inspection, repair, the lease, and coverage tests.
+   Shipped in PR #2036 (`GoogleRequestContext`, `withGoogleRetry`,
+   `CHANNEL_EXPIRATION_MIN` default raised to 10080 minutes / 7 days).
 1. Replace the single-page helper with a CalendarList page generator that
    preserves the original request parameters, follows `nextPageToken`, and
    returns `nextSyncToken` only from the final page.

--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -39,7 +39,7 @@ class CalendarService {
       Resource_Sync.CALENDAR,
       userObjectId.toString(),
       Resource_Sync.CALENDAR,
-      { nextSyncToken, nextPageToken: nextPageToken! },
+      { nextSyncToken, nextPageToken },
       session,
     );
 

--- a/packages/backend/src/common/errors/integration/gcal/gcal.errors.ts
+++ b/packages/backend/src/common/errors/integration/gcal/gcal.errors.ts
@@ -6,6 +6,7 @@ interface GcalErrors {
   CalendarlistMissing: ErrorMetadata;
   CodeInvalid: ErrorMetadata;
   CodeMissing: ErrorMetadata;
+  MultiplePrimaryCalendars: ErrorMetadata;
   NoSyncToken: ErrorMetadata;
   PaginationNotSupported: ErrorMetadata;
   Unauthorized: ErrorMetadata;
@@ -29,13 +30,18 @@ export const GcalError: GcalErrors = {
     status: Status.FORBIDDEN,
     isOperational: true,
   },
+  MultiplePrimaryCalendars: {
+    description: "Google CalendarList returned more than one primary calendar",
+    status: Status.INTERNAL_SERVER,
+    isOperational: true,
+  },
   NoSyncToken: {
     description: "nextSyncToken is missing",
     status: Status.INTERNAL_SERVER,
     isOperational: true,
   },
   PaginationNotSupported: {
-    description: "Compass doesn't support pagination yet",
+    description: "Calendarlist final page is missing a sync token",
     status: Status.INTERNAL_SERVER,
     isOperational: true,
   },

--- a/packages/backend/src/common/services/gcal/gcal.service.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.test.ts
@@ -123,3 +123,80 @@ describe("gcal.service watch callbacks", () => {
     expect(result.data).toEqual({ items: [] });
   });
 });
+
+describe("gcal.service getAllCalendarListPages", () => {
+  it("follows nextPageToken across pages and only returns nextSyncToken from the final page", async () => {
+    const list = jest
+      .fn()
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { items: [{ id: "cal-1" }], nextPageToken: "page-2" },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { items: [{ id: "cal-2" }], nextSyncToken: "final-token" },
+      });
+    const context = {
+      gcal: { calendarList: { list } },
+      quotaUser: "user-1",
+    } as unknown as GoogleRequestContext;
+
+    const pages = [];
+
+    for await (const page of gcalService.getAllCalendarListPages(context)) {
+      pages.push(page);
+    }
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ pageToken: "page-2" }),
+    );
+    expect(pages.map((p) => p.nextSyncToken)).toEqual([
+      undefined,
+      "final-token",
+    ]);
+    expect(pages.flatMap((p) => p.items ?? [])).toEqual([
+      { id: "cal-1" },
+      { id: "cal-2" },
+    ]);
+  });
+
+  it("defaults a page's items to an empty array when Google omits them", async () => {
+    const list = jest.fn().mockResolvedValueOnce({
+      status: 200,
+      data: { nextSyncToken: "final-token" },
+    });
+    const context = {
+      gcal: { calendarList: { list } },
+      quotaUser: "user-1",
+    } as unknown as GoogleRequestContext;
+
+    const pages = [];
+
+    for await (const page of gcalService.getAllCalendarListPages(context)) {
+      pages.push(page);
+    }
+
+    expect(pages).toEqual([{ items: [], nextSyncToken: "final-token" }]);
+  });
+
+  it("throws PaginationNotSupported when the final page has neither a nextPageToken nor a nextSyncToken", async () => {
+    const list = jest.fn().mockResolvedValueOnce({
+      status: 200,
+      data: { items: [{ id: "cal-1" }] },
+    });
+    const context = {
+      gcal: { calendarList: { list } },
+      quotaUser: "user-1",
+    } as unknown as GoogleRequestContext;
+
+    const drain = async () => {
+      for await (const _page of gcalService.getAllCalendarListPages(context)) {
+        // draining the generator
+      }
+    };
+
+    await expect(drain()).rejects.toThrow(/sync token/i);
+  });
+});

--- a/packages/backend/src/common/services/gcal/gcal.service.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.ts
@@ -2,6 +2,7 @@ import { type GaxiosResponse } from "gaxios";
 import { GCAL_NOTIFICATION_ENDPOINT } from "@core/constants/core.constants";
 import {
   type gParamsEventsList,
+  type gSchema$CalendarList,
   type gSchema$Event,
   type gSchema$Events,
 } from "@core/types/gcal";
@@ -205,28 +206,54 @@ class GCalService {
     } while (hasNextPage || !isLastPage);
   }
 
-  async getCalendarlist(
+  /**
+   * getAllCalendarListPages
+   * generator function to list all pages of the user's Google CalendarList.
+   *
+   * Google only returns `nextSyncToken` on the FINAL page - intermediate
+   * pages return `nextPageToken` instead. `PaginationNotSupported` only
+   * fires when the final page (no `nextPageToken`) also lacks a
+   * `nextSyncToken`, since that's a genuine API contract violation rather
+   * than a normal mid-pagination state.
+   */
+  async *getAllCalendarListPages(
     { gcal, quotaUser }: GoogleRequestContext,
     {
       nextSyncToken: syncToken,
       nextPageToken: pageToken,
     }: Partial<Pick<SyncDetails, "nextSyncToken" | "nextPageToken">> = {},
-  ) {
-    const response = await withGoogleRetry(() =>
-      gcal.calendarList.list({ syncToken, pageToken, quotaUser }),
-    );
+  ): AsyncGenerator<
+    Pick<gSchema$CalendarList, "nextPageToken" | "nextSyncToken" | "items">
+  > {
+    let hasNextPage = false;
 
-    if (!response.data.nextSyncToken) {
-      throw error(
-        GcalError.PaginationNotSupported,
-        "Calendarlist sync token not saved",
+    do {
+      const response = await withGoogleRetry(() =>
+        gcal.calendarList.list({ syncToken, pageToken, quotaUser }),
       );
-    }
 
-    if (!response.data.items) {
-      throw error(GcalError.CalendarlistMissing, "gCalendarlist not found");
-    }
-    return response.data;
+      const { data = {} } = this.validateGCalResponse(
+        response,
+        "Failed to fetch gcal calendarlist",
+      );
+
+      const { nextPageToken, nextSyncToken, items = [] } = data;
+
+      pageToken = nextPageToken === null ? undefined : nextPageToken;
+      syncToken = nextSyncToken === null ? undefined : nextSyncToken;
+
+      hasNextPage =
+        typeof nextPageToken === "string" && nextPageToken.length > 0;
+
+      if (!hasNextPage && !nextSyncToken) {
+        throw error(
+          GcalError.PaginationNotSupported,
+          "Calendarlist sync token not saved",
+        );
+      }
+
+      yield { nextPageToken, nextSyncToken, items };
+    } while (hasNextPage);
   }
 
   /**

--- a/packages/backend/src/sync/services/init/google-sync-init.test.ts
+++ b/packages/backend/src/sync/services/init/google-sync-init.test.ts
@@ -1,4 +1,6 @@
+import { createMockCalendarListEntry } from "@core/__tests__/helpers/gcal.factory";
 import { GoogleCalendarMetadataSchema } from "@core/types/calendar.types";
+import { type gSchema$CalendarListEntry } from "@core/types/gcal";
 import { StringV4Schema } from "@core/types/type.utils";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
@@ -6,6 +8,7 @@ import {
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
+import { compassTestState } from "@backend/__tests__/helpers/mock.setup";
 import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import { getCalendarsToSync } from "@backend/sync/services/init/google-sync-init";
@@ -43,17 +46,147 @@ describe("getCalendarsToSync", () => {
     expect(StringV4Schema.safeParse(result.nextSyncToken).success).toBe(true);
   });
 
+  it("returns an empty list when the calendarlist has no entries", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const context = await createGoogleRequestContext(user._id.toString());
+
+    compassTestState().calendarlist = [];
+
+    const result = await getCalendarsToSync(context);
+
+    expect(result.calendars).toEqual([]);
+    expect(result.gCalendarIds).toEqual([]);
+    expect(result.nextPageToken).toBeUndefined();
+    expect(StringV4Schema.safeParse(result.nextSyncToken).success).toBe(true);
+  });
+
+  it("paginates through many calendars and finds primary even when it isn't first or on the first page", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const context = await createGoogleRequestContext(user._id.toString());
+
+    // The test mock's calendarList.list pages 3 entries at a time, so 25
+    // entries span 9 pages.
+    const entries = Array.from({ length: 25 }, (_, i) =>
+      createMockCalendarListEntry({ id: `calendar-${i}`, primary: false }),
+    );
+    entries[20] = createMockCalendarListEntry({
+      id: "primary-calendar",
+      primary: true,
+    });
+
+    compassTestState().calendarlist = entries;
+
+    const result = await getCalendarsToSync(context);
+
+    expect(result.calendars).toHaveLength(25);
+    expect(result.gCalendarIds).toHaveLength(25);
+    expect(result.calendars.filter((c) => c.primary === true)).toHaveLength(1);
+    expect(result.nextPageToken).toBeUndefined();
+    expect(StringV4Schema.safeParse(result.nextSyncToken).success).toBe(true);
+  });
+
+  it("filters out hidden and deleted entries but keeps non-primary, read-only, and unselected calendars", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const context = await createGoogleRequestContext(user._id.toString());
+
+    compassTestState().calendarlist = [
+      createMockCalendarListEntry({ id: "primary", primary: true }),
+      createMockCalendarListEntry({
+        id: "hidden-cal",
+        primary: false,
+        hidden: true,
+      }),
+      createMockCalendarListEntry({
+        id: "deleted-cal",
+        primary: false,
+        deleted: true,
+      }),
+      createMockCalendarListEntry({
+        id: "readonly-unselected",
+        primary: false,
+        accessRole: "reader",
+        selected: false,
+      }),
+      createMockCalendarListEntry({
+        id: "freebusy-cal",
+        primary: false,
+        accessRole: "freeBusyReader",
+      }),
+    ];
+
+    const result = await getCalendarsToSync(context);
+
+    expect(result.gCalendarIds.sort()).toEqual(
+      ["freebusy-cal", "primary", "readonly-unselected"].sort(),
+    );
+  });
+
+  it("dedupes calendars with the same id, even across pages", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const context = await createGoogleRequestContext(user._id.toString());
+
+    // The test mock pages 3 at a time, so this spans 2 pages.
+    compassTestState().calendarlist = [
+      createMockCalendarListEntry({ id: "dup", primary: true }),
+      createMockCalendarListEntry({ id: "dup", primary: true }),
+      createMockCalendarListEntry({ id: "dup", primary: true }),
+      createMockCalendarListEntry({ id: "dup", primary: true }),
+    ];
+
+    const result = await getCalendarsToSync(context);
+
+    expect(result.calendars).toHaveLength(1);
+    expect(result.gCalendarIds).toEqual(["dup"]);
+  });
+
+  it("throws when more than one calendar is marked primary", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const context = await createGoogleRequestContext(user._id.toString());
+
+    compassTestState().calendarlist = [
+      createMockCalendarListEntry({ id: "cal-1", primary: true }),
+      createMockCalendarListEntry({ id: "cal-2", primary: true }),
+    ];
+
+    await expect(getCalendarsToSync(context)).rejects.toThrow(/primary/i);
+  });
+
+  it("doesn't require id/etag/accessRole beyond what dedup and the primary check need", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const context = await createGoogleRequestContext(user._id.toString());
+
+    compassTestState().calendarlist = [
+      createMockCalendarListEntry({ id: "primary", primary: true }),
+      {
+        id: "sparse-cal",
+        // no etag, no accessRole, no summary - getCalendarsToSync (unlike
+        // mapGoogleCalendar) shouldn't need these to include the entry.
+      } as gSchema$CalendarListEntry,
+    ];
+
+    const result = await getCalendarsToSync(context);
+
+    expect(result.gCalendarIds.sort()).toEqual(
+      ["primary", "sparse-cal"].sort(),
+    );
+  });
+
   it("throws when nextSyncToken is invalid", async () => {
     const { user } = await UtilDriver.setupTestUser();
     const context = await createGoogleRequestContext(user._id.toString());
-    const getCalendarlist = gcalService.getCalendarlist.bind(gcalService);
-    const getCalendarlistSpy = jest.spyOn(gcalService, "getCalendarlist");
+    const getAllCalendarListPages =
+      gcalService.getAllCalendarListPages.bind(gcalService);
+    const getAllCalendarListPagesSpy = jest.spyOn(
+      gcalService,
+      "getAllCalendarListPages",
+    );
 
-    getCalendarlistSpy.mockImplementation(async (context) =>
-      getCalendarlist(context).then((res) => ({
-        ...res,
-        nextSyncToken: "",
-      })),
+    getAllCalendarListPagesSpy.mockImplementation(
+      async function* (ctx, params) {
+        for await (const page of getAllCalendarListPages(ctx, params)) {
+          yield { ...page, nextSyncToken: "" };
+        }
+      },
     );
 
     await expect(getCalendarsToSync(context)).rejects.toThrow(

--- a/packages/backend/src/sync/services/init/google-sync-init.ts
+++ b/packages/backend/src/sync/services/init/google-sync-init.ts
@@ -1,19 +1,49 @@
+import { type gSchema$CalendarListEntry } from "@core/types/gcal";
 import { StringV4Schema } from "@core/types/type.utils";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { GcalError } from "@backend/common/errors/integration/gcal/gcal.errors";
 import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 
 export const getCalendarsToSync = async (context: GoogleRequestContext) => {
-  const calendarListResponse = await gcalService.getCalendarlist(context);
-  const { items = [], nextPageToken } = calendarListResponse;
+  const items: gSchema$CalendarListEntry[] = [];
+  let nextSyncToken: string | null | undefined;
 
-  const nextSyncToken = StringV4Schema.parse(
-    calendarListResponse.nextSyncToken,
-    { error: () => "Failed to get Calendar(list)s to sync" },
+  for await (const {
+    items: pageItems = [],
+    nextSyncToken: pageSyncToken,
+  } of gcalService.getAllCalendarListPages(context)) {
+    items.push(...pageItems);
+    nextSyncToken = pageSyncToken;
+  }
+
+  const parsedSyncToken = StringV4Schema.parse(nextSyncToken, {
+    error: () => "Failed to get Calendar(list)s to sync",
+  });
+
+  const eligible = items.filter(
+    (entry) => entry.deleted !== true && entry.hidden !== true,
   );
 
-  const primaryGcal = items.find(({ primary }) => primary);
+  const deduped = new Map<string, gSchema$CalendarListEntry>();
 
-  const calendars = primaryGcal ? [primaryGcal] : [];
+  for (const entry of eligible) {
+    if (!entry.id) continue;
+    if (!deduped.has(entry.id)) {
+      deduped.set(entry.id, entry);
+    }
+  }
+
+  const calendars = [...deduped.values()];
+
+  const primaryCalendars = calendars.filter(({ primary }) => primary);
+
+  if (primaryCalendars.length > 1) {
+    throw error(
+      GcalError.MultiplePrimaryCalendars,
+      "Google CalendarList returned more than one primary calendar",
+    );
+  }
 
   const gCalendarIds = calendars
     .map(({ id }) => id)
@@ -22,7 +52,7 @@ export const getCalendarsToSync = async (context: GoogleRequestContext) => {
   return {
     calendars,
     gCalendarIds,
-    nextSyncToken,
-    nextPageToken,
+    nextSyncToken: parsedSyncToken,
+    nextPageToken: undefined as string | undefined,
   };
 };


### PR DESCRIPTION
## Summary
- `getCalendarsToSync` now follows CalendarList pagination to completion via the new `gcalService.getAllCalendarListPages` generator (Google only returns `nextSyncToken` on the final page — the old single-page `getCalendarlist` threw on any intermediate page).
- Returns every eligible calendar (deleted/hidden filtered, deduped by Google id, at-most-one-primary asserted) instead of just the primary entry.
- `calendar.service.ts`'s bulk-upsert reconciliation (`initializeGoogleCalendars`) was already generic over the full list — this alone widens the Compass calendar table to match the full Google account. Event import stays primary-only until packet 04's later steps (4-9).

Step 1-2 of handoff/someday/04-initial-multi-calendar-import.md; builds on the request-context/retry work in #2036.

## Test plan
- [x] bun run type-check — clean
- [x] Focused suites (gcal, google-sync-init, calendar.service) — 9 suites / 95 tests
- [x] Broader sync/watch/import/google suites (unaffected consumers) — 31 suites / 215 tests
- [x] bun run lint — 0 errors
- [x] /simplify pass — reviewed, nothing to change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>