### PR TITLE
fix(web): keep multi-week drag source

### DIFF
--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.test.ts
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.test.ts
@@ -1,0 +1,52 @@
+import { EventIdSchema } from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { resolveInteractionSourceEvent } from "./WeekInteractionCoordinator";
+import { describe, expect, it } from "bun:test";
+
+const createSourceEvent = (kind: "allDay" | "timed") =>
+  createMockEvent({
+    id: EventIdSchema.parse(
+      kind === "timed"
+        ? "aaaaaaaaaaaaaaaaaaaaaaaa"
+        : "bbbbbbbbbbbbbbbbbbbbbbbb",
+    ),
+    schedule: EventScheduleSchema.parse(
+      kind === "timed"
+        ? {
+            kind,
+            start: "2026-05-20T09:00:00.000Z",
+            end: "2026-05-20T10:00:00.000Z",
+            timeZone: "UTC",
+          }
+        : {
+            kind,
+            start: "2026-05-20",
+            end: "2026-05-21",
+          },
+    ),
+  });
+
+describe("resolveInteractionSourceEvent", () => {
+  for (const kind of ["timed", "allDay"] as const) {
+    it(`retains the ${kind} source after navigation replaces the visible week`, () => {
+      const activeEvent = createSourceEvent(kind);
+
+      expect(
+        resolveInteractionSourceEvent(activeEvent.id, new Map(), activeEvent),
+      ).toBe(activeEvent);
+    });
+  }
+
+  it("does not reuse an active event for a different interaction", () => {
+    const activeEvent = createSourceEvent("timed");
+
+    expect(
+      resolveInteractionSourceEvent(
+        "cccccccccccccccccccccccc",
+        new Map(),
+        activeEvent,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -42,6 +42,7 @@ export const WeekInteractionCoordinator: FC<Props> = ({
   });
   const { actions, confirmation, setters, state } = useDraftContext();
   const mutations = useEventMutations();
+  const activeInteractionEventRef = useRef<Event | null>(null);
   const layoutSourcesRef = useRef(getLayoutSources);
   const timedEventsById = useMemo(() => {
     return mapEventsById(timedEvents);
@@ -96,7 +97,13 @@ export const WeekInteractionCoordinator: FC<Props> = ({
   // draft from the query cache's source Event plus the engine's resulting
   // dates.
   const gridEventDraftFromSavedResult = (event: GridEvent) => {
-    const sourceEvent = event._id ? eventsById.get(event._id) : undefined;
+    const sourceEvent = event._id
+      ? resolveInteractionSourceEvent(
+          event._id,
+          eventsById,
+          activeInteractionEventRef.current,
+        )
+      : undefined;
     const draft = sourceEvent ? editGridEventDraft(sourceEvent, "this") : null;
 
     if (!draft) return null;
@@ -176,6 +183,13 @@ export const WeekInteractionCoordinator: FC<Props> = ({
     onCommitTimedDrag: commitSavedMutation,
     onCommitTimedResize: commitSavedMutation,
     onMotionActivation: (target) => {
+      // Edge navigation replaces the visible query before pointer-up. Retain
+      // the canonical source so the destination-week commit can still build
+      // its strict mutation input.
+      activeInteractionEventRef.current = target.event._id
+        ? (eventsById.get(target.event._id) ?? null)
+        : null;
+
       if (target.hadFormOpenBeforeInteraction) {
         actions.closeForm();
       }
@@ -208,3 +222,11 @@ const mapEventsById = (events: GridEvent[]) => {
 
   return eventsById;
 };
+
+export const resolveInteractionSourceEvent = (
+  eventId: string,
+  visibleEventsById: ReadonlyMap<string, Event>,
+  activeInteractionEvent: Event | null,
+) =>
+  visibleEventsById.get(eventId) ??
+  (activeInteractionEvent?.id === eventId ? activeInteractionEvent : undefined);


### PR DESCRIPTION
## Summary

- retain the canonical source event while a drag navigates between week queries
- allow timed and all-day drops to build and issue their saved-event mutation in the destination week
- cover both event types when the visible-week map no longer contains the source

Related to #1784 and #1786.

## Simplicity

- keeps the fix inside the Week interaction coordinator and reuses the existing strict mutation pipeline
- avoids new cross-layer state or changes to drag geometry
- no separate simplification commit was needed after removing unnecessary teardown control flow

## Manual Testing Steps

- [ ] Drag a timed event to the next week, drop it in a different day column, and confirm it appears immediately in that slot
- [ ] Drag an all-day event to the previous week, drop it in a different day column, and confirm it appears immediately in that slot
- [ ] Confirm both interactions leave the browser console free of errors or warnings

## Test plan

- [x] bun test:web -- WeekInteractionCoordinator week-interaction.timed-drag week-interaction.all-day-drag
- [x] bun type-check
- [x] bun lint
- [x] bun run verify
- [x] local browser validation on the Week view for timed next-week and all-day previous-week drops