### PR TITLE
fix(backend): handle unsupported google watches

### DIFF
--- a/packages/backend/src/common/services/gcal/gcal.util.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.util.test.ts
@@ -8,6 +8,7 @@ import {
   isFullSyncRequired,
   isGoogleError,
   isGoogleRepairQuotaError,
+  isGoogleWatchUnsupported,
   isInvalidGoogleToken,
   isInvalidValue,
 } from "./gcal.utils";
@@ -85,6 +86,28 @@ describe("Google Error Parsing", () => {
     expect(isGoogleRepairQuotaError(createGoogleError({ code: "500" }))).toBe(
       false,
     );
+  });
+  it("recognizes resources that do not support push watches", () => {
+    const unsupported = createGoogleError({
+      code: "400",
+      responseStatus: 400,
+    });
+    if (unsupported.response) {
+      unsupported.response.data = {
+        error: {
+          code: 400,
+          message: "Push notifications are not supported by this resource.",
+          errors: [{ reason: "pushNotSupportedForRequestedResource" }],
+        },
+      };
+    }
+
+    expect(isGoogleWatchUnsupported(unsupported)).toBe(true);
+    expect(
+      isGoogleWatchUnsupported(
+        createGoogleError({ code: "500", responseStatus: 500 }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/backend/src/common/services/gcal/gcal.utils.ts
+++ b/packages/backend/src/common/services/gcal/gcal.utils.ts
@@ -152,6 +152,14 @@ export const isGoogleRepairQuotaError = (e: unknown): boolean => {
   );
 };
 
+export const isGoogleWatchUnsupported = (e: unknown): boolean => {
+  if (getGoogleErrorStatus(e) !== 400) return false;
+
+  const googleError = getGoogleApiError(e);
+  const reasons = googleError?.errors?.map(({ reason }) => reason) ?? [];
+  return reasons.includes("pushNotSupportedForRequestedResource");
+};
+
 export const isInvalidValue = (e: GaxiosError) => {
   return e.message === "Invalid Value";
 };

--- a/packages/backend/src/sync/services/google-sync/google-sync.health.test.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.health.test.ts
@@ -73,4 +73,15 @@ describe("googleSyncHealth", () => {
 
     await expect(isGoogleCalendarSyncHealthy(userId)).resolves.toBe(false);
   });
+
+  it("does not require a watch for a synced resource that rejects push", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const userId = user._id.toString();
+    await updateSync(Resource_Sync.EVENTS, userId, "public-holidays", {
+      nextSyncToken: "holiday-token",
+      watchSupported: false,
+    });
+
+    await expect(isGoogleCalendarSyncHealthy(userId)).resolves.toBe(true);
+  });
 });

--- a/packages/backend/src/sync/services/google-sync/google-sync.health.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.health.ts
@@ -42,8 +42,9 @@ export const isGoogleCalendarSyncHealthy = async (
     return false;
   }
 
-  return eventSyncs.every(({ gCalendarId }) =>
-    activeWatchCalendarIds.has(gCalendarId),
+  return eventSyncs.every(
+    ({ gCalendarId, watchSupported }) =>
+      watchSupported === false || activeWatchCalendarIds.has(gCalendarId),
   );
 };
 

--- a/packages/backend/src/sync/services/watch/google-watch-state.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-state.test.ts
@@ -420,6 +420,22 @@ describe("inspectGoogleWatchState", () => {
     expect(result.expectedWatchCalendarIds).toEqual([Resource_Sync.CALENDAR]);
   });
 
+  it("case 6d: excludes a synced calendar whose resource rejects push watches", async () => {
+    const { user, userId } = await seedHealthyUser(0);
+    const gCalendarId = faker.string.uuid();
+    await seedActiveGoogleCalendar(user._id, gCalendarId);
+    await updateSync(Resource_Sync.EVENTS, userId, gCalendarId, {
+      nextSyncToken: faker.string.alphanumeric(16),
+      watchSupported: false,
+    });
+
+    const result = await inspectGoogleWatchState(userId);
+
+    expect(result.status).toBe(GoogleWatchStateStatus.HEALTHY);
+    expect(result.expectedWatchCalendarIds).toEqual([Resource_Sync.CALENDAR]);
+    expect(result.incompleteCalendarIds).toEqual([]);
+  });
+
   it("case 7: a freeBusyReader calendar's lingering watch is stale, and the calendar is excluded from the expected set", async () => {
     const { user, userId } = await seedHealthyUser(0);
     const gCalendarId = faker.string.uuid();

--- a/packages/backend/src/sync/services/watch/google-watch-state.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-state.ts
@@ -232,14 +232,15 @@ export const inspectGoogleWatchState = async (
     if (record.access === "freeBusyReader") continue;
 
     const gCalendarId = record.source.calendarId;
-    eventCapableCalendarIds.push(gCalendarId);
-
-    const hasSyncToken = eventSyncs.some(
-      (entry) =>
-        entry.gCalendarId === gCalendarId && Boolean(entry.nextSyncToken),
+    const eventSync = eventSyncs.find(
+      (entry) => entry.gCalendarId === gCalendarId,
     );
+    const hasSyncToken = Boolean(eventSync?.nextSyncToken);
 
     if (!hasSyncToken) incompleteCalendarIds.push(gCalendarId);
+    if (eventSync?.watchSupported !== false) {
+      eventCapableCalendarIds.push(gCalendarId);
+    }
   }
 
   if (incompleteCalendarIds.length > 0) {

--- a/packages/backend/src/sync/services/watch/google-watch.service.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.test.ts
@@ -20,7 +20,10 @@ import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { googleCalendarListService } from "@backend/sync/services/calendarlist/google-calendarlist.service";
 import { seedGoogleCalendar } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
-import { updateSync } from "@backend/sync/services/records/sync-records.repository";
+import {
+  getSync,
+  updateSync,
+} from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
 import {
@@ -620,6 +623,61 @@ describe("googleWatchService", () => {
       expect(inspection.status).toBe(GoogleWatchStateStatus.REPAIR_REQUIRED);
       expect(inspection.reason).toBe("WATCHES_MISSING");
       expect(inspection.missingWatchCalendarIds).toContain(failingGCalId);
+    });
+
+    it("records an unsupported event resource without making watch health fail", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const context = await createGoogleRequestContext(userId);
+      const gCalendarId = faker.string.uuid();
+
+      await seedGoogleCalendar(user._id, {
+        isPrimary: true,
+        source: { provider: "google", calendarId: gCalendarId, etag: "etag-1" },
+      });
+      await updateSync(Resource_Sync.CALENDAR, userId, Resource_Sync.CALENDAR, {
+        nextSyncToken: faker.string.alphanumeric(16),
+      });
+      await updateSync(Resource_Sync.EVENTS, userId, gCalendarId, {
+        nextSyncToken: faker.string.alphanumeric(16),
+      });
+
+      jest.spyOn(gcalService, "watchCalendars").mockResolvedValue({
+        watch: {
+          resourceId: "resource-calendarlist",
+          expiration: String(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        },
+      });
+      const unsupported = createGoogleError({
+        code: "400",
+        responseStatus: 400,
+      });
+      if (unsupported.response) {
+        unsupported.response.data = {
+          error: {
+            code: 400,
+            message: "Push notifications are not supported by this resource.",
+            errors: [{ reason: "pushNotSupportedForRequestedResource" }],
+          },
+        };
+      }
+      jest.spyOn(gcalService, "watchEvents").mockRejectedValue(unsupported);
+
+      await googleWatchService.startGoogleWatches(
+        userId,
+        [{ gCalendarId: Resource_Sync.CALENDAR }, { gCalendarId }],
+        context,
+      );
+
+      const sync = await getSync({ userId });
+      expect(
+        sync?.google?.events.find((entry) => entry.gCalendarId === gCalendarId)
+          ?.watchSupported,
+      ).toBe(false);
+      expect(await inspectGoogleWatchState(userId)).toMatchObject({
+        status: GoogleWatchStateStatus.HEALTHY,
+        reason: "WATCHES_HEALTHY",
+      });
     });
 
     it("contains a calendarlist-watch failure: event watches still start, and the inspector reports WATCHES_MISSING for the calendar list", async () => {

--- a/packages/backend/src/sync/services/watch/google-watch.service.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.ts
@@ -22,6 +22,7 @@ import {
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import {
   getGoogleErrorStatus,
+  isGoogleWatchUnsupported,
   isInvalidGoogleToken,
 } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
@@ -29,7 +30,10 @@ import { sseServer } from "@backend/servers/sse/sse.server";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
 import { GCalEventsNotificationHandler } from "@backend/sync/services/notify/handler/gcal-events.notification.handler";
 import { type NotificationOutcome } from "@backend/sync/services/notify/notification.outcome";
-import { getSync } from "@backend/sync/services/records/sync-records.repository";
+import {
+  getSync,
+  updateSync,
+} from "@backend/sync/services/records/sync-records.repository";
 import { isUsingGcalWebhookHttps } from "@backend/sync/services/watch/google-watch-config";
 import { isWatchingGoogleResource } from "@backend/sync/services/watch/google-watch-state";
 import { getChannelExpiration } from "@backend/sync/services/watch/google-watch-timing";
@@ -379,8 +383,27 @@ async function startEventWatch(
         throw error;
       });
 
+    await updateSync(Resource_Sync.EVENTS, user, params.gCalendarId, {
+      watchSupported: true,
+    });
+
     return watch;
   } catch (err) {
+    if (isGoogleWatchUnsupported(err)) {
+      await updateSync(Resource_Sync.EVENTS, user, params.gCalendarId, {
+        watchSupported: false,
+      }).catch((metadataError) => {
+        logger.error(
+          `Failed to record unsupported events watch for user: ${user}`,
+          metadataError,
+        );
+      });
+      logger.info(
+        `Events watch is not supported for a Google calendar (user: ${user})`,
+      );
+      return { acknowledged: false };
+    }
+
     logger.error(`Error starting events watch for user: ${user}`, err);
 
     return { acknowledged: false };

--- a/packages/core/src/types/sync.types.ts
+++ b/packages/core/src/types/sync.types.ts
@@ -21,6 +21,8 @@ export interface SyncDetails {
   nextSyncToken: string;
   nextPageToken?: string;
   lastSyncedAt?: Date;
+  /** False when Google explicitly rejects push watches for this resource. */
+  watchSupported?: boolean;
 }
 
 export enum Resource_Sync {


### PR DESCRIPTION
## Summary
- recognize Google's exact pushNotSupportedForRequestedResource response
- persist watch capability per synced calendar
- exclude only explicitly unsupported resources from watch health and repair expectations
- clear the marker when watch creation later succeeds
- keep all other watch failures unhealthy and repairable

## Why
The v1.0.210 full staging import completed successfully in 17.8 seconds with zero invalid records, but the account still showed "Your Google Calendar is out of date". The public Holidays calendar imports normally yet Google rejects push watches for that resource. Compass treated the missing watch as a sync failure and repeatedly offered a repair.

## Simplicity
Capability is stored on the existing per-calendar sync entry; no new collection or migration is needed. Both health readers consume the same boolean. The final simplify-code pass uses a single predicate and preserves the existing fault-containment behavior if capability persistence itself fails.

## Validation
- bun run verify passed
- 74 backend suites passed (654 tests; 4 skipped)
- 237 core tests passed
- focused watch/health/metadata suite passed (75 tests)
- type-check passed
- lint passed (8 pre-existing web warnings)

## Staging follow-up
After release, run one forced full sync. The Holidays watch rejection should be logged as informational, the sync should complete, and the account should assess HEALTHY without a watch for that resource.