### PR TITLE
fix(web): unify day view header border and show new all-day events immediately

### DIFF
--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -8,7 +8,7 @@ export const DayCalendarColumnHeaders = ({
 }) => (
   <section
     aria-label="Calendars"
-    className="grid min-h-12 shrink-0 border-border-secondary/25 border-b"
+    className="grid min-h-12 shrink-0"
     style={{
       gridTemplateColumns: `repeat(${calendars.length}, minmax(0, 1fr))`,
       marginLeft: CALENDAR_GRID_MARGIN_LEFT,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -95,7 +95,7 @@ export function DayCalendarGrid() {
     timedEvents,
   } = useDayEventViewModel({
     startDate: dateInView.startOf("day").utc(true).format(),
-    endDate: dateInView.endOf("day").utc(true).format(),
+    endDate: dateInView.add(1, "day").startOf("day").utc(true).format(),
   });
   const {
     calendarColumnIndexById,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -44,6 +44,7 @@ import { CalendarGrid } from "@web/layout/calendar-grid/components/CalendarGrid"
 import { useAllDayDraftCreation } from "@web/layout/calendar-grid/hooks/useAllDayDraftCreation";
 import { useCalendarDateCalcs } from "@web/layout/calendar-grid/hooks/useCalendarDateCalcs";
 import { useCalendarGridLayout } from "@web/layout/calendar-grid/hooks/useCalendarGridLayout";
+import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
 import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDayEventNudgeShortcuts } from "@web/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts";
 import { DayInteractionCoordinator } from "@web/views/Day/interaction/DayInteractionCoordinator";
@@ -93,10 +94,7 @@ export function DayCalendarGrid() {
     events: dayEvents,
     rowCount: allDayRowsCount,
     timedEvents,
-  } = useDayEventViewModel({
-    startDate: dateInView.startOf("day").utc(true).format(),
-    endDate: dateInView.add(1, "day").startOf("day").utc(true).format(),
-  });
+  } = useDayEventViewModel(dayEventQueryRange(dateInView));
   const {
     calendarColumnIndexById,
     displayedAllDayEvents,

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -24,7 +24,7 @@ const { renderHook } =
   require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");
 const { createCompassQueryClient } =
   require("@web/api/query-client") as typeof import("@web/api/query-client");
-const { useDayEvents } =
+const { dayEventQueryRange, useDayEvents } =
   require("@web/views/Day/hooks/events/useDayEvents") as typeof import("@web/views/Day/hooks/events/useDayEvents");
 
 describe("useDayEvents", () => {
@@ -37,8 +37,7 @@ describe("useDayEvents", () => {
   // date-range metadata (like the read hooks' own keys do) rather than
   // asserting a specific source.
   const findDayEntry = (queryClient: QueryClient, date: dayjs.Dayjs) => {
-    const startDate = date.startOf("day").utc(true).format();
-    const endDate = date.add(1, "day").startOf("day").utc(true).format();
+    const { startDate, endDate } = dayEventQueryRange(date);
     const match = queryClient
       .getQueriesData({ queryKey: eventQueryKeys.scope("day") })
       .find(([key]) => {

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -38,7 +38,7 @@ describe("useDayEvents", () => {
   // asserting a specific source.
   const findDayEntry = (queryClient: QueryClient, date: dayjs.Dayjs) => {
     const startDate = date.startOf("day").utc(true).format();
-    const endDate = date.endOf("day").utc(true).format();
+    const endDate = date.add(1, "day").startOf("day").utc(true).format();
     const match = queryClient
       .getQueriesData({ queryKey: eventQueryKeys.scope("day") })
       .find(([key]) => {

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.ts
@@ -4,30 +4,35 @@ import { dayEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useDayEventsQuery } from "@web/events/queries/useDayEventsQuery";
 import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjacentEvents";
 
-const dayRange = (date: dayjs.Dayjs) => ({
+/**
+ * A day's event query range as `[startDate, endDate)`: `endDate` is the next
+ * calendar day's start, not this day's end, so all-day events spanning only
+ * this single day still fall within the range's exclusive upper bound.
+ */
+export const dayEventQueryRange = (date: dayjs.Dayjs) => ({
   startDate: date.startOf("day").utc(true).format(),
   endDate: date.add(1, "day").startOf("day").utc(true).format(),
 });
 
 export function useDayEvents(dateInView: dayjs.Dayjs) {
-  const { startDateUtc, endDateUtc } = useMemo(
-    () => ({
-      startDateUtc: dateInView.startOf("day").utc(true).format(),
-      endDateUtc: dateInView.add(1, "day").startOf("day").utc(true).format(),
-    }),
+  const { startDate, endDate } = useMemo(
+    () => dayEventQueryRange(dateInView),
     [dateInView],
   );
 
-  useDayEventsQuery({ startDate: startDateUtc, endDate: endDateUtc });
+  useDayEventsQuery({ startDate, endDate });
 
   // Warm the previous/next day so the next prev/next click resolves from
   // cache. Uses the same start/end-of-day UTC formatting as the read above,
   // so the prefetched entries land under the exact keys a subsequent read
   // looks up.
   const previous = useMemo(
-    () => dayRange(dateInView.subtract(1, "day")),
+    () => dayEventQueryRange(dateInView.subtract(1, "day")),
     [dateInView],
   );
-  const next = useMemo(() => dayRange(dateInView.add(1, "day")), [dateInView]);
+  const next = useMemo(
+    () => dayEventQueryRange(dateInView.add(1, "day")),
+    [dateInView],
+  );
   usePrefetchAdjacentEvents(dayEventsQueryOptions, previous, next);
 }

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.ts
@@ -6,14 +6,14 @@ import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjace
 
 const dayRange = (date: dayjs.Dayjs) => ({
   startDate: date.startOf("day").utc(true).format(),
-  endDate: date.endOf("day").utc(true).format(),
+  endDate: date.add(1, "day").startOf("day").utc(true).format(),
 });
 
 export function useDayEvents(dateInView: dayjs.Dayjs) {
   const { startDateUtc, endDateUtc } = useMemo(
     () => ({
       startDateUtc: dateInView.startOf("day").utc(true).format(),
-      endDateUtc: dateInView.endOf("day").utc(true).format(),
+      endDateUtc: dateInView.add(1, "day").startOf("day").utc(true).format(),
     }),
     [dateInView],
   );


### PR DESCRIPTION
## Summary
- Removed a redundant `border-b` on the day view's calendar-label row so it and the all-day row render as one unified block (Week view's equivalent already relies solely on the shared all-day row's border).
- Fixed the day view's event query range: it built `endDate` as `endOf("day")` of the *same* date as `startDate`, so it was never an exclusive next-day boundary. Since the backend and offline-store all-day filters compare `event.schedule.start < endDate.slice(0,10)`, a same-day all-day event created from Day view could never satisfy that check — it wouldn't appear until switching to Week view (whose multi-day range doesn't usually collapse this way).

## Simplicity
Net reduction: the day-range formula (`startOf("day")` / next-day-`startOf("day")` in UTC) was duplicated 3x across `DayCalendarGrid.tsx` and `useDayEvents.ts` — exactly the kind of drift that caused the original bug. Extracted a single `dayEventQueryRange` helper in `useDayEvents.ts` and had both call sites (plus the test helper) use it, so the two files can no longer diverge again. No new `useEffect`/`useRef`/`useState`; the one pre-existing `useMemo` in `useDayEvents` is unchanged — it was already there to memoize the query range and prefetch args, unrelated to this refactor.

## Manual Testing Steps
- [ ] Open the Day view for any date and confirm the calendar label row and the all-day row appear as a single bordered block, with no double line between them.
- [ ] While on a day with no all-day events, press `a` (or use the equivalent create action) to open a new all-day draft, give it a title, and save — confirm it appears in the all-day row immediately without navigating away.
- [ ] Reload the page on that same day and confirm the event still appears (not just an optimistic-cache artifact).
- [ ] Switch to Week view and confirm the same event still shows on the correct day.

## Test plan
- [x] `bun test src/views/Day/hooks/events/useDayEvents.test.ts src/views/Day/components/Calendar/DayCalendarGrid.test.tsx` — 25 pass, 0 fail
- [x] `bun run type-check` — clean
- [x] `bun run lint` — no findings in touched files (8 pre-existing warnings elsewhere, unrelated)
- [x] Manually verified in the Browser pane and in the user's real Chrome (real account): created a new all-day event in Day view, confirmed it rendered immediately, persisted across reload, and the header showed a single unified block with no console/network errors