### PR TITLE
docs(web): correct the muted-text contrast comment surface

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -44,9 +44,12 @@
   --compass-color-tag-three: hsl(270 100 83);
   --compass-color-text-light: hsl(47 7 73);
   --compass-color-text-lighter: hsl(0 0 100);
-  /* 54.9% alpha measured 3.53:1 against --compass-color-bg-primary, below
-     the 4.5:1 minimum for normal text (e.g. past-week day labels). 70%
-     clears 5:1 while staying visibly muted relative to --color-text-light. */
+  /* At 54.9% alpha this measured 3.53:1 against --compass-color-bg-primary,
+     below the 4.5:1 minimum for normal text. 70% composites to ~5.0:1 there
+     (e.g. past-week day labels) and to ~4.9:1 against
+     --compass-color-bg-secondary - the real backdrop for the event form's
+     muted text, whose shell is transparent over the sidebar - so both
+     surfaces clear 4.5:1 while staying muted relative to --color-text-light. */
   --compass-color-text-light-inactive: hsl(208 13 71 / 70%);
   --compass-color-text-dark: hsl(222 28 7);
   --compass-color-text-dark-placeholder: hsl(219 8 46 / 90.2%);


### PR DESCRIPTION
## Summary

The comment on `--compass-color-text-light-inactive` in `index.css` only cited its contrast against `--compass-color-bg-primary` (~5.0:1, the past-week day labels). But the token's tighter real surface is the event form's muted text: the form shell is transparent, so it composites over the sidebar's `--compass-color-bg-secondary`, where it measures ~4.9:1 — still above the 4.5:1 AA minimum, but the binding case the old comment omitted. The comment now names both measured surfaces. The token value is unchanged.

## Simplicity

Comment-only change; no code, no hooks. No simplification opportunities found.

## Manual Testing Steps

Not browser-observable (a CSS comment). A reviewer can confirm the measured ratios themselves:

- [ ] Open the app, right-click nothing — just inspect. In DevTools console, composite the token color `hsl(208 13 71 / 70%)` over `--compass-color-bg-primary` `hsl(222 28 7)` and over `--compass-color-bg-secondary` `hsl(218 24 9)`, and confirm the WCAG contrast ratios are ~5.0:1 and ~4.9:1 respectively (both ≥ 4.5:1).

## Test plan

- [x] `bun run lint` — clean (biome checks CSS).
- [x] Contrast ratios measured live in the browser via computed styles: 5.02:1 over bg-primary, 4.93:1 over bg-secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)