### PR TITLE
fix(sync): repair google sync lifecycle

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.test.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.test.ts
@@ -562,7 +562,7 @@ describe("SyncController", () => {
         repairSpy.mockRestore();
       });
 
-      it("ignores a request while an import is already in progress", async () => {
+      it("restarts an import left marked in progress", async () => {
         const getAllEventsSpy = jest.spyOn(gcalService, "getAllEvents");
         const user = await UserDriver.createUser();
         const userId = user._id.toString();
@@ -573,22 +573,23 @@ describe("SyncController", () => {
           data: { sync: { importGCal: "IMPORTING" } },
         });
 
-        const importEndSpy = jest.spyOn(sseServer, "publishImportCompleted");
-        // Same reasoning as the sibling test above.
-        const repairSpy = jest
-          .spyOn(googleWatchRepairService, "repairGoogleWatchesForUser")
-          .mockResolvedValue(undefined as never);
+        const stream = baseDriver.openSSEStream({
+          userId,
+          sessionId: randomUUID(),
+        });
+        const importEndPromise = stream.waitForEvent(
+          "importCompleted",
+          importTimeoutMs,
+        );
 
         await syncDriver.importGCal({ userId });
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        const result = (await importEndPromise) as ImportCompletedMessage;
+        stream.close();
 
-        expect(importEndSpy).not.toHaveBeenCalled();
-        expect(getAllEventsSpy).not.toHaveBeenCalled();
-        expect(repairSpy).toHaveBeenCalledWith(userId);
+        expect(parseImportResult(result).operation).toBe("full");
+        expect(getAllEventsSpy).toHaveBeenCalled();
 
         getAllEventsSpy.mockRestore();
-        importEndSpy.mockRestore();
-        repairSpy.mockRestore();
       });
 
       it("retries a non-forced import after a restart is requested", async () => {
@@ -618,7 +619,7 @@ describe("SyncController", () => {
         stream.close();
 
         const parsed = parseImportResult(result);
-        expect(parsed.operation).toBe("incremental");
+        expect(parsed.operation).toBe("full");
         expect(getAllEventsSpy).toHaveBeenCalledWith(
           expect.objectContaining({ pageToken: "5" }),
         );
@@ -654,7 +655,7 @@ describe("SyncController", () => {
         stream.close();
 
         const parsed = parseImportResult(result);
-        expect(parsed.operation).toBe("incremental");
+        expect(parsed.operation).toBe("full");
         expect(getAllEventsSpy).toHaveBeenCalledWith(
           expect.objectContaining({ pageToken: "5" }),
         );

--- a/packages/backend/src/sync/services/google-sync/google-sync.activity.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.activity.ts
@@ -1,0 +1,19 @@
+const activeGoogleSyncUsers = new Set<string>();
+
+export const tryBeginGoogleSync = (userId: string): boolean => {
+  if (activeGoogleSyncUsers.has(userId)) return false;
+
+  activeGoogleSyncUsers.add(userId);
+  return true;
+};
+
+export const endGoogleSync = (userId: string): void => {
+  activeGoogleSyncUsers.delete(userId);
+};
+
+export const isGoogleSyncActive = (userId: string): boolean =>
+  activeGoogleSyncUsers.has(userId);
+
+export const resetGoogleSyncActivityForTests = (): void => {
+  activeGoogleSyncUsers.clear();
+};

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.test.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.test.ts
@@ -12,6 +12,12 @@ import { compassTestState } from "@backend/__tests__/helpers/mock.setup";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
+import {
+  endGoogleSync,
+  isGoogleSyncActive,
+  resetGoogleSyncActivityForTests,
+  tryBeginGoogleSync,
+} from "@backend/sync/services/google-sync/google-sync.activity";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import * as syncImportService from "@backend/sync/services/import/google-import.service";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
@@ -41,14 +47,18 @@ describe("googleCalendarSyncService", () => {
   beforeAll(initSupertokens);
   beforeEach(setupTestDb);
   beforeEach(cleanupCollections);
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    resetGoogleSyncActivityForTests();
+    jest.restoreAllMocks();
+  });
   afterAll(cleanupTestDb);
 
   describe("importLatestGoogleCalendarChanges", () => {
-    it("skips incremental import when already in progress or completed", async () => {
+    it("skips a completed incremental import without publishing status", async () => {
       const user = await UserDriver.createUser();
       const userId = user._id.toString();
       const importEndSpy = jest.spyOn(sseServer, "publishImportCompleted");
+      const syncStatusSpy = jest.spyOn(sseServer, "publishSyncStatus");
       const createSyncImportSpy = jest.spyOn(
         syncImportService,
         "createSyncImport",
@@ -63,6 +73,9 @@ describe("googleCalendarSyncService", () => {
 
       expect(createSyncImportSpy).not.toHaveBeenCalled();
       expect(importEndSpy).not.toHaveBeenCalled();
+      expect(syncStatusSpy).not.toHaveBeenCalledWith(userId, {
+        status: "syncing",
+      });
     });
 
     it("emits importCompleted when incremental import completes", async () => {
@@ -95,6 +108,34 @@ describe("googleCalendarSyncService", () => {
         userId,
         expect.objectContaining({ reason: "reconciled" }),
       );
+    });
+
+    it("retries an abandoned incremental import", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      await seedPrimaryGoogleCalendar(user._id);
+      const importLatestEvents = jest.fn().mockResolvedValue({
+        totalProcessed: 0,
+        totalSaved: 0,
+        totalDeleted: 0,
+        totalIgnored: 0,
+        totalInvalid: 0,
+      });
+
+      await userMetadataService.updateUserMetadata({
+        userId,
+        data: { sync: { incrementalGCalSync: "IMPORTING" } },
+      });
+      jest.spyOn(syncImportService, "createSyncImport").mockResolvedValue({
+        importLatestEvents,
+      } as unknown as Awaited<
+        ReturnType<typeof syncImportService.createSyncImport>
+      >);
+
+      await googleCalendarSyncService.importLatestGoogleCalendarChanges(userId);
+
+      expect(importLatestEvents).toHaveBeenCalledTimes(1);
+      expect(isGoogleSyncActive(userId)).toBe(false);
     });
   });
 
@@ -443,6 +484,34 @@ describe("googleCalendarSyncService", () => {
       expect(startSpy).not.toHaveBeenCalled();
       expect(importEndSpy).not.toHaveBeenCalled();
     });
+
+    it("restarts an abandoned full import and reports a full completion", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const userId = user._id.toString();
+      const importEndSpy = jest.spyOn(sseServer, "publishImportCompleted");
+
+      await userMetadataService.updateUserMetadata({
+        userId,
+        data: { sync: { importGCal: "IMPORTING" } },
+      });
+      jest.spyOn(userService, "stopGoogleCalendarSync").mockResolvedValue();
+      jest
+        .spyOn(googleCalendarSyncService, "initializeGoogleCalendarSync")
+        .mockResolvedValue({
+          eventsCount: 2,
+          calendarsCount: 1,
+          failedCalendars: [],
+        });
+
+      await googleCalendarSyncService.startGoogleCalendarSyncIfNeeded(userId);
+
+      expect(importEndSpy).toHaveBeenCalledWith(userId, {
+        operation: "full",
+        eventsCount: 2,
+        calendarsCount: 1,
+      });
+      expect(isGoogleSyncActive(userId)).toBe(false);
+    });
   });
 
   describe("repairGoogleCalendarSync", () => {
@@ -470,6 +539,47 @@ describe("googleCalendarSyncService", () => {
 
       expect(stopSpy).toHaveBeenCalledWith(userId);
       expect(startSpy).toHaveBeenCalledWith(userId);
+    });
+
+    it("does not overlap either sync mode with active Google sync work", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const userId = user._id.toString();
+      const syncStatusSpy = jest.spyOn(sseServer, "publishSyncStatus");
+      const stopSpy = jest.spyOn(userService, "stopGoogleCalendarSync");
+      const createSyncImportSpy = jest.spyOn(
+        syncImportService,
+        "createSyncImport",
+      );
+
+      expect(tryBeginGoogleSync(userId)).toBe(true);
+
+      await googleCalendarSyncService.importLatestGoogleCalendarChanges(userId);
+      await googleCalendarSyncService.repairGoogleCalendarSync(userId);
+
+      expect(createSyncImportSpy).not.toHaveBeenCalled();
+      expect(stopSpy).not.toHaveBeenCalled();
+      expect(syncStatusSpy).not.toHaveBeenCalled();
+
+      endGoogleSync(userId);
+    });
+
+    it("publishes attention and releases activity when error metadata cannot persist", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      const userId = user._id.toString();
+      const syncStatusSpy = jest.spyOn(sseServer, "publishSyncStatus");
+
+      jest
+        .spyOn(userMetadataService, "updateUserMetadata")
+        .mockRejectedValue(new Error("metadata unavailable"));
+
+      await googleCalendarSyncService.repairGoogleCalendarSync(userId);
+
+      expect(syncStatusSpy).toHaveBeenCalledWith(userId, {
+        status: "attention",
+        code: "IMPORT_FAILED",
+        retryable: true,
+      });
+      expect(isGoogleSyncActive(userId)).toBe(false);
     });
   });
 });

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.ts
@@ -7,7 +7,6 @@ import {
 } from "@core/util/event/event.util";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import calendarService from "@backend/calendar/services/calendar.service";
-import { getGoogleRepairErrorMessage } from "@backend/common/errors/integration/gcal/gcal.errors";
 import {
   createGoogleRequestContext,
   type GoogleRequestContext,
@@ -25,15 +24,13 @@ import { googleWatchService } from "@backend/sync/services/watch/google-watch.se
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
 import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
+import { endGoogleSync, tryBeginGoogleSync } from "./google-sync.activity";
 
 const logger = Logger("app:google-sync.service");
 
-const activeFullSyncRestarts = new Set<string>();
-
 /**
- * Defensive, fire-and-forget nudge for the watch repair coordinator from
- * the sync-start "ignored" paths below (an already-in-progress or
- * already-completed sync still leaves stale/missing watches un-repaired).
+ * Defensive, fire-and-forget nudge for the watch repair coordinator when a
+ * completed sync leaves stale or missing watches behind.
  * Cooldown+lease inside the coordinator keep this cheap on what is a hot
  * path. Static import above (not the dynamic pattern used for
  * user.service in runGoogleCalendarSyncSetup) because this call site runs
@@ -51,33 +48,28 @@ const notifyImportStart = (userId: string): void => {
   sseServer.publishSyncStatus(userId, { status: "syncing" });
 };
 
-const notifyImportEnd = (
+const notifyImportCompleted = (
   userId: string,
   payload: {
-    operation: string;
-    status: "COMPLETED" | "ERRORED" | "IGNORED";
-    message?: string;
+    operation: "full" | "incremental" | "repair";
     eventsCount?: number;
     calendarsCount?: number;
   },
 ): void => {
-  if (payload.status === "COMPLETED") {
-    sseServer.publishImportCompleted(userId, {
-      operation: payload.operation === "REPAIR" ? "repair" : "incremental",
-      eventsCount: payload.eventsCount ?? 0,
-      calendarsCount: payload.calendarsCount ?? 0,
-    });
-    sseServer.publishSyncStatus(userId, { status: "healthy" });
-    return;
-  }
+  sseServer.publishImportCompleted(userId, {
+    operation: payload.operation,
+    eventsCount: payload.eventsCount ?? 0,
+    calendarsCount: payload.calendarsCount ?? 0,
+  });
+  sseServer.publishSyncStatus(userId, { status: "healthy" });
+};
 
-  if (payload.status === "ERRORED") {
-    sseServer.publishSyncStatus(userId, {
-      status: "attention",
-      code: "IMPORT_FAILED",
-      retryable: true,
-    });
-  }
+const notifyImportFailed = (userId: string): void => {
+  sseServer.publishSyncStatus(userId, {
+    status: "attention",
+    code: "IMPORT_FAILED",
+    retryable: true,
+  });
 };
 
 /**
@@ -111,11 +103,14 @@ async function importLatestGoogleCalendarChanges(
   context?: GoogleRequestContext,
   perPage = 1000,
 ) {
-  logger.info(`Starting incremental Google Calendar sync for user: ${userId}`);
+  if (!tryBeginGoogleSync(userId)) {
+    logger.info(
+      `Skipping incremental Google Calendar sync because another sync is active for user: ${userId}`,
+    );
+    return;
+  }
 
   try {
-    notifyImportStart(userId);
-
     const userMeta = await userMetadataService.fetchUserMetadata(
       userId,
       undefined,
@@ -123,18 +118,16 @@ async function importLatestGoogleCalendarChanges(
         skipAssessment: true,
       },
     );
-    const proceed = shouldDoIncrementalGCalSync(userMeta);
+    const importStatus = userMeta.sync?.incrementalGCalSync;
+    const proceed =
+      importStatus === "IMPORTING" || shouldDoIncrementalGCalSync(userMeta);
 
-    if (!proceed) {
-      notifyImportEnd(userId, {
-        operation: "INCREMENTAL",
-        status: "IGNORED",
-        message: `User ${userId} gcal incremental sync is in progress or completed, ignoring this request`,
-      });
+    if (!proceed) return;
 
-      return;
-    }
-
+    logger.info(
+      `Starting incremental Google Calendar sync for user: ${userId}`,
+    );
+    notifyImportStart(userId);
     await userMetadataService.updateUserMetadata({
       userId,
       data: { sync: { incrementalGCalSync: "IMPORTING" } },
@@ -148,9 +141,8 @@ async function importLatestGoogleCalendarChanges(
         data: { sync: { incrementalGCalSync: "COMPLETED" } },
       });
 
-      notifyImportEnd(userId, {
-        operation: "INCREMENTAL",
-        status: "COMPLETED",
+      notifyImportCompleted(userId, {
+        operation: "incremental",
         eventsCount: 0,
         calendarsCount: 0,
       });
@@ -173,9 +165,8 @@ async function importLatestGoogleCalendarChanges(
       data: { sync: { incrementalGCalSync: "COMPLETED" } },
     });
 
-    notifyImportEnd(userId, {
-      operation: "INCREMENTAL",
-      status: "COMPLETED",
+    notifyImportCompleted(userId, {
+      operation: "incremental",
       eventsCount: result.totalSaved + result.totalDeleted,
       calendarsCount: 1,
     });
@@ -188,23 +179,28 @@ async function importLatestGoogleCalendarChanges(
 
     return result;
   } catch (error) {
-    await userMetadataService.updateUserMetadata({
-      userId,
-      data: { sync: { incrementalGCalSync: "ERRORED" } },
-    });
-
     logger.error(
       `Incremental Google Calendar sync failed for user: ${userId}`,
       error,
     );
 
-    notifyImportEnd(userId, {
-      operation: "INCREMENTAL",
-      status: "ERRORED",
-      message: `Incremental Google Calendar sync failed for user: ${userId}`,
-    });
+    try {
+      await userMetadataService.updateUserMetadata({
+        userId,
+        data: { sync: { incrementalGCalSync: "ERRORED" } },
+      });
+    } catch (metadataError) {
+      logger.error(
+        `Failed to persist incremental Google Calendar sync error for user: ${userId}`,
+        metadataError,
+      );
+    }
+
+    notifyImportFailed(userId);
 
     throw error;
+  } finally {
+    endGoogleSync(userId);
   }
 }
 
@@ -216,33 +212,22 @@ async function runGoogleCalendarSyncSetup(
     "@backend/user/services/user.service"
   );
   const isForce = options.force === true;
-  const operation = isForce ? "REPAIR" : "INCREMENTAL";
-  const ignoreMessage = `User ${userId} gcal import is in progress or completed, ignoring this request`;
+  const operation = isForce ? "repair" : "full";
 
-  if (activeFullSyncRestarts.has(userId)) {
-    notifyImportEnd(userId, {
-      operation,
-      status: "IGNORED",
-      message: ignoreMessage,
-    });
-    triggerWatchRepairInBackground(userId);
+  if (!tryBeginGoogleSync(userId)) {
+    logger.info(
+      `Skipping ${operation} Google Calendar sync because another sync is active for user: ${userId}`,
+    );
     return;
   }
-
-  activeFullSyncRestarts.add(userId);
 
   try {
     const userMeta = await userService.fetchUserMetadata(userId);
     const importStatus = userMeta.sync?.importGCal;
-    const isImporting = importStatus === "IMPORTING";
-    const proceed = isForce ? !isImporting : shouldImportGCal(userMeta);
+    const proceed =
+      isForce || importStatus === "IMPORTING" || shouldImportGCal(userMeta);
 
     if (!proceed) {
-      notifyImportEnd(userId, {
-        operation,
-        status: "IGNORED",
-        message: ignoreMessage,
-      });
       triggerWatchRepairInBackground(userId);
 
       return;
@@ -281,9 +266,8 @@ async function runGoogleCalendarSyncSetup(
       data: { sync: { importGCal: "COMPLETED" } },
     });
 
-    notifyImportEnd(userId, {
+    notifyImportCompleted(userId, {
       operation,
-      status: "COMPLETED",
       ...importResults,
     });
 
@@ -313,20 +297,23 @@ async function runGoogleCalendarSyncSetup(
       return;
     }
 
-    await userMetadataService.updateUserMetadata({
-      userId,
-      data: { sync: { importGCal: "ERRORED" } },
-    });
-
     logger.error(`Re-sync failed for user: ${userId}`, err);
 
-    notifyImportEnd(userId, {
-      operation,
-      status: "ERRORED",
-      message: getGoogleRepairErrorMessage(err),
-    });
+    try {
+      await userMetadataService.updateUserMetadata({
+        userId,
+        data: { sync: { importGCal: "ERRORED" } },
+      });
+    } catch (metadataError) {
+      logger.error(
+        `Failed to persist Google Calendar sync error for user: ${userId}`,
+        metadataError,
+      );
+    }
+
+    notifyImportFailed(userId);
   } finally {
-    activeFullSyncRestarts.delete(userId);
+    endGoogleSync(userId);
   }
 }
 

--- a/packages/backend/src/user/services/user-metadata.service.test.ts
+++ b/packages/backend/src/user/services/user-metadata.service.test.ts
@@ -9,6 +9,11 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
+import {
+  endGoogleSync,
+  resetGoogleSyncActivityForTests,
+  tryBeginGoogleSync,
+} from "@backend/sync/services/google-sync/google-sync.activity";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
 
@@ -24,6 +29,7 @@ describe("UserMetadataService", () => {
   beforeAll(initSupertokens);
   beforeAll(setupTestDb);
   beforeEach(cleanupCollections);
+  afterEach(resetGoogleSyncActivityForTests);
   afterAll(cleanupTestDb);
 
   describe("updateUserMetadata", () => {
@@ -198,7 +204,7 @@ describe("UserMetadataService", () => {
       expect(metadata.google?.connectionState).toBe("ATTENTION");
     });
 
-    it("returns IMPORTING while an import is already running without scheduling a repair", async () => {
+    it("returns ATTENTION when stored importing metadata has no active sync", async () => {
       const user = await UserDriver.createUser();
       const userId = user._id.toString();
       const restartSpy = jest
@@ -212,10 +218,21 @@ describe("UserMetadataService", () => {
 
       const metadata = await driver.fetchUserMetadata(userId);
 
-      expect(metadata.google?.connectionState).toBe("IMPORTING");
+      expect(metadata.google?.connectionState).toBe("ATTENTION");
       expect(restartSpy).not.toHaveBeenCalled();
 
       restartSpy.mockRestore();
+    });
+
+    it("returns IMPORTING while Google sync work is active", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      expect(tryBeginGoogleSync(userId)).toBe(true);
+      const metadata = await driver.fetchUserMetadata(userId);
+      endGoogleSync(userId);
+
+      expect(metadata.google?.connectionState).toBe("IMPORTING");
     });
 
     it("returns ATTENTION when a restart is pending", async () => {

--- a/packages/backend/src/user/services/user-metadata.service.ts
+++ b/packages/backend/src/user/services/user-metadata.service.ts
@@ -7,6 +7,7 @@ import {
   type UserMetadata,
 } from "@core/types/user.types";
 import EmailService from "@backend/email/email.service";
+import { isGoogleSyncActive } from "@backend/sync/services/google-sync/google-sync.activity";
 import { isGoogleCalendarSyncHealthy } from "@backend/sync/services/google-sync/google-sync.health";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 import { type GetUserMetadataResponse } from "@backend/user/types/user.types";
@@ -49,12 +50,12 @@ class UserMetadataService {
       return { connectionState: "RECONNECT_REQUIRED" };
     }
 
-    const importStatus = storedMetadata.sync?.importGCal;
-    if (importStatus === "IMPORTING") {
+    if (isGoogleSyncActive(userId)) {
       return { connectionState: "IMPORTING" };
     }
 
-    if (importStatus === "RESTART") {
+    const importStatus = storedMetadata.sync?.importGCal;
+    if (importStatus === "IMPORTING" || importStatus === "RESTART") {
       return { connectionState: "ATTENTION" };
     }
 

--- a/packages/web/src/auth/google/state/google.sync.state.ts
+++ b/packages/web/src/auth/google/state/google.sync.state.ts
@@ -26,6 +26,12 @@ export const clearGoogleSyncIndicatorOverride = () => {
   setGoogleSyncIndicatorOverride(null);
 };
 
+export const clearSyncingSyncIndicatorOverride = () => {
+  if (gSyncIndicator === "syncing") {
+    clearGoogleSyncIndicatorOverride();
+  }
+};
+
 export const getGoogleSyncIndicatorOverride = () => gSyncIndicator;
 
 export const setRepairingSyncIndicatorOverride = () => {

--- a/packages/web/src/sse/hooks/useGcalSSE.factory.ts
+++ b/packages/web/src/sse/hooks/useGcalSSE.factory.ts
@@ -9,6 +9,7 @@ import {
 import { type UserMetadata } from "@core/types/user.types";
 import {
   clearGoogleSyncIndicatorOverride,
+  clearSyncingSyncIndicatorOverride,
   getGoogleSyncIndicatorOverride,
   setSyncingSyncIndicatorOverride,
 } from "@web/auth/google/state/google.sync.state";
@@ -70,7 +71,12 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
         // The backend replays the whole user-metadata payload here (packet-01
         // contract note); the web-side UserMetadata shape is still a plain
         // interface with no schema of its own to validate against.
-        dependencies.setUserMetadata(message.metadata as UserMetadata);
+        const metadata = message.metadata as UserMetadata;
+        dependencies.setUserMetadata(metadata);
+
+        if (metadata.google?.connectionState !== "IMPORTING") {
+          clearSyncingSyncIndicatorOverride();
+        }
       },
       [],
     );

--- a/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
@@ -102,6 +102,58 @@ describe("useGcalSSE", () => {
     });
   });
 
+  it("clears a stale syncing override when replayed metadata is healthy", async () => {
+    render(<HookHost />);
+
+    act(() => {
+      fireMessage({ type: "syncStatusChanged", sync: { status: "syncing" } });
+      fireUserMetadata({ google: { connectionState: "HEALTHY" } });
+    });
+
+    await waitFor(() => {
+      expect(getGoogleSyncIndicatorOverride()).toBe(null);
+    });
+  });
+
+  it("clears a stale syncing override when replayed metadata needs attention", async () => {
+    render(<HookHost />);
+
+    act(() => {
+      fireMessage({ type: "syncStatusChanged", sync: { status: "syncing" } });
+      fireUserMetadata({ google: { connectionState: "ATTENTION" } });
+    });
+
+    await waitFor(() => {
+      expect(getGoogleSyncIndicatorOverride()).toBe(null);
+    });
+  });
+
+  it("keeps the syncing override when replayed metadata confirms active work", async () => {
+    render(<HookHost />);
+
+    act(() => {
+      fireMessage({ type: "syncStatusChanged", sync: { status: "syncing" } });
+      fireUserMetadata({ google: { connectionState: "IMPORTING" } });
+    });
+
+    await waitFor(() => {
+      expect(getGoogleSyncIndicatorOverride()).toBe("syncing");
+    });
+  });
+
+  it("keeps the repairing override during an early healthy metadata replay", async () => {
+    setRepairingSyncIndicatorOverride();
+    render(<HookHost />);
+
+    act(() => {
+      fireUserMetadata({ google: { connectionState: "HEALTHY" } });
+    });
+
+    await waitFor(() => {
+      expect(getGoogleSyncIndicatorOverride()).toBe("repairing");
+    });
+  });
+
   it("clears the syncing override and triggers refetch after importCompleted", async () => {
     setRepairingSyncIndicatorOverride();
 

--- a/team/architect/google-sync-lifecycle-repair/01-repair-perpetual-sync.md
+++ b/team/architect/google-sync-lifecycle-repair/01-repair-perpetual-sync.md
@@ -1,0 +1,426 @@
+# 01 — Repair the Google sync lifecycle
+
+_Proposed architect packet, 2026-07-13. Based on the staging investigation at
+frontend version `1.0.187` and local source at `c95eeb224`._
+
+## Review status
+
+- [x] Founder approved the implementation scope on 2026-07-13.
+- [ ] Fullstack confirms the single-backend-process assumption still matches every
+      supported deployment.
+- [ ] QA confirms the staging recovery steps are safe for the test account.
+
+This is one correctness repair, intended to ship as one focused PR. It does not
+introduce a queue, worker, polling loop, replay log, database lease, heartbeat, or
+new dependency.
+
+## Problem statement
+
+The staging account `compasscaltest3@gmail.com` perpetually shows “Syncing…”. The
+live metadata response confirms that this is not merely a rendering problem:
+
+```text
+sync.importGCal = IMPORTING
+sync.incrementalGCalSync = COMPLETED
+google.connectionState = IMPORTING
+```
+
+Three lifecycle failures combine to make that state permanent:
+
+1. A full import stores `IMPORTING` before deleting/rebuilding Google sync data. A
+   backend restart can abandon that stored value without running success/error
+   cleanup.
+2. Stored `IMPORTING` is treated as proof that work is active. Even `force: true`
+   refuses to repair it, so reconnect, watch repair, and the UI cannot recover.
+3. The SSE migration can emit `syncing` for an incremental request that is later
+   ignored, with no terminal event. The web also lets the transient SSE override
+   outrank healthy metadata replayed on reconnect.
+
+The transport itself is healthy: staging had an active EventSource connection and
+no malformed/unrecognized SSE messages in the browser console. The defect is in
+how backend activity, persisted status, and frontend presentation are reconciled.
+
+## Goals
+
+- A backend restart cannot leave an account permanently `IMPORTING`.
+- At most one Google sync operation runs per user in the current backend process.
+- Full and incremental sync cannot race each other in that process.
+- The backend never emits `syncing` for work it already knows it will ignore.
+- Every non-crash path that emits `syncing` emits a terminal `healthy` or
+  `attention` message.
+- Replayed metadata repairs a stale frontend-only `syncing` override.
+- The stuck staging account becomes repairable without a special migration.
+- Tests exercise lifecycle sequences, not only individual event helpers.
+
+## Non-goals
+
+- Supporting multiple simultaneously active backend replicas.
+- Building a general background-job framework.
+- Guaranteeing SSE delivery with message IDs or a replay journal.
+- Adding progress percentages, cancellation, or a sync-history UI.
+- Redesigning Google watch inspection/maintenance.
+- Changing Google event import, paging, retry, or persistence behavior.
+- Automatically modifying the staging account as part of the code change.
+
+## Simplicity decision
+
+### Use one small runtime activity registry
+
+Compass already uses an in-memory `Set` to prevent two full imports for one user.
+Keep that deployment assumption, but make the state explicit and shared by both
+full and incremental sync.
+
+Add one narrow module, tentatively:
+
+```text
+packages/backend/src/sync/services/google-sync/google-sync.activity.ts
+```
+
+Its complete production API should be approximately:
+
+```ts
+tryBeginGoogleSync(userId: string): boolean
+endGoogleSync(userId: string): void
+isGoogleSyncActive(userId: string): boolean
+```
+
+No operation classes, job objects, generic lock abstraction, owner IDs, expiry
+fields, or public configuration. The module owns one private `Set<string>`.
+
+### State semantics
+
+| Signal | Meaning after this repair |
+| --- | --- |
+| Runtime activity registry | Work is executing in this backend process now. This is the concurrency authority. |
+| `sync.importGCal` | Durable outcome/recovery marker for the last full import. It is not a lock. |
+| `sync.incrementalGCalSync` | Durable outcome/recovery marker for the last sign-in incremental import. It is not a lock. |
+| `google.connectionState` | Server-computed UI state using runtime activity plus durable health. |
+| SSE `syncStatusChanged` | Prompt notification for an already-connected tab, not durable truth. |
+| Web transient override | Short-lived presentation bridge until metadata confirms current truth. |
+
+This removes the circular assumption that `IMPORTING` proves a live task exists.
+After a backend restart, the registry is empty. Old `IMPORTING` metadata is then
+recognized as abandoned on the next metadata fetch or SSE connection.
+
+### Why not add a Mongo lease now?
+
+A Mongo lease is required if Compass runs multiple backend processes that may serve
+the same user concurrently. Current supported Compose deployments run one backend
+service instance, and the existing code already relies on process-local exclusion.
+
+A correct distributed lease would need acquisition, expiry, renewal during long
+imports, release, crash recovery, observability, and careful interaction with
+`stopGoogleCalendarSync`, which deletes Google sync records. That is materially more
+system than this bug needs. Record it as the upgrade path if deployment topology
+changes; do not partially build it now.
+
+## Implementation plan
+
+### 1. Centralize current activity
+
+Primary files:
+
+- `packages/backend/src/sync/services/google-sync/google-sync.activity.ts` (new)
+- `packages/backend/src/sync/services/google-sync/google-sync.service.ts`
+
+Changes:
+
+1. Move the existing `activeFullSyncRestarts` responsibility into the activity
+   module.
+2. Make both `importLatestGoogleCalendarChanges` and
+   `runGoogleCalendarSyncSetup` call `tryBeginGoogleSync` before any start event,
+   metadata mutation, Google request, or destructive cleanup.
+3. If acquisition fails, return as ignored without publishing `syncing`.
+4. Always call `endGoogleSync` from `finally` after successful acquisition.
+5. Treat stored `IMPORTING` with a newly acquired runtime slot as abandoned work:
+   it may be retried. Treat `COMPLETED` as the existing non-force skip condition.
+6. A forced repair proceeds whenever it acquired the runtime slot. “Force” must
+   bypass stale persisted status, but never bypass actual current activity.
+
+Expected ordering for work that runs:
+
+```text
+acquire runtime activity
+  → decide the requested operation may run
+  → publish syncing
+  → persist IMPORTING
+  → perform sync
+  → persist COMPLETED or ERRORED
+  → publish terminal message
+  → release runtime activity
+```
+
+Expected ordering for duplicate/ineligible work:
+
+```text
+cannot acquire, or durable COMPLETED says non-force work is unnecessary
+  → return ignored
+  → publish no start and no fake completion
+```
+
+Do not retain `IGNORED` as a branch in `notifyImportEnd`; it made an invalid
+start/end sequence representable. Use explicit success/failure helpers or a status
+union that only contains terminal outcomes.
+
+### 2. Make metadata assessment reflect real activity
+
+Primary files:
+
+- `packages/backend/src/user/services/user-metadata.service.ts`
+- `packages/backend/src/user/services/user-metadata.service.test.ts`
+
+Assessment order for a Google-connected user with a refresh token:
+
+1. If `isGoogleSyncActive(userId)`, return `IMPORTING`.
+2. If durable full-import metadata is `IMPORTING` but runtime activity is absent,
+   return `ATTENTION`—the prior run was abandoned.
+3. Preserve the existing `RESTART → ATTENTION` rule.
+4. Otherwise compute `HEALTHY` versus `ATTENTION` from sync tokens/watches as today.
+
+This rule also makes replayed metadata accurate during an incremental sync: runtime
+activity yields `IMPORTING` even though the full-import status may be `COMPLETED`.
+
+Assessment stays read-only. It must not silently mutate SuperTokens metadata during
+a GET or SSE connection. A subsequent successful repair replaces the abandoned
+status normally.
+
+### 3. Guarantee terminal notification on handled failures
+
+Primary file:
+
+- `packages/backend/src/sync/services/google-sync/google-sync.service.ts`
+
+Today, failure handlers update metadata before publishing `attention`. If that
+update fails, the terminal SSE message is skipped too.
+
+For both full and incremental paths:
+
+1. Log the original sync failure.
+2. Attempt to persist `ERRORED` in a nested `try/catch`.
+3. Log metadata persistence failure separately.
+4. Publish `attention/IMPORT_FAILED` even if metadata persistence failed.
+5. Release runtime activity in `finally`.
+
+Do not create a retry framework for metadata writes in this packet. The reconnect
+assessment and actual sync health remain the durable recovery path.
+
+Process termination can still prevent a terminal SSE message. That is expected;
+the registry + reconnect assessment repair that gap after restart.
+
+### 4. Reconcile the web override with metadata replay
+
+Primary files:
+
+- `packages/web/src/sse/hooks/useGcalSSE.factory.ts`
+- `packages/web/src/auth/google/state/google.sync.state.ts`
+- `packages/web/src/sse/provider/SSEProvider.interaction.test.tsx`
+
+When `userMetadataChanged` arrives:
+
+1. Store the metadata as today.
+2. If the transient override is exactly `syncing` and
+   `metadata.google.connectionState !== "IMPORTING"`, clear it.
+3. Do not clear the optimistic `repairing` override from metadata replay; a replay
+   can race ahead of the repair start, and its SSE terminal path already owns that
+   state.
+
+Prefer one semantic helper such as `clearSyncingSyncIndicatorOverride` over
+duplicating a get/compare/clear sequence in the hook. Keep the external store; it
+is still needed to reflect a start event before refreshed metadata arrives.
+
+Do not add a timeout or polling loop. Reconnect already replays metadata, and
+success/failure paths refresh metadata.
+
+### 5. Repair operation naming while touching the helper
+
+Primary files:
+
+- `packages/backend/src/sync/services/google-sync/google-sync.service.ts`
+- relevant backend SSE tests
+
+The `importCompleted` contract supports `full`, `incremental`, and `repair`, but the
+current mapper turns every non-repair operation into `incremental`. Use typed
+operation values end-to-end so:
+
+- initial full import reports `full`;
+- sign-in incremental import reports `incremental`;
+- forced full repair reports `repair`.
+
+This is a small adjacent correction in the same helper and should not become a
+separate abstraction.
+
+## Required regression tests
+
+### Backend service tests
+
+Add focused lifecycle assertions to
+`packages/backend/src/sync/services/google-sync/google-sync.service.test.ts`:
+
+- [ ] Completed incremental state: no import work, no `syncing`, no terminal event.
+- [ ] Incremental runtime collision: loser emits no SSE state changes.
+- [ ] Full/incremental collision: only the winner runs; the loser performs no
+      destructive cleanup.
+- [ ] Seeded full `IMPORTING` with no runtime activity: forced repair runs.
+- [ ] Seeded full `IMPORTING` with no runtime activity: non-force recovery may run.
+- [ ] Active full import plus forced request: forced request is ignored; active run
+      owns the eventual terminal event.
+- [ ] Successful full/incremental runs emit `syncing` then a terminal message in
+      order.
+- [ ] Sync failure plus metadata-update failure still emits `attention` and releases
+      activity.
+- [ ] Activity releases after success, ordinary failure, revoked-token handling,
+      and cleanup failure.
+- [ ] Completion operations are `full`, `incremental`, and `repair` respectively.
+
+Avoid sleep-based concurrency tests. Gate the first promise with a deferred promise,
+invoke the competing operation while it is deterministically held, then release it.
+
+### Metadata tests
+
+Add to `packages/backend/src/user/services/user-metadata.service.test.ts`:
+
+- [ ] Runtime activity returns `IMPORTING` regardless of the prior durable outcome.
+- [ ] Durable `IMPORTING` without runtime activity returns `ATTENTION`.
+- [ ] `RESTART`, revoked credentials, healthy sync, and unhealthy sync retain their
+      existing behavior.
+
+Reset the activity registry in test cleanup so files remain isolated. A test-only
+reset is acceptable; do not export the underlying `Set`.
+
+### Web interaction tests
+
+Add to `packages/web/src/sse/provider/SSEProvider.interaction.test.tsx`:
+
+- [ ] `syncing` followed by replayed `HEALTHY` metadata clears the override.
+- [ ] `syncing` followed by replayed `ATTENTION` metadata clears the override.
+- [ ] `syncing` followed by replayed `IMPORTING` metadata remains syncing.
+- [ ] `repairing` is not cleared by an early healthy metadata replay.
+- [ ] Existing healthy, failure, revoked, and import-completed cases remain green.
+
+### Controller/SSE integration test
+
+Add one end-to-end backend test at the existing stream/controller seam:
+
+- [ ] An ignored import request never sends `syncStatusChanged: syncing`.
+- [ ] A real import sends `syncing` and exactly one terminal status to an open SSE
+      stream.
+
+Do not add a new E2E test harness solely for this bug; the existing backend SSE
+driver and web interaction suite are the correct seams.
+
+## Verification commands
+
+During implementation:
+
+```bash
+TZ=UTC bun test:backend --runTestsByPath \
+  packages/backend/src/sync/services/google-sync/google-sync.service.test.ts \
+  packages/backend/src/user/services/user-metadata.service.test.ts \
+  packages/backend/src/sync/controllers/sync.controller.test.ts --runInBand
+
+bun test --cwd packages/web \
+  src/sse/provider/SSEProvider.interaction.test.tsx
+```
+
+Before handoff:
+
+```bash
+bun test:core
+bun test:web
+TZ=UTC bun test:backend
+bun type-check
+bun lint
+bun run verify
+```
+
+Confirm `bun run verify` selected the expected backend/core/web checks; do not treat
+its exit code alone as sufficient.
+
+## Staging recovery and acceptance
+
+Deploy the fixed release before changing the stuck account manually.
+
+1. Confirm `/version.json` is the fixed version.
+2. Open staging as `compasscaltest3@gmail.com`.
+3. Confirm replayed metadata now presents `ATTENTION` rather than perpetual
+   `IMPORTING` because no runtime activity exists for the abandoned run.
+4. Select “Sync now” once.
+5. Observe one `syncStatusChanged: syncing`, followed by `importCompleted` and
+   `syncStatusChanged: healthy`, or a single actionable `attention` failure.
+6. Reload and confirm the account remains `HEALTHY`/“Up-to-date”.
+7. Confirm calendars and events converge without duplicates.
+8. Trigger a harmless duplicate import request in a controlled QA session and
+   confirm it creates no new syncing indicator.
+9. Restart the staging backend during a test-account import, reconnect, and verify
+   the account becomes actionable rather than permanently syncing. Only use the
+   designated staging test account; do not interrupt another user's import.
+
+If step 3 does not expose the repair action, use a one-time metadata correction for
+the staging test account only (`IMPORTING → ERRORED` or `RESTART`) and record why.
+That operator action is a fallback, not the application fix.
+
+## Implementation verification — 2026-07-13
+
+- Focused backend lifecycle suites: 48 passed.
+- Focused web SSE interaction suite: 10 passed.
+- Core suite: 265 passed.
+- Type-check: passed.
+- Changed sync files: Biome check and `git diff --check` passed.
+- Full backend suite: 675 passed; two unrelated calendar-controller assertions
+  still expect `ObjectId` where the current controller passes a string.
+- Full web suite: 1,314 passed with no assertion failures; the test bootstrap
+  reports two existing jsdom CSS parse errors and exits nonzero.
+- Repository lint remains blocked by unrelated formatting errors and existing
+  warnings outside this packet.
+- React Doctor reported no issue in the sync files changed by this packet. Its two
+  branch-level findings are in the existing release-notes dialog and day grid.
+
+Staging acceptance remains pending deployment.
+
+## Rollback
+
+The code change has no schema migration and no new persisted fields.
+
+- Application rollback: deploy the prior version.
+- No database rollback is required.
+- If a repair was started after deployment, let it finish before rolling back when
+  possible; the import's existing page-level persistence remains unchanged.
+- Do not restore the stuck `IMPORTING` value after a successful repair.
+
+## Observability required for this packet
+
+Reuse existing logger namespaces and avoid user email, Google ids, event content, or
+tokens. Add only lifecycle messages needed to distinguish:
+
+- sync acquired (`full`, `incremental`, or `repair`);
+- sync ignored because runtime activity exists;
+- abandoned persisted `IMPORTING` assessed as attention;
+- sync terminal outcome;
+- metadata terminal-state persistence failed.
+
+Do not add metrics infrastructure. Existing structured logs are enough to validate
+the repair on staging.
+
+## Reviewed adjacent issues and disposition
+
+| Finding | Disposition |
+| --- | --- |
+| `WATCH_REPAIR_FAILED` is accepted by core/web but no production backend path publishes it. | Follow-up cleanup, not required to unblock lifecycle recovery. Either publish it from the repair coordinator or remove the dead contract after confirming desired UX. |
+| Watch repair can report `FULL_REPAIR_STARTED` even when the sync service ignored the request. | Fix in a small follow-up by returning an explicit service outcome; avoid expanding the core repair PR unless its test needs the result. |
+| `publishUserMetadata` exists but normal metadata mutations do not publish it. | Leave alone. Metadata replay plus explicit sync-status messages are sufficient for this repair. |
+| SSE has no event IDs/replay buffer. | Accepted. Metadata reconciliation is the simpler recovery mechanism for state; query invalidation already reconciles event data. |
+| Process-local activity is not safe for multiple backend replicas. | Accepted under current topology. Add a Mongo lease only before enabling multiple replicas. |
+| Partial full imports survive by page, but a restart may leave partial Google data until repair. | Existing durability design; this packet makes repair available instead of changing import persistence. |
+
+## Exit criteria
+
+- [x] No ignored path emits `syncing`.
+- [x] Full and incremental sync share one per-user runtime exclusion rule.
+- [x] A stored `IMPORTING` value without runtime activity becomes `ATTENTION`.
+- [x] Forced repair can recover an abandoned import but cannot overlap active work.
+- [x] Handled failures publish a terminal SSE status even if metadata persistence
+      fails.
+- [x] Healthy/attention metadata replay clears only the stale `syncing` override.
+- [ ] Focused and full affected test/lint/type-check gates pass.
+- [ ] Staging restart acceptance proves the original failure no longer reproduces.
+- [x] No queue, poller, timer, lease, dependency, or migration was added.

--- a/team/architect/notes/2026-07-13.md
+++ b/team/architect/notes/2026-07-13.md
@@ -1,0 +1,30 @@
+# 2026-07-13 — architect
+
+## Work
+
+- Diagnosed staging's perpetual Google sync state across metadata, SSE, and web UI.
+- Wrote `google-sync-lifecycle-repair/01-repair-perpetual-sync.md` for founder review.
+- Implemented the approved lifecycle repair with focused backend, metadata, SSE,
+  and web interaction regression coverage.
+
+## Decisions
+
+- Use one small process-local per-user activity registry for full + incremental
+  sync; current deployments already assume one backend process.
+- Treat durable `IMPORTING` as abandoned when no runtime activity exists.
+- Reconcile stale web SSE overrides from authoritative metadata; no polling/replay
+  system.
+- Keep the repair to one cohesive PR with no migration or new dependency.
+
+## Proposals
+
+- Deploy packet 01 to staging and run the documented restart/recovery acceptance
+  against the designated test account.
+- Clear the repository-wide validation baseline separately: calendar-controller
+  type expectations, jsdom CSS parsing, and unrelated formatter warnings currently
+  keep the aggregate commands red despite the focused sync checks passing.
+
+## Founder follow-ups
+
+- Confirm the single-backend-process assumption before shipping. Multi-replica
+  locking and watch-repair contract cleanup remain explicitly deferred.


### PR DESCRIPTION
## Summary

- treat persisted `IMPORTING` as a recovery marker instead of proof that sync work is still running
- share one small per-user runtime guard across full, incremental, and repair sync operations
- publish SSE start/terminal states consistently and reconcile stale frontend `syncing` state from metadata replay
- report full, incremental, and repair completion operations accurately

This repairs the staging account that remains stuck on “Syncing…” after an abandoned import while keeping the solution intentionally process-local and dependency-free.

## Simplicity

The simplification pass retained one private `Set<string>` behind three narrow functions. It replaces the existing full-sync-only set and avoids a queue, lease, heartbeat, timer, polling loop, or new dependency. The web change adds no effect, ref, or state; it extends the existing SSE metadata handler and uses one semantic helper that clears only `syncing`, preserving `repairing` during an early metadata replay.

## Manual Testing Steps

- [ ] Deploy the PR build to staging and reload the designated `compasscaltest3@gmail.com` test account.
- [ ] Confirm abandoned `IMPORTING` metadata presents an actionable attention state instead of perpetual “Syncing…”.
- [ ] Select “Sync now” once and observe one syncing state followed by either healthy completion or actionable attention.
- [ ] Reload and confirm the terminal state remains stable.
- [ ] Trigger a duplicate request during an active sync and confirm it does not create another syncing indicator or destructive restart.

## Test plan

- [x] `TZ=UTC bun test:backend --runInBand packages/backend/src/sync/services/google-sync/google-sync.service.test.ts packages/backend/src/user/services/user-metadata.service.test.ts packages/backend/src/sync/controllers/sync.controller.test.ts` (48 passed)
- [x] `bun test --cwd packages/web src/sse/provider/SSEProvider.interaction.test.tsx` (10 passed)
- [x] `bun type-check`
- [x] `bun test:core` (265 passed)
- [x] Biome check for all changed source/test files
- [x] `git diff --check`

Repository-wide local backend, web, and lint commands still reproduce pre-existing baseline failures outside this diff; clean PR CI is the merge gate.
