### PR TITLE
fix(web): show evening events on the day view and up next card

### DIFF
--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -122,6 +122,18 @@ describe("loadDateParam", () => {
 
     expect(result).toMatchObject({ dateString: "2026-05-20" });
   });
+
+  // dayEventQueryRange formats dateInView to build the day's query bounds, so
+  // a UTC-mode value would shift the window off local midnight and drop
+  // evening events from the day view and Up Next card.
+  it("returns local-mode midnight, not UTC", () => {
+    const result = loadDateParam({
+      params: { dateString: "2026-05-20" },
+    });
+
+    expect(result.dateInView.isUTC()).toBe(false);
+    expect(result.dateInView.hour()).toBe(0);
+  });
 });
 
 describe("validateWeekDateParam", () => {

--- a/packages/web/src/routers/loaders.ts
+++ b/packages/web/src/routers/loaders.ts
@@ -4,7 +4,10 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 
 export interface DayLoaderData {
-  dateInView: Dayjs; // in UTC
+  // Local-mode, not UTC: dayEventQueryRange formats this to build the day's
+  // query bounds, so a UTC-mode value would shift the window off local
+  // midnight and drop evening events.
+  dateInView: Dayjs;
   dateString: string;
 }
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
@@ -18,6 +18,7 @@ import {
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { type GridMeasurements } from "@web/grid/types/grid.types";
+import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
 import { DayCalendarBusyPeriodsLayer } from "./DayCalendarBusyPeriods";
 import { afterEach, describe, expect, it } from "bun:test";
 
@@ -53,11 +54,16 @@ function Provider({ children }: PropsWithChildren) {
     client.setQueryData(calendarQueryKeys.all, seededCalendars);
 
     const calendarIds = deriveAvailabilityCalendarIds(seededCalendars);
-    const start = dateInView.startOf("day").utc(true).format();
-    const end = dateInView.endOf("day").utc(true).format();
+    // Same range the layer queries, so the seeded entry lands under the key
+    // it reads.
+    const { startDate, endDate } = dayEventQueryRange(dateInView);
     const response: AvailabilityResponse = { busyPeriods: seededBusyPeriods };
     client.setQueryData(
-      availabilityQueryOptions({ calendarIds, start, end }).queryKey,
+      availabilityQueryOptions({
+        calendarIds,
+        start: startDate,
+        end: endDate,
+      }).queryKey,
       response,
     );
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
@@ -10,6 +10,7 @@ import {
   type GridMeasurements,
   type GridVisibleDate,
 } from "@web/grid/types/grid.types";
+import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
 
 const ID_GRID_BUSY_PERIODS = "busyPeriods";
 
@@ -23,10 +24,9 @@ interface Props {
 /**
  * Day-grid counterpart to MainGridBusyPeriods (packet 08 phase 4; A7):
  * renders freeBusyReader calendars' busy time as inert decoration in the day
- * timed grid, mounted beside DayCalendarTimedEventsLayer. Matches
- * DayCalendarGrid's own event-range convention
- * (dateInView.startOf/endOf("day").utc(true).format()) so the availability
- * range agrees with the day events query. Renders nothing while the
+ * timed grid, mounted beside DayCalendarTimedEventsLayer. Shares
+ * dayEventQueryRange with the day events query so the availability range
+ * agrees with the events drawn beneath it. Renders nothing while the
  * availability query is loading/errored/disabled.
  */
 export const DayCalendarBusyPeriodsLayer = ({
@@ -35,15 +35,11 @@ export const DayCalendarBusyPeriodsLayer = ({
   measurements,
   visibleDates,
 }: Props) => {
-  const start = useMemo(
-    () => dateInView.startOf("day").utc(true).format(),
+  const { startDate, endDate } = useMemo(
+    () => dayEventQueryRange(dateInView),
     [dateInView],
   );
-  const end = useMemo(
-    () => dateInView.endOf("day").utc(true).format(),
-    [dateInView],
-  );
-  const { data } = useAvailabilityQuery({ start, end });
+  const { data } = useAvailabilityQuery({ start: startDate, end: endDate });
   const calendarLookup = useCalendarLookup();
   const segments = useMemo(
     () => splitBusyPeriodsByDay(data?.busyPeriods ?? [], visibleDates),

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.tsx
@@ -35,10 +35,7 @@ export const DayCalendarBusyPeriodsLayer = ({
   measurements,
   visibleDates,
 }: Props) => {
-  const { startDate, endDate } = useMemo(
-    () => dayEventQueryRange(dateInView),
-    [dateInView],
-  );
+  const { startDate, endDate } = dayEventQueryRange(dateInView);
   const { data } = useAvailabilityQuery({ start: startDate, end: endDate });
   const calendarLookup = useCalendarLookup();
   const segments = useMemo(

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -63,7 +63,8 @@ describe("useDayEvents", () => {
 
   it("fetches day events into the query cache", async () => {
     const queryClient = createCompassQueryClient();
-    const date = dayjs.utc("2025-11-11T00:00:00Z");
+    // Local-mode, like the route loader hands the hook (see loaders.test.ts).
+    const date = dayjs("2025-11-11T00:00:00.000");
 
     renderHook(() => useDayEvents(date), { queryClient });
 
@@ -85,7 +86,7 @@ describe("useDayEvents", () => {
 
   it("re-fetches with a new key when the date changes", async () => {
     const queryClient = createCompassQueryClient();
-    const initialDate = dayjs.utc("2025-11-11T00:00:00Z");
+    const initialDate = dayjs("2025-11-11T00:00:00.000");
 
     const { rerender } = renderHook(({ date }) => useDayEvents(date), {
       initialProps: { date: initialDate },

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -47,11 +47,9 @@ describe("useDayEvents", () => {
     return match?.[1];
   };
 
-  // Regression: the bounds must be the real local-midnight instants. They
-  // were previously relabeled as UTC via .utc(true), which shifted the whole
-  // window earlier by the local offset (6h in MDT) and dropped evening events
-  // from the day view and the Up Next card. Pins an explicit offset zone so
-  // the assertion holds regardless of the machine's timezone.
+  // Pins an explicit offset zone (the machine's may be UTC, where the
+  // correct and incorrect formats coincide) so a return to .utc(true), which
+  // shifted the window off local midnight, fails here.
   it("keeps the local offset so evening events stay inside the day window", () => {
     const date = dayjs.tz("2026-07-16 12:00", "America/Denver");
     const { startDate, endDate } = dayEventQueryRange(date);

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -47,6 +47,22 @@ describe("useDayEvents", () => {
     return match?.[1];
   };
 
+  // Regression: the bounds must be the real local-midnight instants. They
+  // were previously relabeled as UTC via .utc(true), which shifted the whole
+  // window earlier by the local offset (6h in MDT) and dropped evening events
+  // from the day view and the Up Next card. Pins an explicit offset zone so
+  // the assertion holds regardless of the machine's timezone.
+  it("keeps the local offset so evening events stay inside the day window", () => {
+    const date = dayjs.tz("2026-07-16 12:00", "America/Denver");
+    const { startDate, endDate } = dayEventQueryRange(date);
+
+    const eveningEvent = dayjs.tz("2026-07-16 21:00", "America/Denver");
+    expect(eveningEvent.valueOf()).toBeGreaterThanOrEqual(
+      Date.parse(startDate),
+    );
+    expect(eveningEvent.valueOf()).toBeLessThan(Date.parse(endDate));
+  });
+
   it("fetches day events into the query cache", async () => {
     const queryClient = createCompassQueryClient();
     const date = dayjs.utc("2025-11-11T00:00:00Z");

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.ts
@@ -10,10 +10,9 @@ import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjace
  * calendar day's start, not this day's end, so all-day events spanning only
  * this single day still fall within the range's exclusive upper bound.
  *
- * Bounds keep the local UTC offset (like the week query) so they are the real
- * local-midnight instants. Relabeling them as UTC would shift the window by
- * the offset and drop evening events from the fetch and cache-membership
- * checks.
+ * Bounds keep their local UTC offset (like the week query) so they are real
+ * local-midnight instants; relabeling them as UTC shifts the window by the
+ * offset and drops evening events.
  */
 export const dayEventQueryRange = (date: dayjs.Dayjs) => ({
   startDate: toUTCOffset(date.startOf("day")),

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type dayjs from "@core/util/date/dayjs";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { dayEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useDayEventsQuery } from "@web/events/queries/useDayEventsQuery";
 import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjacentEvents";
@@ -8,10 +9,15 @@ import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjace
  * A day's event query range as `[startDate, endDate)`: `endDate` is the next
  * calendar day's start, not this day's end, so all-day events spanning only
  * this single day still fall within the range's exclusive upper bound.
+ *
+ * Bounds keep the local UTC offset (like the week query) so they are the real
+ * local-midnight instants. Relabeling them as UTC would shift the window by
+ * the offset and drop evening events from the fetch and cache-membership
+ * checks.
  */
 export const dayEventQueryRange = (date: dayjs.Dayjs) => ({
-  startDate: date.startOf("day").utc(true).format(),
-  endDate: date.add(1, "day").startOf("day").utc(true).format(),
+  startDate: toUTCOffset(date.startOf("day")),
+  endDate: toUTCOffset(date.add(1, "day").startOf("day")),
 });
 
 export function useDayEvents(dateInView: dayjs.Dayjs) {
@@ -23,7 +29,7 @@ export function useDayEvents(dateInView: dayjs.Dayjs) {
   useDayEventsQuery({ startDate, endDate });
 
   // Warm the previous/next day so the next prev/next click resolves from
-  // cache. Uses the same start/end-of-day UTC formatting as the read above,
+  // cache. Uses the same start/end-of-day formatting as the read above,
   // so the prefetched entries land under the exact keys a subsequent read
   // looks up.
   const previous = useMemo(


### PR DESCRIPTION
## Summary

Creating an event after ~6 PM on the Day view didn't show up in the day grid (the week view showed it fine), and the Up Next card never rendered for later-today events. Both trace to one line.

`dayEventQueryRange` built its bounds with dayjs `.utc(true)`, which keeps the wall-clock numbers but relabels the zone as UTC. In MDT that turns local midnight into `2026-07-16T00:00:00Z` — actually 6 PM the *previous* day — so the whole day window sat 6 hours early.

Evening events then fell outside those bounds twice over: the backend fetch never returned them, and the cache-membership check gated them out of the optimistic insert (the create mutation does write to the day key — it was just rejected on arrival). The week view was immune because it already formats its bounds with `toUTCOffset`. The Up Next card reuses the same range, so its window ended at 6 PM local and it found nothing upcoming.

The fix formats the day bounds with `toUTCOffset` like the week query, so they stay real local-midnight instants. All consumers share the one builder, so the read and prefetch keys stay identical.

Two adjacent things surfaced while fixing it and are included:

- `DayCalendarBusyPeriods` hand-rolled the same range with `.utc(true)`, and its doc comment claimed it did so *to agree with the day events query*. Left alone, the busy overlay would have kept the 6-hour shift while the events beneath it got fixed. It's now the fourth consumer of the shared builder, which also settles its inclusive `endOf("day")` bound against the exclusive next-day-start the rest of the day range uses.
- `DayLoaderData.dateInView` was annotated `// in UTC`. It never was — and the fix depends on it staying local-mode, since `toUTCOffset` is just `.format()` and would re-emit `Z` for a UTC-mode value. Honoring that stale comment would have silently reintroduced the bug with no test failure, so the comment now states the real contract and a loader test pins it.

## Simplicity

Net reduction. The change removes a hand-rolled range in favor of the shared `dayEventQueryRange` builder (four consumers, one definition), and drops a `useMemo` that was pure ceremony — `useAvailabilityQuery` destructures `start`/`end` into a structurally-hashed query key, so the range object's identity never mattered, and `DayCalendarGrid` already called the builder inline. Comments were trimmed to the constraint the code can't state for itself.

No `useEffect`, `useRef`, or `useState` added. One `useMemo` remains in `DayCalendarBusyPeriods`, kept deliberately for `segments`: `splitBusyPeriodsByDay` walks every busy period against every visible date, which is real per-render work, unlike the two string builds it previously wrapped.

## Manual Testing Steps

- [ ] Set your machine to a negative-offset timezone (e.g. America/Denver) — the bug is invisible under UTC.
- [ ] Go to `/day` and click an empty slot after 6 PM. Give it a title, save, and confirm the event appears on the grid immediately.
- [ ] Confirm the "Up Next" card appears in the left sidebar showing that event.
- [ ] Hard-reload the page and confirm both the event and the Up Next card are still there (this exercises the server fetch, not just the optimistic write).
- [ ] Create an evening event using the keyboard shortcut instead of a click; confirm it also appears.
- [ ] Create a morning event and confirm it still appears (this path always worked — checking for a regression).
- [ ] Switch to the week view and confirm evening events still render as before.
- [ ] Use the day view's prev/next arrows across a few days and confirm events stay on their correct days.

## Test plan

- [x] `bun run test:web` — 1231 pass, 0 fail (192 files)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] New regression test pins the range against an explicit offset zone (`America/Denver`), verified to fail on a return to `.utc(true)` — confirmed the mode check has teeth on a UTC machine, where the correct and incorrect formats otherwise coincide
- [x] New loader test pins `dateInView` as local-mode midnight
- [x] Updated `DayCalendarBusyPeriods` test to seed the range from the shared builder rather than the old hand-rolled bounds
- [x] Validated in local Chrome: evening event renders on the day grid, Up Next card shows, both survive a hard reload, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)