### PR TITLE
fix(scripts): backfill schedule.timeZone for events stamped UTC by the sync fallback

### DIFF
--- a/packages/scripts/src/migrations/2026.07.15T22.00.00.timed-event-timezone-repair.test.ts
+++ b/packages/scripts/src/migrations/2026.07.15T22.00.00.timed-event-timezone-repair.test.ts
@@ -1,0 +1,175 @@
+import { MigratorType } from "@scripts/common/cli.types";
+import Migration from "@scripts/migrations/2026.07.15T22.00.00.timed-event-timezone-repair";
+import { ObjectId } from "mongodb";
+import { Logger } from "@core/logger/winston.logger";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import mongoService from "@backend/common/services/mongo.service";
+import { type EventRecord } from "@backend/event/event.record";
+
+const buildCalendar = (
+  overrides: Partial<CalendarRecord> = {},
+): CalendarRecord => ({
+  _id: new ObjectId(),
+  userId: new ObjectId(),
+  name: "Personal",
+  description: "",
+  timeZone: "America/Denver",
+  foregroundColor: "#000000",
+  backgroundColor: "#ffffff",
+  access: "owner",
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+  source: { provider: "local" },
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: null,
+  ...overrides,
+});
+
+const buildEvent = (
+  calendarId: ObjectId,
+  overrides: Partial<EventRecord> = {},
+): EventRecord => ({
+  _id: new ObjectId(),
+  calendarId,
+  content: { kind: "details", title: "lunch", description: "" },
+  schedule: {
+    kind: "timed",
+    start: new Date("2026-07-14T15:00:00.000Z"),
+    end: new Date("2026-07-14T16:00:00.000Z"),
+    timeZone: "UTC",
+  },
+  recurrence: { kind: "single" },
+  externalReference: null,
+  createdAt: new Date("2026-07-10T00:00:00.000Z"),
+  updatedAt: null,
+  ...overrides,
+});
+
+describe("2026.07.15T22.00.00.timed-event-timezone-repair", () => {
+  const migration = new Migration();
+
+  const contextFor = (dryRun: boolean) => ({
+    name: migration.name,
+    context: {
+      logger: Logger("test:migration"),
+      migratorType: MigratorType.MIGRATION,
+      unsafe: false,
+      dryRun,
+    },
+  });
+
+  beforeAll(setupTestDb);
+  afterEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("no-ops cleanly against a fresh, empty database", async () => {
+    await expect(migration.up(contextFor(false))).resolves.not.toThrow();
+  });
+
+  it("re-derives schedule.timeZone from the owning calendar for a UTC-tagged event", async () => {
+    const calendar = buildCalendar({ timeZone: "America/Denver" });
+    const event = buildEvent(calendar._id);
+    await mongoService.calendar.insertOne(calendar);
+    await mongoService.event.insertOne(event);
+
+    await migration.up(contextFor(false));
+
+    const updated = await mongoService.event.findOne({ _id: event._id });
+    expect(updated?.schedule).toMatchObject({ timeZone: "America/Denver" });
+  });
+
+  it("never changes schedule.start/end, only timeZone", async () => {
+    const calendar = buildCalendar({ timeZone: "Europe/Istanbul" });
+    const event = buildEvent(calendar._id);
+    await mongoService.calendar.insertOne(calendar);
+    await mongoService.event.insertOne(event);
+
+    await migration.up(contextFor(false));
+
+    const updated = await mongoService.event.findOne({ _id: event._id });
+    expect(updated?.schedule).toMatchObject({
+      start: event.schedule.kind === "timed" ? event.schedule.start : null,
+      end: event.schedule.kind === "timed" ? event.schedule.end : null,
+    });
+  });
+
+  it("leaves events already tagged with a non-UTC timeZone untouched", async () => {
+    const calendar = buildCalendar({ timeZone: "America/Denver" });
+    const event = buildEvent(calendar._id, {
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-07-14T15:00:00.000Z"),
+        end: new Date("2026-07-14T16:00:00.000Z"),
+        timeZone: "America/Chicago",
+      },
+    });
+    await mongoService.calendar.insertOne(calendar);
+    await mongoService.event.insertOne(event);
+
+    await migration.up(contextFor(false));
+
+    const untouched = await mongoService.event.findOne({ _id: event._id });
+    expect(untouched?.schedule).toMatchObject({ timeZone: "America/Chicago" });
+  });
+
+  it("skips (does not write) when the owning calendar cannot be found", async () => {
+    const event = buildEvent(new ObjectId());
+    await mongoService.event.insertOne(event);
+
+    await migration.up(contextFor(false));
+
+    const unchanged = await mongoService.event.findOne({ _id: event._id });
+    expect(unchanged?.schedule).toMatchObject({ timeZone: "UTC" });
+  });
+
+  it("skips when the owning calendar's timeZone is null or also UTC", async () => {
+    const nullTzCalendar = buildCalendar({ timeZone: null });
+    const utcTzCalendar = buildCalendar({ timeZone: "UTC" });
+    const eventUnderNullTz = buildEvent(nullTzCalendar._id);
+    const eventUnderUtcTz = buildEvent(utcTzCalendar._id);
+    await mongoService.calendar.insertMany([nullTzCalendar, utcTzCalendar]);
+    await mongoService.event.insertMany([eventUnderNullTz, eventUnderUtcTz]);
+
+    await migration.up(contextFor(false));
+
+    const first = await mongoService.event.findOne({
+      _id: eventUnderNullTz._id,
+    });
+    const second = await mongoService.event.findOne({
+      _id: eventUnderUtcTz._id,
+    });
+    expect(first?.schedule).toMatchObject({ timeZone: "UTC" });
+    expect(second?.schedule).toMatchObject({ timeZone: "UTC" });
+  });
+
+  it("dry-run reports without writing changes", async () => {
+    const calendar = buildCalendar({ timeZone: "America/Los_Angeles" });
+    const event = buildEvent(calendar._id);
+    await mongoService.calendar.insertOne(calendar);
+    await mongoService.event.insertOne(event);
+
+    await migration.up(contextFor(true));
+
+    const unchanged = await mongoService.event.findOne({ _id: event._id });
+    expect(unchanged?.schedule).toMatchObject({ timeZone: "UTC" });
+  });
+
+  it("is safe to rerun: converges to zero further changes once fixed", async () => {
+    const calendar = buildCalendar({ timeZone: "America/Denver" });
+    const event = buildEvent(calendar._id);
+    await mongoService.calendar.insertOne(calendar);
+    await mongoService.event.insertOne(event);
+
+    await migration.up(contextFor(false));
+    await expect(migration.up(contextFor(false))).resolves.not.toThrow();
+
+    const updated = await mongoService.event.findOne({ _id: event._id });
+    expect(updated?.schedule).toMatchObject({ timeZone: "America/Denver" });
+  });
+});

--- a/packages/scripts/src/migrations/2026.07.15T22.00.00.timed-event-timezone-repair.ts
+++ b/packages/scripts/src/migrations/2026.07.15T22.00.00.timed-event-timezone-repair.ts
@@ -1,0 +1,138 @@
+import { type MigrationContext } from "@scripts/common/cli.types";
+import { type AnyBulkWriteOperation, ObjectId } from "mongodb";
+import { type MigrationParams, type RunnableMigration } from "umzug";
+import { MONGO_BATCH_SIZE } from "@backend/common/constants/backend.constants";
+import mongoService from "@backend/common/services/mongo.service";
+import { type EventRecord } from "@backend/event/event.record";
+
+interface SkippedRecord {
+  eventId: string;
+  calendarId: string;
+  reason: "calendarNotFound" | "calendarTimeZoneUnusable";
+}
+
+const calendarIdKey = (id: unknown): string =>
+  id instanceof ObjectId ? id.toHexString() : String(id);
+
+/**
+ * One-off repair for `packages/backend/src/event/google-event.adapter.ts`'s
+ * `event.start?.timeZone ?? calendarTimeZone ?? "UTC"` fallback: whenever
+ * both were unavailable at sync time, the event's real timeZone (needed to
+ * render its wall-clock time correctly - see event.record.mapper.ts) was
+ * silently stamped "UTC" instead. This was invisible before the wire-format
+ * fix (PR #2150) because every event rendered in UTC regardless of the
+ * stored value; the fix now faithfully renders whatever is stored, which
+ * exposed these records as displaying the wrong time.
+ *
+ * Re-derives `schedule.timeZone` from the event's owning calendar for any
+ * timed event still tagged "UTC" - the same fallback the sync adapter
+ * itself uses, applied after the fact. Only `schedule.timeZone` is written;
+ * `schedule.start`/`end` (the actual instant) are never touched, so this
+ * cannot change which absolute moment an event represents - only which
+ * wall-clock time it's displayed as.
+ *
+ * No transaction: each event's fix is independent, so partial completion on
+ * abort is safe and the migration is naturally resumable (see MigrationContext
+ * dryRun and the shared-tier notes in compass-calendar-internal/prod-operations.md
+ * - bulkWrite in batches, no per-doc round trips, no transaction to blow the
+ * 60s lifetime). Safe to rerun: converges to zero further changes once every
+ * resolvable record is fixed; unresolved records (see SkippedRecord) need a
+ * human, not a rerun.
+ */
+export default class Migration implements RunnableMigration<MigrationContext> {
+  readonly name: string = "2026.07.15T22.00.00.timed-event-timezone-repair";
+  readonly path: string = "2026.07.15T22.00.00.timed-event-timezone-repair.ts";
+
+  async up(params: MigrationParams<MigrationContext>): Promise<void> {
+    const { logger, dryRun } = params.context;
+    const prefix = dryRun ? "[dry-run] " : "";
+
+    const calendars = await mongoService.calendar
+      .find({}, { projection: { timeZone: 1 } })
+      .toArray();
+    const calendarTimeZoneById = new Map<string, string | null>(
+      calendars.map((c) => [calendarIdKey(c._id), c.timeZone]),
+    );
+
+    const cursor = mongoService.event.find(
+      { "schedule.kind": "timed", "schedule.timeZone": "UTC" },
+      { batchSize: MONGO_BATCH_SIZE },
+    );
+
+    let scanned = 0;
+    let updated = 0;
+    const updatedByTimeZone = new Map<string, number>();
+    const skipped: SkippedRecord[] = [];
+    let ops: AnyBulkWriteOperation<EventRecord>[] = [];
+
+    const flush = async (): Promise<void> => {
+      if (ops.length === 0) return;
+      if (!dryRun) {
+        await mongoService.event.bulkWrite(ops, { ordered: false });
+      }
+      ops = [];
+    };
+
+    for await (const event of cursor) {
+      scanned += 1;
+      if (event.schedule.kind !== "timed") continue;
+
+      const calendarKey = calendarIdKey(event.calendarId);
+      const calendarTimeZone = calendarTimeZoneById.get(calendarKey);
+
+      if (calendarTimeZone === undefined) {
+        skipped.push({
+          eventId: calendarIdKey(event._id),
+          calendarId: calendarKey,
+          reason: "calendarNotFound",
+        });
+        continue;
+      }
+      if (!calendarTimeZone || calendarTimeZone === "UTC") {
+        skipped.push({
+          eventId: calendarIdKey(event._id),
+          calendarId: calendarKey,
+          reason: "calendarTimeZoneUnusable",
+        });
+        continue;
+      }
+
+      ops.push({
+        updateOne: {
+          filter: { _id: event._id },
+          update: { $set: { "schedule.timeZone": calendarTimeZone } },
+        },
+      });
+      updated += 1;
+      updatedByTimeZone.set(
+        calendarTimeZone,
+        (updatedByTimeZone.get(calendarTimeZone) ?? 0) + 1,
+      );
+
+      if (ops.length >= MONGO_BATCH_SIZE) await flush();
+    }
+    await flush();
+
+    logger.info(
+      `${prefix}Timed-event timeZone repair: scanned=${scanned} updated=${updated} skipped=${skipped.length}`,
+    );
+    for (const [timeZone, count] of updatedByTimeZone) {
+      logger.info(`${prefix}  -> ${timeZone}: ${count}`);
+    }
+    if (skipped.length > 0) {
+      logger.info(
+        `${prefix}Unresolved records (need manual follow-up): ${JSON.stringify(
+          skipped,
+        )}`,
+      );
+    }
+  }
+
+  async down(params: MigrationParams<MigrationContext>): Promise<void> {
+    params.context.logger.info(
+      "Down migration is a non-destructive no-op: reverting schedule.timeZone " +
+        'back to "UTC" would just resurrect the display bug this repair fixes.',
+    );
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2150. That PR fixed the wire-format bug (events always serialized in UTC regardless of their real timezone), but exposed a separate, pre-existing data issue: `google-event.adapter.ts`'s `event.start?.timeZone ?? calendarTimeZone ?? "UTC"` fallback silently stamps `schedule.timeZone: "UTC"` whenever both Google's sync payload and the calendar's own timezone were unavailable at ingest time. This was invisible before #2150 (every event rendered in UTC regardless of the stored value, so a wrongly-tagged "UTC" record looked identical to a correctly-tagged one); the fix now faithfully renders whatever timezone is stored, which surfaced these records as displaying the wrong wall-clock time (right grid position, wrong label).

This migration (`2026.07.15T22.00.00.timed-event-timezone-repair`) re-derives `schedule.timeZone` from the event's owning calendar for any timed event still tagged `"UTC"` — the same fallback the sync adapter itself uses, applied after the fact. It never touches `schedule.start`/`end` (the actual instant), so no event's real time changes — only which wall-clock time it's displayed as. No transaction (each event's fix is independent, and shared-tier Atlas transactions abort at 60s per `compass-calendar-internal/prod-operations.md`); batched `bulkWrite` calls instead. Records whose calendar has no usable `timeZone` either are skipped and logged for manual follow-up rather than guessed at or crashing the run.

**Already validated against staging's real data**, not just synthetic tests: dry-run then a real run against staging's Atlas cluster fixed 2,540 of 2,541 bad records (all resolving to `America/Denver`), with 1 correctly left for manual review (its calendar's own `timeZone` is also unusable). Verified visually in-browser afterward: a recurring `lunch` series that showed `5 - 6:15 PM` while sitting in the 11 AM grid row now correctly shows `11 AM - 12:15 PM`.

**Prod has the same class of bad data** (not yet backfilled) — this PR is scoped to landing the migration; running it against prod is a separate, deliberate operational step per `compass-calendar-internal/migrations/playbook.md` (dry-run against a restored prod copy first, backup, etc.), not something this PR does automatically.

## Simplicity

Follows the existing migration pattern in this repo exactly (see `2026.07.13T12.00.00.recurring-series-first-occurrence-repair.ts` for the sibling this was modeled on): a single `RunnableMigration` class, `dryRun`-aware, batched `bulkWrite`, non-destructive no-op `down()`. No new abstractions. No `useEffect`/`useRef`/`useState` — this is a backend/scripts-only change.

## Manual Testing Steps

- [ ] Sign in as a user with an old recurring event that predates this fix (or check staging's `compasscaltest3@gmail.com` test account, which already had this migration applied).
- [ ] Open the Week or Day view for a week containing that event.
- [ ] Confirm the event's displayed time label matches the grid row it's drawn in (e.g. `lunch` at `11 AM - 12:15 PM`, sitting in the 11 AM row — not showing a UTC-shifted time like `5 - 6:15 PM`).

## Test plan

- [x] `bun run type-check` — clean
- [x] `bun run test:scripts` (filtered to this migration) — 8/8 pass: re-derives timeZone from the owning calendar, never touches start/end, leaves already-correct events untouched, skips (no write) when the calendar can't be found or its own timeZone is null/UTC, dry-run writes nothing, safe to rerun (idempotent)
- [x] `bun run lint` — clean
- [x] Dry-run against staging's live Atlas cluster (`--dry-run`): reported 2,541 scanned / 2,540 would-update / 1 skip, no crashes
- [x] Real run against staging: same counts, verified via direct Mongo query that `schedule.timeZone` updated correctly (e.g. `America/Denver`) and `schedule.start`/`end` were untouched
- [x] Manual browser verification on staging post-migration: `lunch` series across the week now shows `11 AM - 12:15 PM` matching its grid position (previously showed `5 - 6:15 PM`)