### PR TITLE
feat: query freebusy availability for reader-only calendars end to end

### DIFF
--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
@@ -17,6 +17,7 @@ import {
   type gSchema$Event,
   type gSchema$EventBase,
   type gSchema$Events,
+  type gSchema$FreeBusyResponse,
   type WithGcalId,
 } from "@core/types/gcal";
 import { Resource_Sync } from "@core/types/sync.types";
@@ -476,6 +477,29 @@ export const mockGcal = ({
               Status.NO_CONTENT,
               "OK",
               params.requestBody!.address!,
+            ),
+          ),
+      ),
+    },
+    freebusy: {
+      ...calendarClient.freebusy,
+      // Default to "nobody's busy" - no shared compassTestState() slot exists
+      // for freebusy (unlike events/calendarlist), so tests that care about a
+      // specific busy response override this per-test with
+      // `jest.spyOn(gcalService, "queryFreeBusy")` instead of reaching down
+      // into this mock (see calendar.service.test.ts's getAvailability
+      // describe block).
+      query: jest.fn(
+        async (
+          _params: calendar_v3.Params$Resource$Freebusy$Query,
+          options: MethodOptions = {},
+        ): GaxiosPromise<gSchema$FreeBusyResponse> =>
+          Promise.resolve(
+            createMockGaxiosResponse<gSchema$FreeBusyResponse>(
+              { calendars: {} },
+              options,
+              200,
+              "OK",
             ),
           ),
       ),

--- a/packages/backend/src/calendar/calendar.routes.config.ts
+++ b/packages/backend/src/calendar/calendar.routes.config.ts
@@ -19,6 +19,11 @@ export class CalendarRoutes extends CommonRoutesConfig {
       .all(verifySession())
       .put(calendarController.setVisibility);
 
+    this.app
+      .route(`/api/calendars/availability`)
+      .all(verifySession())
+      .get(calendarController.availability);
+
     return this.app;
   }
 }

--- a/packages/backend/src/calendar/controllers/calendar.controller.test.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.test.ts
@@ -1,0 +1,89 @@
+import { ObjectId } from "mongodb";
+import { type SessionRequest } from "supertokens-node/framework/express";
+import { BaseError } from "@core/errors/errors.base";
+import { Status } from "@core/errors/status.codes";
+import { type AvailabilityResponse } from "@core/types/event-command.contracts";
+import calendarController from "@backend/calendar/controllers/calendar.controller";
+import calendarService from "@backend/calendar/services/calendar.service";
+import { type Res_Promise } from "@backend/common/types/express.types";
+
+// These exercise calendarController.availability directly against fake
+// req/res objects (no supertest), mirroring events.controller.test.ts - the
+// route itself is a one-line wire-up (calendar.routes.config.ts) and the
+// business logic under test (query parsing, the A7 62-day bound,
+// ownership/visibility) belongs to the controller and calendarService
+// respectively. calendarService.getAvailability's own owned/visible/
+// freeBusyReader/google-error behavior is covered in calendar.service.test.ts;
+// this file only pins the controller's request-shape parsing and its
+// backend-only range bound.
+
+describe("CalendarController availability", () => {
+  const userId = "507f1f77bcf86cd799439011";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const buildReq = (query: Record<string, string>): SessionRequest =>
+    ({
+      query,
+      session: { getUserId: () => userId },
+    }) as unknown as SessionRequest;
+
+  const buildRes = () => {
+    const promise = jest.fn();
+    return { promise } as unknown as Res_Promise;
+  };
+
+  it("parses comma-separated calendarIds and forwards start/end to calendarService.getAvailability", async () => {
+    const availabilityResponse: AvailabilityResponse = { busyPeriods: [] };
+    const getAvailabilitySpy = jest
+      .spyOn(calendarService, "getAvailability")
+      .mockResolvedValue(availabilityResponse);
+
+    const req = buildReq({
+      calendarIds: "507f1f77bcf86cd799439012,507f1f77bcf86cd799439013",
+      start: "2024-01-15T00:00:00.000Z",
+      end: "2024-01-16T00:00:00.000Z",
+    });
+    const res = buildRes();
+
+    await calendarController.availability(req, res);
+
+    expect(getAvailabilitySpy).toHaveBeenCalledWith(
+      expect.any(ObjectId),
+      expect.objectContaining({
+        calendarIds: ["507f1f77bcf86cd799439012", "507f1f77bcf86cd799439013"],
+        start: "2024-01-15T00:00:00.000Z",
+        end: "2024-01-16T00:00:00.000Z",
+      }),
+    );
+    expect(res.promise).toHaveBeenCalledWith(availabilityResponse);
+  });
+
+  it("rejects a range longer than 62 days with a 400, without calling calendarService.getAvailability (A7 bounded)", async () => {
+    const getAvailabilitySpy = jest.spyOn(calendarService, "getAvailability");
+
+    const req = buildReq({
+      calendarIds: "507f1f77bcf86cd799439012",
+      start: "2024-01-01T00:00:00.000Z",
+      end: "2024-05-01T00:00:00.000Z", // ~121 days, well past the 62-day bound
+    });
+    const res = buildRes();
+
+    await calendarController.availability(req, res);
+
+    expect(getAvailabilitySpy).not.toHaveBeenCalled();
+    expect(res.promise).toHaveBeenCalledTimes(1);
+
+    const rejection = (res.promise as jest.Mock).mock
+      .calls[0]?.[0] as Promise<unknown>;
+    await expect(rejection).rejects.toBeInstanceOf(BaseError);
+    await rejection.catch((e) => {
+      expect((e as BaseError).statusCode).toBe(Status.BAD_REQUEST);
+      // `error()`'s second arg lands on `.result`, not `.message` (the first
+      // arg's `.description` does) - see error.handler.ts.
+      expect((e as BaseError).result).toMatch(/62 days/i);
+    });
+  });
+});

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -3,15 +3,55 @@ import {
   type CalendarListResponse,
   SetCalendarVisibilityInputSchema,
 } from "@core/types/calendar.contracts";
+import {
+  type AvailabilityQuery,
+  AvailabilityQuerySchema,
+} from "@core/types/event-command.contracts";
 import { zObjectId } from "@core/types/type.utils";
 import { mapCalendarRecord } from "@backend/calendar/calendar.record.mapper";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
+import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import {
   type Res_Promise,
   type SReqBody,
 } from "@backend/common/types/express.types";
+
+// A7 "bounded": AvailabilityQuerySchema (core) only enforces end > start, not
+// a maximum span - an unbounded range would let one request fan a Google
+// freebusy call out across an arbitrary window. Kept as a small local check
+// rather than a core-contract change (packet 08 phase 4).
+const MAX_AVAILABILITY_RANGE_DAYS = 62;
+
+const assertBoundedAvailabilityRange = (query: AvailabilityQuery) => {
+  const rangeMs = Date.parse(query.end) - Date.parse(query.start);
+  const maxMs = MAX_AVAILABILITY_RANGE_DAYS * 24 * 60 * 60 * 1000;
+
+  if (rangeMs > maxMs) {
+    throw error(
+      GenericError.BadRequest,
+      `Availability range must not exceed ${MAX_AVAILABILITY_RANGE_DAYS} days`,
+    );
+  }
+};
+
+// calendarIds travels as a single comma-separated query param (mirrors
+// EventListQuery's `priorities`, see event.controller.ts's parseListQuery) -
+// the web api client (availability.api.ts) must format requests this way.
+const parseAvailabilityQuery = (query: SessionRequest["query"]) => {
+  const calendarIdsParam = query["calendarIds"];
+  const calendarIds =
+    typeof calendarIdsParam === "string" && calendarIdsParam.length > 0
+      ? calendarIdsParam.split(",")
+      : [];
+
+  return AvailabilityQuerySchema.parse({
+    calendarIds,
+    start: query["start"],
+    end: query["end"],
+  });
+};
 
 class CalendarController {
   list = async (req: SessionRequest, res: Res_Promise) => {
@@ -41,6 +81,24 @@ class CalendarController {
       await calendarService.setVisibility(userId, items);
 
       res.promise({ statusCode: 204 });
+    } catch (e) {
+      res.promise(Promise.reject(e));
+    }
+  };
+
+  availability = async (req: SessionRequest, res: Res_Promise) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId(), {
+        error: () =>
+          error(AuthError.InadequatePermissions, "Availability Failed"),
+      });
+
+      const query = parseAvailabilityQuery(req.query);
+      assertBoundedAvailabilityRange(query);
+
+      const response = await calendarService.getAvailability(userId, query);
+
+      res.promise(response);
     } catch (e) {
       res.promise(Promise.reject(e));
     }

--- a/packages/backend/src/calendar/services/calendar.service.test.ts
+++ b/packages/backend/src/calendar/services/calendar.service.test.ts
@@ -1,4 +1,6 @@
 import { ObjectId } from "mongodb";
+import { type CalendarAccess } from "@core/types/calendar.contracts";
+import { AvailabilityQuerySchema } from "@core/types/event-command.contracts";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
   cleanupCollections,
@@ -8,6 +10,7 @@ import {
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
+import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 
 describe("CalendarService", () => {
@@ -29,6 +32,45 @@ describe("CalendarService", () => {
       isVisible: true,
       isActive: true,
       source: { provider: "local" },
+      createdAt: new Date(),
+      updatedAt: null,
+    });
+    await mongoService.calendar.insertOne(record);
+    return record;
+  };
+
+  const seedGoogleCalendar = async (
+    userId: ObjectId,
+    overrides: {
+      access?: CalendarAccess;
+      googleCalendarId?: string;
+      isActive?: boolean;
+      isVisible?: boolean;
+    } = {},
+  ) => {
+    const {
+      access = "freeBusyReader",
+      googleCalendarId = `google-cal-${new ObjectId().toHexString()}`,
+      isActive = true,
+      isVisible = true,
+    } = overrides;
+    const record = CalendarRecordSchema.parse({
+      _id: new ObjectId(),
+      userId,
+      name: "Shared calendar",
+      description: "",
+      timeZone: null,
+      foregroundColor: "#000000",
+      backgroundColor: "#ffffff",
+      access,
+      isPrimary: false,
+      isVisible,
+      isActive,
+      source: {
+        provider: "google",
+        calendarId: googleCalendarId,
+        etag: "etag-1",
+      },
       createdAt: new Date(),
       updatedAt: null,
     });
@@ -180,6 +222,196 @@ describe("CalendarService", () => {
       expect(result.deletedCount).toBeGreaterThan(0);
       const remaining = await calendarService.list(user._id.toString());
       expect(remaining).toHaveLength(0);
+    });
+  });
+
+  describe("getAvailability", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("merges busy periods from multiple freeBusyReader calendars, mapped back to compass ids", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const calendarA = await seedGoogleCalendar(user._id, {
+        googleCalendarId: "google-a",
+      });
+      const calendarB = await seedGoogleCalendar(user._id, {
+        googleCalendarId: "google-b",
+      });
+      jest.spyOn(gcalService, "queryFreeBusy").mockResolvedValue({
+        calendars: {
+          "google-a": {
+            busy: [
+              {
+                start: "2024-01-15T09:00:00.000Z",
+                end: "2024-01-15T10:00:00.000Z",
+              },
+            ],
+          },
+          "google-b": {
+            busy: [
+              {
+                start: "2024-01-15T11:00:00.000Z",
+                end: "2024-01-15T12:00:00.000Z",
+              },
+            ],
+          },
+        },
+      });
+
+      const query = AvailabilityQuerySchema.parse({
+        calendarIds: [calendarA._id.toHexString(), calendarB._id.toHexString()],
+        start: "2024-01-15T00:00:00.000Z",
+        end: "2024-01-16T00:00:00.000Z",
+      });
+
+      const response = await calendarService.getAvailability(
+        user._id.toString(),
+        query,
+      );
+
+      expect(response.busyPeriods).toHaveLength(2);
+      expect(response.busyPeriods).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            calendarId: calendarA._id.toHexString(),
+            start: "2024-01-15T09:00:00.000Z",
+            end: "2024-01-15T10:00:00.000Z",
+          }),
+          expect.objectContaining({
+            calendarId: calendarB._id.toHexString(),
+            start: "2024-01-15T11:00:00.000Z",
+            end: "2024-01-15T12:00:00.000Z",
+          }),
+        ]),
+      );
+    });
+
+    it("rejects a writer calendar's id (busy time must come from its synced events, not freebusy)", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const writerCalendar = await seedGoogleCalendar(user._id, {
+        access: "writer",
+      });
+      const queryFreeBusySpy = jest.spyOn(gcalService, "queryFreeBusy");
+
+      const query = AvailabilityQuerySchema.parse({
+        calendarIds: [writerCalendar._id.toHexString()],
+        start: "2024-01-15T00:00:00.000Z",
+        end: "2024-01-16T00:00:00.000Z",
+      });
+
+      await expect(
+        calendarService.getAvailability(user._id.toString(), query),
+      ).rejects.toThrow();
+      expect(queryFreeBusySpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects an id for a calendar the user does not own", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const { user: otherUser } = await UtilDriver.setupTestUser();
+      const othersCalendar = await seedGoogleCalendar(otherUser._id);
+
+      const query = AvailabilityQuerySchema.parse({
+        calendarIds: [othersCalendar._id.toHexString()],
+        start: "2024-01-15T00:00:00.000Z",
+        end: "2024-01-16T00:00:00.000Z",
+      });
+
+      await expect(
+        calendarService.getAvailability(user._id.toString(), query),
+      ).rejects.toThrow();
+    });
+
+    it("filters a hidden freeBusyReader calendar out of the request instead of rejecting it", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const visibleCalendar = await seedGoogleCalendar(user._id, {
+        googleCalendarId: "google-visible",
+      });
+      const hiddenCalendar = await seedGoogleCalendar(user._id, {
+        googleCalendarId: "google-hidden",
+        isVisible: false,
+      });
+      const queryFreeBusySpy = jest
+        .spyOn(gcalService, "queryFreeBusy")
+        .mockResolvedValue({
+          calendars: {
+            "google-visible": {
+              busy: [
+                {
+                  start: "2024-01-15T09:00:00.000Z",
+                  end: "2024-01-15T10:00:00.000Z",
+                },
+              ],
+            },
+          },
+        });
+
+      const query = AvailabilityQuerySchema.parse({
+        calendarIds: [
+          visibleCalendar._id.toHexString(),
+          hiddenCalendar._id.toHexString(),
+        ],
+        start: "2024-01-15T00:00:00.000Z",
+        end: "2024-01-16T00:00:00.000Z",
+      });
+
+      const response = await calendarService.getAvailability(
+        user._id.toString(),
+        query,
+      );
+
+      expect(response.busyPeriods).toEqual([
+        expect.objectContaining({
+          calendarId: visibleCalendar._id.toHexString(),
+        }),
+      ]);
+      expect(queryFreeBusySpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ gCalendarIds: ["google-visible"] }),
+      );
+    });
+
+    it("treats a per-calendar Google freebusy error as an empty busy list for that calendar", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const okCalendar = await seedGoogleCalendar(user._id, {
+        googleCalendarId: "google-ok",
+      });
+      const erroringCalendar = await seedGoogleCalendar(user._id, {
+        googleCalendarId: "google-erroring",
+      });
+      jest.spyOn(gcalService, "queryFreeBusy").mockResolvedValue({
+        calendars: {
+          "google-ok": {
+            busy: [
+              {
+                start: "2024-01-15T09:00:00.000Z",
+                end: "2024-01-15T10:00:00.000Z",
+              },
+            ],
+          },
+          "google-erroring": {
+            errors: [{ domain: "calendar", reason: "notFound" }],
+          },
+        },
+      });
+
+      const query = AvailabilityQuerySchema.parse({
+        calendarIds: [
+          okCalendar._id.toHexString(),
+          erroringCalendar._id.toHexString(),
+        ],
+        start: "2024-01-15T00:00:00.000Z",
+        end: "2024-01-16T00:00:00.000Z",
+      });
+
+      const response = await calendarService.getAvailability(
+        user._id.toString(),
+        query,
+      );
+
+      expect(response.busyPeriods).toEqual([
+        expect.objectContaining({ calendarId: okCalendar._id.toHexString() }),
+      ]);
     });
   });
 });

--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -5,14 +5,30 @@ import {
   type ClientSession,
   type ObjectId,
 } from "mongodb";
+import { Logger } from "@core/logger/winston.logger";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type BusyPeriod, BusyPeriodSchema } from "@core/types/event.contracts";
+import {
+  type AvailabilityQuery,
+  type AvailabilityResponse,
+  AvailabilityResponseSchema,
+} from "@core/types/event-command.contracts";
 import { Resource_Sync } from "@core/types/sync.types";
 import { zObjectId } from "@core/types/type.utils";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { mapGoogleCalendar } from "@backend/calendar/calendar.record.mapper";
-import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
+import { GenericError } from "@backend/common/errors/generic/generic.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import {
+  createGoogleRequestContext,
+  type GoogleRequestContext,
+} from "@backend/common/services/gcal/gcal.context";
+import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { getCalendarsToSync } from "@backend/sync/services/init/google-sync-init";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
+
+const logger = Logger("app:calendar.service");
 
 class CalendarService {
   /**
@@ -304,6 +320,101 @@ class CalendarService {
       userId: zObjectId.parse(userId),
       isActive: true,
     });
+  };
+
+  /**
+   * Resolves compass calendar ids -> BusyPeriod[] via Google's freebusy API
+   * (packet 08 phase 4; A7). Strict-parse ethos: every requested id must
+   * resolve to a calendar this user owns that's active, google-sourced, and
+   * freeBusyReader specifically - an owner/writer/reader calendar's busy
+   * time is already derivable from its synced events, so re-querying
+   * freebusy for it here would just double it up and cost an extra Google
+   * round trip. A hidden calendar is filtered out silently rather than
+   * rejected (mirrors packet 08 step 4's read filtering) - the server must
+   * never leak a hidden calendar's busy time even if the client still asks
+   * for it mid visibility-toggle.
+   */
+  getAvailability = async (
+    userId: ObjectId | string,
+    query: AvailabilityQuery,
+  ): Promise<AvailabilityResponse> => {
+    const userObjectId = zObjectId.parse(userId);
+    const requestedIds = query.calendarIds.map((id) => zObjectId.parse(id));
+
+    const records = await mongoService.calendar
+      .find({ _id: { $in: requestedIds }, userId: userObjectId })
+      .toArray();
+    const recordById = new Map(
+      records.map((record) => [record._id.toHexString(), record]),
+    );
+
+    const resolved = requestedIds.map((id) => {
+      const record = recordById.get(id.toHexString());
+      const isOwnedFreeBusyReaderCalendar =
+        !!record &&
+        record.isActive &&
+        record.source.provider === "google" &&
+        record.access === "freeBusyReader";
+
+      if (!isOwnedFreeBusyReaderCalendar) {
+        throw error(
+          GenericError.BadRequest,
+          "Availability can only be queried for the user's own active freeBusyReader Google calendars",
+        );
+      }
+
+      return record;
+    });
+
+    const visible = resolved.filter((record) => record.isVisible);
+    if (visible.length === 0) {
+      return { busyPeriods: [] };
+    }
+
+    const googleIdToCompassId = new Map<string, CalendarId>();
+    for (const record of visible) {
+      if (record.source.provider === "google") {
+        googleIdToCompassId.set(
+          record.source.calendarId,
+          record._id.toHexString() as CalendarId,
+        );
+      }
+    }
+
+    const context = await createGoogleRequestContext(userObjectId.toString());
+    const response = await gcalService.queryFreeBusy(context, {
+      timeMin: query.start,
+      timeMax: query.end,
+      gCalendarIds: [...googleIdToCompassId.keys()],
+    });
+
+    const busyPeriods: BusyPeriod[] = [];
+    for (const [googleId, compassId] of googleIdToCompassId) {
+      const calendarResult = response.calendars?.[googleId];
+      if (!calendarResult) continue;
+
+      if (calendarResult.errors && calendarResult.errors.length > 0) {
+        // Never log the google calendar id - compassId is the safe handle.
+        logger.warn(
+          `getAvailability: Google returned a freebusy error for calendar ${compassId}`,
+        );
+        continue;
+      }
+
+      for (const busy of calendarResult.busy ?? []) {
+        if (!busy.start || !busy.end) continue;
+
+        busyPeriods.push(
+          BusyPeriodSchema.parse({
+            calendarId: compassId,
+            start: busy.start,
+            end: busy.end,
+          }),
+        );
+      }
+    }
+
+    return AvailabilityResponseSchema.parse({ busyPeriods });
   };
 
   /**

--- a/packages/backend/src/common/services/gcal/gcal.service.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.test.ts
@@ -241,6 +241,11 @@ describe("gcal.service quotaUser passthrough (packet 07 step 7 pin)", () => {
       channels: {
         stop: jest.fn().mockResolvedValue({ status: 204, data: {} }),
       },
+      freebusy: {
+        query: jest
+          .fn()
+          .mockResolvedValue({ status: 200, data: { calendars: {} } }),
+      },
     },
     quotaUser: QUOTA_USER,
   } as unknown as GoogleRequestContext;
@@ -299,6 +304,16 @@ describe("gcal.service quotaUser passthrough (packet 07 step 7 pin)", () => {
       method: "getEvents",
       call: () => gcalService.getEvents(context, { calendarId: "cal-1" }),
       mock: () => context.gcal.events.list as jest.Mock,
+    },
+    {
+      method: "queryFreeBusy",
+      call: () =>
+        gcalService.queryFreeBusy(context, {
+          timeMin: "2024-01-01T00:00:00.000Z",
+          timeMax: "2024-01-02T00:00:00.000Z",
+          gCalendarIds: ["cal-1"],
+        }),
+      mock: () => context.gcal.freebusy.query as jest.Mock,
     },
     {
       method: "patchEvent",

--- a/packages/backend/src/common/services/gcal/gcal.service.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.ts
@@ -6,6 +6,7 @@ import {
   type gSchema$CalendarList,
   type gSchema$Event,
   type gSchema$Events,
+  type gSchema$FreeBusyResponse,
 } from "@core/types/gcal";
 import {
   type Params_WatchEvents,
@@ -164,6 +165,32 @@ class GCalService {
     );
 
     return this.validateGCalResponse(response);
+  }
+
+  /**
+   * Bounded free/busy lookup for a set of Google calendars (packet 08 phase
+   * 4; A7). Unlike getEvents, this never returns event details - Google
+   * collapses each calendar down to a list of opaque busy time ranges, which
+   * is exactly what a freeBusyReader grant exposes. Range bounding (A7
+   * "bounded") is enforced by the caller (calendar.controller's availability
+   * handler), not here - this method just forwards whatever window it's given.
+   */
+  async queryFreeBusy(
+    { gcal, quotaUser }: GoogleRequestContext,
+    params: { timeMin: string; timeMax: string; gCalendarIds: string[] },
+  ): Promise<gSchema$FreeBusyResponse> {
+    const response = await withGoogleRetry(() =>
+      gcal.freebusy.query({
+        quotaUser,
+        requestBody: {
+          timeMin: params.timeMin,
+          timeMax: params.timeMax,
+          items: params.gCalendarIds.map((id) => ({ id })),
+        },
+      }),
+    );
+
+    return this.validateGCalResponse(response).data;
   }
 
   async *getBaseRecurringEventInstances({

--- a/packages/core/src/types/gcal.d.ts
+++ b/packages/core/src/types/gcal.d.ts
@@ -27,6 +27,8 @@ export declare type gSchema$EventInstance = WithGcalId<
 
 export declare type gSchema$Events = calendar_v3.Schema$Events;
 export declare type gSchema$Events$Union = gSchema$Events | gSchema$Events[];
+export declare type gSchema$FreeBusyResponse =
+  calendar_v3.Schema$FreeBusyResponse;
 export declare type gSchema$ErrorReason = {
   reason?: string;
 };

--- a/packages/web/src/calendars/availability.api.ts
+++ b/packages/web/src/calendars/availability.api.ts
@@ -1,0 +1,36 @@
+import { type CalendarId } from "@core/types/domain-primitives";
+import {
+  type AvailabilityResponse,
+  AvailabilityResponseSchema,
+} from "@core/types/event-command.contracts";
+import { BaseApi } from "@web/api/base/base.api";
+
+export interface AvailabilityQueryParams {
+  calendarIds: CalendarId[];
+  start: string;
+  end: string;
+}
+
+// calendarIds travels as a single comma-separated query param (mirrors
+// EventApi's `priorities` - see event.api.ts's buildListQueryString). The
+// backend (calendar.controller.ts's parseAvailabilityQuery) parses the exact
+// same format.
+const AvailabilityApi = {
+  query: async ({
+    calendarIds,
+    start,
+    end,
+  }: AvailabilityQueryParams): Promise<AvailabilityResponse> => {
+    const params = new URLSearchParams();
+    params.set("calendarIds", calendarIds.join(","));
+    params.set("start", start);
+    params.set("end", end);
+
+    const response = await BaseApi.get<unknown>(
+      `/calendars/availability?${params.toString()}`,
+    );
+    return AvailabilityResponseSchema.parse(response.data);
+  },
+};
+
+export { AvailabilityApi };

--- a/packages/web/src/calendars/availability.query.test.ts
+++ b/packages/web/src/calendars/availability.query.test.ts
@@ -1,0 +1,110 @@
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { deriveAvailabilityCalendarIds } from "./availability.query";
+import { describe, expect, it } from "bun:test";
+
+function makeCalendar(overrides: Partial<Calendar> = {}): Calendar {
+  const access = overrides.access ?? "freeBusyReader";
+
+  return {
+    id: "507f1f77bcf86cd799439011" as Calendar["id"],
+    name: "Cal",
+    description: "",
+    timeZone: null,
+    foregroundColor: "#000000",
+    backgroundColor: "#ffffff",
+    provider: "google",
+    access,
+    capabilities: getCalendarCapabilities(access),
+    isPrimary: false,
+    isVisible: true,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe("deriveAvailabilityCalendarIds", () => {
+  it("returns an empty array when calendars data hasn't loaded yet", () => {
+    expect(deriveAvailabilityCalendarIds(undefined)).toEqual([]);
+  });
+
+  it("returns an empty array when there are no calendars", () => {
+    expect(deriveAvailabilityCalendarIds([])).toEqual([]);
+  });
+
+  it("includes an active, visible freeBusyReader calendar", () => {
+    const calendar = makeCalendar({
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+
+    expect(deriveAvailabilityCalendarIds([calendar])).toEqual([calendar.id]);
+  });
+
+  it("excludes a hidden freeBusyReader calendar", () => {
+    const hidden = makeCalendar({
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+      isVisible: false,
+    });
+
+    expect(deriveAvailabilityCalendarIds([hidden])).toEqual([]);
+  });
+
+  it("excludes an inactive freeBusyReader calendar", () => {
+    const inactive = makeCalendar({
+      id: "507f1f77bcf86cd799439014" as Calendar["id"],
+      isActive: false,
+    });
+
+    expect(deriveAvailabilityCalendarIds([inactive])).toEqual([]);
+  });
+
+  it("excludes an event-capable (writer) calendar - its busy time already comes from synced events", () => {
+    const writer = makeCalendar({
+      id: "507f1f77bcf86cd799439015" as Calendar["id"],
+      access: "writer",
+      capabilities: getCalendarCapabilities("writer"),
+    });
+
+    expect(deriveAvailabilityCalendarIds([writer])).toEqual([]);
+  });
+
+  it("excludes an owner calendar and a reader calendar the same way", () => {
+    const owner = makeCalendar({
+      id: "507f1f77bcf86cd799439016" as Calendar["id"],
+      access: "owner",
+      capabilities: getCalendarCapabilities("owner"),
+    });
+    const reader = makeCalendar({
+      id: "507f1f77bcf86cd799439017" as Calendar["id"],
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+
+    expect(deriveAvailabilityCalendarIds([owner, reader])).toEqual([]);
+  });
+
+  it("picks only the qualifying calendars out of a visible/hidden/writer mix", () => {
+    const qualifyingVisible = makeCalendar({
+      id: "507f1f77bcf86cd799439018" as Calendar["id"],
+    });
+    const hiddenFreeBusy = makeCalendar({
+      id: "507f1f77bcf86cd799439019" as Calendar["id"],
+      isVisible: false,
+    });
+    const writer = makeCalendar({
+      id: "507f1f77bcf86cd79943901a" as Calendar["id"],
+      access: "writer",
+      capabilities: getCalendarCapabilities("writer"),
+    });
+
+    expect(
+      deriveAvailabilityCalendarIds([
+        qualifyingVisible,
+        hiddenFreeBusy,
+        writer,
+      ]),
+    ).toEqual([qualifyingVisible.id]);
+  });
+});

--- a/packages/web/src/calendars/availability.query.ts
+++ b/packages/web/src/calendars/availability.query.ts
@@ -1,0 +1,69 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { AvailabilityApi } from "@web/calendars/availability.api";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+
+const AVAILABILITY_STALE_TIME_MS = 5 * 60_000;
+
+export interface AvailabilityRange {
+  start: string;
+  end: string;
+}
+
+/**
+ * The calendars whose busy time is worth querying: active, currently
+ * VISIBLE (packet 08 step 4's read filtering applies here too - a hidden
+ * calendar's busy time must not render), and freeBusyReader specifically -
+ * an owner/writer/reader calendar already surfaces its busy time as real
+ * synced events, so re-querying free/busy for it here would just double it
+ * up (A7). Exported standalone (not inlined into the hook below) so a test
+ * can derive the exact same id set - and therefore the exact same query key -
+ * from a seeded calendars list without duplicating this filter.
+ */
+export function deriveAvailabilityCalendarIds(
+  calendars: Calendar[] | undefined,
+): CalendarId[] {
+  if (!calendars) return [];
+
+  return calendars
+    .filter(
+      (calendar) =>
+        calendar.isActive &&
+        calendar.isVisible &&
+        calendar.access === "freeBusyReader",
+    )
+    .map((calendar) => calendar.id);
+}
+
+export function availabilityQueryOptions({
+  calendarIds,
+  start,
+  end,
+}: AvailabilityRange & { calendarIds: CalendarId[] }) {
+  return queryOptions({
+    queryKey: ["availability", { calendarIds, start, end }] as const,
+    queryFn: () => AvailabilityApi.query({ calendarIds, start, end }),
+    enabled: calendarIds.length > 0,
+    staleTime: AVAILABILITY_STALE_TIME_MS,
+  });
+}
+
+/**
+ * Renders busy blocks best-effort only (packet 08 phase 4; A7): there are no
+ * push notifications for free/busy, so a short staleTime plus TanStack's
+ * default refetch-on-window-focus is the whole freshness story here - no
+ * polling loop, no SSE wiring. calendarIds are derived from the calendars
+ * query, so hiding a calendar re-keys this query naturally (the hidden
+ * calendar just stops appearing in calendarIds) with zero cache surgery.
+ */
+export function useAvailabilityQuery({ start, end }: AvailabilityRange) {
+  const { data: calendars } = useCalendarsQuery();
+  const calendarIds = useMemo(
+    () => deriveAvailabilityCalendarIds(calendars),
+    [calendars],
+  );
+
+  return useQuery(availabilityQueryOptions({ calendarIds, start, end }));
+}

--- a/packages/web/src/common/constants/web.constants.ts
+++ b/packages/web/src/common/constants/web.constants.ts
@@ -37,6 +37,11 @@ export const CLASS_MONTH_SOMEDAY_EVENT = "month-someday-event";
 export const SOMEDAY_EVENT_HEIGHT = 28;
 
 export enum ZIndex {
+  // Below LAYER_1 (the default saved-event-card z-index) so a freeBusy
+  // decoration block never paints over a real event card sharing its slot
+  // (packet 08 phase 4; A7 - busy blocks are inert decoration, never a
+  // stand-in for the real event).
+  BUSY_PERIOD = 0,
   LAYER_1 = 1,
   LAYER_2 = 2,
   LAYER_3 = 3,

--- a/packages/web/src/layout/calendar-grid/components/CalendarBusyPeriodBlock.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarBusyPeriodBlock.tsx
@@ -1,0 +1,43 @@
+import { type CSSProperties } from "react";
+import { ZIndex } from "@web/common/constants/web.constants";
+import { type CalendarEventPosition } from "@web/layout/calendar-grid/types/calendarGrid.types";
+
+interface CalendarBusyPeriodBlockProps {
+  ariaLabel: string;
+  position: CalendarEventPosition;
+}
+
+/**
+ * Inert decoration only (packet 08 phase 4; A7): a freeBusyReader calendar
+ * only ever exposes aggregate free/busy ranges, never event details, so this
+ * block carries no title, no click/keyboard handlers, and no context menu -
+ * there is nothing here for the drag/resize engine or any event action to
+ * attach to. `pointer-events-none` backs that structurally (clicks/right-
+ * clicks pass through to whatever's underneath) rather than relying on the
+ * absence of handlers alone. `role="img"` gives it a single accessible name
+ * (mirrors AsciiPortrait.tsx / SomedayEventRectangle.tsx) without exposing
+ * it as an interactive control - never `role="button"`.
+ */
+export const CalendarBusyPeriodBlock = ({
+  ariaLabel,
+  position,
+}: CalendarBusyPeriodBlockProps) => {
+  const style: CSSProperties = {
+    backgroundImage:
+      "repeating-linear-gradient(135deg, var(--color-panel-badge-bg) 0px, var(--color-panel-badge-bg) 4px, transparent 4px, transparent 9px)",
+    height: position.height || 0,
+    left: position.left,
+    top: position.top,
+    width: position.width || 0,
+    zIndex: position.zIndex ?? ZIndex.BUSY_PERIOD,
+  };
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      className="pointer-events-none absolute overflow-hidden rounded-xs border border-border-primary bg-panel-badge-bg"
+      role="img"
+      style={style}
+    />
+  );
+};

--- a/packages/web/src/layout/calendar-grid/layout/calendarBusyPeriodLayout.test.ts
+++ b/packages/web/src/layout/calendar-grid/layout/calendarBusyPeriodLayout.test.ts
@@ -1,0 +1,114 @@
+import { type BusyPeriod, BusyPeriodSchema } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { splitBusyPeriodsByDay } from "./calendarBusyPeriodLayout";
+import { describe, expect, it } from "bun:test";
+
+const weekVisibleDates = Array.from({ length: 7 }, (_, index) => {
+  const date = dayjs("2026-05-17T00:00:00.000").add(index, "day");
+
+  return { date, key: date.format("YYYY-MM-DD") };
+});
+
+// Overrides take plain strings (not branded CalendarId/DateTime) - parsing
+// through BusyPeriodSchema brands them, so callers below don't need an `as`
+// cast per fixture.
+const makeBusyPeriod = (
+  overrides: Partial<{ calendarId: string; start: string; end: string }> = {},
+): BusyPeriod =>
+  BusyPeriodSchema.parse({
+    calendarId: "507f1f77bcf86cd799439011",
+    start: "2026-05-19T09:00:00.000Z",
+    end: "2026-05-19T10:00:00.000Z",
+    ...overrides,
+  });
+
+describe("splitBusyPeriodsByDay", () => {
+  it("produces one segment for a period contained within a single day", () => {
+    const period = makeBusyPeriod();
+
+    const segments = splitBusyPeriodsByDay([period], weekVisibleDates);
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]?.calendarId).toBe(period.calendarId);
+    // dayjs' .format() round-trips "Z" to "+00:00" - both are valid
+    // DateTimeSchema values, so compare instants rather than raw strings.
+    expect(dayjs(segments[0]?.start).isSame(dayjs(period.start))).toBe(true);
+    expect(dayjs(segments[0]?.end).isSame(dayjs(period.end))).toBe(true);
+  });
+
+  it("splits a two-day period into two segments, each clamped to its day's boundary", () => {
+    const period = makeBusyPeriod({
+      start: "2026-05-19T20:00:00.000Z",
+      end: "2026-05-20T04:00:00.000Z",
+    });
+
+    const segments = splitBusyPeriodsByDay([period], weekVisibleDates);
+
+    expect(segments).toHaveLength(2);
+
+    // Segments serialize via dayjs' bare .format() (matches toUTCOffset
+    // elsewhere in the app), which omits milliseconds - so a boundary at
+    // endOf("day") (…23:59:59.999) round-trips as …23:59:59.000. Irrelevant
+    // to rendering (position math diffs in whole minutes), so these compare
+    // at "second" granularity rather than exact instants.
+    const [first, second] = segments;
+    expect(dayjs(first?.start).isSame(dayjs(period.start), "second")).toBe(
+      true,
+    );
+    expect(
+      dayjs(first?.end).isSame(dayjs("2026-05-19T23:59:59.999Z"), "second"),
+    ).toBe(true);
+    expect(
+      dayjs(second?.start).isSame(dayjs("2026-05-20T00:00:00.000Z"), "second"),
+    ).toBe(true);
+    expect(dayjs(second?.end).isSame(dayjs(period.end), "second")).toBe(true);
+  });
+
+  it("splits a period spanning several full days into one segment per day", () => {
+    const period = makeBusyPeriod({
+      start: "2026-05-18T00:00:00.000Z",
+      end: "2026-05-21T00:00:00.000Z",
+    });
+
+    const segments = splitBusyPeriodsByDay([period], weekVisibleDates);
+
+    // 05-18, 05-19, 05-20 each get a full-day segment; the period ends
+    // exactly at 05-21's midnight, so it doesn't overlap that day.
+    expect(segments).toHaveLength(3);
+    expect(segments.map((segment) => segment.key)).toEqual([
+      expect.stringContaining("2026-05-18"),
+      expect.stringContaining("2026-05-19"),
+      expect.stringContaining("2026-05-20"),
+    ]);
+  });
+
+  it("produces no segments for a period entirely outside the visible days", () => {
+    const period = makeBusyPeriod({
+      start: "2026-06-01T09:00:00.000Z",
+      end: "2026-06-01T10:00:00.000Z",
+    });
+
+    expect(splitBusyPeriodsByDay([period], weekVisibleDates)).toEqual([]);
+  });
+
+  it("keeps segments from different calendars independent", () => {
+    const calendarA = makeBusyPeriod({
+      calendarId: "507f1f77bcf86cd799439011",
+    });
+    const calendarB = makeBusyPeriod({
+      calendarId: "507f1f77bcf86cd799439012",
+      start: "2026-05-19T11:00:00.000Z",
+      end: "2026-05-19T12:00:00.000Z",
+    });
+
+    const segments = splitBusyPeriodsByDay(
+      [calendarA, calendarB],
+      weekVisibleDates,
+    );
+
+    expect(segments).toHaveLength(2);
+    expect(new Set(segments.map((segment) => segment.calendarId))).toEqual(
+      new Set([calendarA.calendarId, calendarB.calendarId]),
+    );
+  });
+});

--- a/packages/web/src/layout/calendar-grid/layout/calendarBusyPeriodLayout.ts
+++ b/packages/web/src/layout/calendar-grid/layout/calendarBusyPeriodLayout.ts
@@ -1,0 +1,55 @@
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type BusyPeriod } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { type CalendarGridVisibleDate } from "@web/layout/calendar-grid/types/calendarGrid.types";
+
+export interface CalendarBusyPeriodDaySegment {
+  calendarId: CalendarId;
+  end: string;
+  key: string;
+  start: string;
+}
+
+/**
+ * Splits each BusyPeriod into one segment per visible day it overlaps,
+ * clamped to that day's [00:00, 24:00) window (packet 08 phase 4; A7). A
+ * period that spans multiple days (or a full day) becomes multiple
+ * same-calendar segments rather than one block that visually spills across
+ * day columns - segments are then positioned independently by
+ * {@link getCalendarBusyPeriodPosition} (calendarEventPosition.ts), the same
+ * way each day of a recurring event gets its own card.
+ */
+export const splitBusyPeriodsByDay = (
+  busyPeriods: BusyPeriod[],
+  visibleDates: CalendarGridVisibleDate[],
+): CalendarBusyPeriodDaySegment[] => {
+  const segments: CalendarBusyPeriodDaySegment[] = [];
+
+  for (const period of busyPeriods) {
+    const periodStart = dayjs(period.start);
+    const periodEnd = dayjs(period.end);
+
+    for (const { date: day, key: dayKey } of visibleDates) {
+      const dayStart = day.startOf("day");
+      const dayEnd = day.endOf("day");
+      const overlapsDay =
+        periodStart.isBefore(dayEnd) && periodEnd.isAfter(dayStart);
+      if (!overlapsDay) continue;
+
+      const segmentStart = periodStart.isAfter(dayStart)
+        ? periodStart
+        : dayStart;
+      const segmentEnd = periodEnd.isBefore(dayEnd) ? periodEnd : dayEnd;
+      if (!segmentEnd.isAfter(segmentStart)) continue;
+
+      segments.push({
+        calendarId: period.calendarId,
+        end: segmentEnd.format(),
+        key: `${period.calendarId}-${period.start}-${period.end}-${dayKey}`,
+        start: segmentStart.format(),
+      });
+    }
+  }
+
+  return segments;
+};

--- a/packages/web/src/layout/calendar-grid/layout/calendarEventPosition.ts
+++ b/packages/web/src/layout/calendar-grid/layout/calendarEventPosition.ts
@@ -55,6 +55,50 @@ export const getCalendarTimedEventPosition = (
   };
 };
 
+export interface CalendarBusyPeriodPositionInput {
+  measurements: CalendarGridMeasurements;
+  visibleDates: CalendarGridVisibleDate[];
+}
+
+/**
+ * Positions an already day-clamped {start, end} segment, reusing the same
+ * column/hour math as {@link getCalendarTimedEventPosition} (left/width from
+ * colWidths, top/height from minutes-of-day) minus its widthMultiplier/deck
+ * concerns - busy blocks never overlap-fan like event cards, they just
+ * render at full column width. Callers (MainGridBusyPeriods /
+ * DayCalendarBusyPeriods) clamp a possibly multi-day BusyPeriod to one day's
+ * [00:00, 24:00) window per call via splitBusyPeriodsByDay before reaching
+ * here, so `segment.start`/`segment.end` are always within a single day
+ * (packet 08 phase 4; A7). A full-day busy range still renders as one tall
+ * timed block per day rather than in the all-day row - acceptable for v1.
+ */
+export const getCalendarBusyPeriodPosition = (
+  segment: { start: string; end: string },
+  input: CalendarBusyPeriodPositionInput,
+): CalendarEventPosition => {
+  const start = dayjs(segment.start);
+  const end = dayjs(segment.end);
+  const dateIndex = getVisibleDateIndex(start, input.visibleDates);
+  if (dateIndex === null) {
+    return zeroPosition();
+  }
+
+  const columnLeft = sumWidthsBefore(input.measurements.colWidths, dateIndex);
+  const columnWidth = input.measurements.colWidths[dateIndex] ?? 0;
+  const minutesFromStartOfDay = start.diff(start.startOf("day"), "minute");
+  const durationMinutes = Math.max(1, end.diff(start, "minute"));
+
+  return {
+    height: (durationMinutes / 60) * input.measurements.hourHeight,
+    left:
+      CALENDAR_GRID_MARGIN_LEFT +
+      columnLeft +
+      CALENDAR_TIMED_EVENT_COLUMN_INSET,
+    top: (minutesFromStartOfDay / 60) * input.measurements.hourHeight,
+    width: Math.max(0, columnWidth - CALENDAR_TIMED_EVENT_COLUMN_INSET * 2),
+  };
+};
+
 export const getCalendarAllDayEventPosition = (
   event: Schema_GridEvent,
   input: CalendarEventPositionInput,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { type PropsWithChildren, useState } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { type BusyPeriod, BusyPeriodSchema } from "@core/types/event.contracts";
+import { type AvailabilityResponse } from "@core/types/event-command.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { cleanup, render, screen } from "@web/__tests__/__mocks__/mock.render";
+import { createCompassQueryClient } from "@web/api/query-client";
+import {
+  availabilityQueryOptions,
+  deriveAvailabilityCalendarIds,
+} from "@web/calendars/availability.query";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { type CalendarGridMeasurements } from "@web/layout/calendar-grid/types/calendarGrid.types";
+import { DayCalendarBusyPeriodsLayer } from "./DayCalendarBusyPeriods";
+import { afterEach, describe, expect, it } from "bun:test";
+
+let seededCalendars: Calendar[] = [];
+let seededBusyPeriods: BusyPeriod[] = [];
+
+const dateInView = dayjs("2026-05-20T00:00:00.000");
+const visibleDates = [
+  { date: dateInView, key: dateInView.format(YEAR_MONTH_DAY_FORMAT) },
+];
+const measurements = {
+  allDayRow: null,
+  colWidths: [180],
+  hourHeight: 60,
+  mainGrid: {
+    bottom: 780,
+    height: 780,
+    left: 0,
+    right: 180,
+    top: 0,
+    width: 180,
+    x: 0,
+    y: 0,
+  },
+} satisfies CalendarGridMeasurements;
+
+// useState initializer, matching MainGridBusyPeriods.test.tsx's Provider -
+// seeding in the render body would rebuild an empty client on every
+// re-render (see that file's comment for why that's a real, CI-only bug).
+function Provider({ children }: PropsWithChildren) {
+  const [queryClient] = useState(() => {
+    const client = createCompassQueryClient();
+    client.setQueryData(calendarQueryKeys.all, seededCalendars);
+
+    const calendarIds = deriveAvailabilityCalendarIds(seededCalendars);
+    const start = dateInView.startOf("day").utc(true).format();
+    const end = dateInView.endOf("day").utc(true).format();
+    const response: AvailabilityResponse = { busyPeriods: seededBusyPeriods };
+    client.setQueryData(
+      availabilityQueryOptions({ calendarIds, start, end }).queryKey,
+      response,
+    );
+
+    return client;
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  seededCalendars = [];
+  seededBusyPeriods = [];
+});
+
+const makeFreeBusyCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Team Offsite",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "freeBusyReader",
+  capabilities: getCalendarCapabilities("freeBusyReader"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+const renderLayer = () =>
+  render(
+    <Provider>
+      <DayCalendarBusyPeriodsLayer
+        dateInView={dateInView}
+        measurements={measurements}
+        visibleDates={visibleDates}
+      />
+    </Provider>,
+  );
+
+describe("DayCalendarBusyPeriodsLayer", () => {
+  it("renders a busy block with the calendar name and time range in its aria-label", () => {
+    const calendar = makeFreeBusyCalendar();
+    seededCalendars = [calendar];
+    seededBusyPeriods = [
+      BusyPeriodSchema.parse({
+        calendarId: calendar.id,
+        start: "2026-05-20T09:00:00.000Z",
+        end: "2026-05-20T10:00:00.000Z",
+      }),
+    ];
+
+    renderLayer();
+
+    expect(
+      screen.getByRole("img", {
+        name: /busy, team offsite calendar, .*9.*10.*am/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders no busy blocks when the only seeded calendar is a hidden freeBusyReader calendar", () => {
+    // deriveAvailabilityCalendarIds excludes it (own unit tests in
+    // availability.query.test.ts cover the filter itself), so
+    // useAvailabilityQuery's derived calendarIds is empty here - this pins
+    // that the render path correctly shows nothing for that disabled query,
+    // not just that the id-derivation function does.
+    const hiddenCalendar = makeFreeBusyCalendar({ isVisible: false });
+    seededCalendars = [hiddenCalendar];
+    seededBusyPeriods = [];
+
+    renderLayer();
+
+    expect(
+      screen.queryByRole("img", { name: /busy/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { useAvailabilityQuery } from "@web/calendars/availability.query";
+import { useCalendarLookup } from "@web/calendars/useCalendarLookup";
+import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
+import { CalendarBusyPeriodBlock } from "@web/layout/calendar-grid/components/CalendarBusyPeriodBlock";
+import { splitBusyPeriodsByDay } from "@web/layout/calendar-grid/layout/calendarBusyPeriodLayout";
+import { getCalendarBusyPeriodPosition } from "@web/layout/calendar-grid/layout/calendarEventPosition";
+import {
+  type CalendarGridMeasurements,
+  type CalendarGridVisibleDate,
+} from "@web/layout/calendar-grid/types/calendarGrid.types";
+
+const ID_GRID_BUSY_PERIODS = "busyPeriods";
+
+interface Props {
+  dateInView: Dayjs;
+  measurements: CalendarGridMeasurements;
+  visibleDates: CalendarGridVisibleDate[];
+}
+
+/**
+ * Day-grid counterpart to MainGridBusyPeriods (packet 08 phase 4; A7):
+ * renders freeBusyReader calendars' busy time as inert decoration in the day
+ * timed grid, mounted beside DayCalendarTimedEventsLayer. Matches
+ * DayCalendarGrid's own event-range convention
+ * (dateInView.startOf/endOf("day").utc(true).format()) so the availability
+ * range agrees with the day events query. Renders nothing while the
+ * availability query is loading/errored/disabled.
+ */
+export const DayCalendarBusyPeriodsLayer = ({
+  dateInView,
+  measurements,
+  visibleDates,
+}: Props) => {
+  const start = useMemo(
+    () => dateInView.startOf("day").utc(true).format(),
+    [dateInView],
+  );
+  const end = useMemo(
+    () => dateInView.endOf("day").utc(true).format(),
+    [dateInView],
+  );
+  const { data } = useAvailabilityQuery({ start, end });
+  const calendarLookup = useCalendarLookup();
+  const segments = useMemo(
+    () => splitBusyPeriodsByDay(data?.busyPeriods ?? [], visibleDates),
+    [data, visibleDates],
+  );
+
+  return (
+    <div id={ID_GRID_BUSY_PERIODS}>
+      {segments.map((segment) => {
+        const position = getCalendarBusyPeriodPosition(segment, {
+          measurements,
+          visibleDates,
+        });
+        const calendarName =
+          calendarLookup.get(segment.calendarId)?.name ?? "Calendar";
+
+        return (
+          <CalendarBusyPeriodBlock
+            ariaLabel={`Busy, ${calendarName} calendar, ${getTimesLabel(segment.start, segment.end)}`}
+            key={segment.key}
+            position={position}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -41,6 +41,7 @@ import {
   type EventFormProps,
   useEventForm,
 } from "@web/views/Forms/hooks/useEventForm";
+import { DayCalendarBusyPeriodsLayer } from "./DayCalendarBusyPeriods";
 import { useDayCalendarContextMenu } from "./DayCalendarContextMenu";
 import {
   DayCalendarAllDayEventsLayer,
@@ -305,15 +306,29 @@ export function DayCalendarGrid() {
   );
   const timedEventsLayer = useMemo(
     () => (
-      <DayCalendarTimedEventsLayer
-        events={timedEvents}
-        draft={draft}
-        measurements={measurements}
-        onOpenEvent={openEventFormForEvent}
-        visibleDates={visibleDates}
-      />
+      <>
+        <DayCalendarBusyPeriodsLayer
+          dateInView={dateInView}
+          measurements={measurements}
+          visibleDates={visibleDates}
+        />
+        <DayCalendarTimedEventsLayer
+          events={timedEvents}
+          draft={draft}
+          measurements={measurements}
+          onOpenEvent={openEventFormForEvent}
+          visibleDates={visibleDates}
+        />
+      </>
     ),
-    [draft, measurements, openEventFormForEvent, timedEvents, visibleDates],
+    [
+      dateInView,
+      draft,
+      measurements,
+      openEventFormForEvent,
+      timedEvents,
+      visibleDates,
+    ],
   );
 
   return (

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.tsx
@@ -3,6 +3,7 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { type Ref_Callback } from "@web/common/types/util.types";
 import { CalendarTimedGrid } from "@web/layout/calendar-grid/components/CalendarTimedGrid";
+import { MainGridBusyPeriods } from "@web/views/Week/components/Grid/MainGrid/MainGridBusyPeriods";
 import { MainGridEvents } from "@web/views/Week/components/Grid/MainGrid/MainGridEvents";
 import { type DateCalcs } from "@web/views/Week/hooks/grid/useDateCalcs";
 import { useDragEventSmartScroll } from "@web/views/Week/hooks/grid/useDragEventSmartScroll";
@@ -88,7 +89,15 @@ const MainGridChildren: FC<MainGridChildrenProps> = ({
   weekProps,
 }) => {
   const timedEventsLayer = useMemo(
-    () => <MainGridEvents measurements={measurements} weekProps={weekProps} />,
+    () => (
+      <>
+        <MainGridBusyPeriods
+          measurements={measurements}
+          weekProps={weekProps}
+        />
+        <MainGridEvents measurements={measurements} weekProps={weekProps} />
+      </>
+    ),
     [measurements, weekProps],
   );
 
@@ -124,7 +133,15 @@ const MainGridCalendar: FC<MainGridCalendarProps> = ({
   weekProps,
 }) => {
   const timedEventsLayer = useMemo(
-    () => <MainGridEvents measurements={measurements} weekProps={weekProps} />,
+    () => (
+      <>
+        <MainGridBusyPeriods
+          measurements={measurements}
+          weekProps={weekProps}
+        />
+        <MainGridEvents measurements={measurements} weekProps={weekProps} />
+      </>
+    ),
     [measurements, weekProps],
   );
 

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridBusyPeriods.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridBusyPeriods.test.tsx
@@ -1,0 +1,206 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { type PropsWithChildren, useState } from "react";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import {
+  type CalendarId,
+  CalendarIdSchema,
+} from "@core/types/domain-primitives";
+import { type BusyPeriod, BusyPeriodSchema } from "@core/types/event.contracts";
+import { type AvailabilityResponse } from "@core/types/event-command.contracts";
+import dayjs from "@core/util/date/dayjs";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@web/__tests__/__mocks__/mock.render";
+import { createCompassQueryClient } from "@web/api/query-client";
+import {
+  availabilityQueryOptions,
+  deriveAvailabilityCalendarIds,
+} from "@web/calendars/availability.query";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { useDraftStore } from "@web/events/stores/draft.store";
+import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
+import { WEEK_INTERACTION_EVENT_ID_ATTRIBUTE } from "@web/views/Week/interaction/registry/weekEventRegistry";
+import { MainGridBusyPeriods } from "./MainGridBusyPeriods";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+let seededCalendars: Calendar[] = [];
+let seededBusyPeriods: BusyPeriod[] = [];
+
+const startOfView = dayjs("2024-01-14T00:00:00.000");
+const weekProps = {
+  component: {
+    category: "current" as const,
+    endOfView: startOfView.endOf("week"),
+    isCurrentWeek: true,
+    startOfView,
+    week: startOfView.week(),
+    weekDays: Array.from({ length: 7 }, (_, index) =>
+      startOfView.add(index, "day"),
+    ),
+  },
+  state: { goToDate: mock() },
+  util: {
+    decrementWeek: mock(),
+    getLastNavigationSource: mock(() => "manual" as const),
+    goToToday: mock(),
+    incrementWeek: mock(),
+    shiftViewByDay: mock(),
+  },
+};
+
+const measurements = {
+  allDayRow: null,
+  colWidths: [100, 100, 100, 100, 100, 100, 100],
+  hourHeight: 60,
+  mainGrid: {
+    bottom: 780,
+    height: 780,
+    left: 0,
+    right: 700,
+    top: 0,
+    width: 700,
+    x: 0,
+    y: 0,
+  },
+} satisfies Measurements_Grid;
+
+// useState initializer: exactly one client per mounted tree (matches
+// eventReadOnlyInteraction.test.tsx's Provider) - seeding in the render body
+// would rebuild an empty client on every re-render and the fresh cache would
+// then really try to fetch /api/calendars and /api/calendars/availability
+// (no handlers here), a timing-dependent failure on slow CI runners.
+function Provider({ children }: PropsWithChildren) {
+  const [queryClient] = useState(() => {
+    const client = createCompassQueryClient();
+    client.setQueryData(calendarQueryKeys.all, seededCalendars);
+
+    const calendarIds = deriveAvailabilityCalendarIds(seededCalendars);
+    const start = toUTCOffset(weekProps.component.startOfView);
+    const end = toUTCOffset(weekProps.component.endOfView);
+    const response: AvailabilityResponse = { busyPeriods: seededBusyPeriods };
+    client.setQueryData(
+      availabilityQueryOptions({ calendarIds, start, end }).queryKey,
+      response,
+    );
+
+    return client;
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  seededCalendars = [];
+  seededBusyPeriods = [];
+});
+
+const makeFreeBusyCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Team Offsite",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "freeBusyReader",
+  capabilities: getCalendarCapabilities("freeBusyReader"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+const makeBusyPeriod = (
+  calendarId: CalendarId,
+  overrides: Partial<{ start: string; end: string }> = {},
+): BusyPeriod =>
+  BusyPeriodSchema.parse({
+    calendarId,
+    start: "2024-01-15T09:00:00.000Z",
+    end: "2024-01-15T10:00:00.000Z",
+    ...overrides,
+  });
+
+const renderMainGridBusyPeriods = () =>
+  render(
+    <Provider>
+      <MainGridBusyPeriods measurements={measurements} weekProps={weekProps} />
+    </Provider>,
+  );
+
+describe("MainGridBusyPeriods", () => {
+  it("renders a busy block with the calendar name and time range in its aria-label", () => {
+    const calendar = makeFreeBusyCalendar();
+    seededCalendars = [calendar];
+    seededBusyPeriods = [makeBusyPeriod(calendar.id)];
+
+    renderMainGridBusyPeriods();
+
+    expect(
+      screen.getByRole("img", {
+        name: /busy, team offsite calendar, .*9.*10.*am/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders no interactive affordances and does nothing to the draft store on click", () => {
+    const calendar = makeFreeBusyCalendar();
+    seededCalendars = [calendar];
+    seededBusyPeriods = [makeBusyPeriod(calendar.id)];
+
+    renderMainGridBusyPeriods();
+
+    const block = screen.getByRole("img", { name: /busy/i });
+    expect(block).not.toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE);
+    expect(
+      screen.queryByRole("button", { name: /busy/i }),
+    ).not.toBeInTheDocument();
+
+    const draftBefore = useDraftStore.getState();
+    fireEvent.mouseDown(block, { button: 0, buttons: 1 });
+    fireEvent.click(block);
+    const draftAfter = useDraftStore.getState();
+
+    expect(draftAfter.status?.activity ?? null).toBe(
+      draftBefore.status?.activity ?? null,
+    );
+    expect(draftAfter.event).toBe(draftBefore.event);
+  });
+
+  it("splits a multi-day busy period into one block per day column", () => {
+    const calendar = makeFreeBusyCalendar();
+    seededCalendars = [calendar];
+    seededBusyPeriods = [
+      makeBusyPeriod(calendar.id, {
+        start: "2024-01-15T20:00:00.000Z",
+        end: "2024-01-16T04:00:00.000Z",
+      }),
+    ];
+
+    renderMainGridBusyPeriods();
+
+    expect(screen.getAllByRole("img", { name: /busy/i })).toHaveLength(2);
+  });
+
+  it("renders no busy blocks when there are no qualifying freeBusyReader calendars (query stays disabled)", () => {
+    seededCalendars = [];
+    seededBusyPeriods = [];
+
+    renderMainGridBusyPeriods();
+
+    expect(
+      screen.queryByRole("img", { name: /busy/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridBusyPeriods.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridBusyPeriods.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { useAvailabilityQuery } from "@web/calendars/availability.query";
+import { useCalendarLookup } from "@web/calendars/useCalendarLookup";
+import {
+  getTimesLabel,
+  toUTCOffset,
+} from "@web/common/utils/datetime/web.date.util";
+import { CalendarBusyPeriodBlock } from "@web/layout/calendar-grid/components/CalendarBusyPeriodBlock";
+import { splitBusyPeriodsByDay } from "@web/layout/calendar-grid/layout/calendarBusyPeriodLayout";
+import { getCalendarBusyPeriodPosition } from "@web/layout/calendar-grid/layout/calendarEventPosition";
+import { type CalendarGridVisibleDate } from "@web/layout/calendar-grid/types/calendarGrid.types";
+import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
+import { type WeekProps } from "@web/views/Week/hooks/useWeek";
+
+const ID_GRID_BUSY_PERIODS = "busyPeriods";
+
+interface Props {
+  measurements: Measurements_Grid;
+  weekProps: WeekProps;
+}
+
+/**
+ * Sibling layer to MainGridEvents rendering freeBusyReader calendars' busy
+ * time as inert decoration (packet 08 phase 4; A7) - no event actions, no
+ * leaked details. Queries the full week (mirrors MainGridEvents fetching the
+ * whole week via useWeekEventViewModel) so the query key doesn't churn as
+ * the responsive visible-day window resizes; a multi-day busy period is
+ * split and clamped per visible day column by splitBusyPeriodsByDay. Renders
+ * nothing while the availability query is loading/errored/disabled -
+ * best-effort decoration only, never a loading state of its own.
+ */
+export const MainGridBusyPeriods = ({ measurements, weekProps }: Props) => {
+  const { component } = weekProps;
+  const start = useMemo(
+    () => toUTCOffset(component.startOfView),
+    [component.startOfView],
+  );
+  const end = useMemo(
+    () => toUTCOffset(component.endOfView),
+    [component.endOfView],
+  );
+  const { data } = useAvailabilityQuery({ start, end });
+  const calendarLookup = useCalendarLookup();
+  const visibleDates: CalendarGridVisibleDate[] = useMemo(
+    () =>
+      component.weekDays.map((date) => ({
+        date,
+        key: date.format(YEAR_MONTH_DAY_FORMAT),
+      })),
+    [component.weekDays],
+  );
+  const segments = useMemo(
+    () => splitBusyPeriodsByDay(data?.busyPeriods ?? [], visibleDates),
+    [data, visibleDates],
+  );
+
+  return (
+    <div id={ID_GRID_BUSY_PERIODS}>
+      {segments.map((segment) => {
+        const position = getCalendarBusyPeriodPosition(segment, {
+          measurements,
+          visibleDates,
+        });
+        const calendarName =
+          calendarLookup.get(segment.calendarId)?.name ?? "Calendar";
+
+        return (
+          <CalendarBusyPeriodBlock
+            ariaLabel={`Busy, ${calendarName} calendar, ${getTimesLabel(segment.start, segment.end)}`}
+            key={segment.key}
+            position={position}
+          />
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Packet 08 phase 4 of 5: freeBusyReader availability, end to end (the remaining clause of packet 08 step 8; A7). The packet-01 `AvailabilityQuery`/`AvailabilityResponse`/`BusyPeriod` contracts existed with no implementation on either side — this builds both.

**Backend**
- `gcalService.queryFreeBusy` wraps Google's `freebusy.query` with the shared retry policy and quota attribution — and joins the packet-07 reflection-guarded quotaUser table (the guard failed until it did, exactly as designed).
- `GET /api/calendars/availability?calendarIds=a,b&start=…&end=…` (session-gated): strict-parses the core `AvailabilityQuery`, enforces a backend-only 62-day range bound (A7 "bounded"), **rejects any id that isn't an owned, active, google-sourced `freeBusyReader` calendar** (event-capable calendars' busy time is already their synced events — re-querying would double it), filters to visible calendars server-side, maps compass↔google ids, and degrades per-calendar Google errors to empty lists with no google ids in logs.

**Web**
- `useAvailabilityQuery` derives the queryable set (active + visible + freeBusyReader) from the calendars cache, so visibility toggles re-key the query and hidden calendars drop out with zero cache surgery; 5-minute staleTime is the freshness mechanism (freebusy has no push channel).
- Busy periods render as **inert striped blocks** in the week and day timed grids: `pointer-events-none`, `role="img"` with a "Busy, <calendar> calendar, <times>" label, no interaction attributes or context menu, z-indexed under real event cards, positioned by the same math as timed cards (genuine reuse of the position helpers, not a parallel implementation) and split per visible day column. Full-day busy ranges render as tall timed blocks — no all-day-row representation in v1 (noted in code).

## Testing

- Backend: availability happy path with compass-id mapping, writer-id and unowned-id rejection, 62-day bound, hidden-calendar filtering, per-calendar Google error degradation, quotaUser table inclusion.
- Web: id-derivation mixes (visible/hidden/inactive/writer), block rendering with labelled name/times, inertness (no button role, click hits nothing), two-day span splits into two column blocks.
- `bun test:web`: 1333 pass / 0 fail (208 files). Backend: 70 suites, 649 passed / 1 pre-existing skip. `bun run type-check` clean; `bun run lint` steady at 15 pre-existing warnings.
- Live-verified against local dev servers: route registered (401 unauthenticated, not 404), day/week views clean with the query correctly disabled for accounts with no freeBusyReader calendars.

Part of `handoff/someday/08-web-calendar-experience.md` (next: two-calendar e2e + packet close-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)