### PR TITLE
refactor(web): decouple sidebar details state

### DIFF
--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
@@ -27,4 +27,27 @@ describe("PlannerSidebar", () => {
     expect(screen.getByText("Calendar list")).toBeTruthy();
     expect(screen.getByText("Sidebar actions")).toBeTruthy();
   });
+
+  it("shows event details only while the parent says they are open", () => {
+    const { rerender } = render(
+      <PlannerSidebar
+        {...sidebarProps}
+        eventDetails={<div>Event details</div>}
+      />,
+    );
+
+    expect(screen.queryByText("Event details")).toBeNull();
+    expect(screen.getByText("Calendar picker")).toBeTruthy();
+
+    rerender(
+      <PlannerSidebar
+        {...sidebarProps}
+        eventDetails={<div>Event details</div>}
+        isEventDetailsOpen
+      />,
+    );
+
+    expect(screen.getByText("Event details")).toBeTruthy();
+    expect(screen.queryByText("Calendar picker")).toBeNull();
+  });
 });

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
@@ -2,10 +2,6 @@ import { type HTMLAttributes, type ReactNode } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type ShortcutOverlaySection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutsOverlay";
-import {
-  selectIsEventFormOpen,
-  useDraftStore,
-} from "@web/events/stores/draft.store";
 import { PlannerCalendarList } from "./PlannerCalendarList/PlannerCalendarList";
 import { PlannerMonthPicker } from "./PlannerMonthPicker/PlannerMonthPicker";
 import { PlannerSidebarActions } from "./PlannerSidebarActions/PlannerSidebarActions";
@@ -19,6 +15,7 @@ export interface PlannerSidebarProps extends HTMLAttributes<HTMLDivElement> {
    * editing always happens in the sidebar.
    */
   eventDetails?: ReactNode;
+  isEventDetailsOpen?: boolean;
   monthsShown?: number;
   isShortcutsOpen: boolean;
   onCloseShortcuts: () => void;
@@ -45,6 +42,7 @@ export function createPlannerSidebar({
   return function PlannerSidebar({
     calendarDate,
     eventDetails,
+    isEventDetailsOpen = false,
     monthsShown = 1,
     isShortcutsOpen,
     onCloseShortcuts,
@@ -55,8 +53,7 @@ export function createPlannerSidebar({
     shortcutsViewLabel,
     ...props
   }: PlannerSidebarProps) {
-    const isGridFormOpen = useDraftStore(selectIsEventFormOpen);
-    const showEventDetails = Boolean(eventDetails) && isGridFormOpen;
+    const showEventDetails = Boolean(eventDetails) && isEventDetailsOpen;
 
     return (
       <aside

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -137,6 +137,7 @@ export const DayViewContent = memo(() => {
         <PlannerSidebar
           calendarDate={dateInView}
           eventDetails={<SidebarEventDetails />}
+          isEventDetailsOpen={isEventDetailsOpen}
           isShortcutsOpen={isShortcutsOpen}
           onCloseShortcuts={closeShortcuts}
           onToggleShortcuts={toggleShortcuts}

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -159,6 +159,7 @@ export const WeekView = () => {
               <PlannerSidebar
                 calendarDate={calendarDate}
                 eventDetails={<WeekSidebarEventDetails />}
+                isEventDetailsOpen={isEventDetailsOpen}
                 isShortcutsOpen={isShortcutsOpen}
                 onCloseShortcuts={closeShortcuts}
                 onToggleShortcuts={toggleShortcuts}


### PR DESCRIPTION
## Summary

- Move event-details visibility ownership from `PlannerSidebar` to its Day and Week callers.
- Keep the shared sidebar focused on layout and render the normal body or details panel from an explicit prop.

## Simplicity

- Removed the shared sidebar's hidden dependency on the draft store.
- No new React effects, refs, or state.

## Manual Testing Steps

- [ ] Open an event in Day view with the sidebar collapsed; confirm the sidebar opens to event details.
- [ ] Close the event; confirm the normal sidebar body returns.
- [ ] Repeat in Week view.

## Test plan

- [x] `bun test:web -- PlannerSidebar.test.tsx`
- [x] `bun type-check`
- [x] `bun lint` (passes with pre-existing warnings outside this diff)
- [x] `react-doctor --diff` (no changed-file issues)

## Validation note

Live browser validation is pending because the available browser connection fails during initialization before a page can be opened.