### PR TITLE
chore(team): standup 2026-07-13

### DIFF
--- a/team/standups/2026-07-13.md
+++ b/team/standups/2026-07-13.md
@@ -1,0 +1,104 @@
+# Standup — 2026-07-13
+
+- **Window:** first standup; 7-day window `2026-07-06..2026-07-13`.
+- **Main / CI status:** 🔴 **RED** — main's `Test` job is failing on the web unit
+  test `router redirects > redirects /week to the start of the current week`
+  (expects `/week/2026-07-12`). #2074 was a `team/**`-only docs commit and did
+  not author the break; a prior merge left main red and re-running CI exposed it.
+  Open PR #2073 ("anchor week view on today instead of start of week") changes
+  exactly this behavior. Release-on-main and CodeQL pass; no non-e2e CI step
+  exceeds ~1m22s.
+- **Roadmap:** Google sub-calendars v1 packets 01–08 complete; the project has
+  moved from `team/backlog/` to `team/archive/google-subcalendar-project/`.
+  `team/backlog/` is now empty. The single remaining v1 exit box — staging
+  migration/rollback rehearsal + manual acceptance on production-shaped data —
+  is PO-gated (packet 09, decision A36).
+
+## QA
+
+### Recent work
+- Read-only calendar enforcement landed end-to-end: freebusy for reader-only calendars (#2065), read-only render/enforcement in web (#2064), and write-capability enforcement on event mutations (#2046) — core correctness surface QA should regression-test.
+- Test coverage push closed v1 release-gate gaps: fault/contract tests (#2068), backend import-at-scale benchmarks + index plans + non-https webhook warning (#2069), and a new real-browser e2e suite for calendar experience flows (#2066).
+- Sync/webhook hardening merged (#2060 retry-after/quota, #2059 idempotent watch repair, #2058 watch state inspector) — these affect background reliability that only shows up in staging/prod logs, not local runs.
+
+### Top 3 priorities
+1. Fix the CI break on main: `router redirects > redirects /week to the start of the current week` is failing (expects `/week/2026-07-12`) as of run #2074. Root cause looks like open PR #2073 (anchor-week-view-on-today) changing the exact redirect behavior this test asserts — coordinate the test fix with that PR rather than patching blind. This is squarely in standing authority (fix flaky/broken test) — no approval needed.
+2. Run `qa-test-staging` / a11y sweep over the just-merged sidebar calendar list + visibility controls (#2062) and event-card calendar identity/create-target picker (#2063) — new interactive UI surfaces from this window haven't had a QA pass yet.
+3. Review staging/prod logs for the sync/webhook hardening batch (#2058–#2060, #2049, #2050) to confirm no regressions in notification suppression or watch repair under real traffic. **[needs approval]** — charter requires staging/prod log review but I have no access confirmed; if access isn't already provisioned this is a blocker, not a task I can self-serve.
+
+### Blockers
+- Cannot yet confirm staging/prod log access for priority 3 review — will report as a genuine blocker (not guess) if founder-provided access isn't already in place.
+
+## Fullstack
+
+### Recent work
+- Automated portions of packet 09's release runbook landed (#2068-#2070): benchmark import at scale, pin index plans, non-https webhook warnings, plus cutover/rollback/upgrades/acceptance docs — all v1 packets (01-08) are now checked complete.
+- Prior windows' calendar-identity, sidebar visibility, read-only enforcement, and freebusy work (#2062-#2065) finished the sub-calendar UI surface; no fullstack code merged in the last few days besides the team restructure (#2074, notes-only).
+- CI on main is currently red: `router redirects > redirects /week to the start of the current week` fails because open PR #2073 already changed that behavior (anchors on today) without updating the test — this is fullstack's to fix.
+
+### Top 3 priorities
+1. Fix the failing `router redirects` unit test to match #2073's new "anchor on today" behavior (or fix #2073 if the test is actually right) — this is blocking a green main and is a plain bug fix, within standing authority.
+2. Pick up the known follow-up noted in the master-doc: the read-only card left-click open race — plain bug fix, within standing authority.
+3. Stand by to implement any fixes surfaced by the packet 09 staging rehearsal / manual acceptance pass once PO runs it — that work is PO-gated, not started yet. **[needs approval]** only if it uncovers scope beyond bug fixes (new features would need founder/architect sign-off per charter).
+
+### Blockers
+- None — CI failure on main is actionable (priority 1), not a blocker on other approved work.
+
+## Architect
+
+### Recent work
+- Sub-calendar v1 (#530) shipped packets 01-08 across #2015-#2066; the `09-v1-release-hardening` gate closed its automated/fault/contract and docs criteria in #2068-#2071, leaving only PO-gated staging rehearsal and manual acceptance — consistent with the plan-review's A-decision log, no re-litigation needed.
+- `team/` restructured (#2074) into role-based charters/operating-rules, and the old `team/backlog/google-subcalendar-project/` was archived to `team/archive/google-subcalendar-project/` — the backlog directory is now empty, so there is no active near-term packet queued.
+- Week interaction files (drag/resize/targeting/registry) in `packages/web/src/views/Week/interaction/` show only small window-tail edits from the legacy-bridge dissolution and strict-mutation cutover (#2019, #2029, #2030) — no ad hoc pattern drift found in this surface.
+
+### Top 3 priorities
+1. Repopulate `team/backlog/` with the next near-term packet now that sub-calendar v1's build work is done — architect standing authority to draft, but choosing *what* comes after v1 is a priority call **[needs approval]** from founder/product-owner.
+2. Fix CI: main's Test job is failing on `router redirects > redirects /week to the start of the current week`; PR #2073 already changes that redirect behavior and PR #2072 adjusts CI skip rules — get one of these merged to restore a green main before more work lands on top of a broken gate.
+3. Drift-review notes are empty (`team/architect/notes/` doesn't exist yet) — start today's note now that the sub-calendar project has moved to archive, so the next session isn't re-deriving the ledger/gate status from scratch.
+
+### Blockers
+- None — the two open items that block v1's final exit criteria (staging migration/rollback rehearsal, manual acceptance runbook with a real Google account) are explicitly PO-gated and out of Architect's standing authority per `09-v1-release-hardening.md`.
+
+## Product Owner
+
+### Recent work
+- Merged packets 01-08 of the sub-calendars v1 project (schema cutover, migration+rollback, multi-calendar import, calendar-aware CRUD, watch routing/repair, and the web calendar sidebar/visibility experience), plus PR #2065/#2064/#2063/#2062 delivering read-only calendar enforcement, freebusy for reader-only calendars, calendar identity on event cards, and sidebar visibility controls — all user-facing v1 surface area.
+- Automated release-hardening work landed (PRs #2068-#2070): migration import benchmarks, index plans, non-HTTPS webhook warnings, and finalized migration/rollback/observability runbook docs (#2071) — closing out everything in v1's release-hardening checklist except the actual rehearsal.
+- Open PR #2073 proposes anchoring week view on today instead of week start — a product-facing change to week-landing behavior that should be evaluated for user impact, not just merged as a bug fix.
+
+### Top 3 priorities
+1. **[needs approval]** Run the staging migration/rollback rehearsal and the 12-step manual acceptance runbook (packet 09, PO-gated) with a real Google account covering writer, reader-with-private-event, and freeBusyReader calendars — this is the sole remaining item blocking v1's "release runbooks exercised on production-shaped data" box and gates production cutover (decision A36).
+2. Assess PR #2073 ("anchor week view on today") for product impact before it merges — it changes default week-landing behavior for all users and touches a test that's currently failing CI on main; confirm this is the right default before it ships as-is.
+3. Track the known follow-up (read-only calendar card left-click open race) against actual usage once v1 ships, and flag it for backlog re-prioritization if it surfaces as a real friction point post-cutover.
+
+### Blockers
+- No usage metrics or user feedback were supplied for this standup window, so priorities above are traced to the backlog/master-doc rather than observed user behavior — real signal is needed once v1 reaches production to validate these recommendations.
+
+## Needs founder
+
+1. **Restore green main (QA #1 / Fullstack #1 / Architect #2):** Main's `Test`
+   job is red on the `/week` redirect test, which open PR #2073 already changes.
+   Should we authorize fixing it by landing/adjusting PR #2073 (reconcile the
+   test to the new "anchor on today" behavior)? — *A broken gate blocks every
+   other merge.*
+2. **PR #2073 product decision (PO #2):** Anchoring week view on **today**
+   instead of **start of week** changes default week-landing for all users. Is
+   "anchor on today" the intended default we want to ship? — *The test fix
+   depends on which behavior is correct.*
+3. **Run the v1 staging rehearsal + manual acceptance (PO #1):** This is the
+   only remaining v1 exit box and gates production cutover (A36). Authorize the
+   PO to run the staging migration/rollback rehearsal and 12-step acceptance
+   with a real Google account? — *Nothing else blocks v1 cutover.*
+4. **Next backlog after v1 (Architect #1):** `team/backlog/` is empty now that
+   v1 build work is archived. What should the architect draft as the next
+   near-term packet? — *Team has no queued build work once v1 ships.*
+5. **Staging/prod log access for QA (QA #3 / blocker):** QA's charter requires
+   staging/prod log review but access isn't confirmed. Is log access already
+   provisioned, or should it be? — *Blocks post-merge reliability review of the
+   sync/watch hardening batch.*
+
+## Founder decisions (2026-07-13)
+- DEFERRED: qa/fullstack/architect: fix the red `/week` redirect test + PR #2073 product decision — founder is handling the CI failure in a separate session; standup does not act on it here.
+- DEFERRED: product-owner: v1 staging rehearsal + manual acceptance — not now; production cutover stays blocked until it runs.
+- APPROVED: architect: draft the next near-term packet into `team/backlog/` for founder approval (founder still decides what it covers before any build starts).
+- RESOLVED: qa: staging/prod log access is already provisioned — QA's post-merge reliability review of the sync/watch hardening batch (#2058–#2060, #2049, #2050) may proceed; no longer a blocker.


### PR DESCRIPTION
First team standup. Records the four role reports (QA, Fullstack, Architect, Product Owner) for the 2026-07-06..2026-07-13 window and the founder decisions.

Founder decisions:
- DEFERRED: red `/week` redirect test + PR #2073 product call — handled in a separate session.
- DEFERRED: v1 staging rehearsal + manual acceptance.
- APPROVED: architect drafts the next near-term packet into `team/backlog/`.
- RESOLVED: staging/prod log access already provisioned for QA.

`team/**`-only; CI-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)