### PR TITLE
fix(backend): batch google event imports

### DIFF
--- a/packages/backend/src/event/event.repository.test.ts
+++ b/packages/backend/src/event/event.repository.test.ts
@@ -281,6 +281,37 @@ describe("EventRepository", () => {
       expect(foundOnB?._id.toHexString()).toBe(eventOnB._id.toHexString());
       expect(foundOnA?._id.toHexString()).not.toBe(foundOnB?._id.toHexString());
     });
+
+    it("finds a batch without crossing calendar ownership", async () => {
+      const calendarA = new ObjectId();
+      const calendarB = new ObjectId();
+      const eventOnA = buildEvent({
+        calendarId: calendarA,
+        externalReference: {
+          provider: "google",
+          eventId: "event-a",
+          recurringEventId: null,
+        },
+      });
+      const eventOnB = buildEvent({
+        calendarId: calendarB,
+        externalReference: {
+          provider: "google",
+          eventId: "event-b",
+          recurringEventId: null,
+        },
+      });
+      await eventRepository.insertMany([eventOnA, eventOnB]);
+
+      const found = await eventRepository.findByExternalReferences(calendarA, [
+        "event-a",
+        "event-b",
+      ]);
+
+      expect(found.map((event) => event._id.toHexString())).toEqual([
+        eventOnA._id.toHexString(),
+      ]);
+    });
   });
 
   describe("deleteBySeriesId", () => {

--- a/packages/backend/src/event/event.repository.ts
+++ b/packages/backend/src/event/event.repository.ts
@@ -146,6 +146,24 @@ class EventRepository {
     );
   }
 
+  async findByExternalReferences(
+    calendarId: ObjectId,
+    externalEventIds: string[],
+    session?: ClientSession,
+  ): Promise<EventRecord[]> {
+    if (externalEventIds.length === 0) return [];
+
+    return mongoService.event
+      .find(
+        {
+          calendarId,
+          "externalReference.eventId": { $in: externalEventIds },
+        },
+        { session },
+      )
+      .toArray();
+  }
+
   async deleteByExternalReference(
     calendarId: ObjectId,
     externalEventId: string,

--- a/packages/backend/src/event/google-event-sync.service.test.ts
+++ b/packages/backend/src/event/google-event-sync.service.test.ts
@@ -1,0 +1,167 @@
+import { ObjectId } from "mongodb";
+import { type gSchema$Event } from "@core/types/gcal";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
+import { type EventRecord } from "@backend/event/event.record";
+import { eventRepository } from "@backend/event/event.repository";
+import { GoogleEventSync } from "@backend/event/google-event-sync.service";
+
+const calendar: CalendarRecord = {
+  _id: new ObjectId(),
+  userId: new ObjectId(),
+  name: "Primary",
+  description: "",
+  timeZone: "America/Denver",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#000000",
+  access: "owner",
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+  source: {
+    provider: "google",
+    calendarId: "primary@example.com",
+    etag: "etag",
+  },
+  createdAt: new Date("2026-07-14T00:00:00.000Z"),
+  updatedAt: null,
+};
+
+const googleEvent = (id: string): gSchema$Event => ({
+  id,
+  summary: id,
+  start: {
+    dateTime: "2026-07-14T09:00:00-06:00",
+    timeZone: "America/Denver",
+  },
+  end: {
+    dateTime: "2026-07-14T10:00:00-06:00",
+    timeZone: "America/Denver",
+  },
+});
+
+describe("GoogleEventSync", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("writes a page of standalone events in one batch", async () => {
+    const findSpy = jest
+      .spyOn(eventRepository, "findByExternalReference")
+      .mockResolvedValue(null);
+    const findManySpy = jest
+      .spyOn(eventRepository, "findByExternalReferences")
+      .mockResolvedValue([]);
+    const insertSpy = jest
+      .spyOn(eventRepository, "insertOne")
+      .mockImplementation(async (record) => record);
+    const bulkSpy = jest
+      .spyOn(eventRepository, "bulkReplace")
+      .mockResolvedValue();
+    const sync = new GoogleEventSync({} as GoogleRequestContext, calendar);
+
+    const page = Array.from({ length: 2500 }, (_, index) =>
+      googleEvent(`event-${index}`),
+    );
+    const result = await sync.apply(page);
+
+    expect(result).toMatchObject({ processed: 2500, saved: 2500 });
+    expect(bulkSpy).toHaveBeenCalledTimes(1);
+    expect(findManySpy).toHaveBeenCalledTimes(1);
+    expect(findSpy).not.toHaveBeenCalled();
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps cancellation handling on the individual event path", async () => {
+    jest
+      .spyOn(eventRepository, "findByExternalReferences")
+      .mockResolvedValue([]);
+    const bulkSpy = jest
+      .spyOn(eventRepository, "bulkReplace")
+      .mockResolvedValue();
+    const deletedId = new ObjectId();
+    const deleteSpy = jest
+      .spyOn(eventRepository, "deleteByExternalReference")
+      .mockResolvedValue({ deletedIds: [deletedId] });
+    const sync = new GoogleEventSync({} as GoogleRequestContext, calendar);
+
+    const result = await sync.apply([
+      googleEvent("standalone"),
+      { id: "cancelled", status: "cancelled" },
+    ]);
+
+    expect(result).toMatchObject({ processed: 2, saved: 1, deleted: 1 });
+    expect(bulkSpy.mock.calls[0]![0]).toHaveLength(1);
+    expect(deleteSpy).toHaveBeenCalledWith(
+      calendar._id,
+      "cancelled",
+      undefined,
+    );
+  });
+
+  it("preserves database identity when replacing an existing event", async () => {
+    const existing: EventRecord = {
+      _id: new ObjectId(),
+      calendarId: calendar._id,
+      content: { kind: "details", title: "old", description: "" },
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-14T15:00:00.000Z"),
+        end: new Date("2026-07-14T16:00:00.000Z"),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      externalReference: {
+        provider: "google",
+        eventId: "event-1",
+        recurringEventId: null,
+      },
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      updatedAt: null,
+    };
+    jest
+      .spyOn(eventRepository, "findByExternalReferences")
+      .mockResolvedValue([existing]);
+    const bulkSpy = jest
+      .spyOn(eventRepository, "bulkReplace")
+      .mockResolvedValue();
+    const sync = new GoogleEventSync({} as GoogleRequestContext, calendar);
+
+    await sync.apply([googleEvent("event-1")]);
+
+    const [records] = bulkSpy.mock.calls[0]!;
+    expect(records[0]).toMatchObject({
+      _id: existing._id,
+      createdAt: existing.createdAt,
+      content: { kind: "details", title: "event-1" },
+    });
+  });
+
+  it("counts ignored and invalid standalone events without individual writes", async () => {
+    jest
+      .spyOn(eventRepository, "findByExternalReferences")
+      .mockResolvedValue([]);
+    const insertSpy = jest
+      .spyOn(eventRepository, "insertOne")
+      .mockImplementation(async (record) => record);
+    const bulkSpy = jest
+      .spyOn(eventRepository, "bulkReplace")
+      .mockResolvedValue();
+    const missingId = googleEvent("missing-id");
+    delete missingId.id;
+    const sync = new GoogleEventSync({} as GoogleRequestContext, calendar);
+
+    const result = await sync.apply([
+      googleEvent("event-1"),
+      { ...googleEvent("ignored"), eventType: "outOfOffice" },
+      missingId,
+    ]);
+
+    expect(result).toMatchObject({
+      processed: 3,
+      saved: 1,
+      ignored: 1,
+      invalid: 1,
+    });
+    expect(bulkSpy.mock.calls[0]![0]).toHaveLength(1);
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/event/google-event-sync.service.ts
+++ b/packages/backend/src/event/google-event-sync.service.ts
@@ -3,6 +3,7 @@ import { type gSchema$Event } from "@core/types/gcal";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
+import { type EventRecord } from "@backend/event/event.record";
 import { eventRepository } from "@backend/event/event.repository";
 import { mapGoogleEvent } from "@backend/event/google-event.adapter";
 import { getAnchorDate } from "@backend/event/services/recur/util/recur.util";
@@ -60,6 +61,11 @@ const merge = (
   affectedEventIds: [...a.affectedEventIds, ...b.affectedEventIds],
 });
 
+const isStandalone = (event: gSchema$Event): boolean =>
+  event.status !== "cancelled" &&
+  !event.recurringEventId &&
+  (!event.recurrence || event.recurrence.length === 0);
+
 /**
  * Applies a batch of Google Calendar events onto the owning CalendarRecord's
  * events, per B8 (match strictly by (calendarId, externalReference.eventId),
@@ -101,14 +107,85 @@ export class GoogleEventSync {
     const seriesMap = new Map<string, ObjectId>();
     await this.preloadSeriesMap(events, seriesMap, session);
 
-    let result = emptyResult();
+    const standalone: gSchema$Event[] = [];
+    const remaining: gSchema$Event[] = [];
     for (const event of events) {
+      (isStandalone(event) ? standalone : remaining).push(event);
+    }
+    let result = await this.applyStandalone(standalone, session);
+
+    for (const event of remaining) {
       result = merge(
         result,
         await this.applyOne(event, seriesMap, perPage, session, true),
       );
     }
     return result;
+  }
+
+  private async applyStandalone(
+    events: gSchema$Event[],
+    session?: ClientSession,
+  ): Promise<GoogleEventSyncResult> {
+    if (events.length === 0) return emptyResult();
+
+    const records: EventRecord[] = [];
+    let ignored = 0;
+    let invalid = 0;
+    const now = new Date();
+
+    for (const event of events) {
+      const mapped = mapGoogleEvent(event, {
+        calendarId: this.calendar._id,
+        calendarTimeZone: this.calendar.timeZone,
+        resolveSeriesObjectId: () => undefined,
+        now,
+      });
+
+      if (mapped.kind === "ignored") {
+        ignored += 1;
+      } else if (mapped.kind === "invalid") {
+        invalid += 1;
+      } else if (mapped.kind === "mapped") {
+        records.push(mapped.event);
+      }
+    }
+
+    const providerIds = records.flatMap((record) =>
+      record.externalReference ? [record.externalReference.eventId] : [],
+    );
+    const existing = await eventRepository.findByExternalReferences(
+      this.calendar._id,
+      providerIds,
+      session,
+    );
+    const existingByProviderId = new Map(
+      existing.flatMap((record) =>
+        record.externalReference
+          ? [[record.externalReference.eventId, record] as const]
+          : [],
+      ),
+    );
+    const replacements = records.map((record) => {
+      const providerId = record.externalReference?.eventId;
+      const match = providerId
+        ? existingByProviderId.get(providerId)
+        : undefined;
+      return match
+        ? { ...record, _id: match._id, createdAt: match.createdAt }
+        : record;
+    });
+
+    await eventRepository.bulkReplace(replacements, session);
+
+    return {
+      processed: events.length,
+      saved: replacements.length,
+      deleted: 0,
+      ignored,
+      invalid,
+      affectedEventIds: replacements.map((record) => record._id.toHexString()),
+    };
   }
 
   private async preloadSeriesMap(
@@ -123,14 +200,16 @@ export class GoogleEventSync {
           .filter((id): id is string => !!id),
       ),
     ].filter((id) => !seriesMap.has(id));
+    if (gRecurringEventIds.length === 0) return;
 
-    for (const gRecurringEventId of gRecurringEventIds) {
-      const existing = await eventRepository.findByExternalReference(
-        this.calendar._id,
-        gRecurringEventId,
-        session,
-      );
-      if (existing) seriesMap.set(gRecurringEventId, existing._id);
+    const existingSeries = await eventRepository.findByExternalReferences(
+      this.calendar._id,
+      gRecurringEventIds,
+      session,
+    );
+    for (const existing of existingSeries) {
+      const providerId = existing.externalReference?.eventId;
+      if (providerId) seriesMap.set(providerId, existing._id);
     }
   }
 


### PR DESCRIPTION
## Summary
- batch standalone Google event lookup and upsert per import page
- preserve existing Compass event identity and creation timestamps
- keep recurring events and cancellations on their established correctness path while batching recurring-series preload
- add regression coverage for 2,500-event pages, replacements, invalid/ignored records, cancellation routing, and calendar ownership

## Why
The staging priority-schema repair removed the validation failure, but exposed that a 50k-event full sync spent about 17 minutes doing serial lookup/write operations. A normal 2,500-event page could issue roughly 5,000 database round trips. This changes that standalone path to one scoped lookup and one unordered bulk upsert.

## Simplicity
The optimization stays inside the shared Google event sync service and reuses the repository bulk-write primitive. Recurrence and cancellation behavior is unchanged. The final simplify-code pass removed duplicate partitioning and empty batch work.

## Validation
- 74 backend suites passed (650 tests; 1 skipped)
- focused Google import/propagation suites passed (36 tests)
- type-check passed
- lint passed (8 pre-existing web warnings)
- `bun run verify` passed
- production-shaped benchmark: 1,900 events in 3.4s; 7,125 events across 25 calendars in 4.1s

## Staging follow-up
After merge/release, force a full sync for the affected staging user and compare completion time and validation logs against the pre-change 17-minute baseline.