### PR TITLE
feat(backend): reconcile google calendar list changes incrementally

### DIFF
--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -1,5 +1,7 @@
+import { type calendar_v3 } from "@googleapis/calendar";
 import {
   type AnyBulkWriteOperation,
+  type BulkWriteResult,
   type ClientSession,
   type ObjectId,
 } from "mongodb";
@@ -43,6 +45,68 @@ class CalendarService {
       session,
     );
 
+    const { result } = await this.upsertGoogleCalendarEntries(
+      userObjectId,
+      googleCalendars,
+      session,
+    );
+
+    const googleCalendarIds = googleCalendars
+      .map(({ id }) => id)
+      .filter((id): id is string => !!id);
+
+    // Valid ONLY here because `googleCalendars` is the complete calendarlist
+    // (full discovery), not a delta - archiving every google calendar absent
+    // from a delta would wipe out calendars the delta simply didn't mention.
+    // Kept out of `upsertGoogleCalendarEntries` for that reason.
+    const sweepResult = await mongoService.calendar.updateMany(
+      {
+        userId: userObjectId,
+        "source.provider": "google",
+        "source.calendarId": { $nin: googleCalendarIds },
+      },
+      { $set: { isActive: false, updatedAt: new Date() } },
+      { session },
+    );
+
+    const upsertOk = result === null || result.ok === 1;
+
+    return {
+      googleCalendars,
+      nextPageToken,
+      nextSyncToken,
+      acknowledged: upsertOk && sweepResult.acknowledged,
+      insertedCount: result?.insertedCount ?? 0,
+      insertedIds: result?.insertedIds ?? {},
+      modifiedCount: (result?.modifiedCount ?? 0) + sweepResult.modifiedCount,
+      upsertedIds: result?.upsertedIds ?? {},
+      deletedCount: result?.deletedCount ?? 0,
+    };
+  }
+
+  /**
+   * upsertGoogleCalendarEntries
+   *
+   * Shared upsert core for both full-list discovery
+   * (initializeGoogleCalendars) and incremental calendarlist reconciliation
+   * (google-calendarlist.service): maps each Google entry onto its Compass
+   * CalendarRecord - reusing an existing row's _id/isVisible when one exists
+   * (A3, A16) - and bulk-upserts. Deliberately does NOT archive anything
+   * absent from `entries`; that sweep is only correct against a full list
+   * (see initializeGoogleCalendars) and would wrongly archive every calendar
+   * a partial delta simply didn't mention.
+   */
+  async upsertGoogleCalendarEntries(
+    userId: ObjectId | string,
+    entries: calendar_v3.Schema$CalendarListEntry[],
+    session?: ClientSession,
+  ): Promise<{ records: CalendarRecord[]; result: BulkWriteResult | null }> {
+    const userObjectId = zObjectId.parse(userId);
+
+    if (entries.length === 0) {
+      return { records: [], result: null };
+    }
+
     const existingByGoogleId = new Map<
       string,
       Pick<CalendarRecord, "_id" | "isVisible">
@@ -66,7 +130,7 @@ class CalendarService {
       ),
     );
 
-    const records = googleCalendars.map((entry) =>
+    const records = entries.map((entry) =>
       mapGoogleCalendar(entry, {
         userId: userObjectId,
         existing: entry.id ? existingByGoogleId.get(entry.id) : undefined,
@@ -112,38 +176,50 @@ class CalendarService {
       },
     );
 
-    const googleCalendarIds = googleCalendars
-      .map(({ id }) => id)
-      .filter((id): id is string => !!id);
-
-    operations.push({
-      updateMany: {
-        filter: {
-          userId: userObjectId,
-          "source.provider": "google",
-          "source.calendarId": { $nin: googleCalendarIds },
-        },
-        update: { $set: { isActive: false, updatedAt: new Date() } },
-      },
-    });
-
     const result = await mongoService.calendar.bulkWrite(operations, {
       ordered: false,
       session,
     });
 
-    return {
-      googleCalendars,
-      nextPageToken,
-      nextSyncToken,
-      acknowledged: result.ok === 1,
-      insertedCount: result.insertedCount,
-      insertedIds: result.insertedIds,
-      modifiedCount: result.modifiedCount,
-      upsertedIds: result.upsertedIds,
-      deletedCount: result.deletedCount,
-    };
+    const googleCalendarIds = entries
+      .map(({ id }) => id)
+      .filter((id): id is string => !!id);
+
+    const freshRecords = await mongoService.calendar
+      .find(
+        {
+          userId: userObjectId,
+          "source.provider": "google",
+          "source.calendarId": { $in: googleCalendarIds },
+        },
+        { session },
+      )
+      .toArray();
+
+    return { records: freshRecords, result };
   }
+
+  /**
+   * Soft-deletes one Google calendar (the calendarlist delta says it was
+   * hidden or removed). Idempotent: archiving an already-inactive row is a
+   * no-op state-wise. Returns null when the user never had a row for this
+   * Google calendar id (e.g. it was never imported) - callers should treat
+   * that as "nothing to tear down", not create an archived row for it.
+   */
+  archiveGoogleCalendar = async (
+    userId: ObjectId | string,
+    gCalendarId: string,
+  ) => {
+    return mongoService.calendar.findOneAndUpdate(
+      {
+        userId: zObjectId.parse(userId),
+        "source.provider": "google",
+        "source.calendarId": gCalendarId,
+      },
+      { $set: { isActive: false, updatedAt: new Date() } },
+      { returnDocument: "after" },
+    );
+  };
 
   /**
    * Get every calendar record owned by a user.

--- a/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.test.ts
+++ b/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.test.ts
@@ -1,0 +1,675 @@
+import { faker } from "@faker-js/faker";
+import { ObjectId } from "mongodb";
+import { createMockCalendarListEntry } from "@core/__tests__/helpers/gcal.factory";
+import { Resource_Sync } from "@core/types/sync.types";
+import { WatchSchema } from "@core/types/watch.types";
+import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { compassTestState } from "@backend/__tests__/helpers/mock.setup";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
+import gcalService from "@backend/common/services/gcal/gcal.service";
+import mongoService from "@backend/common/services/mongo.service";
+import { type EventRecord } from "@backend/event/event.record";
+import { sseServer } from "@backend/servers/sse/sse.server";
+import { googleCalendarListService } from "@backend/sync/services/calendarlist/google-calendarlist.service";
+import * as syncImportService from "@backend/sync/services/import/google-import.service";
+import { updateSync } from "@backend/sync/services/records/sync-records.repository";
+
+const buildGoogleCalendar = (
+  userId: ObjectId,
+  overrides: Partial<CalendarRecord> = {},
+): CalendarRecord => ({
+  _id: new ObjectId(),
+  userId,
+  name: "Calendar",
+  description: "",
+  timeZone: "America/Denver",
+  foregroundColor: "#000000",
+  backgroundColor: "#ffffff",
+  access: "writer",
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  source: { provider: "google", calendarId: "cal", etag: "etag-1" },
+  createdAt: new Date(),
+  updatedAt: null,
+  ...overrides,
+});
+
+const buildEvent = (
+  calendarId: ObjectId,
+  overrides: Partial<EventRecord> = {},
+): EventRecord => ({
+  _id: new ObjectId(),
+  calendarId,
+  content: { kind: "details", title: "Event", description: "" },
+  schedule: {
+    kind: "timed",
+    start: new Date("2026-01-15T10:00:00.000Z"),
+    end: new Date("2026-01-15T11:00:00.000Z"),
+    timeZone: "America/Denver",
+  },
+  recurrence: { kind: "single" },
+  priority: "unassigned",
+  externalReference: null,
+  createdAt: new Date(),
+  updatedAt: null,
+  ...overrides,
+});
+
+const seedActiveGoogleCalendar = async (
+  userId: ObjectId,
+  gCalendarId: string,
+  overrides: Partial<CalendarRecord> = {},
+): Promise<CalendarRecord> => {
+  const calendar = buildGoogleCalendar(userId, {
+    ...overrides,
+    source: { provider: "google", calendarId: gCalendarId, etag: "etag-1" },
+  });
+  await mongoService.calendar.insertOne(calendar);
+  return calendar;
+};
+
+const seedEventsSyncEntry = (userId: string, gCalendarId: string) =>
+  updateSync(Resource_Sync.EVENTS, userId, gCalendarId, {
+    nextSyncToken: faker.string.alphanumeric(16),
+  });
+
+const seedWatch = async (userId: string, gCalendarId: string) => {
+  const watch = WatchSchema.parse({
+    _id: new ObjectId(),
+    user: userId,
+    resourceId: faker.string.uuid(),
+    expiration: new Date(Date.now() + 60_000),
+    gCalendarId,
+    createdAt: new Date(),
+  });
+  await mongoService.watch.insertOne(watch);
+  return watch;
+};
+
+const seedCalendarlistToken = async (userId: string): Promise<string> => {
+  const token = faker.string.alphanumeric(16);
+  await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+    nextSyncToken: token,
+  });
+  return token;
+};
+
+const getCalendarlistToken = async (userId: string) => {
+  const sync = await mongoService.sync.findOne({ user: userId });
+  return sync?.google?.calendarlist?.find(
+    (entry) => entry.gCalendarId === Resource_Sync.CALENDAR,
+  )?.nextSyncToken;
+};
+
+const getEventsSyncGCalIds = async (userId: string) => {
+  const sync = await mongoService.sync.findOne({ user: userId });
+  return sync?.google?.events?.map((entry) => entry.gCalendarId) ?? [];
+};
+
+const reconcile = async (userId: string) => {
+  const context = await createGoogleRequestContext(userId);
+  return googleCalendarListService.reconcileCalendarList(context, userId);
+};
+
+describe("googleCalendarListService", () => {
+  beforeAll(initSupertokens);
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterEach(() => jest.restoreAllMocks());
+  afterAll(cleanupTestDb);
+
+  describe("reconcileCalendarList", () => {
+    it("imports a newly-added writer calendar: row, events, watch, sync entry, and SSE", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const initialToken = await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "new-cal",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      const calendarsChangedSpy = jest.spyOn(
+        sseServer,
+        "publishCalendarsChanged",
+      );
+      const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+      const result = await reconcile(userId);
+
+      expect(result).toEqual({ outcome: "RECONCILED" });
+
+      const row = await mongoService.calendar.findOne({
+        userId: user._id,
+        "source.calendarId": "new-cal",
+      });
+      expect(row?.isActive).toBe(true);
+
+      const events = await mongoService.event
+        .find({ calendarId: row!._id })
+        .toArray();
+      expect(events.length).toBeGreaterThan(0);
+
+      const eventsSyncGCalIds = await getEventsSyncGCalIds(userId);
+      expect(eventsSyncGCalIds).toContain("new-cal");
+
+      const watch = await mongoService.watch.findOne({
+        user: userId,
+        gCalendarId: "new-cal",
+      });
+      expect(watch).not.toBeNull();
+
+      expect(calendarsChangedSpy).toHaveBeenCalledWith(
+        userId,
+        expect.arrayContaining([row!._id.toHexString()]),
+      );
+      expect(eventsChangedSpy).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          calendarId: row!._id.toHexString(),
+          reason: "reconciled",
+        }),
+      );
+
+      const newToken = await getCalendarlistToken(userId);
+      expect(newToken).toBeTruthy();
+      expect(newToken).not.toBe(initialToken);
+    });
+
+    it("applies metadata changes without touching isVisible, _id, or triggering a re-import", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const existing = await seedActiveGoogleCalendar(
+        user._id,
+        "existing-cal",
+        {
+          name: "Old Name",
+          isVisible: false,
+        },
+      );
+      await seedEventsSyncEntry(userId, "existing-cal");
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "existing-cal",
+          summary: "New Name",
+          backgroundColor: "#123456",
+          selected: true,
+          accessRole: "writer",
+          primary: false,
+        }),
+      ];
+
+      const getEventsSpy = jest.spyOn(gcalService, "getEvents");
+
+      const result = await reconcile(userId);
+
+      expect(result).toEqual({ outcome: "RECONCILED" });
+      expect(getEventsSpy).not.toHaveBeenCalled();
+
+      const updated = await mongoService.calendar.findOne({
+        _id: existing._id,
+      });
+      expect(updated?.name).toBe("New Name");
+      expect(updated?.backgroundColor).toBe("#123456");
+      expect(updated?.isVisible).toBe(false);
+      expect(updated?._id).toEqual(existing._id);
+    });
+
+    it.each([
+      { label: "hidden", field: "hidden" as const },
+      { label: "deleted", field: "deleted" as const },
+    ])("archives a $label calendar and tears down its watch/sync entry/events, leaving other calendars intact", async ({
+      field,
+    }) => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      const calA = await seedActiveGoogleCalendar(user._id, "cal-a");
+      const calB = await seedActiveGoogleCalendar(user._id, "cal-b");
+      await seedEventsSyncEntry(userId, "cal-a");
+      await seedEventsSyncEntry(userId, "cal-b");
+      await seedWatch(userId, "cal-a");
+      await seedWatch(userId, "cal-b");
+      await mongoService.event.insertMany([
+        buildEvent(calA._id),
+        buildEvent(calA._id),
+      ]);
+      await mongoService.event.insertMany([buildEvent(calB._id)]);
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          [field]: true,
+        }),
+      ];
+
+      const stopWatchSpy = jest.spyOn(gcalService, "stopWatch");
+      const calendarsChangedSpy = jest.spyOn(
+        sseServer,
+        "publishCalendarsChanged",
+      );
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+
+      const rowA = await mongoService.calendar.findOne({ _id: calA._id });
+      expect(rowA?.isActive).toBe(false);
+
+      expect(stopWatchSpy).toHaveBeenCalled();
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: "cal-a",
+        }),
+      ).toBeNull();
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: "cal-b",
+        }),
+      ).not.toBeNull();
+
+      const eventsSyncGCalIds = await getEventsSyncGCalIds(userId);
+      expect(eventsSyncGCalIds).not.toContain("cal-a");
+      expect(eventsSyncGCalIds).toContain("cal-b");
+      expect(await getCalendarlistToken(userId)).toBeTruthy();
+
+      expect(
+        await mongoService.event.countDocuments({ calendarId: calA._id }),
+      ).toBe(0);
+      expect(
+        await mongoService.event.countDocuments({ calendarId: calB._id }),
+      ).toBe(1);
+
+      expect(calendarsChangedSpy).toHaveBeenCalledWith(
+        userId,
+        expect.arrayContaining([calA._id.toHexString()]),
+      );
+    });
+
+    it("tears down event machinery when an existing calendar's role drops to freeBusyReader, keeping the row active", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      const cal = await seedActiveGoogleCalendar(user._id, "cal-a", {
+        access: "writer",
+      });
+      await seedEventsSyncEntry(userId, "cal-a");
+      await seedWatch(userId, "cal-a");
+      await mongoService.event.insertMany([buildEvent(cal._id)]);
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          selected: true,
+          accessRole: "freeBusyReader",
+        }),
+      ];
+
+      const stopWatchSpy = jest.spyOn(gcalService, "stopWatch");
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+
+      const row = await mongoService.calendar.findOne({ _id: cal._id });
+      expect(row?.isActive).toBe(true);
+      expect(row?.access).toBe("freeBusyReader");
+
+      expect(stopWatchSpy).toHaveBeenCalled();
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: "cal-a",
+        }),
+      ).toBeNull();
+
+      const eventsSyncGCalIds = await getEventsSyncGCalIds(userId);
+      expect(eventsSyncGCalIds).not.toContain("cal-a");
+
+      expect(
+        await mongoService.event.countDocuments({ calendarId: cal._id }),
+      ).toBe(0);
+    });
+
+    it("imports events and starts a watch when an existing freeBusyReader calendar's role is upgraded", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      const cal = await seedActiveGoogleCalendar(user._id, "cal-a", {
+        access: "freeBusyReader",
+      });
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+
+      const row = await mongoService.calendar.findOne({ _id: cal._id });
+      expect(row?.access).toBe("writer");
+      expect(row?.isActive).toBe(true);
+
+      const eventsSyncGCalIds = await getEventsSyncGCalIds(userId);
+      expect(eventsSyncGCalIds).toContain("cal-a");
+
+      const watch = await mongoService.watch.findOne({
+        user: userId,
+        gCalendarId: "cal-a",
+      });
+      expect(watch).not.toBeNull();
+    });
+
+    it("clears isPrimary from the previous primary when a delta marks a different calendar primary", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      const calA = await seedActiveGoogleCalendar(user._id, "cal-a", {
+        isPrimary: true,
+      });
+      const calB = await seedActiveGoogleCalendar(user._id, "cal-b", {
+        isPrimary: false,
+      });
+      await seedEventsSyncEntry(userId, "cal-a");
+      await seedEventsSyncEntry(userId, "cal-b");
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-b",
+          primary: true,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+
+      const updatedA = await mongoService.calendar.findOne({ _id: calA._id });
+      const updatedB = await mongoService.calendar.findOne({ _id: calB._id });
+      expect(updatedA?.isPrimary).toBe(false);
+      expect(updatedB?.isPrimary).toBe(true);
+    });
+
+    it("re-adding a calendar after archiving it reuses the Compass id, preserves visibility, and reimports events", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      const cal = await seedActiveGoogleCalendar(user._id, "cal-a", {
+        isVisible: false,
+      });
+      await seedEventsSyncEntry(userId, "cal-a");
+      await mongoService.event.insertMany([buildEvent(cal._id)]);
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          deleted: true,
+        }),
+      ];
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+
+      const archived = await mongoService.calendar.findOne({ _id: cal._id });
+      expect(archived?.isActive).toBe(false);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+
+      const readded = await mongoService.calendar.findOne({
+        userId: user._id,
+        "source.calendarId": "cal-a",
+      });
+      expect(readded?._id).toEqual(cal._id);
+      expect(readded?.isActive).toBe(true);
+      expect(readded?.isVisible).toBe(false);
+
+      const events = await mongoService.event
+        .find({ calendarId: cal._id })
+        .toArray();
+      expect(events.length).toBeGreaterThan(0);
+    });
+
+    it("applies every entry across a multi-page delta and advances the token", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const initialToken = await seedCalendarlistToken(userId);
+
+      // freeBusyReader keeps this test focused on pagination rather than
+      // fanning out 7 real event imports.
+      compassTestState().calendarlist = Array.from({ length: 7 }, (_, i) =>
+        createMockCalendarListEntry({
+          id: `cal-${i}`,
+          primary: false,
+          selected: true,
+          accessRole: "freeBusyReader",
+        }),
+      );
+
+      const result = await reconcile(userId);
+      expect(result).toEqual({ outcome: "RECONCILED" });
+
+      const rows = await mongoService.calendar
+        .find({ userId: user._id, "source.provider": "google" })
+        .toArray();
+      expect(rows).toHaveLength(7);
+
+      const newToken = await getCalendarlistToken(userId);
+      expect(newToken).toBeTruthy();
+      expect(newToken).not.toBe(initialToken);
+    });
+
+    it("converges when the same delta is delivered twice: no duplicate rows or watches, stable event count", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+      const rowsAfterFirst = await mongoService.calendar
+        .find({ userId: user._id, "source.provider": "google" })
+        .toArray();
+      const watchesAfterFirst = await mongoService.watch
+        .find({ user: userId })
+        .toArray();
+      const eventsAfterFirst = await mongoService.event.countDocuments({
+        calendarId: rowsAfterFirst[0]!._id,
+      });
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+      const rowsAfterSecond = await mongoService.calendar
+        .find({ userId: user._id, "source.provider": "google" })
+        .toArray();
+      const watchesAfterSecond = await mongoService.watch
+        .find({ user: userId })
+        .toArray();
+      const eventsAfterSecond = await mongoService.event.countDocuments({
+        calendarId: rowsAfterFirst[0]!._id,
+      });
+
+      expect(rowsAfterSecond).toHaveLength(rowsAfterFirst.length);
+      expect(watchesAfterSecond).toHaveLength(watchesAfterFirst.length);
+      expect(eventsAfterSecond).toBe(eventsAfterFirst);
+    });
+
+    it("resumes an interrupted import on redelivery instead of treating the checkpoint as complete", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const cal = await seedActiveGoogleCalendar(user._id, "cal-a");
+      // A mid-failed import leaves an events entry holding only its
+      // nextPageToken checkpoint - no nextSyncToken. The gcal mock reads
+      // page tokens as numeric offsets, so "0" resumes from the start.
+      await updateSync(Resource_Sync.EVENTS, userId, "cal-a", {
+        nextPageToken: "0",
+      });
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "RECONCILED",
+      });
+
+      const sync = await mongoService.sync.findOne({ user: userId });
+      const entry = sync?.google?.events?.find(
+        (e) => e.gCalendarId === "cal-a",
+      );
+      expect(entry?.nextSyncToken).toBeTruthy();
+      expect(
+        await mongoService.event.countDocuments({ calendarId: cal._id }),
+      ).toBeGreaterThan(0);
+    });
+
+    it("does not advance the calendarlist token when a new calendar's import fails", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const initialToken = await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "broken-cal",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      jest.spyOn(syncImportService, "createSyncImport").mockResolvedValue({
+        importAllEvents: jest
+          .fn()
+          .mockRejectedValue(new Error("simulated import failure")),
+      } as unknown as Awaited<
+        ReturnType<typeof syncImportService.createSyncImport>
+      >);
+
+      await expect(reconcile(userId)).rejects.toThrow(
+        "simulated import failure",
+      );
+
+      const tokenAfterFailure = await getCalendarlistToken(userId);
+      expect(tokenAfterFailure).toBe(initialToken);
+    });
+
+    it("returns IGNORED for an empty delta, publishes no SSE, and still refreshes the token", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const initialToken = await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [];
+
+      const calendarsChangedSpy = jest.spyOn(
+        sseServer,
+        "publishCalendarsChanged",
+      );
+      const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+      await expect(reconcile(userId)).resolves.toEqual({
+        outcome: "IGNORED",
+      });
+
+      expect(calendarsChangedSpy).not.toHaveBeenCalled();
+      expect(eventsChangedSpy).not.toHaveBeenCalled();
+
+      const tokenAfter = await getCalendarlistToken(userId);
+      expect(tokenAfter).not.toBe(initialToken);
+    });
+
+    it("serializes concurrent reconcile calls for the same user without producing duplicate rows or watches", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      await seedCalendarlistToken(userId);
+
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      const context = await createGoogleRequestContext(userId);
+      const [first, second] = await Promise.all([
+        googleCalendarListService.reconcileCalendarList(context, userId),
+        googleCalendarListService.reconcileCalendarList(context, userId),
+      ]);
+
+      expect(first).toEqual({ outcome: "RECONCILED" });
+      expect(second).toEqual({ outcome: "RECONCILED" });
+
+      const rows = await mongoService.calendar
+        .find({
+          userId: user._id,
+          "source.provider": "google",
+          "source.calendarId": "cal-a",
+        })
+        .toArray();
+      expect(rows).toHaveLength(1);
+
+      const watches = await mongoService.watch
+        .find({ user: userId, gCalendarId: "cal-a" })
+        .toArray();
+      expect(watches).toHaveLength(1);
+    });
+  });
+});

--- a/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
+++ b/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
@@ -1,0 +1,296 @@
+import { type calendar_v3 } from "@googleapis/calendar";
+import { ObjectId } from "mongodb";
+import { Logger } from "@core/logger/winston.logger";
+import { type CalendarId, type EventId } from "@core/types/domain-primitives";
+import { Resource_Sync } from "@core/types/sync.types";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import calendarService from "@backend/calendar/services/calendar.service";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { SyncError } from "@backend/common/errors/sync/sync.errors";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
+import gcalService from "@backend/common/services/gcal/gcal.service";
+import mongoService from "@backend/common/services/mongo.service";
+import { eventRepository } from "@backend/event/event.repository";
+import { sseServer } from "@backend/servers/sse/sse.server";
+import {
+  createSyncImport,
+  type SyncImport,
+} from "@backend/sync/services/import/google-import.service";
+import {
+  getSync,
+  removeSyncEntry,
+  updateSync,
+} from "@backend/sync/services/records/sync-records.repository";
+import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
+
+const logger = Logger("app:google-calendarlist.service");
+
+type ReconcileResult = { outcome: "RECONCILED" | "IGNORED" };
+
+/**
+ * Per-user serialization: concurrent webhook deliveries for the same user
+ * must not race each other (e.g. double-importing a newly-added calendar or
+ * double-starting a watch). A call for a user whose reconcile is already in
+ * flight chains after it instead of running in parallel; the map entry is
+ * cleaned up once the last chained run settles.
+ */
+const inFlightByUser = new Map<string, Promise<unknown>>();
+
+async function reconcileCalendarList(
+  context: GoogleRequestContext,
+  userId: string,
+): Promise<ReconcileResult> {
+  const previous = inFlightByUser.get(userId) ?? Promise.resolve();
+  const run = previous
+    .catch(() => undefined)
+    .then(() => runReconcile(context, userId));
+
+  inFlightByUser.set(userId, run);
+
+  try {
+    return await run;
+  } finally {
+    if (inFlightByUser.get(userId) === run) {
+      inFlightByUser.delete(userId);
+    }
+  }
+}
+
+async function runReconcile(
+  context: GoogleRequestContext,
+  userId: string,
+): Promise<ReconcileResult> {
+  // Re-read at run time (not passed in as a param) so a call that was
+  // queued behind another sees that predecessor's already-advanced token.
+  const sync = await getSync({ userId });
+  const storedToken = sync?.google?.calendarlist?.find(
+    (entry) => entry.gCalendarId === Resource_Sync.CALENDAR,
+  )?.nextSyncToken;
+
+  if (!storedToken) {
+    throw error(
+      SyncError.NoSyncToken,
+      `Calendarlist notification not handled because no sync token was found for user: ${userId}`,
+    );
+  }
+
+  const items: calendar_v3.Schema$CalendarListEntry[] = [];
+  let finalToken: string | undefined;
+
+  for await (const page of gcalService.getAllCalendarListPages(context, {
+    nextSyncToken: storedToken,
+  })) {
+    items.push(...(page.items ?? []));
+    if (page.nextSyncToken) finalToken = page.nextSyncToken;
+  }
+
+  if (!finalToken) {
+    // getAllCalendarListPages always yields a nextSyncToken on whichever
+    // page ends pagination (it throws GcalError.PaginationNotSupported
+    // otherwise), so this is unreachable - kept only to narrow the type.
+    throw error(
+      SyncError.NoSyncToken,
+      `Calendarlist delta finished without a sync token for user: ${userId}`,
+    );
+  }
+
+  if (items.length === 0) {
+    if (finalToken !== storedToken) {
+      await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+        nextSyncToken: finalToken,
+      });
+    }
+
+    return { outcome: "IGNORED" };
+  }
+
+  // A calendar showing up as deleted/hidden in a delta must be archived,
+  // not skipped - A2's "ineligible" filter only applies to the *initial*
+  // full-list import, where skipping is enough because there's no existing
+  // row to reconcile away.
+  const removals = items.filter(
+    (entry) => entry.deleted === true || entry.hidden === true,
+  );
+  const upserts = items.filter(
+    (entry) => entry.deleted !== true && entry.hidden !== true,
+  );
+
+  // Snapshot taken before this run's own writes. Deciding "is this
+  // calendar's event import brand new" from this fixed point (rather than
+  // re-checking after each write) keeps every entry in this delta judged
+  // against the same state, and correctly reflects an earlier run's
+  // completed import when this call is itself a duplicate/retried delivery.
+  // Only entries holding a nextSyncToken count: a mid-failed import leaves
+  // an entry with just a nextPageToken checkpoint, and importAllEvents must
+  // run again to resume it from that checkpoint.
+  const alreadyImportedGCalIds = new Set(
+    (sync?.google?.events ?? [])
+      .filter((entry) => entry.nextSyncToken)
+      .map((entry) => entry.gCalendarId),
+  );
+
+  const affectedHexIds = new Set<string>();
+  const eventsChangedHexIds = new Set<string>();
+  let importedCount = 0;
+
+  for (const entry of removals) {
+    const gCalendarId = entry.id;
+    if (!gCalendarId) continue;
+
+    // Only tear down calendars Compass actually knows about; a removal for
+    // a calendar that was never imported has nothing to reconcile away.
+    const row = await calendarService.archiveGoogleCalendar(
+      userId,
+      gCalendarId,
+    );
+    if (!row) continue;
+
+    affectedHexIds.add(row._id.toHexString());
+
+    await stopWatchIfPresent(userId, gCalendarId, context);
+    await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
+    await eventRepository.deleteByCalendarIds([row._id]);
+
+    if (row.isVisible) eventsChangedHexIds.add(row._id.toHexString());
+  }
+
+  let syncImport: SyncImport | undefined;
+
+  if (upserts.length > 0) {
+    const { records } = await calendarService.upsertGoogleCalendarEntries(
+      userId,
+      upserts,
+    );
+
+    for (const record of records) {
+      if (record.source.provider !== "google") continue;
+
+      const hexId = record._id.toHexString();
+      const gCalendarId = record.source.calendarId;
+      affectedHexIds.add(hexId);
+
+      if (record.access === "freeBusyReader") {
+        // A7: freeBusyReader calendars never manufacture event records -
+        // tear down anything left behind by a prior, more-permissive role.
+        await stopWatchIfPresent(userId, gCalendarId, context);
+        await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
+        await eventRepository.deleteByCalendarIds([record._id]);
+        continue;
+      }
+
+      if (!alreadyImportedGCalIds.has(gCalendarId)) {
+        syncImport ??= await createSyncImport(context);
+        await syncImport.importAllEvents(userId, record, 2500);
+        importedCount += 1;
+        if (record.isVisible) eventsChangedHexIds.add(hexId);
+      }
+
+      // Idempotent (already-watching-guarded) and HTTPS-gated internally,
+      // so it's safe to call unconditionally for every event-capable
+      // calendar in this delta, not just newly-imported ones.
+      await googleWatchService.startGoogleWatches(
+        userId,
+        [{ gCalendarId }],
+        context,
+      );
+    }
+
+    const userObjectId = new ObjectId(userId);
+    const clearedIds = await clearStalePrimaryFlags(userObjectId, records);
+    clearedIds.forEach((id) => affectedHexIds.add(id.toHexString()));
+  }
+
+  // Advance the token only after every removal/upsert/primary-cleanup step
+  // above has succeeded - an error anywhere above must leave the stored
+  // token where it was so Google's redelivery retries the same delta.
+  await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+    nextSyncToken: finalToken,
+  });
+
+  if (affectedHexIds.size > 0) {
+    sseServer.publishCalendarsChanged(userId, [
+      ...affectedHexIds,
+    ] as CalendarId[]);
+  }
+
+  eventsChangedHexIds.forEach((hexId) => {
+    sseServer.publishEventsChanged(userId, {
+      calendarId: hexId as CalendarId,
+      eventIds: [] as EventId[],
+      reason: "reconciled",
+    });
+  });
+
+  logger.info(
+    `CalendarList reconciled for user: ${userId} (upserted=${upserts.length} archived=${removals.length} imported=${importedCount})`,
+  );
+
+  return { outcome: "RECONCILED" };
+}
+
+async function stopWatchIfPresent(
+  userId: string,
+  gCalendarId: string,
+  context: GoogleRequestContext,
+): Promise<void> {
+  const watch = await mongoService.watch.findOne({
+    user: userId,
+    gCalendarId,
+  });
+  if (!watch) return;
+
+  await googleWatchService.stopWatch(
+    userId,
+    watch._id.toString(),
+    watch.resourceId,
+    context,
+  );
+}
+
+/**
+ * Clears `isPrimary` on every OTHER google calendar the user has once a
+ * delta entry claims it. Reads the stale rows directly from Mongo rather
+ * than from `records`, because the calendar losing primary status often
+ * doesn't appear in this delta at all (Google only resends the entry that
+ * changed).
+ */
+async function clearStalePrimaryFlags(
+  userObjectId: ObjectId,
+  records: CalendarRecord[],
+): Promise<ObjectId[]> {
+  const primaryClaims = records.filter((record) => record.isPrimary);
+  if (primaryClaims.length === 0) return [];
+
+  // Google should only ever mark one calendar primary; if a single delta
+  // somehow claims it twice, the later entry wins.
+  const winner = primaryClaims[primaryClaims.length - 1]!;
+  if (winner.source.provider !== "google") return [];
+  const winnerGCalendarId = winner.source.calendarId;
+
+  const staleRows = await mongoService.calendar
+    .find({
+      userId: userObjectId,
+      "source.provider": "google",
+      "source.calendarId": { $ne: winnerGCalendarId },
+      isPrimary: true,
+    })
+    .toArray();
+
+  if (staleRows.length === 0) return [];
+
+  await mongoService.calendar.updateMany(
+    {
+      userId: userObjectId,
+      "source.provider": "google",
+      "source.calendarId": { $ne: winnerGCalendarId },
+      isPrimary: true,
+    },
+    { $set: { isPrimary: false, updatedAt: new Date() } },
+  );
+
+  return staleRows.map((row) => row._id);
+}
+
+export const googleCalendarListService = {
+  reconcileCalendarList,
+};

--- a/packages/backend/src/sync/services/records/sync-records.repository.ts
+++ b/packages/backend/src/sync/services/records/sync-records.repository.ts
@@ -151,6 +151,28 @@ export const deleteAllByGcalId = (
   );
 };
 
+/**
+ * Removes a single resource's sync entry (by gCalendarId) from the user's
+ * sync document, leaving the rest of the document - the calendarlist token
+ * and every other calendar's entries - untouched. Unlike `deleteAllByGcalId`
+ * (which deletes the whole sync document), this only ever touches one array
+ * entry.
+ */
+export const removeSyncEntry = (
+  resource: Exclude<Resource_Sync, Resource_Sync.SETTINGS>,
+  userId: string,
+  gCalendarId: string,
+  session?: ClientSession,
+): Promise<UpdateResult<Schema_Sync>> => {
+  const operation: UpdateFilter<Schema_Sync> = {
+    $pull: { [`google.${resource}`]: { gCalendarId } },
+  };
+
+  return mongoService.sync.updateOne({ user: userId }, operation, {
+    session,
+  });
+};
+
 export const deleteAllByUser = (userId: string, session?: ClientSession) => {
   return mongoService.sync.deleteMany({ user: userId }, { session });
 };
@@ -169,6 +191,7 @@ const syncRecords = {
   getGCalEventsSyncPageToken,
   getSync,
   getSyncByToken,
+  removeSyncEntry,
   updateSync,
 };
 

--- a/packages/backend/src/sync/services/watch/google-watch.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.test.ts
@@ -17,6 +17,7 @@ import { initSupertokens } from "@backend/common/middleware/supertokens.middlewa
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
+import { googleCalendarListService } from "@backend/sync/services/calendarlist/google-calendarlist.service";
 import { seedGoogleCalendar } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
@@ -191,7 +192,7 @@ describe("googleWatchService", () => {
     expect(cleanupSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("acknowledges a calendarlist notification without processing events or publishing SSE", async () => {
+  it("dispatches a calendarlist notification to the reconciler and returns its outcome", async () => {
     const user = await UserDriver.createUser();
     const userId = user._id.toString();
 
@@ -201,7 +202,9 @@ describe("googleWatchService", () => {
     const watch = await createWatch(userId, Resource_Sync.CALENDAR);
 
     const getEventsSpy = jest.spyOn(gcalService, "getEvents");
-    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+    const reconcileSpy = jest
+      .spyOn(googleCalendarListService, "reconcileCalendarList")
+      .mockResolvedValue({ outcome: "RECONCILED" });
 
     await expect(
       googleWatchService.handleGoogleWatchNotification({
@@ -211,10 +214,10 @@ describe("googleWatchService", () => {
         resourceState: XGoogleResourceState.EXISTS,
         expiration: watch.expiration,
       }),
-    ).resolves.toBe("IGNORED");
+    ).resolves.toBe("RECONCILED");
 
+    expect(reconcileSpy).toHaveBeenCalledWith(expect.anything(), userId);
     expect(getEventsSpy).not.toHaveBeenCalled();
-    expect(eventsChangedSpy).not.toHaveBeenCalled();
   });
 
   it("returns IGNORED when the events handler finds no changes to process", async () => {

--- a/packages/backend/src/sync/services/watch/google-watch.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.ts
@@ -188,14 +188,20 @@ async function handleGoogleWatchNotification(
   }
 
   if (resource === Resource_Sync.CALENDAR) {
-    // Calendarlist reconciliation (upsert/archive from the notified change)
-    // lands in a later phase; for now just acknowledge so Google stops
-    // retrying.
-    logger.info(
-      "calendarlist notification acknowledged; reconciliation lands with calendar-list sync",
+    const context = await createGoogleRequestContext(userId);
+    // Dynamic import mirrors google-sync.service's user.service pattern to
+    // avoid a static import cycle with this module.
+    const { googleCalendarListService } = await import(
+      "@backend/sync/services/calendarlist/google-calendarlist.service"
+    );
+    const { outcome } = await googleCalendarListService.reconcileCalendarList(
+      context,
+      userId,
     );
 
-    return "IGNORED";
+    logger.info(`CalendarList notification for user: ${userId} ${outcome}`);
+
+    return outcome;
   }
 
   const context = await createGoogleRequestContext(userId);


### PR DESCRIPTION
## Summary

Packet 06 phase 2 of 3 — the core: CalendarList push notifications now reconcile the user's Compass calendar set incrementally (packet 06 steps 2-4, 6, and the step-1 handler). Builds on #2054's dispatch split.

**New `googleCalendarListService.reconcileCalendarList`** (`sync/services/calendarlist/`), wired into the webhook dispatcher's calendarlist branch (dynamic import mirrors the existing cycle-avoidance pattern):

- **Incremental fetch** with the stored calendarlist sync token (`getAllCalendarListPages` already supported it; this is the first production caller). The token advances **only after every change succeeds** — a failed new-calendar import leaves it untouched so Google's redelivery retries the same delta.
- **Add/unhide**: upsert reusing an archived row's `_id` and user-set visibility (A16/A3); event-capable roles get a full event import (which persists the per-calendar events token itself) plus an events watch; `freeBusyReader` keeps metadata only (A7).
- **Metadata/access change**: provider fields updated, Compass `isVisible` never overwritten; transitions to/from `freeBusyReader` tear down or initialize event sync state and watches idempotently.
- **Delete/hide/lost access**: archive the row (`isActive: false`), stop its watch, `$pull` its events sync entry, and delete **only that calendar's** events.
- **Primary change**: last claim wins; stale `isPrimary` flags cleared (the default writable calendar is computed from flags at read time, so no separate recompute).
- **Idempotency**: state-based decisions (not delta-based) + per-user serialization of concurrent deliveries; a mid-failed import's page checkpoint is resumed on redelivery rather than mistaken for a completed import (entries without a `nextSyncToken` don't count as imported).
- **SSE**: publishes `calendarsChanged` (first production caller of the existing contract) and visibility-gated `eventsChanged` per affected calendar.

**Supporting changes**: `removeSyncEntry` (`$pull` one array entry — the existing `deleteAllByGcalId` removes whole sync documents and would nuke the calendarlist token); `upsertGoogleCalendarEntries` extracted from `initializeGoogleCalendars` for reuse (the `$nin` archive sweep deliberately stays init-only — it is valid only against a full list); `archiveGoogleCalendar` soft-delete.

A calendarlist-token 410 currently falls through to the existing full-repair path; phase 3 adds the targeted recovery plus remaining hardening tests.

## Testing

14 new reconciler tests: add (row/events/watch/sync-entry/SSE/token), metadata-preserves-visibility-and-id, hide + delete teardown (other calendars' events/watches/sync entries untouched), role→freeBusyReader teardown, freeBusyReader→writer initialization, primary handoff, re-add-after-archive id/visibility reuse, multi-page delta, duplicate-delivery convergence, checkpoint-resume on redelivery, import-failure token hold, empty delta, concurrent-call serialization. Dispatcher test updated to assert the reconciler's outcome propagates.

- `TZ=UTC jest --selectProjects backend`: 65 suites, 565 passed / 1 pre-existing skip.
- `bun run type-check` clean; `bun run lint` only the 15 pre-existing web warnings.

Part of `handoff/someday/06-calendar-list-sync-and-watch-routing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)