### PR TITLE
feat(core): add canonical sync event contracts

### DIFF
--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -1,0 +1,375 @@
+import { faker } from "@faker-js/faker";
+import {
+  AttendeeSchema,
+  ConferenceSchema,
+  EventOccurrenceListQuerySchema,
+  EventOccurrenceListResponseSchema,
+  OrganizerSchema,
+  SyncEventOccurrenceSchema,
+  SyncEventOwnershipSchema,
+  SyncEventRecurrenceSchema,
+  SyncEventSchema,
+} from "@core/types/sync/event.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const timedSchedule = {
+  kind: "timed",
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+
+// 2026-03-08 is the US spring-forward transition; 09:00-10:00 local crosses
+// it in wall-clock time while the UTC offset itself changes (R-EVENT-04).
+const dstCrossingSchedule = {
+  kind: "timed",
+  start: "2026-03-08T01:30:00-07:00",
+  end: "2026-03-08T03:30:00-06:00",
+  timeZone: "America/Denver",
+};
+
+const allDaySchedule = {
+  kind: "allDay",
+  start: "2026-07-14",
+  end: "2026-07-15",
+};
+
+const unlinkedOwnership = { kind: "unlinked" };
+
+const linkedOwnership = () => ({
+  kind: "linked",
+  connectionId: objectId(),
+  calendarId: objectId(),
+  providerEventId: "abc123@google.com",
+  providerVersion: "etag-1",
+  providerUpdatedAt: "2026-07-20T12:00:00.000Z",
+  deliveryState: "confirmed",
+});
+
+const baseContent = {
+  title: "Standup",
+  description: "Daily sync",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+};
+
+const baseEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: objectId(),
+  clientEventId: null,
+  origin: "compass",
+  ownership: unlinkedOwnership,
+  content: baseContent,
+  schedule: timedSchedule,
+  recurrence: { kind: "single" },
+  lifecycleState: "active",
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+  confirmedAt: null,
+  ...overrides,
+});
+
+describe("Sync event contracts", () => {
+  describe("SyncEventSchema", () => {
+    it("accepts a timed, unlinked, single event", () => {
+      expect(SyncEventSchema.safeParse(baseEvent()).success).toBe(true);
+    });
+
+    it("accepts an all-day event", () => {
+      const event = baseEvent({ schedule: allDaySchedule });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("round-trips a DST-crossing timed schedule unchanged", () => {
+      const event = baseEvent({ schedule: dstCrossingSchedule });
+      const parsed = SyncEventSchema.parse(event);
+      expect(
+        SyncEventSchema.parse(JSON.parse(JSON.stringify(parsed))).schedule,
+      ).toEqual(dstCrossingSchedule);
+    });
+
+    it("accepts a linked event with full ownership evidence", () => {
+      const event = baseEvent({
+        origin: "provider",
+        ownership: linkedOwnership(),
+      });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("accepts a linked event carrying opaque provider metadata", () => {
+      const event = baseEvent({
+        ownership: {
+          ...linkedOwnership(),
+          providerMetadata: { iCalUID: "abc@google.com", sequence: "3" },
+        },
+      });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("rejects a linked event missing providerVersion", () => {
+      const { providerVersion: _dropped, ...incomplete } = linkedOwnership();
+      const event = baseEvent({ ownership: incomplete });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+
+    it("accepts a deletionPending event", () => {
+      const event = baseEvent({ lifecycleState: "deletionPending" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("accepts a null confirmedAt before provider confirmation", () => {
+      expect(SyncEventSchema.safeParse(baseEvent()).success).toBe(true);
+    });
+
+    it("rejects a raw provider payload field", () => {
+      const event = baseEvent({ googleEventId: "leak" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+
+    it("rejects an unknown lifecycle state", () => {
+      const event = baseEvent({ lifecycleState: "deleted" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+  });
+
+  describe("SyncEventOwnershipSchema", () => {
+    it("accepts unlinked", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse(unlinkedOwnership).success,
+      ).toBe(true);
+    });
+
+    it("accepts linked with full evidence", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse(linkedOwnership()).success,
+      ).toBe(true);
+    });
+
+    it("accepts a null providerUpdatedAt before the provider has reported one", () => {
+      const ownership = { ...linkedOwnership(), providerUpdatedAt: null };
+      expect(SyncEventOwnershipSchema.safeParse(ownership).success).toBe(true);
+    });
+
+    it("rejects an unrecognized kind", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse({ kind: "mirrored" }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("SyncEventRecurrenceSchema", () => {
+    it("accepts single", () => {
+      expect(
+        SyncEventRecurrenceSchema.safeParse({ kind: "single" }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a series master with rules", () => {
+      const recurrence = { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects a series master with empty rules", () => {
+      const recurrence = { kind: "seriesMaster", rules: [] };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+
+    it("accepts a cancelled exception overriding one occurrence", () => {
+      const recurrence = {
+        kind: "exception",
+        seriesId: objectId(),
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: true,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a non-cancelled override exception", () => {
+      const recurrence = {
+        kind: "exception",
+        seriesId: objectId(),
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: false,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an exception missing seriesId", () => {
+      const recurrence = {
+        kind: "exception",
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: false,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("OrganizerSchema and AttendeeSchema", () => {
+    it("accepts an organizer with a display name", () => {
+      const organizer = {
+        email: "founder@compasscalendar.com",
+        displayName: "Tyler",
+      };
+      expect(OrganizerSchema.safeParse(organizer).success).toBe(true);
+    });
+
+    it("accepts an organizer with a null display name", () => {
+      const organizer = {
+        email: "founder@compasscalendar.com",
+        displayName: null,
+      };
+      expect(OrganizerSchema.safeParse(organizer).success).toBe(true);
+    });
+
+    it.each([
+      "needsAction",
+      "accepted",
+      "declined",
+      "tentative",
+    ] as const)("accepts attendee response status %s", (responseStatus) => {
+      const attendee = {
+        email: "guest@example.com",
+        displayName: null,
+        responseStatus,
+      };
+      expect(AttendeeSchema.safeParse(attendee).success).toBe(true);
+    });
+
+    it("rejects an unknown response status", () => {
+      const attendee = {
+        email: "guest@example.com",
+        displayName: null,
+        responseStatus: "maybe",
+      };
+      expect(AttendeeSchema.safeParse(attendee).success).toBe(false);
+    });
+  });
+
+  describe("ConferenceSchema", () => {
+    it("accepts a conference URL with a label", () => {
+      const conference = {
+        url: "https://meet.google.com/abc-defg-hij",
+        label: "Google Meet",
+      };
+      expect(ConferenceSchema.safeParse(conference).success).toBe(true);
+    });
+
+    it("rejects a non-URL value", () => {
+      const conference = { url: "not-a-url", label: null };
+      expect(ConferenceSchema.safeParse(conference).success).toBe(false);
+    });
+  });
+
+  describe("SyncEventOccurrenceSchema", () => {
+    const baseOccurrence = () => ({
+      occurrenceKey: "event-id:2026-07-21T09:00:00.000Z",
+      eventId: objectId(),
+      calendarId: objectId(),
+      schedule: timedSchedule,
+      busy: true,
+      title: "Standup",
+      cancelled: false,
+    });
+
+    it("accepts a busy timed occurrence", () => {
+      expect(
+        SyncEventOccurrenceSchema.safeParse(baseOccurrence()).success,
+      ).toBe(true);
+    });
+
+    it("accepts a cancelled occurrence", () => {
+      const occurrence = { ...baseOccurrence(), cancelled: true };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a free (non-blocking) occurrence", () => {
+      const occurrence = { ...baseOccurrence(), busy: false };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts an all-day occurrence", () => {
+      const occurrence = { ...baseOccurrence(), schedule: allDaySchedule };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("EventOccurrenceListQuerySchema", () => {
+    const baseQuery = () => ({
+      calendarIds: [objectId()],
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-08-01T00:00:00.000Z",
+    });
+
+    it("accepts a bounded range with at least one calendar", () => {
+      expect(
+        EventOccurrenceListQuerySchema.safeParse(baseQuery()).success,
+      ).toBe(true);
+    });
+
+    it("accepts an optional cursor and limit", () => {
+      const query = { ...baseQuery(), cursor: "page-2", limit: 100 };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an empty calendarIds array", () => {
+      const query = { ...baseQuery(), calendarIds: [] };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects end before start", () => {
+      const query = {
+        ...baseQuery(),
+        start: baseQuery().end,
+        end: baseQuery().start,
+      };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects a limit above the bound", () => {
+      const query = { ...baseQuery(), limit: 501 };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("EventOccurrenceListResponseSchema", () => {
+    it("accepts an empty page with no next cursor", () => {
+      const response = { occurrences: [], nextCursor: null };
+      expect(
+        EventOccurrenceListResponseSchema.safeParse(response).success,
+      ).toBe(true);
+    });
+
+    it("accepts a page with a next cursor", () => {
+      const response = { occurrences: [], nextCursor: "page-2" };
+      expect(
+        EventOccurrenceListResponseSchema.safeParse(response).success,
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -5,6 +5,7 @@ import {
   EventOccurrenceListQuerySchema,
   EventOccurrenceListResponseSchema,
   OrganizerSchema,
+  SyncEventCalendarIdSchema,
   SyncEventOccurrenceSchema,
   SyncEventOwnershipSchema,
   SyncEventRecurrenceSchema,
@@ -119,8 +120,9 @@ describe("Sync event contracts", () => {
       expect(SyncEventSchema.safeParse(event).success).toBe(true);
     });
 
-    it("accepts a null confirmedAt before provider confirmation", () => {
-      expect(SyncEventSchema.safeParse(baseEvent()).success).toBe(true);
+    it("accepts a non-null confirmedAt once the provider has confirmed", () => {
+      const event = baseEvent({ confirmedAt: "2026-07-20T12:00:00.000Z" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
     });
 
     it("rejects a raw provider payload field", () => {
@@ -307,6 +309,22 @@ describe("Sync event contracts", () => {
       const occurrence = { ...baseOccurrence(), schedule: allDaySchedule };
       expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
         true,
+      );
+    });
+
+    // An occurrence must be groupable by calendar whether its source event is
+    // still unlinked (Compass's own calendar id) or provider-linked (the
+    // provider calendar id) — Sync is the store of record for both (R-LIFE-03).
+    it("accepts a Compass calendar id for an unlinked event's occurrence", () => {
+      expect(SyncEventCalendarIdSchema.safeParse(objectId()).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects a calendarId that isn't a 24-character hex id", () => {
+      const occurrence = { ...baseOccurrence(), calendarId: "not-an-id" };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        false,
       );
     });
   });

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -1,0 +1,204 @@
+import { z } from "zod/v4";
+import {
+  DateTimeSchema,
+  EventIdSchema,
+  RRuleSchema,
+} from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import {
+  ConnectionIdSchema,
+  ProviderCalendarIdSchema,
+  ProviderEventIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Canonical, provider-neutral event contracts for Compass Sync (ledger S03).
+// This is the logical record Sync persists per event/series (01-domain-model
+// "Event"); Google/Microsoft SDK shapes stay inside provider adapters and
+// never appear here. Schedule reuses the app-facing EventScheduleSchema
+// (event.contracts.ts) since timed-vs-all-day/DST semantics are identical.
+
+export const ClientEventIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .brand<"ClientEventId">();
+export type ClientEventId = z.infer<typeof ClientEventIdSchema>;
+
+export const ProviderEventVersionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(1024)
+  .brand<"ProviderEventVersion">();
+export type ProviderEventVersion = z.infer<typeof ProviderEventVersionSchema>;
+
+export const SyncEventOriginSchema = z.enum(["compass", "provider"]);
+export type SyncEventOrigin = z.infer<typeof SyncEventOriginSchema>;
+
+export const ProviderDeliveryStateSchema = z.enum([
+  "pending",
+  "confirmed",
+  "failed",
+]);
+export type ProviderDeliveryState = z.infer<typeof ProviderDeliveryStateSchema>;
+
+// Present only once an event is linked to exactly one owning provider
+// calendar (R-EVENT-01, R-EVENT-02). Unlinked events have no provider truth.
+export const SyncEventOwnershipSchema = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("unlinked") }),
+  z.strictObject({
+    kind: z.literal("linked"),
+    connectionId: ConnectionIdSchema,
+    calendarId: ProviderCalendarIdSchema,
+    providerEventId: ProviderEventIdSchema,
+    providerVersion: ProviderEventVersionSchema,
+    // Provider's own last-update timestamp; null until the provider has
+    // reported one (e.g. immediately after an ambiguous create).
+    providerUpdatedAt: DateTimeSchema.nullable(),
+    deliveryState: ProviderDeliveryStateSchema,
+    // Minimal opaque bag for adapter-internal identity/concurrency facts
+    // (e.g. a recurring-instance fingerprint), never the full provider
+    // payload (01-domain-model.md). Preserves what R-EVENT-05 needs without
+    // duplicating provider state Sync doesn't otherwise model.
+    providerMetadata: z.record(z.string(), z.string()).readonly().optional(),
+  }),
+]);
+export type SyncEventOwnership = z.infer<typeof SyncEventOwnershipSchema>;
+
+export const OrganizerSchema = z.strictObject({
+  email: z.string().trim().min(1).max(320),
+  displayName: z.string().trim().min(1).max(256).nullable(),
+});
+export type Organizer = z.infer<typeof OrganizerSchema>;
+
+export const AttendeeResponseStatusSchema = z.enum([
+  "needsAction",
+  "accepted",
+  "declined",
+  "tentative",
+]);
+export type AttendeeResponseStatus = z.infer<
+  typeof AttendeeResponseStatusSchema
+>;
+
+export const AttendeeSchema = z.strictObject({
+  email: z.string().trim().min(1).max(320),
+  displayName: z.string().trim().min(1).max(256).nullable(),
+  responseStatus: AttendeeResponseStatusSchema,
+});
+export type Attendee = z.infer<typeof AttendeeSchema>;
+
+export const ConferenceSchema = z.strictObject({
+  url: z.url(),
+  label: z.string().trim().min(1).max(256).nullable(),
+});
+export type Conference = z.infer<typeof ConferenceSchema>;
+
+export const SyncEventContentSchema = z.strictObject({
+  title: z.string(),
+  description: z.string(),
+  location: z.string().nullable(),
+  organizer: OrganizerSchema.nullable(),
+  attendees: z.array(AttendeeSchema).readonly(),
+  conference: ConferenceSchema.nullable(),
+});
+export type SyncEventContent = z.infer<typeof SyncEventContentSchema>;
+
+const SingleRecurrenceSchema = z.strictObject({ kind: z.literal("single") });
+
+const SeriesMasterRecurrenceSchema = z.strictObject({
+  kind: z.literal("seriesMaster"),
+  rules: RRuleSchema,
+});
+
+// One overridden or cancelled instance of a recurring series (R-EVENT-06).
+// recurrenceId is the instance's original scheduled start before override —
+// the standard identity providers use to address one occurrence.
+const RecurrenceExceptionSchema = z.strictObject({
+  kind: z.literal("exception"),
+  seriesId: EventIdSchema,
+  recurrenceId: DateTimeSchema,
+  cancelled: z.boolean(),
+});
+
+export const SyncEventRecurrenceSchema = z.discriminatedUnion("kind", [
+  SingleRecurrenceSchema,
+  SeriesMasterRecurrenceSchema,
+  RecurrenceExceptionSchema,
+]);
+export type SyncEventRecurrence = z.infer<typeof SyncEventRecurrenceSchema>;
+
+// Visible while a Compass-initiated deletion has not yet been provider
+// confirmed (R-EVENT-09). The record is removed, and a content-free
+// deletion marker takes its place, only after confirmation.
+export const SyncEventLifecycleStateSchema = z.enum([
+  "active",
+  "deletionPending",
+]);
+export type SyncEventLifecycleState = z.infer<
+  typeof SyncEventLifecycleStateSchema
+>;
+
+export const SyncEventSchema = z.strictObject({
+  id: EventIdSchema,
+  // Caller-generated id used to make anonymous-to-cloud promotion and retry
+  // idempotent (R-LIFE-02); null once no longer needed for that purpose.
+  clientEventId: ClientEventIdSchema.nullable(),
+  origin: SyncEventOriginSchema,
+  ownership: SyncEventOwnershipSchema,
+  content: SyncEventContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: SyncEventRecurrenceSchema,
+  lifecycleState: SyncEventLifecycleStateSchema,
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+  confirmedAt: DateTimeSchema.nullable(),
+});
+export type SyncEvent = z.infer<typeof SyncEventSchema>;
+
+// One derived, display-ready instance within the rolling sync horizon (12
+// months past / 18 months future). Never expand a non-ending series to
+// completion; project only the bounded window a query needs (R-AVAIL-06).
+export const OccurrenceKeySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(512)
+  .brand<"OccurrenceKey">();
+export type OccurrenceKey = z.infer<typeof OccurrenceKeySchema>;
+
+export const SyncEventOccurrenceSchema = z.strictObject({
+  occurrenceKey: OccurrenceKeySchema,
+  eventId: EventIdSchema,
+  calendarId: ProviderCalendarIdSchema,
+  schedule: EventScheduleSchema,
+  busy: z.boolean(),
+  title: z.string(),
+  cancelled: z.boolean(),
+});
+export type SyncEventOccurrence = z.infer<typeof SyncEventOccurrenceSchema>;
+
+export const EventOccurrenceListQuerySchema = z
+  .strictObject({
+    calendarIds: z.array(ProviderCalendarIdSchema).min(1).readonly(),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    cursor: z.string().trim().min(1).max(1024).optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Range end must be after start",
+    path: ["end"],
+  });
+export type EventOccurrenceListQuery = z.infer<
+  typeof EventOccurrenceListQuerySchema
+>;
+
+export const EventOccurrenceListResponseSchema = z.strictObject({
+  occurrences: z.array(SyncEventOccurrenceSchema).readonly(),
+  nextCursor: z.string().trim().min(1).max(1024).nullable(),
+});
+export type EventOccurrenceListResponse = z.infer<
+  typeof EventOccurrenceListResponseSchema
+>;

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import {
+  CalendarIdSchema,
   DateTimeSchema,
   EventIdSchema,
   RRuleSchema,
@@ -157,6 +158,16 @@ export const SyncEventSchema = z.strictObject({
 });
 export type SyncEvent = z.infer<typeof SyncEventSchema>;
 
+// Sync is the store of record for both provider-linked and still-unlinked
+// Compass cloud events (S26), so an occurrence's calendar grouping key must
+// accept either identity space: Compass's own calendar id for an unlinked
+// event, or the provider calendar id once one exists (R-LIFE-03).
+export const SyncEventCalendarIdSchema = z.union([
+  CalendarIdSchema,
+  ProviderCalendarIdSchema,
+]);
+export type SyncEventCalendarId = z.infer<typeof SyncEventCalendarIdSchema>;
+
 // One derived, display-ready instance within the rolling sync horizon (12
 // months past / 18 months future). Never expand a non-ending series to
 // completion; project only the bounded window a query needs (R-AVAIL-06).
@@ -171,7 +182,7 @@ export type OccurrenceKey = z.infer<typeof OccurrenceKeySchema>;
 export const SyncEventOccurrenceSchema = z.strictObject({
   occurrenceKey: OccurrenceKeySchema,
   eventId: EventIdSchema,
-  calendarId: ProviderCalendarIdSchema,
+  calendarId: SyncEventCalendarIdSchema,
   schedule: EventScheduleSchema,
   busy: z.boolean(),
   title: z.string(),
@@ -181,7 +192,7 @@ export type SyncEventOccurrence = z.infer<typeof SyncEventOccurrenceSchema>;
 
 export const EventOccurrenceListQuerySchema = z
   .strictObject({
-    calendarIds: z.array(ProviderCalendarIdSchema).min(1).readonly(),
+    calendarIds: z.array(SyncEventCalendarIdSchema).min(1).readonly(),
     start: DateTimeSchema,
     end: DateTimeSchema,
     cursor: z.string().trim().min(1).max(1024).optional(),


### PR DESCRIPTION
## Summary

Adds the third provider-neutral Zod contract packet for Compass Sync, per the internal architecture packet in `compass-calendar-internal/projects/sync-service/` (ledger item **S03** of `07-commit-ledger.md`):

- **`packages/core/src/types/sync/event.contracts.ts`**: the canonical, provider-neutral event Sync persists per event/series (doc 01's "Event" entity) — origin (`compass`/`provider`), a discriminated `unlinked`/`linked` ownership union (a linked event always carries provider identity, version, delivery state, and an optional opaque metadata bag together; an unlinked event carries none of it), organizer/attendee/conference content fidelity fields, a `single`/`seriesMaster`/`exception` recurrence union (exceptions carry `recurrenceId` + `cancelled` so overrides and cancellations are distinguishable), a `deletionPending` lifecycle state for R-EVENT-09's "visible until provider-confirmed" rule, and a derived occurrence projection with a bounded, cursor-paginated query contract. Schedule is reused directly from the existing app-facing `EventScheduleSchema` rather than reinvented, since timed/all-day/DST semantics are identical.

Purely additive — nothing imports these yet, no runtime behavior changes.

An independent correctness review (code-reviewer agent) ran against the diff and found one real bug, fixed in the second commit before push: `SyncEventOccurrenceSchema.calendarId` and the query contract's `calendarIds` were typed as `ProviderCalendarIdSchema` only, which made an unlinked event's occurrence unrepresentable — Sync is the store of record for unlinked Compass cloud events too (S26), so the occurrence's calendar-grouping key needs to accept either identity space. Fixed with a `SyncEventCalendarIdSchema` union of the compass-native and provider calendar id types, used in both places. The review also flagged a redundant `confirmedAt` test that never exercised its non-null branch; replaced.

## Simplicity

Considered extracting a shared "contact" schema for `Organizer`/`Attendee`'s identical `email`/`displayName` fields, and left them separate: they're semantically distinct (attendees carry RSVP state, organizer may later need different rules) and it's two fields repeated once — not the copy-pasted-scaffolding pattern worth an abstraction. No simplification commit needed this time; the diff already reuses three existing schemas (`EventScheduleSchema`, `EventIdSchema`, `CalendarIdSchema`) rather than reinventing them.

No `useEffect`/`useRef`/`useState` in this diff — schema-only, no React.

## Manual Testing Steps

Not browser-observable (additive type contracts, no UI/route wiring). Equivalent CLI verification:

- [ ] `bun run test:core` — expect 166 pass, 0 fail
- [ ] `bun run type-check` — expect a clean exit
- [ ] `bunx biome check packages/core/src/types/sync/` — expect no errors

## Test plan

- [x] `bun run test:core` — 166 pass, 0 fail (171 expect() calls)
- [x] `bun run type-check` — clean
- [x] `bunx biome check` on touched files — clean
- [x] Independent correctness review (code-reviewer agent) — 1 real finding (calendar-id union gap) fixed and re-verified; 1 test-quality finding fixed; no other issues at or above confidence threshold
