### PR TITLE
feat(web): prompt new users for release notes

### DIFF
--- a/packages/web/src/auth/compass/user/util/subscribe.util.ts
+++ b/packages/web/src/auth/compass/user/util/subscribe.util.ts
@@ -1,0 +1,7 @@
+import { UserApi } from "@web/api/user.api";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+
+export async function subscribeToReleaseNotes(): Promise<void> {
+  const metadata = await UserApi.updateMetadata({ subscribeToUpdates: true });
+  userMetadataActions.set(metadata);
+}

--- a/packages/web/src/auth/google/authorization/complete-google-authorization.ts
+++ b/packages/web/src/auth/google/authorization/complete-google-authorization.ts
@@ -30,6 +30,7 @@ export type GoogleAuthorizationAuthAdapter = {
     config?: ApiMethodConfig,
   ): Promise<unknown>;
   loginOrSignup(data: GoogleAuthCodeRequest): Promise<{
+    createdNewRecipeUser: boolean;
     user: { emails?: string[] };
   }>;
 };
@@ -47,6 +48,7 @@ export type CompleteGoogleAuthorizationResult =
   | {
       returnPath: string;
       status: "completed";
+      isNewUser: boolean;
     }
   | {
       message: string;
@@ -132,11 +134,13 @@ export async function completeGoogleAuthorization({
     await completeAuthentication({
       email: result.user.emails?.[0],
     });
+    return result.createdNewRecipeUser;
   };
 
   try {
+    let isNewUser = false;
     if (savedIntent.intent === "signIn") {
-      await completeGoogleSignIn();
+      isNewUser = await completeGoogleSignIn();
     } else {
       const hasActiveSession = doesSessionExist
         ? await doesSessionExist()
@@ -162,6 +166,7 @@ export async function completeGoogleAuthorization({
     return {
       returnPath,
       status: "completed",
+      isNewUser,
     };
   } catch (error) {
     const parsedMessage = parseGoogleConnectErrorMessage(error);

--- a/packages/web/src/auth/google/authorization/google-authorization.test.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.test.ts
@@ -47,7 +47,11 @@ describe("completeGoogleAuthorization", () => {
         ...deps,
         search: callbackSearch("state-1"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/week" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/week",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.loginOrSignup).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -79,7 +83,11 @@ describe("completeGoogleAuthorization", () => {
         ...deps,
         search: callbackSearch("state-2"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/day" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/day",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.connectGoogle).toHaveBeenCalledTimes(1);
     expect(deps.refreshUserMetadata).toHaveBeenCalledTimes(1);
@@ -101,7 +109,11 @@ describe("completeGoogleAuthorization", () => {
         doesSessionExist: mock(async () => false),
         search: callbackSearch("state-session-missing"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/day" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/day",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.connectGoogle).not.toHaveBeenCalled();
     expect(deps.authApi.loginOrSignup).toHaveBeenCalledTimes(1);
@@ -133,7 +145,11 @@ describe("completeGoogleAuthorization", () => {
         ...deps,
         search: callbackSearch("state-session-expired"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/day" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/day",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.connectGoogle).toHaveBeenCalledTimes(1);
     expect(deps.authApi.loginOrSignup).toHaveBeenCalledTimes(1);

--- a/packages/web/src/auth/state/release-notes-prompt.store.ts
+++ b/packages/web/src/auth/state/release-notes-prompt.store.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface ReleaseNotesPromptState {
+  isOpen: boolean;
+}
+
+export const useReleaseNotesPromptStore = create<ReleaseNotesPromptState>()(
+  () => ({ isOpen: false }),
+);
+
+export const releaseNotesPromptActions = {
+  open: () => useReleaseNotesPromptStore.setState({ isOpen: true }),
+  close: () => useReleaseNotesPromptStore.setState({ isOpen: false }),
+};
+
+export const selectReleaseNotesPromptOpen = (state: ReleaseNotesPromptState) =>
+  state.isOpen;

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -637,39 +637,6 @@ describe("AuthModal", () => {
       expect(mockUpdateMetadata).not.toHaveBeenCalled();
     });
 
-    it("subscribes to updates after sign-up when the checkbox is checked", async () => {
-      const user = userEvent.setup();
-      await renderWithProviders(<ModalTrigger />);
-
-      await user.click(screen.getByRole("button", { name: /open modal/i }));
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: /^sign up$/i }),
-        ).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
-
-      await waitFor(() => {
-        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
-      });
-
-      await user.type(screen.getByLabelText(/name/i), "Alex");
-      await user.type(screen.getByLabelText(/email/i), "test@example.com");
-      await user.type(screen.getByLabelText(/password/i), "password123");
-      await user.click(
-        screen.getByRole("checkbox", { name: /subscribe to updates/i }),
-      );
-      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
-
-      await waitFor(() => {
-        expect(mockUpdateMetadata).toHaveBeenCalledWith({
-          subscribeToUpdates: true,
-        });
-      });
-    });
-
     it("skips existing-session linking during email/password sign in", async () => {
       const user = userEvent.setup();
       await renderWithProviders(<ModalTrigger />);

--- a/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
@@ -1,20 +1,15 @@
-import { type ChangeEvent, type FC, useCallback, useState } from "react";
+import { type ChangeEvent, type FC, useCallback } from "react";
 import {
   type SignUpFormData,
   SignUpSchema,
 } from "@web/auth/compass/schemas/auth.schemas";
-import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import { AuthButton } from "../components/AuthButton";
 import { AuthInput } from "../components/AuthInput";
 import { useZodForm } from "../hooks/useZodForm";
 
-export type SignUpSubmitData = SignUpFormData & {
-  subscribeToUpdates: boolean;
-};
-
 interface SignUpFormProps {
   /** Callback when form is submitted with valid data */
-  onSubmit: (data: SignUpSubmitData) => void | Promise<void>;
+  onSubmit: (data: SignUpFormData) => void | Promise<void>;
   /** Callback when name field changes (for dynamic greeting) */
   onNameChange?: (name: string) => void;
   /** Whether form submission is in progress */
@@ -31,12 +26,10 @@ export const SignUpForm: FC<SignUpFormProps> = ({
   onNameChange,
   isSubmitting,
 }) => {
-  const [subscribeToUpdates, setSubscribeToUpdates] = useState(false);
-
   const form = useZodForm({
     schema: SignUpSchema,
     initialValues: { name: "", email: "", password: "" },
-    onSubmit: (data) => onSubmit({ ...data, subscribeToUpdates }),
+    onSubmit,
   });
 
   const handleNameChange = useCallback(
@@ -84,18 +77,6 @@ export const SignUpForm: FC<SignUpFormProps> = ({
         hasError={!!form.touched.password && !!form.errors.password}
         autoComplete="new-password"
       />
-
-      <TooltipWrapper description="Once a month. Unsubscribe anytime.">
-        <label className="flex w-fit items-center gap-2 text-sm text-text-lighter">
-          <input
-            type="checkbox"
-            checked={subscribeToUpdates}
-            onChange={(e) => setSubscribeToUpdates(e.target.checked)}
-            className="h-4 w-4 rounded-full border-border-primary accent-accent-primary"
-          />
-          Subscribe to updates
-        </label>
-      </TooltipWrapper>
 
       <AuthButton
         type="submit"

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -1,14 +1,14 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import EmailPassword from "supertokens-web-js/recipe/emailpassword";
-import { UserApi } from "@web/api/user.api";
 import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAuthentication";
 import {
   type ForgotPasswordFormData,
   type LogInFormData,
   type ResetPasswordFormData,
+  type SignUpFormData,
 } from "@web/auth/compass/schemas/auth.schemas";
-import { type SignUpSubmitData } from "../forms/SignUpForm";
+import { releaseNotesPromptActions } from "@web/auth/state/release-notes-prompt.store";
 import { getAuthSubmitErrorMessage } from "./useAuthFormHandlers.util";
 import { type AuthView } from "./useAuthModal";
 
@@ -22,7 +22,7 @@ interface UseAuthFormHandlersOptions {
 export interface UseAuthFormHandlersResult {
   isSubmitting: boolean;
   submitError: string | null;
-  handleSignUp: (data: SignUpSubmitData) => Promise<void>;
+  handleSignUp: (data: SignUpFormData) => Promise<void>;
   handleLogin: (data: LogInFormData) => Promise<void>;
   handleForgotPassword: (data: ForgotPasswordFormData) => Promise<void>;
   handleResetPassword: (data: ResetPasswordFormData) => Promise<void>;
@@ -51,7 +51,7 @@ export function useAuthFormHandlers({
   }, [currentView]);
 
   const handleSignUp = useCallback(
-    async (data: SignUpSubmitData) => {
+    async (data: SignUpFormData) => {
       setIsSubmitting(true);
       setSubmitError(null);
 
@@ -69,12 +69,8 @@ export function useAuthFormHandlers({
             await completeAuthentication({
               email: response.user.emails[0] ?? data.email,
             });
-            if (data.subscribeToUpdates) {
-              void UserApi.updateMetadata({ subscribeToUpdates: true }).catch(
-                () => {},
-              );
-            }
             closeModal();
+            releaseNotesPromptActions.open();
             return;
           case "FIELD_ERROR":
             setSubmitError(response.formFields[0]?.error ?? "Sign up failed");

--- a/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
@@ -1,9 +1,8 @@
 import { BellIcon } from "@phosphor-icons/react";
-import { UserApi } from "@web/api/user.api";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { subscribeToReleaseNotes } from "@web/auth/compass/user/util/subscribe.util";
 import {
   selectUserMetadata,
-  userMetadataActions,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { SUBSCRIBE_TO_UPDATES_TOAST_ID } from "@web/common/constants/toast.constants";
@@ -32,9 +31,8 @@ export const useSubscribeCmdItems = (): CommandItem[] => {
       label: "Subscribe to Updates",
       icon: BellIcon,
       onClick: () => {
-        UserApi.updateMetadata({ subscribeToUpdates: true })
-          .then((metadata) => {
-            userMetadataActions.set(metadata);
+        subscribeToReleaseNotes()
+          .then(() => {
             showStatusToast(
               SUBSCRIBE_TO_UPDATES_TOAST_ID,
               "Subscribed to updates",

--- a/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
+++ b/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
@@ -1,0 +1,139 @@
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { subscribeToReleaseNotes } from "@web/auth/compass/user/util/subscribe.util";
+import {
+  releaseNotesPromptActions,
+  selectReleaseNotesPromptOpen,
+  useReleaseNotesPromptStore,
+} from "@web/auth/state/release-notes-prompt.store";
+import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
+
+type PromptState = "asking" | "confirmed" | "declined";
+
+export function ReleaseNotesPrompt() {
+  const isOpen = useReleaseNotesPromptStore(selectReleaseNotesPromptOpen);
+  const [state, setState] = useState<PromptState>("asking");
+  const [closing, setClosing] = useState(false);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (isOpen) {
+      setState("asking");
+      setClosing(false);
+      backdropRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => () => window.clearTimeout(timerRef.current), []);
+
+  if (!isOpen) return null;
+
+  const dismiss = () => {
+    if (closing) return;
+    setClosing(true);
+    const reducedMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    timerRef.current = window.setTimeout(
+      () => releaseNotesPromptActions.close(),
+      reducedMotion ? 0 : 400,
+    );
+  };
+
+  const decline = () => {
+    if (state !== "asking") return;
+    setState("declined");
+    timerRef.current = window.setTimeout(dismiss, 1300);
+  };
+
+  const subscribe = async () => {
+    if (state !== "asking") return;
+    try {
+      await subscribeToReleaseNotes();
+      setState("confirmed");
+      timerRef.current = window.setTimeout(dismiss, 1300);
+    } catch {
+      showErrorToast("Couldn't subscribe to updates. Please try again.");
+      dismiss();
+    }
+  };
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) decline();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") decline();
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the modal.
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-bg-primary/85 p-8 backdrop-blur-sm transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none"
+      data-closing={closing || undefined}
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      ref={backdropRef}
+      role="presentation"
+      style={{ zIndex: Z_INDEX_MODAL }}
+      tabIndex={-1}
+    >
+      <div
+        role="dialog"
+        aria-modal
+        aria-label="Release notes subscription"
+        data-closing={closing || undefined}
+        className="flex w-120 max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)] transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none"
+      >
+        <PixelPirate className="h-14 w-14" />
+        {state === "asking" ? (
+          <>
+            <div className="flex flex-col gap-2">
+              <h2 className="font-bold text-2xl text-text-lighter leading-snug">
+                Want the latest Compass news?
+              </h2>
+              <p className="text-text-light">
+                Get monthly release notes with new features, improvements, and
+                helpful tips. Unsubscribe anytime from the email footer.
+              </p>
+            </div>
+            <div className="flex flex-wrap justify-end gap-3">
+              <button
+                type="button"
+                onClick={decline}
+                className="c-button rounded-full px-5"
+              >
+                Nah, I don&apos;t want updates
+              </button>
+              <button
+                type="button"
+                onClick={() => void subscribe()}
+                className="c-button c-button-primary c-button-elevated rounded-full px-5"
+              >
+                Yes, Keep Me Updated
+              </button>
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <h2 className="font-bold text-2xl text-text-lighter leading-snug">
+              {state === "confirmed" ? "You're in!" : "No problem."}
+            </h2>
+            <p className="text-text-light">
+              {state === "confirmed"
+                ? "Monthly notes headed your way."
+                : "No problem, you can signup using the cmd palette if you change your mind."}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "@tanstack/react-router";
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
+import { ReleaseNotesPrompt } from "@web/components/ReleaseNotesPrompt/ReleaseNotesPrompt";
 import { WelcomeModal } from "@web/components/WelcomeModal/WelcomeModal";
 
 /**
@@ -15,6 +16,7 @@ export function RootShell() {
       <Outlet />
       <AuthModal />
       <WelcomeModal />
+      <ReleaseNotesPrompt />
     </AuthModalProvider>
   );
 }

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
@@ -6,6 +6,7 @@ import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAu
 import { session } from "@web/auth/compass/session/Session";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { completeGoogleAuthorization } from "@web/auth/google/authorization/complete-google-authorization";
+import { releaseNotesPromptActions } from "@web/auth/state/release-notes-prompt.store";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
@@ -35,6 +36,8 @@ export async function completeGoogleAuthCallback({
 
   if (result.status === "failed") {
     showErrorToast(result.message);
+  } else if (result.isNewUser) {
+    releaseNotesPromptActions.open();
   }
 
   navigate(result.returnPath, { replace: true });


### PR DESCRIPTION
## Summary

- Replace the easy-to-miss signup checkbox with a post-signup release-notes prompt.
- Show it for new email/password accounts and newly-created Google accounts, never returning logins.
- Reuse the subscription metadata write from the command palette and preserve the existing modal animation/motion behavior.

## Simplicity

- Extracted the shared metadata update into one narrow `subscribeToReleaseNotes` helper used by both subscription entry points.
- Kept the prompt state machine local because asking, confirmed, declined, delayed dismissal, and error dismissal are one component concern.
- No speculative persistence or extra global state was added; the trigger is an ephemeral Zustand flag as required.

## Manual Testing Steps

- [ ] Open the auth modal and confirm the signup form no longer has a subscription checkbox.
- [ ] Complete a new email/password signup and confirm the release-notes prompt appears after authentication.
- [ ] Choose `Yes, Keep Me Updated`; verify the confirmation message, dismissal animation, and that the command-palette subscription item disappears.
- [ ] Repeat a fresh signup and choose `Nah, I don't want updates`; verify the cmd-palette reassurance and that the command-palette item remains available.
- [ ] Log out and back into the same account; verify the prompt does not appear.
- [ ] Complete a new Google signup and verify the prompt appears; verify a returning Google login does not.
- [ ] Press Escape and verify the prompt dismisses without subscribing.
- [ ] Verify both prompt buttons are reachable in tab order and reduced-motion users do not receive the exit delay.

## Test plan

- [x] `bun run type-check`
- [x] `bun test:web` (1,258 passed)
- [x] `bun lint`
- [x] `git diff --check`
- [x] React Doctor (`bunx react-doctor@latest . --scope changed --base origin/main`)
- [x] Local browser preview: auth modal/signup form inspection and no console errors
- [ ] Full authenticated signup/manual flow requires backend/auth credentials
