### PR TITLE
fix(web): calendar grid, header, and read-only event details + backend-down page and up next card

### DIFF
--- a/packages/core/src/errors/status.codes.ts
+++ b/packages/core/src/errors/status.codes.ts
@@ -17,6 +17,7 @@ export enum Status {
   /* 5xx - Server Error */
   INTERNAL_SERVER = 500,
   NOT_IMPLEMENTED = 501,
+  BAD_GATEWAY = 502,
   SERVICE_UNAVAILABLE = 503,
   GATEWAY_TIMEOUT = 504,
 

--- a/packages/web/src/api/util/backend-unavailable-error.util.test.ts
+++ b/packages/web/src/api/util/backend-unavailable-error.util.test.ts
@@ -1,3 +1,5 @@
+import { Status } from "@core/errors/status.codes";
+import { type ApiError, type ApiResponse } from "../api.types";
 import {
   isBackendUnavailable,
   isBackendUnavailableError,
@@ -5,6 +7,14 @@ import {
   markBackendUnavailable,
   resetBackendAvailabilityForTests,
 } from "./backend-unavailable-error.util";
+
+/** Mirrors what `createApiError` builds for a response the backend/proxy returned. */
+const createApiErrorWithStatus = (status: number): ApiError => {
+  const error = new Error(`Request failed with status ${status}`) as ApiError;
+  error.name = "ApiError";
+  error.response = { status } as ApiResponse<unknown>;
+  return error;
+};
 
 beforeEach(() => {
   resetBackendAvailabilityForTests();
@@ -24,11 +34,36 @@ describe("isBackendUnavailableError", () => {
     );
   });
 
-  it("does not treat server responses as backend availability failures", () => {
-    const error = new Error("Request failed with status 500");
-    error.name = "ApiError";
+  it.each([
+    ["bad gateway", Status.BAD_GATEWAY],
+    ["service unavailable", Status.SERVICE_UNAVAILABLE],
+    ["gateway timeout", Status.GATEWAY_TIMEOUT],
+  ])("detects a proxy %s response", (_label, status) => {
+    expect(isBackendUnavailableError(createApiErrorWithStatus(status))).toBe(
+      true,
+    );
+  });
 
-    expect(isBackendUnavailableError(error)).toBe(false);
+  it("does not treat server responses as backend availability failures", () => {
+    // The backend answered, so it is up; the failure belongs to this request.
+    expect(
+      isBackendUnavailableError(
+        createApiErrorWithStatus(Status.INTERNAL_SERVER),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat client errors as backend availability failures", () => {
+    expect(
+      isBackendUnavailableError(createApiErrorWithStatus(Status.UNAUTHORIZED)),
+    ).toBe(false);
+  });
+
+  it("ignores non-API errors", () => {
+    expect(isBackendUnavailableError(new Error("Something else broke"))).toBe(
+      false,
+    );
+    expect(isBackendUnavailableError("not an error")).toBe(false);
   });
 });
 

--- a/packages/web/src/api/util/backend-unavailable-error.util.ts
+++ b/packages/web/src/api/util/backend-unavailable-error.util.ts
@@ -1,32 +1,66 @@
+import { useSyncExternalStore } from "react";
+import { Status } from "@core/errors/status.codes";
+import { createExternalStore } from "@web/common/utils/external-store.util";
 import { refreshEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
+import { type ApiError } from "../api.types";
 
-let isBackendUnavailableFlag = false;
+/**
+ * Statuses a proxy returns when it cannot reach the backend, or cannot get a
+ * timely answer from it. A 500 is excluded on purpose: the backend answered,
+ * so it is up and the failure belongs to the individual request.
+ */
+const BACKEND_DOWN_STATUSES: number[] = [
+  Status.BAD_GATEWAY,
+  Status.SERVICE_UNAVAILABLE,
+  Status.GATEWAY_TIMEOUT,
+];
+
+const unavailableStore = createExternalStore(false);
 
 export function isBackendUnavailableError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
   }
 
-  return (
-    (error.name === "ApiError" && error.message === "Request failed") ||
-    error.message === "Failed to fetch"
-  );
+  if (error.name === "ApiError") {
+    // Read the status off the response rather than the message: `createApiError`
+    // bakes the status into the message text, and string-matching that is what
+    // previously let real 502s through as ordinary request failures.
+    const status = (error as ApiError).response?.status;
+    // No response at all means the request never reached the backend.
+    return status === undefined || BACKEND_DOWN_STATUSES.includes(status);
+  }
+
+  return error.message === "Failed to fetch";
 }
 
 export function isBackendUnavailable(): boolean {
-  return isBackendUnavailableFlag;
+  return unavailableStore.get();
+}
+
+/**
+ * React hook: subscribe to backend availability so the UI can render off it.
+ */
+export function useIsBackendUnavailable(): boolean {
+  return useSyncExternalStore(unavailableStore.subscribe, unavailableStore.get);
 }
 
 export function markBackendAvailable(): void {
-  isBackendUnavailableFlag = false;
+  // Runs on every successful request, so only do the transition work when the
+  // flag actually flips; the repository source only needs re-keying then.
+  if (!unavailableStore.get()) return;
+
+  unavailableStore.set(false);
+  // Source flips back to "remote"; re-key active queries.
+  refreshEventRepositorySource();
 }
 
 export function markBackendUnavailable(): void {
-  isBackendUnavailableFlag = true;
+  unavailableStore.set(true);
   // Source flips to "local" once the backend is unavailable; re-key active queries.
   refreshEventRepositorySource();
 }
 
 export function resetBackendAvailabilityForTests(): void {
-  isBackendUnavailableFlag = false;
+  unavailableStore.set(false);
 }

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -1,5 +1,7 @@
 import { ObjectId } from "bson";
+import { Status } from "@core/errors/status.codes";
 import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
+import { type ApiError, type ApiResponse } from "@web/api/api.types";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -40,8 +42,11 @@ describe("handleError", () => {
   });
 
   it("logs once and does not reload on a server error", () => {
-    const error = new Error("Request failed with status 500");
+    // Carries a `response` like a real 500 from `createApiError`: backend
+    // availability is judged on the response status, not the message text.
+    const error = new Error("Request failed with status 500") as ApiError;
     error.name = "ApiError";
+    error.response = { status: Status.INTERNAL_SERVER } as ApiResponse<unknown>;
 
     handleError(error);
 

--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -25,8 +25,9 @@ interface Props {
 }
 
 /**
- * Shared header for the Day and Week views: a left-aligned heading and a
- * right-aligned control cluster (view switcher, today, prev/next).
+ * Shared header for the Day and Week views: a left-aligned heading with the
+ * prev/next arrows beside it, and a right-aligned control cluster (today, view
+ * switcher).
  * Owns the heading markup, sidebar-toggle state, and the control layout so both
  * views stay consistent without re-wiring these concerns per caller.
  */
@@ -42,7 +43,7 @@ export const CalendarHeader: FC<Props> = ({
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
 
   return (
-    <div className="flex h-12 w-full shrink-0 items-center text-text-light">
+    <div className="flex h-12 w-full shrink-0 items-center gap-3 text-text-light">
       {!isSidebarOpen ? (
         <TooltipWrapper
           description="Open sidebar"
@@ -59,18 +60,19 @@ export const CalendarHeader: FC<Props> = ({
         </TooltipWrapper>
       ) : null}
 
-      <h1 className="pl-8 text-text-lighter" aria-live="polite">
+      <h1 className="text-text-lighter" aria-live="polite">
         <span className="relative text-xl">{label}</span>
       </h1>
 
+      <TooltipWrapper shortcut="J">
+        <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
+      </TooltipWrapper>
+      <TooltipWrapper shortcut="K">
+        <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
+      </TooltipWrapper>
+
       <div className="z-2 ml-auto flex items-center gap-3 pr-5">
         <TodayButton navigateToToday={onToday} isToday={isToday} />
-        <TooltipWrapper shortcut="J">
-          <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
-        </TooltipWrapper>
-        <TooltipWrapper shortcut="K">
-          <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
-        </TooltipWrapper>
         <SelectView />
       </div>
     </div>

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.test.tsx
@@ -9,6 +9,7 @@ const PlannerSidebar = createPlannerSidebar({
   PlannerSidebarActions: () => <div>Sidebar actions</div>,
   ShortcutsOverlay: () => null,
   TasksRemovalNotice: () => null,
+  UpNextCard: () => <div>Up next</div>,
 });
 
 const sidebarProps = {

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebar.tsx
@@ -7,6 +7,7 @@ import { PlannerMonthPicker } from "./PlannerMonthPicker/PlannerMonthPicker";
 import { PlannerSidebarActions } from "./PlannerSidebarActions/PlannerSidebarActions";
 import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
 import { TasksRemovalNotice } from "./TasksRemovalNotice/TasksRemovalNotice";
+import { UpNextCard } from "./UpNextCard/UpNextCard";
 
 export interface PlannerSidebarProps extends HTMLAttributes<HTMLDivElement> {
   calendarDate: Dayjs;
@@ -33,6 +34,7 @@ type PlannerSidebarDependencies = {
   PlannerSidebarActions: typeof PlannerSidebarActions;
   ShortcutsOverlay: typeof ShortcutsOverlay;
   TasksRemovalNotice: typeof TasksRemovalNotice;
+  UpNextCard: typeof UpNextCard;
 };
 
 export function createPlannerSidebar({
@@ -41,6 +43,7 @@ export function createPlannerSidebar({
   PlannerSidebarActions: PlannerSidebarActionsComponent,
   ShortcutsOverlay: ShortcutsOverlayComponent,
   TasksRemovalNotice: TasksRemovalNoticeComponent,
+  UpNextCard: UpNextCardComponent,
 }: PlannerSidebarDependencies) {
   return function PlannerSidebar({
     calendarDate,
@@ -82,6 +85,7 @@ export function createPlannerSidebar({
               onToggleSidebar={onToggleSidebar}
               selectedDate={calendarDate}
             />
+            <UpNextCardComponent />
             <PlannerCalendarListComponent />
             <TasksRemovalNoticeComponent />
           </div>
@@ -109,4 +113,5 @@ export const PlannerSidebar = createPlannerSidebar({
   PlannerSidebarActions,
   ShortcutsOverlay,
   TasksRemovalNotice,
+  UpNextCard,
 });

--- a/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.test.tsx
@@ -1,0 +1,123 @@
+import { EventIdSchema } from "@core/types/domain-primitives";
+import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@web/__tests__/__mocks__/mock.render";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
+import { formatStartsIn, UpNextCard } from "./UpNextCard";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import "@testing-library/jest-dom";
+
+const SOON_EVENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+const LATER_EVENT_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+
+// Events are built relative to the real clock because the card's whole job is
+// comparing today's events against "now".
+const timedEvent = (
+  id: string,
+  title: string,
+  startsInMinutes: number,
+): Event => {
+  const start = dayjs().add(startsInMinutes, "minute");
+  return createMockEvent({
+    id: EventIdSchema.parse(id),
+    content: { kind: "details", title, description: "" },
+    schedule: EventScheduleSchema.parse({
+      kind: "timed",
+      start: start.format(),
+      end: start.add(30, "minute").format(),
+      timeZone: "UTC",
+    }),
+  });
+};
+
+beforeEach(() => {
+  draftActions.discard();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("formatStartsIn", () => {
+  const now = dayjs("2026-05-20T09:00:00.000Z");
+  const inMinutes = (minutes: number) => now.add(minutes, "minute");
+
+  it("counts down in minutes below an hour", () => {
+    expect(formatStartsIn(inMinutes(5), now)).toBe("Starts in 5 minutes");
+  });
+
+  it("uses the singular for one minute", () => {
+    expect(formatStartsIn(inMinutes(1), now)).toBe("Starts in 1 minute");
+  });
+
+  it("rolls up to hours at an hour and beyond", () => {
+    expect(formatStartsIn(inMinutes(60), now)).toBe("Starts in 1 hour");
+    expect(formatStartsIn(inMinutes(120), now)).toBe("Starts in 2 hours");
+  });
+
+  it("reads 'Starts now' within the last half minute", () => {
+    expect(formatStartsIn(now.add(20, "second"), now)).toBe("Starts now");
+  });
+});
+
+describe("UpNextCard", () => {
+  it("shows the soonest upcoming timed event left today", () => {
+    render(<UpNextCard />, {
+      events: [
+        timedEvent(LATER_EVENT_ID, "Later Event", 90),
+        timedEvent(SOON_EVENT_ID, "Soon Event", 30),
+      ],
+    });
+
+    expect(screen.getByText("Soon Event")).toBeInTheDocument();
+    expect(screen.getByText("Starts in 30 minutes")).toBeInTheDocument();
+    expect(screen.queryByText("Later Event")).toBeNull();
+  });
+
+  it("renders nothing when today has no upcoming timed events", () => {
+    render(<UpNextCard />, {
+      events: [
+        // Already underway, so nothing is "up next".
+        timedEvent(SOON_EVENT_ID, "Past Event", -30),
+        createMockEvent({
+          id: EventIdSchema.parse(LATER_EVENT_ID),
+          content: { kind: "details", title: "All Day Event", description: "" },
+          schedule: EventScheduleSchema.parse({
+            kind: "allDay",
+            start: dayjs().format("YYYY-MM-DD"),
+            end: dayjs().add(1, "day").format("YYYY-MM-DD"),
+          }),
+        }),
+      ],
+    });
+
+    expect(screen.queryByRole("region", { name: "Up next" })).toBeNull();
+    expect(screen.queryByText("Past Event")).toBeNull();
+    expect(screen.queryByText("All Day Event")).toBeNull();
+  });
+
+  it("opens the event's details in the sidebar when clicked", async () => {
+    render(<UpNextCard />, {
+      events: [timedEvent(SOON_EVENT_ID, "Soon Event", 30)],
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Up next: Soon Event/ }),
+    );
+
+    await waitFor(() => {
+      const state = useDraftStore.getState();
+      expect(state.status?.isFormOpen).toBe(true);
+      expect(state.gridDraft?.source?.id).toBe(
+        EventIdSchema.parse(SOON_EVENT_ID),
+      );
+    });
+  });
+});

--- a/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.tsx
@@ -1,0 +1,94 @@
+import { type FC, useEffect, useState } from "react";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { useDayEventViewModel } from "@web/events/queries/useDayEventsQuery";
+import { draftActions } from "@web/events/stores/draft.store";
+import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
+
+/**
+ * Countdown copy for the card's top row. Only ever called with a start that is
+ * still ahead of `now` (the card drops an event the moment it begins), so
+ * there's no "already started" branch - the sub-minute case reads "Starts now".
+ */
+export function formatStartsIn(start: Dayjs, now: Dayjs): string {
+  const minutes = Math.round(start.diff(now, "minute", true));
+  if (minutes <= 0) return "Starts now";
+  if (minutes < 60) {
+    return `Starts in ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  const hours = Math.round(minutes / 60);
+  return `Starts in ${hours} hour${hours === 1 ? "" : "s"}`;
+}
+
+/**
+ * Re-renders once a minute so the countdown copy stays current, mirroring the
+ * grid's now-line ticker (CalendarTimedGrid.tsx). Crossing midnight also rolls
+ * the day query below onto the new day for free.
+ */
+function useMinuteTick(): Dayjs {
+  const [now, setNow] = useState(() => dayjs());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(dayjs()), 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return now;
+}
+
+/**
+ * The next timed event starting later today, with a live countdown. Clicking it
+ * opens the event in the sidebar's details form. Renders nothing once today has
+ * no upcoming timed events left.
+ *
+ * All-day events are excluded by construction: the view model's `timedEvents`
+ * projection already splits them out, and "Starts in X minutes" is meaningless
+ * for them.
+ */
+export const UpNextCard: FC = () => {
+  const now = useMinuteTick();
+  // Today's range explicitly, not the week/day in view - "Up next" means today
+  // even while the user is looking at another week. Reusing the Day view's
+  // range builder means this shares that view's cache entry when today is shown.
+  const { startDate, endDate } = dayEventQueryRange(now);
+  const { events, timedEvents } = useDayEventViewModel({ startDate, endDate });
+
+  // The query range is [todayStart, tomorrowStart), so anything still ahead of
+  // `now` within it starts later today - no separate same-day filter needed.
+  const upNext = timedEvents
+    .filter((event) => dayjs(event.startDate).isAfter(now))
+    .sort(
+      (a, b) => dayjs(a.startDate).valueOf() - dayjs(b.startDate).valueOf(),
+    )[0];
+
+  if (!upNext) return null;
+
+  const countdown = formatStartsIn(dayjs(upNext.startDate), now);
+
+  const openEventDetails = () => {
+    const sourceEvent = events.find((candidate) => candidate.id === upNext._id);
+    if (!sourceEvent) return;
+
+    const draft = editGridEventDraft(sourceEvent);
+    if (!draft) return;
+
+    draftActions.startGridDraft({ activity: "gridClick", draft });
+    draftActions.setFormOpen(true);
+  };
+
+  return (
+    <section aria-label="Up next">
+      <button
+        aria-label={`Up next: ${upNext.title}. ${countdown}.`}
+        className="c-focus-ring flex w-full min-w-0 flex-col gap-0.5 rounded border border-border-primary bg-bg-secondary px-2 py-1.5 text-left hover:brightness-110"
+        onClick={openEventDetails}
+        type="button"
+      >
+        <span className="text-accent-primary text-xs">{countdown}</span>
+        <span className="min-w-0 truncate font-medium text-sm text-text-lighter">
+          {upNext.title}
+        </span>
+      </button>
+    </section>
+  );
+};

--- a/packages/web/src/layout/calendar-grid/calendarGrid.constants.ts
+++ b/packages/web/src/layout/calendar-grid/calendarGrid.constants.ts
@@ -8,6 +8,9 @@ export const CALENDAR_EVENT_PADDING_RIGHT = 10;
 export const CALENDAR_TIMED_EVENT_COLUMN_INSET = 5;
 export const CALENDAR_GRID_EVENT_TIME_LABEL_FONT_SIZE = "11px";
 export const CALENDAR_GRID_EVENT_TIME_LABEL_OPACITY = "0.78";
+// Line box the 11px time label occupies. The title's line clamp subtracts this
+// so the label keeps its row instead of being pushed past the card's clipped edge.
+export const CALENDAR_GRID_EVENT_TIME_LABEL_LINE_HEIGHT = 13;
 export const CALENDAR_GRID_EVENT_TITLE_LINE_HEIGHT = "16px";
 export const CALENDAR_MIN_EVENT_HEIGHT_FOR_TIME_LABEL = 36;
 export const CALENDAR_MIN_EVENT_WIDTH_FOR_TIME_LABEL = 90;

--- a/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarTimedEventCard.tsx
@@ -21,12 +21,14 @@ import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 import { getLineClamp } from "@web/common/utils/grid/grid.util";
 import {
   CALENDAR_GRID_EVENT_TIME_LABEL_FONT_SIZE,
+  CALENDAR_GRID_EVENT_TIME_LABEL_LINE_HEIGHT,
   CALENDAR_GRID_EVENT_TIME_LABEL_OPACITY,
   CALENDAR_GRID_EVENT_TITLE_LINE_HEIGHT,
   CALENDAR_MIN_EVENT_HEIGHT_FOR_TIME_LABEL,
   CALENDAR_MIN_EVENT_WIDTH_FOR_TIME_LABEL,
 } from "@web/layout/calendar-grid/calendarGrid.constants";
 import {
+  CALENDAR_EVENT_CONTENT_ATTRIBUTE,
   CALENDAR_EVENT_RESIZE_HANDLE_ATTRIBUTE,
   CALENDAR_EVENT_TIME_LABEL_ATTRIBUTE,
 } from "@web/layout/calendar-grid/interaction/calendarInteractionDom";
@@ -101,14 +103,24 @@ const CalendarTimedEventCardBase = (
     durationMinutes >= REPEAT_ICON_MIN_DURATION_MINUTES &&
     position.width >= REPEAT_ICON_MIN_WIDTH;
 
-  const lineClamp = useMemo(
-    () => getLineClamp(position.height),
-    [position.height],
-  );
-  const isTallEnoughForTimeLabel =
-    position.height >= CALENDAR_MIN_EVENT_HEIGHT_FOR_TIME_LABEL;
-  const isWideEnoughForTimeLabel =
+  const showTimeLabel =
+    !event.isAllDay &&
+    (isDraft || !isInPast) &&
+    position.height >= CALENDAR_MIN_EVENT_HEIGHT_FOR_TIME_LABEL &&
     position.width >= CALENDAR_MIN_EVENT_WIDTH_FOR_TIME_LABEL;
+
+  // Clamp the title against the height the label leaves behind, not the whole
+  // card. Clamping against the full height lets a wrapping title occupy every
+  // line the card has and shove the label past the card's clipped edge.
+  const lineClamp = useMemo(
+    () =>
+      getLineClamp(
+        showTimeLabel
+          ? position.height - CALENDAR_GRID_EVENT_TIME_LABEL_LINE_HEIGHT
+          : position.height,
+      ),
+    [position.height, showTimeLabel],
+  );
 
   const baseColor = EVENT_COLOR;
   const draftColor = darken(baseColor, 18);
@@ -256,23 +268,24 @@ const CalendarTimedEventCardBase = (
           style={{ backgroundColor: calendarIdentity.backgroundColor }}
         />
       )}
-      <div className="flex flex-col flex-wrap items-start">
+      <div
+        className="flex flex-col flex-wrap items-start"
+        {...{ [CALENDAR_EVENT_CONTENT_ATTRIBUTE]: "true" }}
+      >
         <span className={titleColorClassName} style={titleStyle}>
           {event.title}
         </span>
         {!event.isAllDay && (
           <>
-            {(isDraft || !isInPast) &&
-              isTallEnoughForTimeLabel &&
-              isWideEnoughForTimeLabel && (
-                <span
-                  className="relative"
-                  {...{ [CALENDAR_EVENT_TIME_LABEL_ATTRIBUTE]: "true" }}
-                  style={{ ...timeLabelStyle, zIndex: ZIndex.LAYER_3 }}
-                >
-                  {timeRange}
-                </span>
-              )}
+            {showTimeLabel && (
+              <span
+                className="relative"
+                {...{ [CALENDAR_EVENT_TIME_LABEL_ATTRIBUTE]: "true" }}
+                style={{ ...timeLabelStyle, zIndex: ZIndex.LAYER_3 }}
+              >
+                {timeRange}
+              </span>
+            )}
             {/* biome-ignore lint/a11y/noStaticElementInteractions: Resize handles are pointer-only drag targets hidden from assistive tech. */}
             <div
               aria-hidden="true"

--- a/packages/web/src/layout/calendar-grid/interaction/calendarInteractionDom.ts
+++ b/packages/web/src/layout/calendar-grid/interaction/calendarInteractionDom.ts
@@ -2,7 +2,13 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 import { type FloatingDraftEventMount } from "@web/interaction/CalendarInteractionAdapter";
 import { createDraftEventClone } from "@web/interaction/dom/clone/createDraftEventClone";
+import {
+  CALENDAR_GRID_EVENT_TIME_LABEL_FONT_SIZE,
+  CALENDAR_GRID_EVENT_TIME_LABEL_OPACITY,
+} from "@web/layout/calendar-grid/calendarGrid.constants";
 
+export const CALENDAR_EVENT_CONTENT_ATTRIBUTE = "data-calendar-event-content";
+export const CALENDAR_EVENT_CONTENT_SELECTOR = `[${CALENDAR_EVENT_CONTENT_ATTRIBUTE}='true']`;
 export const CALENDAR_EVENT_RESIZE_HANDLE_ATTRIBUTE =
   "data-calendar-event-resize-handle";
 export const CALENDAR_EVENT_TIME_LABEL_ATTRIBUTE =
@@ -82,7 +88,9 @@ const getOrCreateCalendarDraftEventTimeLabel = (node: HTMLElement) => {
   const label = document.createElement("span");
 
   label.setAttribute(CALENDAR_EVENT_TIME_LABEL_ATTRIBUTE, "true");
-  label.style.fontSize = "0.563rem";
+  label.style.fontSize = CALENDAR_GRID_EVENT_TIME_LABEL_FONT_SIZE;
+  label.style.opacity = CALENDAR_GRID_EVENT_TIME_LABEL_OPACITY;
+  label.style.whiteSpace = "nowrap";
   label.style.position = "relative";
   label.style.zIndex = "3";
 
@@ -94,15 +102,12 @@ const getOrCreateCalendarDraftEventTimeLabel = (node: HTMLElement) => {
   return label;
 };
 
-const getDraftEventTimeLabelParent = (node: HTMLElement) => {
-  const firstChild = node.firstElementChild;
-
-  if (firstChild instanceof HTMLElement && firstChild.tagName !== "SPAN") {
-    return firstChild;
-  }
-
-  return node;
-};
+// Match on the content container explicitly. Selecting it by "first child that
+// isn't a SPAN" instead lands on the calendar accent bar, a 3px-wide absolutely
+// positioned div, whenever the event carries a calendar identity — which
+// renders the label squished against the card's left edge.
+const getDraftEventTimeLabelParent = (node: HTMLElement) =>
+  node.querySelector<HTMLElement>(CALENDAR_EVENT_CONTENT_SELECTOR) ?? node;
 
 const getFirstDirectResizeHandle = (node: HTMLElement) => {
   for (const child of node.children) {

--- a/packages/web/src/views/BackendDown/BackendDown.tsx
+++ b/packages/web/src/views/BackendDown/BackendDown.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { AppConfigApi } from "@web/api/app-config.api";
+import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
+
+// Long enough to stay polite while the servers come back, short enough that a
+// user who steps away finds the app already recovered.
+const POLL_INTERVAL_MS = 20_000;
+
+/**
+ * A successful request flips the availability flag through `BaseApi`, which
+ * unmounts this view. A failure keeps the flag set, so nothing to do here.
+ */
+const checkBackend = () => AppConfigApi.get().catch(() => undefined);
+
+export const BackendDownView = () => {
+  const [isChecking, setIsChecking] = useState(false);
+
+  useEffect(() => {
+    const timer = setInterval(checkBackend, POLL_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  const handleRetry = async () => {
+    setIsChecking(true);
+    await checkBackend();
+    setIsChecking(false);
+  };
+
+  return (
+    <div className="c-not-found gap-4 px-6 text-center">
+      <PixelPirate className="h-20 w-20" />
+
+      <h1 className="font-[VT323,monospace] text-4xl">
+        🏴‍☠️ Blimey! Our servers walked the plank
+      </h1>
+
+      <p className="max-w-xl text-text-light text-xl">
+        Compass can't reach its own crew right now. It's us, not you.
+      </p>
+      <p className="max-w-xl text-text-light text-xl">
+        Your calendar is safe below deck — nothing's lost.
+      </p>
+      <p className="max-w-xl text-text-light text-xl">
+        We're bailing water as we speak. This page sails on by itself once we're
+        back.
+      </p>
+
+      <button
+        type="button"
+        onClick={handleRetry}
+        disabled={isChecking}
+        className="mt-5 cursor-pointer rounded border-2 border-border-primary bg-fg-primary-dark px-4 py-2 font-semibold text-[16px] text-text-lighter transition-all duration-200 ease-in-out hover:brightness-120 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-70"
+      >
+        {isChecking ? "Scanning the horizon..." : "Try again"}
+      </button>
+    </div>
+  );
+};

--- a/packages/web/src/views/BackendDown/index.ts
+++ b/packages/web/src/views/BackendDown/index.ts
@@ -1,0 +1,3 @@
+import { BackendDownView } from "./BackendDown";
+
+export { BackendDownView };

--- a/packages/web/src/views/Root.tsx
+++ b/packages/web/src/views/Root.tsx
@@ -1,18 +1,29 @@
 import { useMemo } from "react";
+import { useIsBackendUnavailable } from "@web/api/util/backend-unavailable-error.util";
+import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import { UserProvider } from "@web/auth/compass/user/context/UserProvider";
 import { isMobileOS } from "@web/common/utils/device/device.util";
 import { AuthenticatedLayout } from "@web/components/AuthenticatedLayout/AuthenticatedLayout";
 import { GlobalShortcutsHost } from "@web/components/CompassProvider/CompassProvider";
 import { MobileGate } from "@web/components/MobileGate/MobileGate";
 import SSEProvider from "@web/sse/provider/SSEProvider";
+import { BackendDownView } from "@web/views/BackendDown";
 
 export const RootView = () => {
   // Gate on the device OS, not the window width: narrow desktop windows get
   // the responsive layout. Static per session, so no listener is needed.
   const isMobile = useMemo(() => isMobileOS(), []);
+  const isBackendUnavailable = useIsBackendUnavailable();
 
   if (isMobile) {
     return <MobileGate />;
+  }
+
+  // Never-authenticated users read/write local IndexedDB, so a missing backend
+  // is expected (frontend-only dev, UI-only self-hosted deploys) and the app
+  // still works. Only gate users whose events actually live on the backend.
+  if (isBackendUnavailable && hasUserEverAuthenticated()) {
+    return <BackendDownView />;
   }
 
   return (

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   type CalendarCardIdentity,
   isEventReadOnly,
@@ -10,6 +10,7 @@ import {
   Categories_Event,
   type GridEvent,
 } from "@web/common/types/web.event.types";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import {
   draftActions,
@@ -37,7 +38,11 @@ interface Props {
 
 export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   const draft = useDraftStore(selectDraft);
-  const { isPending: isLoadingWeekView, timedEvents } = useWeekEventViewModel({
+  const {
+    events: weekEvents,
+    isPending: isLoadingWeekView,
+    timedEvents,
+  } = useWeekEventViewModel({
     startOfView: weekProps.component.startOfView,
     endOfView: weekProps.component.endOfView,
   });
@@ -94,6 +99,25 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
     });
   };
 
+  // Read-only cards can't be repositioned, so they don't need the
+  // keyboardEdit path above - and must not use it: `start` leaves `gridDraft`
+  // null, which opens the sidebar form with nothing to render.
+  const openReadOnlyDetails = useCallback(
+    (event: GridEvent) => {
+      const sourceEvent = weekEvents.find(
+        (candidate) => candidate.id === event._id,
+      );
+      const draft = sourceEvent ? editGridEventDraft(sourceEvent) : null;
+      if (!draft) {
+        return;
+      }
+
+      draftActions.startGridDraft({ activity: "gridClick", draft });
+      draftActions.setFormOpen(true);
+    },
+    [weekEvents],
+  );
+
   return (
     <div id={ID_GRID_EVENTS_TIMED}>
       {!isLoadingWeekView &&
@@ -124,6 +148,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
                 key={`initial-${event._id}`}
                 measurements={measurements}
                 onEventKeyDown={handleKeyDown}
+                onOpenReadOnlyDetails={openReadOnlyDetails}
                 weekProps={weekProps}
               />
             );
@@ -141,6 +166,7 @@ interface MainGridEventItemProps {
   isReadOnly: boolean;
   measurements: Measurements_Grid;
   onEventKeyDown: (event: GridEvent) => void;
+  onOpenReadOnlyDetails: (event: GridEvent) => void;
   weekProps: WeekProps;
 }
 
@@ -152,6 +178,7 @@ const MainGridEventItem = ({
   isReadOnly,
   measurements,
   onEventKeyDown,
+  onOpenReadOnlyDetails,
   weekProps,
 }: MainGridEventItemProps) => {
   // Read-only events never register as an interaction target below, so the
@@ -179,11 +206,11 @@ const MainGridEventItem = ({
   // Being unregistered above also means the interaction engine's own click
   // resolution never fires, so a read-only card would otherwise stop being
   // clickable - events must stay inspectable even when they can't be
-  // mutated. Wiring the click straight to the same "open" action the
-  // keyboard path uses bypasses the engine entirely for this card, so it
-  // never becomes a drag/resize target no matter how the pointer moves.
+  // mutated. Wiring the click straight to an "open" action bypasses the
+  // engine entirely for this card, so it never becomes a drag/resize target
+  // no matter how the pointer moves.
   const onEventMouseDown = isReadOnly
-    ? (clickedEvent: GridEvent) => onEventKeyDown(clickedEvent)
+    ? (clickedEvent: GridEvent) => onOpenReadOnlyDetails(clickedEvent)
     : undefined;
 
   return (
@@ -194,7 +221,7 @@ const MainGridEventItem = ({
       event={event}
       interactionAttributes={interactionAttributes}
       measurements={measurements}
-      onEventKeyDown={onEventKeyDown}
+      onEventKeyDown={isReadOnly ? onOpenReadOnlyDetails : onEventKeyDown}
       onEventMouseDown={onEventMouseDown}
       ref={registrationRef}
       weekProps={weekProps}

--- a/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
@@ -260,8 +260,11 @@ describe("Week grid read-only interaction gate", () => {
       fireEvent.mouseDown(card, { button: 0, buttons: 1 });
     });
 
-    expect(useDraftStore.getState().status?.activity).toBe("keyboardEdit");
-    expect(useDraftStore.getState().event?._id).toBe(event.id);
+    // Assert the draft the form actually renders from, not just that some
+    // draft activity started: opening the form without a `gridDraft` is what
+    // used to blank the sidebar.
+    expect(useDraftStore.getState().status?.activity).toBe("gridClick");
+    expect(useDraftStore.getState().gridDraft?.source?.id).toBe(event.id);
 
     act(() => draftActions.discard());
   });


### PR DESCRIPTION
Batches five of the items from the work list. The remaining items are tracked separately (see *Not in this PR*).

## Bugs

**0 — Time labels squished while resizing.** The resize clone inserted its time label by looking for the "first child that isn't a SPAN". That heuristic lands on the calendar accent bar — a 3px-wide absolutely-positioned div — whenever the event carries a calendar identity, so the label rendered inside a 3px box pinned to the card's left edge. Now matches the content container explicitly, and the synthesized label gets the same font size/opacity/nowrap as the React one.

**4 — Time labels cut off.** The title's line clamp was computed against the card's *full* height, so a wrapping title could claim every line the card had and push the label past the `overflow-hidden` edge. `getLineClamp(36)` returns 2 lines = 32px of title, + ~13px label = 45px inside a 36px card. The clamp now subtracts the label's row, so the label either has its space or isn't rendered — never clipped.

**1 — Read-only event details blanked the sidebar.** Read-only cards are deliberately excluded from the interaction engine, so their click was wired to the keyboard open-action to keep them inspectable. But that action leaves `gridDraft` null, so the form opened with nothing to render and the sidebar body went blank. They now build a real draft via `editGridEventDraft`, mirroring the Day view (which was already correct). The owned-event `keyboardEdit` path is untouched — it still needs its grid-layout `position` for arrow-key nudging.

**2 — Header gap and arrow placement.** The heading applied its own `pl-8` on top of the `pl-8` `#main` already applies, putting it 64px from the content edge. Dropped the redundant padding and lifted the prev/next arrows out of the right-hand `ml-auto` cluster so they sit beside the heading. Today + view switcher stay right.

## Features

**5 — Branded backend-down page.** A proxy 502 surfaced as a toast literally reading `Request failed with status 502`: `isBackendUnavailableError` matched the message string `"Request failed"` *exactly*, and a 502's message carries the status suffix — so the flag never flipped for a real 502, while connection-refused took a silent local-fallback path. Two "backend is down" cases, two behaviors. Now detects on `error.response.status` (502/503/504), adds the missing `BAD_GATEWAY` code, and makes the flag observable. Reuses the existing `PixelPirate` art, VT323 font, and `c-not-found` layout.

**7 — Up Next card.** Next timed event starting later today, countdown ticking every minute, click opens details, hides when nothing's left today. Queries today's range explicitly so it still means *today* while browsing another week, sharing a cache entry with the Day view rather than adding a fetch.

## Not in this PR
- **8 (prefetch)** — already shipped. `useWeekEventsQuery`'s `usePrefetchAdjacentEvents` already warms prev+next on first load and every range change; hover-prefetch would be a no-op since `prefetchQuery` short-circuits within `staleTime`.
- **3 (placeholder colors)**, **9 (grid skeleton)**, **6 (delete account)**, **10 (all-day↔timed DnD)** — still in progress.

## Notable review points
- `views/Root.tsx` gates the backend-down page behind `hasUserEverAuthenticated` rather than the raw flag — the same flag drives a local-IndexedDB fallback that keeps frontend-only dev and UI-only self-hosted deploys usable.
- `markBackendAvailable()` now calls `refreshEventRepositorySource()` on the down→up transition; previously it never did, so recovery would leave queries stuck on `local`.
- `event.util.test.ts`'s 500 fixture claimed status 500 with no `response` — something `createApiError` can't produce. Given a real `response`, intent preserved.
- `eventReadOnlyInteraction.test.tsx` asserted only store activity, so it passed while the UX was broken. Now asserts the draft the form renders from.

## Manual testing steps
1. Resize a short event on a colored (sub-)calendar — the time label should track the card, not stick to the left edge.
2. Shrink an event until the title wraps — the time label should disappear cleanly rather than clip.
3. Click an event on a calendar you don't own — details should appear in the sidebar (read-only, no Save/Delete).
4. Check the Week/Day header — title near the left edge, arrows beside it.
5. Stop the backend and reload as a signed-in user — pirate page, not a 502 toast. Restart it and hit Try again.
6. Sidebar shows "Up Next" under the month picker when an event is upcoming today; click it to open details.

Local: `bun run type-check`, `bun run lint`, `bun run test:web` (1192 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)