### PR TITLE
feat(backend): recover calendarlist sync from 410 without full repair, close packet 06 test gaps

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.test.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.test.ts
@@ -19,6 +19,10 @@ import { missingRefreshTokenError } from "@backend/__tests__/mocks.gcal/errors/e
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
+import {
+  buildEventRecord,
+  seedLocalCalendar,
+} from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { GCalEventsNotificationHandler } from "@backend/sync/services/notify/handler/gcal-events.notification.handler";
 import * as syncQueries from "@backend/sync/services/records/sync-records.repository";
@@ -329,6 +333,56 @@ describe("SyncController", () => {
       handleGoogleWatchNotificationSpy.mockRestore();
       pruneGoogleDataSpy.mockRestore();
       handleGoogleRevokedSpy.mockRestore();
+    });
+
+    it("preserves the Compass-local calendar and its events when access is revoked (pins the safe prune, not a wipe)", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const userId = user._id.toString();
+
+      const localCalendar = await seedLocalCalendar(user._id);
+      await mongoService.event.insertOne(buildEventRecord(localCalendar._id));
+
+      const watch = await mongoService.watch.findOne({
+        user: userId,
+        gCalendarId: { $ne: Resource_Sync.CALENDAR },
+      });
+
+      expect(watch).toBeDefined();
+      expect(watch).not.toBeNull();
+
+      // Unlike the sibling "user revokes access" test above, pruneGoogleData
+      // is NOT mocked here - it runs for real so this test actually pins
+      // local-data survival through the notification path, not just that
+      // pruneGoogleData was called.
+      const handleGoogleWatchNotificationSpy = jest
+        .spyOn(googleWatchService, "handleGoogleWatchNotification")
+        .mockRejectedValue(invalidGrant400Error);
+
+      const response = await syncDriver.handleGoogleNotification(
+        {
+          resource: Resource_Sync.EVENTS,
+          channelId: watch!._id,
+          resourceId: watch!.resourceId,
+          resourceState: XGoogleResourceState.EXISTS,
+          expiration: watch!.expiration,
+        },
+        Status.GONE,
+      );
+
+      expect(response.body).toEqual(
+        expect.objectContaining({ code: "GOOGLE_REVOKED" }),
+      );
+
+      expect(
+        await mongoService.calendar.findOne({ _id: localCalendar._id }),
+      ).not.toBeNull();
+      expect(
+        await mongoService.event.countDocuments({
+          calendarId: localCalendar._id,
+        }),
+      ).toBe(1);
+
+      handleGoogleWatchNotificationSpy.mockRestore();
     });
 
     it("should prune Google data, notify client via SSE, and return structured response when refresh token is missing", async () => {

--- a/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.test.ts
+++ b/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.test.ts
@@ -10,6 +10,8 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { compassTestState } from "@backend/__tests__/helpers/mock.setup";
+import { createGoogleError } from "@backend/__tests__/mocks.gcal/errors/error.google.factory";
+import { invalidSyncTokenError } from "@backend/__tests__/mocks.gcal/errors/error.invalidSyncToken";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
@@ -18,6 +20,7 @@ import mongoService from "@backend/common/services/mongo.service";
 import { type EventRecord } from "@backend/event/event.record";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { googleCalendarListService } from "@backend/sync/services/calendarlist/google-calendarlist.service";
+import { seedLocalCalendar } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
 import * as syncImportService from "@backend/sync/services/import/google-import.service";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 
@@ -670,6 +673,126 @@ describe("googleCalendarListService", () => {
         .find({ user: userId, gCalendarId: "cal-a" })
         .toArray();
       expect(watches).toHaveLength(1);
+    });
+  });
+
+  describe("410 recovery: targeted full-list rebuild", () => {
+    it("rebuilds from a full CalendarList fetch when the stored token is rejected, preserving survivors (events/token/watch/visibility) and Compass-local data, while archiving what disappeared (visibility preserved)", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      // isVisible: false on both proves visibility survives each path this
+      // recovery can take: cal-a survives via the upsert path, cal-b is
+      // torn down via the removal path.
+      const calA = await seedActiveGoogleCalendar(user._id, "cal-a", {
+        isVisible: false,
+      });
+      const calB = await seedActiveGoogleCalendar(user._id, "cal-b", {
+        isVisible: false,
+      });
+      await seedEventsSyncEntry(userId, "cal-a");
+      await seedEventsSyncEntry(userId, "cal-b");
+      await seedWatch(userId, "cal-a");
+      await seedWatch(userId, "cal-b");
+      await mongoService.event.insertMany([
+        buildEvent(calA._id),
+        buildEvent(calA._id),
+      ]);
+      await mongoService.event.insertMany([buildEvent(calB._id)]);
+
+      const localCalendar = await seedLocalCalendar(user._id);
+      await mongoService.event.insertOne(buildEvent(localCalendar._id));
+
+      const initialToken = await seedCalendarlistToken(userId);
+
+      // The full list Google serves once cal-b has disappeared: only cal-a
+      // remains.
+      compassTestState().calendarlist = [
+        createMockCalendarListEntry({
+          id: "cal-a",
+          primary: false,
+          selected: true,
+          accessRole: "writer",
+        }),
+      ];
+
+      jest
+        .spyOn(gcalService, "getAllCalendarListPages")
+        .mockImplementationOnce(() => {
+          throw invalidSyncTokenError;
+        });
+
+      const stopWatchSpy = jest.spyOn(gcalService, "stopWatch");
+
+      const result = await reconcile(userId);
+
+      expect(result).toEqual({ outcome: "RECONCILED" });
+
+      // cal-a survives untouched: active, events intact, sync entry +
+      // watch intact, visibility preserved.
+      const rowA = await mongoService.calendar.findOne({ _id: calA._id });
+      expect(rowA?.isActive).toBe(true);
+      expect(rowA?.isVisible).toBe(false);
+      expect(
+        await mongoService.event.countDocuments({ calendarId: calA._id }),
+      ).toBe(2);
+      const eventsSyncGCalIds = await getEventsSyncGCalIds(userId);
+      expect(eventsSyncGCalIds).toContain("cal-a");
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: "cal-a",
+        }),
+      ).not.toBeNull();
+
+      // cal-b was archived: watch stopped, events sync entry pulled,
+      // events deleted, but visibility preserved on the archived row.
+      const rowB = await mongoService.calendar.findOne({ _id: calB._id });
+      expect(rowB?.isActive).toBe(false);
+      expect(rowB?.isVisible).toBe(false);
+      expect(stopWatchSpy).toHaveBeenCalled();
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: "cal-b",
+        }),
+      ).toBeNull();
+      expect(eventsSyncGCalIds).not.toContain("cal-b");
+      expect(
+        await mongoService.event.countDocuments({ calendarId: calB._id }),
+      ).toBe(0);
+
+      // Compass-local data is untouched by the recovery.
+      expect(
+        await mongoService.calendar.findOne({ _id: localCalendar._id }),
+      ).not.toBeNull();
+      expect(
+        await mongoService.event.countDocuments({
+          calendarId: localCalendar._id,
+        }),
+      ).toBe(1);
+
+      // The stored token was replaced by the recovery fetch's token, not
+      // the (rejected) one Google returned the 410 for.
+      const newToken = await getCalendarlistToken(userId);
+      expect(newToken).toBeTruthy();
+      expect(newToken).not.toBe(initialToken);
+    });
+
+    it("propagates a non-410 calendarlist fetch error without recovering and without touching the stored token", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const initialToken = await seedCalendarlistToken(userId);
+
+      jest
+        .spyOn(gcalService, "getAllCalendarListPages")
+        .mockImplementationOnce(() => {
+          throw createGoogleError({ code: "500", responseStatus: 500 });
+        });
+
+      await expect(reconcile(userId)).rejects.toMatchObject({ code: "500" });
+
+      expect(await getCalendarlistToken(userId)).toBe(initialToken);
     });
   });
 });

--- a/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
+++ b/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
@@ -2,7 +2,7 @@ import { type calendar_v3 } from "@googleapis/calendar";
 import { ObjectId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
-import { Resource_Sync } from "@core/types/sync.types";
+import { Resource_Sync, type SyncDetails } from "@core/types/sync.types";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { error } from "@backend/common/errors/handlers/error.handler";
@@ -75,16 +75,13 @@ async function runReconcile(
     );
   }
 
-  const items: calendar_v3.Schema$CalendarListEntry[] = [];
-  let finalToken: string | undefined;
+  let items: calendar_v3.Schema$CalendarListEntry[];
+  let finalToken: string;
 
   try {
-    for await (const page of gcalService.getAllCalendarListPages(context, {
+    ({ items, finalToken } = await drainCalendarListPages(context, userId, {
       nextSyncToken: storedToken,
-    })) {
-      items.push(...(page.items ?? []));
-      if (page.nextSyncToken) finalToken = page.nextSyncToken;
-    }
+    }));
   } catch (err) {
     if (!isFullSyncRequired(err)) throw err;
 
@@ -98,16 +95,6 @@ async function runReconcile(
     );
 
     return reconcileFromFullList(context, userId);
-  }
-
-  if (!finalToken) {
-    // getAllCalendarListPages always yields a nextSyncToken on whichever
-    // page ends pagination (it throws GcalError.PaginationNotSupported
-    // otherwise), so this is unreachable - kept only to narrow the type.
-    throw error(
-      SyncError.NoSyncToken,
-      `Calendarlist delta finished without a sync token for user: ${userId}`,
-    );
   }
 
   if (items.length === 0) {
@@ -186,6 +173,57 @@ async function runReconcile(
     nextSyncToken: finalToken,
   });
 
+  publishReconcileChanges(userId, affectedHexIds, eventsChangedHexIds);
+
+  logger.info(
+    `CalendarList reconciled for user: ${userId} (upserted=${upserts.length} archived=${removals.length} imported=${importedCount})`,
+  );
+
+  return { outcome: "RECONCILED" };
+}
+
+/**
+ * Pages the CalendarList (delta when params carry a nextSyncToken, full
+ * list otherwise) and returns every entry plus the final sync token.
+ * getAllCalendarListPages always yields a nextSyncToken on whichever page
+ * ends pagination (throwing GcalError.PaginationNotSupported otherwise),
+ * so the missing-token throw here is unreachable - kept only to narrow the
+ * type.
+ */
+async function drainCalendarListPages(
+  context: GoogleRequestContext,
+  userId: string,
+  params: Partial<Pick<SyncDetails, "nextSyncToken" | "nextPageToken">>,
+): Promise<{
+  items: calendar_v3.Schema$CalendarListEntry[];
+  finalToken: string;
+}> {
+  const items: calendar_v3.Schema$CalendarListEntry[] = [];
+  let finalToken: string | undefined;
+
+  for await (const page of gcalService.getAllCalendarListPages(
+    context,
+    params,
+  )) {
+    items.push(...(page.items ?? []));
+    if (page.nextSyncToken) finalToken = page.nextSyncToken;
+  }
+
+  if (!finalToken) {
+    throw error(
+      SyncError.NoSyncToken,
+      `CalendarList pagination finished without a sync token for user: ${userId}`,
+    );
+  }
+
+  return { items, finalToken };
+}
+
+function publishReconcileChanges(
+  userId: string,
+  affectedHexIds: Set<string>,
+  eventsChangedHexIds: Set<string>,
+): void {
   if (affectedHexIds.size > 0) {
     sseServer.publishCalendarsChanged(userId, [
       ...affectedHexIds,
@@ -199,12 +237,6 @@ async function runReconcile(
       reason: "reconciled",
     });
   });
-
-  logger.info(
-    `CalendarList reconciled for user: ${userId} (upserted=${upserts.length} archived=${removals.length} imported=${importedCount})`,
-  );
-
-  return { outcome: "RECONCILED" };
 }
 
 /**
@@ -225,23 +257,11 @@ async function reconcileFromFullList(
   context: GoogleRequestContext,
   userId: string,
 ): Promise<ReconcileResult> {
-  const entries: calendar_v3.Schema$CalendarListEntry[] = [];
-  let finalToken: string | undefined;
-
-  for await (const page of gcalService.getAllCalendarListPages(context, {})) {
-    entries.push(...(page.items ?? []));
-    if (page.nextSyncToken) finalToken = page.nextSyncToken;
-  }
-
-  if (!finalToken) {
-    // getAllCalendarListPages always yields a nextSyncToken on whichever
-    // page ends pagination (it throws GcalError.PaginationNotSupported
-    // otherwise), so this is unreachable - kept only to narrow the type.
-    throw error(
-      SyncError.NoSyncToken,
-      `CalendarList full-list recovery finished without a sync token for user: ${userId}`,
-    );
-  }
+  const { items: entries, finalToken } = await drainCalendarListPages(
+    context,
+    userId,
+    {},
+  );
 
   // Belt-and-braces: a full list shouldn't contain either flag (Google's
   // default showHidden: false omits hidden calendars, and deleted ones
@@ -313,19 +333,7 @@ async function reconcileFromFullList(
     nextSyncToken: finalToken,
   });
 
-  if (affectedHexIds.size > 0) {
-    sseServer.publishCalendarsChanged(userId, [
-      ...affectedHexIds,
-    ] as CalendarId[]);
-  }
-
-  eventsChangedHexIds.forEach((hexId) => {
-    sseServer.publishEventsChanged(userId, {
-      calendarId: hexId as CalendarId,
-      eventIds: [] as EventId[],
-      reason: "reconciled",
-    });
-  });
+  publishReconcileChanges(userId, affectedHexIds, eventsChangedHexIds);
 
   logger.info(
     `CalendarList recovered from full list for user: ${userId} (upserted=${upserts.length} archived=${staleGCalendarIds.length} imported=${importedCount})`,

--- a/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
+++ b/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
@@ -9,6 +9,7 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 import { SyncError } from "@backend/common/errors/sync/sync.errors";
 import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
+import { isFullSyncRequired } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
 import { eventRepository } from "@backend/event/event.repository";
 import { sseServer } from "@backend/servers/sse/sse.server";
@@ -77,11 +78,26 @@ async function runReconcile(
   const items: calendar_v3.Schema$CalendarListEntry[] = [];
   let finalToken: string | undefined;
 
-  for await (const page of gcalService.getAllCalendarListPages(context, {
-    nextSyncToken: storedToken,
-  })) {
-    items.push(...(page.items ?? []));
-    if (page.nextSyncToken) finalToken = page.nextSyncToken;
+  try {
+    for await (const page of gcalService.getAllCalendarListPages(context, {
+      nextSyncToken: storedToken,
+    })) {
+      items.push(...(page.items ?? []));
+      if (page.nextSyncToken) finalToken = page.nextSyncToken;
+    }
+  } catch (err) {
+    if (!isFullSyncRequired(err)) throw err;
+
+    // The stored token is rejected (410) - rebuild from a full CalendarList
+    // fetch instead of the nuclear full repair (which deletes every google
+    // event and reimports everything). Called directly rather than through
+    // reconcileCalendarList so it stays inside this call's per-user
+    // serialization instead of re-entering the lock.
+    logger.warn(
+      `CalendarList sync token rejected (410) for user: ${userId}; recovering via full list fetch`,
+    );
+
+    return reconcileFromFullList(context, userId);
   }
 
   if (!finalToken) {
@@ -131,7 +147,6 @@ async function runReconcile(
 
   const affectedHexIds = new Set<string>();
   const eventsChangedHexIds = new Set<string>();
-  let importedCount = 0;
 
   for (const entry of removals) {
     const gCalendarId = entry.id;
@@ -139,22 +154,14 @@ async function runReconcile(
 
     // Only tear down calendars Compass actually knows about; a removal for
     // a calendar that was never imported has nothing to reconcile away.
-    const row = await calendarService.archiveGoogleCalendar(
-      userId,
-      gCalendarId,
-    );
-    if (!row) continue;
+    const removed = await teardownRemovedCalendar(userId, gCalendarId, context);
+    if (!removed) continue;
 
-    affectedHexIds.add(row._id.toHexString());
-
-    await stopWatchIfPresent(userId, gCalendarId, context);
-    await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
-    await eventRepository.deleteByCalendarIds([row._id]);
-
-    if (row.isVisible) eventsChangedHexIds.add(row._id.toHexString());
+    affectedHexIds.add(removed.hexId);
+    if (removed.isVisible) eventsChangedHexIds.add(removed.hexId);
   }
 
-  let syncImport: SyncImport | undefined;
+  let importedCount = 0;
 
   if (upserts.length > 0) {
     const { records } = await calendarService.upsertGoogleCalendarEntries(
@@ -162,42 +169,14 @@ async function runReconcile(
       upserts,
     );
 
-    for (const record of records) {
-      if (record.source.provider !== "google") continue;
-
-      const hexId = record._id.toHexString();
-      const gCalendarId = record.source.calendarId;
-      affectedHexIds.add(hexId);
-
-      if (record.access === "freeBusyReader") {
-        // A7: freeBusyReader calendars never manufacture event records -
-        // tear down anything left behind by a prior, more-permissive role.
-        await stopWatchIfPresent(userId, gCalendarId, context);
-        await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
-        await eventRepository.deleteByCalendarIds([record._id]);
-        continue;
-      }
-
-      if (!alreadyImportedGCalIds.has(gCalendarId)) {
-        syncImport ??= await createSyncImport(context);
-        await syncImport.importAllEvents(userId, record, 2500);
-        importedCount += 1;
-        if (record.isVisible) eventsChangedHexIds.add(hexId);
-      }
-
-      // Idempotent (already-watching-guarded) and HTTPS-gated internally,
-      // so it's safe to call unconditionally for every event-capable
-      // calendar in this delta, not just newly-imported ones.
-      await googleWatchService.startGoogleWatches(
-        userId,
-        [{ gCalendarId }],
-        context,
-      );
-    }
-
-    const userObjectId = new ObjectId(userId);
-    const clearedIds = await clearStalePrimaryFlags(userObjectId, records);
-    clearedIds.forEach((id) => affectedHexIds.add(id.toHexString()));
+    ({ importedCount } = await applyUpsertedRecords(
+      userId,
+      context,
+      records,
+      alreadyImportedGCalIds,
+      affectedHexIds,
+      eventsChangedHexIds,
+    ));
   }
 
   // Advance the token only after every removal/upsert/primary-cleanup step
@@ -226,6 +205,217 @@ async function runReconcile(
   );
 
   return { outcome: "RECONCILED" };
+}
+
+/**
+ * Targeted 410 recovery: rebuilds calendar state from a full CalendarList
+ * fetch (the rejected token is discarded, not retried) rather than the
+ * nuclear full repair, which deletes every google event and reimports
+ * everything. Preserves Compass-local data (never touched here), each
+ * calendar's own events sync token (untouched unless that calendar is torn
+ * down), and user visibility preferences (upsertGoogleCalendarEntries
+ * reuses each existing row's _id/isVisible).
+ *
+ * Drives the identical removal/upsert logic runReconcile uses for a delta,
+ * just decided by "missing from the full list" instead of "flagged
+ * deleted/hidden in the delta" - Google's full calendarList.list omits
+ * hidden/deleted entries outright, so there's no delta-style flag to read.
+ */
+async function reconcileFromFullList(
+  context: GoogleRequestContext,
+  userId: string,
+): Promise<ReconcileResult> {
+  const entries: calendar_v3.Schema$CalendarListEntry[] = [];
+  let finalToken: string | undefined;
+
+  for await (const page of gcalService.getAllCalendarListPages(context, {})) {
+    entries.push(...(page.items ?? []));
+    if (page.nextSyncToken) finalToken = page.nextSyncToken;
+  }
+
+  if (!finalToken) {
+    // getAllCalendarListPages always yields a nextSyncToken on whichever
+    // page ends pagination (it throws GcalError.PaginationNotSupported
+    // otherwise), so this is unreachable - kept only to narrow the type.
+    throw error(
+      SyncError.NoSyncToken,
+      `CalendarList full-list recovery finished without a sync token for user: ${userId}`,
+    );
+  }
+
+  // Belt-and-braces: a full list shouldn't contain either flag (Google's
+  // default showHidden: false omits hidden calendars, and deleted ones
+  // don't appear at all), but don't trust that blindly.
+  const upserts = entries.filter(
+    (entry) => entry.deleted !== true && entry.hidden !== true,
+  );
+  const fetchedGCalendarIds = new Set(
+    upserts.map((entry) => entry.id).filter((id): id is string => !!id),
+  );
+
+  // Same rationale as runReconcile's alreadyImportedGCalIds: only entries
+  // holding a nextSyncToken count as "already imported", so an import left
+  // mid-checkpoint by an earlier run resumes instead of being skipped.
+  const sync = await getSync({ userId });
+  const alreadyImportedGCalIds = new Set(
+    (sync?.google?.events ?? [])
+      .filter((entry) => entry.nextSyncToken)
+      .map((entry) => entry.gCalendarId),
+  );
+
+  const userObjectId = new ObjectId(userId);
+  const staleRows = await mongoService.calendar
+    .find({
+      userId: userObjectId,
+      "source.provider": "google",
+      isActive: true,
+    })
+    .toArray();
+  const staleGCalendarIds = staleRows.flatMap((row) =>
+    row.source.provider === "google" &&
+    !fetchedGCalendarIds.has(row.source.calendarId)
+      ? [row.source.calendarId]
+      : [],
+  );
+
+  const affectedHexIds = new Set<string>();
+  const eventsChangedHexIds = new Set<string>();
+
+  for (const gCalendarId of staleGCalendarIds) {
+    const removed = await teardownRemovedCalendar(userId, gCalendarId, context);
+    if (!removed) continue;
+
+    affectedHexIds.add(removed.hexId);
+    if (removed.isVisible) eventsChangedHexIds.add(removed.hexId);
+  }
+
+  let importedCount = 0;
+
+  if (upserts.length > 0) {
+    const { records } = await calendarService.upsertGoogleCalendarEntries(
+      userId,
+      upserts,
+    );
+
+    ({ importedCount } = await applyUpsertedRecords(
+      userId,
+      context,
+      records,
+      alreadyImportedGCalIds,
+      affectedHexIds,
+      eventsChangedHexIds,
+    ));
+  }
+
+  // Advance the token only after every removal/upsert/primary-cleanup step
+  // above has succeeded, same invariant as runReconcile.
+  await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+    nextSyncToken: finalToken,
+  });
+
+  if (affectedHexIds.size > 0) {
+    sseServer.publishCalendarsChanged(userId, [
+      ...affectedHexIds,
+    ] as CalendarId[]);
+  }
+
+  eventsChangedHexIds.forEach((hexId) => {
+    sseServer.publishEventsChanged(userId, {
+      calendarId: hexId as CalendarId,
+      eventIds: [] as EventId[],
+      reason: "reconciled",
+    });
+  });
+
+  logger.info(
+    `CalendarList recovered from full list for user: ${userId} (upserted=${upserts.length} archived=${staleGCalendarIds.length} imported=${importedCount})`,
+  );
+
+  return { outcome: "RECONCILED" };
+}
+
+/**
+ * Archives one Google calendar row and tears down everything that depends
+ * on it being live: its watch, its events sync entry, and its events.
+ * Shared by the delta path (an entry flagged deleted/hidden) and the
+ * full-list recovery path (a row missing from a fresh CalendarList).
+ * Returns null when Compass never had a row for this calendar - nothing to
+ * tear down.
+ */
+async function teardownRemovedCalendar(
+  userId: string,
+  gCalendarId: string,
+  context: GoogleRequestContext,
+): Promise<{ hexId: string; isVisible: boolean } | null> {
+  const row = await calendarService.archiveGoogleCalendar(userId, gCalendarId);
+  if (!row) return null;
+
+  await stopWatchIfPresent(userId, gCalendarId, context);
+  await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
+  await eventRepository.deleteByCalendarIds([row._id]);
+
+  return { hexId: row._id.toHexString(), isVisible: row.isVisible };
+}
+
+/**
+ * Applies a batch of freshly-upserted Google CalendarRecords: tears down
+ * event machinery for anything that dropped to freeBusyReader, imports
+ * events for any not-yet-imported event-capable calendar, ensures a watch
+ * for every event-capable calendar, and clears stale isPrimary flags.
+ * Shared by the delta path and the full-list recovery path. Mutates
+ * affectedHexIds/eventsChangedHexIds in place (both are accumulated across
+ * the removal step too); returns the imported count for the caller's log
+ * line.
+ */
+async function applyUpsertedRecords(
+  userId: string,
+  context: GoogleRequestContext,
+  records: CalendarRecord[],
+  alreadyImportedGCalIds: Set<string>,
+  affectedHexIds: Set<string>,
+  eventsChangedHexIds: Set<string>,
+): Promise<{ importedCount: number }> {
+  let syncImport: SyncImport | undefined;
+  let importedCount = 0;
+
+  for (const record of records) {
+    if (record.source.provider !== "google") continue;
+
+    const hexId = record._id.toHexString();
+    const gCalendarId = record.source.calendarId;
+    affectedHexIds.add(hexId);
+
+    if (record.access === "freeBusyReader") {
+      // A7: freeBusyReader calendars never manufacture event records - tear
+      // down anything left behind by a prior, more-permissive role.
+      await stopWatchIfPresent(userId, gCalendarId, context);
+      await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
+      await eventRepository.deleteByCalendarIds([record._id]);
+      continue;
+    }
+
+    if (!alreadyImportedGCalIds.has(gCalendarId)) {
+      syncImport ??= await createSyncImport(context);
+      await syncImport.importAllEvents(userId, record, 2500);
+      importedCount += 1;
+      if (record.isVisible) eventsChangedHexIds.add(hexId);
+    }
+
+    // Idempotent (already-watching-guarded) and HTTPS-gated internally, so
+    // it's safe to call unconditionally for every event-capable calendar
+    // processed here, not just newly-imported ones.
+    await googleWatchService.startGoogleWatches(
+      userId,
+      [{ gCalendarId }],
+      context,
+    );
+  }
+
+  const userObjectId = new ObjectId(userId);
+  const clearedIds = await clearStalePrimaryFlags(userObjectId, records);
+  clearedIds.forEach((id) => affectedHexIds.add(id.toHexString()));
+
+  return { importedCount };
 }
 
 async function stopWatchIfPresent(

--- a/packages/backend/src/sync/services/event-propagation/__tests__/google-to-compass.event-propagation.test.ts
+++ b/packages/backend/src/sync/services/event-propagation/__tests__/google-to-compass.event-propagation.test.ts
@@ -218,4 +218,100 @@ describe("GoogleToCompassEventPropagation", () => {
     expect(result.ignored).toBe(1);
     expect(result.saved).toBe(0);
   });
+
+  /**
+   * Packet 06 test-matrix item: a user moving an event between two of their
+   * own Google calendars delivers as an upsert on the target calendar and a
+   * cancellation on the source calendar, in either order (Google doesn't
+   * guarantee delivery order across two distinct watches). Convergence to
+   * exactly one copy, owned by the target, relies on deleteByExternalReference
+   * being scoped to `this.calendar._id` (google-event-sync.service.ts) - a
+   * cancellation on cal-src can never delete cal-tgt's copy of the same
+   * provider event id, regardless of delivery order.
+   */
+  describe("cross-calendar move convergence", () => {
+    // Both calendars belong to the same user - a move happens within one
+    // account's calendar set.
+    const moveUserId = new ObjectId();
+    const buildTestCalendar = (
+      gCalendarId: string,
+      overrides: Partial<CalendarRecord> = {},
+    ): CalendarRecord => ({
+      _id: new ObjectId(),
+      userId: moveUserId,
+      name: gCalendarId,
+      description: "",
+      timeZone: "America/Denver",
+      foregroundColor: "#000000",
+      backgroundColor: "#ffffff",
+      access: "owner",
+      isPrimary: false,
+      isVisible: true,
+      isActive: true,
+      source: { provider: "google", calendarId: gCalendarId, etag: "etag-1" },
+      createdAt: new Date(),
+      updatedAt: null,
+      ...overrides,
+    });
+
+    it("converges to one event owned by the target when the target upsert arrives before the source cancellation", async () => {
+      const calSrc = buildTestCalendar("cal-src");
+      const calTgt = buildTestCalendar("cal-tgt");
+      await mongoService.calendar.insertMany([calSrc, calTgt]);
+
+      const gEvent = mockRegularGcalEvent({ id: "evt-1" });
+      const srcPropagation = new GoogleToCompassEventPropagation(
+        context,
+        calSrc,
+      );
+      await srcPropagation.processEvents([gEvent]);
+
+      // Order A: target upsert, then source cancellation.
+      const tgtPropagation = new GoogleToCompassEventPropagation(
+        context,
+        calTgt,
+      );
+      await tgtPropagation.processEvents([gEvent]);
+      await srcPropagation.processEvents([{ ...gEvent, status: "cancelled" }]);
+
+      const matching = await mongoService.event
+        .find({ "externalReference.eventId": "evt-1" })
+        .toArray();
+      expect(matching).toHaveLength(1);
+      expect(matching[0]?.calendarId).toEqual(calTgt._id);
+      expect(
+        await mongoService.event.countDocuments({ calendarId: calSrc._id }),
+      ).toBe(0);
+    });
+
+    it("converges to one event owned by the target when the source cancellation arrives before the target upsert", async () => {
+      const calSrc = buildTestCalendar("cal-src");
+      const calTgt = buildTestCalendar("cal-tgt");
+      await mongoService.calendar.insertMany([calSrc, calTgt]);
+
+      const gEvent = mockRegularGcalEvent({ id: "evt-1" });
+      const srcPropagation = new GoogleToCompassEventPropagation(
+        context,
+        calSrc,
+      );
+      await srcPropagation.processEvents([gEvent]);
+
+      // Order B: source cancellation, then target upsert.
+      await srcPropagation.processEvents([{ ...gEvent, status: "cancelled" }]);
+      const tgtPropagation = new GoogleToCompassEventPropagation(
+        context,
+        calTgt,
+      );
+      await tgtPropagation.processEvents([gEvent]);
+
+      const matching = await mongoService.event
+        .find({ "externalReference.eventId": "evt-1" })
+        .toArray();
+      expect(matching).toHaveLength(1);
+      expect(matching[0]?.calendarId).toEqual(calTgt._id);
+      expect(
+        await mongoService.event.countDocuments({ calendarId: calSrc._id }),
+      ).toBe(0);
+    });
+  });
 });

--- a/packages/backend/src/sync/services/watch/google-watch.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.test.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import { type GaxiosResponse } from "gaxios";
 import { ObjectId } from "mongodb";
 import { Resource_Sync, XGoogleResourceState } from "@core/types/sync.types";
-import { WatchSchema } from "@core/types/watch.types";
+import { type Schema_Watch, WatchSchema } from "@core/types/watch.types";
 import { GoogleSyncDriver } from "@backend/__tests__/drivers/google-sync.driver";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import {
@@ -192,6 +192,76 @@ describe("googleWatchService", () => {
     expect(cleanupSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores a notification whose channelId matches but resourceId doesn't, leaving the real watch untouched", async () => {
+    const user = await UserDriver.createUser();
+    const watch = await createWatch(user._id.toString());
+
+    const cleanupSpy = jest.spyOn(googleWatchService, "cleanupStaleWatch");
+    const stopWatchSpy = jest.spyOn(gcalService, "stopWatch");
+
+    await expect(
+      googleWatchService.handleGoogleWatchNotification({
+        resource: Resource_Sync.EVENTS,
+        channelId: watch._id,
+        // Right channel, wrong resource - cleanupStaleWatch's exact
+        // (channelId, resourceId) lookup misses this watch too, so there's
+        // nothing to clean up.
+        resourceId: faker.string.uuid(),
+        resourceState: XGoogleResourceState.EXISTS,
+        expiration: watch.expiration,
+      }),
+    ).resolves.toBe("IGNORED");
+
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+    expect(stopWatchSpy).not.toHaveBeenCalled();
+    expect(await mongoService.watch.findOne({ _id: watch._id })).toEqual(
+      expect.objectContaining({
+        user: user._id.toString(),
+        resourceId: watch.resourceId,
+      }),
+    );
+  });
+
+  it("cleans up a stale watch record when the notification's expiration is newer than the stored one", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+
+    // Built directly rather than through WatchSchema.parse: its
+    // ExpirationDateSchema requires a future date (correct for a freshly
+    // created watch), but this fixture needs to represent one that's
+    // already expired.
+    const expiredWatch: Schema_Watch = {
+      _id: new ObjectId(),
+      user: userId,
+      resourceId: faker.string.uuid(),
+      expiration: new Date(Date.now() - 60_000), // already expired
+      gCalendarId: faker.string.uuid(),
+      createdAt: new Date(),
+    };
+    await mongoService.watch.insertOne(expiredWatch);
+
+    const stopWatchSpy = jest.spyOn(gcalService, "stopWatch");
+
+    await expect(
+      googleWatchService.handleGoogleWatchNotification({
+        resource: Resource_Sync.EVENTS,
+        channelId: expiredWatch._id,
+        resourceId: expiredWatch.resourceId,
+        resourceState: XGoogleResourceState.EXISTS,
+        // Newer than the stored (already expired) watch, so the exact
+        // `expiration: {$gte: ...}` lookup misses and this falls through to
+        // cleanupStaleWatch's looser (channelId, resourceId) lookup, which
+        // finds and stops the stale record.
+        expiration: new Date(),
+      }),
+    ).resolves.toBe("IGNORED");
+
+    expect(stopWatchSpy).toHaveBeenCalled();
+    expect(
+      await mongoService.watch.findOne({ _id: expiredWatch._id }),
+    ).toBeNull();
+  });
+
   it("dispatches a calendarlist notification to the reconciler and returns its outcome", async () => {
     const user = await UserDriver.createUser();
     const userId = user._id.toString();
@@ -255,6 +325,78 @@ describe("googleWatchService", () => {
       expect.objectContaining({
         calendarId: calendar!._id.toHexString(),
         reason: "reconciled",
+      }),
+    );
+  });
+
+  it("routes an events notification to the calendar its watch names, not any other calendar the user has (packet 06 step 9 secondary-calendar routing proof)", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+
+    const primaryGCalId = faker.string.uuid();
+    const secondaryGCalId = faker.string.uuid();
+
+    await seedGoogleCalendar(user._id, {
+      isPrimary: true,
+      source: {
+        provider: "google",
+        calendarId: primaryGCalId,
+        etag: "etag-1",
+      },
+    });
+    const secondaryCalendar = await seedGoogleCalendar(user._id, {
+      isPrimary: false,
+      source: {
+        provider: "google",
+        calendarId: secondaryGCalId,
+        etag: "etag-1",
+      },
+    });
+
+    await updateSync(Resource_Sync.EVENTS, userId, primaryGCalId, {
+      nextSyncToken: faker.string.alphanumeric(16),
+    });
+    await updateSync(Resource_Sync.EVENTS, userId, secondaryGCalId, {
+      nextSyncToken: faker.string.alphanumeric(16),
+    });
+
+    await createWatch(userId, primaryGCalId);
+    const secondaryWatch = await createWatch(userId, secondaryGCalId);
+
+    const getEventsSpy = jest
+      .spyOn(gcalService, "getEvents")
+      .mockResolvedValue({
+        status: 200,
+        statusText: "OK",
+        data: { items: [mockRegularGcalEvent({ summary: "Secondary event" })] },
+      } as unknown as GaxiosResponse);
+    const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    // The notification only names the secondary watch's channel/resource -
+    // no calendar id travels with it anywhere else. The stored watch is the
+    // only thing that routes this to the right calendar.
+    await expect(
+      googleWatchService.handleGoogleWatchNotification({
+        resource: Resource_Sync.EVENTS,
+        channelId: secondaryWatch._id,
+        resourceId: secondaryWatch.resourceId,
+        resourceState: XGoogleResourceState.EXISTS,
+        expiration: secondaryWatch.expiration,
+      }),
+    ).resolves.toBe("PROCESSED");
+
+    expect(getEventsSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ calendarId: secondaryGCalId }),
+    );
+    expect(getEventsSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ calendarId: primaryGCalId }),
+    );
+    expect(eventsChangedSpy).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({
+        calendarId: secondaryCalendar._id.toHexString(),
       }),
     );
   });


### PR DESCRIPTION
## Summary

Packet 06 phase 3 of 3 (final): targeted 410 recovery + the remaining test matrix. Builds on #2054 and #2055.

**Targeted calendarlist-410 recovery** (packet 06 step 5): when Google rejects the stored CalendarList sync token, the reconciler now rebuilds from a full CalendarList fetch instead of letting the 410 escape to the controller's full repair (`repairGoogleCalendarSync` deletes every google event via `stopGoogleCalendarSync` and re-imports everything). The recovery:
- archives calendars missing from the fresh full list with the same teardown as delta removals (watch stop, events-sync-entry pull, calendar-scoped event deletion);
- leaves surviving calendars' events, per-calendar events sync tokens, watches, and user visibility preferences untouched (per-calendar events tokens are independent of the calendarlist token);
- never touches Compass-local calendars or events;
- runs inside the same per-user serialization, and only a calendarlist-fetch 410 is intercepted — a 410 from an events import still propagates.

The delta path's removal/upsert logic is extracted into helpers (`teardownRemovedCalendar`, `applyUpsertedRecords`) shared by both paths; a follow-up refactor commit also shares the page-drain and SSE-publish blocks. Delta-path behavior is unchanged (phase 2 tests pass unmodified).

**Test matrix closed** (packet 06 step 9 + test list):
- Google-side cross-calendar event move converges to exactly one Compass event on the target calendar in **both delivery orders** (pins the calendar-scoped cancellation delete).
- Wrong-resource-id notification → IGNORED, real watch untouched; expired-watch notification → IGNORED, stale record cleaned up.
- Secondary-calendar routing proof: the route carries no calendar id; the stored watch alone routes an events notification to the right calendar (asserted on both the Google fetch target and the SSE payload). Preserves the archived #734 disposition (already recorded in the ledger).
- Revoked access through the notification path preserves the Compass-local calendar and events with the **real** `pruneGoogleData` running (the existing sibling test mocks it). The unsafe maintenance-path wipe (A29) remains packet 07 scope.
- 410 recovery test asserts survivor state (events/sync-entry/watch/visibility), disappeared-calendar teardown, local-data preservation, and token replacement; non-410 fetch errors still propagate with the token held.

## Testing

- `TZ=UTC jest --selectProjects backend`: 65 suites, 573 passed / 1 pre-existing skip.
- `bun run type-check` clean; `bun run lint` only the 15 pre-existing web warnings.

Completes the implementation work of `handoff/someday/06-calendar-list-sync-and-watch-routing.md`; docs/checkbox close-out follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)