### PR TITLE
feat(backend): enforce calendar write capability on event mutations

### DIFF
--- a/packages/backend/src/event/services/event.service.test.ts
+++ b/packages/backend/src/event/services/event.service.test.ts
@@ -8,6 +8,11 @@ import {
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import mongoService from "@backend/common/services/mongo.service";
 import eventService from "@backend/event/services/event.service";
+import {
+  buildEventRecord,
+  seedGoogleCalendar,
+  seedLocalCalendar as seedLocalCalendarHelper,
+} from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
 
 const seedLocalCalendar = async (userId: ObjectId) => {
   const record = CalendarRecordSchema.parse({
@@ -336,5 +341,229 @@ describe("EventService (local calendar)", () => {
         created._id.toHexString(),
       ),
     ).toBeTruthy();
+  });
+});
+
+describe("EventService (calendar write-capability enforcement)", () => {
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  const createInput = (calendarId: string) => ({
+    calendarId: calendarId as never,
+    content: { kind: "details" as const, title: "Standup", description: "" },
+    schedule: {
+      kind: "timed" as const,
+      start: "2026-07-14T15:00:00-06:00",
+      end: "2026-07-14T16:00:00-06:00",
+      timeZone: "America/Denver" as never,
+    },
+    recurrence: { kind: "single" as const },
+    priority: "unassigned" as const,
+  });
+
+  const replaceInput = () => ({
+    content: { kind: "details" as const, title: "Updated", description: "" },
+    schedule: {
+      kind: "timed" as const,
+      start: "2026-07-14T15:00:00-06:00",
+      end: "2026-07-14T16:00:00-06:00",
+      timeZone: "America/Denver" as never,
+    },
+    recurrence: { kind: "single" as const },
+    priority: "unassigned" as const,
+    scope: "this" as const,
+  });
+
+  const somedayCreateInput = (calendarId: string) => ({
+    calendarId: calendarId as never,
+    content: { kind: "details" as const, title: "Plan trip", description: "" },
+    schedule: {
+      kind: "someday" as const,
+      period: "week" as const,
+      anchorDate: "2026-07-13",
+      sortOrder: 0,
+    },
+    recurrence: { kind: "single" as const },
+    priority: "unassigned" as const,
+  });
+
+  const scheduleTransitionInput = (targetCalendarId: string) => ({
+    kind: "schedule" as const,
+    targetCalendarId: targetCalendarId as never,
+    schedule: {
+      kind: "timed" as const,
+      start: "2026-07-14T15:00:00-06:00",
+      end: "2026-07-14T16:00:00-06:00",
+      timeZone: "America/Denver" as never,
+    },
+  });
+
+  it("create succeeds on a writer calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(user._id, { access: "writer" });
+
+    const created = await eventService.create(
+      user._id.toString(),
+      createInput(calendar._id.toHexString()),
+    );
+
+    expect(created.calendarId).toEqual(calendar._id);
+  });
+
+  it("create fails with CALENDAR_READ_ONLY on a reader calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(user._id, { access: "reader" });
+
+    await expect(
+      eventService.create(
+        user._id.toString(),
+        createInput(calendar._id.toHexString()),
+      ),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_READ_ONLY" });
+  });
+
+  it("create fails with CALENDAR_READ_ONLY on a freeBusyReader calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(user._id, {
+      access: "freeBusyReader",
+    });
+
+    await expect(
+      eventService.create(
+        user._id.toString(),
+        createInput(calendar._id.toHexString()),
+      ),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_READ_ONLY" });
+  });
+
+  it("create fails with CALENDAR_NOT_FOUND for a cross-user calendar id", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const { user: otherUser } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(otherUser._id, {
+      access: "writer",
+    });
+
+    await expect(
+      eventService.create(
+        user._id.toString(),
+        createInput(calendar._id.toHexString()),
+      ),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_NOT_FOUND" });
+  });
+
+  it("create fails with CALENDAR_NOT_FOUND for a stale calendar id", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const staleId = new ObjectId().toHexString();
+
+    await expect(
+      eventService.create(user._id.toString(), createInput(staleId)),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_NOT_FOUND" });
+  });
+
+  it("replace succeeds on an existing event on a writer calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(user._id, { access: "writer" });
+    const event = buildEventRecord(calendar._id);
+    await mongoService.event.insertOne(event);
+
+    const replaced = await eventService.replace(
+      user._id.toString(),
+      event._id.toHexString(),
+      replaceInput() as never,
+    );
+
+    expect(replaced.content).toEqual({
+      kind: "details",
+      title: "Updated",
+      description: "",
+    });
+  });
+
+  it("replace fails with CALENDAR_READ_ONLY on an existing event on a reader calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(user._id, { access: "reader" });
+    const event = buildEventRecord(calendar._id);
+    await mongoService.event.insertOne(event);
+
+    await expect(
+      eventService.replace(
+        user._id.toString(),
+        event._id.toHexString(),
+        replaceInput() as never,
+      ),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_READ_ONLY" });
+  });
+
+  it("delete succeeds on an existing event on a writer calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(user._id, { access: "writer" });
+    const event = buildEventRecord(calendar._id);
+    await mongoService.event.insertOne(event);
+
+    await eventService.delete(user._id.toString(), event._id.toHexString(), {
+      scope: "this",
+    });
+
+    await expect(
+      eventService.readById(user._id.toString(), event._id.toHexString()),
+    ).rejects.toMatchObject({ mutationCode: "EVENT_NOT_FOUND" });
+  });
+
+  it("delete fails with CALENDAR_READ_ONLY on an existing event on a reader calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedGoogleCalendar(user._id, { access: "reader" });
+    const event = buildEventRecord(calendar._id);
+    await mongoService.event.insertOne(event);
+
+    await expect(
+      eventService.delete(user._id.toString(), event._id.toHexString(), {
+        scope: "this",
+      }),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_READ_ONLY" });
+
+    expect(
+      await eventService.readById(user._id.toString(), event._id.toHexString()),
+    ).toBeTruthy();
+  });
+
+  it("transition schedule fails with CALENDAR_READ_ONLY when the target calendar is a reader calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const local = await seedLocalCalendarHelper(user._id);
+    const readerCalendar = await seedGoogleCalendar(user._id, {
+      access: "reader",
+    });
+
+    const created = await eventService.create(
+      user._id.toString(),
+      somedayCreateInput(local._id.toHexString()),
+    );
+
+    await expect(
+      eventService.transition(
+        user._id.toString(),
+        created._id.toHexString(),
+        scheduleTransitionInput(readerCalendar._id.toHexString()),
+      ),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_READ_ONLY" });
+  });
+
+  it("transition schedule fails with CALENDAR_NOT_FOUND for a stale target calendar id", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const local = await seedLocalCalendarHelper(user._id);
+    const staleId = new ObjectId().toHexString();
+
+    const created = await eventService.create(
+      user._id.toString(),
+      somedayCreateInput(local._id.toHexString()),
+    );
+
+    await expect(
+      eventService.transition(
+        user._id.toString(),
+        created._id.toHexString(),
+        scheduleTransitionInput(staleId),
+      ),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_NOT_FOUND" });
   });
 });

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -1,4 +1,5 @@
 import { type ClientSession, ObjectId } from "mongodb";
+import { getCalendarCapabilities } from "@core/types/calendar.contracts";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
 import {
   type CreateEventInput,
@@ -8,6 +9,7 @@ import {
   type ReplaceEventInput,
   type TransitionEventInput,
 } from "@core/types/event-command.contracts";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import calendarService from "@backend/calendar/services/calendar.service";
 import mongoService from "@backend/common/services/mongo.service";
 import {
@@ -59,6 +61,32 @@ class EventService {
   private async ownedCalendarIds(userId: string): Promise<ObjectId[]> {
     const calendars = await calendarService.list(userId);
     return calendars.filter((c) => c.isActive).map((c) => c._id);
+  }
+
+  /**
+   * Resolves a calendar the user owns and is currently active, and enforces
+   * write capability derived from its access role (packet 05 step 6):
+   * reader/freeBusyReader calendars must reject mutations before any
+   * optimistic write reaches Google.
+   */
+  private async requireWritableCalendar(
+    userId: string,
+    calendarId: ObjectId | string,
+  ): Promise<CalendarRecord> {
+    const calendar = await calendarService.getOwnedActiveCalendar(
+      userId,
+      calendarId,
+    );
+    if (!calendar) {
+      throw eventMutationError("CALENDAR_NOT_FOUND", "Calendar not found");
+    }
+    if (!getCalendarCapabilities(calendar.access).canWrite) {
+      throw eventMutationError(
+        "CALENDAR_READ_ONLY",
+        "Calendar does not permit writes",
+      );
+    }
+    return calendar;
   }
 
   private async requireOwnedEvent(
@@ -133,13 +161,7 @@ class EventService {
     userId: string,
     input: CreateEventInput,
   ): Promise<EventRecord> => {
-    const calendar = await calendarService.getOwnedActiveCalendar(
-      userId,
-      input.calendarId,
-    );
-    if (!calendar) {
-      throw eventMutationError("CALENDAR_NOT_FOUND", "Calendar not found");
-    }
+    await this.requireWritableCalendar(userId, input.calendarId);
 
     if (input.id) {
       const existing = await mongoService.event.findOne({
@@ -182,6 +204,7 @@ class EventService {
     input: ReplaceEventInput,
   ): Promise<EventRecord> => {
     const target = await this.requireOwnedEvent(userId, eventId);
+    await this.requireWritableCalendar(userId, target.calendarId);
     const ownedCalendarIds = await this.ownedCalendarIds(userId);
     const series = await this.seriesContext(target, ownedCalendarIds);
     const plan = analyzeReplace(target, series, input, new Date());
@@ -209,6 +232,7 @@ class EventService {
     input: DeleteEventInput,
   ): Promise<void> => {
     const target = await this.requireOwnedEvent(userId, eventId);
+    await this.requireWritableCalendar(userId, target.calendarId);
     const ownedCalendarIds = await this.ownedCalendarIds(userId);
     const series = await this.seriesContext(target, ownedCalendarIds);
     const plan = analyzeDelete(target, series, input);
@@ -243,13 +267,10 @@ class EventService {
 
     let targetCalendarId: ObjectId | null = null;
     if (input.kind === "schedule") {
-      const calendar = await calendarService.getOwnedActiveCalendar(
+      const calendar = await this.requireWritableCalendar(
         userId,
         input.targetCalendarId,
       );
-      if (!calendar) {
-        throw eventMutationError("CALENDAR_NOT_FOUND", "Calendar not found");
-      }
       targetCalendarId = calendar._id;
     } else {
       const local = await calendarService.getLocalCalendar(userId);


### PR DESCRIPTION
## Summary
- Packet 05 (calendar-aware CRUD) phase 1: reader/freeBusyReader calendars could accept `create`/`replace`/`delete`/schedule-`transition` writes because the existing ownership+active calendar lookup (`calendarService.getOwnedActiveCalendar`) never checked access role.
- Adds a single `requireWritableCalendar` helper in `event.service.ts` on top of the existing `getCalendarCapabilities` mapper (`@core/types/calendar.contracts`) and the existing `CALENDAR_READ_ONLY` → 403 error contract, and wires it into every mutation path before any optimistic write reaches Google.
- No new authorization service — `calendar.service.ts` is unchanged; only `event.service.ts` gained the enforcement.

## Test plan
- [x] `TZ=UTC ./node_modules/.bin/jest --selectProjects backend -t "EventService"` — 21 passed
- [x] Broader backend event/calendar/sync-propagation run — no regressions
- [x] `bun run type-check`
- [x] `bun run lint`

Part of the [Google sub-calendars v1 packet 05](../../blob/main/handoff/someday/05-calendar-aware-crud.md) rollout (staging-first per A36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)