### PR TITLE
fix(web): preserve sidebar width across views and refreshes

### DIFF
--- a/packages/web/src/components/PlannerSidebar/storage/sidebar-width.storage.test.ts
+++ b/packages/web/src/components/PlannerSidebar/storage/sidebar-width.storage.test.ts
@@ -35,9 +35,24 @@ describe("sidebar width storage", () => {
     expect(readSidebarWidth()).toBe(SIDEBAR_MAX_WIDTH);
   });
 
+  it("rounds fractional stored widths instead of resetting to the default", () => {
+    // Drags on zoomed/HiDPI displays used to persist values like "400.5",
+    // which the old integer-only guard rejected — resetting the sidebar on
+    // every view switch and refresh.
+    localStorage.setItem(STORAGE_KEYS.SIDEBAR_WIDTH, "400.5");
+
+    expect(readSidebarWidth()).toBe(401);
+  });
+
   it("writes widths through the storage abstraction", () => {
     writeSidebarWidth(360);
 
     expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_WIDTH)).toBe("360");
+  });
+
+  it("rounds fractional widths on write", () => {
+    writeSidebarWidth(400.5);
+
+    expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_WIDTH)).toBe("401");
   });
 });

--- a/packages/web/src/components/PlannerSidebar/storage/sidebar-width.storage.ts
+++ b/packages/web/src/components/PlannerSidebar/storage/sidebar-width.storage.ts
@@ -9,12 +9,17 @@ export function readSidebarWidth(): number {
   const stored = persistentBrowserStore.get(STORAGE_KEYS.SIDEBAR_WIDTH);
   if (stored === null) return SIDEBAR_DEFAULT_WIDTH;
 
+  // Drags on zoomed/HiDPI displays produce fractional widths, so tolerate
+  // (and heal) any finite stored value instead of resetting to the default.
   const width = Number(stored);
-  return Number.isInteger(width)
-    ? clampSidebarWidth(width)
+  return Number.isFinite(width)
+    ? clampSidebarWidth(Math.round(width))
     : SIDEBAR_DEFAULT_WIDTH;
 }
 
 export function writeSidebarWidth(width: number): void {
-  persistentBrowserStore.set(STORAGE_KEYS.SIDEBAR_WIDTH, String(width));
+  persistentBrowserStore.set(
+    STORAGE_KEYS.SIDEBAR_WIDTH,
+    String(Math.round(width)),
+  );
 }


### PR DESCRIPTION
## Summary

Dragging the sidebar wider could silently reset to the default 285px on the next view switch or refresh. Drags on zoomed/HiDPI displays produce fractional pixel widths (from `e.clientX`), and `readSidebarWidth`'s `Number.isInteger` guard rejected any fractional stored value, falling back to the default. Since the Day and Week views each mount their own sidebar panel (re-reading localStorage on every switch), any drag that ended on a fractional pixel looked like "my width didn't stick."

The fix rounds widths when persisting so stored values stay canonical, and accepts any finite stored value on read (round + clamp) so fractional values already sitting in users' localStorage heal instead of resetting. The ESC-vs-Save asymmetry in the original report was a red herring: both paths close the form identically and neither touches width — whether the width "stuck" just depended on whether the drag happened to end on an integer pixel.

## Simplicity

Net-neutral: two one-line semantic changes (`isInteger` → `isFinite` + round on read; round on write) at the single read/write chokepoint, plus two tests. No new `useEffect`/`useRef`/`useState` — the fix deliberately avoids touching the resize hook or adding any state, since the storage layer is the sole reader/writer of the width key. Simplify pass found nothing to change.

## Manual Testing Steps

- [ ] On the Day view, open an event so its form appears in the sidebar, then drag the sidebar divider to make it wider.
- [ ] Press ESC to discard the form, switch to the Week view: the sidebar keeps the width you dragged (previously it could snap back to narrow).
- [ ] Drag the sidebar to a different width on the Week view and switch back to Day via the view dropdown: width is preserved.
- [ ] Hard-refresh the page: width is still preserved.
- [ ] Edge case (the underlying bug): in devtools run `localStorage.setItem('compass.sidebar.width', '400.5')` and reload — the sidebar renders at 401px instead of resetting to the narrow default.

## Test plan

- [x] `bun test src/components/PlannerSidebar/storage/sidebar-width.storage.test.ts` — 5 pass, 0 fail (includes 2 new tests covering fractional read heal and rounded write)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] Validated in Chrome against local dev: fractional stored value heals to 401; drag → ESC → view switch → reload all preserve width; no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)