### PR TITLE
style(web): refine datepicker, week header, and event-form menu styling

### DIFF
--- a/packages/web/src/components/Button/Button.tsx
+++ b/packages/web/src/components/Button/Button.tsx
@@ -18,7 +18,7 @@ export const Btn = forwardRef<
     {...props}
     type={type}
     className={classNames(
-      "c-focus-ring flex cursor-pointer items-center justify-center rounded-[2px]",
+      "c-focus-ring flex cursor-pointer items-center justify-center rounded-xs",
       className,
     )}
     ref={ref}
@@ -51,7 +51,7 @@ export const SaveButton = forwardRef<
       {...props}
       aria-disabled={disabled || undefined}
       className={classNames(
-        "c-button-elevated min-w-[158px] px-2 text-text-dark transition-[background-color,color,box-shadow,transform] duration-500 hover:bg-bg-primary hover:text-(--save-button-hover-color)",
+        "c-button-elevated min-w-39.5 px-2 text-text-dark transition-[background-color,color,box-shadow,transform] duration-500 hover:bg-bg-primary hover:text-(--save-button-hover-color)",
         disabled && "pointer-events-none opacity-50",
         className,
       )}

--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -64,15 +64,14 @@ export const CalendarHeader: FC<Props> = ({
         <span className="relative text-xl">{label}</span>
       </h1>
 
-      <TooltipWrapper shortcut="J">
-        <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
-      </TooltipWrapper>
-      <TooltipWrapper shortcut="K">
-        <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
-      </TooltipWrapper>
-
       <div className="z-2 ml-auto flex items-center gap-3 pr-5">
         <TodayButton navigateToToday={onToday} isToday={isToday} />
+        <TooltipWrapper shortcut="J">
+          <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
+        </TooltipWrapper>
+        <TooltipWrapper shortcut="K">
+          <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
+        </TooltipWrapper>
         <SelectView />
       </div>
     </div>

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -11,6 +11,8 @@ import { MonthNavButton } from "@web/components/DatePicker/MonthNavButton";
 import { ChevronLeftIcon } from "@web/components/Icons/ChevronLeftIcon";
 import { ChevronRightIcon } from "@web/components/Icons/ChevronRightIcon";
 import { Focusable, INPUT_RESET_CLASSNAME } from "../Focusable/Focusable";
+import { CircleIcon } from "../Icons/CircleIcon";
+import { TooltipWrapper } from "../Tooltip/TooltipWrapper";
 
 export interface Props extends Omit<ReactDatePickerProps, "autoFocus"> {
   animationOnToggle?: boolean;
@@ -112,16 +114,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
               headerClassName,
             )}
           >
-            <div
-              className={classNames(
-                "min-w-0 items-start",
-                // Grid pickers grow the label so the arrows sit at the right
-                // edge. The sidebar keeps the label at intrinsic width so the
-                // month label and nav arrows read as one group on the left,
-                // clearly separate from the sidebar-close control.
-                view !== "sidebar" && "flex-1",
-              )}
-            >
+            <div className={classNames("w-16 items-start")}>
               <span
                 className={classNames("relative", monthTextClassName)}
                 style={{ color: headerColor }}
@@ -160,20 +153,23 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                   </MonthNavButton>
                 </div>
                 {withTodayButton && (
-                  <button
-                    className={classNames(
-                      "relative mr-10 cursor-pointer border-0 bg-transparent px-1.5 text-l hover:brightness-160 hover:transition-[filter] hover:duration-350 hover:ease-out",
-                      currentMonth === selectedMonth && "opacity-0",
-                    )}
-                    onClick={() => {
-                      headerProps.changeMonth(dayjs().month());
-                      headerProps.changeYear(dayjs().year());
-                    }}
-                    style={{ color: "var(--compass-color-text-light)" }}
-                    type="button"
-                  >
-                    Today
-                  </button>
+                  <TooltipWrapper description={currentMonth}>
+                    <button
+                      type="button"
+                      aria-label="Go to this month"
+                      className={classNames(
+                        "flex h-6 w-6 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-text-lighter/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary",
+                        currentMonth === selectedMonth && "invisible",
+                      )}
+                      style={{ color: headerColor }}
+                      onClick={() => {
+                        headerProps.changeMonth(dayjs().month());
+                        headerProps.changeYear(dayjs().year());
+                      }}
+                    >
+                      <CircleIcon />
+                    </button>
+                  </TooltipWrapper>
                 )}
               </div>
             )}

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -51,7 +51,9 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
   } = datePickerProps;
   const resolvedBgColor = bgColor ?? theme.color.bg.primary;
   const datePickerStyle: CSSVariables = {
-    "--date-picker-bg": bgColor ?? "var(--compass-color-bg-primary)",
+    // Grid (popover) pickers read as an elevated surface a step above the app
+    // background; the sidebar picker overrides this to transparent in CSS.
+    "--date-picker-bg": bgColor ?? "var(--compass-color-bg-secondary)",
   };
   const isDarkBackground = isDark(resolvedBgColor);
   const headerColor =

--- a/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
+++ b/packages/web/src/components/PlannerSidebar/PlannerMonthPicker/PlannerMonthPicker.tsx
@@ -89,7 +89,7 @@ export const PlannerMonthPicker: FC<Props> = ({
         selected={focusedDate.toDate()}
         shouldCloseOnSelect={false}
         view="sidebar"
-        withTodayButton={false}
+        withTodayButton={true}
       />
     </fieldset>
   );

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -590,7 +590,9 @@
   }
 
   &.calendar--open {
-    height: 230px;
+    /* Match the month-container height so 6-row months aren't clipped by the
+       overflow:hidden on .calendar. The two heights must stay in sync. */
+    height: 240px;
   }
 
   &[data-view="sidebar"].calendar--open {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -451,6 +451,19 @@
     background-color: transparent;
   }
 
+  /*
+   * Grid (popover) pickers float over the app at the same darkness as the
+   * background, so give them a 1px edge + elevation to read as a distinct
+   * surface. Drawn as a box-shadow ring rather than a border: the popover is
+   * height-clamped with overflow:hidden (see .calendar--open), and a border-box
+   * border would eat into that height and re-clip 6-row months.
+   */
+  &:not([data-view="sidebar"]) {
+    box-shadow:
+      0 0 0 1px var(--color-border-primary),
+      0 8px 24px var(--color-shadow-default);
+  }
+
   & .react-datepicker__month-container {
     display: flex;
     width: 100%;

--- a/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/ActionsMenu.tsx
@@ -138,7 +138,7 @@ export const ActionsMenu: React.FC<ActionsMenuProps> = ({
             returnFocus={false}
           >
             <div
-              className="flex flex-col gap-2 rounded-sm bg-(--actions-menu-bg) p-2 shadow-[0_4px_8px_rgb(0_0_0/10%)]"
+              className="flex flex-col gap-1 rounded-sm border border-border-primary bg-(--actions-menu-bg) p-1 shadow-[0_8px_24px_var(--color-shadow-default)]"
               ref={refs.setFloating}
               style={{
                 ...context.floatingStyles,

--- a/packages/web/src/views/Forms/ActionsMenu/MenuItem.tsx
+++ b/packages/web/src/views/Forms/ActionsMenu/MenuItem.tsx
@@ -87,8 +87,11 @@ const MenuItem: React.FC<MenuItemProps> = ({
       role="menuitem"
       tabIndex={tabIndex}
       type={type}
-      className="c-focus-ring flex w-full cursor-pointer items-center gap-2 border-0 bg-(--actions-menu-item-bg) px-2 py-1 text-left text-m text-text-dark hover:[text-shadow:0_0_0.5px_var(--compass-color-text-dark),0_0_0.5px_var(--compass-color-text-dark)]"
-      style={{ backgroundColor: bgColor }}
+      className="c-focus-ring flex w-full cursor-pointer items-center gap-2 rounded-xs border-0 bg-(--actions-menu-item-bg) px-2 py-1.5 text-left text-m text-text-light transition-colors hover:bg-text-lighter/10 focus-visible:bg-text-lighter/10"
+      // Paint the resting background through a CSS variable (not an inline
+      // background-color) so the hover/focus utilities above can override it;
+      // an inline background-color would always win over a class.
+      style={{ "--actions-menu-item-bg": bgColor } as React.CSSProperties}
     >
       {children}
     </button>

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
@@ -179,7 +179,7 @@ export const DatePickers: FC<Props> = ({
           <DatePicker
             calendarClassName="startDatePicker"
             isOpen={isStartDatePickerOpen}
-            monthTextClassName="text-base"
+            monthTextClassName="text-medium"
             onCalendarClose={closeStartDatePicker}
             onCalendarOpen={() => {
               setIsStartDatePickerOpen(true);
@@ -206,7 +206,7 @@ export const DatePickers: FC<Props> = ({
           <DatePicker
             calendarClassName="endDatePicker"
             isOpen={isEndDatePickerOpen}
-            monthTextClassName="text-base"
+            monthTextClassName="text-medium"
             onCalendarClose={closeEndDatePicker}
             onCalendarOpen={() => setIsEndDatePickerOpen(true)}
             onChange={() => null}

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -544,7 +544,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
             }
             actions={
               <EventActionMenu
-                bgColor="var(--color-menu-bg)"
+                bgColor="var(--color-bg-secondary)"
                 isExistingEvent={isExistingEvent}
                 isReadOnly={isReadOnly}
                 onDuplicate={onDuplicateEvent}

--- a/packages/web/src/views/Forms/EventFormShell.tsx
+++ b/packages/web/src/views/Forms/EventFormShell.tsx
@@ -7,10 +7,9 @@ interface EventFormShellProps extends ComponentPropsWithoutRef<"form"> {
 
 /**
  * Outer `<form>` for the event form. Transparent full-height flex column so
- * the sidebar's own background shows through — the form is part of the
- * sidebar, not a card floating on it. Children own scrolling and padding
+ * the sidebar's own background shows through. Children own scrolling and padding
  * (EventForm renders a scrollable body plus a pinned footer). The
- * (resizable) sidebar width is the single source of the form's size.
+ * resizable sidebar width is the single source of the form's size.
  * Content-agnostic: callers pass their fields as children and any
  * form-specific props (`name`, mouse handlers, an extra `className`).
  */


### PR DESCRIPTION
## Summary

A set of styling refinements to the datepicker, the week/day view header, and the event-form action menu, developed on the `chore/cleanup-ux` branch:

- **Week/day header**: moved the prev/next arrows out of the left group (beside the label) into the right-aligned cluster, so it reads `label … [today dot] < > [view switcher]` again — the pattern it had before. Shared `CalendarHeader`, so Day and Week both update.
- **Sidebar month picker**: the "today" dot now matches the month-label color (was a dimmer token) and only appears when viewing a non-current month.
- **6-row month clipping**: the grid datepicker popover clamped its open height (`230px`) below its content height (`240px`), shearing the bottom row off 6-row months (e.g. Aug 2026). Raised the open height to match, mirroring what the sidebar variant already does.
- **Consistent dark surfaces**: the event-form action menu was a white block in the dark app, and the grid datepicker popover shared the app background exactly (0 surface contrast, no border) so it read only as a drop shadow. Both now use the app's canonical elevated-dark treatment (`bg-secondary` + `border-primary` edge + shadow + light text) — the same recipe as the command palette and view-switcher dropdown. Measured after: menu/popover text 9.7–19:1, both surfaces distinguishable from the background.
- **Minor consistency cleanups**: arbitrary Tailwind values swapped for semantic scale utilities (`rounded-[2px]`→`rounded-xs`, `min-w-[158px]`→`min-w-39.5`), datepicker month-label size aligned, and a comment tidy.

## Simplicity

Net-neutral-to-simpler. No `useEffect`/`useRef`/`useState` were added or removed — these are style/markup changes only. The datepicker's popover edge is drawn as a `box-shadow` ring rather than a real `border` specifically because the popover is height-clamped with `overflow:hidden`; a border-box border would consume 2px and re-clip 6-row months. The action-menu item background moved from an inline `background-color` to a CSS variable so the `hover:`/`focus-visible:` utilities can win (an inline style always beats a class) — this replaced a hard-to-read `text-shadow` hover hack. A shared `c-elevated-surface` utility was considered and left alone: the two in-diff surfaces differ in mechanism (border vs box-shadow ring) and the other consumers are untouched files, so unifying would be over-DRYing.

## Manual Testing Steps

- [ ] Open the app on the Week view. Confirm the header reads: date label on the left, and on the far right a cluster of `< >` arrows and the `Week` view switcher. Navigate to a different week (`<`/`>` or J/K) and confirm a small filled "today" dot appears just left of the arrows; return to the current week and confirm the dot disappears.
- [ ] Switch to Day view (view switcher or the `D` shortcut) and confirm the same header pattern applies.
- [ ] In the left sidebar month picker, page forward a month (the `>` next to the month label). Confirm a small "today" dot appears to the right of the arrows in the same color as the month label text, and that it's hidden when viewing the current month.
- [ ] Open an event to bring up the event form, click the three-dots (⋮) menu top-right. Confirm the menu is a dark panel (not white) with light "Duplicate Event" / "Delete" text and a subtle border, and that hovering a row highlights it.
- [ ] Create an all-day event (`A` shortcut), click a date field to open the calendar popover. Confirm the popover reads as a distinct dark panel with a visible edge (not blending into the background). Page to a 6-row month (e.g. August 2026) and confirm the entire bottom week row is visible and not cut off.

## Test plan

- [x] `bun run type-check` — passes
- [x] `bun run lint` (Biome + semantic-colors check) — 1129 files, no issues
- [x] `bun test --cwd packages/web src/views/Forms/ActionsMenu/` — 4 pass
- [x] `bun test --cwd packages/web src/components/DatePicker/` — 2 pass
- [x] Manual walkthrough in real Chrome against local dev build (all steps above), console clean (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)