### PR TITLE
docs: drop remaining Tasks-removal history lessons

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 ## Common Change Paths
 
 - Auth or session behavior: [Frontend Runtime Flow](./frontend/frontend-runtime-flow.md), [Password Auth Flow](./features/password-auth-flow.md), [Google Sync And SSE Flow](./features/google-sync-and-sse-flow.md)
-- Event shape or recurrence behavior: [Event Domain Model](./architecture/event-and-task-domain-model.md), [Recurrence Handling](./features/recurring-events-handling.md)
+- Event shape or recurrence behavior: [Event Domain Model](./architecture/event-domain-model.md), [Recurrence Handling](./features/recurring-events-handling.md)
 - Event caching, reads, or optimistic writes: [Event Caching](./frontend/event-caching.md)
 - Dragging/resizing events on the week grid: [Week Drag Interaction](./frontend/week-drag-interaction.md)
 - Local-first or storage behavior: [Offline Storage And Migrations](./features/offline-storage-and-migrations.md)
@@ -29,7 +29,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 ## Architecture And Domain
 
 - [Repo Architecture](./architecture/repo-architecture.md)
-- [Event Domain Model](./architecture/event-and-task-domain-model.md)
+- [Event Domain Model](./architecture/event-domain-model.md)
 - [Glossary](./architecture/glossary.md)
 
 ## Development And Operations

--- a/docs/architecture/event-domain-model.md
+++ b/docs/architecture/event-domain-model.md
@@ -139,16 +139,6 @@ The web generates a real Mongo `ObjectId` client-side (`createObjectIdString()`)
 
 Do not assume every incoming `id` is already a durable Mongo id.
 
-## Tasks (removed)
-
-The Tasks and Someday features were removed from the app in 2026-07 (v1.0.194).
-`StoredTask` and the read-only legacy `tasks` IndexedDB table are retained in
-`packages/web/src/common/storage/offline-data/offline-data.store.ts` for
-one-time data recovery only (`getAllTasks`/`getTaskCount`/`clearAllTasks`) —
-there is no live task-creation or task-editing path anywhere in the app. See
-`packages/web/src/components/PlannerSidebar/TasksRemovalNotice` for the
-user-facing removal notice.
-
 ## Invariants To Preserve
 
 - Every persisted event must have a stable Compass `id`.

--- a/docs/features/offline-storage-and-migrations.md
+++ b/docs/features/offline-storage-and-migrations.md
@@ -6,9 +6,8 @@ Compass supports a meaningful local-first path for unauthenticated users and res
 
 Compass uses two intentionally separate storage abstractions:
 
-- `OfflineDataStore` owns asynchronous event and migration-record data (plus a
-  retained, read-only legacy `tasks` table — see below). Its current
-  implementation is `IndexedDbOfflineDataStore`.
+- `OfflineDataStore` owns asynchronous event and migration-record data. Its
+  current implementation is `IndexedDbOfflineDataStore`.
 - `BrowserKeyValueStore` owns synchronous browser key-value state backed by
   `localStorage` or `sessionStorage`.
 
@@ -48,32 +47,28 @@ Current database name:
 Current table groups:
 
 - `events`
-- `tasks` — retained read-only for recovery; the Tasks feature was removed
-  (2026-07) and there is no live task-creation or task-editing path anymore
 - `_migrations`
 
 The IndexedDB store keeps:
 
 - events keyed by `_id`
-- tasks keyed by `_id` and associated to a `dateKey` (legacy rows only, see
-  `StoredTask` in `offline-data.store.ts`)
 - migration completion records in `_migrations`
 
-## Legacy Primary-Key Migration
+## Schema Upgrade Recovery
 
 File:
 
 - `packages/web/src/common/storage/offline-data/legacy-primary-key.migration.ts`
 
-There is explicit support for an older task schema that used `id` instead of `_id`. This exists purely so the retained legacy `tasks` rows (see Tasks below) survive a Dexie schema upgrade without data loss.
+Handles a Dexie `UpgradeError` when a table's primary key changes shape in-place (the schema change Dexie can't apply automatically).
 
 Recovery strategy:
 
-1. detect the Dexie upgrade error
-2. read legacy records through a legacy Dexie schema
+1. detect the Dexie upgrade error (`isPrimaryKeyUpgradeError`)
+2. read existing records through a matching legacy Dexie schema
 3. delete the old database
 4. reopen using the current schema
-5. reinsert events and legacy tasks
+5. reinsert the recovered records
 
 ## Data Migrations
 
@@ -123,16 +118,6 @@ Event operations:
 - query overlapping date ranges
 - put one or many events
 - delete by event id
-
-## Legacy Task Recovery
-
-The only remaining task-shaped operations are read-only, for recovering data a user had before the feature was removed:
-
-- `getAllTasks()` — read every retained legacy task row
-- `getTaskCount()` — cheap existence check without reading every row
-- `clearAllTasks()` — clear the retained legacy table
-
-There is no create/update/reorder/move path for tasks anymore.
 
 ## When To Add A Migration
 

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -29,7 +29,6 @@ Browser IndexedDB data is not included in Docker volume backups. That means:
 
 - anonymous events created before signup
 - any pre-signup local data not yet copied to the backend
-- leftover data from the removed Tasks feature, retained read-only for recovery
 
 There's no repo-supported export for browser-only data yet.
 


### PR DESCRIPTION
## Summary
- Follow-up to #2174: removes the leftover "Tasks (removed)" section and other history-lesson callouts about the removed Tasks feature — docs should describe current state, not explain what used to exist.
- Renames `event-and-task-domain-model.md` -> `event-domain-model.md` since it no longer discusses tasks.

## Test plan
- [x] `bun run lint`
- [x] Grep sweep confirms no remaining Tasks-removal narration in docs (the one intentional exception, `event-migration-runbook.md`'s Someday-exclusion notes, documents real migration-script output fields operators still see today)