### PR TITLE
fix(web): mute the title placeholder and fix the subscribe prompt

### DIFF
--- a/packages/web/src/components/Focusable/Focusable.tsx
+++ b/packages/web/src/components/Focusable/Focusable.tsx
@@ -10,11 +10,10 @@ import {
 import { type UnderlinedInput } from "@web/common/types/component.types";
 import { Divider } from "@web/components/Divider/Divider";
 
-// Placeholders match the time pickers' value color (--color-text-lighter)
-// rather than a muted grey, so the event form's title and its date/time
-// controls read as one row of text instead of two different states.
+// Muted placeholders, matching Textarea: full white is what the user typed,
+// so a hint that borrows it reads as a real value.
 export const INPUT_RESET_CLASSNAME =
-  "h-8.5 border-0 px-2 outline-none placeholder:text-text-lighter hover:bg-border-primary";
+  "h-8.5 border-0 px-2 outline-none placeholder:text-text-light-inactive hover:bg-border-primary";
 
 export interface Props
   extends UnderlinedInput,

--- a/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
+++ b/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
@@ -88,14 +88,14 @@ export function ReleaseNotesPrompt() {
               </h2>
               <p className="text-text-light">
                 Get monthly release notes with new features, improvements, and
-                helpful tips. Unsubscribe anytime from the email footer.
+                helpful tips. Unsubscribe anytime.
               </p>
             </div>
             <div className="flex flex-wrap justify-end gap-3">
               <button
                 type="button"
                 onClick={decline}
-                className="c-button rounded-full px-5"
+                className="c-button c-button-secondary rounded-full px-5"
               >
                 Nah, I don&apos;t want updates
               </button>


### PR DESCRIPTION
## Summary

Two small UI fixes.

**The Title placeholder rendered at full white**, identical to text the user had typed, so an empty form looked like it already said "Title". [#2155](https://github.com/SwitchbackTech/compass-calendar/pull/2155) deliberately pointed the shared input reset at the time pickers' *value* colour so the form would read as one row rather than two text states. The row does read better — but a hint shouldn't borrow the colour that means "you wrote this". It's back to the muted token, which is what `Textarea`'s placeholder already uses, so Title and Description now match.

Nothing else moves: the date inputs share that reset but are never handed a `placeholder`, so the rule was a no-op there. That's why this is a straight revert of the one line rather than an override on the Title field.

**The subscribe prompt's decline button had `c-button` with no modifier.** That utility carries layout, shadow and focus ring but *no colour*, so the button fell back to the UA default — black text on the near-black panel. Measured in the browser: **1.19:1**, against a 4.5:1 minimum. It now pairs with `c-button-secondary` exactly as its sibling pairs with `c-button-primary`, giving **14.59:1**. It was the only bare-`c-button` in the codebase.

Also dropped "from the email footer" from the unsubscribe line.

## Simplicity

Net simpler: one token reverted on a shared class instead of a per-field override, and one existing utility applied instead of a bespoke colour. No new abstractions, no hooks.

## Manual Testing Steps

- [ ] Click an empty slot on `/week` to open the event form. The "Title" placeholder should look muted — the same weight as "Description" below it — not bright white.
- [ ] Type a title. The text you type should be bright, clearly distinct from the placeholder it replaced.
- [ ] Confirm the start/end time values in the same form are still bright (they're values, not placeholders — they should not have changed).
- [ ] Clear the title and confirm the muted placeholder returns.
- [ ] Trigger the release-notes prompt (sign up, or via the command palette). "Nah, I don't want updates" should be clearly readable — light text on a subtle raised surface, not black-on-black.
- [ ] Confirm the copy reads "Unsubscribe anytime." with no mention of the email footer.
- [ ] Confirm "Yes, Keep Me Updated" is unchanged.

## Test plan

- [x] `bun run test:web` — 1221 pass, 0 fail
- [x] `bun run type-check`, `bun run lint` — clean
- [x] Measured the placeholder in the browser: Title's `::placeholder` is now `rgba(171,182,191,0.7)`, **identical to Description's**, while typed text stays `rgb(250,250,250)`
- [x] Measured the button's contrast in the browser, compositing the translucent surface over the panel behind it: **1.19:1 before → 14.59:1 after**. Confirmed the "before" number by temporarily reverting the class and re-measuring
- [x] Verified no `placeholderText` is ever passed to the DatePicker, so reverting the shared class touches only the Title
- [x] Verified this was the only `c-button` without a colour modifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)