### PR TITLE
fix(web): preserve shifted week window on today

### DIFF
--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -179,6 +179,24 @@ describe("useWeek", () => {
     });
   });
 
+  it("preserves a shifted window when returning to today", () => {
+    mockParams.dateString = "2026-01-01";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { rerender, result } = renderHook(() => useWeek(today));
+
+    act(() => result.current.util.shiftViewByDay(1));
+    mockParams.dateString = "2026-01-02";
+    rerender();
+    mockNavigate.mockClear();
+
+    act(() => result.current.util.goToToday());
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/week/$dateString",
+      params: { dateString: "2026-05-22" },
+    });
+  });
+
   it("does not navigate on goToToday when already viewing today's week", () => {
     mockParams.dateString = "2026-05-20";
     const today = dayjs("2026-05-20", DATE_FORMAT);

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -119,9 +119,15 @@ export const useWeek = (
   };
 
   const goToToday = () => {
+    const navigationSource = navigationSourceRef.current;
     navigationSourceRef.current = "manual";
     if (!isCurrentWeek) {
-      setAnchor(today.startOf("week"));
+      const todayWindowStart = today.startOf("week");
+      const shiftedWindowOffset =
+        navigationSource === "day-shift"
+          ? start.diff(start.startOf("week"), "day")
+          : 0;
+      setAnchor(todayWindowStart.add(shiftedWindowOffset, "day"));
     }
   };
 


### PR DESCRIPTION
## Summary
- retain the weekday offset introduced by Shift+J/K when `T` returns to today
- keep standard manual return-to-today navigation anchored to Sunday

## Simplicity
- derive the offset directly from the existing navigation source and visible start date

## Manual Testing Steps
- [ ] In Week view, shift the visible window with Shift+J or Shift+K, then press T; confirm the shifted weekday remains the first visible day.
- [ ] Navigate manually to another week and press T; confirm the standard current-week window is restored.

## Test plan
- [x] bun test --cwd packages/web src/views/Week/hooks/useWeek.test.tsx
