### PR TITLE
fix(web): open the event form with details on Enter

### DIFF
--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useCallback, useMemo } from "react";
+import { type MouseEvent, useMemo } from "react";
 import {
   type CalendarCardIdentity,
   isEventReadOnly,
@@ -7,15 +7,14 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import {
-  draftActions,
   selectDraft,
   selectDraftId,
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { AllDayEventMemo } from "@web/views/Week/components/Grid/AllDayRow/AllDayEvent";
+import { useGridEventDraftHandlers } from "@web/views/Week/components/Grid/useGridEventDraftHandlers";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import {
@@ -83,40 +82,8 @@ export const AllDayEvents = ({
     [visibleAllDayEvents, calendarLookup],
   );
 
-  const gridDraftFor = useCallback(
-    (event: GridEvent) => {
-      const sourceEvent = weekEvents.find(
-        (candidate) => candidate.id === event._id,
-      );
-      return sourceEvent ? editGridEventDraft(sourceEvent) : null;
-    },
-    [weekEvents],
-  );
-
-  // startGridDraft, not `start`: `start` leaves gridDraft null, which both
-  // opens the sidebar form with nothing to render and strands arrow-key
-  // repositioning (it reads the draft's own schedule). Mirrors
-  // MainGridEvents' timed-event handler.
-  const handleKeyDown = useCallback(
-    (event: GridEvent) => {
-      const draft = gridDraftFor(event);
-      if (!draft) return;
-
-      draftActions.startGridDraft({ activity: "keyboardEdit", draft });
-    },
-    [gridDraftFor],
-  );
-
-  const openReadOnlyDetails = useCallback(
-    (event: GridEvent) => {
-      const draft = gridDraftFor(event);
-      if (!draft) return;
-
-      draftActions.startGridDraft({ activity: "gridClick", draft });
-      draftActions.setFormOpen(true);
-    },
-    [gridDraftFor],
-  );
+  const { onEventKeyDown, onOpenReadOnlyDetails } =
+    useGridEventDraftHandlers(weekEvents);
 
   return (
     <div
@@ -149,8 +116,8 @@ export const AllDayEvents = ({
                 isReadOnly={isReadOnly}
                 key={event._id}
                 measurements={measurements}
-                onKeyDown={handleKeyDown}
-                onOpenReadOnlyDetails={openReadOnlyDetails}
+                onKeyDown={onEventKeyDown}
+                onOpenReadOnlyDetails={onOpenReadOnlyDetails}
                 weekDays={weekDays}
               />
             );

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -6,10 +6,7 @@ import {
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
-import {
-  Categories_Event,
-  type GridEvent,
-} from "@web/common/types/web.event.types";
+import { type GridEvent } from "@web/common/types/web.event.types";
 import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import {
@@ -86,37 +83,39 @@ export const AllDayEvents = ({
     [visibleAllDayEvents, calendarLookup],
   );
 
-  // NOT converted to GridEventDraft/editGridEventDraft: useDraftActions.ts
-  // reads `draft.position.dragOffset` off this store's `event` field when a
-  // keyboardEdit draft is subsequently repositioned by arrow keys, and
-  // gridEventDraftToSchemaEvent has no grid-layout `position` to give it.
-  // See packet-03-phase-3c scoping note.
-  const handleKeyDown = (event: GridEvent) => {
-    draftActions.start({
-      activity: "keyboardEdit",
-      event,
-      eventType: Categories_Event.ALLDAY,
-    });
-  };
-
-  // Read-only cards can't be repositioned, so they don't need the
-  // keyboardEdit path above - and must not use it: `start` leaves `gridDraft`
-  // null, which opens the sidebar form with nothing to render. Mirrors
-  // MainGridEvents' timed-event handler.
-  const openReadOnlyDetails = useCallback(
+  const gridDraftFor = useCallback(
     (event: GridEvent) => {
       const sourceEvent = weekEvents.find(
         (candidate) => candidate.id === event._id,
       );
-      const draft = sourceEvent ? editGridEventDraft(sourceEvent) : null;
-      if (!draft) {
-        return;
-      }
+      return sourceEvent ? editGridEventDraft(sourceEvent) : null;
+    },
+    [weekEvents],
+  );
+
+  // startGridDraft, not `start`: `start` leaves gridDraft null, which both
+  // opens the sidebar form with nothing to render and strands arrow-key
+  // repositioning (it reads the draft's own schedule). Mirrors
+  // MainGridEvents' timed-event handler.
+  const handleKeyDown = useCallback(
+    (event: GridEvent) => {
+      const draft = gridDraftFor(event);
+      if (!draft) return;
+
+      draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    },
+    [gridDraftFor],
+  );
+
+  const openReadOnlyDetails = useCallback(
+    (event: GridEvent) => {
+      const draft = gridDraftFor(event);
+      if (!draft) return;
 
       draftActions.startGridDraft({ activity: "gridClick", draft });
       draftActions.setFormOpen(true);
     },
-    [weekEvents],
+    [gridDraftFor],
   );
 
   return (

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import {
   type CalendarCardIdentity,
   isEventReadOnly,
@@ -7,10 +7,8 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_TIMED } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import {
-  draftActions,
   selectDraft,
   selectDraftId,
   useDraftStore,
@@ -19,6 +17,7 @@ import {
   createTimedEventLayout,
   type TimedDeckLayout,
 } from "@web/grid/layout/timed-deck.layout";
+import { useGridEventDraftHandlers } from "@web/views/Week/components/Grid/useGridEventDraftHandlers";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import {
@@ -82,39 +81,8 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
     [timedEventItems, calendarLookup],
   );
 
-  const gridDraftFor = useCallback(
-    (event: GridEvent) => {
-      const sourceEvent = weekEvents.find(
-        (candidate) => candidate.id === event._id,
-      );
-      return sourceEvent ? editGridEventDraft(sourceEvent) : null;
-    },
-    [weekEvents],
-  );
-
-  // startGridDraft, not `start`: `start` leaves gridDraft null, which both
-  // opens the sidebar form with nothing to render and strands arrow-key
-  // repositioning (it reads the draft's own schedule).
-  const handleKeyDown = useCallback(
-    (event: GridEvent) => {
-      const draft = gridDraftFor(event);
-      if (!draft) return;
-
-      draftActions.startGridDraft({ activity: "keyboardEdit", draft });
-    },
-    [gridDraftFor],
-  );
-
-  const openReadOnlyDetails = useCallback(
-    (event: GridEvent) => {
-      const draft = gridDraftFor(event);
-      if (!draft) return;
-
-      draftActions.startGridDraft({ activity: "gridClick", draft });
-      draftActions.setFormOpen(true);
-    },
-    [gridDraftFor],
-  );
+  const { onEventKeyDown, onOpenReadOnlyDetails } =
+    useGridEventDraftHandlers(weekEvents);
 
   return (
     <div id={ID_GRID_EVENTS_TIMED}>
@@ -145,8 +113,8 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
                 isReadOnly={isReadOnly}
                 key={`initial-${event._id}`}
                 measurements={measurements}
-                onEventKeyDown={handleKeyDown}
-                onOpenReadOnlyDetails={openReadOnlyDetails}
+                onEventKeyDown={onEventKeyDown}
+                onOpenReadOnlyDetails={onOpenReadOnlyDetails}
                 weekProps={weekProps}
               />
             );

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -6,10 +6,7 @@ import {
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_TIMED } from "@web/common/constants/web.constants";
-import {
-  Categories_Event,
-  type GridEvent,
-} from "@web/common/types/web.event.types";
+import { type GridEvent } from "@web/common/types/web.event.types";
 import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import {
@@ -84,38 +81,39 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
       })),
     [timedEventItems, calendarLookup],
   );
-  const category = Categories_Event.TIMED;
 
-  // NOT converted to GridEventDraft/editGridEventDraft: useDraftActions.ts
-  // reads `draft.position.dragOffset` off this store's `event` field when a
-  // keyboardEdit draft is subsequently repositioned by arrow keys, and
-  // gridEventDraftToSchemaEvent has no grid-layout `position` to give it.
-  // See packet-03-phase-3c scoping note.
-  const handleKeyDown = (event: GridEvent) => {
-    draftActions.start({
-      activity: "keyboardEdit",
-      event,
-      eventType: category,
-    });
-  };
-
-  // Read-only cards can't be repositioned, so they don't need the
-  // keyboardEdit path above - and must not use it: `start` leaves `gridDraft`
-  // null, which opens the sidebar form with nothing to render.
-  const openReadOnlyDetails = useCallback(
+  const gridDraftFor = useCallback(
     (event: GridEvent) => {
       const sourceEvent = weekEvents.find(
         (candidate) => candidate.id === event._id,
       );
-      const draft = sourceEvent ? editGridEventDraft(sourceEvent) : null;
-      if (!draft) {
-        return;
-      }
+      return sourceEvent ? editGridEventDraft(sourceEvent) : null;
+    },
+    [weekEvents],
+  );
+
+  // startGridDraft, not `start`: `start` leaves gridDraft null, which both
+  // opens the sidebar form with nothing to render and strands arrow-key
+  // repositioning (it reads the draft's own schedule).
+  const handleKeyDown = useCallback(
+    (event: GridEvent) => {
+      const draft = gridDraftFor(event);
+      if (!draft) return;
+
+      draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    },
+    [gridDraftFor],
+  );
+
+  const openReadOnlyDetails = useCallback(
+    (event: GridEvent) => {
+      const draft = gridDraftFor(event);
+      if (!draft) return;
 
       draftActions.startGridDraft({ activity: "gridClick", draft });
       draftActions.setFormOpen(true);
     },
-    [weekEvents],
+    [gridDraftFor],
   );
 
   return (

--- a/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
@@ -292,6 +292,64 @@ describe("Week grid read-only interaction gate", () => {
     act(() => draftActions.discard());
   });
 
+  // The keyboard path had the same blank-sidebar defect the read-only cases
+  // above were routed around: it opened the form via `start`, which leaves
+  // gridDraft null. That also stranded arrow-key repositioning, which reads
+  // the draft's own schedule.
+  it("opens a writable timed event with its details when focused and Entered", () => {
+    const writableCalendar = makeCalendar({
+      access: "owner",
+      capabilities: getCalendarCapabilities("owner"),
+    });
+    seededCalendars = [writableCalendar];
+    const event = createTimedEvent(writableCalendar.id, {
+      content: {
+        kind: "details",
+        title: "Keyboard focus block",
+        description: "",
+      },
+    });
+    seededEvents = [event];
+
+    renderMainGridEvents();
+
+    const card = screen.getByRole("button", { name: /keyboard focus block/i });
+    act(() => {
+      fireEvent.keyDown(card, { key: "Enter" });
+    });
+
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardEdit");
+    expect(useDraftStore.getState().gridDraft?.source?.id).toBe(event.id);
+
+    act(() => draftActions.discard());
+  });
+
+  it("opens a writable all-day event with its details when focused and Entered", () => {
+    const writableCalendar = makeCalendar({
+      access: "owner",
+      capabilities: getCalendarCapabilities("owner"),
+    });
+    seededCalendars = [writableCalendar];
+    const event = createAllDayEvent(writableCalendar.id, {
+      content: { kind: "details", title: "Keyboard holiday", description: "" },
+    });
+    seededEvents = [event];
+
+    renderAllDayEvents();
+
+    const card = screen.getByRole("button", {
+      name: /all-day event: keyboard holiday/i,
+    });
+    act(() => {
+      fireEvent.keyDown(card, { key: "Enter" });
+    });
+
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardEdit");
+    expect(useDraftStore.getState().gridDraft?.source?.id).toBe(event.id);
+
+    act(() => draftActions.discard());
+  });
+
   it("treats a busy timed event as read-only, and renders 'Busy' as its title, even on a writable calendar", () => {
     const writableCalendar = makeCalendar({
       access: "owner",

--- a/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
@@ -1,0 +1,167 @@
+import { HotkeyManager } from "@tanstack/react-hotkeys";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, type PropsWithChildren, useRef, useState } from "react";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@web/__tests__/__mocks__/mock.render";
+import { seedEventQueries } from "@web/__tests__/utils/event-query-test-data";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { createCompassQueryClient } from "@web/api/query-client";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { draftActions } from "@web/events/stores/draft.store";
+import { DraftProvider } from "@web/views/Week/components/Draft/context/DraftProvider";
+import { WeekSidebarEventDetails } from "@web/views/Week/components/Draft/sidebar/WeekSidebarEventDetails";
+import { useDateCalcs } from "@web/views/Week/hooks/grid/useDateCalcs";
+import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
+import { weekEventRegistry } from "@web/views/Week/interaction/registry/week-event.registry";
+import { MainGridEvents } from "./MainGridEvents";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+
+// The store-level assertions in eventReadOnlyInteraction.test.tsx can't see
+// the symptom this bug actually produced: the sidebar panel opened while the
+// form inside it rendered nothing. That needs the real DraftProvider (so
+// useDraftActions' keyboardEdit branch really runs) mounted alongside the
+// form, which is what this file adds.
+
+const startOfView = dayjs("2024-01-14T00:00:00.000");
+const weekDays = Array.from({ length: 7 }, (_, index) =>
+  startOfView.add(index, "day"),
+);
+const measurements = {
+  allDayRow: null,
+  colWidths: [100, 100, 100, 100, 100, 100, 100],
+  hourHeight: 60,
+  mainGrid: {
+    bottom: 780,
+    height: 780,
+    left: 0,
+    right: 700,
+    top: 0,
+    width: 700,
+    x: 0,
+    y: 0,
+  },
+} satisfies Measurements_Grid;
+
+const weekProps = {
+  component: {
+    category: "current" as const,
+    endOfView: startOfView.endOf("week"),
+    isCurrentWeek: true,
+    startOfView,
+    week: startOfView.week(),
+    weekDays,
+  },
+  state: { goToDate: mock() },
+  util: {
+    decrementWeek: mock(),
+    getLastNavigationSource: mock(() => "manual" as const),
+    goToToday: mock(),
+    incrementWeek: mock(),
+    shiftViewByDay: mock(),
+  },
+};
+
+const writableCalendar: Calendar = {
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Compass",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+};
+
+let seededEvents: Event[] = [];
+
+function Harness({ children }: PropsWithChildren) {
+  const [queryClient] = useState(() => {
+    const client = createCompassQueryClient();
+    seedEventQueries(client, seededEvents);
+    client.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    return client;
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function GridWithSidebar() {
+  const mainGridRef = useRef<HTMLDivElement | null>(null);
+  const dateCalcs = useDateCalcs(measurements, mainGridRef, weekDays);
+
+  return (
+    <DraftProvider dateCalcs={dateCalcs} weekProps={weekProps as never}>
+      <div ref={mainGridRef}>
+        <MainGridEvents
+          measurements={measurements}
+          weekProps={weekProps as never}
+        />
+      </div>
+      <WeekSidebarEventDetails />
+    </DraftProvider>
+  );
+}
+
+beforeEach(() => {
+  HotkeyManager.resetInstance();
+});
+
+afterEach(() => {
+  act(() => draftActions.discard());
+  cleanup();
+  weekEventRegistry.clear();
+  seededEvents = [];
+});
+
+describe("Enter on a focused grid event", () => {
+  it("opens the sidebar form populated with the event's details", async () => {
+    seededEvents = [
+      createMockEvent({
+        calendarId: writableCalendar.id,
+        content: {
+          kind: "details",
+          title: "Quarterly review",
+          description: "",
+        },
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2024-01-15T09:00:00.000Z",
+          end: "2024-01-15T10:00:00.000Z",
+          timeZone: "UTC",
+        }),
+      }),
+    ];
+
+    render(
+      <Harness>
+        <GridWithSidebar />
+      </Harness>,
+    );
+
+    const card = screen.getByRole("button", { name: /quarterly review/i });
+    await act(async () => {
+      fireEvent.keyDown(card, { key: "Enter" });
+    });
+
+    expect(await screen.findByDisplayValue("Quarterly review")).toBeVisible();
+  });
+});

--- a/packages/web/src/views/Week/components/Grid/useGridEventDraftHandlers.ts
+++ b/packages/web/src/views/Week/components/Grid/useGridEventDraftHandlers.ts
@@ -1,0 +1,53 @@
+import { useCallback } from "react";
+import { type Event } from "@core/types/event.contracts";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
+
+/**
+ * How the timed grid and the all-day row both open a card in the sidebar
+ * form. Cards are projections of `weekEvents`, so the draft is rebuilt from
+ * the source event they were derived from.
+ *
+ * Always startGridDraft, never `start`: `start` leaves gridDraft null, which
+ * renders the form empty and strands arrow-key repositioning (it reads the
+ * draft's own schedule). startGridDraft also derives eventType from the
+ * schedule, so neither caller passes a category.
+ */
+export const useGridEventDraftHandlers = (weekEvents: Event[]) => {
+  const gridDraftFor = useCallback(
+    (event: GridEvent) => {
+      const sourceEvent = weekEvents.find(
+        (candidate) => candidate.id === event._id,
+      );
+      return sourceEvent ? editGridEventDraft(sourceEvent) : null;
+    },
+    [weekEvents],
+  );
+
+  const onEventKeyDown = useCallback(
+    (event: GridEvent) => {
+      const draft = gridDraftFor(event);
+      if (!draft) return;
+
+      draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    },
+    [gridDraftFor],
+  );
+
+  // Read-only cards never reach the keyboard path (they get no interaction
+  // attributes), so they open the same form through the click activity and
+  // ask for it directly.
+  const onOpenReadOnlyDetails = useCallback(
+    (event: GridEvent) => {
+      const draft = gridDraftFor(event);
+      if (!draft) return;
+
+      draftActions.startGridDraft({ activity: "gridClick", draft });
+      draftActions.setFormOpen(true);
+    },
+    [gridDraftFor],
+  );
+
+  return { onEventKeyDown, onOpenReadOnlyDetails };
+};


### PR DESCRIPTION
## Summary

Tabbing to an event on the week grid and pressing Enter opened the sidebar panel with an **empty** form (see `c-empty-form-details.png`).

`handleKeyDown` called `draftActions.start(...)`, which explicitly sets `gridDraft: null`. The `keyboardEdit` branch in `useDraftActions` only calls `setDraft` when a `gridDraft` is present, so the local draft stayed null — `openForm()` still ran, opening the panel shell, while the form inside it returned `null` and rendered nothing.

The fix builds the draft from the source event and hands it to `startGridDraft`, which sets both `gridDraft` and the legacy `event` projection. That's the same thing the read-only path already does. Applied to the all-day row too, which had the identical defect.

### The comment that justified the bug was wrong

The keyboard path carried this note explaining why it couldn't use `editGridEventDraft`:

> NOT converted to GridEventDraft/editGridEventDraft: useDraftActions.ts reads `draft.position.dragOffset` off this store's `event` field when a keyboardEdit draft is subsequently repositioned by arrow keys

Nothing reads `position.dragOffset` — the only two occurrences of that string in `packages/web` were this comment and its copy in `AllDayEvents`. `dragOffset` comes from `useDraftState`'s local `useState`, and arrow-key repositioning reads `draft.values.schedule` and **bails when the draft is null**. So leaving `gridDraft` null was itself breaking the repositioning the comment claimed to protect. Both work now, and the comment is gone.

`duplicateEvent` was dead on this path for the same reason (it early-returns without a `gridDraft`) and is now reachable.

`eventType` is no longer passed because `startGridDraft` derives it from the schedule kind, and the view model only ever puts `allDay` schedules in the all-day list and `timed` schedules in the timed list — so the derivation is provably identical to the literals it replaces.

## Simplicity

Net reduction. Dropping the `eventType` argument left the two grid rows with byte-identical copies of the lookup, both handlers, and the four-line comment explaining the `start` hazard — so that shape moved into one `useGridEventDraftHandlers` hook and the rule now lives in one place instead of two that can drift. Two stale comments and three now-dead imports (`editGridEventDraft`, `draftActions`, `useCallback`) were removed from the components.

No `useEffect`, `useRef`, or `useState` added. Three `useCallback` live in the new hook — the same three they replace, kept because the handlers are props on memoized cards whose comparators would otherwise re-render every card on each parent render.

## Manual Testing Steps

- [ ] Open `/week` with at least one event on your own (writable) calendar.
- [ ] Press Tab until an event card has focus, then press Enter. The sidebar form should open showing that event's title, start/end times, and calendar — not an empty form.
- [ ] Press Escape, then repeat on an **all-day** event in the top row. Its details should populate too.
- [ ] With an event open via Enter, press the arrow keys — the event should move on the grid (this was silently broken before).
- [ ] Click (don't Tab) an event and confirm the form still opens with details, as before.
- [ ] If you have a shared/read-only calendar, click one of its events and confirm it still opens for inspection.
- [ ] Create a brand-new event by clicking an empty slot and confirm that form still opens blank, ready for a title.

## Test plan

- [x] `bun run test:web` — 1234 pass, 0 fail (193 files)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] New integration test (`keyboardEditForm.test.tsx`) mounts the real `DraftProvider` + sidebar and asserts the form renders the event's title after Enter — verified it fails with "Unable to find an element with the display value" when the old `start` call is restored, i.e. it pins the actual blank-form symptom rather than store internals
- [x] New store-level tests for the timed and all-day keyboard paths; reintroducing the bug in the shared hook fails 3 tests across both rows
- [x] Validated in local Chrome: Enter on a focused timed event and on an all-day event both open populated forms, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)