### PR TITLE
fix(web): abbreviate datepicker month labels

### DIFF
--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -104,9 +104,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
       showPopperArrow={false}
       renderCustomHeader={(headerProps) => {
         const { customHeaderCount, monthDate } = headerProps;
-        const selectedMonth = dayjs(monthDate).format(
-          view === "sidebar" ? "MMMM YYYY" : "MMM YYYY",
-        );
+        const selectedMonth = dayjs(monthDate).format("MMM YYYY");
         const currentMonth = dayjs().format("MMM YYYY");
 
         return (


### PR DESCRIPTION
## Summary

- Abbreviate datepicker month labels to `MMM YYYY` in both sidebar and grid views.
- Keep month navigation arrows in a stable position regardless of the month name.

## Simplicity

This is the minimal inline change: one shared date format replaces the view-specific conditional. No new state, refs, effects, abstractions, or dependencies were added.

## Manual Testing Steps

- [ ] Open the planner at `/` and confirm the sidebar shows a three-letter month label such as `Jul 2026`.
- [ ] Click `Next month` and confirm the label changes to `Aug 2026` while the arrows stay aligned.
- [ ] Click `Previous month` and confirm the label returns to `Jul 2026`.
- [ ] Verify the previous and next month controls remain keyboard accessible by tabbing to them and pressing Enter.

## Test plan

- [x] `bun test:web` — 1,272 passed, 0 failed.
- [x] `bun type-check`.
- [x] `bunx biome check packages/web/src/components/DatePicker/DatePicker.tsx`.
- [x] Browser validation at `http://localhost:9085` for July/August navigation and visual alignment.
- [ ] Full `bun lint` — currently blocked by pre-existing unrelated lint errors outside this change.
- [ ] React Doctor — unavailable because the repository's TypeScript override conflicts with the installed direct dependency.
