### PR TITLE
feat(backend): add PostHog log export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,9 @@
       "dependencies": {
         "@compass/core": "1.0.0",
         "@googleapis/calendar": "^14.1.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
+        "@opentelemetry/resources": "^2.9.0",
+        "@opentelemetry/sdk-logs": "^0.220.0",
         "cors": "^2.8.5",
         "exponential-backoff": "^3.1.2",
         "express": "^4.17.1",
@@ -57,6 +60,7 @@
       "name": "@compass/core",
       "version": "1.0.0",
       "dependencies": {
+        "@opentelemetry/api-logs": "^0.220.0",
         "bson": "^7.2.0",
         "dayjs": "^1.11.19",
         "winston": "^3.8.1",
@@ -542,6 +546,28 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@open-draft/until": ["@open-draft/until@1.0.3", "", {}, "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.9.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "@opentelemetry/core": "2.9.0", "@opentelemetry/otlp-exporter-base": "0.220.0", "@opentelemetry/otlp-transformer": "0.220.0", "@opentelemetry/sdk-logs": "0.220.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.220.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/otlp-transformer": "0.220.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/sdk-logs": "0.220.0", "@opentelemetry/sdk-metrics": "2.9.0", "@opentelemetry/sdk-trace": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@
 /** @type { Exclude<Exclude<import("jest").Config["projects"], undefined>[number], string>} */
 const backendProject = {
   displayName: "backend",
+  roots: ["<rootDir>/packages/backend"],
   moduleNameMapper: {
     "^@core(/(.*)$)?": "<rootDir>/packages/core/src/$1",
     "^@backend/auth(/(.*)$)?": "<rootDir>/packages/backend/src/auth/$1",
@@ -40,6 +41,7 @@ const backendProject = {
 /** @type { Exclude<Exclude<import("jest").Config["projects"], undefined>[number], string>} */
 const coreProject = {
   displayName: "core",
+  roots: ["<rootDir>/packages/core"],
   moduleNameMapper: {
     "^@core(/(.*)$)?": "<rootDir>/packages/core/src/$1",
   },
@@ -54,6 +56,7 @@ const coreProject = {
 /** @type { Exclude<Exclude<import("jest").Config["projects"], undefined>[number], string>} */
 const scriptsProject = {
   displayName: "scripts",
+  roots: ["<rootDir>/packages/scripts"],
   moduleNameMapper: {
     ...backendProject.moduleNameMapper,
     "^@scripts(/(.*)$)?": "<rootDir>/packages/scripts/src/$1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,6 +7,9 @@
   "dependencies": {
     "@compass/core": "1.0.0",
     "@googleapis/calendar": "^14.1.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
+    "@opentelemetry/resources": "^2.9.0",
+    "@opentelemetry/sdk-logs": "^0.220.0",
     "cors": "^2.8.5",
     "exponential-backoff": "^3.1.2",
     "express": "^4.17.1",

--- a/packages/backend/src/__tests__/backend.test.init.ts
+++ b/packages/backend/src/__tests__/backend.test.init.ts
@@ -16,3 +16,4 @@ process.env["EMAILER_USER_TAG_ID"] = "910111213";
 process.env["TOKEN_GCAL_NOTIFICATION"] = "secretToken1";
 process.env["TOKEN_COMPASS_SYNC"] = "secretToken2";
 process.env["FRONTEND_URL"] = "http://localhost:9080";
+process.env["TZ"] = "Etc/UTC";

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -3,6 +3,7 @@ import mongoService from "@backend/common/services/mongo.service";
 import { initExpressServer } from "@backend/servers/express/express.server";
 import { warnIfWebhookNotPublicHttps } from "@backend/sync/services/watch/google-watch-config";
 import { logger } from "./init"; //must be first import
+import { stopPostHogLogs } from "./logging/posthog-logs";
 import { createServer, type Server } from "node:http";
 
 const app = initExpressServer();
@@ -43,6 +44,7 @@ async function gracefulShutdown(): Promise<void> {
   try {
     await closeHttpServer();
     await mongoService.stop();
+    await stopPostHogLogs();
   } catch (error) {
     logger.error("Problems encountered while shutting down", error);
   }

--- a/packages/backend/src/calendar/controllers/calendar.controller.test.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.test.ts
@@ -56,13 +56,14 @@ describe("CalendarController availability", () => {
     await calendarController.availability(req, res);
 
     expect(getAvailabilitySpy).toHaveBeenCalledWith(
-      expect.any(ObjectId),
+      expect.anything(),
       expect.objectContaining({
         calendarIds: ["507f1f77bcf86cd799439012", "507f1f77bcf86cd799439013"],
         start: "2024-01-15T00:00:00.000Z",
         end: "2024-01-16T00:00:00.000Z",
       }),
     );
+    expect(String(getAvailabilitySpy.mock.calls[0]?.[0])).toBe(userId);
     expect(res.promise).toHaveBeenCalledWith(availabilityResponse);
     // Packet 09 step 2: pin the response-boundary shape of GET
     // /api/calendars/availability against the shared core schema.
@@ -138,7 +139,8 @@ describe("CalendarController list", () => {
 
     await calendarController.list(req, res);
 
-    expect(listSpy).toHaveBeenCalledWith(expect.any(ObjectId));
+    expect(listSpy).toHaveBeenCalledWith(expect.anything());
+    expect(String(listSpy.mock.calls[0]?.[0])).toBe(userId);
     expect(promise).toHaveBeenCalledTimes(1);
 
     const sentBody = promise.mock.calls[0]?.[0];

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -33,6 +33,8 @@ const ConfigSchema = z
     SUPERTOKENS_KEY: z.string().nonempty(),
     TOKEN_GCAL_NOTIFICATION: z.string().default(""),
     TOKEN_COMPASS_SYNC: z.string().nonempty(),
+    POSTHOG_KEY: z.string().nonempty().optional(),
+    POSTHOG_HOST: z.string().url().optional(),
   })
   .strict()
   .superRefine((env, context) => {
@@ -104,6 +106,8 @@ function parseRawConfig(config: CompassConfig): Config {
     SUPERTOKENS_KEY: config.supertokens.key,
     TOKEN_GCAL_NOTIFICATION: nonEmpty(config.google?.notificationToken) ?? "",
     TOKEN_COMPASS_SYNC: config.backend.compassToken,
+    POSTHOG_KEY: nonEmpty(config.posthog?.key),
+    POSTHOG_HOST: nonEmpty(config.posthog?.host) || "https://us.i.posthog.com",
   });
 }
 
@@ -131,6 +135,8 @@ export function parseConfigFromEnv(
     SUPERTOKENS_KEY: rawEnv["SUPERTOKENS_KEY"],
     TOKEN_GCAL_NOTIFICATION: rawEnv["TOKEN_GCAL_NOTIFICATION"],
     TOKEN_COMPASS_SYNC: rawEnv["TOKEN_COMPASS_SYNC"],
+    POSTHOG_KEY: rawEnv["POSTHOG_KEY"],
+    POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || "https://us.i.posthog.com",
   });
 }
 

--- a/packages/backend/src/event/classes/gcal.event.rrule.test.ts
+++ b/packages/backend/src/event/classes/gcal.event.rrule.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { ObjectId } from "mongodb";
-import { RRule } from "rrule";
+import { RRule, rrulestr } from "rrule";
 import { recurring } from "@core/__mocks__/v1/events/gcal/gcal.recurring";
 import { GCAL_MAX_RECURRENCES } from "@core/constants/core.constants";
 import { type gSchema$EventBase } from "@core/types/gcal";
@@ -88,13 +88,12 @@ describe("GcalEventRRule: ", () => {
 
   describe("diffOptions", () => {
     it("should return the differences between two rrule options", () => {
-      const until = dayjs();
+      const until = dayjs("2026-01-01T00:00:00.000Z");
       const untilRule = `UNTIL=${until.toRRuleDTSTARTString()}`;
       const rule = [`RRULE:FREQ=DAILY;COUNT=10;BYDAY=MO,WE,FR;${untilRule}`];
       const baseEvent = { ...mockRecurringGcalBaseEvent(), recurrence: rule };
       const rrule = new GcalEventRRule(baseEvent);
-      const untilFormat = dayjs.DateFormat.RFC5545;
-      const nextUntil = dayjs(until.toRRuleDTSTARTString(), untilFormat);
+      const nextUntil = dayjs(rrulestr(rule[0]).options.until);
 
       const rruleA = new GcalEventRRule(
         { ...baseEvent, recurrence: [] },

--- a/packages/backend/src/init.ts
+++ b/packages/backend/src/init.ts
@@ -22,5 +22,8 @@ if (isBuildRuntime) {
 }
 
 import { Logger } from "@core/logger/winston.logger";
+import { startPostHogLogs } from "./logging/posthog-logs";
+
+startPostHogLogs();
 
 export const logger = Logger("app:root");

--- a/packages/backend/src/logging/posthog-logs.ts
+++ b/packages/backend/src/logging/posthog-logs.ts
@@ -1,0 +1,39 @@
+import { logs } from "@opentelemetry/api-logs";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  BatchLogRecordProcessor,
+  LoggerProvider,
+} from "@opentelemetry/sdk-logs";
+import { NodeEnv } from "@core/constants/core.constants";
+import { CONFIG } from "@backend/common/constants/config.constants";
+
+const isRemoteLoggingEnvironment =
+  CONFIG.NODE_ENV === NodeEnv.Staging || CONFIG.NODE_ENV === NodeEnv.Production;
+
+const loggerProvider =
+  isRemoteLoggingEnvironment && CONFIG.POSTHOG_KEY
+    ? new LoggerProvider({
+        resource: resourceFromAttributes({
+          "service.name": "compass-backend",
+        }),
+        processors: [
+          new BatchLogRecordProcessor({
+            exporter: new OTLPLogExporter({
+              url: `${CONFIG.POSTHOG_HOST}/i/v1/logs`,
+              headers: {
+                Authorization: `Bearer ${CONFIG.POSTHOG_KEY}`,
+              },
+            }),
+          }),
+        ],
+      })
+    : undefined;
+
+export function startPostHogLogs(): void {
+  if (loggerProvider) logs.setGlobalLoggerProvider(loggerProvider);
+}
+
+export async function stopPostHogLogs(): Promise<void> {
+  await loggerProvider?.shutdown();
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "@opentelemetry/api-logs": "^0.220.0",
     "bson": "^7.2.0",
     "dayjs": "^1.11.19",
     "winston": "^3.8.1",

--- a/packages/core/src/logger/winston.logger.ts
+++ b/packages/core/src/logger/winston.logger.ts
@@ -1,6 +1,32 @@
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
 import { type TransformableInfo } from "logform";
 import * as winston from "winston";
 import { MB_50 } from "@core/constants/core.constants";
+
+const otelLogger = logs.getLogger("compass");
+
+const severityNumbers: Record<string, SeverityNumber> = {
+  debug: SeverityNumber.DEBUG,
+  info: SeverityNumber.INFO,
+  warn: SeverityNumber.WARN,
+  error: SeverityNumber.ERROR,
+};
+
+const emitOpenTelemetryLog = (info: TransformableInfo) => {
+  otelLogger.emit({
+    severityText: info.level,
+    severityNumber: severityNumbers[info.level],
+    body: String(info.message),
+    attributes: {
+      namespace: String(info["namespace"] || ""),
+    },
+  });
+};
+
+const openTelemetryFormat = winston.format((info) => {
+  emitOpenTelemetryLog(info);
+  return info;
+});
 
 const consoleFormat = winston.format.combine(
   winston.format.splat(),
@@ -38,6 +64,7 @@ export const Logger = (namespace?: string, logFile?: string) => {
   if (!namespace) {
     return winston.createLogger({
       level: process.env["LOG_LEVEL"],
+      format: openTelemetryFormat(),
       transports: transports(),
     });
   }
@@ -45,6 +72,7 @@ export const Logger = (namespace?: string, logFile?: string) => {
   if (logFile) {
     const secondaryLogger = winston.createLogger({
       level: process.env["LOG_LEVEL"],
+      format: openTelemetryFormat(),
       transports: transports(logFile),
     });
     return secondaryLogger.child({ namespace });
@@ -52,6 +80,7 @@ export const Logger = (namespace?: string, logFile?: string) => {
 
   const primaryLogger = winston.createLogger({
     level: process.env["LOG_LEVEL"],
+    format: openTelemetryFormat(),
     transports: transports(),
   });
 


### PR DESCRIPTION
## Summary

- Forward existing Winston backend logs to PostHog Logs through OpenTelemetry.
- Keep Winston console/file logging and enable remote export only in staging and production.
- Keep the OpenTelemetry dependency split package-local and use the US PostHog endpoint by default.
- Make Jest package roots and backend test setup reliable when repository worktrees are present.

## Simplicity

The implementation uses the existing Winston logger as the application logging API and adds a single OpenTelemetry format bridge. Node-only exporter packages remain in `packages/backend`; only the lightweight log API is shared where the logger implementation lives in `packages/core`.

## Manual Testing Steps
- [ ] Deploy or run the backend with staging/production configuration containing a `phc_` PostHog project token.
- [ ] Trigger a backend request that emits an application log.
- [ ] Confirm the log appears in PostHog Logs with service name `compass-backend` and its logger namespace.
- [ ] Run the backend without PostHog credentials and confirm local console/file logging continues without a PostHog connection attempt.

## Test plan
- [x] `bun test:core`
- [x] `bun test:backend`
- [x] `bun type-check`
- [x] `bun lint`
- [x] `git diff --check`
