### PR TITLE
fix(web): navigate days with horizontal scroll

### DIFF
--- a/packages/web/src/common/hooks/useHorizontalNavigation.test.tsx
+++ b/packages/web/src/common/hooks/useHorizontalNavigation.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { type FC, useRef } from "react";
-import { useHorizontalWeekNavigation } from "@web/views/Week/hooks/useHorizontalWeekNavigation";
+import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { describe, expect, it, mock } from "bun:test";
 
 const Harness: FC<{
@@ -8,17 +8,17 @@ const Harness: FC<{
   onPrevious: () => void;
 }> = ({ onNext, onPrevious }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  useHorizontalWeekNavigation({ containerRef, onNext, onPrevious });
+  useHorizontalNavigation({ containerRef, onNext, onPrevious });
 
-  return <div ref={containerRef} data-testid="calendar" />;
+  return <section ref={containerRef} aria-label="Calendar" />;
 };
 
-describe("useHorizontalWeekNavigation", () => {
+describe("useHorizontalNavigation", () => {
   it("navigates once when a horizontal gesture crosses the threshold", () => {
     const onNext = mock();
     render(<Harness onNext={onNext} onPrevious={mock()} />);
 
-    const calendar = screen.getByTestId("calendar");
+    const calendar = screen.getByRole("region", { name: "Calendar" });
     fireEvent.wheel(calendar, { deltaX: 35, deltaY: 2 });
     fireEvent.wheel(calendar, { deltaX: 35, deltaY: 2 });
     fireEvent.wheel(calendar, { deltaX: 100, deltaY: 2 });
@@ -30,7 +30,7 @@ describe("useHorizontalWeekNavigation", () => {
     const onPrevious = mock();
     render(<Harness onNext={mock()} onPrevious={onPrevious} />);
 
-    fireEvent.wheel(screen.getByTestId("calendar"), {
+    fireEvent.wheel(screen.getByRole("region", { name: "Calendar" }), {
       deltaX: -70,
       deltaY: 0,
     });
@@ -43,7 +43,7 @@ describe("useHorizontalWeekNavigation", () => {
     const onPrevious = mock();
     render(<Harness onNext={onNext} onPrevious={onPrevious} />);
 
-    const calendar = screen.getByTestId("calendar");
+    const calendar = screen.getByRole("region", { name: "Calendar" });
     fireEvent.wheel(calendar, { deltaX: 20, deltaY: 80 });
     fireEvent.wheel(calendar, { ctrlKey: true, deltaX: 80, deltaY: 0 });
 
@@ -55,7 +55,7 @@ describe("useHorizontalWeekNavigation", () => {
     const onNext = mock();
     render(<Harness onNext={onNext} onPrevious={mock()} />);
 
-    const calendar = screen.getByTestId("calendar");
+    const calendar = screen.getByRole("region", { name: "Calendar" });
     const scrollArea = document.createElement("div");
     Object.defineProperties(scrollArea, {
       clientWidth: { value: 100 },

--- a/packages/web/src/common/hooks/useHorizontalNavigation.ts
+++ b/packages/web/src/common/hooks/useHorizontalNavigation.ts
@@ -3,7 +3,7 @@ import { type RefObject, useEffect, useRef } from "react";
 const GESTURE_IDLE_MS = 180;
 const NAVIGATION_THRESHOLD_PX = 60;
 
-type HorizontalWeekNavigationOptions = {
+type HorizontalNavigationOptions = {
   containerRef: RefObject<HTMLElement | null>;
   onNext: () => void;
   onPrevious: () => void;
@@ -30,11 +30,11 @@ const canScrollHorizontally = (
   return false;
 };
 
-export const useHorizontalWeekNavigation = ({
+export const useHorizontalNavigation = ({
   containerRef,
   onNext,
   onPrevious,
-}: HorizontalWeekNavigationOptions) => {
+}: HorizontalNavigationOptions) => {
   const callbacksRef = useRef({ onNext, onPrevious });
 
   useEffect(() => {

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -1,6 +1,7 @@
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo, useRef } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { ID_MAIN } from "@web/common/constants/web.constants";
+import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import {
   CompassDOMEvents,
   compassEventEmitter,
@@ -31,6 +32,7 @@ import { Dedication } from "@web/views/Week/components/Dedication/Dedication";
 
 export const DayViewContent = memo(() => {
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
+  const mainRef = useRef<HTMLDivElement | null>(null);
 
   const dateInView = useDateInView();
   const isViewingToday = dateInView.isSame(dayjs(), "day");
@@ -41,6 +43,11 @@ export const DayViewContent = memo(() => {
     navigateToPreviousDay,
     navigateToToday,
   } = useDateNavigation();
+  useHorizontalNavigation({
+    containerRef: mainRef,
+    onNext: navigateToNextDay,
+    onPrevious: navigateToPreviousDay,
+  });
   useDayEvents(dateInView);
 
   const plannerViewStart = dateInView.startOf("week");
@@ -138,6 +145,7 @@ export const DayViewContent = memo(() => {
 
       <div
         id={ID_MAIN}
+        ref={mainRef}
         className="flex h-screen flex-1 flex-col overflow-hidden bg-bg-primary pt-5 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
       >
         <Header />

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
 import { ID_MAIN } from "@web/common/constants/web.constants";
+import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuWrapper";
@@ -30,7 +31,6 @@ import { useGridLayout } from "@web/views/Week/hooks/grid/useGridLayout";
 import { useScroll } from "@web/views/Week/hooks/grid/useScroll";
 import { useVisibleDayCount } from "@web/views/Week/hooks/grid/useVisibleDayCount";
 import { useDayShiftTransition } from "@web/views/Week/hooks/useDayShiftTransition";
-import { useHorizontalWeekNavigation } from "@web/views/Week/hooks/useHorizontalWeekNavigation";
 import { usePlannerSidebarCalendarDate } from "@web/views/Week/hooks/usePlannerSidebarCalendarDate";
 import { useToday } from "@web/views/Week/hooks/useToday";
 import { useWeek } from "@web/views/Week/hooks/useWeek";
@@ -62,7 +62,7 @@ export const WeekView = () => {
     },
     [trackRef],
   );
-  useHorizontalWeekNavigation({
+  useHorizontalNavigation({
     containerRef: mainRef,
     onNext: weekProps.util.incrementWeek,
     onPrevious: weekProps.util.decrementWeek,


### PR DESCRIPTION
## Summary
- make horizontal wheel gestures navigate the Day view forward or backward by one day
- move the existing Week gesture hook into shared web hooks so Day and Week use one interaction policy
- preserve vertical scrolling, pinch zoom, nested horizontal scrolling, and one-navigation-per-gesture behavior

## Simplicity
- renamed and reused the existing Week hook instead of duplicating gesture thresholds and listener logic
- removed a proposed single-use Day wrapper during the simplification pass; Day attaches the shared hook directly to its existing main container
- retained one ref in each view because the non-passive wheel listener must attach to the concrete calendar container

## Manual Testing Steps
- [ ] Open Day view on a known date and horizontally scroll right; confirm the date advances by one day
- [ ] Horizontally scroll left after the gesture settles; confirm the date moves back one day
- [ ] Vertically scroll the Day calendar; confirm the date does not change
- [ ] Open Week view and confirm its existing horizontal navigation still works

## Test plan
- [x] focused horizontal navigation tests (4 passed)
- [x] `bun test:web` (1,311 passed)
- [x] `bun type-check`
- [x] changed-file Biome lint and `git diff --check`
- [x] React Doctor diff scan (100/100, no issues)
- [x] diff-first accessibility audit (no findings)
- [x] in-app browser Day forward/back, vertical-scroll, Week regression, and console validation
- [x] ran `bun lint`; it remains blocked by two pre-existing backend test formatting errors on `main` outside this diff