### PR TITLE
fix(web): show today in the single-day (phone) week view

### DIFF
--- a/e2e/oauth/google-auth-callback.spec.ts
+++ b/e2e/oauth/google-auth-callback.spec.ts
@@ -93,7 +93,7 @@ test("finishes a saved Google sign-in callback", async ({ page }) => {
   await expect(
     page.locator('[role="status"][aria-busy="true"][aria-live="polite"]'),
   ).toBeVisible();
-  await expect(page).toHaveURL(/\/week\/\d{4}-\d{2}-\d{2}$/);
+  await expect(page).toHaveURL(/\/week$/);
   expect(apiMocks.loginOrSignupRequests).toHaveLength(1);
   expect(
     await page.evaluate(

--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -50,7 +50,8 @@ function createTestRouter(initialEntries: string[]) {
   const weekIndexRoute = createRoute({
     getParentRoute: () => weekRoute,
     path: "/",
-    beforeLoad: () => redirectToToday(ROOT_ROUTES.WEEK_DATE),
+    // Bare /week renders the view (no redirect); useWeek derives the anchor.
+    component: () => null,
   });
   const weekDateRoute = createRoute({
     getParentRoute: () => weekRoute,
@@ -90,15 +91,6 @@ describe("router redirects", () => {
     await router.load();
 
     expect(router.state.location.pathname).toBe(`/day/${dateString}`);
-  });
-
-  it("redirects /week to today's dated week route", async () => {
-    const { dateString } = loadTodayData();
-    const router = createTestRouter(["/week"]);
-
-    await router.load();
-
-    expect(router.state.location.pathname).toBe(`/week/${dateString}`);
   });
 
   it("preserves ?auth=login across the today redirect", async () => {

--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -5,7 +5,6 @@ import {
   createRouter,
   isRedirect,
 } from "@tanstack/react-router";
-import dayjs from "@core/util/date/dayjs";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import {
   loadDateParam,
@@ -93,10 +92,8 @@ describe("router redirects", () => {
     expect(router.state.location.pathname).toBe(`/day/${dateString}`);
   });
 
-  it("redirects /week to the start of the current week", async () => {
-    const dateString = dayjs()
-      .startOf("week")
-      .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
+  it("redirects /week to today's dated week route", async () => {
+    const { dateString } = loadTodayData();
     const router = createTestRouter(["/week"]);
 
     await router.load();

--- a/packages/web/src/routers/loaders.ts
+++ b/packages/web/src/routers/loaders.ts
@@ -42,18 +42,6 @@ export function redirectToToday(
   });
 }
 
-export function redirectToCurrentWeek(): never {
-  const dateString = dayjs()
-    .startOf("week")
-    .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
-
-  throw redirect({
-    to: ROOT_ROUTES.WEEK_DATE,
-    params: { dateString },
-    search: (prev: Record<string, unknown>) => prev,
-  });
-}
-
 // Deliberately not params.parse: a throwing parser makes the route not
 // match (-> NotFound), but the existing UX redirects an invalid dateString
 // to the base route instead. Runs in beforeLoad so an invalid param never

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -74,6 +74,15 @@ export const dayIndexRoute = createRoute({
 export const weekRoute = createRoute({
   getParentRoute: () => authenticatedLayoutRoute,
   path: ROOT_ROUTES.WEEK,
+  // WeekView lives on the parent so a single instance persists across the bare
+  // /week (index) and /week/$dateString routes. Navigating between them updates
+  // the anchor without remounting the view (a remount would restart the sidebar
+  // open-animation). useWeek reads the optional dateString param and falls back
+  // to a width-aware default (today at phone width, start of week on desktop).
+  component: lazyRouteComponent(
+    () => import("@web/views/Week/WeekView"),
+    "WeekView",
+  ),
 });
 
 export const weekDateRoute = createRoute({
@@ -81,16 +90,11 @@ export const weekDateRoute = createRoute({
   path: "$dateString",
   beforeLoad: validateWeekDateParam,
   loader: loadDateParam,
-  component: lazyRouteComponent(
-    () => import("@web/views/Week/WeekView"),
-    "WeekView",
-  ),
 });
 
 export const weekIndexRoute = createRoute({
   getParentRoute: () => weekRoute,
   path: "/",
-  beforeLoad: () => redirectToToday(ROOT_ROUTES.WEEK_DATE),
 });
 
 export const rootIndexRoute = createRoute({

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -9,7 +9,6 @@ import { validateAuthSearch } from "@web/components/AuthModal/hooks/useAuthModal
 import {
   loadAuthenticated,
   loadDateParam,
-  redirectToCurrentWeek,
   redirectToToday,
   validateDayDateParam,
   validateWeekDateParam,
@@ -91,7 +90,7 @@ export const weekDateRoute = createRoute({
 export const weekIndexRoute = createRoute({
   getParentRoute: () => weekRoute,
   path: "/",
-  beforeLoad: redirectToCurrentWeek,
+  beforeLoad: () => redirectToToday(ROOT_ROUTES.WEEK_DATE),
 });
 
 export const rootIndexRoute = createRoute({

--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -66,12 +66,28 @@ describe("useWeek", () => {
     ).not.toContain(today.format(DATE_FORMAT));
   });
 
-  it("falls back to today when no dateString param is present", () => {
-    const today = dayjs("2026-07-07", DATE_FORMAT);
+  it("defaults the anchor to the week start on multi-day widths when no dateString", () => {
+    const today = dayjs("2026-07-07", DATE_FORMAT); // Tuesday
 
     const { result } = renderHook(() => useWeek(today));
 
+    expect(result.current.component.startOfView.format(DATE_FORMAT)).toBe(
+      "2026-07-05", // Sunday, start of the week containing today
+    );
     expect(result.current.component.isCurrentWeek).toBe(true);
+  });
+
+  it("defaults the anchor to today at single-day (phone) width when no dateString", () => {
+    const today = dayjs("2026-07-07", DATE_FORMAT); // Tuesday
+
+    const { result } = renderHook(() => useWeek(today, 1));
+
+    expect(result.current.component.startOfView.format(DATE_FORMAT)).toBe(
+      "2026-07-07",
+    );
+    expect(
+      result.current.component.weekDays.map((d) => d.format(DATE_FORMAT)),
+    ).toEqual(["2026-07-07"]);
   });
 
   it("navigates to the incremented week on incrementWeek", () => {
@@ -159,7 +175,7 @@ describe("useWeek", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/week/$dateString",
-      params: { dateString: "2026-05-20" },
+      params: { dateString: "2026-05-17" },
     });
   });
 

--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -159,7 +159,7 @@ describe("useWeek", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       to: "/week/$dateString",
-      params: { dateString: "2026-05-17" },
+      params: { dateString: "2026-05-20" },
     });
   });
 

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -27,7 +27,15 @@ export const useWeek = (
     from: ROUTE_IDS.WEEK_DATE,
     shouldThrow: false,
   });
-  const anchorDateString = params?.dateString ?? today.format(DATE_FORMAT);
+  // Bare /week has no dateString. Default to today when only one day is
+  // visible (phone width, where there is no someday sidebar), otherwise the
+  // week-aligned start so the desktop someday sidebar's week bucket stays
+  // aligned. Once navigation writes a dateString, that drives the anchor at
+  // every width.
+  const defaultAnchorDate =
+    visibleDayCount === 1 ? today : today.startOf("week");
+  const anchorDateString =
+    params?.dateString ?? defaultAnchorDate.format(DATE_FORMAT);
   const anchor = useMemo(
     () => dayjs(anchorDateString, DATE_FORMAT),
     [anchorDateString],
@@ -117,7 +125,7 @@ export const useWeek = (
   const goToToday = () => {
     navigationSourceRef.current = "manual";
     if (!isCurrentWeek) {
-      setAnchor(today);
+      setAnchor(today.startOf("week"));
     }
   };
 

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -117,7 +117,7 @@ export const useWeek = (
   const goToToday = () => {
     navigationSourceRef.current = "manual";
     if (!isCurrentWeek) {
-      setAnchor(today.startOf("week"));
+      setAnchor(today);
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes a week-view regression from #2047. That PR made the week a rolling window whose first visible day is the URL date, and made bare `/week` redirect to the **start of the calendar week**. At phone-like widths only one day fits, so `/week` showed the week's start day (e.g. Sunday) instead of **today**. The someday sidebar — which is week-based and **desktop-only** — must keep its week-aligned anchor, so desktop stays on the week start.

**Approach:**
- Render `WeekView` on the parent `/week` route so a single instance persists across bare `/week` and `/week/$dateString`. Navigating between them no longer remounts the view (a remount restarted the sidebar open-animation and broke the someday drag flow).
- In `useWeek`, when there is no `dateString`, default the anchor **width-awarely**: `today` when a single day is visible (phone width, where there's no someday sidebar), otherwise the **week-aligned start** (keeps the desktop someday sidebar's week bucket aligned). Once navigation writes a `dateString`, the URL drives the anchor at every width.
- Desktop landing and the go-to-today shortcut stay on the week start. `redirectToCurrentWeek` is removed; bare `/week` no longer redirects to a dated URL.

### Also fixes date-dependent CI time-bombs
Three #2047-era tests only passed when CI ran on a **Sunday** (the one day `today === startOf("week")`): the `/week` redirect unit test, the phone-width e2e, and — indirectly — the someday specs. #2047 merged during a UTC-Sunday so they went green and stayed green for ~24h, then broke at the UTC rollover into Monday. All are corrected here.

## Simplicity

Net removes a near-duplicate redirect helper (`redirectToCurrentWeek`) and moves `WeekView` to the parent route (standard TanStack parent-owns-the-view pattern, matching `dayRoute`). The one added branch is the width-aware default anchor in `useWeek`. No `useEffect`/`useRef`/`useState` added.

## Manual Testing Steps

- [ ] At desktop width, open `/week`; confirm the visible week begins on the **week start** (e.g. Sunday) and the someday sidebar shows.
- [ ] Create a someday event on the sidebar; confirm it appears, and drag it onto the timed grid — confirm the drag preview shows.
- [ ] Narrow the browser to ~320px on `/week`; confirm the single visible day is **today**.
- [ ] Page to another week, then back; confirm navigation works and the someday sidebar stays open (no flicker/remount).
- [ ] Open `/week/2026-08-01` directly; confirm it opens that exact date at every width.

## Test plan

- [x] `bun run test:web` — 1333 pass, 0 fail.
- [x] `bun run test:e2e` (full suite, `--workers=1`) — 16 passed, including week-view-layout (phone + desktop), someday event-smoke, someday drag preview, and the oauth callback.
- [x] `bun run type-check` — clean.
- [x] `bun run lint` — no new warnings from changed files.