### PR TITLE
fix(web): let the status overlays actually be announced

### DIFF
--- a/e2e/oauth/google-auth-callback.spec.ts
+++ b/e2e/oauth/google-auth-callback.spec.ts
@@ -91,7 +91,7 @@ test("finishes a saved Google sign-in callback", async ({ page }) => {
   await page.goto(getCallbackUrl(state));
 
   await expect(
-    page.locator('[role="status"][aria-busy="true"][aria-live="polite"]'),
+    page.locator('[role="status"][aria-live="polite"]'),
   ).toBeVisible();
   await expect(page).toHaveURL(/\/week$/);
   expect(apiMocks.loginOrSignupRequests).toHaveLength(1);

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
@@ -69,9 +69,12 @@ describe("DeleteAccountConfirmationProvider", () => {
     await confirmDeletion();
 
     // Still in flight: the request has not resolved yet.
-    expect(await screen.findByRole("status")).toHaveTextContent(
-      /so long captain@example.com/i,
-    );
+    const farewell = await screen.findByRole("status");
+    expect(farewell).toHaveTextContent(/so long captain@example.com/i);
+    // aria-busy on a live region withholds the announcement until it flips
+    // false, and this one never does - it lives until the reload, so a screen
+    // reader user got silence where everyone else got the farewell.
+    expect(farewell).not.toHaveAttribute("aria-busy");
     expect(assign).not.toHaveBeenCalled();
 
     finishDelete();

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -131,7 +131,6 @@ export const OverlayPanel = ({
         aria-labelledby={title ? titleId : undefined}
         aria-describedby={message ? messageId : undefined}
         aria-live={role === "status" ? "polite" : undefined}
-        aria-busy={role === "status" ? true : undefined}
       >
         {icon}
         {title && (


### PR DESCRIPTION
## Summary

From the cleanup UX sweep over the merge window.

`OverlayPanel` set `aria-busy` on its status variant, right next to `aria-live="polite"`. `aria-busy` tells assistive tech to *withhold* the announcement until it flips false — and it never does: the panel lives until the page navigates away. So both panels that use the status variant announced nothing at all.

The one that matters is the farewell after deleting an account. [#2164](https://github.com/SwitchbackTech/compass-calendar/pull/2164) made it appear the instant you confirm, so sighted users now get immediate feedback that the deletion is working. A screen reader user got silence, and then a page reload. The other consumer is the Google auth callback's progress panel — same semantic, same fix.

## Simplicity

One attribute removed. `aria-busy` is now absent from the codebase entirely; it had no other users.

## Manual Testing Steps

- [ ] With VoiceOver (or any screen reader) on, sign in and delete your account from the command palette. The farewell ("Until our sails cross paths again, so long …") should be announced when it appears, rather than passing silently.
- [ ] Confirm the farewell still looks and behaves the same visually — it should cover the calendar immediately and hold for a beat before the reload.
- [ ] Sign in with Google and confirm the auth callback's status panel still renders normally.

## Test plan

- [x] `bun run test:web` — 1223 pass, 0 fail
- [x] `bun run type-check`, `bun run lint` — clean
- [x] The existing farewell test now also asserts the panel isn't marked busy; verified it fails when `aria-busy` is restored
- [x] Confirmed only two components use the status variant (the farewell and the Google auth callback), and both want their status announced

### Found but not fixed here

The sweep also found the grid context menu is **openable by keyboard but not operable**: Shift+F10 on a focused event card opens it, but focus stays on the card and the menu is portalled to the end of `<body>`, so its items are a page of tabbing away. Every action has another route (Enter opens the form, whose actions menu has duplicate/delete and manages focus correctly), so it's friction rather than a blocker — and it predates this window: the wrapper spans the whole grid, so the menu was never in a card's tab order even before it was portalled.

I tried the obvious fix — wrapping it in `FloatingFocusManager` like `ActionsMenu` does — and **verified in the browser that it doesn't work**: focus still lands back on the event card, because opening the menu updates the draft store and something in the grid re-focuses the card. Fixing it properly means finding that focus-stealer and likely adding `useListNavigation`, which is more than a cleanup pass should take on unattended. Left for a deliberate pass rather than shipped half-working. Details in `team/qa/notes/2026-07-16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)