### PR TITLE
feat(backend): add read-only google watch state inspector

### DIFF
--- a/packages/backend/src/sync/services/watch/google-watch-state.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-state.test.ts
@@ -1,0 +1,519 @@
+import { faker } from "@faker-js/faker";
+import { ObjectId, type WithId } from "mongodb";
+import { Resource_Sync } from "@core/types/sync.types";
+import { type Schema_User } from "@core/types/user.types";
+import { type Schema_Watch, WatchSchema } from "@core/types/watch.types";
+import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
+import gcalService from "@backend/common/services/gcal/gcal.service";
+import mongoService from "@backend/common/services/mongo.service";
+import { updateSync } from "@backend/sync/services/records/sync-records.repository";
+import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
+import {
+  classifyWatchState,
+  GoogleWatchStateStatus,
+  inspectGoogleWatchState,
+} from "@backend/sync/services/watch/google-watch-state";
+
+jest.mock("@backend/sync/services/watch/google-watch-config", () => {
+  const actual = jest.requireActual(
+    "@backend/sync/services/watch/google-watch-config",
+  );
+  return {
+    ...actual,
+    isUsingGcalWebhookHttps: jest.fn(() => actual.isUsingGcalWebhookHttps()),
+  };
+});
+
+// Comfortably outside SYNC_BUFFER_DAYS (3) so these watches never trip the
+// "expiring soon" bucket; SOON sits inside that buffer but still in the
+// future so it stays a valid, active watch.
+const FAR_FUTURE = () => new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+const SOON = () => new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+const buildGoogleCalendar = (
+  userId: ObjectId,
+  overrides: Partial<CalendarRecord> = {},
+): CalendarRecord => ({
+  _id: new ObjectId(),
+  userId,
+  name: "Calendar",
+  description: "",
+  timeZone: "America/Denver",
+  foregroundColor: "#000000",
+  backgroundColor: "#ffffff",
+  access: "writer",
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  source: { provider: "google", calendarId: "cal", etag: "etag-1" },
+  createdAt: new Date(),
+  updatedAt: null,
+  ...overrides,
+});
+
+const seedActiveGoogleCalendar = async (
+  userId: ObjectId,
+  gCalendarId: string,
+  overrides: Partial<CalendarRecord> = {},
+): Promise<CalendarRecord> => {
+  const calendar = buildGoogleCalendar(userId, {
+    ...overrides,
+    source: { provider: "google", calendarId: gCalendarId, etag: "etag-1" },
+  });
+  await mongoService.calendar.insertOne(calendar);
+  return calendar;
+};
+
+const seedWatch = async (
+  userId: string,
+  gCalendarId: string,
+  overrides: Partial<Schema_Watch> = {},
+): Promise<Schema_Watch> => {
+  const watch = WatchSchema.parse({
+    _id: new ObjectId(),
+    user: userId,
+    resourceId: faker.string.uuid(),
+    expiration: FAR_FUTURE(),
+    gCalendarId,
+    createdAt: new Date(),
+    ...overrides,
+  });
+  await mongoService.watch.insertOne(watch);
+  return watch;
+};
+
+// WatchSchema's ExpirationDateSchema requires a future date (correct for a
+// freshly-created watch), so an already-expired fixture can't go through
+// `WatchSchema.parse` - it's inserted as a plain object instead, the same
+// way inspectGoogleWatchState itself reads watches back (plain find, never
+// parse - see the comment in google-watch-state.ts).
+const seedExpiredWatch = async (
+  userId: string,
+  gCalendarId: string,
+): Promise<Schema_Watch> => {
+  const watch: Schema_Watch = {
+    _id: new ObjectId(),
+    user: userId,
+    resourceId: faker.string.uuid(),
+    expiration: new Date(Date.now() - 60_000),
+    gCalendarId,
+    createdAt: new Date(),
+  };
+  await mongoService.watch.insertOne(watch);
+  return watch;
+};
+
+const seedCalendarlistToken = (
+  userId: string,
+  token: string = faker.string.alphanumeric(16),
+) =>
+  updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+    nextSyncToken: token,
+  });
+
+const seedEventsSyncEntry = (
+  userId: string,
+  gCalendarId: string,
+  token: string = faker.string.alphanumeric(16),
+) =>
+  updateSync(Resource_Sync.EVENTS, userId, gCalendarId, {
+    nextSyncToken: token,
+  });
+
+// Mid-pagination checkpoint: a page token but no sync token yet, e.g. an
+// interrupted initial import.
+const seedEventsCheckpointOnly = (userId: string, gCalendarId: string) =>
+  updateSync(Resource_Sync.EVENTS, userId, gCalendarId, {
+    nextPageToken: faker.string.alphanumeric(12),
+  });
+
+/**
+ * Seeds one active, event-capable calendar with a token-bearing events sync
+ * entry and a healthy (far-future) watch; returns its Google calendar id.
+ */
+const seedHealthyCalendar = async (
+  user: WithId<Schema_User>,
+  gCalendarId: string = faker.string.uuid(),
+): Promise<string> => {
+  const userId = user._id.toString();
+  await seedActiveGoogleCalendar(user._id, gCalendarId);
+  await seedEventsSyncEntry(userId, gCalendarId);
+  await seedWatch(userId, gCalendarId);
+  return gCalendarId;
+};
+
+/**
+ * Seeds a user with a fully healthy Google watch state: calendarlist token
+ * + watch, plus `calendarCount` event-capable calendars each with a
+ * token-bearing sync entry and a healthy watch.
+ */
+const seedHealthyUser = async (calendarCount: number) => {
+  const user = await UserDriver.createUser();
+  const userId = user._id.toString();
+
+  await seedCalendarlistToken(userId);
+  await seedWatch(userId, Resource_Sync.CALENDAR);
+
+  const gCalendarIds: string[] = [];
+  for (let i = 0; i < calendarCount; i += 1) {
+    gCalendarIds.push(await seedHealthyCalendar(user));
+  }
+
+  return { user, userId, gCalendarIds };
+};
+
+describe("classifyWatchState", () => {
+  const makeWatch = (
+    gCalendarId: string,
+    overrides: Partial<Schema_Watch> = {},
+  ): Schema_Watch => ({
+    _id: new ObjectId(),
+    user: new ObjectId().toString(),
+    resourceId: faker.string.uuid(),
+    expiration: FAR_FUTURE(),
+    gCalendarId,
+    createdAt: new Date(),
+    ...overrides,
+  });
+
+  // Builds an independent watch/expectation pair per requested condition so
+  // each flag exercises exactly one bucket, letting the precedence tests
+  // below combine/remove conditions without them interfering with each
+  // other.
+  const buildScenario = (flags: {
+    expired?: boolean;
+    missing?: boolean;
+    duplicated?: boolean;
+    stale?: boolean;
+    expiring?: boolean;
+  }) => {
+    const expectedWatchCalendarIds: string[] = [];
+    const watches: Schema_Watch[] = [];
+
+    if (flags.expired) {
+      expectedWatchCalendarIds.push("cal-expired");
+      watches.push(
+        makeWatch("cal-expired", { expiration: new Date(Date.now() - 60_000) }),
+      );
+    }
+
+    if (flags.missing) {
+      expectedWatchCalendarIds.push("cal-missing");
+      // No watch seeded - that's what makes it missing.
+    }
+
+    if (flags.duplicated) {
+      expectedWatchCalendarIds.push("cal-duplicated");
+      watches.push(makeWatch("cal-duplicated"));
+      watches.push(makeWatch("cal-duplicated"));
+    }
+
+    if (flags.stale) {
+      // Deliberately NOT added to expectedWatchCalendarIds - that's what
+      // makes it stale.
+      watches.push(makeWatch("cal-stale"));
+    }
+
+    if (flags.expiring) {
+      expectedWatchCalendarIds.push("cal-expiring");
+      watches.push(makeWatch("cal-expiring", { expiration: SOON() }));
+    }
+
+    return { expectedWatchCalendarIds, watches };
+  };
+
+  it("case 12a: expired beats missing, duplicated, stale, and expiring", () => {
+    const { expectedWatchCalendarIds, watches } = buildScenario({
+      expired: true,
+      missing: true,
+      duplicated: true,
+      stale: true,
+      expiring: true,
+    });
+
+    const result = classifyWatchState({ expectedWatchCalendarIds, watches });
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_EXPIRED");
+  });
+
+  it("case 12b: missing beats duplicated, stale, and expiring when nothing is expired", () => {
+    const { expectedWatchCalendarIds, watches } = buildScenario({
+      missing: true,
+      duplicated: true,
+      stale: true,
+      expiring: true,
+    });
+
+    const result = classifyWatchState({ expectedWatchCalendarIds, watches });
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_MISSING");
+  });
+
+  it("case 12c: duplicated beats stale and expiring when nothing is expired or missing", () => {
+    const { expectedWatchCalendarIds, watches } = buildScenario({
+      duplicated: true,
+      stale: true,
+      expiring: true,
+    });
+
+    const result = classifyWatchState({ expectedWatchCalendarIds, watches });
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_DUPLICATED");
+  });
+
+  it("case 12d: stale beats expiring when nothing is expired, missing, or duplicated", () => {
+    const { expectedWatchCalendarIds, watches } = buildScenario({
+      stale: true,
+      expiring: true,
+    });
+
+    const result = classifyWatchState({ expectedWatchCalendarIds, watches });
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_STALE");
+  });
+
+  it("case 12e: expiring wins when nothing else is wrong", () => {
+    const { expectedWatchCalendarIds, watches } = buildScenario({
+      expiring: true,
+    });
+
+    const result = classifyWatchState({ expectedWatchCalendarIds, watches });
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REFRESH_REQUIRED);
+    expect(result.reason).toBe("WATCHES_EXPIRING_SOON");
+  });
+
+  it("case 12f: healthy when a matched calendar has no issues", () => {
+    const { expectedWatchCalendarIds, watches } = buildScenario({});
+    expectedWatchCalendarIds.push("cal-healthy");
+    watches.push(makeWatch("cal-healthy"));
+
+    const result = classifyWatchState({ expectedWatchCalendarIds, watches });
+
+    expect(result.status).toBe(GoogleWatchStateStatus.HEALTHY);
+    expect(result.reason).toBe("WATCHES_HEALTHY");
+  });
+});
+
+describe("inspectGoogleWatchState", () => {
+  beforeAll(initSupertokens);
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterEach(() => jest.restoreAllMocks());
+  afterAll(cleanupTestDb);
+
+  it("case 1: NOT_APPLICABLE/GOOGLE_NOT_CONNECTED when the user has no google credentials", async () => {
+    const user = await UserDriver.createUser({ withGoogle: false });
+
+    const result = await inspectGoogleWatchState(user._id.toString());
+
+    expect(result).toMatchObject({
+      status: GoogleWatchStateStatus.NOT_APPLICABLE,
+      reason: "GOOGLE_NOT_CONNECTED",
+    });
+  });
+
+  it("case 2: NOT_APPLICABLE/PUBLIC_NOTIFICATIONS_DISABLED when the webhook baseurl isn't https", async () => {
+    // Once: this test's single inspection call sees `false`; every other
+    // test in the file falls through to the real (https) implementation.
+    (isUsingGcalWebhookHttps as jest.Mock).mockReturnValueOnce(false);
+    const user = await UserDriver.createUser();
+
+    const result = await inspectGoogleWatchState(user._id.toString());
+
+    expect(result).toMatchObject({
+      status: GoogleWatchStateStatus.NOT_APPLICABLE,
+      reason: "PUBLIC_NOTIFICATIONS_DISABLED",
+    });
+  });
+
+  it("case 3: FULL_REPAIR_REQUIRED/SYNC_RECORD_MISSING when there is no sync record", async () => {
+    const user = await UserDriver.createUser();
+
+    const result = await inspectGoogleWatchState(user._id.toString());
+
+    expect(result).toMatchObject({
+      status: GoogleWatchStateStatus.FULL_REPAIR_REQUIRED,
+      reason: "SYNC_RECORD_MISSING",
+    });
+  });
+
+  it("case 4: FULL_REPAIR_REQUIRED/SYNC_TOKEN_MISSING when the calendarlist sync entry has no token", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+    // Creates sync.google (via the events array) without ever seeding a
+    // calendarlist entry.
+    await seedEventsSyncEntry(userId, faker.string.uuid());
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result).toMatchObject({
+      status: GoogleWatchStateStatus.FULL_REPAIR_REQUIRED,
+      reason: "SYNC_TOKEN_MISSING",
+    });
+  });
+
+  it("case 5: FULL_REPAIR_REQUIRED/SYNC_INCOMPLETE for event-capable calendars with no token-bearing events entry (absent, and checkpoint-only)", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+    await seedCalendarlistToken(userId);
+
+    const absentEntryGCalId = faker.string.uuid();
+    await seedActiveGoogleCalendar(user._id, absentEntryGCalId);
+    // No events sync entry at all for this one.
+
+    const checkpointOnlyGCalId = faker.string.uuid();
+    await seedActiveGoogleCalendar(user._id, checkpointOnlyGCalId);
+    await seedEventsCheckpointOnly(userId, checkpointOnlyGCalId);
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.FULL_REPAIR_REQUIRED);
+    expect(result.reason).toBe("SYNC_INCOMPLETE");
+    expect([...result.incompleteCalendarIds].sort()).toEqual(
+      [absentEntryGCalId, checkpointOnlyGCalId].sort(),
+    );
+  });
+
+  it("case 6a: HEALTHY with one event-capable calendar", async () => {
+    const { userId, gCalendarIds } = await seedHealthyUser(1);
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.HEALTHY);
+    expect(result.reason).toBe("WATCHES_HEALTHY");
+    expect(result.expectedWatchCalendarIds.sort()).toEqual(
+      [Resource_Sync.CALENDAR, ...gCalendarIds].sort(),
+    );
+  });
+
+  it("case 6b: HEALTHY with three event-capable calendars", async () => {
+    const { userId, gCalendarIds } = await seedHealthyUser(3);
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.HEALTHY);
+    expect(result.reason).toBe("WATCHES_HEALTHY");
+    expect(result.expectedWatchCalendarIds.sort()).toEqual(
+      [Resource_Sync.CALENDAR, ...gCalendarIds].sort(),
+    );
+  });
+
+  it("case 6c: HEALTHY with zero event-capable calendars (expected set is just the calendarlist watch)", async () => {
+    const { userId } = await seedHealthyUser(0);
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.HEALTHY);
+    expect(result.reason).toBe("WATCHES_HEALTHY");
+    expect(result.expectedWatchCalendarIds).toEqual([Resource_Sync.CALENDAR]);
+  });
+
+  it("case 7: a freeBusyReader calendar's lingering watch is stale, and the calendar is excluded from the expected set", async () => {
+    const { user, userId } = await seedHealthyUser(0);
+    const gCalendarId = faker.string.uuid();
+    await seedActiveGoogleCalendar(user._id, gCalendarId, {
+      access: "freeBusyReader",
+    });
+    await seedWatch(userId, gCalendarId);
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_STALE");
+    expect(result.staleWatches.map((w) => w.gCalendarId)).toEqual([
+      gCalendarId,
+    ]);
+    expect(result.expectedWatchCalendarIds).toEqual([Resource_Sync.CALENDAR]);
+  });
+
+  it("case 8: an archived calendar's lingering watch is stale", async () => {
+    const { user, userId } = await seedHealthyUser(0);
+    const gCalendarId = faker.string.uuid();
+    await seedActiveGoogleCalendar(user._id, gCalendarId, {
+      isActive: false,
+    });
+    await seedWatch(userId, gCalendarId);
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_STALE");
+    expect(result.staleWatches.map((w) => w.gCalendarId)).toEqual([
+      gCalendarId,
+    ]);
+  });
+
+  it("case 9: an expired expected watch triggers REPAIR_REQUIRED/WATCHES_EXPIRED and appears in expiredWatches", async () => {
+    const { userId, gCalendarIds } = await seedHealthyUser(1);
+    const gCalendarId = gCalendarIds[0]!;
+    // Replace the healthy events watch seeded by seedHealthyUser with an
+    // already-expired one for the same calendar.
+    await mongoService.watch.deleteOne({ user: userId, gCalendarId });
+    const expiredWatch = await seedExpiredWatch(userId, gCalendarId);
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_EXPIRED");
+    expect(result.expiredWatches.map((w) => w._id.toString())).toContain(
+      expiredWatch._id.toString(),
+    );
+  });
+
+  it("case 10: a missing expected watch triggers REPAIR_REQUIRED/WATCHES_MISSING with its id in missingWatchCalendarIds", async () => {
+    const { userId, gCalendarIds } = await seedHealthyUser(1);
+    const gCalendarId = gCalendarIds[0]!;
+    await mongoService.watch.deleteOne({ user: userId, gCalendarId });
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+    expect(result.reason).toBe("WATCHES_MISSING");
+    expect(result.missingWatchCalendarIds).toEqual([gCalendarId]);
+  });
+
+  it("case 11: a watch expiring inside the renew buffer triggers REFRESH_REQUIRED/WATCHES_EXPIRING_SOON", async () => {
+    const { userId, gCalendarIds } = await seedHealthyUser(1);
+    const gCalendarId = gCalendarIds[0]!;
+    await mongoService.watch.updateOne(
+      { user: userId, gCalendarId },
+      { $set: { expiration: SOON() } },
+    );
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.REFRESH_REQUIRED);
+    expect(result.reason).toBe("WATCHES_EXPIRING_SOON");
+    expect(result.watchesToRefresh.map((w) => w.gCalendarId)).toEqual([
+      gCalendarId,
+    ]);
+  });
+
+  it("case 13: makes zero Google API calls during a full inspection", async () => {
+    const { userId } = await seedHealthyUser(2);
+    const getEventsSpy = jest.spyOn(gcalService, "getEvents");
+    const watchEventsSpy = jest.spyOn(gcalService, "watchEvents");
+    const watchCalendarsSpy = jest.spyOn(gcalService, "watchCalendars");
+    const stopWatchSpy = jest.spyOn(gcalService, "stopWatch");
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.HEALTHY);
+    expect(getEventsSpy).not.toHaveBeenCalled();
+    expect(watchEventsSpy).not.toHaveBeenCalled();
+    expect(watchCalendarsSpy).not.toHaveBeenCalled();
+    expect(stopWatchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/sync/services/watch/google-watch-state.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-state.ts
@@ -1,6 +1,267 @@
 import { type ClientSession } from "mongodb";
+import { Resource_Sync } from "@core/types/sync.types";
+import { type Schema_Watch } from "@core/types/watch.types";
 import dayjs from "@core/util/date/dayjs";
+import calendarService from "@backend/calendar/services/calendar.service";
 import mongoService from "@backend/common/services/mongo.service";
+import { getSync } from "@backend/sync/services/records/sync-records.repository";
+import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
+import {
+  syncExpired,
+  syncExpiresSoon,
+} from "@backend/sync/services/watch/google-watch-timing";
+import { findCompassUserBy } from "@backend/user/queries/user.queries";
+
+export enum GoogleWatchStateStatus {
+  NOT_APPLICABLE = "NOT_APPLICABLE",
+  HEALTHY = "HEALTHY",
+  REFRESH_REQUIRED = "REFRESH_REQUIRED",
+  REPAIR_REQUIRED = "REPAIR_REQUIRED",
+  FULL_REPAIR_REQUIRED = "FULL_REPAIR_REQUIRED",
+}
+
+export type GoogleWatchStateReason =
+  | "GOOGLE_NOT_CONNECTED"
+  | "PUBLIC_NOTIFICATIONS_DISABLED"
+  | "SYNC_RECORD_MISSING"
+  | "SYNC_TOKEN_MISSING"
+  | "SYNC_INCOMPLETE"
+  | "WATCHES_HEALTHY"
+  | "WATCHES_EXPIRING_SOON"
+  | "WATCHES_EXPIRED"
+  | "WATCHES_MISSING"
+  | "WATCHES_DUPLICATED"
+  | "WATCHES_STALE";
+
+export type GoogleWatchStateInspection = {
+  status: GoogleWatchStateStatus;
+  reason: GoogleWatchStateReason;
+  expectedWatchCalendarIds: string[];
+  activeWatches: Schema_Watch[];
+  duplicateWatches: Schema_Watch[];
+  expiredWatches: Schema_Watch[];
+  missingWatchCalendarIds: string[];
+  staleWatches: Schema_Watch[];
+  watchesToRefresh: Schema_Watch[];
+  // Active event-capable calendars whose events sync entry has no
+  // nextSyncToken yet (absent, or mid-pagination with only a checkpoint
+  // nextPageToken). Empty for every outcome except SYNC_INCOMPLETE.
+  incompleteCalendarIds: string[];
+};
+
+const createInspection = (
+  params: Partial<GoogleWatchStateInspection> &
+    Pick<GoogleWatchStateInspection, "reason" | "status">,
+): GoogleWatchStateInspection => ({
+  expectedWatchCalendarIds: [],
+  activeWatches: [],
+  duplicateWatches: [],
+  expiredWatches: [],
+  missingWatchCalendarIds: [],
+  staleWatches: [],
+  watchesToRefresh: [],
+  incompleteCalendarIds: [],
+  ...params,
+});
+
+const unique = (values: string[]) => Array.from(new Set(values));
+
+/**
+ * Sorts stored watches into the buckets a repair coordinator needs and
+ * picks one overall status/reason by precedence: expired > missing >
+ * duplicated > stale > expiring > healthy. Pulled out of
+ * `inspectGoogleWatchState` as a pure function because the unique
+ * `(user, gCalendarId)` watch index makes duplicates practically
+ * unseedable through a real insert - tests exercise duplicate/precedence
+ * behavior by calling this directly with hand-built inputs.
+ */
+export const classifyWatchState = ({
+  expectedWatchCalendarIds,
+  watches,
+}: {
+  expectedWatchCalendarIds: string[];
+  watches: Schema_Watch[];
+}): GoogleWatchStateInspection => {
+  const expectedWatchCalendarIdSet = new Set(expectedWatchCalendarIds);
+  const activeWatches = watches.filter(
+    ({ expiration }) => !syncExpired(expiration),
+  );
+  const expiredWatches = watches.filter(({ expiration }) =>
+    syncExpired(expiration),
+  );
+  const staleWatches = watches.filter(
+    ({ gCalendarId }) => !expectedWatchCalendarIdSet.has(gCalendarId),
+  );
+  const missingWatchCalendarIds = expectedWatchCalendarIds.filter(
+    (gCalendarId) =>
+      !activeWatches.some((watch) => watch.gCalendarId === gCalendarId),
+  );
+  const watchesToRefresh = activeWatches.filter(
+    ({ gCalendarId, expiration }) =>
+      expectedWatchCalendarIdSet.has(gCalendarId) &&
+      syncExpiresSoon(expiration),
+  );
+  const duplicateWatches = expectedWatchCalendarIds.flatMap((gCalendarId) => {
+    const matches = activeWatches.filter(
+      (watch) => watch.gCalendarId === gCalendarId,
+    );
+
+    return matches.length > 1 ? matches : [];
+  });
+  const expectedExpiredWatches = expiredWatches.filter(({ gCalendarId }) =>
+    expectedWatchCalendarIdSet.has(gCalendarId),
+  );
+  const base = {
+    expectedWatchCalendarIds,
+    activeWatches,
+    duplicateWatches,
+    expiredWatches,
+    missingWatchCalendarIds,
+    staleWatches,
+    watchesToRefresh,
+  };
+
+  if (expectedExpiredWatches.length > 0) {
+    return createInspection({
+      ...base,
+      status: GoogleWatchStateStatus.REPAIR_REQUIRED,
+      reason: "WATCHES_EXPIRED",
+    });
+  }
+
+  if (missingWatchCalendarIds.length > 0) {
+    return createInspection({
+      ...base,
+      status: GoogleWatchStateStatus.REPAIR_REQUIRED,
+      reason: "WATCHES_MISSING",
+    });
+  }
+
+  if (duplicateWatches.length > 0) {
+    return createInspection({
+      ...base,
+      status: GoogleWatchStateStatus.REPAIR_REQUIRED,
+      reason: "WATCHES_DUPLICATED",
+    });
+  }
+
+  if (staleWatches.length > 0) {
+    return createInspection({
+      ...base,
+      status: GoogleWatchStateStatus.REPAIR_REQUIRED,
+      reason: "WATCHES_STALE",
+    });
+  }
+
+  if (watchesToRefresh.length > 0) {
+    return createInspection({
+      ...base,
+      status: GoogleWatchStateStatus.REFRESH_REQUIRED,
+      reason: "WATCHES_EXPIRING_SOON",
+    });
+  }
+
+  return createInspection({
+    ...base,
+    status: GoogleWatchStateStatus.HEALTHY,
+    reason: "WATCHES_HEALTHY",
+  });
+};
+
+/**
+ * Cheap, read-only classification of a user's Google watch health, built
+ * entirely from Compass-owned state (no Google API calls) so it is safe to
+ * call defensively/often. A later repair coordinator acts on the result;
+ * this function only inspects and reports.
+ */
+export const inspectGoogleWatchState = async (
+  userId: string,
+): Promise<GoogleWatchStateInspection> => {
+  const user = await findCompassUserBy("_id", userId);
+  const hasGoogleCredentials = Boolean(
+    user?.google?.googleId && user.google.gRefreshToken,
+  );
+
+  if (!hasGoogleCredentials) {
+    return createInspection({
+      status: GoogleWatchStateStatus.NOT_APPLICABLE,
+      reason: "GOOGLE_NOT_CONNECTED",
+    });
+  }
+
+  if (!isUsingGcalWebhookHttps()) {
+    return createInspection({
+      status: GoogleWatchStateStatus.NOT_APPLICABLE,
+      reason: "PUBLIC_NOTIFICATIONS_DISABLED",
+    });
+  }
+
+  const sync = await getSync({ userId });
+
+  if (!sync?.google) {
+    return createInspection({
+      status: GoogleWatchStateStatus.FULL_REPAIR_REQUIRED,
+      reason: "SYNC_RECORD_MISSING",
+    });
+  }
+
+  const calendarListToken = (sync.google.calendarlist ?? []).find(
+    (entry) => entry.gCalendarId === Resource_Sync.CALENDAR,
+  )?.nextSyncToken;
+
+  if (!calendarListToken) {
+    return createInspection({
+      status: GoogleWatchStateStatus.FULL_REPAIR_REQUIRED,
+      reason: "SYNC_TOKEN_MISSING",
+    });
+  }
+
+  // Expected watches are calendar-record-driven (not sync-entry-driven):
+  // an events sync entry surviving for an archived/freeBusyReader calendar
+  // must NOT keep that calendar "expected" (its watch, if any, is stale).
+  const eventSyncs = sync.google.events ?? [];
+  const activeGoogleCalendars =
+    await calendarService.getActiveGoogleCalendars(userId);
+  const eventCapableCalendarIds: string[] = [];
+  const incompleteCalendarIds: string[] = [];
+
+  for (const record of activeGoogleCalendars) {
+    if (record.source.provider !== "google") continue;
+    // A7: freeBusyReader calendars have no Events watch or incremental
+    // token - availability is a bounded on-demand query, not a sync target.
+    if (record.access === "freeBusyReader") continue;
+
+    const gCalendarId = record.source.calendarId;
+    eventCapableCalendarIds.push(gCalendarId);
+
+    const hasSyncToken = eventSyncs.some(
+      (entry) =>
+        entry.gCalendarId === gCalendarId && Boolean(entry.nextSyncToken),
+    );
+
+    if (!hasSyncToken) incompleteCalendarIds.push(gCalendarId);
+  }
+
+  if (incompleteCalendarIds.length > 0) {
+    return createInspection({
+      status: GoogleWatchStateStatus.FULL_REPAIR_REQUIRED,
+      reason: "SYNC_INCOMPLETE",
+      incompleteCalendarIds,
+    });
+  }
+
+  const expectedWatchCalendarIds = unique([
+    Resource_Sync.CALENDAR,
+    ...eventCapableCalendarIds,
+  ]);
+
+  // Read with a plain find, never `WatchSchema.parse`: its
+  // ExpirationDateSchema requires a future date (correct on the write
+  // path), but finding already-EXPIRED watches is this inspector's job.
+  const watches = await mongoService.watch.find({ user: userId }).toArray();
+
+  return classifyWatchState({ expectedWatchCalendarIds, watches });
+};
 
 export const isWatchingGoogleResource = async (
   userId: string,


### PR DESCRIPTION
## Summary

Packet 07 (watch repair, quota, retries) phase 1 of 3: the cheap health inspection (packet 07 steps 1-2). `inspectGoogleWatchState(userId)` classifies a user's Google watch state **from Compass-owned state only — zero Google API calls** — so the phase-2 repair coordinator (and defensive user-start hooks) can call it often and act only when needed.

- **States**: `NOT_APPLICABLE` (no Google credentials / non-HTTPS webhook), `HEALTHY`, `REFRESH_REQUIRED` (expiring inside the 3-day renew buffer), `REPAIR_REQUIRED` (expired / missing / duplicated / stale watches, precedence in that order), `FULL_REPAIR_REQUIRED` (missing sync record, missing calendarlist token, or `SYNC_INCOMPLETE` — an active event-capable calendar whose events sync entry has no `nextSyncToken`, i.e. an interrupted import checkpoint).
- **Expected watch set** (step 2): one CalendarList watch plus one Events watch per imported active event-capable calendar with a usable sync token; `freeBusyReader` calendars are excluded and visibility is ignored. Derivation is calendar-record-driven, so a lingering watch for an archived or role-downgraded calendar classifies as **stale** rather than keeping the calendar "expected".
- Watches are read with plain finds, never `WatchSchema.parse` — `ExpirationDateSchema` rejects past dates, and finding expired watches is this inspector's job (packet step 1's caution).
- The bucket classification is an exported pure function (`classifyWatchState`) composed by the async inspector, because the unique `(user, gCalendarId)` watch index makes duplicates unseedable through real inserts — precedence/duplicate tests drive the pure function directly.
- Ported from unmerged branch commit `b572a3ca4` (per the packet's "reuse carefully" note) with its single-calendar assumptions corrected; its process-local repair lock and metadata cooldown are deliberately NOT ported — phase 2 replaces them with a Mongo-backed lease.

Packet-doc note: the packet's "10-minute channel TTL / every watch permanently expiring" premise is stale — packet 04 shipped the 7-day TTL (`CHANNEL_EXPIRATION_MIN` default `10080`), so no timing change is needed or made here. This will be recorded in the packet close-out.

Nothing calls the inspector in production yet; phase 2 wires it into the repair coordinator, scheduled maintenance, and the SSE-subscribe defensive path.

## Testing

20 new tests: every inspection state for 0/1/many calendars, freeBusyReader/archived stale classification, absent-and-checkpoint-only incomplete detection, expired/missing/expiring buckets, full precedence cascade, and a zero-Google-calls assertion.

- `TZ=UTC jest --selectProjects backend`: 66 suites, 593 passed / 1 pre-existing skip.
- `bun run type-check` clean; `bun run lint` only the 15 pre-existing web warnings.

Part of `handoff/someday/07-watch-repair-quota-and-retries.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)