### PR TITLE
refactor(core): collapse triplicated logger construction

### DIFF
--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -13,6 +13,8 @@ import {
 
 const logger = Logger("app:constants");
 
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+
 const ConfigSchema = z
   .object({
     BASEURL: z.string().nonempty(),
@@ -107,7 +109,7 @@ function parseRawConfig(config: CompassConfig): Config {
     TOKEN_GCAL_NOTIFICATION: nonEmpty(config.google?.notificationToken) ?? "",
     TOKEN_COMPASS_SYNC: config.backend.compassToken,
     POSTHOG_KEY: nonEmpty(config.posthog?.key),
-    POSTHOG_HOST: nonEmpty(config.posthog?.host) || "https://us.i.posthog.com",
+    POSTHOG_HOST: nonEmpty(config.posthog?.host) || DEFAULT_POSTHOG_HOST,
   });
 }
 
@@ -136,7 +138,7 @@ export function parseConfigFromEnv(
     TOKEN_GCAL_NOTIFICATION: rawEnv["TOKEN_GCAL_NOTIFICATION"],
     TOKEN_COMPASS_SYNC: rawEnv["TOKEN_COMPASS_SYNC"],
     POSTHOG_KEY: rawEnv["POSTHOG_KEY"],
-    POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || "https://us.i.posthog.com",
+    POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || DEFAULT_POSTHOG_HOST,
   });
 }
 

--- a/packages/core/src/logger/winston.logger.ts
+++ b/packages/core/src/logger/winston.logger.ts
@@ -42,47 +42,20 @@ const consoleFormat = winston.format.combine(
   }),
 );
 
-const transports = (logFileName?: string) => {
-  const fileTransport = new winston.transports.File({
-    filename: logFileName ? logFileName : "logs/app.log",
-    level: process.env["LOG_LEVEL"],
-    maxsize: MB_50,
-    maxFiles: 1,
-  });
-  const consoleTransport = new winston.transports.Console({
-    format: consoleFormat,
-  });
-
-  if (logFileName) {
-    return [fileTransport];
-  } else {
-    return [fileTransport, consoleTransport];
-  }
-};
-
-export const Logger = (namespace?: string, logFile?: string) => {
-  if (!namespace) {
-    return winston.createLogger({
-      level: process.env["LOG_LEVEL"],
-      format: openTelemetryFormat(),
-      transports: transports(),
-    });
-  }
-
-  if (logFile) {
-    const secondaryLogger = winston.createLogger({
-      level: process.env["LOG_LEVEL"],
-      format: openTelemetryFormat(),
-      transports: transports(logFile),
-    });
-    return secondaryLogger.child({ namespace });
-  }
-
-  const primaryLogger = winston.createLogger({
+export const Logger = (namespace?: string) => {
+  const logger = winston.createLogger({
     level: process.env["LOG_LEVEL"],
     format: openTelemetryFormat(),
-    transports: transports(),
+    transports: [
+      new winston.transports.File({
+        filename: "logs/app.log",
+        level: process.env["LOG_LEVEL"],
+        maxsize: MB_50,
+        maxFiles: 1,
+      }),
+      new winston.transports.Console({ format: consoleFormat }),
+    ],
   });
 
-  return primaryLogger.child({ namespace });
+  return namespace ? logger.child({ namespace }) : logger;
 };


### PR DESCRIPTION
## Summary

Cleanup-ritual follow-up to the PostHog log export (f34a21a96), which had to paste the same `format: openTelemetryFormat()` line into three near-identical `winston.createLogger` branches. The branching only existed to serve `Logger`'s `logFile` second parameter, which has zero callers repo-wide, so:

- `Logger(namespace?, logFile?)` → `Logger(namespace?)`: one `createLogger` plus `namespace ? logger.child({ namespace }) : logger`, with the single-use `transports()` helper inlined. The surviving path is byte-for-byte the old no-`logFile` behavior.
- The PostHog host default `"https://us.i.posthog.com"`, previously duplicated in `parseRawConfig` and `parseConfigFromEnv`, is hoisted into one `DEFAULT_POSTHOG_HOST` constant so the two config entry points can't silently drift.

Net −25 lines, behavior-preserving.

## Simplicity

Net reduction: three `createLogger` call sites collapse to one, a dead parameter and its dead file-only transport mode are deleted, and a magic string is deduplicated. No `useEffect`/`useRef`/`useState` in play (backend/core only). An 8-angle correctness review ran on the diff; the only candidates raised assumed a two-arg `Logger()` caller exists, refuted by repo-wide grep and the green type-check.

## Manual Testing Steps

Not browser-observable (backend/core logging only). Equivalent checks a reviewer can run:

- [ ] `rg "Logger(" packages --type ts` and confirm no call passes a second argument.
- [ ] `bun run dev:backend` locally and confirm log lines still appear on the console AND in `logs/app.log`, prefixed with their namespace (e.g. `app:root`).
- [ ] After the staging deploy, confirm backend log events still arrive in PostHog (Logs, service.name `compass-backend`) and that the staging health check passes.

## Test plan

- [x] `bun run type-check` — green (repo-wide, would fail on any two-arg `Logger()` call)
- [x] `bun run test:core` — 233 pass, 0 fail
- [x] `bun run test:backend` — 655 pass, 4 skipped, 0 fail
- [x] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)