### PR TITLE
fix(backend): batch google recurring instances

### DIFF
--- a/packages/backend/src/event/event.repository.test.ts
+++ b/packages/backend/src/event/event.repository.test.ts
@@ -314,6 +314,46 @@ describe("EventRepository", () => {
     });
   });
 
+  describe("findUnlinkedOccurrences", () => {
+    it("finds timed and all-day anchors only within the requested series", async () => {
+      const seriesId = new ObjectId();
+      const otherSeriesId = new ObjectId();
+      const timed = buildEvent({
+        recurrence: { kind: "occurrence", seriesId },
+      });
+      const allDay = buildEvent({
+        schedule: { kind: "allDay", start: "2026-07-15", end: "2026-07-16" },
+        recurrence: { kind: "occurrence", seriesId },
+      });
+      const otherSeries = buildEvent({
+        recurrence: { kind: "occurrence", seriesId: otherSeriesId },
+      });
+      const alreadyLinked = buildEvent({
+        recurrence: { kind: "occurrence", seriesId },
+        externalReference: {
+          provider: "google",
+          eventId: "linked",
+          recurringEventId: "series",
+        },
+      });
+      await eventRepository.insertMany([
+        timed,
+        allDay,
+        otherSeries,
+        alreadyLinked,
+      ]);
+
+      const found = await eventRepository.findUnlinkedOccurrences(seriesId, [
+        new Date("2026-07-14T15:00:00.000Z"),
+        new Date("2026-07-15T00:00:00.000Z"),
+      ]);
+
+      expect(found.map((event) => event._id.toHexString()).sort()).toEqual(
+        [timed._id.toHexString(), allDay._id.toHexString()].sort(),
+      );
+    });
+  });
+
   describe("deleteBySeriesId", () => {
     it("deletes the base and every occurrence", async () => {
       const base = buildEvent({

--- a/packages/backend/src/event/event.repository.ts
+++ b/packages/backend/src/event/event.repository.ts
@@ -201,19 +201,41 @@ class EventRepository {
     anchor: Date,
     session?: ClientSession,
   ): Promise<EventRecord | null> {
-    const allDayDate = anchor.toISOString().slice(0, 10);
-    return mongoService.event.findOne(
-      {
-        "recurrence.kind": "occurrence",
-        "recurrence.seriesId": seriesId,
-        externalReference: null,
-        $or: [
-          { "schedule.kind": "timed", "schedule.start": anchor },
-          { "schedule.kind": "allDay", "schedule.start": allDayDate },
-        ],
-      },
-      { session },
+    const [occurrence] = await this.findUnlinkedOccurrences(
+      seriesId,
+      [anchor],
+      session,
     );
+    return occurrence ?? null;
+  }
+
+  async findUnlinkedOccurrences(
+    seriesId: ObjectId,
+    anchors: Date[],
+    session?: ClientSession,
+  ): Promise<EventRecord[]> {
+    if (anchors.length === 0) return [];
+
+    const allDayDates = anchors.map((anchor) =>
+      anchor.toISOString().slice(0, 10),
+    );
+    return mongoService.event
+      .find(
+        {
+          "recurrence.kind": "occurrence",
+          "recurrence.seriesId": seriesId,
+          externalReference: null,
+          $or: [
+            { "schedule.kind": "timed", "schedule.start": { $in: anchors } },
+            {
+              "schedule.kind": "allDay",
+              "schedule.start": { $in: allDayDates },
+            },
+          ],
+        },
+        { session },
+      )
+      .toArray();
   }
 
   async insertOne(

--- a/packages/backend/src/event/google-event-sync.service.test.ts
+++ b/packages/backend/src/event/google-event-sync.service.test.ts
@@ -2,6 +2,7 @@ import { ObjectId } from "mongodb";
 import { type gSchema$Event } from "@core/types/gcal";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
+import gcalService from "@backend/common/services/gcal/gcal.service";
 import { type EventRecord } from "@backend/event/event.record";
 import { eventRepository } from "@backend/event/event.repository";
 import { GoogleEventSync } from "@backend/event/google-event-sync.service";
@@ -39,6 +40,27 @@ const googleEvent = (id: string): gSchema$Event => ({
     timeZone: "America/Denver",
   },
 });
+
+const googleInstance = (
+  recurringEventId: string,
+  index: number,
+): gSchema$Event => {
+  const start = new Date("2026-01-01T15:00:00.000Z");
+  start.setUTCDate(start.getUTCDate() + index);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+  return {
+    id: `${recurringEventId}-${index}`,
+    recurringEventId,
+    originalStartTime: { dateTime: start.toISOString() },
+    summary: `Occurrence ${index}`,
+    start: { dateTime: start.toISOString(), timeZone: "America/Denver" },
+    end: { dateTime: end.toISOString(), timeZone: "America/Denver" },
+  };
+};
+
+const asInstancePages = async function* (...pages: gSchema$Event[][]) {
+  for (const items of pages) yield { items };
+};
 
 describe("GoogleEventSync", () => {
   afterEach(() => jest.restoreAllMocks());
@@ -95,6 +117,94 @@ describe("GoogleEventSync", () => {
       "cancelled",
       undefined,
     );
+  });
+
+  it("writes a page of recurring instances in one batch", async () => {
+    const base = {
+      ...googleEvent("series"),
+      recurrence: ["RRULE:FREQ=DAILY;COUNT=2500"],
+    };
+    const instances = Array.from({ length: 2500 }, (_, index) =>
+      googleInstance("series", index),
+    );
+    const findSpy = jest
+      .spyOn(eventRepository, "findByExternalReference")
+      .mockResolvedValue(null);
+    jest
+      .spyOn(eventRepository, "findByExternalReferences")
+      .mockResolvedValue([]);
+    const unlinkedSpy = jest
+      .spyOn(eventRepository, "findUnlinkedOccurrences")
+      .mockResolvedValue([]);
+    const insertSpy = jest
+      .spyOn(eventRepository, "insertOne")
+      .mockImplementation(async (record) => record);
+    const bulkSpy = jest
+      .spyOn(eventRepository, "bulkReplace")
+      .mockResolvedValue();
+    jest
+      .spyOn(gcalService, "getBaseRecurringEventInstances")
+      .mockReturnValue(asInstancePages(instances));
+    const sync = new GoogleEventSync({} as GoogleRequestContext, calendar);
+
+    const result = await sync.apply([base], 2500);
+
+    expect(result).toMatchObject({ processed: 2501, saved: 2501 });
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+    expect(unlinkedSpy).toHaveBeenCalledTimes(1);
+    expect(bulkSpy).toHaveBeenCalledTimes(1);
+    expect(bulkSpy.mock.calls[0]![0]).toHaveLength(2500);
+  });
+
+  it("adopts unlinked local occurrences during a batched import", async () => {
+    const base = {
+      ...googleEvent("series"),
+      recurrence: ["RRULE:FREQ=DAILY;COUNT=1"],
+    };
+    const instance = googleInstance("series", 0);
+    const unlinked: EventRecord = {
+      _id: new ObjectId(),
+      calendarId: calendar._id,
+      content: { kind: "details", title: "local", description: "" },
+      schedule: {
+        kind: "timed",
+        start: new Date(instance.originalStartTime!.dateTime!),
+        end: new Date(instance.end!.dateTime!),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "occurrence", seriesId: new ObjectId() },
+      externalReference: null,
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+      updatedAt: null,
+    };
+    jest
+      .spyOn(eventRepository, "findByExternalReference")
+      .mockResolvedValue(null);
+    jest
+      .spyOn(eventRepository, "findByExternalReferences")
+      .mockResolvedValue([]);
+    jest
+      .spyOn(eventRepository, "findUnlinkedOccurrences")
+      .mockResolvedValue([unlinked]);
+    jest
+      .spyOn(eventRepository, "insertOne")
+      .mockImplementation(async (record) => record);
+    const bulkSpy = jest
+      .spyOn(eventRepository, "bulkReplace")
+      .mockResolvedValue();
+    jest
+      .spyOn(gcalService, "getBaseRecurringEventInstances")
+      .mockReturnValue(asInstancePages([instance]));
+    const sync = new GoogleEventSync({} as GoogleRequestContext, calendar);
+
+    await sync.apply([base]);
+
+    expect(bulkSpy.mock.calls[0]![0][0]).toMatchObject({
+      _id: unlinked._id,
+      createdAt: unlinked.createdAt,
+      externalReference: { eventId: instance.id },
+    });
   });
 
   it("preserves database identity when replacing an existing event", async () => {

--- a/packages/backend/src/event/google-event-sync.service.ts
+++ b/packages/backend/src/event/google-event-sync.service.ts
@@ -66,6 +66,11 @@ const isStandalone = (event: gSchema$Event): boolean =>
   !event.recurringEventId &&
   (!event.recurrence || event.recurrence.length === 0);
 
+type MappedOccurrence = {
+  record: EventRecord;
+  anchor: Date;
+};
+
 /**
  * Applies a batch of Google Calendar events onto the owning CalendarRecord's
  * events, per B8 (match strictly by (calendarId, externalReference.eventId),
@@ -312,23 +317,22 @@ export class GoogleEventSync {
 
     if (expandSeries && record.recurrence.kind === "series" && event.id) {
       seriesMap.set(event.id, record._id);
-      const instances = await this.fetchInstances(event.id, perPage);
-      for (const instance of instances) {
-        result = merge(
-          result,
-          await this.applyOne(instance, seriesMap, perPage, session, false),
-        );
-      }
+      result = merge(
+        result,
+        await this.applyInstances(event.id, seriesMap, perPage, session),
+      );
     }
 
     return result;
   }
 
-  private async fetchInstances(
+  private async applyInstances(
     gEventId: string,
+    seriesMap: Map<string, ObjectId>,
     perPage: number,
-  ): Promise<gSchema$Event[]> {
-    const instances: gSchema$Event[] = [];
+    session?: ClientSession,
+  ): Promise<GoogleEventSyncResult> {
+    let result = emptyResult();
     const response = gcalService.getBaseRecurringEventInstances({
       context: this.context,
       calendarId: this.gCalendarId,
@@ -337,9 +341,115 @@ export class GoogleEventSync {
     });
 
     for await (const { items = [] } of response) {
-      instances.push(...items);
+      result = merge(
+        result,
+        await this.applyInstancePage(items, seriesMap, perPage, session),
+      );
     }
 
-    return instances;
+    return result;
+  }
+
+  private async applyInstancePage(
+    events: gSchema$Event[],
+    seriesMap: Map<string, ObjectId>,
+    perPage: number,
+    session?: ClientSession,
+  ): Promise<GoogleEventSyncResult> {
+    const occurrences: MappedOccurrence[] = [];
+    let result = emptyResult();
+    const now = new Date();
+
+    for (const event of events) {
+      const mapped = mapGoogleEvent(event, {
+        calendarId: this.calendar._id,
+        calendarTimeZone: this.calendar.timeZone,
+        resolveSeriesObjectId: (id) => seriesMap.get(id),
+        now,
+      });
+
+      if (mapped.kind === "ignored") {
+        result.processed += 1;
+        result.ignored += 1;
+      } else if (mapped.kind === "invalid") {
+        result.processed += 1;
+        result.invalid += 1;
+      } else if (
+        mapped.kind === "mapped" &&
+        mapped.event.recurrence.kind === "occurrence"
+      ) {
+        occurrences.push({
+          record: mapped.event,
+          anchor:
+            getInstanceAnchor(event) ?? getAnchorDate(mapped.event.schedule),
+        });
+      } else {
+        result = merge(
+          result,
+          await this.applyOne(event, seriesMap, perPage, session, false),
+        );
+      }
+    }
+
+    return merge(result, await this.replaceOccurrences(occurrences, session));
+  }
+
+  private async replaceOccurrences(
+    occurrences: MappedOccurrence[],
+    session?: ClientSession,
+  ): Promise<GoogleEventSyncResult> {
+    if (occurrences.length === 0) return emptyResult();
+
+    const providerIds = occurrences.map(
+      ({ record }) => record.externalReference!.eventId,
+    );
+    const existing = await eventRepository.findByExternalReferences(
+      this.calendar._id,
+      providerIds,
+      session,
+    );
+    const existingByProviderId = new Map(
+      existing.map((record) => [record.externalReference!.eventId, record]),
+    );
+
+    const unmatched = occurrences.filter(
+      ({ record }) =>
+        !existingByProviderId.has(record.externalReference!.eventId),
+    );
+    const seriesId = occurrences[0]!.record.recurrence;
+    const unlinked =
+      seriesId.kind === "occurrence"
+        ? await eventRepository.findUnlinkedOccurrences(
+            seriesId.seriesId,
+            unmatched.map(({ anchor }) => anchor),
+            session,
+          )
+        : [];
+    const unlinkedByAnchor = new Map(
+      unlinked.map((record) => [
+        getAnchorDate(record.schedule).toISOString(),
+        record,
+      ]),
+    );
+
+    const replacements = occurrences.map(({ record, anchor }) => {
+      const providerId = record.externalReference!.eventId;
+      const match =
+        existingByProviderId.get(providerId) ??
+        unlinkedByAnchor.get(anchor.toISOString());
+      return match
+        ? { ...record, _id: match._id, createdAt: match.createdAt }
+        : record;
+    });
+    await eventRepository.bulkReplace(replacements, session);
+
+    return {
+      processed: occurrences.length,
+      saved: replacements.length,
+      deleted: 0,
+      ignored: 0,
+      invalid: 0,
+      affectedEventIds: replacements.map((record) => record._id.toHexString()),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- process Google recurring instances page-by-page instead of materializing and writing them serially
- batch provider-id lookups, unlinked local-occurrence adoption, and bulk replacements
- keep cancellation fallback behavior unchanged
- centralize single and batched unlinked-occurrence matching in the repository

## Why
PR #2109 reduced a standalone-heavy staging calendar from ~84 seconds to 1.8 seconds, but a recurrence-heavy 143-event calendar remained ~57 seconds and the large primary calendar was still running after eight minutes. Each materialized recurring occurrence still performed individual database operations.

## Simplicity
The follow-up preserves the existing mapper and cancellation path. It adds one batch lookup primitive and reuses the existing bulk replacement. Instance pages are applied as they stream, which also keeps memory bounded. The requested simplify-code pass consolidated single-occurrence lookup onto the batch primitive.

## Validation
- 74 backend suites passed (650 tests; 4 skipped)
- focused import/propagation coverage passed (39 tests)
- type-check passed
- lint passed (8 pre-existing web warnings)
- production-shaped benchmark improved from PR #2109 baseline:
  - 1,900 events: 3.39s -> 0.36s
  - 7,125 events / 25 calendars: 4.11s -> 0.96s
- regression covers a 2,500-instance page in one bulk write and preserves unlinked local identity

## Staging follow-up
After merge/release, restart the affected full sync and capture all three calendar totals, durations, UI completion, and absence of Mongo code 121.