### PR TITLE
test(web): cover getTimesLabel same-meridiem spacing

### DIFF
--- a/packages/web/src/common/utils/datetime/web.date.util.test.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.test.ts
@@ -8,6 +8,7 @@ import {
   getCalendarHeadingLabel,
   getColorsByHour,
   getHourLabels,
+  getTimesLabel,
   getWeekRangeLabel,
   toUTCOffset,
 } from "@web/common/utils/datetime/web.date.util";
@@ -256,6 +257,18 @@ const getColorTotals = (colors: string[]) => {
   const colorTotals = [color1.length, color2.length];
   return colorTotals;
 };
+
+describe("getTimesLabel", () => {
+  it("collapses the shared meridiem without leaving a double space", () => {
+    const label = getTimesLabel("2025-01-05 09:00", "2025-01-05 10:00");
+    expect(label).toBe("9 - 10 AM");
+  });
+
+  it("keeps both meridiems when the range crosses noon", () => {
+    const label = getTimesLabel("2025-01-05 11:00", "2025-01-05 13:00");
+    expect(label).toBe("11 AM - 1 PM");
+  });
+});
 
 describe("getHourLabels", () => {
   it("has 23 intervals by default (excludes midnight)", () => {


### PR DESCRIPTION
## Summary

Adds a direct unit test for `getTimesLabel` in `packages/web/src/common/utils/datetime/web.date.util.ts`. The same-meridiem double-space bug was fixed in #2166 (`_cleanStartMeridiem` now `.trimEnd()`s the stripped start label), but that fix shipped without a dedicated test. Existing coverage in the busy-periods tests asserts with `.*` wildcards between the numbers, which happily match any amount of whitespace — so they can't catch a whitespace regression like `"9  - 10 AM"`.

This adds two exact-string assertions:
- same-meridiem collapse → `"9 - 10 AM"` (the regression guard)
- cross-noon range → `"11 AM - 1 PM"` (guards against over-trimming the differing-meridiem branch)

Test-only change; no product code touched.

## Simplicity

No simplification opportunities and no complexity added — the diff is two additive test cases with no duplication and no `useEffect`/`useRef`/`useState` in play (it's a pure-function util test). Net complexity is flat; the value is a regression guard the wildcard-based tests couldn't provide.

## Manual Testing Steps

This is a test-only change with no browser-observable surface, so verification is a command a reviewer can run rather than a click-through:

- [ ] From the repo root, run `TZ=UTC bun test --cwd packages/web src/common/utils/datetime/web.date.util.test.ts`
- [ ] Confirm the `getTimesLabel` block reports two passing cases: "collapses the shared meridiem without leaving a double space" and "keeps both meridiems when the range crosses noon"
- [ ] Confirm the whole file is green (27 tests pass)

## Test plan

- [x] `TZ=UTC bun test --cwd packages/web src/common/utils/datetime/web.date.util.test.ts` — 27 pass, 0 fail (2 new)
- [x] `bun run type-check` — clean