### PR TITLE
refactor(web): remove dead EventForm plumbing and latest-ref indirection

### DIFF
--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -3,7 +3,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
 } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Calendar } from "@core/types/calendar.contracts";
@@ -193,11 +192,6 @@ export function DayCalendarGrid() {
       openDraftEventForm,
     );
   }, [dateInView, draft, openDraftEventForm]);
-  const createAllDayDraftRef = useRef(createAllDayDraftFromShortcut);
-
-  useEffect(() => {
-    createAllDayDraftRef.current = createAllDayDraftFromShortcut;
-  }, [createAllDayDraftFromShortcut]);
 
   // "c" shortcut: create a timed draft on the day in view, defaulting to the
   // next quarter-hour (or the current time when viewing today), mirroring the
@@ -214,34 +208,18 @@ export function DayCalendarGrid() {
       openDraftEventForm,
     );
   }, [dateInView, draft, openDraftEventForm]);
-  const createTimedDraftRef = useRef(createTimedDraftFromShortcut);
 
-  useEffect(() => {
-    createTimedDraftRef.current = createTimedDraftFromShortcut;
-  }, [createTimedDraftFromShortcut]);
-
-  useEffect(() => {
-    const handleCreateAllDayDraft = () => {
-      createAllDayDraftRef.current();
-    };
-    const handleCreateTimedDraft = () => {
-      createTimedDraftRef.current();
-    };
-
-    const unsubscribeCreateAllDayDraft = onViewCommand(
-      "CREATE_ALLDAY_DRAFT",
-      handleCreateAllDayDraft,
-    );
-    const unsubscribeCreateTimedDraft = onViewCommand(
-      "CREATE_TIMED_DRAFT",
-      handleCreateTimedDraft,
-    );
-
-    return () => {
-      unsubscribeCreateAllDayDraft();
-      unsubscribeCreateTimedDraft();
-    };
-  }, []);
+  // onViewCommand returns its own unsubscribe and emitViewCommand reads the
+  // listener set at emit time, so re-subscribing when the handler identity
+  // changes is safe — no latest-ref mirror needed.
+  useEffect(
+    () => onViewCommand("CREATE_ALLDAY_DRAFT", createAllDayDraftFromShortcut),
+    [createAllDayDraftFromShortcut],
+  );
+  useEffect(
+    () => onViewCommand("CREATE_TIMED_DRAFT", createTimedDraftFromShortcut),
+    [createTimedDraftFromShortcut],
+  );
   const onAllDayMouseDown = useAllDayDraftCreation({
     getStartDate: getAllDayDraftStartDate,
     onCreateDraft: openDraftEventForm,

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect, useRef } from "react";
+import { type RefObject, useCallback, useEffect } from "react";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { getCurrentMinute } from "@web/common/utils/grid/grid.util";
 import { CALENDAR_TIMED_VISIBLE_HOURS } from "@web/layout/calendar-grid/calendarGrid.constants";
@@ -17,18 +17,15 @@ export const useDayCalendarScrollToNow = (
       top: getCurrentMinute() * minuteHeight - 150,
     });
   }, [mainGridRef]);
-  const scrollToNowRef = useRef(scrollToNow);
 
   useEffect(() => {
     if (mainGridRef.current) scrollToNow();
   }, [mainGridRef, scrollToNow]);
 
-  useEffect(() => {
-    scrollToNowRef.current = scrollToNow;
-  }, [scrollToNow]);
-
-  useEffect(() => {
-    const handleScrollToNow = () => scrollToNowRef.current();
-    return onViewCommand("SCROLL_TO_NOW_LINE", handleScrollToNow);
-  }, []);
+  // scrollToNow is stable (depends only on the stable mainGridRef), and
+  // onViewCommand returns its own unsubscribe, so subscribe directly.
+  useEffect(
+    () => onViewCommand("SCROLL_TO_NOW_LINE", scrollToNow),
+    [scrollToNow],
+  );
 };

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayViewShortcuts.ts
@@ -16,9 +16,6 @@ interface KeyboardShortcutsConfig {
   onNextDay?: () => void;
   onPrevDay?: () => void;
   onGoToToday?: () => void;
-
-  // General
-  onEscape?: () => void;
 }
 
 /**
@@ -36,7 +33,6 @@ export function useDayViewShortcuts(config: KeyboardShortcutsConfig) {
     onNextDay,
     onPrevDay,
     onGoToToday,
-    onEscape,
   } = config;
 
   useAppShortcutUp("J", () => {
@@ -63,16 +59,12 @@ export function useDayViewShortcuts(config: KeyboardShortcutsConfig) {
     onCreateAllDayEvent?.();
   });
 
-  useAppShortcut(
-    "Escape",
-    () => {
-      onEscape?.();
-    },
-    {
-      ignoreInputs: false,
-      blurOnTrigger: true,
-    },
-  );
+  // No handler body: this registration exists only for blurOnTrigger, which
+  // blurs the focused element on Escape regardless of the callback.
+  useAppShortcut("Escape", () => {}, {
+    ignoreInputs: false,
+    blurOnTrigger: true,
+  });
 
   // Calendar shortcuts
   useAppShortcutUp("I", () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -1,7 +1,7 @@
 import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { act, createRef, type SetStateAction, useState } from "react";
+import { act, type SetStateAction, useState } from "react";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { renderWithStore } from "@web/__tests__/render-with-store";
@@ -585,25 +585,5 @@ describe("EventForm", () => {
     await user.keyboard("{Enter}");
 
     expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("exposes the title input ref to the parent", () => {
-    const titleInputRef = createRef<HTMLInputElement>();
-
-    renderWithStore(
-      <EventForm
-        draft={createEditDraft()}
-        isDraft={true}
-        isExistingEvent={false}
-        onClose={mock()}
-        onDelete={mock()}
-        onDuplicate={mock()}
-        onSubmit={mock()}
-        setDraft={mock()}
-        titleInputRef={titleInputRef}
-      />,
-    );
-
-    expect(titleInputRef.current).toBe(screen.getByPlaceholderText("Title"));
   });
 });

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -130,7 +130,7 @@ const handleEventFormDelete = ({
   onDelete();
 };
 
-export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
+export const EventForm: React.FC<GridEventFormProps> = memo(
   ({
     draft,
     onClose: _onClose,
@@ -138,7 +138,6 @@ export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
     onSubmit,
     onDuplicate,
     setDraft,
-    titleInputRef,
     isDraft,
     isExistingEvent,
     ...props
@@ -187,7 +186,6 @@ export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
       () => createDateTimeState(eventStartDate, eventEndDate),
     );
 
-    const descriptionRef = useRef<HTMLTextAreaElement>(null);
     const currentDateTimeState = useMemo(
       () => resolveDateTimeState(dateTimeState, eventStartDate, eventEndDate),
       [dateTimeState, eventEndDate, eventStartDate],
@@ -539,7 +537,6 @@ export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
                 onKeyDown={handleTitleKeyDown}
                 placeholder="Title"
                 name="Event Title"
-                ref={titleInputRef}
                 underlineColor={EVENT_COLOR}
                 value={displayTitle}
                 withUnderline
@@ -589,7 +586,6 @@ export const EventForm: React.FC<Omit<GridEventFormProps, "category">> = memo(
                 onChange={onChangeEventTextField("description")}
                 onKeyDown={handleIgnoredKeys}
                 placeholder="Description"
-                ref={descriptionRef}
                 value={event.description || ""}
                 className="relative max-h-45 w-full overflow-y-auto border-hidden bg-transparent"
               />

--- a/packages/web/src/views/Forms/EventForm/types.ts
+++ b/packages/web/src/views/Forms/EventForm/types.ts
@@ -1,13 +1,11 @@
-import { type Dispatch, type Ref, type SetStateAction } from "react";
+import { type Dispatch, type SetStateAction } from "react";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
-import { type Categories_Event } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 
 // EventForm's props: the grid draft forms (Day + Week) both converge on the
 // canonical GridEventDraft.
 export interface GridEventFormProps {
   draft: GridEventDraft;
-  category: Categories_Event;
   isDraft: boolean;
   isExistingEvent: boolean;
   onClose: () => void;
@@ -15,11 +13,6 @@ export interface GridEventFormProps {
   onDuplicate?: (draft: GridEventDraft) => void;
   onSubmit: (draft: GridEventDraft | null) => void;
   setDraft: Dispatch<SetStateAction<GridEventDraft | null>>;
-  titleInputRef?: Ref<HTMLInputElement>;
 }
 
-type EventField = "title" | "description" | "startDate" | "endDate";
-export type SetEventFormField = (
-  field: Partial<CompassEvent>,
-  value?: CompassEvent[EventField],
-) => void;
+export type SetEventFormField = (field: Partial<CompassEvent>) => void;


### PR DESCRIPTION
## Summary

Cross-PR cleanup surfaced by the evening cleanup ritual reviewing the merge
window since the last cleanup. The #2091 (someday removal) / #2092 (sidebar
docking) reconciliation and the Day split-by-calendar work left behind dead
props and unnecessary React ref/effect indirection. All changes are
behavior-preserving.

- **DayCalendarGrid / useDayCalendarScrollToNow** — drop the "latest-ref"
  mirrors (`useRef` + a syncing `useEffect`) around the view-command handlers.
  `onViewCommand` returns its own unsubscribe and `emitViewCommand` reads the
  listener set at emit time, so subscribing each handler directly (with the
  effect keyed on the handler's identity) is equivalent — no ref needed.
- **useDayViewShortcuts** — remove the `onEscape` prop, which no caller ever
  supplied (so `onEscape?.()` was always a no-op). The `Escape` registration
  stays for its `blurOnTrigger` side effect.
- **EventForm** — remove the dead `titleInputRef` (unused since the sidebar
  relocation replaced type-to-focus-title with `autoFocus`) and its now-orphan
  test, the never-dereferenced `descriptionRef`, the `category` type field
  (already `Omit`-ted by the only consumer), and `SetEventFormField`'s unused
  second `value` parameter.

## Simplicity

Net **−64 lines** and a strict reduction in hooks: **−4 `useRef`, −2 `useEffect`**,
with **zero** new state or effects introduced. The removed effects were pure
indirection — they mirrored a callback into a ref so a `[]`-deps subscription
could read "the latest" version; subscribing the callback directly and letting
the effect re-run on its identity change does the same thing with less code.
No `useEffect`/`useRef`/`useState` was added or deliberately kept.

## Manual Testing Steps

> Note: local browser validation was constrained — this worktree's dev server
> port (9080) was held by another session and is config-file-driven, so the
> walkthrough below is for a reviewer to run. The rewritten subscription pattern
> is directly covered by the automated "scrolls to now when the Day view
> requests it" test, which drives the same `emitViewCommand` → direct-subscribe
> path.

- [ ] Open the Day view. Press `c` — a new timed event draft form should open on
      the day in view. Press Escape to dismiss it.
- [ ] In the Day view, press `a` — a new all-day event draft form should open.
- [ ] In the Day view while viewing today, scroll away from the current time,
      then trigger "scroll to now" (switch off and back to today) — the timed
      grid should smooth-scroll back to the current-time line.
- [ ] Click an existing event to open its details form in the sidebar. Confirm
      the title field is focused on open, you can edit the title and description,
      and Save persists the change.
- [ ] With an event form open, press Escape — the form closes and focus leaves
      the field (blur).

## Test plan

- [x] `bun run type-check` — green
- [x] `bun test --cwd packages/web src/views/Forms/EventForm src/views/Day` —
      102 pass, 0 fail
- [x] Correctness review (code-review, medium) on the diff — no findings