### PR TITLE
fix(web): match someday event text and cursor

### DIFF
--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
@@ -59,6 +59,8 @@ describe("SomedayEvent", () => {
     expect(event.style.getPropertyValue("--someday-event-hover-bg")).toBe(
       gridHoverColorByPriority[Priorities.WORK],
     );
+    expect(event.className).toContain("text-text-dark");
+    expect(event.className).toContain("hover:cursor-pointer");
   });
 
   it("does not open the row when Space is pressed on an inner action button", () => {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
@@ -76,7 +76,7 @@ export const SomedayEvent = ({
   return (
     <div
       {...somedayEventProps}
-      className="group w-full cursor-grab rounded-xs bg-(--someday-event-bg) px-2 py-0.75 text-text-lighter text-xs transition-[background-color_.2s,opacity_.12s,box-shadow_.2s] hover:bg-(--someday-event-hover-bg) focus-visible:outline-1 focus-visible:outline-accent-primary focus-visible:outline-offset-1 data-[dragging=true]:pointer-events-none data-[dragging=true]:cursor-grabbing data-[dragging=true]:opacity-0"
+      className="group w-full cursor-grab rounded-xs bg-(--someday-event-bg) px-2 py-0.75 text-text-dark text-xs transition-[background-color_.2s,opacity_.12s,box-shadow_.2s] hover:cursor-pointer hover:bg-(--someday-event-hover-bg) focus-visible:outline-1 focus-visible:outline-accent-primary focus-visible:outline-offset-1 data-[dragging=true]:pointer-events-none data-[dragging=true]:cursor-grabbing data-[dragging=true]:opacity-0"
       data-dragging={isDragging}
       style={
         {


### PR DESCRIPTION
## Summary

- match Someday event text color to equivalent calendar grid events
- use a pointer cursor when hovering the Someday event row
- preserve the grab cursor for drag behavior and add regression assertions

## Root cause

The Someday row explicitly used the lighter text token and only declared a grab cursor. Grid events inherit dark text and add a hover pointer cursor.

## Validation

- focused SomedayEvent test
- bun type-check
- Biome check