### PR TITLE
fix(scripts): repair priority event validator

### DIFF
--- a/docs/self-hosting/event-migration-runbook.md
+++ b/docs/self-hosting/event-migration-runbook.md
@@ -1,5 +1,11 @@
 # Event migration runbook (sub-calendar v1)
 
+> For Compass-operated staging and the eventual coordinated production release,
+> use the
+> [Google sub-calendar big-bang deployment runbook](../../team/architect/google-subcalendar-big-bang-runbook.md).
+> It splits pre-rename migrations from post-cutover repairs; an unbounded
+> pre-rename `migrate up` is no longer safe.
+
 How to run, verify, and — later — cut over the calendar-owned event migration
 from plan packet `02`. Read the whole page before touching production.
 
@@ -192,18 +198,11 @@ promptly or not at all.
   the new schema — no production code reads it.
 - Dev databases use the `_dev.` collection prefix; the commands above show
   production names.
-- `priority-data-cleanup` (`2026.07.14T10.00.00`) is unrelated to this
-  runbook's two migrations and does not require the staging-first rollout
-  above — it's independent storage hygiene, not a schema cutover. The
-  priority-tagging feature was removed (events, contracts, and UI); this
-  migration `$unset`s the now-dead `priority` field from legacy `event`
-  documents and drops the orphaned standalone `priority` collection from the
-  old priority-CRUD feature. Safe to run anytime, in any order relative to
-  the calendar/event-record migrations — it does not touch `event_new`, the
-  `calendar` collection, or any validator. `event_new` needs no equivalent
-  cleanup: it's fully rebuilt from legacy `event` on every backfill rerun, so
-  it stops carrying `priority` automatically the next time
-  `event-record-backfill` runs (its transform no longer reads the field).
-  Like the other migrations here, its `down()` is a non-destructive no-op —
-  the removed field and dropped collection are not recoverable without a
-  backup.
+- Priority removal now has an ordered pair of post-cutover migrations.
+  `event-priority-schema-repair` (`2026.07.14T09.59.00`) reapplies the current
+  strict `EventRecordSchema` to the active final `event` collection and removes
+  stale `priority` fields. It must run before `priority-data-cleanup`
+  (`2026.07.14T10.00.00`), which also drops the orphaned standalone `priority`
+  collection. Run this pair only after `event_new` has become the active
+  `event`; before the rename, `event` is legacy-shaped. Both `down()` methods
+  are non-destructive no-ops, so rollback is from backup.

--- a/packages/scripts/src/migrations/2026.07.14T09.59.00.event-priority-schema-repair.test.ts
+++ b/packages/scripts/src/migrations/2026.07.14T09.59.00.event-priority-schema-repair.test.ts
@@ -1,0 +1,138 @@
+import { MigratorType } from "@scripts/common/cli.types";
+import { zodToMongoSchema } from "@scripts/common/zod-to-mongo-schema";
+import Migration from "@scripts/migrations/2026.07.14T09.59.00.event-priority-schema-repair";
+import { type Document, ObjectId } from "mongodb";
+import { Logger } from "@core/logger/winston.logger";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  type EventRecord,
+  EventRecordSchema,
+} from "@backend/event/event.record";
+
+describe("2026.07.14T09.59.00.event-priority-schema-repair", () => {
+  const migration = new Migration();
+  const collectionName = () => mongoService.event.collectionName;
+  const events = () =>
+    mongoService.db.collection<EventRecord & { priority?: string }>(
+      collectionName(),
+    );
+  const migrationContext = {
+    name: migration.name,
+    context: {
+      logger: Logger("test:migration"),
+      migratorType: MigratorType.MIGRATION,
+      unsafe: false,
+      dryRun: false,
+    },
+  };
+
+  const eventRecord = (): EventRecord => ({
+    _id: new ObjectId(),
+    calendarId: new ObjectId(),
+    content: { kind: "details", title: "Standup", description: "" },
+    schedule: {
+      kind: "timed",
+      start: new Date("2026-07-14T16:00:00.000Z"),
+      end: new Date("2026-07-14T16:30:00.000Z"),
+      timeZone: "Etc/UTC",
+    },
+    recurrence: { kind: "single" },
+    externalReference: null,
+    createdAt: new Date("2026-07-14T15:00:00.000Z"),
+    updatedAt: null,
+  });
+
+  const createCollectionWithStaleValidator = async () => {
+    const currentSchema = zodToMongoSchema(EventRecordSchema);
+    const staleSchema = {
+      ...currentSchema,
+      properties: {
+        ...currentSchema.properties,
+        priority: { bsonType: "string" },
+      },
+      required: [...(currentSchema.required ?? []), "priority"],
+    };
+
+    await mongoService.db.createCollection(collectionName(), {
+      validator: { $jsonSchema: staleSchema },
+      validationLevel: "strict",
+    });
+  };
+
+  beforeAll(setupTestDb);
+  afterEach(async () => {
+    await events()
+      .drop()
+      .catch(() => undefined);
+    await cleanupCollections();
+  });
+  afterAll(cleanupTestDb);
+
+  it("no-ops when the active event collection does not exist", async () => {
+    await expect(migration.up(migrationContext)).resolves.not.toThrow();
+  });
+
+  it("refuses to modify a pre-cutover legacy event collection", async () => {
+    await mongoService.db.createCollection(collectionName());
+    await mongoService.db.collection(collectionName()).insertOne({
+      _id: new ObjectId(),
+      user: new ObjectId().toHexString(),
+      title: "Legacy event",
+      priority: "work",
+    });
+
+    await expect(migration.up(migrationContext)).rejects.toThrow(
+      /run it after the event collection rename/,
+    );
+
+    expect(
+      await mongoService.db
+        .collection(collectionName())
+        .countDocuments({ priority: "work" }),
+    ).toBe(1);
+  });
+
+  it("repairs the validator and removes stale priority data", async () => {
+    await createCollectionWithStaleValidator();
+    const staleEvent = { ...eventRecord(), priority: "work" };
+    await events().insertOne(staleEvent);
+
+    await expect(events().insertOne(eventRecord())).rejects.toThrow(
+      /Document failed validation/,
+    );
+
+    await migration.up(migrationContext);
+
+    expect(await events().countDocuments({ priority: { $exists: true } })).toBe(
+      0,
+    );
+    await expect(events().insertOne(eventRecord())).resolves.not.toThrow();
+
+    const info = await mongoService.db
+      .listCollections({ name: collectionName() })
+      .next();
+    const schema = (info?.options?.validator as Document)?.["$jsonSchema"] as
+      | Document
+      | undefined;
+    expect(schema?.["required"]).not.toContain("priority");
+    expect(schema?.["properties"]).not.toHaveProperty("priority");
+  });
+
+  it("is idempotent", async () => {
+    await createCollectionWithStaleValidator();
+    await events().insertOne({ ...eventRecord(), priority: "unassigned" });
+
+    await migration.up(migrationContext);
+    await expect(migration.up(migrationContext)).resolves.not.toThrow();
+
+    expect(await events().countDocuments()).toBe(1);
+    expect(await events().countDocuments({ priority: { $exists: true } })).toBe(
+      0,
+    );
+  });
+});

--- a/packages/scripts/src/migrations/2026.07.14T09.59.00.event-priority-schema-repair.ts
+++ b/packages/scripts/src/migrations/2026.07.14T09.59.00.event-priority-schema-repair.ts
@@ -1,0 +1,74 @@
+import { type MigrationContext } from "@scripts/common/cli.types";
+import { zodToMongoSchema } from "@scripts/common/zod-to-mongo-schema";
+import { type Document } from "mongodb";
+import { type MigrationParams, type RunnableMigration } from "umzug";
+import mongoService from "@backend/common/services/mongo.service";
+import { EventRecordSchema } from "@backend/event/event.record";
+
+async function assertCalendarOwnedCollection(
+  collectionName: string,
+): Promise<void> {
+  const info = (await mongoService.db
+    .listCollections({ name: collectionName })
+    .next()) as Document;
+  const options = info["options"] as Document | undefined;
+  const validator = options?.["validator"] as Document | undefined;
+  const schema = validator?.["$jsonSchema"] as Document | undefined;
+  const required = schema?.["required"];
+  const hasFinalValidator =
+    Array.isArray(required) && required.includes("calendarId");
+  const hasFinalRecord = await mongoService.db
+    .collection<Document>(collectionName)
+    .findOne({ calendarId: { $exists: true } }, { projection: { _id: 1 } });
+
+  if (hasFinalValidator || hasFinalRecord) return;
+
+  throw new Error(
+    `Event priority schema repair requires the calendar-owned "${collectionName}" collection; run it after the event collection rename`,
+  );
+}
+
+export default class Migration implements RunnableMigration<MigrationContext> {
+  readonly name: string = "2026.07.14T09.59.00.event-priority-schema-repair";
+  readonly path: string = "2026.07.14T09.59.00.event-priority-schema-repair.ts";
+
+  async up(params: MigrationParams<MigrationContext>): Promise<void> {
+    const { logger } = params.context;
+    const collectionName = mongoService.event.collectionName;
+    const exists = await mongoService.db
+      .listCollections({ name: collectionName })
+      .hasNext();
+
+    if (!exists) {
+      logger.info(
+        `Event priority schema repair: collection "${collectionName}" is absent`,
+      );
+      return;
+    }
+
+    await assertCalendarOwnedCollection(collectionName);
+
+    await mongoService.db.command({
+      collMod: collectionName,
+      validator: { $jsonSchema: zodToMongoSchema(EventRecordSchema) },
+      validationLevel: "strict",
+    });
+
+    const events = mongoService.db.collection<Document>(collectionName);
+    const result = await events.updateMany(
+      { priority: { $exists: true } },
+      { $unset: { priority: "" } },
+    );
+
+    logger.info(
+      `Event priority schema repair: updated validator and cleared priority from ${result.modifiedCount} active event document(s)`,
+    );
+  }
+
+  async down(params: MigrationParams<MigrationContext>): Promise<void> {
+    params.context.logger.info(
+      "Down migration is a non-destructive no-op for the event priority schema repair",
+    );
+    return Promise.resolve();
+  }
+}

--- a/packages/scripts/src/migrations/2026.07.14T10.00.00.priority-data-cleanup.test.ts
+++ b/packages/scripts/src/migrations/2026.07.14T10.00.00.priority-data-cleanup.test.ts
@@ -36,7 +36,9 @@ describe("2026.07.14T10.00.00.priority-data-cleanup", () => {
   });
 
   it("unsets the priority field from event documents that still carry it", async () => {
-    const events = mongoService.db.collection(mongoService.event.collectionName);
+    const events = mongoService.db.collection(
+      mongoService.event.collectionName,
+    );
     await events.insertMany([
       { _id: new ObjectId(), title: "Standup", priority: "work" },
       { _id: new ObjectId(), title: "Focus block", priority: "unassigned" },
@@ -58,7 +60,9 @@ describe("2026.07.14T10.00.00.priority-data-cleanup", () => {
   });
 
   it("leaves event documents without a priority field untouched", async () => {
-    const events = mongoService.db.collection(mongoService.event.collectionName);
+    const events = mongoService.db.collection(
+      mongoService.event.collectionName,
+    );
     const id = new ObjectId();
     await events.insertOne({ _id: id, title: "No priority here" });
 
@@ -82,7 +86,9 @@ describe("2026.07.14T10.00.00.priority-data-cleanup", () => {
   });
 
   it("is idempotent: rerunning after a clean run makes no further changes", async () => {
-    const events = mongoService.db.collection(mongoService.event.collectionName);
+    const events = mongoService.db.collection(
+      mongoService.event.collectionName,
+    );
     await events.insertOne({
       _id: new ObjectId(),
       title: "Standup",

--- a/packages/scripts/src/migrations/2026.07.14T10.00.00.priority-data-cleanup.ts
+++ b/packages/scripts/src/migrations/2026.07.14T10.00.00.priority-data-cleanup.ts
@@ -1,8 +1,8 @@
-import { IS_DEV } from "@backend/common/constants/config.constants";
-import mongoService from "@backend/common/services/mongo.service";
+import { type MigrationContext } from "@scripts/common/cli.types";
 import { type Document } from "mongodb";
 import { type MigrationParams, type RunnableMigration } from "umzug";
-import { type MigrationContext } from "@scripts/common/cli.types";
+import { IS_DEV } from "@backend/common/constants/config.constants";
+import mongoService from "@backend/common/services/mongo.service";
 
 // The standalone priority-CRUD collection was never exposed via
 // `Collections` after the feature was removed; its name is reconstructed
@@ -47,7 +47,9 @@ export default class Migration implements RunnableMigration<MigrationContext> {
       .hasNext();
     if (priorityCollectionExists) {
       await mongoService.db.collection(priorityCollectionName).drop();
-      logger.info(`Priority cleanup: dropped collection "${priorityCollectionName}"`);
+      logger.info(
+        `Priority cleanup: dropped collection "${priorityCollectionName}"`,
+      );
     } else {
       logger.info(
         `Priority cleanup: collection "${priorityCollectionName}" already absent`,

--- a/team/architect/google-subcalendar-big-bang-runbook.md
+++ b/team/architect/google-subcalendar-big-bang-runbook.md
@@ -1,0 +1,279 @@
+# Google sub-calendar big-bang deployment runbook
+
+Status: **staging recovery is ready to rehearse; production is locked**.
+
+This is the master operator runbook for landing the work from
+[`google-subcalendar-project`](../archive/google-subcalendar-project/master-doc.md)
+as one coordinated database and application cutover. It includes the event
+collection rename, every post-cutover repair, the removal of `priority`, Google
+multi-calendar sync, the calendar-aware runtime, and the release-hardening
+acceptance checks.
+
+The current task is staging only. Do not run the production phase until the
+staging evidence table in this document is complete and the product owner opens
+the production gate.
+
+## Why this runbook supersedes the earlier sequence
+
+The original production plan ran every pending migration before renaming
+`event_new` to `event`. That stopped being safe when post-cutover migrations
+were added:
+
+- `recurring-series-first-occurrence-repair` operates on the active, final
+  `event` schema. Before the rename, production's `event` collection is still
+  legacy-shaped, so the repair would no-op and be recorded as complete.
+- PR #2101 removed `priority` from `EventRecordSchema`, but staging's active
+  Mongo validator still required it. New sync inserts consequently fail with
+  Mongo code `121`.
+- `priority-data-cleanup` unsets `priority` from whichever collection is named
+  `event` when it runs. Under the stale validator, that unset is rejected.
+
+The safe order is therefore:
+
+1. Run only the legacy-to-final calendar migration and inactive event backfill.
+2. Verify and rename the collections.
+3. Run all post-cutover repairs against the newly active final `event`.
+4. Deploy the final runtime and run acceptance.
+
+## Included release surface
+
+The selected release must include all completed packets `01` through `08` and
+the automated work from packet `09`, plus these database migrations in order:
+
+| Order | Migration | Runs against |
+| --- | --- | --- |
+| 1 | `2026.07.10T21.00.00.calendar-record-migration` | live `calendar` |
+| 2 | `2026.07.10T21.30.00.event-record-backfill` | legacy `event` → inactive `event_new` |
+| rename | `event` → `event_legacy_v1`; `event_new` → `event` | physical collections |
+| 3 | `2026.07.13T12.00.00.recurring-series-first-occurrence-repair` | final active `event` |
+| 4 | `2026.07.14T09.59.00.event-priority-schema-repair` | final active `event` validator and rows |
+| 5 | `2026.07.14T10.00.00.priority-data-cleanup` | active `event` hygiene and orphaned `priority` collection |
+
+The `09.59` timestamp is intentional: the validator must stop requiring
+`priority` before the `10.00` cleanup attempts to unset that field.
+
+## Environment state matrix
+
+Confirm physical state before running any write command. Hosted staging and
+production processes use the `prod_calendar` database because their runtime
+`nodeEnv` is `production`; the environment is selected by `MONGO_URI`, not by a
+different database name.
+
+| Environment | Expected state now | Allowed action |
+| --- | --- | --- |
+| staging-cloud | Already cut over; active `event` uses `calendarId` and may have the stale `priority` validator | Run the staging recovery below |
+| staging-selfhosted | Confirm independently; do not assume it matches staging-cloud | Run recovery only if already cut over |
+| production | Legacy `event`; no big-bang cutover performed | Read-only preflight only |
+
+For each target, capture these results without event content:
+
+```javascript
+use prod_calendar;
+db.getCollectionInfos({ name: "event" })[0].options.validator;
+db.event.countDocuments({ calendarId: { $exists: true } });
+db.event.countDocuments({ user: { $exists: true } });
+db.getCollectionInfos({ name: "event_new" }).length;
+db.getCollectionInfos({ name: "event_legacy_v1" }).length;
+db.migrations.find({}, { name: 1 }).sort({ name: 1 });
+```
+
+Stop if the observed shape does not match the matrix. Do not use collection
+counts alone to infer which schema is active.
+
+## Phase S0 — staging preparation
+
+Run separately for `staging-cloud` and `staging-selfhosted`; record which target
+each command used.
+
+1. Choose the release tag containing the validator repair and this runbook.
+2. Confirm its CI, scripts tests, type-check, and lint are green.
+3. Prepare a trusted admin checkout at that exact tag and a target-specific
+   `compass.yaml`. Never commit the file.
+4. Record the currently deployed tag from `/version.json`.
+5. Capture the environment-state queries above.
+6. Take a backup:
+   - staging-cloud: managed Mongo snapshot plus `mongodump` through the trusted
+     admin path;
+   - staging-selfhosted: the documented Mongo dump/volume procedure.
+7. Verify the dump is non-empty and restore at least its metadata into a scratch
+   database.
+8. Announce the staging maintenance window and identify the operator and
+   rollback owner.
+
+## Phase S1 — repair already-cut-over staging
+
+This phase is the only write procedure currently approved.
+
+1. Stop the target staging backend so no sync or event writes race the repair:
+
+   ```bash
+   ssh <staging-host> \
+     'cd ~/compass && docker compose --project-name compass -f compose.yaml stop backend'
+   ```
+2. From the release checkout, inspect pending migrations:
+
+   ```bash
+   COMPASS_CONFIG_FILE=<target-staging.yaml> bun run cli migrate pending
+   ```
+
+3. Confirm the calendar migration and event backfill are already recorded. If
+   either is pending while the active `event` is already calendar-owned, stop;
+   the ledger and physical state disagree.
+4. Confirm the pending list includes
+   `2026.07.14T09.59.00.event-priority-schema-repair` before
+   `2026.07.14T10.00.00.priority-data-cleanup`. The recurring-series repair may
+   also be pending.
+5. Run the remaining migrations:
+
+   ```bash
+   COMPASS_CONFIG_FILE=<target-staging.yaml> bun run cli migrate up
+   ```
+
+6. Verify the migration ledger records every pending migration exactly once.
+7. Verify the active collection:
+
+   ```javascript
+   use prod_calendar;
+   const eventInfo = db.getCollectionInfos({ name: "event" })[0];
+   eventInfo.options.validationLevel;
+   eventInfo.options.validator.$jsonSchema.required;
+   eventInfo.options.validator.$jsonSchema.properties.priority;
+   db.event.countDocuments({ priority: { $exists: true } });
+   db.event.validate({ full: true });
+   ```
+
+   Required result: validation is `strict`; `priority` is absent from both the
+   required list and properties; the count is zero; collection validation is
+   valid.
+8. Deploy or rerun **Deploy staging** for the same release tag. This restarts
+   the backend and runs the standard environment health check.
+
+## Phase S2 — staging smoke and Google acceptance
+
+Use only designated staging accounts. At minimum:
+
+1. Trigger a full Google resync for the account that reproduced Mongo code
+   `121`; it must complete without `Document failed validation`.
+2. Make a Google-side add, edit, and delete and confirm each reconciles onto
+   the correct Compass calendar.
+3. Create, edit, and delete Compass timed and all-day events on a writable
+   secondary Google calendar.
+4. Confirm recurring-series repair creates no duplicates and does not resurrect
+   cancelled Google occurrences.
+5. Confirm the backend logs have no Mongo `121`, sync `ERRORED`, fatal, or
+   unhandled-rejection entries after the test start time.
+6. Run all 12 manual acceptance steps in
+   [`09-v1-release-hardening.md`](../archive/google-subcalendar-project/09-v1-release-hardening.md#manual-acceptance-runbook).
+7. Let both staging targets run through at least one watch renewal/catch-up
+   cycle before closing the staging gate.
+
+## Phase S3 — staging rollback rehearsal
+
+The migrations have non-destructive `down()` methods; rollback is a database
+restore, not `migrate down`.
+
+1. Stop the staging backend.
+2. Dump the post-repair `event` collection so new staging writes remain
+   available for diagnosis.
+3. Restore the Phase S0 backup into the staging database.
+4. Redeploy the previously recorded staging tag.
+5. Verify legacy behavior and record the accepted write-loss window.
+6. Repeat Phase S1 and Phase S2. The second forward run must converge cleanly.
+
+Do not perform this rehearsal on production.
+
+## Staging evidence gate
+
+Fill this table with links to logs or internal artifacts that contain no event
+content or credentials.
+
+| Evidence | staging-cloud | staging-selfhosted |
+| --- | --- | --- |
+| Preflight state captured | pending | pending |
+| Backup restore checked | pending | pending |
+| Validator repair migrated | pending | pending |
+| Google sync code `121` absent | pending | pending |
+| 12-step acceptance passed | pending | pending |
+| Rollback and second forward run passed | pending | pending |
+| Operator/date/release tag | pending | pending |
+
+Production remains locked while any cell is pending.
+
+## Future Phase P — production big-bang cutover
+
+This section is a reference plan, not current authorization.
+
+### Production go/no-go
+
+- Every staging evidence cell above is complete.
+- Packet `09` is marked complete in the project master plan.
+- The exact release tag passed staging and its images exist.
+- Production still has legacy `event`, and the migration ledger matches that
+  state.
+- A managed snapshot and verified `mongodump` exist.
+- The maintenance window, rollback owner, communications, and previous release
+  tag are recorded.
+
+### Production execution
+
+1. Stop the production backend and verify writes have ceased.
+2. Run only through the inactive final-schema backfill:
+
+   ```bash
+   COMPASS_CONFIG_FILE=<prod.yaml> bun run cli migrate up \
+     --to 2026.07.10T21.30.00.event-record-backfill
+   ```
+
+3. Require the backfill verification summary to pass. Verify indexes, category
+   counts, hashes, excluded someday count, and disk headroom.
+4. Rename the collections:
+
+   ```javascript
+   use prod_calendar;
+   db.event.renameCollection("event_legacy_v1");
+   db.event_new.renameCollection("event");
+   ```
+
+5. Run every post-cutover repair against the newly active collection:
+
+   ```bash
+   COMPASS_CONFIG_FILE=<prod.yaml> bun run cli migrate up
+   ```
+
+6. Repeat the strict-validator checks from Phase S1. Keep
+   `event_legacy_v1`; it is the rollback source.
+7. Deploy the selected tag with **Deploy production**, resume service, and run
+   the Phase S2 smoke plus production health checks.
+
+If the installed Umzug CLI does not accept `up --to`, stop during rehearsal and
+resolve the exact supported syntax. Do not replace the boundary with an
+unbounded pre-rename `migrate up`.
+
+### Production rollback
+
+1. Stop the backend and dump the post-cutover `event` collection.
+2. Rename `event` back to `event_new` and `event_legacy_v1` back to `event`.
+3. Redeploy the recorded pre-cutover tag.
+4. Restore `calendar` from the pre-cutover backup if its in-place migration is
+   implicated.
+5. Preserve the dumps and migration logs for reconciliation; do not drop either
+   event collection.
+
+Rollback abandons writes made after cutover from the active application view;
+the post-cutover dump keeps them available for manual recovery.
+
+## Source documents
+
+- Project source of truth:
+  [`master-doc.md`](../archive/google-subcalendar-project/master-doc.md)
+- Release gate and full acceptance:
+  [`09-v1-release-hardening.md`](../archive/google-subcalendar-project/09-v1-release-hardening.md)
+- Migration details:
+  [`event-migration-runbook.md`](../../docs/self-hosting/event-migration-runbook.md)
+- Backup and physical rename:
+  [`backup-and-restore.md`](../../docs/self-hosting/backup-and-restore.md)
+- Historical production plan:
+  [`prod-cutover-plan-subcalendar-v1.md`](./prod-cutover-plan-subcalendar-v1.md)
+- Deployment workflows:
+  [`deploy-staging.yml`](../../.github/workflows/deploy-staging.yml),
+  [`deploy-production.yml`](../../.github/workflows/deploy-production.yml)

--- a/team/architect/prod-cutover-plan-subcalendar-v1.md
+++ b/team/architect/prod-cutover-plan-subcalendar-v1.md
@@ -1,5 +1,11 @@
 # Sub-calendar v1 — Safe production cutover plan
 
+> Superseded for execution by the
+> [Google sub-calendar big-bang deployment runbook](./google-subcalendar-big-bang-runbook.md).
+> This file preserves the original production analysis. Its single unbounded
+> pre-rename `migrate up` sequence predates post-cutover repair migrations and
+> must not be used as the live command list.
+
 _Architect deliverable, 2026-07-13. Verified against `origin/main` @ `2c08e9f2e`._
 
 ## Context

--- a/team/archive/google-subcalendar-project/master-doc.md
+++ b/team/archive/google-subcalendar-project/master-doc.md
@@ -1,5 +1,10 @@
 # Google sub-calendars v1 master plan
 
+Operator execution now lives in the
+[Google sub-calendar big-bang deployment runbook](../../architect/google-subcalendar-big-bang-runbook.md).
+That runbook is staging-only until its evidence gate is complete; production
+remains locked.
+
 This directory replaces GitHub Project 6, **Google Subcalendars**, as the
 implementation source of truth. The project query
 `org:SwitchbackTech project:SwitchbackTech/6` returned 25 cards on 2026-07-10:
@@ -9,6 +14,11 @@ All 12 issues that were open in Project 6 were closed as `not planned` on
 2026-07-10 because Compass no longer uses GitHub issues for this work. Closure
 does not mean implementation is complete. `00-project-ledger.md` preserves the
 requirements, and the checkboxes in these files are the only progress tracker.
+
+Current rollout correction (2026-07-14): packets `01`–`08` are merged and
+staging is already collection-cut-over; production remains on the legacy
+collection. Later releases retired Someday and priority behavior. The master
+operator sequence, including those removals, is the linked big-bang runbook.
 
 ## v1 outcome
 
@@ -250,6 +260,7 @@ only by appending a dated decision and updating every affected plan.
 | A43 | (2026-07-12) Raw Google wire data stays typed via the `calendar_v3` `.d.ts` re-exports, not parsed with Zod; strictness applies at Compass's own mappers and record/contract schemas. Packet 09 step 2's "parse representative Google responses with shared Zod" is satisfied by mapper tests over the shared fixtures plus strict parsing of every Compass boundary.     | Zod-modeling Google's full resource surface duplicates a vendor contract we do not own and violates "keep optionality at the edges: untrusted Google responses"; the mapper is the validation boundary. Packet 09, PR #2068.                                                 |
 | A44 | (2026-07-12) V1 observability is structured logs (import summaries, watch repair actions, retry attempts/outcomes, maintenance tallies) — no metrics/counter subsystem ships in v1; the ops counters in packet 09's list derive from log aggregation.                                                                                                                     | The repo has zero metrics infrastructure; adding one for the release would be a speculative subsystem against the complexity guardrails, and every listed counter already exists as a structured log line. Packet 09, PR #2069.                                              |
 | A45 | (2026-07-13) A series base is metadata-only: it never renders as a grid card. `materializeSeriesInstances` materializes every occurrence, including the one at the base's own start; the web view-model drops `recurrence.kind === "series"` events from grid rendering. `analyzeReplace`/`analyzeDelete` collapse a `thisAndFollowing` scope targeting the series' earliest occurrence to `"all"`. `GoogleEventSync` matches an unlinked occurrence by `(seriesId, original position)` before inserting, so a Compass-created series' Google echo adopts its already-materialized local occurrences instead of duplicating them. | The runtime-cutover base-is-the-first-occurrence model (A17) collided with the Google import path, which always saves the base AND every Google-reported instance including the first — producing a duplicate card on day one, and (for Compass-created series) a full duplicate set once the series echoed back from Google's webhook. Fixed on `claude/google-calendar-duplicate-events-476653`; a one-off repair migration (`2026.07.13T12.00.00.recurring-series-first-occurrence-repair`) heals data written before this fix. |
+| A46 | (2026-07-14) The big-bang cutover has a hard migration boundary: run through `event-record-backfill`, rename collections, then run recurring-series and priority repairs against the final active `event`. Staging must complete repair, acceptance, rollback, and a second forward run before production is unlocked. | Post-cutover migrations target the collection named `event`; running them before the rename either silently no-ops on legacy rows or conflicts with the legacy validator. The staging priority-sync failure exposed this stale assumption. |
 
 ## Complexity guardrails
 


### PR DESCRIPTION
## Summary

- repair the active calendar-owned event collection validator after priority removal, then clear stale priority fields
- refuse to mutate a legacy pre-cutover event collection and cover the failing Mongo validation path, legacy guard, and idempotent rerun
- add the staging-first big-bang operator runbook, split pre-rename and post-cutover migrations, and keep production explicitly locked behind staging evidence

Users on staging can resume Google sync after the ordered migrations are run; this PR does not run migrations or deploy production.

## Simplicity

The migration has one guard, one validator replacement, and one cleanup write. The separate simplification pass found no additional abstraction or state worth adding. No React effects, refs, or state were introduced.

## Manual Testing Steps

- [ ] On each staging target, stop the backend and confirm the active event collection is calendar-owned.
- [ ] Run pending migrations and confirm the schema repair precedes priority-data-cleanup.
- [ ] Confirm the event validator is strict and no longer contains priority in its required list or properties.
- [ ] Trigger the previously failing Google resync and confirm it completes without Mongo code 121.
- [ ] Complete the staging smoke, acceptance, and rollback evidence in the master runbook; do not run the production phase.

## Test plan

- [x] `TZ=Etc/UTC bun test:scripts` — 148/148
- [x] `bun run verify` — core, web, and type-check passed
- [x] `bun lint` — passed with eight existing warnings on main
- [x] `git diff --check origin/main...HEAD`
