### PR TITLE
fix(web): drop the double space from same-meridiem time labels

### DIFF
--- a/packages/web/src/common/utils/datetime/date.label.test.ts
+++ b/packages/web/src/common/utils/datetime/date.label.test.ts
@@ -18,6 +18,24 @@ describe("Time Labels", () => {
     expect(meridians(eveningLabel)).toBe(1);
   });
 
+  // Counting meridiems missed that dropping the start's took its trailing
+  // space with it, so every same-meridiem label - most of them - rendered as
+  // "6  - 7 AM" on the card and in its aria-label. Assert the whole string.
+  it("reads as one range when both ends share a meridiem", () => {
+    expect(
+      getTimesLabel("2022-07-06T06:00:00-05:00", "2022-07-06T07:00:00-05:00"),
+    ).toBe("6 - 7 AM");
+    expect(
+      getTimesLabel("2022-07-06T10:45:00-05:00", "2022-07-06T11:00:00-05:00"),
+    ).toBe("10:45 - 11 AM");
+  });
+
+  it("keeps both meridiems when the range crosses noon", () => {
+    expect(
+      getTimesLabel("2022-07-06T11:00:00-05:00", "2022-07-06T13:00:00-05:00"),
+    ).toBe("11 AM - 1 PM");
+  });
+
   it("preserves am/pm when needed", () => {
     const label = getTimesLabel(
       "2022-07-06T01:00:00-05:00",

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -235,11 +235,14 @@ const _addTimesToDates = (dt: SelectedDates, timeZone: string) => {
   return { startDate, endDate };
 };
 
+// "6 AM" - "7 AM" reads as "6 - 7 AM": the start's meridiem is redundant when
+// the end repeats it. trimEnd because dropping it also leaves the space that
+// separated it, which the caller's " - " would double up on.
 const _cleanStartMeridiem = (start: string, end: string) => {
   const meridiems = [start.slice(-2), end.slice(-2)];
   const verboseMeridiems = meridiems[0] === meridiems[1];
   if (verboseMeridiems) {
-    return start.slice(0, -2);
+    return start.slice(0, -2).trimEnd();
   }
   return start;
 };

--- a/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
+++ b/packages/web/src/components/ContextMenu/GridContextMenuWrapper.tsx
@@ -1,15 +1,7 @@
-import {
-  autoUpdate,
-  FloatingPortal,
-  flip,
-  offset,
-  shift,
-  useFloating,
-} from "@floating-ui/react";
+import { FloatingPortal, useFloating } from "@floating-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import type React from "react";
 import { useState } from "react";
-import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import {
   assembleGridEvent,
   getCalendarEventIdFromElement,
@@ -23,6 +15,11 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { ContextMenu } from "./ContextMenu";
+import {
+  CONTEXT_MENU_FLOATING_OPTIONS,
+  contextMenuStyle,
+  cursorReference,
+} from "./contextMenu.floating";
 
 export const ContextMenuWrapper = ({
   id,
@@ -38,8 +35,7 @@ export const ContextMenuWrapper = ({
   const [isOpen, setIsOpen] = useState(false);
 
   const { refs, floatingStyles, context } = useFloating({
-    placement: "right-start",
-    middleware: [offset(5), flip(), shift()],
+    ...CONTEXT_MENU_FLOATING_OPTIONS,
     open: isOpen,
     onOpenChange(newIsOpen, _, reason) {
       setIsOpen(newIsOpen);
@@ -47,11 +43,6 @@ export const ContextMenuWrapper = ({
         handleDiscard();
       }
     },
-    // The reference is a virtual element at the click's viewport coordinates,
-    // and the menu is portalled out of the scrolling grid, so anchor it to
-    // the viewport rather than an offset parent.
-    strategy: "fixed",
-    whileElementsMounted: autoUpdate,
   });
 
   const getSelectedEvent = (eventId: string) => {
@@ -84,10 +75,7 @@ export const ContextMenuWrapper = ({
       const draft = editGridEventDraft(getSelectedEvent(eventId));
       if (!draft) return;
 
-      // Create a virtual element where the user clicked
-      refs.setReference({
-        getBoundingClientRect: () => new DOMRect(e.clientX, e.clientY, 0, 0), // Position menu exactly at the click position
-      });
+      refs.setReference(cursorReference(e.clientX, e.clientY));
 
       draftActions.startGridDraft({ activity: "eventRightClick", draft });
 
@@ -108,8 +96,6 @@ export const ContextMenuWrapper = ({
     >
       {children}
       {isOpen && (
-        // Portalled: rendered inline it shared a stacking context with the
-        // event cards and lost to any card stacked above it.
         <FloatingPortal>
           <ContextMenu
             ref={refs.setFloating}
@@ -118,7 +104,7 @@ export const ContextMenuWrapper = ({
                 ? assembleGridEvent(draftEvent)
                 : undefined
             }
-            style={{ ...floatingStyles, zIndex: Z_INDEX_FLOATING_MENU }}
+            style={contextMenuStyle(floatingStyles)}
             context={context}
             close={closeMenu}
             onOutsideClick={handleDiscard}

--- a/packages/web/src/components/ContextMenu/contextMenu.floating.ts
+++ b/packages/web/src/components/ContextMenu/contextMenu.floating.ts
@@ -1,0 +1,42 @@
+import {
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  type UseFloatingOptions,
+} from "@floating-ui/react";
+import { type CSSProperties } from "react";
+import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
+
+/**
+ * How both grids anchor their event context menu. The reference is a virtual
+ * element at the click's viewport coordinates and the menu is portalled out
+ * of the scrolling grid, so it positions against the viewport rather than an
+ * offset parent - which also means it needs no repositioning on scroll.
+ */
+export const CONTEXT_MENU_FLOATING_OPTIONS: Pick<
+  UseFloatingOptions,
+  "middleware" | "placement" | "strategy" | "whileElementsMounted"
+> = {
+  middleware: [offset(5), flip(), shift()],
+  placement: "right-start",
+  strategy: "fixed",
+  whileElementsMounted: autoUpdate,
+};
+
+/** A zero-size reference at the cursor, so the menu opens where they clicked. */
+export const cursorReference = (clientX: number, clientY: number) => ({
+  getBoundingClientRect: () => new DOMRect(clientX, clientY, 0, 0),
+});
+
+/**
+ * Rendered inline, the menu shares a stacking context with the event cards
+ * and loses to any card stacked above it, so it carries the same z-index as
+ * the app's other floating menus and is portalled out.
+ */
+export const contextMenuStyle = (
+  floatingStyles: CSSProperties,
+): CSSProperties => ({
+  ...floatingStyles,
+  zIndex: Z_INDEX_FLOATING_MENU,
+});

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarContextMenu.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarContextMenu.tsx
@@ -1,22 +1,19 @@
-import {
-  autoUpdate,
-  FloatingPortal,
-  flip,
-  offset,
-  shift,
-  useFloating,
-} from "@floating-ui/react";
+import { FloatingPortal, useFloating } from "@floating-ui/react";
 import {
   type MouseEvent as ReactMouseEvent,
   useCallback,
   useMemo,
   useState,
 } from "react";
-import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getCalendarEventIdFromElement } from "@web/common/utils/event/event.util";
 import { ContextMenu } from "@web/components/ContextMenu/ContextMenu";
 import { type ContextMenuItemsActions } from "@web/components/ContextMenu/ContextMenuItems";
+import {
+  CONTEXT_MENU_FLOATING_OPTIONS,
+  contextMenuStyle,
+  cursorReference,
+} from "@web/components/ContextMenu/contextMenu.floating";
 import { useDeleteEvent } from "@web/views/Forms/hooks/useDeleteEvent";
 import { useDuplicateEvent } from "@web/views/Forms/hooks/useDuplicateEvent";
 
@@ -36,15 +33,9 @@ export const useDayCalendarContextMenu = ({
   const deleteContextMenuEvent = useDeleteEvent(contextMenuEventId);
 
   const { context, refs, floatingStyles } = useFloating({
-    placement: "right-start",
-    middleware: [offset(5), flip(), shift()],
+    ...CONTEXT_MENU_FLOATING_OPTIONS,
     open: isOpen,
     onOpenChange: setIsOpen,
-    // Same as GridContextMenuWrapper: the reference is a virtual element at
-    // the click's viewport coordinates, and the menu is portalled out of the
-    // scrolling grid, so anchor it to the viewport.
-    strategy: "fixed",
-    whileElementsMounted: autoUpdate,
   });
 
   const closeContextMenu = useCallback(() => {
@@ -75,12 +66,7 @@ export const useDayCalendarContextMenu = ({
         return;
       }
 
-      // Anchor the menu to a virtual element at the cursor (the idiomatic
-      // floating-ui pattern, matching GridContextMenuWrapper).
-      refs.setReference({
-        getBoundingClientRect: () =>
-          new DOMRect(event.clientX, event.clientY, 0, 0),
-      });
+      refs.setReference(cursorReference(event.clientX, event.clientY));
       setContextMenuEvent(selectedEvent);
       setIsOpen(true);
     },
@@ -121,7 +107,7 @@ export const useDayCalendarContextMenu = ({
           event={contextMenuEvent ?? undefined}
           onOutsideClick={closeContextMenu}
           ref={refs.setFloating}
-          style={{ ...floatingStyles, zIndex: Z_INDEX_FLOATING_MENU }}
+          style={contextMenuStyle(floatingStyles)}
         />
       </FloatingPortal>
     ) : null,


### PR DESCRIPTION
## Summary

Cleanup pass over the merge window since [#2155](https://github.com/SwitchbackTech/compass-calendar/pull/2155).

**Every same-meridiem event label had a double space.** An event from 10:45 AM to 11 AM rendered as `"10:45  - 11 AM"` — on the card and in its aria-label. `_cleanStartMeridiem` drops the start's redundant meridiem (`"10:45 AM"` → `"10:45 "`) but keeps the space that separated it, and `getTimesLabel` then adds its own `" - "`. It hits the common case: any event that starts and ends in the same half of the day.

Four tests covered that function and **none of them could catch it** — they counted meridiems (`meridians(label)`) and asked whether the string `.includes(":45")`, so a stray space had nothing to fail against. The new tests assert the whole string. That's the more general lesson: for anything that renders, assert the label, not a property of it.

**Also folded the two context menus' floating-ui wiring together.** The week and day menus keep their own logic — one looks the event up in the query cache and drives the draft store, the other takes a `getDayEventById` callback and its own delete/duplicate actions — and those differences are real. But the floating-ui wiring was verbatim identical, down to a comment reading *"Same as GridContextMenuWrapper"*: a comment whose only job was to point at its own copy. The config, the cursor reference, and the z-index style now live in one place, with the reason for them stated once instead of twice.

## Simplicity

Net reduction in duplication: two copies of the floating config, the virtual-reference construction, and the "why `strategy: fixed`" rationale collapse into one small module. The menus' genuinely different logic is untouched — this deliberately extracts only the identical part.

Considered and left alone (each verified, not assumed): the Day view's draft handling vs `useGridEventDraftHandlers` (the Day path has a `createGridEventDraft` fallback the Week path doesn't — they only look similar); the week/day event-targeting bindings (already thin wrappers over a shared generic, all exports live); two dead fields in `interaction.metrics.ts` and a copy-pasted block across `MainGridEvents`/`AllDayEvents` (both pre-date this window). No new hooks; no `useEffect`/`useRef`/`useState` added.

## Manual Testing Steps

- [ ] Open `/week` with an event that starts and ends in the same half of the day (e.g. 10:45–11 AM). Its label should read "10:45 - 11 AM" with single spaces — not "10:45  - 11 AM".
- [ ] Check an event spanning noon (e.g. 11 AM–1 PM). It should still show both meridiems: "11 AM - 1 PM".
- [ ] Check an on-the-hour range (e.g. 6–7 AM): "6 - 7 AM".
- [ ] Right-click an event on `/week` — the context menu should still open at the cursor, above the other events.
- [ ] Right-click an event on `/day` — same.
- [ ] Press Escape to dismiss the week menu, and click outside to dismiss it; both should still work.

## Test plan

- [x] `bun run test:web` — 1223 pass, 0 fail
- [x] `bun run type-check`, `bun run lint` — clean
- [x] New label tests assert the exact string; verified they fail against the double-space bug and pass with the fix
- [x] Verified live: every timed-event aria-label on the week grid now has zero double spaces (`"10:45 - 11 AM"`)
- [x] Verified the context menu is unchanged after the extraction — still `z-index: 22`, `position: fixed`, portalled out of the grid, and topmost at all three corners by hit-test. The existing `contextMenuLayering` tests (both wrappers) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)