### PR TITLE
fix(backend): serialize event times with their real utc offset

### DIFF
--- a/packages/backend/src/event/event.record.mapper.test.ts
+++ b/packages/backend/src/event/event.record.mapper.test.ts
@@ -55,14 +55,11 @@ describe("mapEventRecord", () => {
     // recognized IANA zone; dayjs.tz() throws on this rather than silently
     // falling back, so the mapper must guard it itself. `as EventRecord`
     // bypasses the branded TimeZone type to simulate that bad data.
+    const start = new Date("2026-07-14T15:00:00.000Z");
+    const end = new Date("2026-07-14T16:00:00.000Z");
     const record = {
       ...buildRecord(),
-      schedule: {
-        kind: "timed",
-        start: new Date("2026-07-14T15:00:00.000Z"),
-        end: new Date("2026-07-14T16:00:00.000Z"),
-        timeZone: "",
-      },
+      schedule: { kind: "timed", start, end, timeZone: "" },
     } as EventRecord;
 
     let event: ReturnType<typeof mapEventRecord> | undefined;
@@ -70,12 +67,8 @@ describe("mapEventRecord", () => {
       event = mapEventRecord(record);
     }).not.toThrow();
     if (event?.schedule.kind === "timed") {
-      expect(event.schedule.start).toBe(
-        (record.schedule as { start: Date }).start.toISOString(),
-      );
-      expect(event.schedule.end).toBe(
-        (record.schedule as { end: Date }).end.toISOString(),
-      );
+      expect(event.schedule.start).toBe(start.toISOString());
+      expect(event.schedule.end).toBe(end.toISOString());
     } else {
       throw new Error("expected timed schedule");
     }

--- a/packages/backend/src/event/event.record.mapper.test.ts
+++ b/packages/backend/src/event/event.record.mapper.test.ts
@@ -32,13 +32,53 @@ describe("mapEventRecord", () => {
     expect(event.id).toBe(record._id.toHexString());
     expect(event.calendarId).toBe(record.calendarId.toHexString());
     if (event.schedule.kind === "timed") {
-      expect(event.schedule.start).toBe(record.schedule.start.toISOString());
-      expect(event.schedule.end).toBe(record.schedule.end.toISOString());
+      // America/Denver is UTC-6 in July (MDT), so the wire string should
+      // carry that offset instead of a bare "Z", while still representing
+      // the same instant as the stored UTC Date.
+      expect(event.schedule.start).toBe("2026-07-14T09:00:00.000-06:00");
+      expect(event.schedule.end).toBe("2026-07-14T10:00:00.000-06:00");
+      expect(new Date(event.schedule.start).getTime()).toBe(
+        record.schedule.start.getTime(),
+      );
+      expect(new Date(event.schedule.end).getTime()).toBe(
+        record.schedule.end.getTime(),
+      );
     } else {
       throw new Error("expected timed schedule");
     }
     expect(event.createdAt).toBe(record.createdAt.toISOString());
     expect(event.updatedAt).toBeNull();
+  });
+
+  it("falls back to a UTC offset instead of throwing when a legacy record has an invalid timeZone", () => {
+    // Un-migrated/corrupt records can carry a timeZone that isn't a
+    // recognized IANA zone; dayjs.tz() throws on this rather than silently
+    // falling back, so the mapper must guard it itself. `as EventRecord`
+    // bypasses the branded TimeZone type to simulate that bad data.
+    const record = {
+      ...buildRecord(),
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-14T15:00:00.000Z"),
+        end: new Date("2026-07-14T16:00:00.000Z"),
+        timeZone: "",
+      },
+    } as EventRecord;
+
+    let event: ReturnType<typeof mapEventRecord> | undefined;
+    expect(() => {
+      event = mapEventRecord(record);
+    }).not.toThrow();
+    if (event?.schedule.kind === "timed") {
+      expect(event.schedule.start).toBe(
+        (record.schedule as { start: Date }).start.toISOString(),
+      );
+      expect(event.schedule.end).toBe(
+        (record.schedule as { end: Date }).end.toISOString(),
+      );
+    } else {
+      throw new Error("expected timed schedule");
+    }
   });
 
   it("maps an all-day event unchanged", () => {

--- a/packages/backend/src/event/event.record.mapper.ts
+++ b/packages/backend/src/event/event.record.mapper.ts
@@ -1,5 +1,4 @@
 import { ObjectId } from "mongodb";
-import dayjs from "@core/util/date/dayjs";
 import {
   type CalendarId,
   type DateTime,
@@ -7,6 +6,7 @@ import {
 } from "@core/types/domain-primitives";
 import { type Event, type EventSchedule } from "@core/types/event.contracts";
 import { type CreateEventInput } from "@core/types/event-command.contracts";
+import dayjs from "@core/util/date/dayjs";
 import {
   type EventRecord,
   type EventScheduleRecord,

--- a/packages/backend/src/event/event.record.mapper.ts
+++ b/packages/backend/src/event/event.record.mapper.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from "mongodb";
+import dayjs from "@core/util/date/dayjs";
 import {
   type CalendarId,
   type DateTime,
@@ -13,6 +14,22 @@ import {
 
 const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
 
+const WIRE_DATETIME_FORMAT = "YYYY-MM-DDTHH:mm:ss.SSSZ";
+
+// The web client reads the offset embedded in this string to decide what
+// wall-clock time to display, so format in the event's own timeZone instead
+// of toISOString() (which always forces a UTC "Z" suffix). dayjs.tz() throws
+// on an unrecognized zone, which un-migrated/corrupt records could still
+// carry - fall back to the old UTC-offset behavior rather than 500ing the
+// whole read.
+const toWireDateTime = (date: Date, timeZone: string): DateTime => {
+  try {
+    return dayjs(date).tz(timeZone).format(WIRE_DATETIME_FORMAT) as DateTime;
+  } catch {
+    return date.toISOString() as DateTime;
+  }
+};
+
 const mapScheduleRecordToSchedule = (
   schedule: EventScheduleRecord,
 ): EventSchedule => {
@@ -20,10 +37,8 @@ const mapScheduleRecordToSchedule = (
 
   return {
     kind: "timed",
-    // BSON Dates serialize with a "Z" offset, which satisfies the
-    // DateTimeSchema RFC 3339 offset requirement.
-    start: schedule.start.toISOString() as DateTime,
-    end: schedule.end.toISOString() as DateTime,
+    start: toWireDateTime(schedule.start, schedule.timeZone),
+    end: toWireDateTime(schedule.end, schedule.timeZone),
     timeZone: schedule.timeZone,
   };
 };


### PR DESCRIPTION
## Summary

After the recent prod cutover, timed events rendered at the correct grid position but showed the wrong time label (e.g. sidebar said "12:30 – 1:15 PM" while the event sat elsewhere). Root cause: `mapScheduleRecordToSchedule` in `packages/backend/src/event/event.record.mapper.ts` serialized `schedule.start`/`end` via `.toISOString()`, which always forces a UTC `Z` suffix. The web client's time-label formatter deliberately reads the offset embedded in that ISO string to pick a display timezone (a documented, tested contract — see `grid-event-draft.adapter.test.ts`), while grid *position* separately converts to the browser's local zone. So the label always showed raw UTC time while the grid slot showed local time.

This wasn't backfill-specific — the same `.toISOString()` call was hit by every timed event (synced, manually-created, or migrated) that flows through this mapper, which is the single point all API responses go through. The cutover just made it visible because the backfill touched every event at once.

Fix: format using the event's own `timeZone` field (`dayjs(...).tz(schedule.timeZone).format(...)`) instead of `.toISOString()`, with a fallback to the old UTC-offset behavior if `timeZone` isn't a valid IANA zone — code review surfaced that un-migrated/corrupt records could carry an invalid `timeZone`, and `dayjs.tz()` throws on those rather than silently falling back, which would otherwise turn a display bug into a 500 on the whole event-list read. Also preserved millisecond precision in the wire format, which `.toISOString()` had and the initial fix's `.format()` call would have silently dropped.

## Simplicity

Net simplification: the fix itself is a small, self-contained helper (`toWireDateTime`) replacing two inline `.toISOString()` calls — no new abstractions beyond what's needed. The follow-up simplify pass removed a double-cast (`record.schedule as {...}`) in the new test by hoisting the test's `start`/`end` Dates into named locals, and fixed an import-sort lint violation. No `useEffect`/`useRef`/`useState` in play — this is a backend-only change.

## Manual Testing Steps

- [ ] Sign in and open the Day view for any date.
- [ ] Create a timed event (e.g. drag to create 8:45 AM – 9 AM).
- [ ] Confirm the event card's displayed time (visible on hover/click, or via the "Timed event: ..." accessible label) matches the grid row it's drawn in — e.g. an event drawn between the 8 AM and 9 AM gridlines should say "8:45 AM - 9 AM", not a UTC-shifted time.
- [ ] Create a second, longer event (e.g. 10 AM – 12 PM) and confirm the same match holds.
- [ ] Delete both test events.

## Test plan

- [x] `bun run type-check` — clean
- [x] `packages/backend/src/event/event.record.mapper.test.ts` — 8/8 pass, including a new test asserting a `2026-07-14T15:00:00.000Z` Date + `America/Denver` timeZone maps to `2026-07-14T09:00:00.000-06:00` (not `Z`), and a new fallback test asserting an invalid `timeZone` degrades to the old UTC-offset string instead of throwing
- [x] `packages/web/src/common/utils/datetime/date.label.test.ts` and `packages/web/src/events/grid-event-draft.adapter.test.ts` — 11/11 pass, confirming no regression to the client's offset-sniffing contract
- [x] `bun run lint` — clean
- [x] Manual verification in a live dev backend + web session (real Chrome): created two timed events, confirmed via the DOM's accessible label ("Timed event: ..., 8:45 - 9 AM" and "..., 10 AM - 12 PM") that the label now exactly matches the grid slot, round-tripped through the real fixed mapper and a real API call. No console errors.