### PR TITLE
feat(web): make account identity the sidebar calendar list header

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -235,6 +235,19 @@ async function setupCalendarExperiencePage(
         body: JSON.stringify(body),
       });
 
+    if (pathname.endsWith("/api/user/profile")) {
+      // The calendar list header shows the profile email; the catch-all `{}`
+      // below would leave it null and render the anonymous header instead.
+      return json({
+        userId: "e2e-user",
+        email: "e2e@example.com",
+        firstName: "E2E",
+        lastName: "User",
+        name: "E2E User",
+        locale: "en",
+        picture: "",
+      });
+    }
     if (pathname.endsWith("/api/user/metadata")) {
       return json({ google: { connectionState: "HEALTHY" } });
     }
@@ -304,9 +317,15 @@ test("sidebar lists calendars, coalesces a visibility toggle, and shows card ide
   const sidebar = page.locator("#sidebar");
   const grid = page.locator("#mainGrid");
 
+  // The list header is the account email; the primary calendar's own name
+  // (which duplicates it) is replaced by a "primary" row.
   await expect(
-    sidebar.getByText(CALENDAR_A_NAME, { exact: true }),
+    sidebar.getByRole("heading", { name: "e2e@example.com" }),
   ).toBeVisible();
+  await expect(sidebar.getByText("primary", { exact: true })).toBeVisible();
+  await expect(sidebar.getByText(CALENDAR_A_NAME, { exact: true })).toHaveCount(
+    0,
+  );
   await expect(
     sidebar.getByText(CALENDAR_B_NAME, { exact: true }),
   ).toBeVisible();

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
@@ -46,6 +46,11 @@ const { PlannerCalendarList } = (await import(
   plannerCalendarListModuleUrl.href
 )) as typeof import("./PlannerCalendarList");
 
+// The real header renders the account email / temporary-account CTA via its
+// own auth+sync hooks (covered in PlannerCalendarListHeader.test.tsx); stub it
+// here so list tests don't need those hooks mocked.
+const StubHeader = () => <h2>Calendars</h2>;
+
 const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
   id: CalendarIdSchema.parse(createObjectIdString()),
   name: "Work",
@@ -78,7 +83,10 @@ const renderCalendarList = (
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
 
   const utils = render(
-    <PlannerCalendarList coalesceDelayMs={coalesceDelayMs} />,
+    <PlannerCalendarList
+      coalesceDelayMs={coalesceDelayMs}
+      Header={StubHeader}
+    />,
     {
       wrapper,
     },
@@ -126,12 +134,31 @@ describe("PlannerCalendarList", () => {
     expect(screen.queryByText("Archived")).not.toBeInTheDocument();
   });
 
-  it("hides the visibility toggle for anonymous sessions", () => {
-    const local = makeCalendar({ name: "Local", provider: "local" });
+  it("relabels the primary provider calendar as 'primary' since the header already shows its name", () => {
+    const primary = makeCalendar({ name: "ahab@pequod.com", isPrimary: true });
+
+    renderCalendarList([primary]);
+
+    expect(
+      screen.getByRole("button", { name: "Hide primary calendar" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("primary")).toBeInTheDocument();
+    expect(screen.queryByText("ahab@pequod.com")).not.toBeInTheDocument();
+  });
+
+  it("hides the visibility toggle for anonymous sessions and keeps the local sentinel's own name", () => {
+    // The anonymous synthesized local calendar is isPrimary, but must not be
+    // relabeled "primary" - the header shows "Temporary account", not its name.
+    const local = makeCalendar({
+      name: "Local",
+      provider: "local",
+      isPrimary: true,
+    });
 
     renderCalendarList([local], { authenticated: false });
 
     expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.queryByText("primary")).not.toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
@@ -283,7 +310,7 @@ describe("PlannerCalendarList", () => {
     BaseApi.defaults.adapter = () => new Promise(() => {});
     const { wrapper } = createStoreWrapper();
 
-    render(<PlannerCalendarList />, { wrapper });
+    render(<PlannerCalendarList Header={StubHeader} />, { wrapper });
 
     expect(screen.getByText(/loading calendars/i)).toBeInTheDocument();
   });
@@ -310,7 +337,7 @@ describe("PlannerCalendarList", () => {
       };
     };
     const { wrapper } = createStoreWrapper();
-    render(<PlannerCalendarList />, { wrapper });
+    render(<PlannerCalendarList Header={StubHeader} />, { wrapper });
 
     await waitFor(() => {
       expect(screen.getByText(/couldn.t load calendars/i)).toBeInTheDocument();

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.tsx
@@ -3,6 +3,7 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
+import { PlannerCalendarListHeader } from "./PlannerCalendarListHeader";
 
 // Primary calendars first, then alphabetical by name; the local calendar
 // (offline/anonymous synthesized calendar, or the server's own local
@@ -20,9 +21,14 @@ function sortCalendars(calendars: Calendar[]): Calendar[] {
 interface Props {
   /** Test seam only: production callers rely on useCalendarVisibility's default. */
   coalesceDelayMs?: number;
+  /** Test seam only: lets list tests stub the account header's auth/sync hooks. */
+  Header?: FC;
 }
 
-export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
+export const PlannerCalendarList: FC<Props> = ({
+  coalesceDelayMs,
+  Header = PlannerCalendarListHeader,
+}) => {
   const { authenticated } = useSession();
   const { data, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
@@ -34,9 +40,7 @@ export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
 
   return (
     <section aria-label="Calendars">
-      <h2 className="mb-2 min-w-0 truncate font-semibold text-sm text-text-lighter leading-none">
-        Calendars
-      </h2>
+      <Header />
 
       {isPending ? (
         <p className="text-text-light-inactive text-xs">Loading calendars…</p>
@@ -56,6 +60,14 @@ export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
       ) : (
         <ul className="flex flex-col gap-1.5">
           {calendars.map((calendar) => {
+            // The header already shows the primary calendar's name (the account
+            // email), so its row reads "primary" instead. The anonymous local
+            // sentinel is also isPrimary, but a lone "primary" row under a
+            // "Temporary account" header reads wrong - keep its own name.
+            const displayName =
+              calendar.isPrimary && calendar.provider !== "local"
+                ? "primary"
+                : calendar.name;
             const calendarRow = (
               <>
                 <span
@@ -68,9 +80,7 @@ export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
                     borderColor: calendar.backgroundColor,
                   }}
                 />
-                <span className="min-w-0 flex-1 truncate">
-                  {calendar.name}
-                </span>
+                <span className="min-w-0 flex-1 truncate">{displayName}</span>
               </>
             );
 
@@ -78,7 +88,7 @@ export const PlannerCalendarList: FC<Props> = ({ coalesceDelayMs }) => {
               <li key={calendar.id}>
                 {authenticated ? (
                   <button
-                    aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${calendar.name} calendar`}
+                    aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${displayName} calendar`}
                     aria-pressed={calendar.isVisible}
                     className="c-focus-ring group flex w-full min-w-0 items-center gap-2 rounded px-1 py-0.5 text-left text-text-lighter text-xs hover:bg-panel-bg"
                     onClick={() =>

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarListHeader.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarListHeader.test.tsx
@@ -57,10 +57,22 @@ afterAll(() => {
   isAuthModalMocked = false;
 });
 
-const { PlannerAccountSummary } =
-  require("./PlannerAccountSummary") as typeof import("./PlannerAccountSummary");
+// PlannerCalendarListHeader.tsx is already cached by the time this file runs -
+// PlannerCalendarList.test.tsx (which sorts before this file) imports
+// PlannerCalendarList.tsx, whose own top-level import evaluated this module and
+// bound its hook imports to whatever was active at that earlier point. A plain
+// require here would return that stale instance. A cache-busted URL forces a
+// fresh evaluation that re-resolves the hooks against the mocks above (same
+// technique as PlannerCalendarList.test.tsx).
+const headerModuleUrl = new URL(
+  `./PlannerCalendarListHeader.tsx?test=${Math.random().toString(36).slice(2)}`,
+  import.meta.url,
+);
+const { PlannerCalendarListHeader } = (await import(
+  headerModuleUrl.href
+)) as typeof import("./PlannerCalendarListHeader");
 
-const renderSummary = ({
+const renderHeader = ({
   pendingEventIds = [],
 }: {
   pendingEventIds?: string[];
@@ -70,12 +82,12 @@ const renderSummary = ({
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <PlannerAccountSummary />
+      <PlannerCalendarListHeader />
     </QueryClientProvider>,
   );
 };
 
-describe("PlannerAccountSummary", () => {
+describe("PlannerCalendarListHeader", () => {
   beforeEach(() => {
     mockEmail = undefined;
     mockGoogleState = "NOT_CONNECTED";
@@ -86,13 +98,16 @@ describe("PlannerAccountSummary", () => {
     mockUseConnectGoogle.mockClear();
   });
 
-  it("shows a default-colored temporary account label with a sign-up tooltip before any changes are made", async () => {
+  it("shows a default-colored temporary account heading with a sign-up tooltip before any changes are made", async () => {
     const user = userEvent.setup();
 
-    renderSummary();
+    renderHeader();
 
+    expect(
+      screen.getByRole("heading", { name: "Temporary account" }),
+    ).toBeInTheDocument();
     const trigger = screen.getByRole("button", { name: "Temporary account" });
-    expect(trigger).toHaveClass("text-text-light");
+    expect(trigger).toHaveClass("text-text-lighter");
     expect(trigger).not.toHaveClass("c-sync-text-wave");
     expect(screen.queryByText("Sign up")).toBeNull();
 
@@ -108,28 +123,31 @@ describe("PlannerAccountSummary", () => {
   it("shows the wave shimmer on the temporary account label once the anonymous user makes a change", () => {
     mockIsAnonymousDirty = true;
 
-    renderSummary();
+    renderHeader();
 
     const trigger = screen.getByRole("button", { name: "Temporary account" });
     expect(trigger).toHaveClass("c-sync-text-wave");
-    expect(trigger).not.toHaveClass("text-text-light");
+    expect(trigger).not.toHaveClass("text-text-lighter");
   });
 
   it("also opens sign up by clicking the temporary account label directly (keyboard path)", async () => {
     const user = userEvent.setup();
 
-    renderSummary();
+    renderHeader();
 
     await user.click(screen.getByRole("button", { name: "Temporary account" }));
     expect(mockOpenModal).toHaveBeenCalledWith("signUp");
   });
 
-  it("renders a plain, non-interactive email when Google is not connected", () => {
+  it("renders a plain, non-interactive email heading when Google is not connected", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "NOT_CONNECTED";
 
-    renderSummary();
+    renderHeader();
 
+    expect(
+      screen.getByRole("heading", { name: "ahab@pequod.com" }),
+    ).toBeInTheDocument();
     const email = screen.getByText("ahab@pequod.com");
     expect(email.tagName).toBe("SPAN");
     expect(email).not.toHaveAttribute("tabindex");
@@ -142,10 +160,10 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "HEALTHY";
 
-    renderSummary();
+    renderHeader();
 
     const email = screen.getByText("ahab@pequod.com");
-    expect(email).toHaveClass("text-text-light");
+    expect(email).toHaveClass("text-text-lighter");
     expect(screen.getByRole("status")).toHaveTextContent("Up-to-date");
 
     await user.hover(email);
@@ -163,7 +181,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = state;
 
-    renderSummary();
+    renderHeader();
 
     const email = screen.getByText("ahab@pequod.com");
     expect(email).toHaveClass("c-sync-text-wave");
@@ -179,7 +197,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "ATTENTION";
 
-    renderSummary();
+    renderHeader();
 
     const trigger = screen.getByText("ahab@pequod.com");
     expect(trigger).toHaveClass("text-status-warning");
@@ -201,7 +219,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "ATTENTION";
 
-    renderSummary();
+    renderHeader();
 
     await user.click(screen.getByText("ahab@pequod.com"));
     expect(mockOnRepairGoogle).toHaveBeenCalledTimes(1);
@@ -212,7 +230,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "RECONNECT_REQUIRED";
 
-    renderSummary();
+    renderHeader();
 
     const trigger = screen.getByText("ahab@pequod.com");
     expect(trigger).toHaveClass("text-status-error");
@@ -229,7 +247,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "HEALTHY";
 
-    renderSummary({ pendingEventIds: ["event-1"] });
+    renderHeader({ pendingEventIds: ["event-1"] });
 
     expect(screen.getByText("Syncing changes…")).toBeTruthy();
     expect(screen.queryByText("Up-to-date")).toBeNull();
@@ -239,7 +257,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "NOT_CONNECTED";
 
-    renderSummary({ pendingEventIds: ["event-1"] });
+    renderHeader({ pendingEventIds: ["event-1"] });
 
     expect(screen.getByText("Syncing changes…")).toBeTruthy();
   });
@@ -248,7 +266,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "RECONNECT_REQUIRED";
 
-    renderSummary({ pendingEventIds: ["event-1"] });
+    renderHeader({ pendingEventIds: ["event-1"] });
 
     expect(screen.getByRole("status")).toHaveTextContent("needs reconnecting");
     expect(screen.queryByText("Syncing changes…")).toBeNull();
@@ -258,7 +276,7 @@ describe("PlannerAccountSummary", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "IMPORTING";
 
-    renderSummary({ pendingEventIds: ["event-1"] });
+    renderHeader({ pendingEventIds: ["event-1"] });
 
     expect(screen.getByText("Syncing…")).toBeTruthy();
     expect(screen.queryByText("Syncing changes…")).toBeNull();

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarListHeader.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarListHeader.tsx
@@ -21,24 +21,33 @@ const TEMPORARY_ACCOUNT_MESSAGE = "Sign up to save your changes";
 const TOOLTIP_ACTION_BUTTON_CLASSNAME =
   "c-focus-ring self-start rounded-xs bg-accent-primary px-2 py-1 font-medium text-s text-text-dark hover:brightness-110";
 
-// Shared by every account-label trigger (button or span) so the sidebar's
+const HEADING_CLASSNAME =
+  "mb-2 flex min-w-0 font-semibold text-sm leading-none";
+
+// Shared by every account-label trigger (button or span) so the header's
 // email/temporary-account text stays keyboard-focusable and reset the same way.
 const TRIGGER_FOCUS_CLASSNAME =
-  "min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary";
+  "min-w-0 truncate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary";
 const TRIGGER_BUTTON_RESET_CLASSNAME =
-  "appearance-none border-0 bg-transparent p-0 text-left";
+  "appearance-none border-0 bg-transparent p-0 text-left font-semibold";
 
-export const PlannerAccountSummary: FC = () => {
+/**
+ * The calendar list's heading is the account identity (email, or the
+ * temporary-account label when anonymous) rather than a generic "Calendars"
+ * title, and carries the sync status treatment (wave shimmer while syncing,
+ * warning/error colors) plus the sign-up-to-save CTA for anonymous users.
+ */
+export const PlannerCalendarListHeader: FC = () => {
   const { email } = useUser();
 
   if (!email) {
-    return <TemporaryAccountSummary />;
+    return <TemporaryAccountHeader />;
   }
 
-  return <AuthenticatedAccountSummary email={email} />;
+  return <AuthenticatedAccountHeader email={email} />;
 };
 
-const TemporaryAccountSummary: FC = () => {
+const TemporaryAccountHeader: FC = () => {
   const { openModal } = useAuthModal();
   const isDirty = useSyncExternalStore(
     subscribeToAuthState,
@@ -51,15 +60,14 @@ const TemporaryAccountSummary: FC = () => {
   }, [openModal]);
 
   return (
-    <div className="flex w-full min-w-0 shrink-0 items-center border-border-primary border-t px-4 py-2">
+    <h2 className={HEADING_CLASSNAME}>
       <Tooltip interactive>
         <TooltipTrigger asChild>
           <button
             className={classNames(
               TRIGGER_FOCUS_CLASSNAME,
               TRIGGER_BUTTON_RESET_CLASSNAME,
-              "truncate font-normal text-xs leading-tight",
-              isDirty ? "c-sync-text-wave" : "text-text-light",
+              isDirty ? "c-sync-text-wave" : "text-text-lighter",
             )}
             onClick={handleOpenSignUp}
             type="button"
@@ -78,7 +86,7 @@ const TemporaryAccountSummary: FC = () => {
           </button>
         </TooltipContent>
       </Tooltip>
-    </div>
+    </h2>
   );
 };
 
@@ -109,12 +117,12 @@ const SYNC_STATUS_VARIANT_CLASSNAME: Record<
   string
 > = {
   syncing: "c-sync-text-wave",
-  healthy: "text-text-light",
+  healthy: "text-text-lighter",
   warning: "text-status-warning",
   error: "text-status-error",
 };
 
-const AuthenticatedAccountSummary: FC<{ email: string }> = ({ email }) => {
+const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
   const { state, onRepairGoogle, onOpenGoogleAuth } = useConnectGoogle();
   const hasPendingEventMutations = useHasPendingEventMutations();
   const accountLabel = email;
@@ -127,64 +135,71 @@ const AuthenticatedAccountSummary: FC<{ email: string }> = ({ email }) => {
     hasPendingEventMutations,
   );
 
-  const emailClassName = classNames(
-    "truncate font-normal text-xs leading-tight",
-    syncStatus
-      ? SYNC_STATUS_VARIANT_CLASSNAME[syncStatus.variant]
-      : "text-text-light",
-  );
+  const emailClassName = syncStatus
+    ? SYNC_STATUS_VARIANT_CLASSNAME[syncStatus.variant]
+    : "text-text-lighter";
 
   return (
-    <div className="flex w-full min-w-0 shrink-0 items-center border-border-primary border-t px-4 py-2 text-text-light">
+    <>
+      <h2 className={HEADING_CLASSNAME}>
+        {syncStatus ? (
+          <Tooltip interactive={!!syncStatus.action}>
+            <TooltipTrigger asChild>
+              {syncStatus.action ? (
+                <button
+                  className={classNames(
+                    emailClassName,
+                    TRIGGER_FOCUS_CLASSNAME,
+                    TRIGGER_BUTTON_RESET_CLASSNAME,
+                  )}
+                  onClick={syncStatus.action.onClick}
+                  translate="no"
+                  type="button"
+                >
+                  {accountLabel}
+                </button>
+              ) : (
+                <span
+                  className={classNames(
+                    emailClassName,
+                    TRIGGER_FOCUS_CLASSNAME,
+                  )}
+                  // biome-ignore lint/a11y/noNoninteractiveTabindex: focusable so useFocus can reveal the status tooltip via keyboard; there is no action to trigger here.
+                  tabIndex={0}
+                  translate="no"
+                >
+                  {accountLabel}
+                </span>
+              )}
+            </TooltipTrigger>
+            <TooltipContent className="flex max-w-55 flex-col gap-1.5">
+              <span>{syncStatus.tooltip}</span>
+              {syncStatus.action ? (
+                <button
+                  className={TOOLTIP_ACTION_BUTTON_CLASSNAME}
+                  onClick={syncStatus.action.onClick}
+                  type="button"
+                >
+                  {syncStatus.action.label}
+                </button>
+              ) : null}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <span
+            className={classNames(emailClassName, "min-w-0 truncate")}
+            translate="no"
+          >
+            {accountLabel}
+          </span>
+        )}
+      </h2>
       {syncStatus ? (
-        <Tooltip interactive={!!syncStatus.action}>
-          <TooltipTrigger asChild>
-            {syncStatus.action ? (
-              <button
-                className={classNames(
-                  emailClassName,
-                  TRIGGER_FOCUS_CLASSNAME,
-                  TRIGGER_BUTTON_RESET_CLASSNAME,
-                )}
-                onClick={syncStatus.action.onClick}
-                translate="no"
-                type="button"
-              >
-                {accountLabel}
-              </button>
-            ) : (
-              <span
-                className={classNames(emailClassName, TRIGGER_FOCUS_CLASSNAME)}
-                // biome-ignore lint/a11y/noNoninteractiveTabindex: focusable so useFocus can reveal the status tooltip via keyboard; there is no action to trigger here.
-                tabIndex={0}
-                translate="no"
-              >
-                {accountLabel}
-              </span>
-            )}
-          </TooltipTrigger>
-          <TooltipContent className="flex max-w-55 flex-col gap-1.5">
-            <span>{syncStatus.tooltip}</span>
-            {syncStatus.action ? (
-              <button
-                className={TOOLTIP_ACTION_BUTTON_CLASSNAME}
-                onClick={syncStatus.action.onClick}
-                type="button"
-              >
-                {syncStatus.action.label}
-              </button>
-            ) : null}
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        <span className={emailClassName} translate="no">
-          {accountLabel}
-        </span>
-      )}
-      {syncStatus ? (
-        // `status` doesn't derive its accessible name from text content per the
-        // ARIA spec, so an explicit aria-label is required for the name to be
-        // announced/queryable (e.g. by role+name in tests).
+        // Outside the h2 so the status copy doesn't pollute the heading's
+        // accessible name. `status` doesn't derive its accessible name from
+        // text content per the ARIA spec, so an explicit aria-label is
+        // required for the name to be announced/queryable (e.g. by role+name
+        // in tests).
         <span
           aria-label={syncStatus.tooltip}
           aria-live="polite"
@@ -194,6 +209,6 @@ const AuthenticatedAccountSummary: FC<{ email: string }> = ({ email }) => {
           {syncStatus.tooltip}
         </span>
       ) : null}
-    </div>
+    </>
   );
 };

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
@@ -4,7 +4,6 @@ import { createPlannerSidebar } from "./PlannerSidebar";
 import { describe, expect, it, mock } from "bun:test";
 
 const PlannerSidebar = createPlannerSidebar({
-  PlannerAccountSummary: () => <div>Account summary</div>,
   PlannerCalendarList: () => <div>Calendar list</div>,
   PlannerMonthPicker: () => <div>Calendar picker</div>,
   PlannerSidebarActions: () => <div>Sidebar actions</div>,
@@ -26,7 +25,6 @@ describe("PlannerSidebar", () => {
 
     expect(screen.getByText("Calendar picker")).toBeTruthy();
     expect(screen.getByText("Calendar list")).toBeTruthy();
-    expect(screen.getByText("Account summary")).toBeTruthy();
     expect(screen.getByText("Sidebar actions")).toBeTruthy();
   });
 });

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
@@ -6,7 +6,6 @@ import {
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { PlannerAccountSummary } from "./PlannerAccountSummary/PlannerAccountSummary";
 import { PlannerCalendarList } from "./PlannerCalendarList/PlannerCalendarList";
 import { PlannerMonthPicker } from "./PlannerMonthPicker/PlannerMonthPicker";
 import { PlannerSidebarActions } from "./PlannerSidebarActions/PlannerSidebarActions";
@@ -31,7 +30,6 @@ export interface PlannerSidebarProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 type PlannerSidebarDependencies = {
-  PlannerAccountSummary: typeof PlannerAccountSummary;
   PlannerCalendarList: typeof PlannerCalendarList;
   PlannerMonthPicker: typeof PlannerMonthPicker;
   PlannerSidebarActions: typeof PlannerSidebarActions;
@@ -39,7 +37,6 @@ type PlannerSidebarDependencies = {
 };
 
 export function createPlannerSidebar({
-  PlannerAccountSummary: PlannerAccountSummaryComponent,
   PlannerCalendarList: PlannerCalendarListComponent,
   PlannerMonthPicker: PlannerMonthPickerComponent,
   PlannerSidebarActions: PlannerSidebarActionsComponent,
@@ -87,8 +84,6 @@ export function createPlannerSidebar({
           </div>
         )}
 
-        <PlannerAccountSummaryComponent />
-
         <PlannerSidebarActionsComponent
           isShortcutsOpen={isShortcutsOpen}
           onToggleShortcuts={onToggleShortcuts}
@@ -106,7 +101,6 @@ export function createPlannerSidebar({
 }
 
 export const PlannerSidebar = createPlannerSidebar({
-  PlannerAccountSummary,
   PlannerCalendarList,
   PlannerMonthPicker,
   PlannerSidebarActions,


### PR DESCRIPTION
## Summary

The sidebar showed the account email twice — as the primary Google calendar's row name and again in the pinned bottom account bar — under a generic "Calendars" heading. This PR makes the calendar list heading the account identity itself and removes the bottom bar:

- The list heading is now the email (signed in) or "Temporary account" (anonymous), replacing the static "Calendars" text.
- The sync-status treatment moves onto the heading: wave shimmer while syncing, warning/error colors, and the actionable tooltips ("Sync now"/"Reconnect"), plus the anonymous "Sign up to save your changes" CTA.
- The primary provider calendar's row reads **primary** instead of duplicating the email. The anonymous local sentinel (also flagged `isPrimary`) keeps its own name, since its header says "Temporary account" rather than a calendar name.
- `PlannerAccountSummary` is deleted; its logic lives on as `PlannerCalendarListHeader` inside the list. The sr-only sync-status region moved outside the `<h2>` so status copy doesn't pollute the heading's accessible name.

## Simplicity

Net reduction: one component instead of two rendering the same identity, and the whole bottom-bar container is gone. No `useEffect`/`useRef`/`useState` anywhere in the diff — the carried-over `useCallback`/`useSyncExternalStore` in the header are unchanged from the old component. One test seam was added (`Header?: FC` prop on `PlannerCalendarList`, defaulting to the real header) following the file's existing `coalesceDelayMs` seam convention, so list tests can stub the header without process-wide `mock.module` leaks.

## Manual Testing Steps

- [ ] Open the app signed out and click "Start Now": the sidebar's calendar list is headed by a bold "Temporary account" title with the "Local" calendar row (color dot) beneath it, and there is no account/email bar at the sidebar's bottom anymore.
- [ ] Drag any event to a new time: the "Temporary account" heading starts a subtle wave/shimmer animation.
- [ ] Hover the "Temporary account" heading: a tooltip reads "Sign up to save your changes" with a "Sign up" button that opens the sign-up modal.
- [ ] Signed in with Google: the heading shows your account email, the first calendar row reads "primary" (toggle announces "Hide primary calendar"), and other calendars keep their names.
- [ ] Stop the backend (or block the API) and reload: the heading still renders with "Couldn't load calendars. Retry" beneath it.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bun test --cwd packages/web` — 1165 pass, 0 fail (includes moved `PlannerCalendarListHeader.test.tsx` and new "primary"-label cases)
- [x] `bunx playwright test e2e/calendars/calendar-experience.spec.ts` — 6 passed (re-run after rebasing onto origin/main)
- [x] `bun run lint` — clean (8 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)