### PR TITLE
fix(e2e): wait for read-only gate before dragging in calendar-experience spec

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -463,6 +463,17 @@ test("a read-only event blocks a drag attempt", async ({ page }) => {
     .last();
 
   await card.scrollIntoViewIfNeeded();
+
+  // isEventReadOnly (useCalendarLookup.ts) fails OPEN as writable until the
+  // authenticated calendars query resolves, so the card can briefly render
+  // interactive right after setupCalendarExperiencePage returns (its own
+  // wait only confirms the sidebar reflects the refetch, not this card's
+  // next render). Wait for the read-only gate's actual DOM signal - the
+  // absence of the interaction-registry id attribute
+  // (WEEK_INTERACTION_EVENT_ID_ATTRIBUTE in weekEventRegistry.ts) - before
+  // dragging, so the drag itself isn't racing that same settling window.
+  await expect(card).not.toHaveAttribute("data-week-interaction-event-id");
+
   const box = await card.boundingBox();
   if (!box) {
     throw new Error("Expected the read-only event card to be visible.");


### PR DESCRIPTION
## Summary
- Investigated the axe `color-contrast` warnings and the flaky test flagged in [PR #2145's CI run](https://github.com/SwitchbackTech/compass-calendar/actions/runs/29455856615/job/87488752333?pr=2145).
- The axe `color-contrast` "incomplete" results are expected, not bugs: `docs/development/testing-playbook.md` documents that axe cannot reliably sample text over gradients/absolutely-positioned overlaps/pseudo-elements, and these exact states are already covered by the datepicker's dedicated contrast regression test. `incomplete` results never fail the suite by design. No change needed there.
- The real issue was the "1 flaky" line: `a read-only event blocks a drag attempt` occasionally recorded a stray `PUT` mutation for a read-only event. Root cause: `isEventReadOnly` (`packages/web/src/calendars/useCalendarLookup.ts`) intentionally fails **open** (treats an event as writable) until its calendar resolves in the authenticated calendars query — a deliberate, documented tradeoff since the backend re-enforces the real capability on every write. The test's setup only waited for the *sidebar* to reflect the authenticated refetch, not for this specific event card's own re-render to catch up, leaving a narrow window (usually sub-millisecond, occasionally wider under CI resource contention) where the card was still briefly draggable.
- Fix: the drag test now waits for the actual DOM signal the read-only gate produces — absence of the `data-week-interaction-event-id` interaction-registry attribute — before starting the drag gesture, closing the race at its real boundary instead of adding an arbitrary sleep.

## Simplicity
No simplification opportunities found — the diff is an 11-line addition (mostly a comment) to a single test file, with no hooks, mocks, or duplication in play.

## Manual Testing Steps
This is a test-only change with no browser-observable UI difference; there's no user-facing flow to click through. The equivalent verification is the automated test run below.

## Test plan
- [x] `bunx playwright test e2e/calendars/calendar-experience.spec.ts --workers=1` — 6/6 passed, including the previously-flaky "a read-only event blocks a drag attempt"
- [x] `bunx playwright test e2e/calendars/calendar-experience.spec.ts -g "read-only event blocks a drag" --workers=1` — passed in isolation
- [x] `bun run type-check` — clean