### PR TITLE
fix(sync): repair google watches idempotently, stop wiping accounts on invalid_grant

### DIFF
--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -22,11 +22,10 @@ import {
   type Info_Error,
 } from "@backend/common/types/error.types";
 import { type SessionResponse } from "@backend/common/types/express.types";
-import { sseServer } from "@backend/servers/sse/sse.server";
+import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { getSyncByToken } from "@backend/sync/services/records/sync-records.repository";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
-import userService from "@backend/user/services/user.service";
 
 const logger = Logger("app:express.handler");
 
@@ -115,16 +114,7 @@ const handleGoogleError = async (
   e: GaxiosError,
 ) => {
   if (isInvalidGoogleToken(e)) {
-    await userService.pruneGoogleData(userId);
-    sseServer.publishSyncStatus(userId, {
-      status: "attention",
-      code: "GOOGLE_REVOKED",
-      retryable: false,
-    });
-
-    logger.warn(
-      `Invalid Google token for user: ${userId}. Google data pruned and client notified.`,
-    );
+    await pruneGoogleDataAndNotifyRevoked(userId, "invalid google token");
 
     res.status(Status.UNAUTHORIZED).send({
       code: "GOOGLE_REVOKED",

--- a/packages/backend/src/events/controllers/events.controller.test.ts
+++ b/packages/backend/src/events/controllers/events.controller.test.ts
@@ -1,0 +1,89 @@
+import { type Request, type Response } from "express";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
+import eventsController from "@backend/events/controllers/events.controller";
+import {
+  type GoogleWatchRepairResult,
+  googleWatchRepairService,
+} from "@backend/sync/services/watch/google-watch-repair.service";
+import { GoogleWatchStateStatus } from "@backend/sync/services/watch/google-watch-state";
+
+describe("EventsController", () => {
+  beforeAll(initSupertokens);
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterEach(() => jest.restoreAllMocks());
+  afterAll(cleanupTestDb);
+
+  it("11: fire-and-forgets the watch repair coordinator after subscribing and replaying metadata", async () => {
+    const userId = "507f1f77bcf86cd799439011";
+    const noneResult: GoogleWatchRepairResult = {
+      action: "NONE",
+      inspection: {
+        status: GoogleWatchStateStatus.NOT_APPLICABLE,
+        reason: "GOOGLE_NOT_CONNECTED",
+        expectedWatchCalendarIds: [],
+        activeWatches: [],
+        duplicateWatches: [],
+        expiredWatches: [],
+        missingWatchCalendarIds: [],
+        staleWatches: [],
+        watchesToRefresh: [],
+        incompleteCalendarIds: [],
+      },
+    };
+    const repairSpy = jest
+      .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
+      .mockResolvedValue(noneResult);
+
+    const req = {
+      session: { getUserId: () => userId },
+      on: jest.fn(),
+    } as unknown as Request;
+    const res = {
+      setHeader: jest.fn(),
+      flushHeaders: jest.fn(),
+      write: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+      headersSent: false,
+    } as unknown as Response;
+
+    await eventsController.streamEvents(req, res);
+
+    expect(repairSpy).toHaveBeenCalledWith(userId);
+  });
+
+  it("does not let a repair failure affect the SSE response", async () => {
+    const userId = "507f1f77bcf86cd799439012";
+    jest
+      .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
+      .mockRejectedValue(new Error("simulated repair failure"));
+
+    const req = {
+      session: { getUserId: () => userId },
+      on: jest.fn(),
+    } as unknown as Request;
+    const res = {
+      setHeader: jest.fn(),
+      flushHeaders: jest.fn(),
+      write: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+      headersSent: false,
+    } as unknown as Response;
+
+    await expect(
+      eventsController.streamEvents(req, res),
+    ).resolves.toBeUndefined();
+    expect(res.status).not.toHaveBeenCalled();
+
+    // Let the fire-and-forget rejection's .catch handler settle so it
+    // doesn't surface as an unhandled rejection in a later test.
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+});

--- a/packages/backend/src/events/controllers/events.controller.ts
+++ b/packages/backend/src/events/controllers/events.controller.ts
@@ -1,6 +1,7 @@
 import { type Request, type Response } from "express";
 import { Logger } from "@core/logger/winston.logger";
 import { sseServer } from "@backend/servers/sse/sse.server";
+import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 
 const logger = Logger("app:events.controller");
@@ -20,6 +21,16 @@ class EventsController {
         type: "userMetadataChanged",
         metadata: metadata as Record<string, unknown>,
       });
+
+      // Defensive, fire-and-forget: a client reconnecting is a cheap,
+      // frequent moment to notice/repair stale Google watches. Cooldown +
+      // lease inside the coordinator keep this safe across multiple tabs
+      // and repeated reconnects; must never block or fail the stream.
+      void googleWatchRepairService
+        .repairGoogleWatchesForUser(userId)
+        .catch((err) => {
+          logger.error(`Google watch repair failed for user ${userId}:`, err);
+        });
     } catch (err) {
       logger.error(`Failed to open SSE stream for user ${userId}:`, err);
       if (!res.headersSent) {

--- a/packages/backend/src/sync/controllers/sync.controller.test.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.test.ts
@@ -28,6 +28,7 @@ import { GCalEventsNotificationHandler } from "@backend/sync/services/notify/han
 import * as syncQueries from "@backend/sync/services/records/sync-records.repository";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
+import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 import { randomUUID } from "node:crypto";
@@ -540,15 +541,25 @@ describe("SyncController", () => {
 
         const getAllEventsSpy = jest.spyOn(gcalService, "getAllEvents");
         const importEndSpy = jest.spyOn(sseServer, "publishImportCompleted");
+        // The ignored path also fire-and-forgets the watch repair
+        // coordinator (packet 07); this fixture wasn't crafted to be
+        // watch-healthy, so a real coordinator run would do unrelated
+        // repair work within this test's wait window. Stub it out - it's
+        // covered on its own in google-watch-repair.service.test.ts.
+        const repairSpy = jest
+          .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
+          .mockResolvedValue(undefined as never);
 
         await syncDriver.importGCal({ userId });
         await new Promise((resolve) => setTimeout(resolve, 200));
 
         expect(importEndSpy).not.toHaveBeenCalled();
         expect(getAllEventsSpy).not.toHaveBeenCalled();
+        expect(repairSpy).toHaveBeenCalledWith(userId);
 
         getAllEventsSpy.mockRestore();
         importEndSpy.mockRestore();
+        repairSpy.mockRestore();
       });
 
       it("ignores a request while an import is already in progress", async () => {
@@ -563,15 +574,21 @@ describe("SyncController", () => {
         });
 
         const importEndSpy = jest.spyOn(sseServer, "publishImportCompleted");
+        // Same reasoning as the sibling test above.
+        const repairSpy = jest
+          .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
+          .mockResolvedValue(undefined as never);
 
         await syncDriver.importGCal({ userId });
         await new Promise((resolve) => setTimeout(resolve, 200));
 
         expect(importEndSpy).not.toHaveBeenCalled();
         expect(getAllEventsSpy).not.toHaveBeenCalled();
+        expect(repairSpy).toHaveBeenCalledWith(userId);
 
         getAllEventsSpy.mockRestore();
         importEndSpy.mockRestore();
+        repairSpy.mockRestore();
       });
 
       it("retries a non-forced import after a restart is requested", async () => {

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -11,15 +11,14 @@ import {
   isInvalidGoogleToken,
 } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
-import { sseServer } from "@backend/servers/sse/sse.server";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
+import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { type NotificationOutcome } from "@backend/sync/services/notify/notification.outcome";
 import { publicWatchNotificationIngress } from "@backend/sync/services/public-watch-notifications/public-watch-notification.ingress";
 import { getSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { googleWatchMaintenanceService } from "@backend/sync/services/watch/google-watch-maintenance.service";
-import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 import { ImportGCalRequestSchema } from "../sync.types";
 
@@ -36,12 +35,15 @@ export class SyncController {
     const watch = await mongoService.watch.findOne({ _id, resourceId });
 
     if (watch) {
-      await pruneAndNotifyGoogleRevoked(watch.user, "missing refresh token");
+      await pruneGoogleDataAndNotifyRevoked(
+        watch.user,
+        "missing refresh token",
+      );
       res.status(Status.GONE).send({
         // This ack body goes back to Google's webhook infra, not to our
         // frontend; the client-facing signal is the syncStatusChanged/
-        // GOOGLE_REVOKED message published by pruneAndNotifyGoogleRevoked
-        // below.
+        // GOOGLE_REVOKED message published by pruneGoogleDataAndNotifyRevoked
+        // above.
         code: "GOOGLE_REVOKED",
         message: "Missing refresh token, pruned Google data",
       });
@@ -60,12 +62,12 @@ export class SyncController {
     userId: string | undefined,
   ): Promise<void> => {
     if (userId) {
-      await pruneAndNotifyGoogleRevoked(userId, "revoked access");
+      await pruneGoogleDataAndNotifyRevoked(userId, "revoked access");
       res.status(Status.GONE).send({
         // This ack body goes back to Google's webhook infra, not to our
         // frontend; the client-facing signal is the syncStatusChanged/
-        // GOOGLE_REVOKED message published by pruneAndNotifyGoogleRevoked
-        // below.
+        // GOOGLE_REVOKED message published by pruneGoogleDataAndNotifyRevoked
+        // above.
         code: "GOOGLE_REVOKED",
         message: "User revoked access, pruned Google data",
       });
@@ -287,20 +289,3 @@ export class SyncController {
     res.status(Status.NO_CONTENT).send();
   };
 }
-
-/**
- * Prunes Google data for a user and notifies connected clients.
- * Used when Google access has been revoked or refresh token is missing.
- */
-const pruneAndNotifyGoogleRevoked = async (
-  userId: string,
-  reason: string,
-): Promise<void> => {
-  logger.warn(`Cleaning data after ${reason} for user: ${userId}`);
-  await userService.pruneGoogleData(userId);
-  sseServer.publishSyncStatus(userId, {
-    status: "attention",
-    code: "GOOGLE_REVOKED",
-    retryable: false,
-  });
-};

--- a/packages/backend/src/sync/services/google-sync/google-sync.revoked.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.revoked.ts
@@ -1,0 +1,27 @@
+import { Logger } from "@core/logger/winston.logger";
+import { sseServer } from "@backend/servers/sse/sse.server";
+import userService from "@backend/user/services/user.service";
+
+const logger = Logger("app:google-sync.revoked");
+
+/**
+ * Shared revoked/missing-Google-access handling (A29): prunes Google-owned
+ * data while preserving everything Compass-local, then notifies connected
+ * clients. Every entry point that detects this (webhook notifications,
+ * google-sync setup, express error handling, watch maintenance, watch
+ * repair) funnels through here instead of each calling
+ * `deleteCompassDataForUser` (a full account wipe) or reimplementing the
+ * prune-and-notify pair.
+ */
+export const pruneGoogleDataAndNotifyRevoked = async (
+  userId: string,
+  reason: string,
+): Promise<void> => {
+  logger.warn(`Cleaning data after ${reason} for user: ${userId}`);
+  await userService.pruneGoogleData(userId);
+  sseServer.publishSyncStatus(userId, {
+    status: "attention",
+    code: "GOOGLE_REVOKED",
+    retryable: false,
+  });
+};

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.ts
@@ -16,17 +16,36 @@ import { isInvalidGoogleToken } from "@backend/common/services/gcal/gcal.utils";
 import { createConcurrencyLimiter } from "@backend/common/util/concurrency-limiter.util";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import compassToGoogleBackfill from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google-backfill";
+import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
 import {
   createSyncImport,
   type SyncImport,
 } from "@backend/sync/services/import/google-import.service";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
+import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 
 const logger = Logger("app:google-sync.service");
 
 const activeFullSyncRestarts = new Set<string>();
+
+/**
+ * Defensive, fire-and-forget nudge for the watch repair coordinator from
+ * the sync-start "ignored" paths below (an already-in-progress or
+ * already-completed sync still leaves stale/missing watches un-repaired).
+ * Cooldown+lease inside the coordinator keep this cheap on what is a hot
+ * path. Static import above (not the dynamic pattern used for
+ * user.service in runGoogleCalendarSyncSetup) because this call site runs
+ * on every ignored request; google-watch-repair.service.ts reaches back to
+ * this module dynamically instead, which breaks the cycle without paying
+ * dynamic-import cost here - same trade-off as google-watch.service.ts:192-193.
+ */
+const triggerWatchRepairInBackground = (userId: string): void => {
+  googleWatchRepairService.repairGoogleWatchesForUser(userId).catch((err) => {
+    logger.error(`Google watch repair failed for user: ${userId}`, err);
+  });
+};
 
 const notifyImportStart = (userId: string): void => {
   sseServer.publishSyncStatus(userId, { status: "syncing" });
@@ -206,6 +225,7 @@ async function runGoogleCalendarSyncSetup(
       status: "IGNORED",
       message: ignoreMessage,
     });
+    triggerWatchRepairInBackground(userId);
     return;
   }
 
@@ -223,6 +243,7 @@ async function runGoogleCalendarSyncSetup(
         status: "IGNORED",
         message: ignoreMessage,
       });
+      triggerWatchRepairInBackground(userId);
 
       return;
     }
@@ -285,16 +306,10 @@ async function runGoogleCalendarSyncSetup(
     }
 
     if (isInvalidGoogleToken(err)) {
-      logger.warn(
-        `Google Calendar repair failed because access was revoked for user: ${userId}`,
+      await pruneGoogleDataAndNotifyRevoked(
+        userId,
+        "google calendar sync setup",
       );
-
-      await userService.pruneGoogleData(userId);
-      sseServer.publishSyncStatus(userId, {
-        status: "attention",
-        code: "GOOGLE_REVOKED",
-        retryable: false,
-      });
       return;
     }
 

--- a/packages/backend/src/sync/services/records/sync-records.repository.ts
+++ b/packages/backend/src/sync/services/records/sync-records.repository.ts
@@ -177,6 +177,71 @@ export const deleteAllByUser = (userId: string, session?: ClientSession) => {
   return mongoService.sync.deleteMany({ user: userId }, { session });
 };
 
+/**
+ * Ensures a sync doc exists for `userId` before the atomic acquisition
+ * below - the acquisition itself must never upsert, since an upserting
+ * acquire would let a losing racer "succeed" by creating a brand new doc
+ * instead of correctly losing to the real holder. Same upsert-on-user
+ * pattern `updateSync` uses above; a concurrent first-ever-call race can
+ * still insert two docs for the same user here (pre-existing to this
+ * pattern, accepted).
+ */
+export const acquireWatchRepairLease = async (
+  userId: string,
+  leaseMs: number,
+): Promise<boolean> => {
+  await mongoService.sync.updateOne(
+    { user: userId },
+    { $setOnInsert: { user: userId } },
+    { upsert: true },
+  );
+
+  const acquired = await mongoService.sync.findOneAndUpdate(
+    {
+      user: userId,
+      $or: [
+        { "googleWatchRepair.leaseExpiresAt": { $exists: false } },
+        { "googleWatchRepair.leaseExpiresAt": null },
+        { "googleWatchRepair.leaseExpiresAt": { $lt: new Date() } },
+      ],
+    },
+    {
+      $set: {
+        "googleWatchRepair.leaseExpiresAt": new Date(Date.now() + leaseMs),
+      },
+    },
+  );
+
+  return acquired !== null;
+};
+
+export const releaseWatchRepairLease = (
+  userId: string,
+): Promise<UpdateResult<Schema_Sync>> =>
+  mongoService.sync.updateOne(
+    { user: userId },
+    { $set: { "googleWatchRepair.leaseExpiresAt": null } },
+  );
+
+export const markWatchRepairAttempt = (
+  userId: string,
+): Promise<UpdateResult<Schema_Sync>> =>
+  mongoService.sync.updateOne(
+    { user: userId },
+    { $set: { "googleWatchRepair.lastAttemptAt": new Date() } },
+  );
+
+export const getWatchRepairState = async (
+  userId: string,
+): Promise<{ leaseExpiresAt: Date | null; lastAttemptAt: Date | null }> => {
+  const sync = await mongoService.sync.findOne({ user: userId });
+
+  return {
+    leaseExpiresAt: sync?.googleWatchRepair?.leaseExpiresAt ?? null,
+    lastAttemptAt: sync?.googleWatchRepair?.lastAttemptAt ?? null,
+  };
+};
+
 export const deleteByIntegration = (integration: "google", userId: string) => {
   return mongoService.db
     .collection(Collections.SYNC)
@@ -184,6 +249,7 @@ export const deleteByIntegration = (integration: "google", userId: string) => {
 };
 
 const syncRecords = {
+  acquireWatchRepairLease,
   canDoIncrementalSync,
   deleteAllByGcalId,
   deleteAllByUser,
@@ -191,6 +257,9 @@ const syncRecords = {
   getGCalEventsSyncPageToken,
   getSync,
   getSyncByToken,
+  getWatchRepairState,
+  markWatchRepairAttempt,
+  releaseWatchRepairLease,
   removeSyncEntry,
   updateSync,
 };

--- a/packages/backend/src/sync/services/watch/google-watch-maintenance.planner.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-maintenance.planner.ts
@@ -1,22 +1,17 @@
-import { ObjectId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import { type Result_Watch_Stop } from "@core/types/sync.types";
 import { type Schema_Watch } from "@core/types/watch.types";
 import dayjs from "@core/util/date/dayjs";
 import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
-import {
-  isFullSyncRequired,
-  isInvalidGoogleToken,
-} from "@backend/common/services/gcal/gcal.utils";
+import { isInvalidGoogleToken } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
-import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
+import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { hasUpdatedCompassEventRecently } from "@backend/sync/services/watch/google-watch-activity";
 import {
   syncExpired,
   syncExpiresSoon,
 } from "@backend/sync/services/watch/google-watch-timing";
-import userService from "@backend/user/services/user.service";
 
 const logger = Logger("app:google-watch-maintenance.planner");
 
@@ -53,7 +48,12 @@ const getWatchesToRefresh = async (user: string) => {
 
 export const prepWatchMaintenanceForUser = async (
   userId: string,
-): Promise<Record<"prune" | "ignore" | "refresh", Schema_Watch[]>> => {
+): Promise<{
+  prune: Schema_Watch[];
+  ignore: Schema_Watch[];
+  refresh: Schema_Watch[];
+  isActive: boolean;
+}> => {
   const deadline = getActiveDeadline();
   const isUserActive = await hasUpdatedCompassEventRecently(userId, deadline);
   const { active, expired, refresh } = await getWatchesToRefresh(userId);
@@ -62,6 +62,7 @@ export const prepWatchMaintenanceForUser = async (
     refresh: isUserActive ? refresh : [],
     prune: expired.concat(isUserActive ? [] : [...active, ...refresh]),
     ignore: isUserActive ? active : [],
+    isActive: isUserActive,
   };
 };
 
@@ -69,7 +70,7 @@ export const pruneSync = async (
   records: Array<{ user: string; payload: Schema_Watch[] }>,
 ) => {
   const _prunes = records.map(async ({ user, payload }) => {
-    let deletedUserData = false;
+    let prunedGoogleData = false;
     let stopped: Result_Watch_Stop = [];
 
     const context = await createGoogleRequestContext(user);
@@ -91,74 +92,21 @@ export const pruneSync = async (
       );
     } catch (e) {
       if (isInvalidGoogleToken(e as Error)) {
-        await userService.deleteCompassDataForUser(user, false);
-        deletedUserData = true;
+        // A29: prune Google-owned data (archives google calendars, deletes
+        // google events, clears watches/sync/refresh token) and preserve
+        // everything Compass-local - never deleteCompassDataForUser, which
+        // wipes the whole account including local-only data.
+        await pruneGoogleDataAndNotifyRevoked(user, "watch maintenance");
+        prunedGoogleData = true;
       } else {
         logger.warn("Unexpected error during prune:", e);
         throw e;
       }
     }
 
-    return { user, results: stopped, deletedUserData };
+    return { user, results: stopped, prunedGoogleData };
   });
 
   const pruneResult = await Promise.all(_prunes);
   return pruneResult;
-};
-
-export const refreshWatch = async (
-  toRefresh: {
-    user: string;
-    payload: Schema_Watch[];
-  }[],
-) => {
-  const _refreshes = toRefresh.map(async (r) => {
-    let resynced = false;
-
-    try {
-      const context = await createGoogleRequestContext(r.user);
-
-      const refreshesByUser = await Promise.all(
-        r.payload.map(async ({ _id, user, expiration, ...syncPayload }) => {
-          const _refresh = await googleWatchService.refreshWatch(
-            user,
-            {
-              ...syncPayload,
-              channelId: _id.toString(),
-              expiration: expiration.getTime().toString(),
-            },
-            context,
-          );
-
-          return {
-            gcalendarId: syncPayload.gCalendarId,
-            success:
-              _refresh?.acknowledged &&
-              ObjectId.isValid(_refresh.insertedId ?? ""),
-          };
-        }),
-      );
-
-      return {
-        user: r.user,
-        results: refreshesByUser,
-        resynced,
-      };
-    } catch (e) {
-      if (isFullSyncRequired(e as Error)) {
-        void googleCalendarSyncService.repairGoogleCalendarSync(r.user);
-        resynced = true;
-      } else {
-        logger.error(
-          `Unexpected error during refresh for user: ${r.user}:\n`,
-          e,
-        );
-        throw e;
-      }
-      return { user: r.user, results: [], resynced };
-    }
-  });
-
-  const refreshes = await Promise.all(_refreshes);
-  return refreshes;
 };

--- a/packages/backend/src/sync/services/watch/google-watch-maintenance.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-maintenance.service.test.ts
@@ -1,18 +1,34 @@
+import { faker } from "@faker-js/faker";
 import { ObjectId } from "mongodb";
+import { Resource_Sync } from "@core/types/sync.types";
+import { WatchSchema } from "@core/types/watch.types";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import {
   cleanupCollections,
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
+import { invalidGrant400Error } from "@backend/__tests__/mocks.gcal/errors/error.google.invalidGrant";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import mongoService from "@backend/common/services/mongo.service";
+import { sseServer } from "@backend/servers/sse/sse.server";
+import {
+  buildEventRecord,
+  seedGoogleCalendar,
+  seedLocalCalendar,
+} from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
+import { updateSync } from "@backend/sync/services/records/sync-records.repository";
+import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
+import * as googleWatchActivityService from "@backend/sync/services/watch/google-watch-activity";
 import { googleWatchMaintenanceService } from "@backend/sync/services/watch/google-watch-maintenance.service";
+import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
+import userService from "@backend/user/services/user.service";
 
 describe("googleWatchMaintenanceService", () => {
   beforeAll(initSupertokens);
   beforeEach(setupTestDb);
   beforeEach(cleanupCollections);
+  afterEach(() => jest.restoreAllMocks());
   afterAll(cleanupTestDb);
 
   it("returns maintenance buckets in dry mode without mutating watches", async () => {
@@ -35,5 +51,101 @@ describe("googleWatchMaintenanceService", () => {
 
     expect(result.prune[0].payload).toEqual([watch]);
     expect(await mongoService.watch.countDocuments({ user: userId })).toBe(1);
+  });
+
+  it("9: A29 regression - an invalid_grant error during prune archives/prunes Google data instead of wiping the account", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+
+    // No recent Compass-origin event -> inactive -> every watch lands in
+    // the prune bucket (prepWatchMaintenanceForUser's activity gate).
+    const localCalendar = await seedLocalCalendar(user._id);
+    const localEvent = await mongoService.event.insertOne(
+      buildEventRecord(localCalendar._id),
+    );
+    const googleCalendar = await seedGoogleCalendar(user._id);
+    await mongoService.watch.insertOne(
+      WatchSchema.parse({
+        _id: new ObjectId(),
+        user: userId,
+        resourceId: faker.string.uuid(),
+        expiration: new Date(Date.now() + 60 * 60 * 1000),
+        gCalendarId: googleCalendar.source.calendarId,
+        createdAt: new Date(),
+      }),
+    );
+
+    const deleteCompassDataSpy = jest.spyOn(
+      userService,
+      "deleteCompassDataForUser",
+    );
+    // stopWatch already swallows an invalid_grant Google response
+    // internally (see google-watch.service.test.ts), deleting the local
+    // watch without throwing - mocking stopWatch directly here isolates
+    // the planner's OWN catch/A29 handling instead of re-proving
+    // stopWatch's already-covered behavior.
+    jest
+      .spyOn(googleWatchService, "stopWatch")
+      .mockRejectedValue(invalidGrant400Error);
+    const publishSyncStatusSpy = jest.spyOn(sseServer, "publishSyncStatus");
+
+    const result =
+      await googleWatchMaintenanceService.runMaintenanceByUser(userId);
+
+    expect(deleteCompassDataSpy).not.toHaveBeenCalled();
+    expect(await mongoService.user.findOne({ _id: user._id })).not.toBeNull();
+    expect(
+      await mongoService.calendar.findOne({ _id: localCalendar._id }),
+    ).not.toBeNull();
+    expect(
+      await mongoService.event.findOne({ _id: localEvent.insertedId }),
+    ).not.toBeNull();
+    expect(
+      await mongoService.calendar.findOne({ _id: googleCalendar._id }),
+    ).toMatchObject({ isActive: false });
+    expect(publishSyncStatusSpy).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({ code: "GOOGLE_REVOKED" }),
+    );
+    expect(result.revoked).toBeGreaterThan(0);
+  });
+
+  it("10: an active user with an expiring watch routes through the repair coordinator and refreshes", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+
+    // hasUpdatedCompassEventRecently is a plain function export (not part
+    // of a service object) - mocking it directly isolates "does
+    // runMaintenanceByUser wire an active user through the coordinator"
+    // from activity-detection itself, which is a separate concern.
+    jest
+      .spyOn(googleWatchActivityService, "hasUpdatedCompassEventRecently")
+      .mockResolvedValue(true);
+
+    await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+      nextSyncToken: faker.string.alphanumeric(16),
+    });
+    await mongoService.watch.insertOne(
+      WatchSchema.parse({
+        _id: new ObjectId(),
+        user: userId,
+        resourceId: faker.string.uuid(),
+        // Inside SYNC_BUFFER_DAYS (3) but still in the future.
+        expiration: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        gCalendarId: Resource_Sync.CALENDAR,
+        createdAt: new Date(),
+      }),
+    );
+
+    const repairSpy = jest.spyOn(
+      googleWatchRepairService,
+      "repairGoogleWatchesForUser",
+    );
+
+    const result =
+      await googleWatchMaintenanceService.runMaintenanceByUser(userId);
+
+    expect(repairSpy).toHaveBeenCalledWith(userId);
+    expect(result.repairAction).toBe("REFRESHED");
   });
 });

--- a/packages/backend/src/sync/services/watch/google-watch-maintenance.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-maintenance.service.ts
@@ -6,8 +6,11 @@ import { createConcurrencyLimiter } from "@backend/common/util/concurrency-limit
 import {
   prepWatchMaintenanceForUser,
   pruneSync,
-  refreshWatch,
 } from "@backend/sync/services/watch/google-watch-maintenance.planner";
+import {
+  type GoogleWatchRepairAction,
+  googleWatchRepairService,
+} from "@backend/sync/services/watch/google-watch-repair.service";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 
 const logger = Logger("app:google-watch-maintenance.service");
@@ -100,25 +103,30 @@ async function runMaintenanceByUser(
     revoked: 0,
     deleted: 0,
     resynced: 0,
+    repairAction: undefined as GoogleWatchRepairAction | "INACTIVE" | undefined,
   };
 
   if (params?.dry) return result;
 
   const pruneResult = await pruneSync(prune);
-  const pruned = pruneResult.filter((p) => !p.deletedUserData);
-  const deletedDuringPrune = pruneResult.filter((p) => p.deletedUserData);
-  const refreshResult = await refreshWatch(refresh);
-  const refreshed = refreshResult;
-  const resynced = refreshResult.filter((r) => r.resynced);
+  const pruned = pruneResult.filter((p) => !p.prunedGoogleData);
+  const revokedDuringPrune = pruneResult.filter((p) => p.prunedGoogleData);
+
+  // The coordinator re-inspects fresh state itself, so it must only run
+  // for active users: calling it right after an inactive user's watches
+  // were just stopped above would see them as newly "missing" and restart
+  // them, undoing prepWatchMaintenanceForUser's activity gate.
+  const repair = maintenance.isActive
+    ? await googleWatchRepairService.repairGoogleWatchesForUser(userId)
+    : undefined;
 
   if (params?.log) {
     logger.debug(`Sync Maintenance Results:
       IGNORED: ${ignore.length}
       PRUNED: ${pruned.flatMap((p) => p.results).length}
-      REFRESHED: ${refreshed.flatMap((r) => r.results.filter((r) => r.success)).length}
+      REPAIR ACTION: ${repair?.action ?? "INACTIVE"}
 
-      DELETED DURING PRUNE: ${deletedDuringPrune.map((r) => r.user).toString()}
-      RESYNCED DURING REFRESH: ${resynced.map((r) => r.user).toString()}
+      REVOKED DURING PRUNE: ${revokedDuringPrune.map((r) => r.user).toString()}
     `);
   }
 
@@ -126,11 +134,16 @@ async function runMaintenanceByUser(
     ...result,
     ignored: ignore.flatMap(({ payload }) => payload).length,
     pruned: pruned.flatMap(({ results }) => results).length,
-    refreshed: refreshed.flatMap(({ results }) =>
-      results.filter((r) => r.success),
-    ).length,
-    deleted: deletedDuringPrune.length,
-    resynced: resynced.length,
+    refreshed:
+      repair?.action === "REFRESHED"
+        ? repair.inspection.watchesToRefresh.length
+        : 0,
+    revoked: revokedDuringPrune.length + (repair?.action === "PRUNED" ? 1 : 0),
+    // A29: deleteCompassDataForUser is never called from maintenance
+    // anymore - kept at 0 for response-shape stability.
+    deleted: 0,
+    resynced: repair?.action === "FULL_REPAIR_STARTED" ? 1 : 0,
+    repairAction: repair?.action ?? "INACTIVE",
   };
 }
 

--- a/packages/backend/src/sync/services/watch/google-watch-repair.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-repair.service.test.ts
@@ -1,0 +1,380 @@
+import { faker } from "@faker-js/faker";
+import { ObjectId, type WithId } from "mongodb";
+import { Resource_Sync } from "@core/types/sync.types";
+import { type Schema_User } from "@core/types/user.types";
+import { type Schema_Watch, WatchSchema } from "@core/types/watch.types";
+import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { compassTestState } from "@backend/__tests__/helpers/mock.setup";
+import { invalidGrant400Error } from "@backend/__tests__/mocks.gcal/errors/error.google.invalidGrant";
+import { invalidSyncTokenError } from "@backend/__tests__/mocks.gcal/errors/error.invalidSyncToken";
+import { mockRegularGcalEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
+import gcalService from "@backend/common/services/gcal/gcal.service";
+import mongoService from "@backend/common/services/mongo.service";
+import { sseServer } from "@backend/servers/sse/sse.server";
+import { seedLocalCalendar } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
+import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
+import {
+  getWatchRepairState,
+  updateSync,
+} from "@backend/sync/services/records/sync-records.repository";
+import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
+import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
+
+const FAR_FUTURE = () => new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+const buildGoogleCalendar = (
+  userId: ObjectId,
+  overrides: Partial<CalendarRecord> = {},
+): CalendarRecord => ({
+  _id: new ObjectId(),
+  userId,
+  name: "Calendar",
+  description: "",
+  timeZone: "America/Denver",
+  foregroundColor: "#000000",
+  backgroundColor: "#ffffff",
+  access: "writer",
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  source: { provider: "google", calendarId: "cal", etag: "etag-1" },
+  createdAt: new Date(),
+  updatedAt: null,
+  ...overrides,
+});
+
+const seedActiveGoogleCalendar = async (
+  userId: ObjectId,
+  gCalendarId: string,
+  overrides: Partial<CalendarRecord> = {},
+): Promise<CalendarRecord> => {
+  const calendar = buildGoogleCalendar(userId, {
+    ...overrides,
+    source: { provider: "google", calendarId: gCalendarId, etag: "etag-1" },
+  });
+  await mongoService.calendar.insertOne(calendar);
+  return calendar;
+};
+
+const seedWatch = async (
+  userId: string,
+  gCalendarId: string,
+  overrides: Partial<Schema_Watch> = {},
+): Promise<Schema_Watch> => {
+  const watch = WatchSchema.parse({
+    _id: new ObjectId(),
+    user: userId,
+    resourceId: faker.string.uuid(),
+    expiration: FAR_FUTURE(),
+    gCalendarId,
+    createdAt: new Date(),
+    ...overrides,
+  });
+  await mongoService.watch.insertOne(watch);
+  return watch;
+};
+
+const seedCalendarlistToken = (
+  userId: string,
+  token: string = faker.string.alphanumeric(16),
+) =>
+  updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+    nextSyncToken: token,
+  });
+
+const seedEventsSyncEntry = (
+  userId: string,
+  gCalendarId: string,
+  token: string = faker.string.alphanumeric(16),
+) =>
+  updateSync(Resource_Sync.EVENTS, userId, gCalendarId, {
+    nextSyncToken: token,
+  });
+
+/**
+ * Seeds one active, event-capable calendar with a token-bearing events sync
+ * entry and a healthy (far-future) watch; returns its Google calendar id.
+ */
+const seedHealthyCalendar = async (
+  user: WithId<Schema_User>,
+  gCalendarId: string = faker.string.uuid(),
+): Promise<string> => {
+  const userId = user._id.toString();
+  await seedActiveGoogleCalendar(user._id, gCalendarId);
+  await seedEventsSyncEntry(userId, gCalendarId);
+  await seedWatch(userId, gCalendarId);
+  return gCalendarId;
+};
+
+/**
+ * Seeds a user with a fully healthy Google watch state: calendarlist token
+ * + watch, plus `calendarCount` event-capable calendars each with a
+ * token-bearing sync entry and a healthy watch. Mirrors the identically
+ * named helper in google-watch-state.test.ts.
+ */
+const seedHealthyUser = async (calendarCount: number) => {
+  const user = await UserDriver.createUser();
+  const userId = user._id.toString();
+
+  await seedCalendarlistToken(userId);
+  await seedWatch(userId, Resource_Sync.CALENDAR);
+
+  const gCalendarIds: string[] = [];
+  for (let i = 0; i < calendarCount; i += 1) {
+    gCalendarIds.push(await seedHealthyCalendar(user));
+  }
+
+  return { user, userId, gCalendarIds };
+};
+
+/** seedHealthyUser(1) with that one calendar's watch deleted - the
+ *  "missed a notification while unwatched" starting point shared by the
+ *  catch-up tests (6, 7, 8). */
+const seedUserWithOneMissingWatch = async () => {
+  const { user, userId, gCalendarIds } = await seedHealthyUser(1);
+  const gCalendarId = gCalendarIds[0]!;
+  await mongoService.watch.deleteOne({ user: userId, gCalendarId });
+  return { user, userId, gCalendarId };
+};
+
+describe("googleWatchRepairService", () => {
+  beforeAll(initSupertokens);
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterEach(() => jest.restoreAllMocks());
+  afterAll(cleanupTestDb);
+
+  describe("repairGoogleWatchesForUser", () => {
+    it("1: HEALTHY makes zero Google calls and zero lease writes", async () => {
+      const { userId } = await seedHealthyUser(2);
+
+      const getEventsSpy = jest.spyOn(gcalService, "getEvents");
+      const watchEventsSpy = jest.spyOn(gcalService, "watchEvents");
+      const watchCalendarsSpy = jest.spyOn(gcalService, "watchCalendars");
+      const stopWatchSpy = jest.spyOn(gcalService, "stopWatch");
+
+      const result =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+
+      expect(result.action).toBe("HEALTHY");
+      expect(getEventsSpy).not.toHaveBeenCalled();
+      expect(watchEventsSpy).not.toHaveBeenCalled();
+      expect(watchCalendarsSpy).not.toHaveBeenCalled();
+      expect(stopWatchSpy).not.toHaveBeenCalled();
+
+      const state = await getWatchRepairState(userId);
+      expect(state).toEqual({ leaseExpiresAt: null, lastAttemptAt: null });
+    });
+
+    it("2: two concurrent runs perform exactly one repair; the other is SKIPPED/LOCKED", async () => {
+      const { userId, gCalendarId } = await seedUserWithOneMissingWatch();
+      const startGoogleWatchesSpy = jest.spyOn(
+        googleWatchService,
+        "startGoogleWatches",
+      );
+
+      const [first, second] = await Promise.all([
+        googleWatchRepairService.repairGoogleWatchesForUser(userId),
+        googleWatchRepairService.repairGoogleWatchesForUser(userId),
+      ]);
+
+      const actions = [first.action, second.action].sort();
+      expect(actions).toEqual(["REPAIRED", "SKIPPED"]);
+
+      const skipped = first.action === "SKIPPED" ? first : second;
+      expect(skipped.reason).toBe("LOCKED");
+
+      // Only the winner actually attempted to start the missing watch.
+      expect(startGoogleWatchesSpy).toHaveBeenCalledTimes(1);
+
+      const watches = await mongoService.watch
+        .find({ user: userId, gCalendarId })
+        .toArray();
+      expect(watches).toHaveLength(1);
+    });
+
+    it("3: an expired lease is recovered from - acquisition succeeds and repair runs", async () => {
+      const { userId, gCalendarId } = await seedUserWithOneMissingWatch();
+
+      // Simulate a crashed holder: an old lease that already expired, plus
+      // an old attempt well outside the cooldown window.
+      await mongoService.sync.updateOne(
+        { user: userId },
+        {
+          $set: {
+            "googleWatchRepair.leaseExpiresAt": new Date(Date.now() - 60_000),
+            "googleWatchRepair.lastAttemptAt": new Date(
+              Date.now() - 60 * 60 * 1000,
+            ),
+          },
+        },
+      );
+
+      const result =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+
+      expect(result.action).toBe("REPAIRED");
+      expect(
+        await mongoService.watch.findOne({ user: userId, gCalendarId }),
+      ).not.toBeNull();
+    });
+
+    it("4: a recent lastAttemptAt with no lease held SKIPs on COOLDOWN without Google calls (persisted, not in-memory)", async () => {
+      const { userId } = await seedUserWithOneMissingWatch();
+
+      await mongoService.sync.updateOne(
+        { user: userId },
+        { $set: { "googleWatchRepair.lastAttemptAt": new Date() } },
+      );
+
+      const startGoogleWatchesSpy = jest.spyOn(
+        googleWatchService,
+        "startGoogleWatches",
+      );
+
+      const result =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+
+      expect(result).toMatchObject({ action: "SKIPPED", reason: "COOLDOWN" });
+      expect(startGoogleWatchesSpy).not.toHaveBeenCalled();
+    });
+
+    it("5: repairing a missing watch is idempotent across repeated runs (no duplicate watches)", async () => {
+      const { userId, gCalendarId } = await seedUserWithOneMissingWatch();
+
+      const first =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+      expect(first.action).toBe("REPAIRED");
+      expect(
+        await mongoService.watch.countDocuments({ user: userId, gCalendarId }),
+      ).toBe(1);
+
+      // Simulate real time passing: clear the cooldown, and push the
+      // channel the first run just created (test env: CHANNEL_EXPIRATION_MIN
+      // = 5, so it's otherwise "expiring soon" the instant it's created)
+      // safely past the refresh buffer.
+      await mongoService.sync.updateOne(
+        { user: userId },
+        {
+          $set: {
+            "googleWatchRepair.lastAttemptAt": new Date(
+              Date.now() - 60 * 60 * 1000,
+            ),
+          },
+        },
+      );
+      await mongoService.watch.updateOne(
+        { user: userId, gCalendarId },
+        { $set: { expiration: FAR_FUTURE() } },
+      );
+
+      const second =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+      expect(second.action).toBe("HEALTHY");
+      expect(
+        await mongoService.watch.countDocuments({ user: userId, gCalendarId }),
+      ).toBe(1);
+    });
+
+    it("6: catch-up after a missed notification starts the watch and imports the missed event", async () => {
+      const { userId, gCalendarId } = await seedUserWithOneMissingWatch();
+
+      const missedEvent = mockRegularGcalEvent({ id: "missed-during-outage" });
+      compassTestState().events.gcalEvents.all.push(missedEvent);
+
+      const result =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+
+      expect(result.action).toBe("REPAIRED");
+      expect(
+        await mongoService.watch.findOne({ user: userId, gCalendarId }),
+      ).not.toBeNull();
+      expect(
+        await mongoService.event.findOne({
+          "externalReference.eventId": "missed-during-outage",
+        }),
+      ).not.toBeNull();
+    });
+
+    it("7: a 410 during catch-up import falls back to a full repair", async () => {
+      const { userId } = await seedUserWithOneMissingWatch();
+
+      jest
+        .spyOn(gcalService, "getEvents")
+        .mockRejectedValueOnce(invalidSyncTokenError);
+      const fullRepairSpy = jest
+        .spyOn(googleCalendarSyncService, "repairGoogleCalendarSync")
+        .mockResolvedValue(undefined);
+
+      const result =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+
+      expect(result.action).toBe("FULL_REPAIR_STARTED");
+      expect(fullRepairSpy).toHaveBeenCalledWith(userId);
+    });
+
+    it("8: revoked credentials during repair prune Google data, preserve Compass-local data, and notify GOOGLE_REVOKED", async () => {
+      const { user, userId, gCalendarId } = await seedUserWithOneMissingWatch();
+
+      const localCalendar = await seedLocalCalendar(user._id);
+      const localEvent = await mongoService.event.insertOne({
+        _id: new ObjectId(),
+        calendarId: localCalendar._id,
+        content: { kind: "details", title: "Local event", description: "" },
+        schedule: {
+          kind: "timed",
+          start: new Date("2026-07-14T15:00:00.000Z"),
+          end: new Date("2026-07-14T16:00:00.000Z"),
+          timeZone: "America/Denver",
+        },
+        recurrence: { kind: "single" },
+        priority: "unassigned",
+        externalReference: null,
+        createdAt: new Date(),
+        updatedAt: null,
+      });
+
+      jest
+        .spyOn(gcalService, "getEvents")
+        .mockRejectedValueOnce(invalidGrant400Error);
+      const publishSyncStatusSpy = jest.spyOn(sseServer, "publishSyncStatus");
+
+      const result =
+        await googleWatchRepairService.repairGoogleWatchesForUser(userId);
+
+      expect(result.action).toBe("PRUNED");
+
+      // Compass-local data survives untouched.
+      expect(
+        await mongoService.calendar.findOne({ _id: localCalendar._id }),
+      ).not.toBeNull();
+      expect(
+        await mongoService.event.findOne({ _id: localEvent.insertedId }),
+      ).not.toBeNull();
+
+      // Google data is gone: calendar archived, watches deleted, refresh
+      // token cleared.
+      const googleCalendarRow = await mongoService.calendar.findOne({
+        userId: user._id,
+        "source.calendarId": gCalendarId,
+      });
+      expect(googleCalendarRow?.isActive).toBe(false);
+      expect(await mongoService.watch.countDocuments({ user: userId })).toBe(0);
+      const updatedUser = await mongoService.user.findOne({ _id: user._id });
+      expect(updatedUser?.google?.gRefreshToken).toBe("");
+
+      expect(publishSyncStatusSpy).toHaveBeenCalledWith(userId, {
+        status: "attention",
+        code: "GOOGLE_REVOKED",
+        retryable: false,
+      });
+    });
+  });
+});

--- a/packages/backend/src/sync/services/watch/google-watch-repair.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-repair.service.ts
@@ -1,0 +1,309 @@
+import { ObjectId } from "mongodb";
+import { Logger } from "@core/logger/winston.logger";
+import { Resource_Sync } from "@core/types/sync.types";
+import { type Schema_Watch } from "@core/types/watch.types";
+import {
+  createGoogleRequestContext,
+  type GoogleRequestContext,
+} from "@backend/common/services/gcal/gcal.context";
+import {
+  isFullSyncRequired,
+  isInvalidGoogleToken,
+} from "@backend/common/services/gcal/gcal.utils";
+import mongoService from "@backend/common/services/mongo.service";
+import { googleCalendarListService } from "@backend/sync/services/calendarlist/google-calendarlist.service";
+import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
+import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
+import {
+  createSyncImport,
+  type SyncImport,
+} from "@backend/sync/services/import/google-import.service";
+import {
+  acquireWatchRepairLease,
+  getWatchRepairState,
+  markWatchRepairAttempt,
+  releaseWatchRepairLease,
+} from "@backend/sync/services/records/sync-records.repository";
+import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
+import {
+  type GoogleWatchStateInspection,
+  GoogleWatchStateStatus,
+  inspectGoogleWatchState,
+} from "@backend/sync/services/watch/google-watch-state";
+
+const logger = Logger("app:google-watch-repair");
+
+/** How long a completed (or skipped) attempt suppresses the next one. */
+const WATCH_REPAIR_COOLDOWN_MS = 5 * 60 * 1000;
+/** Upper bound on one repair run; also how long a crashed lease holder
+ *  blocks a new attempt before the lease is considered abandoned. */
+const WATCH_REPAIR_LEASE_MS = 10 * 60 * 1000;
+
+export type GoogleWatchRepairAction =
+  | "NONE"
+  | "HEALTHY"
+  | "SKIPPED"
+  | "REFRESHED"
+  | "REPAIRED"
+  | "FULL_REPAIR_STARTED"
+  | "PRUNED";
+
+export type GoogleWatchRepairResult = {
+  action: GoogleWatchRepairAction;
+  reason?: string;
+  inspection: GoogleWatchStateInspection;
+};
+
+const withinCooldown = (lastAttemptAt: Date | null): boolean =>
+  lastAttemptAt !== null &&
+  Date.now() - lastAttemptAt.getTime() < WATCH_REPAIR_COOLDOWN_MS;
+
+/**
+ * Dynamic import breaks the module cycle with google-sync.service: that
+ * module imports this one statically (its sync-start hot path calls
+ * `repairGoogleWatchesForUser` directly), so the edge back to it has to be
+ * the dynamic one - same pattern as google-watch.service.ts:192-193.
+ */
+async function startFullRepair(userId: string): Promise<void> {
+  const { googleCalendarSyncService } = await import(
+    "@backend/sync/services/google-sync/google-sync.service"
+  );
+  await googleCalendarSyncService.repairGoogleCalendarSync(userId);
+}
+
+async function refreshExpiringWatches(
+  userId: string,
+  context: GoogleRequestContext,
+  watchesToRefresh: Schema_Watch[],
+): Promise<void> {
+  await Promise.all(
+    watchesToRefresh.map((watch) =>
+      googleWatchService.refreshWatch(
+        userId,
+        {
+          gCalendarId: watch.gCalendarId,
+          channelId: watch._id.toString(),
+          resourceId: watch.resourceId,
+          // Unused by refreshWatch's own body (stop-then-start doesn't
+          // need it) but required by the Params_WatchEvents type.
+          expiration: watch.expiration.getTime().toString(),
+        },
+        context,
+      ),
+    ),
+  );
+}
+
+async function stopUnhealthyWatches(
+  userId: string,
+  context: GoogleRequestContext,
+  watches: Schema_Watch[],
+): Promise<void> {
+  const seen = new Set<string>();
+  const unique = watches.filter((watch) => {
+    const id = watch._id.toString();
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  await Promise.all(
+    unique.map((watch) =>
+      googleWatchService.stopWatch(
+        userId,
+        watch._id.toString(),
+        watch.resourceId,
+        context,
+      ),
+    ),
+  );
+}
+
+async function catchUpEventCalendars(
+  userId: string,
+  syncImport: SyncImport,
+  gCalendarIds: string[],
+): Promise<void> {
+  const userObjectId = new ObjectId(userId);
+
+  for (const gCalendarId of gCalendarIds) {
+    const record = await mongoService.calendar.findOne({
+      userId: userObjectId,
+      "source.provider": "google",
+      "source.calendarId": gCalendarId,
+    });
+
+    // No CalendarRecord (e.g. archived through some other path since the
+    // inspection ran) means there's nothing left to catch up on - starting
+    // its watch above already did the only repair this id still needed.
+    if (!record) continue;
+
+    await syncImport.importLatestEvents(userId, record);
+  }
+}
+
+/**
+ * Stops every unhealthy watch, (re)starts a fresh watch for every expected
+ * id left without one, then converges any events missed while unwatched.
+ * The "needs a watch" set is derived from the pre-repair inspection
+ * snapshot: missing ids, expired-and-expected ids, and duplicated ids
+ * (whose copies were ALL just stopped above, so each needs one fresh
+ * watch). `startGoogleWatches`'s already-watching guard makes over-asking
+ * harmless, so this stays a one-pass, non-recursive repair.
+ */
+async function repairWatches(
+  userId: string,
+  context: GoogleRequestContext,
+  inspection: GoogleWatchStateInspection,
+): Promise<void> {
+  await stopUnhealthyWatches(userId, context, [
+    ...inspection.duplicateWatches,
+    ...inspection.staleWatches,
+    ...inspection.expiredWatches,
+  ]);
+
+  const expiredExpectedIds = inspection.expiredWatches
+    .map((watch) => watch.gCalendarId)
+    .filter((gCalendarId) =>
+      inspection.expectedWatchCalendarIds.includes(gCalendarId),
+    );
+  const duplicatedIds = inspection.duplicateWatches.map(
+    (watch) => watch.gCalendarId,
+  );
+  const idsNeedingWatch = Array.from(
+    new Set([
+      ...inspection.missingWatchCalendarIds,
+      ...expiredExpectedIds,
+      ...duplicatedIds,
+    ]),
+  );
+
+  if (idsNeedingWatch.length === 0) return;
+
+  await googleWatchService.startGoogleWatches(
+    userId,
+    idsNeedingWatch.map((gCalendarId) => ({ gCalendarId })),
+    context,
+  );
+
+  const calendarListId = Resource_Sync.CALENDAR as string;
+
+  if (idsNeedingWatch.includes(calendarListId)) {
+    await googleCalendarListService.reconcileCalendarList(context, userId);
+  }
+
+  const eventCalendarIds = idsNeedingWatch.filter(
+    (gCalendarId) => gCalendarId !== calendarListId,
+  );
+
+  if (eventCalendarIds.length > 0) {
+    const syncImport = await createSyncImport(context);
+    await catchUpEventCalendars(userId, syncImport, eventCalendarIds);
+  }
+}
+
+const countsOf = (inspection: GoogleWatchStateInspection): string =>
+  `expected=${inspection.expectedWatchCalendarIds.length} ` +
+  `missing=${inspection.missingWatchCalendarIds.length} ` +
+  `expired=${inspection.expiredWatches.length} ` +
+  `duplicate=${inspection.duplicateWatches.length} ` +
+  `stale=${inspection.staleWatches.length} ` +
+  `refresh=${inspection.watchesToRefresh.length}`;
+
+/**
+ * Acts on `inspectGoogleWatchState`'s result: refreshes soon-to-expire
+ * watches, repairs missing/duplicated/stale/expired ones (with catch-up
+ * import for anything that may have missed a notification while
+ * unwatched), or kicks off a full resync when Compass's own sync state is
+ * unusable. A per-user Mongo lease plus a persisted cooldown make this
+ * cheap and multi-process safe to call defensively/often (SSE subscribe,
+ * sync-start's ignored path, scheduled maintenance) - a crashed lease
+ * holder is recovered from once `leaseExpiresAt` passes.
+ */
+async function repairGoogleWatchesForUser(
+  userId: string,
+): Promise<GoogleWatchRepairResult> {
+  const inspection = await inspectGoogleWatchState(userId);
+
+  if (inspection.status === GoogleWatchStateStatus.NOT_APPLICABLE) {
+    return { action: "NONE", inspection };
+  }
+
+  if (inspection.status === GoogleWatchStateStatus.HEALTHY) {
+    return { action: "HEALTHY", inspection };
+  }
+
+  // Checked before the lease so a cooldown skip never churns a lease write.
+  const { lastAttemptAt } = await getWatchRepairState(userId);
+
+  if (withinCooldown(lastAttemptAt)) {
+    logger.debug(
+      `Google watch repair SKIPPED (COOLDOWN) for user: ${userId}, status: ${inspection.status}, ${countsOf(inspection)}`,
+    );
+    return { action: "SKIPPED", reason: "COOLDOWN", inspection };
+  }
+
+  const acquired = await acquireWatchRepairLease(userId, WATCH_REPAIR_LEASE_MS);
+
+  if (!acquired) {
+    logger.debug(
+      `Google watch repair SKIPPED (LOCKED) for user: ${userId}, status: ${inspection.status}, ${countsOf(inspection)}`,
+    );
+    return { action: "SKIPPED", reason: "LOCKED", inspection };
+  }
+
+  await markWatchRepairAttempt(userId);
+
+  try {
+    if (inspection.status === GoogleWatchStateStatus.FULL_REPAIR_REQUIRED) {
+      await startFullRepair(userId);
+      logger.info(
+        `Google watch repair FULL_REPAIR_STARTED for user: ${userId}, reason: ${inspection.reason}`,
+      );
+      return { action: "FULL_REPAIR_STARTED", inspection };
+    }
+
+    const context = await createGoogleRequestContext(userId);
+
+    if (inspection.status === GoogleWatchStateStatus.REFRESH_REQUIRED) {
+      await refreshExpiringWatches(
+        userId,
+        context,
+        inspection.watchesToRefresh,
+      );
+      logger.info(
+        `Google watch repair REFRESHED for user: ${userId}, ${countsOf(inspection)}`,
+      );
+      return { action: "REFRESHED", inspection };
+    }
+
+    // Only REPAIR_REQUIRED remains.
+    await repairWatches(userId, context, inspection);
+    logger.info(
+      `Google watch repair REPAIRED for user: ${userId}, reason: ${inspection.reason}, ${countsOf(inspection)}`,
+    );
+    return { action: "REPAIRED", inspection };
+  } catch (err) {
+    if (isMissingGoogleRefreshToken(err) || isInvalidGoogleToken(err)) {
+      await pruneGoogleDataAndNotifyRevoked(userId, "watch repair");
+      logger.info(`Google watch repair PRUNED for user: ${userId}`);
+      return { action: "PRUNED", inspection };
+    }
+
+    if (isFullSyncRequired(err)) {
+      await startFullRepair(userId);
+      logger.info(
+        `Google watch repair FULL_REPAIR_STARTED (during catch-up) for user: ${userId}`,
+      );
+      return { action: "FULL_REPAIR_STARTED", inspection };
+    }
+
+    throw err;
+  } finally {
+    await releaseWatchRepairLease(userId);
+  }
+}
+
+export const googleWatchRepairService = {
+  repairGoogleWatchesForUser,
+};

--- a/packages/core/src/types/sync.types.ts
+++ b/packages/core/src/types/sync.types.ts
@@ -83,4 +83,11 @@ export interface Schema_Sync {
     calendarlist: SyncDetails[];
     events: SyncDetails[];
   };
+  // Packet 07: per-user Mongo lease + persisted cooldown guarding the
+  // Google watch repair coordinator (multi-process safe, recovers from a
+  // crashed lease holder once leaseExpiresAt passes).
+  googleWatchRepair?: {
+    leaseExpiresAt?: Date | null;
+    lastAttemptAt?: Date | null;
+  };
 }


### PR DESCRIPTION
## Summary

Packet 07 phase 2 of 3: the repair coordinator, its Mongo lease, and the A29 data-safety fix (packet 07 steps 3-5). Builds on #2058's inspector.

**Repair coordinator** (`googleWatchRepairService.repairGoogleWatchesForUser`):
- Acts on `inspectGoogleWatchState`: NOT_APPLICABLE/HEALTHY exit with **zero Google calls and zero lease writes** (the healthy check stays cheap); REFRESH_REQUIRED replaces only expiring watches; REPAIR_REQUIRED stops duplicated/stale/expired watches, restarts the expected set, and runs **incremental catch-up** (packet 06's calendarlist reconcile if the CalendarList watch was down, `importLatestEvents` per rebuilt event calendar) so notifications missed while unwatched converge; FULL_REPAIR_REQUIRED (or a 410 during catch-up) starts the existing full repair; revoked credentials prune Google data only.
- **Mongo-backed per-user lease + persisted cooldown** on the sync document (atomic `findOneAndUpdate` acquire with expiry — no new collection or migration needed; the sync collection has no schema validator). Two concurrent calls across processes → one winner, one `SKIPPED/LOCKED`; a crashed holder recovers once `leaseExpiresAt` passes; the 5-minute cooldown survives restarts because it lives in Mongo, not process memory. This replaces the unmerged reference branch's process-local `Set` lock and metadata cooldown, per the packet's correction note.

**Wiring** (step 5): scheduled maintenance routes active users through the coordinator (the inactive-user prune gate stays — the coordinator must not resurrect just-pruned watches); SSE subscribe (`streamEvents`) and the sync-start ignored paths fire it defensively in the background. Metadata reads remain side-effect-free.

**A29**: the maintenance planner's `invalid_grant` handler called `deleteCompassDataForUser` — deleting priorities, calendars, ALL events, and the user document. All five revoked-access sites (webhook controller, google-sync setup, express error handler, maintenance prune, the new coordinator) now funnel through one `pruneGoogleDataAndNotifyRevoked` helper (prune google data, archive calendars, notify `GOOGLE_REVOKED`) that preserves everything Compass-local. `deleteCompassDataForUser` itself remains only for the legitimate account-deletion CLI.

**Known-issue note (deferred to phase 3, will be a dated decision):** the maintenance activity gate `hasUpdatedCompassEventRecently` still queries legacy `user`/`origin` event fields that no longer exist post-cutover, so it currently classifies every user inactive. Discovered during this work; fixing the signal is phase 3 scope, tests here mock the gate.

## Testing

10 new tests: healthy = zero Google calls/lease writes; concurrent-call single-winner; expired-lease recovery; cooldown-across-restart; idempotent repair (no duplicate watches); catch-up lands a missed event; 410-during-catch-up → full repair; revoked → prune preserves local data; **A29 regression: invalid_grant inside maintenance leaves the user document and local data intact with `deleteCompassDataForUser` never called**; maintenance routes active users through the coordinator. Plus SSE-subscribe hook tests.

- `TZ=UTC jest --selectProjects backend`: 68 suites, 605 passed / 1 pre-existing skip.
- `bun run type-check` clean; `bun run lint` only the 15 pre-existing web warnings.

Part of `handoff/someday/07-watch-repair-quota-and-retries.md` (phase 3: quota/retry verification, Retry-After support, activity-gate fix, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)