### PR TITLE
refactor(backend): dedupe gcal events per-page default into a shared constant

### DIFF
--- a/packages/backend/src/event/google-event-sync.service.ts
+++ b/packages/backend/src/event/google-event-sync.service.ts
@@ -9,6 +9,13 @@ import { mapGoogleEvent } from "@backend/event/google-event.adapter";
 import { getAnchorDate } from "@backend/event/services/recur/util/recur.util";
 
 /**
+ * Default number of Google events to request per page when importing/syncing.
+ * Shared by the event-apply path here and the import/sync services that drive
+ * it, so a future tuning pass changes one number instead of six call sites.
+ */
+export const DEFAULT_GCAL_EVENTS_PER_PAGE = 1000;
+
+/**
  * The instant Google considers this event's fixed position in a recurrence
  * pattern (stays fixed even after the instance's own start/end are edited).
  * Present on both live instances and cancellation notifications, so it is
@@ -106,7 +113,7 @@ export class GoogleEventSync {
 
   async apply(
     events: gSchema$Event[],
-    perPage = 1000,
+    perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
     session?: ClientSession,
   ): Promise<GoogleEventSyncResult> {
     const seriesMap = new Map<string, ObjectId>();

--- a/packages/backend/src/sync/services/google-sync/google-sync.service.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.service.ts
@@ -13,6 +13,7 @@ import {
 } from "@backend/common/services/gcal/gcal.context";
 import { isInvalidGoogleToken } from "@backend/common/services/gcal/gcal.utils";
 import { createConcurrencyLimiter } from "@backend/common/util/concurrency-limiter.util";
+import { DEFAULT_GCAL_EVENTS_PER_PAGE } from "@backend/event/google-event-sync.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import compassToGoogleBackfill from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google-backfill";
 import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
@@ -101,7 +102,7 @@ const toErrorMessage = (err: unknown): string =>
 async function importLatestGoogleCalendarChanges(
   userId: string,
   context?: GoogleRequestContext,
-  perPage = 1000,
+  perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
 ) {
   if (!tryBeginGoogleSync(userId)) {
     logger.info(

--- a/packages/backend/src/sync/services/import/google-import.service.ts
+++ b/packages/backend/src/sync/services/import/google-import.service.ts
@@ -9,7 +9,10 @@ import {
   type GoogleRequestContext,
 } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
-import { GoogleEventSync } from "@backend/event/google-event-sync.service";
+import {
+  DEFAULT_GCAL_EVENTS_PER_PAGE,
+  GoogleEventSync,
+} from "@backend/event/google-event-sync.service";
 import {
   getGCalEventsSyncPageToken,
   getSync,
@@ -79,7 +82,7 @@ export class SyncImport {
   async importAllEvents(
     userId: string,
     calendar: CalendarRecord,
-    perPage = 1000,
+    perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
   ): Promise<ImportStats & { nextSyncToken: string }> {
     if (calendar.source.provider !== "google") {
       throw error(
@@ -166,7 +169,7 @@ export class SyncImport {
   async importLatestEvents(
     userId: string,
     calendar: CalendarRecord,
-    perPage = 1000,
+    perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
   ): Promise<ImportStats> {
     if (calendar.source.provider !== "google") {
       throw error(
@@ -203,7 +206,7 @@ export class SyncImport {
     userId: string,
     calendar: CalendarRecord,
     initialSyncToken: string,
-    perPage = 1000,
+    perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
   ): Promise<ImportStats> {
     if (calendar.source.provider !== "google") {
       throw error(


### PR DESCRIPTION
## Summary

Two items adopted as standing-authority work in the 2026-07-14 standup.

**Part 1 — dedupe the `perPage = 1000` default (done).** The Google events
per-page default was hard-coded independently at five call sites across three
files. Pulled into one exported constant, `DEFAULT_GCAL_EVENTS_PER_PAGE`, in
`packages/backend/src/event/google-event-sync.service.ts`, and referenced from:

- `GoogleEventSync.apply()` (same file)
- `SyncImport.importAllEvents` / `importLatestEvents` / `importEventsByCalendar`
  (`sync/services/import/google-import.service.ts`)
- `importLatestGoogleCalendarChanges` (`sync/services/google-sync/google-sync.service.ts`)

The constant lives in the `event/` layer deliberately: `import/` and
`google-sync/` already depend on `google-event-sync.service.ts` (they import
`GoogleEventSync` from it), and that module imports nothing back from `sync/`,
so this introduces no import cycle and no new abstraction layer. Value is
unchanged (1000); this is a pure mechanical dedupe with no behavior change.

**Part 2 — recurring base-series batching (assessed; no change, by design).**
The standalone-event path and the recurring-instance-page path were previously
batched; the base recurring-series path in `apply()` (the `remaining` loop,
~L122-127) still processes events one at a time via
`applyOne`/`insertOne`/`replaceOne`. I assessed whether it needs the same
batching and concluded it does **not**, for concrete reasons:

- **Base series are inherently low-cardinality.** A page holds up to `perPage`
  events, but the number of distinct recurring *bases* in a page is a small
  fraction — a user has at most dozens-to-low-hundreds of recurring series
  total, spread across many pages. The batched paths were batched precisely
  because they are high-volume: a page can be dominated by hundreds of
  standalone events, and a single series can expand to hundreds/thousands of
  instances.
- **The per-base DB cost is already negligible relative to what each base
  triggers.** Each base does one indexed point query
  (`findByExternalReference`) plus one `insertOne`/`replaceOne`. But when a base
  is a series, `applyOne` then calls `applyInstances`, which makes a *Google
  API round trip* (`getBaseRecurringEventInstances`) and batches the resulting
  instance writes. That network fetch dwarfs the single base upsert, and it is
  inherently per-series and serial (each base needs its own instances call
  keyed by its freshly-resolved Compass `_id`), so it is not batchable anyway.
- Batching the base upserts would therefore save at most a handful of point
  queries per page while adding real complexity (separating bases, bulk
  preloading/replacing, then *still* looping per-base for the instance fetch).
  Net: negligible benefit, added complexity — not worth it.

No evidence of a real bottleneck here, so the base-series path is left as-is per
the standup guidance that a justified no-op is a good outcome.

## Simplicity

Net complexity reduction: five duplicated magic-number literals collapse into
one named constant with a single explanatory comment, so a future tuning pass
edits one number instead of hunting six sites. No React hooks are involved
(backend-only change). No simplification opportunities beyond the dedupe itself,
which is the whole change.

## Manual Testing Steps

This is a backend-only refactor with no browser-observable surface; the default
value is unchanged, so there is nothing new for a reviewer to click. To verify
mechanically:

- [ ] From the repo root, run `bun run type-check` and confirm it passes.
- [ ] Run `grep -rn "= 1000" packages/backend/src/sync packages/backend/src/event | grep -v test`
      and confirm the only hit is the constant definition
      (`DEFAULT_GCAL_EVENTS_PER_PAGE = 1000`) — no stray literal defaults remain.
- [ ] Run `bun run test:backend` and confirm the Google sync/import suites pass
      (behavior is unchanged since the default value is identical).

## Test plan

- [x] `bun run type-check` — passes (full monorepo type-check, incl. web test tsconfig).
- [x] `grep` audit — only remaining `= 1000` in the two touched dirs is the new constant.
- [x] CI `unit (backend)` + `type-check` matrix — see checks on this PR.
