### PR TITLE
refactor(team): redesign standup for hands-off multi-agent execution

### DIFF
--- a/.claude/skills/standup/SKILL.md
+++ b/.claude/skills/standup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: standup
-description: Team standup for the Compass roles. Spawns the four agent roles (QA, Fullstack, Architect, Product Owner) in parallel; each reviews the codebase/app against its charter and reports 3 bullets of recent work, top-3 next priorities, and blockers. Synthesizes into team/standups/YYYY-MM-DD.md and records founder decisions. Use when the founder says "/standup", "run standup", "team standup", or "what's the team's status".
+description: Team standup for the Compass roles. Spawns the four agent roles (QA, Fullstack, Architect, Product Owner) in parallel; each reviews the codebase/app against its charter and reports 3 bullets of recent work, top-3 next priorities, and blockers. Synthesizes into team/standups/YYYY-MM-DD.md, records founder decisions, then autonomously implements and lands every approved item via a serialized-merge workflow — no further launches needed from the founder. Use when the founder says "/standup", "run standup", "team standup", or "what's the team's status".
 ---
 
 # standup
@@ -84,14 +84,108 @@ the outcomes to the same file:
 If the founder is running standup read-only (says "just show me status"), skip the
 questions and leave `## Needs founder` unanswered — a later session can pick it up.
 
-## 4. Commit and hand off
+## 4. Land the standup file
 
-- Commit the standup file **directly to main**: `chore(team): standup <today>`.
-  It's `team/**`-only, so CI ignores it — never open a notes-only PR
-  (`team/TEAM.md` → Repo hygiene).
-- Close by listing the approved items as ready-to-launch role sessions, e.g.
-  "act as fullstack: execute the approved <X> proposal" — the founder launches
-  them when ready.
+Branch protection on `main` blocks direct pushes, so this is a self-contained
+branch → PR → merge, not a bare commit:
+
+- `git checkout -b claude/standup-<today>`, commit the file:
+  `chore(team): standup <today>`.
+- `git push -u origin HEAD`, `gh pr create --base main --title "chore(team): standup <today>" --body "..."`.
+- `gh pr merge <n> --squash --admin` immediately — `team/**` is path-ignored by
+  CI, so there is nothing to wait for. Do this yourself, in this same turn;
+  never leave it as an open PR for the founder to notice and merge later.
+
+## 5. Auto-execute the approved items
+
+If step 3 produced any `APPROVED` items, don't stop and hand the founder a
+list of sessions to launch — execute them now, in this same turn, via the
+`Workflow` tool. (This skill's own instructions are the opt-in: invoking
+`Workflow` here is expected, not a judgment call to re-litigate.) Read-only
+research already happened per-role in step 1; this phase implements.
+
+**Why a workflow and not just parallel `Agent` calls:** the failure modes
+you're fixing — agents fighting over merges/deploys, agents drifting behind a
+`main` that moved while they worked — both come from treating *merge* as
+parallelizable when it isn't. Implementation can fan out safely (isolated
+worktrees don't collide). Merge cannot: it's a single shared resource
+(`main`), so it must be a queue of one, not a fan-out. `Workflow`'s
+`pipeline()` gives you exactly that shape — independent parallel stages with a
+serialized final stage — for free.
+
+Split `APPROVED` items into two kinds:
+
+- **Notes/backlog-only** (no code — e.g. an architect backlog edit, a PO
+  write-up): handle these directly, same pattern as step 4 (branch → PR →
+  `--squash --admin`, no CI wait). Do them one at a time in this main session;
+  they're small enough that a full workflow is overkill.
+- **Code work**: run through `Workflow`, one queue item per approved proposal,
+  each tagged with its owning role. Shape:
+
+```js
+export const meta = {
+  name: 'standup-execute',
+  description: 'Implement and land the standup-approved backlog',
+  phases: [{ title: 'Implement' }, { title: 'Merge' }],
+}
+
+// Merge is a queue of one — chain onto this promise, never parallel().
+let mergeChain = Promise.resolve()
+function serialized(fn) {
+  const result = mergeChain.then(fn, fn)
+  mergeChain = result.catch(() => null)
+  return result
+}
+
+const results = await pipeline(
+  approvedCodeItems,
+  item => agent(
+    `Act as ${item.role}. Implement the approved proposal: ${item.summary}. ` +
+    `Read team/${item.role}/charter.md and team/operating-rules.md first. ` +
+    `Branch off current origin/main. Implement, then run the \`ship\` skill ` +
+    `through PR creation and green CI — but STOP before merging. Return the ` +
+    `PR number and branch name.`,
+    { phase: 'Implement', isolation: 'worktree', label: item.role }
+  ),
+  (impl, item) => serialized(() =>
+    agent(
+      `A PR is ready to merge: #${impl.prNumber} (${impl.branch}), for the ` +
+      `approved "${item.summary}" proposal. git fetch origin, rebase this ` +
+      `branch onto the current origin/main tip (main may have moved since ` +
+      `this PR was opened — that's expected, this is a serialized merge ` +
+      `queue), push, confirm CI is still green, then ` +
+      `\`gh pr merge --squash --admin\`. If the rebase has a real conflict ` +
+      `(not trivial), stop and report it rather than guessing at a resolution. ` +
+      `Then append a Work bullet with the PR link to ` +
+      `team/${item.role}/notes/<today>.md (create it if this is the role's ` +
+      `first entry today) — you're merging on the role's behalf, so the note ` +
+      `is your responsibility, not theirs.`,
+      { phase: 'Merge', label: item.role }
+    )
+  )
+)
+return results
+```
+
+- Each `Implement` agent starts from **whatever `main` looks like when it
+  spins up** — fine, because it never merges directly; the `Merge` stage
+  re-fetches and rebases immediately before landing, so the gap between
+  "branched from" and "merged onto" main is always small even when several
+  items are queued.
+- A merge failure (real conflict, CI regression after rebase) is a
+  **push-notify**, not a silent drop — surface it in the final summary (step
+  6) rather than letting the item vanish from the queue.
+- Cap what you auto-execute per run to what's actually reasonable to land in
+  one sitting — if `APPROVED` has many items, say so and ask the founder
+  whether to run the full batch or a subset, rather than silently queuing
+  everything.
+
+## 6. Report back
+
+Once the workflow (if any) completes, post a short summary in chat: what
+merged (PR links), what's still open/blocked and why, and where notes/backlog
+updates landed. This is the only round-trip back to the founder after the
+step-3 approval — no further launches needed.
 
 ## Guardrails
 
@@ -99,5 +193,9 @@ questions and leave `## Needs founder` unanswered — a later session can pick i
   invented metrics. "Nothing this window" is a valid recent-work bullet.
 - Priorities must trace to the charter, the backlog, or an observed problem; a
   priority that needs new scope gets `[needs approval]`, not silent adoption.
-- This skill never starts implementation work itself. It reports, records
-  decisions, and stops.
+- Step 1 (research/reporting) stays read-only — no implementation before the
+  founder approves. Everything after approval (steps 4-6) is this skill's job
+  to drive to completion; it doesn't hand off half-finished work.
+- Never parallelize the merge stage. If you find yourself reaching for
+  `parallel()` around a `gh pr merge`, stop — that's the exact bug this
+  redesign exists to fix.

--- a/team/TEAM.md
+++ b/team/TEAM.md
@@ -31,7 +31,7 @@ a charter.
 
 ## How work happens
 
-The loop is **propose → approve → launch → self-split**:
+The loop is **propose → approve → execute**, and there are two ways execute happens:
 
 1. **Propose.** A role writes a proposal in its daily note (`## Proposals`: what, why,
    rough size, risk) or surfaces it as a `[needs approval]` priority in standup.
@@ -39,19 +39,28 @@ The loop is **propose → approve → launch → self-split**:
    day's standup file, or as an `Approved by founder <date>` line appended to the
    proposal in the role's note. That markdown line **is** the authorization record;
    there is no other tracker.
-3. **Launch.** The founder starts (or continues) a role session: "act as QA, execute
-   the approved test-speed proposal." The session reads its charter, the approval
-   record, and its latest notes.
-4. **Self-split.** The role splits the work into ship-sized PRs using its own
-   judgment — one concern per PR, shipped via the `ship` skill, auto-merged once CI
-   is green. Genuine blockers follow the push-notify rules in
-   [operating-rules.md](./operating-rules.md); everything else is the role's call.
+3. **Execute**, one of:
+   - **Standup-driven (default for anything approved during `/standup`).** The
+     `standup` skill implements and lands the approved backlog itself, same turn —
+     no founder launch needed. Implementation fans out in parallel across isolated
+     worktrees; merges land through a **serialized queue**, one at a time, each
+     rebased onto the current `main` right before merging, so agents never race
+     each other for a merge or a deploy slot. See `.claude/skills/standup/SKILL.md`
+     step 5.
+   - **Manual launch (for proposals approved outside standup).** The founder starts
+     a role session directly — "act as QA, execute the approved test-speed
+     proposal." The session reads its charter, the approval record, and its latest
+     notes, then splits the work into ship-sized PRs using its own judgment, shipped
+     via the `ship` skill. Genuine blockers follow the push-notify rules in
+     [operating-rules.md](./operating-rules.md); everything else is the role's call.
 
 Recurring rituals:
 
 - **Standup** (`/standup`, founder-run, any time): each agent role reviews the
   codebase/app against its charter and reports recent work, top-3 priorities, and
-  blockers. Output lands in `team/standups/<date>.md` along with founder decisions.
+  blockers. Output lands in `team/standups/<date>.md` along with founder decisions,
+  and every approved item is implemented and merged before the skill hands control
+  back — see above.
 - **Cleanup** (`/cleanup`, founder-run): reviews everything merged since the last
   cleanup, simplifies, sweeps UX, and verifies staging.
 
@@ -95,10 +104,13 @@ Other locations:
 ## Repo hygiene
 
 `team/**` is committed but ignored by CI (`paths-ignore` in the test and release
-workflows). Notes-, standup-, and backlog-only changes commit **directly to main**
-as `chore(team): …` — never open a notes-only PR, because a paths-ignored PR has no
-CI checks for `ship`'s green gate to watch. Any change that touches code goes
-through the normal PR flow.
+workflows). Branch protection on `main` blocks direct pushes, so notes-,
+standup-, and backlog-only changes still go through a PR — but a self-merged one,
+same turn: branch, commit as `chore(team): …`, `gh pr create`, then
+`gh pr merge --squash --admin` immediately, since a paths-ignored PR has no CI
+checks to wait for anyway. Never leave one of these open for the founder to
+merge. Any change that touches code goes through the normal PR flow (real CI
+gate, `ship`'s green-then-merge).
 
 ## Production workflow
 

--- a/team/operating-rules.md
+++ b/team/operating-rules.md
@@ -81,8 +81,32 @@ full context; the founder does not.
 ## Autonomy boundaries
 
 - Auto-merge a PR only once **CI is green** (via the `ship` skill).
-- Notes-, standup-, and backlog-only changes commit directly to main as
-  `chore(team): …` — never a notes-only PR (CI ignores `team/**`, so there would be
-  no green gate to watch).
+- Notes-, standup-, and backlog-only changes still go through a PR (branch
+  protection blocks direct pushes) but merge it yourself, same turn —
+  `gh pr merge --squash --admin` immediately after `gh pr create`, since CI
+  ignores `team/**` and there's nothing to wait for. Never leave one of these
+  open for the founder to merge.
 - Respect the deny-list in `.claude/settings.json` (no force-push, no `rm -rf`, no `.env`
   reads/writes). If a task seems to need one of those, that's a push-notify, not a workaround.
+
+## Merging is a queue of one — never parallelize it
+
+Implementation can safely run in parallel (isolated worktrees don't collide).
+Merging onto `main` cannot — it's a single shared resource, and treating it as
+parallelizable is what produces PRs racing each other for a merge or a deploy
+slot (a CI-level concurrency queue on the deploy job stops two deploys from
+overlapping, but that doesn't stop two branches from conflicting with each
+other or with a `main` that moved mid-flight).
+
+- If several PRs are ready around the same time — during standup's
+  auto-execution (`.claude/skills/standup/SKILL.md` step 5) or otherwise —
+  merge them **one at a time**, and re-fetch/rebase each onto the current
+  `origin/main` tip immediately before its merge, not at whatever point it was
+  branched.
+- When merging on behalf of a role you're not currently acting as (e.g. the
+  standup orchestrator merging a fullstack PR), append the Work bullet to that
+  role's `team/<role>/notes/<date>.md` yourself — the note is the merger's
+  responsibility, not something to leave for a session that never runs.
+- A merge that hits a real conflict (not a trivial rebase) is a push-notify,
+  not something to force through — report it and keep the rest of the queue
+  moving.


### PR DESCRIPTION
## Summary
- Fixes the stale "commit directly to main" step in standup (branch protection blocks it) — now self-merges its own PR via `gh pr merge --squash --admin`, same turn, no wait (docs/team paths are CI-ignored).
- After founder approval, standup no longer hands off a list of sessions to launch manually — it auto-executes the approved backlog itself via a `Workflow` pipeline: parallel implementation in isolated worktrees, merges serialized through a queue of one.
- Adds a repo-wide "merging is a queue of one" rule to `operating-rules.md` so this applies beyond just standup — no more agents racing each other for a merge or deploy slot, no more drift against a `main` that moved mid-flight.

## Simplicity
Docs-only change, no hooks/code involved.

## Manual Testing Steps
Not applicable — no runtime surface (skill/docs prose only). Real verification happens the next time `/standup` runs end-to-end with an approved item.

## Test plan
- [x] N/A — no code paths changed, nothing to run