### PR TITLE
fix(web): align all-day row surfaces

### DIFF
--- a/packages/web/src/layout/calendar-grid/components/CalendarAllDayRow.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarAllDayRow.tsx
@@ -49,7 +49,7 @@ export const CalendarAllDayRow: FC<CalendarAllDayRowProps> = ({
   visibleDates,
 }) => (
   <div
-    className="relative flex w-full shrink-0 items-start bg-bg-secondary"
+    className="relative flex w-full shrink-0 items-start bg-bg-primary"
     aria-label="All-day events"
     id={rowId}
     ref={allDayRowRef}

--- a/packages/web/src/layout/calendar-grid/components/CalendarGrid.test.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarGrid.test.tsx
@@ -53,6 +53,9 @@ describe("CalendarGrid", () => {
   it("keeps explicit event layers on their surfaces", () => {
     renderGrid(1);
 
+    expect(screen.getByRole("region", { name: "All-day events" })).toHaveClass(
+      "bg-bg-primary",
+    );
     expect(
       screen.getByRole("region", { name: "All-day events" }),
     ).toContainElement(screen.getByTestId("all-day-events-layer"));

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -8,7 +8,7 @@ export const DayCalendarColumnHeaders = ({
 }) => (
   <section
     aria-label="Calendars"
-    className="grid min-h-12 shrink-0"
+    className="grid min-h-12 shrink-0 bg-bg-primary"
     style={{
       gridTemplateColumns: `repeat(${calendars.length}, minmax(0, 1fr))`,
       marginLeft: CALENDAR_GRID_MARGIN_LEFT,
@@ -16,7 +16,7 @@ export const DayCalendarColumnHeaders = ({
   >
     {calendars.map((calendar) => (
       <div
-        className="flex min-w-0 items-center justify-center gap-2 border-border-secondary/25 border-l px-3 last:border-r"
+        className="flex min-w-0 items-center justify-center gap-2 border-grid-line-primary border-l px-3 last:border-r"
         key={calendar.id}
       >
         <span


### PR DESCRIPTION
## Summary
- match all-day row and day calendar header backgrounds to the primary calendar surface
- use timed-grid divider colors between day calendars

## Simplicity
- reuse the shared all-day surface styling for both Day and Week views

## Manual Testing Steps
- [ ] Open Week view and confirm the all-day area matches the calendar background and stops at the grid boundary.
- [ ] Open Day view and confirm the all-day area and calendar dividers match the timed grid.

## Test plan
- [x] bun test --cwd packages/web src/layout/calendar-grid/components/CalendarGrid.test.tsx src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
