### PR TITLE
fix(scripts): make priority schema repair cutover-safe

### DIFF
--- a/docs/self-hosting/event-migration-runbook.md
+++ b/docs/self-hosting/event-migration-runbook.md
@@ -199,7 +199,7 @@ promptly or not at all.
 - Dev databases use the `_dev.` collection prefix; the commands above show
   production names.
 - Priority removal now has an ordered pair of post-cutover migrations.
-  `event-priority-schema-repair` (`2026.07.14T09.59.00`) reapplies the current
+  `event-priority-schema-repair` (`2026.07.13T11.59.00`) reapplies the current
   strict `EventRecordSchema` to the active final `event` collection and removes
   stale `priority` fields. It must run before `priority-data-cleanup`
   (`2026.07.14T10.00.00`), which also drops the orphaned standalone `priority`

--- a/packages/scripts/src/migrations/2026.07.13T11.59.00.event-priority-schema-repair.test.ts
+++ b/packages/scripts/src/migrations/2026.07.13T11.59.00.event-priority-schema-repair.test.ts
@@ -1,6 +1,6 @@
 import { MigratorType } from "@scripts/common/cli.types";
 import { zodToMongoSchema } from "@scripts/common/zod-to-mongo-schema";
-import Migration from "@scripts/migrations/2026.07.14T09.59.00.event-priority-schema-repair";
+import Migration from "@scripts/migrations/2026.07.13T11.59.00.event-priority-schema-repair";
 import { type Document, ObjectId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import {
@@ -14,7 +14,7 @@ import {
   EventRecordSchema,
 } from "@backend/event/event.record";
 
-describe("2026.07.14T09.59.00.event-priority-schema-repair", () => {
+describe("2026.07.13T11.59.00.event-priority-schema-repair", () => {
   const migration = new Migration();
   const collectionName = () => mongoService.event.collectionName;
   const events = () =>
@@ -67,6 +67,10 @@ describe("2026.07.14T09.59.00.event-priority-schema-repair", () => {
   beforeAll(setupTestDb);
   afterEach(async () => {
     await events()
+      .drop()
+      .catch(() => undefined);
+    await mongoService.db
+      .collection(`${collectionName()}_legacy_v1`)
       .drop()
       .catch(() => undefined);
     await cleanupCollections();
@@ -134,5 +138,51 @@ describe("2026.07.14T09.59.00.event-priority-schema-repair", () => {
     expect(await events().countDocuments({ priority: { $exists: true } })).toBe(
       0,
     );
+  });
+
+  it("removes leaked Someday data only when the legacy archive preserves it", async () => {
+    await createCollectionWithStaleValidator();
+    const leakedSomeday = {
+      ...eventRecord(),
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-14",
+        sortOrder: 0,
+      },
+      priority: "work",
+    };
+    await events().insertOne(leakedSomeday as never, {
+      bypassDocumentValidation: true,
+    });
+    await mongoService.db
+      .collection(`${collectionName()}_legacy_v1`)
+      .insertOne({ _id: leakedSomeday._id });
+
+    await migration.up(migrationContext);
+
+    expect(await events().findOne({ _id: leakedSomeday._id })).toBeNull();
+  });
+
+  it("keeps an unarchived Someday leak and fails closed", async () => {
+    await createCollectionWithStaleValidator();
+    const leakedSomeday = {
+      ...eventRecord(),
+      schedule: {
+        kind: "someday",
+        period: "week",
+        anchorDate: "2026-07-14",
+        sortOrder: 0,
+      },
+      priority: "work",
+    };
+    await events().insertOne(leakedSomeday as never, {
+      bypassDocumentValidation: true,
+    });
+
+    await expect(migration.up(migrationContext)).rejects.toThrow(
+      /only 0 are preserved in the legacy archive/,
+    );
+    expect(await events().findOne({ _id: leakedSomeday._id })).not.toBeNull();
   });
 });

--- a/packages/scripts/src/migrations/2026.07.13T11.59.00.event-priority-schema-repair.ts
+++ b/packages/scripts/src/migrations/2026.07.13T11.59.00.event-priority-schema-repair.ts
@@ -29,8 +29,8 @@ async function assertCalendarOwnedCollection(
 }
 
 export default class Migration implements RunnableMigration<MigrationContext> {
-  readonly name: string = "2026.07.14T09.59.00.event-priority-schema-repair";
-  readonly path: string = "2026.07.14T09.59.00.event-priority-schema-repair.ts";
+  readonly name: string = "2026.07.13T11.59.00.event-priority-schema-repair";
+  readonly path: string = "2026.07.13T11.59.00.event-priority-schema-repair.ts";
 
   async up(params: MigrationParams<MigrationContext>): Promise<void> {
     const { logger } = params.context;
@@ -48,20 +48,49 @@ export default class Migration implements RunnableMigration<MigrationContext> {
 
     await assertCalendarOwnedCollection(collectionName);
 
+    const events = mongoService.db.collection<Document>(collectionName);
+    const somedayIds = await events
+      .find({ "schedule.kind": "someday" }, { projection: { _id: 1 } })
+      .map(({ _id }) => _id)
+      .toArray();
+
+    if (somedayIds.length > 0) {
+      const archivedCount = await mongoService.db
+        .collection<Document>(`${collectionName}_legacy_v1`)
+        .countDocuments({ _id: { $in: somedayIds } });
+      if (archivedCount !== somedayIds.length) {
+        throw new Error(
+          `Event priority schema repair found ${somedayIds.length} active Someday document(s), but only ${archivedCount} are preserved in the legacy archive`,
+        );
+      }
+      await events.deleteMany({ _id: { $in: somedayIds } });
+    }
+
+    const finalSchema = zodToMongoSchema(EventRecordSchema);
+    const transitionalSchema = {
+      ...finalSchema,
+      properties: { ...finalSchema.properties, priority: {} },
+    };
+
     await mongoService.db.command({
       collMod: collectionName,
-      validator: { $jsonSchema: zodToMongoSchema(EventRecordSchema) },
+      validator: { $jsonSchema: transitionalSchema },
       validationLevel: "strict",
     });
 
-    const events = mongoService.db.collection<Document>(collectionName);
     const result = await events.updateMany(
       { priority: { $exists: true } },
       { $unset: { priority: "" } },
     );
 
+    await mongoService.db.command({
+      collMod: collectionName,
+      validator: { $jsonSchema: finalSchema },
+      validationLevel: "strict",
+    });
+
     logger.info(
-      `Event priority schema repair: updated validator and cleared priority from ${result.modifiedCount} active event document(s)`,
+      `Event priority schema repair: removed ${somedayIds.length} archived Someday leak(s), updated the validator, and cleared priority from ${result.modifiedCount} active event document(s)`,
     );
   }
 

--- a/team/architect/google-subcalendar-big-bang-runbook.md
+++ b/team/architect/google-subcalendar-big-bang-runbook.md
@@ -45,12 +45,13 @@ the automated work from packet `09`, plus these database migrations in order:
 | 1 | `2026.07.10T21.00.00.calendar-record-migration` | live `calendar` |
 | 2 | `2026.07.10T21.30.00.event-record-backfill` | legacy `event` → inactive `event_new` |
 | rename | `event` → `event_legacy_v1`; `event_new` → `event` | physical collections |
-| 3 | `2026.07.13T12.00.00.recurring-series-first-occurrence-repair` | final active `event` |
-| 4 | `2026.07.14T09.59.00.event-priority-schema-repair` | final active `event` validator and rows |
+| 3 | `2026.07.13T11.59.00.event-priority-schema-repair` | final active `event` validator and rows |
+| 4 | `2026.07.13T12.00.00.recurring-series-first-occurrence-repair` | final active `event` |
 | 5 | `2026.07.14T10.00.00.priority-data-cleanup` | active `event` hygiene and orphaned `priority` collection |
 
-The `09.59` timestamp is intentional: the validator must stop requiring
-`priority` before the `10.00` cleanup attempts to unset that field.
+The `11.59` timestamp is intentional: the validator must stop requiring
+`priority` before the recurring repair inserts rows without that removed field
+and before the `10.00` cleanup attempts to unset it.
 
 ## Environment state matrix
 
@@ -120,9 +121,8 @@ This phase is the only write procedure currently approved.
    either is pending while the active `event` is already calendar-owned, stop;
    the ledger and physical state disagree.
 4. Confirm the pending list includes
-   `2026.07.14T09.59.00.event-priority-schema-repair` before
-   `2026.07.14T10.00.00.priority-data-cleanup`. The recurring-series repair may
-   also be pending.
+   `2026.07.13T11.59.00.event-priority-schema-repair` before the recurring-series
+   repair and `2026.07.14T10.00.00.priority-data-cleanup`.
 5. Run the remaining migrations:
 
    ```bash
@@ -145,6 +145,11 @@ This phase is the only write procedure currently approved.
    Required result: validation is `strict`; `priority` is absent from both the
    required list and properties; the count is zero; collection validation is
    valid.
+
+   The schema repair also removes any active `schedule.kind: "someday"` row
+   leaked by an earlier cutover, but fails closed unless every removed `_id` is
+   present in `event_legacy_v1`. Someday data remains recoverable only from that
+   archive, as established by the event migration runbook.
 8. Deploy or rerun **Deploy staging** for the same release tag. This restarts
    the backend and runs the standard environment health check.
 
@@ -189,8 +194,8 @@ content or credentials.
 
 | Evidence | staging-cloud | staging-selfhosted |
 | --- | --- | --- |
-| Preflight state captured | pending | pending |
-| Backup restore checked | pending | pending |
+| Preflight state captured | 2026-07-14: cut over; 50,500 active rows; 9 migration records | 2026-07-14: cut over; 1 active row; 9 migration records |
+| Backup restore checked | 2026-07-14: 103,940 documents restored to scratch DB; 0 failures | 2026-07-14: 17 documents restored to scratch DB; 0 failures |
 | Validator repair migrated | pending | pending |
 | Google sync code `121` absent | pending | pending |
 | 12-step acceptance passed | pending | pending |
@@ -198,6 +203,13 @@ content or credentials.
 | Operator/date/release tag | pending | pending |
 
 Production remains locked while any cell is pending.
+
+The first `v1.0.205` rehearsal stopped safely before backend restart. It exposed
+two pre-existing active-data leaks: 104 cloud and 1 self-hosted Someday rows,
+all matched by `_id` in `event_legacy_v1`. It also proved the priority validator
+repair must precede the recurring-series repair. Release `v1.0.205` must not be
+used for another migration attempt; use the corrective release containing the
+`11.59` repair.
 
 ## Future Phase P — production big-bang cutover
 


### PR DESCRIPTION
## Summary

- run the priority schema repair before the recurring-series repair
- fail closed unless leaked active Someday rows are preserved in the legacy archive, then remove those invalid active rows
- use a transitional validator while clearing priority before enforcing the final strict schema
- record the v1.0.205 staging rehearsal evidence and corrective release requirement in the master runbook

## Simplicity

The migration remains one linear, idempotent repair. It uses the existing legacy archive as the safety boundary and avoids a separate one-off staging command.

## Manual testing steps

1. Create an active final event collection with a stale priority validator.
2. Add a Someday-shaped active row and a matching legacy archive row.
3. Run the migration and confirm the Someday row is absent, priority is absent, and the final validator is strict.
4. Repeat without the archive row and confirm the migration fails without deleting the active row.

## Test plan

- bun run verify
- bun lint
- focused migration integration suite
- isolated rerun of the existing memory-boundedness test after one resource-pressure-only failure