### PR TITLE
feat(web): show calendar identity on event cards and pick create targets

### DIFF
--- a/packages/web/src/calendars/calendarCardIdentity.test.tsx
+++ b/packages/web/src/calendars/calendarCardIdentity.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen } from "@testing-library/react";
+import { type ReactElement } from "react";
+import { Origin, Priorities } from "@core/constants/core.constants";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import {
+  resolveCalendarCardIdentity,
+  useCalendarLookup,
+} from "@web/calendars/useCalendarLookup";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { assembleGridEvent } from "@web/common/utils/event/event.util";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { CalendarAllDayEventCard } from "@web/layout/calendar-grid/components/CalendarAllDayEventCard";
+import { CalendarTimedEventCard } from "@web/layout/calendar-grid/components/CalendarTimedEventCard";
+import { describe, expect, it } from "bun:test";
+
+// This suite exercises the real useCalendarLookup -> resolveCalendarCardIdentity
+// -> card chain end to end (calendars seeded through the query cache, exactly
+// as PlannerCalendarList.test.tsx seeds calendars.query.ts), rather than
+// stubbing the resolved identity - the id -> name resolution and the
+// single-calendar gate are the behavior under test, not just the card's
+// rendering of a given prop.
+
+const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Work",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+const POSITION = { top: 0, left: 0, width: 100, height: 60 };
+
+const makeGridEvent = (
+  overrides: Partial<Schema_GridEvent> = {},
+): Schema_GridEvent =>
+  assembleGridEvent({
+    _id: createObjectIdString(),
+    title: "Team sync",
+    description: "",
+    startDate: "2026-07-13T09:00:00.000-05:00",
+    endDate: "2026-07-13T10:00:00.000-05:00",
+    priority: Priorities.WORK,
+    origin: Origin.COMPASS,
+    isAllDay: false,
+    isSomeday: false,
+    user: "user-1",
+    ...overrides,
+  });
+
+// Local test-only harness: mirrors how a list component (MainGridEvents,
+// AllDayEvents) resolves calendarIdentity via the shared hook/helper and
+// passes it down as a prop - not new production code.
+function TimedCardWithResolvedIdentity({ event }: { event: Schema_GridEvent }) {
+  const lookup = useCalendarLookup();
+  const calendarIdentity = resolveCalendarCardIdentity(
+    lookup,
+    event.calendarId,
+  );
+
+  return (
+    <CalendarTimedEventCard
+      calendarIdentity={calendarIdentity}
+      displayMode="saved"
+      event={event}
+      motionMode="idle"
+      position={POSITION}
+    />
+  );
+}
+
+function AllDayCardWithResolvedIdentity({
+  event,
+}: {
+  event: Schema_GridEvent;
+}) {
+  const lookup = useCalendarLookup();
+  const calendarIdentity = resolveCalendarCardIdentity(
+    lookup,
+    event.calendarId,
+  );
+
+  return (
+    <CalendarAllDayEventCard
+      calendarIdentity={calendarIdentity}
+      event={event}
+      isPlaceholder={false}
+      position={POSITION}
+    />
+  );
+}
+
+const renderWithCalendars = (ui: ReactElement, calendars: Calendar[]) => {
+  const { queryClient, wrapper } = createStoreWrapper();
+  queryClient.setQueryData(calendarQueryKeys.all, calendars);
+  return render(ui, { wrapper });
+};
+
+describe("Calendar identity on event cards", () => {
+  it("includes the calendar name in the timed card's accessible label when more than one calendar is active", () => {
+    const work = makeCalendar({ name: "Work" });
+    const personal = makeCalendar({ name: "Personal" });
+    const event = makeGridEvent({ calendarId: work.id });
+
+    renderWithCalendars(<TimedCardWithResolvedIdentity event={event} />, [
+      work,
+      personal,
+    ]);
+
+    expect(
+      screen.getByRole("button", { name: /Team sync.*Work calendar/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("includes the calendar name in the all-day card's accessible label when more than one calendar is active", () => {
+    const work = makeCalendar({ name: "Work" });
+    const personal = makeCalendar({ name: "Personal" });
+    const event = makeGridEvent({ calendarId: personal.id, isAllDay: true });
+
+    renderWithCalendars(<AllDayCardWithResolvedIdentity event={event} />, [
+      work,
+      personal,
+    ]);
+
+    expect(
+      screen.getByRole("button", { name: /Team sync.*Personal calendar/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the calendar name from the timed card's label for a single-calendar account", () => {
+    const onlyCalendar = makeCalendar({ name: "Work" });
+    const event = makeGridEvent({ calendarId: onlyCalendar.id });
+
+    renderWithCalendars(<TimedCardWithResolvedIdentity event={event} />, [
+      onlyCalendar,
+    ]);
+
+    const card = screen.getByRole("button", { name: /Team sync/ });
+    expect(card.getAttribute("aria-label")).not.toMatch(/calendar$/);
+  });
+
+  it("omits the calendar name from the all-day card's label for a single-calendar account", () => {
+    const onlyCalendar = makeCalendar({ name: "Work" });
+    const event = makeGridEvent({
+      calendarId: onlyCalendar.id,
+      isAllDay: true,
+    });
+
+    renderWithCalendars(<AllDayCardWithResolvedIdentity event={event} />, [
+      onlyCalendar,
+    ]);
+
+    const card = screen.getByRole("button", { name: /Team sync/ });
+    expect(card.getAttribute("aria-label")).not.toMatch(/calendar$/);
+  });
+
+  it("omits the calendar name when the event's calendarId doesn't resolve to any active calendar", () => {
+    const work = makeCalendar({ name: "Work" });
+    const personal = makeCalendar({ name: "Personal" });
+    const event = makeGridEvent({
+      calendarId: CalendarIdSchema.parse(createObjectIdString()),
+    });
+
+    renderWithCalendars(<TimedCardWithResolvedIdentity event={event} />, [
+      work,
+      personal,
+    ]);
+
+    const card = screen.getByRole("button", { name: /Team sync/ });
+    expect(card.getAttribute("aria-label")).not.toMatch(/calendar$/);
+  });
+});

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -1,0 +1,47 @@
+import { useMemo } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+
+const EMPTY_CALENDAR_LOOKUP: ReadonlyMap<CalendarId, Calendar> = new Map();
+
+/**
+ * Memoized id -> Calendar lookup, built once per calendars-query data
+ * reference rather than rescanned per event/card render (packet 08 step 5).
+ * Call this once in a list-rendering parent (e.g. MainGridEvents,
+ * AllDayEvents, SomedayEventsContainer) and resolve/pass down per-card via
+ * {@link resolveCalendarCardIdentity} - not from inside every card.
+ */
+export function useCalendarLookup(): ReadonlyMap<CalendarId, Calendar> {
+  const { data } = useCalendarsQuery();
+
+  return useMemo(() => {
+    if (!data) return EMPTY_CALENDAR_LOOKUP;
+    return new Map(data.map((calendar) => [calendar.id, calendar]));
+  }, [data]);
+}
+
+export type CalendarCardIdentity = {
+  name: string;
+  backgroundColor: string;
+};
+
+/**
+ * Resolves the calendar-colored accent + accessible-label suffix for a
+ * single event card. Identity is never conveyed by color alone (A9): the
+ * name always travels with the accent. Gated on there being more than one
+ * active calendar - a single-calendar account's cards gain nothing from
+ * either the accent or a redundant name suffix, since every card would say
+ * the same thing.
+ */
+export function resolveCalendarCardIdentity(
+  lookup: ReadonlyMap<CalendarId, Calendar>,
+  calendarId: CalendarId | null | undefined,
+): CalendarCardIdentity | null {
+  if (!calendarId || lookup.size <= 1) return null;
+
+  const calendar = lookup.get(calendarId);
+  return calendar
+    ? { name: calendar.name, backgroundColor: calendar.backgroundColor }
+    : null;
+}

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { type CalendarId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { CompassCoreEventSchema } from "@core/types/event.types";
 import { IDSchema } from "@core/types/type.utils";
@@ -43,7 +44,20 @@ export type Schema_WebEvent = z.infer<typeof WebCoreEventSchema>;
 
 export type Schema_SomedayEvent = z.infer<typeof SomedayEventSchema>;
 
-export type Schema_GridEvent = z.infer<typeof GridEventSchema>;
+// calendarId is a plain type-level addition, not part of GridEventSchema
+// itself: CalendarIdSchema (domain-primitives.ts) is a zod/v4 schema, while
+// this file's schemas are all zod v3 ("zod") - z.object.extend() with a v4
+// field schema mixed into a v3 shape crashes at parse time ("_parse is not a
+// function"). calendarId is populated out-of-band (event.view-model.ts's
+// gridEventsFrom, grid-event-draft.adapter.ts's gridEventDraftToSchemaEvent)
+// rather than through GridEventSchema.parse, so it never needed to be a
+// schema-validated field - only a typed one. Optional (rather than required,
+// matching the strict core `Event` contract) so the legacy bridge doesn't
+// have to guarantee it in every branch - card rendering degrades gracefully
+// (no accent/label suffix) when it's missing.
+export type Schema_GridEvent = z.infer<typeof GridEventSchema> & {
+  calendarId?: CalendarId;
+};
 
 export interface Schema_OptimisticEvent extends Schema_GridEvent {
   _id: string; // We guarantee that we have an _id for optimistic events, unlike `Schema_Event`

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.test.tsx
@@ -25,12 +25,15 @@ const formProps = {
 } as unknown as Props_DraftForm;
 
 const renderSomedayEvent = ({
+  calendarIdentity,
   onClick = mock(),
 }: {
+  calendarIdentity?: { name: string; backgroundColor: string } | null;
   onClick?: () => void;
 } = {}) => {
   render(
     <SomedayEvent
+      calendarIdentity={calendarIdentity}
       category={Categories_Event.SOMEDAY_WEEK}
       event={createEvent()}
       formProps={formProps}
@@ -77,5 +80,22 @@ describe("SomedayEvent", () => {
     );
 
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("includes the calendar name in its accessible label when a calendar identity is resolved", () => {
+    renderSomedayEvent({
+      calendarIdentity: { name: "Local", backgroundColor: "#ffffff" },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Plan launch, Local calendar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits a calendar suffix from its accessible label when no calendar identity is resolved", () => {
+    renderSomedayEvent();
+
+    const event = screen.getAllByRole("button")[0];
+    expect(event.getAttribute("aria-label")).toBeNull();
   });
 });

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEvent/SomedayEvent.tsx
@@ -1,6 +1,7 @@
 import { type KeyboardEvent, type Ref } from "react";
 import { type Priorities } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import {
@@ -17,6 +18,7 @@ import {
 } from "./someday-event.constants";
 
 interface Props {
+  calendarIdentity?: CalendarCardIdentity | null;
   category: SomedayInteractionCategory;
   event: Event;
   status: {
@@ -32,6 +34,7 @@ interface Props {
   formProps: Props_DraftForm;
 }
 export const SomedayEvent = ({
+  calendarIdentity = null,
   category,
   event,
   status,
@@ -61,9 +64,20 @@ export const SomedayEvent = ({
   const hoverColor = gridHoverColorByPriority[priority];
   const tint = (color: string, percent: number) =>
     `color-mix(in srgb, ${color} ${percent}%, transparent)`;
+  // Explicit only when there's a calendar to name - otherwise this falls
+  // through to the existing name-from-content computation (title +
+  // migrate-button labels), unchanged from before this prop existed.
+  // Priority remains the row's fill; the accent + this label are the only
+  // calendar signal, and the name (never color alone) is what makes it
+  // accessible (A9).
+  const title = event.content.kind === "details" ? event.content.title : "";
+  const accessibleLabel = calendarIdentity
+    ? `${title || "Untitled event"}, ${calendarIdentity.name} calendar`
+    : undefined;
   const somedayEventProps = {
     [DATA_EVENT_ELEMENT_ID]: event.id,
     "aria-hidden": isDragging || undefined,
+    "aria-label": accessibleLabel,
     onBlur,
     onClick,
     onFocus,
@@ -76,7 +90,7 @@ export const SomedayEvent = ({
   return (
     <div
       {...somedayEventProps}
-      className="group w-full cursor-grab rounded-xs bg-(--someday-event-bg) px-2 py-0.75 text-text-dark text-xs transition-[background-color_.2s,opacity_.12s,box-shadow_.2s] hover:cursor-pointer hover:bg-(--someday-event-hover-bg) focus-visible:outline-1 focus-visible:outline-accent-primary focus-visible:outline-offset-1 data-[dragging=true]:pointer-events-none data-[dragging=true]:cursor-grabbing data-[dragging=true]:opacity-0"
+      className="group relative w-full cursor-grab rounded-xs bg-(--someday-event-bg) px-2 py-0.75 text-text-dark text-xs transition-[background-color_.2s,opacity_.12s,box-shadow_.2s] hover:cursor-pointer hover:bg-(--someday-event-hover-bg) focus-visible:outline-1 focus-visible:outline-accent-primary focus-visible:outline-offset-1 data-[dragging=true]:pointer-events-none data-[dragging=true]:cursor-grabbing data-[dragging=true]:opacity-0"
       data-dragging={isDragging}
       style={
         {
@@ -91,6 +105,13 @@ export const SomedayEvent = ({
         } as CSSVariables
       }
     >
+      {calendarIdentity && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 w-[3px] rounded-l-xs"
+          style={{ backgroundColor: calendarIdentity.backgroundColor }}
+        />
+      )}
       <SomedayEventRectangle
         category={category}
         event={event}

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventContainer/SomedayEventContainer.tsx
@@ -11,6 +11,7 @@ import {
 import dayjs from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { computeCurrentEventDateRange } from "@web/common/utils/datetime/web.date.util";
 import { getDraftTimes } from "@web/common/utils/draft/draft.util";
 import { refocusEventElement } from "@web/common/utils/event/event.util";
@@ -31,6 +32,7 @@ import { useDraftForm } from "@web/views/Week/components/Draft/hooks/state/useDr
 import { getSidebarOpenWidth } from "@web/views/Week/layout.constants";
 
 export interface Props {
+  calendarIdentity?: CalendarCardIdentity | null;
   category: SomedayInteractionCategory;
   event: Event;
   isDrafting: boolean;
@@ -47,6 +49,7 @@ export interface Props {
 }
 
 export const SomedayEventContainer = ({
+  calendarIdentity,
   category,
   event,
   isDrafting,
@@ -164,6 +167,7 @@ export const SomedayEventContainer = ({
   return (
     <>
       <SomedayEvent
+        calendarIdentity={calendarIdentity}
         category={category}
         event={event}
         status={{

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventItem/SomedayEventItem.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventItem/SomedayEventItem.tsx
@@ -1,5 +1,6 @@
 import { type FC, useLayoutEffect, useRef } from "react";
 import { type Event } from "@core/types/event.contracts";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { useSidebarContext } from "@web/components/PlannerSidebar/draft/context/useSidebarContext";
 import {
   type SomedayInteractionCategory,
@@ -12,6 +13,7 @@ const SOMEDAY_SORT_ANIMATION_MS = 180;
 const SOMEDAY_SORT_ANIMATION_EASING = "cubic-bezier(0.2, 0, 0, 1)";
 
 export interface Props {
+  calendarIdentity?: CalendarCardIdentity | null;
   category: SomedayInteractionCategory;
   draftId: string;
   event: Event;
@@ -109,6 +111,7 @@ const useSomedayRowLayoutAnimation = () => {
 };
 
 export const SomedayEventItem: FC<Props> = ({
+  calendarIdentity,
   category,
   draftId,
   event,
@@ -137,6 +140,7 @@ export const SomedayEventItem: FC<Props> = ({
       ref={layoutAnimationRef}
     >
       <SomedayEventContainer
+        calendarIdentity={calendarIdentity}
         category={category}
         event={event}
         interactionRef={interactionRef}

--- a/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventsContainer/SomedayEventsContainer.tsx
+++ b/packages/web/src/components/PlannerSidebar/SomedayEventSections/SomedayEvents/SomedayEventsContainer/SomedayEventsContainer.tsx
@@ -7,6 +7,10 @@ import {
 import { type Event } from "@core/types/event.contracts";
 import { Categories_Event } from "@core/types/event.types";
 import {
+  resolveCalendarCardIdentity,
+  useCalendarLookup,
+} from "@web/calendars/useCalendarLookup";
+import {
   COLUMN_MONTH,
   COLUMN_WEEK,
   ID_SOMEDAY_DRAFT,
@@ -67,6 +71,8 @@ export const SomedayEventsContainer: FC<Props> = ({
   const dropTargetRef = useSomedayDropTargetRegistrationRef({
     category,
   });
+  // One lookup build for the whole list (packet 08 step 5) - not per card.
+  const calendarLookup = useCalendarLookup();
 
   const { isFetching } = useSomedayEventsQueryStatus();
   const { reservedMinHeight, shouldAnimateRowEntrance } =
@@ -104,6 +110,10 @@ export const SomedayEventsContainer: FC<Props> = ({
         {events.map((event, index) => (
           <SomedayEventItem
             animateEnter={shouldAnimateRowEntrance}
+            calendarIdentity={resolveCalendarCardIdentity(
+              calendarLookup,
+              event.calendarId,
+            )}
             category={category}
             draftId={state.draft?.id || ID_SOMEDAY_DRAFT}
             event={event}
@@ -131,6 +141,10 @@ export const SomedayEventsContainer: FC<Props> = ({
 
       {isDraftingThisCategory && state.draft && (
         <SomedayEventItem
+          calendarIdentity={resolveCalendarCardIdentity(
+            calendarLookup,
+            state.draft.calendarId,
+          )}
           category={category}
           draftId={ID_SOMEDAY_DRAFT}
           event={state.draft}

--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -1,7 +1,12 @@
 import { Priorities } from "@core/constants/core.constants";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
 import { type Event } from "@core/types/event.contracts";
 import {
   createGridEventDraft,
+  duplicateGridEventDraft,
   editGridEventDraft,
   gridEventDraftToSchemaEvent,
   parseGridEventDraft,
@@ -112,4 +117,40 @@ test("parses an edit draft into a replace command", () => {
       recurrence: { kind: "preserve" },
     },
   });
+});
+
+test("duplicate defaults to the source event's calendar when it's still writable", () => {
+  const writableSourceCalendar = {
+    id: timedEvent.calendarId,
+    capabilities: getCalendarCapabilities("owner"),
+  } as unknown as Calendar;
+
+  const duplicate = duplicateGridEventDraft(timedEvent, [
+    writableSourceCalendar,
+  ]);
+
+  expect(duplicate).toMatchObject({
+    kind: "create",
+    source: null,
+    values: { calendarId: timedEvent.calendarId, title: "Focus" },
+  });
+});
+
+test("duplicate falls back to no calendar (later defaulted) when the source calendar is read-only", () => {
+  const readOnlySourceCalendar = {
+    id: timedEvent.calendarId,
+    capabilities: getCalendarCapabilities("reader"),
+  } as unknown as Calendar;
+
+  const duplicate = duplicateGridEventDraft(timedEvent, [
+    readOnlySourceCalendar,
+  ]);
+
+  expect(duplicate?.values.calendarId).toBeNull();
+});
+
+test("duplicate falls back to no calendar when the source calendar isn't in the given list", () => {
+  const duplicate = duplicateGridEventDraft(timedEvent, []);
+
+  expect(duplicate?.values.calendarId).toBeNull();
 });

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -1,5 +1,6 @@
 import { Priorities } from "@core/constants/core.constants";
-import { type EventId } from "@core/types/domain-primitives";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId, type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { type Schema_Event } from "@core/types/event.types";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
@@ -83,9 +84,27 @@ export function editGridEventDraft(
 // A duplicate is a brand-new, standalone event: it starts from the source
 // event's fields but is never linked back to it (kind "create", source
 // null), so editing/deleting the duplicate never touches the original.
-export function duplicateGridEventDraft(event: Event): GridEventDraft | null {
+//
+// Defaults the new draft's calendar to the source event's calendar only when
+// that calendar is still writable - duplicating an event viewed on a
+// read-only calendar can't recreate it there, so this leaves calendarId
+// unset and lets the same null-calendarId fallback every other new draft
+// uses (CalendarSelect's displayed default, useSaveEventForm.ts/
+// useDraftActions.ts's submit-time fallback) pick the default target
+// calendar instead.
+export function duplicateGridEventDraft(
+  event: Event,
+  calendars: Calendar[],
+): GridEventDraft | null {
   const schedule = gridScheduleFromEvent(event);
   if (!schedule) return null;
+
+  const sourceCalendar = calendars.find(
+    (calendar) => calendar.id === event.calendarId,
+  );
+  const calendarId: CalendarId | null = sourceCalendar?.capabilities.canWrite
+    ? event.calendarId
+    : null;
 
   return {
     kind: "create",
@@ -96,7 +115,7 @@ export function duplicateGridEventDraft(event: Event): GridEventDraft | null {
         event.content.kind === "details" ? event.content.description : "",
       schedule,
       priority: event.priority,
-      calendarId: event.calendarId,
+      calendarId,
       recurrence: { kind: "single" },
     },
   };
@@ -186,13 +205,20 @@ function legacyRecurrenceFromDraft(
 // require Schema_Event. Keeping this projection beside the GridEventDraft
 // adapter lets the draft store expose one canonical grid draft without a
 // second store while legacy consumers are migrated incrementally.
+//
+// Return type is widened (rather than adding calendarId to the shared,
+// hand-written core `Schema_Event` interface, which 10+ unrelated consumers
+// also use) so the calendar-colored card accent/label stays correct on a
+// dragging/resizing existing-event placeholder (draft.store.ts stores this
+// projection for that display path) without touching Schema_Event itself.
 export function gridEventDraftToSchemaEvent(
   draft: GridEventDraft,
-): Schema_Event {
+): Schema_Event & { calendarId?: CalendarId } {
   const { schedule } = draft.values;
 
   return {
     _id: draft.kind === "edit" ? draft.source.id : draft.clientId,
+    calendarId: draft.values.calendarId ?? undefined,
     description: draft.values.description,
     endDate:
       schedule.kind === "allDay"

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -69,13 +69,39 @@ const isValidScheduledEvent = (event: Event): boolean => {
   return isValid;
 };
 
-const gridEventsFrom = (events: Event[], kind: "timed" | "allDay") =>
-  events
+// Re-attaches calendarId onto the Schema_GridEvent produced by the
+// Event -> Schema_Event -> Schema_GridEvent bridge above. scheduledEventToSchemaEvent
+// returns the legacy, hand-written core `Schema_Event` shape (event.types.ts),
+// which has no calendarId field, so the bridge itself can't carry it through
+// without widening that shared type (used by 10+ unrelated consumers). Joining
+// back by event id after assembleGridEvent keeps the bridge untouched and scopes
+// the new field to Schema_GridEvent only (packet 08 step 5).
+const withCalendarId = (
+  events: Event[],
+  gridEvents: Schema_GridEvent[],
+): Schema_GridEvent[] => {
+  const calendarIdByEventId = new Map<string, Event["calendarId"]>(
+    events.map((event) => [event.id, event.calendarId]),
+  );
+  return gridEvents.map((gridEvent) => ({
+    ...gridEvent,
+    calendarId: gridEvent._id
+      ? calendarIdByEventId.get(gridEvent._id)
+      : undefined,
+  }));
+};
+
+const gridEventsFrom = (events: Event[], kind: "timed" | "allDay") => {
+  const scheduled = events
     .filter(isValidScheduledEvent)
-    .filter((event) => event.schedule.kind === kind)
+    .filter((event) => event.schedule.kind === kind);
+  const assembled = scheduled
     .map(scheduledEventToSchemaEvent)
     .filter((event): event is EventWithDates => hasEventDates(event))
     .map(assembleGridEvent);
+
+  return withCalendarId(scheduled, assembled);
+};
 
 const timedEventsFrom = (events: Event[]) => gridEventsFrom(events, "timed");
 

--- a/packages/web/src/layout/calendar-grid/components/CalendarAllDayEventCard.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarAllDayEventCard.tsx
@@ -9,6 +9,7 @@ import {
 import { Priorities } from "@core/constants/core.constants";
 import dayjs from "@core/util/date/dayjs";
 import { isRecurringEvent } from "@core/util/event/event.util";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
@@ -26,6 +27,8 @@ import { GridEventRepeatIcon } from "./GridEventRepeatIcon";
 const REPEAT_ICON_MIN_WIDTH = 60;
 
 export interface CalendarAllDayEventCardProps {
+  /** Resolved by a list-level useCalendarLookup call, not fetched here. */
+  calendarIdentity?: CalendarCardIdentity | null;
   event: Schema_GridEvent;
   interactionAttributes?: Record<string, string | undefined>;
   isCommitAcknowledged?: boolean;
@@ -44,6 +47,7 @@ export interface CalendarAllDayEventCardProps {
 
 const CalendarAllDayEventCardBase = (
   {
+    calendarIdentity = null,
     event,
     interactionAttributes,
     isCommitAcknowledged = false,
@@ -91,7 +95,13 @@ const CalendarAllDayEventCardBase = (
     cursor: showResizeCursor ? "col-resize" : undefined,
     ...placement,
   });
-  const accessibleLabel = `${isRecurring ? "Recurring " : ""}All-day event: ${event.title || "Untitled event"}`;
+  const baseAccessibleLabel = `${isRecurring ? "Recurring " : ""}All-day event: ${event.title || "Untitled event"}`;
+  // Priority remains the card's fill; the accent + this suffix are the only
+  // calendar signal, and the name (never color alone) is what makes it
+  // accessible (A9).
+  const accessibleLabel = calendarIdentity
+    ? `${baseAccessibleLabel}, ${calendarIdentity.name} calendar`
+    : baseAccessibleLabel;
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: All-day events are draggable/resizable blocks, not native buttons.
@@ -130,6 +140,13 @@ const CalendarAllDayEventCardBase = (
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
+      {calendarIdentity && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 w-[3px]"
+          style={{ backgroundColor: calendarIdentity.backgroundColor }}
+        />
+      )}
       <div
         className={cn("flex min-w-0 items-center", {
           // Reserve room so a long title truncates before the bottom-right icon.

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
@@ -10,6 +10,7 @@ import {
 import { Priorities } from "@core/constants/core.constants";
 import dayjs from "@core/util/date/dayjs";
 import { isRecurringEvent } from "@core/util/event/event.util";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
@@ -47,6 +48,8 @@ const REPEAT_ICON_MIN_WIDTH = 40;
 
 interface CalendarTimedEventCardProps {
   boxShadow?: CSSProperties["boxShadow"];
+  /** Resolved by a list-level useCalendarLookup call, not fetched here. */
+  calendarIdentity?: CalendarCardIdentity | null;
   displayMode: "draft" | "placeholder" | "saved";
   event: Schema_GridEvent;
   interactionAttributes?: Record<string, string | undefined>;
@@ -70,6 +73,7 @@ interface CalendarTimedEventCardProps {
 const CalendarTimedEventCardBase = (
   {
     boxShadow,
+    calendarIdentity = null,
     displayMode,
     event,
     interactionAttributes,
@@ -191,9 +195,15 @@ const CalendarTimedEventCardBase = (
       ? getTimesLabel(event.startDate, event.endDate)
       : null;
   const recurringPrefix = isRecurring ? "Recurring " : "";
-  const accessibleLabel = event.isAllDay
+  const baseAccessibleLabel = event.isAllDay
     ? `${recurringPrefix}All-day event: ${eventTitle}`
     : `${recurringPrefix}Timed event: ${eventTitle}, ${timeRange ?? "time not set"}`;
+  // Priority remains the card's fill; the accent + this suffix are the only
+  // calendar signal, and the name (never color alone) is what makes it
+  // accessible (A9).
+  const accessibleLabel = calendarIdentity
+    ? `${baseAccessibleLabel}, ${calendarIdentity.name} calendar`
+    : baseAccessibleLabel;
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: Grid events are draggable/resizable blocks, not native buttons.
@@ -239,6 +249,13 @@ const CalendarTimedEventCardBase = (
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
+      {calendarIdentity && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 w-[3px]"
+          style={{ backgroundColor: calendarIdentity.backgroundColor }}
+        />
+      )}
       <div className="flex flex-col flex-wrap items-start">
         <span style={titleStyle}>{event.title}</span>
         {!event.isAllDay && (

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { theme } from "@web/common/styles/theme";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
@@ -27,6 +28,7 @@ import {
 } from "@web/views/Day/interaction/targeting/dayCalendarEventTargeting";
 
 interface DayEventCardProps {
+  calendarIdentity?: CalendarCardIdentity | null;
   event: Schema_GridEvent;
   isActiveDraft: boolean;
   isPlaceholder: boolean;
@@ -40,6 +42,7 @@ interface DayTimedEventCardProps extends DayEventCardProps {
 }
 
 export const DayAllDayCalendarEvent = ({
+  calendarIdentity = null,
   event,
   isActiveDraft,
   isPlaceholder,
@@ -72,6 +75,7 @@ export const DayAllDayCalendarEvent = ({
 
   return (
     <CalendarAllDayEventCard
+      calendarIdentity={calendarIdentity}
       event={event}
       interactionAttributes={interactionAttributes}
       isPlaceholder={isPlaceholder}
@@ -96,6 +100,7 @@ export const DayAllDayCalendarEvent = ({
 };
 
 export const DayTimedCalendarEvent = ({
+  calendarIdentity = null,
   deckLayout,
   event,
   isActiveDraft,
@@ -146,6 +151,7 @@ export const DayTimedCalendarEvent = ({
   return (
     <CalendarTimedEventCard
       boxShadow={deckBoxShadow}
+      calendarIdentity={calendarIdentity}
       displayMode={isPlaceholder ? "placeholder" : "saved"}
       event={event}
       interactionAttributes={interactionAttributes}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
 import { type Schema_Event } from "@core/types/event.types";
 import {
+  resolveCalendarCardIdentity,
+  useCalendarLookup,
+} from "@web/calendars/useCalendarLookup";
+import {
   ID_GRID_EVENTS_ALLDAY,
   ID_GRID_EVENTS_TIMED,
 } from "@web/common/constants/web.constants";
@@ -37,6 +41,8 @@ export const DayCalendarAllDayEventsLayer = ({
   onOpenEvent,
   visibleDates,
 }: DayEventsProps) => {
+  // One lookup build for the whole list (packet 08 step 5) - not per card.
+  const calendarLookup = useCalendarLookup();
   const savedEventIds = useMemo(
     () => getCalendarEventIdSet(allDayEvents),
     [allDayEvents],
@@ -64,6 +70,10 @@ export const DayCalendarAllDayEventsLayer = ({
     >
       {renderedEvents.map((event) => (
         <DayAllDayCalendarEvent
+          calendarIdentity={resolveCalendarCardIdentity(
+            calendarLookup,
+            event.calendarId,
+          )}
           event={event}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
@@ -84,6 +94,8 @@ export const DayCalendarTimedEventsLayer = ({
   onOpenEvent,
   visibleDates,
 }: DayEventsProps) => {
+  // One lookup build for the whole list (packet 08 step 5) - not per card.
+  const calendarLookup = useCalendarLookup();
   const savedEventIds = useMemo(
     () => getCalendarEventIdSet(timedEvents),
     [timedEvents],
@@ -107,6 +119,10 @@ export const DayCalendarTimedEventsLayer = ({
     <div id={ID_GRID_EVENTS_TIMED}>
       {timedEventItems.map(({ deckLayout, event }) => (
         <DayTimedCalendarEvent
+          calendarIdentity={resolveCalendarCardIdentity(
+            calendarLookup,
+            event.calendarId,
+          )}
           deckLayout={deckLayout}
           event={event}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import {
+  type CalendarId,
+  CalendarIdSchema,
+} from "@core/types/domain-primitives";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Work",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+const renderCalendarSelect = (
+  calendars: Calendar[],
+  {
+    value = null,
+    onChange = mock(),
+  }: {
+    value?: CalendarId | null;
+    onChange?: (id: CalendarId) => void;
+  } = {},
+) => {
+  const { queryClient, wrapper } = createStoreWrapper();
+  queryClient.setQueryData(calendarQueryKeys.all, calendars);
+
+  const utils = render(<CalendarSelect onChange={onChange} value={value} />, {
+    wrapper,
+  });
+
+  return { queryClient, onChange, ...utils };
+};
+
+async function openDropdown() {
+  const user = userEvent.setup();
+  const button = screen.getByRole("combobox", { name: /calendar/i });
+  await user.click(button);
+
+  await waitFor(() => {
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  return { button, user };
+}
+
+describe("CalendarSelect", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("lists only writable, active calendars and marks the primary one", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const writable = makeCalendar({ name: "Team" });
+    const readOnly = makeCalendar({
+      name: "Holidays",
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+    const inactive = makeCalendar({ name: "Archived", isActive: false });
+
+    renderCalendarSelect([primary, writable, readOnly, inactive]);
+
+    await openDropdown();
+
+    const listbox = screen.getByRole("listbox");
+    const optionNames = within(listbox)
+      .getAllByRole("option")
+      .map((option) => option.textContent);
+
+    expect(optionNames).toEqual(["Personal (primary)", "Team"]);
+    expect(within(listbox).queryByText("Holidays")).not.toBeInTheDocument();
+    expect(within(listbox).queryByText("Archived")).not.toBeInTheDocument();
+  });
+
+  it("defaults the displayed/selected calendar to the default target when no value is chosen yet", async () => {
+    const primaryGoogle = makeCalendar({ name: "Personal", isPrimary: true });
+    const other = makeCalendar({ name: "Team" });
+
+    renderCalendarSelect([primaryGoogle, other], { value: null });
+
+    expect(
+      screen.getByRole("combobox", {
+        name: /Calendar:.*Personal \(primary\)/,
+      }),
+    ).toBeInTheDocument();
+
+    await openDropdown();
+    const defaultOption = screen.getByRole("option", {
+      name: "Personal (primary)",
+    });
+    expect(defaultOption).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("calls onChange with the selected calendar's id and closes the dropdown", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const team = makeCalendar({ name: "Team" });
+    const onChange = mock();
+
+    renderCalendarSelect([primary, team], { onChange });
+
+    const { user } = await openDropdown();
+    await user.click(screen.getByRole("option", { name: "Team" }));
+
+    expect(onChange).toHaveBeenCalledWith(team.id);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("shows a no-writable-calendar message and no combobox when every calendar is read-only", () => {
+    const readOnly = makeCalendar({
+      name: "Holidays",
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+
+    renderCalendarSelect([readOnly]);
+
+    expect(
+      screen.getByText("No writable calendar available"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("opens with Enter, navigates options with the arrow keys, and closes with Escape", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const team = makeCalendar({ name: "Team" });
+
+    renderCalendarSelect([primary, team]);
+
+    const button = screen.getByRole("combobox", { name: /calendar/i });
+    const user = userEvent.setup();
+    button.focus();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    const primaryOption = screen.getByRole("option", {
+      name: "Personal (primary)",
+    });
+    primaryOption.focus();
+
+    await user.keyboard("{ArrowDown}");
+
+    await waitFor(() => {
+      const teamOption = screen.getByRole("option", { name: "Team" });
+      expect(teamOption).toHaveAttribute("tabindex", "0");
+      expect(primaryOption).toHaveAttribute("tabindex", "-1");
+    });
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -1,0 +1,209 @@
+import {
+  useClick,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useListNavigation,
+  useRole,
+} from "@floating-ui/react";
+import classNames from "classnames";
+import { useRef, useState } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+
+interface CalendarSelectProps {
+  value: CalendarId | null;
+  onChange: (calendarId: CalendarId) => void;
+}
+
+// Only calendars the user can actually write to are offered as a create
+// target - a reader/freeBusy-only calendar would silently fail to accept a
+// new event.
+const getWritableCalendars = (calendars: Calendar[]): Calendar[] =>
+  calendars.filter(
+    (calendar) => calendar.isActive && calendar.capabilities.canWrite,
+  );
+
+// Primary first (it's the default target), then alphabetical - mirrors
+// PlannerCalendarList's sort so the same calendar lands in the same relative
+// position across the sidebar list and this picker.
+const sortWritableCalendars = (calendars: Calendar[]): Calendar[] =>
+  [...calendars].sort((a, b) => {
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+const calendarOptionLabel = (calendar: Calendar): string =>
+  calendar.isPrimary ? `${calendar.name} (primary)` : calendar.name;
+
+/**
+ * Labeled calendar picker for NEW/DUPLICATE event forms (writable calendars
+ * only). Existing-event forms never render this - A6 forbids moving a saved
+ * event between calendars, so the edit form shows read-only text instead
+ * (see EventForm.tsx).
+ *
+ * Follows SelectView.tsx's floating-ui pattern (useFloating +
+ * useListNavigation + useClick + useDismiss + useRole, roving tabindex, no
+ * FloatingFocusManager) rather than a generalized SelectView, since that
+ * component is view-switcher-specific and this field has its own writable-
+ * filter/no-calendar-state concerns.
+ */
+export const CalendarSelect = ({ value, onChange }: CalendarSelectProps) => {
+  const { data } = useCalendarsQuery();
+  const writableCalendars = sortWritableCalendars(
+    getWritableCalendars(data ?? []),
+  );
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const listRef = useRef<Array<HTMLElement | null>>([]);
+
+  const selectedCalendar =
+    writableCalendars.find((calendar) => calendar.id === value) ?? null;
+  // A fresh create-draft has no calendarId yet; showing/selecting the
+  // eventual default target here (rather than a blank control) is purely a
+  // display default - it doesn't write to the draft until the user actually
+  // picks something. useSaveEventForm.ts/useDraftActions.ts fall back to the
+  // same default target at submit time if the user never touches this.
+  const defaultCalendar = getDefaultTargetCalendar(writableCalendars) ?? null;
+  const displayedCalendar = selectedCalendar ?? defaultCalendar;
+  const displayedIndex = displayedCalendar
+    ? writableCalendars.findIndex(
+        (calendar) => calendar.id === displayedCalendar.id,
+      )
+    : -1;
+
+  const { refs, context } = useFloating({
+    open: isOpen,
+    onOpenChange: (open) => {
+      setIsOpen(open);
+      if (open) {
+        setActiveIndex(displayedIndex >= 0 ? displayedIndex : 0);
+      } else {
+        setActiveIndex(null);
+        listRef.current = [];
+      }
+    },
+  });
+
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const role = useRole(context, { role: "listbox" });
+  const listNavigation = useListNavigation(context, {
+    listRef,
+    activeIndex,
+    onNavigate: setActiveIndex,
+    loop: true,
+  });
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions(
+    [click, dismiss, role, listNavigation],
+  );
+
+  const selectCalendar = (calendar: Calendar) => {
+    onChange(calendar.id);
+    setIsOpen(false);
+  };
+
+  if (writableCalendars.length === 0) {
+    return (
+      <p className="my-1.5 text-status-error text-xs">
+        No writable calendar available
+      </p>
+    );
+  }
+
+  const dropdownId = "calendar-select-dropdown";
+  const buttonLabel = displayedCalendar
+    ? `Calendar: ${calendarOptionLabel(displayedCalendar)}`
+    : "Calendar";
+
+  return (
+    <div className="relative my-1.5">
+      <button
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-controls={isOpen ? dropdownId : undefined}
+        aria-label={buttonLabel}
+        className="c-focus-ring flex w-full items-center gap-2 rounded-xs px-1.5 py-1 text-left text-text-lighter text-xs hover:bg-text-lighter/10"
+        type="button"
+      >
+        <span
+          aria-hidden
+          className="size-2.5 shrink-0 rounded-full"
+          style={{
+            backgroundColor:
+              displayedCalendar?.backgroundColor ?? "transparent",
+          }}
+        />
+        <span className="min-w-0 flex-1 truncate">
+          {displayedCalendar
+            ? calendarOptionLabel(displayedCalendar)
+            : "Select a calendar"}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div
+          ref={refs.setFloating}
+          {...getFloatingProps({
+            onKeyDown: (e) => {
+              if (
+                activeIndex !== null &&
+                (e.key === "Enter" || e.key === " ")
+              ) {
+                e.preventDefault();
+                const calendar = writableCalendars[activeIndex];
+                if (calendar) {
+                  selectCalendar(calendar);
+                }
+              }
+            },
+          })}
+          id={dropdownId}
+          aria-label="Calendar"
+          className="absolute top-full left-0 z-50 mt-1 min-w-[200px] rounded border border-border-primary bg-bg-secondary py-1 shadow-lg"
+          role="listbox"
+        >
+          {writableCalendars.map((calendar, index) => {
+            const isSelected = calendar.id === displayedCalendar?.id;
+            const isActive = activeIndex === index;
+
+            return (
+              <div
+                key={calendar.id}
+                ref={(node) => {
+                  listRef.current[index] = node;
+                }}
+                {...getItemProps({
+                  onClick: () => selectCalendar(calendar),
+                  active: isActive,
+                })}
+                role="option"
+                aria-selected={isSelected}
+                tabIndex={isActive ? 0 : -1}
+                className={classNames(
+                  "flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors",
+                  isSelected ? "text-accent-primary" : "text-text-light",
+                  isActive ? "bg-text-lighter/10" : "hover:bg-text-lighter/10",
+                )}
+              >
+                <span
+                  aria-hidden
+                  className="size-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: calendar.backgroundColor }}
+                />
+                <span className="min-w-0 flex-1 truncate">
+                  {calendarOptionLabel(calendar)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/views/Forms/EventForm/EventForm.calendarSelect.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.calendarSelect.test.tsx
@@ -1,0 +1,144 @@
+import { HotkeyManager } from "@tanstack/react-hotkeys";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  createGridEventDraft,
+  editGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { EventForm } from "@web/views/Forms/EventForm/EventForm";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// This file covers EventForm's integration with CalendarSelect specifically
+// (packet 08 step 7) - EventForm.test.tsx already covers the form's other
+// behaviors and carries pre-existing lint warnings, so this is a sibling
+// file rather than an extension of it.
+
+const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Work",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+const createNewDraft = (): GridEventDraft =>
+  createGridEventDraft(
+    timedGridSchedule(
+      new Date("2026-07-13T09:00:00.000Z"),
+      new Date("2026-07-13T10:00:00.000Z"),
+    ),
+  );
+
+const renderEventForm = (
+  draft: GridEventDraft,
+  calendars: Calendar[],
+  overrides: { onSubmit?: (draft: GridEventDraft | null) => void } = {},
+) => {
+  const { queryClient, wrapper } = createStoreWrapper();
+  queryClient.setQueryData(calendarQueryKeys.all, calendars);
+
+  const onSubmit = overrides.onSubmit ?? mock();
+
+  const utils = render(
+    <EventForm
+      draft={draft}
+      isDraft={draft.kind === "create"}
+      isExistingEvent={draft.kind === "edit"}
+      onClose={mock()}
+      onDelete={mock()}
+      onDuplicate={mock()}
+      onSubmit={onSubmit}
+      setDraft={mock()}
+    />,
+    { wrapper },
+  );
+
+  return { onSubmit, ...utils };
+};
+
+describe("EventForm calendar selection", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+  });
+
+  it("renders the calendar combobox for a new-event draft and reflects the picked calendar in the submitted draft", async () => {
+    const user = userEvent.setup();
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const team = makeCalendar({ name: "Team" });
+    const onSubmit = mock();
+
+    renderEventForm(createNewDraft(), [primary, team], { onSubmit });
+
+    const trigger = screen.getByRole("combobox", { name: /Calendar:/ });
+    expect(trigger.getAttribute("aria-label")).toMatch(/Personal \(primary\)/);
+
+    await user.click(trigger);
+    await user.click(await screen.findByRole("option", { name: "Team" }));
+
+    const titleField = screen.getByPlaceholderText("Title");
+    titleField.focus();
+    await user.type(titleField, "Plan launch");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({ calendarId: team.id }),
+      }),
+    );
+  });
+
+  it("shows read-only calendar text (no combobox) when editing an existing event", () => {
+    const work = makeCalendar({ name: "Work" });
+    const event = createMockEvent({ calendarId: work.id });
+    const draft = editGridEventDraft(event);
+    if (!draft) throw new Error("expected an edit draft");
+
+    renderEventForm(draft, [work]);
+
+    expect(screen.getByText("Calendar: Work")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: /calendar/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("shows a no-writable-calendar message instead of a combobox when creating with only read-only calendars", () => {
+    const readOnly = makeCalendar({
+      name: "Holidays",
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+
+    renderEventForm(createNewDraft(), [readOnly]);
+
+    expect(
+      screen.getByText("No writable calendar available"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("combobox", { name: /calendar/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -1,9 +1,10 @@
 import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef, type SetStateAction, useState } from "react";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
@@ -161,7 +162,7 @@ describe("EventForm", () => {
   });
 
   it("renders the title before the actions on the same row", () => {
-    render(
+    renderWithStore(
       <EventForm
         draft={createEditDraft({ description: "Plan the launch" })}
         isDraft={false}
@@ -190,7 +191,7 @@ describe("EventForm", () => {
     const draft = createEditDraft();
     const onDuplicate = mock();
 
-    render(
+    renderWithStore(
       <EventForm
         draft={draft}
         isDraft={false}
@@ -219,7 +220,7 @@ describe("EventForm", () => {
     const onClose = mock();
     const onDelete = mock();
 
-    render(
+    renderWithStore(
       <EventForm
         draft={createNewDraft({ title: "Unsaved draft" })}
         isDraft={true}
@@ -242,7 +243,7 @@ describe("EventForm", () => {
     const onClose = mock();
     const onDelete = mock();
 
-    render(
+    renderWithStore(
       <EventForm
         draft={createEditDraft()}
         isDraft={false}
@@ -269,7 +270,7 @@ describe("EventForm", () => {
     const onClose = mock();
     const onDelete = mock();
 
-    render(
+    renderWithStore(
       <EventForm
         draft={createEditDraft({ description: "Plan the launch" })}
         isDraft={false}
@@ -296,7 +297,7 @@ describe("EventForm", () => {
     const onClose = mock();
     const onDelete = mock();
 
-    render(
+    renderWithStore(
       <EventForm
         draft={createEditDraft()}
         isDraft={false}
@@ -330,7 +331,7 @@ describe("EventForm", () => {
       timeZone: "UTC",
     });
 
-    const { rerender } = render(
+    const { rerender } = renderWithStore(
       <EventForm
         draft={draft}
         isDraft={false}
@@ -374,7 +375,7 @@ describe("EventForm", () => {
   it("lets an untouched empty draft title keep normal arrow-key behavior", () => {
     const draft = createNewDraft({ title: "" });
 
-    render(
+    renderWithStore(
       <EventForm
         draft={draft}
         isDraft={true}
@@ -396,7 +397,7 @@ describe("EventForm", () => {
   it("lets an untouched existing event title keep normal arrow-key behavior", () => {
     const draft = createEditDraft({ title: "Planning" });
 
-    render(
+    renderWithStore(
       <EventForm
         draft={draft}
         isDraft={false}
@@ -416,7 +417,7 @@ describe("EventForm", () => {
   });
 
   it("lets the description field keep normal arrow-key behavior", () => {
-    render(
+    renderWithStore(
       <EventForm
         draft={createEditDraft({ description: "Plan the launch" })}
         isDraft={false}
@@ -438,7 +439,7 @@ describe("EventForm", () => {
   it("lets directly edited existing event titles keep normal arrow-key behavior", () => {
     const draft = createEditDraft({ title: "Planning" });
 
-    render(
+    renderWithStore(
       <EventForm
         draft={draft}
         isDraft={false}
@@ -493,7 +494,7 @@ describe("EventForm", () => {
       );
     }
 
-    render(<Harness />);
+    renderWithStore(<Harness />);
 
     const titleField = screen.getByPlaceholderText("Title");
     titleField.focus();
@@ -513,7 +514,7 @@ describe("EventForm", () => {
     const user = userEvent.setup();
     const onSubmit = mock();
 
-    render(
+    renderWithStore(
       <EventForm
         draft={createEditDraft()}
         isDraft={true}
@@ -538,7 +539,7 @@ describe("EventForm", () => {
     const user = userEvent.setup();
     const onSubmit = mock();
 
-    render(
+    renderWithStore(
       <>
         <button type="button">Draft block</button>
         <EventForm
@@ -564,7 +565,7 @@ describe("EventForm", () => {
   it("exposes the title input ref to the parent", () => {
     const titleInputRef = createRef<HTMLInputElement>();
 
-    render(
+    renderWithStore(
       <EventForm
         draft={createEditDraft()}
         isDraft={true}

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -12,8 +12,10 @@ import {
   useState,
 } from "react";
 import { Priorities } from "@core/constants/core.constants";
+import { type CalendarId } from "@core/types/domain-primitives";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
+import { useCalendarLookup } from "@web/calendars/useCalendarLookup";
 import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
 import { darken } from "@web/common/styles/color.utils";
 import {
@@ -39,6 +41,7 @@ import {
   replaceGridDraftSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
 import { RecurrenceSection } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection";
@@ -142,6 +145,15 @@ export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
       draft.values.schedule.kind === "allDay"
         ? Categories_Event.ALLDAY
         : Categories_Event.TIMED;
+    // A6: an existing event's calendar is display-only here, never a move
+    // control - draft.source.calendarId is the only calendar an edit draft
+    // can show.
+    const calendarLookup = useCalendarLookup();
+    const originalCalendarName =
+      draft.kind === "edit"
+        ? (calendarLookup.get(draft.source.calendarId)?.name ??
+          "Unknown calendar")
+        : null;
     const latestDraftRef = useRef(draft);
     const eventStartDate = event.startDate as string;
     const eventEndDate = event.endDate as string;
@@ -232,6 +244,19 @@ export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
         setDraft(resolvedDraft);
       },
       [setDraft],
+    );
+
+    // Only a "create" draft (new or duplicate) can target a calendar; an
+    // "edit" draft's calendar is fixed (A6) and CalendarSelect isn't shown
+    // for it.
+    const onSelectCalendar = useCallback(
+      (calendarId: CalendarId) => {
+        setLatestDraft((current) => {
+          if (!current || current.kind !== "create") return current;
+          return { ...current, values: { ...current.values, calendarId } };
+        });
+      },
+      [setLatestDraft],
     );
 
     // Schema_Event-shaped writer for the still-unconverted DatePickers/
@@ -509,6 +534,17 @@ export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
           onSetEventField={onSetEventField}
           priority={priority}
         />
+
+        {draft.kind === "create" ? (
+          <CalendarSelect
+            onChange={onSelectCalendar}
+            value={draft.values.calendarId}
+          />
+        ) : (
+          <p className="my-1.5 text-text-light text-xs">
+            Calendar: {originalCalendarName}
+          </p>
+        )}
 
         <DateControlsSection
           dateTimeSectionProps={dateTimeSectionProps}

--- a/packages/web/src/views/Forms/hooks/useDuplicateEvent.ts
+++ b/packages/web/src/views/Forms/hooks/useDuplicateEvent.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { duplicateGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useEventById } from "@web/events/queries/useEventById";
 import { draftActions } from "@web/events/stores/draft.store";
@@ -12,11 +13,12 @@ import { useCloseEventForm } from "@web/views/Forms/hooks/useCloseEventForm";
 export function useDuplicateEvent(_id: string) {
   const event = useEventById(_id);
   const onClose = useCloseEventForm();
+  const { data: calendars } = useCalendarsQuery();
 
   const duplicateEvent = useCallback(() => {
     if (!event) return;
 
-    const duplicate = duplicateGridEventDraft(event);
+    const duplicate = duplicateGridEventDraft(event, calendars ?? []);
     if (!duplicate) return;
 
     onClose();
@@ -25,7 +27,7 @@ export function useDuplicateEvent(_id: string) {
     // floating reference, so the form anchors itself once mounted.
     draftActions.startGridDraft({ activity: "gridClick", draft: duplicate });
     draftActions.setFormOpen(true);
-  }, [event, onClose]);
+  }, [calendars, event, onClose]);
 
   return duplicateEvent;
 }

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
@@ -21,7 +21,12 @@ export function useSaveEventForm() {
       if (!draft) return closeEventForm();
 
       if (draft.kind === "create") {
-        const calendarId = getDefaultTargetCalendar(calendars ?? [])?.id;
+        // Respects a calendar the user explicitly chose via CalendarSelect;
+        // only an untouched draft (calendarId still null) falls back to the
+        // default target calendar.
+        const calendarId =
+          draft.values.calendarId ??
+          getDefaultTargetCalendar(calendars ?? [])?.id;
         if (!calendarId) return closeEventForm();
 
         const parsed = parseGridEventDraft({

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -287,7 +287,12 @@ export const useDraftActions = (
         case "CREATE": {
           if (draft.kind !== "create") return;
 
-          const calendarId = getDefaultTargetCalendar(calendars ?? [])?.id;
+          // Respects a calendar the user explicitly chose via CalendarSelect;
+          // only an untouched draft (calendarId still null) falls back to the
+          // default target calendar.
+          const calendarId =
+            draft.values.calendarId ??
+            getDefaultTargetCalendar(calendars ?? [])?.id;
           if (!calendarId) return;
 
           const parsed = parseGridEventDraft({
@@ -354,7 +359,10 @@ export const useDraftActions = (
       return;
     }
 
-    const duplicate = duplicateGridEventDraft(gridDraftFromStore.source);
+    const duplicate = duplicateGridEventDraft(
+      gridDraftFromStore.source,
+      calendars ?? [],
+    );
     if (!duplicate) {
       discard();
       return;
@@ -384,7 +392,7 @@ export const useDraftActions = (
 
     void submit(withRecurrence);
     discard();
-  }, [gridDraftFromStore, submit, discard]);
+  }, [calendars, gridDraftFromStore, submit, discard]);
 
   const isInsideVisibleWeek = useCallback(
     (start: Dayjs) => {

--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { theme } from "@web/common/styles/theme";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
@@ -26,6 +27,7 @@ import {
 } from "@web/views/Week/interaction/targeting/weekCalendarEventTargeting";
 
 interface Props {
+  calendarIdentity?: CalendarCardIdentity | null;
   deckLayout?: CalendarTimedDeckLayout | null;
   displayMode: GridEventDisplayMode;
   event: Schema_GridEvent;
@@ -47,6 +49,7 @@ type GridEventMotionMode = "dragging" | "idle" | "resizing";
 
 const GridEventBase = (
   {
+    calendarIdentity = null,
     deckLayout = null,
     displayMode,
     event: _event,
@@ -142,6 +145,7 @@ const GridEventBase = (
     <CalendarTimedEventCard
       onBlur={isDeck ? () => setIsFocused(false) : undefined}
       boxShadow={deckBoxShadow}
+      calendarIdentity={calendarIdentity}
       displayMode={displayMode}
       event={event}
       onFocus={isDeck ? () => setIsFocused(true) : undefined}
@@ -168,6 +172,7 @@ const GridEventBase = (
 export const GridEvent = forwardRef(GridEventBase);
 export const GridEventMemo = memo(GridEvent, (prev, next) => {
   return (
+    prev.calendarIdentity === next.calendarIdentity &&
     prev.displayMode === next.displayMode &&
     prev.deckLayout === next.deckLayout &&
     prev.event === next.event &&

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -1,5 +1,6 @@
 import { type ForwardedRef, forwardRef, type MouseEvent, memo } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { useSomedayCommitAcknowledgement } from "@web/components/PlannerSidebar/SomedayEventSections/interaction/state/somedayCommitAcknowledgementState";
 import { CalendarAllDayEventCard } from "@web/layout/calendar-grid/components/CalendarAllDayEventCard";
@@ -12,6 +13,7 @@ import {
 } from "@web/views/Week/interaction/targeting/weekCalendarEventTargeting";
 
 interface Props {
+  calendarIdentity?: CalendarCardIdentity | null;
   event: Schema_GridEvent;
   interactionAttributes?: Record<string, string | undefined>;
   isPlaceholder: boolean;
@@ -28,6 +30,7 @@ interface Props {
 
 const AllDayEventBase = (
   {
+    calendarIdentity = null,
     event,
     interactionAttributes,
     isPlaceholder,
@@ -68,6 +71,7 @@ const AllDayEventBase = (
 
   return (
     <CalendarAllDayEventCard
+      calendarIdentity={calendarIdentity}
       event={event}
       interactionAttributes={interactionAttributes}
       isCommitAcknowledged={shouldAcknowledgeCommit}
@@ -93,6 +97,7 @@ const AllDayEvent = forwardRef(AllDayEventBase);
 
 export const AllDayEventMemo = memo(AllDayEvent, (prev, next) => {
   return (
+    prev.calendarIdentity === next.calendarIdentity &&
     prev.event === next.event &&
     prev.interactionAttributes === next.interactionAttributes &&
     prev.isPlaceholder === next.isPlaceholder &&

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from "react";
 import { Categories_Event } from "@core/types/event.types";
+import {
+  type CalendarCardIdentity,
+  resolveCalendarCardIdentity,
+  useCalendarLookup,
+} from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
@@ -37,6 +42,8 @@ export const AllDayEvents = ({
   });
 
   const draftId = useDraftStore(selectDraftId);
+  // One lookup build for the whole list (packet 08 step 5) - not per card.
+  const calendarLookup = useCalendarLookup();
   // The query covers the full week; only mount events overlapping the visible
   // window so off-window events never land in the DOM or the interaction
   // registry.
@@ -46,6 +53,20 @@ export const AllDayEvents = ({
         isAllDayEventInVisibleDays(event, weekDays),
       ),
     [allDayEvents, weekDays],
+  );
+  // Resolved once per event here (not inside each card) and kept referentially
+  // stable across renders where neither the events nor the calendars changed,
+  // so AllDayEventMemo's per-card comparator doesn't over-invalidate.
+  const visibleAllDayEventsWithIdentity = useMemo(
+    () =>
+      visibleAllDayEvents.map((event) => ({
+        event,
+        calendarIdentity: resolveCalendarCardIdentity(
+          calendarLookup,
+          event.calendarId,
+        ),
+      })),
+    [visibleAllDayEvents, calendarLookup],
   );
 
   // NOT converted to GridEventDraft/editGridEventDraft: useDraftActions.ts
@@ -67,15 +88,25 @@ export const AllDayEvents = ({
       id={ID_GRID_EVENTS_ALLDAY}
     >
       {!isLoadingWeekView &&
-        visibleAllDayEvents.map((event: Schema_GridEvent) => {
+        visibleAllDayEventsWithIdentity.map(({ event, calendarIdentity }) => {
           const isPlaceholder = event._id === draftId;
           const eventForDisplay =
             isPlaceholder && draft && draft._id === event._id
               ? { ...event, ...draft }
               : event;
+          // The placeholder can carry a live (dragging/resizing) calendarId
+          // from the draft store; everything else reuses the stable,
+          // list-level resolved identity above.
+          const identityForDisplay = isPlaceholder
+            ? resolveCalendarCardIdentity(
+                calendarLookup,
+                eventForDisplay.calendarId,
+              )
+            : calendarIdentity;
 
           return (
             <AllDayEventItem
+              calendarIdentity={identityForDisplay}
               event={eventForDisplay}
               isPlaceholder={isPlaceholder}
               key={event._id}
@@ -90,6 +121,7 @@ export const AllDayEvents = ({
 };
 
 interface AllDayEventItemProps {
+  calendarIdentity: CalendarCardIdentity | null;
   event: Schema_GridEvent;
   isPlaceholder: boolean;
   measurements: Measurements_Grid;
@@ -98,6 +130,7 @@ interface AllDayEventItemProps {
 }
 
 const AllDayEventItem = ({
+  calendarIdentity,
   event,
   isPlaceholder,
   measurements,
@@ -124,6 +157,7 @@ const AllDayEventItem = ({
 
   return (
     <AllDayEventMemo
+      calendarIdentity={calendarIdentity}
       event={event}
       interactionAttributes={interactionAttributes}
       isPlaceholder={isPlaceholder}

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from "react";
 import { Categories_Event } from "@core/types/event.types";
+import {
+  type CalendarCardIdentity,
+  resolveCalendarCardIdentity,
+  useCalendarLookup,
+} from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_TIMED } from "@web/common/constants/web.constants";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
@@ -35,6 +40,8 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   });
   const draftId = useDraftStore(selectDraftId);
   const weekDays = weekProps.component.weekDays;
+  // One lookup build for the whole list (packet 08 step 5) - not per card.
+  const calendarLookup = useCalendarLookup();
   // The query covers the full week; only mount events for the visible window
   // so off-window events never land in the DOM or the interaction registry.
   const visibleTimedEvents = useMemo(
@@ -45,6 +52,20 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   const timedEventItems = useMemo(
     () => createCalendarTimedEventLayout(visibleTimedEvents),
     [visibleTimedEvents],
+  );
+  // Resolved once per event here (not inside each card) and kept referentially
+  // stable across renders where neither the events nor the calendars changed,
+  // so GridEventMemo's per-card comparator doesn't over-invalidate.
+  const timedEventItemsWithIdentity = useMemo(
+    () =>
+      timedEventItems.map((item) => ({
+        ...item,
+        calendarIdentity: resolveCalendarCardIdentity(
+          calendarLookup,
+          item.event.calendarId,
+        ),
+      })),
+    [timedEventItems, calendarLookup],
   );
   const category = Categories_Event.TIMED;
 
@@ -64,30 +85,43 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   return (
     <div id={ID_GRID_EVENTS_TIMED}>
       {!isLoadingWeekView &&
-        timedEventItems.map(({ deckLayout, event }) => {
-          const isPlaceholder = event._id === draftId;
-          const eventForDisplay =
-            isPlaceholder && draft && draft._id === event._id
-              ? { ...event, ...draft }
-              : event;
+        timedEventItemsWithIdentity.map(
+          ({ deckLayout, event, calendarIdentity }) => {
+            const isPlaceholder = event._id === draftId;
+            const eventForDisplay =
+              isPlaceholder && draft && draft._id === event._id
+                ? { ...event, ...draft }
+                : event;
+            // The placeholder can carry a live (dragging/resizing) calendarId
+            // from the draft store; everything else reuses the stable,
+            // list-level resolved identity above.
+            const identityForDisplay = isPlaceholder
+              ? resolveCalendarCardIdentity(
+                  calendarLookup,
+                  eventForDisplay.calendarId,
+                )
+              : calendarIdentity;
 
-          return (
-            <MainGridEventItem
-              deckLayout={deckLayout}
-              event={eventForDisplay}
-              isPlaceholder={isPlaceholder}
-              key={`initial-${event._id}`}
-              measurements={measurements}
-              onEventKeyDown={handleKeyDown}
-              weekProps={weekProps}
-            />
-          );
-        })}
+            return (
+              <MainGridEventItem
+                calendarIdentity={identityForDisplay}
+                deckLayout={deckLayout}
+                event={eventForDisplay}
+                isPlaceholder={isPlaceholder}
+                key={`initial-${event._id}`}
+                measurements={measurements}
+                onEventKeyDown={handleKeyDown}
+                weekProps={weekProps}
+              />
+            );
+          },
+        )}
     </div>
   );
 };
 
 interface MainGridEventItemProps {
+  calendarIdentity: CalendarCardIdentity | null;
   deckLayout: CalendarTimedDeckLayout | null;
   event: Schema_GridEvent;
   isPlaceholder: boolean;
@@ -97,6 +131,7 @@ interface MainGridEventItemProps {
 }
 
 const MainGridEventItem = ({
+  calendarIdentity,
   deckLayout,
   event,
   isPlaceholder,
@@ -123,6 +158,7 @@ const MainGridEventItem = ({
 
   return (
     <GridEventMemo
+      calendarIdentity={calendarIdentity}
       deckLayout={deckLayout}
       displayMode={isPlaceholder ? "placeholder" : "saved"}
       event={event}


### PR DESCRIPTION
## Summary

Packet 08 phase 2 of 5: calendar identity on every event surface + the target-calendar picker (packet 08 steps 5-7). Builds on #2062.

- **Calendar identity on cards** (step 6): timed, all-day, day, week, and someday cards render a narrow `aria-hidden` accent strip in the calendar's color and append `, <name> calendar` to their accessible labels. Priority remains the card fill and the *name* — never the color — is the accessible identity (A9). Single-calendar accounts render no accent (nothing to distinguish).
- **Memoized lookup** (step 5): `useCalendarLookup` builds one `Map<CalendarId, Calendar>` per calendars-query result; list components resolve identity once per event and pass it to the memoized cards as a prop, so no N×M scans and no broken memo comparators.
- **Threading**: core `Event.calendarId` was dropped by the legacy `Event → Schema_Event → Schema_GridEvent` bridge. It now joins back onto `Schema_GridEvent` after `assembleGridEvent` as a **type-only** addition — `CalendarIdSchema` is zod v4 while the legacy grid schemas are v3, and extending a v3 shape with a v4 field schema crashes at parse time (caught by pre-existing tests). Draft placeholders carry it through `gridEventDraftToSchemaEvent` so drag/resize keeps the accent.
- **CalendarSelect** (step 7): a labeled combobox on NEW and DUPLICATE forms following `SelectView`'s floating-ui listbox pattern — writable calendars only, primary marked, Enter/arrows/Escape keyboard flow, effect-free display default (the default target), and an honest "No writable calendar available" state. Duplicates default to the source calendar when still writable. **Edit forms show read-only "Calendar: <name>" text — never a move control (A6).**
- **Bug fix**: both create-submit paths (`useSaveEventForm`, `useDraftActions`) unconditionally overwrote the draft's calendarId with the default target — any explicit selection was silently discarded. They now prefer the draft's choice and fall back to the default only when untouched.

## Testing

18 new web tests across five files: card labels with/without resolved identity (timed/all-day/someday), single-vs-multi calendar accent gating, combobox writable-only listing + primary marking + selection-to-submitted-input, duplicate defaulting (writable source vs read-only fallback), edit-mode read-only text, no-writable state, and full keyboard flow.

- `bun test:web`: 1291 pass / 0 fail (201 files).
- Backend untouched (`git diff --stat` is all web): 69 suites, 641 passed / 1 pre-existing skip.
- `bun run type-check` clean; `bun run lint` steady at the 15 pre-existing warnings (zero added).

Part of `handoff/someday/08-web-calendar-experience.md` (next: web read-only mode + busy-content rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)