### PR TITLE
fix(web): align someday event priority colors

### DIFF
--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
@@ -3,6 +3,10 @@ import { Priorities } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
 import { Categories_Event } from "@core/types/event.types";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import {
+  gridColorByPriority,
+  gridHoverColorByPriority,
+} from "@web/common/styles/theme.util";
 import { type Props_DraftForm } from "@web/views/Week/components/Draft/hooks/state/useDraftForm";
 import { SomedayEvent } from "./SomedayEvent";
 import { describe, expect, it, mock } from "bun:test";
@@ -44,6 +48,19 @@ const renderSomedayEvent = ({
 };
 
 describe("SomedayEvent", () => {
+  it("uses the calendar grid priority colors for saved events", () => {
+    renderSomedayEvent();
+
+    const event = screen.getAllByRole("button")[0];
+
+    expect(event.style.getPropertyValue("--someday-event-bg")).toBe(
+      gridColorByPriority[Priorities.WORK],
+    );
+    expect(event.style.getPropertyValue("--someday-event-hover-bg")).toBe(
+      gridHoverColorByPriority[Priorities.WORK],
+    );
+  });
+
   it("does not open the row when Space is pressed on an inner action button", () => {
     const { onClick } = renderSomedayEvent();
 

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
@@ -3,7 +3,10 @@ import { type Priorities } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type CSSVariables } from "@web/common/styles/css.types";
-import { colorByPriority } from "@web/common/styles/theme.util";
+import {
+  gridColorByPriority,
+  gridHoverColorByPriority,
+} from "@web/common/styles/theme.util";
 import { type Actions_Sidebar } from "@web/components/PlannerSidebar/draft/hooks/useSidebarActions";
 import { type SomedayInteractionCategory } from "@web/components/PlannerSidebar/SomedayEventSections/interaction/registry/somedayEventRegistry";
 import { type Props_DraftForm } from "@web/views/Week/components/Draft/hooks/state/useDraftForm";
@@ -54,8 +57,10 @@ export const SomedayEvent = ({
     onClick();
   };
 
-  const tint = (percent: number) =>
-    `color-mix(in srgb, ${colorByPriority[priority]} ${percent}%, transparent)`;
+  const baseColor = gridColorByPriority[priority];
+  const hoverColor = gridHoverColorByPriority[priority];
+  const tint = (color: string, percent: number) =>
+    `color-mix(in srgb, ${color} ${percent}%, transparent)`;
   const somedayEventProps = {
     [DATA_EVENT_ELEMENT_ID]: event.id,
     "aria-hidden": isDragging || undefined,
@@ -75,8 +80,12 @@ export const SomedayEvent = ({
       data-dragging={isDragging}
       style={
         {
-          "--someday-event-bg": tint(isDrafting ? (isDragging ? 45 : 35) : 15),
-          "--someday-event-hover-bg": tint(25),
+          "--someday-event-bg": isDrafting
+            ? tint(baseColor, isDragging ? 45 : 35)
+            : baseColor,
+          "--someday-event-hover-bg": isDrafting
+            ? tint(hoverColor, 25)
+            : hoverColor,
           height: SOMEDAY_EVENT_ROW_HEIGHT,
           marginBlock: SOMEDAY_EVENT_ROW_VERTICAL_MARGIN,
         } as CSSVariables


### PR DESCRIPTION
## Summary

- align saved Someday event rows with the calendar grid priority palette
- keep draft and drag opacity behavior intact
- add a regression test for base and hover color parity

## Root cause

Someday rows used the general priority palette with a 15% transparent tint, while timed and all-day calendar cards used the opaque grid palette.

## Validation

- focused SomedayEvent test
- bun test:web
- bun type-check
- bun lint