### PR TITLE
fix(web): remove primary/read-only labels from sidebar calendar list

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -305,9 +305,11 @@ test("sidebar lists calendars, coalesces a visibility toggle, and shows card ide
   const sidebar = page.locator("#sidebar");
   const grid = page.locator("#mainGrid");
 
-  await expect(sidebar.getByText(`${CALENDAR_A_NAME} · primary`)).toBeVisible();
   await expect(
-    sidebar.getByText(`${CALENDAR_B_NAME} · read-only`),
+    sidebar.getByText(CALENDAR_A_NAME, { exact: true }),
+  ).toBeVisible();
+  await expect(
+    sidebar.getByText(CALENDAR_B_NAME, { exact: true }),
   ).toBeVisible();
   await expect(
     sidebar.getByText(LOCAL_CALENDAR_NAME, { exact: true }),

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
@@ -107,7 +107,7 @@ describe("PlannerCalendarList", () => {
     });
   });
 
-  it("renders active calendars with pressed buttons, hides inactive calendars, and spells out primary/read-only context as text", () => {
+  it("renders active calendars with pressed buttons and hides inactive calendars", () => {
     const active = makeCalendar({ name: "Work" });
     const primary = makeCalendar({ name: "Personal", isPrimary: true });
     const readOnly = makeCalendar({
@@ -123,8 +123,6 @@ describe("PlannerCalendarList", () => {
     expect(
       screen.getByRole("button", { name: "Hide Work calendar" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/primary/)).toBeInTheDocument();
-    expect(screen.getByText(/read-only/)).toBeInTheDocument();
     expect(screen.queryByText("Archived")).not.toBeInTheDocument();
   });
 

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.tsx
@@ -17,16 +17,6 @@ function sortCalendars(calendars: Calendar[]): Calendar[] {
   });
 }
 
-// Identity is never conveyed by color alone: primary/read-only context is
-// spelled out as text next to the calendar name.
-function calendarContextLabel(calendar: Calendar): string | null {
-  const labels = [
-    calendar.isPrimary ? "primary" : null,
-    calendar.capabilities.canWrite ? null : "read-only",
-  ].filter((label): label is string => label !== null);
-  return labels.length > 0 ? labels.join(", ") : null;
-}
-
 interface Props {
   /** Test seam only: production callers rely on useCalendarVisibility's default. */
   coalesceDelayMs?: number;
@@ -66,7 +56,6 @@ export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
       ) : (
         <ul className="flex flex-col gap-1.5">
           {calendars.map((calendar) => {
-            const contextLabel = calendarContextLabel(calendar);
             const calendarRow = (
               <>
                 <span
@@ -81,12 +70,6 @@ export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
                 />
                 <span className="min-w-0 flex-1 truncate">
                   {calendar.name}
-                  {contextLabel ? (
-                    <span className="text-text-light-inactive">
-                      {" "}
-                      · {contextLabel}
-                    </span>
-                  ) : null}
                 </span>
               </>
             );


### PR DESCRIPTION
## Summary
- Removes the "· primary" / "· read-only" text suffix that appeared after calendar names in the sidebar calendar list.
- Calendars now show only the color swatch and name; sort order (primary calendars first) is unchanged.

## Simplicity
Net reduction: deletes the `calendarContextLabel` helper and its call site (20 lines removed, no lines added beyond the test tweak). No `useEffect`/`useRef`/`useState` in this diff.

## Manual Testing Steps
- [ ] Open the calendar app while signed in and look at the "Calendars" section in the left sidebar.
- [ ] Confirm each calendar row shows only a color dot and the calendar's name — no "primary" or "read-only" text after the name.
- [ ] Confirm clicking a calendar row still toggles its visibility (dot fills/empties) as before.

## Test plan
- [x] `bun test src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx` — 9 pass, 0 fail
- [x] `bun run type-check` — clean