### PR TITLE
fix(web): make the grid context menu keyboard-operable

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -510,7 +510,7 @@ test("a read-only event opens as a read-only form", async ({ page }) => {
   // close-out; keyboard ("M") and this View path are the deterministic
   // inspection routes today.
   await card.click({ button: "right" });
-  await page.getByRole("menu").getByRole("button", { name: "View" }).click();
+  await page.getByRole("menu").getByRole("menuitem", { name: "View" }).click();
 
   const form = page.getByRole("form");
   const titleInput = form.getByPlaceholder("Title");
@@ -535,7 +535,7 @@ test("a read-only event's context menu offers view and duplicate but not delete"
   await card.click({ button: "right" });
 
   const menu = page.getByRole("menu");
-  await expect(menu.getByRole("button", { name: "View" })).toBeVisible();
-  await expect(menu.getByRole("button", { name: "Duplicate" })).toBeVisible();
-  await expect(menu.getByRole("button", { name: "Delete" })).toHaveCount(0);
+  await expect(menu.getByRole("menuitem", { name: "View" })).toBeVisible();
+  await expect(menu.getByRole("menuitem", { name: "Duplicate" })).toBeVisible();
+  await expect(menu.getByRole("menuitem", { name: "Delete" })).toHaveCount(0);
 });

--- a/packages/web/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenu.tsx
@@ -1,11 +1,11 @@
 import {
   type FloatingContext,
-  useClick,
   useDismiss,
   useInteractions,
+  useListNavigation,
   useRole,
 } from "@floating-ui/react";
-import React from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { darken } from "@web/common/styles/color.utils";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import { EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
@@ -14,6 +14,7 @@ import {
   ContextMenuItems,
   type ContextMenuItemsActions,
   ContextMenuItemsView,
+  ContextMenuNavContext,
 } from "./ContextMenuItems";
 
 interface ContextMenuProps {
@@ -27,6 +28,63 @@ interface ContextMenuProps {
 
 export const ContextMenu = React.forwardRef<HTMLUListElement, ContextMenuProps>(
   ({ actions, event, onOutsideClick, close, style, context }, ref) => {
+    // Seed the active index to the first item so it carries tabIndex={0} and
+    // arrow-key navigation has a starting point.
+    const [activeIndex, setActiveIndex] = useState<number | null>(0);
+    const listRef = useRef<Array<HTMLElement | null>>([]);
+    const menuRef = useRef<HTMLUListElement | null>(null);
+    const setMenuRef = useCallback(
+      (node: HTMLUListElement | null) => {
+        menuRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref],
+    );
+
+    // The menu opens from a raw contextmenu handler rather than a floating-ui
+    // interaction, so FloatingFocusManager never seats focus for us. Do it
+    // ourselves: pull focus into the first item once the menu is open, and hand
+    // focus back to the opener (the event card, for a Shift+F10 keyboard open)
+    // when it closes.
+    const openerRef = useRef<HTMLElement | null>(
+      typeof document === "undefined"
+        ? null
+        : (document.activeElement as HTMLElement | null),
+    );
+    // Depend on the boolean, not `event`: `event` is a fresh object every
+    // render, so a `[event]` effect would re-run and its cleanup would cancel
+    // the pending timeout before it ever fired. `hasEvent` only flips when the
+    // menu opens or closes.
+    const hasEvent = !!event;
+    useEffect(() => {
+      if (!hasEvent) return;
+      // Seat focus on the first item, deferred and retried for a short window.
+      // A synchronous focus is a no-op (the portalled menu isn't laid out during
+      // the commit), and opening writes the grid draft, whose re-render reclaims
+      // focus to the source card once, shortly after. So we can't stop at the
+      // first success: keep re-seating focus whenever it has fallen back out of
+      // the menu, until the draft settles. setTimeout (not rAF) keeps firing in
+      // a background tab. The in-menu guard leaves arrow-key focus alone.
+      let attemptsLeft = 12;
+      let id: ReturnType<typeof setTimeout>;
+      const tryFocus = () => {
+        const menu = menuRef.current;
+        if (menu && !menu.contains(document.activeElement)) {
+          menu.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+        }
+        if (attemptsLeft-- > 0) id = setTimeout(tryFocus, 16);
+      };
+      id = setTimeout(tryFocus, 0);
+      return () => clearTimeout(id);
+    }, [hasEvent]);
+    useEffect(() => {
+      return () => {
+        const opener = openerRef.current;
+        if (opener && document.contains(opener)) opener.focus();
+      };
+    }, []);
+
     const dismiss = useDismiss(context, {
       outsidePress: (event) => {
         event.preventDefault(); // Prevents clicking another UI element when dismissing
@@ -35,11 +93,20 @@ export const ContextMenu = React.forwardRef<HTMLUListElement, ContextMenuProps>(
       },
     });
 
-    const click = useClick(context, { enabled: true });
-
     const role = useRole(context, { role: "menu" });
 
-    const { getFloatingProps } = useInteractions([dismiss, click, role]);
+    const listNavigation = useListNavigation(context, {
+      listRef,
+      activeIndex,
+      onNavigate: setActiveIndex,
+      loop: true,
+    });
+
+    const { getFloatingProps, getItemProps } = useInteractions([
+      dismiss,
+      role,
+      listNavigation,
+    ]);
 
     if (!event) return null;
 
@@ -48,7 +115,7 @@ export const ContextMenu = React.forwardRef<HTMLUListElement, ContextMenuProps>(
     return (
       <ul
         className="c-context-menu"
-        ref={ref}
+        ref={setMenuRef}
         style={
           {
             ...style,
@@ -58,11 +125,19 @@ export const ContextMenu = React.forwardRef<HTMLUListElement, ContextMenuProps>(
         }
         {...getFloatingProps()}
       >
-        {actions ? (
-          <ContextMenuItemsView actions={actions} close={close} event={event} />
-        ) : (
-          <ContextMenuItems event={event} close={close} />
-        )}
+        <ContextMenuNavContext.Provider
+          value={{ getItemProps, listRef, activeIndex }}
+        >
+          {actions ? (
+            <ContextMenuItemsView
+              actions={actions}
+              close={close}
+              event={event}
+            />
+          ) : (
+            <ContextMenuItems event={event} close={close} />
+          )}
+        </ContextMenuNavContext.Provider>
       </ul>
     );
   },

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
@@ -124,7 +124,7 @@ describe("ContextMenuItems", () => {
 
     renderWithTheme(<ContextMenuItems event={event} close={mockClose} />);
 
-    const editButton = screen.getByRole("button", { name: "Edit" });
+    const editButton = screen.getByRole("menuitem", { name: "Edit" });
     await user.click(editButton);
 
     expect(mockSetDraft).toHaveBeenCalled();
@@ -143,7 +143,7 @@ describe("ContextMenuItems", () => {
       pendingEventIds: ["pending-event-1"],
     });
 
-    const deleteButton = screen.getByRole("button", { name: "Delete" });
+    const deleteButton = screen.getByRole("menuitem", { name: "Delete" });
     expect(deleteButton).not.toBeDisabled();
     await user.click(deleteButton);
 
@@ -163,7 +163,7 @@ describe("ContextMenuItems", () => {
       pendingEventIds: ["pending-event-1"],
     });
 
-    const editButton = screen.getByRole("button", { name: "Edit" });
+    const editButton = screen.getByRole("menuitem", { name: "Edit" });
     await user.click(editButton);
 
     expect(mockSetDraft).toHaveBeenCalled();
@@ -182,7 +182,7 @@ describe("ContextMenuItems", () => {
       pendingEventIds: ["pending-event-1"],
     });
 
-    const duplicateButton = screen.getByRole("button", { name: "Duplicate" });
+    const duplicateButton = screen.getByRole("menuitem", { name: "Duplicate" });
     await user.click(duplicateButton);
 
     expect(mockDuplicateEvent).toHaveBeenCalled();
@@ -199,7 +199,7 @@ describe("ContextMenuItems", () => {
       pendingEventIds: ["pending-event-1"],
     });
 
-    const deleteButton = screen.getByRole("button", { name: "Delete" });
+    const deleteButton = screen.getByRole("menuitem", { name: "Delete" });
     expect(deleteButton).not.toBeDisabled();
     expect(deleteButton).not.toHaveStyle({ cursor: "wait" });
   });
@@ -243,15 +243,15 @@ describe("ContextMenuItems read-only gate", () => {
       calendars: [readOnlyCalendar],
     });
 
-    expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "View" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Edit" }),
+      screen.queryByRole("menuitem", { name: "Edit" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Duplicate" }),
+      screen.getByRole("menuitem", { name: "Duplicate" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Delete" }),
+      screen.queryByRole("menuitem", { name: "Delete" }),
     ).not.toBeInTheDocument();
   });
 
@@ -271,9 +271,9 @@ describe("ContextMenuItems read-only gate", () => {
       calendars: [writableCalendar],
     });
 
-    expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "View" })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Delete" }),
+      screen.queryByRole("menuitem", { name: "Delete" }),
     ).not.toBeInTheDocument();
   });
 
@@ -292,7 +292,9 @@ describe("ContextMenuItems read-only gate", () => {
       calendars: [writableCalendar],
     });
 
-    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Edit" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete" }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -1,5 +1,6 @@
 import { Copy, PenNib, Trash } from "@phosphor-icons/react";
 import type React from "react";
+import { createContext, useContext } from "react";
 import {
   isEventReadOnly,
   useCalendarLookup,
@@ -15,6 +16,21 @@ export interface ContextMenuAction {
   onClick: () => void;
   icon: React.ReactNode;
 }
+
+// Supplied by ContextMenu so each item can wire into floating-ui's roving-focus
+// list navigation (arrow keys) and register its node in the shared listRef. The
+// menu still renders standalone (e.g. in tests) without a provider, in which
+// case items fall back to plain roving-free buttons.
+interface ContextMenuNavContextValue {
+  getItemProps: (
+    userProps?: React.HTMLProps<HTMLElement>,
+  ) => Record<string, unknown>;
+  listRef: React.MutableRefObject<Array<HTMLElement | null>>;
+  activeIndex: number | null;
+}
+
+export const ContextMenuNavContext =
+  createContext<ContextMenuNavContextValue | null>(null);
 
 export interface ContextMenuItemsActions {
   delete: () => void;
@@ -72,22 +88,37 @@ export function ContextMenuItemsView({
         ]),
   ];
 
+  const nav = useContext(ContextMenuNavContext);
+
   return (
-    <div id={ID_CONTEXT_MENU_ITEMS}>
-      {menuActions.map((item) => (
-        <button
-          className="c-context-menu-item"
-          key={item.id}
-          type="button"
-          onClick={() => {
-            item.onClick();
-            close();
-          }}
-        >
-          {item.icon}
-          <span className="text-l">{item.label}</span>
-        </button>
-      ))}
+    // role="none" keeps the menu -> menuitem ownership valid across this
+    // container (the id is also how isContextMenuOpen() detects the menu).
+    <div id={ID_CONTEXT_MENU_ITEMS} role="none">
+      {menuActions.map((item, index) => {
+        const select = () => {
+          item.onClick();
+          close();
+        };
+        const itemProps = nav
+          ? nav.getItemProps({ onClick: select })
+          : { onClick: select };
+        return (
+          <button
+            className="c-context-menu-item"
+            key={item.id}
+            type="button"
+            role="menuitem"
+            ref={(node) => {
+              if (nav) nav.listRef.current[index] = node;
+            }}
+            tabIndex={nav ? (nav.activeIndex === index ? 0 : -1) : undefined}
+            {...itemProps}
+          >
+            {item.icon}
+            <span className="text-l">{item.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/components/ContextMenu/ContextMenuKeyboard.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuKeyboard.test.tsx
@@ -1,11 +1,11 @@
 import { useFloating } from "@floating-ui/react";
 import { useEffect } from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
   screen,
-  waitFor,
 } from "@web/__tests__/__mocks__/mock.render";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
@@ -70,17 +70,23 @@ const OpenMenuHarness = ({
 
 const getMenu = () => screen.getByRole("menu");
 
+// The menu seats focus on a deferred + retried timeout (the portalled menu
+// isn't focusable during the synchronous commit). Flush that whole retry window
+// deterministically rather than polling with waitFor, which races the timer
+// chain and runs slow enough to time out on CI.
+const flushFocusSeat = () =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+
 describe("ContextMenu keyboard operability", () => {
   afterEach(cleanup);
 
   it("moves focus into the menu (first item) when it opens", async () => {
     render(<OpenMenuHarness />);
+    await flushFocusSeat();
 
-    // Focus is seated on a deferred timeout (the portalled menu isn't focusable
-    // during the synchronous commit), so wait for it to land.
-    await waitFor(() =>
-      expect(screen.getByRole("menuitem", { name: "Edit" })).toHaveFocus(),
-    );
+    expect(screen.getByRole("menuitem", { name: "Edit" })).toHaveFocus();
   });
 
   it("returns focus to the opener when the menu closes", async () => {
@@ -90,12 +96,11 @@ describe("ContextMenu keyboard operability", () => {
     opener.focus();
 
     const { rerender } = render(<OpenMenuHarness open />);
-    await waitFor(() =>
-      expect(screen.getByRole("menuitem", { name: "Edit" })).toHaveFocus(),
-    );
+    await flushFocusSeat();
+    expect(screen.getByRole("menuitem", { name: "Edit" })).toHaveFocus();
 
     rerender(<OpenMenuHarness open={false} />);
-    await waitFor(() => expect(opener).toHaveFocus());
+    expect(opener).toHaveFocus();
 
     opener.remove();
   });

--- a/packages/web/src/components/ContextMenu/ContextMenuKeyboard.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuKeyboard.test.tsx
@@ -1,0 +1,123 @@
+import { useFloating } from "@floating-ui/react";
+import { useEffect } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@web/__tests__/__mocks__/mock.render";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { ContextMenu } from "@web/components/ContextMenu/ContextMenu";
+import { type ContextMenuItemsActions } from "@web/components/ContextMenu/ContextMenuItems";
+import {
+  CONTEXT_MENU_FLOATING_OPTIONS,
+  contextMenuStyle,
+  cursorReference,
+} from "@web/components/ContextMenu/contextMenu.floating";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+
+const gridEvent = {
+  _id: "evt-1",
+  title: "Standup",
+  position: gridEventDefaultPosition,
+} as unknown as GridEvent;
+
+const actions: ContextMenuItemsActions = {
+  delete: mock(),
+  duplicate: mock(),
+  edit: mock(),
+};
+
+// Mirrors how the day/week wrappers mount the menu: a virtual cursor reference
+// and an externally-controlled `open`, which is exactly the flow where
+// floating-ui's own initialFocus is skipped.
+const OpenMenuHarness = ({
+  onClose = () => {},
+  open = true,
+}: {
+  onClose?: () => void;
+  open?: boolean;
+}) => {
+  const { context, refs, floatingStyles } = useFloating({
+    ...CONTEXT_MENU_FLOATING_OPTIONS,
+    open,
+    onOpenChange: (next) => {
+      if (!next) onClose();
+    },
+  });
+
+  useEffect(() => {
+    refs.setReference(cursorReference(10, 10));
+  }, [refs]);
+
+  if (!open) return null;
+
+  return (
+    <ContextMenu
+      actions={actions}
+      close={onClose}
+      context={context}
+      event={gridEvent}
+      onOutsideClick={onClose}
+      ref={refs.setFloating}
+      style={contextMenuStyle(floatingStyles)}
+    />
+  );
+};
+
+const getMenu = () => screen.getByRole("menu");
+
+describe("ContextMenu keyboard operability", () => {
+  afterEach(cleanup);
+
+  it("moves focus into the menu (first item) when it opens", async () => {
+    render(<OpenMenuHarness />);
+
+    // Focus is seated on a deferred timeout (the portalled menu isn't focusable
+    // during the synchronous commit), so wait for it to land.
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "Edit" })).toHaveFocus(),
+    );
+  });
+
+  it("returns focus to the opener when the menu closes", async () => {
+    const opener = document.createElement("button");
+    opener.textContent = "opener";
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { rerender } = render(<OpenMenuHarness open />);
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "Edit" })).toHaveFocus(),
+    );
+
+    rerender(<OpenMenuHarness open={false} />);
+    await waitFor(() => expect(opener).toHaveFocus());
+
+    opener.remove();
+  });
+
+  it("navigates between items with the arrow keys", () => {
+    render(<OpenMenuHarness />);
+
+    const menu = getMenu();
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(screen.getByRole("menuitem", { name: "Duplicate" })).toHaveFocus();
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toHaveFocus();
+
+    fireEvent.keyDown(menu, { key: "ArrowUp" });
+    expect(screen.getByRole("menuitem", { name: "Duplicate" })).toHaveFocus();
+  });
+
+  it("exposes the menu with valid menu -> menuitem semantics", () => {
+    render(<OpenMenuHarness />);
+
+    expect(getMenu()).toBeInTheDocument();
+    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

The event-card right-click / Shift+F10 context menu (shared by week + day views) opened but left focus on the event card, and its items — portalled to the end of `<body>` — were a full page of tabbing away with no arrow-key support. Screen readers also entered an empty menu: the items were plain `<button>`s behind a generic `<div>`, breaking `menu`→`menuitem` ownership.

This PR:
- Adds `role="menuitem"` to the items and `role="none"` to their container so the menu exposes valid `menu`/`menuitem` semantics (the container keeps its id, still used by `isContextMenuOpen()`).
- Adds `useListNavigation` + roving `tabindex` for arrow-key movement between items.
- Seats focus on the first item when the menu opens and returns it to the opener (the card) on close.
- Drops a dead `useClick(context)` call (`useClick` only returns *reference* props, which this component never spreads).

**Why the focus handling looks the way it does** (this was the trap): `FloatingFocusManager` cannot seat focus here — the menu opens from a raw `contextmenu` handler via `setIsOpen`, not a floating-ui interaction, so floating-ui records no open event and FFM's `initialFocus` never fires. The real focus-stealer is the grid **draft re-render** (opening writes `draftActions.startGridDraft`), which reclaims focus to the source card once, shortly after open. A synchronous focus (mount effect / callback ref) is also a no-op because the portalled menu isn't laid out during the commit. So focus is seated via a `setTimeout`-deferred effect that briefly **retries** (re-seating only while focus has fallen back out of the menu) until the draft settles. It must be `setTimeout`, not `requestAnimationFrame`.

## Simplicity

Net increase, justified — keyboard operability requires focus state. Hooks in the diff:
- `useState(activeIndex)` — roving-tabindex position for `useListNavigation` (seeded to 0 so the first item is tabbable).
- `useRef(listRef)` — the item-node list `useListNavigation` needs; `useRef(menuRef)` — to query a live first item from the deferred callback; `useRef(openerRef)` — the element to return focus to on close.
- `useCallback(setMenuRef)` — composes the forwarded ref with the local `menuRef`.
- `useEffect([hasEvent])` — seats focus on open (deferred + retried); `useEffect([])` — returns focus to the opener on unmount. Depends on `!!event`, not `event` (fresh object each render), so the cleanup doesn't cancel the pending timer every render.

Verified/rejected alternatives: `FloatingFocusManager` (doesn't seat focus for an externally-opened menu — removed), synchronous callback-ref focus (no-op during commit), `requestAnimationFrame` (doesn't fire in a background tab).

## Manual Testing Steps

- [ ] Open the app, go to Day view. Click an event to focus it, then press Shift+F10 (or right-click it) to open the context menu. Confirm focus moves into the menu — the first item ("Edit") is focused — rather than staying on the card.
- [ ] With the menu open, press Down/Up arrows and confirm focus moves between Edit → Duplicate → Delete and wraps around.
- [ ] Press Escape and confirm the menu closes and focus returns to the event card you opened it from.
- [ ] Repeat the open on Week view (same shared component) and confirm the same behavior.
- [ ] Right-click a read-only event (e.g. a busy event) and confirm the menu still opens with its reduced item set (View, Duplicate) and focus lands on the first item.

## Test plan

- [x] `bun test --cwd packages/web src/components/ContextMenu/` — 15 pass, incl. new `ContextMenuKeyboard.test.tsx` covering focus-on-open (async, `waitFor`), return-focus-to-opener on close, arrow-key navigation, and valid `menu`/`menuitem` semantics.
- [x] `bun run type-check` — passes.
- [x] `bun run lint` — clean.
- [x] Verified live in the browser (Day view): focus lands on and *stays* at the first menu item after open (read via `document.activeElement`). Note: the preview browser tab runs `hidden`, so arrow-key delivery and focus-visible rendering couldn't be confirmed there — those are covered by the jsdom `fireEvent` tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)