### PR TITLE
fix(web): prevent datepicker contrast regressions

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,6 +1,14 @@
 name: Test
 
 on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - ".gitignore"
+      - "team/**"
+      - "**/*.md"
+      - "docs/**"
   push:
     paths-ignore:
       - ".gitignore"
@@ -12,6 +20,39 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.18
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install Dependencies
+        run: |
+          bun install --frozen-lockfile
+
+      - name: Run lint
+        run: |
+          bun run lint
+
   type-check:
     runs-on: ubuntu-latest
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "tslib": "^2.4.0",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@babel/core": "^7.15.5",
         "@babel/preset-env": "^7.16.0",
         "@babel/preset-react": "^7.16.7",
@@ -144,6 +145,8 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -806,6 +809,8 @@
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
 

--- a/e2e/accessibility/datepicker-a11y.spec.ts
+++ b/e2e/accessibility/datepicker-a11y.spec.ts
@@ -1,0 +1,157 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, type Locator, test } from "@playwright/test";
+import {
+  ensureSidebarOpen,
+  prepareCalendarPage,
+} from "../utils/event-test-utils";
+
+const MIN_NORMAL_TEXT_CONTRAST = 4.5;
+
+test("sidebar datepicker meets baseline accessibility and contrast checks", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+  await ensureSidebarOpen(page);
+
+  const sidebar = page.locator("#sidebar");
+  const monthPicker = sidebar.getByRole("group", { name: "Date navigation" });
+  await expect(monthPicker).toBeVisible();
+
+  const scanResults = await new AxeBuilder({ page })
+    .include("#sidebar")
+    .analyze();
+  expect(scanResults.violations).toEqual([]);
+
+  const days = monthPicker.locator(
+    ".react-datepicker__day:not(.react-datepicker__day--disabled)",
+  );
+  await expect(days.first()).toBeVisible();
+
+  await expectDateContrast(days, "default");
+  await expectDateContrast(days, "hover");
+});
+
+const expectDateContrast = async (
+  days: Locator,
+  state: "default" | "hover",
+) => {
+  const count = await days.count();
+
+  for (let index = 0; index < count; index++) {
+    const day = days.nth(index);
+    const text = (await day.textContent())?.trim();
+    const box = await day.boundingBox();
+
+    if (!text || !box) {
+      continue;
+    }
+
+    if (state === "hover") {
+      await day.hover();
+    }
+
+    const contrast = await getRenderedContrast(day);
+    expect(
+      contrast.ratio,
+      `${state} date ${text} contrast ${contrast.ratio.toFixed(2)}:1 for ${contrast.color} on ${contrast.background}`,
+    ).toBeGreaterThanOrEqual(MIN_NORMAL_TEXT_CONTRAST);
+  }
+};
+
+const getRenderedContrast = (locator: Locator) =>
+  locator.evaluate((element) => {
+    type Rgba = { a: number; b: number; g: number; r: number };
+
+    const parseRgb = (value: string): Rgba => {
+      const match = value.match(
+        /rgba?\(\s*([.\d]+)\s*,\s*([.\d]+)\s*,\s*([.\d]+)(?:\s*,\s*([.\d]+))?\s*\)/,
+      );
+
+      if (!match) {
+        return { a: 0, b: 0, g: 0, r: 0 };
+      }
+
+      return {
+        r: Number(match[1]),
+        g: Number(match[2]),
+        b: Number(match[3]),
+        a: match[4] === undefined ? 1 : Number(match[4]),
+      };
+    };
+
+    const blend = (foreground: Rgba, background: Rgba): Rgba => {
+      const alpha = foreground.a + background.a * (1 - foreground.a);
+
+      if (alpha === 0) {
+        return { a: 0, b: 0, g: 0, r: 0 };
+      }
+
+      return {
+        r:
+          (foreground.r * foreground.a +
+            background.r * background.a * (1 - foreground.a)) /
+          alpha,
+        g:
+          (foreground.g * foreground.a +
+            background.g * background.a * (1 - foreground.a)) /
+          alpha,
+        b:
+          (foreground.b * foreground.a +
+            background.b * background.a * (1 - foreground.a)) /
+          alpha,
+        a: alpha,
+      };
+    };
+
+    const formatRgb = ({ b, g, r }: Rgba) =>
+      `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`;
+
+    const channelLuminance = (channel: number) => {
+      const ratio = channel / 255;
+      return ratio <= 0.03928
+        ? ratio / 12.92
+        : ((ratio + 0.055) / 1.055) ** 2.4;
+    };
+
+    const luminance = ({ b, g, r }: Rgba) =>
+      0.2126 * channelLuminance(r) +
+      0.7152 * channelLuminance(g) +
+      0.0722 * channelLuminance(b);
+
+    const contrastRatio = (foreground: Rgba, background: Rgba) => {
+      const foregroundLuminance = luminance(foreground);
+      const backgroundLuminance = luminance(background);
+      const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+      const darker = Math.min(foregroundLuminance, backgroundLuminance);
+
+      return (lighter + 0.05) / (darker + 0.05);
+    };
+
+    const getRenderedBackground = () => {
+      const ancestors: Element[] = [];
+      let current: Element | null = element;
+
+      while (current) {
+        ancestors.push(current);
+        current = current.parentElement;
+      }
+
+      return ancestors
+        .reverse()
+        .map((ancestor) => parseRgb(getComputedStyle(ancestor).backgroundColor))
+        .reduce<Rgba>(
+          (background, foreground) => blend(foreground, background),
+          { a: 1, b: 255, g: 255, r: 255 },
+        );
+    };
+
+    const style = getComputedStyle(element);
+    const background = getRenderedBackground();
+    const color = blend(parseRgb(style.color), background);
+
+    return {
+      background: formatRgb(background),
+      color: formatRgb(color),
+      ratio: contrastRatio(color, background),
+    };
+  });

--- a/e2e/accessibility/datepicker-a11y.spec.ts
+++ b/e2e/accessibility/datepicker-a11y.spec.ts
@@ -136,13 +136,23 @@ const getRenderedContrast = (locator: Locator) =>
         current = current.parentElement;
       }
 
-      return ancestors
+      const inheritedBackground = ancestors
         .reverse()
         .map((ancestor) => parseRgb(getComputedStyle(ancestor).backgroundColor))
         .reduce<Rgba>(
           (background, foreground) => blend(foreground, background),
           { a: 1, b: 255, g: 255, r: 255 },
         );
+      const beforeStyle = getComputedStyle(element, "::before");
+
+      if (beforeStyle.content !== "none") {
+        return blend(
+          parseRgb(beforeStyle.backgroundColor),
+          inheritedBackground,
+        );
+      }
+
+      return inheritedBackground;
     };
 
     const style = getComputedStyle(element);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "test": "bun test:core && bun test:web && bun test:backend && bun test:scripts",
+    "test:a11y": "bunx playwright test e2e/accessibility",
     "test:e2e": "bunx playwright test",
     "test:backend": "./node_modules/.bin/jest --selectProjects backend",
     "test:core": "bun test packages/core/src --preload packages/scripts/src/testing/core.preload.ts",
@@ -46,6 +47,7 @@
     "tslib": "^2.4.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-react": "^7.16.7",

--- a/packages/scripts/src/testing/verify.ts
+++ b/packages/scripts/src/testing/verify.ts
@@ -3,14 +3,14 @@ import { execSync } from "node:child_process";
 /**
  * Smart verify script for AI coding loops.
  * Detects which packages changed via git diff and runs the minimum
- * necessary test suites plus type-check.
+ * necessary test suites plus type-check and lint.
  *
  * Test execution is delegated to the root `test:<project>` package.json scripts.
  *
  * Usage:
  *   bun run verify              — auto-detect from git diff
- *   bun run verify web          — run web suite + type-check
- *   bun run verify core web     — run specific suites + type-check
+ *   bun run verify web          — run web suite + type-check + lint
+ *   bun run verify core web     — run specific suites + type-check + lint
  */
 
 type BunRuntime = {
@@ -109,6 +109,48 @@ function runTypeCheck(): boolean {
   return result.exitCode === 0;
 }
 
+function runLint(): boolean {
+  console.log("\n→ lint");
+  const result = bunRuntime.spawnSync({
+    cmd: ["bun", "run", "lint"],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      TZ: process.env["TZ"] ?? "Etc/UTC",
+    },
+    stderr: "inherit",
+    stdin: "inherit",
+    stdout: "inherit",
+  });
+  return result.exitCode === 0;
+}
+
+function runA11y(): boolean {
+  console.log("\n→ test:a11y");
+  const result = bunRuntime.spawnSync({
+    cmd: ["bun", "run", "test:a11y"],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      TZ: process.env["TZ"] ?? "Etc/UTC",
+    },
+    stderr: "inherit",
+    stdin: "inherit",
+    stdout: "inherit",
+  });
+  return result.exitCode === 0;
+}
+
+function describeChecks(packagesToRun: Package[]): string {
+  const checks = [...packagesToRun, "type-check", "lint"];
+
+  if (packagesToRun.includes("web")) {
+    checks.push("test:a11y");
+  }
+
+  return checks.join(" → ");
+}
+
 function main() {
   const args = process.argv.slice(2);
 
@@ -123,18 +165,18 @@ function main() {
       process.exit(1);
     }
     packagesToRun = args as Package[];
-    console.log(`Running: ${packagesToRun.join(" → ")} → type-check`);
+    console.log(`Running: ${describeChecks(packagesToRun)}`);
   } else {
     packagesToRun = getChangedPackages();
 
     if (packagesToRun.length === 0) {
       console.log(
-        "No changed packages detected — falling back to: core → web → type-check",
+        "No changed packages detected — falling back to: core → web → type-check → lint → test:a11y",
       );
       packagesToRun = ["core", "web"];
     } else {
       console.log(
-        `Detected changes in: ${packagesToRun.join(", ")}\nRunning: ${packagesToRun.join(" → ")} → type-check`,
+        `Detected changes in: ${packagesToRun.join(", ")}\nRunning: ${describeChecks(packagesToRun)}`,
       );
     }
   }
@@ -149,6 +191,14 @@ function main() {
 
   if (!runTypeCheck()) {
     failed.push("type-check");
+  }
+
+  if (!runLint()) {
+    failed.push("lint");
+  }
+
+  if (packagesToRun.includes("web") && !runA11y()) {
+    failed.push("test:a11y");
   }
 
   if (failed.length > 0) {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -723,7 +723,7 @@
  * after c-date-picker, it wins on source order, so the !important hacks the
  * @utility form needed are no longer required.
  */
-.c-month-picker {
+.c-month-picker .c-date-picker {
   & .react-datepicker__month-container,
   & .react-datepicker__month {
     overflow: visible;
@@ -732,14 +732,18 @@
     position: relative;
     isolation: isolate;
     background: transparent;
-    color: var(--compass-color-text-lighter);
+    color: var(--date-picker-selected-text);
+  }
+  & .react-datepicker__day--selected:hover {
+    background: transparent;
+    color: var(--date-picker-selected-text);
   }
   & .react-datepicker__day--selected::before {
     position: absolute;
     inset: -2px;
     z-index: -1;
     border-radius: var(--radius-default);
-    background: var(--compass-color-accent-primary-shadow);
+    background: var(--date-picker-selected-bg);
     content: "";
   }
   & .react-datepicker__week:has(.react-datepicker__day--selected) {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -410,6 +410,9 @@
     var(--date-picker-bg) 82%,
     var(--compass-color-fg-primary)
   );
+  --date-picker-hover-text: var(--compass-color-text-lighter);
+  --date-picker-selected-bg: var(--compass-color-accent-primary);
+  --date-picker-selected-text: var(--compass-color-text-dark);
 
   &[data-view="sidebar"] {
     background-color: transparent;
@@ -491,7 +494,7 @@
 
   & .react-datepicker__day:hover {
     background-color: var(--date-picker-hover-bg);
-    color: inherit;
+    color: var(--date-picker-hover-text);
   }
 
   & .react-datepicker__day-names {
@@ -503,8 +506,8 @@
   }
 
   & .react-datepicker__day--selected {
-    background-color: var(--compass-color-accent-primary-shadow);
-    color: var(--compass-color-text-lighter);
+    background-color: var(--date-picker-selected-bg);
+    color: var(--date-picker-selected-text);
   }
 
   & .react-datepicker__day--today:not(.react-datepicker__day--selected) {
@@ -521,7 +524,8 @@
   }
 
   & .react-datepicker__day--today:hover {
-    color: inherit;
+    color: var(--date-picker-hover-text);
+    text-decoration-color: var(--date-picker-hover-text);
   }
 
   & .react-datepicker__day--keyboard-selected {


### PR DESCRIPTION
## Summary

- Fixes datepicker hover, today-hover, and selected date color pairs so the sidebar datepicker meets WCAG AA contrast for normal text.
- Adds a focused Playwright accessibility gate using axe plus rendered contrast assertions for default and hover date states, including selected-date pseudo-element backgrounds.
- Wires the new `test:a11y` command into `bun run verify` for web changes and adds lint to PR CI.

## Simplicity

- Kept the fix in the existing datepicker CSS tokens instead of adding a new theme layer.
- Scoped the sidebar selected-date override to `.c-month-picker .c-date-picker` so it wins the existing cascade without `!important`.
- No separate simplification commit was needed; review found the remaining issue was a cascade bug, not avoidable structural complexity.

## Manual Testing Steps

- [ ] Open the week view locally and confirm the planner sidebar date navigation is visible.
- [ ] Confirm the selected date uses dark text on the blue selected pill.
- [ ] Select another date in the sidebar date navigation and confirm the selected pill moves while keeping readable text.
- [ ] Hover date cells in the sidebar date navigation and confirm the text remains readable against the hover background.

## Test plan

- [x] `bun run test:a11y`
- [x] `bun run verify web`
- [x] Chrome manual validation on `http://localhost:9082/week`
- [x] `bunx react-doctor@latest . --verbose --diff` (no changed React source files to scan)

Notes: `bun run verify web` still prints existing unrelated jsdom/Tailwind CSS parse noise, React act warnings, and Biome warnings in week-grid files, but exits successfully.