### PR TITLE
fix(web): clarify day calendar columns

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -288,7 +288,10 @@ async function setupCalendarExperiencePage(
   // useSSEConnection.ts invalidates the calendars query when `authenticated`
   // flips; wait for that refetch to land before handing control to the test.
   await expect(
-    page.locator("#sidebar").getByRole("button", { name: /calendar$/ }).first(),
+    page
+      .locator("#sidebar")
+      .getByRole("button", { name: /calendar$/ })
+      .first(),
   ).toBeVisible({
     timeout: 10000,
   });
@@ -348,6 +351,54 @@ test("sidebar lists calendars, coalesces a visibility toggle, and shows card ide
   expect(harness.putCalls[1]).toEqual([
     { calendarId: CALENDAR_B_ID, isVisible: true },
   ]);
+});
+
+test("day view separates visible calendars into distinct columns", async ({
+  page,
+}) => {
+  await setupCalendarExperiencePage(page);
+
+  await page
+    .getByRole("button", { name: /select view, currently week/i })
+    .click();
+  await page.getByRole("option", { name: /^day/i }).click();
+
+  const dayAgenda = page.getByRole("region", { name: "Calendar agenda" });
+  const calendarHeaders = dayAgenda.getByRole("region", {
+    name: "Calendars",
+  });
+  const primaryHeader = calendarHeaders.getByText(CALENDAR_A_NAME);
+  const readerHeader = calendarHeaders.getByText(CALENDAR_B_NAME);
+  const primaryEvent = dayAgenda.getByRole("button", {
+    name: new RegExp(`${EVENT_A_TITLE}.*${CALENDAR_A_NAME} calendar`),
+  });
+  const readerEvent = dayAgenda.getByRole("button", {
+    name: new RegExp(`${EVENT_B_TITLE}.*${CALENDAR_B_NAME} calendar`),
+  });
+
+  await expect(primaryHeader).toBeVisible();
+  await expect(readerHeader).toBeVisible();
+  await expect(primaryHeader).toHaveCSS("color", "rgb(255, 255, 255)");
+  await expect(readerHeader).toHaveCSS("color", "rgb(255, 255, 255)");
+  await expect(primaryEvent).toBeVisible();
+  await expect(readerEvent).toBeVisible();
+
+  const [primaryHeaderBox, readerHeaderBox, primaryEventBox, readerEventBox] =
+    await Promise.all([
+      primaryHeader.locator("..").boundingBox(),
+      readerHeader.locator("..").boundingBox(),
+      primaryEvent.boundingBox(),
+      readerEvent.boundingBox(),
+    ]);
+
+  expect(primaryHeaderBox).not.toBeNull();
+  expect(readerHeaderBox).not.toBeNull();
+  expect(primaryEventBox).not.toBeNull();
+  expect(readerEventBox).not.toBeNull();
+  expect(readerHeaderBox!.x).toBeGreaterThan(primaryHeaderBox!.x);
+  expect(readerEventBox!.x).toBeGreaterThan(primaryEventBox!.x);
+  expect(primaryEventBox!.width).toBeLessThanOrEqual(primaryHeaderBox!.width);
+  expect(readerEventBox!.width).toBeLessThanOrEqual(readerHeaderBox!.width);
 });
 
 test("a new event form offers only writable calendars and supports keyboard selection", async ({

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -8,7 +8,7 @@ export const DayCalendarColumnHeaders = ({
 }) => (
   <section
     aria-label="Calendars"
-    className="grid min-h-12 shrink-0 border-grid-line-primary border-b"
+    className="grid min-h-12 shrink-0 border-border-secondary/25 border-b"
     style={{
       gridTemplateColumns: `repeat(${calendars.length}, minmax(0, 1fr))`,
       marginLeft: CALENDAR_GRID_MARGIN_LEFT,
@@ -16,7 +16,7 @@ export const DayCalendarColumnHeaders = ({
   >
     {calendars.map((calendar) => (
       <div
-        className="flex min-w-0 items-center justify-center gap-2 border-grid-line-primary border-l px-3"
+        className="flex min-w-0 items-center justify-center gap-2 border-border-secondary/25 border-l px-3 last:border-r"
         key={calendar.id}
       >
         <span
@@ -24,7 +24,7 @@ export const DayCalendarColumnHeaders = ({
           className="size-2 shrink-0 rounded-full"
           style={{ backgroundColor: calendar.backgroundColor }}
         />
-        <span className="truncate text-sm text-text-primary">
+        <span className="truncate text-sm text-text-lighter">
           {calendar.name}
         </span>
       </div>


### PR DESCRIPTION
## Summary

- render Day view calendar labels with Compass's readable light text token
- strengthen header dividers so each enabled subcalendar reads as a distinct column
- add browser coverage proving headers and events occupy separate calendar columns

The root cause was an undefined `text-text-primary` class, which left calendar labels at the browser-default black on the dark calendar surface. The existing column geometry was correct, but unreadable labels and subtle header dividers made the view appear as one undifferentiated column.

## Simplicity

The fix stays within the existing Day header component and changes only three semantic utility classes. The existing calendar selection and event-positioning path is retained because deterministic browser coverage confirms it already produces separate columns. No new effects, refs, state, helpers, or abstractions were added.

## Manual Testing Steps

- [ ] Open Day view with two or more enabled subcalendars and confirm each calendar has a readable label and its own separated column.
- [ ] Confirm events from different calendars render beneath their matching calendar labels.
- [ ] Disable all subcalendars and confirm the primary calendar remains as the single fallback column.
- [ ] Re-enable a subcalendar and confirm its column returns without console errors.

## Test plan

- [x] `bun test:web src/views/Day/components/Calendar/DayCalendarGrid.test.tsx src/layout/calendar-grid/layout/calendarEventPosition.test.ts` — 32 passed
- [x] `bunx playwright test e2e/calendars/calendar-experience.spec.ts --project=chromium-desktop` — 6 passed
- [x] `bun run verify` — core/web tests and type-check passed
- [x] changed-file semantic-color and Biome checks passed
- [x] React Doctor — 100/100, no changed-file issues
- [x] local browser validation — readable white calendar label, aligned column geometry, no console warnings/errors

Full `bun lint` remains blocked by two pre-existing backend formatting errors on `main`.
