### PR TITLE
style(web): give events dark text on a lighter fill

### DIFF
--- a/packages/web/src/common/styles/color.utils.ts
+++ b/packages/web/src/common/styles/color.utils.ts
@@ -7,3 +7,8 @@ export const darken = (color: string, amount?: number) =>
   tinycolor(color).darken(amount).toString();
 
 export const isDark = (color: string) => tinycolor(color).isDark();
+
+// WCAG contrast ratio between two colors (1–21). Used to pick the more
+// readable of two candidate text colors against a variable background.
+export const readability = (color1: string, color2: string) =>
+  tinycolor.readability(color1, color2);

--- a/packages/web/src/common/styles/theme.ts
+++ b/packages/web/src/common/styles/theme.ts
@@ -1,4 +1,4 @@
-import { isDark } from "@web/common/styles/color.utils";
+import { readability } from "@web/common/styles/color.utils";
 import { colors } from "@web/common/styles/colors";
 
 export const theme = {
@@ -22,9 +22,14 @@ export const theme = {
       extraBold: 900,
     },
   },
-  // Light text on dark backgrounds, dark text on light backgrounds.
+  // Return whichever text token actually has the higher contrast against the
+  // background. A brightness threshold misfires on mid-tone fills, where the
+  // "lighter" side is still too dark for light text (and vice versa).
   getContrastText: (backgroundColor: string): string =>
-    isDark(backgroundColor) ? colors.text : colors.onAccent,
+    readability(colors.onAccent, backgroundColor) >=
+    readability(colors.text, backgroundColor)
+      ? colors.onAccent
+      : colors.text,
   transition: {
     default: "0.3s",
   },

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -1,9 +1,11 @@
 import { brighten, darken } from "./color.utils";
 import { colors } from "./colors";
 
-// Flat neutral color used everywhere an event was previously colored by
-// priority (event grid cards, event form, save button, tags, context menu).
-export const EVENT_COLOR = colors.accentSecondary;
+// Flat neutral fill shared by every event surface (grid cards, event form
+// accents, save button). A muted steel-blue kept light enough that event
+// titles/times render in DARK text at >= 4.5:1 — a darker fill forced light,
+// "glowing" title text that read as too visually loud on the near-black grid.
+export const EVENT_COLOR = "#82A0B2";
 // Derived (not colors.accentSecondaryHover) so the hover delta scales with
 // EVENT_COLOR the same way it always has, rather than being pinned to a
 // fixed step that happens to be smaller for this palette's base lightness.

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -13,7 +13,8 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { darken, isDark } from "@web/common/styles/color.utils";
+import { darken } from "@web/common/styles/color.utils";
+import { theme } from "@web/common/styles/theme";
 import { EVENT_COLOR, EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
@@ -70,10 +71,10 @@ const AllDayEventCardBase = (
   // isInPast is excluded here (falls through to bgColor) so a past event
   // stays dimmed on hover instead of snapping to full brightness.
   const hoverBgColor = !isPlaceholder && !isInPast ? hoverColor : bgColor;
-  // The fill only ever gets darkened for past events, never lightened, but
-  // check dynamically (matching TimedEventCard) rather than assuming
-  // a fixed dark title color stays safe if the fill or darken amount changes.
-  const titleColorClassName = isDark(bgColor) ? "text-text" : "text-on-accent";
+  // Chosen per-fill (whichever of dark/light reads better) rather than a fixed
+  // color, matching TimedEventCard, so a future fill/darken tweak can't quietly
+  // drop the title below 4.5:1.
+  const titleColor = theme.getContrastText(bgColor);
 
   const eventStyle = {
     "--event-bg": bgColor,
@@ -157,10 +158,8 @@ const AllDayEventCardBase = (
         })}
       >
         <span
-          className={cn(
-            "relative min-w-0 truncate text-xs",
-            titleColorClassName,
-          )}
+          className="relative min-w-0 truncate text-xs"
+          style={{ color: titleColor }}
         >
           {event.title}
           <SpaceCharacter />

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -14,7 +14,8 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { brighten, darken, isDark } from "@web/common/styles/color.utils";
+import { brighten, darken } from "@web/common/styles/color.utils";
+import { theme } from "@web/common/styles/theme";
 import { EVENT_COLOR, EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
@@ -123,11 +124,13 @@ const TimedEventCardBase = (
   );
 
   const baseColor = EVENT_COLOR;
-  const draftColor = darken(baseColor, 18);
-  // A `brightness()` filter would scale the title text toward black right
-  // along with the fill, which is what let past events fall below the 4.5:1
-  // contrast minimum. Darkening only the fill keeps the (fixed) title color's
-  // contrast ratio intact.
+  // Darkened well past the mid-tone "dead zone" (where neither dark nor light
+  // text clears 4.5:1) so the draft fill is unambiguously dark and takes the
+  // light title color, visibly distinct from the light-filled saved events.
+  const draftColor = darken(baseColor, 38);
+  // A `brightness()` filter would scale the title text along with the fill,
+  // which is what let past events fall below the 4.5:1 contrast minimum.
+  // Darkening the fill only a little keeps it light enough for dark text.
   const pastColor = darken(baseColor, 5);
   const hoverColor = EVENT_HOVER_COLOR;
   const selectedBoxShadow = "0 0 0 1px rgba(255,255,255,0.55)";
@@ -150,11 +153,10 @@ const TimedEventCardBase = (
     !isDraft && !isPlaceholder && !isResizing && !isInPast
       ? hoverColor
       : bgColor;
-  // The fill is neutral and its lightness swings widely across states (the
-  // draft overlay in particular darkens far more than the others), so the
-  // title needs a text color chosen per-state rather than one fixed value to
-  // keep 4.5:1+ contrast against every fill.
-  const titleColorClassName = isDark(bgColor) ? "text-text" : "text-on-accent";
+  // The fill is neutral and its lightness swings widely across states, so the
+  // text color is chosen per-state (whichever of dark/light reads better) and
+  // set on the content wrapper so the title and time label share it.
+  const contentColor = theme.getContrastText(bgColor);
 
   const eventStyle = {
     "--event-bg": bgColor,
@@ -267,11 +269,10 @@ const TimedEventCardBase = (
       )}
       <div
         className="flex flex-col flex-wrap items-start"
+        style={{ color: contentColor }}
         {...{ [EVENT_CONTENT_ATTRIBUTE]: "true" }}
       >
-        <span className={titleColorClassName} style={titleStyle}>
-          {event.title}
-        </span>
+        <span style={titleStyle}>{event.title}</span>
         {!event.isAllDay && (
           <>
             {showTimeLabel && (

--- a/packages/web/src/grid/grid.constants.ts
+++ b/packages/web/src/grid/grid.constants.ts
@@ -6,7 +6,9 @@ export const EVENT_ALLDAY_ROW_HEIGHT = EVENT_ALLDAY_HEIGHT + EVENT_ALLDAY_GAP;
 export const EVENT_PADDING_RIGHT = 10;
 export const TIMED_EVENT_COLUMN_INSET = 5;
 export const GRID_EVENT_TIME_LABEL_FONT_SIZE = "11px";
-export const GRID_EVENT_TIME_LABEL_OPACITY = "0.78";
+// Dims the time label relative to the title. Kept high enough that the label,
+// composited over the event fill, still clears 4.5:1 with the dark title color.
+export const GRID_EVENT_TIME_LABEL_OPACITY = "0.82";
 // Line box the 11px time label occupies. The title's line clamp subtracts this
 // so the label keeps its row instead of being pushed past the card's clipped edge.
 export const GRID_EVENT_TIME_LABEL_LINE_HEIGHT = 13;

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { type CSSVariables } from "@web/common/styles/css.types";
+import { theme } from "@web/common/styles/theme";
 import { type FrequencyValues } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/constants/recurrence.constants";
 import { CaretInput } from "./CaretInput";
 import { FreqSelect } from "./FreqSelect";
@@ -42,8 +43,13 @@ export const RecurrenceIntervalSelect = ({
       <span className="relative text-l">Every</span>
 
       <input
-        className="ml-1 h-9.5 w-8 rounded-sm border border-transparent bg-[var(--recurrence-bg)] px-1 text-center text-s transition-all duration-300 hover:brightness-90 focus:shadow-[0_0_0_2px_var(--border-strong)] [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none [&[type=number]]:[appearance:textfield]"
-        style={{ "--recurrence-bg": bgColor } as CSSVariables}
+        className="ml-1 h-9.5 w-8 rounded-sm border border-transparent bg-[var(--recurrence-bg)] px-1 text-center text-[var(--recurrence-text)] text-s transition-all duration-300 hover:brightness-90 focus:shadow-[0_0_0_2px_var(--border-strong)] [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none [&[type=number]]:[appearance:textfield]"
+        style={
+          {
+            "--recurrence-bg": bgColor,
+            "--recurrence-text": theme.getContrastText(bgColor),
+          } as CSSVariables
+        }
         type="number"
         max={max}
         min={min}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/WeekDay.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/WeekDay.tsx
@@ -14,13 +14,15 @@ export const WeekDay = ({ day, bgColor, onClick, selected }: WeekDayProps) => {
   return (
     <button
       type="button"
-      className="size-6 cursor-pointer rounded-full border border-[var(--border-strong)] bg-[var(--weekday-bg)] text-m transition-all duration-300 focus:shadow-[0_0_0_2px_var(--border-strong)] data-[selected=true]:bg-[var(--weekday-selected-bg)] data-[selected=true]:text-[var(--weekday-selected-text)] data-[selected=false]:hover:bg-background data-[selected=false]:hover:text-text-muted"
+      className="size-6 cursor-pointer rounded-full border border-[var(--border-strong)] bg-[var(--weekday-bg)] text-[var(--weekday-text)] text-m transition-all duration-300 focus:shadow-[0_0_0_2px_var(--border-strong)] data-[selected=true]:bg-[var(--weekday-selected-bg)] data-[selected=true]:text-[var(--weekday-selected-text)] data-[selected=false]:hover:bg-background data-[selected=false]:hover:text-text-muted"
       data-selected={selected}
       style={
         {
           "--weekday-bg": bgColor,
+          "--weekday-text": theme.getContrastText(bgColor),
           "--weekday-selected-bg": darken(bgColor, 30),
-          "--weekday-selected-text": theme.getContrastText(bgColor),
+          // Contrast text for the actual (darkened) selected fill, not bgColor.
+          "--weekday-selected-text": theme.getContrastText(darken(bgColor, 30)),
         } as CSSVariables
       }
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Summary
Calendar event titles and times rendered light "glowing" text on a dark steel-blue fill, which read as too visually loud against the near-black grid. This lightens the shared event fill (`#5C7C92` → `#82A0B2`) so titles and times render in **dark** text, and makes the text-color decision robust:

- `getContrastText` now returns whichever text token (dark `on-accent` or light `text`) actually has the higher WCAG contrast against the background, instead of a brightness threshold that misfires on mid-tone fills (the same misalignment that had forced the Save button to near-illegible light text in the prior restyle).
- Event cards set the chosen color on the content wrapper, so the title and the time label share one per-state color (the time label previously inherited an unrelated ambient color).
- Draft events darken past the mid-tone "dead zone" (where neither dark nor light text clears 4.5:1) so they stay unambiguously dark with light text — visibly distinct from the now light-filled saved events.
- The Save button, weekday toggles, and recurrence-interval input all derive from the same fill and follow the same contrast-picking rule, so each stays ≥ 4.5:1 with the lighter fill.

Every event/form state was checked to clear WCAG AA (4.5:1): saved 6.88:1, past 5.88:1, draft 7.28:1, Save button 5.00:1, weekday 6.88:1.

## Simplicity
Net-neutral to slightly simpler. No new abstraction was added: both card components reuse the existing `getContrastText` utility rather than each hand-rolling a text-color branch, and `getContrastText` itself replaces a hand-tuned brightness threshold with a direct contrast comparison over the two candidate tokens. One tiny helper (`readability`, a one-line tinycolor wrapper) was added alongside the existing `brighten`/`darken`/`isDark` wrappers in the same file. No `useEffect`, `useRef`, or `useState` were added or removed.

## Manual Testing Steps
- [ ] Open the calendar week view with a few events on it — confirm each event's title and time read as **dark** text on a muted steel-blue fill, not white text, and are comfortably legible.
- [ ] Hover an event — confirm it brightens slightly and the text stays dark and legible.
- [ ] Drag on an empty part of the grid to start creating a new event — confirm the in-progress (draft) event appears as a distinctly darker slate block with **light** text, clearly different from the saved events around it.
- [ ] Scroll to a day/time in the past that has an event — confirm the past event is slightly dimmer but its dark text is still legible.
- [ ] Open an event's form and confirm the "Save" button text is legible against the button.

## Test plan
- [x] `bun run lint` — 0 errors (5 pre-existing nursery warnings, unrelated)
- [x] `bun run type-check` — 0 errors
- [x] `bun run test:web` — 1253 passed, 0 failed
- [x] Correctness review of the diff (dead imports, inline-color cascade to the time label, WeekDay variant specificity, circular-import risk, contrast-comparison direction, hover-fill contrast) — no defects found
- [x] Verified in the user's real Chrome: computed styles confirm saved cards `#82A0B2` + `#05121A` text, past `#7294a8`, draft `#2c3c47` + light text, Save button `#62889f` + dark text; no console errors