### PR TITLE
fix(web): unify datepicker colors and layout

### DIFF
--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -116,7 +116,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
           >
             <div
               className={classNames(
-                "mr-2 flex items-start",
+                "min-w-0 flex-1 items-start",
                 monthContainerClassName,
               )}
             >

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -405,6 +405,11 @@
   @apply select-none rounded-xs border-0 shadow-[0_4px_4px_var(--color-shadow-default)];
   background-color: var(--date-picker-bg);
   font-size: 11px;
+  --date-picker-hover-bg: color-mix(
+    in srgb,
+    var(--date-picker-bg) 82%,
+    var(--compass-color-fg-primary)
+  );
 
   &[data-view="sidebar"] {
     background-color: transparent;
@@ -485,8 +490,8 @@
   }
 
   & .react-datepicker__day:hover {
-    background-color: var(--compass-color-fg-primary);
-    color: var(--compass-color-text-dark);
+    background-color: var(--date-picker-hover-bg);
+    color: inherit;
   }
 
   & .react-datepicker__day-names {
@@ -498,7 +503,7 @@
   }
 
   & .react-datepicker__day--selected {
-    background-color: var(--compass-color-accent-primary);
+    background-color: var(--compass-color-accent-primary-shadow);
     color: var(--compass-color-text-lighter);
   }
 
@@ -516,7 +521,7 @@
   }
 
   & .react-datepicker__day--today:hover {
-    color: var(--compass-color-text-dark);
+    color: inherit;
   }
 
   & .react-datepicker__day--keyboard-selected {
@@ -740,11 +745,7 @@
     position: absolute;
     inset: 0 -3px;
     border-radius: var(--radius-default);
-    background: color-mix(
-      in srgb,
-      var(--compass-color-panel-scrollbar-active) 50%,
-      transparent
-    );
+    background: var(--date-picker-hover-bg);
     content: "";
   }
   &

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -728,14 +728,14 @@
     position: relative;
     isolation: isolate;
     background: transparent;
-    color: var(--compass-color-text-dark);
+    color: var(--compass-color-text-lighter);
   }
   & .react-datepicker__day--selected::before {
     position: absolute;
     inset: -2px;
     z-index: -1;
     border-radius: var(--radius-default);
-    background: var(--compass-color-accent-primary);
+    background: var(--compass-color-accent-primary-shadow);
     content: "";
   }
   & .react-datepicker__week:has(.react-datepicker__day--selected) {


### PR DESCRIPTION
## Summary
- keep datepicker arrows anchored while the month label changes width
- improve day, hover, today, and selected-day contrast
- share the same visual treatment across sidebar and form datepickers while preserving their responsive surfaces

## Simplicity
- centralize hover color through one datepicker variable
- use the existing selected-day styling for all datepicker variants

## Manual Testing Steps
- [ ] Open the sidebar datepicker and move across months; confirm the arrows stay aligned.
- [ ] Open an all-day or recurring-event datepicker and verify hover, today, and selected dates remain readable.
- [ ] Expand and collapse the sidebar; confirm the picker remains responsive.

## Test plan
- [x] bun test --cwd packages/web src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.test.tsx
