### PR TITLE
fix(gcal): respect retry-after hints, fix maintenance activity gate, prove quota attribution

### DIFF
--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -63,7 +63,7 @@ Both `google.clientId` and `google.clientSecret` must be real values for Google 
 |---|---|---|
 | `google.clientId` | No | Google OAuth client ID. Rebuild the web image after changing it. |
 | `google.clientSecret` | No | Google OAuth client secret. Backend-only. |
-| `google.channelExpirationMin` | No | Google Calendar watch channel lifetime in minutes. |
+| `google.channelExpirationMin` | No | Google Calendar watch channel lifetime in minutes. Defaults to `10080` (7 days). Watch repair renews a channel once it's within a 3-day buffer of expiring. Short values (e.g. single-digit minutes) are a dev/test override, not a self-hosting setting. |
 | `google.webhookUrl` | No | Public HTTPS API URL for Google Calendar push notifications. When omitted, Compass uses `backend.apiUrl`. |
 | `google.notificationToken` | Required for HTTPS Google webhooks | Token used to verify Google Calendar webhook requests. |
 

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -162,6 +162,8 @@ To confirm sync is live: create or edit one event directly in Google Calendar an
 
 The repo has the code paths for Google watches and repair. The self-host Docker stack does not schedule watch renewal, so you need to verify and wire up maintenance separately before treating ongoing Google sync as dependable.
 
+Google push delivery to `/api/sync/gcal/notifications` is not guaranteed. Notifications can be delayed or dropped, so Compass does not depend on them alone. Every calendar also converges through incremental catch-up sync (per-calendar sync tokens). The watch repair coordinator keeps channels registered too, combining a defensive repair check on every client SSE (re)connect with scheduled maintenance that re-verifies all watches via `POST /api/sync/maintain-all`. Channels expire after 7 days by default (`google.channelExpirationMin`, in minutes) and renew inside a 3-day buffer before expiry.
+
 ## What to read next
 
 If you need public Google watch notifications, continue with [Server hosting guide](./server-guide.md).

--- a/docs/self-hosting/monitoring.md
+++ b/docs/self-hosting/monitoring.md
@@ -24,6 +24,18 @@ No authentication required.
 
 The check calls `db.admin().ping()` against MongoDB. Call it on whatever schedule makes sense for your setup — Compass does not impose a polling interval.
 
+## Google sync health
+
+If Google Calendar sync is enabled, watch (channel) health is worth watching separately from the health endpoint above — it degrades quietly (missed notifications, expired channels) rather than returning an error.
+
+What to watch, in backend logs:
+
+- **`app:google-watch-repair`** — one line per repair attempt: `REFRESHED`, `REPAIRED`, `FULL_REPAIR_STARTED`, or `PRUNED` (info level), or `SKIPPED` with reason `COOLDOWN`/`LOCKED` (debug level). A `HEALTHY`/`NONE` outcome (nothing to do) is not logged, so silence on this namespace is itself a healthy sign. Repair runs opportunistically on every client SSE (re)connect and via scheduled maintenance.
+- **`app:google-watch-maintenance.service`** — a debug-level summary after each `POST /api/sync/maintain-all` run (counts of ignored/pruned/refreshed/revoked watches across all users).
+- **`GOOGLE_REVOKED` sync-status events** — published over SSE and logged when a user's Google access was revoked or their refresh token went missing. Compass prunes that user's Google-owned data automatically (see [Google Calendar](./google-calendar.md)). They'll need to reconnect.
+
+`POST /api/sync/maintain-all` re-verifies every user's watches and is how expired/missing channels get caught outside the opportunistic SSE-triggered repair. The self-host Docker stack does not schedule calls to it for you — wire up your own external scheduler (cron, systemd timer, etc.) hitting it with the `x-comp-token` header set to `backend.compassToken`.
+
 ----
 
 Have an idea on how we can make self-hosting easier? Let us know in [this GitHub Discussion](https://github.com/SwitchbackTech/compass/discussions/1694).

--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -31,6 +31,18 @@ describe("config.constants", () => {
     expect(env.GCAL_WEBHOOK_BASEURL).toBe("http://localhost:3000/api");
   });
 
+  it("defaults CHANNEL_EXPIRATION_MIN to 10080 minutes (7 days) when not provided (packet 07 step 11 pin)", () => {
+    // The test env always overrides CHANNEL_EXPIRATION_MIN (see
+    // backend.test.init.ts), so this pins the zod schema's own default
+    // directly rather than asserting against a real channel watch.
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      CHANNEL_EXPIRATION_MIN: undefined,
+    });
+
+    expect(env.CHANNEL_EXPIRATION_MIN).toBe("10080");
+  });
+
   it("falls back GCAL_WEBHOOK_BASEURL to BASEURL when blank", () => {
     const env = parseConfigFromEnv({ ...validEnv, GCAL_WEBHOOK_BASEURL: "" });
 

--- a/packages/backend/src/common/services/gcal/gcal.retry.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.retry.test.ts
@@ -1,18 +1,45 @@
 import { GaxiosError, type GaxiosResponse } from "gaxios";
+import { Logger } from "@core/logger/winston.logger";
 import {
   computeBackoffDelayMs,
   isRetryableGoogleError,
   withGoogleRetry,
 } from "@backend/common/services/gcal/gcal.retry";
 
+// Local override so the retry module's own `logger` instance (captured once
+// at import time) is this mock, letting the observability tests below assert
+// on it directly instead of the repo-wide no-op logger mock. Babel hoists
+// `import`s above any same-file `const`, so the shared mock object is
+// defined inside the factory itself (nothing external to dereference too
+// early) and recovered afterward from `Logger`'s single recorded call.
+jest.mock("@core/logger/winston.logger", () => ({
+  Logger: jest.fn(() => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    verbose: jest.fn(),
+  })),
+}));
+
+const mockLogger = (Logger as unknown as jest.Mock).mock.results[0]?.value as {
+  debug: jest.Mock;
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+  verbose: jest.Mock;
+};
+
 const makeGaxiosError = ({
   status,
   reasons,
   noResponse = false,
+  headers,
 }: {
   status?: number;
   reasons?: string[];
   noResponse?: boolean;
+  headers?: Record<string, string>;
 }): GaxiosError => {
   const err = new GaxiosError(
     "Gcal request failed",
@@ -22,7 +49,7 @@ const makeGaxiosError = ({
       : ({
           status,
           statusText: "",
-          headers: new Headers(),
+          headers: new Headers(headers),
           config: {
             headers: new Headers(),
             url: new URL("https://example.com"),
@@ -179,5 +206,135 @@ describe("withGoogleRetry", () => {
     );
     expect(fn).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("withGoogleRetry Retry-After handling", () => {
+  const noopSleep = async () => undefined;
+
+  it("uses a Retry-After hint that's shorter than the computed backoff", async () => {
+    // random=1 pushes computed backoff to its max (30s for attempt 0 with a
+    // 500ms base is still only 500ms, so pick a big base to make sure the
+    // hint -- not the backoff -- is what's asserted below).
+    const randomSpy = jest.spyOn(Math, "random").mockReturnValue(1);
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({
+      status: 429,
+      headers: { "retry-after": "2" },
+    });
+    const fn = jest.fn().mockRejectedValueOnce(err).mockResolvedValueOnce("ok");
+
+    await expect(
+      withGoogleRetry(fn, { sleep, baseDelayMs: 10_000, maxDelayMs: 30_000 }),
+    ).resolves.toBe("ok");
+
+    expect(sleep).toHaveBeenCalledWith(2000);
+
+    randomSpy.mockRestore();
+  });
+
+  it("clamps a Retry-After hint larger than maxDelayMs", async () => {
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({
+      status: 429,
+      headers: { "retry-after": "9999" },
+    });
+    const fn = jest.fn().mockRejectedValueOnce(err).mockResolvedValueOnce("ok");
+
+    await expect(
+      withGoogleRetry(fn, { sleep, maxDelayMs: 30_000 }),
+    ).resolves.toBe("ok");
+
+    expect(sleep).toHaveBeenCalledWith(30_000);
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["an HTTP-date", "Wed, 21 Oct 2015 07:28:00 GMT"],
+    ["garbage", "soon-ish"],
+  ])("falls back to computed backoff when the hint is %s", async (_case, value) => {
+    const randomSpy = jest.spyOn(Math, "random").mockReturnValue(0.5);
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({
+      status: 429,
+      headers: value === undefined ? undefined : { "retry-after": value },
+    });
+    const fn = jest.fn().mockRejectedValueOnce(err).mockResolvedValueOnce("ok");
+
+    await expect(
+      withGoogleRetry(fn, { sleep, baseDelayMs: 500, maxDelayMs: 30_000 }),
+    ).resolves.toBe("ok");
+
+    // computeBackoffDelayMs(0, {baseDelayMs: 500, maxDelayMs: 30000}) with
+    // Math.random() mocked to 0.5: cap = 500, delay = 0.5 * 500.
+    expect(sleep).toHaveBeenCalledWith(250);
+
+    randomSpy.mockRestore();
+  });
+});
+
+describe("withGoogleRetry observability logging", () => {
+  const noopSleep = async () => undefined;
+
+  it("logs nothing on the common first-try-success path", async () => {
+    const sleep = jest.fn(noopSleep);
+    const fn = jest.fn().mockResolvedValue("ok");
+
+    await withGoogleRetry(fn, { sleep });
+
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("logs once when a call succeeds after retrying", async () => {
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({ status: 429 });
+    const fn = jest.fn().mockRejectedValueOnce(err).mockResolvedValueOnce("ok");
+
+    await withGoogleRetry(fn, { sleep });
+
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        attempts: 2,
+        outcome: "success",
+        code: 429,
+        elapsedMs: expect.any(Number),
+      }),
+    );
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("logs once when a call fails after exhausting retries", async () => {
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({ status: 500 });
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(withGoogleRetry(fn, { sleep, maxAttempts: 2 })).rejects.toBe(
+      err,
+    );
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        attempts: 2,
+        outcome: "failure",
+        code: 500,
+        elapsedMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it("logs nothing extra when a non-retryable error fails on the first try", async () => {
+    const sleep = jest.fn(noopSleep);
+    const err = makeGaxiosError({ status: 404 });
+    const fn = jest.fn().mockRejectedValue(err);
+
+    await expect(withGoogleRetry(fn, { sleep })).rejects.toBe(err);
+
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/common/services/gcal/gcal.retry.ts
+++ b/packages/backend/src/common/services/gcal/gcal.retry.ts
@@ -98,9 +98,94 @@ export const computeBackoffDelayMs = (
 };
 
 /**
+ * Reads a `Retry-After` value off a Gaxios response's `headers`, which is
+ * normally a fetch-style `Headers` (has `.get()`) but is handled as a plain
+ * object too, defensively.
+ */
+const readRetryAfterHeader = (headers: unknown): string | undefined => {
+  if (!headers || typeof headers !== "object") return undefined;
+
+  const getter = (headers as { get?: unknown }).get;
+
+  if (typeof getter === "function") {
+    const value = (headers as { get(name: string): string | null }).get(
+      "retry-after",
+    );
+
+    return value ?? undefined;
+  }
+
+  const bag = headers as Record<string, unknown>;
+  const value = bag["retry-after"] ?? bag["Retry-After"];
+
+  return typeof value === "string" ? value : undefined;
+};
+
+/**
+ * Parses a `Retry-After` header as integer seconds, Google's only form in
+ * practice. The HTTP-date form (and anything else unparseable) is treated as
+ * no hint, so the caller falls back to computed backoff.
+ */
+const parseRetryAfterSeconds = (
+  value: string | undefined,
+): number | undefined => {
+  if (value === undefined) return undefined;
+
+  const trimmed = value.trim();
+
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  return Number.parseInt(trimmed, 10);
+};
+
+/**
+ * A retryable error's `Retry-After` hint, as a delay in ms clamped to
+ * `maxDelayMs` -- the same cap computed backoff respects, so a hostile or
+ * oversized hint can't stall retries. Returns undefined when the error
+ * carries no usable hint.
+ */
+const getRetryAfterDelayMs = (
+  err: unknown,
+  maxDelayMs: number,
+): number | undefined => {
+  if (!(err instanceof GaxiosError)) return undefined;
+
+  const seconds = parseRetryAfterSeconds(
+    readRetryAfterHeader(err.response?.headers),
+  );
+
+  if (seconds === undefined) return undefined;
+
+  return Math.min(seconds * 1000, maxDelayMs);
+};
+
+/**
+ * A loggable HTTP status / error code -- never the message, url, or payload,
+ * which can carry a raw Google calendar id (often the user's email).
+ */
+const getLoggableErrorCode = (err: unknown): string | number | undefined => {
+  if (err instanceof GaxiosError) {
+    return err.response?.status ?? err.status ?? err.code;
+  }
+
+  const code = (err as { code?: unknown } | null | undefined)?.code;
+
+  return typeof code === "string" || typeof code === "number"
+    ? code
+    : undefined;
+};
+
+/**
  * Runs `fn`, retrying with truncated exponential backoff (full jitter) on
- * retryable Google API failures (see `isRetryableGoogleError`). Non-retryable
- * errors and the final attempt's error are rethrown as-is.
+ * retryable Google API failures (see `isRetryableGoogleError`). When a
+ * retryable error carries a `Retry-After` header, its hint is used for the
+ * wait instead of the computed backoff. Non-retryable errors and the final
+ * attempt's error are rethrown as-is.
+ *
+ * Logs one structured line -- attempts used, elapsed ms, outcome, and the
+ * last error's HTTP status/code -- whenever the call needed at least one
+ * retry, whether it eventually succeeded or exhausted its attempts. Silent
+ * on the common first-try-success path.
  */
 export const withGoogleRetry = async <T>(
   fn: () => Promise<T>,
@@ -113,20 +198,44 @@ export const withGoogleRetry = async <T>(
     sleep = defaultSleep,
   } = opts;
 
+  const startedAt = Date.now();
+  let lastErrorCode: string | number | undefined;
+
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      return await fn();
+      const result = await fn();
+
+      if (attempt > 0) {
+        logger.info("Google API call succeeded after retrying", {
+          attempts: attempt + 1,
+          elapsedMs: Date.now() - startedAt,
+          outcome: "success",
+          code: lastErrorCode,
+        });
+      }
+
+      return result;
     } catch (err) {
       const isLastAttempt = attempt === maxAttempts - 1;
 
+      lastErrorCode = getLoggableErrorCode(err);
+
       if (!isRetryableGoogleError(err) || isLastAttempt) {
+        if (attempt > 0) {
+          logger.error("Google API call failed after retrying", {
+            attempts: attempt + 1,
+            elapsedMs: Date.now() - startedAt,
+            outcome: "failure",
+            code: lastErrorCode,
+          });
+        }
+
         throw err;
       }
 
-      const delayMs = computeBackoffDelayMs(attempt, {
-        baseDelayMs,
-        maxDelayMs,
-      });
+      const delayMs =
+        getRetryAfterDelayMs(err, maxDelayMs) ??
+        computeBackoffDelayMs(attempt, { baseDelayMs, maxDelayMs });
 
       logger.warn(
         `Retrying Google API call after retryable error (attempt ${attempt + 1}/${maxAttempts}), waiting ${Math.round(delayMs)}ms`,

--- a/packages/backend/src/common/services/gcal/gcal.service.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.test.ts
@@ -8,6 +8,7 @@ jest.mock("@backend/sync/services/watch/google-watch-token", () => ({
 
 import { GaxiosError, type GaxiosResponse } from "gaxios";
 import { GCAL_NOTIFICATION_ENDPOINT } from "@core/constants/core.constants";
+import { type gSchema$Event } from "@core/types/gcal";
 import { type GoogleRequestContext } from "./gcal.context";
 import gcalService from "./gcal.service";
 
@@ -198,5 +199,217 @@ describe("gcal.service getAllCalendarListPages", () => {
     };
 
     await expect(drain()).rejects.toThrow(/sync token/i);
+  });
+});
+
+describe("gcal.service quotaUser passthrough (packet 07 step 7 pin)", () => {
+  const QUOTA_USER = "user-123";
+  const CHANNEL_ID = "507f1f77bcf86cd799439011";
+
+  // One shared context for the whole table: `clearMocks` (jest.config.js)
+  // wipes each jest.fn()'s recorded calls between tests, so reusing these
+  // mocks across `it.each` cases below doesn't leak call history.
+  const context = {
+    gcal: {
+      events: {
+        get: jest.fn().mockResolvedValue({ status: 200, data: {} }),
+        insert: jest.fn().mockResolvedValue({ status: 200, data: {} }),
+        delete: jest.fn().mockResolvedValue({ status: 204, data: {} }),
+        instances: jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { items: [] } }),
+        list: jest.fn().mockResolvedValue({
+          status: 200,
+          data: { items: [], nextSyncToken: "sync-token" },
+        }),
+        patch: jest.fn().mockResolvedValue({ status: 200, data: {} }),
+        watch: jest.fn().mockResolvedValue({
+          status: 200,
+          data: { resourceId: "resource-1" },
+        }),
+      },
+      calendarList: {
+        list: jest.fn().mockResolvedValue({
+          status: 200,
+          data: { items: [], nextSyncToken: "sync-token" },
+        }),
+        watch: jest.fn().mockResolvedValue({
+          status: 200,
+          data: { resourceId: "resource-1" },
+        }),
+      },
+      channels: {
+        stop: jest.fn().mockResolvedValue({ status: 204, data: {} }),
+      },
+    },
+    quotaUser: QUOTA_USER,
+  } as unknown as GoogleRequestContext;
+
+  // getEventInstances is a private method (TS-only), but it does call
+  // Google directly, so the packet asks for it to be covered too -- this
+  // narrow cast is the only way to reach it from outside the class. Kept as
+  // a property on the cast object (not destructured) so the call below
+  // still goes through `obj.method(...)` and keeps its `this` binding.
+  const gcalServiceInternal = gcalService as unknown as {
+    getEventInstances: (
+      ctx: GoogleRequestContext,
+      calendarId: string,
+      eventId: string,
+    ) => Promise<unknown>;
+  };
+
+  // Every GCalService method that reaches Google, paired with a call
+  // exercising it and the underlying client mock it should reach. A flat
+  // table (not a loop deriving calls from method names) so a signature
+  // mismatch fails as a normal assertion, not a runtime crash.
+  const cases: Array<{
+    method: string;
+    call: () => Promise<unknown>;
+    mock: () => jest.Mock;
+  }> = [
+    {
+      method: "getEvent",
+      call: () => gcalService.getEvent(context, "event-1"),
+      mock: () => context.gcal.events.get as jest.Mock,
+    },
+    {
+      method: "createEvent",
+      call: () =>
+        gcalService.createEvent(context, "cal-1", {} as gSchema$Event),
+      mock: () => context.gcal.events.insert as jest.Mock,
+    },
+    {
+      method: "deleteEvent",
+      call: () => gcalService.deleteEvent(context, "cal-1", "event-1"),
+      mock: () => context.gcal.events.delete as jest.Mock,
+    },
+    {
+      method: "getEventInstances",
+      call: () =>
+        gcalServiceInternal.getEventInstances(context, "cal-1", "event-1"),
+      mock: () => context.gcal.events.instances as jest.Mock,
+    },
+    {
+      method: "findEventInstance",
+      call: () =>
+        gcalService.findEventInstance(context, "cal-1", "event-1", new Date()),
+      mock: () => context.gcal.events.instances as jest.Mock,
+    },
+    {
+      method: "getEvents",
+      call: () => gcalService.getEvents(context, { calendarId: "cal-1" }),
+      mock: () => context.gcal.events.list as jest.Mock,
+    },
+    {
+      method: "patchEvent",
+      call: () =>
+        gcalService.patchEvent(
+          context,
+          "cal-1",
+          "event-1",
+          {} as gSchema$Event,
+        ),
+      mock: () => context.gcal.events.patch as jest.Mock,
+    },
+    {
+      method: "watchCalendars",
+      call: () =>
+        gcalService.watchCalendars(context, {
+          channelId: CHANNEL_ID,
+          expiration: "123",
+        }),
+      mock: () => context.gcal.calendarList.watch as jest.Mock,
+    },
+    {
+      method: "watchEvents",
+      call: () =>
+        gcalService.watchEvents(context, {
+          channelId: CHANNEL_ID,
+          expiration: "123",
+          gCalendarId: "cal-1",
+        }),
+      mock: () => context.gcal.events.watch as jest.Mock,
+    },
+    {
+      method: "stopWatch",
+      call: () =>
+        gcalService.stopWatch(context, {
+          channelId: "channel-1",
+          resourceId: "resource-1",
+        }),
+      mock: () => context.gcal.channels.stop as jest.Mock,
+    },
+    {
+      method: "getAllEvents",
+      call: async () => {
+        for await (const _page of gcalService.getAllEvents({
+          context,
+          calendarId: "cal-1",
+        })) {
+          break;
+        }
+      },
+      mock: () => context.gcal.events.list as jest.Mock,
+    },
+    {
+      method: "getAllCalendarListPages",
+      call: async () => {
+        for await (const _page of gcalService.getAllCalendarListPages(
+          context,
+        )) {
+          break;
+        }
+      },
+      mock: () => context.gcal.calendarList.list as jest.Mock,
+    },
+  ];
+
+  it.each(cases)("passes quotaUser through $method", async ({ call, mock }) => {
+    await call();
+
+    expect(mock()).toHaveBeenCalledWith(
+      expect.objectContaining({ quotaUser: QUOTA_USER }),
+    );
+  });
+
+  // Not covered above by design: validateGCalResponse never calls Google
+  // (it only inspects a response already received), and
+  // getBaseRecurringEventInstances is a thin generator wrapper around the
+  // already-covered getEventInstances.
+  const ACKNOWLEDGED_WITHOUT_OWN_CASE = [
+    "validateGCalResponse",
+    "getBaseRecurringEventInstances",
+  ];
+
+  /**
+   * GCalService's arrow-field methods (watchCalendars, watchEvents,
+   * stopWatch) are own properties of the instance; its regular `async`
+   * methods live on the prototype instead -- both have to be walked to see
+   * the whole method surface.
+   */
+  const listMethodNames = (instance: object): string[] => {
+    const ownNames = Object.getOwnPropertyNames(instance);
+    const proto = Object.getPrototypeOf(instance) as object | null;
+    const protoNames =
+      proto && proto !== Object.prototype
+        ? Object.getOwnPropertyNames(proto).filter(
+            (name) => name !== "constructor",
+          )
+        : [];
+
+    return [...new Set([...ownNames, ...protoNames])].filter(
+      (name) =>
+        typeof (instance as Record<string, unknown>)[name] === "function",
+    );
+  };
+
+  it("covers every GCalService method (fails loudly if a new one is added without updating this table)", () => {
+    const actualMethodNames = listMethodNames(gcalService);
+    const coveredMethodNames = [
+      ...cases.map((c) => c.method),
+      ...ACKNOWLEDGED_WITHOUT_OWN_CASE,
+    ];
+
+    expect(new Set(actualMethodNames)).toEqual(new Set(coveredMethodNames));
   });
 });

--- a/packages/backend/src/events/controllers/events.controller.test.ts
+++ b/packages/backend/src/events/controllers/events.controller.test.ts
@@ -11,6 +11,7 @@ import {
   googleWatchRepairService,
 } from "@backend/sync/services/watch/google-watch-repair.service";
 import { GoogleWatchStateStatus } from "@backend/sync/services/watch/google-watch-state";
+import userService from "@backend/user/services/user.service";
 
 describe("EventsController", () => {
   beforeAll(initSupertokens);
@@ -63,6 +64,92 @@ describe("EventsController", () => {
     jest
       .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
       .mockRejectedValue(new Error("simulated repair failure"));
+
+    const req = {
+      session: { getUserId: () => userId },
+      on: jest.fn(),
+    } as unknown as Request;
+    const res = {
+      setHeader: jest.fn(),
+      flushHeaders: jest.fn(),
+      write: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+      headersSent: false,
+    } as unknown as Response;
+
+    await expect(
+      eventsController.streamEvents(req, res),
+    ).resolves.toBeUndefined();
+    expect(res.status).not.toHaveBeenCalled();
+
+    // Let the fire-and-forget rejection's .catch handler settle so it
+    // doesn't surface as an unhandled rejection in a later test.
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it("fire-and-forgets a lastSeenAt touch alongside the repair coordinator (A40)", async () => {
+    const userId = "507f1f77bcf86cd799439013";
+    const noneResult: GoogleWatchRepairResult = {
+      action: "NONE",
+      inspection: {
+        status: GoogleWatchStateStatus.NOT_APPLICABLE,
+        reason: "GOOGLE_NOT_CONNECTED",
+        expectedWatchCalendarIds: [],
+        activeWatches: [],
+        duplicateWatches: [],
+        expiredWatches: [],
+        missingWatchCalendarIds: [],
+        staleWatches: [],
+        watchesToRefresh: [],
+        incompleteCalendarIds: [],
+      },
+    };
+    jest
+      .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
+      .mockResolvedValue(noneResult);
+    const touchSpy = jest.spyOn(userService, "touchLastSeenAt");
+
+    const req = {
+      session: { getUserId: () => userId },
+      on: jest.fn(),
+    } as unknown as Request;
+    const res = {
+      setHeader: jest.fn(),
+      flushHeaders: jest.fn(),
+      write: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      end: jest.fn(),
+      headersSent: false,
+    } as unknown as Response;
+
+    await eventsController.streamEvents(req, res);
+
+    expect(touchSpy).toHaveBeenCalledWith(userId);
+  });
+
+  it("does not let a lastSeenAt touch failure affect the SSE response", async () => {
+    const userId = "507f1f77bcf86cd799439014";
+    jest
+      .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
+      .mockResolvedValue({
+        action: "NONE",
+        inspection: {
+          status: GoogleWatchStateStatus.NOT_APPLICABLE,
+          reason: "GOOGLE_NOT_CONNECTED",
+          expectedWatchCalendarIds: [],
+          activeWatches: [],
+          duplicateWatches: [],
+          expiredWatches: [],
+          missingWatchCalendarIds: [],
+          staleWatches: [],
+          watchesToRefresh: [],
+          incompleteCalendarIds: [],
+        },
+      });
+    jest
+      .spyOn(userService, "touchLastSeenAt")
+      .mockRejectedValue(new Error("simulated touch failure"));
 
     const req = {
       session: { getUserId: () => userId },

--- a/packages/backend/src/events/controllers/events.controller.ts
+++ b/packages/backend/src/events/controllers/events.controller.ts
@@ -2,6 +2,7 @@ import { type Request, type Response } from "express";
 import { Logger } from "@core/logger/winston.logger";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
+import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 
 const logger = Logger("app:events.controller");
@@ -31,6 +32,13 @@ class EventsController {
         .catch((err) => {
           logger.error(`Google watch repair failed for user ${userId}:`, err);
         });
+
+      // Same fire-and-forget shape: lets scheduled watch maintenance (A40)
+      // tell an active user apart from an abandoned account without
+      // blocking or failing the stream.
+      void userService.touchLastSeenAt(userId).catch((err) => {
+        logger.error(`Failed to record lastSeenAt for user ${userId}:`, err);
+      });
     } catch (err) {
       logger.error(`Failed to open SSE stream for user ${userId}:`, err);
       if (!res.headersSent) {

--- a/packages/backend/src/sync/services/watch/google-watch-activity.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-activity.test.ts
@@ -1,0 +1,70 @@
+import dayjs from "@core/util/date/dayjs";
+import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
+import mongoService from "@backend/common/services/mongo.service";
+import { hasUserBeenActiveSince } from "@backend/sync/services/watch/google-watch-activity";
+
+describe("hasUserBeenActiveSince", () => {
+  beforeAll(initSupertokens);
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  const deadline = dayjs().subtract(14, "days").format();
+
+  it("is active when lastSeenAt is after the deadline", async () => {
+    const user = await UserDriver.createUser();
+    await mongoService.user.updateOne(
+      { _id: user._id },
+      { $set: { lastSeenAt: new Date() } },
+    );
+
+    await expect(
+      hasUserBeenActiveSince(user._id.toString(), deadline),
+    ).resolves.toBe(true);
+  });
+
+  it("is active when only lastLoggedInAt is after the deadline", async () => {
+    const user = await UserDriver.createUser();
+    await mongoService.user.updateOne(
+      { _id: user._id },
+      { $set: { lastLoggedInAt: new Date() } },
+    );
+
+    await expect(
+      hasUserBeenActiveSince(user._id.toString(), deadline),
+    ).resolves.toBe(true);
+  });
+
+  it("is inactive when both lastSeenAt and lastLoggedInAt are stale", async () => {
+    const user = await UserDriver.createUser();
+    const staleDate = dayjs().subtract(30, "days").toDate();
+    await mongoService.user.updateOne(
+      { _id: user._id },
+      { $set: { lastSeenAt: staleDate, lastLoggedInAt: staleDate } },
+    );
+
+    await expect(
+      hasUserBeenActiveSince(user._id.toString(), deadline),
+    ).resolves.toBe(false);
+  });
+
+  it("is inactive when both lastSeenAt and lastLoggedInAt are missing", async () => {
+    const user = await UserDriver.createUser();
+
+    await expect(
+      hasUserBeenActiveSince(user._id.toString(), deadline),
+    ).resolves.toBe(false);
+  });
+
+  it("is inactive when the user no longer exists", async () => {
+    await expect(
+      hasUserBeenActiveSince("507f1f77bcf86cd799439011", deadline),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/backend/src/sync/services/watch/google-watch-activity.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-activity.ts
@@ -1,15 +1,30 @@
-import { Origin } from "@core/constants/core.constants";
-import mongoService from "@backend/common/services/mongo.service";
+import { findCompassUserBy } from "@backend/user/queries/user.queries";
 
-export const hasUpdatedCompassEventRecently = async (
+/**
+ * Whether `userId` has been active since `deadline`: either their client
+ * connected to the SSE stream (`lastSeenAt`, touched on every (re)connect)
+ * or they signed in (`lastLoggedInAt`). Missing both (a never-reconnected
+ * or pre-lastSeenAt account) counts as inactive, same as a user that no
+ * longer exists.
+ *
+ * A40: replaces a prior check that queried EventRecord's `user`/`origin`
+ * fields, which post-cutover EventRecords never have -- it always returned
+ * false, so scheduled maintenance classified every user inactive and pruned
+ * all their watches each run.
+ */
+export const hasUserBeenActiveSince = async (
   userId: string,
   deadline: string,
-) => {
-  const recentChanges = await mongoService.event.countDocuments({
-    user: userId,
-    origin: Origin.COMPASS,
-    updatedAt: { $gt: new Date(deadline) },
-  });
+): Promise<boolean> => {
+  const user = await findCompassUserBy("_id", userId);
 
-  return recentChanges > 0;
+  if (!user) return false;
+
+  const deadlineMs = new Date(deadline).getTime();
+  const isAfterDeadline = (at?: Date): boolean =>
+    at !== undefined && at.getTime() > deadlineMs;
+
+  return (
+    isAfterDeadline(user.lastSeenAt) || isAfterDeadline(user.lastLoggedInAt)
+  );
 };

--- a/packages/backend/src/sync/services/watch/google-watch-maintenance.planner.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-maintenance.planner.ts
@@ -7,7 +7,7 @@ import { isInvalidGoogleToken } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
 import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
-import { hasUpdatedCompassEventRecently } from "@backend/sync/services/watch/google-watch-activity";
+import { hasUserBeenActiveSince } from "@backend/sync/services/watch/google-watch-activity";
 import {
   syncExpired,
   syncExpiresSoon,
@@ -55,7 +55,7 @@ export const prepWatchMaintenanceForUser = async (
   isActive: boolean;
 }> => {
   const deadline = getActiveDeadline();
-  const isUserActive = await hasUpdatedCompassEventRecently(userId, deadline);
+  const isUserActive = await hasUserBeenActiveSince(userId, deadline);
   const { active, expired, refresh } = await getWatchesToRefresh(userId);
 
   return {

--- a/packages/backend/src/sync/services/watch/google-watch-maintenance.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-maintenance.service.test.ts
@@ -19,7 +19,6 @@ import {
 } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
-import * as googleWatchActivityService from "@backend/sync/services/watch/google-watch-activity";
 import { googleWatchMaintenanceService } from "@backend/sync/services/watch/google-watch-maintenance.service";
 import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
 import userService from "@backend/user/services/user.service";
@@ -57,8 +56,9 @@ describe("googleWatchMaintenanceService", () => {
     const user = await UserDriver.createUser();
     const userId = user._id.toString();
 
-    // No recent Compass-origin event -> inactive -> every watch lands in
-    // the prune bucket (prepWatchMaintenanceForUser's activity gate).
+    // A freshly created user has no lastSeenAt/lastLoggedInAt yet -> inactive
+    // -> every watch lands in the prune bucket (prepWatchMaintenanceForUser's
+    // activity gate).
     const localCalendar = await seedLocalCalendar(user._id);
     const localEvent = await mongoService.event.insertOne(
       buildEventRecord(localCalendar._id),
@@ -114,13 +114,13 @@ describe("googleWatchMaintenanceService", () => {
     const user = await UserDriver.createUser();
     const userId = user._id.toString();
 
-    // hasUpdatedCompassEventRecently is a plain function export (not part
-    // of a service object) - mocking it directly isolates "does
-    // runMaintenanceByUser wire an active user through the coordinator"
-    // from activity-detection itself, which is a separate concern.
-    jest
-      .spyOn(googleWatchActivityService, "hasUpdatedCompassEventRecently")
-      .mockResolvedValue(true);
+    // A recent lastSeenAt (touched on every SSE (re)connect) is what the
+    // activity gate now keys off - seeding it directly exercises the real
+    // hasUserBeenActiveSince check instead of mocking it away.
+    await mongoService.user.updateOne(
+      { _id: user._id },
+      { $set: { lastSeenAt: new Date() } },
+    );
 
     await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
       nextSyncToken: faker.string.alphanumeric(16),

--- a/packages/backend/src/sync/services/watch/google-watch-timing.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-timing.test.ts
@@ -1,11 +1,31 @@
 import { faker } from "@faker-js/faker";
 import dayjs from "@core/util/date/dayjs";
+import { CONFIG } from "@backend/common/constants/config.constants";
 import {
+  getChannelExpiration,
   syncExpired,
   syncExpiresSoon,
 } from "@backend/sync/services/watch/google-watch-timing";
 
 describe("googleWatchTiming", () => {
+  describe("getChannelExpiration", () => {
+    it("returns an epoch-ms timestamp CONFIG.CHANNEL_EXPIRATION_MIN minutes from now", () => {
+      // Reads the value straight off CONFIG rather than hardcoding either
+      // the prod default (10080) or the test env's override (backend.test
+      // .init.ts sets "5") - see config.constants.test.ts for the pin on
+      // what the default itself resolves to.
+      const numMin = Number(CONFIG.CHANNEL_EXPIRATION_MIN);
+      const before = dayjs().add(numMin, "minutes").valueOf();
+
+      const expiration = Number(getChannelExpiration());
+
+      const after = dayjs().add(numMin, "minutes").valueOf();
+
+      expect(expiration).toBeGreaterThanOrEqual(before);
+      expect(expiration).toBeLessThanOrEqual(after);
+    });
+  });
+
   describe("syncExpired", () => {
     it("returns true if expiry before now", () => {
       const expired = dayjs("1675097074000").toDate(); // Jan 30, 2023

--- a/packages/backend/src/sync/services/watch/google-watch.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.test.ts
@@ -14,6 +14,7 @@ import { createGoogleError } from "@backend/__tests__/mocks.gcal/errors/error.go
 import { invalidGrant400Error } from "@backend/__tests__/mocks.gcal/errors/error.google.invalidGrant";
 import { mockRegularGcalEvent } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
+import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
@@ -422,5 +423,57 @@ describe("googleWatchService", () => {
 
     expect(startCalendarWatchSpy).not.toHaveBeenCalled();
     expect(startEventWatchSpy).not.toHaveBeenCalled();
+  });
+
+  it("persists the expiration Google actually returns for an event watch, not the requested one (packet 07 step 11 pin)", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+    const context = await createGoogleRequestContext(userId);
+    // Deliberately far from getChannelExpiration()'s requested value (a few
+    // minutes out in the test env) so the assertion below can only pass if
+    // the persisted value came from Google's response.
+    const googleExpiration = (Date.now() + 30 * 24 * 60 * 60 * 1000).toString();
+
+    jest.spyOn(gcalService, "watchEvents").mockResolvedValueOnce({
+      watch: {
+        resourceId: "resource-from-google",
+        expiration: googleExpiration,
+      },
+    });
+
+    await googleWatchService.startEventWatch(
+      userId,
+      { gCalendarId: "some-calendar" },
+      context,
+    );
+
+    const watch = await mongoService.watch.findOne({ user: userId });
+
+    expect(watch).not.toBeNull();
+    expect(watch?.expiration.getTime()).toBe(Number(googleExpiration));
+  });
+
+  it("persists the expiration Google actually returns for a calendar-list watch, not the requested one (packet 07 step 11 pin)", async () => {
+    const user = await UserDriver.createUser();
+    const userId = user._id.toString();
+    const context = await createGoogleRequestContext(userId);
+    const googleExpiration = (Date.now() + 30 * 24 * 60 * 60 * 1000).toString();
+
+    jest.spyOn(gcalService, "watchCalendars").mockResolvedValueOnce({
+      watch: {
+        resourceId: "resource-from-google",
+        expiration: googleExpiration,
+      },
+    });
+
+    await googleWatchService.startCalendarListWatch(userId, context);
+
+    const watch = await mongoService.watch.findOne({
+      user: userId,
+      gCalendarId: Resource_Sync.CALENDAR,
+    });
+
+    expect(watch).not.toBeNull();
+    expect(watch?.expiration.getTime()).toBe(Number(googleExpiration));
   });
 });

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -368,6 +368,20 @@ class UserService {
     });
   };
 
+  /**
+   * Records that `userId`'s client is actively connected right now (called
+   * on every SSE (re)connect). This is what the watch-maintenance activity
+   * gate (A40) reads to tell an active user apart from an abandoned account,
+   * since post-cutover EventRecords carry no `user`/`origin` field to query
+   * instead. Callers fire this off without awaiting/blocking on it.
+   */
+  touchLastSeenAt = async (userId: string): Promise<void> => {
+    await mongoService.user.updateOne(
+      { _id: zObjectId.parse(userId) },
+      { $set: { lastSeenAt: new Date() } },
+    );
+  };
+
   fetchUserMetadata = async (
     userId: string,
     userContext?: Record<string, JSONObject>,

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -14,6 +14,10 @@ export interface Schema_User {
   };
   signedUpAt?: Date;
   lastLoggedInAt?: Date;
+  /** Last time this user's client connected to the SSE stream -- touched on
+   *  every (re)connect, distinct from `lastLoggedInAt`'s sign-in moment.
+   *  Used to tell an active user apart from an abandoned account (A40). */
+  lastSeenAt?: Date;
 }
 
 type SyncStatus = "IMPORTING" | "ERRORED" | "COMPLETED" | "RESTART" | null;


### PR DESCRIPTION
## Summary

Packet 07 phase 3 of 3 (final): the retry/quota verification layer, a live-bug fix in the maintenance activity gate, and the operator docs (packet 07 steps 6-11). Builds on #2058/#2059.

- **Retry-After hints** (step 8 gap): `withGoogleRetry` now uses a retryable error's `Retry-After` header (integer seconds — the only form Google sends) for the wait instead of computed backoff, clamped to the existing 30s cap so an oversized hint can't stall retries; unparseable/absent hints fall back to truncated-exponential-backoff-with-jitter. Fake-timer tests cover hint-used, hint-clamped, and fallback.
- **Activity gate fix (A40, live bug)**: `hasUpdatedCompassEventRecently` queried `user`/`origin` event fields that post-cutover EventRecords never have, so it always returned false — scheduled maintenance classified every user inactive and pruned all their watches each run (the SSE-subscribe repair from #2059 would then rebuild them: a churn loop). Activity is now `lastSeenAt` (new optional `Schema_User` field, touched fire-and-forget on every SSE (re)connect) or `lastLoggedInAt` within the 14-day window. Will be recorded as dated decision A40 in the packet close-out.
- **Quota attribution proof** (step 7): the random-quota-id cleanup turned out already complete (verified — every path flows through the request context); a table-driven test asserts all 12 Google-calling `GCalService` methods pass the context `quotaUser`, with a reflection guard forcing any future method to join the table.
- **Channel expiration pins** (step 11): tests prove watches persist **Google's returned** expiration (not the requested one) and pin the 7-day `CHANNEL_EXPIRATION_MIN` schema default; short TTLs remain an explicit dev/test override.
- **Retry observability** (step 9): one structured log line (attempts, elapsed ms, outcome, HTTP status/code — never messages/urls/payloads, which can carry raw google calendar ids) whenever a call needed at least one retry; silent on first-try success. Import concurrency remains bounded separately (4 per user, 5 users in maintenance) — retries are not flow control.
- **Docs** (step 10): `docs/self-hosting/google-calendar.md` now states push delivery is not guaranteed and incremental catch-up + the repair coordinator are the source of convergence (plus 7-day expiration/renewal); `docs/self-hosting/monitoring.md` gains a "Google sync health" section (repair actions, maintenance summaries, `GOOGLE_REVOKED`, maintain-all scheduling + internal token); `docs/Config/README.md` documents the `channelExpirationMin` default.

Packet-doc corrections to be recorded in close-out: the packet's "10-minute channel TTL / every watch permanently expiring" premise was stale (packet 04 shipped the 7-day TTL), and step 7's "remaining random quota ids" were already gone.

## Testing

- `TZ=UTC jest --selectProjects backend`: 69 suites, 638 passed / 1 pre-existing skip.
- `bun run type-check` clean; `bun run lint` only the 15 pre-existing web warnings.

Completes the implementation work of `handoff/someday/07-watch-repair-quota-and-retries.md`; docs/checkbox close-out follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)