### PR TITLE
feat(cutover): open prod gate, fix backfill string-_id crash, add execution plan

### DIFF
--- a/packages/scripts/src/migrations/2026.07.10T21.30.00.event-record-backfill.test.ts
+++ b/packages/scripts/src/migrations/2026.07.10T21.30.00.event-record-backfill.test.ts
@@ -299,6 +299,39 @@ describe("2026.07.10T21.30.00.event-record-backfill", () => {
       );
     });
 
+    it("migrates a series whose legacy base has a string _id (anomalous prod rows)", async () => {
+      const user = await UserDriver.createUser({ withGoogle: false });
+      await insertLocalCalendar(user._id);
+      const userIdHex = user._id.toHexString();
+
+      // Some production rows carry a hex string _id instead of an ObjectId;
+      // the transform accepts both, and the series-base scan must too.
+      const stringBaseId = new ObjectId().toHexString();
+      const seriesBase = legacyEvent(userIdHex, {
+        _id: stringBaseId,
+        title: "String-id series base",
+        recurrence: { rule: ["FREQ=WEEKLY;COUNT=3"] },
+      });
+      const occurrence = legacyEvent(userIdHex, {
+        title: "Occurrence of string-id base",
+        recurrence: { eventId: stringBaseId },
+      });
+
+      await legacyCollection().insertMany([seriesBase, occurrence]);
+
+      await migration.up(migrationContext);
+
+      const docs = await destinationCollection().find({}).toArray();
+      expect(docs).toHaveLength(2);
+      const base = docs.find((d) => d["recurrence"]?.["kind"] === "series");
+      const occ = docs.find((d) => d["recurrence"]?.["kind"] === "occurrence");
+      expect(base?.["_id"]).toBeInstanceOf(ObjectId);
+      expect((base?.["_id"] as ObjectId).toHexString()).toBe(stringBaseId);
+      expect(
+        (occ?.["recurrence"]?.["seriesId"] as ObjectId).toHexString(),
+      ).toBe(stringBaseId);
+    });
+
     it("excludes a mix of someday events, migrates timed/allDay, reports the excluded count, and verifies cleanly", async () => {
       // Regression for the Someday-removal cutover: legacy someday events are
       // counted and dropped rather than migrated, the timed/allDay events for

--- a/packages/scripts/src/migrations/2026.07.10T21.30.00.event-record-backfill.ts
+++ b/packages/scripts/src/migrations/2026.07.10T21.30.00.event-record-backfill.ts
@@ -154,7 +154,10 @@ export default class Migration implements RunnableMigration<MigrationContext> {
         { projection: { _id: 1 }, batchSize: MONGO_BATCH_SIZE },
       );
       for await (const base of baseCursor) {
-        baseIds.add((base._id as unknown as ObjectId).toHexString());
+        // Legacy rows may carry a string _id (hex) instead of an ObjectId --
+        // the transform tolerates both, so this scan must too.
+        const baseId = base._id as unknown as ObjectId | string;
+        baseIds.add(typeof baseId === "string" ? baseId : baseId.toHexString());
       }
       legacyBaseIdsByUser.set(userIdHex, baseIds);
 

--- a/team/architect/google-subcalendar-big-bang-runbook.md
+++ b/team/architect/google-subcalendar-big-bang-runbook.md
@@ -1,7 +1,9 @@
 # Google sub-calendar big-bang deployment runbook
 
-Status: **staging validator recovery and full-sync acceptance are complete;
-production is locked**.
+Status: **staging complete; production gate opened by the founder on
+2026-07-15**. Execution of Phase P is planned and logged in
+[`prod-cutover-execution-2026-07-15.md`](./prod-cutover-execution-2026-07-15.md);
+the operator gate is [`prod-go-no-go-checklist.md`](./prod-go-no-go-checklist.md).
 
 This is the master operator runbook for landing the work from
 [`google-subcalendar-project`](../archive/google-subcalendar-project/master-doc.md)
@@ -199,11 +201,18 @@ content or credentials.
 | Backup restore checked | 2026-07-14: 103,940 documents restored to scratch DB; 0 failures | 2026-07-14: 17 documents restored to scratch DB; 0 failures |
 | Validator repair migrated | 2026-07-14, `v1.0.207`: 12 ledger records; strict validator valid; `priority` absent; 50,396 active rows | 2026-07-14, `v1.0.207`: 12 ledger records; strict validator valid; `priority` absent; 0 active rows |
 | Google sync code `121` absent | 2026-07-14, `v1.0.211`: designated account full resync passed with 0 invalid rows and no code `121` | Not applicable: no Google account is configured on this target; service health and logs passed |
-| 12-step acceptance passed | pending | pending |
-| Rollback and second forward run passed | pending | pending |
-| Operator/date/release tag | Codex / 2026-07-14 / `v1.0.211` | Codex / 2026-07-14 / `v1.0.211` |
+| 12-step acceptance passed | 2026-07-15: founder-validated on staging (running `v1.0.235`) through real use of the signed-in app, including Google multi-calendar sync | Not applicable: no Google account on this target; service health passed |
+| Rollback and second forward run passed | **Waived by founder, 2026-07-15** — see waiver below | **Waived by founder, 2026-07-15** — see waiver below |
+| Operator/date/release tag | Codex / 2026-07-14 / `v1.0.211`; founder / 2026-07-15 / `v1.0.235` | Codex / 2026-07-14 / `v1.0.211` |
 
-Production remains locked while any cell is pending.
+**Founder waiver (2026-07-15):** the Phase S3 staging rollback + second-forward-run
+rehearsal is waived. Rationale: the forward path was effectively rehearsed twice on
+staging during the `v1.0.205` → `v1.0.207` recovery (both targets converged cleanly on
+the second forward run), and staging has run the cut-over schema in real use since
+2026-07-14. The rollback path (backup restore + reverse rename) therefore remains
+**untested end-to-end**; this is an accepted risk, compensated by treating the
+production abort rules as hard stops and by the pre-window dry-run rehearsal of the
+full forward sequence on a restored copy of production data (see the execution plan).
 
 ### Recorded staging rehearsal — 2026-07-14
 
@@ -229,13 +238,16 @@ entries after the acceptance start time. Self-hosted staging has no configured
 Google account, so direct Google acceptance there is not applicable; do not
 misread that as evidence for a production Google sync.
 
-Production remains locked because the complete packet `09` manual acceptance,
-watch-renewal soak, and rollback/second-forward rehearsal are still pending.
-Release `v1.0.205` must not be used for another migration attempt.
+The gate closed on 2026-07-15: the founder validated acceptance on staging
+(`v1.0.235`) and waived the rollback/second-forward rehearsal (see the waiver in
+the evidence table). Release `v1.0.205` must not be used for another migration
+attempt.
 
-## Future Phase P — production big-bang cutover
+## Phase P — production big-bang cutover
 
-This section is a reference plan, not current authorization.
+Authorized by the founder on 2026-07-15. The operator-facing execution plan,
+including production-specific preflight findings and the data-policy pre-clean,
+is [`prod-cutover-execution-2026-07-15.md`](./prod-cutover-execution-2026-07-15.md).
 
 ### Production go/no-go
 
@@ -284,9 +296,10 @@ bullets below are its summary.
 7. Deploy the selected tag with **Deploy production**, resume service, and run
    the Phase S2 smoke plus production health checks.
 
-If the installed Umzug CLI does not accept `up --to`, stop during rehearsal and
-resolve the exact supported syntax. Do not replace the boundary with an
-unbounded pre-rename `migrate up`.
+Resolved 2026-07-15: the CLI is Umzug `3.8.2`'s standard CLI and `up --to <name>`
+is supported (applies every pending migration up to and including the named one).
+Verified against production with `migrate pending`. Do not replace the boundary
+with an unbounded pre-rename `migrate up`.
 
 ### Production rollback
 

--- a/team/architect/prod-cutover-execution-2026-07-15.md
+++ b/team/architect/prod-cutover-execution-2026-07-15.md
@@ -1,0 +1,285 @@
+# Production cutover execution — 2026-07-15
+
+Operator log and execution plan for the sub-calendar v1 production big-bang
+cutover. Procedure source of truth:
+[`google-subcalendar-big-bang-runbook.md`](./google-subcalendar-big-bang-runbook.md)
+Phase P. Gate: [`prod-go-no-go-checklist.md`](./prod-go-no-go-checklist.md).
+Operator: Claude (driving from the founder's trusted admin machine), with the
+founder (Tyler) as rollback owner confirming every irreversible gate.
+
+> **Private operator notes:** hostnames, cluster addresses, SSH details, config
+> and backup paths live in `~/src/compass/private-docs/prod-cutover-2026-07-15-operator-notes.md`
+> on the operator machine — deliberately outside git. This doc says "operator
+> notes" wherever such a value is needed.
+
+## Founder decisions (2026-07-15)
+
+1. **Release tag**: the tag cut from this PR's merge (runtime code
+   byte-identical to `v1.0.235`, the founder-validated staging build — the
+   delta is docs, the backfill string-`_id` fix, and its test). Staging
+   auto-deploys it before prod does. Originally `v1.0.235` was chosen; the
+   rehearsal-discovered backfill bug forced a fix, and the founder approved
+   shipping it as a new tag rather than running migrations from an unreleased
+   checkout.
+2. **Staging gate closed**: 12-step acceptance founder-validated on staging;
+   the Phase S3 rollback + second-forward-run rehearsal **waived** (waiver and
+   rationale recorded in the runbook's evidence table).
+3. **Execution mode**: Claude drives; Tyler confirms each gate (window open,
+   backend stop, collection rename, deploy).
+4. **Data-policy deletion approved**: all 168,015 flagged legacy rows
+   (167,878 by `_id` list + 137 empty docs), preserved in backup and
+   `event_legacy_v1`.
+5. **Sync-token reset scope**: the 165 affected users only (id list preserved
+   with the backup artifacts — operator notes), followed by a post-deploy
+   `maintain-all` call to trigger their full Google re-imports.
+
+## Production facts verified during preflight (2026-07-15)
+
+| Fact | Value | How verified |
+| --- | --- | --- |
+| Prod frontend | `https://compasscalendar.com`, `/version.json` = `1.0.97` | curl |
+| Prod VPS | SSH access verified (host/key in operator notes) | SSH |
+| Prod containers | `compass-backend-1` (`1.0.97`, healthy), `compass-web-1` (`production-1.0.97`), `compass-static` | `docker ps` over SSH |
+| Prod Mongo | Managed Atlas cluster (address in operator notes), db `prod_calendar`, Mongo 8.0.27, shared tier (`allowDiskUse` unsupported) | `mongosh` |
+| Event collection | Legacy: 989,268 docs; 989,131 `user`-owned; 0 `calendarId`-owned; no validator; no `event_new`/`event_legacy_v1` | `mongosh` |
+| Users / calendars | 941 users; 908 `calendar` rows (33 users have none — the calendar migration creates each user's local calendar) | `mongosh` |
+| Migrations ledger | 5 records (`2025.10.03` … `2025.10.16`); ledger field is `migrationName` | `mongosh` |
+| Pending migrations | 7: the `2025.10.18` prototype pair + the five v1 migrations | `bun run cli migrate pending` with the prod config |
+| Disk headroom | `prod_calendar` ≈ 197 MB on disk (data 466 MB, storage 87 MB, index 109 MB); backfill's second copy fits at any Atlas tier | `db.stats()` |
+| CI for `v1.0.235` | `Test`, `Release on main`, `CodeQL` all green at SHA `6d9a46fd6` | `gh run list --commit` |
+| Docker Hub images | `compass-backend:1.0.235`, `compass-mongo:1.0.235`, `compass-web:1.0.235` present; `production-1.0.235` web image is built by the deploy workflow | Docker Hub API |
+| `migrate up --to` | Supported (Umzug 3.8.2 CLI) | CLI + `node_modules/umzug` source |
+| Preflight dump | 996,660 docs, 33 MB gzipped, ~90 s wall (path in operator notes) | `mongodump` (read-only) |
+| Restore test | Restored into a local Mongo 8.0 single-node replica set: 996,660 restored, 0 failures, counts match prod exactly | `mongorestore` + count comparison |
+
+## Production-specific findings the runbook did not cover
+
+### 1. The `2025.10.18` prototype pair is unexecuted on prod
+
+Staging ran `2025.10.18T19.43.00.new-events-collection` and
+`2025.10.18T20.01.14.migrate-events-to-new-events-collection` back in October
+2025 under contemporaneous code; prod's ledger stops at `2025.10.16`. On prod,
+`migrate up --to …event-record-backfill` therefore runs this frozen prototype
+pair first — a path **no environment has exercised under v1.0.235**. The v1
+backfill was built to tolerate it: it collMods the final validator onto
+`event_new`, drops the prototype indexes by name, and `deleteMany`s the
+destination before writing. The dry-run rehearsal (below) validates the full
+7-migration sequence on a restored copy of production data before the window.
+
+### 2. Data-policy rows present on prod (will fail-close the backfill)
+
+The backfill is fail-closed and the documented remedy is operator deletion of
+the named rows ([event-migration-runbook — cutover data policy](../../docs/self-hosting/event-migration-runbook.md)).
+**The dry-run rehearsal measured the real scale: 168,015 legacy rows (17% of
+the collection) fail the strict contract and must be deleted before the
+backfill passes** — far beyond what ad-hoc preflight queries suggested. Every
+flagged row is Google-linked (`gEventId` set), i.e. re-importable from Google,
+which is exactly the data policy's "recoverable from its source of truth"
+criterion. Composition (from rehearsal runs 3–5):
+
+| Class | Count | Nature |
+| --- | --- | --- |
+| `invalidDates` | 40,668 | Mostly old Google imports saved with offset-less datetimes (`2022-11-19T09:00:00`, no zone); includes the 7,224 zero-duration rows; 139 users |
+| `missingRecurrenceBase` | 36,621 + 43,513 cascade | Orphaned Google recurring occurrences (base row absent), concentrated in **4 users**; the cascade is occurrences of bases deleted in the first pre-clean round |
+| `emptyRecurrenceRules` | 16,857 | `recurrence.rule: []` Google rows, **5 users** |
+| `missingPrimaryGoogleCalendar` | 15,423 | Google events of users with no Google calendar row (disconnected accounts), **12 users** |
+| `invalidShape` | 13,490 | Malformed Google import rows, **13 users** |
+| `duplicateOrWriteError` | 1,290 | Duplicate `gEventId` copies (first write wins), **2 users** |
+| `flagDateMismatch` / `recurrenceConflict` | 16 | Contradictory flag/date or rule+eventId rows |
+| Empty docs (`_id` only) | 137 | Unreachable by any user; fail the verifier's re-scan |
+| Events of deleted user accounts | **0** | n/a on prod |
+| Legacy someday rows | 3,614 | **Not deleted** — counted `excludedSomeday`, stays in the legacy collection |
+
+**Affected users: 166 of 941** (154 with Google sync records). Heavily
+concentrated: the top two accounts hold 50,379 and 37,111 rows (~52% of the
+total — broken historical imports); only 68 users lose more than 10 rows.
+
+All deletions happen **inside the window, after the backup**, so every deleted
+row is preserved in the backup and in `event_legacy_v1`. The `_id` lists come
+from the backfill's own failure output (run to a fixed point — deleting a
+series base orphans its occurrences, so expect 2–3 delete/rerun iterations),
+never from hand-written queries.
+
+### 2b. Deleted Google rows do NOT come back by themselves — token reset required
+
+The cutover does not touch the `sync` collection, so users' Google
+`nextSyncToken`s survive. Incremental sync only fetches Google-side changes
+made after the token — it never re-fetches events deleted from Compass's own
+collection. With healthy tokens, sign-in stays on `SIGNIN_INCREMENTAL` and
+watch maintenance never escalates to a full import
+(`packages/backend/src/auth/services/google/util/google.auth.util.ts`,
+`google-watch-state.ts`). Remediation, part of the window:
+
+- For the **166 affected users**: clear `sync.google.events` entries (null the
+  tokens). This flips `canDoIncrementalSync` to false → their next sign-in
+  takes `RECONNECT_REPAIR` → full Google re-import; and
+  `inspectGoogleWatchState` reports `FULL_REPAIR_REQUIRED` → the maintenance
+  endpoint rebuilds them without waiting for sign-in.
+- Post-deploy: call `POST /api/sync/maintain-all` (header `x-comp-token:
+  $COMPASS_SYNC_TOKEN`) to proactively run that repair for affected users.
+- Re-import safety: the unique `externalReference` index + upsert import path
+  prevents duplicates (validated on staging by the `v1.0.209`–`v1.0.211`
+  forced resyncs).
+
+### 3. Dry-run rehearsal on restored prod data (pre-window)
+
+The restore-test copy doubles as a full forward rehearsal: run the entire
+migration sequence + rename + post-cutover repairs against the local restored
+copy, capture every failure `_id`, and record real timings for the window
+estimate. This partially compensates for the waived S3 rehearsal (forward path
+only; rollback remains untested by founder-accepted waiver).
+
+**Rehearsal results (2026-07-15):**
+
+- **Run 1** (`migrate up --to …backfill`, all 7 pending): **failed in ~1 s.**
+  `2025.10.18T20.01.14` crashed on a real prod event with no `title` (its frozen
+  `EventNewSchema` requires one) after logging "No calendar found" skips for a
+  user with no calendar row. Confirms the prototype pair cannot run on prod data
+  under current code → **decision: mark the pair executed in the ledger without
+  running it** (mirrors staging's final ledger state; the v1 backfill rebuilds
+  `event_new` from scratch and owns its validator/indexes). Ledger insert shape:
+  `{ migrationName: "<name>" }`.
+- **Operational hazard found**: `bun run cli migrate up` **exits 0 even when a
+  migration fails.** In the window, success is judged by the log output and by
+  ledger/collection state — never by exit code, and never chained with `&&`.
+- **Run 2** (pair ledger-skipped; calendar migration + backfill): calendar
+  migration **passed** (1,849 calendar rows = 908 reshaped + 941 created local
+  calendars; validator and indexes applied). Backfill **crashed mid-run**:
+  `base._id.toHexString is not a function`. Root cause: **1,712 prod events
+  carry string `_id`s** (all valid 24-hex; an anomalous import path), 12 of them
+  series bases. The transform tolerates string `_id`s by design
+  (`z.union([ObjectId, string])`) but the per-user series-base scan did not.
+  Staging data never had string `_id`s, so no environment had hit this.
+- **Fix**: one-line guard in the base scan of
+  `2026.07.10T21.30.00.event-record-backfill.ts` (accept string or ObjectId),
+  plus a regression test, shipped through the normal PR flow with this doc set.
+- **Run 3** (fix applied): scan completed —
+  `attempted=989131 inserted=861152 failed=124365 excludedSomeday=3614`.
+  Fail-closed as designed; failure list captured (see the data-policy section).
+- **Run 4** (after deleting the 124,365 + 137 empty docs): 43,513 new
+  `missingRecurrenceBase` failures — the cascade from deleted series bases.
+  Pre-clean must run to a fixed point.
+- **Run 5** (after cascade delete): **converged and verification PASSED** —
+  `attempted=821253 inserted=817639 failed=0 excludedSomeday=3614`;
+  `legacyTotal=821253 destinationTotal=817639`, categories match exactly
+  (`timed 492,544 / allDay 325,095`), `seriesCount=9898`,
+  `occurrenceCount=632035`.
+- **Rename + post-cutover repairs**: rename instant; the three repairs ran in
+  **8 s** (`0` someday leaks, validator updated; `seriesScanned=9898,
+  echoDuplicatesRemoved=0, firstOccurrencesBackfilled=0`; priority cleared from
+  0 docs; `priority` collection dropped).
+- **Final state checks**: validation `strict`; `priority` absent from
+  required + properties; 0 events with `priority`;
+  `db.event.validate({full:true}).valid === true`; **12 ledger records**
+  (identical set to staging); 0 active someday rows.
+
+**Window timing estimate (from rehearsal wall-clock on the full prod copy):**
+dump ≈ 90 s; backfill scan ≈ 90 s + verify ≈ 60 s per iteration (expect 1–2
+iterations after the list-based pre-clean); pre-clean deletes ≈ 60 s; rename
+instant; repairs ≈ 10 s; deploy + health check ≈ 10 min (workflow-bound).
+**Total window ≈ 20–30 minutes** including slack.
+
+## Execution sequence (the window)
+
+Timings in brackets to be filled from the rehearsal.
+
+### GATE 1 — window open (Tyler confirms; downtime announced)
+1. Tyler triggers an **Atlas on-demand snapshot** of `production1` and records
+   the snapshot id here: `_______`
+2. Fresh `mongodump --gzip` of `prod_calendar` (the formal backup — the only
+   rollback for the in-place `calendar` migration). Verify counts; record here:
+   `_______`
+
+### GATE 2 — stop writes (Tyler confirms)
+3. SSH to the prod VPS (operator notes) and
+   `docker compose --project-name compass stop backend`
+   (web/static stay up; Mongo is external). Verify no writes via `db.currentOp()`.
+4. **Ledger-mark the 2025.10.18 prototype pair** (rehearsal-validated; they
+   crash on prod data and are fully superseded by the v1 backfill):
+   insert `{ migrationName: "2025.10.18T19.43.00.new-events-collection" }` and
+   `{ migrationName: "2025.10.18T20.01.14.migrate-events-to-new-events-collection" }`
+   into `prod_calendar.migrations`. Confirm `migrate pending` then lists
+   exactly the five v1 migrations.
+5. **Data-policy pre-clean** (founder-approved; after the backup): delete the
+   167,878 events by `_id` list (preserved with the backup artifacts —
+   operator notes) plus
+   `deleteMany({user: {$exists: false}})` for the 137 empty docs. Record
+   deleted counts here: `_______`. Expect small residue from rows written
+   after the preflight dump — handled by the delete/rerun loop in step 6.
+6. `COMPASS_CONFIG_FILE=<prod config, operator notes> bun run cli migrate up --to 2026.07.10T21.30.00.event-record-backfill`
+   — runs the calendar migration and the backfill.
+   **Judge success by the log line `Event backfill verification passed` and by
+   ledger/collection state — the CLI exits 0 even on failure.**
+   If the backfill throws with *data-policy class* failures (rows created
+   since the dump): delete exactly the named `_id`s and rerun — it is
+   convergent (rehearsed). Any *verification mismatch* (count/hash/category)
+   → abort to rollback; do not rename.
+7. **Sync-token reset** for the 165 affected users (id list — operator
+   notes): clear their `sync.google.events` tokens so post-deploy maintenance
+   runs a full Google re-import for them.
+8. Verify `event_new`: strict validator, final indexes, zero someday rows,
+   counts match the verification summary.
+
+### GATE 3 — rename (Tyler confirms; the point of no easy return)
+9. ```javascript
+   use prod_calendar;
+   db.event.renameCollection("event_legacy_v1");
+   db.event_new.renameCollection("event");
+   ```
+10. `COMPASS_CONFIG_FILE=<prod config, operator notes> bun run cli migrate up`
+    — runs the three post-cutover repairs against the now-active `event`.
+11. Strict-validator checks (runbook Phase S1 step 7): validation `strict`,
+    `priority` absent, zero `priority` fields, `db.event.validate({full:true})`
+    valid, ledger records all 12 migrations exactly once.
+
+### GATE 4 — deploy (Tyler confirms; checklist sign-off happens here)
+12. `gh workflow run deploy-production.yml -f tag=<TAG>` (the tag cut from this
+    PR) — watch the run and the automated health check (version gate,
+    `/api/health`, Mongo data, log scan, Discord alert on failure).
+
+### Post-cutover
+13. `/version.json` = `<TAG>`; manual smoke (sign in, week view, create/edit/
+    delete timed + all-day, calendar list + visibility toggles, Google-side
+    change reconciles); backend logs clean of Mongo code `121`,
+    `Document failed validation`, `Re-sync failed`, `ERRORED`, fatal,
+    unhandled rejections.
+14. `POST /api/sync/maintain-all` with `x-comp-token: $COMPASS_SYNC_TOKEN` —
+    triggers `FULL_REPAIR_REQUIRED` full Google re-imports for the 165
+    token-reset users. Spot-check a few of the most-affected accounts regain
+    their Google events; watch for import errors.
+15. **Keep `event_legacy_v1`** (rollback source — do not drop in v1). Retain
+    the backups. Watch logs/Discord for several hours.
+16. Final results commit to this file; merge the docs PR.
+
+## Abort rules (bright lines, from the go/no-go checklist)
+
+Abort to rollback, without debate, if any of these occur:
+- The backfill verification summary does not pass (after the pre-clean).
+- The strict-validator checks fail after the post-cutover repairs.
+- The automated health check fails, or `/version.json` ≠ `1.0.235`.
+- Any Mongo code `121` during or after the run.
+
+## Rollback (rehearsed forward-only; reverse path is founder-accepted risk)
+
+1. Stop the backend.
+2. `mongodump` the post-cutover `event` collection (preserves post-cutover writes).
+3. Reverse rename: `event` → `event_new`, `event_legacy_v1` → `event`.
+4. `gh workflow run deploy-production.yml -f tag=v1.0.97`.
+5. Confirm legacy events readable; if `calendar` is implicated, restore it from
+   the GATE 1 backup / Atlas snapshot (its migration has no programmatic reverse).
+6. Preserve all dumps and logs for reconciliation; drop neither event collection.
+
+## Live log
+
+| Time (local) | Step | Result |
+| --- | --- | --- |
+| 14:2x | Preflight state queries against prod | Legacy shape confirmed (see facts table) |
+| 14:34 | Read-only preflight `mongodump` | 996,660 docs, 0 errors, ~90 s |
+| 14:36 | Restore test into local Mongo 8.0 replica set | 996,660 restored, 0 failures, counts match |
+| 14:37 | Rehearsal run 1 (all 7 pending) | Failed in ~1 s: 2025.10.18 prototype pair crashes on prod data → ledger-mark decision |
+| 14:39 | Reset + ledger-mark pair; run 2 (calendar migration + backfill) | Calendar migration passed (1,849 rows); backfill crashed on string `_id` series bases → code fix |
+| 14:4x | Run 3 (fix applied) | Fail-closed cleanly: 124,365 data-policy failures enumerated |
+| 14:47 | Run 4 (after round-1 pre-clean of 124,502 rows) | 43,513 cascade failures (orphaned occurrences of deleted bases) |
+| 14:53 | Run 5 (after cascade delete) | **failed=0; verification PASSED** (817,639 destination rows; categories exact) |
+| 14:55 | Rename + `migrate up` (3 repairs) + strict-validator checks | All green in 8 s; 12 ledger records; validate full valid |
+| 15:0x | Founder approvals | 168k deletion approved; fix ships as new tag via PR; token reset for 165 affected users |

--- a/team/architect/prod-go-no-go-checklist.md
+++ b/team/architect/prod-go-no-go-checklist.md
@@ -1,9 +1,10 @@
 # Production go/no-go checklist — sub-calendar v1 cutover
 
-> **This document does not authorize a cutover.** It is the fill-in-and-sign gate
-> that must be complete *before* one is scheduled. Execution steps live in
-> [`google-subcalendar-big-bang-runbook.md`](./google-subcalendar-big-bang-runbook.md),
-> Phase P. Production remains locked.
+> **Gate opened by the founder on 2026-07-15.** This is the fill-in-and-sign gate
+> completed before execution. Execution steps live in
+> [`google-subcalendar-big-bang-runbook.md`](./google-subcalendar-big-bang-runbook.md)
+> Phase P, operationalized with production-specific findings in
+> [`prod-cutover-execution-2026-07-15.md`](./prod-cutover-execution-2026-07-15.md).
 
 _Architect deliverable, approved by the founder in
 [standup 2026-07-14](../standups/2026-07-14.md). Prepared ahead of the gate closing
@@ -13,49 +14,58 @@ This checklist exists because the runbook's Phase P go/no-go is a six-bullet
 *reference plan*. This is the operator-facing version: every line is a box someone
 ticks, with a name and a date next to it, and an explicit abort rule.
 
-## State as of 2026-07-14 (refresh before use)
+## State as of 2026-07-15 (verified against live systems this day)
 
 | Fact | Value |
 | --- | --- |
-| Staging release | `v1.0.211`, both targets healthy |
+| Staging release | `v1.0.235` (read from staging `/version.json`), healthy |
 | Staging event collection | Cut over to the final strict schema |
-| Production event collection | **Legacy** — `event` is still legacy-shaped |
-| Staging evidence cells complete | 4 of 6 |
-| Cells outstanding | 12-step acceptance; rollback + second forward run |
-| Blocking decision | Staging rehearsal deferred by the founder on 2026-07-13 and again on 2026-07-14 |
+| Production release | `v1.0.97` (read from `https://compasscalendar.com/version.json`) |
+| Production event collection | **Legacy** — 989,131 `user`-owned rows, 0 `calendarId`-owned, no `event_new`/`event_legacy_v1`, no validator |
+| Production migrations ledger | 5 records (through `2025.10.16`); **7 pending**, including the `2025.10.18` prototype pair — see the execution plan |
+| Production Mongo | Managed Atlas cluster (address in the operator's private notes, outside git), db `prod_calendar` (~197 MB on disk; shared tier — `allowDiskUse` unavailable) |
+| Staging evidence cells | Complete: acceptance founder-validated 2026-07-15 on `v1.0.235`; S3 rollback rehearsal **waived by founder 2026-07-15** (see runbook waiver) |
 
-**Nothing below can be signed while the two evidence cells are `pending`.**
-Section A is a hard precondition, not a formality.
+Section A is satisfied via the founder's 2026-07-15 acceptance + waiver decision.
 
 ---
 
 ## A. Preconditions (hard gate — no sign-off is valid without these)
 
-- [ ] Every cell in the runbook's **Staging evidence gate** table is filled and
-      passing. Today two are `pending`; both are PO-gated and a human must run them.
-- [ ] Packet `09` is marked complete in the
-      [master plan](../archive/google-subcalendar-project/master-doc.md).
-- [ ] Production still has a legacy `event` collection and its `migrations` ledger
-      matches that state. **Verify, don't assume** — if prod has drifted, stop and
-      re-plan.
-- [ ] Disk headroom: `db.event.stats()` on prod shows the cluster has **≥ 2×** the
-      `event` collection size free. The backfill writes a full second copy into
-      `event_new` before the rename.
+- [x] Every cell in the runbook's **Staging evidence gate** table is filled and
+      passing. Closed 2026-07-15: acceptance founder-validated on `v1.0.235`;
+      S3 rollback rehearsal waived by founder (waiver recorded in the runbook).
+- [x] Packet `09` is marked complete in the
+      [master plan](../archive/google-subcalendar-project/master-doc.md)
+      (closed 2026-07-15 with the founder acceptance + waiver note).
+- [x] Production still has a legacy `event` collection and its `migrations` ledger
+      matches that state. Verified 2026-07-15 by direct `mongosh` queries:
+      989,131 `user`-owned events, 0 `calendarId`-owned, no `event_new` /
+      `event_legacy_v1`, no validator, ledger has exactly the five 2025.10.03–10.16
+      records. `migrate pending` lists 7 (the 2025.10.18 prototype pair + the five
+      v1 migrations) — see the execution plan for how the pair is handled.
+- [x] Disk headroom: verified 2026-07-15 — `prod_calendar` is ~197 MB on disk
+      (dataSize 466 MB, storageSize 87 MB, indexSize 109 MB); the backfill's second
+      copy adds well under 1× even on the smallest Atlas shared tier.
 
 ## B. Release tag selection
 
 The tag is the single most consequential choice here: it is simultaneously what
 gets deployed and what the rollback is measured against.
 
-- [ ] **Tag chosen:** `v_______` — must be the exact tag validated on staging by the
-      evidence gate, not "latest `main`". A newer `main` has not been through the gate.
-- [ ] Backend, mongo, and web images for that tag exist on Docker Hub. (`release-on-main`
-      produces them for every tag; confirm rather than trust.)
-- [ ] `Test` and `Release on main` are green **for that tag's exact SHA**, not merely
-      green on `main` today.
-- [ ] **Previous production tag recorded:** `v_______` — read from
-      `https://<prod>/version.json` *before* anything changes. This is the rollback
-      deploy target and is unrecoverable from memory once the deploy runs.
+- [x] **Tag chosen:** the tag cut from the cutover-prep PR (originally `v1.0.235`
+      from staging `/version.json`; the dry-run rehearsal exposed a backfill crash
+      on prod's string-`_id` rows, and the founder approved shipping the one-line
+      fix as a new tag — runtime code stays byte-identical to the validated
+      `v1.0.235`; the delta is docs, the migration fix, and its test). Record the
+      final tag here once cut: `v_______`
+- [ ] Backend, mongo, and web images for the final tag exist on Docker Hub
+      (`release-on-main` builds them on merge; confirm before GATE 4).
+- [ ] `Test` and `Release on main` are green for the final tag's exact SHA, and
+      the staging auto-deploy + health check for it pass before the prod window.
+- [x] **Previous production tag recorded: `v1.0.97`** — read from
+      `https://compasscalendar.com/version.json` on 2026-07-15. This is the rollback
+      deploy target.
 
 ## C. Backup verification (the only rollback for `calendar`)
 
@@ -63,40 +73,47 @@ The `calendar` migration is an **in-place rewrite with no programmatic reverse**
 backup is not a precaution here; it is the rollback mechanism. The `event` path is
 safer (legacy is retained as `event_legacy_v1`), but `calendar` has no such net.
 
-- [ ] Managed-provider **snapshot** of the prod cluster triggered and confirmed
-      complete. (Prod uses external managed MongoDB — the volume-tar procedure in
-      `backup-and-restore.md` is self-host only and is **not** the prod backup.)
-- [ ] `mongodump --uri "$MONGO_URI" --db prod_calendar --out <dir>` completed, dump
-      is non-empty, document counts recorded here: `_______`
-- [ ] **Restore-tested**: the dump was actually restored into a scratch database and
-      the counts matched. An unrestored backup is an untested backup.
-- [ ] Backup location and retention recorded: `_______________`
+- [ ] Managed-provider **snapshot** of the prod cluster (Atlas `production1`)
+      triggered by the founder and confirmed complete. (Prod uses external managed
+      MongoDB — the volume-tar procedure in `backup-and-restore.md` is self-host
+      only and is **not** the prod backup.) *In-window step.*
+- [ ] Fresh in-window `mongodump --gzip --db prod_calendar` completed after the
+      backend stops; counts recorded here: `_______`
+- [x] **Restore-tested**: the 2026-07-15 preflight dump (996,660 docs, all 9
+      collections) was restored into a local Mongo 8.0 replica set with 0 failures
+      and exact count matches — and then used as the dry-run rehearsal target.
+      The in-window dump uses the identical command and is spot-verified the same way.
+- [x] Backup location and retention: preflight and in-window dumps live on the
+      founder's admin machine (exact paths in the operator's private notes,
+      outside git), plus the Atlas snapshot. Retain all three at least until
+      `event_legacy_v1` is dropped in some future release.
 
 ## D. Maintenance window
 
 Per decisions A10/A21: one short downtime window, no dual-write, no feature flag —
 **enablement is the cutover.**
 
-- [ ] Window scheduled (low-traffic): `____-__-__  __:__ – __:__  TZ ____`
-- [ ] **Duration estimated from the rehearsal's actual timings**, not guessed. The
-      Phase S1–S3 rehearsal produces the number; the perf work in `v1.0.209`–`v1.0.211`
-      cut import time dramatically on staging (a 2,745-event calendar went from ~17m21s
-      to 17.81s), so the estimate should come from post-`v1.0.211` runs — older figures
-      will badly overstate the window.
+- [ ] Window scheduled (low-traffic): `2026-07-15  __:__ – __:__  TZ ____` —
+      founder confirms at GATE 1.
+- [x] **Duration estimated from actual timings** of the 2026-07-15 dry-run
+      rehearsal on a full restored copy of production data (see the execution
+      log's timing table). Dump ≈ 90 s; migration timings recorded there.
 - [ ] Downtime announced to users, with a stated end time.
-- [ ] Confirmed nobody else is deploying or migrating during the window.
+- [ ] Confirmed nobody else is deploying or migrating during the window
+      (the autonomous team must be idle; no standup workflow mid-flight).
 
 ## E. Rollback owner and communications
 
-- [ ] **Rollback owner named:** `_______________` — one person, with the authority to
-      call the abort and the access to execute it. Not "the team".
-- [ ] That person has, *tested and in hand before the window opens*: SSH to the prod
-      VPS, `mongosh` against `MONGO_URI`, and permission to run the **Deploy production**
-      Action. Discovering a missing credential mid-rollback is the worst case this line
-      exists to prevent.
-- [ ] Rollback procedure (runbook Phase P → Production rollback) has been **rehearsed**
-      on staging by that same person — Section A already requires the rehearsal; this
-      line requires that the rollback owner is the one who did it.
+- [x] **Rollback owner named: Tyler (founder)** — with the authority to call the
+      abort and the access to execute it.
+- [x] Access tested in hand before the window (2026-07-15, from the admin machine
+      Claude drives under Tyler's credentials): SSH to the prod VPS verified,
+      `mongosh` against the prod `MONGO_URI` verified (read-only preflight
+      queries), `gh` authenticated for the **Deploy production** Action.
+- [ ] ~~Rollback rehearsed on staging by the rollback owner~~ — **waived by the
+      founder 2026-07-15** (waiver in the runbook). Compensating control: the
+      full forward sequence was dry-run on a restored copy of production data
+      before the window, and the abort rules below are treated as hard stops.
 - [ ] Discord deploy webhook confirmed working (the automated health check alerts through it).
 - [ ] Comms plan for a failed cutover: who tells users, through which channel.
 
@@ -104,8 +121,12 @@ Per decisions A10/A21: one short downtime window, no dual-write, no feature flag
 
 Abort to rollback, without debate, if any of these occur:
 
-- The backfill **verification summary does not pass.** Do not rename. Do not "fix it
-  live". Stop.
+- The backfill **verification summary does not pass.** Do not rename. Stop.
+  One nuance, rehearsed and founder-approved 2026-07-15: *data-policy class*
+  failures naming specific rows (rows written after the preflight dump) are
+  handled by deleting exactly the named `_id`s and rerunning — that loop is
+  convergent and is part of the procedure, not a "fix it live". Any
+  count/hash/category **verification mismatch** is a hard abort.
 - The strict-validator checks fail after the post-cutover repairs.
 - The automated health check fails, or `/version.json` does not equal the deployed tag.
 - Any Mongo code `121` (document validation failure) appears during or after the run.

--- a/team/archive/google-subcalendar-project/master-doc.md
+++ b/team/archive/google-subcalendar-project/master-doc.md
@@ -95,11 +95,12 @@ unfinished.
       identity, selection, and read-only UX. Shipped in PRs #2062, #2063,
       #2064, #2065, #2066 (one known follow-up: read-only card left-click
       open race, see the packet's exit criteria).
-- [ ] 09. [V1 release hardening](./09-v1-release-hardening.md) — prove migration,
+- [x] 09. [V1 release hardening](./09-v1-release-hardening.md) — prove migration,
       reliability, performance, accessibility, and rollback. Automated gate,
       benchmarks, observability, and docs shipped in PRs #2068, #2069,
-      #2070; the box stays open until the PO-gated staging rehearsal and
-      manual acceptance pass (see the packet's "Remaining PO-gated work").
+      #2070. Closed 2026-07-15: manual acceptance founder-validated on staging
+      (`v1.0.235`); the S3 rollback rehearsal was waived by founder decision
+      (waiver recorded in the big-bang runbook's staging evidence gate).
 
 ## Progress rules for agents
 


### PR DESCRIPTION
## Summary

Prepares the production big-bang cutover (sub-calendar v1):

- **Runbook**: staging gate closed — 12-step acceptance founder-validated on staging (`v1.0.235`); Phase S3 rollback rehearsal **waived by founder** with recorded rationale. Phase P is now authorized; the `up --to` CLI question is resolved (Umzug 3.8.2 supports it).
- **Go/no-go checklist**: filled with 2026-07-15 verified facts (prod legacy state, ledger, headroom, CI/images, backups, rollback owner).
- **New execution plan** `team/architect/prod-cutover-execution-2026-07-15.md`: production-specific findings from a full dry-run rehearsal on a restored copy of prod data — the unexecuted 2025.10.18 prototype pair (ledger-mark decision), the founder-approved data-policy deletion of 168,015 Google-linked rows, the sync-token reset + forced re-import remediation, window timings, and gate-by-gate procedure. Sensitive infra details are kept in private operator notes outside git.
- **Backfill fix**: the series-base scan crashed on legacy rows with string `_id`s (1,712 exist on prod; staging never had any). One-line guard + regression test; validated by the rehearsal end-to-end (backfill verification passed, repairs green, strict-validator checks clean).

## Manual Testing Steps

1. Rehearsal evidence is in the execution plan's live log (dry-run against a full restored copy of prod data: verification passed, 12 ledger records, `validate({full:true})` valid).
2. `TZ=UTC ./node_modules/.bin/jest scripts` — 150 tests pass, including the new string-`_id` series-base regression test.
3. `bun run type-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)