### PR TITLE
feat(backend): fan out event import across every eligible calendar

### DIFF
--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -203,6 +203,20 @@ class CalendarService {
   };
 
   /**
+   * Every active Google-sourced calendar the user has (any access level),
+   * used to fan out per-calendar event import (packet 04).
+   */
+  getActiveGoogleCalendars = async (userId: ObjectId | string) => {
+    return mongoService.calendar
+      .find({
+        userId: zObjectId.parse(userId),
+        "source.provider": "google",
+        isActive: true,
+      })
+      .toArray();
+  };
+
+  /**
    * A calendar the user owns and can currently write to.
    */
   getOwnedActiveCalendar = async (

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.test.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.test.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from "mongodb";
+import { createMockCalendarListEntry } from "@core/__tests__/helpers/gcal.factory";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
@@ -6,6 +7,7 @@ import {
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
+import { compassTestState } from "@backend/__tests__/helpers/mock.setup";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
@@ -128,6 +130,221 @@ describe("googleCalendarSyncService", () => {
 
       expect(callOrder).toEqual(["importFull", "startWatching"]);
     });
+
+    it("imports events for every owner/writer/reader calendar and skips freeBusyReader calendars", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "primary-cal",
+          primary: true,
+          accessRole: "owner",
+        }),
+        createMockCalendarListEntry({
+          id: "reader-cal",
+          primary: false,
+          accessRole: "reader",
+        }),
+        createMockCalendarListEntry({
+          id: "freebusy-cal",
+          primary: false,
+          accessRole: "freeBusyReader",
+        }),
+      ];
+
+      const importAllEvents = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _userId: string,
+            calendar: { source: { calendarId: string } },
+          ) => ({
+            totalProcessed: 1,
+            totalSaved: 1,
+            totalDeleted: 0,
+            totalIgnored: 0,
+            totalInvalid: 0,
+            nextSyncToken: `token-${calendar.source.calendarId}`,
+          }),
+        );
+      jest.spyOn(syncImportService, "createSyncImport").mockResolvedValue({
+        importAllEvents,
+      } as unknown as Awaited<
+        ReturnType<typeof syncImportService.createSyncImport>
+      >);
+
+      const result =
+        await googleCalendarSyncService.initializeGoogleCalendarSync(userId);
+
+      expect(result.eventsCount).toBe(2);
+      expect(result.calendarsCount).toBe(2);
+      expect(result.failedCalendars).toEqual([]);
+
+      const importedGCalendarIds = importAllEvents.mock.calls.map(
+        ([, calendar]) => calendar.source.calendarId,
+      );
+      expect(importedGCalendarIds.sort()).toEqual([
+        "primary-cal",
+        "reader-cal",
+      ]);
+      expect(importedGCalendarIds).not.toContain("freebusy-cal");
+
+      const freeBusyRecord = await mongoService.calendar.findOne({
+        userId: user._id,
+        "source.calendarId": "freebusy-cal",
+      });
+      expect(freeBusyRecord).not.toBeNull();
+
+      const sync = await mongoService.sync.findOne({ user: userId });
+      const eventSyncGCalendarIds =
+        sync?.google?.events?.map((e) => e.gCalendarId) ?? [];
+      expect(eventSyncGCalendarIds).not.toContain("freebusy-cal");
+    });
+
+    it("attributes each imported event to its own Compass calendar id when importing calendars concurrently", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "primary-cal",
+          primary: true,
+          accessRole: "owner",
+        }),
+        createMockCalendarListEntry({
+          id: "second-cal",
+          primary: false,
+          accessRole: "writer",
+        }),
+      ];
+
+      const seenCalendarIds: string[] = [];
+      const importAllEvents = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _userId: string,
+            calendar: { _id: ObjectId; source: { calendarId: string } },
+          ) => {
+            seenCalendarIds.push(calendar._id.toHexString());
+            return {
+              totalProcessed: 1,
+              totalSaved: 1,
+              totalDeleted: 0,
+              totalIgnored: 0,
+              totalInvalid: 0,
+              nextSyncToken: `token-${calendar.source.calendarId}`,
+            };
+          },
+        );
+      jest.spyOn(syncImportService, "createSyncImport").mockResolvedValue({
+        importAllEvents,
+      } as unknown as Awaited<
+        ReturnType<typeof syncImportService.createSyncImport>
+      >);
+
+      await googleCalendarSyncService.initializeGoogleCalendarSync(userId);
+
+      const calendarRecords = await mongoService.calendar
+        .find({ userId: user._id, "source.provider": "google" })
+        .toArray();
+      const recordIds = calendarRecords.map((c) => c._id.toHexString());
+
+      // Every call received a distinct, real Compass calendar id - no
+      // cross-attribution between the two concurrently-imported calendars.
+      expect(new Set(seenCalendarIds).size).toBe(2);
+      expect(seenCalendarIds.sort()).toEqual(recordIds.sort());
+    });
+
+    it("does not abort other calendars when one calendar's import fails, and still starts watches for primary", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "primary-cal",
+          primary: true,
+          accessRole: "owner",
+        }),
+        createMockCalendarListEntry({
+          id: "broken-cal",
+          primary: false,
+          accessRole: "reader",
+        }),
+      ];
+
+      const importAllEvents = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _userId: string,
+            calendar: { source: { calendarId: string } },
+          ) => {
+            if (calendar.source.calendarId === "broken-cal") {
+              throw new Error("simulated calendar import failure");
+            }
+            return {
+              totalProcessed: 1,
+              totalSaved: 1,
+              totalDeleted: 0,
+              totalIgnored: 0,
+              totalInvalid: 0,
+              nextSyncToken: "token-primary-cal",
+            };
+          },
+        );
+      jest.spyOn(syncImportService, "createSyncImport").mockResolvedValue({
+        importAllEvents,
+      } as unknown as Awaited<
+        ReturnType<typeof syncImportService.createSyncImport>
+      >);
+      const startWatchesSpy = jest
+        .spyOn(googleWatchService, "startGoogleWatches")
+        .mockResolvedValue(undefined as never);
+
+      const result =
+        await googleCalendarSyncService.initializeGoogleCalendarSync(userId);
+
+      expect(result.eventsCount).toBe(1);
+      expect(result.calendarsCount).toBe(1);
+      expect(result.failedCalendars).toHaveLength(1);
+      expect(result.failedCalendars[0]?.error).toContain(
+        "simulated calendar import failure",
+      );
+      expect(startWatchesSpy).toHaveBeenCalledWith(
+        userId,
+        expect.arrayContaining([
+          expect.objectContaining({ gCalendarId: "primary-cal" }),
+        ]),
+        expect.anything(),
+      );
+    });
+
+    it("fails the whole sync when the primary calendar's import fails", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "primary-cal",
+          primary: true,
+          accessRole: "owner",
+        }),
+      ];
+
+      jest.spyOn(syncImportService, "createSyncImport").mockResolvedValue({
+        importAllEvents: jest
+          .fn()
+          .mockRejectedValue(new Error("primary calendar import failure")),
+      } as unknown as Awaited<
+        ReturnType<typeof syncImportService.createSyncImport>
+      >);
+
+      await expect(
+        googleCalendarSyncService.initializeGoogleCalendarSync(userId),
+      ).rejects.toThrow("primary calendar import failure");
+    });
   });
 
   describe("startGoogleCalendarSyncIfNeeded", () => {
@@ -170,7 +387,11 @@ describe("googleCalendarSyncService", () => {
         .mockResolvedValue();
       const startSpy = jest
         .spyOn(googleCalendarSyncService, "initializeGoogleCalendarSync")
-        .mockResolvedValue({ eventsCount: 0, calendarsCount: 0 });
+        .mockResolvedValue({
+          eventsCount: 0,
+          calendarsCount: 0,
+          failedCalendars: [],
+        });
 
       await googleCalendarSyncService.repairGoogleCalendarSync(userId);
 

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.ts
@@ -13,7 +13,7 @@ import {
   type GoogleRequestContext,
 } from "@backend/common/services/gcal/gcal.context";
 import { isInvalidGoogleToken } from "@backend/common/services/gcal/gcal.utils";
-import mongoService from "@backend/common/services/mongo.service";
+import { createConcurrencyLimiter } from "@backend/common/util/concurrency-limiter.util";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import compassToGoogleBackfill from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google-backfill";
 import {
@@ -62,40 +62,30 @@ const notifyImportEnd = (
 };
 
 /**
- * Full import for the primary Google calendar (import stays
- * primary-calendar-only at this packet; multi-calendar discovery/import is
- * packet 04), inside a single transaction.
+ * Bounds how many calendars import events concurrently (B5). Kept low
+ * relative to Google's per-user quota; each calendar's own paging already
+ * bounds how much work is in flight for that calendar.
+ */
+const CALENDAR_IMPORT_CONCURRENCY = 4;
+
+/**
+ * Full import for a single Google calendar. Deliberately runs with no
+ * Mongo transaction wrapper - see the comment on
+ * `SyncImport.importAllEvents` for why per-page durability (rather than
+ * one big rollback-or-commit) is what makes a failed calendar resumable.
  */
 async function importFull(
   syncImport: SyncImport,
   calendar: CalendarRecord,
   userId: string,
 ) {
-  const session = await mongoService.startSession({
-    causalConsistency: true,
-  });
-
-  session.startTransaction();
-
-  try {
-    const result = await syncImport.importAllEvents(
-      userId,
-      calendar,
-      2500,
-      session,
-    );
-
-    await session.commitTransaction();
-
-    return result;
-  } catch (err: unknown) {
-    await session.abortTransaction();
-
-    throw err;
-  } finally {
-    await session.endSession();
-  }
+  return syncImport.importAllEvents(userId, calendar, 2500);
 }
+
+type CalendarImportFailure = { calendarId: string; error: string };
+
+const toErrorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : "Unknown error";
 
 async function importLatestGoogleCalendarChanges(
   userId: string,
@@ -247,8 +237,14 @@ async function runGoogleCalendarSyncSetup(
     });
 
     await userService.stopGoogleCalendarSync(userId);
-    const importResults =
+    const { failedCalendars, ...importResults } =
       await googleCalendarSyncService.initializeGoogleCalendarSync(userId);
+
+    if (failedCalendars.length > 0) {
+      logger.error(
+        `Google Calendar import completed for user: ${userId} with ${failedCalendars.length} calendar(s) that failed to import; each retains any progress made before failing and can be retried in isolation.`,
+      );
+    }
 
     await compassToGoogleBackfill
       .syncCompassEventsToGoogle(userId)
@@ -320,42 +316,100 @@ async function runGoogleCalendarSyncSetup(
 }
 
 /**
- * Discovers the user's Google calendars, then imports events for the
- * primary calendar only (A per the packet-03-phase-2 scope: multi-calendar
- * import/discovery is packet 04) and starts webhook watches for it.
+ * Discovers the user's Google calendars, then imports events for every
+ * owner/writer/reader calendar (bounded concurrency, B5) - freeBusyReader
+ * calendars get a CalendarRecord from reconciliation above but no event
+ * import, since their availability comes from a separate freeBusy.query
+ * contract (packet 01, out of scope here). One calendar's import failure
+ * doesn't abort the others (B8): each is isolated via Promise.allSettled,
+ * and because `SyncImport.importAllEvents` persists per-page progress with
+ * no surrounding transaction, a failed calendar retains whatever pages it
+ * already completed and can be retried in isolation. A primary-calendar
+ * failure is still treated as fatal for this call (watches only start for
+ * primary + CalendarList, same as before this packet).
  */
-async function initializeGoogleCalendarSync(
-  user: string,
-): Promise<{ eventsCount: number; calendarsCount: number }> {
+async function initializeGoogleCalendarSync(user: string): Promise<{
+  eventsCount: number;
+  calendarsCount: number;
+  failedCalendars: CalendarImportFailure[];
+}> {
   const context = await createGoogleRequestContext(user);
 
   await calendarService.initializeGoogleCalendars(user, context);
 
-  const calendar = await calendarService.getPrimaryGoogleCalendar(user);
+  const calendars = await calendarService.getActiveGoogleCalendars(user);
+  const primaryCalendar = calendars.find(
+    (c) => c.source.provider === "google" && c.isPrimary,
+  );
 
-  if (!calendar || calendar.source.provider !== "google") {
+  if (!primaryCalendar || primaryCalendar.source.provider !== "google") {
     logger.warn(`No primary Google calendar found for user: ${user}`);
-    return { eventsCount: 0, calendarsCount: 0 };
+    return { eventsCount: 0, calendarsCount: 0, failedCalendars: [] };
   }
 
+  // freeBusyReader calendars get no event import - their CalendarRecord
+  // already exists from initializeGoogleCalendars above.
+  const importableCalendars = calendars.filter(
+    (c) => c.source.provider === "google" && c.access !== "freeBusyReader",
+  );
+
   const syncImport = await createSyncImport(context);
-  const importResult = await importFull(syncImport, calendar, user);
+  const limit = createConcurrencyLimiter(CALENDAR_IMPORT_CONCURRENCY);
+
+  const outcomes = await Promise.allSettled(
+    importableCalendars.map((calendar) =>
+      limit(async () => ({
+        calendar,
+        result: await importFull(syncImport, calendar, user),
+      })),
+    ),
+  );
+
+  let eventsCount = 0;
+  let calendarsCount = 0;
+  const failedCalendars: CalendarImportFailure[] = [];
+  let primaryFailure: unknown;
+
+  outcomes.forEach((outcome, index) => {
+    const calendar = importableCalendars[index]!;
+    const calendarId = calendar._id.toHexString();
+
+    if (outcome.status === "fulfilled") {
+      eventsCount += outcome.value.result.totalSaved;
+      calendarsCount += 1;
+      return;
+    }
+
+    failedCalendars.push({ calendarId, error: toErrorMessage(outcome.reason) });
+
+    // No calendar names/Google ids/tokens in logs (B10 head start) - a
+    // Compass calendar _id is an internal identifier, not user data.
+    logger.warn(
+      `Google Calendar event import failed for calendar ${calendarId} (user: ${user}); already-imported pages remain durable and this calendar can be retried in isolation.`,
+      outcome.reason,
+    );
+
+    if (calendar._id.equals(primaryCalendar._id)) {
+      primaryFailure = outcome.reason;
+    }
+  });
+
+  if (primaryFailure !== undefined) {
+    throw primaryFailure;
+  }
 
   if (isUsingGcalWebhookHttps()) {
     await googleWatchService.startGoogleWatches(
       user,
       [
         { gCalendarId: Resource_Sync.CALENDAR },
-        { gCalendarId: calendar.source.calendarId },
+        { gCalendarId: primaryCalendar.source.calendarId },
       ],
       context,
     );
   }
 
-  return {
-    eventsCount: importResult.totalSaved,
-    calendarsCount: 1,
-  };
+  return { eventsCount, calendarsCount, failedCalendars };
 }
 
 async function repairGoogleCalendarSync(userId: string) {

--- a/packages/backend/src/sync/services/import/google-import.service.test.ts
+++ b/packages/backend/src/sync/services/import/google-import.service.test.ts
@@ -150,6 +150,77 @@ describe("SyncImport", () => {
       ).toBe(0);
     });
 
+    it("retains already-persisted pages and their pageToken checkpoint when a later page throws, then resumes on retry without duplicating or advancing the sync token prematurely", async () => {
+      const page1Event = mockRegularGcalEvent({ id: "page-1-event" });
+      const page2Event = mockRegularGcalEvent({ id: "page-2-event" });
+
+      const throwOnPage2 = async function* () {
+        yield { items: [page1Event], nextPageToken: "page-2-token" };
+        throw new Error("simulated network failure fetching page 2");
+      };
+      (gcalService.getAllEvents as jest.Mock).mockReturnValueOnce(
+        throwOnPage2(),
+      );
+
+      const syncImport = new SyncImport(context);
+
+      await expect(
+        syncImport.importAllEvents(userId, calendar, 1000),
+      ).rejects.toThrow("simulated network failure fetching page 2");
+
+      // Page 1's event and its pageToken checkpoint are durably saved even
+      // though the overall import threw - no surrounding transaction to
+      // roll them back.
+      expect(
+        await mongoService.event.countDocuments({
+          "externalReference.eventId": page1Event.id,
+        }),
+      ).toBe(1);
+
+      const pageTokenAfterFailure = await getGCalEventsSyncPageToken(
+        userId,
+        calendar.source.provider === "google" ? calendar.source.calendarId : "",
+      );
+      expect(pageTokenAfterFailure).toBe("page-2-token");
+
+      // The sync token must not have advanced past the unpersisted page.
+      const syncAfterFailure = await getSync({ userId });
+      const eventSyncAfterFailure = syncAfterFailure?.google?.events?.find(
+        (e) => e.gCalendarId === "primary",
+      );
+      expect(eventSyncAfterFailure?.nextSyncToken).toBeUndefined();
+
+      // A retry resumes from the saved pageToken rather than page 1.
+      (gcalService.getAllEvents as jest.Mock).mockReturnValueOnce(
+        asPages({ items: [page2Event], nextSyncToken: "final-sync-token" }),
+      );
+
+      const result = await syncImport.importAllEvents(userId, calendar, 1000);
+
+      expect(gcalService.getAllEvents).toHaveBeenLastCalledWith(
+        expect.objectContaining({ pageToken: "page-2-token" }),
+      );
+      expect(result.nextSyncToken).toBe("final-sync-token");
+
+      // Page 1's event was not re-fetched/duplicated by the retry.
+      expect(
+        await mongoService.event.countDocuments({
+          "externalReference.eventId": page1Event.id,
+        }),
+      ).toBe(1);
+      expect(
+        await mongoService.event.countDocuments({
+          "externalReference.eventId": page2Event.id,
+        }),
+      ).toBe(1);
+
+      const syncAfterRetry = await getSync({ userId });
+      const eventSyncAfterRetry = syncAfterRetry?.google?.events?.find(
+        (e) => e.gCalendarId === "primary",
+      );
+      expect(eventSyncAfterRetry?.nextSyncToken).toBe("final-sync-token");
+    });
+
     it("resumes import using the stored nextPageToken", async () => {
       await updateSync(
         Resource_Sync.EVENTS,

--- a/packages/backend/src/sync/services/import/google-import.service.ts
+++ b/packages/backend/src/sync/services/import/google-import.service.ts
@@ -1,4 +1,3 @@
-import { type ClientSession } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import { Resource_Sync } from "@core/types/sync.types";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
@@ -53,10 +52,10 @@ const addStats = (
 });
 
 /**
- * Imports Google Calendar events onto their owning CalendarRecord (B8). At
- * this packet, import is primary-calendar-only (multi-calendar discovery is
- * packet 04): callers resolve the primary Google CalendarRecord once and
- * pass it in.
+ * Imports Google Calendar events onto their owning CalendarRecord (B8).
+ * Callers resolve a Google CalendarRecord (any owner/writer/reader calendar,
+ * not just primary - packet 04) and pass it in; each call operates on
+ * exactly the one calendar it was given.
  */
 export class SyncImport {
   private context: GoogleRequestContext;
@@ -68,12 +67,19 @@ export class SyncImport {
   /**
    * Full sync: imports every event on the calendar (Compass never saw it
    * before, or is reconciling from scratch).
+   *
+   * Deliberately runs with no Mongo transaction/session: each page's event
+   * writes and its `nextPageToken` checkpoint (via `updateSync`) commit as
+   * their own atomic operation as the page completes. That gives resumable
+   * per-calendar progress for free - if a later page throws, the pages
+   * already processed stay durably saved and a retry of this calendar picks
+   * up from the last saved pageToken instead of re-importing everything or
+   * rolling back other calendars' work.
    */
   async importAllEvents(
     userId: string,
     calendar: CalendarRecord,
     perPage = 1000,
-    session?: ClientSession,
   ): Promise<ImportStats & { nextSyncToken: string }> {
     if (calendar.source.provider !== "google") {
       throw error(
@@ -95,7 +101,6 @@ export class SyncImport {
     const pageToken = await getGCalEventsSyncPageToken(
       userId,
       calendar.source.calendarId,
-      session,
     );
 
     const gCalResponse = gcalService.getAllEvents({
@@ -111,7 +116,7 @@ export class SyncImport {
       nextPageToken,
     } of gCalResponse) {
       if (items.length > 0) {
-        const delta = await sync.apply(items, perPage, session);
+        const delta = await sync.apply(items, perPage);
         stats = addStats(stats, delta);
       }
 
@@ -120,7 +125,6 @@ export class SyncImport {
         userId,
         calendar.source.calendarId,
         { nextPageToken: nextPageToken ?? undefined },
-        session,
       );
 
       if (nextSyncToken) syncToken = nextSyncToken;
@@ -132,6 +136,16 @@ export class SyncImport {
         `Failed to finalize full import because nextSyncToken was not found for ${calendar.source.calendarId}. Incremental sync may not work correctly.`,
       );
     }
+
+    // Only persisted once the loop finishes without throwing, so a final
+    // sync token becomes durable only after the whole calendar succeeds -
+    // a calendar that throws mid-import keeps its per-page pageToken
+    // checkpoint (written above) but never advances past it to a sync
+    // token, so a subsequent incremental sync can't run against
+    // unpersisted/partial data.
+    await updateSync(Resource_Sync.EVENTS, userId, calendar.source.calendarId, {
+      nextSyncToken: syncToken,
+    });
 
     const duration = (performance.now() - startTime) / 1000;
     logger.info(


### PR DESCRIPTION
## Summary
- `initializeGoogleCalendarSync` now imports events for every active owner/writer/reader Google calendar (bounded concurrency of 4 via the existing `createConcurrencyLimiter`), not just primary. `freeBusyReader` calendars get a `CalendarRecord` from reconciliation but no event import — their availability comes from the bounded `freeBusy.query` contract (packet 01), never synthetic events.
- Removes the Mongo transaction wrapper around each calendar's import. `SyncImport.importAllEvents` already persists per-page progress (events + `nextPageToken` checkpoint) as it goes; without a surrounding transaction, a later page's failure no longer rolls back earlier pages, so a partially-failed calendar retains its progress and can be retried in isolation instead of re-importing from scratch or dragging down calendars that already succeeded.
- One calendar's import failure no longer aborts the others — isolated via `Promise.allSettled`, with a structured `failedCalendars` list returned and logged (Compass `_id` only, no Google ids/titles/tokens). Only a primary-calendar failure fails the whole sync (matches pre-packet behavior when only primary existed).
- **Bug fix found along the way**: `importAllEvents` computed a final `nextSyncToken` but never persisted it — a completed full import could never be followed by incremental sync. Fixed, gated on successful loop completion so a sync token still only becomes durable once the whole calendar succeeds.

Packet 04 steps 4-8 ([handoff/someday/04-initial-multi-calendar-import.md](handoff/someday/04-initial-multi-calendar-import.md)); builds on #2036 (request context/retry) and #2038 (pagination/eligibility). Step 9 (per-calendar watch fan-out) and steps 10-11 (logging/docs) are separate follow-up phases — watches still start only for primary + CalendarList, unchanged from before this PR.

## Test plan
- [x] `bun run type-check` — clean
- [x] Focused suites (`google-sync`, `google-import`, `calendar.service`, `concurrency-limiter`) — 7 suites / 44 tests, including an end-to-end resumability test (page 2 throws → page 1's event and pageToken checkpoint survive, sync token doesn't advance → retry resumes from the checkpoint without duplicating, final token persists correctly)
- [x] Broader sync/watch/import/event-propagation suites (unaffected consumers) — 23 suites / 159 tests
- [x] `bun run lint` — 0 errors
- [x] `/simplify` pass — reviewed, nothing to change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>