### PR TITLE
fix(web): close time picker menu on outside click and fix wrong scroll target

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { type SelectOption } from "@web/common/types/component.types";
+import { TimePicker } from "./TimePicker";
+import { describe, expect, it } from "bun:test";
+
+const options: SelectOption<string>[] = [
+  { value: "13:00", label: "1 PM" },
+  { value: "13:15", label: "1:15 PM" },
+  { value: "13:30", label: "1:30 PM" },
+];
+
+function Harness() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [value, setValue] = useState(options[0]);
+
+  return (
+    <div>
+      <TimePicker
+        bgColor="#000"
+        inputId="startTimePicker"
+        isMenuOpen={isMenuOpen}
+        onChange={setValue}
+        options={options}
+        setIsMenuOpen={setIsMenuOpen}
+        value={value}
+      />
+      <button type="button">Description</button>
+    </div>
+  );
+}
+
+describe("TimePicker", () => {
+  it("closes its menu when focus moves elsewhere in the form, instead of staying open forever", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Description" }));
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useRef } from "react";
 import ReactSelect, { type Props as RSProps } from "react-select";
 import { darken } from "@web/common/styles/color.utils";
 import { type CSSVariables } from "@web/common/styles/css.types";
@@ -26,10 +27,12 @@ export const TimePicker = ({
   ...props
 }: Props) => {
   const TIMEPICKER = "timepicker";
+  const containerRef = useRef<HTMLDivElement>(null);
   let scrollTimer: number;
 
   return (
     <div
+      ref={containerRef}
       className="c-time-picker"
       style={
         {
@@ -71,7 +74,7 @@ export const TimePicker = ({
         }}
         onMenuOpen={() => {
           scrollTimer = window.setTimeout(() => {
-            const defaultOpt = document.getElementsByClassName(
+            const defaultOpt = containerRef.current?.getElementsByClassName(
               `${TIMEPICKER}__option--is-selected`,
             )[0];
             if (defaultOpt) {
@@ -82,6 +85,7 @@ export const TimePicker = ({
         }}
         onMenuClose={() => {
           clearTimeout(scrollTimer);
+          setIsMenuOpen(false);
         }}
         openMenuOnFocus={true}
         options={options}


### PR DESCRIPTION
## Summary
Fixes both bugs from the open `handoff/20260711/spec.md` item "fix(web): time picker input selection" (found live while running the new `ux-sweep` skill's evening pass):

- **Bug 1**: the time picker's dropdown list stayed open when a user clicked elsewhere in the form (e.g. into Description). Root cause: `onMenuClose` never called `setIsMenuOpen(false)`, so the controlled `react-select` menu had no way to actually close once `react-select` decided it should.
- **Bug 2**: the end-time picker's dropdown sometimes opened scrolled to the wrong position (top of list / `12 AM`) instead of its own current value. Root cause: both the start and end pickers share the same `classNamePrefix` ("timepicker"), and the scroll-into-view logic queried `document.getElementsByClassName(...)[0]` — a page-wide, unscoped lookup. Once bug 1 left the start menu stuck open, opening the end menu's query grabbed the *start* menu's selected option first.

The fix scopes the scroll query to each picker's own container (via a `ref`) instead of `document`, and makes `onMenuClose` actually flip `isMenuOpen` to `false`.

## Simplicity
Minimal diff (6 lines in the component, plus one focused test). Ran `simplify` against it and it found nothing to change. No new `useEffect`/`useState`; one `useRef` added to scope the container query to its own DOM subtree — a real imperative DOM handle, not a substitute for derivable state.

## Manual Testing Steps
- [ ] Open any day/week view, click on the grid to create a new timed event.
- [ ] Click the start time input to open its dropdown — confirm it opens scrolled to the current start time.
- [ ] Click the Description field (still inside the form, not the time picker) — confirm the start time dropdown closes.
- [ ] Click the start time input again, then click the end time input — confirm the start dropdown closes and the end dropdown opens scrolled to its own current end time (not `12 AM` / top of list).

## Test plan
- [x] Added `TimePicker.test.tsx`: closes its menu when focus moves elsewhere in the form (`bun test` in `packages/web`, 1 pass).
- [x] `bun run type-check` — clean.
- [x] `bun test src/views/Forms/EventForm` in `packages/web` — 42 pass, 0 fail.