### PR TITLE
refactor(web): drop the export webhook, self-serve someday recovery instead

### DIFF
--- a/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
@@ -6,9 +6,8 @@ import {
   createCollectExportData,
   createRunExportMyData,
   getExportFilename,
-  notifyExport,
 } from "./export-user-data.util";
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const ensureOfflineDataStoreReady = mock();
 const getAllTasks = mock();
@@ -50,10 +49,11 @@ describe("collectExportData", () => {
     expect(typeof result.exportedAt).toBe("string");
   });
 
-  it("includes a message explaining someday events arrive separately by email", async () => {
+  it("includes a message inviting pre-cutoff signups to email for their someday events", async () => {
     const result = await collectExportData();
 
     expect(result.message).toContain("tyler@switchback.tech");
+    expect(result.message).toContain("July 15, 2026");
     expect(result.message.toLowerCase()).toContain("someday");
   });
 
@@ -91,61 +91,16 @@ describe("clearExportedTasks", () => {
   });
 });
 
-describe("notifyExport", () => {
-  // Assigned in beforeEach/restored in afterEach (not module scope) so this
-  // reliably wins against MSW's global fetch patching — matches
-  // useVersionCheck.test.ts's pattern for mocking a raw external fetch call.
-  const mockFetch = mock();
-  const originalFetch = globalThis.fetch;
-
-  beforeEach(() => {
-    mockFetch.mockClear();
-    mockFetch.mockResolvedValue({ ok: true });
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
-  });
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it("posts the user's email to the webhook", async () => {
-    notifyExport("user@example.com");
-
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const [url, requestInit] = mockFetch.mock.calls[0];
-    expect(url).toContain("discord.com/api/webhooks");
-    expect(requestInit.method).toBe("POST");
-    expect(JSON.parse(requestInit.body as string).content).toContain(
-      "user@example.com",
-    );
-
-    // Let notifyExport's internal .catch() chain settle before the test ends
-    // so its resolution doesn't bleed into the next test.
-    await Promise.resolve();
-    await Promise.resolve();
-  });
-
-  // A rejected-fetch case isn't covered here directly (mocking a raw fetch
-  // reliably across bun test files fighting MSW's global patching proved too
-  // flaky to justify) — notifyExport's implementation is a trivial
-  // `fetch(...).catch(() => {})`, and useExportDataCmdItems.test.ts's "still
-  // exports and clears tasks even when the webhook notification throws"
-  // covers the behavior that actually matters: a failing notification must
-  // never break the export.
-});
-
 describe("runExportMyData", () => {
   const mockCollectExportData = mock();
   const mockDownloadAsJsonFile = mock();
   const mockClearExportedTasks = mock();
-  const mockNotifyExport = mock();
   const mockGetExportFilename = mock();
 
   const runExportMyData = createRunExportMyData({
     collectExportData: mockCollectExportData,
     downloadAsJsonFile: mockDownloadAsJsonFile,
     clearExportedTasks: mockClearExportedTasks,
-    notifyExport: mockNotifyExport,
     getExportFilename: mockGetExportFilename,
   });
 
@@ -153,7 +108,6 @@ describe("runExportMyData", () => {
     mockCollectExportData.mockClear();
     mockDownloadAsJsonFile.mockClear();
     mockClearExportedTasks.mockClear();
-    mockNotifyExport.mockClear();
     mockGetExportFilename.mockClear();
 
     mockCollectExportData.mockResolvedValue({
@@ -166,35 +120,30 @@ describe("runExportMyData", () => {
     mockGetExportFilename.mockReturnValue("compass-export-2026-07-15.json");
   });
 
-  it("downloads the export, notifies the webhook with the user's email, then clears tasks", async () => {
-    await runExportMyData("user@example.com");
+  it("downloads the export, then clears tasks", async () => {
+    await runExportMyData();
 
     expect(mockDownloadAsJsonFile).toHaveBeenCalledWith(
       expect.objectContaining({ version: 1 }),
       "compass-export-2026-07-15.json",
     );
-    expect(mockNotifyExport).toHaveBeenCalledWith("user@example.com");
     expect(mockClearExportedTasks).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects and skips download/notify/clear when collecting export data fails", async () => {
+  it("rejects and skips download/clear when collecting export data fails", async () => {
     mockCollectExportData.mockRejectedValue(new Error("dexie is closed"));
 
-    await expect(runExportMyData("user@example.com")).rejects.toThrow(
-      "dexie is closed",
-    );
+    await expect(runExportMyData()).rejects.toThrow("dexie is closed");
 
     expect(mockDownloadAsJsonFile).not.toHaveBeenCalled();
-    expect(mockNotifyExport).not.toHaveBeenCalled();
     expect(mockClearExportedTasks).not.toHaveBeenCalled();
   });
 
   it("resolves even when clearing the tasks table fails after a successful download", async () => {
     mockClearExportedTasks.mockRejectedValue(new Error("write conflict"));
 
-    await expect(runExportMyData("user@example.com")).resolves.toBeUndefined();
+    await expect(runExportMyData()).resolves.toBeUndefined();
 
     expect(mockDownloadAsJsonFile).toHaveBeenCalledTimes(1);
-    expect(mockNotifyExport).toHaveBeenCalledWith("user@example.com");
   });
 });

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.ts
@@ -7,7 +7,7 @@ import {
 } from "@web/common/storage/offline-data/offline-data.store.registry";
 
 const SOMEDAY_EVENTS_NOTICE =
-  "Someday events aren't included in this file. If you had any, they'll be emailed to you separately by tyler@switchback.tech.";
+  "Someday events aren't included in this file. If you signed up before July 15, 2026 and want your Someday events, email tyler@switchback.tech. If you signed up after that date, you never had Someday events, so no action is needed.";
 
 interface CompassDataExport {
   exportedAt: string;
@@ -89,26 +89,6 @@ export function getExportFilename(date = new Date()): string {
   return `compass-export-${dateKey}.json`;
 }
 
-// Public by necessity: this fires from the browser. Rotate the URL in the
-// Discord channel settings if it's ever spammed or leaked in ways that matter.
-const EXPORT_NOTIFY_WEBHOOK_URL =
-  "https://discord.com/api/webhooks/1526960288878952685/5OP3VrtAAdllsUlmPZ1N9f4tox6xTq5PWSmCH8aoUcd0oJDcdyj52XisVE_1blxH0Qb-";
-
-/**
- * Best-effort notification so a someday-events export can be handled by
- * hand; failure here must never block or fail the data export itself.
- */
-export function notifyExport(email: string): void {
-  fetch(EXPORT_NOTIFY_WEBHOOK_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ content: `Compass data export: ${email}` }),
-  }).catch(() => {
-    // Best-effort notification only; the export itself must not fail if
-    // Discord is unreachable.
-  });
-}
-
 export const collectExportData = createCollectExportData({
   ensureOfflineDataStoreReady,
   getOfflineDataStore,
@@ -122,7 +102,6 @@ type RunExportMyDataDependencies = {
   collectExportData: typeof collectExportData;
   downloadAsJsonFile: typeof downloadAsJsonFile;
   clearExportedTasks: typeof clearExportedTasks;
-  notifyExport: typeof notifyExport;
   getExportFilename: typeof getExportFilename;
 };
 
@@ -130,24 +109,20 @@ export function createRunExportMyData({
   collectExportData,
   downloadAsJsonFile,
   clearExportedTasks,
-  notifyExport,
   getExportFilename,
 }: RunExportMyDataDependencies) {
   /**
-   * Collect -> download -> notify -> clear, shared by every surface that
-   * triggers "export my data" (command palette, sidebar notice). Callers own
+   * Collect -> download -> clear, shared by every surface that triggers
+   * "export my data" (command palette, sidebar notice). Callers own
    * presentation (toasts, inline loading state) - this only resolves/rejects.
    */
-  return async function runExportMyData(email: string): Promise<void> {
+  return async function runExportMyData(): Promise<void> {
     const data = await collectExportData();
     downloadAsJsonFile(data, getExportFilename());
-    // notifyExport is best-effort and already swallows its own failures (see
-    // its own implementation) — it can't fail the export the user is waiting on.
-    notifyExport(email);
     // Clearing the legacy tasks table is cleanup, not part of the export the
-    // user is waiting on — the download and webhook above have already
-    // succeeded by this point, so a failure here must not surface as an
-    // export failure (which would wrongly invite the user to retry).
+    // user is waiting on — the download above has already succeeded by this
+    // point, so a failure here must not surface as an export failure (which
+    // would wrongly invite the user to retry).
     clearExportedTasks().catch(() => {
       // Ignored; the table is retried on the user's next export.
     });
@@ -158,6 +133,5 @@ export const runExportMyData = createRunExportMyData({
   collectExportData,
   downloadAsJsonFile,
   clearExportedTasks,
-  notifyExport,
   getExportFilename,
 });

--- a/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.test.ts
@@ -7,11 +7,6 @@ mock.module("@web/auth/compass/session/useSession", () => ({
   useSession: mockUseSession,
 }));
 
-const mockUseUser = mock();
-mock.module("@web/auth/compass/user/hooks/useUser", () => ({
-  useUser: mockUseUser,
-}));
-
 // Same fragility as useSubscribeCmdItems.test.ts: react-toastify's binding
 // is process-wide and shared across suites, so mock the two util modules
 // useExportDataCmdItems.ts imports directly instead.
@@ -51,7 +46,7 @@ afterAll(() => {
 });
 
 // CommandPalette.tsx statically imports the default-wired useExportDataCmdItems;
-// cache-bust so this file's useSession/useUser mocks apply, matching
+// cache-bust so this file's useSession mock applies, matching
 // useSubscribeCmdItems.test.ts. runExportMyData is injected directly via
 // createUseExportDataCmdItems below instead of mock.module — that
 // dependency's module is also imported for real by
@@ -80,13 +75,11 @@ describe("useExportDataCmdItems", () => {
 
   beforeEach(() => {
     mockUseSession.mockClear();
-    mockUseUser.mockClear();
     mockRunExportMyData.mockClear();
     mockShowStatusToast.mockClear();
     mockShowErrorToast.mockClear();
 
     mockUseSession.mockReturnValue({ authenticated: true });
-    mockUseUser.mockReturnValue({ email: "user@example.com" });
     mockRunExportMyData.mockResolvedValue(undefined);
   });
 
@@ -99,16 +92,7 @@ describe("useExportDataCmdItems", () => {
     expect(result.current).toEqual([]);
   });
 
-  it("returns no items when signed in but email is missing", async () => {
-    mockUseUser.mockReturnValue({ email: undefined });
-    const useExportDataCmdItems = await buildHook();
-
-    const { result } = renderHook(() => useExportDataCmdItems());
-
-    expect(result.current).toEqual([]);
-  });
-
-  it("runs the export with the user's email and shows a success toast", async () => {
+  it("runs the export and shows a success toast", async () => {
     const useExportDataCmdItems = await buildHook();
 
     const { result } = renderHook(() => useExportDataCmdItems());
@@ -125,7 +109,7 @@ describe("useExportDataCmdItems", () => {
       );
     });
 
-    expect(mockRunExportMyData).toHaveBeenCalledWith("user@example.com");
+    expect(mockRunExportMyData).toHaveBeenCalledTimes(1);
     expect(mockShowErrorToast).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useExportDataCmdItems.ts
@@ -1,6 +1,5 @@
 import { DownloadIcon } from "@phosphor-icons/react";
 import { useSession } from "@web/auth/compass/session/useSession";
-import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { EXPORT_MY_DATA_TOAST_ID } from "@web/common/constants/toast.constants";
 import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
@@ -13,19 +12,16 @@ type ExportDataDependencies = {
 
 /**
  * Returns a command palette item that downloads the user's local IndexedDB
- * data (recoverable tasks + non-demo events) as a JSON file, notifies Tyler
- * via webhook so someday events can be pulled from Mongo by hand, then
- * clears the retained tasks table. Signed-in only: the webhook exists to
- * locate a user's someday events, which only signed-in users have.
+ * data (recoverable tasks + non-demo events) as a JSON file, then clears the
+ * retained tasks table. Signed-in only, matching the sidebar's export CTA.
  */
 export function createUseExportDataCmdItems({
   runExportMyData,
 }: ExportDataDependencies) {
   return function useExportDataCmdItems(): CommandItem[] {
     const { authenticated } = useSession();
-    const { email } = useUser();
 
-    if (!authenticated || !email) {
+    if (!authenticated) {
       return [];
     }
 
@@ -35,7 +31,7 @@ export function createUseExportDataCmdItems({
         label: "Export my data",
         icon: DownloadIcon,
         onClick: () => {
-          runExportMyData(email)
+          runExportMyData()
             .then(() => {
               showStatusToast(EXPORT_MY_DATA_TOAST_ID, "Data exported");
             })

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
@@ -3,18 +3,13 @@ import { act } from "react";
 import { createTasksRemovalNotice } from "./TasksRemovalNotice";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
-// Matches useExportDataCmdItems.test.ts's convention: useSession/useUser are
-// auth hooks with no injection seam of their own, so they're mock.module'd;
-// everything else this component depends on is a plain function, injected
-// via createTasksRemovalNotice below — no mock.module, no cache-busting.
+// Matches useExportDataCmdItems.test.ts's convention: useSession is an auth
+// hook with no injection seam of its own, so it's mock.module'd; everything
+// else this component depends on is a plain function, injected via
+// createTasksRemovalNotice below — no mock.module, no cache-busting.
 const mockUseSession = mock();
 mock.module("@web/auth/compass/session/useSession", () => ({
   useSession: mockUseSession,
-}));
-
-const mockUseUser = mock();
-mock.module("@web/auth/compass/user/hooks/useUser", () => ({
-  useUser: mockUseUser,
 }));
 
 describe("TasksRemovalNotice", () => {
@@ -33,14 +28,12 @@ describe("TasksRemovalNotice", () => {
 
   beforeEach(() => {
     mockUseSession.mockClear();
-    mockUseUser.mockClear();
     mockUseTasksRemovalNotice.mockClear();
     mockRunExportMyData.mockClear();
     mockShowStatusToast.mockClear();
     mockShowErrorToast.mockClear();
 
     mockUseSession.mockReturnValue({ authenticated: true });
-    mockUseUser.mockReturnValue({ email: "user@example.com" });
     mockUseTasksRemovalNotice.mockReturnValue({
       visible: true,
       dismiss: mock(),
@@ -60,16 +53,7 @@ describe("TasksRemovalNotice", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders nothing when visible but there's no email", () => {
-    mockUseUser.mockReturnValue({ email: undefined });
-    const TasksRemovalNotice = buildComponent();
-
-    const { container } = render(<TasksRemovalNotice />);
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it("renders nothing when visible with an email but not authenticated (e.g. a stale cached email right after sign-out)", () => {
+  it("renders nothing when visible but not authenticated", () => {
     mockUseSession.mockReturnValue({ authenticated: false });
     const TasksRemovalNotice = buildComponent();
 
@@ -122,7 +106,7 @@ describe("TasksRemovalNotice", () => {
       );
     });
 
-    expect(mockRunExportMyData).toHaveBeenCalledWith("user@example.com");
+    expect(mockRunExportMyData).toHaveBeenCalledTimes(1);
     expect(mockDismiss).toHaveBeenCalledTimes(1);
     expect(mockShowErrorToast).not.toHaveBeenCalled();
   });

--- a/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
+++ b/packages/web/src/components/PlannerSidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
@@ -1,7 +1,6 @@
 import { XIcon } from "@phosphor-icons/react";
 import { useRef, useState } from "react";
 import { useSession } from "@web/auth/compass/session/useSession";
-import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { EXPORT_MY_DATA_TOAST_ID } from "@web/common/constants/toast.constants";
 import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
@@ -26,24 +25,21 @@ export function createTasksRemovalNotice({
   return function TasksRemovalNotice() {
     const { visible, dismiss } = useTasksRemovalNotice();
     const { authenticated } = useSession();
-    const { email } = useUser();
     const [exportStatus, setExportStatus] = useState<ExportStatus>("idle");
     // A ref, not just exportStatus: two clicks in the same synchronous event
     // batch both read state before React flushes the first setExportStatus,
     // so state alone can't block the second click.
     const isExportingRef = useRef(false);
 
-    // Signed-in only, matching the command palette's export item: useUser()'s
-    // email can still resolve to a last-known cached value for a brief
-    // window right after sign-out, and notifyExport must never fire then.
-    if (!visible || !authenticated || !email) return null;
+    // Signed-in only, matching the command palette's export item.
+    if (!visible || !authenticated) return null;
 
     const handleExport = () => {
       if (isExportingRef.current) return;
       isExportingRef.current = true;
       setExportStatus("exporting");
 
-      runExportMyData(email)
+      runExportMyData()
         .then(() => {
           showStatusToast(EXPORT_MY_DATA_TOAST_ID, "Data exported");
           // A successful export is a one-shot action, like the command
@@ -67,8 +63,9 @@ export function createTasksRemovalNotice({
         <div className="flex items-start justify-between gap-2">
           <p className="text-text-lighter leading-relaxed">
             Tasks and Someday were removed from Compass. Your old task data is
-            still saved locally — export it below before it's cleared. Someday
-            events will be emailed to you separately.
+            still saved locally — export it below before it's cleared. If you
+            signed up before July 15, 2026 and want your Someday events, email
+            tyler@switchback.tech.
           </p>
           <button
             aria-label="Dismiss"


### PR DESCRIPTION
## Summary
- Removes the Discord webhook notification from the "export my data" flow (command palette + sidebar notice card).
- Replaces it with a static message: the exported file's `message` field and the sidebar card's copy both tell users who signed up before July 15, 2026 to email tyler@switchback.tech if they want their Someday events recovered; everyone else is told no action is needed.
- Since the webhook was the only reason `runExportMyData` needed an email, it now takes no arguments, and both export entry points gate on `authenticated` alone (dropping the `useUser()`/email dependency entirely).

## Simplicity
Net complexity went down (-116 lines across 6 files, no new abstractions). Removing the webhook eliminated: the webhook URL constant, the `notifyExport` function and its dedicated test suite (which had to work around MSW/fetch-mocking fragility), the `email` parameter threaded through `runExportMyData` and both its callers, and the `useUser()` dependency in both `useExportDataCmdItems.ts` and `TasksRemovalNotice.tsx`. No hooks were added or changed in this diff.

## Manual Testing Steps
- [ ] Sign in, seed a leftover local Tasks row (or use an account that already has one), open the sidebar — confirm the notice card reads "...If you signed up before July 15, 2026 and want your Someday events, email tyler@switchback.tech." (no mention of being emailed automatically).
- [ ] Click "Export my data" on the card — confirm a JSON file downloads whose `message` field contains the same self-serve wording, a "Data exported" toast appears, and the card auto-dismisses.
- [ ] Open the browser's Network tab (or devtools) during the export click — confirm no request to `discord.com` fires.
- [ ] Run "Export my data" from the command palette — confirm it still works the same way (download + success toast), now also with no Discord request.

## Test plan
- [x] `bun run type-check` — passes
- [x] `bun test` (full `packages/web` suite) — 1172 pass, 0 fail
- [x] `bun run lint` — passes after `bun run format`
- [x] Manual verification in the user's real Chrome profile (signed-in test account): seeded a real Dexie task row, confirmed the updated sidebar copy renders, exported the file and inspected its `message` field directly (intercepted `URL.createObjectURL`), and confirmed zero `fetch` calls fired during the export (instrumented `window.fetch`) — no console errors