### PR TITLE
docs(someday): close out packet 05 checkboxes

### DIFF
--- a/handoff/someday/05-calendar-aware-crud.md
+++ b/handoff/someday/05-calendar-aware-crud.md
@@ -84,9 +84,20 @@ Depends on: `04-initial-multi-calendar-import.md`.
 
 ## Exit criteria
 
-- [ ] No GCal event write has a primary-calendar default.
-- [ ] Server authorization covers every CRUD path and recurrence expansion.
-- [ ] All provider event lookups include calendar scope.
-- [ ] CRUD works for writable secondary calendars and fails clearly for readers.
+- [x] No GCal event write has a primary-calendar default. (Already true
+      entering this packet except `GCalService.getEvent`'s read-only default;
+      every write path already threaded an explicit calendar id.)
+- [x] Server authorization covers every CRUD path and recurrence expansion.
+      Shipped in PR #2046 (write-capability enforcement) and PR #2049
+      (series-occurrence Google sync + series-calendar consistency guard).
+- [x] All provider event lookups include calendar scope. Google-to-Compass
+      matching was already scoped by `(calendarId, externalReference.eventId)`
+      entering this packet; PR #2050 added the missing test proving an
+      identical Google event id in two calendars never collides.
+- [x] CRUD works for writable secondary calendars and fails clearly for
+      readers. Shipped in PR #2046 (403 `CALENDAR_READ_ONLY`) and PR #2050
+      (SSE suppression for invisible calendars).
+
+Shipped in PRs #2046, #2049, #2050.
 
 Suggested commit: `feat(events): route writes by calendar`

--- a/handoff/someday/master-doc.md
+++ b/handoff/someday/master-doc.md
@@ -63,8 +63,9 @@ unfinished.
       import all eligible Google calendars and events; starts with the request
       context, retry policy, and 7-day channel expiration pulled forward from
       `07` (A30). Shipped in PRs #2036, #2038, #2040, #2043.
-- [ ] 05. [Calendar-aware CRUD](./05-calendar-aware-crud.md) — route writes to the
-      correct provider calendar and enforce permissions.
+- [x] 05. [Calendar-aware CRUD](./05-calendar-aware-crud.md) — route writes to the
+      correct provider calendar and enforce permissions. Shipped in PRs
+      #2046, #2049, #2050.
 - [ ] 06. [Calendar-list sync and watch routing](./06-calendar-list-sync-and-watch-routing.md)
       — keep the calendar set current.
 - [ ] 07. [Watch repair, quota, and retries](./07-watch-repair-quota-and-retries.md) —
@@ -126,7 +127,14 @@ unfinished.
   drops someday `order`; it also omits the legacy but currently unused
   `allDayOrder`. The existing backfill can silently skip invalid rows,
   choose the wrong calendar, and accumulate the whole migration in memory.
-- Google event create/update/delete still default to `GCAL_PRIMARY`.
+- ~~Google event create/update/delete still default to `GCAL_PRIMARY`.~~
+  (2026-07-11 correction, packet 05: only `GCalService.getEvent`'s read
+  path ever had this default; `createEvent`/`updateEvent`/`deleteEvent`
+  already required an explicit calendar id entering packet 05, and
+  Compass-to-Google propagation already resolved the target from
+  `calendar.source.calendarId`. This bullet was stale by the time packet 05
+  started — likely already fixed as a side effect of packet 04's per-calendar
+  fan-out work without this summary being updated.)
 - The public notification endpoint already resolves a stored watch by channel
   id/resource id and derives its Google calendar. A calendar id in the route is
   unnecessary and less trustworthy than that stored association.


### PR DESCRIPTION
## Summary
- Marks packet 05 (calendar-aware CRUD) complete in `handoff/someday/05-calendar-aware-crud.md` and `master-doc.md`'s execution list, citing PRs #2046, #2049, #2050.
- Corrects a stale current-state-summary bullet: GCal writes never actually defaulted to `GCAL_PRIMARY` (only the read-only `getEvent` path did) — this was already fixed before packet 05 started, likely as a side effect of packet 04's per-calendar fan-out, without the summary being updated at the time.

Packet 06 (calendar-list sync and watch routing) is next per the ordered execution list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)