### PR TITLE
fix(web): name the local calendar "Compass" to match the server

### DIFF
--- a/packages/web/src/calendars/local-calendar.sentinel.ts
+++ b/packages/web/src/calendars/local-calendar.sentinel.ts
@@ -31,7 +31,9 @@ export function getLocalCalendarSentinelId(): CalendarId {
 export function synthesizeLocalCalendar(id: CalendarId): Calendar {
   return {
     id,
-    name: "Local",
+    // Matches the server's ensureLocalCalendar name so the sidebar row doesn't
+    // rename itself from "Local" to "Compass" when an anonymous user signs up.
+    name: "Compass",
     description: "",
     timeZone: null,
     foregroundColor: "#000000",

--- a/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerCalendarList/PlannerCalendarList.test.tsx
@@ -150,14 +150,14 @@ describe("PlannerCalendarList", () => {
     // The anonymous synthesized local calendar is isPrimary, but must not be
     // relabeled "primary" - the header shows "Temporary account", not its name.
     const local = makeCalendar({
-      name: "Local",
+      name: "Compass",
       provider: "local",
       isPrimary: true,
     });
 
     renderCalendarList([local], { authenticated: false });
 
-    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByText("Compass")).toBeInTheDocument();
     expect(screen.queryByText("primary")).not.toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

The client synthesized the anonymous/offline calendar as "Local" (`synthesizeLocalCalendar`) while the backend `ensureLocalCalendar` names it "Compass". As a result the sidebar calendar row renamed itself from "Local" to "Compass" the moment an anonymous user signed up. Aligned the client on "Compass". `isPrimary` is intentionally left differing between the two sides: the client sentinel is `isPrimary: true` because in anonymous mode it's the only calendar, while the server keeps it `false` so a connected Google primary keeps that role (and `getDefaultTargetCalendar` falls back to it).

## Simplicity

One string change plus a comment; no code paths added, no hooks. No simplification opportunities found.

## Manual Testing Steps

- [ ] Open the app in a fresh/anonymous session (not signed in). In the left sidebar under "Temporary account", confirm the single calendar row reads **"Compass"** (previously "Local").
- [ ] Confirm the row is not relabeled "primary" and shows no visibility toggle button (anonymous sessions hide it).

## Test plan

- [x] `bun test --cwd packages/web src/components/PlannerSidebar/PlannerCalendarList src/common/utils/sync src/calendars` — 40 tests pass (updated the anonymous-sentinel fixture/assertion from "Local" to "Compass").
- [x] `bun run type-check` — passes.
- [x] `bun run lint` — clean.
- [x] Verified live in the browser: anonymous sidebar shows "Compass"; the string "Local" no longer appears in the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)