### PR TITLE
fix: sync a timed event dragged to the all-day row

### DIFF
--- a/packages/backend/src/event/google-event.adapter.test.ts
+++ b/packages/backend/src/event/google-event.adapter.test.ts
@@ -330,10 +330,15 @@ describe("mapEventRecordToGoogle", () => {
       summary: "Design review",
       description: "notes",
       start: {
+        date: null,
         dateTime: "2026-07-14T15:00:00.000Z",
         timeZone: "America/Denver",
       },
-      end: { dateTime: "2026-07-14T16:00:00.000Z", timeZone: "America/Denver" },
+      end: {
+        date: null,
+        dateTime: "2026-07-14T16:00:00.000Z",
+        timeZone: "America/Denver",
+      },
       recurrence: null,
     });
   });
@@ -343,9 +348,47 @@ describe("mapEventRecordToGoogle", () => {
       schedule: { kind: "allDay", start: "2026-08-03", end: "2026-08-06" },
     });
     const patch = mapEventRecordToGoogle(record);
-    expect(patch.start).toEqual({ date: "2026-08-03" });
-    expect(patch.end).toEqual({ date: "2026-08-06" });
+    expect(patch.start).toEqual({
+      date: "2026-08-03",
+      dateTime: null,
+      timeZone: null,
+    });
+    expect(patch.end).toEqual({
+      date: "2026-08-06",
+      dateTime: null,
+      timeZone: null,
+    });
     expect(patch.recurrence).toBeNull();
+  });
+
+  // events.patch merges start/end key by key, so a converted event has to
+  // clear the keys its previous kind used. Omitting them left a dragged
+  // timed->all-day event with both a date and a dateTime on Google, which it
+  // rejects with "Invalid start time" - surfacing as a 502 PROVIDER_FAILURE.
+  it.each([
+    [
+      "timed to all-day",
+      { kind: "allDay", start: "2026-08-03", end: "2026-08-04" },
+      "dateTime",
+    ],
+    [
+      "all-day to timed",
+      {
+        kind: "timed",
+        start: new Date("2026-07-14T15:00:00.000Z"),
+        end: new Date("2026-07-14T16:00:00.000Z"),
+        timeZone: "America/Denver",
+      },
+      "date",
+    ],
+  ])("clears the other kind's keys when converting %s", (_label, schedule, clearedKey) => {
+    const patch = mapEventRecordToGoogle(
+      buildRecord({ schedule: schedule as EventRecord["schedule"] }),
+    );
+
+    // Present-and-null, not absent: an omitted key is left as-is by Google.
+    expect(patch.start).toHaveProperty(clearedKey, null);
+    expect(patch.end).toHaveProperty(clearedKey, null);
   });
 
   it("includes recurrence rules for a series event", () => {

--- a/packages/backend/src/event/google-event.adapter.ts
+++ b/packages/backend/src/event/google-event.adapter.ts
@@ -182,21 +182,32 @@ export const mapEventRecordToGoogle = (
     throw new Error("Cannot write busy-content event to Google");
   }
 
+  // Same key-merge rule as `recurrence` below: the keys the other schedule
+  // kind uses must be nulled, not omitted. Omitting them leaves the previous
+  // kind's keys on Google, and it rejects a start holding both a date and a
+  // dateTime ("Invalid start time") - which is what dragging a timed event
+  // into the all-day row sends.
   const scheduleFields: Pick<GoogleEventWriteInput, "start" | "end"> =
     record.schedule.kind === "timed"
       ? {
           start: {
+            date: null,
             dateTime: record.schedule.start.toISOString(),
             timeZone: record.schedule.timeZone,
           },
           end: {
+            date: null,
             dateTime: record.schedule.end.toISOString(),
             timeZone: record.schedule.timeZone,
           },
         }
       : {
-          start: { date: record.schedule.start },
-          end: { date: record.schedule.end },
+          start: {
+            date: record.schedule.start,
+            dateTime: null,
+            timeZone: null,
+          },
+          end: { date: record.schedule.end, dateTime: null, timeZone: null },
         };
 
   return {

--- a/packages/web/src/api/util/backend-unavailable-error.util.test.ts
+++ b/packages/web/src/api/util/backend-unavailable-error.util.test.ts
@@ -9,10 +9,10 @@ import {
 } from "./backend-unavailable-error.util";
 
 /** Mirrors what `createApiError` builds for a response the backend/proxy returned. */
-const createApiErrorWithStatus = (status: number): ApiError => {
+const createApiErrorWithStatus = (status: number, data?: unknown): ApiError => {
   const error = new Error(`Request failed with status ${status}`) as ApiError;
   error.name = "ApiError";
-  error.response = { status } as ApiResponse<unknown>;
+  error.response = { status, data } as ApiResponse<unknown>;
   return error;
 };
 
@@ -57,6 +57,30 @@ describe("isBackendUnavailableError", () => {
     expect(
       isBackendUnavailableError(createApiErrorWithStatus(Status.UNAUTHORIZED)),
     ).toBe(false);
+  });
+
+  // The backend answers PROVIDER_FAILURE with a 502 of its own, e.g. when
+  // Google rejects a sync. Treating that as "backend down" dropped the app
+  // into local mode mid-mutation, which either threw "Event not found" from
+  // IndexedDB or silently re-keyed the queries and lost the edit from view.
+  it("does not treat a backend-authored gateway error as unavailability", () => {
+    expect(
+      isBackendUnavailableError(
+        createApiErrorWithStatus(Status.BAD_GATEWAY, {
+          code: "PROVIDER_FAILURE",
+          message: "Failed to sync the change to Google Calendar",
+          retryable: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still treats a gateway error with no backend body as unavailability", () => {
+    expect(
+      isBackendUnavailableError(
+        createApiErrorWithStatus(Status.BAD_GATEWAY, "<html>502 Bad Gateway"),
+      ),
+    ).toBe(true);
   });
 
   it("ignores non-API errors", () => {

--- a/packages/web/src/api/util/backend-unavailable-error.util.ts
+++ b/packages/web/src/api/util/backend-unavailable-error.util.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from "react";
 import { Status } from "@core/errors/status.codes";
+import { EventMutationErrorSchema } from "@core/types/event-command.contracts";
 import { createExternalStore } from "@web/common/utils/external-store.util";
 import { refreshEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { type ApiError } from "../api.types";
@@ -17,6 +18,17 @@ const BACKEND_DOWN_STATUSES: number[] = [
 
 const unavailableStore = createExternalStore(false);
 
+/**
+ * The backend answers PROVIDER_FAILURE with a 502 (event.error.ts), so a
+ * gateway status alone doesn't mean it's unreachable. A body in the mutation
+ * error shape can only have come from the backend itself - a proxy that
+ * couldn't reach it has no way to write one - which puts it under the same
+ * rule as the 500 above: it answered, so the failure is this request's.
+ */
+function isBackendAuthoredError(data: unknown): boolean {
+  return EventMutationErrorSchema.safeParse(data).success;
+}
+
 export function isBackendUnavailableError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -26,9 +38,12 @@ export function isBackendUnavailableError(error: unknown): boolean {
     // Read the status off the response rather than the message: `createApiError`
     // bakes the status into the message text, and string-matching that is what
     // previously let real 502s through as ordinary request failures.
-    const status = (error as ApiError).response?.status;
+    const response = (error as ApiError).response;
     // No response at all means the request never reached the backend.
-    return status === undefined || BACKEND_DOWN_STATUSES.includes(status);
+    if (response === undefined) return true;
+    if (!BACKEND_DOWN_STATUSES.includes(response.status)) return false;
+
+    return !isBackendAuthoredError(response.data);
   }
 
   return error.message === "Failed to fetch";


### PR DESCRIPTION
## Summary

Dragging a timed event into the all-day row produced a full-page error (`b-502-error.png`), and in another case silently dropped the event from view with nothing logged. Both are the same chain.

**Google rejected the write.** Propagation uses `events.patch`, which merges `start`/`end` key by key, and the all-day body only set `date`. The event's existing `dateTime` therefore survived the merge, leaving Google a start holding *both* a `date` and a `dateTime` — "Invalid start time" — which the backend surfaces as `502 PROVIDER_FAILURE`. The fix nulls the keys the other schedule kind uses so the merge clears them, exactly as `recurrence: null` in the same body already clears stale rules. The reverse conversion had the mirror bug: an all-day event moved back to a time left a stale `date` behind.

**The 502 then became the second failure.** `isBackendUnavailableError` mapped every gateway status to "the backend is down", so an error the backend itself *authored* flipped the app into local mode mid-mutation. From there the write either threw `Event not found: <id>` out of IndexedDB (the event lives on the server, not locally) and took the page down, or resolved locally and re-keyed every event query to the `local` source — stranding the optimistic update under the abandoned `remote` key. That is the disappearing event: no backend error, no UI error, no event.

A body in the mutation error shape can only have come from the backend, so it now falls under the rule the 500 already had — *it answered, so it is up, and the failure belongs to this request*. The real Google error reaches the user instead of a crash, and the classification stays correct for any future `PROVIDER_FAILURE`.

## Simplicity

No simplification opportunities found — the diff is four small edits and their tests. The classification check reuses core's existing `EventMutationErrorSchema` rather than hand-rolling a `"code" in data` test, so the definition of "a backend-authored error" stays in one place. No `useEffect`/`useRef`/`useState` involved.

## Manual Testing Steps

Requires a Google-connected account (the bug is in Google propagation).

- [ ] On `/week`, drag an existing **timed** event that is already synced to Google up into the all-day row. It should become an all-day event with no error page and no toast.
- [ ] Confirm the event is still visible in the all-day row afterwards, and still there after a page reload.
- [ ] Check the event in Google Calendar: it should now be all-day on the expected date.
- [ ] Drag it back down into the timed grid. It should convert back cleanly and show the right time in Google (this is the mirror case).
- [ ] Confirm attendees/location/reminders on that Google event are untouched by both drags.
- [ ] Create a brand-new event (not previously synced) and confirm it still reaches Google normally — the write body changed for creates too.
- [ ] Open the command palette and confirm it reports the calendar as up to date rather than showing a sync failure.

## Test plan

- [x] Backend suite — 662 pass, 0 fail (73 suites), run against this worktree
- [x] `bun run test:web` — 1218 pass, 0 fail
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] New adapter tests pin that each conversion clears the other kind's keys as **present-and-null** (not absent, which is what `patch` ignores). Verified 4 tests fail when the nulls are removed
- [x] New classification tests: a 502 with a `PROVIDER_FAILURE` body is not unavailability; a 502 with an HTML/gateway body still is
- [x] Verified inbound `mapGoogleEvent` round-trips safely — the all-day `date` branch is checked before `dateTime`, and `parseInstant` already tolerates null
- [x] Validated the drag in local Chrome: timed event converts to "All-day event", no full-page error, still visible, and survives a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)