### PR TITLE
refactor(backend): dedupe repeated helpers across google sync services

### DIFF
--- a/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
+++ b/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.ts
@@ -29,6 +29,22 @@ const logger = Logger("app:google-calendarlist.service");
 type ReconcileResult = { outcome: "RECONCILED" | "IGNORED" };
 
 /**
+ * The set of Google calendar ids whose event import has completed at least
+ * one full pass, i.e. holds a nextSyncToken. An import left mid-checkpoint
+ * carries only a nextPageToken, so it is deliberately excluded here and will
+ * resume from that checkpoint rather than being treated as already imported.
+ */
+function importedGCalIds(
+  sync: Awaited<ReturnType<typeof getSync>>,
+): Set<string> {
+  return new Set(
+    (sync?.google?.events ?? [])
+      .filter((entry) => entry.nextSyncToken)
+      .map((entry) => entry.gCalendarId),
+  );
+}
+
+/**
  * Per-user serialization: concurrent webhook deliveries for the same user
  * must not race each other (e.g. double-importing a newly-added calendar or
  * double-starting a watch). A call for a user whose reconcile is already in
@@ -123,14 +139,7 @@ async function runReconcile(
   // re-checking after each write) keeps every entry in this delta judged
   // against the same state, and correctly reflects an earlier run's
   // completed import when this call is itself a duplicate/retried delivery.
-  // Only entries holding a nextSyncToken count: a mid-failed import leaves
-  // an entry with just a nextPageToken checkpoint, and importAllEvents must
-  // run again to resume it from that checkpoint.
-  const alreadyImportedGCalIds = new Set(
-    (sync?.google?.events ?? [])
-      .filter((entry) => entry.nextSyncToken)
-      .map((entry) => entry.gCalendarId),
-  );
+  const alreadyImportedGCalIds = importedGCalIds(sync);
 
   const affectedHexIds = new Set<string>();
   const eventsChangedHexIds = new Set<string>();
@@ -273,15 +282,8 @@ async function reconcileFromFullList(
     upserts.map((entry) => entry.id).filter((id): id is string => !!id),
   );
 
-  // Same rationale as runReconcile's alreadyImportedGCalIds: only entries
-  // holding a nextSyncToken count as "already imported", so an import left
-  // mid-checkpoint by an earlier run resumes instead of being skipped.
   const sync = await getSync({ userId });
-  const alreadyImportedGCalIds = new Set(
-    (sync?.google?.events ?? [])
-      .filter((entry) => entry.nextSyncToken)
-      .map((entry) => entry.gCalendarId),
-  );
+  const alreadyImportedGCalIds = importedGCalIds(sync);
 
   const userObjectId = new ObjectId(userId);
   const staleRows = await mongoService.calendar
@@ -343,6 +345,23 @@ async function reconcileFromFullList(
 }
 
 /**
+ * Tears down the event machinery a Google calendar accumulates while it is
+ * event-capable: its watch, its events sync entry, and its imported events.
+ * Shared by a full removal (the calendar row is archived) and an access
+ * downgrade to freeBusyReader (the row stays, but stops carrying events).
+ */
+async function tearDownEventMachinery(
+  userId: string,
+  gCalendarId: string,
+  calendarObjectId: ObjectId,
+  context: GoogleRequestContext,
+): Promise<void> {
+  await stopWatchIfPresent(userId, gCalendarId, context);
+  await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
+  await eventRepository.deleteByCalendarIds([calendarObjectId]);
+}
+
+/**
  * Archives one Google calendar row and tears down everything that depends
  * on it being live: its watch, its events sync entry, and its events.
  * Shared by the delta path (an entry flagged deleted/hidden) and the
@@ -358,9 +377,7 @@ async function teardownRemovedCalendar(
   const row = await calendarService.archiveGoogleCalendar(userId, gCalendarId);
   if (!row) return null;
 
-  await stopWatchIfPresent(userId, gCalendarId, context);
-  await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
-  await eventRepository.deleteByCalendarIds([row._id]);
+  await tearDownEventMachinery(userId, gCalendarId, row._id, context);
 
   return { hexId: row._id.toHexString(), isVisible: row.isVisible };
 }
@@ -396,9 +413,7 @@ async function applyUpsertedRecords(
     if (record.access === "freeBusyReader") {
       // A7: freeBusyReader calendars never manufacture event records - tear
       // down anything left behind by a prior, more-permissive role.
-      await stopWatchIfPresent(userId, gCalendarId, context);
-      await removeSyncEntry(Resource_Sync.EVENTS, userId, gCalendarId);
-      await eventRepository.deleteByCalendarIds([record._id]);
+      await tearDownEventMachinery(userId, gCalendarId, record._id, context);
       continue;
     }
 

--- a/packages/backend/src/sync/services/import/google-import.service.ts
+++ b/packages/backend/src/sync/services/import/google-import.service.ts
@@ -54,6 +54,26 @@ const addStats = (
   totalInvalid: stats.totalInvalid + delta.invalid,
 });
 
+type GoogleCalendarRecord = CalendarRecord & {
+  source: Extract<CalendarRecord["source"], { provider: "google" }>;
+};
+
+/**
+ * Every import path operates on exactly one Google calendar, so each entry
+ * point narrows its CalendarRecord to the Google-sourced variant up front.
+ */
+function assertGoogleCalendar(
+  calendar: CalendarRecord,
+  method: string,
+): asserts calendar is GoogleCalendarRecord {
+  if (calendar.source.provider !== "google") {
+    throw error(
+      GcalError.Unsure,
+      `${method} requires a Google-sourced calendar`,
+    );
+  }
+}
+
 /**
  * Imports Google Calendar events onto their owning CalendarRecord (B8).
  * Callers resolve a Google CalendarRecord (any owner/writer/reader calendar,
@@ -84,12 +104,7 @@ export class SyncImport {
     calendar: CalendarRecord,
     perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
   ): Promise<ImportStats & { nextSyncToken: string }> {
-    if (calendar.source.provider !== "google") {
-      throw error(
-        GcalError.Unsure,
-        "importAllEvents requires a Google-sourced calendar",
-      );
-    }
+    assertGoogleCalendar(calendar, "importAllEvents");
 
     logger.info(
       `Starting importAllEvents for user ${userId}, calendar ${calendar.source.calendarId}.`,
@@ -171,12 +186,7 @@ export class SyncImport {
     calendar: CalendarRecord,
     perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
   ): Promise<ImportStats> {
-    if (calendar.source.provider !== "google") {
-      throw error(
-        GcalError.Unsure,
-        "importLatestEvents requires a Google-sourced calendar",
-      );
-    }
+    assertGoogleCalendar(calendar, "importLatestEvents");
 
     const gCalendarId = calendar.source.calendarId;
     const sync = await getSync({ userId });
@@ -208,12 +218,7 @@ export class SyncImport {
     initialSyncToken: string,
     perPage = DEFAULT_GCAL_EVENTS_PER_PAGE,
   ): Promise<ImportStats> {
-    if (calendar.source.provider !== "google") {
-      throw error(
-        GcalError.Unsure,
-        "importEventsByCalendar requires a Google-sourced calendar",
-      );
-    }
+    assertGoogleCalendar(calendar, "importEventsByCalendar");
 
     const sync = new GoogleEventSync(this.context, calendar);
 


### PR DESCRIPTION
## Summary

Cross-PR cleanup surfaced by the evening cleanup ritual reviewing the
sub-calendar sync merge window. Three duplications that only became visible
with the sibling functions side by side, all behavior-preserving:

- **`google-calendarlist.service`** — extract `importedGCalIds(sync)`, the
  identical "google.events entries holding a `nextSyncToken`" set that
  `runReconcile` and `reconcileFromFullList` each built inline.
- **`google-calendarlist.service`** — extract `tearDownEventMachinery()`, the
  `stopWatchIfPresent` + `removeSyncEntry(EVENTS)` + `deleteByCalendarIds` trio
  shared by `teardownRemovedCalendar` (full removal) and the `freeBusyReader`
  access-downgrade branch of `applyUpsertedRecords`.
- **`google-import.service`** — extract `assertGoogleCalendar()`, the identical
  `source.provider !== "google"` guard repeated verbatim at all three import
  entry points (`importAllEvents`, `importLatestEvents`,
  `importEventsByCalendar`), now a single type-narrowing assertion that also
  removes the per-call-site narrowing boilerplate.

## Simplicity

Net small line change but a real reduction in duplication: two copies of the
imported-ids set, two copies of the teardown trio, and three copies of the
provider guard collapse to one definition each. No new state, no new runtime
work — each helper does exactly what the inlined code did. The extracted
`assertGoogleCalendar` is a TypeScript assertion function, so the three call
sites keep their existing narrowing of `calendar.source` to the Google variant
with no `as` casts. No `useEffect`/`useRef`/`useState` involved (backend).

## Manual Testing Steps

This is a backend refactor with no user-observable surface of its own; it
exercises the Google sub-calendar sync paths. A reviewer can confirm the
behavior is unchanged by running the covering suites:

- [ ] `TZ=UTC ./node_modules/.bin/jest --selectProjects backend calendarlist import`
      — the calendarlist reconcile (delta + full-list recovery) and the import
      entry-point guard tests should pass.
- [ ] Sanity-read the diff: the three extracted helpers each match the code
      they replaced (same call order in `tearDownEventMachinery`, same
      `nextSyncToken` filter in `importedGCalIds`, same error type/message in
      `assertGoogleCalendar`).

## Test plan

- [x] `bun run type-check` — green (the `assertGoogleCalendar` assertion
      narrows correctly at all three call sites)
- [x] `TZ=UTC jest --selectProjects backend calendarlist import` — 24 pass, 3 skipped
- [x] `biome check` on both files — clean
- [x] Correctness review (angles: line-by-line, removed-behavior, cross-file) — no findings