### PR TITLE
fix: let a deleted account start over cleanly

### DIFF
--- a/packages/backend/src/__tests__/helpers/mock.setup.ts
+++ b/packages/backend/src/__tests__/helpers/mock.setup.ts
@@ -54,6 +54,12 @@ function mockGoogleapis() {
   );
 }
 
+/**
+ * Stands in for SessionContainer.revokeSession, which clears the response's
+ * cookies. Exported so a test can assert a handler signed its caller out.
+ */
+export const revokeSessionMock = jest.fn(async () => {});
+
 function mockSuperTokens() {
   const userMetadata = new Map<string, UserMetadata>();
 
@@ -101,6 +107,10 @@ function mockSuperTokens() {
           getHandle() {
             return sessionId;
           },
+          // The real SessionContainer clears the response's cookies here;
+          // without a stand-in, a handler that signs its caller out would
+          // throw in tests but work in production.
+          revokeSession: revokeSessionMock,
           getAccessTokenPayload(): SupertokensAccessTokenPayload {
             return {
               iat: now.getMilliseconds(),

--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -3,7 +3,7 @@ import {
   type AnyBulkWriteOperation,
   type BulkWriteResult,
   type ClientSession,
-  type ObjectId,
+  ObjectId,
 } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
 import { type CalendarId } from "@core/types/domain-primitives";
@@ -15,7 +15,10 @@ import {
 } from "@core/types/event-command.contracts";
 import { Resource_Sync } from "@core/types/sync.types";
 import { zObjectId } from "@core/types/type.utils";
-import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import {
+  type CalendarRecord,
+  CalendarRecordSchema,
+} from "@backend/calendar/calendar.record";
 import { mapGoogleCalendar } from "@backend/calendar/calendar.record.mapper";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
@@ -279,6 +282,51 @@ class CalendarService {
       userId: zObjectId.parse(userId),
       "source.provider": "local",
     });
+  };
+
+  /**
+   * Gives the user the local calendar getLocalCalendar reads. Nothing else
+   * creates it: Google discovery only writes google-sourced calendars, so
+   * without this a password-only account owns no calendar at all and every
+   * write fails CALENDAR_NOT_FOUND. syncLocalEventsToCloud needs it too - it
+   * maps the browser's sentinel calendar onto this one when a user who has
+   * been working anonymously signs in.
+   *
+   * Upserts on the same {userId, source.provider} the
+   * calendar_userId_local_unique partial index covers, so two concurrent
+   * calls can't leave the user with two.
+   */
+  ensureLocalCalendar = async (
+    userId: ObjectId | string,
+    session?: ClientSession,
+  ) => {
+    const userObjectId = zObjectId.parse(userId);
+
+    await mongoService.calendar.updateOne(
+      { userId: userObjectId, "source.provider": "local" },
+      {
+        $setOnInsert: CalendarRecordSchema.parse({
+          _id: new ObjectId(),
+          userId: userObjectId,
+          name: "Compass",
+          description: "",
+          timeZone: null,
+          foregroundColor: "#000000",
+          backgroundColor: "#ffffff",
+          access: "owner",
+          // A connected Google account's primary calendar keeps that role;
+          // getDefaultTargetCalendar falls back to this one when there
+          // isn't one.
+          isPrimary: false,
+          isVisible: true,
+          isActive: true,
+          source: { provider: "local" },
+          createdAt: new Date(),
+          updatedAt: null,
+        }),
+      },
+      { upsert: true, session },
+    );
   };
 
   /**

--- a/packages/backend/src/user/controllers/user.controller.test.ts
+++ b/packages/backend/src/user/controllers/user.controller.test.ts
@@ -8,6 +8,7 @@ import {
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
+import { revokeSessionMock } from "@backend/__tests__/helpers/mock.setup";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import supertokensUserCleanupService from "@backend/auth/services/supertokens/supertokens.user-cleanup.service";
 import { UserError } from "@backend/common/errors/user/user.errors";
@@ -58,6 +59,35 @@ describe("UserController", () => {
       );
 
       expect(response.body).toEqual(expect.objectContaining({ user: 1 }));
+      expect(await mongoService.user.findOne({ _id: user._id })).toBeNull();
+    });
+
+    // Revoking the user's sessions server-side leaves this caller holding an
+    // access token that still passes signature checks, so it boots back up as
+    // the deleted user: reads 401, writes fail CALENDAR_NOT_FOUND, and the
+    // next sign-up gets tangled in the dead session.
+    it("should sign the caller out so their cookies can't outlive the account", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+
+      await userDriver.deleteAccount(
+        { userId: user._id.toString() },
+        Status.OK,
+      );
+
+      expect(revokeSessionMock).toHaveBeenCalled();
+    });
+
+    // The account is already gone by then, so reporting a failure would tell
+    // the user to try again on an account that no longer exists.
+    it("should still report success when clearing the cookies fails", async () => {
+      const { user } = await UtilDriver.setupTestUser();
+      revokeSessionMock.mockRejectedValueOnce(new Error("supertokens down"));
+
+      await userDriver.deleteAccount(
+        { userId: user._id.toString() },
+        Status.OK,
+      );
+
       expect(await mongoService.user.findOne({ _id: user._id })).toBeNull();
     });
 

--- a/packages/backend/src/user/controllers/user.controller.ts
+++ b/packages/backend/src/user/controllers/user.controller.ts
@@ -1,12 +1,15 @@
 import { type Request, type Response } from "express";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import { zObjectId } from "@core/types/type.utils";
 import { type UserMetadata, type UserProfile } from "@core/types/user.types";
 import { type SReqBody } from "@backend/common/types/express.types";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 import { type Summary_Delete } from "@backend/user/types/user.types";
+
+const logger = Logger("app:user.controller");
 
 class UserController {
   getProfile = async (
@@ -34,6 +37,25 @@ class UserController {
       // Session-derived only: a user may never delete anyone but themselves.
       const user = zObjectId.parse(req.session?.getUserId());
       const summary = await userService.deleteAccount(user.toString());
+
+      // deleteAccount revokes the user's sessions server-side, but that
+      // leaves this caller holding an access token that still passes
+      // signature checks until it expires - long enough to boot back up as
+      // the deleted user and start failing requests against data that no
+      // longer exists. This clears their cookies on the way out. Safe after
+      // the delete: revokeSession clears them without checking whether the
+      // session row is still there.
+      //
+      // Best-effort on purpose: the account is already gone, so failing here
+      // would tell the user their deletion failed when it didn't.
+      try {
+        await req.session?.revokeSession();
+      } catch (e) {
+        logger.warn(
+          `Deleted ${user.toString()} but could not clear their session cookies`,
+          e,
+        );
+      }
 
       res.status(Status.OK).json(summary);
     } catch (e) {

--- a/packages/backend/src/user/services/user.service.test.ts
+++ b/packages/backend/src/user/services/user.service.test.ts
@@ -180,6 +180,59 @@ describe("UserService", () => {
       expect(storedUser?.google).toBeUndefined();
     });
 
+    // Only Google discovery creates calendars, so without this a
+    // password-only account owns none and every write fails
+    // CALENDAR_NOT_FOUND.
+    it("gives a new user a local calendar to write to", async () => {
+      const userId = mongoService.objectId().toString();
+
+      await userService.upsertUserFromAuth({
+        userId,
+        email: "solo@example.com",
+        name: "Solo User",
+      });
+
+      const calendar = await calendarService.getLocalCalendar(userId);
+      expect(calendar).toEqual(
+        expect.objectContaining({ access: "owner", isActive: true }),
+      );
+      expect(calendar?.source).toEqual({ provider: "local" });
+    });
+
+    it("keeps a single local calendar across repeat sign-ins", async () => {
+      const userId = mongoService.objectId().toString();
+      const input = { userId, email: "repeat@example.com", name: "Repeat" };
+
+      await userService.upsertUserFromAuth(input);
+      const first = await calendarService.getLocalCalendar(userId);
+      await userService.upsertUserFromAuth(input);
+
+      const calendars = await mongoService.calendar
+        .find({
+          userId: mongoService.objectId(userId),
+          "source.provider": "local",
+        })
+        .toArray();
+      expect(calendars).toHaveLength(1);
+      expect(calendars[0]?._id.toString()).toBe(first?._id.toString());
+    });
+
+    // Handing one to everyone who signs in would put a calendar they never
+    // made in every existing Google user's sidebar, and an empty column in
+    // their day view.
+    it("does not hand an existing user a local calendar they never had", async () => {
+      const user = await UserDriver.createUser();
+
+      await userService.upsertUserFromAuth({
+        userId: user._id.toString(),
+        email: user.email,
+      });
+
+      expect(
+        await calendarService.getLocalCalendar(user._id.toString()),
+      ).toBeNull();
+    });
+
     it("updates an existing user without removing stored Google data", async () => {
       const user = await UserDriver.createUser();
 

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -159,6 +159,19 @@ class UserService {
       { upsert: true, session },
     );
 
+    // Every auth path lands here, so this is the one place that can promise a
+    // new account owns somewhere to write: Google discovery only creates
+    // google-sourced calendars, which leaves a password-only account with
+    // none at all, and syncLocalEventsToCloud needs this to be the landing
+    // place for whatever the user wrote before signing up.
+    //
+    // New accounts only. Doing it on every sign-in would also hand one to
+    // every existing Google user, who would find a calendar they never made
+    // in their sidebar and an empty column in their day view.
+    if (isNewUser) {
+      await calendarService.ensureLocalCalendar(userId, session);
+    }
+
     return {
       user: {
         ...nextUser,

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -628,6 +628,7 @@ describe("AuthModal", () => {
         );
       });
       expect(mockEmailPassword.signUp).toHaveBeenCalledWith({
+        shouldTryLinkingWithSessionUser: false,
         formFields: [
           { id: "name", value: "Alex" },
           { id: "email", value: "test@example.com" },
@@ -635,6 +636,36 @@ describe("AuthModal", () => {
         ],
       });
       expect(mockUpdateMetadata).not.toHaveBeenCalled();
+    });
+
+    // Signing up is always a fresh identity. Linking it to whatever session
+    // the browser still holds is how a just-deleted account's leftover cookie
+    // dragged the new one into its dead session.
+    it("skips existing-session linking during email/password sign up", async () => {
+      const user = userEvent.setup();
+      await renderWithProviders(<ModalTrigger />);
+
+      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /^sign up$/i }),
+        ).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+      await user.type(screen.getByLabelText(/name/i), "Alex");
+      await user.type(screen.getByLabelText(/email/i), "test@example.com");
+      await user.type(screen.getByLabelText(/password/i), "password123");
+      await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+
+      await waitFor(() => {
+        expect(mockEmailPassword.signUp).toHaveBeenCalledWith(
+          expect.objectContaining({ shouldTryLinkingWithSessionUser: false }),
+        );
+      });
     });
 
     it("skips existing-session linking during email/password sign in", async () => {

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -57,6 +57,10 @@ export function useAuthFormHandlers({
 
       try {
         const response = await EmailPassword.signUp({
+          // Same as signIn below: signing up is always a fresh identity, so
+          // never link it to whatever session the browser still holds. A
+          // stale cookie would otherwise attach the new account to it.
+          shouldTryLinkingWithSessionUser: false,
           formFields: [
             { id: "name", value: data.name },
             { id: "email", value: data.email },

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import "@testing-library/jest-dom";
+
+const deleteAccount = mock(async () => ({}) as never);
+const clearAllBrowserStorage = mock(async () => {});
+// jsdom's location is unconfigurable and its assign() only warns, so spy on
+// it rather than replacing the object.
+const assign = spyOn(window.location, "assign").mockImplementation(() => {});
+
+mock.module("@web/api/user.api", () => ({ UserApi: { deleteAccount } }));
+mock.module("@web/common/utils/cleanup/browser.cleanup.util", () => ({
+  clearAllBrowserStorage,
+}));
+mock.module("@web/auth/compass/state/auth.state.util", () => ({
+  getLastKnownEmail: () => "captain@example.com",
+}));
+
+const { DeleteAccountConfirmationProvider } =
+  require("./DeleteAccountConfirmationProvider") as typeof import("./DeleteAccountConfirmationProvider");
+const { useDeleteAccountConfirmation } =
+  require("./hooks/useDeleteAccountConfirmation") as typeof import("./hooks/useDeleteAccountConfirmation");
+const { DELETE_ACCOUNT_PHRASE } =
+  require("./DeleteAccountConfirmationDialog") as typeof import("./DeleteAccountConfirmationDialog");
+
+function Opener() {
+  const { openDeleteAccountConfirmation } = useDeleteAccountConfirmation();
+  return (
+    <button type="button" onClick={openDeleteAccountConfirmation}>
+      open
+    </button>
+  );
+}
+
+const confirmDeletion = async () => {
+  const user = userEvent.setup();
+  render(
+    <DeleteAccountConfirmationProvider>
+      <Opener />
+    </DeleteAccountConfirmationProvider>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "open" }));
+  await user.type(screen.getByRole("textbox"), DELETE_ACCOUNT_PHRASE);
+  await user.click(screen.getByRole("button", { name: "Delete account" }));
+};
+
+afterEach(() => {
+  deleteAccount.mockClear();
+  clearAllBrowserStorage.mockClear();
+  assign.mockClear();
+});
+
+describe("DeleteAccountConfirmationProvider", () => {
+  // Deleting spans a Mongo transaction and a Google grant revocation. The
+  // farewell used to wait for that to finish, so the user sat looking at the
+  // calendar of the account they'd just deleted with nothing to say it was
+  // working.
+  it("covers the calendar while the account is still being deleted", async () => {
+    let finishDelete = () => {};
+    deleteAccount.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishDelete = () => resolve({} as never);
+        }) as never,
+    );
+
+    await confirmDeletion();
+
+    // Still in flight: the request has not resolved yet.
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      /so long captain@example.com/i,
+    );
+    expect(assign).not.toHaveBeenCalled();
+
+    finishDelete();
+    // Generous: the farewell is held for its full span before the reload.
+    await waitFor(() => expect(assign).toHaveBeenCalled(), { timeout: 5000 });
+  });
+
+  it("takes the farewell back down if the account could not be deleted", async () => {
+    deleteAccount.mockImplementationOnce(
+      () => Promise.reject(new Error("nope")) as never,
+    );
+
+    await confirmDeletion();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+    expect(assign).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from "@web/components/DeleteAccountConfirmation/hooks/useDeleteAccountConfirmation";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 
+/** How long the farewell stays up, counted from when it appears. */
 const FAREWELL_MS = 3000;
 
 export function DeleteAccountConfirmationProvider({
@@ -23,24 +24,39 @@ export function DeleteAccountConfirmationProvider({
   const handleConfirm = useCallback(() => {
     closeDeleteAccountConfirmation();
 
+    // Up before the request, not after it: deleting spans a Mongo
+    // transaction and a Google grant revocation, and until this covers the
+    // screen the user is looking at the calendar of the account they just
+    // deleted, with nothing to say it's working. Reading the email has to
+    // happen first too, since the cleanup below wipes it from storage.
+    setFarewell(getLastKnownEmail() ?? "friend");
+    // Monotonic: a wall clock that steps backwards mid-delete (NTP, resume
+    // from sleep) would make the wait below longer than the step.
+    const shownAt = performance.now();
+
     void (async () => {
       try {
         await UserApi.deleteAccount();
       } catch (e) {
         console.error("Failed to delete account", e);
+        setFarewell(null);
         showErrorToast("Couldn't delete your account. Please try again.");
         return;
       }
-
-      // Read the email before the cleanup below wipes it from storage.
-      setFarewell(getLastKnownEmail() ?? "friend");
-      await new Promise((resolve) => setTimeout(resolve, FAREWELL_MS));
 
       try {
         await clearAllBrowserStorage();
       } catch {
         // Already logged by clearAllBrowserStorage. The account is gone
         // either way, so still send them off as an anonymous user.
+      }
+
+      // Hold the farewell for its full span measured from when it appeared,
+      // so a slow delete doesn't add to the wait and a fast one doesn't
+      // flash it.
+      const remaining = FAREWELL_MS - (performance.now() - shownAt);
+      if (remaining > 0) {
+        await new Promise((resolve) => setTimeout(resolve, remaining));
       }
 
       // Reload rather than just flipping session state: it's the only way to


### PR DESCRIPTION
## Summary

Deleting an account left the user staring at their own calendar for ~5 seconds, then dropped them into a temporary account that couldn't create events, and a sign-up that ended in "you've been signed out" (`e-502-error-continued.png`). Four things, three of them downstream of one root cause.

**The farewell appeared after the delete finished.** Deleting spans a Mongo transaction plus a Google grant revocation, so for that whole time the user watched the calendar of the account they'd just deleted with nothing to say it was working. It's now shown before the request, held for its full span measured from when it appears — a slow delete no longer adds to the wait, a fast one doesn't flash — and taken back down if the delete fails, since they still have an account.

**The stale cookie was the real bug.** Deletion revoked the user's sessions *in the database* but left the caller holding an access token that still passes signature checks until it expires. On reload the app read that cookie, decided it was signed in, and booted into remote mode as a user who no longer existed — reads 401'd, writes failed `CALENDAR_NOT_FOUND`, and the following sign-up tangled itself in the dead session. `DELETE /api/user` now signs the caller out, which clears their cookies. Deliberately best-effort: the account is already gone by then, so failing there would tell the user their deletion failed when it didn't.

**Sign-up linked to whatever session was lying around.** `signIn` has always passed `shouldTryLinkingWithSessionUser: false`; `signUp` didn't. Signing up is always a fresh identity.

**Underneath all of it, nothing ever created the local calendar.** The backend has had a reader (`getLocalCalendar`, "where password-only / locally-owned scheduled events live") and `syncLocalEventsToCloud` maps the browser's sentinel onto it — but only Google discovery ever *wrote* calendars. So a password-only account owned nowhere to write and failed `CALENDAR_NOT_FOUND` even with a clean session, and events written before signing up had nowhere to land. `upsertUserFromAuth` is the one funnel every auth path goes through, so new accounts get one there.

**New accounts only.** Creating it on every sign-in would also hand one to every *existing* Google user, who'd find a calendar they never made in their sidebar and a permanently empty column in their Day view. That's a visible change to people who didn't ask for it, so it's scoped to accounts being created.

## Simplicity

No new abstractions. The calendar creator sits next to the reader it feeds, and upserts on the same `{userId, source.provider}` key the existing `calendar_userId_local_unique` partial index covers, so concurrent calls can't produce two. The farewell timing uses `performance.now()` rather than `Date.now()` — a wall clock stepping backwards mid-delete (NTP, resume from sleep) would otherwise hold the overlay for the length of the step.

No `useEffect`/`useRef` added. The existing `useState` for the farewell is unchanged; it's local UI state nothing else reads.

## Manual Testing Steps

- [ ] Sign in, open the command palette, and delete your account. The farewell should cover the calendar **immediately** — you should never see your events sitting there while it works.
- [ ] Confirm it stays up for a beat and then the page reloads you into a fresh temporary account.
- [ ] In that temporary account, create an event. It should save and survive a reload.
- [ ] Now sign up for a new account with email + password. It should complete without "you've been signed out".
- [ ] Create an event in the new account and confirm it saves (this is the `CALENDAR_NOT_FOUND` case — it needs a calendar that nothing used to create).
- [ ] Confirm the new account's sidebar lists a "Compass" calendar, sorted last.
- [ ] Sign in to a **pre-existing Google account** and confirm its sidebar and Day view are unchanged — no new "Compass" row, no extra empty column.
- [ ] Write a couple of events while signed out, then sign up: those events should follow you into the new account.
- [ ] Check DevTools → Application → Cookies after a delete: the SuperTokens cookies should be gone before the reload.

## Test plan

- [x] Backend — 667 pass, 0 fail (73 suites), run against this worktree (jest from the main repo root silently tests main's files, not the branch's)
- [x] `bun run test:web` — 1221 pass, 0 fail
- [x] `bun run type-check`, `bun run lint` — clean
- [x] New provider test pins the ordering: the farewell must be on screen **while the delete request is still in flight**. Verified it fails against the original ordering
- [x] New controller tests: the caller is signed out on delete, and a failure to clear cookies still reports success (the account is gone)
- [x] New service tests: a new user gets a local calendar; repeat sign-ins keep exactly one; an existing user is **not** handed one. Verified the last one fails if creation isn't scoped to new accounts
- [x] Added `revokeSession` to the test session mock — it was absent, so a handler that signs its caller out threw in tests while working in production
- [x] `shouldTryLinkingWithSessionUser: false` on sign-up now has the same coverage sign-in already had

Note for review: the SuperTokens revoke-after-delete behaviour was verified by reading the vendored `sessionClass.js` (it clears cookies without checking the revoke result, by design), but the backend tests mock that layer — so the real delete is worth one pass on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)