### PR TITLE
refactor(web): align week event-targeting exports with day naming convention

### DIFF
--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -21,8 +21,8 @@ import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { isWeekInteractionMotionActive } from "@web/views/Week/interaction/state/motion.state";
 import {
-  clearHoveredGridEventTarget,
-  setHoveredGridEventTarget,
+  clearHoveredWeekGridEventTarget,
+  setHoveredWeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 
 interface Props {
@@ -149,10 +149,10 @@ const GridEventBase = (
       onMouseEnter={(e: MouseEvent<HTMLDivElement>) => {
         if (!shouldTrackCalendarHover) return;
 
-        setHoveredGridEventTarget(e.currentTarget);
+        setHoveredWeekGridEventTarget(e.currentTarget);
       }}
       onMouseLeave={(e: MouseEvent<HTMLDivElement>) => {
-        clearHoveredGridEventTarget(e.currentTarget);
+        clearHoveredWeekGridEventTarget(e.currentTarget);
       }}
       onScalerMouseDown={onScalerMouseDown}
       position={{ ...position, zIndex }}

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -7,8 +7,8 @@ import { getAllDayEventPosition } from "@web/grid/layout/event.position";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import {
-  clearHoveredGridEventTarget,
-  setHoveredGridEventTarget,
+  clearHoveredWeekGridEventTarget,
+  setHoveredWeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 
 interface Props {
@@ -74,10 +74,10 @@ const AllDayEventBase = (
       onMouseEnter={(e: MouseEvent<HTMLDivElement>) => {
         if (!shouldTrackCalendarHover) return;
 
-        setHoveredGridEventTarget(e.currentTarget);
+        setHoveredWeekGridEventTarget(e.currentTarget);
       }}
       onMouseLeave={(e: MouseEvent<HTMLDivElement>) => {
-        clearHoveredGridEventTarget(e.currentTarget);
+        clearHoveredWeekGridEventTarget(e.currentTarget);
       }}
       onScalerMouseDown={onScalerMouseDown}
       position={position}

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
@@ -33,8 +33,8 @@ import {
 } from "@web/views/Week/interaction/registry/week-event.registry";
 import { setWeekInteractionMotionActive } from "@web/views/Week/interaction/state/motion.state";
 import {
-  clearHoveredGridEventTarget,
-  getHoveredGridEventTarget,
+  clearHoveredWeekGridEventTarget,
+  getHoveredWeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
@@ -95,7 +95,7 @@ const { MainGrid } = await import("./MainGrid");
 const { MainGridEvents } = await import("./MainGridEvents");
 
 afterEach(() => {
-  clearHoveredGridEventTarget();
+  clearHoveredWeekGridEventTarget();
   cleanup();
   setWeekInteractionMotionActive(false);
   weekEventRegistry.clear();
@@ -542,14 +542,14 @@ describe("Week calendar accessibility", () => {
     const eventButton = screen.getByRole("button", { name: /hover target/i });
 
     fireEvent.mouseEnter(eventButton);
-    expect(getHoveredGridEventTarget()).toMatchObject({
+    expect(getHoveredWeekGridEventTarget()).toMatchObject({
       element: eventButton,
       eventId: event._id,
       eventType: "timed",
     });
 
     fireEvent.mouseLeave(eventButton);
-    expect(getHoveredGridEventTarget()).toBeNull();
+    expect(getHoveredWeekGridEventTarget()).toBeNull();
   });
 
   it("gives all-day events an all-day accessible name and target type", () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -25,8 +25,8 @@ import { initialViewState, useViewStore } from "@web/events/stores/view.store";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { weekEventRegistry } from "@web/views/Week/interaction/registry/week-event.registry";
 import {
-  clearHoveredGridEventTarget,
-  setHoveredGridEventTarget,
+  clearHoveredWeekGridEventTarget,
+  setHoveredWeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -118,7 +118,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  clearHoveredGridEventTarget();
+  clearHoveredWeekGridEventTarget();
   cleanup();
   document.body.innerHTML = "";
   pendingEventIds = [];
@@ -316,7 +316,7 @@ describe("useWeekShortcuts calendar event targeting", () => {
 
   it("deletes the hovered calendar event with Delete when no event is focused", () => {
     const button = addCalendarTarget();
-    setHoveredGridEventTarget(button);
+    setHoveredWeekGridEventTarget(button);
 
     const { queryClient } = renderShortcuts();
     pressKey("Delete");
@@ -539,7 +539,7 @@ describe("useWeekShortcuts shift+arrow event moves", () => {
 
   it("does not move hovered-but-unfocused events", () => {
     const button = addCalendarTarget();
-    setHoveredGridEventTarget(button);
+    setHoveredWeekGridEventTarget(button);
 
     renderShortcuts();
     pressKey("ArrowRight", shiftKey);

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -43,11 +43,11 @@ import { useDraftContext } from "@web/views/Week/components/Draft/context/useDra
 import { type Util_Scroll } from "@web/views/Week/hooks/grid/useScroll";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import {
-  focusGridEventTarget,
-  type GridEventTarget,
-  getFirstVisibleGridEventTarget,
-  getFocusedGridEventTarget,
-  getHoveredGridEventTarget,
+  focusWeekGridEventTarget,
+  getFirstVisibleWeekGridEventTarget,
+  getFocusedWeekGridEventTarget,
+  getHoveredWeekGridEventTarget,
+  type WeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 
 export interface ShortcutProps {
@@ -171,26 +171,31 @@ export const useWeekShortcuts = ({
   }, [isSidebarOpen]);
 
   const focusFirstCalendarEvent = useCallback(() => {
-    const target = getFirstVisibleGridEventTarget();
+    const target = getFirstVisibleWeekGridEventTarget();
     if (!target) return;
 
-    focusGridEventTarget(target);
+    focusWeekGridEventTarget(target);
   }, []);
 
-  const findCalendarEventForTarget = useCallback((target: GridEventTarget) => {
-    const events =
-      target.eventType === "all-day"
-        ? allDayEventsRef.current
-        : timedEventsRef.current;
+  const findCalendarEventForTarget = useCallback(
+    (target: WeekGridEventTarget) => {
+      const events =
+        target.eventType === "all-day"
+          ? allDayEventsRef.current
+          : timedEventsRef.current;
 
-    return events.find((candidate) => candidate._id === target.eventId) ?? null;
-  }, []);
+      return (
+        events.find((candidate) => candidate._id === target.eventId) ?? null
+      );
+    },
+    [],
+  );
 
   const getTargetedCalendarEvent = useCallback(() => {
     const target =
-      getFocusedGridEventTarget() ??
-      getHoveredGridEventTarget() ??
-      getFirstVisibleGridEventTarget();
+      getFocusedWeekGridEventTarget() ??
+      getHoveredWeekGridEventTarget() ??
+      getFirstVisibleWeekGridEventTarget();
 
     if (!target) return null;
 
@@ -244,7 +249,7 @@ export const useWeekShortcuts = ({
 
       // Focused only (no hover/first-visible fallback): moving an event the
       // user isn't focused on would be surprising
-      const target = getFocusedGridEventTarget();
+      const target = getFocusedWeekGridEventTarget();
       if (!target) return;
 
       const event = findCalendarEventForTarget(target);

--- a/packages/web/src/views/Week/interaction/adapter/geometry/week-layout.cache.ts
+++ b/packages/web/src/views/Week/interaction/adapter/geometry/week-layout.cache.ts
@@ -8,8 +8,6 @@ import {
   buildAllDayGridLayoutCache,
   buildDragGridLayoutCache,
   buildTimedGridLayoutCache,
-  type DayColumnCache,
-  type EdgeNavigationCache,
   type GridLayoutCache,
   type GridLayoutCacheOptions,
   type GridLayoutCacheSources,
@@ -35,8 +33,6 @@ export interface WeekLayoutCacheInput extends GridLayoutCacheSources {
   visibleDays: string[];
 }
 
-export type WeekDayColumnCache = DayColumnCache;
-export type WeekEdgeNavigationCache = EdgeNavigationCache;
 export type WeekLayoutCache = GridLayoutCache;
 export type { SmartScrollCache };
 export { getNearestDayColumn };

--- a/packages/web/src/views/Week/interaction/targeting/week-event.targeting.test.ts
+++ b/packages/web/src/views/Week/interaction/targeting/week-event.targeting.test.ts
@@ -1,16 +1,16 @@
 import { weekEventRegistry } from "@web/views/Week/interaction/registry/week-event.registry";
 import {
-  clearHoveredGridEventTarget,
-  focusGridEventTarget,
-  getFirstVisibleGridEventTarget,
-  getFocusedGridEventTarget,
-  getHoveredGridEventTarget,
-  setHoveredGridEventTarget,
+  clearHoveredWeekGridEventTarget,
+  focusWeekGridEventTarget,
+  getFirstVisibleWeekGridEventTarget,
+  getFocusedWeekGridEventTarget,
+  getHoveredWeekGridEventTarget,
+  setHoveredWeekGridEventTarget,
 } from "./week-event.targeting";
 import { afterEach, describe, expect, it } from "bun:test";
 
 afterEach(() => {
-  clearHoveredGridEventTarget();
+  clearHoveredWeekGridEventTarget();
   weekEventRegistry.clear();
   document.body.innerHTML = "";
 });
@@ -53,7 +53,7 @@ describe("weekGridEventTargeting", () => {
     });
     focused.focus();
 
-    expect(getFocusedGridEventTarget()).toMatchObject({
+    expect(getFocusedWeekGridEventTarget()).toMatchObject({
       element: focused,
       eventId: "focused",
       eventType: "all-day",
@@ -62,9 +62,9 @@ describe("weekGridEventTargeting", () => {
 
   it("uses the hovered calendar event when nothing is focused", () => {
     const hovered = addEventButton({ eventId: "hovered" });
-    setHoveredGridEventTarget(hovered);
+    setHoveredWeekGridEventTarget(hovered);
 
-    expect(getHoveredGridEventTarget()).toMatchObject({
+    expect(getHoveredWeekGridEventTarget()).toMatchObject({
       element: hovered,
       eventId: "hovered",
       eventType: "timed",
@@ -76,7 +76,7 @@ describe("weekGridEventTargeting", () => {
     addEventButton({ eventId: "hidden", isVisible: false });
     const firstVisible = addEventButton({ eventId: "visible" });
 
-    expect(getFirstVisibleGridEventTarget()).toMatchObject({
+    expect(getFirstVisibleWeekGridEventTarget()).toMatchObject({
       element: firstVisible,
       eventId: "visible",
       eventType: "timed",
@@ -85,10 +85,10 @@ describe("weekGridEventTargeting", () => {
 
   it("focuses a returned calendar target", () => {
     const button = addEventButton({ eventId: "target" });
-    const target = getFirstVisibleGridEventTarget();
+    const target = getFirstVisibleWeekGridEventTarget();
 
     if (!target) throw new Error("expected target");
-    focusGridEventTarget(target);
+    focusWeekGridEventTarget(target);
 
     expect(document.activeElement).toBe(button);
   });

--- a/packages/web/src/views/Week/interaction/targeting/week-event.targeting.ts
+++ b/packages/web/src/views/Week/interaction/targeting/week-event.targeting.ts
@@ -9,30 +9,33 @@ import {
   weekEventRegistry,
 } from "@web/views/Week/interaction/registry/week-event.registry";
 
-export type GridEventTargetType = WeekInteractionEventType;
+export type WeekGridEventTargetType = WeekInteractionEventType;
 
-export type GridEventTarget = SharedGridEventTarget<GridEventTargetType>;
+export type WeekGridEventTarget =
+  SharedGridEventTarget<WeekGridEventTargetType>;
 
 const TARGET_SELECTOR = `[${WEEK_INTERACTION_EVENT_ID_ATTRIBUTE}][${WEEK_INTERACTION_EVENT_TYPE_ATTRIBUTE}]`;
 
-const weekGridEventTargeting = createGridEventTargeting<GridEventTargetType>({
-  registry: weekEventRegistry,
-  targetSelector: TARGET_SELECTOR,
-});
+const weekGridEventTargeting =
+  createGridEventTargeting<WeekGridEventTargetType>({
+    registry: weekEventRegistry,
+    targetSelector: TARGET_SELECTOR,
+  });
 
-export const setHoveredGridEventTarget =
+export const setHoveredWeekGridEventTarget =
   weekGridEventTargeting.setHoveredGridEventTarget;
 
-export const clearHoveredGridEventTarget =
+export const clearHoveredWeekGridEventTarget =
   weekGridEventTargeting.clearHoveredGridEventTarget;
 
-export const getFocusedGridEventTarget =
+export const getFocusedWeekGridEventTarget =
   weekGridEventTargeting.getFocusedGridEventTarget;
 
-export const getHoveredGridEventTarget =
+export const getHoveredWeekGridEventTarget =
   weekGridEventTargeting.getHoveredGridEventTarget;
 
-export const getFirstVisibleGridEventTarget =
+export const getFirstVisibleWeekGridEventTarget =
   weekGridEventTargeting.getFirstVisibleGridEventTarget;
 
-export const focusGridEventTarget = weekGridEventTargeting.focusGridEventTarget;
+export const focusWeekGridEventTarget =
+  weekGridEventTargeting.focusGridEventTarget;


### PR DESCRIPTION
## Summary
- Removed two dead type aliases (`WeekDayColumnCache`, `WeekEdgeNavigationCache`) from `week-layout.cache.ts` — leftovers from the generic-grid extraction with no consumers beyond their own definition, plus their now-unused imports (`DayColumnCache`, `EdgeNavigationCache`).
- Renamed `week-event.targeting.ts`'s exported consts/types to be Week-prefixed (e.g. `setHoveredGridEventTarget` -> `setHoveredWeekGridEventTarget`, `GridEventTarget` -> `WeekGridEventTarget`) to match the naming convention its sibling `day-event.targeting.ts` already uses (Day-prefixed exports). This was a leftover old-vs-new inconsistency from the recent grid/interaction folder reorg (#2159 and related), found during the evening `/cleanup` review of everything merged since the last cleanup pass.

## Simplicity
Net reduction: two dead exports removed, zero new abstractions, zero new hooks. This is a pure rename plus a dead-code deletion — no `useEffect`/`useRef`/`useState` touched. No simplify follow-up commit needed; this PR is itself the output of the cleanup ritual's simplification analysis step.

## Manual Testing Steps
This is a type/identifier-only rename with no user-visible behavior change (no UI, no logic altered) — not observable in a browser walkthrough. Reviewer-equivalent verification:
- [ ] Run `bun run type-check` from the repo root — should pass with no errors.
- [ ] Run `bun run lint` from the repo root — should pass with no errors.
- [ ] Run `bun test --cwd packages/web src/views/Week/interaction/targeting/week-event.targeting.test.ts src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx` — all tests should pass.

## Test plan
- [x] `bun run type-check` — passes, no errors.
- [x] `bun run lint` — passes, no errors (biome auto-fixed 2 formatting wraps from the longer identifier names).
- [x] `bun test --cwd packages/web` scoped to the affected Week test files — 44 pass, 0 fail.
- [x] Repo-wide grep confirms zero stale references to the old export names remain.