### PR TITLE
feat(web): add light beach theme with command palette switcher

### DIFF
--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -5,6 +5,7 @@ export const StorageKeySchema = z.enum([
   "compass.onboarding.has-seen-welcome",
   "compass.onboarding.has-dismissed-tasks-removal-notice",
   "compass.sidebar.width",
+  "compass.theme",
   "compass.view.sidebar-open",
 ]);
 
@@ -15,7 +16,8 @@ export const STORAGE_KEYS: Record<
   | "HAS_SEEN_WELCOME"
   | "HAS_DISMISSED_TASKS_REMOVAL_NOTICE"
   | "SIDEBAR_WIDTH"
-  | "SIDEBAR_OPEN",
+  | "SIDEBAR_OPEN"
+  | "THEME",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -24,4 +26,5 @@ export const STORAGE_KEYS: Record<
     "compass.onboarding.has-dismissed-tasks-removal-notice",
   SIDEBAR_WIDTH: "compass.sidebar.width",
   SIDEBAR_OPEN: "compass.view.sidebar-open",
+  THEME: "compass.theme",
 } as const;

--- a/packages/web/src/common/styles/colors.ts
+++ b/packages/web/src/common/styles/colors.ts
@@ -29,3 +29,13 @@ export const colors = {
   error: "#C17E70",
   info: "#6E97BE",
 };
+
+// Light Beach counterparts, mirroring the [data-theme="light-beach"] block in
+// index.css (same theme-css.test.ts parity guard). Only the roles a JS
+// consumer actually needs real hex for (contrast math, tinycolor derivations)
+// live here — everything else should keep reading CSS variables.
+export const lightColors = {
+  background: "#F3EEE2",
+  text: "#403A2F",
+  onAccent: "#F6F3EA",
+};

--- a/packages/web/src/common/styles/theme-css.test.ts
+++ b/packages/web/src/common/styles/theme-css.test.ts
@@ -1,4 +1,4 @@
-import { colors } from "./colors";
+import { colors, lightColors } from "./colors";
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -97,6 +97,24 @@ describe("Tailwind theme CSS", () => {
     }
   });
 
+  it("declares the Light Beach theme scope", () => {
+    expect(indexCss).toContain('[data-theme="light-beach"]');
+    expect(indexCss).toContain("color-scheme: light");
+  });
+
+  it("defines every semantic role in the Light Beach theme", () => {
+    // Isolate the light-beach block so we don't accidentally match a role that
+    // only the dark block defines.
+    const block = indexCss.match(/\[data-theme="light-beach"\]\s*\{([^}]*)\}/);
+    expect(block).not.toBeNull();
+    const body = block?.[1] ?? "";
+
+    for (const token of semanticColorTokens) {
+      // Value can be hex or hsl(...); just assert the role is assigned something.
+      expect(body).toMatch(new RegExp(`--${token}:\\s*\\S`));
+    }
+  });
+
   it("does not contain any pre-restyle token names", () => {
     for (const name of deadNames) {
       expect(indexCss).not.toContain(name);
@@ -107,6 +125,27 @@ describe("Tailwind theme CSS", () => {
     for (const [jsKey, cssToken] of Object.entries(jsColorKeyToCssToken)) {
       const hex = colors[jsKey as keyof typeof colors];
       const match = indexCss.match(
+        new RegExp(`--${cssToken}:\\s*(#[0-9a-fA-F]{6});`),
+      );
+      expect(match).not.toBeNull();
+      expect(match?.[1]?.toLowerCase()).toBe(hex.toLowerCase());
+    }
+  });
+
+  it("keeps lightColors hex values in sync with the light-beach block", () => {
+    const block = indexCss.match(/\[data-theme="light-beach"\]\s*\{([^}]*)\}/);
+    const body = block?.[1] ?? "";
+
+    const lightJsColorKeyToCssToken: Record<keyof typeof lightColors, string> =
+      {
+        background: "background",
+        text: "text",
+        onAccent: "on-accent",
+      };
+
+    for (const [jsKey, cssToken] of Object.entries(lightJsColorKeyToCssToken)) {
+      const hex = lightColors[jsKey as keyof typeof lightColors];
+      const match = body.match(
         new RegExp(`--${cssToken}:\\s*(#[0-9a-fA-F]{6});`),
       );
       expect(match).not.toBeNull();

--- a/packages/web/src/common/styles/theme.ts
+++ b/packages/web/src/common/styles/theme.ts
@@ -1,5 +1,19 @@
 import { readability } from "@web/common/styles/color.utils";
-import { colors } from "@web/common/styles/colors";
+import { colors, lightColors } from "@web/common/styles/colors";
+import { type ThemeName } from "@web/settings/theme/theme.constants";
+import { useThemeStore } from "@web/settings/theme/theme.store";
+
+// The two text candidates getContrastText picks between, per theme. Reading
+// the store via getState (not a hook) keeps this callable from plain
+// functions; callers re-render on a theme switch anyway because their fill
+// colors come from useEventPalette.
+const CONTRAST_TEXT_CANDIDATES: Record<
+  ThemeName,
+  { light: string; dark: string }
+> = {
+  "dark-abyss": { light: colors.text, dark: colors.onAccent },
+  "light-beach": { light: lightColors.onAccent, dark: lightColors.text },
+};
 
 export const theme = {
   text: {
@@ -25,11 +39,14 @@ export const theme = {
   // Return whichever text token actually has the higher contrast against the
   // background. A brightness threshold misfires on mid-tone fills, where the
   // "lighter" side is still too dark for light text (and vice versa).
-  getContrastText: (backgroundColor: string): string =>
-    readability(colors.onAccent, backgroundColor) >=
-    readability(colors.text, backgroundColor)
-      ? colors.onAccent
-      : colors.text,
+  getContrastText: (backgroundColor: string): string => {
+    const { light, dark } =
+      CONTRAST_TEXT_CANDIDATES[useThemeStore.getState().theme];
+    return readability(dark, backgroundColor) >=
+      readability(light, backgroundColor)
+      ? dark
+      : light;
+  },
   transition: {
     default: "0.3s",
   },

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -63,5 +63,7 @@ export const accentGradient =
 const mutedGradient =
   "linear-gradient(90deg, var(--text-muted), var(--text-subtle))";
 
-export const getGradient = (color: string) =>
-  color === getEventPalette().base ? getEventPalette().gradient : mutedGradient;
+export const getGradient = (color: string) => {
+  const { base, gradient } = getEventPalette();
+  return color === base ? gradient : mutedGradient;
+};

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -1,22 +1,67 @@
+import { type ThemeName } from "@web/settings/theme/theme.constants";
+import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
 import { brighten, darken } from "./color.utils";
-import { colors } from "./colors";
 
 // Flat neutral fill shared by every event surface (grid cards, event form
-// accents, save button). A muted steel-blue kept light enough that event
-// titles/times render in DARK text at >= 4.5:1 — a darker fill forced light,
-// "glowing" title text that read as too visually loud on the near-black grid.
-export const EVENT_COLOR = "#82A0B2";
-// Derived (not colors.accentSecondaryHover) so the hover delta scales with
-// EVENT_COLOR the same way it always has, rather than being pinned to a
-// fixed step that happens to be smaller for this palette's base lightness.
-export const EVENT_HOVER_COLOR = brighten(EVENT_COLOR);
-export const EVENT_GRADIENT = `linear-gradient(90deg, ${darken(
-  EVENT_COLOR,
-  15,
-)}, ${darken(EVENT_COLOR, 30)})`;
+// accents, save button), one value per theme. Title/time text is picked per
+// fill by theme.getContrastText, so each base just has to sit clearly on one
+// side of the mid-tone dead zone.
+//   Dark Abyss:  muted steel-blue, light enough for dark text (>= 4.5:1) — a
+//                darker fill forced light, "glowing" titles on the near-black
+//                grid that read as too visually loud.
+//   Light Beach: near-neutral ink charcoal that takes light text (8.8:1) —
+//                dark blocks on the warm paper grid, matching the theme's
+//                restrained pen-and-paper brief.
+const EVENT_BASE_COLOR: Record<ThemeName, string> = {
+  "dark-abyss": "#82A0B2",
+  "light-beach": "#454442",
+};
 
-export const accentGradient = `linear-gradient(${colors.accent}, ${colors.accentStrong})`;
-const mutedGradient = `linear-gradient(90deg, ${colors.textMuted}, ${colors.textSubtle})`;
+export interface EventPalette {
+  base: string;
+  /** Derived (not a fixed hex) so the hover delta scales with the base the
+   * same way it always has, rather than being pinned to a step that happens
+   * to suit one palette's lightness. */
+  hover: string;
+  gradient: string;
+  saveButtonBg: string;
+  /** The c-button-elevated underside, a step deeper than the button fill. */
+  saveButtonShadow: string;
+}
+
+const buildEventPalette = (theme: ThemeName): EventPalette => {
+  const base = EVENT_BASE_COLOR[theme];
+  return {
+    base,
+    hover: brighten(base),
+    gradient: `linear-gradient(90deg, ${darken(base, 15)}, ${darken(base, 30)})`,
+    saveButtonBg: darken(base),
+    saveButtonShadow: darken(base, 25),
+  };
+};
+
+// Precomputed for both themes at module load — consumers just index in.
+const EVENT_PALETTES: Record<ThemeName, EventPalette> = {
+  "dark-abyss": buildEventPalette("dark-abyss"),
+  "light-beach": buildEventPalette("light-beach"),
+};
+
+/** The active theme's event palette; subscribes so a theme switch re-renders
+ * the caller with the new fills. */
+export const useEventPalette = (): EventPalette =>
+  EVENT_PALETTES[useThemeStore(selectTheme)];
+
+/** Non-reactive read for plain functions (e.g. getGradient's identity check).
+ * Components should use useEventPalette so they repaint on switch. */
+export const getEventPalette = (): EventPalette =>
+  EVENT_PALETTES[useThemeStore.getState().theme];
+
+// CSS-variable gradients: these land in inline `background` styles, so the
+// browser resolves them against the active [data-theme] — no JS hex needed.
+export const accentGradient =
+  "linear-gradient(var(--accent), var(--accent-strong))";
+const mutedGradient =
+  "linear-gradient(90deg, var(--text-muted), var(--text-subtle))";
 
 export const getGradient = (color: string) =>
-  color === EVENT_COLOR ? EVENT_GRADIENT : mutedGradient;
+  color === getEventPalette().base ? getEventPalette().gradient : mutedGradient;

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -12,7 +12,6 @@ import {
 } from "@core/types/event.contracts";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ACCEPTED_TIMES } from "@web/common/constants/web.constants";
-import { colors as palette } from "@web/common/styles/colors";
 import { type Option_Time } from "@web/common/types/util.types";
 import {
   type Categories_Event,
@@ -33,8 +32,10 @@ export const getColorsByHour = (currentHour: number) => {
   const colors: string[] = [];
 
   [...(new Array(24) as number[])].map((_, index) => {
+    // CSS variables (not hex) so the labels land in inline styles that
+    // resolve against the active [data-theme].
     const isCurrentHour = currentHour - 1 === index;
-    const color = isCurrentHour ? palette.accent : palette.textMuted;
+    const color = isCurrentHour ? "var(--accent)" : "var(--text-muted)";
 
     colors.push(color);
 

--- a/packages/web/src/components/Button/Button.tsx
+++ b/packages/web/src/components/Button/Button.tsx
@@ -4,10 +4,9 @@ import {
   forwardRef,
   type PropsWithChildren,
 } from "react";
-import { darken } from "@web/common/styles/color.utils";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import { theme } from "@web/common/styles/theme";
-import { EVENT_COLOR } from "@web/common/styles/theme.util";
+import { useEventPalette } from "@web/common/styles/theme.util";
 
 // A native button (not a div) so Enter/Space activate it — click handlers
 // often live on a wrapping TooltipTrigger div and rely on bubbling.
@@ -28,11 +27,6 @@ export const Btn = forwardRef<
 
 Btn.displayName = "Btn";
 
-// EVENT_COLOR is a fixed module-level constant, so its derived save-button
-// colors are too — computed once rather than on every SaveButton render.
-const SAVE_BUTTON_BACKGROUND = darken(EVENT_COLOR);
-const SAVE_BUTTON_TEXT_COLOR = theme.getContrastText(SAVE_BUTTON_BACKGROUND);
-
 interface SaveButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "color" | "disabled"> {
   minWidth: number;
@@ -43,12 +37,15 @@ export const SaveButton = forwardRef<
   HTMLButtonElement,
   PropsWithChildren<SaveButtonProps>
 >(({ className, disabled, minWidth, style, ...props }, ref) => {
+  // Per-theme, precomputed in theme.util — the hook subscription is what
+  // repaints the button when the theme switches.
+  const { saveButtonBg, saveButtonShadow } = useEventPalette();
   const buttonStyle: CSSVariables = {
     ...style,
-    "--save-button-text-color": SAVE_BUTTON_TEXT_COLOR,
+    "--save-button-text-color": theme.getContrastText(saveButtonBg),
     "--save-button-hover-color": "var(--color-text-muted)",
-    "--elevated-shadow-color": darken(EVENT_COLOR, 25),
-    background: SAVE_BUTTON_BACKGROUND,
+    "--elevated-shadow-color": saveButtonShadow,
+    background: saveButtonBg,
     minWidth,
   };
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -175,14 +175,14 @@ describe("CommandPalette", () => {
     expect(activeRowText(container)).toBe("Go to Day");
 
     // Walk down to "Create all-day event", then the next ArrowDown skips the
-    // disabled Undo row and lands on the (stubbed, always-first) Google item.
+    // disabled Undo row and lands on the Appearance section's theme toggle.
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Today
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Show Shortcuts
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create event
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create all-day event
     expect(activeRowText(container)).toBe("Create all-day event");
     fireEvent.keyDown(input, { key: "ArrowDown" }); // skips Undo last change
-    expect(activeRowText(container)).toBe("Connect Google Calendar");
+    expect(activeRowText(container)).toBe("Switch to light theme");
   });
 
   it("runs the active item's onClick and closes on Enter", async () => {

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -22,6 +22,7 @@ import { useDeleteAccountCmdItems } from "@web/components/CommandPalette/hooks/u
 import { useExportDataCmdItems } from "@web/components/CommandPalette/hooks/useExportDataCmdItems";
 import { useLogoutCmdItems } from "@web/components/CommandPalette/hooks/useLogoutCmdItems";
 import { useSubscribeCmdItems } from "@web/components/CommandPalette/hooks/useSubscribeCmdItems";
+import { useThemeCmdItems } from "@web/components/CommandPalette/hooks/useThemeCmdItems";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { type EventMutationDependencies } from "@web/events/mutations/useEventMutations";
 import { useUndoRedo } from "@web/events/mutations/useUndoRedo";
@@ -89,6 +90,7 @@ export const CommandPalette = ({
   const authCmdItems = useAuthCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
   const deleteAccountCmdItems = useDeleteAccountCmdItems();
+  const themeCmdItems = useThemeCmdItems();
   const { undo, canUndo } = useUndoRedo(mutationDependencies);
 
   const [search, setSearch] = useState("");
@@ -140,6 +142,11 @@ export const CommandPalette = ({
           onClick: () => queueMicrotask(undo),
         },
       ],
+    },
+    {
+      id: "appearance",
+      heading: "Appearance",
+      items: themeCmdItems,
     },
     {
       id: "settings",

--- a/packages/web/src/components/CommandPalette/hooks/useThemeCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useThemeCmdItems.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { THEME_STORAGE_KEY } from "@web/settings/theme/theme.constants";
+import { useThemeStore } from "@web/settings/theme/theme.store";
+import { useThemeCmdItems } from "./useThemeCmdItems";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("useThemeCmdItems", () => {
+  beforeEach(() => {
+    persistentBrowserStore.remove(THEME_STORAGE_KEY);
+    document.documentElement.removeAttribute("data-theme");
+    useThemeStore.setState({ theme: "dark-abyss" });
+  });
+
+  it("offers a single toggle to the other theme", () => {
+    const { result } = renderHook(() => useThemeCmdItems());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]?.id).toBe("toggle-theme");
+    expect(result.current[0]?.label).toBe("Switch to light theme");
+  });
+
+  it("switches to light on click, then offers the way back", () => {
+    const { result } = renderHook(() => useThemeCmdItems());
+
+    act(() => {
+      result.current[0]?.onClick?.();
+    });
+
+    expect(useThemeStore.getState().theme).toBe("light-beach");
+    expect(document.documentElement.getAttribute("data-theme")).toBe(
+      "light-beach",
+    );
+    expect(result.current[0]?.label).toBe("Switch to dark theme");
+
+    act(() => {
+      result.current[0]?.onClick?.();
+    });
+
+    expect(useThemeStore.getState().theme).toBe("dark-abyss");
+    expect(result.current[0]?.label).toBe("Switch to light theme");
+  });
+});

--- a/packages/web/src/components/CommandPalette/hooks/useThemeCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useThemeCmdItems.ts
@@ -1,0 +1,26 @@
+import { MoonStarsIcon, SunIcon } from "@phosphor-icons/react";
+import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+import {
+  selectTheme,
+  themeActions,
+  useThemeStore,
+} from "@web/settings/theme/theme.store";
+
+/**
+ * A single toggle that switches to the other theme. Two themes exist today,
+ * so "the other one" is a plain ternary — revisit if a third theme lands.
+ */
+export function useThemeCmdItems(): CommandItem[] {
+  const activeTheme = useThemeStore(selectTheme);
+  const isDark = activeTheme === "dark-abyss";
+
+  return [
+    {
+      id: "toggle-theme",
+      label: isDark ? "Switch to light theme" : "Switch to dark theme",
+      icon: isDark ? SunIcon : MoonStarsIcon,
+      onClick: () =>
+        themeActions.setTheme(isDark ? "light-beach" : "dark-abyss"),
+    },
+  ];
+}

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -4,12 +4,13 @@ import * as ReactDatePickerModule from "react-datepicker";
 import { type ReactDatePickerProps } from "react-datepicker";
 import dayjs from "@core/util/date/dayjs";
 import { darken, isDark } from "@web/common/styles/color.utils";
-import { colors } from "@web/common/styles/colors";
+import { colors, lightColors } from "@web/common/styles/colors";
 import { type CSSVariables } from "@web/common/styles/css.types";
 import { resolveDefaultExport } from "@web/common/utils/resolve-default-export.util";
 import { MonthNavButton } from "@web/components/DatePicker/MonthNavButton";
 import { ChevronLeftIcon } from "@web/components/Icons/ChevronLeftIcon";
 import { ChevronRightIcon } from "@web/components/Icons/ChevronRightIcon";
+import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
 import { Focusable, INPUT_RESET_CLASSNAME } from "../Focusable/Focusable";
 import { CircleIcon } from "../Icons/CircleIcon";
 import { TooltipWrapper } from "../Tooltip/TooltipWrapper";
@@ -49,17 +50,24 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
     withTodayButton = true,
     ...props
   } = datePickerProps;
-  const resolvedBgColor = bgColor ?? colors.background;
+  const isDarkTheme = useThemeStore(selectTheme) === "dark-abyss";
+  const resolvedBgColor =
+    bgColor ?? (isDarkTheme ? colors.background : lightColors.background);
   const datePickerStyle: CSSVariables = {
     // Grid (popover) pickers read as an elevated surface a step above the app
     // background; the sidebar picker overrides this to transparent in CSS.
     "--date-picker-bg": bgColor ?? "var(--surface)",
   };
   const isDarkBackground = isDark(resolvedBgColor);
+  // When the picker bg has the same polarity as the theme's surfaces, the
+  // theme's standard --text already contrasts with it; a mismatched bg (e.g.
+  // the light event-fill picker on the dark theme) needs --on-accent, the
+  // token that flips polarity. The CSS keys off this via [data-dark].
+  const usesThemeText = isDarkBackground === isDarkTheme;
   const headerColor =
     view === "sidebar"
       ? "var(--text-muted)"
-      : isDarkBackground
+      : usesThemeText
         ? "var(--text)"
         : "var(--on-accent)";
 
@@ -73,7 +81,7 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
       calendarContainer={({ children, className }) => (
         <div
           className={classNames("c-date-picker", className)}
-          data-dark={isDarkBackground}
+          data-dark={usesThemeText}
           data-view={view}
           style={datePickerStyle}
         >

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -13,9 +13,9 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { darken } from "@web/common/styles/color.utils";
+import { brighten, darken, isDark } from "@web/common/styles/color.utils";
 import { theme } from "@web/common/styles/theme";
-import { EVENT_COLOR, EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
+import { useEventPalette } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { SpaceCharacter } from "@web/components/SpaceCharacter";
 import { EVENT_RESIZE_HANDLE_ATTRIBUTE } from "@web/grid/interaction/dom";
@@ -57,17 +57,21 @@ const AllDayEventCardBase = (
   }: AllDayEventCardProps,
   ref: ForwardedRef<HTMLDivElement>,
 ) => {
-  const baseColor = EVENT_COLOR;
-  const hoverColor = EVENT_HOVER_COLOR;
+  const { base: baseColor, hover: hoverColor } = useEventPalette();
   const isInPast = dayjs().isAfter(dayjs(event.endDate));
   const isRecurring = isRecurringEvent(event);
   const showRepeatIcon =
     isRecurring && !isPlaceholder && position.width >= REPEAT_ICON_MIN_WIDTH;
-  // A `brightness()` filter would scale the title text toward black right
-  // along with the fill, which is what let past events fall below the 4.5:1
-  // contrast minimum. Darkening only the fill keeps the (fixed) title color's
-  // contrast ratio intact.
-  const bgColor = isInPast ? darken(baseColor, 5) : baseColor;
+  // Past events recede in the direction of the theme's grid, matching
+  // TimedEventCard: the dark theme's light steel fill dims slightly, the
+  // light theme's ink fill fades toward the paper. Only the fill moves — a
+  // `brightness()` filter would drag the title text along with it and let
+  // past events fall below the 4.5:1 contrast minimum.
+  const bgColor = isInPast
+    ? isDark(baseColor)
+      ? brighten(baseColor, 14)
+      : darken(baseColor, 5)
+    : baseColor;
   // isInPast is excluded here (falls through to bgColor) so a past event
   // stays dimmed on hover instead of snapping to full brightness.
   const hoverBgColor = !isPlaceholder && !isInPast ? hoverColor : bgColor;

--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { EVENT_COLOR } from "@web/common/styles/theme.util";
+import { getEventPalette } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
@@ -104,8 +104,12 @@ describe("EventCard", () => {
 
     expect(card).toHaveClass("bg-(--event-bg)");
     expect(card).not.toHaveClass("bg-event-selected");
-    expect(card.style.getPropertyValue("--event-bg")).toBe(EVENT_COLOR);
-    expect(card.style.boxShadow).toContain("rgba(255,255,255,0.55)");
+    expect(card.style.getPropertyValue("--event-bg")).toBe(
+      getEventPalette().base,
+    );
+    expect(card.style.boxShadow).toContain(
+      "color-mix(in srgb, var(--text) 55%, transparent)",
+    );
   });
 
   it("keeps timed event keyboard activation from reaching parent shortcuts", () => {

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -14,9 +14,9 @@ import {
   DATA_EVENT_ELEMENT_ID,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { brighten, darken } from "@web/common/styles/color.utils";
+import { brighten, darken, isDark } from "@web/common/styles/color.utils";
 import { theme } from "@web/common/styles/theme";
-import { EVENT_COLOR, EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
+import { useEventPalette } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 import { getLineClamp } from "@web/common/utils/grid/grid.util";
@@ -123,17 +123,23 @@ const TimedEventCardBase = (
     [position.height, showTimeLabel],
   );
 
-  const baseColor = EVENT_COLOR;
+  const { base: baseColor, hover: hoverColor } = useEventPalette();
   // Darkened well past the mid-tone "dead zone" (where neither dark nor light
   // text clears 4.5:1) so the draft fill is unambiguously dark and takes the
   // light title color, visibly distinct from the light-filled saved events.
   const draftColor = darken(baseColor, 38);
-  // A `brightness()` filter would scale the title text along with the fill,
-  // which is what let past events fall below the 4.5:1 contrast minimum.
-  // Darkening the fill only a little keeps it light enough for dark text.
-  const pastColor = darken(baseColor, 5);
-  const hoverColor = EVENT_HOVER_COLOR;
-  const selectedBoxShadow = "0 0 0 1px rgba(255,255,255,0.55)";
+  // Past events recede in the direction of the theme's grid: the dark theme's
+  // light steel fill dims slightly, the light theme's ink fill fades toward
+  // the paper (brighten 14 keeps light text >= 4.5:1 and stays clearly apart
+  // from the brighten-10 hover fill). A `brightness()` filter can't do either
+  // safely — it scales the title text along with the fill.
+  const pastColor = isDark(baseColor)
+    ? brighten(baseColor, 14)
+    : darken(baseColor, 5);
+  // Ring color follows --text so it contrasts with the page in both themes;
+  // a fixed white ring vanished on the light theme's paper background.
+  const selectedBoxShadow =
+    "0 0 0 1px color-mix(in srgb, var(--text) 55%, transparent)";
 
   const bgColor = (() => {
     if (isDraft) return draftColor;

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -126,7 +126,9 @@ const TimedEventCardBase = (
   const { base: baseColor, hover: hoverColor } = useEventPalette();
   // Darkened well past the mid-tone "dead zone" (where neither dark nor light
   // text clears 4.5:1) so the draft fill is unambiguously dark and takes the
-  // light title color, visibly distinct from the light-filled saved events.
+  // light title color. On the dark theme that separates it from the lighter
+  // saved fills; on the light theme (already-dark fills) the drop-shadow
+  // below carries the draft-vs-saved distinction.
   const draftColor = darken(baseColor, 38);
   // Past events recede in the direction of the theme's grid: the dark theme's
   // light steel fill dims slightly, the light theme's ink fill fades toward

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -51,6 +51,52 @@
   --transition-default: 0.3s;
 }
 
+/*
+ * Theme 02 — Light Beach. Redefines the same 22 roles as the dark block above.
+ * Scoped to the attribute only (no :root), so it sits later in source order and
+ * wins over the dark block's :root defaults at equal specificity — placement,
+ * not specificity, is what makes it override. See theme-css.test.ts for parity.
+ */
+[data-theme="light-beach"] {
+  color-scheme: light;
+
+  /* Surfaces — warm sand, layered down */
+  --background: #f3eee2;
+  --surface: #ece6d7;
+  --surface-panel: #e7e0cf;
+  --surface-raised: #e1d9c6;
+  --surface-overlay: hsl(40 25% 25% / 6%);
+
+  /* Borders */
+  --border: hsl(40 20% 30% / 15%);
+  --border-strong: #a89c81;
+
+  /* Text — warm ink, darkest on the lightest surface */
+  --text: #403a2f;
+  --text-muted: #5e5847;
+  --text-subtle: #948b74;
+
+  /* Accents — near-black ink; hover/strong go darker (inverse of dark theme) */
+  --accent: #2b2a27;
+  --accent-hover: #403d37;
+  --accent-strong: #141412; /* pressed / elevated underside */
+  --accent-secondary: #7a7771;
+  --accent-secondary-hover: #6b6862;
+  --on-accent: #f6f3ea; /* text on accent fills */
+
+  /* Status */
+  --success: #57876a;
+  --warning: #9c7d45;
+  --error: #ad6553;
+  --info: #8a8475;
+
+  /* Overlays */
+  --overlay-backdrop: hsl(40 25% 15% / 40%);
+  --shadow-default: hsl(40 25% 25% / 18%);
+
+  --transition-default: 0.3s;
+}
+
 /* Map roles -> Tailwind color-* utilities. Never changes per theme. */
 @theme inline {
   --color-background: var(--background);
@@ -522,6 +568,15 @@
     text-decoration: underline;
     text-decoration-color: var(--on-accent);
     text-underline-offset: 3px;
+  }
+
+  /* data-dark means "bg matches the theme's surface polarity", so today needs
+     the theme's standard text + accent underline to stay readable. Must sit
+     before the sidebar override below (equal specificity, source order). */
+  &[data-dark="true"]
+    .react-datepicker__day--today:not(.react-datepicker__day--selected) {
+    color: var(--text);
+    text-decoration-color: var(--accent);
   }
 
   &[data-view="sidebar"]

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -6,6 +6,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#06090f" />
 
+    <!--
+      Apply the saved theme before first paint so light-theme users don't flash
+      the default dark palette while the app boots (index.tsx awaits IndexedDB
+      first). Runs pre-module, so the key + colors are hard-coded here; keep them
+      in sync with settings/theme/theme.constants.ts. Dark is the CSS default,
+      so only a non-default choice needs touching.
+    -->
+    <script>
+      try {
+        if (localStorage.getItem("compass.theme") === "light-beach") {
+          document.documentElement.setAttribute("data-theme", "light-beach");
+          document
+            .querySelector('meta[name="theme-color"]')
+            .setAttribute("content", "#f3eee2");
+        }
+      } catch {}
+    </script>
+
     <title>Compass Calendar | get organized, simply</title>
     <meta
       name="description"

--- a/packages/web/src/settings/theme/theme.constants.ts
+++ b/packages/web/src/settings/theme/theme.constants.ts
@@ -1,0 +1,21 @@
+/**
+ * The app's themes, keyed by the `data-theme` value they set on <html>. Each
+ * key must match a `[data-theme="…"]` block in index.css. `metaColor` mirrors
+ * that theme's --background and drives the <meta name="theme-color"> chrome.
+ */
+export const THEMES = {
+  "dark-abyss": { metaColor: "#06090f" },
+  "light-beach": { metaColor: "#f3eee2" },
+} satisfies Record<string, { metaColor: string }>;
+
+export type ThemeName = keyof typeof THEMES;
+
+/** Dark is the default (also the index.css :root fallback). */
+export const DEFAULT_THEME: ThemeName = "dark-abyss";
+
+/**
+ * localStorage key for the persisted choice. The no-flash inline script in
+ * index.html hard-codes this same string (it runs before any JS module loads,
+ * so it can't import it) — keep the two in sync.
+ */
+export const THEME_STORAGE_KEY = "compass.theme";

--- a/packages/web/src/settings/theme/theme.constants.ts
+++ b/packages/web/src/settings/theme/theme.constants.ts
@@ -1,3 +1,5 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+
 /**
  * The app's themes, keyed by the `data-theme` value they set on <html>. Each
  * key must match a `[data-theme="…"]` block in index.css. `metaColor` mirrors
@@ -14,8 +16,9 @@ export type ThemeName = keyof typeof THEMES;
 export const DEFAULT_THEME: ThemeName = "dark-abyss";
 
 /**
- * localStorage key for the persisted choice. The no-flash inline script in
- * index.html hard-codes this same string (it runs before any JS module loads,
- * so it can't import it) — keep the two in sync.
+ * localStorage key for the persisted choice, registered in the app-wide
+ * STORAGE_KEYS enum like every other persistent key. The no-flash inline
+ * script in index.html hard-codes the same string (it runs before any JS
+ * module loads, so it can't import it) — keep the two in sync.
  */
-export const THEME_STORAGE_KEY = "compass.theme";
+export const THEME_STORAGE_KEY = STORAGE_KEYS.THEME;

--- a/packages/web/src/settings/theme/theme.store.test.ts
+++ b/packages/web/src/settings/theme/theme.store.test.ts
@@ -1,0 +1,47 @@
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { THEME_STORAGE_KEY } from "./theme.constants";
+import { themeActions, useThemeStore } from "./theme.store";
+import { readStoredTheme } from "./theme.util";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("theme store + util", () => {
+  beforeEach(() => {
+    persistentBrowserStore.remove(THEME_STORAGE_KEY);
+    document.documentElement.removeAttribute("data-theme");
+    useThemeStore.setState({ theme: "dark-abyss" });
+  });
+
+  it("falls back to the default theme when nothing is stored", () => {
+    expect(readStoredTheme()).toBe("dark-abyss");
+  });
+
+  it("falls back to the default theme for an unknown stored value", () => {
+    persistentBrowserStore.set(THEME_STORAGE_KEY, "neon-swamp");
+    expect(readStoredTheme()).toBe("dark-abyss");
+  });
+
+  it("reads back a valid stored theme", () => {
+    persistentBrowserStore.set(THEME_STORAGE_KEY, "light-beach");
+    expect(readStoredTheme()).toBe("light-beach");
+  });
+
+  it("setTheme updates state, persists, and sets the data-theme attribute", () => {
+    themeActions.setTheme("light-beach");
+
+    expect(useThemeStore.getState().theme).toBe("light-beach");
+    expect(persistentBrowserStore.get(THEME_STORAGE_KEY)).toBe("light-beach");
+    expect(document.documentElement.getAttribute("data-theme")).toBe(
+      "light-beach",
+    );
+  });
+
+  it("setTheme back to dark writes the explicit dark attribute", () => {
+    themeActions.setTheme("light-beach");
+    themeActions.setTheme("dark-abyss");
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe(
+      "dark-abyss",
+    );
+    expect(persistentBrowserStore.get(THEME_STORAGE_KEY)).toBe("dark-abyss");
+  });
+});

--- a/packages/web/src/settings/theme/theme.store.ts
+++ b/packages/web/src/settings/theme/theme.store.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { IS_DEV } from "@web/common/constants/env.constants";
+import { type ThemeName } from "./theme.constants";
+import { applyTheme, persistTheme, readStoredTheme } from "./theme.util";
+
+interface ThemeState {
+  theme: ThemeName;
+}
+
+// Seed from localStorage so the store agrees with the data-theme the no-flash
+// script in index.html already applied to <html>.
+export const useThemeStore = create<ThemeState>()(
+  devtools(() => ({ theme: readStoredTheme() }), {
+    name: "compass/theme",
+    enabled: IS_DEV,
+  }),
+);
+
+export const themeActions = {
+  setTheme: (theme: ThemeName) => {
+    applyTheme(theme);
+    persistTheme(theme);
+    useThemeStore.setState({ theme }, false, { type: "setTheme" });
+  },
+};
+
+export const selectTheme = (state: ThemeState) => state.theme;

--- a/packages/web/src/settings/theme/theme.util.ts
+++ b/packages/web/src/settings/theme/theme.util.ts
@@ -1,0 +1,33 @@
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  DEFAULT_THEME,
+  THEME_STORAGE_KEY,
+  THEMES,
+  type ThemeName,
+} from "./theme.constants";
+
+export const isThemeName = (value: string | null): value is ThemeName =>
+  value !== null && value in THEMES;
+
+/** The persisted theme, falling back to the default when unset/unknown. */
+export const readStoredTheme = (): ThemeName => {
+  const stored = persistentBrowserStore.get(THEME_STORAGE_KEY);
+  return isThemeName(stored) ? stored : DEFAULT_THEME;
+};
+
+export const persistTheme = (theme: ThemeName): void => {
+  persistentBrowserStore.set(THEME_STORAGE_KEY, theme);
+};
+
+/**
+ * Point the DOM at a theme: set the `data-theme` attribute index.css keys off,
+ * and match the browser-chrome color to its background. The no-flash script in
+ * index.html does the same before first paint; this keeps them aligned on a
+ * runtime switch.
+ */
+export const applyTheme = (theme: ThemeName): void => {
+  document.documentElement.setAttribute("data-theme", theme);
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", THEMES[theme].metaColor);
+};

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -1,7 +1,6 @@
 import { type MouseEvent, useCallback, useMemo, useRef, useState } from "react";
 import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { ZIndex } from "@web/common/constants/web.constants";
-import { colors } from "@web/common/styles/colors";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { AllDayEventCard } from "@web/grid/components/AllDayEventCard";
 import { TimedEventCard } from "@web/grid/components/TimedEventCard";
@@ -160,7 +159,7 @@ export const DayTimedCalendarEvent = ({
     : undefined;
   const deckBoxShadow = (() => {
     if (!isDeck) return undefined;
-    const ring = `0 0 0 0.75px ${colors.background}`;
+    const ring = `0 0 0 0.75px var(--background)`;
     const drop = isFocused
       ? "0 6px 14px -3px rgba(0,0,0,0.55)"
       : "0 3px 6px -2px rgba(0,0,0,0.4)";

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
@@ -3,7 +3,7 @@ import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { isBackendUnavailable as getIsBackendUnavailable } from "@web/api/util/backend-unavailable-error.util";
 import { type CompassSession } from "@web/auth/compass/session/session.types";
 import { useSession } from "@web/auth/compass/session/useSession";
-import { EVENT_HOVER_COLOR } from "@web/common/styles/theme.util";
+import { useEventPalette } from "@web/common/styles/theme.util";
 import { EndsOnDate } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate";
 import { RecurrenceIntervalSelect } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect";
 import { RecurrenceToggle } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceToggle";
@@ -31,6 +31,7 @@ export function createRecurrenceSection({
     setEvent,
   }: RecurrenceSectionProps) {
     const { authenticated } = useSession();
+    const { hover: inputColor } = useEventPalette();
     const recurrenceHook = useRecurrence(event, { setEvent });
     const { setInterval, setFreq, setWeekDays, setUntil } = recurrenceHook;
     const { weekDays, interval, freq, until, toggleRecurrence } =
@@ -69,7 +70,7 @@ export function createRecurrenceSection({
 
             <EndsOnDate
               bgColor={bgColor}
-              inputColor={EVENT_HOVER_COLOR}
+              inputColor={inputColor}
               until={until}
               minDate={event.endDate}
               setUntil={setUntil}

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -20,7 +20,7 @@ import {
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
-import { EVENT_COLOR } from "@web/common/styles/theme.util";
+import { useEventPalette } from "@web/common/styles/theme.util";
 import { type SelectOption } from "@web/common/types/component.types";
 import { Categories_Event } from "@web/common/types/web.event.types";
 import { mapToBackend } from "@web/common/utils/datetime/web.date.util";
@@ -148,6 +148,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     // gridEventDraftToSchemaEvent doc comment.
     const event = useMemo(() => gridEventDraftToSchemaEvent(draft), [draft]);
     const { title } = event;
+    const { base: eventColor } = useEventPalette();
     const category =
       draft.values.schedule.kind === "allDay"
         ? Categories_Event.ALLDAY
@@ -437,7 +438,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     };
 
     const recurrenceSectionProps = {
-      bgColor: EVENT_COLOR,
+      bgColor: eventColor,
       event,
       setEvent: setLatestEvent,
     };
@@ -537,7 +538,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 onKeyDown={handleTitleKeyDown}
                 placeholder="Title"
                 name="Event Title"
-                underlineColor={EVENT_COLOR}
+                underlineColor={eventColor}
                 value={displayTitle}
                 withUnderline
               />
@@ -581,7 +582,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
             <FormCard>
               <Textarea
-                underlineColor={EVENT_COLOR}
+                underlineColor={eventColor}
                 onChange={onChangeEventTextField("description")}
                 onKeyDown={handleIgnoredKeys}
                 placeholder="Description"

--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -8,7 +8,6 @@ import {
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { ZIndex } from "@web/common/constants/web.constants";
-import { colors } from "@web/common/styles/colors";
 import { type GridEvent as GridEventEntity } from "@web/common/types/web.event.types";
 import { isRightClick } from "@web/common/utils/mouse/mouse.util";
 import { TimedEventCard } from "@web/grid/components/TimedEventCard";
@@ -105,7 +104,7 @@ const GridEventBase = (
 
   const deckBoxShadow = (() => {
     if (!isDeck) return undefined;
-    const ring = `0 0 0 0.75px ${colors.background}`;
+    const ring = `0 0 0 0.75px var(--background)`;
     const drop = isFocused
       ? "0 6px 14px -3px rgba(0,0,0,0.55)"
       : "0 3px 6px -2px rgba(0,0,0,0.4)";


### PR DESCRIPTION
## Summary

Adds a second theme, Light Beach: warm sand surfaces with near-neutral ink accents, keyed off `[data-theme="light-beach"]` on `<html>`. Dark Abyss stays the default via the existing `:root` block, so a fresh visitor sees no change.

- New `settings/theme` module: theme constants, localStorage persistence (registered in the app-wide `STORAGE_KEYS` registry), and a Zustand store seeded from the stored choice
- Command palette gains an Appearance section with a single toggle ("Switch to light theme" / "Switch to dark theme")
- Event fills become per-theme JS palettes (dark keeps `#82A0B2` exactly; light gets ink charcoal `#454442`), consumed via a `useEventPalette` hook so cards repaint live on switch; `getContrastText` picks from per-theme text candidates
- Time labels, now-line, and event-deck rings move from static hex to CSS-var strings so they follow the active theme for free
- Past events fade toward the paper on the light theme (a darken step is imperceptible on an ink fill); the selected-event ring follows `--text` instead of hardcoded white
- A no-flash inline script in index.html applies the stored theme before first paint; DatePicker text polarity now accounts for the theme, and popover-picker "today" is readable in both themes

All new light-theme fills hold WCAG >= 4.5:1 for their text (base 8.8:1, past 5.0:1, save button 12.9:1).

## Simplicity

Net reduction in indirection for the dark path: three module-level color constants plus two save-button constants collapsed into one precomputed per-theme palette record with a single reactive accessor. The follow-up simplification commit routes the storage key through the existing `STORAGE_KEYS` registry, dedupes a double palette read in `getGradient`, and fixes a stale comment. No new `useEffect`, `useRef`, or `useState` anywhere in the diff — theme reactivity rides the existing Zustand store pattern (`useEventPalette` is a plain store selector hook). Deliberately kept simple and named as revisit points: the `=== "dark-abyss"` polarity ternaries (two themes today) and the hard-coded values in the pre-module no-flash script.

## Manual Testing Steps

- [ ] Open the app in a fresh browser profile: it loads in the dark theme by default
- [ ] Press Cmd+K: an "Appearance" section shows exactly one entry, "Switch to light theme" with a sun icon; select it and the entire app flips to the warm sand palette with charcoal ink event blocks
- [ ] Scroll the week grid to the current time: the current hour label and the thin now-line render in ink, not blue
- [ ] Click an event: the form opens on a light panel with an ink title underline and a near-black Save button with light text
- [ ] Confirm past events render as faded gray ink, visibly lighter than upcoming events' darker charcoal
- [ ] Reload the page: it comes back in the light theme immediately, with no dark flash during load
- [ ] Press Cmd+K again: the Appearance entry now reads "Switch to dark theme" with a moon icon; select it and the app returns to Dark Abyss exactly as before (steel-blue events, blue accents)
- [ ] While switching back and forth, watch the console for errors (there should be none)

## Test plan

- [x] `bun run test:web` — 1263 pass, 0 fail (includes new suites: theme store persistence/apply, palette toggle behavior, light-beach CSS token parity + colors.ts sync guards)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — 0 errors (5 pre-existing warnings on main, untouched files)
- [x] Chrome walkthrough of both themes: toggle round-trip, persistence, no-flash reload, past-event fade, save button, console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)