### PR TITLE
fix(web): explain someday events are emailed separately in export file

### DIFF
--- a/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
@@ -49,6 +49,13 @@ describe("collectExportData", () => {
     expect(typeof result.exportedAt).toBe("string");
   });
 
+  it("includes a message explaining someday events arrive separately by email", async () => {
+    const result = await collectExportData();
+
+    expect(result.message).toContain("tyler@switchback.tech");
+    expect(result.message.toLowerCase()).toContain("someday");
+  });
+
   it("omits _migrations entirely (only tasks/events are read)", async () => {
     await collectExportData();
 

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.ts
@@ -6,9 +6,13 @@ import {
   getOfflineDataStore,
 } from "@web/common/storage/offline-data/offline-data.store.registry";
 
+const SOMEDAY_EVENTS_NOTICE =
+  "Someday events aren't included in this file. If you had any, they'll be emailed to you separately by tyler@switchback.tech.";
+
 interface CompassDataExport {
   exportedAt: string;
   version: 1;
+  message: string;
   tasks: unknown[];
   events: unknown[];
 }
@@ -44,6 +48,7 @@ export function createCollectExportData({
     return {
       exportedAt: new Date().toISOString(),
       version: 1,
+      message: SOMEDAY_EVENTS_NOTICE,
       tasks,
       events: events.filter((record) => !record.isDemo),
     };


### PR DESCRIPTION
## Summary
- Adds a `message` field to the "Export my data" JSON output explaining that someday events aren't included in the file and will be emailed separately by tyler@switchback.tech, so an empty `"events": []` doesn't read as data loss to users who had someday events.

## Simplicity
No simplification opportunities found — this is a single static string added to an existing object literal, with a matching unit test. No `useEffect`/`useRef`/`useState` involved.

## Manual Testing Steps
- [ ] Sign in, open the command palette (`Cmd+K`), and run **Export my data**.
- [ ] Open the downloaded `compass-export-<date>.json` file and confirm it contains a `message` field explaining someday events will be emailed separately by tyler@switchback.tech.

## Test plan
- [x] `bun run test:web` (scoped: `export-user-data.util.test.ts`, `useExportDataCmdItems.test.ts`) — all pass, including a new test asserting the message mentions "someday" and the email address
- [x] `bun run type-check` — clean
- [x] `bunx biome check` on changed files — clean
- [x] Manual browser verification in real Chrome against the local dev server: triggered "Export my data" as a signed-in user with `fetch`/`URL.createObjectURL` intercepted (to avoid re-sending a real Discord notification during testing) and confirmed the downloaded JSON's `message` field reads exactly as intended
