### PR TITLE
fix(web): contain event-form date fields within the card

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
@@ -183,64 +183,60 @@ export const DatePickers: FC<Props> = ({
 
   return (
     <>
-      <div className={dateFieldClassName}>
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: This wrapper only stops date picker mouse events from bubbling to the form. */}
-        <div
-          className="w-full"
-          onMouseUp={stopPropagation}
-          onMouseDown={stopPropagation}
-        >
-          <DatePicker
-            calendarClassName="startDatePicker"
-            isOpen={isStartDatePickerOpen}
-            monthTextClassName="text-medium"
-            onCalendarClose={closeStartDatePicker}
-            onCalendarOpen={() => {
-              setIsStartDatePickerOpen(true);
-            }}
-            onChange={() => null}
-            onInputClick={() => {
-              if (isEndDatePickerOpen) {
-                setIsEndDatePickerOpen(false);
-              }
-              setIsStartDatePickerOpen(true);
-            }}
-            onKeyDown={(e) => onPickerKeyDown("start", e)}
-            onSelect={onSelectStartDate}
-            selected={selectedStartDate}
-            title="Pick Start Date"
-            view="grid"
-          />
-        </div>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: This wrapper only stops date picker mouse events from bubbling to the form. */}
+      <div
+        className={dateFieldClassName}
+        onMouseUp={stopPropagation}
+        onMouseDown={stopPropagation}
+      >
+        <DatePicker
+          calendarClassName="startDatePicker"
+          isOpen={isStartDatePickerOpen}
+          monthTextClassName="text-medium"
+          onCalendarClose={closeStartDatePicker}
+          onCalendarOpen={() => {
+            setIsStartDatePickerOpen(true);
+          }}
+          onChange={() => null}
+          onInputClick={() => {
+            if (isEndDatePickerOpen) {
+              setIsEndDatePickerOpen(false);
+            }
+            setIsStartDatePickerOpen(true);
+          }}
+          onKeyDown={(e) => onPickerKeyDown("start", e)}
+          onSelect={onSelectStartDate}
+          selected={selectedStartDate}
+          title="Pick Start Date"
+          view="grid"
+        />
       </div>
 
-      <div className={dateFieldClassName}>
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: This wrapper only stops date picker mouse events from bubbling to the form. */}
-        <div
-          className="w-full"
-          onMouseUp={stopPropagation}
-          onMouseDown={stopPropagation}
-        >
-          <DatePicker
-            calendarClassName="endDatePicker"
-            isOpen={isEndDatePickerOpen}
-            monthTextClassName="text-medium"
-            onCalendarClose={closeEndDatePicker}
-            onCalendarOpen={() => setIsEndDatePickerOpen(true)}
-            onChange={() => null}
-            onInputClick={() => {
-              if (isStartDatePickerOpen) {
-                setIsStartDatePickerOpen(false);
-              }
-              setIsEndDatePickerOpen(true);
-            }}
-            onKeyDown={(e) => onPickerKeyDown("end", e)}
-            onSelect={onSelectEndDate}
-            selected={displayEndDate}
-            title="Pick End Date"
-            view="grid"
-          />
-        </div>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: This wrapper only stops date picker mouse events from bubbling to the form. */}
+      <div
+        className={dateFieldClassName}
+        onMouseUp={stopPropagation}
+        onMouseDown={stopPropagation}
+      >
+        <DatePicker
+          calendarClassName="endDatePicker"
+          isOpen={isEndDatePickerOpen}
+          monthTextClassName="text-medium"
+          onCalendarClose={closeEndDatePicker}
+          onCalendarOpen={() => setIsEndDatePickerOpen(true)}
+          onChange={() => null}
+          onInputClick={() => {
+            if (isStartDatePickerOpen) {
+              setIsStartDatePickerOpen(false);
+            }
+            setIsEndDatePickerOpen(true);
+          }}
+          onKeyDown={(e) => onPickerKeyDown("end", e)}
+          onSelect={onSelectEndDate}
+          selected={displayEndDate}
+          title="Pick End Date"
+          view="grid"
+        />
       </div>
     </>
   );

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
@@ -12,6 +12,16 @@ const stopPropagation = (e: React.MouseEvent<HTMLDivElement>) => {
   e.stopPropagation();
 };
 
+// The start and end date pickers share one row inside a narrow sidebar card.
+// react-datepicker's wrapper/input-container are inline-block and size to the
+// input's fixed width, so two of them overflow the card and the end date spills
+// past its right edge. flex-1 + min-w-0 lets each field shrink to stay inside
+// the card (max-w-28 keeps them compact on a wide sidebar); forcing the whole
+// react-datepicker chain to fill the field is what lets the shrink reach the
+// input instead of stopping at the inline-block wrappers.
+const dateFieldClassName =
+  "flex min-w-0 max-w-28 flex-1 items-center [&_.react-datepicker-wrapper]:w-full [&_.react-datepicker\\_\\_input-container]:w-full [&_input]:w-full [&_input]:min-w-0";
+
 interface Props {
   displayEndDate: Date;
   isEndDatePickerOpen: boolean;
@@ -173,9 +183,13 @@ export const DatePickers: FC<Props> = ({
 
   return (
     <>
-      <div className="flex items-center">
+      <div className={dateFieldClassName}>
         {/* biome-ignore lint/a11y/noStaticElementInteractions: This wrapper only stops date picker mouse events from bubbling to the form. */}
-        <div onMouseUp={stopPropagation} onMouseDown={stopPropagation}>
+        <div
+          className="w-full"
+          onMouseUp={stopPropagation}
+          onMouseDown={stopPropagation}
+        >
           <DatePicker
             calendarClassName="startDatePicker"
             isOpen={isStartDatePickerOpen}
@@ -200,9 +214,13 @@ export const DatePickers: FC<Props> = ({
         </div>
       </div>
 
-      <div className="flex w-30 items-center">
+      <div className={dateFieldClassName}>
         {/* biome-ignore lint/a11y/noStaticElementInteractions: This wrapper only stops date picker mouse events from bubbling to the form. */}
-        <div onMouseUp={stopPropagation} onMouseDown={stopPropagation}>
+        <div
+          className="w-full"
+          onMouseUp={stopPropagation}
+          onMouseDown={stopPropagation}
+        >
           <DatePicker
             calendarClassName="endDatePicker"
             isOpen={isEndDatePickerOpen}


### PR DESCRIPTION
## Summary

The all-day event form's start and end date pickers used fixed widths (`w-28`, plus an asymmetric `w-30` wrapper on the end field) that together exceeded the sidebar card's inner width. On a narrow sidebar this pushed the end date past the card's right edge, and at larger font sizes the end-date label visibly spilled outside the card (reported from staging).

Root cause: react-datepicker wraps the `customInput` in two `inline-block` divs (`.react-datepicker-wrapper` → `.react-datepicker__input-container`) that size themselves to the input's fixed width, so no amount of flex on the outer wrapper could make the fields shrink. The fix makes the two fields `flex-1 min-w-0 max-w-28` (share the row, shrink to fit the card, stay compact on a wide sidebar) and forces the whole react-datepicker chain to `w-full` so the shrink actually reaches the input. A follow-up commit collapses a now-redundant wrapper div per field.

Verified: end date stays inside the card at both narrow (fields shrink to ~108px) and wide (capped at 112px) sidebar widths, the longest date (`12-31-2026`) fits without clipping, and the date-picker calendar popover still opens and positions correctly.

## Simplicity

Net-reduced complexity. The two field wrappers, which previously carried different ad-hoc widths (`flex items-center` vs `flex w-30 items-center`), now share one named `dateFieldClassName` constant, and the redundant inner wrapper div per field (which only held `w-full` + mouse handlers) was collapsed into the layout div. No `useEffect`/`useRef`/`useState` were added or are present in the diff — this is a pure CSS/markup change.

## Manual Testing Steps

- [ ] Open the calendar in Week view.
- [ ] Click an empty spot in the all-day row (the strip directly below the day-of-week headers) to start a new all-day event; the event editor opens in the left sidebar.
- [ ] Confirm the date row shows the start and end date side by side (e.g. `7-12-2026   7-12-2026`) and both dates sit fully inside the rounded card — neither spills past the card's right edge.
- [ ] Click the start date and confirm the month calendar popover opens directly beneath it and you can pick a date.
- [ ] Drag the sidebar wider with the resize handle and confirm the two dates stay compact and contained (they don't stretch across the whole card).
- [ ] Set the end date to a two-digit month/day such as `12-31-2026` and confirm the full date is visible, not clipped.

## Test plan

- [x] `bun run type-check` — passed (root, web-app, web-tests).
- [x] `bun test --cwd packages/web src/views/Forms/EventForm/EventForm.test.tsx .../TimePicker/TimePickers.test.tsx` — 16 pass / 0 fail.
- [x] Manual verification in real Chrome: containment at narrow + wide sidebar, popover positioning, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)