### PR TITLE
fix(web): restore global cursor lock during event drag/resize

### DIFF
--- a/packages/web/src/interaction/dom/cursor/globalCursorLock.test.ts
+++ b/packages/web/src/interaction/dom/cursor/globalCursorLock.test.ts
@@ -1,0 +1,58 @@
+import { lockGlobalCursor } from "./globalCursorLock";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  document.documentElement.className = "";
+});
+
+describe("lockGlobalCursor", () => {
+  it("adds the cursor class while locked and removes it on release", () => {
+    const release = lockGlobalCursor("move");
+
+    expect(document.documentElement.classList.contains("cursor-move")).toBe(
+      true,
+    );
+
+    release();
+
+    expect(document.documentElement.classList.contains("cursor-move")).toBe(
+      false,
+    );
+  });
+
+  it("has an idempotent release (repeated calls are safe)", () => {
+    const release = lockGlobalCursor("move");
+
+    release();
+    release();
+
+    expect(document.documentElement.classList.contains("cursor-move")).toBe(
+      false,
+    );
+  });
+
+  it("tracks distinct cursors independently", () => {
+    const releaseMove = lockGlobalCursor("move");
+    const releaseResize = lockGlobalCursor("row-resize");
+
+    expect(document.documentElement.classList.contains("cursor-move")).toBe(
+      true,
+    );
+    expect(
+      document.documentElement.classList.contains("cursor-row-resize"),
+    ).toBe(true);
+
+    releaseMove();
+    expect(document.documentElement.classList.contains("cursor-move")).toBe(
+      false,
+    );
+    expect(
+      document.documentElement.classList.contains("cursor-row-resize"),
+    ).toBe(true);
+
+    releaseResize();
+    expect(
+      document.documentElement.classList.contains("cursor-row-resize"),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/interaction/dom/cursor/globalCursorLock.ts
+++ b/packages/web/src/interaction/dom/cursor/globalCursorLock.ts
@@ -1,0 +1,59 @@
+/**
+ * Single place that forces a cursor globally during a drag/resize interaction.
+ *
+ * Adds a `cursor-<value>` class to <html>, backed by a stylesheet this module
+ * injects into <head>. The rule uses `* { cursor: <value> !important }` so it
+ * wins over the `cursor-*` classes that event cards/grid declare (which
+ * otherwise own the cursor under the pointer). Inline `document.body.style`
+ * can't win that fight, and a rule placed in index.css ends up inside a Tailwind
+ * `@layer` and loses to the layered utilities — so the rule is injected at
+ * runtime, unlayered, which beats the layered utilities deterministically.
+ *
+ * Every drag path calls this directly and keeps the returned release fn: the
+ * engine draft event (Week + Day saved events) and the Week draft. Interactions
+ * are mutually exclusive (one drag/resize at a time, and the engine releases
+ * its prior lock before mounting a new draft event), so a plain add-on-lock /
+ * remove-on-release is sufficient. The release is idempotent so repeated calls
+ * (e.g. React StrictMode cleanup) are safe.
+ */
+
+const STYLE_ELEMENT_ID = "compass-global-cursor-lock";
+
+const CURSOR_LOCK_CSS = `
+html.cursor-move, html.cursor-move * { cursor: move !important; }
+html.cursor-col-resize, html.cursor-col-resize * { cursor: col-resize !important; }
+html.cursor-row-resize, html.cursor-row-resize * { cursor: row-resize !important; }
+`;
+
+const ensureStyleInjected = () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  if (document.getElementById(STYLE_ELEMENT_ID)) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = STYLE_ELEMENT_ID;
+  style.textContent = CURSOR_LOCK_CSS;
+  document.head.appendChild(style);
+};
+
+export const lockGlobalCursor = (cursor: string): (() => void) => {
+  ensureStyleInjected();
+
+  const className = `cursor-${cursor}`;
+  document.documentElement.classList.add(className);
+
+  let released = false;
+
+  return () => {
+    if (released) {
+      return;
+    }
+
+    released = true;
+    document.documentElement.classList.remove(className);
+  };
+};

--- a/packages/web/src/interaction/dom/draft-event/FloatingDraftEvent.ts
+++ b/packages/web/src/interaction/dom/draft-event/FloatingDraftEvent.ts
@@ -1,14 +1,18 @@
 import { ZIndex } from "@web/common/constants/web.constants";
 import { type CalendarInteractionPoint } from "../../CalendarInteractionSession";
+import { lockGlobalCursor } from "../cursor/globalCursorLock";
 
 export class FloatingDraftEvent {
   #node: HTMLElement | null = null;
+  #releaseCursor: (() => void) | null = null;
 
   mount({
     clone,
+    cursor,
     rect,
   }: {
     clone: HTMLElement;
+    cursor?: string;
     rect: {
       height: number;
       left: number;
@@ -32,6 +36,10 @@ export class FloatingDraftEvent {
 
     document.body.append(clone);
     this.#node = clone;
+
+    if (cursor) {
+      this.#releaseCursor = lockGlobalCursor(cursor);
+    }
   }
 
   update({
@@ -66,6 +74,9 @@ export class FloatingDraftEvent {
   }
 
   unmount() {
+    this.#releaseCursor?.();
+    this.#releaseCursor = null;
+
     this.#node?.remove();
     this.#node = null;
   }

--- a/packages/web/src/layout/calendar-grid/interaction/calendarInteractionDom.ts
+++ b/packages/web/src/layout/calendar-grid/interaction/calendarInteractionDom.ts
@@ -40,8 +40,10 @@ export const updateCalendarDraftEventTimeLabel = (
 };
 
 export const createCalendarInteractionDraftEventMount = ({
+  cursor,
   source,
 }: {
+  cursor?: string;
   source: HTMLElement;
 }): FloatingDraftEventMount => {
   const rect = source.getBoundingClientRect();
@@ -58,6 +60,7 @@ export const createCalendarInteractionDraftEventMount = ({
 
   return {
     clone,
+    cursor,
     rect: {
       height: rect.height,
       left: rect.left,

--- a/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/DayInteractionAdapter.ts
@@ -312,8 +312,9 @@ export const createDayInteractionAdapter = ({
           startMinutes: getLocalMinutes(target.event.startDate),
         });
       },
-      getDraftEventMount: ({ sourceElement }) =>
+      getDraftEventMount: ({ sourceElement, target }) =>
         createCalendarInteractionDraftEventMount({
+          cursor: getInteractionCursor(target),
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
@@ -798,6 +799,18 @@ const getOwnershipReason = (target: DayInteractionTarget) => {
       return "saved-timed-resize";
     case "timedDrag":
       return "saved-timed-drag";
+  }
+};
+
+const getInteractionCursor = (target: DayInteractionTarget) => {
+  switch (target.type) {
+    case "allDayResize":
+      return "col-resize";
+    case "timedResize":
+      return "row-resize";
+    case "allDayDrag":
+    case "timedDrag":
+      return "move";
   }
 };
 

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
@@ -1,6 +1,7 @@
-import { type Dispatch, type SetStateAction, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
+import { lockGlobalCursor } from "@web/interaction/dom/cursor/globalCursorLock";
 
 export interface Status_Drag {
   durationMin: number;
@@ -47,6 +48,17 @@ const ZERO_DRAG_OFFSET: DragOffset = { x: 0, y: 0 };
 export const useDraftState = () => {
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
+
+  // Force the `move` cursor while dragging a draft, via the same global lock
+  // the engine uses. Callers only toggle `setIsDragging`; the cursor follows.
+  // The lock is released when the drag stops or the component unmounts.
+  useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+
+    return lockGlobalCursor("move");
+  }, [isDragging]);
   const [draft, setDraft] = useState<GridEventDraft | null>(null);
   // Mid-drag cursor-offset (pixels between the pointer and the dragged
   // event's origin), populated only while a mouse-drag is active. Kept as a

--- a/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/WeekInteractionAdapter.ts
@@ -314,8 +314,9 @@ export const createWeekInteractionAdapter = ({
           target,
         });
       },
-      getDraftEventMount: ({ sourceElement }) =>
+      getDraftEventMount: ({ sourceElement, target }) =>
         createCalendarInteractionDraftEventMount({
+          cursor: getInteractionCursor(target),
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
@@ -727,6 +728,18 @@ const getOwnershipReason = (target: WeekInteractionTarget) => {
       return "saved-timed-resize";
     case "timedDrag":
       return "saved-timed-drag";
+  }
+};
+
+const getInteractionCursor = (target: WeekInteractionTarget) => {
+  switch (target.type) {
+    case "allDayResize":
+      return "col-resize";
+    case "timedResize":
+      return "row-resize";
+    case "allDayDrag":
+    case "timedDrag":
+      return "move";
   }
 };
 


### PR DESCRIPTION
## Summary

Closes #1786.

[#1886](https://github.com/SwitchbackTech/compass-calendar/pull/1886) removed cursor styling from the interaction engine with nothing replacing it. Pointer capture still redirects pointer *events* during a drag, but it can't influence the browser's native cursor rendering — that's purely a function of what DOM element sits under the screen coordinates. So the moment the pointer drifts off-grid mid-drag (header, sidebar, "Add to week" button), that element's own `cursor-*` class wins and the drag looks broken/disconnected.

This restores the tested global-cursor-lock approach from the never-merged commit `4cdba1c98`, ported onto the renamed post-#1886 files:

- **`interaction/dom/cursor/globalCursorLock.ts`** (new, + test): `lockGlobalCursor(cursor)` adds a `cursor-<value>` class to `<html>`, backed by a runtime-injected `* { cursor: <value> !important }` rule. Injected unlayered so it deterministically beats Tailwind's layered `cursor-pointer`/`cursor-default` utilities on event cards. Returns an idempotent release fn.
- **`FloatingDraftEvent`**: `mount()` accepts the (already-typed, previously unused) `cursor` field and takes the lock; `unmount()` releases it — so the lock lifetime exactly matches the drag-visual lifetime, including the engine's deferred teardown.
- **Week + Day adapters**: restored `getInteractionCursor(target)` (`move` for drags, `col-resize`/`row-resize` for all-day/timed resizes) and pass it through `createCalendarInteractionDraftEventMount`.
- **`useDraftState`** (legacy Week draft path): `isDragging` effect takes/releases the same lock.

No new clamping logic: the draft-event position math already clamps to grid bounds; the "lost mouse" / "gap" symptoms in the issue come from the missing cursor lock.

## Manual Testing Steps

1. In Week view, drag a saved timed event and, while the mouse is down, move the pointer over the header/sidebar — cursor stays `move`, including over hover-styled buttons.
2. Resize a timed event (`row-resize`) and an all-day event (`col-resize`) — cursor holds while the pointer strays off-grid.
3. Release the pointer off-grid — cursor returns to normal after the drop commits; no stuck `move` cursor.
4. Drag an unsaved draft event — same `move` lock via the legacy path.

## Verification done

- `bun run type-check`, `bun run lint`, and 84 interaction/draft tests + 3 new `globalCursorLock` tests all pass.
- Verified live in a local preview: simulated a full drag lifecycle; mid-drag over a sidebar button the computed cursor was `move`, style tag injected once, and the `cursor-move` class was released after the engine's deferred teardown. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)