### PR TITLE
feat(web): replace signup subscribe checkbox with post-signup release-notes prompt

### DIFF
--- a/packages/web/declaration.d.ts
+++ b/packages/web/declaration.d.ts
@@ -37,13 +37,20 @@ declare const BUILD_VERSION: string;
 interface Window {
   /** Set by Playwright prepareOAuthTestPage; disables SuperTokens session checks in e2e mode. */
   __COMPASS_E2E_TEST__?: boolean;
-  /** Semantic user-metadata bridge for e2e tests. Set by packages/web/src/auth/state/user-metadata.store.ts. */
+  /** Semantic store bridges for e2e tests. Each store sets its own key (see
+   * user-metadata.store.ts, release-notes-prompt.store.ts); keys are optional
+   * because they populate independently as their modules evaluate. */
   __COMPASS_E2E_STORE__?: {
-    userMetadata: {
+    userMetadata?: {
       getState: () => import("@web/auth/state/user-metadata.store").UserMetadataState;
       set: (metadata: import("@core/types/user.types").UserMetadata) => void;
       setLoading: () => void;
       clear: () => void;
+    };
+    releaseNotesPrompt?: {
+      getState: () => import("@web/auth/state/release-notes-prompt.store").ReleaseNotesPromptState;
+      open: () => void;
+      close: () => void;
     };
   };
   /** Session test hooks exposed by SessionProvider for e2e auth control. */

--- a/packages/web/src/auth/compass/user/util/subscribe.util.ts
+++ b/packages/web/src/auth/compass/user/util/subscribe.util.ts
@@ -1,0 +1,17 @@
+import { type UserMetadata } from "@core/types/user.types";
+import { UserApi } from "@web/api/user.api";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+
+/**
+ * Opt the current user into monthly release-note emails.
+ *
+ * One-way: unsubscribing happens via the email's own footer link, not from
+ * within Compass. On success the local metadata store is updated so UI that
+ * gates on `subscribeToUpdates` (e.g. the command palette item) reacts
+ * immediately. Callers own their own success/error feedback.
+ */
+export async function subscribeToReleaseNotes(): Promise<UserMetadata> {
+  const metadata = await UserApi.updateMetadata({ subscribeToUpdates: true });
+  userMetadataActions.set(metadata);
+  return metadata;
+}

--- a/packages/web/src/auth/google/authorization/complete-google-authorization.ts
+++ b/packages/web/src/auth/google/authorization/complete-google-authorization.ts
@@ -30,6 +30,7 @@ export type GoogleAuthorizationAuthAdapter = {
     config?: ApiMethodConfig,
   ): Promise<unknown>;
   loginOrSignup(data: GoogleAuthCodeRequest): Promise<{
+    createdNewRecipeUser: boolean;
     user: { emails?: string[] };
   }>;
 };
@@ -45,6 +46,7 @@ export type CompleteGoogleAuthorizationOptions = {
 
 export type CompleteGoogleAuthorizationResult =
   | {
+      isNewUser: boolean;
       returnPath: string;
       status: "completed";
     }
@@ -127,8 +129,13 @@ export async function completeGoogleAuthorization({
     redirectUri: buildGoogleAuthCallbackUrl(),
   });
 
+  // Whether this callback created a brand-new account (vs. a returning login or
+  // a Google connect). Drives the post-signup release-notes prompt downstream.
+  let isNewUser = false;
+
   const completeGoogleSignIn = async () => {
     const result = await authApi.loginOrSignup(payload);
+    isNewUser = result.createdNewRecipeUser;
     await completeAuthentication({
       email: result.user.emails?.[0],
     });
@@ -160,6 +167,7 @@ export async function completeGoogleAuthorization({
     }
 
     return {
+      isNewUser,
       returnPath,
       status: "completed",
     };

--- a/packages/web/src/auth/google/authorization/google-authorization.test.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.test.ts
@@ -47,7 +47,11 @@ describe("completeGoogleAuthorization", () => {
         ...deps,
         search: callbackSearch("state-1"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/week" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/week",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.loginOrSignup).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -66,6 +70,31 @@ describe("completeGoogleAuthorization", () => {
     expect(readGoogleAuthorizationIntent("state-1")).toBeNull();
   });
 
+  it("reports a brand-new account via isNewUser on sign-in", async () => {
+    const deps = makeDeps();
+    deps.authApi.loginOrSignup.mockResolvedValue({
+      createdNewRecipeUser: true,
+      status: "OK" as const,
+      user: { emails: ["new@example.com"] },
+    });
+    writeGoogleAuthorizationIntent("state-new", {
+      intent: "signIn",
+      returnPath: "/day",
+      createdAt: Date.now(),
+    });
+
+    await expect(
+      completeGoogleAuthorization({
+        ...deps,
+        search: callbackSearch("state-new"),
+      }),
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/day",
+      isNewUser: true,
+    });
+  });
+
   it("completes a saved Google Calendar connect intent", async () => {
     const deps = makeDeps();
     writeGoogleAuthorizationIntent("state-2", {
@@ -79,7 +108,11 @@ describe("completeGoogleAuthorization", () => {
         ...deps,
         search: callbackSearch("state-2"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/day" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/day",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.connectGoogle).toHaveBeenCalledTimes(1);
     expect(deps.refreshUserMetadata).toHaveBeenCalledTimes(1);
@@ -101,7 +134,11 @@ describe("completeGoogleAuthorization", () => {
         doesSessionExist: mock(async () => false),
         search: callbackSearch("state-session-missing"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/day" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/day",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.connectGoogle).not.toHaveBeenCalled();
     expect(deps.authApi.loginOrSignup).toHaveBeenCalledTimes(1);
@@ -133,7 +170,11 @@ describe("completeGoogleAuthorization", () => {
         ...deps,
         search: callbackSearch("state-session-expired"),
       }),
-    ).resolves.toEqual({ status: "completed", returnPath: "/day" });
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/day",
+      isNewUser: false,
+    });
 
     expect(deps.authApi.connectGoogle).toHaveBeenCalledTimes(1);
     expect(deps.authApi.loginOrSignup).toHaveBeenCalledTimes(1);

--- a/packages/web/src/auth/state/release-notes-prompt.store.ts
+++ b/packages/web/src/auth/state/release-notes-prompt.store.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { IS_DEV } from "@web/common/constants/env.constants";
+
+export interface ReleaseNotesPromptState {
+  isOpen: boolean;
+}
+
+export const initialReleaseNotesPromptState: ReleaseNotesPromptState = {
+  isOpen: false,
+};
+
+// In-memory only: the prompt is raised right after a new signup and lives for
+// that single session. If the user reloads before answering, they can still
+// opt in via the command palette (which is what the "Nah" copy points them to).
+export const useReleaseNotesPromptStore = create<ReleaseNotesPromptState>()(
+  devtools(() => initialReleaseNotesPromptState, {
+    name: "compass/releaseNotesPrompt",
+    enabled: IS_DEV,
+  }),
+);
+
+export const releaseNotesPromptActions = {
+  open: () =>
+    useReleaseNotesPromptStore.setState({ isOpen: true }, false, {
+      type: "open",
+    }),
+  close: () =>
+    useReleaseNotesPromptStore.setState({ isOpen: false }, false, {
+      type: "close",
+    }),
+};
+
+export const selectReleaseNotesPromptOpen = (state: ReleaseNotesPromptState) =>
+  state.isOpen;
+
+// Semantic bridge for e2e tests (see e2e/utils/compass-window.ts), mirroring
+// the user-metadata store. Lets tests raise the post-signup prompt without a
+// live backend. Merge (don't overwrite) so sibling stores' bridges survive.
+if (typeof window !== "undefined") {
+  window.__COMPASS_E2E_STORE__ = {
+    ...window.__COMPASS_E2E_STORE__,
+    releaseNotesPrompt: {
+      getState: useReleaseNotesPromptStore.getState,
+      open: releaseNotesPromptActions.open,
+      close: releaseNotesPromptActions.close,
+    },
+  };
+}

--- a/packages/web/src/auth/state/user-metadata.store.ts
+++ b/packages/web/src/auth/state/user-metadata.store.ts
@@ -54,6 +54,7 @@ export const userMetadataActions = {
 // Tests drive connection-status scenarios by setting metadata directly.
 if (typeof window !== "undefined") {
   window.__COMPASS_E2E_STORE__ = {
+    ...window.__COMPASS_E2E_STORE__,
     userMetadata: {
       getState: useUserMetadataStore.getState,
       set: userMetadataActions.set,

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -11,6 +11,7 @@ import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
+import { useReleaseNotesPromptStore } from "@web/auth/state/release-notes-prompt.store";
 import { validateAuthSearch } from "@web/components/AuthModal/hooks/useAuthModal";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -212,6 +213,7 @@ describe("AuthModal", () => {
     mockEmailPassword.submitNewPassword.mockClear();
     mockUpdateMetadata.mockClear();
     mockUpdateMetadata.mockResolvedValue({ subscribeToUpdates: true });
+    useReleaseNotesPromptStore.setState({ isOpen: false });
     mockUseSession.mockReturnValue({
       authenticated: false,
       setAuthenticated: mock(),
@@ -637,7 +639,7 @@ describe("AuthModal", () => {
       expect(mockUpdateMetadata).not.toHaveBeenCalled();
     });
 
-    it("subscribes to updates after sign-up when the checkbox is checked", async () => {
+    it("opens the release-notes prompt after a successful sign-up", async () => {
       const user = userEvent.setup();
       await renderWithProviders(<ModalTrigger />);
 
@@ -655,19 +657,23 @@ describe("AuthModal", () => {
         expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
       });
 
+      // The subscribe opt-in is no longer a checkbox on the form — it's a
+      // dedicated prompt raised (via its store) right after signup succeeds.
+      expect(
+        screen.queryByRole("checkbox", { name: /subscribe to updates/i }),
+      ).not.toBeInTheDocument();
+
       await user.type(screen.getByLabelText(/name/i), "Alex");
       await user.type(screen.getByLabelText(/email/i), "test@example.com");
       await user.type(screen.getByLabelText(/password/i), "password123");
-      await user.click(
-        screen.getByRole("checkbox", { name: /subscribe to updates/i }),
-      );
       await user.click(screen.getByRole("button", { name: /^sign up$/i }));
 
       await waitFor(() => {
-        expect(mockUpdateMetadata).toHaveBeenCalledWith({
-          subscribeToUpdates: true,
-        });
+        expect(useReleaseNotesPromptStore.getState().isOpen).toBe(true);
       });
+      // Signup itself must not write subscription metadata — that only happens
+      // if the user says yes in the prompt.
+      expect(mockUpdateMetadata).not.toHaveBeenCalled();
     });
 
     it("skips existing-session linking during email/password sign in", async () => {

--- a/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
@@ -1,20 +1,15 @@
-import { type ChangeEvent, type FC, useCallback, useState } from "react";
+import { type ChangeEvent, type FC, useCallback } from "react";
 import {
   type SignUpFormData,
   SignUpSchema,
 } from "@web/auth/compass/schemas/auth.schemas";
-import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import { AuthButton } from "../components/AuthButton";
 import { AuthInput } from "../components/AuthInput";
 import { useZodForm } from "../hooks/useZodForm";
 
-export type SignUpSubmitData = SignUpFormData & {
-  subscribeToUpdates: boolean;
-};
-
 interface SignUpFormProps {
   /** Callback when form is submitted with valid data */
-  onSubmit: (data: SignUpSubmitData) => void | Promise<void>;
+  onSubmit: (data: SignUpFormData) => void | Promise<void>;
   /** Callback when name field changes (for dynamic greeting) */
   onNameChange?: (name: string) => void;
   /** Whether form submission is in progress */
@@ -31,12 +26,10 @@ export const SignUpForm: FC<SignUpFormProps> = ({
   onNameChange,
   isSubmitting,
 }) => {
-  const [subscribeToUpdates, setSubscribeToUpdates] = useState(false);
-
   const form = useZodForm({
     schema: SignUpSchema,
     initialValues: { name: "", email: "", password: "" },
-    onSubmit: (data) => onSubmit({ ...data, subscribeToUpdates }),
+    onSubmit,
   });
 
   const handleNameChange = useCallback(
@@ -84,18 +77,6 @@ export const SignUpForm: FC<SignUpFormProps> = ({
         hasError={!!form.touched.password && !!form.errors.password}
         autoComplete="new-password"
       />
-
-      <TooltipWrapper description="Once a month. Unsubscribe anytime.">
-        <label className="flex w-fit items-center gap-2 text-sm text-text-lighter">
-          <input
-            type="checkbox"
-            checked={subscribeToUpdates}
-            onChange={(e) => setSubscribeToUpdates(e.target.checked)}
-            className="h-4 w-4 rounded-full border-border-primary accent-accent-primary"
-          />
-          Subscribe to updates
-        </label>
-      </TooltipWrapper>
 
       <AuthButton
         type="submit"

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -1,14 +1,14 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import EmailPassword from "supertokens-web-js/recipe/emailpassword";
-import { UserApi } from "@web/api/user.api";
 import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAuthentication";
 import {
   type ForgotPasswordFormData,
   type LogInFormData,
   type ResetPasswordFormData,
+  type SignUpFormData,
 } from "@web/auth/compass/schemas/auth.schemas";
-import { type SignUpSubmitData } from "../forms/SignUpForm";
+import { releaseNotesPromptActions } from "@web/auth/state/release-notes-prompt.store";
 import { getAuthSubmitErrorMessage } from "./useAuthFormHandlers.util";
 import { type AuthView } from "./useAuthModal";
 
@@ -22,7 +22,7 @@ interface UseAuthFormHandlersOptions {
 export interface UseAuthFormHandlersResult {
   isSubmitting: boolean;
   submitError: string | null;
-  handleSignUp: (data: SignUpSubmitData) => Promise<void>;
+  handleSignUp: (data: SignUpFormData) => Promise<void>;
   handleLogin: (data: LogInFormData) => Promise<void>;
   handleForgotPassword: (data: ForgotPasswordFormData) => Promise<void>;
   handleResetPassword: (data: ResetPasswordFormData) => Promise<void>;
@@ -51,7 +51,7 @@ export function useAuthFormHandlers({
   }, [currentView]);
 
   const handleSignUp = useCallback(
-    async (data: SignUpSubmitData) => {
+    async (data: SignUpFormData) => {
       setIsSubmitting(true);
       setSubmitError(null);
 
@@ -69,12 +69,10 @@ export function useAuthFormHandlers({
             await completeAuthentication({
               email: response.user.emails[0] ?? data.email,
             });
-            if (data.subscribeToUpdates) {
-              void UserApi.updateMetadata({ subscribeToUpdates: true }).catch(
-                () => {},
-              );
-            }
             closeModal();
+            // A successful sign-up is always a brand-new account, so offer the
+            // monthly release-notes opt-in.
+            releaseNotesPromptActions.open();
             return;
           case "FIELD_ERROR":
             setSubmitError(response.formFields[0]?.error ?? "Sign up failed");

--- a/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
@@ -1,9 +1,8 @@
 import { BellIcon } from "@phosphor-icons/react";
-import { UserApi } from "@web/api/user.api";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { subscribeToReleaseNotes } from "@web/auth/compass/user/util/subscribe.util";
 import {
   selectUserMetadata,
-  userMetadataActions,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { SUBSCRIBE_TO_UPDATES_TOAST_ID } from "@web/common/constants/toast.constants";
@@ -32,9 +31,8 @@ export const useSubscribeCmdItems = (): CommandItem[] => {
       label: "Subscribe to Updates",
       icon: BellIcon,
       onClick: () => {
-        UserApi.updateMetadata({ subscribeToUpdates: true })
-          .then((metadata) => {
-            userMetadataActions.set(metadata);
+        subscribeToReleaseNotes()
+          .then(() => {
             showStatusToast(
               SUBSCRIBE_TO_UPDATES_TOAST_ID,
               "Subscribed to updates",

--- a/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
+++ b/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
@@ -1,0 +1,169 @@
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useCallback,
+  useState,
+} from "react";
+import { subscribeToReleaseNotes } from "@web/auth/compass/user/util/subscribe.util";
+import { releaseNotesPromptActions } from "@web/auth/state/release-notes-prompt.store";
+import { SUBSCRIBE_TO_UPDATES_TOAST_ID } from "@web/common/constants/toast.constants";
+import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
+
+type PromptStatus = "asking" | "confirmed" | "declined";
+
+// How long the confirmation / reassurance message lingers before the panel
+// fades away into the app.
+const MESSAGE_LINGER_MS = 1600;
+// Matches the WelcomeModal fade/scale duration (duration-400).
+const EXIT_MS = 400;
+
+const prefersReducedMotion = () =>
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+/**
+ * Shown once, right after a new user signs up (email/password or Google),
+ * offering to subscribe to monthly release-note emails. RootShell mounts this
+ * only while the store flag is open, so each open is a fresh mount (status
+ * starts at "asking", no reset needed).
+ *
+ * Mirrors WelcomeModal's panel styling and fade/scale dismiss animation so the
+ * first-run experience feels of a piece.
+ */
+export function ReleaseNotesPrompt() {
+  const [status, setStatus] = useState<PromptStatus>("asking");
+  const [closing, setClosing] = useState(false);
+
+  // Focus the backdrop on mount so Escape works without a click first. A
+  // callback ref beats useEffect here (fires exactly on attach, no deps).
+  const focusOnMount = useCallback((node: HTMLDivElement | null) => {
+    node?.focus();
+  }, []);
+
+  // Fade the backdrop and gently scale the panel before clearing the store, so
+  // the reveal of the planner underneath feels smooth rather than abrupt.
+  const dismiss = () => {
+    if (closing) return;
+    setClosing(true);
+    window.setTimeout(
+      () => releaseNotesPromptActions.close(),
+      prefersReducedMotion() ? 0 : EXIT_MS,
+    );
+  };
+
+  // Show a closing message for a beat, then fade out.
+  const lingerThenDismiss = () => {
+    window.setTimeout(dismiss, MESSAGE_LINGER_MS);
+  };
+
+  const handleYes = async () => {
+    if (status !== "asking") return;
+    try {
+      await subscribeToReleaseNotes();
+    } catch {
+      showErrorToast("Couldn't subscribe to updates. Please try again.", {
+        toastId: SUBSCRIBE_TO_UPDATES_TOAST_ID,
+      });
+      dismiss();
+      return;
+    }
+    setStatus("confirmed");
+    lingerThenDismiss();
+  };
+
+  const handleNo = () => {
+    if (status !== "asking") return;
+    setStatus("declined");
+    lingerThenDismiss();
+  };
+
+  // Escape / backdrop click bails straight out without subscribing.
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      dismiss();
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      dismiss();
+    }
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the prompt.
+    <div
+      className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-bg-primary/85 py-8 backdrop-blur-sm transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none"
+      data-closing={closing || undefined}
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      ref={focusOnMount}
+      role="presentation"
+      style={{ zIndex: Z_INDEX_MODAL }}
+      tabIndex={-1}
+    >
+      <div
+        role="dialog"
+        aria-modal
+        aria-label="Stay in the loop"
+        data-closing={closing || undefined}
+        className="flex w-112 max-w-[90vw] flex-col gap-6 rounded-xl bg-panel-bg p-8 text-center shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)] transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none"
+      >
+        <PixelPirate className="mx-auto h-14 w-14 shrink-0" />
+
+        {status === "asking" && (
+          <>
+            <div className="flex flex-col gap-2">
+              <h2 className="font-bold text-2xl text-text-lighter leading-snug">
+                Want monthly release notes?
+              </h2>
+              <p className="text-text-light">
+                Once a month we&apos;ll email you what&apos;s new in Compass —
+                the useful stuff, none of the noise. Unsubscribe anytime with
+                one click from any email.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <button
+                type="button"
+                onClick={handleYes}
+                className="c-button c-button-primary c-button-elevated rounded-full px-8"
+              >
+                Yes, Keep Me Updated
+              </button>
+              <button
+                type="button"
+                onClick={handleNo}
+                className="c-focus-ring rounded-full px-8 py-2 text-sm text-text-light transition-colors hover:text-text-lighter"
+              >
+                Nah, I don&apos;t want updates
+              </button>
+            </div>
+          </>
+        )}
+
+        {status === "confirmed" && (
+          <div className="flex flex-col gap-2">
+            <h2 className="font-bold text-2xl text-text-lighter leading-snug">
+              You&apos;re in! 🎉
+            </h2>
+            <p className="text-text-light">Monthly notes headed your way.</p>
+          </div>
+        )}
+
+        {status === "declined" && (
+          <div className="flex flex-col gap-2">
+            <h2 className="font-bold text-2xl text-text-lighter leading-snug">
+              No problem.
+            </h2>
+            <p className="text-text-light">
+              You can sign up using the cmd palette if you change your mind.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -1,6 +1,11 @@
 import { Outlet } from "@tanstack/react-router";
+import {
+  selectReleaseNotesPromptOpen,
+  useReleaseNotesPromptStore,
+} from "@web/auth/state/release-notes-prompt.store";
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
+import { ReleaseNotesPrompt } from "@web/components/ReleaseNotesPrompt/ReleaseNotesPrompt";
 import { WelcomeModal } from "@web/components/WelcomeModal/WelcomeModal";
 
 /**
@@ -10,11 +15,16 @@ import { WelcomeModal } from "@web/components/WelcomeModal/WelcomeModal";
  * available on every matched route, including 404s.
  */
 export function RootShell() {
+  const isReleaseNotesPromptOpen = useReleaseNotesPromptStore(
+    selectReleaseNotesPromptOpen,
+  );
+
   return (
     <AuthModalProvider>
       <Outlet />
       <AuthModal />
       <WelcomeModal />
+      {isReleaseNotesPromptOpen && <ReleaseNotesPrompt />}
     </AuthModalProvider>
   );
 }

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
@@ -6,6 +6,7 @@ import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAu
 import { session } from "@web/auth/compass/session/Session";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { completeGoogleAuthorization } from "@web/auth/google/authorization/complete-google-authorization";
+import { releaseNotesPromptActions } from "@web/auth/state/release-notes-prompt.store";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
@@ -35,6 +36,13 @@ export async function completeGoogleAuthCallback({
 
   if (result.status === "failed") {
     showErrorToast(result.message);
+  }
+
+  // Raise the release-notes prompt for brand-new signups. The navigate below is
+  // a client-side replace (no reload), so this in-memory flag survives into the
+  // app where the prompt is mounted.
+  if (result.status === "completed" && result.isNewUser) {
+    releaseNotesPromptActions.open();
   }
 
   navigate(result.returnPath, { replace: true });


### PR DESCRIPTION
## Summary

The old "Subscribe to updates" checkbox on the sign-up form was easy to miss, and it was only wired to the email/password path — users who signed up with **Continue with Google** were never offered the subscription at all.

This replaces the checkbox with a dedicated, hard-to-miss prompt shown **once, right after a new user signs up** (email/password *or* Google), asking whether they want monthly release notes, with an unsubscribe note and two clear choices:

- **Yes, Keep Me Updated** → subscribes, shows a brief "You're in!" beat, then animates into the app.
- **Nah, I don't want updates** → shows *"No problem. You can sign up using the cmd palette if you change your mind."* then animates into the app.

Both signup paths flip an in-memory `release-notes-prompt` store flag that a single globally-mounted `ReleaseNotesPrompt` (in `RootShell`) renders off of. The Google path now surfaces the backend's `createdNewRecipeUser` as `isNewUser`, so returning logins and Google-calendar reconnects don't trigger it. The subscribe API call is extracted into a shared `subscribeToReleaseNotes()` helper reused by the existing command-palette item. The prompt reuses `WelcomeModal`'s panel styling and fade/scale (reduced-motion-aware) animation.

## Simplicity

Net complexity is down: the per-form checkbox `useState` and its submit plumbing are gone, and duplicated subscribe logic is unified into one helper. The new `ReleaseNotesPrompt` carries **two `useState`** (`status` for the asking→confirmed/declined machine, `closing` for the exit animation) — both UI-only, nothing outside the component needs them. It has **no `useEffect` and no `useRef`**: `RootShell` conditionally mounts the prompt so each open is a fresh mount (no reset effect needed), and focus-on-mount uses a callback ref rather than an effect+ref pair.

## Manual Testing Steps

- [ ] Open the app and go to the sign-up form (click **Log in** → toggle to **Sign up**, or load `/day/<today>?auth=signup`). Confirm there is **no** "Subscribe to updates" checkbox — only Name, Email, Password, and Sign up.
- [ ] Complete a **new** email/password sign-up. Confirm a "Want monthly release notes?" prompt appears immediately after.
- [ ] Click **Yes, Keep Me Updated**. Confirm a brief "You're in!" confirmation shows, then the prompt fades away into the app. Open the command palette (Cmd/Ctrl+K) and confirm **"Subscribe to Updates" is gone** (proves the subscription saved).
- [ ] Sign up as another new user and click **Nah, I don't want updates**. Confirm it shows "No problem. You can sign up using the cmd palette if you change your mind." then fades away, and that **"Subscribe to Updates" is still present** in the command palette.
- [ ] Sign up with **Continue with Google** as a brand-new account; confirm the same prompt appears after the redirect. Log out and log back into that same account; confirm the prompt does **not** appear for the returning login.
- [ ] With the prompt open, press **Escape** (or click the backdrop); confirm it dismisses without subscribing.

## Test plan

- [x] `bun run type-check` — clean.
- [x] `bun run lint` (Biome) on all touched files — clean.
- [x] `bun test packages/web` affected suites — 50 pass, 0 fail (`AuthModal.test.tsx`, `google-authorization.test.ts`, `useSubscribeCmdItems.test.ts`), including a new `isNewUser`-on-signin case and the rewritten "opens the release-notes prompt after a successful sign-up" test.
- [x] Validated in real Chrome: prompt renders correctly, the "Nah" path shows the right copy and fully unmounts after dismissal, the sign-up form has no checkbox, and no console errors. The "Yes → confirmed" success state requires a live SuperTokens backend, so it was covered by unit tests rather than the local walkthrough.