### PR TITLE
feat(core): add sync identity and connection contracts

### DIFF
--- a/packages/core/src/types/domain-primitives.ts
+++ b/packages/core/src/types/domain-primitives.ts
@@ -1,21 +1,20 @@
 import { z } from "zod/v4";
 import {
+  OBJECT_ID_STRING_PATTERN,
   RGBHexSchema,
   TimezoneSchema,
   zYearMonthDayString,
 } from "@core/types/type.utils";
 
-const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
-
 export const EventIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"EventId">();
 export type EventId = z.infer<typeof EventIdSchema>;
 
 export const CalendarIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"CalendarId">();
 export type CalendarId = z.infer<typeof CalendarIdSchema>;
 

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -1,0 +1,276 @@
+import { faker } from "@faker-js/faker";
+import {
+  CalendarAccessRoleSchema,
+  CalendarListQuerySchema,
+  CalendarListResponseSchema,
+  ConnectionListResponseSchema,
+  ConnectionStateSchema,
+  ProviderAccountFactsSchema,
+  ProviderCalendarSchema,
+  ProviderConnectionSchema,
+} from "@core/types/sync/connection.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const validConnection = () => ({
+  id: objectId(),
+  tenantId: objectId(),
+  principalId: objectId(),
+  provider: "google",
+  account: {
+    providerAccountId: "112233445566778899000",
+    email: "user@gmail.com",
+    displayName: "Test User",
+  },
+  capabilities: ["readEvents", "writeEvents"],
+  state: "healthy",
+  stateReason: null,
+  lastSyncedAt: "2026-07-20T12:00:00.000Z",
+  lastHealthyAt: "2026-07-20T12:00:00.000Z",
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-20T12:00:00.000Z",
+});
+
+const validCalendar = () => ({
+  id: objectId(),
+  tenantId: objectId(),
+  principalId: objectId(),
+  connectionId: objectId(),
+  providerCalendarId: "primary",
+  displayName: "Personal",
+  color: "#9fe1e7",
+  active: true,
+  primary: true,
+  accessRole: "owner",
+  capabilities: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-20T12:00:00.000Z",
+});
+
+describe("Sync connection contracts", () => {
+  describe("ProviderConnectionSchema", () => {
+    it("accepts a healthy connection", () => {
+      expect(
+        ProviderConnectionSchema.safeParse(validConnection()).success,
+      ).toBe(true);
+    });
+
+    it.each([
+      "connecting",
+      "importing",
+      "catchingUp",
+      "disconnected",
+    ] as const)("accepts state %s without a reason", (state) => {
+      const connection = { ...validConnection(), state };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(true);
+    });
+
+    it("accepts delayed with and without a reason", () => {
+      const delayed = { ...validConnection(), state: "delayed" };
+      expect(ProviderConnectionSchema.safeParse(delayed).success).toBe(true);
+      expect(
+        ProviderConnectionSchema.safeParse({
+          ...delayed,
+          stateReason: "workOverdue",
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts actionRequired with a reason", () => {
+      const connection = {
+        ...validConnection(),
+        state: "actionRequired",
+        stateReason: "authorizationRevoked",
+      };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(true);
+    });
+
+    it("rejects actionRequired without a reason", () => {
+      const connection = { ...validConnection(), state: "actionRequired" };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(
+        false,
+      );
+    });
+
+    it.each([
+      "connecting",
+      "importing",
+      "catchingUp",
+      "healthy",
+      "disconnected",
+    ] as const)("rejects a reason on state %s", (state) => {
+      const connection = {
+        ...validConnection(),
+        state,
+        stateReason: "workOverdue",
+      };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(
+        false,
+      );
+    });
+
+    it("accepts null evidence timestamps before first sync", () => {
+      const connection = {
+        ...validConnection(),
+        state: "connecting",
+        lastSyncedAt: null,
+        lastHealthyAt: null,
+      };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(true);
+    });
+
+    it("rejects unknown fields", () => {
+      const connection = { ...validConnection(), accessToken: "leak" };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects an unknown provider", () => {
+      const connection = { ...validConnection(), provider: "caldav" };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects an unknown state", () => {
+      const connection = { ...validConnection(), state: "syncing" };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(
+        false,
+      );
+    });
+
+    it("round-trips through JSON unchanged", () => {
+      const parsed = ProviderConnectionSchema.parse(validConnection());
+      expect(
+        ProviderConnectionSchema.parse(JSON.parse(JSON.stringify(parsed))),
+      ).toEqual(parsed);
+    });
+  });
+
+  describe("ConnectionStateSchema", () => {
+    it("covers exactly the seven user-facing states", () => {
+      expect(ConnectionStateSchema.options).toEqual([
+        "connecting",
+        "importing",
+        "catchingUp",
+        "healthy",
+        "delayed",
+        "actionRequired",
+        "disconnected",
+      ]);
+    });
+  });
+
+  describe("ProviderAccountFactsSchema", () => {
+    it("accepts null display fields", () => {
+      const facts = {
+        providerAccountId: "1122334455",
+        email: null,
+        displayName: null,
+      };
+      expect(ProviderAccountFactsSchema.safeParse(facts).success).toBe(true);
+    });
+
+    it("rejects unknown fields", () => {
+      const facts = {
+        providerAccountId: "1122334455",
+        email: null,
+        displayName: null,
+        refreshToken: "leak",
+      };
+      expect(ProviderAccountFactsSchema.safeParse(facts).success).toBe(false);
+    });
+  });
+
+  describe("ProviderCalendarSchema", () => {
+    it("accepts a writable primary calendar", () => {
+      expect(ProviderCalendarSchema.safeParse(validCalendar()).success).toBe(
+        true,
+      );
+    });
+
+    // Every capability combination is representable: facts describe what the
+    // provider permits, and no combination is privileged (R-CAL-05).
+    it.each(
+      Array.from({ length: 16 }, (_, mask) => [
+        {
+          canReadEvents: Boolean(mask & 1),
+          canWriteEvents: Boolean(mask & 2),
+          canReadBusy: Boolean(mask & 4),
+          canInviteAttendees: Boolean(mask & 8),
+        },
+      ]),
+    )("accepts capability combination %o", (capabilities) => {
+      const calendar = { ...validCalendar(), capabilities };
+      expect(ProviderCalendarSchema.safeParse(calendar).success).toBe(true);
+    });
+
+    it.each([
+      "owner",
+      "editor",
+      "viewer",
+      "busyOnly",
+    ] as const)("accepts access role %s", (accessRole) => {
+      const calendar = { ...validCalendar(), accessRole };
+      expect(ProviderCalendarSchema.safeParse(calendar).success).toBe(true);
+    });
+
+    it("rejects a provider-specific access role", () => {
+      expect(CalendarAccessRoleSchema.safeParse("freeBusyReader").success).toBe(
+        false,
+      );
+    });
+
+    it("accepts an inactive, null-color calendar", () => {
+      const calendar = { ...validCalendar(), active: false, color: null };
+      expect(ProviderCalendarSchema.safeParse(calendar).success).toBe(true);
+    });
+
+    it("rejects product preference fields", () => {
+      const calendar = { ...validCalendar(), visible: true };
+      expect(ProviderCalendarSchema.safeParse(calendar).success).toBe(false);
+    });
+
+    it("rejects a missing capability field", () => {
+      const { canReadBusy: _dropped, ...partial } =
+        validCalendar().capabilities;
+      const calendar = { ...validCalendar(), capabilities: partial };
+      expect(ProviderCalendarSchema.safeParse(calendar).success).toBe(false);
+    });
+  });
+
+  describe("list and query contracts", () => {
+    it("accepts a connection list", () => {
+      const response = { connections: [validConnection()] };
+      expect(ConnectionListResponseSchema.safeParse(response).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts an empty calendar list", () => {
+      expect(
+        CalendarListResponseSchema.safeParse({ calendars: [] }).success,
+      ).toBe(true);
+    });
+
+    it("accepts an empty calendar query", () => {
+      expect(CalendarListQuerySchema.safeParse({}).success).toBe(true);
+    });
+
+    it("accepts a narrowed calendar query", () => {
+      const query = { connectionId: objectId(), activeOnly: true };
+      expect(CalendarListQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("rejects principal scoping via the query body", () => {
+      const query = { principalId: objectId() };
+      expect(CalendarListQuerySchema.safeParse(query).success).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -1,0 +1,150 @@
+import { z } from "zod/v4";
+import { DateTimeSchema } from "@core/types/domain-primitives";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  ProviderAccountIdSchema,
+  ProviderCalendarIdSchema,
+  ProviderCalendarSourceIdSchema,
+  ProviderCapabilitySetSchema,
+  ProviderKindSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Connection and calendar contracts for Compass Sync (ledger S02).
+// R-CONN-01..06, R-CAL-01..05: provider facts only — no credentials, and no
+// product preferences (visibility, blocking, booking target) which belong to
+// the Compass product layer.
+
+// The one user-facing connection state (R-CONN-03). Only the shared health
+// derivation may produce these values; no code path reports healthy because a
+// single operation succeeded.
+export const ConnectionStateSchema = z.enum([
+  "connecting",
+  "importing",
+  "catchingUp",
+  "healthy",
+  "delayed",
+  "actionRequired",
+  "disconnected",
+]);
+export type ConnectionState = z.infer<typeof ConnectionStateSchema>;
+
+// Sanitized reason exposed alongside delayed/actionRequired states.
+export const ConnectionStateReasonSchema = z.enum([
+  "authorizationRevoked",
+  "authorizationExpired",
+  "insufficientScopes",
+  "permanentConflict",
+  "workOverdue",
+  "providerErrors",
+]);
+export type ConnectionStateReason = z.infer<typeof ConnectionStateReasonSchema>;
+
+// Display facts about the authorized provider account. The stable
+// providerAccountId is the only ownership proof; email is display data and
+// may change without changing identity (R-CONN-02).
+export const ProviderAccountFactsSchema = z.strictObject({
+  providerAccountId: ProviderAccountIdSchema,
+  email: z.string().trim().min(1).max(320).nullable(),
+  displayName: z.string().trim().min(1).max(256).nullable(),
+});
+export type ProviderAccountFacts = z.infer<typeof ProviderAccountFactsSchema>;
+
+const STATES_WITH_REASON: ReadonlySet<ConnectionState> = new Set([
+  "delayed",
+  "actionRequired",
+]);
+
+export const ProviderConnectionSchema = z
+  .strictObject({
+    id: ConnectionIdSchema,
+    tenantId: TenantIdSchema,
+    principalId: PrincipalIdSchema,
+    provider: ProviderKindSchema,
+    account: ProviderAccountFactsSchema,
+    capabilities: ProviderCapabilitySetSchema,
+    state: ConnectionStateSchema,
+    // Present exactly when the state needs a user-facing explanation.
+    stateReason: ConnectionStateReasonSchema.nullable(),
+    // Evidence timestamps (R-CONN-04): data sync vs verified health are
+    // distinct facts. Null until the first successful pass.
+    lastSyncedAt: DateTimeSchema.nullable(),
+    lastHealthyAt: DateTimeSchema.nullable(),
+    createdAt: DateTimeSchema,
+    updatedAt: DateTimeSchema,
+  })
+  .superRefine((connection, ctx) => {
+    if (connection.state === "actionRequired" && !connection.stateReason) {
+      ctx.addIssue({
+        code: "custom",
+        message: "actionRequired state requires a stateReason",
+        path: ["stateReason"],
+      });
+    }
+    if (connection.stateReason && !STATES_WITH_REASON.has(connection.state)) {
+      ctx.addIssue({
+        code: "custom",
+        message: `stateReason is not allowed for state "${connection.state}"`,
+        path: ["stateReason"],
+      });
+    }
+  });
+export type ProviderConnection = z.infer<typeof ProviderConnectionSchema>;
+
+// Provider-neutral access role for a calendar. Normalized capabilities are
+// the operational truth; the role is a display/diagnostic fact.
+export const CalendarAccessRoleSchema = z.enum([
+  "owner",
+  "editor",
+  "viewer",
+  "busyOnly",
+]);
+export type CalendarAccessRole = z.infer<typeof CalendarAccessRoleSchema>;
+
+export const CalendarCapabilitiesSchema = z.strictObject({
+  canReadEvents: z.boolean(),
+  canWriteEvents: z.boolean(),
+  canReadBusy: z.boolean(),
+  canInviteAttendees: z.boolean(),
+});
+export type CalendarCapabilities = z.infer<typeof CalendarCapabilitiesSchema>;
+
+export const ProviderCalendarSchema = z.strictObject({
+  id: ProviderCalendarIdSchema,
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  providerCalendarId: ProviderCalendarSourceIdSchema,
+  displayName: z.string().trim().min(1).max(1024),
+  color: z.string().trim().min(1).max(64).nullable(),
+  // Provider facts (R-CAL-02): active reflects the provider/calendar-list
+  // state, primary the provider's default-calendar designation.
+  active: z.boolean(),
+  primary: z.boolean(),
+  accessRole: CalendarAccessRoleSchema,
+  capabilities: CalendarCapabilitiesSchema,
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+});
+export type ProviderCalendar = z.infer<typeof ProviderCalendarSchema>;
+
+export const ConnectionListResponseSchema = z.strictObject({
+  connections: z.array(ProviderConnectionSchema).readonly(),
+});
+export type ConnectionListResponse = z.infer<
+  typeof ConnectionListResponseSchema
+>;
+
+export const CalendarListQuerySchema = z.strictObject({
+  // Optional narrowing; principal scope always comes from authenticated
+  // context, never from the request body (R-SEC-03).
+  connectionId: ConnectionIdSchema.optional(),
+  activeOnly: z.boolean().optional(),
+});
+export type CalendarListQuery = z.infer<typeof CalendarListQuerySchema>;
+
+export const CalendarListResponseSchema = z.strictObject({
+  calendars: z.array(ProviderCalendarSchema).readonly(),
+});
+export type CalendarListResponse = z.infer<typeof CalendarListResponseSchema>;

--- a/packages/core/src/types/sync/identity.contracts.test.ts
+++ b/packages/core/src/types/sync/identity.contracts.test.ts
@@ -1,0 +1,176 @@
+import { faker } from "@faker-js/faker";
+import {
+  ConnectionIdSchema,
+  IdempotencyKeySchema,
+  PrincipalIdSchema,
+  ProviderAccountIdSchema,
+  ProviderCalendarIdSchema,
+  ProviderCalendarSourceIdSchema,
+  ProviderCapabilitySchema,
+  ProviderCapabilitySetSchema,
+  ProviderEventIdSchema,
+  ProviderKindSchema,
+  SyncCommandIdSchema,
+  SyncJobIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+const objectIdSchemas = {
+  TenantIdSchema,
+  PrincipalIdSchema,
+  ConnectionIdSchema,
+  ProviderCalendarIdSchema,
+  SyncCommandIdSchema,
+  SyncJobIdSchema,
+} as const;
+
+const opaqueIdSchemas = {
+  ProviderAccountIdSchema,
+  ProviderCalendarSourceIdSchema,
+  ProviderEventIdSchema,
+  IdempotencyKeySchema,
+} as const;
+
+describe("Sync identity contracts", () => {
+  describe.each(
+    Object.entries(objectIdSchemas),
+  )("%s (ObjectId-shaped)", (_name, schema) => {
+    it("accepts a 24-character hex id", () => {
+      expect(schema.safeParse(faker.database.mongodbObjectId()).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects a short id", () => {
+      expect(schema.safeParse("abc123").success).toBe(false);
+    });
+
+    it("rejects a non-hex id", () => {
+      expect(schema.safeParse("g".repeat(24)).success).toBe(false);
+    });
+
+    it("rejects a non-string value", () => {
+      expect(schema.safeParse(42).success).toBe(false);
+    });
+
+    it("round-trips through JSON unchanged", () => {
+      const id = faker.database.mongodbObjectId();
+      const parsed = schema.parse(id);
+      expect(schema.parse(JSON.parse(JSON.stringify(parsed)))).toBe(id);
+    });
+  });
+
+  describe.each(
+    Object.entries(opaqueIdSchemas),
+  )("%s (provider-issued/opaque)", (_name, schema) => {
+    it("accepts an opaque non-empty string", () => {
+      expect(
+        schema.safeParse("abc_DEF-123@group.calendar.google.com").success,
+      ).toBe(true);
+    });
+
+    it("rejects an empty string", () => {
+      expect(schema.safeParse("").success).toBe(false);
+    });
+
+    it("rejects a whitespace-only string", () => {
+      expect(schema.safeParse("   ").success).toBe(false);
+    });
+
+    it("rejects a non-string value", () => {
+      expect(schema.safeParse(42).success).toBe(false);
+    });
+
+    it("round-trips through JSON unchanged", () => {
+      const parsed = schema.parse("stable-opaque-id");
+      expect(schema.parse(JSON.parse(JSON.stringify(parsed)))).toBe(
+        "stable-opaque-id",
+      );
+    });
+  });
+
+  describe("ProviderAccountIdSchema length bound", () => {
+    it("rejects a value over 256 characters", () => {
+      expect(ProviderAccountIdSchema.safeParse("a".repeat(257)).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("ProviderEventIdSchema length bound", () => {
+    it("accepts a value at the 1024-character provider limit", () => {
+      expect(ProviderEventIdSchema.safeParse("a".repeat(1024)).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects a value over 1024 characters", () => {
+      expect(ProviderEventIdSchema.safeParse("a".repeat(1025)).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("ProviderKindSchema", () => {
+    it("accepts google", () => {
+      expect(ProviderKindSchema.safeParse("google").success).toBe(true);
+    });
+
+    it("rejects an unknown provider", () => {
+      expect(ProviderKindSchema.safeParse("caldav").success).toBe(false);
+    });
+
+    it("rejects provider-cased variants", () => {
+      expect(ProviderKindSchema.safeParse("Google").success).toBe(false);
+    });
+  });
+
+  describe("ProviderCapabilitySchema", () => {
+    it.each([
+      "readEvents",
+      "writeEvents",
+      "readBusy",
+      "inviteAttendees",
+      "changeNotifications",
+      "incrementalChanges",
+    ] as const)("accepts %s", (capability) => {
+      expect(ProviderCapabilitySchema.safeParse(capability).success).toBe(true);
+    });
+
+    it("rejects an unknown capability", () => {
+      expect(ProviderCapabilitySchema.safeParse("teleport").success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("ProviderCapabilitySetSchema", () => {
+    it("accepts an empty set", () => {
+      expect(ProviderCapabilitySetSchema.safeParse([]).success).toBe(true);
+    });
+
+    it("accepts unique capabilities", () => {
+      expect(
+        ProviderCapabilitySetSchema.safeParse(["readEvents", "readBusy"])
+          .success,
+      ).toBe(true);
+    });
+
+    it("rejects duplicate capabilities", () => {
+      expect(
+        ProviderCapabilitySetSchema.safeParse(["readEvents", "readEvents"])
+          .success,
+      ).toBe(false);
+    });
+
+    it("round-trips through JSON unchanged", () => {
+      const set = ProviderCapabilitySetSchema.parse([
+        "writeEvents",
+        "inviteAttendees",
+      ]);
+      expect(
+        ProviderCapabilitySetSchema.parse(JSON.parse(JSON.stringify(set))),
+      ).toEqual(["writeEvents", "inviteAttendees"]);
+    });
+  });
+});

--- a/packages/core/src/types/sync/identity.contracts.ts
+++ b/packages/core/src/types/sync/identity.contracts.ts
@@ -1,27 +1,26 @@
 import { z } from "zod/v4";
+import { OBJECT_ID_STRING_PATTERN } from "@core/types/type.utils";
 
 // Identity primitives for Compass Sync (internal design packet, ledger S01).
 // Compass-issued ids are ObjectId-shaped; provider-issued ids are opaque
 // strings scoped beneath the connection that issued them and must never be
 // treated as globally unique or user-facing.
 
-const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
-
 export const TenantIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"TenantId">();
 export type TenantId = z.infer<typeof TenantIdSchema>;
 
 export const PrincipalIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"PrincipalId">();
 export type PrincipalId = z.infer<typeof PrincipalIdSchema>;
 
 export const ConnectionIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"ConnectionId">();
 export type ConnectionId = z.infer<typeof ConnectionIdSchema>;
 
@@ -30,19 +29,19 @@ export type ConnectionId = z.infer<typeof ConnectionIdSchema>;
 // event ownership survive provider renames and reconnection.
 export const ProviderCalendarIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"ProviderCalendarId">();
 export type ProviderCalendarId = z.infer<typeof ProviderCalendarIdSchema>;
 
 export const SyncCommandIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"SyncCommandId">();
 export type SyncCommandId = z.infer<typeof SyncCommandIdSchema>;
 
 export const SyncJobIdSchema = z
   .string()
-  .regex(OBJECT_ID_PATTERN)
+  .regex(OBJECT_ID_STRING_PATTERN)
   .brand<"SyncJobId">();
 export type SyncJobId = z.infer<typeof SyncJobIdSchema>;
 

--- a/packages/core/src/types/sync/identity.contracts.ts
+++ b/packages/core/src/types/sync/identity.contracts.ts
@@ -1,0 +1,112 @@
+import { z } from "zod/v4";
+
+// Identity primitives for Compass Sync (internal design packet, ledger S01).
+// Compass-issued ids are ObjectId-shaped; provider-issued ids are opaque
+// strings scoped beneath the connection that issued them and must never be
+// treated as globally unique or user-facing.
+
+const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
+
+export const TenantIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"TenantId">();
+export type TenantId = z.infer<typeof TenantIdSchema>;
+
+export const PrincipalIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"PrincipalId">();
+export type PrincipalId = z.infer<typeof PrincipalIdSchema>;
+
+export const ConnectionIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"ConnectionId">();
+export type ConnectionId = z.infer<typeof ConnectionIdSchema>;
+
+// Sync-issued stable id for a provider calendar record. Distinct from the
+// provider's own calendar id (ProviderCalendarSourceId) so preferences and
+// event ownership survive provider renames and reconnection.
+export const ProviderCalendarIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"ProviderCalendarId">();
+export type ProviderCalendarId = z.infer<typeof ProviderCalendarIdSchema>;
+
+export const SyncCommandIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"SyncCommandId">();
+export type SyncCommandId = z.infer<typeof SyncCommandIdSchema>;
+
+export const SyncJobIdSchema = z
+  .string()
+  .regex(OBJECT_ID_PATTERN)
+  .brand<"SyncJobId">();
+export type SyncJobId = z.infer<typeof SyncJobIdSchema>;
+
+export const ProviderKindSchema = z.enum(["google"]);
+export type ProviderKind = z.infer<typeof ProviderKindSchema>;
+
+// Stable subject issued by the provider for one authorized account (for
+// Google, the OpenID `sub`). Ownership proof; email is display data only.
+export const ProviderAccountIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .brand<"ProviderAccountId">();
+export type ProviderAccountId = z.infer<typeof ProviderAccountIdSchema>;
+
+export const ProviderCalendarSourceIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(1024)
+  .brand<"ProviderCalendarSourceId">();
+export type ProviderCalendarSourceId = z.infer<
+  typeof ProviderCalendarSourceIdSchema
+>;
+
+export const ProviderEventIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(1024)
+  .brand<"ProviderEventId">();
+export type ProviderEventId = z.infer<typeof ProviderEventIdSchema>;
+
+// Caller-supplied key that makes durable commands safe to replay. Unique per
+// (tenant, principal); the same key always refers to the same command.
+export const IdempotencyKeySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .brand<"IdempotencyKey">();
+export type IdempotencyKey = z.infer<typeof IdempotencyKeySchema>;
+
+// What a connection or calendar can actually do — the intersection of granted
+// scopes, access role, provider semantics, and transport behavior. Domain
+// code asks about capabilities instead of branching on provider names.
+export const ProviderCapabilitySchema = z.enum([
+  "readEvents",
+  "writeEvents",
+  "readBusy",
+  "inviteAttendees",
+  "changeNotifications",
+  "incrementalChanges",
+]);
+export type ProviderCapability = z.infer<typeof ProviderCapabilitySchema>;
+
+export const ProviderCapabilitySetSchema = z
+  .array(ProviderCapabilitySchema)
+  .refine(
+    (capabilities) => new Set(capabilities).size === capabilities.length,
+    {
+      message: "Capabilities must be unique",
+    },
+  )
+  .readonly();
+export type ProviderCapabilitySet = z.infer<typeof ProviderCapabilitySetSchema>;

--- a/packages/core/src/types/type.utils.ts
+++ b/packages/core/src/types/type.utils.ts
@@ -56,6 +56,8 @@ export const RGBHexSchema = zod4.string().regex(/^#[0-9a-f]{6}$/i, {
   message: "Invalid color. Must be a 7-character hex color code.",
 });
 
+export const OBJECT_ID_STRING_PATTERN = /^[0-9a-f]{24}$/i;
+
 export const ExpirationDateSchema = zod4
   .union([
     zod4.date(),


### PR DESCRIPTION
## Summary

Adds the first two provider-neutral Zod contract packets for the new Compass Sync service, per the internal architecture packet in `compass-calendar-internal/projects/sync-service/` (ledger items **S01** and **S02** of `07-commit-ledger.md`):

- **S01 — Identity primitives** (`packages/core/src/types/sync/identity.contracts.ts`): branded Compass-issued ids (tenant, principal, connection, provider-calendar, sync-command, sync-job), opaque provider-issued ids (provider account, provider-calendar-source, provider-event, idempotency key), a `ProviderKind` enum (currently just `google`), and a `ProviderCapability` enum/set.
- **S02 — Connection and calendar contracts** (`packages/core/src/types/sync/connection.contracts.ts`): the seven-state `ConnectionState` (connecting/importing/catchingUp/healthy/delayed/actionRequired/disconnected), a `superRefine`-enforced state/reason invariant, provider account facts, provider calendar facts/capabilities, and list/query contracts.

These are purely additive contracts — nothing in the app imports them yet, and no runtime behavior changes. Legacy Google sync in `packages/backend` is untouched. This is the first commit of a larger incremental build-out; the founder approved the architecture packet and gave standing autonomy to execute the commit ledger and ship through the normal PR flow.

Two things are deliberately enforced by the schemas, not left to callers:
- `ProviderConnectionSchema` rejects an `actionRequired` connection with no `stateReason`, and rejects a `stateReason` on any state other than `delayed`/`actionRequired` — this is the "no independent code path may set `healthy` merely because one operation succeeded" invariant from the design doc, encoded at the type level.
- `ProviderAccountFactsSchema` and `ProviderCalendarSchema` use `strictObject`, so a stray credential or product-preference field (e.g. `visible`, `accessToken`) fails to parse instead of silently round-tripping — tested explicitly.

## Simplicity

Net simplification: while writing S01, I noticed the 24-character ObjectId regex I needed already existed verbatim in `domain-primitives.ts`. Rather than duplicate it a second time, the third commit extracts it to `type.utils.ts` (the repo's existing home for shared schema fragments like `TimezoneSchema`/`RGBHexSchema`) and both files now import the one definition. No behavior change; verified by the full `test:core` suite passing before and after.

No `useEffect`/`useRef`/`useState` in this diff — it's schema-only, no React.

## Manual Testing Steps

This diff is not browser-observable (additive type contracts with no UI or route wiring), so there's no user-facing flow to click through. Equivalent CLI verification a reviewer can run themselves:

- [ ] `bun run test:core` — expect 351 pass, 0 fail
- [ ] `bun run type-check` — expect a clean exit
- [ ] `bunx biome check packages/core/src/types/` — expect no errors

## Test plan

- [x] `bun run test:core` — 351 pass, 0 fail (855 expect() calls)
- [x] `bun run type-check` — clean
- [x] `bunx biome check` on touched files — clean, no fixes needed
- [x] Independent correctness review (code-reviewer agent) against the diff — no findings at or above confidence threshold; `superRefine` branch logic, branded-id patterns, `strictObject` unknown-key rejection, and capability-combination coverage all verified as intentional and correctly tested
