### PR TITLE
refactor(web): add e2e bridge and slim hooks for release-notes prompt

### DIFF
--- a/packages/web/declaration.d.ts
+++ b/packages/web/declaration.d.ts
@@ -37,13 +37,20 @@ declare const BUILD_VERSION: string;
 interface Window {
   /** Set by Playwright prepareOAuthTestPage; disables SuperTokens session checks in e2e mode. */
   __COMPASS_E2E_TEST__?: boolean;
-  /** Semantic user-metadata bridge for e2e tests. Set by packages/web/src/auth/state/user-metadata.store.ts. */
+  /** Semantic store bridges for e2e tests. Each store sets its own key (see
+   * user-metadata.store.ts, release-notes-prompt.store.ts); keys are optional
+   * because they populate independently as their modules evaluate. */
   __COMPASS_E2E_STORE__?: {
-    userMetadata: {
+    userMetadata?: {
       getState: () => import("@web/auth/state/user-metadata.store").UserMetadataState;
       set: (metadata: import("@core/types/user.types").UserMetadata) => void;
       setLoading: () => void;
       clear: () => void;
+    };
+    releaseNotesPrompt?: {
+      getState: () => import("@web/auth/state/release-notes-prompt.store").ReleaseNotesPromptState;
+      open: () => void;
+      close: () => void;
     };
   };
   /** Session test hooks exposed by SessionProvider for e2e auth control. */

--- a/packages/web/src/auth/state/release-notes-prompt.store.ts
+++ b/packages/web/src/auth/state/release-notes-prompt.store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-interface ReleaseNotesPromptState {
+export interface ReleaseNotesPromptState {
   isOpen: boolean;
 }
 
@@ -15,3 +15,17 @@ export const releaseNotesPromptActions = {
 
 export const selectReleaseNotesPromptOpen = (state: ReleaseNotesPromptState) =>
   state.isOpen;
+
+// Semantic bridge for e2e tests, mirroring the user-metadata store. Lets tests
+// raise the post-signup prompt without completing a real (backend-dependent)
+// signup. Merge (don't overwrite) so sibling stores' bridges survive.
+if (typeof window !== "undefined") {
+  window.__COMPASS_E2E_STORE__ = {
+    ...window.__COMPASS_E2E_STORE__,
+    releaseNotesPrompt: {
+      getState: useReleaseNotesPromptStore.getState,
+      open: releaseNotesPromptActions.open,
+      close: releaseNotesPromptActions.close,
+    },
+  };
+}

--- a/packages/web/src/auth/state/user-metadata.store.ts
+++ b/packages/web/src/auth/state/user-metadata.store.ts
@@ -54,6 +54,7 @@ export const userMetadataActions = {
 // Tests drive connection-status scenarios by setting metadata directly.
 if (typeof window !== "undefined") {
   window.__COMPASS_E2E_STORE__ = {
+    ...window.__COMPASS_E2E_STORE__,
     userMetadata: {
       getState: useUserMetadataStore.getState,
       set: userMetadataActions.set,

--- a/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
+++ b/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
@@ -1,16 +1,11 @@
 import {
   type KeyboardEvent,
   type MouseEvent,
-  useEffect,
-  useRef,
+  useCallback,
   useState,
 } from "react";
 import { subscribeToReleaseNotes } from "@web/auth/compass/user/util/subscribe.util";
-import {
-  releaseNotesPromptActions,
-  selectReleaseNotesPromptOpen,
-  useReleaseNotesPromptStore,
-} from "@web/auth/state/release-notes-prompt.store";
+import { releaseNotesPromptActions } from "@web/auth/state/release-notes-prompt.store";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
@@ -18,30 +13,22 @@ import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
 type PromptState = "asking" | "confirmed" | "declined";
 
 export function ReleaseNotesPrompt() {
-  const isOpen = useReleaseNotesPromptStore(selectReleaseNotesPromptOpen);
   const [state, setState] = useState<PromptState>("asking");
   const [closing, setClosing] = useState(false);
-  const backdropRef = useRef<HTMLDivElement>(null);
-  const timerRef = useRef<number | undefined>(undefined);
 
-  useEffect(() => {
-    if (isOpen) {
-      setState("asking");
-      setClosing(false);
-      backdropRef.current?.focus();
-    }
-  }, [isOpen]);
-
-  useEffect(() => () => window.clearTimeout(timerRef.current), []);
-
-  if (!isOpen) return null;
+  // RootShell mounts this only while the store flag is open, so each open is a
+  // fresh mount (state starts at "asking", no reset effect needed). A callback
+  // ref focuses the backdrop on mount so Escape works without a click first.
+  const focusOnMount = useCallback((node: HTMLDivElement | null) => {
+    node?.focus();
+  }, []);
 
   const dismiss = () => {
     if (closing) return;
     setClosing(true);
     const reducedMotion =
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-    timerRef.current = window.setTimeout(
+    window.setTimeout(
       () => releaseNotesPromptActions.close(),
       reducedMotion ? 0 : 400,
     );
@@ -50,7 +37,7 @@ export function ReleaseNotesPrompt() {
   const decline = () => {
     if (state !== "asking") return;
     setState("declined");
-    timerRef.current = window.setTimeout(dismiss, 1300);
+    window.setTimeout(dismiss, 1300);
   };
 
   const subscribe = async () => {
@@ -58,7 +45,7 @@ export function ReleaseNotesPrompt() {
     try {
       await subscribeToReleaseNotes();
       setState("confirmed");
-      timerRef.current = window.setTimeout(dismiss, 1300);
+      window.setTimeout(dismiss, 1300);
     } catch {
       showErrorToast("Couldn't subscribe to updates. Please try again.");
       dismiss();
@@ -80,7 +67,7 @@ export function ReleaseNotesPrompt() {
       data-closing={closing || undefined}
       onClick={handleBackdropClick}
       onKeyDown={handleKeyDown}
-      ref={backdropRef}
+      ref={focusOnMount}
       role="presentation"
       style={{ zIndex: Z_INDEX_MODAL }}
       tabIndex={-1}

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -1,4 +1,8 @@
 import { Outlet } from "@tanstack/react-router";
+import {
+  selectReleaseNotesPromptOpen,
+  useReleaseNotesPromptStore,
+} from "@web/auth/state/release-notes-prompt.store";
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
 import { ReleaseNotesPrompt } from "@web/components/ReleaseNotesPrompt/ReleaseNotesPrompt";
@@ -11,12 +15,16 @@ import { WelcomeModal } from "@web/components/WelcomeModal/WelcomeModal";
  * available on every matched route, including 404s.
  */
 export function RootShell() {
+  const isReleaseNotesPromptOpen = useReleaseNotesPromptStore(
+    selectReleaseNotesPromptOpen,
+  );
+
   return (
     <AuthModalProvider>
       <Outlet />
       <AuthModal />
       <WelcomeModal />
-      <ReleaseNotesPrompt />
+      {isReleaseNotesPromptOpen && <ReleaseNotesPrompt />}
     </AuthModalProvider>
   );
 }


### PR DESCRIPTION
## Summary

Two small, non-duplicated follow-ups on top of the release-notes prompt that shipped in #2078-era work (`2ef4b0dcd`). (A parallel branch reimplemented the whole feature before realizing it had already merged; this PR salvages only the two pieces worth keeping and drops the rest.)

1. **e2e store bridge** — expose the release-notes-prompt store on `window.__COMPASS_E2E_STORE__` (mirroring the existing user-metadata bridge) so Playwright/e2e can raise the prompt without completing a real, backend-dependent signup. Both stores now **merge** into the bridge instead of overwriting, so their keys coexist regardless of module-eval order.
2. **Slimmer hooks** — `RootShell` now conditionally mounts the prompt, so each open is a fresh mount. That lets the component drop its reset `useEffect` and its store subscription, and focus-on-mount moves from a `useEffect`+`useRef` pair to a single callback ref. UI and behavior are unchanged.

## Simplicity

Net reduction. The prompt component loses **two `useEffect`s** (state reset + timer cleanup) and **two `useRef`s** (backdrop + timer) — visibility moves to `RootShell` (fresh mount per open makes the reset unnecessary) and focus uses a callback ref. The two remaining `useState`s (`state` for the asking→confirmed/declined machine, `closing` for the exit animation) are genuine UI-only local state. The one new `useReleaseNotesPromptStore` selector subscription lives in `RootShell` to gate the mount. No new `useEffect`/`useRef` anywhere.

## Manual Testing Steps

- [ ] Complete a **new** email/password sign-up. Confirm the "Want the latest Compass news?" prompt appears, then click **Yes, Keep Me Updated**; confirm the "You're in!" message shows, the prompt fades away, and the app underneath is interactive.
- [ ] Sign up as another new user and click **Nah, I don't want updates**; confirm the "No problem" message shows, then the prompt fades away and does not reappear.
- [ ] With the prompt open, press **Escape** (or click the backdrop); confirm it dismisses without subscribing.
- [ ] Open the prompt again after a full dismiss (e.g. via a fresh signup) and confirm it starts on the question again — never a stale "You're in!"/"No problem." state.

## Test plan

- [x] `bun run type-check` — clean (includes the `declaration.d.ts` bridge-type change and the exported `ReleaseNotesPromptState`).
- [x] `bun run lint` (Biome) on all touched files — clean.
- [x] `bun test packages/web` around the changed areas (AuthModal, RootShell, auth state) — 40 pass, 0 fail.
- [x] Validated in real Chrome: prompt renders (main's copy/layout unchanged), both the release-notes and user-metadata e2e bridges coexist after the merge-safe change, and the decline path fully **unmounts** the prompt (`role="dialog"` gone, store closed) with no console errors.