### PR TITLE
feat(web): split day view by calendar

### DIFF
--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
@@ -49,8 +49,8 @@ export const CalendarTimedGrid: FC<CalendarTimedGridProps> = ({
   today,
   visibleDates,
 }) => {
-  const todayColumnIndex = visibleDates.findIndex(({ date }) =>
-    date.isSame(today, "day"),
+  const todayColumnIndexes = visibleDates.flatMap(({ date }, index) =>
+    date.isSame(today, "day") ? [index] : [],
   );
 
   return (
@@ -76,12 +76,13 @@ export const CalendarTimedGrid: FC<CalendarTimedGridProps> = ({
           } as CSSVariables
         }
       >
-        {todayColumnIndex >= 0 ? (
+        {todayColumnIndexes.map((columnIndex) => (
           <CalendarNowLine
             columnCount={visibleDates.length}
-            columnIndex={todayColumnIndex}
+            columnIndex={columnIndex}
+            key={visibleDates[columnIndex]?.key}
           />
-        ) : null}
+        ))}
         {visibleDates.map(({ date, key }) => (
           <div
             className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-grid-line-primary border-l data-[past=true]:bg-bg-secondary"
@@ -177,9 +178,8 @@ const CalendarNowLine = ({
 
   return (
     <div
+      aria-hidden="true"
       className="absolute h-px"
-      role="separator"
-      title="now line"
       style={{
         background: blueGradient,
         top: `${percentOfDay}%`,

--- a/packages/web/src/layout/calendar-grid/layout/calendarEventPosition.ts
+++ b/packages/web/src/layout/calendar-grid/layout/calendarEventPosition.ts
@@ -15,6 +15,7 @@ import {
 } from "@web/layout/calendar-grid/types/calendarGrid.types";
 
 export interface CalendarEventPositionInput {
+  columnIndex?: number;
   isDraft: boolean;
   measurements: CalendarGridMeasurements;
   visibleDates: CalendarGridVisibleDate[];
@@ -26,7 +27,8 @@ export const getCalendarTimedEventPosition = (
 ): CalendarEventPosition => {
   const start = dayjs(event.startDate);
   const end = dayjs(event.endDate);
-  const dateIndex = getVisibleDateIndex(start, input.visibleDates);
+  const dateIndex =
+    input.columnIndex ?? getVisibleDateIndex(start, input.visibleDates);
   if (dateIndex === null) {
     return zeroPosition();
   }
@@ -56,6 +58,7 @@ export const getCalendarTimedEventPosition = (
 };
 
 export interface CalendarBusyPeriodPositionInput {
+  columnIndex?: number;
   measurements: CalendarGridMeasurements;
   visibleDates: CalendarGridVisibleDate[];
 }
@@ -78,7 +81,8 @@ export const getCalendarBusyPeriodPosition = (
 ): CalendarEventPosition => {
   const start = dayjs(segment.start);
   const end = dayjs(segment.end);
-  const dateIndex = getVisibleDateIndex(start, input.visibleDates);
+  const dateIndex =
+    input.columnIndex ?? getVisibleDateIndex(start, input.visibleDates);
   if (dateIndex === null) {
     return zeroPosition();
   }
@@ -108,8 +112,10 @@ export const getCalendarAllDayEventPosition = (
     return zeroPosition();
   }
 
-  const startIndex = getVisibleDateIndex(span.start, input.visibleDates);
-  const endIndex = getVisibleDateIndex(span.end, input.visibleDates);
+  const startIndex =
+    input.columnIndex ?? getVisibleDateIndex(span.start, input.visibleDates);
+  const endIndex =
+    input.columnIndex ?? getVisibleDateIndex(span.end, input.visibleDates);
   if (startIndex === null || endIndex === null) {
     return zeroPosition();
   }

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
@@ -14,6 +14,7 @@ import {
 const ID_GRID_BUSY_PERIODS = "busyPeriods";
 
 interface Props {
+  calendarColumnIndexById?: ReadonlyMap<string, number>;
   dateInView: Dayjs;
   measurements: CalendarGridMeasurements;
   visibleDates: CalendarGridVisibleDate[];
@@ -29,6 +30,7 @@ interface Props {
  * availability query is loading/errored/disabled.
  */
 export const DayCalendarBusyPeriodsLayer = ({
+  calendarColumnIndexById,
   dateInView,
   measurements,
   visibleDates,
@@ -51,7 +53,11 @@ export const DayCalendarBusyPeriodsLayer = ({
   return (
     <div id={ID_GRID_BUSY_PERIODS}>
       {segments.map((segment) => {
+        const columnIndex = calendarColumnIndexById?.get(segment.calendarId);
+        if (calendarColumnIndexById && columnIndex === undefined) return null;
+
         const position = getCalendarBusyPeriodPosition(segment, {
+          columnIndex,
           measurements,
           visibleDates,
         });

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -1,0 +1,33 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import { CALENDAR_GRID_MARGIN_LEFT } from "@web/layout/calendar-grid/calendarGrid.constants";
+
+export const DayCalendarColumnHeaders = ({
+  calendars,
+}: {
+  calendars: Calendar[];
+}) => (
+  <section
+    aria-label="Calendars"
+    className="grid min-h-12 shrink-0 border-grid-line-primary border-b"
+    style={{
+      gridTemplateColumns: `repeat(${calendars.length}, minmax(0, 1fr))`,
+      marginLeft: CALENDAR_GRID_MARGIN_LEFT,
+    }}
+  >
+    {calendars.map((calendar) => (
+      <div
+        className="flex min-w-0 items-center justify-center gap-2 border-grid-line-primary border-l px-3"
+        key={calendar.id}
+      >
+        <span
+          aria-hidden="true"
+          className="size-2 shrink-0 rounded-full"
+          style={{ backgroundColor: calendar.backgroundColor }}
+        />
+        <span className="truncate text-sm text-text-primary">
+          {calendar.name}
+        </span>
+      </div>
+    ))}
+  </section>
+);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -29,6 +29,7 @@ import {
 
 interface DayEventCardProps {
   calendarIdentity?: CalendarCardIdentity | null;
+  columnIndex: number;
   event: Schema_GridEvent;
   isActiveDraft: boolean;
   isPlaceholder: boolean;
@@ -44,6 +45,7 @@ interface DayTimedEventCardProps extends DayEventCardProps {
 
 export const DayAllDayCalendarEvent = ({
   calendarIdentity = null,
+  columnIndex,
   event,
   isActiveDraft,
   isPlaceholder,
@@ -82,6 +84,7 @@ export const DayAllDayCalendarEvent = ({
     : undefined;
 
   const position = getCalendarAllDayEventPosition(event, {
+    columnIndex,
     isDraft: isPlaceholder,
     measurements,
     visibleDates,
@@ -116,6 +119,7 @@ export const DayAllDayCalendarEvent = ({
 
 export const DayTimedCalendarEvent = ({
   calendarIdentity = null,
+  columnIndex,
   deckLayout,
   event,
   isActiveDraft,
@@ -165,6 +169,7 @@ export const DayTimedCalendarEvent = ({
   })();
   const shouldFloatAboveDeck = isActiveDraft && !isDeck;
   const position = getDayTimedEventPosition({
+    columnIndex,
     deckLayout,
     event,
     isPlaceholder,
@@ -203,12 +208,14 @@ export const DayTimedCalendarEvent = ({
 };
 
 const getDayTimedEventPosition = ({
+  columnIndex,
   deckLayout,
   event,
   isPlaceholder,
   measurements,
   visibleDates,
 }: {
+  columnIndex: number;
   deckLayout: CalendarTimedDeckLayout | null;
   event: Schema_GridEvent;
   isPlaceholder: boolean;
@@ -216,6 +223,7 @@ const getDayTimedEventPosition = ({
   visibleDates: CalendarGridVisibleDate[];
 }) => {
   const position = getCalendarTimedEventPosition(event, {
+    columnIndex,
     isDraft: isPlaceholder,
     measurements,
     visibleDates,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -28,6 +28,7 @@ import {
 } from "./dayCalendarDraft.util";
 
 interface DayEventsProps {
+  getCalendarColumnIndex: (event: Schema_GridEvent) => number;
   draft: Schema_Event | null;
   events: Schema_GridEvent[];
   measurements: CalendarGridMeasurements;
@@ -38,6 +39,7 @@ interface DayEventsProps {
 export const DayCalendarAllDayEventsLayer = ({
   draft,
   events: allDayEvents,
+  getCalendarColumnIndex,
   measurements,
   onOpenEvent,
   visibleDates,
@@ -75,6 +77,7 @@ export const DayCalendarAllDayEventsLayer = ({
             calendarLookup,
             event.calendarId,
           )}
+          columnIndex={getCalendarColumnIndex(event)}
           event={event}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
@@ -83,7 +86,7 @@ export const DayCalendarAllDayEventsLayer = ({
             event.calendarId,
             event.isBusy ?? false,
           )}
-          key={event._id}
+          key={event._id ?? "all-day-draft"}
           measurements={measurements}
           onOpenEvent={onOpenEvent}
           visibleDates={visibleDates}
@@ -96,6 +99,7 @@ export const DayCalendarAllDayEventsLayer = ({
 export const DayCalendarTimedEventsLayer = ({
   draft,
   events: timedEvents,
+  getCalendarColumnIndex,
   measurements,
   onOpenEvent,
   visibleDates,
@@ -116,10 +120,16 @@ export const DayCalendarTimedEventsLayer = ({
       }),
     [draft, timedEvents, visibleDates],
   );
-  const timedEventItems = useMemo(
-    () => createCalendarTimedEventLayout(renderedEvents),
-    [renderedEvents],
-  );
+  const timedEventItems = useMemo(() => {
+    const eventsByColumn = new Map<number, Schema_GridEvent[]>();
+    for (const event of renderedEvents) {
+      const columnIndex = getCalendarColumnIndex(event);
+      const columnEvents = eventsByColumn.get(columnIndex) ?? [];
+      columnEvents.push(event);
+      eventsByColumn.set(columnIndex, columnEvents);
+    }
+    return [...eventsByColumn.values()].flatMap(createCalendarTimedEventLayout);
+  }, [getCalendarColumnIndex, renderedEvents]);
 
   return (
     <div id={ID_GRID_EVENTS_TIMED}>
@@ -129,6 +139,7 @@ export const DayCalendarTimedEventsLayer = ({
             calendarLookup,
             event.calendarId,
           )}
+          columnIndex={getCalendarColumnIndex(event)}
           deckLayout={deckLayout}
           event={event}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
@@ -138,7 +149,7 @@ export const DayCalendarTimedEventsLayer = ({
             event.calendarId,
             event.isBusy ?? false,
           )}
-          key={event._id}
+          key={event._id ?? "timed-draft"}
           measurements={measurements}
           onOpenEvent={onOpenEvent}
           visibleDates={visibleDates}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { act } from "react";
-import { EventIdSchema } from "@core/types/domain-primitives";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { CalendarIdSchema, EventIdSchema } from "@core/types/domain-primitives";
 import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
 import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
@@ -13,6 +14,8 @@ import {
   within,
 } from "@web/__tests__/__mocks__/mock.render";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { createCompassQueryClient } from "@web/api/query-client";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import {
   DATA_CALENDAR_TIMED_GRID_ROW,
   ZIndex,
@@ -47,7 +50,7 @@ const measurements = {
     x: 0,
     y: 0,
   },
-  colWidths: [180],
+  colWidths: [180, 180],
   hourHeight: 60,
   mainGrid: {
     bottom: 780,
@@ -109,15 +112,47 @@ mock.module("@web/components/FloatingEventForm/FloatingEventForm", () => ({
 const { DayCalendarGrid } =
   require("./DayCalendarGrid") as typeof import("./DayCalendarGrid");
 
-const renderDayCalendarGrid = () => ({
-  user: userEvent.setup(),
-  ...render(
-    <>
-      <DayCalendarGrid />
-      <button type="button">Outside calendar</button>
-    </>,
-    { events: seededEvents },
-  ),
+const renderDayCalendarGrid = (calendars?: Calendar[]) => {
+  const queryClient = createCompassQueryClient();
+  if (calendars) {
+    queryClient.setQueryData(calendarQueryKeys.all, calendars);
+  }
+
+  return {
+    user: userEvent.setup(),
+    ...render(
+      <>
+        <DayCalendarGrid />
+        <button type="button">Outside calendar</button>
+      </>,
+      { events: seededEvents, queryClient },
+    ),
+  };
+};
+
+const makeCalendar = (
+  name: string,
+  overrides: Partial<Calendar> = {},
+): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name,
+  description: "",
+  timeZone: null,
+  foregroundColor: "#ffffff",
+  backgroundColor: "#2563eb",
+  provider: "google",
+  access: "owner",
+  capabilities: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: true,
+    canWatchEvents: true,
+  },
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
 });
 
 // `_id` in the overrides below is a readable test label, not the real id —
@@ -257,6 +292,78 @@ describe("DayCalendarGrid", () => {
 
     const timedGrid = getTimedGrid();
     expect(within(timedGrid).getAllByRole("columnheader")).toHaveLength(1);
+  });
+
+  it("renders enabled calendars as separate event columns", () => {
+    const primary = makeCalendar("Primary", { isPrimary: true });
+    const projects = makeCalendar("Projects");
+    const hidden = makeCalendar("Hidden", { isVisible: false });
+    seededEvents = [
+      createMockEvent({
+        calendarId: primary.id,
+        content: { kind: "details", title: "Primary event", description: "" },
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2026-05-20T09:00:00.000Z",
+          end: "2026-05-20T10:00:00.000Z",
+          timeZone: "UTC",
+        }),
+      }),
+      createMockEvent({
+        calendarId: projects.id,
+        content: { kind: "details", title: "Project event", description: "" },
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2026-05-20T09:00:00.000Z",
+          end: "2026-05-20T10:00:00.000Z",
+          timeZone: "UTC",
+        }),
+      }),
+      createMockEvent({
+        calendarId: hidden.id,
+        content: { kind: "details", title: "Hidden event", description: "" },
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2026-05-20T09:00:00.000Z",
+          end: "2026-05-20T10:00:00.000Z",
+          timeZone: "UTC",
+        }),
+      }),
+    ];
+
+    renderDayCalendarGrid([primary, projects, hidden]);
+
+    const headers = screen.getByRole("region", { name: "Calendars" });
+    expect(within(headers).getByText("Primary")).toBeInTheDocument();
+    expect(within(headers).getByText("Projects")).toBeInTheDocument();
+    expect(within(headers).queryByText("Hidden")).not.toBeInTheDocument();
+
+    const primaryEvent = screen.getByRole("button", {
+      name: /primary event/i,
+    });
+    const projectEvent = screen.getByRole("button", {
+      name: /project event/i,
+    });
+    expect(screen.queryByRole("button", { name: /hidden event/i })).toBeNull();
+    expect(parseFloat(projectEvent.style.left)).toBeGreaterThan(
+      parseFloat(primaryEvent.style.left),
+    );
+    expect(primaryEvent.style.width).toBe(projectEvent.style.width);
+  });
+
+  it("falls back to the primary calendar when every calendar is disabled", () => {
+    const primary = makeCalendar("Primary", {
+      isPrimary: true,
+      isVisible: false,
+    });
+    const disabled = makeCalendar("Disabled", { isVisible: false });
+
+    renderDayCalendarGrid([disabled, primary]);
+
+    const headers = screen.getByRole("region", { name: "Calendars" });
+    expect(within(headers).getByText("Primary")).toBeInTheDocument();
+    expect(within(headers).queryByText("Disabled")).not.toBeInTheDocument();
+    expect(within(getTimedGrid()).getAllByRole("columnheader")).toHaveLength(1);
   });
 
   it("renders all-day and timed regions without rendering tasks", () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
-import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
   CompassDOMEvents,
@@ -50,7 +49,7 @@ import {
   DayCalendarAllDayEventsLayer,
   DayCalendarTimedEventsLayer,
 } from "./DayCalendarEventLayers";
-import { getDayViewCalendars } from "./dayCalendarColumns.util";
+import { useDayCalendarColumns } from "./useDayCalendarColumns";
 import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
 
 const isDayInteractionMotionActive = () => false;
@@ -69,46 +68,6 @@ const createEventFormAnchor = (eventId: string): VirtualElement => {
 
 export function DayCalendarGrid() {
   const dateInView = useDateInView();
-  const { data: calendars = [] } = useCalendarsQuery();
-  const displayedCalendars = useMemo(
-    () => getDayViewCalendars(calendars),
-    [calendars],
-  );
-  const calendarColumnIndexById = useMemo(
-    () =>
-      new Map(
-        displayedCalendars.map((calendar, index) => [calendar.id, index]),
-      ),
-    [displayedCalendars],
-  );
-  const calendarIds = useMemo(
-    () => new Set(calendars.map((calendar) => calendar.id)),
-    [calendars],
-  );
-  const visibleDates = useMemo(() => {
-    const calendarColumns = displayedCalendars.map((calendar) => ({
-      date: dateInView,
-      key: calendar.id,
-    }));
-
-    return calendarColumns.length > 0
-      ? calendarColumns
-      : [
-          {
-            date: dateInView,
-            key: dateInView.format(YEAR_MONTH_DAY_FORMAT),
-          },
-        ];
-  }, [dateInView, displayedCalendars]);
-  const { gridRefs, measurements } = useCalendarGridLayout({
-    isInteractionMotionActive: isDayInteractionMotionActive,
-    visibleDateCount: visibleDates.length,
-  });
-  const dateCalcs = useCalendarDateCalcs(
-    measurements,
-    gridRefs.mainGridRef,
-    visibleDates,
-  );
   const today = useMemo(() => dayjs(), []);
   const {
     allDayEvents,
@@ -119,32 +78,22 @@ export function DayCalendarGrid() {
     startDate: dateInView.startOf("day").utc(true).format(),
     endDate: dateInView.endOf("day").utc(true).format(),
   });
-  const getCalendarColumnIndex = useCallback(
-    (event: Schema_GridEvent) =>
-      (event.calendarId
-        ? calendarColumnIndexById.get(event.calendarId)
-        : undefined) ?? 0,
-    [calendarColumnIndexById],
-  );
-  const displayedTimedEvents = useMemo(
-    () =>
-      timedEvents.filter(
-        (event) =>
-          !event.calendarId ||
-          !calendarIds.has(event.calendarId) ||
-          calendarColumnIndexById.has(event.calendarId),
-      ),
-    [calendarColumnIndexById, calendarIds, timedEvents],
-  );
-  const displayedAllDayEvents = useMemo(
-    () =>
-      allDayEvents.filter(
-        (event) =>
-          !event.calendarId ||
-          !calendarIds.has(event.calendarId) ||
-          calendarColumnIndexById.has(event.calendarId),
-      ),
-    [allDayEvents, calendarColumnIndexById, calendarIds],
+  const {
+    calendarColumnIndexById,
+    displayedAllDayEvents,
+    displayedCalendars,
+    displayedTimedEvents,
+    getCalendarColumnIndex,
+    visibleDates,
+  } = useDayCalendarColumns({ allDayEvents, dateInView, timedEvents });
+  const { gridRefs, measurements } = useCalendarGridLayout({
+    isInteractionMotionActive: isDayInteractionMotionActive,
+    visibleDateCount: visibleDates.length,
+  });
+  const dateCalcs = useCalendarDateCalcs(
+    measurements,
+    gridRefs.mainGridRef,
+    visibleDates,
   );
   useDayEventNudgeShortcuts({ timedEvents: displayedTimedEvents });
   const draft = useDraftStore(selectDraft);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
   CompassDOMEvents,
@@ -43,11 +44,13 @@ import {
   useEventForm,
 } from "@web/views/Forms/hooks/useEventForm";
 import { DayCalendarBusyPeriodsLayer } from "./DayCalendarBusyPeriods";
+import { DayCalendarColumnHeaders } from "./DayCalendarColumnHeaders";
 import { useDayCalendarContextMenu } from "./DayCalendarContextMenu";
 import {
   DayCalendarAllDayEventsLayer,
   DayCalendarTimedEventsLayer,
 } from "./DayCalendarEventLayers";
+import { getDayViewCalendars } from "./dayCalendarColumns.util";
 import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
 
 const isDayInteractionMotionActive = () => false;
@@ -66,18 +69,40 @@ const createEventFormAnchor = (eventId: string): VirtualElement => {
 
 export function DayCalendarGrid() {
   const dateInView = useDateInView();
-  const visibleDates = useMemo(
-    () => [
-      {
-        date: dateInView,
-        key: dateInView.format(YEAR_MONTH_DAY_FORMAT),
-      },
-    ],
-    [dateInView],
+  const { data: calendars = [] } = useCalendarsQuery();
+  const displayedCalendars = useMemo(
+    () => getDayViewCalendars(calendars),
+    [calendars],
   );
+  const calendarColumnIndexById = useMemo(
+    () =>
+      new Map(
+        displayedCalendars.map((calendar, index) => [calendar.id, index]),
+      ),
+    [displayedCalendars],
+  );
+  const calendarIds = useMemo(
+    () => new Set(calendars.map((calendar) => calendar.id)),
+    [calendars],
+  );
+  const visibleDates = useMemo(() => {
+    const calendarColumns = displayedCalendars.map((calendar) => ({
+      date: dateInView,
+      key: calendar.id,
+    }));
+
+    return calendarColumns.length > 0
+      ? calendarColumns
+      : [
+          {
+            date: dateInView,
+            key: dateInView.format(YEAR_MONTH_DAY_FORMAT),
+          },
+        ];
+  }, [dateInView, displayedCalendars]);
   const { gridRefs, measurements } = useCalendarGridLayout({
     isInteractionMotionActive: isDayInteractionMotionActive,
-    visibleDateCount: 1,
+    visibleDateCount: visibleDates.length,
   });
   const dateCalcs = useCalendarDateCalcs(
     measurements,
@@ -94,7 +119,34 @@ export function DayCalendarGrid() {
     startDate: dateInView.startOf("day").utc(true).format(),
     endDate: dateInView.endOf("day").utc(true).format(),
   });
-  useDayEventNudgeShortcuts({ timedEvents });
+  const getCalendarColumnIndex = useCallback(
+    (event: Schema_GridEvent) =>
+      (event.calendarId
+        ? calendarColumnIndexById.get(event.calendarId)
+        : undefined) ?? 0,
+    [calendarColumnIndexById],
+  );
+  const displayedTimedEvents = useMemo(
+    () =>
+      timedEvents.filter(
+        (event) =>
+          !event.calendarId ||
+          !calendarIds.has(event.calendarId) ||
+          calendarColumnIndexById.has(event.calendarId),
+      ),
+    [calendarColumnIndexById, calendarIds, timedEvents],
+  );
+  const displayedAllDayEvents = useMemo(
+    () =>
+      allDayEvents.filter(
+        (event) =>
+          !event.calendarId ||
+          !calendarIds.has(event.calendarId) ||
+          calendarColumnIndexById.has(event.calendarId),
+      ),
+    [allDayEvents, calendarColumnIndexById, calendarIds],
+  );
+  useDayEventNudgeShortcuts({ timedEvents: displayedTimedEvents });
   const draft = useDraftStore(selectDraft);
   const isFormOpen = useDraftStore(selectIsEventFormOpen);
   const draftCategory = draft?.isAllDay
@@ -218,11 +270,14 @@ export function DayCalendarGrid() {
   // re-deriving a fresh Schema_GridEvent from `dayEvents` (Event[]).
   const dayGridEventsById = useMemo(() => {
     const map = new Map<string, Schema_GridEvent>();
-    for (const gridEvent of [...timedEvents, ...allDayEvents]) {
+    for (const gridEvent of [
+      ...displayedTimedEvents,
+      ...displayedAllDayEvents,
+    ]) {
       if (gridEvent._id) map.set(gridEvent._id, gridEvent);
     }
     return map;
-  }, [timedEvents, allDayEvents]);
+  }, [displayedAllDayEvents, displayedTimedEvents]);
 
   const getDayEventById = useCallback(
     (eventId: string): Schema_GridEvent | null =>
@@ -330,25 +385,35 @@ export function DayCalendarGrid() {
   const allDayEventsLayer = useMemo(
     () => (
       <DayCalendarAllDayEventsLayer
-        events={allDayEvents}
+        events={displayedAllDayEvents}
+        getCalendarColumnIndex={getCalendarColumnIndex}
         draft={draft}
         measurements={measurements}
         onOpenEvent={openEventFormForEvent}
         visibleDates={visibleDates}
       />
     ),
-    [allDayEvents, draft, measurements, openEventFormForEvent, visibleDates],
+    [
+      displayedAllDayEvents,
+      draft,
+      getCalendarColumnIndex,
+      measurements,
+      openEventFormForEvent,
+      visibleDates,
+    ],
   );
   const timedEventsLayer = useMemo(
     () => (
       <>
         <DayCalendarBusyPeriodsLayer
+          calendarColumnIndexById={calendarColumnIndexById}
           dateInView={dateInView}
           measurements={measurements}
           visibleDates={visibleDates}
         />
         <DayCalendarTimedEventsLayer
-          events={timedEvents}
+          events={displayedTimedEvents}
+          getCalendarColumnIndex={getCalendarColumnIndex}
           draft={draft}
           measurements={measurements}
           onOpenEvent={openEventFormForEvent}
@@ -357,11 +422,13 @@ export function DayCalendarGrid() {
       </>
     ),
     [
+      calendarColumnIndexById,
       dateInView,
+      displayedTimedEvents,
       draft,
+      getCalendarColumnIndex,
       measurements,
       openEventFormForEvent,
-      timedEvents,
       visibleDates,
     ],
   );
@@ -373,12 +440,15 @@ export function DayCalendarGrid() {
       onContextMenu={handleContextMenu}
     >
       <DayInteractionCoordinator
-        allDayEvents={allDayEvents}
+        allDayEvents={displayedAllDayEvents}
         dateInView={dateInView}
         getLayoutSources={getDayInteractionLayoutSources}
         onOpenEvent={openEventFormForEvent}
-        timedEvents={timedEvents}
+        timedEvents={displayedTimedEvents}
       >
+        {displayedCalendars.length > 0 ? (
+          <DayCalendarColumnHeaders calendars={displayedCalendars} />
+        ) : null}
         <CalendarGrid
           allDayEventsLayer={allDayEventsLayer}
           allDayRowsCount={allDayRowsCount}

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarColumns.util.ts
@@ -1,0 +1,14 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+
+export const getDayViewCalendars = (calendars: Calendar[]): Calendar[] => {
+  const enabledCalendars = calendars.filter(
+    (calendar) => calendar.isActive && calendar.isVisible,
+  );
+
+  if (enabledCalendars.length > 0) {
+    return enabledCalendars;
+  }
+
+  const primaryCalendar = calendars.find((calendar) => calendar.isPrimary);
+  return primaryCalendar ? [primaryCalendar] : calendars.slice(0, 1);
+};

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -1,0 +1,74 @@
+import { useCallback, useMemo } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { type Schema_GridEvent } from "@web/common/types/web.event.types";
+import { getDayViewCalendars } from "./dayCalendarColumns.util";
+
+export const useDayCalendarColumns = ({
+  allDayEvents,
+  dateInView,
+  timedEvents,
+}: {
+  allDayEvents: Schema_GridEvent[];
+  dateInView: Dayjs;
+  timedEvents: Schema_GridEvent[];
+}) => {
+  const { data: calendars = [] } = useCalendarsQuery();
+  const displayedCalendars = useMemo(
+    () => getDayViewCalendars(calendars),
+    [calendars],
+  );
+  const calendarColumnIndexById = useMemo(
+    () =>
+      new Map(
+        displayedCalendars.map((calendar, index) => [calendar.id, index]),
+      ),
+    [displayedCalendars],
+  );
+  const calendarIds = useMemo(
+    () => new Set(calendars.map((calendar) => calendar.id)),
+    [calendars],
+  );
+  const visibleDates = useMemo(() => {
+    const columns = displayedCalendars.map((calendar) => ({
+      date: dateInView,
+      key: calendar.id,
+    }));
+
+    return columns.length
+      ? columns
+      : [{ date: dateInView, key: dateInView.format(YEAR_MONTH_DAY_FORMAT) }];
+  }, [dateInView, displayedCalendars]);
+  const getCalendarColumnIndex = useCallback(
+    (event: Schema_GridEvent) =>
+      (event.calendarId
+        ? calendarColumnIndexById.get(event.calendarId)
+        : undefined) ?? 0,
+    [calendarColumnIndexById],
+  );
+  const isDisplayedEvent = useCallback(
+    (event: Schema_GridEvent) =>
+      !event.calendarId ||
+      !calendarIds.has(event.calendarId) ||
+      calendarColumnIndexById.has(event.calendarId),
+    [calendarColumnIndexById, calendarIds],
+  );
+  const displayedAllDayEvents = useMemo(
+    () => allDayEvents.filter(isDisplayedEvent),
+    [allDayEvents, isDisplayedEvent],
+  );
+  const displayedTimedEvents = useMemo(
+    () => timedEvents.filter(isDisplayedEvent),
+    [isDisplayedEvent, timedEvents],
+  );
+
+  return {
+    calendarColumnIndexById,
+    displayedAllDayEvents,
+    displayedCalendars,
+    displayedTimedEvents,
+    getCalendarColumnIndex,
+    visibleDates,
+  };
+};


### PR DESCRIPTION
## Summary

- Split the Day view into one labeled column per enabled calendar.
- Keep timed events, all-day events, busy periods, overlap layouts, and current-time indicators aligned to their calendar column.
- Fall back to the primary calendar when every calendar is disabled, while keeping stale or legacy events visible in the primary column.

## Simplicity

- Isolated calendar selection, fallback, column mapping, and event filtering in one narrow `useDayCalendarColumns` hook.
- Reused the shared calendar-grid positioning functions through an optional column index instead of duplicating Day-specific layout math.
- Added no state, effects, refs, or dependencies. Memoized values and callbacks remain only where stable identities feed existing layout and event-layer hooks.

## Manual Testing Steps

- [ ] Open the Day view with multiple calendars enabled and confirm each enabled calendar has a labeled column.
- [ ] Confirm timed and all-day events appear under their source calendar and simultaneous events in different calendars use the full column width.
- [ ] Disable calendars one at a time and confirm their columns disappear.
- [ ] Disable every calendar and confirm the primary calendar remains as the single fallback column.
- [ ] Re-enable calendars and confirm the current-time indicator and busy periods align with each restored column.

## Test plan

- [x] `bun test src/views/Day/components/Calendar/DayCalendarGrid.test.tsx src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx` (22 passed)
- [x] `bun run verify` (core tests, 1,307 web tests, and type checking passed)
- [x] Signed-in and anonymous browser walkthroughs, including disabled-primary fallback and console-error check
- [x] `bunx react-doctor@latest . --verbose --scope changed`

`bun lint` is currently blocked by two pre-existing backend test formatting errors on `main`; the changed Day-view files have no lint errors.
