### PR TITLE
fix(ci): serialize environment deployments

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -20,6 +20,10 @@ jobs:
     name: Deploy ${{ inputs.tag }} to ${{ inputs.environment }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    concurrency:
+      group: deploy-${{ inputs.environment }}
+      cancel-in-progress: false
+      queue: max
 
     steps:
       - name: Derive image version


### PR DESCRIPTION
## Summary

- serialize deployment jobs by GitHub Environment
- preserve every queued release deployment in FIFO order
- prevent overlapping jobs from rewriting compass.yaml or racing Docker Compose

## Root cause

Release runs for v1.0.189 and v1.0.190 overlapped. The newer deployment rewrote the shared environment configuration while the older deployment was between teardown and startup, causing the older run to pull 1.0.190 and collide with an existing compass-backend-1 container.

## Validation

- parsed the reusable workflow as YAML
- asserted the deployment job uses an environment-keyed concurrency group, does not cancel active deployments, and retains the full pending queue
- git diff --check