### PR TITLE
chore(team): fullstack notes 2026-07-14 (#2127)

### DIFF
--- a/team/fullstack/notes/2026-07-14.md
+++ b/team/fullstack/notes/2026-07-14.md
@@ -1,0 +1,22 @@
+# Fullstack notes — 2026-07-14
+
+## Work
+- Landed [#2127](https://github.com/SwitchbackTech/compass-calendar/pull/2127) —
+  deduped the hard-coded `perPage = 1000` default (6 call sites across
+  `google-event-sync.service.ts`, `google-sync.service.ts`, and
+  `google-import.service.ts`) into one shared constant. Approved in
+  [standup 2026-07-14](../../standups/2026-07-14.md). Rebased onto the current
+  origin/main tip (already up to date), CI green, squash-merged.
+
+## Notes
+- Value unchanged (1000); pure mechanical dedupe, no behavior change. Constant
+  lives in the `event/` layer because `import/` and `google-sync/` already depend
+  on `google-event-sync.service.ts`, so no import cycle is introduced.
+- Assessed the base recurring-series path in `apply()` (~L122-127, still
+  one-at-a-time via `applyOne`/`insertOne`/`replaceOne`) and concluded it does
+  **not** need the batching the standalone/instance-page paths got: base series
+  are inherently low-cardinality (dozens-to-low-hundreds per user across many
+  pages), and each base's dominant cost is the per-series Google instances fetch
+  (`applyInstances`), which is serial and not batchable. Batching the base
+  upserts would save a handful of point queries per page for real added
+  complexity — a justified no-op.


### PR DESCRIPTION
Fullstack role notes for 2026-07-14: records the #2127 merge (perPage dedupe) and the recurring base-series batching assessment (no change, by design).

team/** is CI-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)