### PR TITLE
refactor(web): isolate day calendar scroll command

### DIFF
--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -22,7 +22,6 @@ import {
   assembleGridEvent,
   hasEventDates,
 } from "@web/common/utils/event/event.util";
-import { getCurrentMinute } from "@web/common/utils/grid/grid.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import {
   createGridEventDraft,
@@ -35,7 +34,6 @@ import {
   selectDraft,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { CALENDAR_TIMED_VISIBLE_HOURS } from "@web/layout/calendar-grid/calendarGrid.constants";
 import { CalendarGrid } from "@web/layout/calendar-grid/components/CalendarGrid";
 import { useAllDayDraftCreation } from "@web/layout/calendar-grid/hooks/useAllDayDraftCreation";
 import { useCalendarDateCalcs } from "@web/layout/calendar-grid/hooks/useCalendarDateCalcs";
@@ -52,6 +50,7 @@ import {
   DayCalendarTimedEventsLayer,
 } from "./DayCalendarEventLayers";
 import { useDayCalendarColumns } from "./useDayCalendarColumns";
+import { useDayCalendarScrollToNow } from "./useDayCalendarScrollToNow";
 import { useDayTimedDraftCreation } from "./useDayTimedDraftCreation";
 
 export const canCreateDraftOnCalendar = (
@@ -104,53 +103,7 @@ export function DayCalendarGrid() {
     [gridRefs.allDayColumnsRef, gridRefs.mainGridRef, gridRefs.timedColumnsRef],
   );
 
-  const scrollToNow = useCallback(() => {
-    const timedGrid = gridRefs.mainGridRef.current;
-
-    if (!timedGrid) {
-      return;
-    }
-
-    const gridRowHeight = timedGrid.clientHeight / CALENDAR_TIMED_VISIBLE_HOURS;
-    const minuteHeight = gridRowHeight / 60;
-    const top = getCurrentMinute() * minuteHeight - 150;
-
-    timedGrid.scroll({
-      behavior: "smooth",
-      top,
-    });
-  }, [gridRefs.mainGridRef]);
-  const scrollToNowRef = useRef(scrollToNow);
-
-  useEffect(() => {
-    if (!gridRefs.mainGridRef.current) {
-      return;
-    }
-
-    scrollToNow();
-  }, [gridRefs.mainGridRef, scrollToNow]);
-
-  useEffect(() => {
-    scrollToNowRef.current = scrollToNow;
-  }, [scrollToNow]);
-
-  useEffect(() => {
-    const handleScrollToNowLine = () => {
-      scrollToNowRef.current();
-    };
-
-    compassEventEmitter.on(
-      CompassDOMEvents.SCROLL_TO_NOW_LINE,
-      handleScrollToNowLine,
-    );
-
-    return () => {
-      compassEventEmitter.off(
-        CompassDOMEvents.SCROLL_TO_NOW_LINE,
-        handleScrollToNowLine,
-      );
-    };
-  }, []);
+  useDayCalendarScrollToNow(gridRefs.mainGridRef);
 
   const openEventFormForEvent = useCallback(
     (event: Schema_GridEvent) => {

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
@@ -1,0 +1,46 @@
+import { type RefObject, useCallback, useEffect, useRef } from "react";
+import {
+  CompassDOMEvents,
+  compassEventEmitter,
+} from "@web/common/utils/dom/event-emitter.util";
+import { getCurrentMinute } from "@web/common/utils/grid/grid.util";
+import { CALENDAR_TIMED_VISIBLE_HOURS } from "@web/layout/calendar-grid/calendarGrid.constants";
+
+export const useDayCalendarScrollToNow = (
+  mainGridRef: RefObject<HTMLElement | null>,
+) => {
+  const scrollToNow = useCallback(() => {
+    const timedGrid = mainGridRef.current;
+    if (!timedGrid) return;
+
+    const minuteHeight =
+      timedGrid.clientHeight / CALENDAR_TIMED_VISIBLE_HOURS / 60;
+    timedGrid.scroll({
+      behavior: "smooth",
+      top: getCurrentMinute() * minuteHeight - 150,
+    });
+  }, [mainGridRef]);
+  const scrollToNowRef = useRef(scrollToNow);
+
+  useEffect(() => {
+    if (mainGridRef.current) scrollToNow();
+  }, [mainGridRef, scrollToNow]);
+
+  useEffect(() => {
+    scrollToNowRef.current = scrollToNow;
+  }, [scrollToNow]);
+
+  useEffect(() => {
+    const handleScrollToNow = () => scrollToNowRef.current();
+    compassEventEmitter.on(
+      CompassDOMEvents.SCROLL_TO_NOW_LINE,
+      handleScrollToNow,
+    );
+    return () => {
+      compassEventEmitter.off(
+        CompassDOMEvents.SCROLL_TO_NOW_LINE,
+        handleScrollToNow,
+      );
+    };
+  }, []);
+};


### PR DESCRIPTION
## Summary
- extract the Day scroll-to-now command lifecycle into a dedicated hook
- keep DayCalendarGrid focused on calendar composition

## Validation
- bun test:web -- DayCalendarGrid.test.tsx
- bun type-check
- bun lint (8 existing unrelated warnings)
- React Doctor changed-files scan

## Manual follow-up
- browser automation was unavailable in this environment; the focused Day grid test covers the scroll-to-now command.