### PR TITLE
feat(web): improve calendar navigation cues

### DIFF
--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -6,7 +6,7 @@ import {
 } from "@core/types/auth.types";
 import { session } from "@web/auth/compass/session/Session";
 import { ENV_WEB } from "@web/common/constants/env.constants";
-import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
 import {
   assignLocation,
   reloadLocation,
@@ -85,10 +85,10 @@ export const signOut = async (status: SignoutStatus) => {
 
   await session.signOut();
 
-  if (window.location.pathname.startsWith(ROOT_ROUTES.DAY)) {
+  if (window.location.pathname.startsWith(DEFAULT_CALENDAR_ROUTE)) {
     return;
   }
-  assignLocation(ROOT_ROUTES.DAY);
+  assignLocation(DEFAULT_CALENDAR_ROUTE);
 };
 
 export const getRequestUrl = (url: string): string => {

--- a/packages/web/src/auth/google/authorization/complete-google-authorization.ts
+++ b/packages/web/src/auth/google/authorization/complete-google-authorization.ts
@@ -4,7 +4,7 @@ import {
   GoogleConnectErrorResponseSchema,
 } from "@core/types/auth.types";
 import { type ApiError, type ApiMethodConfig } from "@web/api/api.types";
-import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
 import {
   GOOGLE_AUTH_SCOPES_REQUIRED,
   GOOGLE_AUTHORIZATION_ERROR_MESSAGE,
@@ -58,7 +58,7 @@ export type CompleteGoogleAuthorizationResult =
 
 const fail = (
   message = GOOGLE_AUTHORIZATION_ERROR_MESSAGE,
-  returnPath: string = ROOT_ROUTES.DAY,
+  returnPath: string = DEFAULT_CALENDAR_ROUTE,
 ): CompleteGoogleAuthorizationResult => ({
   message,
   returnPath,
@@ -101,7 +101,7 @@ export async function completeGoogleAuthorization({
 
   const savedIntent = readGoogleAuthorizationIntent(state);
   clearGoogleAuthorizationIntent(state);
-  const returnPath = savedIntent?.returnPath ?? ROOT_ROUTES.DAY;
+  const returnPath = savedIntent?.returnPath ?? DEFAULT_CALENDAR_ROUTE;
 
   if (!savedIntent || params.get("error")) {
     return fail(GOOGLE_AUTHORIZATION_ERROR_MESSAGE, returnPath);

--- a/packages/web/src/auth/google/authorization/google-authorization.test.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.test.ts
@@ -197,7 +197,7 @@ describe("completeGoogleAuthorization", () => {
     ).resolves.toEqual({
       status: "failed",
       message: "We couldn't connect your Google account. Please try again.",
-      returnPath: "/day",
+      returnPath: "/week",
     });
 
     expect(deps.authApi.loginOrSignup).not.toHaveBeenCalled();

--- a/packages/web/src/auth/google/authorization/google-authorization.util.test.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.util.test.ts
@@ -30,13 +30,13 @@ describe("google-authorization.util", () => {
     ).toBe("/week/2026-07-08?x=1");
   });
 
-  it("falls back to /day for external return paths", () => {
+  it("falls back to /week for external return paths", () => {
     expect(
       getSafeGoogleAuthReturnPath(
         "https://evil.example/phish",
         "http://localhost:9080",
       ),
-    ).toBe("/day");
+    ).toBe("/week");
   });
 
   it("builds the existing auth-code payload shape", () => {

--- a/packages/web/src/auth/google/authorization/google-authorization.util.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.util.ts
@@ -1,4 +1,5 @@
 import { type GoogleAuthCodeRequest } from "@core/types/auth.types";
+import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
 import { GOOGLE_AUTH_CALLBACK_PATH } from "./google-authorization.constants";
 
 export function buildGoogleAuthCallbackUrl(origin = window.location.origin) {
@@ -13,11 +14,11 @@ export function getSafeGoogleAuthReturnPath(
     const url = new URL(href, origin);
 
     if (url.origin !== origin) {
-      return "/day";
+      return DEFAULT_CALENDAR_ROUTE;
     }
 
     if (url.pathname === GOOGLE_AUTH_CALLBACK_PATH) {
-      return "/day";
+      return DEFAULT_CALENDAR_ROUTE;
     }
 
     // Drop the transient auth-modal params so the OAuth round-trip doesn't
@@ -28,7 +29,7 @@ export function getSafeGoogleAuthReturnPath(
 
     return `${url.pathname}${url.search}${url.hash}`;
   } catch {
-    return "/day";
+    return DEFAULT_CALENDAR_ROUTE;
   }
 }
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -1,43 +1,23 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback } from "react";
 import { SyncApi } from "@web/api/sync.api";
 import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
-import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
 import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import {
   clearGoogleSyncIndicatorOverride,
-  getGoogleSyncIndicatorOverride,
   setRepairingSyncIndicatorOverride,
-  subscribeToGoogleSyncUIState,
 } from "@web/auth/google/state/google.sync.state";
 import { syncPendingLocalEvents } from "@web/auth/google/util/google.auth.util";
-import {
-  selectGoogleConnectionState,
-  selectUserMetadataStatus,
-  useUserMetadataStore,
-} from "@web/auth/state/user-metadata.store";
 import { GOOGLE_REPAIR_FAILED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { settingsActions } from "@web/settings/settings.store";
 import { useIsGoogleAvailable } from "../useIsGoogleAvailable/useIsGoogleAvailable";
-import {
-  type GoogleUiState,
-  type UseConnectGoogleResult,
-} from "./useConnectGoogle.types";
+import { type UseConnectGoogleResult } from "./useConnectGoogle.types";
 import { getGoogleConnectionConfig } from "./useConnectGoogle.util";
-
-// Merges store-derived Google connection state with transient UI overrides from
-// google.sync.ui.state.ts; the override is read via useSyncExternalStore so React
-// stays aligned with that external store (see comments there).
+import { useGoogleUiState } from "./useGoogleUiState";
 
 export const useConnectGoogle = (): UseConnectGoogleResult => {
   const isAvailable = useIsGoogleAvailable();
-  const connectionState = useUserMetadataStore(selectGoogleConnectionState);
-  const userMetadataStatus = useUserMetadataStore(selectUserMetadataStatus);
-  const syncIndicator = useSyncExternalStore(
-    subscribeToGoogleSyncUIState,
-    getGoogleSyncIndicatorOverride,
-    getGoogleSyncIndicatorOverride,
-  );
+  const state = useGoogleUiState();
   const { startGoogleAuthorization } = useStartGoogleAuthorization({
     intent: "connectCalendar",
     prompt: "consent",
@@ -87,21 +67,6 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
 
     void startRepair();
   }, []);
-
-  // "checking" is a UI-only state until we have loaded metadata from the server.
-  // Covers both "idle" and "loading" so returning users do not briefly see
-  // NOT_CONNECTED from the selector default.
-  const isCheckingStatus =
-    hasUserEverAuthenticated() && userMetadataStatus !== "loaded";
-
-  const state: GoogleUiState =
-    syncIndicator === "repairing"
-      ? "repairing"
-      : syncIndicator === "syncing"
-        ? "IMPORTING"
-        : isCheckingStatus
-          ? "checking"
-          : connectionState;
 
   return {
     ...getGoogleConnectionConfig(state, onOpenGoogleAuth, onRepairGoogle),

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.test.ts
@@ -1,0 +1,52 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import {
+  resetGoogleSyncUIStateForTests,
+  setRepairingSyncIndicatorOverride,
+  setSyncingSyncIndicatorOverride,
+} from "@web/auth/google/state/google.sync.state";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { resolveGoogleUiState, useGoogleUiState } from "./useGoogleUiState";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+beforeEach(() => {
+  resetGoogleSyncUIStateForTests();
+  userMetadataActions.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  resetGoogleSyncUIStateForTests();
+  userMetadataActions.clear();
+});
+
+describe("useGoogleUiState", () => {
+  it("reflects the loaded Google connection state", () => {
+    userMetadataActions.set({ google: { connectionState: "HEALTHY" } });
+
+    const { result } = renderHook(() => useGoogleUiState());
+
+    expect(result.current).toBe("HEALTHY");
+  });
+
+  it("prioritizes transient syncing and repair states", () => {
+    userMetadataActions.set({ google: { connectionState: "HEALTHY" } });
+    const { result } = renderHook(() => useGoogleUiState());
+
+    act(() => setSyncingSyncIndicatorOverride());
+    expect(result.current).toBe("IMPORTING");
+
+    act(() => setRepairingSyncIndicatorOverride());
+    expect(result.current).toBe("repairing");
+  });
+
+  it("reports checking while a returning user's metadata loads", () => {
+    expect(
+      resolveGoogleUiState({
+        connectionState: "NOT_CONNECTED",
+        hasAuthenticated: true,
+        syncIndicator: null,
+        userMetadataStatus: "loading",
+      }),
+    ).toBe("checking");
+  });
+});

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
@@ -1,0 +1,58 @@
+import { useSyncExternalStore } from "react";
+import { type GoogleConnectionState } from "@core/types/user.types";
+import { hasUserEverAuthenticated } from "@web/auth/compass/state/auth.state.util";
+import {
+  getGoogleSyncIndicatorOverride,
+  subscribeToGoogleSyncUIState,
+} from "@web/auth/google/state/google.sync.state";
+import {
+  selectGoogleConnectionState,
+  selectUserMetadataStatus,
+  type UserMetadataStatus,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+import { type GoogleUiState } from "./useConnectGoogle.types";
+
+type SyncIndicator = ReturnType<typeof getGoogleSyncIndicatorOverride>;
+
+export function resolveGoogleUiState({
+  connectionState,
+  hasAuthenticated,
+  syncIndicator,
+  userMetadataStatus,
+}: {
+  connectionState: GoogleConnectionState;
+  hasAuthenticated: boolean;
+  syncIndicator: SyncIndicator;
+  userMetadataStatus: UserMetadataStatus;
+}): GoogleUiState {
+  if (syncIndicator === "repairing") return "repairing";
+  if (syncIndicator === "syncing") return "IMPORTING";
+
+  if (hasAuthenticated && userMetadataStatus !== "loaded") {
+    return "checking";
+  }
+
+  return connectionState;
+}
+
+// Merges server metadata with transient repair/import overrides. The external
+// store subscription keeps every sync indicator aligned as SSE updates arrive.
+export function useGoogleUiState(): GoogleUiState {
+  const connectionState = useUserMetadataStore(selectGoogleConnectionState);
+  const userMetadataStatus = useUserMetadataStore(selectUserMetadataStatus);
+  const syncIndicator = useSyncExternalStore(
+    subscribeToGoogleSyncUIState,
+    getGoogleSyncIndicatorOverride,
+    getGoogleSyncIndicatorOverride,
+  );
+
+  // Returning users should not briefly look disconnected while their server
+  // metadata is still loading.
+  return resolveGoogleUiState({
+    connectionState,
+    hasAuthenticated: hasUserEverAuthenticated(),
+    syncIndicator,
+    userMetadataStatus,
+  });
+}

--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -10,6 +10,8 @@ export const ROOT_ROUTES = {
   DAY_DATE: "/day/$dateString",
 } as const;
 
+export const DEFAULT_CALENDAR_ROUTE = ROOT_ROUTES.WEEK;
+
 // TanStack route *ids* (used for useMatch/useParams `from`), which diverge
 // from the URL-shaped ROOT_ROUTES above under the pathless "authenticated"
 // layout route. Kept as literals rather than importing the route objects

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions.test.tsx
@@ -1,6 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
-import { afterAll, describe, expect, it, mock } from "bun:test";
+import {
+  resetGoogleSyncUIStateForTests,
+  setSyncingSyncIndicatorOverride,
+} from "@web/auth/google/state/google.sync.state";
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 
 // mock.module is process-wide and not reliably restorable, so the real hook
 // is captured up front and a flag (flipped off in afterAll) decides which
@@ -28,10 +32,33 @@ afterAll(() => {
   isVersionCheckMocked = false;
 });
 
+afterEach(() => {
+  act(() => resetGoogleSyncUIStateForTests());
+});
+
 const { PlannerSidebarActions } =
   require("@web/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions") as typeof import("@web/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions");
 
 describe("PlannerSidebarActions", () => {
+  it("shimmers the command palette icon while Google Calendar is syncing", () => {
+    const { wrapper } = createStoreWrapper();
+    setSyncingSyncIndicatorOverride();
+
+    render(
+      <PlannerSidebarActions
+        isShortcutsOpen={false}
+        onToggleShortcuts={mock()}
+      />,
+      { wrapper },
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Open command palette, calendar syncing",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("does not render the background import spinner in the sidebar", () => {
     const { wrapper } = createStoreWrapper();
 
@@ -48,6 +75,9 @@ describe("PlannerSidebarActions", () => {
         name: "Syncing Google Calendar in the background.",
       }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open command palette" }),
+    ).toBeInTheDocument();
   });
 
   it("labels the shortcuts button as a close action when shortcuts are open", () => {

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions.tsx
@@ -3,6 +3,8 @@ import {
   CommandIcon,
   KeyboardIcon,
 } from "@phosphor-icons/react";
+import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
 import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { useVersionCheck } from "@web/components/PlannerSidebar/PlannerSidebarActions/useVersionCheck";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
@@ -23,6 +25,9 @@ export const PlannerSidebarActions = ({
 }: Props) => {
   const isCmdPaletteOpen = useSettingsStore(selectIsCmdPaletteOpen);
   const { isUpdateAvailable } = useVersionCheck();
+  const googleState = useGoogleUiState();
+  const isCalendarSyncing =
+    getGoogleSyncStatus(googleState)?.variant === "syncing";
 
   const handleUpdateReload = () => {
     reloadLocation();
@@ -69,15 +74,29 @@ export const PlannerSidebarActions = ({
           onClick={toggleCmdPalette}
         >
           <button
-            aria-label="Open command palette"
+            aria-label={
+              isCalendarSyncing
+                ? "Open command palette, calendar syncing"
+                : "Open command palette"
+            }
             className="flex size-9 items-center justify-center rounded-default text-text-light-inactive transition hover:bg-panel-bg hover:text-text-lighter focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
             type="button"
           >
-            <CommandIcon
-              aria-hidden="true"
-              size={16}
-              weight={isCmdPaletteOpen ? "fill" : "regular"}
-            />
+            <span className="relative flex size-4 items-center justify-center">
+              <CommandIcon
+                aria-hidden="true"
+                size={16}
+                weight={isCmdPaletteOpen ? "fill" : "regular"}
+              />
+              {isCalendarSyncing ? (
+                <CommandIcon
+                  aria-hidden="true"
+                  className="c-sync-icon-wave absolute inset-0 text-text-lighter"
+                  size={16}
+                  weight={isCmdPaletteOpen ? "fill" : "regular"}
+                />
+              ) : null}
+            </span>
           </button>
         </TooltipWrapper>
 

--- a/packages/web/src/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerSidebarActions/PlannerSidebarActions.tsx
@@ -3,7 +3,6 @@ import {
   CommandIcon,
   KeyboardIcon,
 } from "@phosphor-icons/react";
-import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
 import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { useVersionCheck } from "@web/components/PlannerSidebar/PlannerSidebarActions/useVersionCheck";
@@ -27,7 +26,7 @@ export const PlannerSidebarActions = ({
   const { isUpdateAvailable } = useVersionCheck();
   const googleState = useGoogleUiState();
   const isCalendarSyncing =
-    getGoogleSyncStatus(googleState)?.variant === "syncing";
+    googleState === "IMPORTING" || googleState === "repairing";
 
   const handleUpdateReload = () => {
     reloadLocation();

--- a/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.test.tsx
+++ b/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import { EventIdSchema } from "@core/types/domain-primitives";
 import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
@@ -11,6 +12,7 @@ import {
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { formatStartsIn, UpNextCard } from "./UpNextCard";
+import { useUpNextEventShortcut } from "./useUpNextEvent";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
 
@@ -79,6 +81,7 @@ describe("UpNextCard", () => {
     expect(screen.getByText("Soon Event")).toBeInTheDocument();
     expect(screen.getByText("Starts in 30 minutes")).toBeInTheDocument();
     expect(screen.queryByText("Later Event")).toBeNull();
+    expect(screen.getByText("N")).toBeInTheDocument();
   });
 
   it("renders nothing when today has no upcoming timed events", () => {
@@ -119,5 +122,44 @@ describe("UpNextCard", () => {
         EventIdSchema.parse(SOON_EVENT_ID),
       );
     });
+  });
+});
+
+describe("useUpNextEventShortcut", () => {
+  it("opens the next event form with n", async () => {
+    const user = userEvent.setup();
+    const ShortcutHarness = () => {
+      useUpNextEventShortcut();
+      return null;
+    };
+
+    render(<ShortcutHarness />, {
+      events: [timedEvent(SOON_EVENT_ID, "Soon Event", 30)],
+    });
+
+    await user.keyboard("n");
+
+    await waitFor(() => {
+      const state = useDraftStore.getState();
+      expect(state.status?.isFormOpen).toBe(true);
+      expect(state.status?.activity).toBe("keyboardEdit");
+      expect(state.gridDraft?.source?.id).toBe(
+        EventIdSchema.parse(SOON_EVENT_ID),
+      );
+    });
+  });
+
+  it("does nothing when there is no upcoming event", async () => {
+    const user = userEvent.setup();
+    const ShortcutHarness = () => {
+      useUpNextEventShortcut();
+      return null;
+    };
+
+    render(<ShortcutHarness />, { events: [] });
+
+    await user.keyboard("n");
+
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(false);
   });
 });

--- a/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.tsx
@@ -1,9 +1,7 @@
-import { type FC, useEffect, useState } from "react";
+import { type FC } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
-import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
-import { useDayEventViewModel } from "@web/events/queries/useDayEventsQuery";
-import { draftActions } from "@web/events/stores/draft.store";
-import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { useUpNextEvent } from "./useUpNextEvent";
 
 /**
  * Countdown copy for the card's top row. Only ever called with a start that is
@@ -21,22 +19,6 @@ export function formatStartsIn(start: Dayjs, now: Dayjs): string {
 }
 
 /**
- * Re-renders once a minute so the countdown copy stays current, mirroring the
- * grid's now-line ticker (TimedGrid.tsx). Crossing midnight also rolls
- * the day query below onto the new day for free.
- */
-function useMinuteTick(): Dayjs {
-  const [now, setNow] = useState(() => dayjs());
-
-  useEffect(() => {
-    const interval = setInterval(() => setNow(dayjs()), 60000);
-    return () => clearInterval(interval);
-  }, []);
-
-  return now;
-}
-
-/**
  * The next timed event starting later today, with a live countdown. Clicking it
  * opens the event in the sidebar's details form. Renders nothing once today has
  * no upcoming timed events left.
@@ -46,45 +28,24 @@ function useMinuteTick(): Dayjs {
  * for them.
  */
 export const UpNextCard: FC = () => {
-  const now = useMinuteTick();
-  // Today's range explicitly, not the week/day in view - "Up next" means today
-  // even while the user is looking at another week. Reusing the Day view's
-  // range builder means this shares that view's cache entry when today is shown.
-  const { startDate, endDate } = dayEventQueryRange(now);
-  const { events, timedEvents } = useDayEventViewModel({ startDate, endDate });
-
-  // The query range is [todayStart, tomorrowStart), so anything still ahead of
-  // `now` within it starts later today - no separate same-day filter needed.
-  const upNext = timedEvents
-    .filter((event) => dayjs(event.startDate).isAfter(now))
-    .sort(
-      (a, b) => dayjs(a.startDate).valueOf() - dayjs(b.startDate).valueOf(),
-    )[0];
+  const { now, openEventDetails, upNext } = useUpNextEvent();
 
   if (!upNext) return null;
 
   const countdown = formatStartsIn(dayjs(upNext.startDate), now);
 
-  const openEventDetails = () => {
-    const sourceEvent = events.find((candidate) => candidate.id === upNext._id);
-    if (!sourceEvent) return;
-
-    const draft = editGridEventDraft(sourceEvent);
-    if (!draft) return;
-
-    draftActions.startGridDraft({ activity: "gridClick", draft });
-    draftActions.setFormOpen(true);
-  };
-
   return (
     <section aria-label="Up next">
       <button
         aria-label={`Up next: ${upNext.title}. ${countdown}.`}
-        className="c-focus-ring flex w-full min-w-0 flex-col gap-0.5 rounded border border-border-primary bg-bg-secondary px-2 py-1.5 text-left hover:brightness-110"
-        onClick={openEventDetails}
+        className="c-focus-ring group relative flex w-full min-w-0 flex-col gap-0.5 rounded border border-border-primary bg-bg-secondary px-2 py-1.5 text-left hover:brightness-110"
+        onClick={() => openEventDetails()}
         type="button"
       >
-        <span className="text-accent-primary text-xs">{countdown}</span>
+        <span className="pr-8 text-accent-primary text-xs">{countdown}</span>
+        <ShortcutHint className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+          N
+        </ShortcutHint>
         <span className="min-w-0 truncate font-medium text-sm text-text-lighter">
           {upNext.title}
         </span>

--- a/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/PlannerSidebar/UpNextCard/UpNextCard.tsx
@@ -39,7 +39,7 @@ export const UpNextCard: FC = () => {
       <button
         aria-label={`Up next: ${upNext.title}. ${countdown}.`}
         className="c-focus-ring group relative flex w-full min-w-0 flex-col gap-0.5 rounded border border-border-primary bg-bg-secondary px-2 py-1.5 text-left hover:brightness-110"
-        onClick={() => openEventDetails()}
+        onClick={() => openEventDetails("gridClick")}
         type="button"
       >
         <span className="pr-8 text-accent-primary text-xs">{countdown}</span>

--- a/packages/web/src/components/PlannerSidebar/UpNextCard/useUpNextEvent.ts
+++ b/packages/web/src/components/PlannerSidebar/UpNextCard/useUpNextEvent.ts
@@ -31,7 +31,7 @@ export function useUpNextEvent() {
     : undefined;
 
   const openEventDetails = useCallback(
-    (activity: "gridClick" | "keyboardEdit" = "gridClick") => {
+    (activity: "gridClick" | "keyboardEdit") => {
       if (!sourceEvent) return;
 
       const draft = editGridEventDraft(sourceEvent);

--- a/packages/web/src/components/PlannerSidebar/UpNextCard/useUpNextEvent.ts
+++ b/packages/web/src/components/PlannerSidebar/UpNextCard/useUpNextEvent.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { useDayEventViewModel } from "@web/events/queries/useDayEventsQuery";
+import { draftActions } from "@web/events/stores/draft.store";
+import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
+import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
+
+function useMinuteTick(): Dayjs {
+  const [now, setNow] = useState(() => dayjs());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(dayjs()), 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return now;
+}
+
+export function useUpNextEvent() {
+  const now = useMinuteTick();
+  const { startDate, endDate } = dayEventQueryRange(now);
+  const { events, timedEvents } = useDayEventViewModel({ startDate, endDate });
+  const upNext = timedEvents
+    .filter((event) => dayjs(event.startDate).isAfter(now))
+    .sort(
+      (a, b) => dayjs(a.startDate).valueOf() - dayjs(b.startDate).valueOf(),
+    )[0];
+  const sourceEvent = upNext
+    ? events.find((candidate) => candidate.id === upNext._id)
+    : undefined;
+
+  const openEventDetails = useCallback(
+    (activity: "gridClick" | "keyboardEdit" = "gridClick") => {
+      if (!sourceEvent) return;
+
+      const draft = editGridEventDraft(sourceEvent);
+      if (!draft) return;
+
+      draftActions.startGridDraft({ activity, draft });
+      draftActions.setFormOpen(true);
+    },
+    [sourceEvent],
+  );
+
+  return { now, openEventDetails, upNext };
+}
+
+export function useUpNextEventShortcut() {
+  const { openEventDetails } = useUpNextEvent();
+
+  useAppShortcutUp("N", () => openEventDetails("keyboardEdit"));
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -147,6 +147,7 @@
   /* Animations */
   --animate-progress-slide: progressSlide 2s ease-out infinite;
   --animate-sync-text-wave: syncTextWave 2.4s linear infinite;
+  --animate-sync-icon-wave: syncIconWave 2.4s linear infinite;
   --animate-loader-spin: loaderSpin 1.1s linear infinite;
   --animate-login-progress: loginProgress 1.5s ease-in-out infinite;
   --animate-login-message-in: loginMessageIn 0.8s ease-in-out;
@@ -166,6 +167,15 @@
     }
     to {
       background-position: -50% 0;
+    }
+  }
+
+  @keyframes syncIconWave {
+    from {
+      mask-position: 150% 0;
+    }
+    to {
+      mask-position: -50% 0;
     }
   }
 
@@ -325,6 +335,23 @@
     animation: none;
     background: none;
     color: var(--color-text-light);
+  }
+}
+
+@utility c-sync-icon-wave {
+  mask-image: linear-gradient(
+    90deg,
+    transparent 35%,
+    black 50%,
+    transparent 65%
+  );
+  mask-position: 150% 0;
+  mask-size: 250% 100%;
+  animation: var(--animate-sync-icon-wave);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    mask: none;
   }
 }
 

--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -9,6 +9,7 @@ import { ROOT_ROUTES } from "@web/common/constants/routes";
 import {
   loadDateParam,
   loadTodayData,
+  redirectToDefaultCalendar,
   redirectToToday,
   validateWeekDateParam,
 } from "@web/routers/loaders";
@@ -60,7 +61,7 @@ function createTestRouter(initialEntries: string[]) {
   const rootIndexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/",
-    beforeLoad: () => redirectToToday(ROOT_ROUTES.DAY_DATE),
+    beforeLoad: redirectToDefaultCalendar,
   });
 
   return createRouter({
@@ -75,13 +76,21 @@ function createTestRouter(initialEntries: string[]) {
 }
 
 describe("router redirects", () => {
-  it("redirects / to today's dated day route", async () => {
-    const { dateString } = loadTodayData();
+  it("redirects / to the bare week route", async () => {
     const router = createTestRouter(["/"]);
 
     await router.load();
 
-    expect(router.state.location.pathname).toBe(`/day/${dateString}`);
+    expect(router.state.location.pathname).toBe(ROOT_ROUTES.WEEK);
+  });
+
+  it("preserves search params when redirecting / to the week route", async () => {
+    const router = createTestRouter(["/?auth=login"]);
+
+    await router.load();
+
+    expect(router.state.location.pathname).toBe(ROOT_ROUTES.WEEK);
+    expect(router.state.location.search).toEqual({ auth: "login" });
   });
 
   it("redirects /day to today's dated day route", async () => {

--- a/packages/web/src/routers/loaders.ts
+++ b/packages/web/src/routers/loaders.ts
@@ -1,7 +1,10 @@
 import { redirect } from "@tanstack/react-router";
 import { zYearMonthDayString } from "@core/types/type.utils";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
-import { ROOT_ROUTES } from "@web/common/constants/routes";
+import {
+  DEFAULT_CALENDAR_ROUTE,
+  ROOT_ROUTES,
+} from "@web/common/constants/routes";
 
 export interface DayLoaderData {
   // Local-mode, not UTC: dayEventQueryRange formats this to build the day's
@@ -41,6 +44,13 @@ export function redirectToToday(
   throw redirect({
     to,
     params: { dateString },
+    search: (prev: Record<string, unknown>) => prev,
+  });
+}
+
+export function redirectToDefaultCalendar(): never {
+  throw redirect({
+    to: DEFAULT_CALENDAR_ROUTE,
     search: (prev: Record<string, unknown>) => prev,
   });
 }

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -9,6 +9,7 @@ import { validateAuthSearch } from "@web/components/AuthModal/hooks/useAuthModal
 import {
   loadAuthenticated,
   loadDateParam,
+  redirectToDefaultCalendar,
   redirectToToday,
   validateDayDateParam,
   validateWeekDateParam,
@@ -100,7 +101,7 @@ export const weekIndexRoute = createRoute({
 export const rootIndexRoute = createRoute({
   getParentRoute: () => authenticatedLayoutRoute,
   path: "/",
-  beforeLoad: () => redirectToToday(ROOT_ROUTES.DAY_DATE),
+  beforeLoad: redirectToDefaultCalendar,
 });
 
 export const cleanupRoute = createRoute({

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -53,6 +53,20 @@ describe("shortcuts.data", () => {
       });
     });
 
+    it("lists the Up Next shortcut in both views", () => {
+      for (const view of ["day", "week"] as const) {
+        const [navigate] = getShortcutMenuSections({
+          view,
+          isViewingCurrentPeriod: true,
+        });
+
+        expect(navigate.shortcuts).toContainEqual({
+          keys: ["n"],
+          label: "Open Up Next event",
+        });
+      }
+    });
+
     it.each([
       ["day", true, "Scroll to now"],
       ["day", false, "Go to today"],

--- a/packages/web/src/shortcuts/data/shortcuts.data.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.ts
@@ -18,6 +18,7 @@ const getNavigateShortcuts = ({
     view === "day" ? VIEW_SHORTCUTS.week : VIEW_SHORTCUTS.day;
 
   return [
+    { keys: ["n"], label: "Open Up Next event" },
     { keys: ["j"], label: `Previous ${view}` },
     { keys: ["k"], label: `Next ${view}` },
     ...(view === "week"

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -7,6 +7,7 @@ import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { SidebarEventDetails } from "@web/components/PlannerSidebar/EventDetails/SidebarEventDetails";
 import { PlannerSidebar } from "@web/components/PlannerSidebar/PlannerSidebar";
 import { ResizableSidebarPanel } from "@web/components/PlannerSidebar/ResizableSidebarPanel";
+import { useUpNextEventShortcut } from "@web/components/PlannerSidebar/UpNextCard/useUpNextEvent";
 import { usePlannerShortcuts } from "@web/components/PlannerSidebar/usePlannerShortcuts";
 import { focusFirstSidebarItem } from "@web/components/PlannerSidebar/util/sidebarFocus.util";
 import {
@@ -51,6 +52,7 @@ export const DayViewContent = memo(() => {
     onPrevious: navigateToPreviousDay,
   });
   useDayEvents(dateInView);
+  useUpNextEventShortcut();
 
   const toggleSidebar = useCallback(() => {
     viewActions.toggleSidebar();

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
@@ -130,6 +130,6 @@ describe("completeGoogleAuthCallback", () => {
     expect(mockShowErrorToast).toHaveBeenCalledWith(
       "We couldn't connect your Google account. Please try again.",
     );
-    expect(navigate).toHaveBeenCalledWith("/day", { replace: true });
+    expect(navigate).toHaveBeenCalledWith("/week", { replace: true });
   });
 });

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -6,6 +6,7 @@ import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuWrapper";
 import { PlannerSidebar } from "@web/components/PlannerSidebar/PlannerSidebar";
 import { ResizableSidebarPanel } from "@web/components/PlannerSidebar/ResizableSidebarPanel";
+import { useUpNextEventShortcut } from "@web/components/PlannerSidebar/UpNextCard/useUpNextEvent";
 import { usePlannerShortcuts } from "@web/components/PlannerSidebar/usePlannerShortcuts";
 import {
   draftActions,
@@ -40,6 +41,7 @@ import { useWeek } from "@web/views/Week/hooks/useWeek";
 import { WeekInteractionCoordinator } from "@web/views/Week/interaction/WeekInteractionCoordinator";
 
 export const WeekView = () => {
+  useUpNextEventShortcut();
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
   // Event details live in the sidebar, so an open form reveals the sidebar
   // even when the user keeps it collapsed; their persisted preference is


### PR DESCRIPTION
## Summary

- make the bare week view the default for root, sign-out, and Google authorization fallbacks
- shimmer the command-palette icon during active Google import or repair while leaving the calendar fully interactive
- add the N shortcut in Day and Week, expose it in shortcut help, and show its keycap on the Up Next card

## Simplicity

- centralize the default calendar route and the read-only Google UI state calculation
- reuse the existing Up Next query and draft flow for both pointer and keyboard activation
- retain one minute-based state/effect so the countdown stays current and the today query rolls across midnight; no additional sync state or blocking UI was added

## Manual Testing Steps

- [ ] Open the app at / and confirm the address resolves to /week while existing search parameters survive the redirect
- [ ] Reconnect or repair Google Calendar and confirm the command-palette icon shimmers, the calendar remains usable, and opening the palette shows the syncing status
- [ ] Create an upcoming timed event today, collapse the sidebar, press N in Week view, and confirm the correct event form opens
- [ ] Repeat the N shortcut in Day view, then hover the Up Next card and confirm the N keycap appears in its upper-right corner
- [ ] With no upcoming event today, press N and confirm the current calendar state is unchanged

## Test plan

- [x] bun run verify
- [x] bun test:web
- [x] bun type-check
- [x] bun lint
- [x] local browser validation in Week and Day with a collapsed sidebar
