### PR TITLE
feat(backend): suppress event notifications for hidden calendars

### DIFF
--- a/packages/backend/src/event/event.repository.test.ts
+++ b/packages/backend/src/event/event.repository.test.ts
@@ -379,6 +379,50 @@ describe("EventRepository", () => {
     });
   });
 
+  // Packet 05 tests list: "Same Google event id in two calendars." Scoping
+  // the lookup by (calendarId, externalReference.eventId) together -- not
+  // externalReference.eventId alone -- is what lets two different Compass
+  // calendars each import their own event carrying an identical Google
+  // event id without one calendar's record shadowing the other's.
+  describe("findByExternalReference (scoped by calendar, step 5)", () => {
+    it("returns only the owning calendar's event when two calendars share the same Google event id", async () => {
+      const calendarA = new ObjectId();
+      const calendarB = new ObjectId();
+      const sharedGoogleEventId = "shared-gevent-1";
+
+      const eventOnA = buildEvent({
+        calendarId: calendarA,
+        externalReference: {
+          provider: "google",
+          eventId: sharedGoogleEventId,
+          recurringEventId: null,
+        },
+      });
+      const eventOnB = buildEvent({
+        calendarId: calendarB,
+        externalReference: {
+          provider: "google",
+          eventId: sharedGoogleEventId,
+          recurringEventId: null,
+        },
+      });
+      await eventRepository.insertMany([eventOnA, eventOnB]);
+
+      const foundOnA = await eventRepository.findByExternalReference(
+        calendarA,
+        sharedGoogleEventId,
+      );
+      const foundOnB = await eventRepository.findByExternalReference(
+        calendarB,
+        sharedGoogleEventId,
+      );
+
+      expect(foundOnA?._id.toHexString()).toBe(eventOnA._id.toHexString());
+      expect(foundOnB?._id.toHexString()).toBe(eventOnB._id.toHexString());
+      expect(foundOnA?._id.toHexString()).not.toBe(foundOnB?._id.toHexString());
+    });
+  });
+
   describe("deleteBySeriesId", () => {
     it("deletes the base and every occurrence", async () => {
       const base = buildEvent({

--- a/packages/backend/src/event/google-event.adapter.test.ts
+++ b/packages/backend/src/event/google-event.adapter.test.ts
@@ -379,4 +379,30 @@ describe("mapEventRecordToGoogle", () => {
     });
     expect(() => mapEventRecordToGoogle(record)).toThrow();
   });
+
+  // Packet 05 tests list: "An events.patch update of a Google event with
+  // attendees, location, and reminders preserves all three." GcalService
+  // uses events.patch (merge-by-key) rather than events.update (whole-
+  // resource replace), so any key omitted from the write body is left
+  // untouched on Google. GoogleEventWriteInput's `Pick` already excludes
+  // attendees/location/reminders at the type level -- EventRecord has no
+  // such fields to begin with -- so mapEventRecordToGoogle structurally
+  // cannot include them. This test guards that invariant at runtime so a
+  // future loosening of the `Pick` (e.g. to plumb through a new field) would
+  // fail a test instead of silently regressing into an events.update-style
+  // wipe of attendees, location, and reminders.
+  it("never includes attendees, location, or reminders in the write body", () => {
+    const record = buildRecord();
+    const patch = mapEventRecordToGoogle(record);
+    expect(patch).not.toHaveProperty("attendees");
+    expect(patch).not.toHaveProperty("location");
+    expect(patch).not.toHaveProperty("reminders");
+    expect(Object.keys(patch).sort()).toEqual([
+      "description",
+      "end",
+      "recurrence",
+      "start",
+      "summary",
+    ]);
+  });
 });

--- a/packages/backend/src/event/services/event.service.test.ts
+++ b/packages/backend/src/event/services/event.service.test.ts
@@ -8,6 +8,7 @@ import {
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import mongoService from "@backend/common/services/mongo.service";
 import eventService from "@backend/event/services/event.service";
+import { sseServer } from "@backend/servers/sse/sse.server";
 import {
   buildEventRecord,
   seedGoogleCalendar,
@@ -649,5 +650,168 @@ describe("EventService (series-calendar consistency guard, step 7)", () => {
         scope: "all",
       }),
     ).rejects.toMatchObject({ mutationCode: "RECURRENCE_CONFLICT" });
+  });
+});
+
+/**
+ * Packet 05 step 9: `notify()` (event.service.ts) suppresses the
+ * `eventsChanged` SSE push for calendars the user has hidden -- the web has
+ * nothing rendered for an invisible calendar, so there's no client state for
+ * that push to reconcile.
+ */
+describe("EventService (SSE suppression for invisible calendars, step 9)", () => {
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("does not publish eventsChanged for a create on a hidden calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedLocalCalendar(user._id);
+    await mongoService.calendar.updateOne(
+      { _id: calendar._id },
+      { $set: { isVisible: false } },
+    );
+    const publishSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await eventService.create(user._id.toString(), {
+      calendarId: calendar._id.toHexString() as never,
+      content: { kind: "details", title: "Hidden event", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T15:00:00-06:00",
+        end: "2026-07-14T16:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it("publishes eventsChanged for a create on a visible calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedLocalCalendar(user._id);
+    const publishSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    const created = await eventService.create(user._id.toString(), {
+      calendarId: calendar._id.toHexString() as never,
+      content: { kind: "details", title: "Visible event", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T15:00:00-06:00",
+        end: "2026-07-14T16:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      user._id.toString(),
+      expect.objectContaining({
+        calendarId: calendar._id.toHexString(),
+        eventIds: [created._id.toHexString()],
+        reason: "created",
+      }),
+    );
+  });
+
+  it("publishes only for the visible calendar when a transition spans a hidden and a visible calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const hiddenLocal = await seedLocalCalendar(user._id);
+    await mongoService.calendar.updateOne(
+      { _id: hiddenLocal._id },
+      { $set: { isVisible: false } },
+    );
+    const visibleWriter = await seedGoogleCalendar(user._id, {
+      access: "writer",
+    });
+
+    const created = await eventService.create(user._id.toString(), {
+      calendarId: hiddenLocal._id.toHexString() as never,
+      content: { kind: "details", title: "Plan trip", description: "" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    const publishSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await eventService.transition(
+      user._id.toString(),
+      created._id.toHexString(),
+      {
+        kind: "schedule",
+        targetCalendarId: visibleWriter._id.toHexString() as never,
+        schedule: {
+          kind: "timed",
+          start: "2026-07-14T15:00:00-06:00",
+          end: "2026-07-14T16:00:00-06:00",
+          timeZone: "America/Denver",
+        },
+      },
+    );
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith(
+      user._id.toString(),
+      expect.objectContaining({ calendarId: visibleWriter._id.toHexString() }),
+    );
+  });
+
+  it("fails open (still publishes) when a touched calendar record's visibility lookup comes back empty", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedLocalCalendar(user._id);
+
+    const created = await eventService.create(user._id.toString(), {
+      calendarId: calendar._id.toHexString() as never,
+      content: { kind: "details", title: "Standup", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T15:00:00-06:00",
+        end: "2026-07-14T16:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    // Simulate the notify() visibility lookup racing a calendar record that
+    // vanished out from under it -- only the `_id: { $in: [...] }` query
+    // notify() runs is stubbed to come back empty; every other `find` call
+    // (e.g. calendarService.list's ownership checks) passes through
+    // untouched. notify() should still publish rather than silently drop it.
+    const originalFind = mongoService.calendar.find.bind(mongoService.calendar);
+    jest
+      .spyOn(mongoService.calendar, "find")
+      .mockImplementation(
+        (...args: Parameters<typeof mongoService.calendar.find>) => {
+          const [filter] = args;
+          const idFilter = (filter as { _id?: { $in?: unknown[] } } | undefined)
+            ?._id?.$in;
+          if (idFilter) {
+            return { toArray: async () => [] } as ReturnType<
+              typeof mongoService.calendar.find
+            >;
+          }
+          return originalFind(...args);
+        },
+      );
+    const publishSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await eventService.delete(user._id.toString(), created._id.toHexString(), {
+      scope: "this",
+    });
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      user._id.toString(),
+      expect.objectContaining({ calendarId: calendar._id.toHexString() }),
+    );
   });
 });

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -35,11 +35,20 @@ import { getAnchorDate } from "@backend/event/services/recur/util/recur.util";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { CompassToGoogleEventPropagation } from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation";
 
-const notify = (
+/**
+ * Publishes `eventsChanged` once per calendar touched by a mutation, but
+ * suppresses the push for calendars the user has hidden (packet 05 step 9):
+ * the web has nothing rendered for an invisible calendar, so there's no
+ * client-side state for that push to reconcile. A calendar record that can't
+ * be found at all (shouldn't happen -- the mutation just touched it) fails
+ * open and still publishes, since suppression is only for a confirmed
+ * `isVisible: false`, not a lookup gap.
+ */
+const notify = async (
   userId: string,
   records: EventRecord[],
   reason: "created" | "updated" | "deleted",
-): void => {
+): Promise<void> => {
   const byCalendar = new Map<string, EventId[]>();
   for (const record of records) {
     const calendarId = record.calendarId.toHexString();
@@ -47,7 +56,20 @@ const notify = (
     ids.push(record._id.toHexString() as EventId);
     byCalendar.set(calendarId, ids);
   }
+
+  const calendarIds = [...byCalendar.keys()].map((id) => new ObjectId(id));
+  const visibilityById = new Map<string, boolean>(
+    (
+      await mongoService.calendar
+        .find({ _id: { $in: calendarIds } }, { projection: { isVisible: 1 } })
+        .toArray()
+    ).map((calendar) => [calendar._id.toHexString(), calendar.isVisible]),
+  );
+
   for (const [calendarId, eventIds] of byCalendar) {
+    const isVisible = visibilityById.get(calendarId) ?? true;
+    if (!isVisible) continue;
+
     sseServer.publishEventsChanged(userId, {
       calendarId: calendarId as CalendarId,
       eventIds,
@@ -194,7 +216,7 @@ class EventService {
       upserted: materialized.upsert,
       deletedBefore: [],
     });
-    notify(userId, [materialized.primary], "created");
+    await notify(userId, [materialized.primary], "created");
 
     return materialized.primary;
   };
@@ -238,7 +260,7 @@ class EventService {
       deletedBefore,
       originalStartByEventId,
     });
-    notify(userId, [materialized.primary], "updated");
+    await notify(userId, [materialized.primary], "updated");
 
     return materialized.primary;
   };
@@ -272,7 +294,7 @@ class EventService {
       upserted: materialized.upsert,
       deletedBefore,
     });
-    notify(userId, deletedBefore, "deleted");
+    await notify(userId, deletedBefore, "deleted");
   };
 
   transition = async (
@@ -315,7 +337,7 @@ class EventService {
       upserted: plan.kind === "schedule" ? [materialized.primary] : [],
       deletedBefore: plan.kind === "unschedule" ? [target] : [],
     });
-    notify(userId, [target, materialized.primary], "updated");
+    await notify(userId, [target, materialized.primary], "updated");
 
     return materialized.primary;
   };


### PR DESCRIPTION
## Summary
- Packet 05 (calendar-aware CRUD) phase 3 (final), closing step 9: `event.service.ts`'s `notify()` published `eventsChanged` for every calendar a mutation touched, regardless of the user's visibility preference — the web has nothing rendered for a hidden calendar, so suppress the push instead. A calendar record that can't be found fails open (still publishes), since suppression is only for a confirmed `isVisible: false`, not a lookup gap.
- Scoped to `event.service.ts`'s CRUD-driven publish path only — the other `publishEventsChanged` call sites (`google-sync.service.ts`, `google-watch.service.ts`) belong to packets 06/07.
- Closes the two remaining items in `05-calendar-aware-crud.md`'s test matrix that weren't yet covered by phases 1/2: `findByExternalReference` scoping by `(calendarId, eventId)` so an identical Google event id in two different calendars never collides, and a runtime guard that `events.patch` write bodies structurally never carry `attendees`/`location`/`reminders`.

## Test plan
- [x] `TZ=UTC ./node_modules/.bin/jest --selectProjects backend --testPathPattern="packages/backend/src/(event|sync/services/event-propagation)/"` — 18 suites / 178 tests
- [x] Full backend suite — 64 suites / 547 passed, no regressions
- [x] `bun run type-check`
- [x] `bun run lint` (15 warnings, same as baseline — no new warnings)

Closes the [Google sub-calendars v1 packet 05](../../blob/main/handoff/someday/05-calendar-aware-crud.md) rollout (staging-first per A36). Packet 06 is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)