### PR TITLE
fix(web): hide active view shortcut

### DIFF
--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -34,7 +34,20 @@ describe("shortcuts.data", () => {
         keys: ["d"],
         label: "Go to Day view",
       });
-      expect(navigate.shortcuts).toContainEqual({
+      expect(navigate.shortcuts).not.toContainEqual({
+        keys: ["w"],
+        label: "Go to Week view",
+      });
+
+      const [dayNavigate] = getShortcutMenuSections({
+        view: "day",
+        isViewingCurrentPeriod: false,
+      });
+      expect(dayNavigate.shortcuts).not.toContainEqual({
+        keys: ["d"],
+        label: "Go to Day view",
+      });
+      expect(dayNavigate.shortcuts).toContainEqual({
         keys: ["w"],
         label: "Go to Week view",
       });

--- a/packages/web/src/shortcuts/data/shortcuts.data.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.ts
@@ -13,30 +13,33 @@ interface ShortcutMenuConfig {
 const getNavigateShortcuts = ({
   view,
   isViewingCurrentPeriod,
-}: ShortcutMenuConfig): Shortcut[] => [
-  { keys: ["j"], label: `Previous ${view}` },
-  { keys: ["k"], label: `Next ${view}` },
-  ...(view === "week"
-    ? [
-        { keys: ["Shift", "j"], label: "Shift view back one day" },
-        { keys: ["Shift", "k"], label: "Shift view forward one day" },
-      ]
-    : []),
-  {
-    keys: ["t"],
-    label: isViewingCurrentPeriod
-      ? "Scroll to now"
-      : view === "day"
-        ? "Go to today"
-        : "Go to current week",
-  },
-  ...(view === "week"
-    ? [{ keys: [VIEW_SHORTCUTS.day.key], label: `Go to ${VIEW_SHORTCUTS.day.label} view` }]
-    : []),
-  ...(view === "day"
-    ? [{ keys: [VIEW_SHORTCUTS.week.key], label: `Go to ${VIEW_SHORTCUTS.week.label} view` }]
-    : []),
-];
+}: ShortcutMenuConfig): Shortcut[] => {
+  const alternateView =
+    view === "day" ? VIEW_SHORTCUTS.week : VIEW_SHORTCUTS.day;
+
+  return [
+    { keys: ["j"], label: `Previous ${view}` },
+    { keys: ["k"], label: `Next ${view}` },
+    ...(view === "week"
+      ? [
+          { keys: ["Shift", "j"], label: "Shift view back one day" },
+          { keys: ["Shift", "k"], label: "Shift view forward one day" },
+        ]
+      : []),
+    {
+      keys: ["t"],
+      label: isViewingCurrentPeriod
+        ? "Scroll to now"
+        : view === "day"
+          ? "Go to today"
+          : "Go to current week",
+    },
+    {
+      keys: [alternateView.key],
+      label: `Go to ${alternateView.label} view`,
+    },
+  ];
+};
 
 const getCreateShortcuts = (): Shortcut[] => [
   { keys: ["c"], label: "Create timed event" },

--- a/packages/web/src/shortcuts/data/shortcuts.data.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.ts
@@ -30,14 +30,12 @@ const getNavigateShortcuts = ({
         ? "Go to today"
         : "Go to current week",
   },
-  {
-    keys: [VIEW_SHORTCUTS.day.key],
-    label: `Go to ${VIEW_SHORTCUTS.day.label} view`,
-  },
-  {
-    keys: [VIEW_SHORTCUTS.week.key],
-    label: `Go to ${VIEW_SHORTCUTS.week.label} view`,
-  },
+  ...(view === "week"
+    ? [{ keys: [VIEW_SHORTCUTS.day.key], label: `Go to ${VIEW_SHORTCUTS.day.label} view` }]
+    : []),
+  ...(view === "day"
+    ? [{ keys: [VIEW_SHORTCUTS.week.key], label: `Go to ${VIEW_SHORTCUTS.week.label} view` }]
+    : []),
 ];
 
 const getCreateShortcuts = (): Shortcut[] => [


### PR DESCRIPTION
## Summary
- hide the shortcut for the view already being displayed
- keep the alternate day/week navigation shortcut available

## Simplicity
- use one alternate-view selection instead of duplicated conditional shortcut entries

## Manual Testing Steps
- [ ] Open the day view and open the shortcuts overlay; confirm the Day shortcut is absent and Week remains.
- [ ] Open the week view and open the shortcuts overlay; confirm the Week shortcut is absent and Day remains.

## Test plan
- [x] bun test --cwd packages/web src/shortcuts/data/shortcuts.data.test.ts
