### PR TITLE
fix(web): unify allday row background across calendar columns

### DIFF
--- a/packages/web/src/layout/calendar-grid/components/CalendarAllDayRow.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarAllDayRow.tsx
@@ -49,7 +49,7 @@ export const CalendarAllDayRow: FC<CalendarAllDayRowProps> = ({
   visibleDates,
 }) => (
   <div
-    className="relative flex w-full shrink-0 items-start"
+    className="relative flex w-full shrink-0 items-start bg-bg-secondary"
     aria-label="All-day events"
     id={rowId}
     ref={allDayRowRef}


### PR DESCRIPTION
## Summary
- In the per-calendar-split Day view, an empty calendar column's all-day area rendered fully transparent while a column with an all-day event showed that event's priority-tinted fill, making the row look like it had two different background colors.
- Gives `CalendarAllDayRow`'s outer container a `bg-bg-secondary` background (the same token already used for "distinguish this region" styling in `CalendarTimedGrid`) so the whole row reads as one consistent band across all calendar columns, whether or not a column has an all-day event.

## Simplicity
No simplification opportunities found — the change is a single Tailwind class addition reusing an existing design token, no hooks involved.

## Manual Testing Steps
- [ ] Go to Day view for any date.
- [ ] Confirm the all-day row (the strip just under the calendar name header, above the hourly grid) shows one consistent background color across its full width, even where there's no all-day event.
- [ ] Click an empty spot in the all-day row to create a new all-day event, give it a title, and save.
- [ ] Confirm the row background still looks uniform on both sides of the new event card (no visible seam between "event" and "empty" areas).
- [ ] Delete the test event and confirm the row returns to its uniform background with no event present.

## Test plan
- [x] `bun run type-check` — passes
- [x] Manually verified in the user's real Chrome profile (signed-in account) on Day view: created and deleted a test all-day event, confirmed uniform row background before/after, no console errors, no network errors