### PR TITLE
feat: add ux-sweep skill for proactive UX/a11y exploration

### DIFF
--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleanup
-description: The evening cleanup ritual from HANDOFF.md. Review everything merged to main since the last cleanup, run the `simplify` skill over those diffs, and auto-merge simplification PR(s) so the day's code ends up cleaner than it started — never sloppier. Then finalize the day's summary.md and run a `/qa-staging` sweep so the PO can do a final review of the living app in staging. Use when the PO says "/cleanup", "run the evening cleanup", "clean up the day's work", or "tidy up before I review staging".
+description: The evening cleanup ritual from HANDOFF.md. Review everything merged to main since the last cleanup, run the `simplify` skill over those diffs, and auto-merge simplification PR(s) so the day's code ends up cleaner than it started — never sloppier. Also run a `ux-sweep` over the day's merge window to catch usability/a11y friction and auto-fix it. Then finalize the day's summary.md and run a `/qa-staging` sweep so the PO can do a final review of the living app in staging. Use when the PO says "/cleanup", "run the evening cleanup", "clean up the day's work", or "tidy up before I review staging".
 ---
 
 # cleanup
@@ -13,9 +13,10 @@ with a clean staging environment to review.
 **This skill is an orchestrator — it does not restate the rules.** The source of
 truth is `handoff/HANDOFF.md` (the rhythm, esp. the "Evening cleanup" section)
 and `handoff/agent-operating-rules.md` (self-governance). It delegates the actual
-work to three existing skills — do not reimplement them here:
+work to existing skills — do not reimplement them here:
 
 - **`simplify`** — finds and applies the quality/legibility fixes.
+- **`ux-sweep`** — proactively explores the day's merge window for usability/a11y friction.
 - **`ship`** — validates, reviews, opens the PR, watches CI, squash-merges on green.
 - **`qa-staging`** — the post-deploy staging sweep in the user's real Chrome.
 
@@ -83,7 +84,22 @@ Ship every cleanup PR via the **`ship`** skill:
   don't force it: leave that PR open, note it under the summary's PO follow-ups, and carry
   on with the rest. Own the call — never spawn a task chip (`no-task-chips-during-handoff`).
 
-## 4. Advance the marker
+## 4. Proactive UX sweep over the day's window
+
+Run the **`ux-sweep`** skill scoped to the full `START..END` review window (not just the
+cleanup PRs — the day's whole merge window, same range established in step 0). This is
+the evening counterpart to the per-PR sweep `handoff` already runs during the day: a
+second pass, with fresh eyes, over everything that shipped.
+
+- `ux-sweep` drives the changed surfaces in the browser looking for usability/a11y
+  friction — confusing focus order, missing labels, unclear states — and fixes what's
+  fixable through the normal `ship` flow, auto-merging on green.
+- Anything it can't fix confidently (needs a product/design call) gets logged under PO
+  follow-ups, not force-fixed and not spawned as a task chip.
+- If the window is UI-only complexity work with no behavior change (rare, but possible
+  after step 2), `ux-sweep` may find nothing — that's a valid, non-padded outcome.
+
+## 5. Advance the marker
 
 Once the cleanup PRs are merged, record the window you reviewed so tomorrow starts fresh:
 
@@ -93,37 +109,45 @@ Once the cleanup PRs are merged, record the window you reviewed so tomorrow star
 - Commit the marker with the cleanup (or as a tiny `chore(handoff): advance cleanup marker`
   commit). It lives in `handoff/`, which is committed — not gitignored like `workflow/`.
 
-## 5. Finalize the day's summary
+## 6. Finalize the day's summary
 
 Close out `handoff/<date>/summary.md` so it's the authoritative record of the day:
 
 - Confirm the **before/after** table reflects the merged state.
 - Fold the cleanup into **Decisions**: what you simplified and why (one or two lines per PR).
+- Fold in what `ux-sweep` found/fixed in step 4 alongside the simplification decisions.
 - Verify **PO follow-ups** are current (add any cleanup PR you left open for review).
 - Record the day's **token spend** (`/usage`) if not already logged.
 
-## 6. Staging sweep, then hand off to the PO
+## 7. Staging sweep, then hand off to the PO
 
 The cleanup PRs auto-deploy to staging on merge. Before the PO reviews:
 
 - Run the **`qa-staging`** skill: verify the correct signed-in staging profile, run the
   standard flows watching console/network, and exercise the Manual Testing Steps from the
   cleanup PRs (and the day's other merged PRs) to catch any regression the simplification
-  introduced. Requires an unlocked screen with the extension connected in the staging
-  profile — if that precondition isn't met, say so and leave the sweep for the PO rather
-  than reporting a green run you didn't do.
+  or `ux-sweep` fixes introduced. Requires an unlocked screen with the extension connected
+  in the staging profile — if that precondition isn't met, say so and leave the sweep for
+  the PO rather than reporting a green run you didn't do.
 
 Then hand off with a short close-out:
 
 - What was simplified (link the merged PRs) and the net effect (lines/indirection removed).
+- What `ux-sweep` found and fixed (link the merged PRs), and anything it flagged for the
+  PO instead.
 - The `qa-staging` result — green, or exactly what looked off.
 - A short **"review in staging"** checklist: the specific flows the PO should click through
   to confirm the living app still works, drawn from the areas the cleanup touched.
 
 ## Guardrails
 
-- **Quality only.** Cleanup never changes behavior. If you spot a correctness bug, that's
-  `/code-review` territory — note it under PO follow-ups, don't silently fix it here.
+- **Quality only, with one deliberate exception.** Steps 1-3 (`simplify`) never change
+  behavior. Step 4 (`ux-sweep`) is the one place this ritual *does* change behavior on
+  purpose — adding a missing keyboard handler or focus ring is a real, if small, behavior
+  change, not a refactor. That's fine: it's still in the "simple, accessible product"
+  remit from `HANDOFF.md` → Priorities, just not literally behavior-preserving. If you spot
+  a correctness bug (not a11y/UX friction), that's `/code-review` territory — note it under
+  PO follow-ups, don't silently fix it here.
 - **Nothing to do is a valid outcome.** If the day's diffs are already clean, say so and
   advance the marker. Don't manufacture churn to justify a PR.
 - **Own follow-up decisions.** Incidental findings are yours to fold in or drop

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -48,6 +48,9 @@ Per `HANDOFF.md` → Daily implementation and `agent-operating-rules.md`:
   - Gate merges on authoritative signals (`gh pr checks --watch` exit code +
     `mergeStateStatus == CLEAN`), never a `grep -c fail` count (grep exits non-zero on
     zero matches — a green PR would look red).
+  - After a PR merges, run the **`ux-sweep`** skill scoped to that PR — it drives the
+    changed surface in the browser looking for usability/a11y friction the correctness
+    review wouldn't catch, and ships fixes the same way (via `ship`, auto-merge on green).
 - Respect `.claude/settings.json` deny-list. Anything needing a denied action is a
   push-notify, not a workaround.
 - **Blocked or need a PO-only decision:** send a mobile push notification, log it under

--- a/.claude/skills/ux-sweep/SKILL.md
+++ b/.claude/skills/ux-sweep/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: ux-sweep
+description: Proactively explore the app's recently-changed surfaces like a first-time user, looking for usability, accessibility, and UX friction (confusing focus order, missing labels, awkward keyboard paths, unclear states) that automated tests wouldn't catch - then fix what's fixable and ship it through the normal PR flow, same autonomy as handoff. Use when the user says "/ux-sweep", "find UX bugs", "check for a11y issues", "play with the app and find problems", or when invoked as a step inside handoff (after a PR ships) or cleanup (over the day's merge window).
+---
+
+# ux-sweep
+
+The proactive counterpart to `a11y-audit` (which reviews a diff statically) and
+`qa-staging` (which checks that staging didn't break). This skill actually
+**drives** the recently-changed surfaces of the app like someone using it for
+the first time, looking for friction a diff review or a breakage check would
+miss: a focus ring that never appears, a control with no accessible name, a
+drag interaction with no keyboard equivalent, an empty state that doesn't
+explain what to do next.
+
+**This skill is not diff review.** Don't read code and infer how it behaves —
+open it in the browser and interact with it the way a real user would, the
+same standard `ship` and `qa-staging` hold themselves to.
+
+Findings get fixed autonomously, same posture as the rest of the handoff
+workflow: no task chips, no waiting for a human to triage first. See
+`handoff/agent-operating-rules.md` → "I own follow-up decisions."
+
+## 0. Determine scope
+
+Figure out which surfaces actually need exploring — never wander the whole
+app by default, that's expensive and unfocused. How you scope depends on how
+this skill was invoked:
+
+- **On-demand, no args**: diff the current branch/worktree against `main`
+  (`git diff main...HEAD --stat`). If there's nothing local, fall back to the
+  most recently merged PR (`gh pr list --state merged --base main --limit 1`).
+- **Called from `/handoff`** (after a task's PR ships): scope to that PR's
+  diff alone — `gh pr diff <number> --name-only`.
+- **Called from `/cleanup`**: scope to the day's whole review window,
+  `START..END` from the cleanup marker (same range `cleanup` already
+  established) — `git diff START..END --stat`.
+
+Map the changed file paths under `packages/web/src` to the routes/flows they
+affect — e.g. `WeekView/*` → open week view and exercise it; `Someday/*` →
+open the someday list; a shared component (`Button`, `Tooltip`, a hook) →
+check every surface that renders it, not just one. If a diff touches only
+non-UI code (backend, core schema, scripts, tests), say so and skip the
+browser walkthrough entirely — there's nothing to explore.
+
+## 1. Start the dev server and open it in Chrome
+
+Same convention as `ship` — use `claude-in-chrome`, not `preview_*`. This
+skill needs the real console/network visibility other skills already rely on,
+and reuses the same session state.
+
+1. Check `.claude/launch.json` for the current web dev command/port (confirm
+   rather than assume — it can change). Start it with Bash `run_in_background`
+   if it isn't already running, and poll until it's actually serving.
+2. Load the Chrome tools if deferred, one batched call:
+   `ToolSearch("select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__computer,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__read_console_messages,mcp__claude-in-chrome__read_network_requests,mcp__claude-in-chrome__find")`.
+3. `tabs_context_mcp` (`createIfEmpty: true`), `tabs_create_mcp`, `navigate`
+   to the local dev server, at the route for the surface in scope.
+
+## 2. Explore like a first-time user
+
+For each surface in scope, work through this checklist live — don't just
+read the DOM, actually operate it with `computer` and confirm with
+`read_page` (`filter: "interactive"`) plus screenshots:
+
+- **Keyboard-only pass**: `Tab`/`Shift+Tab` through the surface. Is every
+  interactive element reachable? Is the focus order sane (matches visual/DOM
+  order)? Is there always a visible focus ring? Can every mouse-only action
+  (drag to create/resize an event, drag-reorder a someday item) also be done
+  from the keyboard, or does it have no equivalent at all?
+- **Accessible names**: for icon-only buttons, custom controls, and anything
+  that isn't a native `<label>`-connected input, check `read_page`'s
+  accessible-name output. Borrow the exact checklist from `a11y-audit`
+  (semantics, labels, ARIA correctness, contrast) but apply it to what's
+  actually rendered, not to a diff.
+- **State coverage**: trigger the empty state (e.g. a day/week with nothing
+  on it), a loading state if one is reachable, and an error state if you can
+  induce one safely (e.g. a bad network condition isn't worth faking — skip
+  states you can't reach without destructive action). Is each state
+  understandable on its own, or does it look broken/blank?
+- **First-run confusion check**: for anything new or changed, ask "would
+  someone who's never seen this before know what to do?" — unlabeled icons,
+  ambiguous empty states, and hover-only affordances (nothing tells a
+  keyboard/touch user they exist) are the recurring failure modes here.
+- Reference `e2e/utils/{event-test-utils,task-test-utils,test-constants}.ts`
+  for this app's existing selector conventions so you're not fighting the
+  test-id scheme while exploring.
+
+Watch `read_console_messages` and `read_network_requests` throughout — a
+silent thrown error or failed request during an interaction is a finding even
+if the UI looked fine.
+
+## 3. Triage findings
+
+Sort what you found into:
+
+- **Fixable now** — a missing `aria-label`, a focus ring suppressed by a
+  stray `outline: none`, a `div` with a click handler that should be a
+  `button`, a keyboard equivalent that's a small addition to existing drag
+  logic, an empty state missing a one-line hint.
+- **Needs a product/design call** — anything where the "right" fix isn't
+  obvious from the code alone (a whole new interaction pattern, a copy
+  rewrite that changes tone, a layout decision). Don't guess at these.
+
+## 4. Fix autonomously, same posture as handoff
+
+For each **fixable-now** finding:
+
+1. Fix it directly. Keep the fix scoped to that one finding — don't bundle
+   unrelated findings into one PR.
+2. Run `bun run type-check` and the relevant test suite for what you touched.
+3. Ship it through the **`ship` skill** — validates in Chrome, runs the
+   correctness review, opens the PR (Manual Testing Steps included), watches
+   CI, squash-merges once green. Don't reimplement any of that here.
+
+For each **needs-a-decision** finding: don't force a fix. Follow the same
+push-notify-vs-log rule as the rest of handoff
+(`agent-operating-rules.md` → "When to push-notify vs. log-and-continue") —
+log it, don't spawn a task chip, don't idle waiting for an answer.
+
+Never use `spawn_task` for anything found here — this skill inherits the
+"I own follow-up decisions" rule from the handoff workflow, whether or not
+it's literally running inside `/handoff`.
+
+## 5. Report
+
+- **Run inside `/handoff` or `/cleanup`**: append what you found and fixed to
+  the day's `handoff/<date>/summary.md` — under Decisions for what shipped,
+  under PO follow-ups for anything needing a call.
+- **Run on-demand**: print a short report grouped the same way `qa-staging`
+  does — fixed (with PR links), needs-a-decision (flagged, not asserted as a
+  bug), and clean (surfaces explored that had nothing wrong, so scope is
+  visible, not just failures).


### PR DESCRIPTION
## Summary
- Adds a new `.claude/skills/ux-sweep/SKILL.md` skill: proactively explores the app's recently-changed surfaces like a first-time user (keyboard-only pass, accessible names, empty/loading/error states, first-run confusion), then auto-fixes what's clearly fixable and ships it via the `ship` skill — same autonomy posture as `/handoff`.
- Wires it into `.claude/skills/handoff/SKILL.md`: after each task's PR merges, run `ux-sweep` scoped to that PR.
- Wires it into `.claude/skills/cleanup/SKILL.md`: a new evening step (renumbered 4-7) that runs `ux-sweep` over the full day's merge window, with the Guardrails section updated to carve out an explicit exception for `ux-sweep`'s small, deliberate behavior changes (unlike `simplify`, which is strictly behavior-preserving).

This closes the gap where usability/a11y bugs only ever got caught if the PO happened to notice and write them up. `ux-sweep` finds and fixes them on its own.

## Simplicity
This is a docs-only change (skill instruction markdown, no application code). No `useEffect`/`useRef`/`useState` in play. Ran the `simplify` skill against the diff and it found nothing to change — pure prose, none of its detectors (mocks, hooks, duplication, dead code) apply.

## Manual Testing Steps
- [ ] Run `claude` in this repo, type `/ux-sweep` with no other input, and confirm it's picked up as an available skill (shows in the skill list / triggers on the slash command).
- [ ] Open `.claude/skills/handoff/SKILL.md` and confirm step 2 mentions running `ux-sweep` after a PR merges.
- [ ] Open `.claude/skills/cleanup/SKILL.md` and read start to finish, confirming the step numbering (0-7) and the Guardrails section read coherently with the new `ux-sweep` step folded in.

## Test plan
- [x] No automated tests apply — docs-only change, no `packages/*` code touched. `bun run type-check` and the unit/e2e suites are unaffected by this diff.