### PR TITLE
fix(web): open read-only all-day events in the sidebar details form

### DIFF
--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useMemo } from "react";
+import { type MouseEvent, useCallback, useMemo } from "react";
 import {
   type CalendarCardIdentity,
   isEventReadOnly,
@@ -10,6 +10,7 @@ import {
   Categories_Event,
   type GridEvent,
 } from "@web/common/types/web.event.types";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import {
   draftActions,
@@ -39,7 +40,11 @@ export const AllDayEvents = ({
   weekDays,
 }: Props) => {
   const draft = useDraftStore(selectDraft);
-  const { allDayEvents, isPending: isLoadingWeekView } = useWeekEventViewModel({
+  const {
+    allDayEvents,
+    events: weekEvents,
+    isPending: isLoadingWeekView,
+  } = useWeekEventViewModel({
     startOfView,
     endOfView,
   });
@@ -94,6 +99,26 @@ export const AllDayEvents = ({
     });
   };
 
+  // Read-only cards can't be repositioned, so they don't need the
+  // keyboardEdit path above - and must not use it: `start` leaves `gridDraft`
+  // null, which opens the sidebar form with nothing to render. Mirrors
+  // MainGridEvents' timed-event handler.
+  const openReadOnlyDetails = useCallback(
+    (event: GridEvent) => {
+      const sourceEvent = weekEvents.find(
+        (candidate) => candidate.id === event._id,
+      );
+      const draft = sourceEvent ? editGridEventDraft(sourceEvent) : null;
+      if (!draft) {
+        return;
+      }
+
+      draftActions.startGridDraft({ activity: "gridClick", draft });
+      draftActions.setFormOpen(true);
+    },
+    [weekEvents],
+  );
+
   return (
     <div
       className="relative ml-[50px] h-full w-full"
@@ -126,6 +151,7 @@ export const AllDayEvents = ({
                 key={event._id}
                 measurements={measurements}
                 onKeyDown={handleKeyDown}
+                onOpenReadOnlyDetails={openReadOnlyDetails}
                 weekDays={weekDays}
               />
             );
@@ -142,6 +168,7 @@ interface AllDayEventItemProps {
   isReadOnly: boolean;
   measurements: Measurements_Grid;
   onKeyDown: (event: GridEvent) => void;
+  onOpenReadOnlyDetails: (event: GridEvent) => void;
   weekDays: WeekProps["component"]["weekDays"];
 }
 
@@ -152,6 +179,7 @@ const AllDayEventItem = ({
   isReadOnly,
   measurements,
   onKeyDown,
+  onOpenReadOnlyDetails,
   weekDays,
 }: AllDayEventItemProps) => {
   // Read-only events never register as an interaction target below, so the
@@ -178,10 +206,11 @@ const AllDayEventItem = ({
   // Being unregistered above also means the interaction engine's own click
   // resolution never fires, so a read-only card would otherwise stop being
   // clickable - events must stay inspectable even when they can't be
-  // mutated. Wiring the click straight to the same "open" action the
-  // keyboard path uses bypasses the engine entirely for this card.
+  // mutated. Wiring the click straight to an "open" action bypasses the
+  // engine entirely for this card.
   const onMouseDown = isReadOnly
-    ? (_e: MouseEvent, clickedEvent: GridEvent) => onKeyDown(clickedEvent)
+    ? (_e: MouseEvent, clickedEvent: GridEvent) =>
+        onOpenReadOnlyDetails(clickedEvent)
     : undefined;
 
   return (
@@ -191,7 +220,7 @@ const AllDayEventItem = ({
       interactionAttributes={interactionAttributes}
       isPlaceholder={isPlaceholder}
       measurements={measurements}
-      onKeyDown={onKeyDown}
+      onKeyDown={isReadOnly ? onOpenReadOnlyDetails : onKeyDown}
       onMouseDown={onMouseDown}
       ref={registrationRef}
       weekDays={weekDays}

--- a/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
@@ -245,6 +245,29 @@ describe("Week grid read-only interaction gate", () => {
     expect(card).not.toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE);
   });
 
+  it("still opens a read-only all-day event for inspection on click", () => {
+    const readOnlyCalendar = makeCalendar();
+    seededCalendars = [readOnlyCalendar];
+    const event = createAllDayEvent(readOnlyCalendar.id);
+    seededEvents = [event];
+
+    renderAllDayEvents();
+
+    const card = screen.getByRole("button", {
+      name: /all-day event: team holiday/i,
+    });
+    act(() => {
+      fireEvent.mouseDown(card, { button: 0, buttons: 1 });
+    });
+
+    // Assert the draft the form renders from - opening the form without a
+    // `gridDraft` is what used to blank the sidebar.
+    expect(useDraftStore.getState().status?.activity).toBe("gridClick");
+    expect(useDraftStore.getState().gridDraft?.source?.id).toBe(event.id);
+
+    act(() => draftActions.discard());
+  });
+
   it("still opens a read-only timed event for inspection on click", () => {
     const readOnlyCalendar = makeCalendar();
     seededCalendars = [readOnlyCalendar];


### PR DESCRIPTION
Found during the evening cleanup's fresh-eyes pass over today's merge window: #2153 fixed the blank-sidebar bug for read-only **timed** events but never converted the **all-day** row, which has the identical broken wiring. Clicking (or pressing Enter on) a read-only all-day event still routed through `draftActions.start({activity:"keyboardEdit"})`, which leaves `gridDraft: null` — the form opens with nothing to render and the sidebar body goes blank.

Same fix, mirrored from `MainGridEvents.tsx`: read-only cards get a dedicated handler that builds a real draft via `editGridEventDraft` → `startGridDraft` → `setFormOpen`. The `keyboardEdit` path stays untouched for writable events, which still need its grid-layout `position` for arrow-key nudging.

**Test hardening:** the new all-day test asserts the draft the form actually renders from (`gridDraft.source.id`), not just store activity — the assertion gap that let both halves of this bug ship. Mutation-tested: swapping the pre-fix component back in makes it fail (1 fail), restoring the fix makes it pass.

## Manual testing steps
1. With a shared/read-only sub-calendar visible, click one of its **all-day** chips in the week view's top row.
2. The sidebar should show the event's details (read-only form — fields disabled, no Save/Delete), not a blank panel.
3. Keyboard: focus the chip and press Enter — same result.
4. Confirm a writable all-day event still opens normally and arrow-key nudging still works on it.

Local: lint ✅, type-check ✅, web 1219 pass / 0 fail, `calendar-experience` e2e 6/6 (real browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)