### PR TITLE
feat(web): add sidebar calendar list with visibility controls

### DIFF
--- a/packages/backend/src/event/services/event.service.test.ts
+++ b/packages/backend/src/event/services/event.service.test.ts
@@ -815,3 +815,158 @@ describe("EventService (SSE suppression for invisible calendars, step 9)", () =>
     );
   });
 });
+
+/**
+ * Packet 08 step 4: `readAll` (list reads) only ever surfaces events on
+ * calendars the user has left visible. Hiding a calendar is presentation-only
+ * (A8) -- it must not affect ownership, so mutation/lookup paths keep working
+ * on a hidden calendar's events even though list reads no longer return them.
+ */
+describe("EventService (visibility filtering for list reads, packet 08)", () => {
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("excludes a hidden calendar's events from a range list read", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const visible = await seedLocalCalendar(user._id);
+    const hidden = await seedGoogleCalendar(user._id, { access: "writer" });
+    await mongoService.calendar.updateOne(
+      { _id: hidden._id },
+      { $set: { isVisible: false } },
+    );
+
+    const visibleEvent = await eventService.create(user._id.toString(), {
+      calendarId: visible._id.toHexString() as never,
+      content: { kind: "details", title: "Visible standup", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T15:00:00-06:00",
+        end: "2026-07-14T16:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+    const hiddenEvent = await eventService.create(user._id.toString(), {
+      calendarId: hidden._id.toHexString() as never,
+      content: { kind: "details", title: "Hidden standup", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T17:00:00-06:00",
+        end: "2026-07-14T18:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    const results = await eventService.readAll(user._id.toString(), {
+      kind: "range",
+      start: "2026-07-14T00:00:00Z",
+      end: "2026-07-15T00:00:00Z",
+      priorities: [],
+    });
+    const resultIds = results.map((e) => e._id.toHexString());
+
+    expect(resultIds).toContain(visibleEvent._id.toHexString());
+    expect(resultIds).not.toContain(hiddenEvent._id.toHexString());
+  });
+
+  it("excludes a hidden calendar's events from a someday list read", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const visible = await seedLocalCalendar(user._id);
+    const hidden = await seedGoogleCalendar(user._id, { access: "writer" });
+    await mongoService.calendar.updateOne(
+      { _id: hidden._id },
+      { $set: { isVisible: false } },
+    );
+
+    const visibleEvent = await eventService.create(user._id.toString(), {
+      calendarId: visible._id.toHexString() as never,
+      content: { kind: "details", title: "Visible someday", description: "" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 0,
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+    const hiddenEvent = await eventService.create(user._id.toString(), {
+      calendarId: hidden._id.toHexString() as never,
+      content: { kind: "details", title: "Hidden someday", description: "" },
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-13",
+        sortOrder: 1,
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    const results = await eventService.readAll(user._id.toString(), {
+      kind: "someday",
+      period: "week",
+      anchorDate: "2026-07-13",
+    });
+    const resultIds = results.map((e) => e._id.toHexString());
+
+    expect(resultIds).toContain(visibleEvent._id.toHexString());
+    expect(resultIds).not.toContain(hiddenEvent._id.toHexString());
+  });
+
+  it("still allows mutating an event on a hidden calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedLocalCalendar(user._id);
+
+    const created = await eventService.create(user._id.toString(), {
+      calendarId: calendar._id.toHexString() as never,
+      content: { kind: "details", title: "Standup", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T15:00:00-06:00",
+        end: "2026-07-14T16:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      priority: "unassigned",
+    });
+
+    await mongoService.calendar.updateOne(
+      { _id: calendar._id },
+      { $set: { isVisible: false } },
+    );
+
+    const replaced = await eventService.replace(
+      user._id.toString(),
+      created._id.toHexString(),
+      {
+        content: { kind: "details", title: "Renamed", description: "" },
+        schedule: {
+          kind: "timed",
+          start: "2026-07-14T15:00:00-06:00",
+          end: "2026-07-14T16:00:00-06:00",
+          timeZone: "America/Denver" as never,
+        },
+        recurrence: { kind: "preserve" },
+        priority: "unassigned",
+        scope: "all",
+      },
+    );
+
+    expect(replaced.content).toEqual({
+      kind: "details",
+      title: "Renamed",
+      description: "",
+    });
+
+    await expect(
+      eventService.delete(user._id.toString(), created._id.toHexString(), {
+        scope: "this",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -87,6 +87,19 @@ class EventService {
   }
 
   /**
+   * Narrower than `ownedCalendarIds`: list reads only ever surface events on
+   * calendars the user has left visible (packet 08 step 4). Hiding a
+   * calendar is presentation-only (A8) -- it must not affect ownership, so
+   * mutation/lookup call sites (requireOwnedEvent, seriesContext, reorder,
+   * etc.) keep using the wider active-only `ownedCalendarIds` and stay able
+   * to edit/delete events on a calendar the user has hidden.
+   */
+  private async visibleCalendarIds(userId: string): Promise<ObjectId[]> {
+    const calendars = await calendarService.list(userId);
+    return calendars.filter((c) => c.isActive && c.isVisible).map((c) => c._id);
+  }
+
+  /**
    * Resolves a calendar the user owns and is currently active, and enforces
    * write capability derived from its access role (packet 05 step 6):
    * reader/freeBusyReader calendars must reject mutations before any
@@ -172,8 +185,8 @@ class EventService {
     userId: string,
     query: EventListQuery,
   ): Promise<EventRecord[]> => {
-    const ownedCalendarIds = await this.ownedCalendarIds(userId);
-    return eventRepository.list(query, ownedCalendarIds);
+    const visibleCalendarIds = await this.visibleCalendarIds(userId);
+    return eventRepository.list(query, visibleCalendarIds);
   };
 
   readById = async (userId: string, eventId: string): Promise<EventRecord> => {

--- a/packages/web/src/calendars/useCalendarVisibility.ts
+++ b/packages/web/src/calendars/useCalendarVisibility.ts
@@ -1,0 +1,88 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { CalendarApi } from "@web/calendars/calendar.api";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { removeEventsByCalendarFromQueries } from "@web/events/queries/event.query.cache";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+
+const DEFAULT_COALESCE_DELAY_MS = 400;
+
+export const CALENDAR_VISIBILITY_FAILURE_MESSAGE =
+  "Couldn't update calendar visibility. The change was undone.";
+
+/**
+ * Optimistic + coalesced calendar visibility toggle (packet 08 step 3).
+ * Every call flips the calendars cache immediately, and on hide drops that
+ * calendar's events from every cached event query so the grid/someday lists
+ * react without waiting on the network. Rapid toggles across calendars
+ * accumulate in a ref and flush as a single `setVisibility` call after
+ * `coalesceDelayMs` of quiet, so dragging through a calendar list doesn't
+ * fire one request per row.
+ */
+export function useCalendarVisibility(
+  coalesceDelayMs = DEFAULT_COALESCE_DELAY_MS,
+) {
+  const queryClient = useQueryClient();
+  const pendingRef = useRef<Map<CalendarId, boolean>>(new Map());
+  const snapshotRef = useRef<Calendar[] | undefined>(undefined);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const [failureAnnouncement, setFailureAnnouncement] = useState("");
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  const flush = useCallback(async () => {
+    const pending = pendingRef.current;
+    const snapshot = snapshotRef.current;
+    pendingRef.current = new Map();
+    snapshotRef.current = undefined;
+    if (pending.size === 0) return;
+
+    const input = [...pending.entries()].map(([calendarId, isVisible]) => ({
+      calendarId,
+      isVisible,
+    }));
+
+    try {
+      await CalendarApi.setVisibility(input);
+      void queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all });
+      void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+    } catch {
+      if (snapshot) {
+        queryClient.setQueryData(calendarQueryKeys.all, snapshot);
+      }
+      void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+      showErrorToast(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
+      setFailureAnnouncement(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
+    }
+  }, [queryClient]);
+
+  const toggleCalendarVisibility = useCallback(
+    (calendarId: CalendarId, isVisible: boolean) => {
+      if (pendingRef.current.size === 0) {
+        snapshotRef.current = queryClient.getQueryData<Calendar[]>(
+          calendarQueryKeys.all,
+        );
+      }
+      pendingRef.current.set(calendarId, isVisible);
+
+      queryClient.setQueryData<Calendar[]>(calendarQueryKeys.all, (current) =>
+        current?.map((calendar) =>
+          calendar.id === calendarId ? { ...calendar, isVisible } : calendar,
+        ),
+      );
+
+      if (!isVisible) {
+        removeEventsByCalendarFromQueries(queryClient, new Set([calendarId]));
+      }
+
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => void flush(), coalesceDelayMs);
+    },
+    [coalesceDelayMs, flush, queryClient],
+  );
+
+  return { toggleCalendarVisibility, failureAnnouncement };
+}

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
@@ -1,0 +1,334 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import {
+  CalendarIdSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { type ApiRequestConfig } from "@web/api/api.types";
+import { BaseApi } from "@web/api/base/base.api";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Mocked at the hook (several sibling test files, e.g. useAuthCmdItems.test.ts,
+// already mock.module this same path without restoring it - mock.module is
+// process-wide, so whichever file registers last "wins" for every later
+// resolution). afterEach below leaves a valid (never `undefined`) return value
+// configured rather than resetting, so a file that runs after this one and
+// inherits this mock without configuring its own doesn't crash destructuring
+// `useSession()`'s result.
+const mockUseSession = mock();
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+// PlannerCalendarList.tsx is already cached by the time this file runs -
+// PlannerSidebar.test.tsx imports createPlannerSidebar from "./PlannerSidebar",
+// and merely loading that file (regardless of the DI stubs it renders with)
+// runs PlannerSidebar.tsx's own top-level `import { PlannerCalendarList }`,
+// binding its useSession import to whatever was active at that earlier point.
+// A plain require here would return that stale instance. A cache-busted URL
+// forces a fresh evaluation that re-resolves useSession against the mock
+// above (same technique as useVersionCheck.test.ts).
+const plannerCalendarListModuleUrl = new URL(
+  `./PlannerCalendarList.tsx?test=${Math.random().toString(36).slice(2)}`,
+  import.meta.url,
+);
+const { PlannerCalendarList } = (await import(
+  plannerCalendarListModuleUrl.href
+)) as typeof import("./PlannerCalendarList");
+
+// `toHaveAttribute`/`toHaveTextContent`/`toHaveFocus` (jest-dom) crash with
+// `ERR_INVALID_THIS` under bun:test when the assertion fails and jest-dom
+// tries to build its failure message, masking the real diff. Reading the DOM
+// directly and using bun's native `toBe`/`toMatch` sidesteps that.
+const ariaChecked = (el: HTMLElement) => el.getAttribute("aria-checked");
+
+const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Work",
+  description: "",
+  timeZone: TimeZoneSchema.parse("America/Denver"),
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+const renderCalendarList = (
+  calendars: Calendar[],
+  {
+    authenticated = true,
+    coalesceDelayMs,
+  }: { authenticated?: boolean; coalesceDelayMs?: number } = {},
+) => {
+  mockUseSession.mockReturnValue({
+    authenticated,
+    setAuthenticated: () => {},
+  });
+
+  const { queryClient, wrapper } = createStoreWrapper();
+  queryClient.setQueryData(calendarQueryKeys.all, calendars);
+
+  const utils = render(
+    <PlannerCalendarList coalesceDelayMs={coalesceDelayMs} />,
+    {
+      wrapper,
+    },
+  );
+
+  return { queryClient, ...utils };
+};
+
+describe("PlannerCalendarList", () => {
+  beforeEach(() => {
+    mockUseSession.mockReturnValue({
+      authenticated: true,
+      setAuthenticated: () => {},
+    });
+  });
+
+  afterEach(() => {
+    BaseApi.defaults.adapter = undefined;
+    // Leave a *valid* value configured (not a full mockReset, which would make
+    // the mock return `undefined` and crash any later file's destructure of
+    // useSession()'s result if this leaked mock.module registration is still
+    // active for them - see the top-of-file comment).
+    mockUseSession.mockReturnValue({
+      authenticated: false,
+      setAuthenticated: () => {},
+    });
+  });
+
+  it("renders active calendars with switch roles, hides inactive calendars, and spells out primary/read-only context as text", () => {
+    const active = makeCalendar({ name: "Work" });
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const readOnly = makeCalendar({
+      name: "Team",
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+    const inactive = makeCalendar({ name: "Archived", isActive: false });
+
+    renderCalendarList([active, primary, readOnly, inactive]);
+
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Show Work calendar" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/primary/)).toBeInTheDocument();
+    expect(screen.getByText(/read-only/)).toBeInTheDocument();
+    expect(screen.queryByText("Archived")).not.toBeInTheDocument();
+  });
+
+  it("hides the visibility toggle for anonymous sessions", () => {
+    const local = makeCalendar({ name: "Local", provider: "local" });
+
+    renderCalendarList([local], { authenticated: false });
+
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("flips aria-checked optimistically and coalesces rapid toggles into one final call", async () => {
+    const calendarA = makeCalendar({ name: "Calendar A" });
+    const calendarB = makeCalendar({ name: "Calendar B" });
+    // Method-aware: a successful flush invalidates the calendars query, which
+    // (since it's actively observed here) triggers a real GET refetch through
+    // this same adapter. That refetch is an expected side effect of the hook,
+    // not what this test is verifying, so only PUT /calendars/select calls
+    // are counted below.
+    const putCalls: unknown[] = [];
+    BaseApi.defaults.adapter = async <T,>(
+      config: ApiRequestConfig & { body?: unknown },
+    ) => {
+      if (config.method === "PUT") {
+        putCalls.push(config.body);
+        return {
+          config,
+          data: undefined as T,
+          headers: new Headers(),
+          status: 204,
+          statusText: "No Content",
+        };
+      }
+      return {
+        config,
+        data: { calendars: [] } as T,
+        headers: new Headers(),
+        status: 200,
+        statusText: "OK",
+      };
+    };
+
+    const user = userEvent.setup();
+    renderCalendarList([calendarA, calendarB], { coalesceDelayMs: 100 });
+
+    const switchA = screen.getByRole("switch", {
+      name: "Show Calendar A calendar",
+    });
+    const switchB = screen.getByRole("switch", {
+      name: "Show Calendar B calendar",
+    });
+
+    await user.click(switchA);
+    expect(ariaChecked(switchA)).toBe("false");
+
+    await user.click(switchB);
+    expect(ariaChecked(switchB)).toBe("false");
+
+    await user.click(switchA);
+    expect(ariaChecked(switchA)).toBe("true");
+
+    await waitFor(() => {
+      expect(putCalls).toHaveLength(1);
+    });
+
+    const body = putCalls[0] as { calendarId: string; isVisible: boolean }[];
+    expect(body).toHaveLength(2);
+    expect(body).toContainEqual({
+      calendarId: calendarA.id,
+      isVisible: true,
+    });
+    expect(body).toContainEqual({
+      calendarId: calendarB.id,
+      isVisible: false,
+    });
+  });
+
+  it("removes the hidden calendar's events from a cached week query immediately on toggle-off", async () => {
+    const hidden = makeCalendar({ name: "Hidden target" });
+    const kept = makeCalendar({ name: "Kept" });
+    const hiddenEvent = createMockEvent({ calendarId: hidden.id });
+    const keptEvent = createMockEvent({ calendarId: kept.id });
+    const weekKey = eventQueryKeys.week({
+      source: "remote",
+      start: "2026-07-13T00:00:00.000Z",
+      end: "2026-07-20T00:00:00.000Z",
+    });
+
+    const user = userEvent.setup();
+    const { queryClient } = renderCalendarList([hidden, kept], {
+      coalesceDelayMs: 100,
+    });
+    queryClient.setQueryData<NormalizedEventQueryData>(weekKey, {
+      ids: [hiddenEvent.id, keptEvent.id],
+      entities: { [hiddenEvent.id]: hiddenEvent, [keptEvent.id]: keptEvent },
+    });
+
+    await user.click(
+      screen.getByRole("switch", { name: "Show Hidden target calendar" }),
+    );
+
+    const cached = queryClient.getQueryData<NormalizedEventQueryData>(weekKey);
+    expect(cached?.ids).toEqual([keptEvent.id]);
+    expect(cached?.entities[hiddenEvent.id]).toBeUndefined();
+    expect(cached?.entities[keptEvent.id]).toBeDefined();
+  });
+
+  it("rolls back the toggle and announces failure when the flush rejects", async () => {
+    const calendar = makeCalendar({ name: "Work" });
+    BaseApi.defaults.adapter = mock(async () => {
+      throw new Error("Simulated network failure");
+    });
+
+    const user = userEvent.setup();
+    renderCalendarList([calendar], { coalesceDelayMs: 100 });
+
+    const toggle = screen.getByRole("switch", { name: "Show Work calendar" });
+    await user.click(toggle);
+    expect(ariaChecked(toggle)).toBe("false");
+
+    await waitFor(() => {
+      expect(ariaChecked(toggle)).toBe("true");
+    });
+    expect(screen.getByRole("status").textContent ?? "").toMatch(
+      /couldn.t update calendar visibility/i,
+    );
+  });
+
+  it("is reachable by Tab and toggles on Enter and Space", async () => {
+    const calendar = makeCalendar({ name: "Work" });
+    BaseApi.defaults.adapter = async <T,>(
+      config: ApiRequestConfig & { body?: unknown },
+    ) => ({
+      config,
+      data: (config.method === "PUT" ? undefined : { calendars: [] }) as T,
+      headers: new Headers(),
+      status: config.method === "PUT" ? 204 : 200,
+      statusText: config.method === "PUT" ? "No Content" : "OK",
+    });
+
+    const user = userEvent.setup();
+    renderCalendarList([calendar], { coalesceDelayMs: 100 });
+
+    const toggle = screen.getByRole("switch", { name: "Show Work calendar" });
+
+    await user.tab();
+    expect(document.activeElement).toBe(toggle);
+
+    await user.keyboard("{Enter}");
+    expect(ariaChecked(toggle)).toBe("false");
+
+    await user.keyboard(" ");
+    expect(ariaChecked(toggle)).toBe("true");
+  });
+
+  it("shows a loading state while calendars are pending", () => {
+    BaseApi.defaults.adapter = () => new Promise(() => {});
+    const { wrapper } = createStoreWrapper();
+
+    render(<PlannerCalendarList />, { wrapper });
+
+    expect(screen.getByText(/loading calendars/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no calendars", () => {
+    renderCalendarList([]);
+
+    expect(screen.getByText(/no calendars yet/i)).toBeInTheDocument();
+  });
+
+  it("shows an error state and recovers via retry", async () => {
+    const calendar = makeCalendar({ name: "Work" });
+    let shouldFail = true;
+    BaseApi.defaults.adapter = async <T,>(
+      config: ApiRequestConfig & { body?: unknown },
+    ) => {
+      if (shouldFail) throw new Error("Simulated load failure");
+      return {
+        config,
+        data: { calendars: [calendar] } as T,
+        headers: new Headers(),
+        status: 200,
+        statusText: "OK",
+      };
+    };
+    const { wrapper } = createStoreWrapper();
+    render(<PlannerCalendarList />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn.t load calendars/i)).toBeInTheDocument();
+    });
+
+    shouldFail = false;
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Work")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.tsx
@@ -1,0 +1,119 @@
+import { type FC } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { useSession } from "@web/auth/compass/session/useSession";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
+
+// Primary calendars first, then alphabetical by name; the local calendar
+// (offline/anonymous synthesized calendar, or the server's own local
+// calendar once signed in) always sorts last since it isn't a
+// provider-backed subscription like the others (packet 08 step 2).
+function sortCalendars(calendars: Calendar[]): Calendar[] {
+  return [...calendars].sort((a, b) => {
+    if (a.provider === "local" && b.provider !== "local") return 1;
+    if (b.provider === "local" && a.provider !== "local") return -1;
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+// Identity is never conveyed by color alone: primary/read-only context is
+// spelled out as text next to the calendar name.
+function calendarContextLabel(calendar: Calendar): string | null {
+  const labels = [
+    calendar.isPrimary ? "primary" : null,
+    calendar.capabilities.canWrite ? null : "read-only",
+  ].filter((label): label is string => label !== null);
+  return labels.length > 0 ? labels.join(", ") : null;
+}
+
+interface Props {
+  /** Test seam only: production callers rely on useCalendarVisibility's default. */
+  coalesceDelayMs?: number;
+}
+
+export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
+  const { authenticated } = useSession();
+  const { data, isPending, isError, refetch } = useCalendarsQuery();
+  const { toggleCalendarVisibility, failureAnnouncement } =
+    useCalendarVisibility(coalesceDelayMs);
+
+  const calendars = sortCalendars(
+    (data ?? []).filter((calendar) => calendar.isActive),
+  );
+
+  return (
+    <section aria-label="Calendars">
+      <h2 className="mb-2 min-w-0 truncate font-semibold text-sm text-text-lighter leading-none">
+        Calendars
+      </h2>
+
+      {isPending ? (
+        <p className="text-text-light-inactive text-xs">Loading calendars…</p>
+      ) : isError ? (
+        <div className="flex items-center justify-between gap-2 text-xs">
+          <p className="text-status-error">Couldn't load calendars.</p>
+          <button
+            className="c-focus-ring rounded-xs px-1.5 py-0.5 text-accent-primary hover:brightness-110"
+            onClick={() => void refetch()}
+            type="button"
+          >
+            Retry
+          </button>
+        </div>
+      ) : calendars.length === 0 ? (
+        <p className="text-text-light-inactive text-xs">No calendars yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {calendars.map((calendar) => {
+            const contextLabel = calendarContextLabel(calendar);
+
+            return (
+              <li className="flex items-center gap-2" key={calendar.id}>
+                <span
+                  aria-hidden
+                  className="size-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: calendar.backgroundColor }}
+                />
+
+                <span className="min-w-0 flex-1 truncate text-text-lighter text-xs">
+                  {calendar.name}
+                  {contextLabel ? (
+                    <span className="text-text-light-inactive">
+                      {" "}
+                      · {contextLabel}
+                    </span>
+                  ) : null}
+                </span>
+
+                {authenticated ? (
+                  <button
+                    aria-checked={calendar.isVisible}
+                    aria-label={`Show ${calendar.name} calendar`}
+                    className="c-focus-ring relative h-4 w-7 shrink-0 rounded-full bg-panel-badge-bg transition-colors data-[checked=true]:bg-accent-primary"
+                    data-checked={calendar.isVisible}
+                    onClick={() =>
+                      toggleCalendarVisibility(calendar.id, !calendar.isVisible)
+                    }
+                    role="switch"
+                    type="button"
+                  >
+                    <span
+                      aria-hidden
+                      className="absolute top-0.5 left-0.5 size-3 rounded-full bg-text-lighter transition-transform data-[checked=true]:translate-x-3"
+                      data-checked={calendar.isVisible}
+                    />
+                  </button>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <span aria-live="polite" className="sr-only" role="status">
+        {failureAnnouncement}
+      </span>
+    </section>
+  );
+};

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, mock } from "bun:test";
 
 const PlannerSidebar = createPlannerSidebar({
   PlannerAccountSummary: () => <div>Account summary</div>,
+  PlannerCalendarList: () => <div>Calendar list</div>,
   PlannerMonthPicker: () => <div>Calendar picker</div>,
   PlannerSidebarActions: () => <div>Sidebar actions</div>,
   ShortcutsOverlay: () => null,

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
@@ -3,6 +3,7 @@ import { type Dayjs } from "@core/util/date/dayjs";
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type ShortcutOverlaySection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutsOverlay";
 import { PlannerAccountSummary } from "./PlannerAccountSummary/PlannerAccountSummary";
+import { PlannerCalendarList } from "./PlannerCalendarList/PlannerCalendarList";
 import { PlannerMonthPicker } from "./PlannerMonthPicker/PlannerMonthPicker";
 import { PlannerSidebarActions } from "./PlannerSidebarActions/PlannerSidebarActions";
 import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
@@ -25,6 +26,7 @@ export interface PlannerSidebarProps extends HTMLAttributes<HTMLDivElement> {
 
 type PlannerSidebarDependencies = {
   PlannerAccountSummary: typeof PlannerAccountSummary;
+  PlannerCalendarList: typeof PlannerCalendarList;
   PlannerMonthPicker: typeof PlannerMonthPicker;
   PlannerSidebarActions: typeof PlannerSidebarActions;
   ShortcutsOverlay: typeof ShortcutsOverlay;
@@ -33,6 +35,7 @@ type PlannerSidebarDependencies = {
 
 export function createPlannerSidebar({
   PlannerAccountSummary: PlannerAccountSummaryComponent,
+  PlannerCalendarList: PlannerCalendarListComponent,
   PlannerMonthPicker: PlannerMonthPickerComponent,
   PlannerSidebarActions: PlannerSidebarActionsComponent,
   ShortcutsOverlay: ShortcutsOverlayComponent,
@@ -68,6 +71,8 @@ export function createPlannerSidebar({
             selectedDate={calendarDate}
           />
 
+          <PlannerCalendarListComponent />
+
           {showSomedayEventSections ? (
             <section aria-label="Someday events">
               <SomedayEventSectionsComponent
@@ -99,6 +104,7 @@ export function createPlannerSidebar({
 
 export const PlannerSidebar = createPlannerSidebar({
   PlannerAccountSummary,
+  PlannerCalendarList,
   PlannerMonthPicker,
   PlannerSidebarActions,
   ShortcutsOverlay,


### PR DESCRIPTION
## Summary

Packet 08 (web calendar experience) phase 1 of 5: the sidebar calendar list, the visibility mutation, and server-side read filtering (packet 08 steps 2-4).

- **`PlannerCalendarList`** — a new `<section aria-label="Calendars">` in the planner sidebar scroll area (between the month picker and someday sections; the packet's "below account status" wording predates the current DOM where account status is a bottom bar — recorded as a decision in the packet close-out). Renders every **active** calendar (inactive provider calendars never render) sorted primary-first/local-last, each with an `aria-hidden` color marker, the name, and textual `primary` / `read-only` context — identity is never conveyed by color alone (A9). Loading, empty, and recoverable error (+retry) states.
- **Visibility toggles** — an accessible `role="switch"` per calendar (authenticated sessions only; the anonymous synthesized local calendar has nothing to persist). `useCalendarVisibility`: optimistic cache flip + immediate removal of a hidden calendar's events from every cached event query (reusing the revoke-flow's `removeEventsByCalendarFromQueries`), **coalescing** rapid toggles into one bulk `PUT /calendars/select` after a 400ms quiet window, single events+calendars invalidation on settle, and rollback + toast + `aria-live` announcement on failure (packet step 3's coalesce/rollback requirements).
- **Server-side filtering** (step 4): `EventService.readAll` now queries only visible+active calendars via a new `visibleCalendarIds` helper. Hiding stays presentation-only (A8): mutation and ownership lookups (`requireOwnedEvent`, reorder, series context) deliberately keep the wider active-only set, and a regression test proves events on hidden calendars remain mutable.

Packet-doc notes for close-out: step 3's claim that `/api/calendars/select` still accepts the legacy `[{id, selected}]` shape was stale — the strict `[{calendarId, isVisible}]` contract already shipped; step 1's calendars query module and step 9/10's SSE + offline-sentinel work were also already done (fallout of the contracts refactor), so this phase adds only what was genuinely missing.

## Testing

- Web (9 new RTL tests): active-only rendering with switch roles and text context labels, anonymous hides toggles, optimistic flip + coalesced single call with final batch state, immediate cache eviction of a hidden calendar's events, failure rollback + announcement, keyboard operation, loading/empty/error+retry.
- Backend (3 new): hidden calendar excluded from range and someday reads; mutations on hidden-calendar events still succeed.
- `bun test:web`: 1273 pass / 0 fail. `TZ=UTC jest --selectProjects backend`: 69 suites, 641 passed / 1 pre-existing skip. `bun run type-check` clean; `bun run lint` steady at the 15 pre-existing warnings (zero added).

Part of `handoff/someday/08-web-calendar-experience.md` (next: calendar identity on event cards + target-calendar combobox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)