### PR TITLE
feat(web): ensure all focus areas have visible feedback

### DIFF
--- a/e2e/accessibility/focus-visible.spec.ts
+++ b/e2e/accessibility/focus-visible.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import {
+  ensureSidebarOpen,
+  prepareCalendarPage,
+} from "../utils/event-test-utils";
+
+// Regression guard for "feat(web): ensure all focus areas have visible
+// feedback". The "u" shortcut used to move focus into the sidebar with no
+// visible indicator (it landed on a month-nav chevron that had no focus
+// style, and a global outline reset stripped the fallback). It now lands on
+// the month picker's tab-stoppable day, which shows an accent focus ring.
+test("the 'u' shortcut moves focus to a visibly-focused sidebar day", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+  await ensureSidebarOpen(page);
+
+  // A real (trusted) keypress so :focus-visible resolves as it would for a
+  // keyboard user, and so the app's keyup shortcut handler fires.
+  await page.locator("#mainGrid").focus();
+  await page.keyboard.press("u");
+
+  const focused = page.locator(".react-datepicker__day:focus");
+  await expect(focused).toBeVisible();
+  await expect(focused).toHaveClass(/react-datepicker__day/);
+
+  // The landing element must actually paint a focus indicator, not just hold
+  // focus. The datepicker day uses an outline; other focus targets use a ring
+  // (box-shadow) — accept either so the assertion tracks "is it visible".
+  const indicator = await focused.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return {
+      matchesFocusVisible: el.matches(":focus-visible"),
+      outlineStyle: s.outlineStyle,
+      boxShadow: s.boxShadow,
+    };
+  });
+  expect(indicator.matchesFocusVisible).toBe(true);
+  expect(
+    indicator.outlineStyle !== "none" || indicator.boxShadow !== "none",
+  ).toBe(true);
+
+  // Arrow keys navigate dates from the landing spot, and the indicator
+  // follows focus to the newly selected day.
+  await page.keyboard.press("ArrowRight");
+  const nextFocused = page.locator(".react-datepicker__day:focus");
+  await expect(nextFocused).toBeVisible();
+  const stillVisible = await nextFocused.evaluate(
+    (el) => getComputedStyle(el).outlineStyle !== "none",
+  );
+  expect(stillVisible).toBe(true);
+});

--- a/packages/web/src/components/Button/ArrowButton.tsx
+++ b/packages/web/src/components/Button/ArrowButton.tsx
@@ -12,12 +12,10 @@ export const ArrowButton = ({
   tabIndex?: number;
   onClick: () => void;
 }) => {
-  const hoverColor = "bg-text-lighter/20";
-
   return (
     <button
       type="button"
-      className={`flex h-6 w-6 items-center justify-center rounded-full text-text-lighter transition-colors hover:${hoverColor} focus:${hoverColor} focus:outline-none focus:ring-2 focus:ring-text-lighter/50`}
+      className="flex h-6 w-6 items-center justify-center rounded-full text-text-lighter transition-colors hover:bg-text-lighter/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
       aria-label={label}
       onClick={onClick}
       tabIndex={tabIndex}

--- a/packages/web/src/components/Button/Button.tsx
+++ b/packages/web/src/components/Button/Button.tsx
@@ -1,17 +1,24 @@
 import classNames from "classnames";
-import { forwardRef, type HTMLAttributes, type PropsWithChildren } from "react";
+import {
+  type ButtonHTMLAttributes,
+  forwardRef,
+  type PropsWithChildren,
+} from "react";
 import { darken } from "@web/common/styles/color.utils";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import { EVENT_COLOR } from "@web/common/styles/theme.util";
 
+// A native button (not a div) so Enter/Space activate it — click handlers
+// often live on a wrapping TooltipTrigger div and rely on bubbling.
 export const Btn = forwardRef<
-  HTMLDivElement,
-  PropsWithChildren<HTMLAttributes<HTMLDivElement>>
->(({ className, ...props }, ref) => (
-  <div
+  HTMLButtonElement,
+  PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>
+>(({ className, type = "button", ...props }, ref) => (
+  <button
     {...props}
+    type={type}
     className={classNames(
-      "flex cursor-pointer items-center justify-center rounded-[2px]",
+      "c-focus-ring flex cursor-pointer items-center justify-center rounded-[2px]",
       className,
     )}
     ref={ref}
@@ -21,13 +28,13 @@ export const Btn = forwardRef<
 Btn.displayName = "Btn";
 
 interface SaveButtonProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "color"> {
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "color" | "disabled"> {
   minWidth: number;
   disabled?: boolean;
 }
 
 export const SaveButton = forwardRef<
-  HTMLDivElement,
+  HTMLButtonElement,
   PropsWithChildren<SaveButtonProps>
 >(({ className, disabled, minWidth, style, ...props }, ref) => {
   const background = darken(EVENT_COLOR);
@@ -44,7 +51,7 @@ export const SaveButton = forwardRef<
       {...props}
       aria-disabled={disabled || undefined}
       className={classNames(
-        "c-button-elevated min-w-[158px] px-2 text-text-dark transition-[background-color,color,box-shadow,transform] duration-500 hover:bg-bg-primary hover:text-(--save-button-hover-color) focus:border-2 focus:border-border-primary-dark",
+        "c-button-elevated min-w-[158px] px-2 text-text-dark transition-[background-color,color,box-shadow,transform] duration-500 hover:bg-bg-primary hover:text-(--save-button-hover-color)",
         disabled && "pointer-events-none opacity-50",
         className,
       )}

--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -49,9 +49,13 @@ export const CalendarHeader: FC<Props> = ({
           onClick={() => viewActions.toggleSidebar()}
           shortcut="["
         >
-          <span className="flex h-6 w-6 items-center justify-center">
+          <button
+            type="button"
+            aria-label="Open sidebar"
+            className="c-focus-ring flex h-6 w-6 cursor-pointer items-center justify-center"
+          >
             <SidebarIcon color={theme.color.text.lightInactive} size={21} />
-          </span>
+          </button>
         </TooltipWrapper>
       ) : null}
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -213,7 +213,7 @@ export const CommandPalette = ({
             value={search}
             placeholder={placeholder}
             aria-label="Command palette search"
-            className="w-full border-border-primary border-b bg-transparent px-4 py-3 text-text-light outline-none placeholder:text-text-lighter"
+            className="w-full border-border-primary border-b bg-transparent px-4 py-3 text-text-light outline-none placeholder:text-text-lighter focus-visible:border-accent-primary"
             onChange={(event) => {
               setSearch(event.target.value);
               setActiveIndex(0);
@@ -236,7 +236,9 @@ export const CommandPalette = ({
                     const index = itemIndex;
                     const isActive = activeIndex === index;
                     const rowClassName = `flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-text-light ${
-                      isActive ? "bg-panel-badge-bg" : ""
+                      isActive
+                        ? "bg-panel-badge-bg ring-1 ring-accent-primary ring-inset"
+                        : ""
                     } ${item.disabled ? "cursor-default opacity-50" : ""}`;
 
                     const commonProps = getItemProps({

--- a/packages/web/src/components/DatePicker/MonthNavButton.test.tsx
+++ b/packages/web/src/components/DatePicker/MonthNavButton.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MonthNavButton } from "./MonthNavButton";
+
+describe("MonthNavButton", () => {
+  it("opts into the shared c-focus-ring utility so keyboard focus is visible", () => {
+    render(
+      <MonthNavButton
+        ariaLabel="Previous month"
+        color="#fff"
+        onClick={() => {}}
+      >
+        <span>‹</span>
+      </MonthNavButton>,
+    );
+
+    // The month-nav chevrons are the first tab stop the "u" shortcut can land
+    // on; without the ring they gave no focus feedback (the reported bug).
+    expect(screen.getByRole("button", { name: "Previous month" })).toHaveClass(
+      "c-focus-ring",
+    );
+  });
+
+  it("is a real button that fires onClick from the keyboard", async () => {
+    const user = userEvent.setup();
+    const onClick = mock(() => {});
+    render(
+      <MonthNavButton ariaLabel="Next month" color="#fff" onClick={onClick}>
+        <span>›</span>
+      </MonthNavButton>,
+    );
+
+    screen.getByRole("button", { name: "Next month" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/DatePicker/MonthNavButton.tsx
+++ b/packages/web/src/components/DatePicker/MonthNavButton.tsx
@@ -19,6 +19,7 @@ export const MonthNavButton = ({
 }: MonthNavButtonProps) => (
   <button
     aria-label={ariaLabel}
+    className="c-focus-ring"
     onClick={onClick}
     onMouseEnter={(e) => {
       if (isSidebarStyle) return;

--- a/packages/web/src/components/PlannerSidebar/ResizableSidebarPanel.tsx
+++ b/packages/web/src/components/PlannerSidebar/ResizableSidebarPanel.tsx
@@ -67,7 +67,7 @@ export function ResizableSidebarPanel({ children, isOpen }: Props) {
           className={classNames(
             "absolute inset-y-1 left-0 w-px rounded-full bg-grid-line-primary transition-[width,background-color] duration-200 ease-out motion-reduce:transition-none",
             "group-hover:w-0.5 group-hover:bg-text-lighter/60",
-            "group-focus-visible:w-0.5 group-focus-visible:bg-text-lighter/60",
+            "group-focus-visible:w-1 group-focus-visible:bg-accent-primary",
             { "w-0.5 bg-text-lighter/60": isResizing },
           )}
         />

--- a/packages/web/src/components/PlannerSidebar/util/sidebarFocus.util.ts
+++ b/packages/web/src/components/PlannerSidebar/util/sidebarFocus.util.ts
@@ -1,17 +1,23 @@
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 
 /**
- * Focuses the first interactive element in the planner sidebar (the month
- * picker). Used by the Day and Week views' "u" shortcut. Returns whether a
- * focus target was found.
+ * Focuses the month picker's tab-stoppable day (react-datepicker keeps
+ * exactly one day at tabindex=0) so arrow keys navigate dates right away,
+ * falling back to the first interactive element in the planner sidebar.
+ * Used by the Day and Week views' "u" shortcut. Returns whether a focus
+ * target was found.
  */
 export const focusFirstSidebarItem = (): boolean => {
   const sidebar = document.getElementById(ID_SIDEBAR);
   if (!sidebar) return false;
 
-  const target = sidebar.querySelector<HTMLElement>(
-    'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
-  );
+  const target =
+    sidebar.querySelector<HTMLElement>(
+      '.react-datepicker__day[tabindex="0"]',
+    ) ??
+    sidebar.querySelector<HTMLElement>(
+      'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+    );
   target?.focus();
   return Boolean(target);
 };

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -177,7 +177,7 @@ export const SelectView = ({
                 aria-selected={isSelected}
                 tabIndex={isActive ? 0 : -1}
                 className={classNames(
-                  "flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
+                  "c-focus-ring flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
                   isSelected ? "text-accent-primary" : "text-text-light",
                   isActive ? "bg-text-lighter/10" : "hover:bg-text-lighter/10",
                 )}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -382,7 +382,7 @@
 }
 
 @utility c-context-menu-item {
-  @apply flex w-full cursor-pointer appearance-none items-center gap-2 whitespace-nowrap border-0 bg-transparent px-3 py-2.5 text-left text-[14px] text-menu-text select-none hover:bg-(--menu-item-hover) disabled:cursor-wait disabled:opacity-50;
+  @apply c-focus-ring flex w-full cursor-pointer appearance-none items-center gap-2 whitespace-nowrap border-0 bg-transparent px-3 py-2.5 text-left text-[14px] text-menu-text select-none hover:bg-(--menu-item-hover) focus-visible:bg-(--menu-item-hover) disabled:cursor-wait disabled:opacity-50;
 }
 
 @utility c-not-found {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -497,6 +497,11 @@
     color: var(--date-picker-hover-text);
   }
 
+  & .react-datepicker__day:focus-visible {
+    outline: 2px solid var(--compass-color-accent-primary);
+    outline-offset: 1px;
+  }
+
   & .react-datepicker__day-names {
     display: flex;
     width: 100%;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -566,10 +566,6 @@
 
 @utility c-scroll {
   @layer components {
-    :focus-visible {
-      outline: none;
-    }
-
     /* scrollbar styling */
     /* biome-ignore lint/style/noDescendingSpecificity: Keep the scrollbar pseudo-elements grouped inside this utility. */
     &::-webkit-scrollbar {

--- a/packages/web/src/views/Forms/ActionsMenu/MenuItem.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/MenuItem.tsx
@@ -87,7 +87,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
       role="menuitem"
       tabIndex={tabIndex}
       type={type}
-      className="flex w-full cursor-pointer items-center gap-2 border-0 bg-(--actions-menu-item-bg) px-2 py-1 text-left text-m text-text-dark outline-none hover:[text-shadow:0_0_0.5px_var(--compass-color-text-dark),0_0_0.5px_var(--compass-color-text-dark)] focus-visible:[text-shadow:0_0_0.5px_var(--compass-color-text-dark),0_0_0.5px_var(--compass-color-text-dark)]"
+      className="c-focus-ring flex w-full cursor-pointer items-center gap-2 border-0 bg-(--actions-menu-item-bg) px-2 py-1 text-left text-m text-text-dark hover:[text-shadow:0_0_0.5px_var(--compass-color-text-dark),0_0_0.5px_var(--compass-color-text-dark)]"
       style={{ backgroundColor: bgColor }}
     >
       {children}

--- a/packages/web/src/views/Forms/EventForm/SaveSection/SaveSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/SaveSection/SaveSection.tsx
@@ -24,19 +24,12 @@ export const SaveSection: React.FC<Props> = ({
     <div className="flex items-center justify-end gap-3 border-border-primary border-t px-4 py-3">
       {onCancel && (
         <TooltipWrapper onClick={onCancel} description={cancelText}>
-          <Btn role="button" tabIndex={0} title={cancelText}>
-            {cancelText}
-          </Btn>
+          <Btn title={cancelText}>{cancelText}</Btn>
         </TooltipWrapper>
       )}
 
       <TooltipWrapper onClick={onSave} shortcut={["Mod", "Enter"]}>
-        <SaveButton
-          minWidth={110}
-          role="button"
-          tabIndex={0}
-          aria-keyshortcuts="Meta+Enter"
-        >
+        <SaveButton minWidth={110} aria-keyshortcuts="Meta+Enter">
           {saveText}
         </SaveButton>
       </TooltipWrapper>

--- a/packages/web/src/views/Week/components/TodayButton/TodayButton.tsx
+++ b/packages/web/src/views/Week/components/TodayButton/TodayButton.tsx
@@ -20,7 +20,7 @@ export const TodayButton = ({
       >
         <button
           type="button"
-          className="flex h-6 w-6 items-center justify-center rounded-full text-text-lighter transition-colors hover:bg-text-lighter/20 focus:bg-text-lighter/20 focus:outline-none focus:ring-2 focus:ring-text-lighter/50"
+          className="flex h-6 w-6 items-center justify-center rounded-full text-text-lighter transition-colors hover:bg-text-lighter/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
           aria-label="Go to today"
         >
           <CircleIcon />


### PR DESCRIPTION
## Summary

Ensures every keyboard-focusable surface shows a clear, consistent focus indicator (WCAG 2.2 AA). The reported trigger — pressing `u` on the week view moved focus into the sidebar with **no** visible feedback — turned out to be one symptom of a systemic bug, fixed here across distinct commits:

- **Root cause (commit 1):** a `:focus-visible { outline: none }` rule accidentally nested inside the `c-scroll` utility during the Tailwind migration compiled to a **descendant selector** (`.c-scroll :focus-visible`), silently stripping the browser's focus outline from nearly every focusable element inside any scroll container. Deleting that one rule restores a working baseline everywhere.
- **The `u` path (commit 2):** `u` now lands on the month picker's tab-stoppable day (so arrow keys navigate dates immediately) instead of an unstyled month-nav chevron; the chevrons and datepicker day cells gain the accent focus ring/outline.
- **Menus, palette, select (commit 3):** context-menu items, the actions menu, `SelectView` options, and the command palette (input border + active-row inset ring for its virtual focus) all get visible indicators.
- **Event-form controls + resize handle (commit 4):** `Btn` becomes a native `<button>` — fixing a latent keyboard bug where the Cancel button couldn't be activated by Enter/Space at all (its click handler lives on a wrapping `TooltipTrigger` div and relied on native bubbling a `<div>` never emits) — and the sidebar resize handle's keyboard-focus state switches from an invisible gray to the accent color.
- **Header controls (commit 5):** the prev/next arrows and Today button move from `:focus` (which flashed a ring on every mouse click) to `:focus-visible` with the accent ring; the header "Open sidebar" control becomes a real `<button>` — it was a plain `<span>`, so keyboard users couldn't reopen the sidebar from the header at all.
- **Tests (commit 6):** an RTL test for the month-nav ring and an e2e spec guarding the `u` path end-to-end.

## Simplicity

Net complexity is roughly flat-to-down. Most changes are one-line additions of the **existing** `c-focus-ring` utility (or the established `ring-2 ring-accent-primary` grid-card pattern), not new abstractions — and commit 1 *removes* a rule rather than adding one. `SaveSection` net-deletes redundant `role="button"`/`tabIndex={0}` props now that its buttons are native, and `ArrowButton` deletes a dead `hoverColor` const (an interpolated `hover:${hoverColor}` class Tailwind never statically extracted). This change adds **no** `useState`/`useEffect`/`useRef` — hook usage is unchanged. The one spot that looks over-complex, `focusFirstSidebarItem`'s two-`querySelector` `??` fallback, is deliberate: a single merged selector list would match in DOM order and silently revert the landing target to the chevron.

## Manual Testing Steps

- [ ] On the **week** view with the sidebar open, click into the calendar grid, then press `u`. Focus should jump to **today's date** in the sidebar mini-month, shown with a clear blue outline. Press the arrow keys — the highlight should move day-to-day, staying visible on each date.
- [ ] With focus on a sidebar date, press `Shift+Tab` to reach the month `‹`/`›` chevrons — each should show a blue focus ring.
- [ ] Press `Cmd/Ctrl+K` to open the command palette. The search field's bottom border should turn blue, and the highlighted result row should have a blue ring around it (not just a faint background). Arrow up/down — the ring should follow the active row.
- [ ] Collapse the sidebar (`[`). A sidebar icon appears at the top-left of the header; `Tab` to it — it should show a focus ring and be operable by keyboard (Enter/Space) to reopen the sidebar.
- [ ] Open an event (press `c`), then `Tab` through the form. The Save button and other controls should each show a visible focus ring; nothing should be focusable without an indicator.
- [ ] Using only the mouse, click the header prev/next arrows and Today button — they should **not** flash a focus ring on click (the ring is keyboard-only now).

## Test plan

- [x] `bun run type-check` — clean.
- [x] `bun run lint` (Biome) on all changed files — clean.
- [x] `bun test` for every touched component area (Button, SelectView, ActionsMenu, EventForm, CommandPalette, DatePicker, PlannerSidebar) — 167 pass, 0 fail.
- [x] New RTL test `MonthNavButton.test.tsx` — 2 pass (ring class present; native button fires onClick from the keyboard).
- [x] `bunx playwright test e2e/accessibility` — 2 pass, including the new `focus-visible.spec.ts` (`u` lands on a `:focus-visible` day with a painted outline, arrow-nav follows) and the existing datepicker axe/contrast spec (confirms the `c-scroll` deletion didn't regress accessibility).
- [x] Manual verification in the user's real Chrome across the flows above — no console errors, no stray/oversized outlines.
