### PR TITLE
test: close the v1 release gate's remaining fault and contract gaps

### DIFF
--- a/packages/backend/src/calendar/controllers/calendar.controller.test.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.test.ts
@@ -2,7 +2,12 @@ import { ObjectId } from "mongodb";
 import { type SessionRequest } from "supertokens-node/framework/express";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
-import { type AvailabilityResponse } from "@core/types/event-command.contracts";
+import { CalendarListResponseSchema } from "@core/types/calendar.contracts";
+import {
+  type AvailabilityResponse,
+  AvailabilityResponseSchema,
+} from "@core/types/event-command.contracts";
+import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import calendarController from "@backend/calendar/controllers/calendar.controller";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { type Res_Promise } from "@backend/common/types/express.types";
@@ -59,6 +64,10 @@ describe("CalendarController availability", () => {
       }),
     );
     expect(res.promise).toHaveBeenCalledWith(availabilityResponse);
+    // Packet 09 step 2: pin the response-boundary shape of GET
+    // /api/calendars/availability against the shared core schema.
+    const sentBody = (res.promise as jest.Mock).mock.calls[0]?.[0];
+    expect(() => AvailabilityResponseSchema.parse(sentBody)).not.toThrow();
   });
 
   it("rejects a range longer than 62 days with a 400, without calling calendarService.getAvailability (A7 bounded)", async () => {
@@ -85,5 +94,54 @@ describe("CalendarController availability", () => {
       // arg's `.description` does) - see error.handler.ts.
       expect((e as BaseError).result).toMatch(/62 days/i);
     });
+  });
+});
+
+// No prior test in this file exercised calendarController.list (GET
+// /api/calendars) at all; this pins its happy path plus the packet 09 step 2
+// response-boundary parse, using the same fake req/res driver as the
+// describe block above.
+describe("CalendarController list", () => {
+  const userId = "507f1f77bcf86cd799439011";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns a CalendarListResponse-shaped body for the session user's calendars", async () => {
+    const record = CalendarRecordSchema.parse({
+      _id: new ObjectId(),
+      userId: new ObjectId(userId),
+      name: "Work",
+      description: "",
+      timeZone: "America/Denver",
+      foregroundColor: "#000000",
+      backgroundColor: "#ffffff",
+      access: "owner",
+      isPrimary: true,
+      isVisible: true,
+      isActive: true,
+      source: { provider: "google", calendarId: "gcal-1", etag: "etag-1" },
+      createdAt: new Date(),
+      updatedAt: null,
+    });
+    const listSpy = jest
+      .spyOn(calendarService, "list")
+      .mockResolvedValue([record]);
+
+    const req = {
+      query: {},
+      session: { getUserId: () => userId },
+    } as unknown as SessionRequest;
+    const promise = jest.fn();
+    const res = { promise } as unknown as Res_Promise;
+
+    await calendarController.list(req, res);
+
+    expect(listSpy).toHaveBeenCalledWith(expect.any(ObjectId));
+    expect(promise).toHaveBeenCalledTimes(1);
+
+    const sentBody = promise.mock.calls[0]?.[0];
+    expect(() => CalendarListResponseSchema.parse(sentBody)).not.toThrow();
   });
 });

--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -1,0 +1,53 @@
+import { type Response } from "express";
+import { ObjectId } from "mongodb";
+import { type SessionRequest } from "supertokens-node/framework/express";
+import { EventListResponseSchema } from "@core/types/event-command.contracts";
+import eventController from "@backend/event/controllers/event.controller";
+import eventService from "@backend/event/services/event.service";
+import { buildEventRecord } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
+
+// No prior test file existed for event.controller.ts. This mirrors the fake
+// req/res driver already established in calendar.controller.test.ts (no
+// supertest, no DB - the route wire-up is a one-line
+// event.routes.config.ts, and eventService's own query/ownership behavior is
+// covered in event.service.test.ts). Packet 09 step 2: pins the
+// response-boundary shape of GET /api/event against the shared core schema.
+describe("EventController readAll", () => {
+  const userId = "507f1f77bcf86cd799439011";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns an EventListResponse-shaped body for a range query", async () => {
+    const record = buildEventRecord(new ObjectId());
+    const readAllSpy = jest
+      .spyOn(eventService, "readAll")
+      .mockResolvedValue([record]);
+
+    const req = {
+      query: {
+        start: "2024-01-15T00:00:00.000Z",
+        end: "2024-01-16T00:00:00.000Z",
+        priorities: "",
+      },
+      session: { getUserId: () => userId },
+    } as unknown as SessionRequest;
+    const json = jest.fn();
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json,
+    } as unknown as Response;
+
+    await eventController.readAll(req, res);
+
+    expect(readAllSpy).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({ kind: "range" }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+
+    const sentBody = json.mock.calls[0]?.[0] as unknown;
+    expect(() => EventListResponseSchema.parse(sentBody)).not.toThrow();
+  });
+});

--- a/packages/backend/src/servers/sse/sse.server.test.ts
+++ b/packages/backend/src/servers/sse/sse.server.test.ts
@@ -6,6 +6,10 @@
 
 import { ObjectId } from "mongodb";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
+import {
+  type ServerMessage,
+  ServerMessageSchema,
+} from "@core/types/server-message.contracts";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 
 jest.mock("supertokens-node/recipe/session/framework/express", () => ({
@@ -153,6 +157,131 @@ describe("SSE Server", () => {
       await expect(eventPromise).rejects.toThrow("Timeout");
 
       stream.close();
+    });
+  });
+
+  describe("Publish-site conformance (A27): every `publish*` helper's written frame is a ServerMessage", () => {
+    let sseServerModule: typeof import("./sse.server");
+
+    beforeAll(async () => {
+      sseServerModule = await import("./sse.server");
+    });
+
+    // One entry per `publish*` helper on SSEServer, each driving it with a
+    // representative payload and the message `type` its frame should carry.
+    // The reflection guard below requires this table to stay exhaustive.
+    const cases: Array<{
+      method: string;
+      type: ServerMessage["type"];
+      publish: (userId: string) => void;
+    }> = [
+      {
+        method: "publishEventsChanged",
+        type: "eventsChanged",
+        publish: (userId) =>
+          sseServerModule.sseServer.publishEventsChanged(userId, {
+            calendarId: new ObjectId().toHexString() as CalendarId,
+            eventIds: [new ObjectId().toHexString() as EventId],
+            reason: "created",
+          }),
+      },
+      {
+        method: "publishCalendarsChanged",
+        type: "calendarsChanged",
+        publish: (userId) =>
+          sseServerModule.sseServer.publishCalendarsChanged(userId, [
+            new ObjectId().toHexString() as CalendarId,
+          ]),
+      },
+      {
+        method: "publishSyncStatus",
+        type: "syncStatusChanged",
+        publish: (userId) =>
+          sseServerModule.sseServer.publishSyncStatus(userId, {
+            status: "attention",
+            code: "GOOGLE_REVOKED",
+            retryable: false,
+          }),
+      },
+      {
+        method: "publishImportCompleted",
+        type: "importCompleted",
+        publish: (userId) =>
+          sseServerModule.sseServer.publishImportCompleted(userId, {
+            operation: "full",
+            eventsCount: 12,
+            calendarsCount: 3,
+          }),
+      },
+      {
+        method: "publishUserMetadata",
+        type: "userMetadataChanged",
+        publish: (userId) =>
+          sseServerModule.sseServer.publishUserMetadata(userId, {
+            syncEnabled: true,
+          }),
+      },
+    ];
+
+    it.each(
+      cases,
+    )("$method's written frame parses with ServerMessageSchema", async ({
+      type,
+      publish,
+    }) => {
+      const userId = new ObjectId().toString();
+      const stream = baseDriver.openSSEStream({ userId });
+
+      // Cold-start replay: also confirms the subscription is registered
+      // server-side before `publish` runs below, same synchronization the
+      // other tests in this file rely on to avoid a publish-before-
+      // subscribe race.
+      await stream.waitForEvent("userMetadataChanged", 2000);
+
+      const framePromise = stream.waitForEvent(type, 2000);
+      publish(userId);
+
+      const frame = await framePromise;
+      expect(() => ServerMessageSchema.parse(frame)).not.toThrow();
+      expect((frame as { type: string }).type).toBe(type);
+
+      stream.close();
+    });
+
+    // Mirrors gcal.service.test.ts's quotaUser conformance table (packet 07):
+    // enumerate the SSEServer instance's own method surface and require
+    // every `publish*` method (excluding the low-level `publish`/
+    // `publishTo` primitives the helpers above are built on) to already
+    // have a case in the table, so a future publisher can't silently skip
+    // this contract.
+    const listMethodNames = (instance: object): string[] => {
+      const ownNames = Object.getOwnPropertyNames(instance);
+      const proto = Object.getPrototypeOf(instance) as object | null;
+      const protoNames =
+        proto && proto !== Object.prototype
+          ? Object.getOwnPropertyNames(proto).filter(
+              (name) => name !== "constructor",
+            )
+          : [];
+
+      return [...new Set([...ownNames, ...protoNames])].filter(
+        (name) =>
+          typeof (instance as Record<string, unknown>)[name] === "function",
+      );
+    };
+
+    it("covers every publish* method on SSEServer (fails loudly if a new one is added without a case above)", () => {
+      const allMethodNames = listMethodNames(sseServerModule.sseServer);
+      const publishMethodNames = allMethodNames.filter(
+        (name) =>
+          name.startsWith("publish") &&
+          name !== "publish" &&
+          name !== "publishTo",
+      );
+
+      expect(new Set(publishMethodNames)).toEqual(
+        new Set(cases.map((c) => c.method)),
+      );
     });
   });
 });

--- a/packages/backend/src/sync/services/watch/google-watch.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.test.ts
@@ -23,6 +23,10 @@ import { seedGoogleCalendar } from "@backend/sync/services/event-propagation/__t
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
+import {
+  GoogleWatchStateStatus,
+  inspectGoogleWatchState,
+} from "@backend/sync/services/watch/google-watch-state";
 
 jest.mock("@backend/sync/services/watch/google-watch-config", () => {
   const actual = jest.requireActual(
@@ -83,10 +87,17 @@ const seedEventsNotification = async (options: {
       })
     : null;
 
+  // A realistic sync-token-bearing response (Google always returns one on
+  // the final page): a fixed value distinct from the driver's seeded
+  // initial token, so the first notify() sees a change and advances the
+  // stored token to it, and a second notify() with the same mock sees no
+  // further change (nextSyncToken === the now-current stored token) -- the
+  // real dedupe path handleNotification/getLatestChanges relies on.
+  const nextSyncToken = faker.string.alphanumeric(20);
   jest.spyOn(gcalService, "getEvents").mockResolvedValue({
     status: 200,
     statusText: "OK",
-    data: { items: options.gcalItems },
+    data: { items: options.gcalItems, nextSyncToken },
   } as unknown as GaxiosResponse);
   const eventsChangedSpy = jest.spyOn(sseServer, "publishEventsChanged");
 
@@ -330,6 +341,32 @@ describe("googleWatchService", () => {
     );
   });
 
+  it("ignores a duplicate delivery of the same events notification via sync-token dedupe, with no additional writes or publishes (packet 09 fault matrix: duplicate notification)", async () => {
+    const { eventsChangedSpy, notify } = await seedEventsNotification({
+      seedCalendar: { isVisible: true },
+      gcalItems: [
+        mockRegularGcalEvent({ summary: "Duplicate-delivery event" }),
+      ],
+    });
+
+    await expect(notify()).resolves.toBe("PROCESSED");
+    expect(eventsChangedSpy).toHaveBeenCalledTimes(1);
+
+    const eventCountAfterFirst = await mongoService.event.countDocuments();
+
+    // Google redelivers notifications; the same channelId/resourceId/
+    // expiration payload arrives again. The packet 06 sync-token dedupe
+    // (GCalEventsNotificationHandler.getLatestChanges: the just-advanced
+    // stored nextSyncToken comes back unchanged from Google) must make this
+    // second delivery a no-op.
+    await expect(notify()).resolves.toBe("IGNORED");
+
+    expect(eventsChangedSpy).toHaveBeenCalledTimes(1);
+    expect(await mongoService.event.countDocuments()).toBe(
+      eventCountAfterFirst,
+    );
+  });
+
   it("routes an events notification to the calendar its watch names, not any other calendar the user has (packet 06 step 9 secondary-calendar routing proof)", async () => {
     const user = await UserDriver.createUser();
     const userId = user._id.toString();
@@ -475,5 +512,168 @@ describe("googleWatchService", () => {
 
     expect(watch).not.toBeNull();
     expect(watch?.expiration.getTime()).toBe(Number(googleExpiration));
+  });
+
+  describe("startGoogleWatches fault containment (packet 09 step 4: watch creation failure)", () => {
+    const future = () => String(Date.now() + 60 * 60 * 1000);
+
+    beforeEach(() => {
+      // isUsingGcalWebhookHttps is a jest.fn() from the jest.mock() factory
+      // at the top of this file, not a jest.spyOn() - the file's
+      // `afterEach(() => jest.restoreAllMocks())` doesn't reset it, and the
+      // "skips direct Google watch setup..." test above permanently stubs
+      // it to false. These tests exercise startGoogleWatches's gated path
+      // directly, so restore its HTTPS-configured default first.
+      (isUsingGcalWebhookHttps as jest.Mock).mockReturnValue(true);
+    });
+
+    it("contains a single event-watch failure: the other watches still start, no watch record persists for the failed calendar, and the inspector reports WATCHES_MISSING for it", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const context = await createGoogleRequestContext(userId);
+
+      const healthyGCalId = faker.string.uuid();
+      const failingGCalId = faker.string.uuid();
+
+      await seedGoogleCalendar(user._id, {
+        isPrimary: true,
+        source: {
+          provider: "google",
+          calendarId: healthyGCalId,
+          etag: "etag-1",
+        },
+      });
+      await seedGoogleCalendar(user._id, {
+        isPrimary: false,
+        source: {
+          provider: "google",
+          calendarId: failingGCalId,
+          etag: "etag-1",
+        },
+      });
+
+      // Sync tokens are already established (as they would be after initial
+      // import) for both calendars -- only watch *creation* is failing here,
+      // a separate concern from token issuance.
+      await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+        nextSyncToken: faker.string.alphanumeric(16),
+      });
+      await updateSync(Resource_Sync.EVENTS, userId, healthyGCalId, {
+        nextSyncToken: faker.string.alphanumeric(16),
+      });
+      await updateSync(Resource_Sync.EVENTS, userId, failingGCalId, {
+        nextSyncToken: faker.string.alphanumeric(16),
+      });
+
+      jest.spyOn(gcalService, "watchCalendars").mockResolvedValue({
+        watch: { resourceId: "resource-calendarlist", expiration: future() },
+      });
+      jest
+        .spyOn(gcalService, "watchEvents")
+        .mockImplementation(async (_ctx, params) => {
+          if (params.gCalendarId === failingGCalId) {
+            throw createGoogleError({ code: "500", responseStatus: 500 });
+          }
+
+          return {
+            watch: {
+              resourceId: `resource-${params.gCalendarId}`,
+              expiration: future(),
+            },
+          };
+        });
+
+      const results = await googleWatchService.startGoogleWatches(
+        userId,
+        [
+          { gCalendarId: Resource_Sync.CALENDAR },
+          { gCalendarId: healthyGCalId },
+          { gCalendarId: failingGCalId },
+        ],
+        context,
+      );
+
+      // Promise.all never rejects: startEventWatch/startCalendarListWatch
+      // each contain their own errors and resolve to {acknowledged: false}.
+      expect(results).toHaveLength(3);
+
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: healthyGCalId,
+        }),
+      ).not.toBeNull();
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: Resource_Sync.CALENDAR,
+        }),
+      ).not.toBeNull();
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: failingGCalId,
+        }),
+      ).toBeNull();
+
+      const inspection = await inspectGoogleWatchState(userId);
+      expect(inspection.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+      expect(inspection.reason).toBe("WATCHES_MISSING");
+      expect(inspection.missingWatchCalendarIds).toContain(failingGCalId);
+    });
+
+    it("contains a calendarlist-watch failure: event watches still start, and the inspector reports WATCHES_MISSING for the calendar list", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const context = await createGoogleRequestContext(userId);
+
+      const gCalendarId = faker.string.uuid();
+
+      await seedGoogleCalendar(user._id, {
+        isPrimary: true,
+        source: { provider: "google", calendarId: gCalendarId, etag: "etag-1" },
+      });
+
+      await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+        nextSyncToken: faker.string.alphanumeric(16),
+      });
+      await updateSync(Resource_Sync.EVENTS, userId, gCalendarId, {
+        nextSyncToken: faker.string.alphanumeric(16),
+      });
+
+      jest
+        .spyOn(gcalService, "watchCalendars")
+        .mockRejectedValue(
+          createGoogleError({ code: "500", responseStatus: 500 }),
+        );
+      jest.spyOn(gcalService, "watchEvents").mockResolvedValue({
+        watch: { resourceId: `resource-${gCalendarId}`, expiration: future() },
+      });
+
+      const results = await googleWatchService.startGoogleWatches(
+        userId,
+        [{ gCalendarId: Resource_Sync.CALENDAR }, { gCalendarId }],
+        context,
+      );
+
+      expect(results).toHaveLength(2);
+
+      expect(
+        await mongoService.watch.findOne({ user: userId, gCalendarId }),
+      ).not.toBeNull();
+      expect(
+        await mongoService.watch.findOne({
+          user: userId,
+          gCalendarId: Resource_Sync.CALENDAR,
+        }),
+      ).toBeNull();
+
+      const inspection = await inspectGoogleWatchState(userId);
+      expect(inspection.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
+      expect(inspection.reason).toBe("WATCHES_MISSING");
+      expect(inspection.missingWatchCalendarIds).toContain(
+        Resource_Sync.CALENDAR as string,
+      );
+    });
   });
 });

--- a/packages/scripts/src/migrations/2026.07.10T21.30.00.event-record-backfill.test.ts
+++ b/packages/scripts/src/migrations/2026.07.10T21.30.00.event-record-backfill.test.ts
@@ -1,7 +1,17 @@
 import { MigratorType } from "@scripts/common/cli.types";
 import { verifyEventMigration } from "@scripts/common/event-migration.verify";
+import NewEventsCollectionMigration from "@scripts/migrations/2025.10.18T19.43.00.new-events-collection";
+import CalendarRecordMigration from "@scripts/migrations/2026.07.10T21.00.00.calendar-record-migration";
 import Migration from "@scripts/migrations/2026.07.10T21.30.00.event-record-backfill";
-import { type Document, ObjectId } from "mongodb";
+import {
+  type AnyBulkWriteOperation,
+  type BulkWriteOptions,
+  type BulkWriteResult,
+  Collection,
+  type Document,
+  ObjectId,
+} from "mongodb";
+import { MongoDBStorage, Umzug } from "umzug";
 import { Priorities } from "@core/constants/core.constants";
 import { Logger } from "@core/logger/winston.logger";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
@@ -11,6 +21,7 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
+import { MONGO_BATCH_SIZE } from "@backend/common/constants/backend.constants";
 import { Collections } from "@backend/common/constants/collections";
 import mongoService from "@backend/common/services/mongo.service";
 
@@ -443,6 +454,175 @@ describe("2026.07.10T21.30.00.event-record-backfill", () => {
           }),
       );
       expect(startIndex).toBeDefined();
+    });
+  });
+
+  describe("interrupted-partial-backfill resume (packet 09 step 3)", () => {
+    // This migration has no incremental checkpoint to resume from: `up`
+    // unconditionally does `destination.deleteMany({})` before writing
+    // anything (see the top of the migration), so its only recovery
+    // strategy -- for a clean rerun AND for a rerun after a mid-run crash --
+    // is "wipe and rebuild from the untouched legacy source". That makes an
+    // injected crash the honest simulation here (per the packet's seam
+    // guidance) rather than hand-authoring a "checkpoint" shape the
+    // implementation doesn't have: it exercises the real per-batch write
+    // seam (`flush`'s `destination.bulkWrite` call) and proves the
+    // wipe-and-rebuild recovery actually converges from a ragged,
+    // mid-batch-written state, not just from a clean prior success (already
+    // covered by the "converges on rerun" test above).
+    it("converges with no duplicates after a mid-run bulkWrite crash, on the next run", async () => {
+      const userA = await UserDriver.createUser({ withGoogle: false });
+      await insertLocalCalendar(userA._id);
+      const userAHex = userA._id.toHexString();
+
+      const userB = await UserDriver.createUser({ withGoogle: false });
+      await insertLocalCalendar(userB._id);
+      const userBHex = userB._id.toHexString();
+
+      // One full batch plus a one-event remainder -- guarantees exactly two
+      // `bulkWrite` calls per user (batch flush mid-loop, remainder flush
+      // after) regardless of what MONGO_BATCH_SIZE resolves to in this test
+      // environment (mocked to a small value; see mock.setup.ts).
+      const eventsPerUser = MONGO_BATCH_SIZE + 1;
+      const makeEvents = (userIdHex: string, label: string) =>
+        Array.from({ length: eventsPerUser }, (_, i) => {
+          const day = 1 + (i % 25);
+          const date = `2026-06-${String(day).padStart(2, "0")}`;
+          return legacyEvent(userIdHex, {
+            title: `${label} ${i}`,
+            startDate: new Date(`${date}T09:00:00.000Z`).toISOString(),
+            endDate: new Date(`${date}T10:00:00.000Z`).toISOString(),
+          });
+        });
+
+      await legacyCollection().insertMany(makeEvents(userAHex, "A"));
+      await legacyCollection().insertMany(makeEvents(userBHex, "B"));
+
+      // Users are processed in `mongoService.user.find({})` order and each
+      // contributes exactly 2 bulkWrite calls (batch + remainder), so call
+      // #3 is always the first user's-worth-of-writes into the second
+      // user's processing -- crashing there always leaves exactly one
+      // user's events durably written and the other user's entirely
+      // unwritten, regardless of which user Mongo iterates first.
+      const originalBulkWrite = Collection.prototype.bulkWrite;
+      let bulkWriteCallCount = 0;
+      const bulkWriteSpy = jest
+        .spyOn(Collection.prototype, "bulkWrite")
+        .mockImplementation(function (
+          this: Collection,
+          operations: ReadonlyArray<AnyBulkWriteOperation<Document>>,
+          options?: BulkWriteOptions,
+        ): Promise<BulkWriteResult> {
+          bulkWriteCallCount += 1;
+          if (bulkWriteCallCount === 3) {
+            return Promise.reject(
+              new Error("simulated process crash mid-batch-write"),
+            );
+          }
+          return originalBulkWrite.call(this, operations, options);
+        });
+
+      try {
+        await expect(migration.up(migrationContext)).rejects.toThrow(
+          /simulated process crash/,
+        );
+      } finally {
+        bulkWriteSpy.mockRestore();
+      }
+
+      // Crash left a ragged state: exactly one user's worth of events
+      // durably written (2 successful flushes), the other user's first
+      // batch never attempted.
+      expect(await destinationCollection().countDocuments()).toBe(
+        eventsPerUser,
+      );
+
+      // Resume = simply rerunning the migration. bulkWrite is real again, so
+      // this is an ordinary full run against the ragged state left above.
+      await expect(migration.up(migrationContext)).resolves.not.toThrow();
+
+      const afterResume = await destinationCollection().find({}).toArray();
+      expect(afterResume).toHaveLength(eventsPerUser * 2);
+
+      const ids = afterResume.map((d) => (d["_id"] as ObjectId).toHexString());
+      expect(new Set(ids).size).toBe(ids.length);
+    }, 30_000);
+  });
+
+  describe("event_new migration already recorded (packet 09 step 3, umzug chain)", () => {
+    const migrationsCollectionName = `${MigratorType.MIGRATION.toLowerCase()}s`;
+    const storageCollection = () =>
+      mongoService.db.collection(migrationsCollectionName);
+
+    afterEach(() =>
+      storageCollection()
+        .drop()
+        .catch(() => undefined),
+    );
+
+    // Mirrors commands/migrate.ts's production wiring (Umzug + MongoDBStorage
+    // over a `migrations` collection) rather than hand-rolling a parallel
+    // migration list -- `migrations()` there isn't exported, so this
+    // constructs the same three-migration slice of the real chain directly
+    // from the migration classes themselves. Returns the storage alongside
+    // the umzug instance (rather than reaching into `umzug`'s private
+    // `storage` field) so the test can pre-seed it through Umzug's own
+    // public UmzugStorage API.
+    const buildUmzug = () => {
+      const storage = new MongoDBStorage({ collection: storageCollection() });
+      const umzug = new Umzug<typeof migrationContext.context>({
+        storage,
+        logger: undefined,
+        migrations: [
+          new NewEventsCollectionMigration(),
+          new CalendarRecordMigration(),
+          migration,
+        ],
+        context: async () => migrationContext.context,
+      });
+
+      return { umzug, storage };
+    };
+
+    it("skips the already-recorded new-events-collection migration and still completes the later backfill", async () => {
+      // Simulate a prior deployment: the 2025.10.18 migration already ran
+      // for real (creating event_new in its old, now-superseded shape) and
+      // Umzug's changelog already has it recorded as executed.
+      // NewEventsCollectionMigration#up ignores its params entirely (it
+      // takes none -- see the migration source), matching how the sibling
+      // 2025.10.18T19.43.00.new-events-collection.test.ts drives it too.
+      const priorDeploymentMigration = new NewEventsCollectionMigration();
+      await priorDeploymentMigration.up();
+
+      const { umzug, storage } = buildUmzug();
+      await storage.logMigration({ name: priorDeploymentMigration.name });
+
+      const user = await UserDriver.createUser({ withGoogle: false });
+      await legacyCollection().insertOne(
+        legacyEvent(user._id.toHexString(), { title: "Chain event" }),
+      );
+
+      const executed = await umzug.up();
+      const executedNames = executed.map((m) => m.name);
+
+      expect(executedNames).not.toContain(priorDeploymentMigration.name);
+      expect(executedNames).toContain(migration.name);
+      expect(executedNames).toContain(
+        "2026.07.10T21.00.00.calendar-record-migration",
+      );
+
+      // The later backfill wasn't broken by inheriting event_new from the
+      // already-skipped migration: it converged to its own final shape.
+      const docs = await destinationCollection().find({}).toArray();
+      expect(docs).toHaveLength(1);
+      expect((docs[0]?.["content"] as Document)["title"]).toBe("Chain event");
+
+      const indexNames = (
+        await destinationCollection().listIndexes().toArray()
+      ).map((i) => i.name);
+      expect(indexNames).toEqual(
+        expect.arrayContaining(["event_calendar_externalReference_unique"]),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Packet 09 phase A of C: the automated release gate's remaining test gaps (packet 09 steps 2-4). The gap analysis showed packets 02-08 already built most of the fault matrix (rate limit, timeout, partial page, 410 recovery, lease/restart, A29 invalid_grant) — this closes what was left. **Tests only; zero production changes.**

- **A27 SSE publish-site conformance**: every `publish*` helper on the SSE server is driven behaviorally and its written frame parsed with `ServerMessageSchema`; a reflection guard (same pattern as packet 07's quotaUser table) forces any future publisher to join the conformance table. This makes the contract file's "a contract test enforces the mapping" comment true.
- **Migration thin spots**: an interrupted-mid-backfill crash injected at the real per-batch `bulkWrite` seam (the migration's recovery design is wipe-and-rebuild — no checkpoint exists to simulate, so honest resume = convergent rerun, asserted duplicate-free), and the "`new-events-collection` already recorded in the umzug changelog" deployment state driven through real `MongoDBStorage` wiring.
- **Watch-creation failure**: direct injection of `watchEvents` / `watchCalendars` rejections → contained (other watches start), nothing persisted for the failed watch, and `inspectGoogleWatchState` reports `WATCHES_MISSING`/`REPAIR_REQUIRED` — the fault heals through the packet 07 repair path.
- **Named duplicate-notification test**: pins the token dedupe explicitly; the shared seeding helper now includes a `nextSyncToken` in the mocked Google response, so the dedupe path is genuinely exercised (it previously wasn't, by any test).
- **Response-boundary parses**: `GET /api/calendars`, `GET /api/event` (new controller test file — none existed), and `GET /api/calendars/availability` responses parse against `CalendarListResponseSchema` / `EventListResponseSchema` / `AvailabilityResponseSchema`.

Two findings recorded for the packet close-out (no code): raw Google wire data deliberately stays typed via `calendar_v3` d.ts with strictness at Compass's own mappers/schemas (will be dated decision A43), and the root tsconfig excludes `*.test.ts` from `bun run type-check` (pre-existing tooling gap, noted rather than churned).

## Testing

- Backend: 71 suites, 660 passed / 1 pre-existing skip. Scripts: 13 suites, 142 passed. Core: 265/265.
- `bun run type-check` clean; `bun run lint` steady at the 15 pre-existing web warnings.

Part of `handoff/someday/09-v1-release-hardening.md` (next: import benchmark + observability, then docs/ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)