### PR TITLE
feat(core): add durable event command contracts

### DIFF
--- a/packages/core/src/types/sync/command.contracts.test.ts
+++ b/packages/core/src/types/sync/command.contracts.test.ts
@@ -1,0 +1,247 @@
+import { faker } from "@faker-js/faker";
+import {
+  SyncCommandFailureReasonSchema,
+  SyncCommandInputSchema,
+  SyncCommandOutcomeSchema,
+  SyncCommandSchema,
+} from "@core/types/sync/command.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const timedSchedule = {
+  kind: "timed",
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+
+const baseContent = {
+  title: "Standup",
+  description: "Daily sync",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+};
+
+const createInput = () => ({
+  kind: "create",
+  calendarId: objectId(),
+  content: baseContent,
+  schedule: timedSchedule,
+  recurrence: { kind: "single" },
+});
+
+const updateInput = (scope: string = "this") => ({
+  kind: "update",
+  content: baseContent,
+  schedule: timedSchedule,
+  recurrence: { kind: "preserve" },
+  scope,
+});
+
+const moveInput = () => ({ kind: "move", calendarId: objectId() });
+
+const deleteInput = (scope: string = "this") => ({
+  kind: "delete",
+  scope,
+});
+
+const pendingOutcome = { state: "pending" };
+
+const confirmedLocalOutcome = {
+  state: "confirmed",
+  providerEventId: null,
+  providerVersion: null,
+};
+
+const confirmedLinkedOutcome = {
+  state: "confirmed",
+  providerEventId: "abc123@google.com",
+  providerVersion: "etag-1",
+};
+
+const baseCommand = (overrides: Record<string, unknown> = {}) => ({
+  id: objectId(),
+  tenantId: objectId(),
+  principalId: objectId(),
+  idempotencyKey: "client-generated-key-1",
+  eventId: objectId(),
+  input: createInput(),
+  expectedVersion: null,
+  outcome: pendingOutcome,
+  attemptCount: 0,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("Sync command contracts", () => {
+  describe("SyncCommandInputSchema", () => {
+    it("accepts a create input", () => {
+      expect(SyncCommandInputSchema.safeParse(createInput()).success).toBe(
+        true,
+      );
+    });
+
+    it.each([
+      "this",
+      "thisAndFollowing",
+      "all",
+    ] as const)("accepts an update input with scope %s", (scope) => {
+      expect(SyncCommandInputSchema.safeParse(updateInput(scope)).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a move input", () => {
+      expect(SyncCommandInputSchema.safeParse(moveInput()).success).toBe(true);
+    });
+
+    it("rejects a move input carrying content", () => {
+      const input = { ...moveInput(), content: baseContent };
+      expect(SyncCommandInputSchema.safeParse(input).success).toBe(false);
+    });
+
+    it.each([
+      "this",
+      "thisAndFollowing",
+      "all",
+    ] as const)("accepts a delete input with scope %s", (scope) => {
+      expect(SyncCommandInputSchema.safeParse(deleteInput(scope)).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an update input carrying a calendarId", () => {
+      const input = { ...updateInput(), calendarId: objectId() };
+      expect(SyncCommandInputSchema.safeParse(input).success).toBe(false);
+    });
+
+    it("rejects an unrecognized kind", () => {
+      expect(
+        SyncCommandInputSchema.safeParse({ kind: "archive" }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("SyncCommandOutcomeSchema", () => {
+    it.each([
+      "pending",
+      "applying",
+      "reconciling",
+      "cancelled",
+    ] as const)("accepts the bare %s state", (state) => {
+      expect(SyncCommandOutcomeSchema.safeParse({ state }).success).toBe(true);
+    });
+
+    it("accepts a locally confirmed outcome with no provider target", () => {
+      expect(
+        SyncCommandOutcomeSchema.safeParse(confirmedLocalOutcome).success,
+      ).toBe(true);
+    });
+
+    it("accepts a provider-confirmed outcome with full identity", () => {
+      expect(
+        SyncCommandOutcomeSchema.safeParse(confirmedLinkedOutcome).success,
+      ).toBe(true);
+    });
+
+    it("rejects a confirmed outcome with providerEventId but no providerVersion", () => {
+      const outcome = { ...confirmedLinkedOutcome, providerVersion: null };
+      expect(SyncCommandOutcomeSchema.safeParse(outcome).success).toBe(false);
+    });
+
+    it("rejects a confirmed outcome with providerVersion but no providerEventId", () => {
+      const outcome = { ...confirmedLinkedOutcome, providerEventId: null };
+      expect(SyncCommandOutcomeSchema.safeParse(outcome).success).toBe(false);
+    });
+
+    it.each(
+      SyncCommandFailureReasonSchema.options,
+    )("accepts a failed outcome with reason %s", (failureReason) => {
+      const outcome = { state: "failed", failureReason };
+      expect(SyncCommandOutcomeSchema.safeParse(outcome).success).toBe(true);
+    });
+
+    it("rejects a failed outcome missing a failureReason", () => {
+      expect(
+        SyncCommandOutcomeSchema.safeParse({ state: "failed" }).success,
+      ).toBe(false);
+    });
+
+    it("rejects an unrecognized state", () => {
+      expect(
+        SyncCommandOutcomeSchema.safeParse({ state: "unknown" }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("SyncCommandSchema", () => {
+    it("accepts a pending create command with no expectedVersion", () => {
+      expect(SyncCommandSchema.safeParse(baseCommand()).success).toBe(true);
+    });
+
+    it("rejects a create command carrying an expectedVersion", () => {
+      const command = baseCommand({ expectedVersion: "etag-0" });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(false);
+    });
+
+    it("accepts an update command with a stale expectedVersion under a versionConflict failure", () => {
+      const command = baseCommand({
+        input: updateInput(),
+        expectedVersion: "etag-stale",
+        outcome: { state: "failed", failureReason: "versionConflict" },
+      });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(true);
+    });
+
+    it("accepts an update command with a null expectedVersion for a not-yet-linked event", () => {
+      const command = baseCommand({
+        input: updateInput(),
+        expectedVersion: null,
+      });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(true);
+    });
+
+    it("accepts a create command that ends up reconciling an ambiguous response", () => {
+      const command = baseCommand({ outcome: { state: "reconciling" } });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(true);
+    });
+
+    it("accepts a delete command rejected for targeting a read-only calendar", () => {
+      const command = baseCommand({
+        input: deleteInput(),
+        outcome: { state: "failed", failureReason: "readOnlyCalendar" },
+      });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(true);
+    });
+
+    it("accepts a high attemptCount representing exhausted retries", () => {
+      const command = baseCommand({ attemptCount: 40 });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(true);
+    });
+
+    it("rejects a negative attemptCount", () => {
+      const command = baseCommand({ attemptCount: -1 });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(false);
+    });
+
+    it("rejects a raw provider credential field", () => {
+      const command = baseCommand({ accessToken: "leak" });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(false);
+    });
+
+    it("round-trips through JSON unchanged", () => {
+      const command = baseCommand({
+        input: updateInput("thisAndFollowing"),
+        expectedVersion: "etag-1",
+        outcome: confirmedLinkedOutcome,
+      });
+      const parsed = SyncCommandSchema.parse(command);
+      expect(
+        SyncCommandSchema.parse(JSON.parse(JSON.stringify(parsed))),
+      ).toEqual(parsed);
+    });
+  });
+});

--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -1,0 +1,161 @@
+import { z } from "zod/v4";
+import { DateTimeSchema, EventIdSchema } from "@core/types/domain-primitives";
+import {
+  EditableRecurrenceSchema,
+  EventScheduleSchema,
+} from "@core/types/event.contracts";
+import {
+  RecurrenceEditSchema,
+  RecurrenceScopeSchema,
+} from "@core/types/event-command.contracts";
+import {
+  ProviderEventVersionSchema,
+  SyncEventCalendarIdSchema,
+  SyncEventContentSchema,
+} from "@core/types/sync/event.contracts";
+import {
+  IdempotencyKeySchema,
+  PrincipalIdSchema,
+  ProviderEventIdSchema,
+  SyncCommandIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Durable event command contracts for Compass Sync (ledger S04). A command
+// records acknowledged user intent (01-domain-model "Command") and is
+// persisted before any asynchronous work begins (R-SYNC-05). This file adds
+// contracts only — nothing here executes a command or reads/writes the
+// existing Compass API event endpoints (02-sync-lifecycle "Durable event
+// commands").
+
+// create has no calendar to move within and no prior scope to preserve, so
+// its recurrence input reuses the existing single/series edit shape.
+const CreateCommandInputSchema = z.strictObject({
+  kind: z.literal("create"),
+  calendarId: SyncEventCalendarIdSchema,
+  content: SyncEventContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: EditableRecurrenceSchema,
+});
+
+// update never changes the owning calendar — that is exclusively the "move"
+// operation's job, so the two stay independently retryable and idempotent.
+const UpdateCommandInputSchema = z.strictObject({
+  kind: z.literal("update"),
+  content: SyncEventContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: RecurrenceEditSchema,
+  scope: RecurrenceScopeSchema,
+});
+
+const MoveCommandInputSchema = z.strictObject({
+  kind: z.literal("move"),
+  calendarId: SyncEventCalendarIdSchema,
+});
+
+const DeleteCommandInputSchema = z.strictObject({
+  kind: z.literal("delete"),
+  scope: RecurrenceScopeSchema,
+});
+
+export const SyncCommandInputSchema = z.discriminatedUnion("kind", [
+  CreateCommandInputSchema,
+  UpdateCommandInputSchema,
+  MoveCommandInputSchema,
+  DeleteCommandInputSchema,
+]);
+export type SyncCommandInput = z.infer<typeof SyncCommandInputSchema>;
+
+// Provider-side rejection classes a command outcome can carry. These map to
+// the failure classification table in 02-sync-lifecycle.md; "capability"
+// failures are typed rather than a silently degraded write (01-domain-model
+// "Provider adapter contract").
+export const SyncCommandFailureReasonSchema = z.enum([
+  "versionConflict",
+  "readOnlyCalendar",
+  "unsupportedCapability",
+  "permanentProviderError",
+  "authorizationRevoked",
+]);
+export type SyncCommandFailureReason = z.infer<
+  typeof SyncCommandFailureReasonSchema
+>;
+
+// Nonterminal: pending (persisted, not yet attempted), applying (in flight
+// at the provider), reconciling (response was ambiguous; identity must be
+// confirmed before another attempt — 02-sync-lifecycle "Create" step 6).
+// Terminal: confirmed, failed, cancelled.
+const PendingOutcomeSchema = z.strictObject({ state: z.literal("pending") });
+const ApplyingOutcomeSchema = z.strictObject({ state: z.literal("applying") });
+const ReconcilingOutcomeSchema = z.strictObject({
+  state: z.literal("reconciling"),
+});
+
+const ConfirmedOutcomeSchema = z
+  .strictObject({
+    state: z.literal("confirmed"),
+    // Both null when the event has no provider target: confirmation is
+    // durable cloud persistence only (02-sync-lifecycle "Create" step 3).
+    // Otherwise both present together — a provider identity without a
+    // version (or vice versa) is not a coherent confirmed state.
+    providerEventId: ProviderEventIdSchema.nullable(),
+    providerVersion: ProviderEventVersionSchema.nullable(),
+  })
+  .refine(
+    (outcome) =>
+      (outcome.providerEventId === null) === (outcome.providerVersion === null),
+    {
+      message:
+        "providerEventId and providerVersion must both be null or both present",
+      path: ["providerVersion"],
+    },
+  );
+
+const FailedOutcomeSchema = z.strictObject({
+  state: z.literal("failed"),
+  failureReason: SyncCommandFailureReasonSchema,
+});
+
+const CancelledOutcomeSchema = z.strictObject({
+  state: z.literal("cancelled"),
+});
+
+export const SyncCommandOutcomeSchema = z.discriminatedUnion("state", [
+  PendingOutcomeSchema,
+  ApplyingOutcomeSchema,
+  ReconcilingOutcomeSchema,
+  ConfirmedOutcomeSchema,
+  FailedOutcomeSchema,
+  CancelledOutcomeSchema,
+]);
+export type SyncCommandOutcome = z.infer<typeof SyncCommandOutcomeSchema>;
+
+export const SyncCommandSchema = z
+  .strictObject({
+    id: SyncCommandIdSchema,
+    tenantId: TenantIdSchema,
+    principalId: PrincipalIdSchema,
+    // Unique per (tenantId, principalId, idempotencyKey) — the same key
+    // always refers to the same command (01-domain-model "Command").
+    idempotencyKey: IdempotencyKeySchema,
+    eventId: EventIdSchema,
+    input: SyncCommandInputSchema,
+    // Last provider version the client observed, for a conditional write on
+    // update/move/delete. Null means no known provider version yet (an
+    // unlinked event, or a first write attempt). Never present on create,
+    // which has no prior provider state to condition against.
+    expectedVersion: ProviderEventVersionSchema.nullable(),
+    outcome: SyncCommandOutcomeSchema,
+    attemptCount: z.number().int().min(0),
+    createdAt: DateTimeSchema,
+    updatedAt: DateTimeSchema,
+  })
+  .refine(
+    (command) =>
+      command.input.kind !== "create" || command.expectedVersion === null,
+    {
+      message: "A create command cannot carry an expectedVersion",
+      path: ["expectedVersion"],
+    },
+  );
+export type SyncCommand = z.infer<typeof SyncCommandSchema>;


### PR DESCRIPTION
## Summary

Adds the fourth provider-neutral Zod contract packet for Compass Sync, per the internal architecture packet in `compass-calendar-internal/projects/sync-service/` (ledger item **S04** of `07-commit-ledger.md`):

- **`packages/core/src/types/sync/command.contracts.ts`**: durable event command contracts — a command records acknowledged user intent and is persisted before any asynchronous work begins (R-SYNC-05). A discriminated `SyncCommandInputSchema` covers the four operations: `create` (calendarId + content + schedule + recurrence), `update` (content/schedule/recurrence/scope, deliberately no calendarId — moving is a separate operation from editing), `move` (calendarId only), `delete` (scope only). A `SyncCommandOutcomeSchema` covers nonterminal `pending`/`applying`/`reconciling` and terminal `confirmed`/`failed`/`cancelled` states, where `confirmed` enforces that `providerEventId` and `providerVersion` are both null (local-only confirmation) or both present (provider-linked) — never partial. A `SyncCommandFailureReasonSchema` types the conflict/capability outcomes the design calls for (`versionConflict`, `readOnlyCalendar`, `unsupportedCapability`, `permanentProviderError`, `authorizationRevoked`). The top-level `SyncCommandSchema` enforces that a `create` command never carries an `expectedVersion` (nothing prior exists to condition against).

Reuses four existing schemas rather than reinventing them: `EditableRecurrenceSchema`, `RecurrenceEditSchema`, `RecurrenceScopeSchema` (all from the app-facing `event-command.contracts.ts`) and `SyncEventContentSchema`/`SyncEventCalendarIdSchema` (from S03). Purely additive — nothing imports these yet, no runtime behavior changes, no existing endpoints touched.

An independent correctness review (code-reviewer agent) ran against the diff, specifically checking the two-level refine composition (a refined discriminated-union member inside a refined top-level object — a pattern already proven elsewhere in this codebase for `EventScheduleSchema`) and both invariants' test coverage. No findings.

## Simplicity

Nothing to simplify — the diff already reuses five existing schemas instead of reinventing them, and no duplicated logic was introduced.

No `useEffect`/`useRef`/`useState` in this diff — schema-only, no React.

## Manual Testing Steps

Not browser-observable (additive type contracts, no UI/route wiring). Equivalent CLI verification:

- [ ] `bun run test:core` — expect 202 pass, 0 fail
- [ ] `bun run type-check` — expect a clean exit
- [ ] `bunx biome check packages/core/src/types/sync/` — expect no errors

## Test plan

- [x] `bun run test:core` — 202 pass, 0 fail (207 expect() calls)
- [x] `bun run type-check` — clean
- [x] `bunx biome check` on touched files — clean
- [x] Independent correctness review (code-reviewer agent) — no findings at or above confidence threshold
