### PR TITLE
feat(web): navigate weeks with horizontal scroll

### DIFF
--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
@@ -29,6 +29,7 @@ import { useDateCalcs } from "@web/views/Week/hooks/grid/useDateCalcs";
 import { useGridLayout } from "@web/views/Week/hooks/grid/useGridLayout";
 import { useScroll } from "@web/views/Week/hooks/grid/useScroll";
 import { useVisibleDayCount } from "@web/views/Week/hooks/grid/useVisibleDayCount";
+import { useHorizontalWeekNavigation } from "@web/views/Week/hooks/useHorizontalWeekNavigation";
 import { usePlannerSidebarCalendarDate } from "@web/views/Week/hooks/usePlannerSidebarCalendarDate";
 import { useToday } from "@web/views/Week/hooks/useToday";
 import { useWeek } from "@web/views/Week/hooks/useWeek";
@@ -51,6 +52,12 @@ export const WeekView = () => {
   const { trackRef, visibleDayCount } = useVisibleDayCount();
 
   const weekProps = useWeek(today, visibleDayCount);
+  const mainRef = useRef<HTMLDivElement | null>(null);
+  useHorizontalWeekNavigation({
+    containerRef: mainRef,
+    onNext: weekProps.util.incrementWeek,
+    onPrevious: weekProps.util.decrementWeek,
+  });
 
   const { gridRefs, measurements } = useGridLayout(visibleDayCount);
 
@@ -153,6 +160,7 @@ export const WeekView = () => {
               </ContextMenuWrapper>
               <div
                 id={ID_MAIN}
+                ref={mainRef}
                 className="flex h-screen flex-1 flex-col overflow-hidden bg-bg-primary pt-5 pr-0 pb-0 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
               >
                 <Header scrollUtil={scrollUtil} weekProps={weekProps} />

--- a/packages/web/src/views/Week/hooks/useHorizontalWeekNavigation.test.tsx
+++ b/packages/web/src/views/Week/hooks/useHorizontalWeekNavigation.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { type FC, useRef } from "react";
+import { useHorizontalWeekNavigation } from "@web/views/Week/hooks/useHorizontalWeekNavigation";
+import { describe, expect, it, mock } from "bun:test";
+
+const Harness: FC<{
+  onNext: () => void;
+  onPrevious: () => void;
+}> = ({ onNext, onPrevious }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useHorizontalWeekNavigation({ containerRef, onNext, onPrevious });
+
+  return <div ref={containerRef} data-testid="calendar" />;
+};
+
+describe("useHorizontalWeekNavigation", () => {
+  it("navigates once when a horizontal gesture crosses the threshold", () => {
+    const onNext = mock();
+    render(<Harness onNext={onNext} onPrevious={mock()} />);
+
+    const calendar = screen.getByTestId("calendar");
+    fireEvent.wheel(calendar, { deltaX: 35, deltaY: 2 });
+    fireEvent.wheel(calendar, { deltaX: 35, deltaY: 2 });
+    fireEvent.wheel(calendar, { deltaX: 100, deltaY: 2 });
+
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates backward for a leftward gesture", () => {
+    const onPrevious = mock();
+    render(<Harness onNext={mock()} onPrevious={onPrevious} />);
+
+    fireEvent.wheel(screen.getByTestId("calendar"), {
+      deltaX: -70,
+      deltaY: 0,
+    });
+
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hijack vertical scrolling or pinch zoom", () => {
+    const onNext = mock();
+    const onPrevious = mock();
+    render(<Harness onNext={onNext} onPrevious={onPrevious} />);
+
+    const calendar = screen.getByTestId("calendar");
+    fireEvent.wheel(calendar, { deltaX: 20, deltaY: 80 });
+    fireEvent.wheel(calendar, { ctrlKey: true, deltaX: 80, deltaY: 0 });
+
+    expect(onNext).not.toHaveBeenCalled();
+    expect(onPrevious).not.toHaveBeenCalled();
+  });
+
+  it("preserves horizontal scrolling inside an overflowing calendar area", () => {
+    const onNext = mock();
+    render(<Harness onNext={onNext} onPrevious={mock()} />);
+
+    const calendar = screen.getByTestId("calendar");
+    const scrollArea = document.createElement("div");
+    Object.defineProperties(scrollArea, {
+      clientWidth: { value: 100 },
+      scrollWidth: { value: 200 },
+    });
+    calendar.append(scrollArea);
+
+    fireEvent.wheel(scrollArea, { deltaX: 80, deltaY: 0 });
+
+    expect(onNext).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/views/Week/hooks/useHorizontalWeekNavigation.ts
+++ b/packages/web/src/views/Week/hooks/useHorizontalWeekNavigation.ts
@@ -74,11 +74,11 @@ export const useHorizontalWeekNavigation = ({
       if (Math.abs(accumulatedDelta) < NAVIGATION_THRESHOLD_PX) return;
 
       hasNavigated = true;
-      if (accumulatedDelta > 0) {
-        callbacksRef.current.onNext();
-      } else {
-        callbacksRef.current.onPrevious();
-      }
+      const navigate =
+        accumulatedDelta > 0
+          ? callbacksRef.current.onNext
+          : callbacksRef.current.onPrevious;
+      navigate();
     };
 
     container.addEventListener("wheel", handleWheel, { passive: false });

--- a/packages/web/src/views/Week/hooks/useHorizontalWeekNavigation.ts
+++ b/packages/web/src/views/Week/hooks/useHorizontalWeekNavigation.ts
@@ -1,0 +1,91 @@
+import { type RefObject, useEffect, useRef } from "react";
+
+const GESTURE_IDLE_MS = 180;
+const NAVIGATION_THRESHOLD_PX = 60;
+
+type HorizontalWeekNavigationOptions = {
+  containerRef: RefObject<HTMLElement | null>;
+  onNext: () => void;
+  onPrevious: () => void;
+};
+
+const canScrollHorizontally = (
+  target: EventTarget | null,
+  container: HTMLElement,
+  deltaX: number,
+) => {
+  let element = target instanceof HTMLElement ? target : null;
+
+  while (element && element !== container) {
+    const maxScrollLeft = element.scrollWidth - element.clientWidth;
+    if (
+      maxScrollLeft > 0 &&
+      (deltaX > 0 ? element.scrollLeft < maxScrollLeft : element.scrollLeft > 0)
+    ) {
+      return true;
+    }
+    element = element.parentElement;
+  }
+
+  return false;
+};
+
+export const useHorizontalWeekNavigation = ({
+  containerRef,
+  onNext,
+  onPrevious,
+}: HorizontalWeekNavigationOptions) => {
+  const callbacksRef = useRef({ onNext, onPrevious });
+
+  useEffect(() => {
+    callbacksRef.current = { onNext, onPrevious };
+  }, [onNext, onPrevious]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let accumulatedDelta = 0;
+    let hasNavigated = false;
+    let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const resetGesture = () => {
+      accumulatedDelta = 0;
+      hasNavigated = false;
+    };
+
+    const handleWheel = (event: WheelEvent) => {
+      if (
+        event.ctrlKey ||
+        event.metaKey ||
+        Math.abs(event.deltaX) <= Math.abs(event.deltaY) ||
+        canScrollHorizontally(event.target, container, event.deltaX)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      clearTimeout(resetTimer);
+      resetTimer = setTimeout(resetGesture, GESTURE_IDLE_MS);
+
+      if (hasNavigated) return;
+
+      accumulatedDelta += event.deltaX;
+      if (Math.abs(accumulatedDelta) < NAVIGATION_THRESHOLD_PX) return;
+
+      hasNavigated = true;
+      if (accumulatedDelta > 0) {
+        callbacksRef.current.onNext();
+      } else {
+        callbacksRef.current.onPrevious();
+      }
+    };
+
+    container.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      clearTimeout(resetTimer);
+      container.removeEventListener("wheel", handleWheel);
+    };
+  }, [containerRef]);
+};


### PR DESCRIPTION
## Summary

Adds deliberate horizontal trackpad navigation to the week calendar so users can move forward and backward without reaching for navigation buttons or shortcuts. The gesture reuses the existing week navigation and adjacent-event prefetch path, while preserving vertical scrolling, pinch zoom, and legitimate horizontal overflow on constrained screens.

Closes #1048.

## Simplicity

The implementation adds one focused hook and reuses the existing week navigation callbacks instead of introducing parallel date state. A small follow-up refactor removes mirrored direction branches. The DOM ref scopes native wheel handling to the calendar; the callback ref prevents stale navigation callbacks; and the effects keep callback references current while owning non-passive listener setup and cleanup. No `useState` was added.

## Manual Testing Steps

- [ ] Open the week calendar and make a deliberate horizontal trackpad gesture to the right; confirm the next displayed week appears.
- [ ] Make a deliberate horizontal gesture to the left; confirm the previous displayed week returns.
- [ ] Scroll vertically or diagonally over the calendar; confirm the displayed dates do not change.
- [ ] At a viewport narrow enough for the calendar to overflow horizontally, scroll within the calendar; confirm the content scrolls before the gesture navigates away from the displayed dates.
- [ ] Pinch to zoom over the calendar; confirm it does not navigate weeks.

## Test plan

- [x] `bun test --cwd packages/web src/views/Week/hooks/useHorizontalWeekNavigation.test.tsx` — 4 passed
- [x] `bun test:web` — 1,257 passed
- [x] `bun type-check`
- [x] `bun lint` — passes with pre-existing warnings only
- [x] React Doctor changed-file scan — no issues, 90/100
- [x] Real Chrome walkthrough covering forward, backward, vertical/diagonal, and constrained-width overflow behavior
- [x] Push-triggered GitHub Actions Test workflow — type-check and core/web/backend/scripts jobs passed