### PR TITLE
fix(web): restore someday drag cursor

### DIFF
--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
@@ -62,7 +62,9 @@ describe("SomedayEvent", () => {
     expect(event.className).toContain("text-text-dark");
     expect(event.className).toContain("hover:cursor-pointer");
     expect(
-      event.querySelector("[data-someday-drag-affordance]")?.className.baseVal,
+      event
+        .querySelector("[data-someday-drag-affordance]")
+        ?.getAttribute("class"),
     ).toContain("cursor-grab");
   });
 

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
@@ -61,6 +61,9 @@ describe("SomedayEvent", () => {
     );
     expect(event.className).toContain("text-text-dark");
     expect(event.className).toContain("hover:cursor-pointer");
+    expect(
+      event.querySelector("[data-someday-drag-affordance]")?.className.baseVal,
+    ).toContain("cursor-grab");
   });
 
   it("does not open the row when Space is pressed on an inner action button", () => {

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventRectangle.tsx
@@ -42,7 +42,7 @@ export const SomedayEventRectangle = ({
         >
           <DotsSixVertical
             aria-hidden="true"
-            className="shrink-0 text-text-light"
+            className="shrink-0 cursor-grab text-text-light"
             data-someday-drag-affordance="true"
             size={14}
             weight="bold"


### PR DESCRIPTION
## Summary

- keep the Someday event row pointer cursor on its empty area
- restore the grab cursor over the vertical drag dots
- add a regression assertion for the nested drag affordance

## Root cause

The row-level hover pointer utility applied to the entire row, including the vertical drag affordance.

## Simplicity

Added one cursor utility to the existing drag affordance; no new state or abstraction.

## Manual Testing Steps

- [ ] Hover over the empty area of a Someday event row and confirm the pointer cursor.
- [ ] Hover over the vertical dots and confirm the grab hand cursor.

## Test plan

- [x] Focused SomedayEvent test
- [x] Biome check
- [x] Diff validation