### PR TITLE
fix(web): match input placeholder color to time values, add grid loading indicator

### DIFF
--- a/packages/web/src/components/Focusable/Focusable.tsx
+++ b/packages/web/src/components/Focusable/Focusable.tsx
@@ -10,8 +10,11 @@ import {
 import { type UnderlinedInput } from "@web/common/types/component.types";
 import { Divider } from "@web/components/Divider/Divider";
 
+// Placeholders match the time pickers' value color (--color-text-lighter)
+// rather than a muted grey, so the event form's title and its date/time
+// controls read as one row of text instead of two different states.
 export const INPUT_RESET_CLASSNAME =
-  "h-8.5 border-0 px-2 outline-none placeholder:text-text-light-inactive hover:bg-border-primary";
+  "h-8.5 border-0 px-2 outline-none placeholder:text-text-lighter hover:bg-border-primary";
 
 export interface Props
   extends UnderlinedInput,

--- a/packages/web/src/layout/calendar-grid/components/CalendarGrid.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarGrid.tsx
@@ -57,9 +57,12 @@ export const CalendarGrid: FC<CalendarGridProps> = ({
       visibleDates={visibleDates}
     />
     {isLoadingEvents && (
+      // pointer-events-none: the loader is informational and covers the whole
+      // grid, so without it the overlay swallows the mousedown that
+      // drag-creates an event for as long as the first fetch runs.
       <AbsoluteOverflowLoader
         aria-label="Loading events"
-        className="[&>div]:my-0"
+        className="pointer-events-none [&>div]:my-0"
         role="status"
       />
     )}

--- a/packages/web/src/layout/calendar-grid/components/CalendarGrid.tsx
+++ b/packages/web/src/layout/calendar-grid/components/CalendarGrid.tsx
@@ -4,6 +4,7 @@ import {
   type ReactNode,
 } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader/AbsoluteOverflowLoader";
 import {
   type CalendarGridRefs,
   type CalendarGridVisibleDate,
@@ -16,6 +17,8 @@ export interface CalendarGridProps {
   allDayGridOffsetTopPx?: number;
   allDayRowsCount?: number;
   gridRefs: CalendarGridRefs;
+  /** First load only. Background refetches keep the grid interactive. */
+  isLoadingEvents?: boolean;
   onAllDayMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
   onTimedMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
   timedEventsLayer: ReactNode;
@@ -28,6 +31,7 @@ export const CalendarGrid: FC<CalendarGridProps> = ({
   allDayGridOffsetTopPx = 0,
   allDayRowsCount = 0,
   gridRefs,
+  isLoadingEvents = false,
   onAllDayMouseDown,
   onTimedMouseDown,
   timedEventsLayer,
@@ -52,5 +56,12 @@ export const CalendarGrid: FC<CalendarGridProps> = ({
       today={today}
       visibleDates={visibleDates}
     />
+    {isLoadingEvents && (
+      <AbsoluteOverflowLoader
+        aria-label="Loading events"
+        className="[&>div]:my-0"
+        role="status"
+      />
+    )}
   </div>
 );

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -70,6 +70,7 @@ export function DayCalendarGrid() {
   const {
     allDayEvents,
     events: dayEvents,
+    isPending: isLoadingEvents,
     rowCount: allDayRowsCount,
     timedEvents,
   } = useDayEventViewModel(dayEventQueryRange(dateInView));
@@ -338,6 +339,7 @@ export function DayCalendarGrid() {
           allDayEventsLayer={allDayEventsLayer}
           allDayRowsCount={allDayRowsCount}
           gridRefs={gridRefs}
+          isLoadingEvents={isLoadingEvents}
           onAllDayMouseDown={handleAllDayMouseDown}
           onTimedMouseDown={handleTimedMouseDown}
           timedEventsLayer={timedEventsLayer}

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -1,6 +1,7 @@
 import { type FC } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { useWeekEventsQueryStatus } from "@web/events/queries/useWeekEventsQuery";
 import { CalendarGrid } from "@web/layout/calendar-grid/components/CalendarGrid";
 import { AllDayRow } from "@web/views/Week/components/Grid/AllDayRow/AllDayRow";
 import { EdgeNavigationIndicators } from "@web/views/Week/components/Grid/MainGrid/EdgeNavigationIndicators/EdgeNavigationIndicators";
@@ -30,6 +31,12 @@ export const Grid: FC<Props> = ({
   weekProps,
 }) => {
   const { allDayRef, allDayRowRef, mainGridElementRef, mainGridRef } = gridRefs;
+  // Subscribes to the same cache entry the event layers read, so this reports
+  // their load without issuing a second fetch.
+  const { isPending: isLoadingEvents } = useWeekEventsQueryStatus({
+    startOfView: weekProps.component.startOfView,
+    endOfView: weekProps.component.endOfView,
+  });
 
   useDragEdgeNavigation(mainGridRef, weekProps);
 
@@ -72,6 +79,7 @@ export const Grid: FC<Props> = ({
                 allDayGridOffsetTopPx={GRID_Y_START}
                 allDayRowsCount={allDayRowsCount}
                 gridRefs={gridRefs}
+                isLoadingEvents={isLoadingEvents}
                 onAllDayMouseDown={onAllDayMouseDown}
                 onTimedMouseDown={onTimedMouseDown}
                 timedEventsLayer={timedEventsLayer}


### PR DESCRIPTION
The last two items from the work list. Independent of #2154.

## 3 — Placeholder / draft text colors

The event form's title placeholder rendered at a muted 70% grey (`--color-text-light-inactive`) while the time pickers render their values at full white (`--color-text-lighter`), so the form read as two different text states.

Worth knowing *why* no shared token existed: these are structurally different things. The title renders a true CSS `::placeholder`; the time picker has **no placeholder rule at all** — a draft always has concrete start/end times, so react-select always renders a populated `__single-value`, never a placeholder.

Per your call, the times are the reference and stay white; the placeholder now points at the same token. The shared reset is used by exactly two inputs — the form's **title** and its **date** input — so the blast radius is the event form.

⚠️ **One tradeoff to eyeball on staging:** a pure-white placeholder is visually indistinguishable from typed text, so an empty title now shows "Title" in white and could read as a real value. If that feels wrong in the app, the middle ground is a token between the two rather than either extreme — say the word and I'll adjust.

## 9 — Grid loading indicator

The grid hid its event layers during a fetch with nothing in their place, so a load looked like an empty calendar. It now renders the existing `AbsoluteOverflowLoader` over the grid.

Week reads `useWeekEventsQueryStatus` — which existed for exactly this purpose, is documented as sharing the cache entry (no extra fetch), and had **zero call sites** in the codebase. Day reads `isPending` off its existing view model.

Gated on `isPending`, not `isFetching`: `isFetching` would also flash on every background refetch and week navigation, which the adjacent-week prefetch already keeps warm — the flash would be pure noise. The loader's `my-15` (tuned for full-page use) is zeroed so it centers in the grid.

## Manual testing steps
1. Open an event form with an empty title — placeholder should match the time values' color.
2. Hard-reload the calendar on a slow connection (or throttle to Slow 3G) — a spinner should appear over the grid during first load, in both Week and Day.
3. Navigate between weeks — the spinner should **not** flash, since adjacent weeks are prefetched.

Local: type-check ✅, lint ✅, web 1184 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)