### PR TITLE
chore(web): drop unused interaction-metrics fields

### DIFF
--- a/packages/web/src/interaction/interaction.metrics.ts
+++ b/packages/web/src/interaction/interaction.metrics.ts
@@ -5,13 +5,11 @@ export interface InteractionMetrics {
   cancellationCount: number;
   firstFrameLatencyMs: number | null;
   frameGaps: number[];
-  layoutReadsDuringMotion: number;
   draftEventMountMs: number | null;
   phase: InteractionPhase;
   pointerMoveCount: number;
   rafCount: number;
   rafDurations: number[];
-  saveRequestsDuringMotion: number;
   styleWritesDuringMotion: number;
 }
 
@@ -20,12 +18,10 @@ export const createInteractionMetrics = (): InteractionMetrics => ({
   cancellationCount: 0,
   firstFrameLatencyMs: null,
   frameGaps: [],
-  layoutReadsDuringMotion: 0,
   draftEventMountMs: null,
   phase: "idle",
   pointerMoveCount: 0,
   rafCount: 0,
   rafDurations: [],
-  saveRequestsDuringMotion: 0,
   styleWritesDuringMotion: 0,
 });


### PR DESCRIPTION
## Summary

`layoutReadsDuringMotion` and `saveRequestsDuringMotion` on `InteractionMetrics` were initialised to `0` and never incremented or read anywhere in the repo (confirmed by grepping both names across `packages/`). Removed both from the interface and its factory. This is dead-field cleanup with no runtime behaviour change — the only remaining metric that is actually written is `styleWritesDuringMotion`.

## Simplicity

Net reduction: two fields removed, nothing added. No `useEffect`/`useRef`/`useState` involved (plain object type + factory). No simplification opportunities beyond the deletion itself.

## Manual Testing Steps

This change is not observable in a browser — the removed fields were never read by any UI or logic. A reviewer can confirm it's inert by:

- [ ] Run `rg 'layoutReadsDuringMotion|saveRequestsDuringMotion' packages/` and confirm zero matches remain (both names are gone, so nothing referenced them).
- [ ] Run `bun run type-check` and confirm it passes (no dangling references).

## Test plan

- [x] `bun run type-check` — passes (no references to the removed fields).
- [x] `bun test --cwd packages/web src/interaction/` — interaction engine metrics tests pass (they use partial `toMatchObject` assertions, so dropping unused keys doesn't affect them).
- [x] `bun run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)