### PR TITLE
fix(web): tighten gap between sidebar month label and nav arrows

### DIFF
--- a/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
@@ -76,7 +76,7 @@ export const PlannerMonthPicker: FC<Props> = ({
         headerClassName="!relative !justify-start !px-0 !pb-3"
         inline
         isOpen={true}
-        monthContainerClassName="!w-32"
+        monthContainerClassName="!w-auto"
         monthTextClassName="text-[14px] font-medium"
         monthsShown={monthsShown}
         onChange={(date) => {


### PR DESCRIPTION
## Summary
- The sidebar month-picker header reserved a fixed `!w-32` (128px) width for the month label ("MMM YYYY"), leaving a large dead gap before the prev/next arrows since the label text is much narrower than 128px.
- Changed the container to `!w-auto` so it sizes to its content, pulling the nav arrows right next to the label — reads as one left-aligned group, matching the requested layout. The sidebar-toggle icon (pushed via `ml-auto`) is unaffected.

## Simplicity
No simplification opportunities found — this is a single Tailwind class change with no logic, hooks, or duplication involved.

## Manual Testing Steps
- [ ] Open the app, go to any view with the left sidebar mini-calendar visible.
- [ ] Confirm the month label (e.g. "Jul 2026") sits close to the `‹` `›` arrows, with a small consistent gap, not a large dead space.
- [ ] Click the `›` arrow and confirm the label updates (e.g. to "Aug 2026") and the arrows stay in the same tight position relative to the new label.
- [ ] Confirm the sidebar-toggle icon on the far right is unaffected.

## Test plan
- [x] Manually verified in the user's real Chrome session at `localhost:9091`: label/arrow spacing tightened, month navigation (Jul 2026 → Aug 2026) works, no console errors.
- No automated tests apply — this is a pure CSS layout change with no logic branches to cover.