### PR TITLE
docs(someday): close out packet 04 checkboxes and calendar lifecycle doc

### DIFF
--- a/docs/features/google-sync-and-sse-flow.md
+++ b/docs/features/google-sync-and-sse-flow.md
@@ -220,6 +220,30 @@ Auto-import guardrail:
 
 - client auto-starts import only when `sync.importGCal === "RESTART"` **and** `google.connectionState` is not `NOT_CONNECTED` or `RECONNECT_REQUIRED`
 
+## Calendar Import And Lifecycle
+
+Compass imports every eligible Google calendar, not just primary. Five distinct
+states apply to a Google-sourced `CalendarRecord` — a calendar can be `true` on
+some and `false` on others independently (e.g. active + not currently watched,
+if its last import attempt failed):
+
+| State        | Meaning                                                                                                                                       | Source                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Eligible** | Present in Google's CalendarList with `deleted !== true` and `hidden !== true`. Determines whether Compass keeps a `CalendarRecord` at all.  | `getCalendarsToSync` (`sync/services/init/google-sync-init.ts`)                              |
+| **Active**   | `CalendarRecord.isActive`. Reconciled from the eligible list on every CalendarList sync; a calendar that drops out of a later, complete list is archived (`isActive: false`), never deleted — its identity/preference row survives (A16). | `calendarService.initializeGoogleCalendars` (`calendar/services/calendar.service.ts`)        |
+| **Visible**  | `CalendarRecord.isVisible`. A Compass user preference, seeded from Google's `selected` only on first insert and never overwritten by a later sync (A3). | `mapGoogleCalendar` (`calendar/calendar.record.mapper.ts`)                                   |
+| **Writable** | Derived from `CalendarRecord.access` (`owner`/`writer` writable; `reader`/`freeBusyReader` not). Not a stored field.                          | `getCalendarCapabilities` (`packages/core/src/types/calendar.contracts.ts`)                  |
+| **Watched**  | Compass currently holds a live Events webhook subscription. Only active, event-capable (`owner`/`writer`/`reader`) calendars whose most recent import succeeded are watched; `freeBusyReader` calendars are never watched (no Events resource to subscribe to). | `initializeGoogleCalendarSync` (`sync/services/google-sync/google-sync.service.ts`)          |
+
+Event import mirrors access role: `owner`/`writer`/`reader` calendars get their
+events imported (with per-calendar bounded concurrency and a resumable,
+per-calendar sync token); `freeBusyReader` calendars get only a `CalendarRecord`
+— their live availability comes from a bounded `freeBusy.query` contract, never
+synthetic events. One calendar's import failure is isolated and does not abort
+the others (only a primary-calendar failure fails the whole sync); a failed
+calendar retains whatever pages it already durably imported and can be retried
+without duplicating work.
+
 ## Import Flow
 
 1. Backend starts import.

--- a/handoff/someday/04-initial-multi-calendar-import.md
+++ b/handoff/someday/04-initial-multi-calendar-import.md
@@ -41,42 +41,54 @@ Depends on: `03-event-runtime-cutover.md`.
      `07` then owns only inspection, repair, the lease, and coverage tests.
    Shipped in PR #2036 (`GoogleRequestContext`, `withGoogleRetry`,
    `CHANNEL_EXPIRATION_MIN` default raised to 10080 minutes / 7 days).
-1. Replace the single-page helper with a CalendarList page generator that
+1. [x] Replace the single-page helper with a CalendarList page generator that
    preserves the original request parameters, follows `nextPageToken`, and
-   returns `nextSyncToken` only from the final page.
-2. Filter only `deleted` or `hidden` entries. Keep readers/free-busy readers.
-   Deduplicate by Google calendar id, assert one primary calendar at most, and
-   preserve Google's intentionally redacted private-event details.
-3. Reconcile calendars with bulk upserts keyed by user/provider/provider id.
-   Preserve existing Compass `isVisible`; use Google's `selected` only to seed
-   it in `$setOnInsert`. Mark stale Google calendars inactive only after a
-   complete list is available; never delete their preference/identity row.
+   returns `nextSyncToken` only from the final page. Shipped in PR #2038.
+2. [x] Filter only `deleted` or `hidden` entries. Keep readers/free-busy
+   readers. Deduplicate by Google calendar id, assert one primary calendar at
+   most, and preserve Google's intentionally redacted private-event details.
+   Shipped in PR #2038.
+3. [x] Reconcile calendars with bulk upserts keyed by user/provider/provider
+   id. Preserve existing Compass `isVisible`; use Google's `selected` only to
+   seed it in `$setOnInsert`. Mark stale Google calendars inactive only after
+   a complete list is available; never delete their preference/identity row.
+   Already implemented generically in `calendar.service.ts` prior to this
+   packet; confirmed correct once PR #2038 supplied the full eligible list.
 4. [x] For owner/writer/reader calendars, import Events with the final Compass
    calendar `_id` so every event is correctly owned and persist an Events sync
    token per calendar. For `freeBusyReader`, persist only calendar metadata;
    availability is fetched through the bounded range-query contract in `01`,
    never stored as synthetic events. Persist one CalendarList sync token per
-   user.
+   user. Shipped in PR #2040.
 5. [x] Use the existing concurrency-limiter utility with a small configurable
    calendar concurrency (start at 4). Bound recurring-instance expansion too;
-   do not replace rate control with fixed sleeps.
+   do not replace rate control with fixed sleeps. Shipped in PR #2040
+   (recurring-instance expansion confirmed already page-bounded via
+   `getBaseRecurringEventInstances`; no separate limiter needed there).
 6. [x] Make each calendar resumable with its page token. A failed calendar
    reports failure and retains progress; successful calendars need not be
-   reimported on retry.
+   reimported on retry. Shipped in PR #2040.
 7. [x] Remove the outer transaction around Google network work. Commit each
    event batch and its resumable progress together; a final sync token
-   becomes durable only after the full calendar succeeds.
+   becomes durable only after the full calendar succeeds. Shipped in PR #2040
+   (also fixed a pre-existing bug: `importAllEvents` computed but never
+   persisted its final `nextSyncToken`).
 8. [x] Treat rejected event work as an import failure with a structured
    summary. Do not advance a final sync token past unpersisted changes.
+   Shipped in PR #2040.
 9. [x] Start the CalendarList watch and each event-capable calendar's Events
    watch only after the matching final sync token is durable. Do not create
    Events watches for `freeBusyReader` calendars. Watch failure marks sync
-   attention but does not erase successfully imported events. (this PR)
+   attention but does not erase successfully imported events. Shipped in PR
+   #2043.
 10. [x] Publish accurate `eventsCount`/`calendarsCount` and per-calendar
     structured logs without titles, Google ids, tokens, or user emails.
-    (this PR)
-11. Update sync/import docs to distinguish eligible, active, visible, writable,
-    and watched calendars.
+    Shipped in PR #2043 (scoped to sync/calendar/gcal/event log paths; a
+    known remaining leak in `google-import.service.ts`'s existing log lines
+    was flagged, not fixed, since that file was out of this step's scope).
+11. [x] Update sync/import docs to distinguish eligible, active, visible,
+    writable, and watched calendars. Added to
+    `docs/Features/google-sync-and-sse-flow.md`.
 
 ## Tests
 
@@ -100,10 +112,12 @@ Depends on: `03-event-runtime-cutover.md`.
 
 ## Exit criteria
 
-- [ ] Initial sync imports all and only eligible calendars.
-- [ ] Each imported event references the correct Compass calendar.
-- [ ] Pagination, retry, concurrency, and partial failure are deterministic.
-- [ ] Every archived #553 acceptance criterion and its performance guidance is
-      covered by implementation and test evidence.
+- [x] Initial sync imports all and only eligible calendars.
+- [x] Each imported event references the correct Compass calendar.
+- [x] Pagination, retry, concurrency, and partial failure are deterministic.
+- [x] Every archived #553 acceptance criterion and its performance guidance is
+      covered by implementation and test evidence (all eligible calendars
+      import with tokens, resume behavior, scale limits at 25 calendars, and
+      partial-failure tests — `00-project-ledger.md`'s summary of #553).
 
 Suggested commit: `feat(backend): import all google calendars`

--- a/handoff/someday/master-doc.md
+++ b/handoff/someday/master-doc.md
@@ -59,10 +59,10 @@ unfinished.
       migration (A32).
 - [x] 03. [Event runtime cutover](./03-event-runtime-cutover.md) — move the codebase
       from the legacy user-owned event shape to calendar-owned storage.
-- [ ] 04. [Initial multi-calendar import](./04-initial-multi-calendar-import.md) —
+- [x] 04. [Initial multi-calendar import](./04-initial-multi-calendar-import.md) —
       import all eligible Google calendars and events; starts with the request
       context, retry policy, and 7-day channel expiration pulled forward from
-      `07` (A30).
+      `07` (A30). Shipped in PRs #2036, #2038, #2040, #2043.
 - [ ] 05. [Calendar-aware CRUD](./05-calendar-aware-crud.md) — route writes to the
       correct provider calendar and enforce permissions.
 - [ ] 06. [Calendar-list sync and watch routing](./06-calendar-list-sync-and-watch-routing.md)
@@ -114,8 +114,11 @@ unfinished.
   and selection routes, and Google calendar mapping already exist.
 - `POST /api/calendars` accepts a client-supplied calendar document even though
   v1 calendar lifecycle is server-owned; the plan removes that unused authority.
-- `getCalendarsToSync()` intentionally returns only the primary Google
-  calendar, so the current initial and incremental flows remain single-calendar.
+- `getCalendarsToSync()` returns every eligible Google calendar (packet `04`,
+  PRs #2036/#2038/#2040/#2043) and initial sync imports/watches all of them;
+  `importLatestGoogleCalendarChanges` (the incremental/webhook-triggered path)
+  remains intentionally primary-only, since multi-calendar incremental sync is
+  driven by per-calendar watches rather than this function.
 - `event_new.types.ts` and an `event_new` collection/backfill exist, but the
   application still reads/writes the legacy `event` collection and legacy
   `Schema_Event` with a `user` field.


### PR DESCRIPTION
## Summary
- Checks off packet 04 steps 1-3 (shipped earlier in #2038 but not marked at the time) and adds PR references to steps 4-10.
- Checks off step 11, adding a "Calendar Import And Lifecycle" section to [docs/Features/google-sync-and-sse-flow.md](docs/Features/google-sync-and-sse-flow.md) distinguishing the five independent calendar states: eligible, active, visible, writable, watched.
- Checks off packet 04's exit criteria and the top-level execution box in [master-doc.md](handoff/someday/master-doc.md), and updates its stale current-state summary line (previously said `getCalendarsToSync()` "intentionally returns only the primary Google calendar" — no longer true).

Closes out packet 04. Next up per master-doc.md's ordered execution: packet 05 (calendar-aware CRUD).

## Test plan
- Docs-only change; no code touched.
- [x] `bun run lint` — 0 errors (15 pre-existing unrelated web warnings)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>