### PR TITLE
feat(backend): watch every imported calendar, redact google ids from logs

### DIFF
--- a/handoff/someday/04-initial-multi-calendar-import.md
+++ b/handoff/someday/04-initial-multi-calendar-import.md
@@ -51,29 +51,30 @@ Depends on: `03-event-runtime-cutover.md`.
    Preserve existing Compass `isVisible`; use Google's `selected` only to seed
    it in `$setOnInsert`. Mark stale Google calendars inactive only after a
    complete list is available; never delete their preference/identity row.
-4. For owner/writer/reader calendars, import Events with the final Compass
+4. [x] For owner/writer/reader calendars, import Events with the final Compass
    calendar `_id` so every event is correctly owned and persist an Events sync
    token per calendar. For `freeBusyReader`, persist only calendar metadata;
    availability is fetched through the bounded range-query contract in `01`,
    never stored as synthetic events. Persist one CalendarList sync token per
    user.
-5. Use the existing concurrency-limiter utility with a small configurable
+5. [x] Use the existing concurrency-limiter utility with a small configurable
    calendar concurrency (start at 4). Bound recurring-instance expansion too;
    do not replace rate control with fixed sleeps.
-6. Make each calendar resumable with its page token. A failed calendar reports
-   failure and retains progress; successful calendars need not be reimported on
-   retry.
-7. Remove the outer transaction around Google network work. Commit each event
-   batch and its resumable progress together; a final sync token becomes durable
-   only after the full calendar succeeds.
-8. Treat rejected event work as an import failure with a structured summary.
-   Do not advance a final sync token past unpersisted changes.
-9. Start the CalendarList watch and each event-capable calendar's Events watch
-   only after the matching final sync token is durable. Do not create Events
-   watches for `freeBusyReader` calendars. Watch failure marks sync attention
-   but does not erase successfully imported events.
-10. Publish accurate `eventsCount`/`calendarsCount` and per-calendar structured
-    logs without titles, Google ids, tokens, or user emails.
+6. [x] Make each calendar resumable with its page token. A failed calendar
+   reports failure and retains progress; successful calendars need not be
+   reimported on retry.
+7. [x] Remove the outer transaction around Google network work. Commit each
+   event batch and its resumable progress together; a final sync token
+   becomes durable only after the full calendar succeeds.
+8. [x] Treat rejected event work as an import failure with a structured
+   summary. Do not advance a final sync token past unpersisted changes.
+9. [x] Start the CalendarList watch and each event-capable calendar's Events
+   watch only after the matching final sync token is durable. Do not create
+   Events watches for `freeBusyReader` calendars. Watch failure marks sync
+   attention but does not erase successfully imported events. (this PR)
+10. [x] Publish accurate `eventsCount`/`calendarsCount` and per-calendar
+    structured logs without titles, Google ids, tokens, or user emails.
+    (this PR)
 11. Update sync/import docs to distinguish eligible, active, visible, writable,
     and watched calendars.
 

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -106,12 +106,10 @@ export class SyncController {
       return;
     }
 
-    const { user: userId, gCalendarId } = watch;
+    const { user: userId } = watch;
     logger.warn("Recovering Google sync after missing sync token", {
       userId,
-      gCalendarId,
       channelId,
-      resourceId,
     });
 
     const metadata = await userMetadataService.fetchUserMetadata(

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.test.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.test.ts
@@ -1,5 +1,6 @@
 import { ObjectId } from "mongodb";
 import { createMockCalendarListEntry } from "@core/__tests__/helpers/gcal.factory";
+import { Resource_Sync } from "@core/types/sync.types";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
@@ -319,6 +320,78 @@ describe("googleCalendarSyncService", () => {
         ]),
         expect.anything(),
       );
+    });
+
+    it("starts an Events watch for every successfully-imported event-capable calendar plus exactly one CalendarList watch", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "primary-cal",
+          primary: true,
+          accessRole: "owner",
+        }),
+        createMockCalendarListEntry({
+          id: "reader-cal",
+          primary: false,
+          accessRole: "reader",
+        }),
+        createMockCalendarListEntry({
+          id: "broken-cal",
+          primary: false,
+          accessRole: "writer",
+        }),
+        createMockCalendarListEntry({
+          id: "freebusy-cal",
+          primary: false,
+          accessRole: "freeBusyReader",
+        }),
+      ];
+
+      const importAllEvents = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _userId: string,
+            calendar: { source: { calendarId: string } },
+          ) => {
+            if (calendar.source.calendarId === "broken-cal") {
+              throw new Error("simulated calendar import failure");
+            }
+            return {
+              totalProcessed: 1,
+              totalSaved: 1,
+              totalDeleted: 0,
+              totalIgnored: 0,
+              totalInvalid: 0,
+              nextSyncToken: `token-${calendar.source.calendarId}`,
+            };
+          },
+        );
+      jest.spyOn(syncImportService, "createSyncImport").mockResolvedValue({
+        importAllEvents,
+      } as unknown as Awaited<
+        ReturnType<typeof syncImportService.createSyncImport>
+      >);
+      const startWatchesSpy = jest
+        .spyOn(googleWatchService, "startGoogleWatches")
+        .mockResolvedValue(undefined as never);
+
+      await googleCalendarSyncService.initializeGoogleCalendarSync(userId);
+
+      expect(startWatchesSpy).toHaveBeenCalledTimes(1);
+      const watchParams = startWatchesSpy.mock.calls[0]?.[1] ?? [];
+      const gCalendarIds = watchParams.map((p) => p.gCalendarId);
+
+      expect(
+        gCalendarIds.filter((id) => id === Resource_Sync.CALENDAR),
+      ).toHaveLength(1);
+      expect(gCalendarIds.sort()).toEqual(
+        [Resource_Sync.CALENDAR, "primary-cal", "reader-cal"].sort(),
+      );
+      expect(gCalendarIds).not.toContain("broken-cal");
+      expect(gCalendarIds).not.toContain("freebusy-cal");
     });
 
     it("fails the whole sync when the primary calendar's import fails", async () => {

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.ts
@@ -399,11 +399,26 @@ async function initializeGoogleCalendarSync(user: string): Promise<{
   }
 
   if (isUsingGcalWebhookHttps()) {
+    // Events watches only make sense for calendars whose import actually
+    // succeeded this run - a failed calendar's sync token isn't durable
+    // (see the comment above outcomes.forEach), so watching it would just
+    // produce notifications with nothing valid to reconcile against.
+    // freeBusyReader calendars fall out naturally since they were already
+    // excluded from importableCalendars/outcomes above.
+    const successfulCalendarIds = outcomes
+      .filter((outcome) => outcome.status === "fulfilled")
+      .map((outcome) => outcome.value.calendar.source)
+      .filter(
+        (source): source is Extract<typeof source, { provider: "google" }> =>
+          source.provider === "google",
+      )
+      .map((source) => source.calendarId);
+
     await googleWatchService.startGoogleWatches(
       user,
       [
         { gCalendarId: Resource_Sync.CALENDAR },
-        { gCalendarId: primaryCalendar.source.calendarId },
+        ...successfulCalendarIds.map((gCalendarId) => ({ gCalendarId })),
       ],
       context,
     );

--- a/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.test.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.test.ts
@@ -22,6 +22,35 @@ jest.mock("@backend/common/services/gcal/gcal.service", () => ({
   },
 }));
 
+type MockLoggerModule = {
+  __mockLogger: {
+    debug: jest.Mock;
+    error: jest.Mock;
+    info: jest.Mock;
+    verbose: jest.Mock;
+    warn: jest.Mock;
+  };
+};
+
+jest.mock("@core/logger/winston.logger", () => {
+  const mockLogger: MockLoggerModule["__mockLogger"] = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    verbose: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  return {
+    __mockLogger: mockLogger,
+    Logger: jest.fn(() => mockLogger),
+  };
+});
+
+const getMockLogger = () =>
+  (jest.requireMock("@core/logger/winston.logger") as MockLoggerModule)
+    .__mockLogger;
+
 describe("GCalNotificationHandler", () => {
   let handler: GCalNotificationHandler;
   let mockGcal: gCalendar;
@@ -33,6 +62,15 @@ describe("GCalNotificationHandler", () => {
 
   beforeAll(setupTestDb);
   beforeEach(cleanupCollections);
+
+  beforeEach(() => {
+    const mockLogger = getMockLogger();
+    mockLogger.debug.mockReset();
+    mockLogger.error.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.verbose.mockReset();
+    mockLogger.warn.mockReset();
+  });
 
   beforeEach(async () => {
     mockUserId = new ObjectId().toString();
@@ -144,6 +182,21 @@ describe("GCalNotificationHandler", () => {
       const result = await handler.handleNotification();
       expect(result.summary).toBe("IGNORED");
       expect(result.eventIds).toEqual([]);
+    });
+
+    it("should not log the raw Google calendar id when there are no changes to process", async () => {
+      (gcalService.getEvents as jest.Mock).mockResolvedValue({
+        data: { items: [] },
+      });
+
+      await handler.handleNotification();
+
+      const mockLogger = getMockLogger();
+      const loggedMessages = mockLogger.info.mock.calls.map((call) => call[0]);
+
+      for (const message of loggedMessages) {
+        expect(String(message)).not.toContain(mockCalendarId);
+      }
     });
 
     it("should return IGNORED when no owning calendar is found for the user", async () => {

--- a/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal.notification.handler.ts
@@ -48,7 +48,7 @@ export class GCalNotificationHandler {
 
     if (!calendar) {
       logger.warn(
-        `Ignoring notification because no owning calendar was found for user ${this.userId}, gCalendarId ${this.gCalendarId}`,
+        `Ignoring notification because no owning calendar was found for user ${this.userId}`,
       );
       return { summary: "IGNORED", calendarId: null, eventIds: [] };
     }
@@ -84,14 +84,14 @@ export class GCalNotificationHandler {
     // If the nextSyncToken matches our current syncToken, we've already processed these changes
     if (nextSyncToken === this.nextSyncToken) {
       logger.info(
-        `Skipping notification - changes already processed for calendar ${this.gCalendarId}`,
+        `Skipping notification - changes already processed for user: ${this.userId}`,
       );
       return { hasChanges: false, changes: [] };
     }
 
     const changes = response.data.items;
     if (!changes || changes.length === 0) {
-      logger.info(`No changes found for calendar ${this.gCalendarId}`);
+      logger.info(`No changes found for user: ${this.userId}`);
       return { hasChanges: false, changes: [] };
     }
 

--- a/packages/backend/src/sync/services/watch/google-watch.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.ts
@@ -206,7 +206,7 @@ async function handleGoogleWatchNotification(payload: Payload_Sync_Notif) {
   const result = "PROCESSED";
 
   logger.info(
-    `GCal Notification for user: ${userId}, calendarId: ${calendarId} ${result}`,
+    `GCal Notification for user: ${userId}, calendarId: ${notification.calendarId?.toHexString() ?? "unknown"} ${result}`,
   );
 
   return result;
@@ -318,7 +318,7 @@ async function startEventWatch(
 
     if (alreadyWatching) {
       logger.error(
-        `Skipped Start Watch for ${params.gCalendarId} ${Resource_Sync.EVENTS}`,
+        `Skipped Start Watch for ${Resource_Sync.EVENTS} (user: ${user})`,
         WatchError.EventWatchExists,
       );
 


### PR DESCRIPTION
## Summary
- `initializeGoogleCalendarSync` now starts an Events watch for every calendar whose import succeeded this run (owner/writer/reader only — `freeBusyReader` and any failed calendar are excluded), alongside the one CalendarList watch, instead of only watching primary.
- A watch failure still can't erase already-imported events: `startEventWatch`/`startCalendarListWatch` already catch and report per-watch failures internally rather than throwing, so this required no change beyond widening the watch-param list — confirmed by reading both functions.
- Fixes several log lines in the notification/watch/sync-recovery path that interpolated raw Google calendar ids, watch resource ids, or other Google-assigned values directly into log messages, substituting Compass-internal identifiers (or dropping the value where none was resolvable in scope).

Packet 04 steps 9-10 ([handoff/someday/04-initial-multi-calendar-import.md](handoff/someday/04-initial-multi-calendar-import.md)); builds on #2036, #2038, #2040. Step 11 (docs) and a broader logging audit beyond this packet's sync/calendar/gcal/event paths are left for later.

## Test plan
- [x] `bun run type-check` — clean
- [x] Focused suites (`google-sync`, `google-watch`, `notification.handler`, `sync.controller`) — 10 suites / 74 tests
- [x] `bun run lint` — 0 errors
- [x] `/simplify` pass — reviewed, nothing to change

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>