### PR TITLE
fix(web): keep keyboard focus on the backend-down retry button

### DIFF
--- a/packages/web/src/views/BackendDown/BackendDown.tsx
+++ b/packages/web/src/views/BackendDown/BackendDown.tsx
@@ -22,6 +22,7 @@ export const BackendDownView = () => {
   }, []);
 
   const handleRetry = async () => {
+    if (isChecking) return;
     setIsChecking(true);
     await checkBackend();
     setIsChecking(false);
@@ -46,11 +47,14 @@ export const BackendDownView = () => {
         back.
       </p>
 
+      {/* aria-disabled + re-entry guard instead of `disabled`: disabling a
+          focused button ejects keyboard focus to <body>, so every retry would
+          cost a keyboard user a full re-Tab back to the button. */}
       <button
         type="button"
         onClick={handleRetry}
-        disabled={isChecking}
-        className="mt-5 cursor-pointer rounded border-2 border-border-primary bg-fg-primary-dark px-4 py-2 font-semibold text-[16px] text-text-lighter transition-all duration-200 ease-in-out hover:brightness-120 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-70"
+        aria-disabled={isChecking}
+        className="mt-5 cursor-pointer rounded border-2 border-border-primary bg-fg-primary-dark px-4 py-2 font-semibold text-[16px] text-text-lighter transition-all duration-200 ease-in-out hover:brightness-120 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2 aria-disabled:cursor-wait aria-disabled:opacity-70"
       >
         {isChecking ? "Scanning the horizon..." : "Try again"}
       </button>


### PR DESCRIPTION
Found by the evening cleanup's qa-ux-sweep, driving the backend-down page keyboard-only in real Chrome.

`disabled={isChecking}` on the retry button ejects keyboard focus to `<body>` the moment a check starts (a focused element that becomes disabled loses focus, and it doesn't come back when re-enabled). Every retry cost a keyboard user a full re-Tab from the top of the page. Verified live on the pre-fix build: Tab → Enter → `document.activeElement` was `BODY`.

Fix: `aria-disabled` + a re-entry guard in the handler instead of the `disabled` attribute. The busy label ("Scanning the horizon...") and the `cursor-wait`/opacity styling behave exactly as before via `aria-disabled:` variants. Verified live post-fix: Tab → Enter → focus remains on the button.

## Manual testing steps
1. With the backend stopped and a previously-authenticated session, load the app — the pirate page appears.
2. Press Tab (focus ring lands on "Try again"), then Enter.
3. The button flashes its checking state; focus stays on the button — pressing Enter again retries without re-Tabbing.

Local: lint ✅, type-check ✅, backend-unavailable unit tests 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)