### PR TITLE
feat(web): implement layered accessibility testing strategy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- What changed and why. -->
+
+## Test plan
+
+<!-- How you verified this: commands run, manual steps, screenshots/recordings. -->
+
+## Accessibility checklist
+
+Only for UI changes. Skip anything not touched by this PR - see the
+"Accessibility Testing" section of
+[docs/development/testing-playbook.md](../docs/development/testing-playbook.md)
+for what automation already covers.
+
+- [ ] Keyboard-only: reached and operated the changed UI with Tab/Shift+Tab
+      and arrow keys, with a visible focus indicator throughout
+- [ ] Exercised dynamic content the changed flow introduces (dialogs, menus,
+      validation/error states) rather than just the resting page
+- [ ] Checked browser zoom/reflow at 200% and 400% if layout changed
+- [ ] Checked screen-reader names/announcements (e.g. VoiceOver) if roles,
+      labels, or live regions changed
+- [ ] Checked reduced-motion / forced-colors behavior if this PR touches
+      animation or relies on color alone

--- a/biome.json
+++ b/biome.json
@@ -21,19 +21,19 @@
     "rules": {
       "recommended": true,
       "a11y": {
-        "noNoninteractiveElementToInteractiveRole": "warn",
         "noNoninteractiveTabindex": "warn",
-        "noPositiveTabindex": "warn",
         "noRedundantRoles": "warn",
         "noStaticElementInteractions": "warn",
-        "noSvgWithoutTitle": "warn",
-        "useAriaPropsForRole": "warn",
         "useAriaPropsSupportedByRole": "warn",
-        "useButtonType": "warn",
-        "useFocusableInteractive": "warn",
-        "useHtmlLang": "warn",
         "useSemanticElements": "warn",
-        "useValidAriaRole": "warn"
+        "noNoninteractiveElementToInteractiveRole": "error",
+        "noPositiveTabindex": "error",
+        "noSvgWithoutTitle": "error",
+        "useAriaPropsForRole": "error",
+        "useButtonType": "error",
+        "useFocusableInteractive": "error",
+        "useHtmlLang": "error",
+        "useValidAriaRole": "error"
       },
       "correctness": {
         "noUnreachable": "warn",

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@playwright/test": "^1.60.0",
         "@types/node": "^22.13.10",
         "@types/node-fetch": "^2.6.13",
+        "axe-core": "^4.12.1",
         "jest": "^29.0.3",
         "typescript": "^6.0.3",
       },

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -355,6 +355,59 @@ a region only when the test intentionally owns that region and document why.
 Treat `violations` as failures and review `incomplete` results: incomplete means
 axe could not make a reliable automated decision and requires human judgment.
 
+#### Shared Helper
+
+`e2e/utils/axe-assertion.ts` exports `expectNoAxeViolations(page, options?)`.
+It runs one `AxeBuilder` scan tagged to Compass's WCAG target
+(`wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa` - the full WCAG 2.2 AA
+set; WCAG 2.2 only added AA-level success criteria, so there is no `wcag22a`
+tag). That tag set was confirmed against the installed axe-core version, not
+assumed:
+
+```bash
+grep -o 'wcag2[0-9a]*' node_modules/axe-core/axe.js | sort -u
+```
+
+Re-run that after bumping axe-core to confirm the tags are still current.
+
+Options:
+
+- `include`: CSS selector to scope the scan to a region (omit for whole-page).
+- `checkpoint`: short label included in failure/log output.
+- `knownIncomplete`: an array of `{ ruleId, reason }`. Any `incomplete` result
+  whose rule id is listed here is reported as an explained, expected result
+  for that checkpoint. This is not a blanket allowlist - it does nothing for
+  other rules or other checkpoints. Everything in `incomplete` that isn't
+  listed is still printed (never silently dropped), just not failed.
+
+**Incomplete-result policy:** `violations` always fail the test. `incomplete`
+never fails the test - axe itself couldn't decide, so treating it as a hard
+failure would make the suite fail on things no one can fix from the report
+alone. Every incomplete result is printed for review, either as "known" (with
+its documented reason) or as an unexplained result to look at. The two
+`knownIncomplete` entries in use today (both on the actions-menu checkpoint,
+see `e2e/accessibility/app-a11y.spec.ts`) are `aria-valid-attr-value` and
+`aria-hidden-focus`, both inherent to how `@floating-ui/react` portals menu
+content and traps focus around it, not app markup - see the reasons recorded
+at the call site. Unexplained `incomplete` results seen in this suite today
+are `color-contrast` (axe cannot compute a background across an
+absolutely-positioned overlap or a CSS gradient, and cannot reliably sample
+single-character date-cell text) - these are exactly the states the
+datepicker's targeted contrast test and manual review already cover.
+
+#### Representative Checkpoints
+
+`e2e/accessibility/app-a11y.spec.ts` covers:
+
+- the week view (main authenticated calendar surface)
+- the timed event form open (sidebar form, a hidden-until-activated region)
+- the all-day event form open (a distinct field set from the timed form)
+- the event actions menu open (a floating, portaled menu)
+- the invalid-date validation error toast (an error state)
+
+`e2e/accessibility/datepicker-a11y.spec.ts` covers the sidebar date navigation
+region and keeps its own targeted per-date contrast regression (below).
+
 #### When To Add A Targeted Regression Test
 
 Keep focused browser assertions when the failure depends on a state or visual
@@ -400,7 +453,10 @@ For a major UI change, verify the affected flow with:
 - reduced-motion and forced-colors/high-contrast settings when relevant
 - a free browser audit such as Accessibility Insights for Web
 
-Record the states reviewed in the PR. Automated checks passing means no tested
+Record the states reviewed in the PR - `.github/PULL_REQUEST_TEMPLATE.md` has a
+short accessibility checklist for exactly the judgment calls automation can't
+make (keyboard reach, dynamic content exercised, zoom/reflow, screen-reader
+names, reduced-motion/forced-colors). Automated checks passing means no tested
 automated violation was found; it does not mean the page conforms to every WCAG
 success criterion.
 
@@ -417,7 +473,25 @@ success criterion.
 
 Browser-based accessibility checks are appropriate for CI and pre-push
 verification. Keep commit hooks limited to fast static checks so normal commits
-do not need to start a browser.
+do not need to start a browser. There is no Husky/git-hook setup in this repo;
+run `bun run verify web` yourself before pushing web/JSX/CSS changes, and rely
+on `test-unit.yml` (lint, type-check) and `test-e2e.yml` (`bun run test:e2e`,
+which includes `e2e/accessibility`) in CI as the enforcement backstop. Both
+workflows trigger on any push/PR that isn't docs-only, so web changes are
+always covered.
+
+#### Biome Rule Levels
+
+`biome.json`'s `linter.rules.a11y` splits into two groups. Rules with no
+standing `biome-ignore` anywhere in the repo are `"error"`, so a new violation
+fails `bun run lint` and CI immediately. Rules that have narrow, pointer-only
+exceptions already in the codebase (`noNoninteractiveTabindex`,
+`noRedundantRoles`, `noStaticElementInteractions`, `useAriaPropsSupportedByRole`,
+`useSemanticElements` - grep for `biome-ignore lint/a11y/<rule>` to find them)
+stay at `"warn"`: promoting a rule to `"error"` while it still has documented
+exceptions would make "error" mean something less than zero exceptions. Before
+promoting a currently-`"warn"` rule, confirm it has no existing
+`biome-ignore` for that rule.
 
 References:
 

--- a/e2e/accessibility/app-a11y.spec.ts
+++ b/e2e/accessibility/app-a11y.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+import { expectNoAxeViolations } from "../utils/axe-assertion";
+import {
+  createEventTitle,
+  ensureSidebarOpen,
+  fillTitleAndSaveEventForm,
+  openAllDayEventFormWithMouse,
+  openEventForEditingWithMouse,
+  openTimedEventFormWithMouse,
+  prepareCalendarPage,
+} from "../utils/event-test-utils";
+
+// A small, representative smoke suite rather than a bespoke scan per
+// component - see "How Axe Coverage Works" in
+// docs/development/testing-playbook.md. Each checkpoint reveals or hides a
+// distinct UI state (dialogs/menus/errors don't exist until activated), so
+// each gets its own scan instead of relying on one page-load scan to cover
+// everything.
+
+test("week view renders with no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+  await ensureSidebarOpen(page);
+
+  await expectNoAxeViolations(page, { checkpoint: "week view" });
+});
+
+test("the timed event form is accessible when open", async ({ page }) => {
+  await prepareCalendarPage(page);
+  await openTimedEventFormWithMouse(page);
+
+  await expectNoAxeViolations(page, { checkpoint: "timed event form open" });
+});
+
+test("the all-day event form is accessible when open", async ({ page }) => {
+  await prepareCalendarPage(page);
+  await openAllDayEventFormWithMouse(page);
+
+  await expectNoAxeViolations(page, { checkpoint: "all-day event form open" });
+});
+
+test("the event actions menu is accessible when open", async ({ page }) => {
+  await prepareCalendarPage(page);
+  const title = createEventTitle("A11y Checkpoint");
+  await openTimedEventFormWithMouse(page);
+  await fillTitleAndSaveEventForm(page, title);
+  await openEventForEditingWithMouse(page, title);
+
+  await page.getByRole("form").getByLabel("Open actions menu").click();
+  await expect(page.getByRole("menu")).toBeVisible();
+
+  await expectNoAxeViolations(page, {
+    checkpoint: "event actions menu open",
+    knownIncomplete: [
+      {
+        ruleId: "aria-valid-attr-value",
+        reason:
+          "@floating-ui/react's FloatingPortal renders the menu into a " +
+          "separate DOM subtree from its trigger button. axe cannot " +
+          "statically confirm the trigger's aria-controls id is reachable " +
+          "across that portal boundary, even though the id exists and is " +
+          "valid at scan time (confirmed by directly querying the DOM in " +
+          "this same open-menu state).",
+      },
+      {
+        ruleId: "aria-hidden-focus",
+        reason:
+          "@floating-ui/react's FloatingFocusManager brackets portaled " +
+          "menu content with aria-hidden focus-guard sentinels and flips " +
+          "their tabindex at runtime to trap Tab focus inside the menu. " +
+          "Axe's static analysis can't evaluate that runtime toggle; the " +
+          "guards are library-owned, not app markup, and the trap is " +
+          "covered by @floating-ui/react's own tests.",
+      },
+    ],
+  });
+});
+
+test("the invalid-date validation error is accessible", async ({ page }) => {
+  await prepareCalendarPage(page);
+  await openAllDayEventFormWithMouse(page);
+
+  const startDateInput = page.locator('input[title="Pick Start Date"]');
+  await startDateInput.fill("not a date");
+  await startDateInput.press("Enter");
+  await expect(page.getByRole("alert")).toBeVisible();
+
+  await expectNoAxeViolations(page, { checkpoint: "invalid date error toast" });
+});

--- a/e2e/accessibility/datepicker-a11y.spec.ts
+++ b/e2e/accessibility/datepicker-a11y.spec.ts
@@ -1,5 +1,5 @@
-import AxeBuilder from "@axe-core/playwright";
 import { expect, type Locator, test } from "@playwright/test";
+import { expectNoAxeViolations } from "../utils/axe-assertion";
 import {
   ensureSidebarOpen,
   prepareCalendarPage,
@@ -17,10 +17,14 @@ test("sidebar datepicker meets baseline accessibility and contrast checks", asyn
   const monthPicker = sidebar.getByRole("group", { name: "Date navigation" });
   await expect(monthPicker).toBeVisible();
 
-  const scanResults = await new AxeBuilder({ page })
-    .include("#sidebar")
-    .analyze();
-  expect(scanResults.violations).toEqual([]);
+  // Scoped to #sidebar (not a whole-page scan): this test owns the
+  // datepicker's targeted contrast regression below, and scoping keeps that
+  // pairing - the axe pass and the per-date contrast check - about the same
+  // element on every run.
+  await expectNoAxeViolations(page, {
+    include: "#sidebar",
+    checkpoint: "sidebar datepicker",
+  });
 
   const days = monthPicker.locator(
     ".react-datepicker__day:not(.react-datepicker__day--disabled)",

--- a/e2e/utils/axe-assertion.ts
+++ b/e2e/utils/axe-assertion.ts
@@ -1,0 +1,104 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, type Page } from "@playwright/test";
+import type axe from "axe-core";
+
+// Verified against the installed axe-core version (4.12.1):
+// `grep -o 'wcag2[0-9a]*' node_modules/axe-core/axe.js | sort -u` returns
+// wcag2a, wcag2aa, wcag21a, wcag21aa, wcag22aa. WCAG 2.2 only added AA-level
+// success criteria (no new "A" ones), so wcag22aa is the complete addition -
+// there is no wcag22a tag to include. Re-run that grep after bumping
+// axe-core to confirm the tag set is still current before changing this.
+const WCAG_22_AA_TAGS = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22aa",
+];
+
+export interface KnownIncompleteResult {
+  /** The axe rule id (e.g. "aria-valid-attr-value"). */
+  ruleId: string;
+  /** Why axe cannot reliably decide this automatically, for this checkpoint. */
+  reason: string;
+}
+
+export interface AxeCheckOptions {
+  /** CSS selector to scope the scan to; omit to scan the whole page. */
+  include?: string;
+  /** Short label identifying the scanned state, used in failure output. */
+  checkpoint?: string;
+  /**
+   * Axe rule ids allowed to resolve as "incomplete" for this checkpoint,
+   * each with a recorded reason. This is not a blanket allowlist - anything
+   * incomplete that isn't listed here still doesn't fail the test (per the
+   * incomplete-result policy below), but is printed for manual review
+   * instead of silently passing through.
+   */
+  knownIncomplete?: KnownIncompleteResult[];
+}
+
+const formatNodes = (nodes: axe.NodeResult[]) =>
+  nodes
+    .map(
+      (node) =>
+        `    - ${node.target.join(" ")}\n      ${node.failureSummary?.replace(/\n/g, "\n      ") ?? ""}`,
+    )
+    .join("\n");
+
+const formatResults = (results: axe.Result[]) =>
+  results
+    .map(
+      (result) =>
+        `  [${result.impact ?? "unknown"}] ${result.id}: ${result.help}\n` +
+        `    ${result.helpUrl}\n${formatNodes(result.nodes)}`,
+    )
+    .join("\n\n");
+
+/**
+ * Runs Compass's standard axe scan against the given page (or a scoped
+ * region within it) and fails on any violation. `incomplete` results are
+ * never silently dropped: entries matching `knownIncomplete` are reported as
+ * explained; everything else is printed for manual review rather than
+ * failing the test, per the incomplete-result policy in
+ * docs/development/testing-playbook.md.
+ */
+export const expectNoAxeViolations = async (
+  page: Page,
+  { include, checkpoint, knownIncomplete = [] }: AxeCheckOptions = {},
+) => {
+  let builder = new AxeBuilder({ page }).withTags(WCAG_22_AA_TAGS);
+  if (include) {
+    builder = builder.include(include);
+  }
+
+  const results = await builder.analyze();
+  const label = checkpoint ? `[${checkpoint}] ` : "";
+
+  expect(
+    results.violations,
+    `${label}axe found ${results.violations.length} accessibility violation(s):\n\n${formatResults(results.violations)}`,
+  ).toEqual([]);
+
+  const explained = results.incomplete.filter((result) =>
+    knownIncomplete.some((known) => known.ruleId === result.id),
+  );
+  const unexplained = results.incomplete.filter(
+    (result) => !knownIncomplete.some((known) => known.ruleId === result.id),
+  );
+
+  if (explained.length > 0) {
+    const reasons = knownIncomplete
+      .filter((known) => explained.some((result) => result.id === known.ruleId))
+      .map((known) => `  - ${known.ruleId}: ${known.reason}`)
+      .join("\n");
+    console.log(`${label}axe reported known incomplete result(s):\n${reasons}`);
+  }
+
+  if (unexplained.length > 0) {
+    console.warn(
+      `${label}axe found ${unexplained.length} incomplete result(s) needing manual review ` +
+        `(not treated as a failure - see docs/development/testing-playbook.md):\n\n${formatResults(unexplained)}`,
+    );
+  }
+};

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@playwright/test": "^1.60.0",
     "@types/node": "^22.13.10",
     "@types/node-fetch": "^2.6.13",
+    "axe-core": "^4.12.1",
     "jest": "^29.0.3",
     "typescript": "^6.0.3"
   },

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -47,7 +47,10 @@
   --compass-color-tag-three: hsl(270 100 83);
   --compass-color-text-light: hsl(47 7 73);
   --compass-color-text-lighter: hsl(0 0 100);
-  --compass-color-text-light-inactive: hsl(208 13 71 / 54.9%);
+  /* 54.9% alpha measured 3.53:1 against --compass-color-bg-primary, below
+     the 4.5:1 minimum for normal text (e.g. past-week day labels). 70%
+     clears 5:1 while staying visibly muted relative to --color-text-light. */
+  --compass-color-text-light-inactive: hsl(208 13 71 / 70%);
   --compass-color-text-dark: hsl(222 28 7);
   --compass-color-text-dark-placeholder: hsl(219 8 46 / 90.2%);
   --compass-color-text-divider: #5f5f5f;

--- a/packages/web/src/layout/calendar-grid/components/CalendarAllDayEventCard.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarAllDayEventCard.tsx
@@ -13,7 +13,7 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { darken } from "@web/common/styles/color.utils";
+import { darken, isDark } from "@web/common/styles/color.utils";
 import { EVENT_COLOR, EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
@@ -67,7 +67,15 @@ const CalendarAllDayEventCardBase = (
   // contrast minimum. Darkening only the fill keeps the (fixed) title color's
   // contrast ratio intact.
   const bgColor = isInPast ? darken(baseColor, 5) : baseColor;
-  const hoverBgColor = !isPlaceholder ? hoverColor : bgColor;
+  // isInPast is excluded here (falls through to bgColor) so a past event
+  // stays dimmed on hover instead of snapping to full brightness.
+  const hoverBgColor = !isPlaceholder && !isInPast ? hoverColor : bgColor;
+  // The fill only ever gets darkened for past events, never lightened, but
+  // check dynamically (matching CalendarTimedEventCard) rather than assuming
+  // a fixed dark title color stays safe if the fill or darken amount changes.
+  const titleColorClassName = isDark(bgColor)
+    ? "text-text-lighter"
+    : "text-text-dark";
 
   const eventStyle = {
     "--event-bg": bgColor,
@@ -150,12 +158,17 @@ const CalendarAllDayEventCardBase = (
           "pr-3.5": showRepeatIcon,
         })}
       >
-        <span className="relative min-w-0 truncate text-text-dark text-xs">
+        <span
+          className={cn(
+            "relative min-w-0 truncate text-xs",
+            titleColorClassName,
+          )}
+        >
           {event.title}
           <SpaceCharacter />
         </span>
       </div>
-      {showRepeatIcon && <GridEventRepeatIcon baseColor={baseColor} />}
+      {showRepeatIcon && <GridEventRepeatIcon baseColor={bgColor} />}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: Resize handles are pointer-only drag targets hidden from assistive tech. */}
       <div
         aria-hidden="true"

--- a/packages/web/src/layout/calendar-grid/components/CalendarAllDayEventCard.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarAllDayEventCard.tsx
@@ -13,6 +13,7 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
+import { darken } from "@web/common/styles/color.utils";
 import { EVENT_COLOR, EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
@@ -61,10 +62,15 @@ const CalendarAllDayEventCardBase = (
   const isRecurring = isRecurringEvent(event);
   const showRepeatIcon =
     isRecurring && !isPlaceholder && position.width >= REPEAT_ICON_MIN_WIDTH;
-  const hoverBgColor = !isPlaceholder ? hoverColor : baseColor;
+  // A `brightness()` filter would scale the title text toward black right
+  // along with the fill, which is what let past events fall below the 4.5:1
+  // contrast minimum. Darkening only the fill keeps the (fixed) title color's
+  // contrast ratio intact.
+  const bgColor = isInPast ? darken(baseColor, 5) : baseColor;
+  const hoverBgColor = !isPlaceholder ? hoverColor : bgColor;
 
   const eventStyle = {
-    "--event-bg": baseColor,
+    "--event-bg": bgColor,
     "--event-hover-bg": hoverBgColor,
     height: position.height,
     left: position.left,
@@ -72,7 +78,6 @@ const CalendarAllDayEventCardBase = (
     top: position.top,
     width: position.width,
     zIndex: position.zIndex ?? ZIndex.LAYER_1,
-    filter: isInPast ? "brightness(0.7)" : "brightness(1)",
   } as CSSProperties;
 
   const showResizeCursor = !isPlaceholder;
@@ -145,7 +150,7 @@ const CalendarAllDayEventCardBase = (
           "pr-3.5": showRepeatIcon,
         })}
       >
-        <span className="relative min-w-0 truncate text-xs">
+        <span className="relative min-w-0 truncate text-text-dark text-xs">
           {event.title}
           <SpaceCharacter />
         </span>

--- a/packages/web/src/layout/calendar-grid/components/CalendarEventCard.test.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarEventCard.test.tsx
@@ -88,7 +88,10 @@ describe("CalendarEventCard", () => {
     render(
       <CalendarTimedEventCard
         displayMode="saved"
-        event={createEvent()}
+        event={createEvent({
+          startDate: "2099-01-15T09:00:00.000Z",
+          endDate: "2099-01-15T10:00:00.000Z",
+        })}
         isSelected={true}
         motionMode="idle"
         position={position}

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
@@ -14,7 +14,7 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { brighten, darken } from "@web/common/styles/color.utils";
+import { brighten, darken, isDark } from "@web/common/styles/color.utils";
 import { EVENT_COLOR, EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
@@ -112,12 +112,18 @@ const CalendarTimedEventCardBase = (
 
   const baseColor = EVENT_COLOR;
   const draftColor = darken(baseColor, 18);
+  // A `brightness()` filter would scale the title text toward black right
+  // along with the fill, which is what let past events fall below the 4.5:1
+  // contrast minimum. Darkening only the fill keeps the (fixed) title color's
+  // contrast ratio intact.
+  const pastColor = darken(baseColor, 5);
   const hoverColor = EVENT_HOVER_COLOR;
   const selectedBoxShadow = "0 0 0 1px rgba(255,255,255,0.55)";
 
   const bgColor = (() => {
     if (isDraft) return draftColor;
     if (isResizing || isDragging) return brighten(baseColor);
+    if (isInPast) return pastColor;
     return baseColor;
   })();
   const eventBoxShadow = isSelected
@@ -128,6 +134,13 @@ const CalendarTimedEventCardBase = (
 
   const hoverBgColor =
     !isDraft && !isPlaceholder && !isResizing ? hoverColor : bgColor;
+  // The fill is neutral and its lightness swings widely across states (the
+  // draft overlay in particular darkens far more than the others), so the
+  // title needs a text color chosen per-state rather than one fixed value to
+  // keep 4.5:1+ contrast against every fill.
+  const titleColorClassName = isDark(bgColor)
+    ? "text-text-lighter"
+    : "text-text-dark";
 
   const eventStyle = {
     "--event-bg": bgColor,
@@ -139,11 +152,7 @@ const CalendarTimedEventCardBase = (
     width: position.width || 0,
     zIndex: position.zIndex ?? ZIndex.LAYER_1,
     boxShadow: eventBoxShadow,
-    filter: isDraft
-      ? "drop-shadow(2px 4px 4px black)"
-      : isInPast
-        ? "brightness(0.7)"
-        : "brightness(1)",
+    filter: isDraft ? "drop-shadow(2px 4px 4px black)" : undefined,
   } as CSSProperties;
 
   const titleStyle: CSSProperties = {
@@ -244,7 +253,9 @@ const CalendarTimedEventCardBase = (
         />
       )}
       <div className="flex flex-col flex-wrap items-start">
-        <span style={titleStyle}>{event.title}</span>
+        <span className={titleColorClassName} style={titleStyle}>
+          {event.title}
+        </span>
         {!event.isAllDay && (
           <>
             {(isDraft || !isInPast) &&

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
@@ -132,8 +132,12 @@ const CalendarTimedEventCardBase = (
       : selectedBoxShadow
     : boxShadow;
 
+  // isInPast is excluded here (falls through to bgColor, i.e. pastColor) so
+  // a past event stays dimmed on hover instead of snapping to full brightness.
   const hoverBgColor =
-    !isDraft && !isPlaceholder && !isResizing ? hoverColor : bgColor;
+    !isDraft && !isPlaceholder && !isResizing && !isInPast
+      ? hoverColor
+      : bgColor;
   // The fill is neutral and its lightness swings widely across states (the
   // draft overlay in particular darkens far more than the others), so the
   // title needs a text color chosen per-state rather than one fixed value to
@@ -294,7 +298,7 @@ const CalendarTimedEventCardBase = (
           </>
         )}
       </div>
-      {showRepeatIcon && <GridEventRepeatIcon baseColor={baseColor} />}
+      {showRepeatIcon && <GridEventRepeatIcon baseColor={bgColor} />}
     </div>
   );
 };

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.test.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import dayjs from "@core/util/date/dayjs";
+import { CalendarTimedGrid } from "./CalendarTimedGrid";
+import { describe, expect, it } from "bun:test";
+
+const today = dayjs("2026-04-24T12:00:00.000Z");
+
+describe("CalendarTimedGrid", () => {
+  it("is reachable by Tab, not just by mouse click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <button type="button">Before</button>
+        <CalendarTimedGrid
+          eventsLayer={null}
+          onMouseDown={() => {}}
+          timedColumnsRef={() => {}}
+          timedGridRef={() => {}}
+          today={today}
+          visibleDates={[{ date: today, key: "today" }]}
+        />
+      </div>,
+    );
+
+    const grid = screen.getByRole("region", { name: "Timed events grid" });
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Before" })).toHaveFocus();
+
+    await user.tab();
+    expect(grid).toHaveFocus();
+  });
+});

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
@@ -56,10 +56,13 @@ export const CalendarTimedGrid: FC<CalendarTimedGridProps> = ({
   return (
     <section
       aria-label="Timed events grid"
-      className="c-scroll relative min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden [--scrollbar-width:0px]"
+      // c-scroll sets `:focus-visible { outline: none }`; restore a visible
+      // indicator now that this is a real Tab stop (see tabIndex below), or
+      // keyboard users get a focusable-but-invisible region.
+      className="c-scroll relative min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden [--scrollbar-width:0px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--compass-color-accent-primary)] focus-visible:[outline-offset:-1px]"
       id={timedGridId}
       ref={timedGridRef}
-      // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); tabIndex={-1} previously made a mouse click the only way in, and the app's arrow-key shortcuts (useWeekShortcuts) only activate once this is focused.
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); tabIndex={-1} previously made a mouse click the only way in.
       tabIndex={0}
     >
       <CalendarTimeColumn />

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedGrid.tsx
@@ -59,7 +59,8 @@ export const CalendarTimedGrid: FC<CalendarTimedGridProps> = ({
       className="c-scroll relative min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden [--scrollbar-width:0px]"
       id={timedGridId}
       ref={timedGridRef}
-      tabIndex={-1}
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); tabIndex={-1} previously made a mouse click the only way in, and the app's arrow-key shortcuts (useWeekShortcuts) only activate once this is focused.
+      tabIndex={0}
     >
       <CalendarTimeColumn />
       <div

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.test.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.test.tsx
@@ -19,6 +19,24 @@ const TestMenuItem = () => {
 };
 
 describe("ActionsMenu", () => {
+  it("exposes the trigger as a real button with aria-expanded reflecting open state", async () => {
+    const user = userEvent.setup();
+
+    renderMenu(
+      <ActionsMenu bgColor="#fff">{() => <TestMenuItem />}</ActionsMenu>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open actions menu" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
   it("keeps mouse hover from stealing focus from the editor action trigger", async () => {
     const user = userEvent.setup();
 

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
@@ -112,20 +112,21 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
 
   return (
     <>
-      <div
-        className="inline-flex"
-        ref={refs.setReference}
-        {...getReferenceProps({
-          onClick: (e: MouseEvent<HTMLDivElement>) => {
-            // Prevent default behaviour (like focusing inputs) and stop bubbling to parent form
-            e.preventDefault();
-            e.stopPropagation();
-            // Only set the flag for actual mouse clicks (detail > 0 indicates mouse click)
-            openedByMouseRef.current = e.detail > 0;
-          },
-        })}
-      >
+      {/* floating-ui's reference element only needs a DOM node to anchor
+      position tracking to; the interactive/ARIA props below go on the
+      button itself so a plain div doesn't end up with button-only
+      attributes like aria-expanded. */}
+      <div className="inline-flex" ref={refs.setReference}>
         <IconButton
+          {...getReferenceProps({
+            onClick: (e: MouseEvent<HTMLButtonElement>) => {
+              // Prevent default behaviour (like focusing inputs) and stop bubbling to parent form
+              e.preventDefault();
+              e.stopPropagation();
+              // Only set the flag for actual mouse clicks (detail > 0 indicates mouse click)
+              openedByMouseRef.current = e.detail > 0;
+            },
+          })}
           id={triggerId}
           aria-label="Open actions menu"
           aria-haspopup="menu"

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection.tsx
@@ -48,7 +48,7 @@ export const DateTimeSection: FC<Props> = ({
   endTime,
 }) => {
   return (
-    <div className="flex items-center gap-2" role="tablist">
+    <div className="flex items-center gap-2">
       {category === Categories_Event.ALLDAY && (
         <DatePickers
           displayEndDate={displayEndDate}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { useState } from "react";
+import dayjs from "@core/util/date/dayjs";
+import { getTimeOptionByValue } from "@web/common/utils/datetime/web.date.util";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { TimePickers } from "./TimePickers";
+import { describe, expect, it } from "bun:test";
+
+const START_DATE = new Date("2026-04-24T14:00:00.000Z");
+const END_DATE = new Date("2026-04-24T15:00:00.000Z");
+
+function Harness() {
+  const [draft, setDraft] = useState<GridEventDraft>(
+    createGridEventDraft(timedGridSchedule(START_DATE, END_DATE)),
+  );
+  const [startTime, setStartTime] = useState(
+    getTimeOptionByValue(dayjs(START_DATE)),
+  );
+  const [endTime, setEndTime] = useState(getTimeOptionByValue(dayjs(END_DATE)));
+
+  return (
+    <TimePickers
+      draft={draft}
+      endTime={endTime}
+      selectedEndDate={END_DATE}
+      selectedStartDate={START_DATE}
+      setDraft={setDraft}
+      setEndTime={setEndTime}
+      setStartTime={setStartTime}
+      startTime={startTime}
+    />
+  );
+}
+
+describe("TimePickers", () => {
+  it("gives the start and end pickers distinct accessible names", () => {
+    render(<Harness />);
+
+    const start = screen.getByRole("combobox", { name: "Start time" });
+    const end = screen.getByRole("combobox", { name: "End time" });
+
+    expect(start).not.toBe(end);
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -131,6 +131,7 @@ export const TimePickers: FC<Props> = ({
   return (
     <div className="flex items-center">
       <TimePicker
+        aria-label="Start time"
         inputId="startTimePicker"
         isMenuOpen={isStartMenuOpen}
         onChange={onStartSelected}
@@ -141,6 +142,7 @@ export const TimePickers: FC<Props> = ({
       />
       -
       <TimePicker
+        aria-label="End time"
         inputId="endTimePicker"
         isMenuOpen={isEndMenuOpen}
         onChange={onEndSelected}

--- a/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
+++ b/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
@@ -8,7 +8,8 @@ export const WeekGridScrollArea: FC<PropsWithChildren> = ({ children }) => {
         className="h-full w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] [scrollbar-width:none] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--compass-color-accent-primary)] focus-visible:[outline-offset:-1px] [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0"
         aria-label="Week calendar horizontal scroll area"
         id={ID_WEEK_GRID_SCROLLER}
-        tabIndex={-1}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); the focus-visible outline above was already styled for this, tabIndex={-1} just made it unreachable by Tab.
+        tabIndex={0}
       >
         {children}
       </section>


### PR DESCRIPTION
## Summary

Turns the accessibility strategy documented in `docs/development/testing-playbook.md` into a practical, maintainable testing system, per the layered model already described there (Biome → RTL → Playwright+axe → targeted regressions → manual review).

**Coverage model:** one shared axe assertion helper (`e2e/utils/axe-assertion.ts`, `expectNoAxeViolations`) used by a small representative smoke suite instead of a bespoke axe test per component.

**States now scanned** (`e2e/accessibility/app-a11y.spec.ts`):
- Week view (main authenticated calendar surface)
- Timed event form open
- All-day event form open
- Event actions menu open (a portaled, floating-ui menu)
- Invalid-date validation error toast

`e2e/accessibility/datepicker-a11y.spec.ts` (sidebar date navigation) was refactored onto the shared helper, preserving its targeted per-date contrast regression (default/hover/selected states, including the selected-date `::before` background) unchanged.

**WCAG tag set:** confirmed against the installed axe-core version (4.12.1) rather than assumed — `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa` (WCAG 2.2 only added AA-level criteria, so there's no `wcag22a` tag).

**Product defects found and fixed** by the new checkpoints:
- A `@floating-ui/react` reference `<div>` carried button-only ARIA attributes (`aria-expanded`, etc.) via a misplaced prop spread — moved onto the actual trigger `<button>` (`ActionsMenu.tsx`).
- `DateTimeSection.tsx` wrapped its (non-tab) date/time inputs in a stray `role="tablist"` — removed.
- The start/end time comboboxes had no accessible name — added `aria-label` (`TimePickers.tsx`).
- The timed-events grid and week horizontal scroll area were keyboard-unreachable (`tabIndex={-1}`) — WCAG 2.1.1 requires scrollable regions to be focusable; changed to `tabIndex={0}` with a `biome-ignore` explaining why (see below).
- Event-card titles had no explicit text color at all (silently inheriting the browser's default black) and past/dimmed events used a `brightness()` CSS filter that crushed whatever contrast existed. Fixed by giving titles a state-aware color (`isDark(bgColor) ? light : dark`) and moving "past" dimming into the background color computation instead of a filter, so text stays legible. Contrast now holds ≥4.5:1 in every state (base, hover/resize, draft, past).
- Bumped `--compass-color-text-light-inactive`'s alpha from 54.9% (3.53:1) to 70% (~5:1) — it was failing AA for muted/past text throughout the app.

**Incomplete-result policy:** `violations` fail the test; `incomplete` never fails (axe itself can't decide) but is never silently dropped — every incomplete result is printed, either as "known" (two documented, narrowly-scoped exceptions on the actions-menu checkpoint, both inherent to how `@floating-ui/react` portals/traps focus, not app markup) or as an unexplained result for manual review. The remaining unexplained `incomplete` results across checkpoints are all `color-contrast` cases axe structurally can't evaluate (overlapping absolutely-positioned elements, a CSS gradient, single-character date-cell text) — the same class of state the datepicker's targeted contrast test and manual review already cover.

**Biome rules promoted warn → error:** `noNoninteractiveElementToInteractiveRole`, `noPositiveTabindex`, `noSvgWithoutTitle`, `useAriaPropsForRole`, `useButtonType`, `useFocusableInteractive`, `useHtmlLang`, `useValidAriaRole` — all clean repo-wide with zero existing exceptions. Five rules stay at `warn` because they have standing, narrow `biome-ignore` exceptions elsewhere in the codebase (pointer-only drag/resize handles, `noStaticElementInteractions`; a `<form>` without an accessible name, `noRedundantRoles`; etc.) — promoting them would make "error" mean something less than zero exceptions.

**Hook/CI:** no Husky/git-hook setup exists in this repo; documented `bun run verify web` as the pre-push command in the testing playbook, relying on `test-unit.yml` (lint, type-check) and `test-e2e.yml` (`bun run test:e2e`, includes `e2e/accessibility`) as the CI backstop. Both workflows already trigger on any non-docs push/PR, so web/JSX/CSS changes are covered without changes to the workflow files themselves.

**PR checklist:** added `.github/PULL_REQUEST_TEMPLATE.md` (none existed) with a short accessibility section covering only what automation can't infer (keyboard reach, dynamic content exercised, zoom/reflow, screen-reader names, reduced-motion/forced-colors).

**Component tests added/updated** for the components the fixes touched: `ActionsMenu.test.tsx` (trigger is a real button, `aria-expanded` toggles), `TimePickers.test.tsx` (distinct accessible names), `CalendarTimedGrid.test.tsx` (reachable by Tab, not just mouse), and a date-fixture fix in `CalendarEventCard.test.tsx` (a test asserting the flat event color used a hardcoded real-past date, which now legitimately renders the new "past" dimmed color).

## Test plan

All commands run locally, full output inspected (not just exit codes):

- [x] `bun run test:web` — 1142 pass, 0 fail
- [x] `bun run test:core` — 233 pass, 0 fail
- [x] `bun run test:a11y` — 6 pass, 0 violations across all checkpoints
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean (1089 files, 0 warnings/errors)
- [x] `bun run verify web` — all checks pass end-to-end
- [x] `bun run test:e2e` — 19 pass, 0 fail (full Playwright suite, including all accessibility checkpoints and every existing calendar/drag/auth flow — no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)