### PR TITLE
style(datepicker): group month label and nav arrows on the left in sidebar

### DIFF
--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -116,7 +116,12 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
           >
             <div
               className={classNames(
-                "min-w-0 flex-1 items-start",
+                "min-w-0 items-start",
+                // Grid pickers grow the label so the arrows sit at the right
+                // edge. The sidebar keeps the label at intrinsic width so the
+                // month label and nav arrows read as one group on the left,
+                // clearly separate from the sidebar-close control.
+                view !== "sidebar" && "flex-1",
                 monthContainerClassName,
               )}
             >

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -20,7 +20,6 @@ export interface Props extends Omit<ReactDatePickerProps, "autoFocus"> {
   headerEndContent?: React.ReactNode;
   inputColor?: string;
   isOpen?: boolean;
-  monthContainerClassName?: string;
   monthTextClassName?: string;
   view: "sidebar" | "grid";
   withTodayButton?: boolean;
@@ -42,7 +41,6 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
     headerEndContent,
     inputColor,
     isOpen = true,
-    monthContainerClassName,
     monthTextClassName,
     portalId = "root",
     view,
@@ -122,7 +120,6 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                 // month label and nav arrows read as one group on the left,
                 // clearly separate from the sidebar-close control.
                 view !== "sidebar" && "flex-1",
-                monthContainerClassName,
               )}
             >
               <span

--- a/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
@@ -76,7 +76,6 @@ export const PlannerMonthPicker: FC<Props> = ({
         headerClassName="!relative !justify-start !px-0 !pb-3"
         inline
         isOpen={true}
-        monthContainerClassName="!w-auto"
         monthTextClassName="text-[14px] font-medium"
         monthsShown={monthsShown}
         onChange={(date) => {


### PR DESCRIPTION
## Summary

In the sidebar's mini month picker, the prev/next month arrows were pushed to the far right edge of the header, directly against the close-sidebar icon — making them read as part of the sidebar-collapse control group instead of month navigation. Root cause: the layout-unification commit 30397d745 added `flex-1` to the shared DatePicker header's month-label wrapper, so the label absorbed all free space. (Prior fix attempts fought label *width* with `w-32`/`w-auto`, which can't override `flex-grow` — this is why the issue kept coming back.)

The label wrapper now keeps `flex-1` only for grid pickers (event form date fields, unchanged output by construction) and uses intrinsic width in the sidebar, so the month label and arrows form one visual group on the left while the close icon's `ml-auto` pins it alone to the far right. Per the earlier decision in #2098, the label→arrow gap stays tight rather than fixed-position, so the arrows shift a few pixels between month-name widths.

## Simplicity

Net reduction: one view-gated class in the shared header, minus the `!w-auto` override that existed only to fight the old layout, minus the now-dead `monthContainerClassName` prop (zero consumers after this change; removed in a follow-up commit). No `useEffect`/`useRef`/`useState` added or touched.

## Manual Testing Steps

- [ ] Open the Week or Day view with the sidebar visible: the mini calendar header shows "Jul 2026 ‹ ›" grouped together on the left, with the close-sidebar icon alone at the far right.
- [ ] Click the ‹ and › arrows: month navigates and the arrows stay grouped beside the label (e.g. "Aug 2026 ‹ ›").
- [ ] Click the close-sidebar icon at the header's right edge: sidebar collapses; press `[` to reopen.
- [ ] Open an all-day event, click a date field: the popup (grid) datepicker's header layout is unchanged.

## Test plan

- [x] `bun test src/components/PlannerSidebar/PlannerMonthPicker src/components/DatePicker` — 3 pass, 0 fail
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] Validated in Chrome against local dev: sidebar grouping correct in both views, month nav works, collapse icon works, grid picker unchanged, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)