### PR TITLE
feat(backend): dispatch google notifications per resource with honest outcomes

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.test.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.test.ts
@@ -14,12 +14,13 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { invalidGrant400Error } from "@backend/__tests__/mocks.gcal/errors/error.google.invalidGrant";
+import { invalidSyncTokenError } from "@backend/__tests__/mocks.gcal/errors/error.invalidSyncToken";
 import { missingRefreshTokenError } from "@backend/__tests__/mocks.gcal/errors/error.missingRefreshToken";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
-import { GCalNotificationHandler } from "@backend/sync/services/notify/handler/gcal.notification.handler";
+import { GCalEventsNotificationHandler } from "@backend/sync/services/notify/handler/gcal-events.notification.handler";
 import * as syncQueries from "@backend/sync/services/records/sync-records.repository";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
@@ -236,10 +237,10 @@ describe("SyncController", () => {
       expect(watch).not.toBeNull();
 
       const notificationSpy = jest
-        .spyOn(GCalNotificationHandler.prototype, "handleNotification")
+        .spyOn(GCalEventsNotificationHandler.prototype, "handleNotification")
         .mockResolvedValue({
           summary: "PROCESSED",
-          calendarId: new ObjectId(),
+          calendar: { _id: new ObjectId(), isVisible: true },
           eventIds: [],
         });
       const backgroundChangeSpy = jest.spyOn(sseServer, "publishEventsChanged");
@@ -398,6 +399,47 @@ describe("SyncController", () => {
       expect(response.text).toBe("Missing refresh token");
 
       handleGoogleWatchNotificationSpy.mockRestore();
+    });
+
+    it("should acknowledge with REPAIR_STARTED and kick off a resync when Google requires a full sync", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const userId = user._id.toString();
+
+      const watch = await mongoService.watch.findOne({
+        user: userId,
+        gCalendarId: { $ne: Resource_Sync.CALENDAR },
+      });
+
+      expect(watch).toBeDefined();
+      expect(watch).not.toBeNull();
+
+      const handleGoogleWatchNotificationSpy = jest
+        .spyOn(googleWatchService, "handleGoogleWatchNotification")
+        .mockRejectedValue(invalidSyncTokenError);
+
+      const repairSpy = jest
+        .spyOn(googleCalendarSyncService, "repairGoogleCalendarSync")
+        .mockResolvedValue();
+
+      const response = await syncDriver.handleGoogleNotification(
+        {
+          resource: Resource_Sync.EVENTS,
+          channelId: watch!._id,
+          resourceId: watch!.resourceId,
+          resourceState: XGoogleResourceState.EXISTS,
+          expiration: watch!.expiration,
+        },
+        Status.OK,
+      );
+
+      expect(response.body).toEqual({
+        outcome: "REPAIR_STARTED",
+        message: "Full sync in progress.",
+      });
+      expect(repairSpy).toHaveBeenCalledWith(userId);
+
+      handleGoogleWatchNotificationSpy.mockRestore();
+      repairSpy.mockRestore();
     });
   });
 

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -14,6 +14,7 @@ import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
+import { type NotificationOutcome } from "@backend/sync/services/notify/notification.outcome";
 import { publicWatchNotificationIngress } from "@backend/sync/services/public-watch-notifications/public-watch-notification.ingress";
 import { getSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
@@ -23,6 +24,7 @@ import userMetadataService from "@backend/user/services/user-metadata.service";
 import { ImportGCalRequestSchema } from "../sync.types";
 
 const logger = Logger("app:sync.controller");
+const REPAIR_STARTED = "REPAIR_STARTED" satisfies NotificationOutcome;
 
 export class SyncController {
   private static handleMissingRefreshToken = async (
@@ -87,7 +89,10 @@ export class SyncController {
       );
     });
 
-    res.status(Status.OK).send({ message: "Full sync in progress." });
+    res.status(Status.OK).send({
+      outcome: REPAIR_STARTED,
+      message: "Full sync in progress.",
+    });
   };
 
   private static handleMissingSyncToken = async (
@@ -131,6 +136,10 @@ export class SyncController {
     // When Google returns 410 (sync token invalid), the token may still exist
     // in the database but is no longer valid. assessGoogleMetadata checks token
     // existence, not validity, so we must force-restart directly.
+    logger.info(
+      `${REPAIR_STARTED}: restarting Google sync for user: ${userId}`,
+    );
+
     googleCalendarSyncService.repairGoogleCalendarSync(userId).catch((err) => {
       logger.error(
         `Something went wrong with recovering google calendars for user: ${userId}`,

--- a/packages/backend/src/sync/services/notify/handler/gcal-events.notification.handler.test.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal-events.notification.handler.test.ts
@@ -1,6 +1,5 @@
 import { ObjectId } from "mongodb";
 import { type gCalendar } from "@core/types/gcal";
-import { Resource_Sync } from "@core/types/sync.types";
 import {
   cleanupCollections,
   cleanupTestDb,
@@ -11,7 +10,7 @@ import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
-import { GCalNotificationHandler } from "@backend/sync/services/notify/handler/gcal.notification.handler";
+import { GCalEventsNotificationHandler } from "@backend/sync/services/notify/handler/gcal-events.notification.handler";
 
 // Mock dependencies
 
@@ -51,8 +50,8 @@ const getMockLogger = () =>
   (jest.requireMock("@core/logger/winston.logger") as MockLoggerModule)
     .__mockLogger;
 
-describe("GCalNotificationHandler", () => {
-  let handler: GCalNotificationHandler;
+describe("GCalEventsNotificationHandler", () => {
+  let handler: GCalEventsNotificationHandler;
   let mockGcal: gCalendar;
   let mockContext: GoogleRequestContext;
   let mockUserId: string;
@@ -111,9 +110,8 @@ describe("GCalNotificationHandler", () => {
     } as unknown as gCalendar;
     mockContext = { gcal: mockGcal, quotaUser: mockUserId };
 
-    handler = new GCalNotificationHandler(
+    handler = new GCalEventsNotificationHandler(
       mockContext,
-      Resource_Sync.EVENTS,
       mockUserId,
       mockCalendarId,
       mockSyncToken,
@@ -144,7 +142,9 @@ describe("GCalNotificationHandler", () => {
         syncToken: "test-sync-token",
       });
       expect(result.summary).toEqual("PROCESSED");
-      expect(result.calendarId?.toHexString()).toBe(calendar._id.toHexString());
+      expect(result.calendar?._id.toHexString()).toBe(
+        calendar._id.toHexString(),
+      );
       expect(result.eventIds.length).toBe(1);
     });
 
@@ -157,19 +157,6 @@ describe("GCalNotificationHandler", () => {
       // Execute and verify
       const result = await handler.handleNotification();
       expect(result.summary).toEqual("IGNORED");
-    });
-
-    it("should return IGNORED if resource is not EVENTS", async () => {
-      handler = new GCalNotificationHandler(
-        mockContext,
-        Resource_Sync.SETTINGS, // Not EVENTS
-        mockUserId,
-        mockCalendarId,
-        mockSyncToken,
-      );
-      const result = await handler.handleNotification();
-      expect(result.summary).toBe("IGNORED");
-      expect(result.eventIds).toEqual([]);
     });
 
     it("should return IGNORED if no changes and nextSyncToken is different", async () => {
@@ -200,9 +187,8 @@ describe("GCalNotificationHandler", () => {
     });
 
     it("should return IGNORED when no owning calendar is found for the user", async () => {
-      handler = new GCalNotificationHandler(
+      handler = new GCalEventsNotificationHandler(
         mockContext,
-        Resource_Sync.EVENTS,
         new ObjectId().toString(),
         mockCalendarId,
         mockSyncToken,
@@ -213,7 +199,7 @@ describe("GCalNotificationHandler", () => {
 
       const result = await handler.handleNotification();
       expect(result.summary).toBe("IGNORED");
-      expect(result.calendarId).toBeNull();
+      expect(result.calendar).toBeNull();
     });
   });
 });

--- a/packages/backend/src/sync/services/notify/handler/gcal-events.notification.handler.ts
+++ b/packages/backend/src/sync/services/notify/handler/gcal-events.notification.handler.ts
@@ -1,43 +1,38 @@
 import { ObjectId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import { Resource_Sync } from "@core/types/sync.types";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { GoogleToCompassEventPropagation } from "@backend/sync/services/event-propagation/google-to-compass/google-to-compass.event-propagation";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 
-const logger = Logger("app:gcal.notification.handler");
+const logger = Logger("app:gcal-events.notification.handler");
 
 export type NotificationSummary = {
   summary: "PROCESSED" | "IGNORED";
-  calendarId: ObjectId | null;
+  calendar: Pick<CalendarRecord, "_id" | "isVisible"> | null;
   eventIds: string[];
 };
 
-export class GCalNotificationHandler {
+export class GCalEventsNotificationHandler {
   constructor(
     private context: GoogleRequestContext,
-    private resource: Resource_Sync,
     private userId: string,
     private gCalendarId: string,
     private nextSyncToken: string,
   ) {}
 
   /**
-   * Handle a Google Calendar notification
+   * Handle a Google Calendar events notification
    */
   async handleNotification(): Promise<NotificationSummary> {
-    if (this.resource !== Resource_Sync.EVENTS) {
-      logger.info(`${this.resource.toUpperCase()} CHANGES - NOT IMPLEMENTED`);
-      return { summary: "IGNORED", calendarId: null, eventIds: [] };
-    }
-
     const { hasChanges, changes } = await this.getLatestChanges();
 
     if (!hasChanges) {
       logger.info("NO CHANGES TO PROCESS");
-      return { summary: "IGNORED", calendarId: null, eventIds: [] };
+      return { summary: "IGNORED", calendar: null, eventIds: [] };
     }
 
     const calendar = await mongoService.calendar.findOne({
@@ -50,7 +45,7 @@ export class GCalNotificationHandler {
       logger.warn(
         `Ignoring notification because no owning calendar was found for user ${this.userId}`,
       );
-      return { summary: "IGNORED", calendarId: null, eventIds: [] };
+      return { summary: "IGNORED", calendar: null, eventIds: [] };
     }
 
     const processor = new GoogleToCompassEventPropagation(
@@ -65,7 +60,7 @@ export class GCalNotificationHandler {
 
     return {
       summary: "PROCESSED",
-      calendarId: calendar._id,
+      calendar: { _id: calendar._id, isVisible: calendar.isVisible },
       eventIds: result.affectedEventIds,
     };
   }

--- a/packages/backend/src/sync/services/notify/notification.outcome.ts
+++ b/packages/backend/src/sync/services/notify/notification.outcome.ts
@@ -1,0 +1,6 @@
+export type NotificationOutcome =
+  | "INITIALIZED"
+  | "PROCESSED"
+  | "IGNORED"
+  | "RECONCILED"
+  | "REPAIR_STARTED";

--- a/packages/backend/src/sync/services/watch/google-watch.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.test.ts
@@ -50,6 +50,56 @@ const createWatch = async (
   return watch;
 };
 
+/**
+ * Seeds a user with healthy Google sync state, points gcalService.getEvents
+ * at the given items, and returns a notify() bound to that user's events
+ * watch. `seedCalendar` controls whether an owning CalendarRecord exists and
+ * whether it is visible.
+ */
+const seedEventsNotification = async (options: {
+  seedCalendar?: { isVisible: boolean };
+  gcalItems: ReturnType<typeof mockRegularGcalEvent>[];
+}) => {
+  const user = await UserDriver.createUser();
+  await GoogleSyncDriver.createHealthyGoogleSync(user, true);
+  const userId = user._id.toString();
+
+  const watch = await mongoService.watch.findOne({
+    user: userId,
+    gCalendarId: { $ne: Resource_Sync.CALENDAR },
+  });
+  if (!watch) throw new Error("expected an events watch from the sync driver");
+
+  const calendar = options.seedCalendar
+    ? await seedGoogleCalendar(user._id, {
+        isVisible: options.seedCalendar.isVisible,
+        source: {
+          provider: "google",
+          calendarId: watch.gCalendarId,
+          etag: "etag-1",
+        },
+      })
+    : null;
+
+  jest.spyOn(gcalService, "getEvents").mockResolvedValue({
+    status: 200,
+    statusText: "OK",
+    data: { items: options.gcalItems },
+  } as unknown as GaxiosResponse);
+  const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+  const notify = () =>
+    googleWatchService.handleGoogleWatchNotification({
+      resource: Resource_Sync.EVENTS,
+      channelId: watch._id,
+      resourceId: watch.resourceId,
+      resourceState: XGoogleResourceState.EXISTS,
+      expiration: watch.expiration,
+    });
+
+  return { userId, calendar, eventsChangedSpy, notify };
+};
+
 describe("googleWatchService", () => {
   beforeAll(initSupertokens);
   beforeEach(setupTestDb);
@@ -168,117 +218,39 @@ describe("googleWatchService", () => {
   });
 
   it("returns IGNORED when the events handler finds no changes to process", async () => {
-    const user = await UserDriver.createUser();
-    await GoogleSyncDriver.createHealthyGoogleSync(user, true);
-    const userId = user._id.toString();
-
-    const watch = await mongoService.watch.findOne({
-      user: userId,
-      gCalendarId: { $ne: Resource_Sync.CALENDAR },
+    const { eventsChangedSpy, notify } = await seedEventsNotification({
+      gcalItems: [],
     });
-    expect(watch).not.toBeNull();
 
-    jest.spyOn(gcalService, "getEvents").mockResolvedValue({
-      status: 200,
-      statusText: "OK",
-      data: { items: [] },
-    } as unknown as GaxiosResponse);
-    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
-
-    await expect(
-      googleWatchService.handleGoogleWatchNotification({
-        resource: Resource_Sync.EVENTS,
-        channelId: watch!._id,
-        resourceId: watch!.resourceId,
-        resourceState: XGoogleResourceState.EXISTS,
-        expiration: watch!.expiration,
-      }),
-    ).resolves.toBe("IGNORED");
+    await expect(notify()).resolves.toBe("IGNORED");
 
     expect(eventsChangedSpy).not.toHaveBeenCalled();
   });
 
   it("suppresses the eventsChanged publish for a hidden calendar but still reports PROCESSED", async () => {
-    const user = await UserDriver.createUser();
-    await GoogleSyncDriver.createHealthyGoogleSync(user, true);
-    const userId = user._id.toString();
-
-    const watch = await mongoService.watch.findOne({
-      user: userId,
-      gCalendarId: { $ne: Resource_Sync.CALENDAR },
-    });
-    expect(watch).not.toBeNull();
-
-    await seedGoogleCalendar(user._id, {
-      isVisible: false,
-      source: {
-        provider: "google",
-        calendarId: watch!.gCalendarId,
-        etag: "etag-1",
-      },
+    const { eventsChangedSpy, notify } = await seedEventsNotification({
+      seedCalendar: { isVisible: false },
+      gcalItems: [mockRegularGcalEvent({ summary: "Hidden event" })],
     });
 
-    jest.spyOn(gcalService, "getEvents").mockResolvedValue({
-      status: 200,
-      statusText: "OK",
-      data: { items: [mockRegularGcalEvent({ summary: "Hidden event" })] },
-    } as unknown as GaxiosResponse);
-    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
-
-    await expect(
-      googleWatchService.handleGoogleWatchNotification({
-        resource: Resource_Sync.EVENTS,
-        channelId: watch!._id,
-        resourceId: watch!.resourceId,
-        resourceState: XGoogleResourceState.EXISTS,
-        expiration: watch!.expiration,
-      }),
-    ).resolves.toBe("PROCESSED");
+    await expect(notify()).resolves.toBe("PROCESSED");
 
     expect(eventsChangedSpy).not.toHaveBeenCalled();
   });
 
   it("publishes the eventsChanged for a visible calendar", async () => {
-    const user = await UserDriver.createUser();
-    await GoogleSyncDriver.createHealthyGoogleSync(user, true);
-    const userId = user._id.toString();
+    const { userId, calendar, eventsChangedSpy, notify } =
+      await seedEventsNotification({
+        seedCalendar: { isVisible: true },
+        gcalItems: [mockRegularGcalEvent({ summary: "Visible event" })],
+      });
 
-    const watch = await mongoService.watch.findOne({
-      user: userId,
-      gCalendarId: { $ne: Resource_Sync.CALENDAR },
-    });
-    expect(watch).not.toBeNull();
-
-    const calendar = await seedGoogleCalendar(user._id, {
-      isVisible: true,
-      source: {
-        provider: "google",
-        calendarId: watch!.gCalendarId,
-        etag: "etag-1",
-      },
-    });
-
-    jest.spyOn(gcalService, "getEvents").mockResolvedValue({
-      status: 200,
-      statusText: "OK",
-      data: { items: [mockRegularGcalEvent({ summary: "Visible event" })] },
-    } as unknown as GaxiosResponse);
-    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
-
-    await expect(
-      googleWatchService.handleGoogleWatchNotification({
-        resource: Resource_Sync.EVENTS,
-        channelId: watch!._id,
-        resourceId: watch!.resourceId,
-        resourceState: XGoogleResourceState.EXISTS,
-        expiration: watch!.expiration,
-      }),
-    ).resolves.toBe("PROCESSED");
+    await expect(notify()).resolves.toBe("PROCESSED");
 
     expect(eventsChangedSpy).toHaveBeenCalledWith(
       userId,
       expect.objectContaining({
-        calendarId: calendar._id.toHexString(),
+        calendarId: calendar!._id.toHexString(),
         reason: "reconciled",
       }),
     );

--- a/packages/backend/src/sync/services/watch/google-watch.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.test.ts
@@ -1,7 +1,9 @@
 import { faker } from "@faker-js/faker";
+import { type GaxiosResponse } from "gaxios";
 import { ObjectId } from "mongodb";
 import { Resource_Sync, XGoogleResourceState } from "@core/types/sync.types";
 import { WatchSchema } from "@core/types/watch.types";
+import { GoogleSyncDriver } from "@backend/__tests__/drivers/google-sync.driver";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import {
   cleanupCollections,
@@ -10,9 +12,13 @@ import {
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { createGoogleError } from "@backend/__tests__/mocks.gcal/errors/error.google.factory";
 import { invalidGrant400Error } from "@backend/__tests__/mocks.gcal/errors/error.google.invalidGrant";
+import { mockRegularGcalEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
+import { sseServer } from "@backend/servers/sse/sse.server";
+import { seedGoogleCalendar } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
+import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
 
@@ -26,13 +32,16 @@ jest.mock("@backend/sync/services/watch/google-watch-config", () => {
   };
 });
 
-const createWatch = async (user: string) => {
+const createWatch = async (
+  user: string,
+  gCalendarId: string = faker.string.uuid(),
+) => {
   const watch = WatchSchema.parse({
     _id: new ObjectId(),
     user,
     resourceId: faker.string.uuid(),
     expiration: new Date(Date.now() + 60_000),
-    gCalendarId: faker.string.uuid(),
+    gCalendarId,
     createdAt: new Date(),
   });
 
@@ -130,6 +139,149 @@ describe("googleWatchService", () => {
     ).resolves.toBe("IGNORED");
 
     expect(cleanupSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("acknowledges a calendarlist notification without processing events or publishing SSE", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+
+    await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+      nextSyncToken: faker.string.alphanumeric(16),
+    });
+    const watch = await createWatch(userId, Resource_Sync.CALENDAR);
+
+    const getEventsSpy = jest.spyOn(gcalService, "getEvents");
+    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await expect(
+      googleWatchService.handleGoogleWatchNotification({
+        resource: Resource_Sync.CALENDAR,
+        channelId: watch._id,
+        resourceId: watch.resourceId,
+        resourceState: XGoogleResourceState.EXISTS,
+        expiration: watch.expiration,
+      }),
+    ).resolves.toBe("IGNORED");
+
+    expect(getEventsSpy).not.toHaveBeenCalled();
+    expect(eventsChangedSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns IGNORED when the events handler finds no changes to process", async () => {
+    const user = await UserDriver.createUser();
+    await GoogleSyncDriver.createHealthyGoogleSync(user, true);
+    const userId = user._id.toString();
+
+    const watch = await mongoService.watch.findOne({
+      user: userId,
+      gCalendarId: { $ne: Resource_Sync.CALENDAR },
+    });
+    expect(watch).not.toBeNull();
+
+    jest.spyOn(gcalService, "getEvents").mockResolvedValue({
+      status: 200,
+      statusText: "OK",
+      data: { items: [] },
+    } as unknown as GaxiosResponse);
+    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await expect(
+      googleWatchService.handleGoogleWatchNotification({
+        resource: Resource_Sync.EVENTS,
+        channelId: watch!._id,
+        resourceId: watch!.resourceId,
+        resourceState: XGoogleResourceState.EXISTS,
+        expiration: watch!.expiration,
+      }),
+    ).resolves.toBe("IGNORED");
+
+    expect(eventsChangedSpy).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the eventsChanged publish for a hidden calendar but still reports PROCESSED", async () => {
+    const user = await UserDriver.createUser();
+    await GoogleSyncDriver.createHealthyGoogleSync(user, true);
+    const userId = user._id.toString();
+
+    const watch = await mongoService.watch.findOne({
+      user: userId,
+      gCalendarId: { $ne: Resource_Sync.CALENDAR },
+    });
+    expect(watch).not.toBeNull();
+
+    await seedGoogleCalendar(user._id, {
+      isVisible: false,
+      source: {
+        provider: "google",
+        calendarId: watch!.gCalendarId,
+        etag: "etag-1",
+      },
+    });
+
+    jest.spyOn(gcalService, "getEvents").mockResolvedValue({
+      status: 200,
+      statusText: "OK",
+      data: { items: [mockRegularGcalEvent({ summary: "Hidden event" })] },
+    } as unknown as GaxiosResponse);
+    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await expect(
+      googleWatchService.handleGoogleWatchNotification({
+        resource: Resource_Sync.EVENTS,
+        channelId: watch!._id,
+        resourceId: watch!.resourceId,
+        resourceState: XGoogleResourceState.EXISTS,
+        expiration: watch!.expiration,
+      }),
+    ).resolves.toBe("PROCESSED");
+
+    expect(eventsChangedSpy).not.toHaveBeenCalled();
+  });
+
+  it("publishes the eventsChanged for a visible calendar", async () => {
+    const user = await UserDriver.createUser();
+    await GoogleSyncDriver.createHealthyGoogleSync(user, true);
+    const userId = user._id.toString();
+
+    const watch = await mongoService.watch.findOne({
+      user: userId,
+      gCalendarId: { $ne: Resource_Sync.CALENDAR },
+    });
+    expect(watch).not.toBeNull();
+
+    const calendar = await seedGoogleCalendar(user._id, {
+      isVisible: true,
+      source: {
+        provider: "google",
+        calendarId: watch!.gCalendarId,
+        etag: "etag-1",
+      },
+    });
+
+    jest.spyOn(gcalService, "getEvents").mockResolvedValue({
+      status: 200,
+      statusText: "OK",
+      data: { items: [mockRegularGcalEvent({ summary: "Visible event" })] },
+    } as unknown as GaxiosResponse);
+    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await expect(
+      googleWatchService.handleGoogleWatchNotification({
+        resource: Resource_Sync.EVENTS,
+        channelId: watch!._id,
+        resourceId: watch!.resourceId,
+        resourceState: XGoogleResourceState.EXISTS,
+        expiration: watch!.expiration,
+      }),
+    ).resolves.toBe("PROCESSED");
+
+    expect(eventsChangedSpy).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({
+        calendarId: calendar._id.toHexString(),
+        reason: "reconciled",
+      }),
+    );
   });
 
   it("skips direct Google watch setup when the Google webhook URL is not HTTPS", async () => {

--- a/packages/backend/src/sync/services/watch/google-watch.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.ts
@@ -27,7 +27,8 @@ import {
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
-import { GCalNotificationHandler } from "@backend/sync/services/notify/handler/gcal.notification.handler";
+import { GCalEventsNotificationHandler } from "@backend/sync/services/notify/handler/gcal-events.notification.handler";
+import { type NotificationOutcome } from "@backend/sync/services/notify/notification.outcome";
 import { getSync } from "@backend/sync/services/records/sync-records.repository";
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
 import { isWatchingGoogleResource } from "@backend/sync/services/watch/google-watch-state";
@@ -126,7 +127,9 @@ async function cleanupStaleWatch({
   }
 }
 
-async function handleGoogleWatchNotification(payload: Payload_Sync_Notif) {
+async function handleGoogleWatchNotification(
+  payload: Payload_Sync_Notif,
+): Promise<NotificationOutcome> {
   const { channelId, resourceId, resourceState, resource } = payload;
   const { expiration } = payload;
 
@@ -184,10 +187,20 @@ async function handleGoogleWatchNotification(payload: Payload_Sync_Notif) {
     );
   }
 
+  if (resource === Resource_Sync.CALENDAR) {
+    // Calendarlist reconciliation (upsert/archive from the notified change)
+    // lands in a later phase; for now just acknowledge so Google stops
+    // retrying.
+    logger.info(
+      "calendarlist notification acknowledged; reconciliation lands with calendar-list sync",
+    );
+
+    return "IGNORED";
+  }
+
   const context = await createGoogleRequestContext(userId);
-  const handler = new GCalNotificationHandler(
+  const handler = new GCalEventsNotificationHandler(
     context,
-    resource,
     userId,
     watch.gCalendarId,
     nextSyncToken,
@@ -195,21 +208,19 @@ async function handleGoogleWatchNotification(payload: Payload_Sync_Notif) {
 
   const notification = await handler.handleNotification();
 
-  if (notification.calendarId) {
+  if (notification.calendar && notification.calendar.isVisible !== false) {
     sseServer.publishEventsChanged(userId, {
-      calendarId: notification.calendarId.toHexString() as CalendarId,
+      calendarId: notification.calendar._id.toHexString() as CalendarId,
       eventIds: notification.eventIds as EventId[],
       reason: "reconciled",
     });
   }
 
-  const result = "PROCESSED";
-
   logger.info(
-    `GCal Notification for user: ${userId}, calendarId: ${notification.calendarId?.toHexString() ?? "unknown"} ${result}`,
+    `GCal Notification for user: ${userId}, calendarId: ${notification.calendar?._id.toHexString() ?? "unknown"} ${notification.summary}`,
   );
 
-  return result;
+  return notification.summary;
 }
 
 async function refreshWatch(

--- a/packages/backend/src/sync/services/watch/google-watch.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.ts
@@ -208,7 +208,7 @@ async function handleGoogleWatchNotification(
 
   const notification = await handler.handleNotification();
 
-  if (notification.calendar && notification.calendar.isVisible !== false) {
+  if (notification.calendar?.isVisible) {
     sseServer.publishEventsChanged(userId, {
       calendarId: notification.calendar._id.toHexString() as CalendarId,
       eventIds: notification.eventIds as EventId[],


### PR DESCRIPTION
## Summary

Packet 06 (calendar-list sync and watch routing) phase 1 of 3: notification plumbing. Prepares the webhook dispatcher for calendarlist reconciliation (phase 2) by fixing two pre-existing honesty gaps and one A8 gap:

- **Split notification handling by resource** (packet 06 step 1): `GCalNotificationHandler` becomes `GCalEventsNotificationHandler` (events-only; `resource` param and dead non-events branch removed). Dispatch lives in `handleGoogleWatchNotification`: `calendarlist` notifications are acknowledged with outcome `IGNORED` (no events handler constructed, no SSE) until phase 2 wires the reconciler. The all-caps "NOT IMPLEMENTED" log is gone.
- **Structured outcomes** (step 8): new `NotificationOutcome` type (`INITIALIZED | PROCESSED | IGNORED | RECONCILED | REPAIR_STARTED`). The dispatcher previously returned a hard-coded `"PROCESSED"` even for notifications it ignored; it now returns the handler's actual summary. Controller repair paths respond/log `REPAIR_STARTED`. HTTP statuses unchanged (stale/duplicate notifications still ACK 200/204 so Google is not encouraged to retry — step 7).
- **Hidden-calendar SSE suppression on the webhook path** (step 6 clause, A8): `eventsChanged` was published unconditionally after webhook-driven event reconciliation, bypassing the packet 05 suppression that covers Compass-side mutations. The handler now returns the owning calendar's `_id` + `isVisible`, and the publish is gated on visibility. Events are still processed into the DB; only the client push is suppressed.

## Testing

- New: calendarlist notification dispatch (IGNORED, no `getEvents`, no SSE), outcome honesty (handler IGNORED propagates), hidden-calendar suppression + visible-calendar publish, `REPAIR_STARTED` response body on 410-triggered repair.
- `TZ=UTC jest --selectProjects backend`: 64 suites, 551 passed / 1 pre-existing skip.
- `bun run type-check` clean; `bun run lint` only the 15 pre-existing web warnings (diff is backend-only).

Part of `handoff/someday/06-calendar-list-sync-and-watch-routing.md` (phase 2: incremental calendarlist reconciliation; phase 3: 410 recovery + hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)