### PR TITLE
feat(web): shift week view by one day

### DIFF
--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -5,6 +5,7 @@ import {
   createRouter,
   isRedirect,
 } from "@tanstack/react-router";
+import dayjs from "@core/util/date/dayjs";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import {
   loadDateParam,
@@ -92,8 +93,10 @@ describe("router redirects", () => {
     expect(router.state.location.pathname).toBe(`/day/${dateString}`);
   });
 
-  it("redirects /week to today's dated week route", async () => {
-    const { dateString } = loadTodayData();
+  it("redirects /week to the start of the current week", async () => {
+    const dateString = dayjs()
+      .startOf("week")
+      .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
     const router = createTestRouter(["/week"]);
 
     await router.load();

--- a/packages/web/src/routers/loaders.ts
+++ b/packages/web/src/routers/loaders.ts
@@ -42,6 +42,18 @@ export function redirectToToday(
   });
 }
 
+export function redirectToCurrentWeek(): never {
+  const dateString = dayjs()
+    .startOf("week")
+    .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
+
+  throw redirect({
+    to: ROOT_ROUTES.WEEK_DATE,
+    params: { dateString },
+    search: (prev: Record<string, unknown>) => prev,
+  });
+}
+
 // Deliberately not params.parse: a throwing parser makes the route not
 // match (-> NotFound), but the existing UX redirects an invalid dateString
 // to the base route instead. Runs in beforeLoad so an invalid param never

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -9,6 +9,7 @@ import { validateAuthSearch } from "@web/components/AuthModal/hooks/useAuthModal
 import {
   loadAuthenticated,
   loadDateParam,
+  redirectToCurrentWeek,
   redirectToToday,
   validateDayDateParam,
   validateWeekDateParam,
@@ -90,7 +91,7 @@ export const weekDateRoute = createRoute({
 export const weekIndexRoute = createRoute({
   getParentRoute: () => weekRoute,
   path: "/",
-  beforeLoad: () => redirectToToday(ROOT_ROUTES.WEEK_DATE),
+  beforeLoad: redirectToCurrentWeek,
 });
 
 export const rootIndexRoute = createRoute({

--- a/packages/web/src/shortcuts/data/shortcuts.data.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.ts
@@ -16,6 +16,12 @@ const getNavigateShortcuts = ({
 }: ShortcutMenuConfig): Shortcut[] => [
   { keys: ["j"], label: `Previous ${view}` },
   { keys: ["k"], label: `Next ${view}` },
+  ...(view === "week"
+    ? [
+        { keys: ["Shift", "j"], label: "Shift view back one day" },
+        { keys: ["Shift", "k"], label: "Shift view forward one day" },
+      ]
+    : []),
   {
     keys: ["t"],
     label: isViewingCurrentPeriod

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -29,6 +29,7 @@ import { useDateCalcs } from "@web/views/Week/hooks/grid/useDateCalcs";
 import { useGridLayout } from "@web/views/Week/hooks/grid/useGridLayout";
 import { useScroll } from "@web/views/Week/hooks/grid/useScroll";
 import { useVisibleDayCount } from "@web/views/Week/hooks/grid/useVisibleDayCount";
+import { useDayShiftTransition } from "@web/views/Week/hooks/useDayShiftTransition";
 import { useHorizontalWeekNavigation } from "@web/views/Week/hooks/useHorizontalWeekNavigation";
 import { usePlannerSidebarCalendarDate } from "@web/views/Week/hooks/usePlannerSidebarCalendarDate";
 import { useToday } from "@web/views/Week/hooks/useToday";
@@ -53,11 +54,24 @@ export const WeekView = () => {
 
   const weekProps = useWeek(today, visibleDayCount);
   const mainRef = useRef<HTMLDivElement | null>(null);
+  const weekTrackElementRef = useRef<HTMLDivElement | null>(null);
+  const setTrackRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      weekTrackElementRef.current = node;
+      trackRef(node);
+    },
+    [trackRef],
+  );
   useHorizontalWeekNavigation({
     containerRef: mainRef,
     onNext: weekProps.util.incrementWeek,
     onPrevious: weekProps.util.decrementWeek,
   });
+  useDayShiftTransition(
+    weekTrackElementRef,
+    weekProps.component.startOfView,
+    weekProps.util.getLastNavigationSource(),
+  );
 
   const { gridRefs, measurements } = useGridLayout(visibleDayCount);
 
@@ -167,7 +181,7 @@ export const WeekView = () => {
 
                 <WeekGridScrollArea>
                   <div
-                    ref={trackRef}
+                    ref={setTrackRef}
                     className="@container relative flex h-full w-full min-w-47.5 flex-col [container-name:week-grid-track]"
                   >
                     <DayLabels

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
@@ -175,6 +175,7 @@ const createWeekProps = () => ({
     getLastNavigationSource: mock(() => "manual" as const),
     goToToday: mock(),
     incrementWeek: mock(),
+    shiftViewByDay: mock(),
   },
 });
 

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -156,6 +156,8 @@ const renderShortcuts = (options?: {
     );
   }
 
+  const shiftViewByDay = mock();
+
   renderHook(
     () =>
       useWeekShortcuts({
@@ -171,13 +173,32 @@ const renderShortcuts = (options?: {
           getLastNavigationSource: mock(),
           goToToday: mock(),
           incrementWeek: mock(),
+          shiftViewByDay,
         },
       }),
     { wrapper },
   );
 
-  return { queryClient };
+  return { queryClient, shiftViewByDay };
 };
+
+describe("useWeekShortcuts day shifting", () => {
+  it("shifts the view backward with Shift+J", () => {
+    const { shiftViewByDay } = renderShortcuts();
+
+    pressKey("J", shiftKey);
+
+    expect(shiftViewByDay).toHaveBeenCalledWith(-1);
+  });
+
+  it("shifts the view forward with Shift+K", () => {
+    const { shiftViewByDay } = renderShortcuts();
+
+    pressKey("K", shiftKey);
+
+    expect(shiftViewByDay).toHaveBeenCalledWith(1);
+  });
+});
 
 describe("useWeekShortcuts calendar event targeting", () => {
   it("focuses the first visible calendar event with I", async () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -95,7 +95,7 @@ export const useWeekShortcuts = ({
   });
   const allDayEventsRef = useRef(allDayEvents);
   const timedEventsRef = useRef(timedEvents);
-  const { decrementWeek, incrementWeek, goToToday } = util;
+  const { decrementWeek, incrementWeek, goToToday, shiftViewByDay } = util;
   const { scrollToNow } = scrollUtil;
 
   useEffect(() => {
@@ -138,6 +138,16 @@ export const useWeekShortcuts = ({
     _discardDraft();
     incrementWeek();
   }, [incrementWeek, _discardDraft]);
+
+  const shiftViewBackward = useCallback(() => {
+    _discardDraft();
+    shiftViewByDay(-1);
+  }, [_discardDraft, shiftViewByDay]);
+
+  const shiftViewForward = useCallback(() => {
+    _discardDraft();
+    shiftViewByDay(1);
+  }, [_discardDraft, shiftViewByDay]);
 
   const createAllDayDraftEvent = useCallback(() => {
     void createAlldayDraft(startOfView, endOfView, "createShortcut");
@@ -377,6 +387,8 @@ export const useWeekShortcuts = ({
 
   useAppShortcutUp("J", goToPreviousWeek);
   useAppShortcutUp("K", goToNextWeek);
+  useAppShortcutUp("Shift+J", shiftViewBackward);
+  useAppShortcutUp("Shift+K", shiftViewForward);
   useAppShortcutUp("T", toToday);
   useAppShortcutUp("A", createAllDayDraftEvent);
   useAppShortcutUp("C", createTimedDraftEvent);

--- a/packages/web/src/views/Week/hooks/useDayShiftTransition.ts
+++ b/packages/web/src/views/Week/hooks/useDayShiftTransition.ts
@@ -1,0 +1,41 @@
+import { type RefObject, useLayoutEffect, useRef } from "react";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { type WeekNavigationSource } from "@web/views/Week/hooks/useWeek";
+
+const TRANSITION_DURATION_MS = 180;
+
+export const useDayShiftTransition = (
+  trackRef: RefObject<HTMLElement | null>,
+  startOfView: Dayjs,
+  navigationSource: WeekNavigationSource,
+) => {
+  const previousStartRef = useRef(startOfView);
+
+  useLayoutEffect(() => {
+    const previousStart = previousStartRef.current;
+    previousStartRef.current = startOfView;
+
+    const track = trackRef.current;
+    if (
+      !track ||
+      navigationSource !== "day-shift" ||
+      previousStart.isSame(startOfView, "day") ||
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+
+    const direction = startOfView.isAfter(previousStart, "day") ? 1 : -1;
+    track.getAnimations().forEach((animation) => animation.cancel());
+    track.animate(
+      [
+        { opacity: 0.82, transform: `translateX(${direction * 12}px)` },
+        { opacity: 1, transform: "translateX(0)" },
+      ],
+      {
+        duration: TRANSITION_DURATION_MS,
+        easing: "cubic-bezier(0.16, 1, 0.3, 1)",
+      },
+    );
+  }, [navigationSource, startOfView, trackRef]);
+};

--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -58,7 +58,7 @@ describe("useWeek", () => {
     const { result } = renderHook(() => useWeek(today));
 
     expect(result.current.component.startOfView.format(DATE_FORMAT)).toBe(
-      dayjs("2026-05-20", DATE_FORMAT).startOf("week").format(DATE_FORMAT),
+      "2026-05-20",
     );
     expect(result.current.component.isCurrentWeek).toBe(false);
     expect(
@@ -104,6 +104,35 @@ describe("useWeek", () => {
     });
   });
 
+  it("shifts the visible range forward by one day", () => {
+    mockParams.dateString = "2026-05-20";
+    const { result } = renderHook(() =>
+      useWeek(dayjs("2026-05-20", DATE_FORMAT)),
+    );
+
+    act(() => result.current.util.shiftViewByDay(1));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/week/$dateString",
+      params: { dateString: "2026-05-21" },
+    });
+    expect(result.current.util.getLastNavigationSource()).toBe("day-shift");
+  });
+
+  it("shifts the visible range backward by one day", () => {
+    mockParams.dateString = "2026-05-20";
+    const { result } = renderHook(() =>
+      useWeek(dayjs("2026-05-20", DATE_FORMAT)),
+    );
+
+    act(() => result.current.util.shiftViewByDay(-1));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/week/$dateString",
+      params: { dateString: "2026-05-19" },
+    });
+  });
+
   it("navigates to the given date on goToDate", () => {
     mockParams.dateString = "2026-05-20";
     const today = dayjs("2026-05-20", DATE_FORMAT);
@@ -130,7 +159,7 @@ describe("useWeek", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/week/$dateString",
-      params: { dateString: "2026-05-20" },
+      params: { dateString: "2026-05-17" },
     });
   });
 
@@ -146,11 +175,7 @@ describe("useWeek", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("pages within a narrower visible window before crossing the week edge", () => {
-    // 2026-05-20 (Wed) sits at window offset 2 in a 3-day window (Tue/Wed/Thu
-    // of the Sun-start week). Paging forward by 3 days lands inside the same
-    // week (offset clamps to maxOffset 4) rather than crossing into the next
-    // one — that edge-crossing behavior is covered by the full-week test above.
+  it("pages by the number of visible days", () => {
     mockParams.dateString = "2026-05-20";
     const today = dayjs("2026-05-20", DATE_FORMAT);
     const { result } = renderHook(() => useWeek(today, 3));
@@ -161,7 +186,7 @@ describe("useWeek", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/week/$dateString",
-      params: { dateString: "2026-05-22" },
+      params: { dateString: "2026-05-23" },
     });
   });
 });

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -19,13 +19,9 @@ export const useWeek = (
   today: Dayjs,
   visibleDayCount: number = WEEK_DAY_COUNT,
 ) => {
-  // The anchor is the day the visible window centers on. The week range and
-  // the window offset both derive from it, so a day-count change re-windows
-  // around the anchor without extra state. The anchor itself lives in the
-  // URL (rather than useState) so a refresh restores the same week; it is
-  // memoized on the date *string* because `today` is a fresh Dayjs every
-  // render, and memoizing on the Dayjs instance would re-derive start/end
-  // (and re-fire the updateDates effect below) on every render.
+  // The URL date is the first visible day, so custom windows survive refresh
+  // and can cross calendar-week boundaries. Memoize from the date string
+  // because `today` is a fresh Dayjs instance on every render.
   const navigate = useNavigate();
   const params = useParams({
     from: ROUTE_IDS.WEEK_DATE,
@@ -61,17 +57,11 @@ export const useWeek = (
     [start, visibleDayCount],
   );
 
-  // Week + someday reads are driven by TanStack Query: changing start/end
-  // re-keys the queries (fetch on new ranges, instant render from cache on
-  // revisits). Queries stay week-granular even when fewer days render, so
-  // window paging within a week never refetches.
+  // Changing the visible range re-keys the query; revisits use cached data.
   useWeekEventsQuery({ startOfView: start, endOfView: end });
   useSomedayEventsQuery(start);
 
-  // Warm the previous/next week so the next prev/next click resolves from
-  // cache. Uses the same toUTCOffset formatting useWeekEventsQuery uses for
-  // the current range, so the prefetched entries land under the exact keys a
-  // subsequent read looks up.
+  // Warm the previous and next visible pages using the exact read-key format.
   const previousStart = useMemo(
     () => start.subtract(visibleDayCount, "day"),
     [start, visibleDayCount],

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -8,14 +8,10 @@ import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjace
 import { useSomedayEventsQuery } from "@web/events/queries/useSomedayEventsQuery";
 import { useWeekEventsQuery } from "@web/events/queries/useWeekEventsQuery";
 import { viewActions } from "@web/events/stores/view.store";
-import {
-  anchorDateForWindowOffset,
-  computeVisibleWindowOffset,
-  WEEK_DAY_COUNT,
-} from "@web/views/Week/util/week-window.util";
+import { WEEK_DAY_COUNT } from "@web/views/Week/util/week-window.util";
 import { type Category_View } from "@web/views/Week/week-view.types";
 
-export type WeekNavigationSource = "manual" | "drag-to-edge";
+export type WeekNavigationSource = "manual" | "drag-to-edge" | "day-shift";
 
 const DATE_FORMAT = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
 
@@ -47,24 +43,22 @@ export const useWeek = (
     });
   const navigationSourceRef = useRef<WeekNavigationSource>("manual");
 
-  const start = useMemo(() => anchor.startOf("week"), [anchor]);
-  const end = useMemo(() => start.endOf("week"), [start]);
+  const start = useMemo(() => anchor.startOf("day"), [anchor]);
+  const end = useMemo(
+    () => start.add(visibleDayCount - 1, "day").endOf("day"),
+    [start, visibleDayCount],
+  );
 
   const week = useMemo(() => start.week(), [start]);
 
-  const isCurrentWeek = today.week() === start.week();
-
-  const windowOffset = computeVisibleWindowOffset({
-    anchorIndex: anchor.startOf("day").diff(start.startOf("day"), "day"),
-    visibleDayCount,
-  });
+  const isCurrentWeek = today.isBetween(start, end, "day", "[]");
 
   const weekDays = useMemo(
     () =>
       Array.from({ length: visibleDayCount }, (_, index) =>
-        start.add(windowOffset + index, "day"),
+        start.add(index, "day"),
       ),
-    [start, visibleDayCount, windowOffset],
+    [start, visibleDayCount],
   );
 
   // Week + someday reads are driven by TanStack Query: changing start/end
@@ -78,17 +72,27 @@ export const useWeek = (
   // cache. Uses the same toUTCOffset formatting useWeekEventsQuery uses for
   // the current range, so the prefetched entries land under the exact keys a
   // subsequent read looks up.
-  const previousStart = useMemo(() => start.subtract(7, "day"), [start]);
-  const nextStart = useMemo(() => start.add(7, "day"), [start]);
+  const previousStart = useMemo(
+    () => start.subtract(visibleDayCount, "day"),
+    [start, visibleDayCount],
+  );
+  const nextStart = useMemo(
+    () => start.add(visibleDayCount, "day"),
+    [start, visibleDayCount],
+  );
   usePrefetchAdjacentEvents(
     weekEventsQueryOptions,
     {
       startDate: toUTCOffset(previousStart),
-      endDate: toUTCOffset(previousStart.endOf("week")),
+      endDate: toUTCOffset(
+        previousStart.add(visibleDayCount - 1, "day").endOf("day"),
+      ),
     },
     {
       startDate: toUTCOffset(nextStart),
-      endDate: toUTCOffset(nextStart.endOf("week")),
+      endDate: toUTCOffset(
+        nextStart.add(visibleDayCount - 1, "day").endOf("day"),
+      ),
     },
   );
 
@@ -104,35 +108,9 @@ export const useWeek = (
     setAnchor(date);
   };
 
-  // Shift the visible window by one page of visibleDayCount days; at the
-  // week's edge, cross into the adjacent week entering from its near side.
   const pageWindow = (direction: 1 | -1, source: WeekNavigationSource) => {
     navigationSourceRef.current = source;
-    const maxOffset = WEEK_DAY_COUNT - visibleDayCount;
-    const isAtWeekEdge =
-      direction === 1 ? windowOffset >= maxOffset : windowOffset <= 0;
-
-    if (isAtWeekEdge) {
-      setAnchor(
-        anchorDateForWindowOffset({
-          weekStart: start.add(direction * WEEK_DAY_COUNT, "day"),
-          windowOffset: direction === 1 ? 0 : maxOffset,
-          visibleDayCount,
-        }),
-      );
-      return;
-    }
-
-    setAnchor(
-      anchorDateForWindowOffset({
-        weekStart: start,
-        windowOffset: Math.min(
-          Math.max(windowOffset + direction * visibleDayCount, 0),
-          maxOffset,
-        ),
-        visibleDayCount,
-      }),
-    );
+    setAnchor(start.add(direction * visibleDayCount, "day"));
   };
 
   const incrementWeek = (source: WeekNavigationSource = "manual") =>
@@ -141,10 +119,15 @@ export const useWeek = (
   const decrementWeek = (source: WeekNavigationSource = "manual") =>
     pageWindow(-1, source);
 
+  const shiftViewByDay = (direction: 1 | -1) => {
+    navigationSourceRef.current = "day-shift";
+    setAnchor(start.add(direction, "day"));
+  };
+
   const goToToday = () => {
     navigationSourceRef.current = "manual";
-    if (!anchor.isSame(today, "day")) {
-      setAnchor(today);
+    if (!isCurrentWeek) {
+      setAnchor(today.startOf("week"));
     }
   };
 
@@ -160,7 +143,13 @@ export const useWeek = (
       weekDays,
     },
     state: { goToDate },
-    util: { decrementWeek, goToToday, incrementWeek, getLastNavigationSource },
+    util: {
+      decrementWeek,
+      getLastNavigationSource,
+      goToToday,
+      incrementWeek,
+      shiftViewByDay,
+    },
   };
   return weekProps;
 };


### PR DESCRIPTION
## Summary

- add Shift+J and Shift+K shortcuts to move the visible calendar range one day backward or forward
- keep J, K, header controls, and horizontal gestures moving one full visible page
- add a subtle directional transition for one-day shifts with reduced-motion support
- preserve the conventional current-week start when entering /week

## Simplicity

- keep the URL date as the single source of truth for the first visible day
- reuse the existing week navigation utility surface and track ref
- retain one small effect for the Web Animations transition; it owns no persistent state and exits for non-day navigation and reduced motion
- simplify stale comments from the previous centered-window model in a separate commit

## Manual Testing Steps

- [ ] Open Week view and press Shift+K; confirm the visible range advances exactly one day with a subtle forward transition
- [ ] Press Shift+J; confirm the visible range moves exactly one day backward with the opposite transition
- [ ] Press J/K and use a horizontal trackpad gesture; confirm each still moves one full visible page
- [ ] Open /week directly; confirm it begins at the start of the current week
- [ ] Enable reduced motion and confirm day shifting occurs without animation

## Test plan

- [x] bun test:web (1263 passing)
- [x] bun type-check
- [x] bun lint
- [x] focused week shortcut, navigation, and router tests
- [x] React Doctor changed-files scan (92/100, no issues)
- [x] local browser validation in both directions with no console errors