### PR TITLE
fix: make the google revoked toast accurate and actionable

### DIFF
--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -118,7 +118,8 @@ const handleGoogleError = async (
 
     res.status(Status.UNAUTHORIZED).send({
       code: "GOOGLE_REVOKED",
-      message: "Google access revoked. Your Google data has been removed.",
+      message:
+        "Google Calendar access expired or was revoked. Reconnect Google Calendar in Compass to resume syncing.",
     });
     return;
   }

--- a/packages/backend/src/common/errors/handlers/error.handler.test.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.test.ts
@@ -84,7 +84,8 @@ describe("error.handler", () => {
       expect(res.status).toHaveBeenCalledWith(Status.UNAUTHORIZED);
       expect(send).toHaveBeenCalledWith({
         code: "GOOGLE_REVOKED",
-        message: "Google access revoked. Your Google data has been removed.",
+        message:
+          "Google Calendar access expired or was revoked. Reconnect Google Calendar in Compass to resume syncing.",
       });
       expect(handleGoogleRevokedSpy).toHaveBeenCalledWith(userId, {
         status: "attention",

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -1,12 +1,22 @@
 import { Status } from "@core/errors/status.codes";
 import { UserApi } from "@web/api/user.api";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { showGoogleReconnectToastOnLoad } from "@web/common/utils/toast/google-reconnect.toast";
 
 let refreshUserMetadataRequest: Promise<void> | null = null;
 
-export const refreshUserMetadata = async (): Promise<void> => {
+export const refreshUserMetadata = async (options?: {
+  force?: boolean;
+}): Promise<void> => {
   if (refreshUserMetadataRequest) {
-    return refreshUserMetadataRequest;
+    if (!options?.force) {
+      return refreshUserMetadataRequest;
+    }
+
+    // The in-flight request predates whatever invalidated the metadata (e.g.
+    // a Google revocation prune), so its response is stale. Let it settle,
+    // then fetch fresh.
+    return refreshUserMetadataRequest.then(() => refreshUserMetadata());
   }
 
   userMetadataActions.setLoading();
@@ -14,6 +24,13 @@ export const refreshUserMetadata = async (): Promise<void> => {
   refreshUserMetadataRequest = UserApi.getMetadata()
     .then((metadata) => {
       userMetadataActions.set(metadata);
+
+      // Catches returning users whose Google grant died while they were away:
+      // they get the actionable reconnect toast on load instead of having to
+      // discover the palette's "Reconnect Google Calendar" action.
+      if (metadata.google?.connectionState === "RECONNECT_REQUIRED") {
+        showGoogleReconnectToastOnLoad();
+      }
     })
     .catch((error) => {
       const status = (error as { response?: { status?: number } })?.response

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -1,9 +1,10 @@
 import { Status } from "@core/errors/status.codes";
 import { UserApi } from "@web/api/user.api";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
-import { showGoogleReconnectToastOnLoad } from "@web/common/utils/toast/google-reconnect.toast";
+import { showGoogleReconnectToast } from "@web/common/utils/toast/google-reconnect.toast";
 
 let refreshUserMetadataRequest: Promise<void> | null = null;
+let hasShownReconnectToastThisLoad = false;
 
 export const refreshUserMetadata = async (options?: {
   force?: boolean;
@@ -26,10 +27,15 @@ export const refreshUserMetadata = async (options?: {
       userMetadataActions.set(metadata);
 
       // Catches returning users whose Google grant died while they were away:
-      // they get the actionable reconnect toast on load instead of having to
-      // discover the palette's "Reconnect Google Calendar" action.
-      if (metadata.google?.connectionState === "RECONNECT_REQUIRED") {
-        showGoogleReconnectToastOnLoad();
+      // they get the actionable reconnect toast instead of having to discover
+      // the palette's "Reconnect Google Calendar" action. At most once per
+      // page load, so a dismissal isn't nagged by later refreshes.
+      if (
+        metadata.google?.connectionState === "RECONNECT_REQUIRED" &&
+        !hasShownReconnectToastThisLoad
+      ) {
+        hasShownReconnectToastThisLoad = true;
+        showGoogleReconnectToast();
       }
     })
     .catch((error) => {

--- a/packages/web/src/auth/google/util/google.auth.util.factory.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.factory.ts
@@ -1,10 +1,7 @@
-import { type Id, type toast } from "react-toastify";
+import { type toast } from "react-toastify";
 import { Status } from "@core/errors/status.codes";
 import { type ApiError } from "@web/api/api.types";
-import {
-  GOOGLE_REVOKED_TOAST_ID,
-  toastDefaultOptions,
-} from "@web/common/constants/toast.constants";
+import { toastDefaultOptions } from "@web/common/constants/toast.constants";
 export interface SyncLocalEventsResult {
   syncedCount: number;
   success: boolean;
@@ -14,19 +11,19 @@ export interface SyncLocalEventsResult {
 export const LOCAL_EVENTS_SYNC_ERROR_MESSAGE =
   "We couldn't save your events to the cloud. Your changes are still safe on this device.";
 export const LOCAL_EVENTS_SYNC_SESSION_EXPIRED_MESSAGE =
-  "You were signed out before Compass could save your events to the cloud. Sign in again to finish — your changes are still safe on this device.";
+  "You were signed out before Compass could save your events to the cloud. Sign in again to finish. Your changes are still safe on this device.";
 
 type GoogleAuthUtilDependencies = {
-  clearUserMetadata: () => void;
   closeStream: () => void;
-  isToastActive: (toastId: Id) => boolean;
   markGoogleAsRevoked: () => void;
   openStream: () => void;
   refreshEventRepositorySource: (sessionExists?: boolean) => void;
+  refreshUserMetadata: () => void;
   // B14: drops cached events belonging to a google-provider calendar (by id),
   // replacing the legacy origin-based prune.
   removeEventsByGoogleCalendars: () => void;
   removeEventQueries: () => void;
+  showReconnectToast: () => void;
   syncLocalEventsToCloud: () => Promise<number>;
   toastError: typeof toast.error;
 };
@@ -35,31 +32,28 @@ const getApiErrorStatus = (error: Error | undefined): number | undefined =>
   (error as ApiError | undefined)?.response?.status;
 
 export function createGoogleAuthUtil({
-  clearUserMetadata,
   closeStream,
-  isToastActive,
   markGoogleAsRevoked,
   openStream,
   refreshEventRepositorySource,
+  refreshUserMetadata,
   removeEventsByGoogleCalendars,
   removeEventQueries,
+  showReconnectToast,
   syncLocalEventsToCloud,
   toastError,
 }: GoogleAuthUtilDependencies) {
   const handleGoogleRevoked = () => {
-    if (!isToastActive(GOOGLE_REVOKED_TOAST_ID)) {
-      toastError("Google access revoked. Your Google data has been removed.", {
-        toastId: GOOGLE_REVOKED_TOAST_ID,
-        autoClose: false,
-      });
-    }
+    showReconnectToast();
 
     markGoogleAsRevoked();
     // Source now resolves to "local"; re-key active queries so their next fetch
     // hits IndexedDB, then drop the stale remote cache entries.
     refreshEventRepositorySource();
 
-    clearUserMetadata();
+    // The server prunes before notifying, so this refetch lands in
+    // RECONNECT_REQUIRED and the palette/sidebar offer "Reconnect" right away.
+    refreshUserMetadata();
 
     removeEventsByGoogleCalendars();
     removeEventQueries();

--- a/packages/web/src/auth/google/util/google.auth.util.test.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.test.ts
@@ -20,8 +20,8 @@ import {
 
 const mockSyncLocalEventsToCloud = mock();
 const mockToastError = mock();
-const mockIsToastActive = mock(() => false);
-const mockClearUserMetadata = mock();
+const mockShowReconnectToast = mock();
+const mockRefreshUserMetadata = mock();
 const mockCloseStream = mock();
 const mockOpenStream = mock();
 const mockRefreshEventRepositorySource = mock();
@@ -29,14 +29,14 @@ const mockRemoveEventsByGoogleCalendars = mock();
 const mockRemoveEventQueries = mock();
 
 const googleAuthUtil = createGoogleAuthUtil({
-  clearUserMetadata: mockClearUserMetadata,
   closeStream: mockCloseStream,
-  isToastActive: mockIsToastActive,
   markGoogleAsRevoked,
   openStream: mockOpenStream,
   refreshEventRepositorySource: mockRefreshEventRepositorySource,
+  refreshUserMetadata: mockRefreshUserMetadata,
   removeEventsByGoogleCalendars: mockRemoveEventsByGoogleCalendars,
   removeEventQueries: mockRemoveEventQueries,
+  showReconnectToast: mockShowReconnectToast,
   syncLocalEventsToCloud: mockSyncLocalEventsToCloud,
   toastError: mockToastError,
 });
@@ -48,9 +48,8 @@ describe("google-auth.util", () => {
   beforeEach(() => {
     mockSyncLocalEventsToCloud.mockClear();
     mockToastError.mockClear();
-    mockIsToastActive.mockClear();
-    mockIsToastActive.mockReturnValue(false);
-    mockClearUserMetadata.mockClear();
+    mockShowReconnectToast.mockClear();
+    mockRefreshUserMetadata.mockClear();
     mockCloseStream.mockClear();
     mockOpenStream.mockClear();
     mockRefreshEventRepositorySource.mockClear();
@@ -148,19 +147,16 @@ describe("google-auth.util", () => {
   });
 
   describe("handleGoogleRevoked", () => {
-    it("shows toast with GOOGLE_REVOKED_TOAST_ID when not already active", () => {
+    it("shows the actionable reconnect toast", () => {
       handleGoogleRevoked();
 
-      expect(mockToastError).toHaveBeenCalledWith(
-        "Google access revoked. Your Google data has been removed.",
-        expect.objectContaining({ autoClose: false }),
-      );
+      expect(mockShowReconnectToast).toHaveBeenCalledTimes(1);
     });
 
-    it("clears user metadata and Google-origin events on revocation", () => {
+    it("refreshes user metadata (not clears) so the UI lands in RECONNECT_REQUIRED, and drops Google-origin events", () => {
       handleGoogleRevoked();
 
-      expect(mockClearUserMetadata).toHaveBeenCalledTimes(1);
+      expect(mockRefreshUserMetadata).toHaveBeenCalledTimes(1);
       expect(mockRemoveEventsByGoogleCalendars).toHaveBeenCalledTimes(1);
     });
 
@@ -182,14 +178,6 @@ describe("google-auth.util", () => {
       handleGoogleRevoked();
 
       expect(isGoogleRevoked()).toBe(true);
-    });
-
-    it("does not show toast when one is already active", () => {
-      mockIsToastActive.mockReturnValue(true);
-
-      handleGoogleRevoked();
-
-      expect(mockToastError).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/auth/google/util/google.auth.util.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.ts
@@ -1,10 +1,12 @@
 import { toast } from "react-toastify";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { queryClient } from "@web/api/query-client";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import { markGoogleAsRevoked } from "@web/auth/google/state/google.auth.state";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { syncLocalEventsToCloud } from "@web/common/utils/sync/local-event-sync.util";
+import { showGoogleReconnectToast } from "@web/common/utils/toast/google-reconnect.toast";
 import { removeEventsByCalendarFromQueries } from "@web/events/queries/event.query.cache";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { refreshEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
@@ -27,12 +29,17 @@ const googleCalendarIds = (): Set<string> => {
 };
 
 const googleAuthUtil = createGoogleAuthUtil({
-  clearUserMetadata: userMetadataActions.clear,
   closeStream,
-  isToastActive: toast.isActive,
   markGoogleAsRevoked,
   openStream,
   refreshEventRepositorySource,
+  // Wipe first (a concurrent in-flight metadata request predates the server's
+  // prune, so its response is stale), then force a fresh fetch so the UI lands
+  // in RECONNECT_REQUIRED instead of a stale connected state.
+  refreshUserMetadata: () => {
+    userMetadataActions.clear();
+    void refreshUserMetadata({ force: true });
+  },
   removeEventsByGoogleCalendars: () =>
     removeEventsByCalendarFromQueries(queryClient, googleCalendarIds()),
   removeEventQueries: () =>
@@ -48,6 +55,7 @@ const googleAuthUtil = createGoogleAuthUtil({
         );
       },
     }),
+  showReconnectToast: () => void showGoogleReconnectToast(),
   syncLocalEventsToCloud: () => syncLocalEventsToCloud(),
   toastError: toast.error,
 });

--- a/packages/web/src/auth/google/util/google.auth.util.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.ts
@@ -55,7 +55,7 @@ const googleAuthUtil = createGoogleAuthUtil({
         );
       },
     }),
-  showReconnectToast: () => void showGoogleReconnectToast(),
+  showReconnectToast: showGoogleReconnectToast,
   syncLocalEventsToCloud: () => syncLocalEventsToCloud(),
   toastError: toast.error,
 });

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// mock.module is process-wide and leaks across test files (deleted-toast's
+// react-toastify mock would otherwise leak in here with no error/dismiss), so
+// this file registers its own full-shape toast mock like the other toast tests.
+const toast = Object.assign(mock(), {
+  error: mock(),
+  dismiss: mock(),
+  isActive: mock(() => false),
+});
+
+mock.module("react-toastify", () => ({
+  ToastContainer: () => null,
+  toast,
+}));
+
+const mockStartGoogleAuthorization = mock();
+mock.module(
+  "@web/auth/google/authorization/useStartGoogleAuthorization",
+  () => ({
+    useStartGoogleAuthorization: () => ({
+      loading: false,
+      startGoogleAuthorization: mockStartGoogleAuthorization,
+    }),
+  }),
+);
+
+// The real module is captured up front and a flag (flipped off in afterAll)
+// decides which implementation runs per call, keeping other test files'
+// imports of google.auth.util intact.
+const actualGoogleAuthUtil = await import(
+  "@web/auth/google/util/google.auth.util"
+);
+const mockSyncPendingLocalEvents = mock();
+let isGoogleAuthUtilMocked = true;
+
+mock.module("@web/auth/google/util/google.auth.util", () => ({
+  ...actualGoogleAuthUtil,
+  syncPendingLocalEvents: () =>
+    isGoogleAuthUtilMocked
+      ? mockSyncPendingLocalEvents()
+      : actualGoogleAuthUtil.syncPendingLocalEvents(),
+}));
+
+const {
+  GoogleReconnectToast,
+  resetGoogleReconnectToastOnLoadForTests,
+  showGoogleReconnectToast,
+  showGoogleReconnectToastOnLoad,
+} = await import("@web/common/utils/toast/google-reconnect.toast");
+
+afterAll(() => {
+  isGoogleAuthUtilMocked = false;
+});
+
+describe("GoogleReconnectToast", () => {
+  beforeEach(() => {
+    mockStartGoogleAuthorization.mockClear();
+    mockSyncPendingLocalEvents.mockClear();
+    toast.error.mockClear();
+    toast.dismiss.mockClear();
+  });
+
+  it("explains the disconnect without blaming the user or implying data loss", () => {
+    render(<GoogleReconnectToast toastId="google-revoked-api" />);
+
+    expect(
+      screen.getByText("Google Calendar disconnected"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This happens when access expires or is revoked. Your events are still safe in Google. Reconnect and Compass will re-import them.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("flushes pending local events, dismisses itself, then starts the consent flow", async () => {
+    mockSyncPendingLocalEvents.mockResolvedValue(true);
+    render(<GoogleReconnectToast toastId="google-revoked-api" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Reconnect Google Calendar" }),
+    );
+
+    await waitFor(() => {
+      expect(mockStartGoogleAuthorization).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSyncPendingLocalEvents).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledWith("google-revoked-api");
+  });
+
+  it("stays open and does not start authorization when the local-event flush fails", async () => {
+    mockSyncPendingLocalEvents.mockResolvedValue(false);
+    render(<GoogleReconnectToast toastId="google-revoked-api" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Reconnect Google Calendar" }),
+    );
+
+    await waitFor(() => {
+      expect(mockSyncPendingLocalEvents).toHaveBeenCalledTimes(1);
+    });
+    expect(mockStartGoogleAuthorization).not.toHaveBeenCalled();
+    expect(toast.dismiss).not.toHaveBeenCalled();
+  });
+});
+
+describe("showGoogleReconnectToast", () => {
+  beforeEach(() => {
+    toast.error.mockClear();
+    toast.isActive.mockReturnValue(false);
+  });
+
+  it("does not stack a second toast while one is already visible", () => {
+    toast.isActive.mockReturnValue(true);
+
+    showGoogleReconnectToast();
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("showGoogleReconnectToastOnLoad", () => {
+  beforeEach(() => {
+    resetGoogleReconnectToastOnLoadForTests();
+  });
+
+  // Asserted via the return value rather than toast.error call counts: other
+  // test files leak process-wide mocks of error-toast.util, so whether the
+  // underlying toast fires here depends on suite order.
+  it("shows the reconnect toast at most once per page load", () => {
+    expect(showGoogleReconnectToastOnLoad()).toBe(true);
+    expect(showGoogleReconnectToastOnLoad()).toBe(false);
+  });
+});

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 // mock.module is process-wide and leaks across test files (deleted-toast's
 // react-toastify mock would otherwise leak in here with no error/dismiss), so
@@ -27,33 +27,19 @@ mock.module(
   }),
 );
 
-// The real module is captured up front and a flag (flipped off in afterAll)
-// decides which implementation runs per call, keeping other test files'
-// imports of google.auth.util intact.
-const actualGoogleAuthUtil = await import(
-  "@web/auth/google/util/google.auth.util"
+const { GoogleReconnectToast, showGoogleReconnectToast } = await import(
+  "@web/common/utils/toast/google-reconnect.toast"
 );
+
 const mockSyncPendingLocalEvents = mock();
-let isGoogleAuthUtilMocked = true;
 
-mock.module("@web/auth/google/util/google.auth.util", () => ({
-  ...actualGoogleAuthUtil,
-  syncPendingLocalEvents: () =>
-    isGoogleAuthUtilMocked
-      ? mockSyncPendingLocalEvents()
-      : actualGoogleAuthUtil.syncPendingLocalEvents(),
-}));
-
-const {
-  GoogleReconnectToast,
-  resetGoogleReconnectToastOnLoadForTests,
-  showGoogleReconnectToast,
-  showGoogleReconnectToastOnLoad,
-} = await import("@web/common/utils/toast/google-reconnect.toast");
-
-afterAll(() => {
-  isGoogleAuthUtilMocked = false;
-});
+const renderToast = () =>
+  render(
+    <GoogleReconnectToast
+      toastId="google-revoked-api"
+      syncPendingLocalEvents={mockSyncPendingLocalEvents}
+    />,
+  );
 
 describe("GoogleReconnectToast", () => {
   beforeEach(() => {
@@ -61,10 +47,11 @@ describe("GoogleReconnectToast", () => {
     mockSyncPendingLocalEvents.mockClear();
     toast.error.mockClear();
     toast.dismiss.mockClear();
+    toast.isActive.mockReturnValue(false);
   });
 
   it("explains the disconnect without blaming the user or implying data loss", () => {
-    render(<GoogleReconnectToast toastId="google-revoked-api" />);
+    renderToast();
 
     expect(
       screen.getByText("Google Calendar disconnected"),
@@ -78,7 +65,7 @@ describe("GoogleReconnectToast", () => {
 
   it("flushes pending local events, dismisses itself, then starts the consent flow", async () => {
     mockSyncPendingLocalEvents.mockResolvedValue(true);
-    render(<GoogleReconnectToast toastId="google-revoked-api" />);
+    renderToast();
 
     await userEvent.click(
       screen.getByRole("button", { name: "Reconnect Google Calendar" }),
@@ -93,7 +80,7 @@ describe("GoogleReconnectToast", () => {
 
   it("stays open and does not start authorization when the local-event flush fails", async () => {
     mockSyncPendingLocalEvents.mockResolvedValue(false);
-    render(<GoogleReconnectToast toastId="google-revoked-api" />);
+    renderToast();
 
     await userEvent.click(
       screen.getByRole("button", { name: "Reconnect Google Calendar" }),
@@ -119,19 +106,5 @@ describe("showGoogleReconnectToast", () => {
     showGoogleReconnectToast();
 
     expect(toast.error).not.toHaveBeenCalled();
-  });
-});
-
-describe("showGoogleReconnectToastOnLoad", () => {
-  beforeEach(() => {
-    resetGoogleReconnectToastOnLoadForTests();
-  });
-
-  // Asserted via the return value rather than toast.error call counts: other
-  // test files leak process-wide mocks of error-toast.util, so whether the
-  // underlying toast fires here depends on suite order.
-  it("shows the reconnect toast at most once per page load", () => {
-    expect(showGoogleReconnectToastOnLoad()).toBe(true);
-    expect(showGoogleReconnectToastOnLoad()).toBe(false);
   });
 });

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -1,0 +1,91 @@
+import { createElement } from "react";
+import { type Id, toast } from "react-toastify";
+import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
+import { GOOGLE_REVOKED_TOAST_ID } from "@web/common/constants/toast.constants";
+import {
+  ErrorToastSeverity,
+  showErrorToast,
+} from "@web/common/utils/toast/error-toast.util";
+
+interface GoogleReconnectToastProps {
+  toastId: Id;
+}
+
+// Shown when Google reports invalid_grant, which covers both "access expired"
+// and "user revoked access" with no way to tell them apart, so the copy must
+// stay accurate for either cause.
+export const GoogleReconnectToast = ({
+  toastId,
+}: GoogleReconnectToastProps) => {
+  // Legal here: ToastContainer renders inside GoogleOAuthProvider
+  // (CompassProvider), so the OAuth context is available.
+  const { startGoogleAuthorization } = useStartGoogleAuthorization({
+    intent: "connectCalendar",
+    prompt: "consent",
+  });
+
+  const handleReconnect = async () => {
+    // Imported dynamically to avoid a module cycle: google.auth.util shows
+    // this toast, and this handler needs google.auth.util's local-event flush.
+    const { syncPendingLocalEvents } = await import(
+      "@web/auth/google/util/google.auth.util"
+    );
+    const didSyncLocalEvents = await syncPendingLocalEvents();
+
+    // The flush already showed its own error toast; keep this one around so
+    // the user can retry once the flush issue is resolved.
+    if (!didSyncLocalEvents) {
+      return;
+    }
+
+    toast.dismiss(toastId);
+    void startGoogleAuthorization();
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <p className="font-medium text-sm text-text-lighter">
+        Google Calendar disconnected
+      </p>
+      <p className="text-sm text-text-lighter">
+        This happens when access expires or is revoked. Your events are still
+        safe in Google. Reconnect and Compass will re-import them.
+      </p>
+      <button
+        className="w-full rounded bg-fg-primary-dark px-3 py-2 font-medium text-sm text-text-lighter transition-colors hover:bg-[color-mix(in_srgb,var(--color-fg-primary-dark)_90%,white)]"
+        onClick={() => void handleReconnect()}
+        type="button"
+      >
+        Reconnect Google Calendar
+      </button>
+    </div>
+  );
+};
+
+export function showGoogleReconnectToast(): Id {
+  return showErrorToast(
+    createElement(GoogleReconnectToast, { toastId: GOOGLE_REVOKED_TOAST_ID }),
+    {
+      toastId: GOOGLE_REVOKED_TOAST_ID,
+      severity: ErrorToastSeverity.CRITICAL,
+    },
+  );
+}
+
+// At most once per page load, so a dismissal isn't nagged mid-session but the
+// reminder returns on the next load until the user reconnects.
+let hasShownOnLoad = false;
+
+export function showGoogleReconnectToastOnLoad(): boolean {
+  if (hasShownOnLoad) {
+    return false;
+  }
+
+  hasShownOnLoad = true;
+  showGoogleReconnectToast();
+  return true;
+}
+
+export function resetGoogleReconnectToastOnLoadForTests(): void {
+  hasShownOnLoad = false;
+}

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -7,29 +7,34 @@ import {
   showErrorToast,
 } from "@web/common/utils/toast/error-toast.util";
 
+// Imported dynamically to avoid a module cycle: google.auth.util shows this
+// toast, and the reconnect flow needs google.auth.util's local-event flush.
+const flushPendingLocalEvents = async (): Promise<boolean> => {
+  const { syncPendingLocalEvents } = await import(
+    "@web/auth/google/util/google.auth.util"
+  );
+  return syncPendingLocalEvents();
+};
+
 interface GoogleReconnectToastProps {
   toastId: Id;
+  syncPendingLocalEvents?: () => Promise<boolean>;
 }
 
 // Shown when Google reports invalid_grant, which covers both "access expired"
 // and "user revoked access" with no way to tell them apart, so the copy must
-// stay accurate for either cause.
+// stay accurate for either cause. Hooks are fine here: ToastContainer renders
+// inside GoogleOAuthProvider (CompassProvider).
 export const GoogleReconnectToast = ({
   toastId,
+  syncPendingLocalEvents = flushPendingLocalEvents,
 }: GoogleReconnectToastProps) => {
-  // Legal here: ToastContainer renders inside GoogleOAuthProvider
-  // (CompassProvider), so the OAuth context is available.
   const { startGoogleAuthorization } = useStartGoogleAuthorization({
     intent: "connectCalendar",
     prompt: "consent",
   });
 
   const handleReconnect = async () => {
-    // Imported dynamically to avoid a module cycle: google.auth.util shows
-    // this toast, and this handler needs google.auth.util's local-event flush.
-    const { syncPendingLocalEvents } = await import(
-      "@web/auth/google/util/google.auth.util"
-    );
     const didSyncLocalEvents = await syncPendingLocalEvents();
 
     // The flush already showed its own error toast; keep this one around so
@@ -70,22 +75,4 @@ export function showGoogleReconnectToast(): Id {
       severity: ErrorToastSeverity.CRITICAL,
     },
   );
-}
-
-// At most once per page load, so a dismissal isn't nagged mid-session but the
-// reminder returns on the next load until the user reconnects.
-let hasShownOnLoad = false;
-
-export function showGoogleReconnectToastOnLoad(): boolean {
-  if (hasShownOnLoad) {
-    return false;
-  }
-
-  hasShownOnLoad = true;
-  showGoogleReconnectToast();
-  return true;
-}
-
-export function resetGoogleReconnectToastOnLoadForTests(): void {
-  hasShownOnLoad = false;
 }


### PR DESCRIPTION
## Summary
When a returning user's Google refresh token dies, Google reports `invalid_grant` for both token expiry and genuine revocation. The old toast ("Google access revoked. Your Google data has been removed.") blamed the user for something they often never did, implied permanent data loss, and offered no recourse; the only fix (the `prompt=consent` reconnect flow, which is the sole way to mint a fresh refresh token) was hidden behind cmd-K. This PR:

- Adds `GoogleReconnectToast`: neutral, accurate copy ("Google Calendar disconnected... Your events are still safe in Google") with a **Reconnect Google Calendar** button that flushes pending local events, dismisses itself, and starts the existing `prompt=consent` OAuth flow.
- `handleGoogleRevoked` now shows that toast and resets metadata with a clear + forced refresh (skipping the in-flight request dedupe, whose stale response could otherwise land the store back on a connected state), so the palette/sidebar immediately offer "Reconnect" instead of "Connect".
- Returning users who missed the live revocation event get the same toast once per page load whenever server metadata reports `RECONNECT_REQUIRED`.
- The backend 401 message is reworded to match reality; the `GOOGLE_REVOKED` code and the prune behavior are unchanged.
- Removes a pre-existing em-dash from the user-facing local-events sync message.

Known, accepted edges: in an environment without Google auth configured for the web bundle, a DB-faked `RECONNECT_REQUIRED` user would still see the toast (unreachable for real users, who can only obtain a `googleId` when Google auth is configured); a backend-pushed `userMetadataChanged` carrying `RECONNECT_REQUIRED` would update the store without toasting (the backend never emits that today, revocations always arrive via `syncStatusChanged`).

## Simplicity
Net reduction: the follow-up refactor commit removed 34 lines by moving the once-per-load latch into its only consumer as a two-line guard (deleting a test-only boolean return and a `*ForTests` reset export) and by giving the toast component a `syncPendingLocalEvents` parameter default so its test injects a plain mock instead of a flag-gated process-wide `mock.module`. No `useEffect`, `useRef`, or `useState` is added anywhere in the diff (the toast uses the existing `useStartGoogleAuthorization` hook only). Considered and left alone: the action-button className shared verbatim with `SessionExpiredToast` (two sites in the same directory; a shared component adds indirection for one string) and the flush-then-authorize similarity with `useConnectGoogle.onOpenGoogleAuth` (six lines each with different success side effects; a shared hook would need an injected callback).

## Manual Testing Steps
- [ ] Sign in as a user whose Google connection is healthy: no toast appears, and cmd-K shows the normal sync status.
- [ ] Put a user into the broken state (revoke Compass at myaccount.google.com/connections, or wait out a staging token expiry), then reload the calendar: a toast appears bottom-left reading "Google Calendar disconnected / This happens when access expires or is revoked. Your events are still safe in Google. Reconnect and Compass will re-import them." with a "Reconnect Google Calendar" button.
- [ ] Open cmd-K: the palette header shows "Calendar needs reconnecting" and a "Reconnect Google Calendar" action (not "Connect Google Calendar").
- [ ] Click the toast's Reconnect button: the toast dismisses and the browser redirects to Google's consent screen; completing consent returns to the calendar and events re-import.
- [ ] Dismiss the toast with its X instead: it stays gone for the rest of the session, and reappears once on the next page load until you reconnect.

## Test plan
- [x] `bun test` (packages/web): 1228 pass, 0 fail across 194 files, including new `google-reconnect.toast.test.tsx` (copy, flush-dismiss-authorize flow, flush-failure abort, toast dedupe) and updated `google.auth.util.test.ts`
- [x] `bun run test:backend`: 667 pass, 4 skipped (updated `error.handler.test.ts` message assertion)
- [x] `bun run type-check`: clean
- [x] `bun run lint`: clean
- [x] Chrome walkthrough on local dev: on-load toast for a `RECONNECT_REQUIRED` user, OAuth redirect fired on click, dismiss + once-per-load behavior, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)