### PR TITLE
feat(day): drag events between calendar columns

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -9,12 +9,22 @@ test.skip(
   "Mouse/keyboard flows are desktop-only in week view.",
 );
 
+// Wide enough for all 7 week columns (track needs GRID_MARGIN_LEFT +
+// 7 * DAY_COLUMN_MIN_USABLE_WIDTH beside the sidebar). At the default
+// 1280px, bare /week shows a 6-day Sun-Fri window anchored on the week
+// start, which EXCLUDES today whenever today is Saturday (UTC) — the
+// today-anchored fixtures below then never render and every assertion on
+// them fails. Full width keeps "the default week view always includes
+// today" true on every weekday.
+test.use({ viewport: { width: 1600, height: 900 } });
+
 // Fixtures. CalendarSchema/EventSchema (packages/core/src/types) are zod
 // strictObjects - an extra or missing field fails parsing client-side and
 // the app renders nothing, so every fixture below is a full, honest member
 // of those shapes. IDs are 24-char hex (ObjectId format). Event times anchor
 // on "today" so the default week view (dayjs().startOf("week"), always
-// including today) renders them without knowing the week-start convention.
+// including today at full width - see the viewport note above) renders them
+// without knowing the week-start convention.
 
 const objectId = (seed: string) => seed.repeat(24);
 

--- a/packages/backend/src/common/services/gcal/gcal.service.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.test.ts
@@ -222,6 +222,7 @@ describe("gcal.service quotaUser passthrough (packet 07 step 7 pin)", () => {
           status: 200,
           data: { items: [], nextSyncToken: "sync-token" },
         }),
+        move: jest.fn().mockResolvedValue({ status: 200, data: {} }),
         patch: jest.fn().mockResolvedValue({ status: 200, data: {} }),
         watch: jest.fn().mockResolvedValue({
           status: 200,
@@ -287,6 +288,11 @@ describe("gcal.service quotaUser passthrough (packet 07 step 7 pin)", () => {
       method: "deleteEvent",
       call: () => gcalService.deleteEvent(context, "cal-1", "event-1"),
       mock: () => context.gcal.events.delete as jest.Mock,
+    },
+    {
+      method: "moveEvent",
+      call: () => gcalService.moveEvent(context, "cal-1", "event-1", "cal-2"),
+      mock: () => context.gcal.events.move as jest.Mock,
     },
     {
       method: "getEventInstances",

--- a/packages/backend/src/common/services/gcal/gcal.service.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.ts
@@ -80,6 +80,30 @@ class GCalService {
     return response;
   }
 
+  /**
+   * Moves an event to another Google calendar. Google preserves the event id
+   * across a move, so the stored externalReference stays valid. No
+   * sendUpdates: re-homing an event between the user's own calendars must
+   * not email attendees (matches createEvent/patchEvent).
+   */
+  async moveEvent(
+    { gcal, quotaUser }: GoogleRequestContext,
+    calendarId: string,
+    gcalEventId: string,
+    destinationCalendarId: string,
+  ): Promise<gSchema$Event> {
+    const response = await withGoogleRetry(() =>
+      gcal.events.move({
+        calendarId,
+        destination: destinationCalendarId,
+        eventId: gcalEventId,
+        quotaUser,
+      }),
+    );
+
+    return this.validateGCalResponse(response).data;
+  }
+
   private async getEventInstances(
     { gcal, quotaUser }: GoogleRequestContext,
     calendarId: string,

--- a/packages/backend/src/event/services/event.service.test.ts
+++ b/packages/backend/src/event/services/event.service.test.ts
@@ -966,15 +966,11 @@ describe("EventService (cross-calendar move)", () => {
       expect.anything(),
       source.source.calendarId,
       "google-event-1",
-      destination.source.provider === "google"
-        ? destination.source.calendarId
-        : "",
+      destination.source.calendarId,
     );
     expect(patchSpy).toHaveBeenCalledWith(
       expect.anything(),
-      destination.source.provider === "google"
-        ? destination.source.calendarId
-        : "",
+      destination.source.calendarId,
       "google-event-1",
       expect.anything(),
     );

--- a/packages/backend/src/event/services/event.service.test.ts
+++ b/packages/backend/src/event/services/event.service.test.ts
@@ -6,6 +6,7 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
+import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import eventService from "@backend/event/services/event.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
@@ -725,5 +726,262 @@ describe("EventService (visibility filtering for list reads, packet 08)", () => 
         scope: "this",
       }),
     ).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * Cross-calendar move (drag between Day-view columns): a replace whose
+ * calendarId differs from the event's current calendar re-homes a single
+ * event. Moves supersede A6's calendar-immutability for single events only;
+ * recurring events are rejected before any write.
+ */
+describe("EventService (cross-calendar move)", () => {
+  beforeEach(setupTestDb);
+  beforeEach(cleanupCollections);
+  afterEach(() => jest.restoreAllMocks());
+  afterAll(cleanupTestDb);
+
+  const moveInput = (calendarId: string) => ({
+    calendarId: calendarId as never,
+    content: { kind: "details" as const, title: "Moved", description: "" },
+    schedule: {
+      kind: "timed" as const,
+      start: "2026-07-14T15:00:00-06:00",
+      end: "2026-07-14T16:00:00-06:00",
+      timeZone: "America/Denver" as never,
+    },
+    recurrence: { kind: "preserve" as const },
+    scope: "this" as const,
+  });
+
+  it("moves a single event to the destination calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedLocalCalendar(user._id);
+    const destination = await seedLocalCalendar(user._id);
+    const event = buildEventRecord(source._id);
+    await mongoService.event.insertOne(event);
+
+    const replaced = await eventService.replace(
+      user._id.toString(),
+      event._id.toHexString(),
+      moveInput(destination._id.toHexString()) as never,
+    );
+
+    expect(replaced.calendarId).toEqual(destination._id);
+
+    const stored = await mongoService.event.findOne({ _id: event._id });
+    expect(stored?.calendarId).toEqual(destination._id);
+  });
+
+  it("treats a matching calendarId as a plain replace, not a move", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedLocalCalendar(user._id);
+    const event = buildEventRecord(calendar._id);
+    await mongoService.event.insertOne(event);
+
+    const replaced = await eventService.replace(
+      user._id.toString(),
+      event._id.toHexString(),
+      moveInput(calendar._id.toHexString()) as never,
+    );
+
+    expect(replaced.calendarId).toEqual(calendar._id);
+    expect(replaced.content.kind === "details" && replaced.content.title).toBe(
+      "Moved",
+    );
+  });
+
+  it("rejects a move for a recurring event with RECURRENCE_CONFLICT", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedLocalCalendar(user._id);
+    const destination = await seedLocalCalendar(user._id);
+    const event = buildEventRecord(source._id, {
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+    });
+    await mongoService.event.insertOne(event);
+
+    await expect(
+      eventService.replace(
+        user._id.toString(),
+        event._id.toHexString(),
+        moveInput(destination._id.toHexString()) as never,
+      ),
+    ).rejects.toMatchObject({ mutationCode: "RECURRENCE_CONFLICT" });
+
+    const stored = await mongoService.event.findOne({ _id: event._id });
+    expect(stored?.calendarId).toEqual(source._id);
+  });
+
+  it("rejects a move that also converts the event to a series", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedLocalCalendar(user._id);
+    const destination = await seedLocalCalendar(user._id);
+    const event = buildEventRecord(source._id);
+    await mongoService.event.insertOne(event);
+
+    await expect(
+      eventService.replace(user._id.toString(), event._id.toHexString(), {
+        ...moveInput(destination._id.toHexString()),
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+      } as never),
+    ).rejects.toMatchObject({ mutationCode: "RECURRENCE_CONFLICT" });
+
+    const stored = await mongoService.event.findOne({ _id: event._id });
+    expect(stored?.calendarId).toEqual(source._id);
+  });
+
+  it("rejects moving a Google event onto a non-Google calendar", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedGoogleCalendar(user._id, { access: "owner" });
+    const destination = await seedLocalCalendar(user._id);
+    const event = buildEventRecord(source._id, {
+      externalReference: {
+        provider: "google",
+        eventId: "google-event-1",
+        recurringEventId: null,
+      },
+    });
+    await mongoService.event.insertOne(event);
+
+    await expect(
+      eventService.replace(
+        user._id.toString(),
+        event._id.toHexString(),
+        moveInput(destination._id.toHexString()) as never,
+      ),
+    ).rejects.toMatchObject({ mutationCode: "PROVIDER_FAILURE" });
+
+    const stored = await mongoService.event.findOne({ _id: event._id });
+    expect(stored?.calendarId).toEqual(source._id);
+  });
+
+  it("reverts the calendar when Google refuses the move", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedGoogleCalendar(user._id, { access: "owner" });
+    const destination = await seedGoogleCalendar(user._id, {
+      access: "writer",
+      isPrimary: false,
+    });
+    const event = buildEventRecord(source._id, {
+      externalReference: {
+        provider: "google",
+        eventId: "google-event-1",
+        recurringEventId: null,
+      },
+    });
+    await mongoService.event.insertOne(event);
+
+    jest
+      .spyOn(gcalService, "moveEvent")
+      .mockRejectedValue(new Error("cannotChangeOrganizer"));
+
+    await expect(
+      eventService.replace(
+        user._id.toString(),
+        event._id.toHexString(),
+        moveInput(destination._id.toHexString()) as never,
+      ),
+    ).rejects.toMatchObject({ mutationCode: "PROVIDER_FAILURE" });
+
+    const stored = await mongoService.event.findOne({ _id: event._id });
+    expect(stored?.calendarId).toEqual(source._id);
+  });
+
+  it("rejects a move to a read-only destination with CALENDAR_READ_ONLY", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedLocalCalendar(user._id);
+    const destination = await seedGoogleCalendar(user._id, {
+      access: "reader",
+    });
+    const event = buildEventRecord(source._id);
+    await mongoService.event.insertOne(event);
+
+    await expect(
+      eventService.replace(
+        user._id.toString(),
+        event._id.toHexString(),
+        moveInput(destination._id.toHexString()) as never,
+      ),
+    ).rejects.toMatchObject({ mutationCode: "CALENDAR_READ_ONLY" });
+
+    const stored = await mongoService.event.findOne({ _id: event._id });
+    expect(stored?.calendarId).toEqual(source._id);
+  });
+
+  it("publishes eventsChanged for both the source and destination calendars", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedLocalCalendar(user._id);
+    const destination = await seedLocalCalendar(user._id);
+    const event = buildEventRecord(source._id);
+    await mongoService.event.insertOne(event);
+    const publishSpy = jest.spyOn(sseServer, "publishEventsChanged");
+
+    await eventService.replace(
+      user._id.toString(),
+      event._id.toHexString(),
+      moveInput(destination._id.toHexString()) as never,
+    );
+
+    const notifiedCalendarIds = publishSpy.mock.calls.map(
+      ([, payload]) => payload.calendarId,
+    );
+    expect(notifiedCalendarIds).toEqual(
+      expect.arrayContaining([
+        source._id.toHexString(),
+        destination._id.toHexString(),
+      ]),
+    );
+  });
+
+  it("moves the Google copy via events.move (then patches) when both calendars are Google", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const source = await seedGoogleCalendar(user._id, { access: "owner" });
+    const destination = await seedGoogleCalendar(user._id, {
+      access: "writer",
+      isPrimary: false,
+    });
+    const event = buildEventRecord(source._id, {
+      externalReference: {
+        provider: "google",
+        eventId: "google-event-1",
+        recurringEventId: null,
+      },
+    });
+    await mongoService.event.insertOne(event);
+
+    const moveSpy = jest
+      .spyOn(gcalService, "moveEvent")
+      .mockResolvedValue({} as never);
+    const patchSpy = jest
+      .spyOn(gcalService, "patchEvent")
+      .mockResolvedValue({} as never);
+
+    await eventService.replace(
+      user._id.toString(),
+      event._id.toHexString(),
+      moveInput(destination._id.toHexString()) as never,
+    );
+
+    expect(moveSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      source.source.calendarId,
+      "google-event-1",
+      destination.source.provider === "google"
+        ? destination.source.calendarId
+        : "",
+    );
+    expect(patchSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      destination.source.provider === "google"
+        ? destination.source.calendarId
+        : "",
+      "google-event-1",
+      expect.anything(),
+    );
+
+    const stored = await mongoService.event.findOne({ _id: event._id });
+    expect(stored?.externalReference).toEqual(
+      expect.objectContaining({ eventId: "google-event-1" }),
+    );
   });
 });

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -21,6 +21,7 @@ import {
 import {
   analyzeDelete,
   analyzeReplace,
+  type ReplacePlan,
   type SeriesContext,
 } from "@backend/event/classes/compass.event.parser";
 import { eventMutationError } from "@backend/event/event.error";
@@ -75,6 +76,26 @@ const notify = async (
 };
 
 const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
+
+/**
+ * Applies a cross-calendar move to the plan's updated record. Only single
+ * (non-recurring) events may move (enforced before planning), so the plan is
+ * always replaceThis — or replaceSeries with no instances when the caller
+ * sent a series scope for a single event; replaceSplit requires an
+ * occurrence and can't occur.
+ */
+const retargetPlanCalendar = (
+  plan: ReplacePlan,
+  calendarId: ObjectId,
+): ReplacePlan => {
+  if (plan.kind === "replaceThis") {
+    return { ...plan, updated: { ...plan.updated, calendarId } };
+  }
+  if (plan.kind === "replaceSeries") {
+    return { ...plan, updatedBase: { ...plan.updatedBase, calendarId } };
+  }
+  return plan;
+};
 
 class EventService {
   private async ownedCalendarIds(userId: string): Promise<ObjectId[]> {
@@ -236,10 +257,52 @@ class EventService {
     input: ReplaceEventInput,
   ): Promise<EventRecord> => {
     const target = await this.requireOwnedEvent(userId, eventId);
-    await this.requireWritableCalendar(userId, target.calendarId);
+    const sourceCalendar = await this.requireWritableCalendar(
+      userId,
+      target.calendarId,
+    );
+    // A differing input.calendarId is a cross-calendar move (drag between
+    // Day-view columns). Moves supersede A6's calendar-immutability for
+    // single events only: a series' materialized instances must stay on the
+    // base's calendar, and Google has no per-occurrence move either. Both
+    // the pre-image AND the incoming recurrence must be single — otherwise
+    // one call could convert-to-series and move at once, recreating the
+    // multi-calendar-series states the guard exists to prevent.
+    const isMove =
+      !!input.calendarId && !target.calendarId.equals(input.calendarId);
+    if (
+      isMove &&
+      (target.recurrence.kind !== "single" ||
+        input.recurrence.kind === "series")
+    ) {
+      throw eventMutationError(
+        "RECURRENCE_CONFLICT",
+        "Recurring events cannot move between calendars",
+      );
+    }
+    const destinationCalendar = isMove
+      ? await this.requireWritableCalendar(userId, input.calendarId!)
+      : null;
+    // Moving a Google event off Google would mean deleting the Google copy —
+    // cancellation emails to every attendee, and attendees/conferencing lost
+    // for good if it's ever recreated. Not supported; Google events may only
+    // move between Google calendars.
+    if (
+      destinationCalendar &&
+      sourceCalendar.source.provider === "google" &&
+      destinationCalendar.source.provider !== "google"
+    ) {
+      throw eventMutationError(
+        "PROVIDER_FAILURE",
+        "Google events can only move to another Google calendar",
+      );
+    }
     const ownedCalendarIds = await this.ownedCalendarIds(userId);
     const series = await this.seriesContext(target, ownedCalendarIds);
-    const plan = analyzeReplace(target, series, input, new Date());
+    let plan = analyzeReplace(target, series, input, new Date());
+    if (destinationCalendar) {
+      plan = retargetPlanCalendar(plan, destinationCalendar._id);
+    }
     const materialized = generateReplace(plan);
     const deletedBefore = [target, ...(series?.instances ?? [])].filter(
       (record) => materialized.deleteIds.some((id) => id.equals(record._id)),
@@ -263,12 +326,46 @@ class EventService {
       executeMutation(materialized, session),
     );
 
-    await CompassToGoogleEventPropagation.propagate(userId, {
-      upserted: materialized.upsert,
-      deletedBefore,
-      originalStartByEventId,
-    });
-    await notify(userId, [materialized.primary], "updated");
+    if (destinationCalendar) {
+      // The generic propagation would patch the Google copy under the
+      // DESTINATION calendar (record.calendarId already points there), where
+      // the event doesn't exist yet — moves need Google's events.move first.
+      try {
+        await CompassToGoogleEventPropagation.propagateCalendarMove(
+          userId,
+          materialized.primary,
+          sourceCalendar,
+          destinationCalendar,
+        );
+      } catch (err) {
+        // Google refused the move (e.g. the user isn't the event's
+        // organizer). The transaction already committed the new calendarId,
+        // so put the record back on the source calendar — otherwise Compass
+        // and Google disagree forever and every later edit patches a Google
+        // event that isn't on that calendar. The client's settle-time
+        // refetch then restores the event to its original column.
+        await eventRepository.replaceOne({
+          ...materialized.primary,
+          calendarId: target.calendarId,
+        });
+        throw err;
+      }
+    } else {
+      await CompassToGoogleEventPropagation.propagate(userId, {
+        upserted: materialized.upsert,
+        deletedBefore,
+        originalStartByEventId,
+      });
+    }
+    // On a move, notify the source calendar too (via the pre-move `target`)
+    // so clients drop the event from the old column as well.
+    await notify(
+      userId,
+      destinationCalendar
+        ? [target, materialized.primary]
+        : [materialized.primary],
+      "updated",
+    );
 
     return materialized.primary;
   };

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
@@ -48,6 +48,31 @@ export const isWritableToGoogle = (record: EventRecord): boolean =>
  * begin with.
  */
 export class CompassToGoogleEventPropagation {
+  /**
+   * Shared failure policy for post-transaction Google effects: a user
+   * without a Google connection is a normal skip; anything else logs and
+   * surfaces as PROVIDER_FAILURE with the given message.
+   */
+  private static async runGoogleEffects(
+    userId: string,
+    failureMessage: string,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    try {
+      await run();
+    } catch (err) {
+      if (isMissingGoogleRefreshToken(err)) {
+        logger.info(
+          `Skipping Google effect for user ${userId} because Google is not connected.`,
+        );
+        return;
+      }
+
+      logger.error(failureMessage, err as Error);
+      throw eventMutationError("PROVIDER_FAILURE", failureMessage);
+    }
+  }
+
   static async propagate(
     userId: string,
     change: EventChangeSet,
@@ -87,39 +112,30 @@ export class CompassToGoogleEventPropagation {
         .map((record) => record._id.toHexString()),
     );
 
-    try {
-      for (const record of change.deletedBefore) {
-        await CompassToGoogleEventPropagation.propagateDelete(
-          userId,
-          record,
-          calendarById.get(record.calendarId.toHexString()),
-          regeneratingSeriesIds,
-        );
-      }
+    await CompassToGoogleEventPropagation.runGoogleEffects(
+      userId,
+      "Failed to sync the change to Google Calendar",
+      async () => {
+        for (const record of change.deletedBefore) {
+          await CompassToGoogleEventPropagation.propagateDelete(
+            userId,
+            record,
+            calendarById.get(record.calendarId.toHexString()),
+            regeneratingSeriesIds,
+          );
+        }
 
-      for (const record of change.upserted) {
-        await CompassToGoogleEventPropagation.propagateUpsert(
-          userId,
-          record,
-          calendarById.get(record.calendarId.toHexString()),
-          change.originalStartByEventId,
-          regeneratingSeriesIds,
-        );
-      }
-    } catch (err) {
-      if (isMissingGoogleRefreshToken(err)) {
-        logger.info(
-          `Skipping Google effect for user ${userId} because Google is not connected.`,
-        );
-        return;
-      }
-
-      logger.error("Compass->Google propagation failed", err as Error);
-      throw eventMutationError(
-        "PROVIDER_FAILURE",
-        "Failed to sync the change to Google Calendar",
-      );
-    }
+        for (const record of change.upserted) {
+          await CompassToGoogleEventPropagation.propagateUpsert(
+            userId,
+            record,
+            calendarById.get(record.calendarId.toHexString()),
+            change.originalStartByEventId,
+            regeneratingSeriesIds,
+          );
+        }
+      },
+    );
   }
 
   /**
@@ -141,64 +157,55 @@ export class CompassToGoogleEventPropagation {
     const fromGoogle = from.source.provider === "google" ? from.source : null;
     const toGoogle = to.source.provider === "google" ? to.source : null;
 
-    try {
-      if (fromGoogle && toGoogle && record.externalReference) {
-        const context = await createGoogleRequestContext(userId);
-        await gcalService.moveEvent(
-          context,
-          fromGoogle.calendarId,
-          record.externalReference.eventId,
-          toGoogle.calendarId,
-        );
-        // Move keeps the Google event id; the follow-up patch applies any
-        // content/schedule change from the same drag. A patch failure is
-        // non-fatal: the move itself landed, and the next ordinary edit
-        // re-patches at the destination.
-        try {
-          await gcalService.patchEvent(
+    await CompassToGoogleEventPropagation.runGoogleEffects(
+      userId,
+      "Failed to sync the calendar move to Google Calendar",
+      async () => {
+        if (fromGoogle && toGoogle && record.externalReference) {
+          const context = await createGoogleRequestContext(userId);
+          await gcalService.moveEvent(
             context,
-            toGoogle.calendarId,
+            fromGoogle.calendarId,
             record.externalReference.eventId,
-            mapEventRecordToGoogle(record),
+            toGoogle.calendarId,
           );
-        } catch (patchError) {
-          logger.warn(
-            `Post-move patch failed for event ${record._id.toHexString()}; the move itself succeeded.`,
-            patchError as Error,
+          // Move keeps the Google event id; the follow-up patch applies any
+          // content/schedule change from the same drag. A patch failure is
+          // non-fatal: the move itself landed, and the next ordinary edit
+          // re-patches at the destination.
+          try {
+            await gcalService.patchEvent(
+              context,
+              toGoogle.calendarId,
+              record.externalReference.eventId,
+              mapEventRecordToGoogle(record),
+            );
+          } catch (patchError) {
+            logger.warn(
+              `Post-move patch failed for event ${record._id.toHexString()}; the move itself succeeded.`,
+              patchError as Error,
+            );
+          }
+          return;
+        }
+
+        if (toGoogle) {
+          // Entering Google from a local calendar (or a Google-owned record
+          // that never synced): create fresh on the destination and store the
+          // new externalReference. Any lingering externalReference is stale —
+          // moves off Google calendars are rejected — so discard it rather
+          // than letting the upsert patch a Google event that isn't there.
+          await CompassToGoogleEventPropagation.propagateUpsert(
+            userId,
+            { ...record, externalReference: null },
+            to,
+            undefined,
+            new Set(),
           );
         }
-        return;
-      }
-
-      if (toGoogle) {
-        // Entering Google from a local calendar (or a Google-owned record
-        // that never synced): create fresh on the destination and store the
-        // new externalReference. Any lingering externalReference is stale —
-        // moves off Google calendars are rejected — so discard it rather
-        // than letting the upsert patch a Google event that isn't there.
-        await CompassToGoogleEventPropagation.propagateUpsert(
-          userId,
-          { ...record, externalReference: null },
-          to,
-          undefined,
-          new Set(),
-        );
-      }
-      // local -> local: nothing to sync.
-    } catch (err) {
-      if (isMissingGoogleRefreshToken(err)) {
-        logger.info(
-          `Skipping Google effect for user ${userId} because Google is not connected.`,
-        );
-        return;
-      }
-
-      logger.error("Compass->Google move propagation failed", err as Error);
-      throw eventMutationError(
-        "PROVIDER_FAILURE",
-        "Failed to sync the calendar move to Google Calendar",
-      );
-    }
+        // local -> local: nothing to sync.
+      },
+    );
   }
 
   /**

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
@@ -123,6 +123,85 @@ export class CompassToGoogleEventPropagation {
   }
 
   /**
+   * Propagates a single event's cross-calendar move (the drag-between-Day-
+   * columns flow). The service restricts moves to non-recurring events and
+   * rejects moves OFF a Google calendar onto a non-Google one (that would
+   * mean deleting the Google copy — cancellation emails, lost attendees), so
+   * the only cases here are Google->Google and local->Google/local->local.
+   * `record` already carries the destination calendarId and the post-edit
+   * content/schedule. Runs after the Mongo transaction, like propagate();
+   * the caller compensates (reverts the calendarId) when this throws.
+   */
+  static async propagateCalendarMove(
+    userId: string,
+    record: EventRecord,
+    from: CalendarRecord,
+    to: CalendarRecord,
+  ): Promise<void> {
+    const fromGoogle = from.source.provider === "google" ? from.source : null;
+    const toGoogle = to.source.provider === "google" ? to.source : null;
+
+    try {
+      if (fromGoogle && toGoogle && record.externalReference) {
+        const context = await createGoogleRequestContext(userId);
+        await gcalService.moveEvent(
+          context,
+          fromGoogle.calendarId,
+          record.externalReference.eventId,
+          toGoogle.calendarId,
+        );
+        // Move keeps the Google event id; the follow-up patch applies any
+        // content/schedule change from the same drag. A patch failure is
+        // non-fatal: the move itself landed, and the next ordinary edit
+        // re-patches at the destination.
+        try {
+          await gcalService.patchEvent(
+            context,
+            toGoogle.calendarId,
+            record.externalReference.eventId,
+            mapEventRecordToGoogle(record),
+          );
+        } catch (patchError) {
+          logger.warn(
+            `Post-move patch failed for event ${record._id.toHexString()}; the move itself succeeded.`,
+            patchError as Error,
+          );
+        }
+        return;
+      }
+
+      if (toGoogle) {
+        // Entering Google from a local calendar (or a Google-owned record
+        // that never synced): create fresh on the destination and store the
+        // new externalReference. Any lingering externalReference is stale —
+        // moves off Google calendars are rejected — so discard it rather
+        // than letting the upsert patch a Google event that isn't there.
+        await CompassToGoogleEventPropagation.propagateUpsert(
+          userId,
+          { ...record, externalReference: null },
+          to,
+          undefined,
+          new Set(),
+        );
+      }
+      // local -> local: nothing to sync.
+    } catch (err) {
+      if (isMissingGoogleRefreshToken(err)) {
+        logger.info(
+          `Skipping Google effect for user ${userId} because Google is not connected.`,
+        );
+        return;
+      }
+
+      logger.error("Compass->Google move propagation failed", err as Error);
+      throw eventMutationError(
+        "PROVIDER_FAILURE",
+        "Failed to sync the calendar move to Google Calendar",
+      );
+    }
+  }
+
+  /**
    * Resolves the Google instance id for a not-yet-synced series occurrence
    * (packet 05 step 4). The series base is looked up fresh from Mongo rather
    * than passed in: by the time propagateDelete/propagateUpsert reaches an

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -45,6 +45,11 @@ export const CreateEventInputSchema = z.strictObject({
 export type CreateEventInput = z.infer<typeof CreateEventInputSchema>;
 
 export const ReplaceEventInputSchema = z.strictObject({
+  // Destination calendar for a cross-calendar move (drag between Day-view
+  // columns). Omitted or equal to the event's current calendar means no
+  // move. Only single (non-recurring) events may move; the server rejects
+  // moves for series/occurrences.
+  calendarId: CalendarIdSchema.optional(),
   content: EditableContentSchema,
   schedule: EventScheduleSchema,
   recurrence: RecurrenceEditSchema,

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -75,6 +75,7 @@ function mergeReplaceInput(existing: Event, input: ReplaceEventInput): Event {
 
   return {
     ...existing,
+    calendarId: input.calendarId ?? existing.calendarId,
     content: input.content,
     schedule: input.schedule,
     recurrence,

--- a/packages/web/src/events/mutations/useUndoRedo.ts
+++ b/packages/web/src/events/mutations/useUndoRedo.ts
@@ -66,6 +66,9 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
       mutations.replace({
         id,
         input: {
+          // Restores the snapshot's calendar too, so undoing a cross-calendar
+          // move puts the event back on its original calendar.
+          calendarId: snapshot.calendarId,
           content: snapshot.content,
           schedule: snapshot.schedule,
           recurrence: { kind: "single" },

--- a/packages/web/src/events/mutations/useUpdateEvent.ts
+++ b/packages/web/src/events/mutations/useUpdateEvent.ts
@@ -4,7 +4,10 @@ import { useCallback } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
-import { buildCalendarLookup } from "@web/calendars/useCalendarLookup";
+import {
+  buildCalendarLookup,
+  isEventReadOnly,
+} from "@web/calendars/useCalendarLookup";
 import {
   type GridEvent,
   type RecurringEventUpdateScope,
@@ -80,11 +83,12 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
           showErrorToast("Repeating events can't move to another calendar.");
           return;
         }
-        const destination = buildCalendarLookup(
+        const lookup = buildCalendarLookup(
           queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all),
-        ).get(nextCalendarId);
-        if (destination && !destination.capabilities.canWrite) {
-          showErrorToast(`You can't move events to ${destination.name}.`);
+        );
+        if (isEventReadOnly(lookup, nextCalendarId, false)) {
+          const name = lookup.get(nextCalendarId)?.name ?? "that calendar";
+          showErrorToast(`You can't move events to ${name}.`);
           return;
         }
       }

--- a/packages/web/src/events/mutations/useUpdateEvent.ts
+++ b/packages/web/src/events/mutations/useUpdateEvent.ts
@@ -1,11 +1,15 @@
 import { useQueryClient } from "@tanstack/react-query";
 import fastDeepEqual from "fast-deep-equal/es6";
 import { useCallback } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { buildCalendarLookup } from "@web/calendars/useCalendarLookup";
 import {
   type GridEvent,
   type RecurringEventUpdateScope,
 } from "@web/common/types/web.event.types";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import {
   editGridEventDraft,
   parseGridEventDraft,
@@ -64,6 +68,27 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
       const sourceEvent = findEventInCache(queryClient, event._id);
       if (!sourceEvent) return;
 
+      // A differing calendarId means the drag dropped the event on another
+      // calendar's column (Day view). Guard here so a blocked move reverts
+      // the whole drag; the backend re-enforces both rules.
+      const nextCalendarId =
+        event.calendarId && event.calendarId !== sourceEvent.calendarId
+          ? event.calendarId
+          : null;
+      if (nextCalendarId) {
+        if (sourceEvent.recurrence.kind !== "single") {
+          showErrorToast("Repeating events can't move to another calendar.");
+          return;
+        }
+        const destination = buildCalendarLookup(
+          queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all),
+        ).get(nextCalendarId);
+        if (destination && !destination.capabilities.canWrite) {
+          showErrorToast(`You can't move events to ${destination.name}.`);
+          return;
+        }
+      }
+
       const sourceDraft = editGridEventDraft(
         sourceEvent,
         toRecurrenceScope(applyTo),
@@ -89,11 +114,21 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
         },
       };
 
-      if (fastDeepEqual(patchedDraft.values, sourceDraft.values)) return;
+      if (
+        !nextCalendarId &&
+        fastDeepEqual(patchedDraft.values, sourceDraft.values)
+      ) {
+        return;
+      }
 
       const parsed = parseGridEventDraft(patchedDraft);
       if (parsed.ok && parsed.mode === "edit") {
-        replace({ id: parsed.eventId, input: parsed.input });
+        replace({
+          id: parsed.eventId,
+          input: nextCalendarId
+            ? { ...parsed.input, calendarId: nextCalendarId }
+            : parsed.input,
+        });
       }
     },
     [replace, queryClient],

--- a/packages/web/src/events/repositories/local.event.repository.ts
+++ b/packages/web/src/events/repositories/local.event.repository.ts
@@ -89,6 +89,7 @@ export class LocalEventRepository implements EventRepository {
 
     const event: Event = {
       ...existing,
+      calendarId: input.calendarId ?? existing.calendarId,
       content: input.content,
       schedule: input.schedule,
       recurrence,

--- a/packages/web/src/grid/interaction/types/all-day-drag.types.ts
+++ b/packages/web/src/grid/interaction/types/all-day-drag.types.ts
@@ -21,6 +21,10 @@ export interface AllDayDragVisual {
    * absolutely, because the converted block lands on the column it was dropped
    * on and has no meaningful offset from where the span started.
    */
+  /**
+   * Column key semantics match TimedDragVisual.dayDate: a date in the Week
+   * view, a calendar id in the Day view.
+   */
   dayDate: string;
   dayIndex: number;
   eventId: string;

--- a/packages/web/src/grid/interaction/types/timed-drag.types.ts
+++ b/packages/web/src/grid/interaction/types/timed-drag.types.ts
@@ -29,7 +29,12 @@ export type CrossRowSize = { height: number; width: number } | null;
  */
 export interface TimedDragVisual {
   crossRowSize: CrossRowSize;
-  /** Local YYYY-MM-DD date of the column currently under the drag. */
+  /**
+   * Key of the column currently under the drag. Week view columns are
+   * local YYYY-MM-DD dates; Day view columns are CALENDAR IDS (all columns
+   * share the visible date there) - do not dayjs-parse this without knowing
+   * which view produced it.
+   */
   dayDate: string;
   dayIndex: number;
   durationMinutes: number;

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -94,6 +94,10 @@ export function DayCalendarGrid() {
   useDayEventNudgeShortcuts({ timedEvents: displayedTimedEvents });
   const draft = useDraftStore(selectDraft);
 
+  const calendarColumnKeys = useMemo(
+    () => displayedCalendars.map((calendar) => calendar.id),
+    [displayedCalendars],
+  );
   const getDayInteractionLayoutSources = useCallback(
     () => ({
       allDayColumnsElement: gridRefs.allDayColumnsRef.current,
@@ -327,6 +331,7 @@ export function DayCalendarGrid() {
     >
       <DayInteractionCoordinator
         allDayEvents={displayedAllDayEvents}
+        calendarColumnKeys={calendarColumnKeys}
         dateInView={dateInView}
         getLayoutSources={getDayInteractionLayoutSources}
         onOpenEvent={openEventFormForEvent}

--- a/packages/web/src/views/Day/interaction/DayInteractionCoordinator.tsx
+++ b/packages/web/src/views/Day/interaction/DayInteractionCoordinator.tsx
@@ -20,6 +20,8 @@ import {
 
 interface Props extends PropsWithChildren {
   allDayEvents?: GridEvent[];
+  /** Ordered calendar ids of the rendered per-calendar columns. */
+  calendarColumnKeys?: string[];
   dateInView: Dayjs;
   getLayoutSources: () => GridLayoutCacheSources;
   onOpenEvent: (event: GridEvent) => void;
@@ -27,9 +29,11 @@ interface Props extends PropsWithChildren {
 }
 
 const EMPTY_GRID_EVENTS: GridEvent[] = [];
+const EMPTY_COLUMN_KEYS: string[] = [];
 
 export const DayInteractionCoordinator: FC<Props> = ({
   allDayEvents = EMPTY_GRID_EVENTS,
+  calendarColumnKeys = EMPTY_COLUMN_KEYS,
   children,
   dateInView,
   getLayoutSources,
@@ -41,6 +45,8 @@ export const DayInteractionCoordinator: FC<Props> = ({
   const isFormOpenRef = useRef(isFormOpen);
   isFormOpenRef.current = isFormOpen;
   const layoutSourcesRef = useRef(getLayoutSources);
+  const calendarColumnKeysRef = useRef(calendarColumnKeys);
+  calendarColumnKeysRef.current = calendarColumnKeys;
   const timedEventsById = useMemo(() => {
     return mapEventsById(timedEvents);
   }, [timedEvents]);
@@ -55,6 +61,7 @@ export const DayInteractionCoordinator: FC<Props> = ({
   const adapter = useMemo(
     () =>
       createDayInteractionAdapter({
+        getColumnKeys: () => calendarColumnKeysRef.current,
         getLayoutSources: () => layoutSourcesRef.current(),
         getVisibleDate: () => dateInView,
         runtime: () => runtimeRef.current,

--- a/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.test.ts
+++ b/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.test.ts
@@ -28,8 +28,12 @@ const allDaySourceRect = {
   width: 320,
 };
 
+const CALENDAR_A = "aaaaaaaaaaaaaaaaaaaaaaaa";
+const CALENDAR_B = "bbbbbbbbbbbbbbbbbbbbbbbb";
+
 const timedEvent: GridEvent = {
   _id: "timed-event",
+  calendarId: CALENDAR_A as never,
   endDate: "2026-05-18T10:00:00.000",
   isAllDay: false,
   origin: Origin.COMPASS,
@@ -41,6 +45,7 @@ const timedEvent: GridEvent = {
 
 const allDayEvent: GridEvent = {
   _id: "all-day-event",
+  calendarId: CALENDAR_A as never,
   endDate: "2026-05-21",
   isAllDay: true,
   origin: Origin.COMPASS,
@@ -112,11 +117,15 @@ const makePointerEvent = (
 };
 
 const createAdapter = ({
+  columnKeys,
+  extraTimedEvents = [],
   mainGridScrollTop = 0,
   onAllDayDrag,
   onTimedDrag,
   onTimedResize,
 }: {
+  columnKeys?: string[];
+  extraTimedEvents?: GridEvent[];
   mainGridScrollTop?: number;
   onAllDayDrag?: (result: DayAllDayDragCommitResult) => void;
   onTimedDrag?: (result: DayTimedDragCommitResult) => void;
@@ -156,6 +165,7 @@ const createAdapter = ({
         return timerId;
       },
     },
+    getColumnKeys: () => columnKeys ?? [],
     getLayoutSources: () => ({
       allDayColumnsElement,
       mainGridElement,
@@ -170,7 +180,8 @@ const createAdapter = ({
             ? multiDayAllDayEvent
             : null,
       getTimedEventById: (eventId) =>
-        eventId === timedEvent._id ? timedEvent : null,
+        extraTimedEvents.find((event) => event._id === eventId) ??
+        (eventId === timedEvent._id ? timedEvent : null),
       onClickAllDayEvent: () => undefined,
       onClickTimedEvent: () => undefined,
       onCommitAllDayDrag: (result) => onAllDayDrag?.(result),
@@ -346,6 +357,50 @@ afterEach(() => {
   dayEventRegistry.clear();
 });
 
+// Two 160px-wide calendar columns across the 320px grid: dragging from
+// column A's center (x=80) to column B's center (x=240) crosses columns.
+const dragEventAcrossCalendarColumns = (
+  event: GridEvent,
+  eventType: "all-day" | "timed",
+  { toX, toY }: { toX: number; toY?: number },
+) => {
+  const results: {
+    allDay?: DayAllDayDragCommitResult;
+    timed?: DayTimedDragCommitResult;
+  } = {};
+  const { child } = registerEvent(event, eventType);
+  const { adapter, flushFrame } = createAdapter({
+    columnKeys: [CALENDAR_A, CALENDAR_B],
+    extraTimedEvents: eventType === "timed" ? [event] : [],
+    onAllDayDrag: (result) => {
+      results.allDay = result;
+    },
+    onTimedDrag: (result) => {
+      results.timed = result;
+    },
+  });
+  const y = eventType === "timed" ? 160 : 20;
+
+  adapter.handlePointerDown(
+    makePointerEvent("pointerdown", { target: child, x: 80, y }),
+  );
+  adapter.handlePointerMove(
+    makePointerEvent("pointermove", { target: child, x: toX, y: toY ?? y }),
+  );
+  flushFrame();
+  adapter.handlePointerUp(
+    makePointerEvent("pointerup", { target: child, x: toX, y: toY ?? y }),
+  );
+
+  const result = eventType === "timed" ? results.timed : results.allDay;
+
+  if (!result) {
+    throw new Error("Expected the drag to commit");
+  }
+
+  return result;
+};
+
 describe("DayInteractionAdapter", () => {
   it("keeps timed drag on the one visible date", () => {
     const result = dragTimedEvent();
@@ -353,6 +408,66 @@ describe("DayInteractionAdapter", () => {
     expect(result.type).toBe("timedDragEnd");
     expect(result.event.isAllDay).toBe(false);
     expect(dayjs(result.event.startDate).isSame(visibleDate, "day")).toBe(true);
+  });
+
+  it("moves a timed event to the other calendar when dropped on its column", () => {
+    const result = dragEventAcrossCalendarColumns(timedEvent, "timed", {
+      toX: 240,
+    });
+
+    expect(result.hasMoved).toBe(true);
+    expect(result.event.calendarId).toBe(CALENDAR_B as never);
+    expect(dayjs(result.event.startDate).isSame(visibleDate, "day")).toBe(true);
+  });
+
+  it("keeps a timed event's calendar when dragged within its own column", () => {
+    const result = dragEventAcrossCalendarColumns(timedEvent, "timed", {
+      toX: 80,
+      toY: 220,
+    });
+
+    expect(result.hasMoved).toBe(true);
+    expect(result.event.calendarId).toBe(CALENDAR_A as never);
+  });
+
+  it("moves an all-day event to the other calendar when dropped on its column", () => {
+    const result = dragEventAcrossCalendarColumns(allDayEvent, "all-day", {
+      toX: 240,
+    });
+
+    expect(result.hasMoved).toBe(true);
+    expect(result.event.calendarId).toBe(CALENDAR_B as never);
+    expect(result.event.startDate).toBe(allDayEvent.startDate);
+    expect(result.event.endDate).toBe(allDayEvent.endDate);
+  });
+
+  it("keeps a multi-day all-day event's dates on a cross-calendar move", () => {
+    const result = dragEventAcrossCalendarColumns(
+      multiDayAllDayEvent,
+      "all-day",
+      { toX: 240 },
+    );
+
+    expect(result.hasMoved).toBe(true);
+    expect(result.event.calendarId).toBe(CALENDAR_B as never);
+    expect(result.event.startDate).toBe(multiDayAllDayEvent.startDate);
+    expect(result.event.endDate).toBe(multiDayAllDayEvent.endDate);
+  });
+
+  it("disables cross-column movement for an event whose calendar has no column", () => {
+    const orphan: GridEvent = {
+      ...timedEvent,
+      _id: "orphan-timed-event",
+      calendarId: "cccccccccccccccccccccccc" as never,
+    };
+    const result = dragEventAcrossCalendarColumns(orphan, "timed", {
+      toX: 240,
+    });
+
+    // Horizontal-only drag in the single-column fallback: no column change,
+    // no time change, so the commit reports no movement at all.
+    expect(result.hasMoved).toBe(false);
+    expect(result.event.calendarId).toBe(orphan.calendarId!);
   });
 
   it("keeps timed resize timed with a valid time range", () => {

--- a/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.ts
@@ -1,4 +1,5 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   ID_ALLDAY_COLUMNS,
@@ -94,6 +95,7 @@ const inertRuntime: DayInteractionRuntime = {
 
 export const createDayInteractionAdapter = ({
   engineOptions,
+  getColumnKeys = () => [],
   getLayoutSources = () => ({}),
   getVisibleDate = () => dayjs(),
   runtime = () => inertRuntime,
@@ -225,7 +227,7 @@ export const createDayInteractionAdapter = ({
         const visibleDate = getVisibleDate();
 
         if (visual.type === "allDayDrag" && target.type === "allDayDrag") {
-          result = commitAllDayDragInteraction(target, visual, visibleDate);
+          result = commitAllDayDragInteraction(target, visual);
         } else if (
           visual.type === "allDayResize" &&
           target.type === "allDayResize"
@@ -249,10 +251,26 @@ export const createDayInteractionAdapter = ({
       },
       createVisual: ({ pointerStart, sourceElement, target }) => {
         const visibleDateKey = getVisibleDate().format(YEAR_MONTH_DAY_FORMAT);
+        // The Day view renders one column per calendar, all sharing one date,
+        // so drag column keys are CALENDAR IDS (not dates like the Week
+        // view) — a column change is a cross-calendar move. Resizes stay
+        // within the event's own column and keep the single-column layout.
+        // An event whose calendar isn't among the rendered columns (columns
+        // and events momentarily out of sync) also falls back to the single
+        // column: anchoring it to column 0 would make a purely vertical drag
+        // commit a calendar move the user never made.
+        const calendarColumnKeys = isDragTarget(target) ? getColumnKeys() : [];
+        const eventColumnIndex = calendarColumnKeys.indexOf(
+          target.event.calendarId ?? "",
+        );
+        const columnKeys =
+          eventColumnIndex >= 0 ? calendarColumnKeys : [visibleDateKey];
+        const initialColumnIndex = Math.max(0, eventColumnIndex);
+        const initialColumnKey = columnKeys[initialColumnIndex]!;
         const nextLayout = buildDayLayoutCacheForTarget(
           target,
           getLayoutSources(),
-          [visibleDateKey],
+          columnKeys,
         );
 
         if (!nextLayout) {
@@ -267,8 +285,8 @@ export const createDayInteractionAdapter = ({
 
         if (target.type === "allDayDrag") {
           return createAllDayDragVisual({
-            dayDate: visibleDateKey,
-            dayIndex: 0,
+            dayDate: initialColumnKey,
+            dayIndex: initialColumnIndex,
             eventId: target.event._id!,
             pointerStart,
             sourceRect,
@@ -298,8 +316,8 @@ export const createDayInteractionAdapter = ({
         }
 
         return createTimedDragVisual({
-          dayDate: visibleDateKey,
-          dayIndex: 0,
+          dayDate: initialColumnKey,
+          dayIndex: initialColumnIndex,
           endMinutes: getLocalMinutes(target.event.endDate),
           eventId: target.event._id!,
           pointerStart,
@@ -683,14 +701,20 @@ const commitTimedResizeInteraction = (
 const commitAllDayDragInteraction = (
   target: DayAllDayDragTarget,
   visual: AllDayDragVisual,
-  visibleDate: Dayjs,
 ): DayAllDayDragCommitResult => {
   const hasMoved =
     "dayDate" in visual ? visual.dayDate !== visual.initialDayDate : false;
 
+  // In the Day view every column shares the visible date, so an all-day drag
+  // that "moved" can only have changed COLUMN, i.e. calendar. Keep the
+  // event's own dates: rewriting them to the visible date would truncate a
+  // multi-day all-day event to a single day.
   return {
     event: hasMoved
-      ? allDayVisualToDayGridEvent(target.event, visibleDate)
+      ? {
+          ...target.event,
+          calendarId: columnMoveCalendarId(visual, target.event),
+        }
       : target.event,
     eventId: target.event._id!,
     hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
@@ -725,6 +749,7 @@ const timedDragVisualToDayGridEvent = (
   visibleDate: Dayjs,
 ): GridEvent => ({
   ...event,
+  calendarId: columnMoveCalendarId(visual, event),
   isAllDay: false,
   endDate: visibleDate
     .startOf("day")
@@ -735,6 +760,20 @@ const timedDragVisualToDayGridEvent = (
     .add(visual.startMinutes, "minutes")
     .format(),
 });
+
+/**
+ * Day-view drag column keys are calendar ids (see createVisual), so a drop
+ * on a different column is a cross-calendar move. Same-column drops (and the
+ * single-column fallback, whose one key is a date string that never changes)
+ * keep the event's own calendarId.
+ */
+const columnMoveCalendarId = (
+  visual: Pick<TimedDragVisual, "dayDate" | "initialDayDate">,
+  event: GridEvent,
+): CalendarId | undefined =>
+  visual.dayDate !== visual.initialDayDate
+    ? (visual.dayDate as CalendarId)
+    : event.calendarId;
 
 const timedResizeVisualToDayGridEvent = (
   event: GridEvent,

--- a/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.types.ts
+++ b/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.types.ts
@@ -24,6 +24,14 @@ export interface DayInteractionPointerOwnership {
 
 export interface DayInteractionAdapterOptions {
   engineOptions?: InteractionEngineSchedulerOptions;
+  /**
+   * Ordered keys of the rendered per-calendar columns (calendar ids, one per
+   * displayed calendar). Drags hit-test against these so an event can be
+   * dropped on another calendar's column; empty means a single dateless
+   * column (no calendar columns rendered), which disables cross-column
+   * movement.
+   */
+  getColumnKeys?: () => string[];
   getLayoutSources?: () => GridLayoutCacheSources;
   getVisibleDate?: () => Dayjs;
   runtime?: () => DayInteractionRuntime;


### PR DESCRIPTION
## Summary

On the Day view, each calendar renders as its own column, but dragging an event sideways never moved it — the drag engine was fed a single full-width column, so hit-testing always resolved to the event's own calendar. This PR makes cross-column drags move the event to the target calendar, end-to-end:

- **Engine (web):** the Day adapter now feeds one drag column per displayed calendar (column keys are calendar ids; every column shares the visible date), so the ghost follows the cursor across columns and a cross-column drop commits a `calendarId` change. All-day drags move calendars too, preserving the event's own dates (a naive commit would have truncated multi-day events). An event whose calendar has no rendered column falls back to a time-only drag rather than mis-anchoring to the first column.
- **Guards (web):** dropping on a read-only calendar's column or moving a repeating event shows an error toast and reverts the drag. Undo (Cmd+Z) restores the original calendar.
- **Contract (core):** `ReplaceEventInput` gains an optional `calendarId`; a differing value is a move request. This deliberately supersedes decision A6 (calendar immutability) for single events only.
- **Backend:** `replace()` re-homes the record after enforcing: destination writable, single (non-recurring) events only — including rejecting a move combined with a convert-to-series input — and Google events may only move to other Google calendars (moving off Google would delete the Google copy: cancellation emails to attendees, attendees/conferencing unrecoverable). Google propagation uses `events.move` (id-preserving, no attendee emails) plus a follow-up patch; if Google refuses the move (e.g. the user isn't the organizer of an invited event), the record's calendar is reverted so Compass and Google never diverge. Both source and destination calendars receive the SSE notify.

## Simplicity

The engine change rides the existing column hit-testing (`buildDayColumns`/`resolveDragColumn`) by treating column keys as opaque strings — no new drag math. The shared `dayDate` fields now document that Day-view values are calendar ids, since the field name suggests otherwise. The simplify pass folded the destination guard into the existing `isEventReadOnly` policy and unified the two Google-effect failure handlers into one `runGoogleEffects` helper. New hooks: none (`useRef` mirror for `calendarColumnKeys` in the coordinator follows the file's existing latest-ref pattern for adapter callbacks; no new `useState`/`useEffect`).

## Manual Testing Steps

- [ ] With two or more writable calendars, open the Day view and drag a timed event sideways onto another calendar's column: it lands there, and after a hard refresh it's still on the new calendar.
- [ ] Drag an event onto a read-only calendar's column: a toast ("You can't move events to <name>.") appears and the event snaps back with its original time.
- [ ] Move an event to another calendar, then press Cmd+Z: the event returns to its original calendar.
- [ ] Drag a multi-day all-day event onto another calendar's column: it moves calendars and keeps its full date span.
- [ ] On the Week view, drag an event to another day: unchanged behavior (date moves, calendar stays).
- [ ] With a Google-connected account, move an event between two Google calendars and confirm it moves in Google Calendar too, with no attendee notification emails.

## Test plan

- [x] `bun test src/views/Day/interaction src/events` (web) — 114 pass, 0 fail (5 new adapter tests: cross-column timed + all-day moves, same-column keeps calendar, multi-day date preservation, unmapped-calendar fallback)
- [x] `bun run test:backend` — 597-677 pass, 0 fail across runs (9 new event.service tests: local move, no-op same-calendar move, recurring rejection, series-input rejection, read-only destination, Google→local rejection, dual-calendar SSE notify, Google `events.move` + patch, calendar revert when Google refuses the move); a handful of suites flake locally with mongodb-memory-server SIGKILLs under load, unrelated to this diff
- [x] `bun run type-check`, `bun run lint` — clean
- [x] Validated in Chrome against local dev with three seeded calendars (one read-only): golden path, persistence across reload, read-only toast + revert, undo, week-view regression check, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note: pre-existing e2e date bomb fixed in passing

The first CI run failed 4 `calendar-experience.spec.ts` tests. This was NOT this PR's diff: it reproduces at the merge base with `TZ=UTC` whenever "today" is Saturday in UTC. At the default 1280px viewport, bare `/week` renders a 6-day Sun-Fri window anchored on the week start, excluding a Saturday "today", so the spec's today-anchored fixtures never render. Fixed here by widening the spec viewport to 1600px (fits all 7 columns). The underlying UX question — bare `/week` hides today on Saturdays at 6-column widths — is left for a product decision.
