### PR TITLE
feat(backend): sync series occurrence edits/deletes to google (packet 05 step 4)

### DIFF
--- a/packages/backend/src/common/services/gcal/gcal.service.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.ts
@@ -1,5 +1,6 @@
 import { type GaxiosResponse } from "gaxios";
 import { GCAL_NOTIFICATION_ENDPOINT } from "@core/constants/core.constants";
+import { Logger } from "@core/logger/winston.logger";
 import {
   type gParamsEventsList,
   type gSchema$CalendarList,
@@ -22,6 +23,8 @@ import { encodeChannelToken } from "@backend/sync/services/watch/google-watch-to
 
 const getGcalNotificationAddress = () =>
   CONFIG.GCAL_WEBHOOK_BASEURL + GCAL_NOTIFICATION_ENDPOINT;
+
+const logger = Logger("app:gcal.service");
 
 class GCalService {
   private validateGCalResponse<T>(
@@ -98,6 +101,61 @@ class GCalService {
     );
 
     return this.validateGCalResponse(response);
+  }
+
+  /**
+   * Resolves the single Google-side instance of a recurring event whose
+   * *original* (pre-edit) position in the recurrence pattern matches
+   * `originalStart` -- Google's `originalStartTime` stays fixed even after
+   * that instance's own `start`/`end` are later edited, so this is how a
+   * Compass occurrence's Google instance id is found the first time it needs
+   * to sync (packet 05 step 4). A narrow window around `originalStart` keeps
+   * this a single page in the overwhelming common case (instance starts
+   * within one series never collide within a few hours of each other).
+   * Returns null -- never throws -- when no instance in that window matches;
+   * the caller decides how to handle a miss.
+   */
+  async findEventInstance(
+    { gcal, quotaUser }: GoogleRequestContext,
+    calendarId: string,
+    recurringEventId: string,
+    originalStart: Date,
+  ): Promise<gSchema$Event | null> {
+    const windowMs = 3 * 60 * 60 * 1000; // +/- 3 hours
+    const timeMin = new Date(originalStart.getTime() - windowMs).toISOString();
+    const timeMax = new Date(originalStart.getTime() + windowMs).toISOString();
+
+    const response = await withGoogleRetry(() =>
+      gcal.events.instances({
+        calendarId,
+        eventId: recurringEventId,
+        timeMin,
+        timeMax,
+        quotaUser,
+      }),
+    );
+
+    const { data } = this.validateGCalResponse(
+      response,
+      `Failed to fetch gcal instances for base event ${recurringEventId}`,
+    );
+
+    const targetMs = originalStart.getTime();
+    const match = (data.items ?? []).find((item) => {
+      const original = item.originalStartTime;
+      const value = original?.dateTime ?? original?.date;
+      if (!value) return false;
+      return new Date(value).getTime() === targetMs;
+    });
+
+    if (!match) {
+      logger.warn(
+        `findEventInstance: no instance of recurring event ${recurringEventId} on calendar ${calendarId} matched originalStartTime ${originalStart.toISOString()}`,
+      );
+      return null;
+    }
+
+    return match;
   }
 
   async getEvents(context: GoogleRequestContext, params: gParamsEventsList) {

--- a/packages/backend/src/event/classes/compass.event.parser.test.ts
+++ b/packages/backend/src/event/classes/compass.event.parser.test.ts
@@ -122,6 +122,25 @@ describe("analyzeReplace", () => {
     expect(plan.deleteInstanceIds).toEqual([laterInstance._id]);
   });
 
+  it("scope all: throws RECURRENCE_CONFLICT when an instance has drifted onto a different calendar than its base (A6 defense-in-depth, step 7)", () => {
+    const base = buildEvent({
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+    });
+    const driftedInstance = buildEvent({
+      calendarId: new ObjectId(),
+      recurrence: { kind: "occurrence", seriesId: base._id },
+    });
+
+    expect(() =>
+      analyzeReplace(
+        base,
+        { base, instances: [driftedInstance] },
+        replaceInput({ scope: "all" }),
+        now,
+      ),
+    ).toThrow();
+  });
+
   it("scope all: converts a series to standalone when recurrence.kind is 'single'", () => {
     const base = buildEvent({
       recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
@@ -175,6 +194,24 @@ describe("analyzeDelete", () => {
       { scope: "all" },
     );
     expect(plan).toEqual({ kind: "deleteSeries", seriesId: base._id });
+  });
+
+  it("scope all: throws RECURRENCE_CONFLICT when an instance has drifted onto a different calendar than its base (A6 defense-in-depth, step 7)", () => {
+    const base = buildEvent({
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const driftedInstance = buildEvent({
+      calendarId: new ObjectId(),
+      recurrence: { kind: "occurrence", seriesId: base._id },
+    });
+
+    expect(() =>
+      analyzeDelete(
+        base,
+        { base, instances: [driftedInstance] },
+        { scope: "all" },
+      ),
+    ).toThrow();
   });
 });
 

--- a/packages/backend/src/event/classes/compass.event.parser.ts
+++ b/packages/backend/src/event/classes/compass.event.parser.ts
@@ -11,6 +11,30 @@ import { withUntil } from "@backend/event/services/recur/util/recur.util";
 const conflict = (message: string) =>
   eventMutationError("RECURRENCE_CONFLICT", message);
 
+/**
+ * Defense-in-depth for A6 (calendar assignment is immutable, so every
+ * materialized instance always copies its base's calendarId): no current
+ * code path can actually construct a series whose instances span more than
+ * one calendar, but an apply-to-series operation (scope "all" or
+ * "thisAndFollowing") trusts `series.instances` wholesale, so a corrupted or
+ * hand-edited document here would otherwise silently mutate/delete events on
+ * a calendar the caller never asked to touch. Fail loudly instead (packet 05
+ * step 7).
+ */
+const assertSeriesCalendarConsistency = (
+  series: SeriesContext | null,
+): void => {
+  if (!series) return;
+  const drifted = series.instances.find(
+    (instance) => !instance.calendarId.equals(series.base.calendarId),
+  );
+  if (drifted) {
+    throw conflict(
+      `Series ${series.base._id.toHexString()} has an instance (${drifted._id.toHexString()}) on a different calendar than its base; refusing to apply a series-wide operation.`,
+    );
+  }
+};
+
 const scheduleStartMs = (schedule: EventRecord["schedule"]): number => {
   if (schedule.kind === "timed") return schedule.start.getTime();
   if (schedule.kind === "allDay") {
@@ -89,6 +113,7 @@ export function analyzeReplace(
   input: ReplaceEventInput,
   now: Date,
 ): ReplacePlan {
+  assertSeriesCalendarConsistency(series);
   const { scope } = input;
 
   if (scope === "this") {
@@ -184,6 +209,7 @@ export function analyzeDelete(
   series: SeriesContext | null,
   input: DeleteEventInput,
 ): DeletePlan {
+  assertSeriesCalendarConsistency(series);
   const { scope } = input;
 
   if (scope === "this") {

--- a/packages/backend/src/event/services/event.service.test.ts
+++ b/packages/backend/src/event/services/event.service.test.ts
@@ -567,3 +567,87 @@ describe("EventService (calendar write-capability enforcement)", () => {
     ).rejects.toMatchObject({ mutationCode: "CALENDAR_NOT_FOUND" });
   });
 });
+
+/**
+ * Packet 05 step 7: A6 makes calendar assignment immutable and every
+ * materialized instance copies its base's calendarId, so no code path
+ * reachable through the public API can construct a series whose instances
+ * span more than one calendar. This is defense-in-depth for that invariant
+ * having somehow been violated anyway (a bad migration, a hand-edited
+ * document, ...) -- seeded directly via Mongo, not through create/replace,
+ * since the public API is exactly what's supposed to make this unreachable.
+ */
+describe("EventService (series-calendar consistency guard, step 7)", () => {
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("fails loudly (RECURRENCE_CONFLICT) on a scope 'all' delete when an instance has drifted onto a different calendar than its base", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendarA = await seedLocalCalendar(user._id);
+    const calendarB = await seedLocalCalendar(user._id);
+
+    const base = buildEventRecord(calendarA._id, {
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+    });
+    const driftedInstance = buildEventRecord(calendarB._id, {
+      recurrence: { kind: "occurrence", seriesId: base._id },
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-21T15:00:00.000Z"),
+        end: new Date("2026-07-21T16:00:00.000Z"),
+        timeZone: "America/Denver",
+      },
+    });
+    await mongoService.event.insertOne(base);
+    await mongoService.event.insertOne(driftedInstance);
+
+    await expect(
+      eventService.delete(user._id.toString(), base._id.toHexString(), {
+        scope: "all",
+      }),
+    ).rejects.toMatchObject({ mutationCode: "RECURRENCE_CONFLICT" });
+
+    // Nothing should have been deleted -- the guard fires before any write.
+    expect(await mongoService.event.findOne({ _id: base._id })).toBeTruthy();
+    expect(
+      await mongoService.event.findOne({ _id: driftedInstance._id }),
+    ).toBeTruthy();
+  });
+
+  it("fails loudly (RECURRENCE_CONFLICT) on a scope 'all' replace when an instance has drifted onto a different calendar than its base", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendarA = await seedLocalCalendar(user._id);
+    const calendarB = await seedLocalCalendar(user._id);
+
+    const base = buildEventRecord(calendarA._id, {
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+    });
+    const driftedInstance = buildEventRecord(calendarB._id, {
+      recurrence: { kind: "occurrence", seriesId: base._id },
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-21T15:00:00.000Z"),
+        end: new Date("2026-07-21T16:00:00.000Z"),
+        timeZone: "America/Denver",
+      },
+    });
+    await mongoService.event.insertOne(base);
+    await mongoService.event.insertOne(driftedInstance);
+
+    await expect(
+      eventService.replace(user._id.toString(), base._id.toHexString(), {
+        content: { kind: "details", title: "Renamed", description: "" },
+        schedule: {
+          kind: "timed",
+          start: "2026-07-14T15:00:00-06:00",
+          end: "2026-07-14T16:00:00-06:00",
+          timeZone: "America/Denver" as never,
+        },
+        recurrence: { kind: "preserve" },
+        priority: "unassigned",
+        scope: "all",
+      }),
+    ).rejects.toMatchObject({ mutationCode: "RECURRENCE_CONFLICT" });
+  });
+});

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -31,6 +31,7 @@ import { eventMutationError } from "@backend/event/event.error";
 import { type EventRecord } from "@backend/event/event.record";
 import { mapCreateInput } from "@backend/event/event.record.mapper";
 import { eventRepository } from "@backend/event/event.repository";
+import { getAnchorDate } from "@backend/event/services/recur/util/recur.util";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { CompassToGoogleEventPropagation } from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation";
 
@@ -213,6 +214,21 @@ class EventService {
       (record) => materialized.deleteIds.some((id) => id.equals(record._id)),
     );
 
+    // Google's originalStartTime is an occurrence's fixed position in the
+    // recurrence pattern -- it never moves even after the instance's own
+    // start/end are later edited. When this same replace() call is what's
+    // editing `target`'s schedule, `target` (the pre-edit record) still
+    // carries the true original anchor; anything derived from `plan`/
+    // `materialized` after this point already reflects the NEW schedule and
+    // would search Google's events.instances at the wrong position (packet
+    // 05 step 4). Only occurrences need this -- a base/single/someday event
+    // resolves by its own externalReference, no instances lookup involved.
+    const originalStartByEventId =
+      target.recurrence.kind === "occurrence" &&
+      target.schedule.kind !== "someday"
+        ? new Map([[target._id.toHexString(), getAnchorDate(target.schedule)]])
+        : undefined;
+
     await this.withEventTransaction((session) =>
       executeMutation(materialized, session),
     );
@@ -220,6 +236,7 @@ class EventService {
     await CompassToGoogleEventPropagation.propagate(userId, {
       upserted: materialized.upsert,
       deletedBefore,
+      originalStartByEventId,
     });
     notify(userId, [materialized.primary], "updated");
 

--- a/packages/backend/src/event/services/recur/util/recur.util.ts
+++ b/packages/backend/src/event/services/recur/util/recur.util.ts
@@ -40,7 +40,14 @@ const shiftDateOnly = (dateOnly: DateOnly, offsetDays: number): DateOnly => {
   return date.toISOString().slice(0, 10) as DateOnly;
 };
 
-const getAnchorDate = (schedule: EventScheduleRecord): Date => {
+/**
+ * The instant a schedule occupies in the recurrence pattern: the timed
+ * instant itself, or midnight UTC of the all-day date. Shared by series
+ * materialization (below) and by Compass->Google propagation, which anchors
+ * an unresolved occurrence's `events.instances` lookup on this same instant
+ * (Google's `originalStartTime`, B-series/packet-05 step 4).
+ */
+export const getAnchorDate = (schedule: EventScheduleRecord): Date => {
   if (schedule.kind === "timed") return schedule.start;
   if (schedule.kind === "allDay") {
     return new Date(`${schedule.start}T00:00:00.000Z`);

--- a/packages/backend/src/sync/services/event-propagation/__tests__/compass-to-google-this-event/instance.test.ts
+++ b/packages/backend/src/sync/services/event-propagation/__tests__/compass-to-google-this-event/instance.test.ts
@@ -1,40 +1,40 @@
+import { ObjectId } from "mongodb";
+import { type gSchema$EventInstance } from "@core/types/gcal";
 import {
   cleanupCollections,
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
+import { compassTestState } from "@backend/__tests__/helpers/mock.setup";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
+import { type EventRecord } from "@backend/event/event.record";
 import eventService from "@backend/event/services/event.service";
 import {
+  buildEventRecord,
   seedGoogleCalendar,
+  seedLocalCalendar,
   setupGoogleUser,
 } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
 
 /**
- * Scope "this" applied to a single series occurrence -- ported from the
- * deleted compass-to-google-this-event/instance.test.ts (9 tests).
+ * Scope "this" applied to a single series occurrence -- packet 05 step 4
+ * closes the "03" gap documented in handoff/someday/05-calendar-aware-crud.md:
+ * a Compass-created series' materialized instances never get their own
+ * externalReference (Google auto-expands them from the base's RRULE), so
+ * resolving the Google-side instance id for a scope "this" edit/delete
+ * requires an events.instances lookup keyed by the occurrence's ORIGINAL
+ * (pre-edit) start -- Google's originalStartTime is fixed for the life of
+ * the instance, even after its own start/end are later edited.
  *
- * INTENT-IMPOSSIBLE (documented, not softened): the old pipeline pushed a
- * per-instance edit to Google as a patch against that occurrence's own
- * gEventId, which it obtained because Google itself expands a recurring
- * base into per-instance events server-side and the old sync flow persisted
- * each instance's Google-assigned id back onto the Compass instance
- * document during the base's initial sync.
- *
- * The new pipeline's propagateUpsert has no equivalent: materialized
- * instances (recurrence.kind === "occurrence") are intentionally excluded
- * from isWritableToGoogle (see base.test.ts) because nothing in this packet
- * resolves an occurrence's Google-side instance id -- there is no
- * events.instances() lookup, and creating a *new*, unlinked Google event per
- * occurrence would be worse than doing nothing (see the base.test.ts bug
- * writeup). Per-occurrence Google sync (exception events) is out of scope
- * for packet 03 (B7 + the "out of scope" list do not mention it) and is left
- * as a follow-up. These tests assert the current, deliberate no-op so a
- * future packet that adds real instance-level sync will have to touch this
- * file instead of silently regressing past it.
+ * These tests seed the Google-side instance list directly (via
+ * compassTestState) rather than relying on the mock gcal client's own RRULE
+ * expansion at series-create time, so each test's "the Google instance the
+ * base's RRULE would already have produced" is deterministic and independent
+ * of any timezone/rrule-library parity between Compass's and the mock's
+ * date math.
  */
-describe("CompassToGoogleEventPropagation - scope 'this' - series occurrence (intent-impossible)", () => {
+describe("CompassToGoogleEventPropagation - scope 'this' - series occurrence", () => {
   beforeEach(setupTestDb);
   beforeEach(cleanupCollections);
   afterAll(cleanupTestDb);
@@ -56,34 +56,237 @@ describe("CompassToGoogleEventPropagation - scope 'this' - series occurrence (in
       .find({ "recurrence.seriesId": created._id })
       .sort({ "schedule.start": 1 })
       .toArray();
-    return { base: created, instances };
+    // `created` is the pre-Google-effect record returned by create(); its
+    // externalReference is only persisted by propagate() after create()
+    // already returned, so re-read it to get the real Google eventId.
+    const base = await eventService.readById(userId, created._id.toHexString());
+
+    // The mock gcal client's events.insert auto-expands the base's RRULE
+    // into its own Google-side instance objects (mirroring what a real
+    // series create triggers server-side), but those mock instances carry
+    // no originalStartTime and would otherwise crowd out the page (mock
+    // pageSize defaults to 3) ahead of the deliberately-seeded instance
+    // below. Clear them so each test controls exactly what
+    // events.instances returns.
+    const state = compassTestState();
+    state.events.gcalEvents.all = state.events.gcalEvents.all.filter(
+      (event) =>
+        (event as { recurringEventId?: string }).recurringEventId !==
+        base.externalReference?.eventId,
+    );
+
+    return { base, instances };
   };
 
-  it("does not call Google when a single occurrence is edited with scope 'this'", async () => {
+  /** Registers a Google-side instance matching `start` for the given base. */
+  const seedGoogleInstance = (
+    recurringEventId: string,
+    start: Date,
+    id = `gcal-instance-${new ObjectId().toHexString()}`,
+  ): gSchema$EventInstance => {
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    const instance = {
+      id,
+      recurringEventId,
+      summary: "Weekly sync",
+      start: { dateTime: start.toISOString(), timeZone: "America/Denver" },
+      end: { dateTime: end.toISOString(), timeZone: "America/Denver" },
+      originalStartTime: {
+        dateTime: start.toISOString(),
+        timeZone: "America/Denver",
+      },
+    } as unknown as gSchema$EventInstance;
+
+    compassTestState().events.gcalEvents.all.push(instance);
+    return instance;
+  };
+
+  const timedStart = (event: EventRecord): Date => {
+    if (event.schedule.kind !== "timed") {
+      throw new Error("expected a timed schedule");
+    }
+    return event.schedule.start;
+  };
+
+  it("resolves the Google instance by its pre-edit start when a not-yet-synced occurrence's time is also edited", async () => {
     const { user } = await setupGoogleUser();
     const calendar = await seedGoogleCalendar(user._id);
-    const { instances } = await seedSeries(
+    const { base, instances } = await seedSeries(
+      user._id.toString(),
+      calendar._id.toHexString(),
+    );
+    const target = instances[1]!;
+    const originalStart = timedStart(target);
+    const mockInstance = seedGoogleInstance(
+      base.externalReference!.eventId,
+      originalStart,
+    );
+
+    const findInstanceSpy = jest.spyOn(gcalService, "findEventInstance");
+    const patchSpy = jest.spyOn(gcalService, "patchEvent");
+
+    await eventService.replace(user._id.toString(), target._id.toHexString(), {
+      content: {
+        kind: "details",
+        title: "Weekly sync (one-off)",
+        description: "",
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-21T18:00:00-06:00",
+        end: "2026-07-21T19:00:00-06:00",
+        timeZone: "America/Denver" as never,
+      },
+      recurrence: { kind: "preserve" },
+      priority: "unassigned",
+      scope: "this",
+    });
+
+    expect(findInstanceSpy).toHaveBeenCalledTimes(1);
+    const [, calendarIdArg, recurringEventIdArg, anchorArg] =
+      findInstanceSpy.mock.calls[0]!;
+    expect(calendarIdArg).toBe(calendar.source.calendarId);
+    expect(recurringEventIdArg).toBe(base.externalReference!.eventId);
+    // The pre-edit start, NOT the new 18:00 time this same call is applying.
+    expect((anchorArg as Date).getTime()).toBe(originalStart.getTime());
+
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const [, patchCalendarIdArg, patchEventIdArg, patchBody] =
+      patchSpy.mock.calls[0]!;
+    expect(patchCalendarIdArg).toBe(calendar.source.calendarId);
+    expect(patchEventIdArg).toBe(mockInstance.id);
+    expect(patchBody).toMatchObject({ summary: "Weekly sync (one-off)" });
+
+    const persisted = await eventService.readById(
+      user._id.toString(),
+      target._id.toHexString(),
+    );
+    expect(persisted.externalReference).toMatchObject({
+      provider: "google",
+      eventId: mockInstance.id,
+      recurringEventId: base.externalReference!.eventId,
+    });
+  });
+
+  it("resolves the Google instance by its current start when a not-yet-synced, never-edited occurrence is deleted", async () => {
+    const { user } = await setupGoogleUser();
+    const calendar = await seedGoogleCalendar(user._id);
+    const { base, instances } = await seedSeries(
       user._id.toString(),
       calendar._id.toHexString(),
     );
     const target = instances[0]!;
+    const originalStart = timedStart(target);
+    const mockInstance = seedGoogleInstance(
+      base.externalReference!.eventId,
+      originalStart,
+    );
 
-    const createSpy = jest.spyOn(gcalService, "createEvent");
-    const patchSpy = jest.spyOn(gcalService, "patchEvent");
+    const findInstanceSpy = jest.spyOn(gcalService, "findEventInstance");
+    const deleteSpy = jest.spyOn(gcalService, "deleteEvent");
 
-    const updated = await eventService.replace(
+    await eventService.delete(user._id.toString(), target._id.toHexString(), {
+      scope: "this",
+    });
+
+    expect(findInstanceSpy).toHaveBeenCalledTimes(1);
+    const [, , , anchorArg] = findInstanceSpy.mock.calls[0]!;
+    expect((anchorArg as Date).getTime()).toBe(originalStart.getTime());
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    const [, deleteCalendarIdArg, deleteEventIdArg] = deleteSpy.mock.calls[0]!;
+    expect(deleteCalendarIdArg).toBe(calendar.source.calendarId);
+    expect(deleteEventIdArg).toBe(mockInstance.id);
+
+    await expect(
+      eventService.readById(user._id.toString(), target._id.toHexString()),
+    ).rejects.toMatchObject({ mutationCode: "EVENT_NOT_FOUND" });
+  });
+
+  it("does not look up events.instances again once an occurrence's externalReference is already resolved", async () => {
+    const { user } = await setupGoogleUser();
+    const calendar = await seedGoogleCalendar(user._id);
+    const { base, instances } = await seedSeries(
       user._id.toString(),
-      target._id.toHexString(),
+      calendar._id.toHexString(),
+    );
+    const target = instances[2]!;
+    const mockInstance = seedGoogleInstance(
+      base.externalReference!.eventId,
+      timedStart(target),
+    );
+
+    // First edit resolves and persists the externalReference.
+    await eventService.replace(user._id.toString(), target._id.toHexString(), {
+      content: { kind: "details", title: "First edit", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-28T15:00:00-06:00",
+        end: "2026-07-28T16:00:00-06:00",
+        timeZone: "America/Denver" as never,
+      },
+      recurrence: { kind: "preserve" },
+      priority: "unassigned",
+      scope: "this",
+    });
+
+    const findInstanceSpy = jest.spyOn(gcalService, "findEventInstance");
+    const patchSpy = jest.spyOn(gcalService, "patchEvent");
+    findInstanceSpy.mockClear();
+    patchSpy.mockClear();
+
+    // Second edit: externalReference is already set, so no lookup is needed.
+    await eventService.replace(user._id.toString(), target._id.toHexString(), {
+      content: { kind: "details", title: "Second edit", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-28T20:00:00-06:00",
+        end: "2026-07-28T21:00:00-06:00",
+        timeZone: "America/Denver" as never,
+      },
+      recurrence: { kind: "preserve" },
+      priority: "unassigned",
+      scope: "this",
+    });
+
+    expect(findInstanceSpy).not.toHaveBeenCalled();
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const [, , eventIdArg, body] = patchSpy.mock.calls[0]!;
+    expect(eventIdArg).toBe(mockInstance.id);
+    expect(body).toMatchObject({ summary: "Second edit" });
+  });
+
+  it("silently skips Google sync for an occurrence whose series base was never synced to Google", async () => {
+    const { user } = await setupGoogleUser();
+    const calendar = await seedLocalCalendar(user._id);
+    const base = buildEventRecord(calendar._id, {
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=5"] },
+    });
+    const occurrence = buildEventRecord(calendar._id, {
+      recurrence: { kind: "occurrence", seriesId: base._id },
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-21T15:00:00.000Z"),
+        end: new Date("2026-07-21T16:00:00.000Z"),
+        timeZone: "America/Denver",
+      },
+    });
+    await mongoService.event.insertMany([base, occurrence]);
+
+    const findInstanceSpy = jest.spyOn(gcalService, "findEventInstance");
+    const patchSpy = jest.spyOn(gcalService, "patchEvent");
+    const createSpy = jest.spyOn(gcalService, "createEvent");
+    const deleteSpy = jest.spyOn(gcalService, "deleteEvent");
+
+    await eventService.replace(
+      user._id.toString(),
+      occurrence._id.toHexString(),
       {
-        content: {
-          kind: "details",
-          title: "Weekly sync (one-off)",
-          description: "",
-        },
+        content: { kind: "details", title: "Edited", description: "" },
         schedule: {
           kind: "timed",
-          start: "2026-07-21T15:00:00-06:00",
-          end: "2026-07-21T16:00:00-06:00",
+          start: "2026-07-21T18:00:00-06:00",
+          end: "2026-07-21T19:00:00-06:00",
           timeZone: "America/Denver" as never,
         },
         recurrence: { kind: "preserve" },
@@ -92,13 +295,13 @@ describe("CompassToGoogleEventPropagation - scope 'this' - series occurrence (in
       },
     );
 
-    expect(updated.recurrence.kind).toBe("occurrence");
-    expect(updated.externalReference).toBeNull();
-    expect(createSpy).not.toHaveBeenCalled();
+    expect(findInstanceSpy).not.toHaveBeenCalled();
     expect(patchSpy).not.toHaveBeenCalled();
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
   });
 
-  it("does not call Google when a single occurrence is deleted with scope 'this'", async () => {
+  it("does not throw and does not write to Google when events.instances has no matching instance", async () => {
     const { user } = await setupGoogleUser();
     const calendar = await seedGoogleCalendar(user._id);
     const { instances } = await seedSeries(
@@ -106,16 +309,36 @@ describe("CompassToGoogleEventPropagation - scope 'this' - series occurrence (in
       calendar._id.toHexString(),
     );
     const target = instances[0]!;
-    const deleteSpy = jest.spyOn(gcalService, "deleteEvent");
+    // No Google-side instance seeded -- the lookup will find nothing.
 
-    await eventService.delete(user._id.toString(), target._id.toHexString(), {
-      scope: "this",
-    });
+    const patchSpy = jest.spyOn(gcalService, "patchEvent");
 
-    expect(deleteSpy).not.toHaveBeenCalled();
     await expect(
-      eventService.readById(user._id.toString(), target._id.toHexString()),
-    ).rejects.toMatchObject({ mutationCode: "EVENT_NOT_FOUND" });
+      eventService.replace(user._id.toString(), target._id.toHexString(), {
+        content: {
+          kind: "details",
+          title: "Weekly sync (one-off)",
+          description: "",
+        },
+        schedule: {
+          kind: "timed",
+          start: "2026-07-21T18:00:00-06:00",
+          end: "2026-07-21T19:00:00-06:00",
+          timeZone: "America/Denver" as never,
+        },
+        recurrence: { kind: "preserve" },
+        priority: "unassigned",
+        scope: "this",
+      }),
+    ).resolves.toMatchObject({ content: { title: "Weekly sync (one-off)" } });
+
+    expect(patchSpy).not.toHaveBeenCalled();
+
+    const persisted = await eventService.readById(
+      user._id.toString(),
+      target._id.toHexString(),
+    );
+    expect(persisted.externalReference).toBeNull();
   });
 
   it("rejects editing the series base itself with scope 'this' (RECURRENCE_CONFLICT, B6)", async () => {

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google-backfill.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google-backfill.ts
@@ -44,6 +44,15 @@ export const syncCompassEventsToGoogle = async (
 
   for (const record of candidates) {
     if (!isWritableToGoogle(record)) continue;
+    // Series occurrences with no externalReference are a Compass-local read
+    // model (packet 05 step 4): the per-instance events.instances
+    // resolution that a real scope "this" edit/delete uses lives in
+    // CompassToGoogleEventPropagation, not here. Backfill only ever
+    // events.insert's a record, and doing that for an occurrence would
+    // create a duplicate, unlinked Google event instead of relying on
+    // Google's own RRULE expansion off the (already- or not-yet-synced)
+    // series base.
+    if (record.recurrence.kind === "occurrence") continue;
 
     const calendar = calendarById.get(record.calendarId.toHexString());
     if (!calendar || calendar.source.provider !== "google") continue;

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
@@ -8,6 +8,7 @@ import { eventMutationError } from "@backend/event/event.error";
 import { type EventRecord } from "@backend/event/event.record";
 import { eventRepository } from "@backend/event/event.repository";
 import { mapEventRecordToGoogle } from "@backend/event/google-event.adapter";
+import { getAnchorDate } from "@backend/event/services/recur/util/recur.util";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
 
 const logger = Logger("app:compass-to-google.event-propagation");
@@ -17,18 +18,25 @@ export type EventChangeSet = {
   upserted: EventRecord[];
   /** Records as they existed immediately before being deleted. */
   deletedBefore: EventRecord[];
+  /**
+   * For an unresolved occurrence (externalReference: null) whose schedule
+   * may have just been edited in this same call, the pre-edit start used to
+   * search Google's events.instances by originalStartTime (packet 05 step
+   * 4). Google's originalStartTime is the occurrence's fixed position in the
+   * recurrence pattern -- it never moves even after the instance's own
+   * start/end are edited -- so the lookup must use the position BEFORE this
+   * edit, not the (possibly different) new time this same call is applying.
+   * Keyed by the occurrence's _id hex string. An absent/missing entry falls
+   * back to record.schedule.start (correct for a virgin, never-edited
+   * occurrence, e.g. one freshly materialized by
+   * materializeSeriesInstances, or a delete -- which has no "new" time to
+   * confuse the anchor with).
+   */
+  originalStartByEventId?: Map<string, Date>;
 };
 
 export const isWritableToGoogle = (record: EventRecord): boolean =>
-  record.content.kind === "details" &&
-  record.schedule.kind !== "someday" &&
-  // Materialized series instances (B6) are a Compass-local read model:
-  // Google expands its own copy of an occurrence from the base event's
-  // RRULE, so pushing each instance through events.insert/patch would
-  // create duplicate, unlinked Google events instead of relying on
-  // Google's own recurrence expansion. Only the series base (and
-  // standalone/single events) carry a syncable identity of their own.
-  record.recurrence.kind !== "occurrence";
+  record.content.kind === "details" && record.schedule.kind !== "someday";
 
 /**
  * Propagates a Compass mutation to the OWNING calendar's Google copy (B7,
@@ -61,12 +69,31 @@ export class CompassToGoogleEventPropagation {
       calendars.map((c) => [c._id.toHexString(), c]),
     );
 
+    // A series base (recurrence.kind === "series") present in this same
+    // upserted batch means a bulk (re)materialization is happening in this
+    // call (a fresh series create, or a scope "all"/"thisAndFollowing"
+    // regeneration/truncation) -- any occurrence records riding along in the
+    // same batch are a Compass-local read model produced by that
+    // regeneration, not an independent edit. Google will expand/truncate its
+    // own copies from the base's RRULE (or the base's own patch/delete
+    // below), so those occurrences must NOT go through the per-instance
+    // events.instances resolution below -- doing so would either fan a
+    // single series create out into N+1 unlinked Google events, or attempt
+    // to resolve/delete an instance the base's own RRULE change already
+    // handles.
+    const regeneratingSeriesIds = new Set(
+      change.upserted
+        .filter((record) => record.recurrence.kind === "series")
+        .map((record) => record._id.toHexString()),
+    );
+
     try {
       for (const record of change.deletedBefore) {
         await CompassToGoogleEventPropagation.propagateDelete(
           userId,
           record,
           calendarById.get(record.calendarId.toHexString()),
+          regeneratingSeriesIds,
         );
       }
 
@@ -75,6 +102,8 @@ export class CompassToGoogleEventPropagation {
           userId,
           record,
           calendarById.get(record.calendarId.toHexString()),
+          change.originalStartByEventId,
+          regeneratingSeriesIds,
         );
       }
     } catch (err) {
@@ -93,19 +122,75 @@ export class CompassToGoogleEventPropagation {
     }
   }
 
+  /**
+   * Resolves the Google instance id for a not-yet-synced series occurrence
+   * (packet 05 step 4). The series base is looked up fresh from Mongo rather
+   * than passed in: by the time propagateDelete/propagateUpsert reaches an
+   * occurrence, the base (if part of the same batch) has already been
+   * processed, and if NOT part of the same batch (the common case: a lone
+   * scope "this" edit/delete on an already-synced series) it is simply the
+   * pre-existing base document. A6 keeps every series member on one
+   * calendar, so scoping the lookup to the occurrence's own calendarId is
+   * safe and avoids needing the caller's full owned-calendar list here.
+   */
+  private static async resolveSeriesBase(
+    record: Extract<EventRecord["recurrence"], { kind: "occurrence" }>,
+    calendarId: EventRecord["calendarId"],
+  ): Promise<EventRecord | null> {
+    const base = await eventRepository.findById(record.seriesId, [calendarId]);
+    if (!base?.externalReference) return null;
+    return base;
+  }
+
   private static async propagateDelete(
     userId: string,
     record: EventRecord,
     calendar: CalendarRecord | undefined,
+    regeneratingSeriesIds: Set<string>,
   ): Promise<void> {
     if (!calendar || calendar.source.provider !== "google") return;
-    if (!record.externalReference) return;
+
+    if (record.externalReference) {
+      const context = await createGoogleRequestContext(userId);
+      await gcalService.deleteEvent(
+        context,
+        calendar.source.calendarId,
+        record.externalReference.eventId,
+      );
+      return;
+    }
+
+    if (record.recurrence.kind !== "occurrence") return;
+    if (regeneratingSeriesIds.has(record.recurrence.seriesId.toHexString())) {
+      return;
+    }
+
+    const base = await CompassToGoogleEventPropagation.resolveSeriesBase(
+      record.recurrence,
+      record.calendarId,
+    );
+    if (!base?.externalReference) return;
 
     const context = await createGoogleRequestContext(userId);
+    const anchorStart = getAnchorDate(record.schedule);
+    const instance = await gcalService.findEventInstance(
+      context,
+      calendar.source.calendarId,
+      base.externalReference.eventId,
+      anchorStart,
+    );
+
+    if (!instance?.id) {
+      logger.warn(
+        `propagateDelete: no Google instance of series ${base._id.toHexString()} matched occurrence ${record._id.toHexString()}'s original start (${anchorStart.toISOString()}); skipping Google delete for this occurrence.`,
+      );
+      return;
+    }
+
     await gcalService.deleteEvent(
       context,
       calendar.source.calendarId,
-      record.externalReference.eventId,
+      instance.id,
     );
   }
 
@@ -113,6 +198,8 @@ export class CompassToGoogleEventPropagation {
     userId: string,
     record: EventRecord,
     calendar: CalendarRecord | undefined,
+    originalStartByEventId: Map<string, Date> | undefined,
+    regeneratingSeriesIds: Set<string>,
   ): Promise<void> {
     if (!calendar || calendar.source.provider !== "google") return;
     if (!isWritableToGoogle(record)) return;
@@ -127,6 +214,53 @@ export class CompassToGoogleEventPropagation {
         record.externalReference.eventId,
         body,
       );
+      return;
+    }
+
+    if (record.recurrence.kind === "occurrence") {
+      if (regeneratingSeriesIds.has(record.recurrence.seriesId.toHexString())) {
+        return;
+      }
+
+      const base = await CompassToGoogleEventPropagation.resolveSeriesBase(
+        record.recurrence,
+        record.calendarId,
+      );
+      if (!base?.externalReference) return;
+
+      const anchorStart =
+        originalStartByEventId?.get(record._id.toHexString()) ??
+        getAnchorDate(record.schedule);
+
+      const instance = await gcalService.findEventInstance(
+        context,
+        calendar.source.calendarId,
+        base.externalReference.eventId,
+        anchorStart,
+      );
+
+      if (!instance?.id) {
+        logger.warn(
+          `propagateUpsert: no Google instance of series ${base._id.toHexString()} matched occurrence ${record._id.toHexString()}'s original start (${anchorStart.toISOString()}); skipping Google sync for this edit.`,
+        );
+        return;
+      }
+
+      await gcalService.patchEvent(
+        context,
+        calendar.source.calendarId,
+        instance.id,
+        body,
+      );
+
+      await eventRepository.replaceOne({
+        ...record,
+        externalReference: {
+          provider: "google",
+          eventId: instance.id,
+          recurringEventId: base.externalReference.eventId,
+        },
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Packet 05 (calendar-aware CRUD) phase 2, closing the explicitly-named "03 gap": a Compass-created recurring series' materialized instances never get their own `externalReference` (Google auto-expands them from the base's RRULE), so a scope-`"this"` edit or delete on a single occurrence of an otherwise-synced series never reached Google — Google kept showing the old time, or kept regenerating a deleted occurrence forever.
- Resolves the Google-side instance via `events.instances`, matched by `originalStartTime` (fixed for the life of the instance even after its own `start`/`end` move) the first time an occurrence needs to sync; persists the resolved id so every later edit patches it directly, same as the existing non-recurring path.
- Bulk series (re)materialization (create, scope `"all"`/`"thisAndFollowing"`) is explicitly guarded out of this per-instance path — those rely on Google expanding/truncating from the base's own RRULE, and individually pushing each materialized instance would fan a single change out into N+1 unlinked Google events.
- Also closes packet 05 step 7: `analyzeReplace`/`analyzeDelete` now fail loudly (`RECURRENCE_CONFLICT`) if a series' instances ever drift onto a different calendar than their base — defense-in-depth; A6 should make this unreachable through the public API today.

## Test plan
- [x] `TZ=UTC ./node_modules/.bin/jest --selectProjects backend --testPathPattern="packages/backend/src/(event|sync/services/event-propagation)/"` — 18 suites / 172 tests
- [x] Full backend suite — 64 suites / 541 passed, no regressions
- [x] `bun run type-check`
- [x] `bun run lint` (no new warnings vs. baseline)

Part of the [Google sub-calendars v1 packet 05](../../blob/main/handoff/someday/05-calendar-aware-crud.md) rollout (staging-first per A36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)