### PR TITLE
feat(web): add sidebar notice for leftover local task data

### DIFF
--- a/packages/web/src/__tests__/utils/storage/mock-offline-data-store.util.ts
+++ b/packages/web/src/__tests__/utils/storage/mock-offline-data-store.util.ts
@@ -26,6 +26,7 @@ export function createMockOfflineDataStore(): MockedOfflineDataStore {
     deleteEvent: mock().mockResolvedValue(undefined),
     clearAllEvents: mock().mockResolvedValue(undefined),
     getAllTasks: mock().mockResolvedValue([]),
+    getTaskCount: mock().mockResolvedValue(0),
     clearAllTasks: mock().mockResolvedValue(undefined),
     getMigrationRecords: mock().mockResolvedValue([]),
     setMigrationRecord: mock().mockResolvedValue(undefined),

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const StorageKeySchema = z.enum([
   "compass.auth",
   "compass.onboarding.has-seen-welcome",
+  "compass.onboarding.has-dismissed-tasks-removal-notice",
   "compass.sidebar.width",
   "compass.view.sidebar-open",
 ]);
@@ -10,11 +11,17 @@ export const StorageKeySchema = z.enum([
 export type StorageKey = z.infer<typeof StorageKeySchema>;
 
 export const STORAGE_KEYS: Record<
-  "AUTH" | "HAS_SEEN_WELCOME" | "SIDEBAR_WIDTH" | "SIDEBAR_OPEN",
+  | "AUTH"
+  | "HAS_SEEN_WELCOME"
+  | "HAS_DISMISSED_TASKS_REMOVAL_NOTICE"
+  | "SIDEBAR_WIDTH"
+  | "SIDEBAR_OPEN",
   StorageKey
 > = {
   AUTH: "compass.auth",
   HAS_SEEN_WELCOME: "compass.onboarding.has-seen-welcome",
+  HAS_DISMISSED_TASKS_REMOVAL_NOTICE:
+    "compass.onboarding.has-dismissed-tasks-removal-notice",
   SIDEBAR_WIDTH: "compass.sidebar.width",
   SIDEBAR_OPEN: "compass.view.sidebar-open",
 } as const;

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
@@ -4,6 +4,7 @@ import { createMockLocalEventRecord } from "@web/__tests__/utils/factories/event
 import {
   createClearExportedTasks,
   createCollectExportData,
+  createRunExportMyData,
   getExportFilename,
   notifyExport,
 } from "./export-user-data.util";
@@ -131,4 +132,71 @@ describe("notifyExport", () => {
   // exports and clears tasks even when the webhook notification throws"
   // covers the behavior that actually matters: a failing notification must
   // never break the export.
+});
+
+describe("runExportMyData", () => {
+  const mockCollectExportData = mock();
+  const mockDownloadAsJsonFile = mock();
+  const mockClearExportedTasks = mock();
+  const mockNotifyExport = mock();
+  const mockGetExportFilename = mock();
+
+  const runExportMyData = createRunExportMyData({
+    collectExportData: mockCollectExportData,
+    downloadAsJsonFile: mockDownloadAsJsonFile,
+    clearExportedTasks: mockClearExportedTasks,
+    notifyExport: mockNotifyExport,
+    getExportFilename: mockGetExportFilename,
+  });
+
+  beforeEach(() => {
+    mockCollectExportData.mockClear();
+    mockDownloadAsJsonFile.mockClear();
+    mockClearExportedTasks.mockClear();
+    mockNotifyExport.mockClear();
+    mockGetExportFilename.mockClear();
+
+    mockCollectExportData.mockResolvedValue({
+      exportedAt: "2026-07-15T00:00:00.000Z",
+      version: 1,
+      tasks: [],
+      events: [],
+    });
+    mockClearExportedTasks.mockResolvedValue(undefined);
+    mockGetExportFilename.mockReturnValue("compass-export-2026-07-15.json");
+  });
+
+  it("downloads the export, notifies the webhook with the user's email, then clears tasks", async () => {
+    await runExportMyData("user@example.com");
+
+    expect(mockDownloadAsJsonFile).toHaveBeenCalledWith(
+      expect.objectContaining({ version: 1 }),
+      "compass-export-2026-07-15.json",
+    );
+    expect(mockNotifyExport).toHaveBeenCalledWith("user@example.com");
+    expect(mockClearExportedTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects and skips download/notify/clear when collecting export data fails", async () => {
+    mockCollectExportData.mockRejectedValue(new Error("dexie is closed"));
+
+    await expect(runExportMyData("user@example.com")).rejects.toThrow(
+      "dexie is closed",
+    );
+
+    expect(mockDownloadAsJsonFile).not.toHaveBeenCalled();
+    expect(mockNotifyExport).not.toHaveBeenCalled();
+    expect(mockClearExportedTasks).not.toHaveBeenCalled();
+  });
+
+  it("resolves even when clearing the tasks table fails after a successful download", async () => {
+    mockClearExportedTasks.mockRejectedValue(new Error("write conflict"));
+
+    await expect(
+      runExportMyData("user@example.com"),
+    ).resolves.toBeUndefined();
+
+    expect(mockDownloadAsJsonFile).toHaveBeenCalledTimes(1);
+    expect(mockNotifyExport).toHaveBeenCalledWith("user@example.com");
+  });
 });

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
@@ -192,9 +192,7 @@ describe("runExportMyData", () => {
   it("resolves even when clearing the tasks table fails after a successful download", async () => {
     mockClearExportedTasks.mockRejectedValue(new Error("write conflict"));
 
-    await expect(
-      runExportMyData("user@example.com"),
-    ).resolves.toBeUndefined();
+    await expect(runExportMyData("user@example.com")).resolves.toBeUndefined();
 
     expect(mockDownloadAsJsonFile).toHaveBeenCalledTimes(1);
     expect(mockNotifyExport).toHaveBeenCalledWith("user@example.com");

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.ts
@@ -117,3 +117,47 @@ export const collectExportData = createCollectExportData({
 export const clearExportedTasks = createClearExportedTasks({
   getOfflineDataStore,
 });
+
+type RunExportMyDataDependencies = {
+  collectExportData: typeof collectExportData;
+  downloadAsJsonFile: typeof downloadAsJsonFile;
+  clearExportedTasks: typeof clearExportedTasks;
+  notifyExport: typeof notifyExport;
+  getExportFilename: typeof getExportFilename;
+};
+
+export function createRunExportMyData({
+  collectExportData,
+  downloadAsJsonFile,
+  clearExportedTasks,
+  notifyExport,
+  getExportFilename,
+}: RunExportMyDataDependencies) {
+  /**
+   * Collect -> download -> notify -> clear, shared by every surface that
+   * triggers "export my data" (command palette, sidebar notice). Callers own
+   * presentation (toasts, inline loading state) - this only resolves/rejects.
+   */
+  return async function runExportMyData(email: string): Promise<void> {
+    const data = await collectExportData();
+    downloadAsJsonFile(data, getExportFilename());
+    // notifyExport is best-effort and already swallows its own failures (see
+    // its own implementation) — it can't fail the export the user is waiting on.
+    notifyExport(email);
+    // Clearing the legacy tasks table is cleanup, not part of the export the
+    // user is waiting on — the download and webhook above have already
+    // succeeded by this point, so a failure here must not surface as an
+    // export failure (which would wrongly invite the user to retry).
+    clearExportedTasks().catch(() => {
+      // Ignored; the table is retried on the user's next export.
+    });
+  };
+}
+
+export const runExportMyData = createRunExportMyData({
+  collectExportData,
+  downloadAsJsonFile,
+  clearExportedTasks,
+  notifyExport,
+  getExportFilename,
+});

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
@@ -72,4 +72,35 @@ describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
 
     store.close();
   });
+
+  it("counts tasks via getTaskCount without reading every row", async () => {
+    const store = new IndexedDbOfflineDataStore();
+    await store.initialize();
+
+    expect(await store.getTaskCount()).toBe(0);
+
+    const recoveryDb = new Dexie("compass-local");
+    recoveryDb.version(4).stores({
+      tasks: "_id, dateKey, status, order",
+    });
+    await recoveryDb.open();
+    await recoveryDb.table<StoredTask, string>("tasks").put({
+      _id: "task-1",
+      dateKey: "2026-07-07",
+      title: "Recover me",
+      status: "todo",
+      order: 0,
+      createdAt: "2026-07-07T00:00:00.000Z",
+      user: "local",
+    });
+    recoveryDb.close();
+
+    expect(await store.getTaskCount()).toBe(1);
+
+    await store.clearAllTasks();
+
+    expect(await store.getTaskCount()).toBe(0);
+
+    store.close();
+  });
 });

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
@@ -220,6 +220,10 @@ export class IndexedDbOfflineDataStore implements OfflineDataStore {
     return this.db.tasks.toArray();
   }
 
+  async getTaskCount(): Promise<number> {
+    return this.db.tasks.count();
+  }
+
   async clearAllTasks(): Promise<void> {
     await this.db.tasks.clear();
   }

--- a/packages/web/src/common/storage/offline-data/offline-data.store.ts
+++ b/packages/web/src/common/storage/offline-data/offline-data.store.ts
@@ -96,6 +96,12 @@ export interface OfflineDataStore {
   getAllTasks(): Promise<StoredTask[]>;
 
   /**
+   * Cheap existence check for the retained legacy tasks table, without
+   * reading every row.
+   */
+  getTaskCount(): Promise<number>;
+
+  /**
    * Clear all rows from the retained legacy tasks table.
    */
   clearAllTasks(): Promise<void>;

--- a/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.test.ts
@@ -52,10 +52,9 @@ afterAll(() => {
 
 // CommandPalette.tsx statically imports the default-wired useExportDataCmdItems;
 // cache-bust so this file's useSession/useUser mocks apply, matching
-// useSubscribeCmdItems.test.ts. The export-data dependencies themselves
-// (collectExportData, downloadAsJsonFile, clearExportedTasks, notifyExport)
-// are injected directly via createUseExportDataCmdItems below instead of
-// mock.module — that dependency's module is also imported for real by
+// useSubscribeCmdItems.test.ts. runExportMyData is injected directly via
+// createUseExportDataCmdItems below instead of mock.module — that
+// dependency's module is also imported for real by
 // export-user-data.util.test.ts, and mock.module's process-wide, order-
 // dependent replacement proved unreliable across files for it.
 async function importHookFactory() {
@@ -70,44 +69,25 @@ async function importHookFactory() {
 }
 
 describe("useExportDataCmdItems", () => {
-  const mockCollectExportData = mock();
-  const mockDownloadAsJsonFile = mock();
-  const mockClearExportedTasks = mock();
-  const mockNotifyExport = mock();
-  const mockGetExportFilename = mock();
+  const mockRunExportMyData = mock();
 
   const buildHook = async () => {
     const { createUseExportDataCmdItems } = await importHookFactory();
     return createUseExportDataCmdItems({
-      collectExportData: mockCollectExportData,
-      downloadAsJsonFile: mockDownloadAsJsonFile,
-      clearExportedTasks: mockClearExportedTasks,
-      notifyExport: mockNotifyExport,
-      getExportFilename: mockGetExportFilename,
+      runExportMyData: mockRunExportMyData,
     });
   };
 
   beforeEach(() => {
     mockUseSession.mockClear();
     mockUseUser.mockClear();
-    mockCollectExportData.mockClear();
-    mockDownloadAsJsonFile.mockClear();
-    mockClearExportedTasks.mockClear();
-    mockNotifyExport.mockClear();
-    mockGetExportFilename.mockClear();
+    mockRunExportMyData.mockClear();
     mockShowStatusToast.mockClear();
     mockShowErrorToast.mockClear();
 
     mockUseSession.mockReturnValue({ authenticated: true });
     mockUseUser.mockReturnValue({ email: "user@example.com" });
-    mockCollectExportData.mockResolvedValue({
-      exportedAt: "2026-07-15T00:00:00.000Z",
-      version: 1,
-      tasks: [],
-      events: [],
-    });
-    mockClearExportedTasks.mockResolvedValue(undefined);
-    mockGetExportFilename.mockReturnValue("compass-export-2026-07-15.json");
+    mockRunExportMyData.mockResolvedValue(undefined);
   });
 
   it("returns no items when unauthenticated", async () => {
@@ -128,7 +108,7 @@ describe("useExportDataCmdItems", () => {
     expect(result.current).toEqual([]);
   });
 
-  it("downloads the export, notifies the webhook with the user's email, then clears tasks", async () => {
+  it("runs the export with the user's email and shows a success toast", async () => {
     const useExportDataCmdItems = await buildHook();
 
     const { result } = renderHook(() => useExportDataCmdItems());
@@ -145,17 +125,12 @@ describe("useExportDataCmdItems", () => {
       );
     });
 
-    expect(mockDownloadAsJsonFile).toHaveBeenCalledWith(
-      expect.objectContaining({ version: 1 }),
-      "compass-export-2026-07-15.json",
-    );
-    expect(mockNotifyExport).toHaveBeenCalledWith("user@example.com");
-    expect(mockClearExportedTasks).toHaveBeenCalledTimes(1);
+    expect(mockRunExportMyData).toHaveBeenCalledWith("user@example.com");
     expect(mockShowErrorToast).not.toHaveBeenCalled();
   });
 
-  it("shows an error toast and does not clear tasks when collecting export data fails", async () => {
-    mockCollectExportData.mockRejectedValue(new Error("dexie is closed"));
+  it("shows an error toast when the export fails", async () => {
+    mockRunExportMyData.mockRejectedValue(new Error("dexie is closed"));
     const useExportDataCmdItems = await buildHook();
 
     const { result } = renderHook(() => useExportDataCmdItems());
@@ -171,29 +146,6 @@ describe("useExportDataCmdItems", () => {
         { toastId: "export-my-data" },
       );
     });
-    expect(mockClearExportedTasks).not.toHaveBeenCalled();
     expect(mockShowStatusToast).not.toHaveBeenCalled();
-  });
-
-  it("still shows success (not an error) when clearing the tasks table fails after a successful download", async () => {
-    mockClearExportedTasks.mockRejectedValue(new Error("write conflict"));
-    const useExportDataCmdItems = await buildHook();
-
-    const { result } = renderHook(() => useExportDataCmdItems());
-    const item = result.current.find((item) => item.id === "export-my-data");
-
-    await act(async () => {
-      item?.onClick?.();
-    });
-
-    await waitFor(() => {
-      expect(mockShowStatusToast).toHaveBeenCalledWith(
-        "export-my-data",
-        "Data exported",
-      );
-    });
-    expect(mockDownloadAsJsonFile).toHaveBeenCalledTimes(1);
-    expect(mockNotifyExport).toHaveBeenCalledWith("user@example.com");
-    expect(mockShowErrorToast).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.ts
@@ -2,23 +2,13 @@ import { DownloadIcon } from "@phosphor-icons/react";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { EXPORT_MY_DATA_TOAST_ID } from "@web/common/constants/toast.constants";
-import {
-  clearExportedTasks,
-  collectExportData,
-  downloadAsJsonFile,
-  getExportFilename,
-  notifyExport,
-} from "@web/common/storage/offline-data/export-user-data.util";
+import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 
 type ExportDataDependencies = {
-  collectExportData: typeof collectExportData;
-  downloadAsJsonFile: typeof downloadAsJsonFile;
-  clearExportedTasks: typeof clearExportedTasks;
-  notifyExport: typeof notifyExport;
-  getExportFilename: typeof getExportFilename;
+  runExportMyData: typeof runExportMyData;
 };
 
 /**
@@ -29,11 +19,7 @@ type ExportDataDependencies = {
  * locate a user's someday events, which only signed-in users have.
  */
 export function createUseExportDataCmdItems({
-  collectExportData,
-  downloadAsJsonFile,
-  clearExportedTasks,
-  notifyExport,
-  getExportFilename,
+  runExportMyData,
 }: ExportDataDependencies) {
   return function useExportDataCmdItems(): CommandItem[] {
     const { authenticated } = useSession();
@@ -49,22 +35,9 @@ export function createUseExportDataCmdItems({
         label: "Export my data",
         icon: DownloadIcon,
         onClick: () => {
-          collectExportData()
-            .then((data) => {
-              downloadAsJsonFile(data, getExportFilename());
-              // notifyExport is best-effort and already swallows its own
-              // failures (see its own implementation) — it can't fail the
-              // export the user is actually waiting on.
-              notifyExport(email);
+          runExportMyData(email)
+            .then(() => {
               showStatusToast(EXPORT_MY_DATA_TOAST_ID, "Data exported");
-              // Clearing the legacy tasks table is cleanup, not part of the
-              // export the user is waiting on — the download and webhook
-              // above have already succeeded by this point, so a failure
-              // here must not surface as an export failure (which would
-              // wrongly invite the user to retry and re-download/re-notify).
-              clearExportedTasks().catch(() => {
-                // Ignored; the table is retried on the user's next export.
-              });
             })
             .catch(() => {
               showErrorToast("Couldn't export your data. Please try again.", {
@@ -78,9 +51,5 @@ export function createUseExportDataCmdItems({
 }
 
 export const useExportDataCmdItems = createUseExportDataCmdItems({
-  collectExportData,
-  downloadAsJsonFile,
-  clearExportedTasks,
-  notifyExport,
-  getExportFilename,
+  runExportMyData,
 });

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
@@ -8,6 +8,7 @@ const PlannerSidebar = createPlannerSidebar({
   PlannerMonthPicker: () => <div>Calendar picker</div>,
   PlannerSidebarActions: () => <div>Sidebar actions</div>,
   ShortcutsOverlay: () => null,
+  TasksRemovalNotice: () => null,
 });
 
 const sidebarProps = {

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
@@ -6,6 +6,7 @@ import { PlannerCalendarList } from "./PlannerCalendarList/PlannerCalendarList";
 import { PlannerMonthPicker } from "./PlannerMonthPicker/PlannerMonthPicker";
 import { PlannerSidebarActions } from "./PlannerSidebarActions/PlannerSidebarActions";
 import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
+import { TasksRemovalNotice } from "./TasksRemovalNotice/TasksRemovalNotice";
 
 export interface PlannerSidebarProps extends HTMLAttributes<HTMLDivElement> {
   calendarDate: Dayjs;
@@ -31,6 +32,7 @@ type PlannerSidebarDependencies = {
   PlannerMonthPicker: typeof PlannerMonthPicker;
   PlannerSidebarActions: typeof PlannerSidebarActions;
   ShortcutsOverlay: typeof ShortcutsOverlay;
+  TasksRemovalNotice: typeof TasksRemovalNotice;
 };
 
 export function createPlannerSidebar({
@@ -38,6 +40,7 @@ export function createPlannerSidebar({
   PlannerMonthPicker: PlannerMonthPickerComponent,
   PlannerSidebarActions: PlannerSidebarActionsComponent,
   ShortcutsOverlay: ShortcutsOverlayComponent,
+  TasksRemovalNotice: TasksRemovalNoticeComponent,
 }: PlannerSidebarDependencies) {
   return function PlannerSidebar({
     calendarDate,
@@ -80,6 +83,7 @@ export function createPlannerSidebar({
               selectedDate={calendarDate}
             />
             <PlannerCalendarListComponent />
+            <TasksRemovalNoticeComponent />
           </div>
         )}
 
@@ -104,4 +108,5 @@ export const PlannerSidebar = createPlannerSidebar({
   PlannerMonthPicker,
   PlannerSidebarActions,
   ShortcutsOverlay,
+  TasksRemovalNotice,
 });

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { createTasksRemovalNotice } from "./TasksRemovalNotice";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
+// Matches useExportDataCmdItems.test.ts's convention: useSession/useUser are
+// auth hooks with no injection seam of their own, so they're mock.module'd;
+// everything else this component depends on is a plain function, injected
+// via createTasksRemovalNotice below — no mock.module, no cache-busting.
 const mockUseSession = mock();
 mock.module("@web/auth/compass/session/useSession", () => ({
   useSession: mockUseSession,
@@ -12,95 +17,20 @@ mock.module("@web/auth/compass/user/hooks/useUser", () => ({
   useUser: mockUseUser,
 }));
 
-// This module is also imported for real by useTasksRemovalNotice.test.ts, and
-// bun:test's mock.module is process-wide and order-dependent — wrap the real
-// exports instead of replacing the module outright, so that file's import of
-// createUseTasksRemovalNotice still resolves once this suite's mock is off.
-const actualUseTasksRemovalNoticeModule = await import(
-  "./useTasksRemovalNotice"
-);
-const mockUseTasksRemovalNotice = mock();
-let isUseTasksRemovalNoticeMocked = true;
-
-mock.module("./useTasksRemovalNotice", () => ({
-  ...actualUseTasksRemovalNoticeModule,
-  useTasksRemovalNotice: (
-    ...args: Parameters<
-      typeof actualUseTasksRemovalNoticeModule.useTasksRemovalNotice
-    >
-  ) =>
-    isUseTasksRemovalNoticeMocked
-      ? mockUseTasksRemovalNotice(...args)
-      : actualUseTasksRemovalNoticeModule.useTasksRemovalNotice(...args),
-}));
-
-// Same fragility as useExportDataCmdItems.test.ts: these modules are also
-// imported for real by other test files (export-user-data.util.test.ts,
-// status-toast/error-toast consumers elsewhere), and bun:test's mock.module
-// is process-wide and order-dependent — wrap the real export instead of
-// replacing it outright, and only swap in the mock while this suite runs.
-const actualRunExportMyData = (
-  await import("@web/common/storage/offline-data/export-user-data.util")
-).runExportMyData;
-const mockRunExportMyData = mock();
-let isRunExportMyDataMocked = true;
-
-mock.module(
-  "@web/common/storage/offline-data/export-user-data.util",
-  () => ({
-    runExportMyData: (...args: Parameters<typeof actualRunExportMyData>) =>
-      isRunExportMyDataMocked
-        ? mockRunExportMyData(...args)
-        : actualRunExportMyData(...args),
-  }),
-);
-
-const actualShowStatusToast = (
-  await import("@web/common/utils/toast/status-toast.util")
-).showStatusToast;
-const mockShowStatusToast = mock();
-let isStatusToastMocked = true;
-
-mock.module("@web/common/utils/toast/status-toast.util", () => ({
-  showStatusToast: (...args: Parameters<typeof actualShowStatusToast>) =>
-    isStatusToastMocked
-      ? mockShowStatusToast(...args)
-      : actualShowStatusToast(...args),
-}));
-
-const actualShowErrorToast = (
-  await import("@web/common/utils/toast/error-toast.util")
-).showErrorToast;
-const mockShowErrorToast = mock();
-let isErrorToastMocked = true;
-
-mock.module("@web/common/utils/toast/error-toast.util", () => ({
-  showErrorToast: (...args: Parameters<typeof actualShowErrorToast>) =>
-    isErrorToastMocked
-      ? mockShowErrorToast(...args)
-      : actualShowErrorToast(...args),
-}));
-
-afterAll(() => {
-  isUseTasksRemovalNoticeMocked = false;
-  isRunExportMyDataMocked = false;
-  isStatusToastMocked = false;
-  isErrorToastMocked = false;
-});
-
-// This file statically imports TasksRemovalNotice via PlannerSidebar.tsx
-// elsewhere; cache-bust so this file's mocks apply, matching
-// useExportDataCmdItems.test.ts.
-async function importComponent() {
-  const moduleUrl = new URL(
-    `./TasksRemovalNotice.tsx?test=${Math.random().toString(36).slice(2)}`,
-    import.meta.url,
-  );
-
-  return (await import(moduleUrl.href)) as typeof import("./TasksRemovalNotice");
-}
-
 describe("TasksRemovalNotice", () => {
+  const mockUseTasksRemovalNotice = mock();
+  const mockRunExportMyData = mock();
+  const mockShowStatusToast = mock();
+  const mockShowErrorToast = mock();
+
+  const buildComponent = () =>
+    createTasksRemovalNotice({
+      useTasksRemovalNotice: mockUseTasksRemovalNotice,
+      runExportMyData: mockRunExportMyData,
+      showStatusToast: mockShowStatusToast,
+      showErrorToast: mockShowErrorToast,
+    });
+
   beforeEach(() => {
     mockUseSession.mockClear();
     mockUseUser.mockClear();
@@ -118,52 +48,53 @@ describe("TasksRemovalNotice", () => {
     mockRunExportMyData.mockResolvedValue(undefined);
   });
 
-  it("renders nothing when not visible", async () => {
-    mockUseTasksRemovalNotice.mockReturnValue({ visible: false, dismiss: mock() });
-    const { TasksRemovalNotice } = await importComponent();
+  it("renders nothing when not visible", () => {
+    mockUseTasksRemovalNotice.mockReturnValue({
+      visible: false,
+      dismiss: mock(),
+    });
+    const TasksRemovalNotice = buildComponent();
 
     const { container } = render(<TasksRemovalNotice />);
 
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders nothing when visible but there's no email", async () => {
+  it("renders nothing when visible but there's no email", () => {
     mockUseUser.mockReturnValue({ email: undefined });
-    const { TasksRemovalNotice } = await importComponent();
+    const TasksRemovalNotice = buildComponent();
 
     const { container } = render(<TasksRemovalNotice />);
 
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders nothing when visible with an email but not authenticated (e.g. a stale cached email right after sign-out)", async () => {
+  it("renders nothing when visible with an email but not authenticated (e.g. a stale cached email right after sign-out)", () => {
     mockUseSession.mockReturnValue({ authenticated: false });
-    const { TasksRemovalNotice } = await importComponent();
+    const TasksRemovalNotice = buildComponent();
 
     const { container } = render(<TasksRemovalNotice />);
 
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders the card with the export CTA and a dismiss control", async () => {
-    const { TasksRemovalNotice } = await importComponent();
+  it("renders the card with the export CTA and a dismiss control", () => {
+    const TasksRemovalNotice = buildComponent();
 
     render(<TasksRemovalNotice />);
 
     expect(screen.getByText(/tasks and someday were removed/i)).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Export my data" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Export my data" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
   });
 
-  it("calls dismiss when the dismiss control is clicked", async () => {
+  it("calls dismiss when the dismiss control is clicked", () => {
     const mockDismiss = mock();
     mockUseTasksRemovalNotice.mockReturnValue({
       visible: true,
       dismiss: mockDismiss,
     });
-    const { TasksRemovalNotice } = await importComponent();
+    const TasksRemovalNotice = buildComponent();
 
     render(<TasksRemovalNotice />);
     screen.getByRole("button", { name: "Dismiss" }).click();
@@ -177,7 +108,7 @@ describe("TasksRemovalNotice", () => {
       visible: true,
       dismiss: mockDismiss,
     });
-    const { TasksRemovalNotice } = await importComponent();
+    const TasksRemovalNotice = buildComponent();
 
     render(<TasksRemovalNotice />);
     await act(async () => {
@@ -203,7 +134,7 @@ describe("TasksRemovalNotice", () => {
         resolveExport = resolve;
       }),
     );
-    const { TasksRemovalNotice } = await importComponent();
+    const TasksRemovalNotice = buildComponent();
 
     render(<TasksRemovalNotice />);
     const exportButton = screen.getByRole("button", { name: "Export my data" });
@@ -227,7 +158,7 @@ describe("TasksRemovalNotice", () => {
       visible: true,
       dismiss: mockDismiss,
     });
-    const { TasksRemovalNotice } = await importComponent();
+    const TasksRemovalNotice = buildComponent();
 
     render(<TasksRemovalNotice />);
     await act(async () => {
@@ -242,8 +173,6 @@ describe("TasksRemovalNotice", () => {
     });
 
     expect(mockDismiss).not.toHaveBeenCalled();
-    expect(
-      screen.getByText("Couldn't export your data."),
-    ).toBeTruthy();
+    expect(screen.getByText("Couldn't export your data.")).toBeTruthy();
   });
 });

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
@@ -1,0 +1,249 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockUseSession = mock();
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+const mockUseUser = mock();
+mock.module("@web/auth/compass/user/hooks/useUser", () => ({
+  useUser: mockUseUser,
+}));
+
+// This module is also imported for real by useTasksRemovalNotice.test.ts, and
+// bun:test's mock.module is process-wide and order-dependent — wrap the real
+// exports instead of replacing the module outright, so that file's import of
+// createUseTasksRemovalNotice still resolves once this suite's mock is off.
+const actualUseTasksRemovalNoticeModule = await import(
+  "./useTasksRemovalNotice"
+);
+const mockUseTasksRemovalNotice = mock();
+let isUseTasksRemovalNoticeMocked = true;
+
+mock.module("./useTasksRemovalNotice", () => ({
+  ...actualUseTasksRemovalNoticeModule,
+  useTasksRemovalNotice: (
+    ...args: Parameters<
+      typeof actualUseTasksRemovalNoticeModule.useTasksRemovalNotice
+    >
+  ) =>
+    isUseTasksRemovalNoticeMocked
+      ? mockUseTasksRemovalNotice(...args)
+      : actualUseTasksRemovalNoticeModule.useTasksRemovalNotice(...args),
+}));
+
+// Same fragility as useExportDataCmdItems.test.ts: these modules are also
+// imported for real by other test files (export-user-data.util.test.ts,
+// status-toast/error-toast consumers elsewhere), and bun:test's mock.module
+// is process-wide and order-dependent — wrap the real export instead of
+// replacing it outright, and only swap in the mock while this suite runs.
+const actualRunExportMyData = (
+  await import("@web/common/storage/offline-data/export-user-data.util")
+).runExportMyData;
+const mockRunExportMyData = mock();
+let isRunExportMyDataMocked = true;
+
+mock.module(
+  "@web/common/storage/offline-data/export-user-data.util",
+  () => ({
+    runExportMyData: (...args: Parameters<typeof actualRunExportMyData>) =>
+      isRunExportMyDataMocked
+        ? mockRunExportMyData(...args)
+        : actualRunExportMyData(...args),
+  }),
+);
+
+const actualShowStatusToast = (
+  await import("@web/common/utils/toast/status-toast.util")
+).showStatusToast;
+const mockShowStatusToast = mock();
+let isStatusToastMocked = true;
+
+mock.module("@web/common/utils/toast/status-toast.util", () => ({
+  showStatusToast: (...args: Parameters<typeof actualShowStatusToast>) =>
+    isStatusToastMocked
+      ? mockShowStatusToast(...args)
+      : actualShowStatusToast(...args),
+}));
+
+const actualShowErrorToast = (
+  await import("@web/common/utils/toast/error-toast.util")
+).showErrorToast;
+const mockShowErrorToast = mock();
+let isErrorToastMocked = true;
+
+mock.module("@web/common/utils/toast/error-toast.util", () => ({
+  showErrorToast: (...args: Parameters<typeof actualShowErrorToast>) =>
+    isErrorToastMocked
+      ? mockShowErrorToast(...args)
+      : actualShowErrorToast(...args),
+}));
+
+afterAll(() => {
+  isUseTasksRemovalNoticeMocked = false;
+  isRunExportMyDataMocked = false;
+  isStatusToastMocked = false;
+  isErrorToastMocked = false;
+});
+
+// This file statically imports TasksRemovalNotice via PlannerSidebar.tsx
+// elsewhere; cache-bust so this file's mocks apply, matching
+// useExportDataCmdItems.test.ts.
+async function importComponent() {
+  const moduleUrl = new URL(
+    `./TasksRemovalNotice.tsx?test=${Math.random().toString(36).slice(2)}`,
+    import.meta.url,
+  );
+
+  return (await import(moduleUrl.href)) as typeof import("./TasksRemovalNotice");
+}
+
+describe("TasksRemovalNotice", () => {
+  beforeEach(() => {
+    mockUseSession.mockClear();
+    mockUseUser.mockClear();
+    mockUseTasksRemovalNotice.mockClear();
+    mockRunExportMyData.mockClear();
+    mockShowStatusToast.mockClear();
+    mockShowErrorToast.mockClear();
+
+    mockUseSession.mockReturnValue({ authenticated: true });
+    mockUseUser.mockReturnValue({ email: "user@example.com" });
+    mockUseTasksRemovalNotice.mockReturnValue({
+      visible: true,
+      dismiss: mock(),
+    });
+    mockRunExportMyData.mockResolvedValue(undefined);
+  });
+
+  it("renders nothing when not visible", async () => {
+    mockUseTasksRemovalNotice.mockReturnValue({ visible: false, dismiss: mock() });
+    const { TasksRemovalNotice } = await importComponent();
+
+    const { container } = render(<TasksRemovalNotice />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when visible but there's no email", async () => {
+    mockUseUser.mockReturnValue({ email: undefined });
+    const { TasksRemovalNotice } = await importComponent();
+
+    const { container } = render(<TasksRemovalNotice />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when visible with an email but not authenticated (e.g. a stale cached email right after sign-out)", async () => {
+    mockUseSession.mockReturnValue({ authenticated: false });
+    const { TasksRemovalNotice } = await importComponent();
+
+    const { container } = render(<TasksRemovalNotice />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the card with the export CTA and a dismiss control", async () => {
+    const { TasksRemovalNotice } = await importComponent();
+
+    render(<TasksRemovalNotice />);
+
+    expect(screen.getByText(/tasks and someday were removed/i)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Export my data" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+  });
+
+  it("calls dismiss when the dismiss control is clicked", async () => {
+    const mockDismiss = mock();
+    mockUseTasksRemovalNotice.mockReturnValue({
+      visible: true,
+      dismiss: mockDismiss,
+    });
+    const { TasksRemovalNotice } = await importComponent();
+
+    render(<TasksRemovalNotice />);
+    screen.getByRole("button", { name: "Dismiss" }).click();
+
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("exports, shows a success toast, and dismisses the card on a successful export", async () => {
+    const mockDismiss = mock();
+    mockUseTasksRemovalNotice.mockReturnValue({
+      visible: true,
+      dismiss: mockDismiss,
+    });
+    const { TasksRemovalNotice } = await importComponent();
+
+    render(<TasksRemovalNotice />);
+    await act(async () => {
+      screen.getByRole("button", { name: "Export my data" }).click();
+    });
+
+    await waitFor(() => {
+      expect(mockShowStatusToast).toHaveBeenCalledWith(
+        "export-my-data",
+        "Data exported",
+      );
+    });
+
+    expect(mockRunExportMyData).toHaveBeenCalledWith("user@example.com");
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockShowErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("ignores a second click while an export is already in flight", async () => {
+    let resolveExport: () => void = () => {};
+    mockRunExportMyData.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveExport = resolve;
+      }),
+    );
+    const { TasksRemovalNotice } = await importComponent();
+
+    render(<TasksRemovalNotice />);
+    const exportButton = screen.getByRole("button", { name: "Export my data" });
+
+    act(() => {
+      exportButton.click();
+      exportButton.click();
+    });
+
+    expect(mockRunExportMyData).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveExport();
+    });
+  });
+
+  it("shows an error toast and keeps the card visible when the export fails", async () => {
+    mockRunExportMyData.mockRejectedValue(new Error("dexie is closed"));
+    const mockDismiss = mock();
+    mockUseTasksRemovalNotice.mockReturnValue({
+      visible: true,
+      dismiss: mockDismiss,
+    });
+    const { TasksRemovalNotice } = await importComponent();
+
+    render(<TasksRemovalNotice />);
+    await act(async () => {
+      screen.getByRole("button", { name: "Export my data" }).click();
+    });
+
+    await waitFor(() => {
+      expect(mockShowErrorToast).toHaveBeenCalledWith(
+        "Couldn't export your data. Please try again.",
+        { toastId: "export-my-data" },
+      );
+    });
+
+    expect(mockDismiss).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Couldn't export your data."),
+    ).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
@@ -1,0 +1,86 @@
+import { XIcon } from "@phosphor-icons/react";
+import { type FC, useRef, useState } from "react";
+import { useSession } from "@web/auth/compass/session/useSession";
+import { useUser } from "@web/auth/compass/user/hooks/useUser";
+import { EXPORT_MY_DATA_TOAST_ID } from "@web/common/constants/toast.constants";
+import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { useTasksRemovalNotice } from "./useTasksRemovalNotice";
+
+export const TasksRemovalNotice: FC = () => {
+  const { visible, dismiss } = useTasksRemovalNotice();
+  const { authenticated } = useSession();
+  const { email } = useUser();
+  const [isExporting, setIsExporting] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  // A ref, not just the isExporting state: two clicks in the same
+  // synchronous event batch both read state before React flushes the first
+  // setIsExporting(true), so state alone can't block the second click.
+  const isExportingRef = useRef(false);
+
+  // Signed-in only, matching the command palette's export item: useUser()'s
+  // email can still resolve to a last-known cached value for a brief window
+  // right after sign-out, and notifyExport must never fire for that case.
+  if (!visible || !authenticated || !email) return null;
+
+  const handleExport = () => {
+    if (isExportingRef.current) return;
+    isExportingRef.current = true;
+
+    setIsExporting(true);
+    setHasError(false);
+
+    runExportMyData(email)
+      .then(() => {
+        showStatusToast(EXPORT_MY_DATA_TOAST_ID, "Data exported");
+        // A successful export is a one-shot action, like the command
+        // palette's version — the card doesn't need to linger afterward.
+        dismiss();
+      })
+      .catch(() => {
+        isExportingRef.current = false;
+        setIsExporting(false);
+        setHasError(true);
+        showErrorToast("Couldn't export your data. Please try again.", {
+          toastId: EXPORT_MY_DATA_TOAST_ID,
+        });
+      });
+  };
+
+  return (
+    <section
+      aria-label="Tasks removed"
+      className="flex flex-col gap-2 rounded-lg bg-panel-badge-bg p-3 text-xs"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-text-lighter leading-relaxed">
+          Tasks and Someday were removed from Compass. Your old task data is
+          still saved locally — export it below before it's cleared. Someday
+          events will be emailed to you separately.
+        </p>
+        <button
+          aria-label="Dismiss"
+          className="c-focus-ring shrink-0 rounded-xs text-text-light-inactive hover:text-text-lighter"
+          onClick={dismiss}
+          type="button"
+        >
+          <XIcon aria-hidden="true" size={14} />
+        </button>
+      </div>
+
+      <button
+        className="c-focus-ring self-start rounded-xs bg-accent-primary px-2 py-1 font-medium text-s text-text-dark hover:brightness-110 disabled:opacity-60"
+        disabled={isExporting}
+        onClick={handleExport}
+        type="button"
+      >
+        {isExporting ? "Exporting…" : "Export my data"}
+      </button>
+
+      {hasError ? (
+        <p className="text-status-error">Couldn't export your data.</p>
+      ) : null}
+    </section>
+  );
+};

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
@@ -1,5 +1,5 @@
 import { XIcon } from "@phosphor-icons/react";
-import { type FC, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { EXPORT_MY_DATA_TOAST_ID } from "@web/common/constants/toast.constants";
@@ -8,79 +8,98 @@ import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { useTasksRemovalNotice } from "./useTasksRemovalNotice";
 
-export const TasksRemovalNotice: FC = () => {
-  const { visible, dismiss } = useTasksRemovalNotice();
-  const { authenticated } = useSession();
-  const { email } = useUser();
-  const [isExporting, setIsExporting] = useState(false);
-  const [hasError, setHasError] = useState(false);
-  // A ref, not just the isExporting state: two clicks in the same
-  // synchronous event batch both read state before React flushes the first
-  // setIsExporting(true), so state alone can't block the second click.
-  const isExportingRef = useRef(false);
+type TasksRemovalNoticeDependencies = {
+  useTasksRemovalNotice: typeof useTasksRemovalNotice;
+  runExportMyData: typeof runExportMyData;
+  showStatusToast: typeof showStatusToast;
+  showErrorToast: typeof showErrorToast;
+};
 
-  // Signed-in only, matching the command palette's export item: useUser()'s
-  // email can still resolve to a last-known cached value for a brief window
-  // right after sign-out, and notifyExport must never fire for that case.
-  if (!visible || !authenticated || !email) return null;
+type ExportStatus = "idle" | "exporting" | "error";
 
-  const handleExport = () => {
-    if (isExportingRef.current) return;
-    isExportingRef.current = true;
+export function createTasksRemovalNotice({
+  useTasksRemovalNotice,
+  runExportMyData,
+  showStatusToast,
+  showErrorToast,
+}: TasksRemovalNoticeDependencies) {
+  return function TasksRemovalNotice() {
+    const { visible, dismiss } = useTasksRemovalNotice();
+    const { authenticated } = useSession();
+    const { email } = useUser();
+    const [exportStatus, setExportStatus] = useState<ExportStatus>("idle");
+    // A ref, not just exportStatus: two clicks in the same synchronous event
+    // batch both read state before React flushes the first setExportStatus,
+    // so state alone can't block the second click.
+    const isExportingRef = useRef(false);
 
-    setIsExporting(true);
-    setHasError(false);
+    // Signed-in only, matching the command palette's export item: useUser()'s
+    // email can still resolve to a last-known cached value for a brief
+    // window right after sign-out, and notifyExport must never fire then.
+    if (!visible || !authenticated || !email) return null;
 
-    runExportMyData(email)
-      .then(() => {
-        showStatusToast(EXPORT_MY_DATA_TOAST_ID, "Data exported");
-        // A successful export is a one-shot action, like the command
-        // palette's version — the card doesn't need to linger afterward.
-        dismiss();
-      })
-      .catch(() => {
-        isExportingRef.current = false;
-        setIsExporting(false);
-        setHasError(true);
-        showErrorToast("Couldn't export your data. Please try again.", {
-          toastId: EXPORT_MY_DATA_TOAST_ID,
+    const handleExport = () => {
+      if (isExportingRef.current) return;
+      isExportingRef.current = true;
+      setExportStatus("exporting");
+
+      runExportMyData(email)
+        .then(() => {
+          showStatusToast(EXPORT_MY_DATA_TOAST_ID, "Data exported");
+          // A successful export is a one-shot action, like the command
+          // palette's version — the card doesn't need to linger afterward.
+          dismiss();
+        })
+        .catch(() => {
+          isExportingRef.current = false;
+          setExportStatus("error");
+          showErrorToast("Couldn't export your data. Please try again.", {
+            toastId: EXPORT_MY_DATA_TOAST_ID,
+          });
         });
-      });
-  };
+    };
 
-  return (
-    <section
-      aria-label="Tasks removed"
-      className="flex flex-col gap-2 rounded-lg bg-panel-badge-bg p-3 text-xs"
-    >
-      <div className="flex items-start justify-between gap-2">
-        <p className="text-text-lighter leading-relaxed">
-          Tasks and Someday were removed from Compass. Your old task data is
-          still saved locally — export it below before it's cleared. Someday
-          events will be emailed to you separately.
-        </p>
+    return (
+      <section
+        aria-label="Tasks removed"
+        className="flex flex-col gap-2 rounded-lg bg-panel-badge-bg p-3 text-xs"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-text-lighter leading-relaxed">
+            Tasks and Someday were removed from Compass. Your old task data is
+            still saved locally — export it below before it's cleared. Someday
+            events will be emailed to you separately.
+          </p>
+          <button
+            aria-label="Dismiss"
+            className="c-focus-ring shrink-0 rounded-xs text-text-light-inactive hover:text-text-lighter"
+            onClick={dismiss}
+            type="button"
+          >
+            <XIcon aria-hidden="true" size={14} />
+          </button>
+        </div>
+
         <button
-          aria-label="Dismiss"
-          className="c-focus-ring shrink-0 rounded-xs text-text-light-inactive hover:text-text-lighter"
-          onClick={dismiss}
+          className="c-focus-ring self-start rounded-xs bg-accent-primary px-2 py-1 font-medium text-s text-text-dark hover:brightness-110 disabled:opacity-60"
+          disabled={exportStatus === "exporting"}
+          onClick={handleExport}
           type="button"
         >
-          <XIcon aria-hidden="true" size={14} />
+          {exportStatus === "exporting" ? "Exporting…" : "Export my data"}
         </button>
-      </div>
 
-      <button
-        className="c-focus-ring self-start rounded-xs bg-accent-primary px-2 py-1 font-medium text-s text-text-dark hover:brightness-110 disabled:opacity-60"
-        disabled={isExporting}
-        onClick={handleExport}
-        type="button"
-      >
-        {isExporting ? "Exporting…" : "Export my data"}
-      </button>
+        {exportStatus === "error" ? (
+          <p className="text-status-error">Couldn't export your data.</p>
+        ) : null}
+      </section>
+    );
+  };
+}
 
-      {hasError ? (
-        <p className="text-status-error">Couldn't export your data.</p>
-      ) : null}
-    </section>
-  );
-};
+export const TasksRemovalNotice = createTasksRemovalNotice({
+  useTasksRemovalNotice,
+  runExportMyData,
+  showStatusToast,
+  showErrorToast,
+});

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/tasks-removal-notice.util.test.ts
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/tasks-removal-notice.util.test.ts
@@ -1,0 +1,19 @@
+import {
+  hasDismissedTasksRemovalNotice,
+  markTasksRemovalNoticeDismissed,
+} from "./tasks-removal-notice.util";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("tasks-removal-notice.util", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("is not dismissed until markTasksRemovalNoticeDismissed is called", () => {
+    expect(hasDismissedTasksRemovalNotice()).toBe(false);
+
+    markTasksRemovalNoticeDismissed();
+
+    expect(hasDismissedTasksRemovalNotice()).toBe(true);
+  });
+});

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/tasks-removal-notice.util.ts
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/tasks-removal-notice.util.ts
@@ -1,0 +1,18 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+export function hasDismissedTasksRemovalNotice(): boolean {
+  if (!persistentBrowserStore.isAvailable()) return true;
+  return (
+    persistentBrowserStore.get(
+      STORAGE_KEYS.HAS_DISMISSED_TASKS_REMOVAL_NOTICE,
+    ) === "true"
+  );
+}
+
+export function markTasksRemovalNoticeDismissed(): void {
+  persistentBrowserStore.set(
+    STORAGE_KEYS.HAS_DISMISSED_TASKS_REMOVAL_NOTICE,
+    "true",
+  );
+}

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/useTasksRemovalNotice.test.ts
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/useTasksRemovalNotice.test.ts
@@ -1,0 +1,94 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { createUseTasksRemovalNotice } from "./useTasksRemovalNotice";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+describe("useTasksRemovalNotice", () => {
+  const ensureOfflineDataStoreReady = mock();
+  const getTaskCount = mock();
+  const getOfflineDataStore = mock(() => ({ getTaskCount }));
+  const hasDismissedTasksRemovalNotice = mock();
+  const markTasksRemovalNoticeDismissed = mock();
+
+  const buildHook = () =>
+    createUseTasksRemovalNotice({
+      ensureOfflineDataStoreReady,
+      getOfflineDataStore,
+      hasDismissedTasksRemovalNotice,
+      markTasksRemovalNoticeDismissed,
+    });
+
+  beforeEach(() => {
+    ensureOfflineDataStoreReady.mockClear();
+    getTaskCount.mockClear();
+    getOfflineDataStore.mockClear();
+    hasDismissedTasksRemovalNotice.mockClear();
+    markTasksRemovalNoticeDismissed.mockClear();
+
+    ensureOfflineDataStoreReady.mockResolvedValue(undefined);
+    hasDismissedTasksRemovalNotice.mockReturnValue(false);
+  });
+
+  it("is not visible when there are no leftover tasks", async () => {
+    getTaskCount.mockResolvedValue(0);
+    const useTasksRemovalNotice = buildHook();
+
+    const { result } = renderHook(() => useTasksRemovalNotice());
+
+    await waitFor(() => {
+      expect(getTaskCount).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.visible).toBe(false);
+  });
+
+  it("is not visible when already dismissed, and never checks the task count", async () => {
+    hasDismissedTasksRemovalNotice.mockReturnValue(true);
+    const useTasksRemovalNotice = buildHook();
+
+    const { result } = renderHook(() => useTasksRemovalNotice());
+
+    expect(result.current.visible).toBe(false);
+    expect(getTaskCount).not.toHaveBeenCalled();
+  });
+
+  it("becomes visible once the task count resolves above zero", async () => {
+    getTaskCount.mockResolvedValue(2);
+    const useTasksRemovalNotice = buildHook();
+
+    const { result } = renderHook(() => useTasksRemovalNotice());
+
+    await waitFor(() => {
+      expect(result.current.visible).toBe(true);
+    });
+  });
+
+  it("dismiss() hides the card immediately and persists the flag", async () => {
+    getTaskCount.mockResolvedValue(1);
+    const useTasksRemovalNotice = buildHook();
+
+    const { result } = renderHook(() => useTasksRemovalNotice());
+
+    await waitFor(() => {
+      expect(result.current.visible).toBe(true);
+    });
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.visible).toBe(false);
+    expect(markTasksRemovalNoticeDismissed).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed (not visible) if the task count check errors", async () => {
+    getTaskCount.mockRejectedValue(new Error("dexie is closed"));
+    const useTasksRemovalNotice = buildHook();
+
+    const { result } = renderHook(() => useTasksRemovalNotice());
+
+    await waitFor(() => {
+      expect(getTaskCount).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.visible).toBe(false);
+  });
+});

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/useTasksRemovalNotice.ts
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/useTasksRemovalNotice.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { type OfflineDataStore } from "@web/common/storage/offline-data/offline-data.store";
+import {
+  ensureOfflineDataStoreReady,
+  getOfflineDataStore,
+} from "@web/common/storage/offline-data/offline-data.store.registry";
+import {
+  hasDismissedTasksRemovalNotice,
+  markTasksRemovalNoticeDismissed,
+} from "./tasks-removal-notice.util";
+
+type TasksRemovalNoticeStorage = Pick<OfflineDataStore, "getTaskCount">;
+
+type TasksRemovalNoticeDependencies = {
+  ensureOfflineDataStoreReady: typeof ensureOfflineDataStoreReady;
+  getOfflineDataStore: () => TasksRemovalNoticeStorage;
+  hasDismissedTasksRemovalNotice: typeof hasDismissedTasksRemovalNotice;
+  markTasksRemovalNoticeDismissed: typeof markTasksRemovalNoticeDismissed;
+};
+
+interface TasksRemovalNoticeState {
+  visible: boolean;
+  dismiss: () => void;
+}
+
+export function createUseTasksRemovalNotice({
+  ensureOfflineDataStoreReady,
+  getOfflineDataStore,
+  hasDismissedTasksRemovalNotice,
+  markTasksRemovalNoticeDismissed,
+}: TasksRemovalNoticeDependencies) {
+  return function useTasksRemovalNotice(): TasksRemovalNoticeState {
+    const [dismissed, setDismissed] = useState(hasDismissedTasksRemovalNotice);
+    const [taskCount, setTaskCount] = useState(0);
+
+    useEffect(() => {
+      if (dismissed) return;
+
+      let cancelled = false;
+
+      ensureOfflineDataStoreReady()
+        .then(() => getOfflineDataStore().getTaskCount())
+        .then((count) => {
+          if (!cancelled) setTaskCount(count);
+        })
+        .catch(() => {
+          // Fail closed: if the count check itself breaks, don't show a
+          // notice that can't reliably know whether there's data to export.
+          if (!cancelled) setTaskCount(0);
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }, [dismissed]);
+
+    const dismiss = useCallback(() => {
+      // Mark dismissed before flipping state, mirroring markWelcomeSeen() in
+      // WelcomeModal — no flash between the click and the card disappearing.
+      markTasksRemovalNoticeDismissed();
+      setDismissed(true);
+    }, []);
+
+    return { visible: !dismissed && taskCount > 0, dismiss };
+  };
+}
+
+export const useTasksRemovalNotice = createUseTasksRemovalNotice({
+  ensureOfflineDataStoreReady,
+  getOfflineDataStore,
+  hasDismissedTasksRemovalNotice,
+  markTasksRemovalNoticeDismissed,
+});


### PR DESCRIPTION
## Summary
- Adds a persistent, dismissible sidebar card for returning users who still have leftover local Tasks data from before the Tasks/Someday removal, gated on a cheap Dexie `getTaskCount()` check plus a localStorage dismiss flag.
- Extracts the command palette's inline export sequence (collect → download → notify → clear) into a shared `runExportMyData` function, so the new card and the existing "Export my data" command item both drive the same flow instead of duplicating it.
- Card copy explains Tasks + Someday were removed, notes Someday events are emailed separately, and its CTA triggers the export directly with its own loading/success/error states; a successful export auto-dismisses the card.

## Simplicity
Net complexity went down: the biggest file in the diff (`TasksRemovalNotice.test.tsx`) shrank from 249 to ~200 lines and dropped from four `mock.module`-with-cache-busting blocks to two, by converting `TasksRemovalNotice.tsx` to the same `createX(deps)` factory pattern already used by its sibling hooks (`createUseExportDataCmdItems`, `createUseTasksRemovalNotice`) — the remaining `mock.module` calls are only for `useSession`/`useUser`, matching the codebase's existing convention for auth hooks with no injection seam of their own. Also merged two always-together `useState` booleans (`isExporting`/`hasError`) into one `exportStatus: "idle" | "exporting" | "error"` enum, removing a representable-but-impossible state combination.

Hooks in the diff:
- `useEffect` in `useTasksRemovalNotice.ts`: syncs with the offline-data IndexedDB store (a non-React system) to check the leftover task count once per mount; a `cancelled` flag guards against a stale `setState` after unmount.
- `useRef` in `TasksRemovalNotice.tsx`: a synchronous re-entrancy guard for the export button. Two rapid clicks land in the same event batch and both read `useState` before React flushes the first update, so state alone can't block a second concurrent export — the ref can.
- `useState` (`exportStatus`) in `TasksRemovalNotice.tsx`: local, UI-only status for the export button; nothing else in the app needs it, so it isn't lifted to a store.

## Manual Testing Steps
- [ ] Sign in, open the sidebar. With no leftover local Tasks data, confirm no notice card appears under the calendar list.
- [ ] Seed a leftover local task (e.g. via the browser's IndexedDB devtools against the `compass-local` database's `tasks` table) and reload — confirm a card appears reading "Tasks and Someday were removed from Compass..." with an "Export my data" button and a dismiss (×) control.
- [ ] Click "Export my data" — confirm a `compass-export-<date>.json` file downloads, a "Data exported" toast appears, and the card disappears automatically.
- [ ] Reload the page — confirm the card stays hidden (the dismiss flag persisted).
- [ ] Re-seed a leftover task and reload; this time click the × dismiss control (not the export button) — confirm the card hides immediately with no toast and no download.
- [ ] Re-seed a leftover task, reload, and rapidly double-click "Export my data" — confirm only one file downloads and one webhook notification fires (not two).
- [ ] Open the command palette and run "Export my data" from there — confirm it still downloads a file and shows the same success toast as before this change.

## Test plan
- [x] `bun run type-check` — passes
- [x] `bun test` (full `packages/web` suite) — 1175 pass, 0 fail
- [x] `bun run lint` — passes after `bun run format`
- [x] Manual verification in the user's real Chrome profile (signed-in test account): seeded a real Dexie task row, confirmed the card renders, the export flow downloads/toasts/auto-dismisses/clears the task table, the manual dismiss (×) path works independently, and a rapid double-click only fires the export webhook once (instrumented via a `window.fetch` wrapper) — no console errors in any pass