### PR TITLE
feat(cutover): shared-tier migration fixes + prod cutover execution record

### DIFF
--- a/packages/scripts/src/common/event-migration.verify.ts
+++ b/packages/scripts/src/common/event-migration.verify.ts
@@ -168,11 +168,17 @@ export const verifyEventMigration = async (
   const destinationIds = new Set<string>();
   const calendarIdCache = new Map<string, boolean>();
   const seriesIds: string[] = [];
+  const providerIdCounts = new Map<string, number>();
 
   for await (const record of destinationCursor) {
     destinationCategoryCounts[record.schedule.kind] += 1;
     destinationIds.add(record._id.toHexString());
     destinationHash.add(projectionOf(record));
+
+    if (record.externalReference?.eventId) {
+      const key = `${record.calendarId.toHexString()}|${record.externalReference.eventId}`;
+      providerIdCounts.set(key, (providerIdCounts.get(key) ?? 0) + 1);
+    }
 
     if (record.recurrence.kind === "series") seriesCount += 1;
     if (record.recurrence.kind === "occurrence") {
@@ -205,30 +211,17 @@ export const verifyEventMigration = async (
 
   // Duplicate provider ids on the destination: the unique partial index
   // should make this structurally impossible, but assert it directly so a
-  // regression in the index definition itself is caught here too.
-  const duplicateProviderIds = await destinationCollection
-    .aggregate<{
-      _id: { calendarId: ObjectId; eventId: string };
-      count: number;
-    }>([
-      { $match: { "externalReference.eventId": { $exists: true, $ne: null } } },
-      {
-        $group: {
-          _id: {
-            calendarId: "$calendarId",
-            eventId: "$externalReference.eventId",
-          },
-          count: { $sum: 1 },
-        },
-      },
-      { $match: { count: { $gt: 1 } } },
-    ])
-    .toArray();
-
-  for (const dup of duplicateProviderIds) {
-    mismatches.push(
-      `duplicate externalReference.eventId ${dup._id.eventId} on calendar ${dup._id.calendarId.toHexString()}`,
-    );
+  // regression in the index definition itself is caught here too. Counted
+  // client-side from the streaming scan above -- a server-side $group over
+  // the full collection exceeds the memory limit on throttled shared-tier
+  // clusters, which also forbid disk spilling (observed on production Atlas).
+  for (const [key, count] of providerIdCounts) {
+    if (count > 1) {
+      const [calendarId, eventId] = key.split("|");
+      mismatches.push(
+        `duplicate externalReference.eventId ${eventId} on calendar ${calendarId}`,
+      );
+    }
   }
 
   // Fail closed: every legacy record must be accounted for as migrated,

--- a/packages/scripts/src/migrations/2026.07.10T21.00.00.calendar-record-migration.ts
+++ b/packages/scripts/src/migrations/2026.07.10T21.00.00.calendar-record-migration.ts
@@ -4,7 +4,7 @@ import {
   transformLegacyCalendar,
 } from "@scripts/common/legacy-calendar.transform";
 import { zodToMongoSchema } from "@scripts/common/zod-to-mongo-schema";
-import { type Document } from "mongodb";
+import { type AnyBulkWriteOperation, type Document } from "mongodb";
 import { type MigrationParams, type RunnableMigration } from "umzug";
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import { MONGO_BATCH_SIZE } from "@backend/common/constants/backend.constants";
@@ -76,6 +76,11 @@ export default class Migration implements RunnableMigration<MigrationContext> {
       let migrated = 0;
       let alreadyMigrated = 0;
 
+      // Writes are batched into bulkWrite calls: per-document round trips
+      // inside one transaction exceed the 60s transaction lifetime on
+      // throttled shared-tier clusters (observed on production Atlas).
+      const replaceOps: AnyBulkWriteOperation<Document>[] = [];
+
       for await (const doc of cursor) {
         scanned += 1;
 
@@ -99,10 +104,22 @@ export default class Migration implements RunnableMigration<MigrationContext> {
           continue;
         }
 
-        await collection.replaceOne({ _id: result.record._id }, result.record, {
-          session,
+        replaceOps.push({
+          replaceOne: {
+            filter: { _id: result.record._id },
+            replacement: result.record as Document,
+          },
         });
         migrated += 1;
+      }
+
+      if (failures.length === 0 && replaceOps.length > 0) {
+        for (let i = 0; i < replaceOps.length; i += MONGO_BATCH_SIZE) {
+          await collection.bulkWrite(
+            replaceOps.slice(i, i + MONGO_BATCH_SIZE),
+            { session, ordered: true },
+          );
+        }
       }
 
       if (failures.length > 0) {
@@ -115,24 +132,35 @@ export default class Migration implements RunnableMigration<MigrationContext> {
       }
 
       // Every user gets exactly one Compass-local calendar (idempotent: skip
-      // users that already have one, e.g. on a rerun).
+      // users that already have one, e.g. on a rerun). One query for the
+      // existing set + one insertMany, for the same shared-tier reason.
       const now = new Date();
+      const existingLocalUserIds = new Set(
+        (
+          await collection
+            .find(
+              { "source.provider": "local" },
+              { projection: { userId: 1 }, session },
+            )
+            .toArray()
+        ).map((c) => String(c["userId"])),
+      );
+
+      const localCalendarsToInsert = [];
       const userCursor = mongoService.user.find(
         {},
         { session, batchSize: MONGO_BATCH_SIZE },
       );
+      for await (const user of userCursor) {
+        if (existingLocalUserIds.has(String(user._id))) continue;
+        localCalendarsToInsert.push(buildLocalCalendarRecord(user._id, now));
+      }
 
       let localCalendarsCreated = 0;
-      for await (const user of userCursor) {
-        const existingLocal = await collection.findOne(
-          { userId: user._id, "source.provider": "local" },
-          { session },
-        );
-        if (existingLocal) continue;
-
-        const localCalendar = buildLocalCalendarRecord(user._id, now);
-        await collection.insertOne(localCalendar, { session });
-        localCalendarsCreated += 1;
+      for (let i = 0; i < localCalendarsToInsert.length; i += MONGO_BATCH_SIZE) {
+        const batch = localCalendarsToInsert.slice(i, i + MONGO_BATCH_SIZE);
+        await collection.insertMany(batch, { session });
+        localCalendarsCreated += batch.length;
       }
 
       await session.commitTransaction();

--- a/packages/scripts/src/migrations/2026.07.10T21.00.00.calendar-record-migration.ts
+++ b/packages/scripts/src/migrations/2026.07.10T21.00.00.calendar-record-migration.ts
@@ -157,7 +157,11 @@ export default class Migration implements RunnableMigration<MigrationContext> {
       }
 
       let localCalendarsCreated = 0;
-      for (let i = 0; i < localCalendarsToInsert.length; i += MONGO_BATCH_SIZE) {
+      for (
+        let i = 0;
+        i < localCalendarsToInsert.length;
+        i += MONGO_BATCH_SIZE
+      ) {
         const batch = localCalendarsToInsert.slice(i, i + MONGO_BATCH_SIZE);
         await collection.insertMany(batch, { session });
         localCalendarsCreated += batch.length;

--- a/team/architect/prod-cutover-execution-2026-07-15.md
+++ b/team/architect/prod-cutover-execution-2026-07-15.md
@@ -283,3 +283,51 @@ Abort to rollback, without debate, if any of these occur:
 | 14:53 | Run 5 (after cascade delete) | **failed=0; verification PASSED** (817,639 destination rows; categories exact) |
 | 14:55 | Rename + `migrate up` (3 repairs) + strict-validator checks | All green in 8 s; 12 ledger records; validate full valid |
 | 15:0x | Founder approvals | 168k deletion approved; fix ships as new tag via PR; token reset for 165 affected users |
+| 15:1x | PR #2144 merged (`c6967be9b`); `v1.0.236` cut; staging auto-updated | CI green; images verified; staging `/api/health` 200 on `1.0.236` |
+| 15:17 | **GATE 1 confirmed by founder** (Atlas snapshot triggered) | Window open |
+| 15:18 | Formal in-window `mongodump` + restore-check | 996,660 docs, 0 errors; counts exact; prod write-quiet (event count unchanged since preflight dump) |
+| 15:19 | **GATE 2 confirmed**; backend stopped; 0 active write ops | Downtime start |
+| 15:20 | Ledger-mark 2025.10.18 pair; pre-clean | 167,878 + 137 deleted; 821,253 remaining — exact match to rehearsal |
+| 15:22 | Calendar migration attempt 1 (from admin machine) | **Transaction aborted at ~60 s** — Atlas shared-tier transaction lifetime limit; rolled back atomically (documented sharp edge: validator left relaxed, repaired by the rerun) |
+| 15:28 | Attempt 2 from the prod VPS (bun 1.2.18 + tag checkout) | Same abort — shared-tier op throttling, not client RTT |
+| 15:30 | Founder approved batch-patch path | Migration rewritten to bulkWrite/insertMany batches (~5 round trips instead of ~2,800); 150 tests + full local prod-copy validation green |
+| 15:35 | Prod run 3 (patched, from VPS) | **Calendar migration committed**: scanned=908 migrated=908 localCalendarsCreated=941. Backfill scan `failed=0`, then the **verifier crashed**: `$group` exceeds shared-tier memory; tier forbids disk spilling |
+| 15:50 | Verifier patched (duplicate check moved into the existing client-side streaming scan); tests + full local revalidation green | Both patches to ship as PR after the window |
+| 16:13 | Prod run 4: backfill + patched verifier | **Verification PASSED on prod**: legacy 821,253 → destination 817,639; excludedSomeday 3,614; categories exact; series 9,898 / occurrences 632,035 |
+| 16:15 | Pre-rename state checks + sync-token reset | `event_new` strict, 0 someday, final indexes; `calendar` strict, 1,849 userId-shaped; ledger 9; tokens nulled for 153 sync docs (165 affected users; 12 have no sync record) |
+| 16:14 | **GATE 3 confirmed**; collections renamed | active `event` = 817,639; `event_legacy_v1` = 821,253 retained |
+| 16:23 | Post-cutover repairs (3 migrations, from VPS) | All green in 7m44s: 0 someday leaks, validator updated; seriesScanned=9898, 0 dupes, 0 backfills; `priority` collection dropped |
+| 16:24 | Strict-validator checks on prod | validation `strict`; `priority` absent; 0 priority fields; 0 someday; `validate({full:true}).valid=true`; **12 unique ledger records** — identical to staging |
+| 16:26 | **GATE 4 confirmed (founder sign-off)**; `Deploy production` dispatched with `v1.0.236` | Run 29455264833 |
+| 16:45 | Deploy + automated health check **green**; backend restarted | `/version.json`=1.0.236; `/api/health` 200 — **downtime ended (~86 min total)** |
+| 16:47 | Backend log scan | 0 occurrences of code 121 / validation failure / ERRORED / fatal / unhandled |
+| 16:49 | `maintain-all` called (200) | `resynced:3, pruned:2` — server-side full re-imports ran for the currently-connected affected users; the rest repair automatically at next sign-in (`RECONNECT_REPAIR`) |
+| 16:50 | Post-resync check | Active `event` grew 817,639 → **888,524** (+70,885 re-imported, correctly shaped, zero validation errors); logs clean |
+
+## Outcome
+
+**Cutover complete 2026-07-15 ~16:50 local.** Production runs `v1.0.236` on the
+calendar-owned event model. Total backend downtime ≈ 86 minutes (planned 20–30;
+overrun entirely due to two shared-tier surprises below). No abort line was
+crossed; every deviation was founder-approved in-window.
+
+**Deviations from plan, both patched + validated on a full prod copy before
+rerunning, shipping as a follow-up PR:**
+1. Calendar migration rewritten to batched writes — the shared tier's op
+   throttling pushed its ~2,800 sequential in-transaction round trips past
+   Mongo's 60 s transaction lifetime (aborted twice, identically, from two
+   client locations; rolled back atomically each time).
+2. Verifier's duplicate-provider-id check moved from a server-side `$group`
+   (exceeds shared-tier memory; tier forbids disk spilling) into the existing
+   client-side streaming scan.
+
+**Follow-ups:**
+- [ ] PR the two migration patches from the VPS checkout back to `main`.
+- [ ] Watch logs/Discord over the next hours; spot-check affected users as they
+  sign in (each should trigger a full Google re-import).
+- [ ] Founder signed-in smoke on prod (create/edit/delete timed + all-day,
+  calendar visibility toggles, Google-side change reconciles).
+- [ ] Keep `event_legacy_v1`, both dumps, and the Atlas snapshot until a future
+  release explicitly retires them.
+- [ ] Remove the VPS `~/cutover-checkout` and local rehearsal container once the
+  follow-up PR merges (details in operator notes).

--- a/team/architect/prod-go-no-go-checklist.md
+++ b/team/architect/prod-go-no-go-checklist.md
@@ -57,12 +57,12 @@ gets deployed and what the rollback is measured against.
       from staging `/version.json`; the dry-run rehearsal exposed a backfill crash
       on prod's string-`_id` rows, and the founder approved shipping the one-line
       fix as a new tag — runtime code stays byte-identical to the validated
-      `v1.0.235`; the delta is docs, the migration fix, and its test). Record the
-      final tag here once cut: `v_______`
-- [ ] Backend, mongo, and web images for the final tag exist on Docker Hub
-      (`release-on-main` builds them on merge; confirm before GATE 4).
-- [ ] `Test` and `Release on main` are green for the final tag's exact SHA, and
-      the staging auto-deploy + health check for it pass before the prod window.
+      `v1.0.235`; the delta is docs, the migration fix, and its test). Final tag:
+      **`v1.0.236`** (cut 2026-07-15 from PR #2144 merge `c6967be9b`).
+- [x] Backend, mongo, and web images for `1.0.236` exist on Docker Hub
+      (verified 2026-07-15 via the Docker Hub API).
+- [x] `Test`, `Release on main`, and `CodeQL` are green for `c6967be9b`, and
+      staging auto-updated to `1.0.236` with `/api/health` 200 before the window.
 - [x] **Previous production tag recorded: `v1.0.97`** — read from
       `https://compasscalendar.com/version.json` on 2026-07-15. This is the rollback
       deploy target.
@@ -73,12 +73,14 @@ The `calendar` migration is an **in-place rewrite with no programmatic reverse**
 backup is not a precaution here; it is the rollback mechanism. The `event` path is
 safer (legacy is retained as `event_legacy_v1`), but `calendar` has no such net.
 
-- [ ] Managed-provider **snapshot** of the prod cluster (Atlas `production1`)
-      triggered by the founder and confirmed complete. (Prod uses external managed
+- [x] Managed-provider **snapshot** of the prod Atlas cluster triggered by the
+      founder — confirmed at GATE 1, 2026-07-15. (Prod uses external managed
       MongoDB — the volume-tar procedure in `backup-and-restore.md` is self-host
-      only and is **not** the prod backup.) *In-window step.*
-- [ ] Fresh in-window `mongodump --gzip --db prod_calendar` completed after the
-      backend stops; counts recorded here: `_______`
+      only and is **not** the prod backup.)
+- [x] Fresh in-window `mongodump --gzip --db prod_calendar` completed 2026-07-15
+      15:18 local: **996,660 documents, 0 errors**, all 9 collections;
+      restore-checked into a scratch DB with exact count matches
+      (989,268 events / 941 users / 908 calendars / 915 sync).
 - [x] **Restore-tested**: the 2026-07-15 preflight dump (996,660 docs, all 9
       collections) was restored into a local Mongo 8.0 replica set with 0 failures
       and exact count matches — and then used as the dry-run rehearsal target.
@@ -143,8 +145,12 @@ No production action begins until every box above is ticked and both signatures 
 
 | Role | Name | Date | Go / No-Go |
 | --- | --- | --- | --- |
-| Rollback owner | | | |
-| Founder | | | |
+| Rollback owner | Tyler | 2026-07-15 | Go (GATE 4 confirmation) |
+| Founder | Tyler | 2026-07-15 | Go (GATE 4 confirmation) |
+
+**Executed 2026-07-15.** Deploy run 29455264833 green; see
+[`prod-cutover-execution-2026-07-15.md`](./prod-cutover-execution-2026-07-15.md)
+for the full live log and outcome.
 
 **Retain `event_legacy_v1` after a successful cutover.** It is the rollback source and
 must not be dropped in v1.


### PR DESCRIPTION
## Summary

Production cutover executed 2026-07-15 — prod is live on `v1.0.236` with the calendar-owned event model. This PR lands the two migration patches that the cutover surfaced and ran with, plus the completed execution record:

- **calendar-record-migration**: batched writes (bulkWrite/insertMany) — per-doc round trips inside one transaction exceeded the 60s transaction lifetime on the throttled Atlas shared tier (aborted identically from two client locations; rolled back atomically each time).
- **event-migration.verify**: duplicate-provider-id check moved from a server-side `$group` (exceeds shared-tier memory; spilling forbidden) into the existing client-side streaming scan.
- **Docs**: execution live log completed through the green deploy (run 29455264833), health check, and resync remediation; go/no-go checklist signed.

Both patches were validated on a full restored copy of production data (verification passed with identical numbers) before the prod runs, and are what actually executed the cutover from the VPS checkout.

## Manual Testing Steps

1. `TZ=UTC ./node_modules/.bin/jest scripts` — 150 tests pass.
2. Prod evidence: active `event` = 817,639 → 888,524 after resyncs; strict validator; `validate({full:true})` valid; 12 ledger records; zero code-121 log lines post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)