### PR TITLE
feat(core): add sync busy and change-feed contracts

### DIFF
--- a/packages/core/src/types/sync/busy.contracts.test.ts
+++ b/packages/core/src/types/sync/busy.contracts.test.ts
@@ -1,0 +1,216 @@
+import { faker } from "@faker-js/faker";
+import {
+  BusyConnectionEvidenceSchema,
+  BusyIntervalSchema,
+  BusyQueryPurposeSchema,
+  BusyQueryResponseSchema,
+  BusyQuerySchema,
+  IncompleteCalendarReasonSchema,
+} from "@core/types/sync/busy.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const baseQuery = () => ({
+  calendarIds: [objectId()],
+  start: "2026-07-01T00:00:00.000Z",
+  end: "2026-08-01T00:00:00.000Z",
+  purpose: "display",
+});
+
+const baseInterval = () => ({
+  start: "2026-07-14T09:00:00.000Z",
+  end: "2026-07-14T10:00:00.000Z",
+});
+
+const baseResponse = () => ({
+  intervals: [baseInterval()],
+  computedAt: "2026-07-20T12:00:00.000Z",
+  connections: [],
+  complete: true,
+  incompleteCalendars: [],
+  bookable: true,
+});
+
+describe("Sync busy contracts", () => {
+  describe("BusyIntervalSchema", () => {
+    it("accepts a half-open interval", () => {
+      expect(BusyIntervalSchema.safeParse(baseInterval()).success).toBe(true);
+    });
+
+    it("rejects end equal to start", () => {
+      const interval = {
+        start: baseInterval().start,
+        end: baseInterval().start,
+      };
+      expect(BusyIntervalSchema.safeParse(interval).success).toBe(false);
+    });
+
+    it("rejects end before start", () => {
+      const interval = { start: baseInterval().end, end: baseInterval().start };
+      expect(BusyIntervalSchema.safeParse(interval).success).toBe(false);
+    });
+
+    it("rejects a title field (privacy: no event content on a busy interval)", () => {
+      const interval = { ...baseInterval(), title: "Therapy" };
+      expect(BusyIntervalSchema.safeParse(interval).success).toBe(false);
+    });
+
+    it("rejects a calendarId field (intervals are merged/normalized)", () => {
+      const interval = { ...baseInterval(), calendarId: objectId() };
+      expect(BusyIntervalSchema.safeParse(interval).success).toBe(false);
+    });
+  });
+
+  describe("BusyQueryPurposeSchema", () => {
+    it.each([
+      "display",
+      "bookingConfirmation",
+    ] as const)("accepts %s", (purpose) => {
+      expect(BusyQueryPurposeSchema.safeParse(purpose).success).toBe(true);
+    });
+
+    it("rejects an unknown purpose", () => {
+      expect(BusyQueryPurposeSchema.safeParse("debugging").success).toBe(false);
+    });
+  });
+
+  describe("BusyQuerySchema", () => {
+    it("accepts a single-calendar query", () => {
+      expect(BusyQuerySchema.safeParse(baseQuery()).success).toBe(true);
+    });
+
+    it("accepts multiple calendars across compass and provider id spaces", () => {
+      const query = { ...baseQuery(), calendarIds: [objectId(), objectId()] };
+      expect(BusyQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("accepts an optional maxDataAgeSeconds", () => {
+      const query = { ...baseQuery(), maxDataAgeSeconds: 30 };
+      expect(BusyQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("rejects an empty calendarIds array", () => {
+      const query = { ...baseQuery(), calendarIds: [] };
+      expect(BusyQuerySchema.safeParse(query).success).toBe(false);
+    });
+
+    it("rejects end before start", () => {
+      const query = {
+        ...baseQuery(),
+        start: baseQuery().end,
+        end: baseQuery().start,
+      };
+      expect(BusyQuerySchema.safeParse(query).success).toBe(false);
+    });
+
+    it("accepts a range at exactly the 366-day ceiling", () => {
+      const query = {
+        ...baseQuery(),
+        start: "2026-01-01T00:00:00.000Z",
+        end: "2027-01-02T00:00:00.000Z",
+      };
+      expect(BusyQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("rejects a range exceeding the 366-day ceiling (R-AVAIL-06 stays a floor, not unbounded)", () => {
+      const query = {
+        ...baseQuery(),
+        start: "2026-01-01T00:00:00.000Z",
+        end: "2027-01-03T00:00:00.000Z",
+      };
+      expect(BusyQuerySchema.safeParse(query).success).toBe(false);
+    });
+
+    it("rejects principal scoping via the query body", () => {
+      const query = { ...baseQuery(), principalId: objectId() };
+      expect(BusyQuerySchema.safeParse(query).success).toBe(false);
+    });
+  });
+
+  describe("BusyConnectionEvidenceSchema", () => {
+    it("accepts null timestamps before first sync", () => {
+      const evidence = {
+        connectionId: objectId(),
+        lastSyncedAt: null,
+        lastHealthyAt: null,
+      };
+      expect(BusyConnectionEvidenceSchema.safeParse(evidence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an unknown field", () => {
+      const evidence = {
+        connectionId: objectId(),
+        lastSyncedAt: null,
+        lastHealthyAt: null,
+        healthy: true,
+      };
+      expect(BusyConnectionEvidenceSchema.safeParse(evidence).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("IncompleteCalendarReasonSchema", () => {
+    it.each([
+      "missing",
+      "stale",
+      "connectionUnhealthy",
+      "capabilityUnavailable",
+    ] as const)("accepts %s", (reason) => {
+      expect(IncompleteCalendarReasonSchema.safeParse(reason).success).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("BusyQueryResponseSchema", () => {
+    it("accepts a complete, bookable response", () => {
+      expect(BusyQueryResponseSchema.safeParse(baseResponse()).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts an incomplete, unbookable response with reasons", () => {
+      const response = {
+        ...baseResponse(),
+        complete: false,
+        incompleteCalendars: [{ calendarId: objectId(), reason: "stale" }],
+        bookable: false,
+      };
+      expect(BusyQueryResponseSchema.safeParse(response).success).toBe(true);
+    });
+
+    it("rejects complete=true with a non-empty incompleteCalendars list", () => {
+      const response = {
+        ...baseResponse(),
+        incompleteCalendars: [{ calendarId: objectId(), reason: "missing" }],
+      };
+      expect(BusyQueryResponseSchema.safeParse(response).success).toBe(false);
+    });
+
+    it("rejects complete=false with an empty incompleteCalendars list", () => {
+      const response = { ...baseResponse(), complete: false, bookable: false };
+      expect(BusyQueryResponseSchema.safeParse(response).success).toBe(false);
+    });
+
+    it("rejects bookable=true when complete is false (fail-closed, R-AVAIL-04)", () => {
+      const response = {
+        ...baseResponse(),
+        complete: false,
+        incompleteCalendars: [{ calendarId: objectId(), reason: "stale" }],
+        bookable: true,
+      };
+      expect(BusyQueryResponseSchema.safeParse(response).success).toBe(false);
+    });
+
+    it("rejects an interval carrying attendee content (privacy)", () => {
+      const response = {
+        ...baseResponse(),
+        intervals: [{ ...baseInterval(), attendees: ["guest@example.com"] }],
+      };
+      expect(BusyQueryResponseSchema.safeParse(response).success).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/types/sync/busy.contracts.ts
+++ b/packages/core/src/types/sync/busy.contracts.ts
@@ -1,0 +1,112 @@
+import { z } from "zod/v4";
+import { DateTimeSchema } from "@core/types/domain-primitives";
+import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
+import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
+
+// Busy-query contracts for Compass Sync (ledger S05). Availability results
+// must disclose freshness/completeness rather than presenting stale or
+// incomplete data as known-current (R-PRINCIPLE-02, R-AVAIL-03), and a
+// booking must fail closed when any required blocker cannot be freshly
+// verified (R-AVAIL-04). Do not add booking policy (working hours, buffers,
+// which calendars block) here — that stays in the Compass booking module
+// (03-availability-and-booking.md).
+
+// Half-open [start, end) interval only: no calendar id, title, or other
+// event content ever appears on a busy interval (R-SEC-04 privacy).
+export const BusyIntervalSchema = z
+  .strictObject({
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Busy interval end must be after start",
+    path: ["end"],
+  });
+export type BusyInterval = z.infer<typeof BusyIntervalSchema>;
+
+export const BusyQueryPurposeSchema = z.enum([
+  "display",
+  "bookingConfirmation",
+]);
+export type BusyQueryPurpose = z.infer<typeof BusyQueryPurposeSchema>;
+
+// R-AVAIL-06 requires supporting at least 12 months into the future; this is
+// the Sync-level ceiling. The booking module further narrows this to its own
+// 60-day window when it calls in (03-availability-and-booking.md).
+const MAX_BUSY_QUERY_RANGE_DAYS = 366;
+const MAX_BUSY_QUERY_RANGE_MS = MAX_BUSY_QUERY_RANGE_DAYS * 24 * 60 * 60 * 1000;
+
+export const BusyQuerySchema = z
+  .strictObject({
+    calendarIds: z.array(SyncEventCalendarIdSchema).min(1).readonly(),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    // Caller's tolerance for how old the underlying sync data may be.
+    // Omitted means the caller accepts whatever freshness evidence returns.
+    maxDataAgeSeconds: z.number().int().positive().optional(),
+    purpose: BusyQueryPurposeSchema,
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Range end must be after start",
+    path: ["end"],
+  })
+  .refine(
+    ({ start, end }) =>
+      Date.parse(end) - Date.parse(start) <= MAX_BUSY_QUERY_RANGE_MS,
+    {
+      message: `Range must not exceed ${MAX_BUSY_QUERY_RANGE_DAYS} days`,
+      path: ["end"],
+    },
+  );
+export type BusyQuery = z.infer<typeof BusyQuerySchema>;
+
+export const BusyConnectionEvidenceSchema = z.strictObject({
+  connectionId: ConnectionIdSchema,
+  lastSyncedAt: DateTimeSchema.nullable(),
+  lastHealthyAt: DateTimeSchema.nullable(),
+});
+export type BusyConnectionEvidence = z.infer<
+  typeof BusyConnectionEvidenceSchema
+>;
+
+export const IncompleteCalendarReasonSchema = z.enum([
+  "missing",
+  "stale",
+  "connectionUnhealthy",
+  "capabilityUnavailable",
+]);
+export type IncompleteCalendarReason = z.infer<
+  typeof IncompleteCalendarReasonSchema
+>;
+
+export const IncompleteCalendarSchema = z.strictObject({
+  calendarId: SyncEventCalendarIdSchema,
+  reason: IncompleteCalendarReasonSchema,
+});
+export type IncompleteCalendar = z.infer<typeof IncompleteCalendarSchema>;
+
+export const BusyQueryResponseSchema = z
+  .strictObject({
+    intervals: z.array(BusyIntervalSchema).readonly(),
+    computedAt: DateTimeSchema,
+    connections: z.array(BusyConnectionEvidenceSchema).readonly(),
+    complete: z.boolean(),
+    incompleteCalendars: z.array(IncompleteCalendarSchema).readonly(),
+    // True only when every blocker meets confirmation freshness
+    // (R-AVAIL-04). Correct fail-closed responses still count as available
+    // service behavior for R-QUALITY-02, not as a failed query.
+    bookable: z.boolean(),
+  })
+  .refine(
+    (response) =>
+      response.complete === (response.incompleteCalendars.length === 0),
+    {
+      message: "complete must agree with an empty incompleteCalendars list",
+      path: ["complete"],
+    },
+  )
+  .refine((response) => !response.bookable || response.complete, {
+    message: "bookable requires complete",
+    path: ["bookable"],
+  });
+export type BusyQueryResponse = z.infer<typeof BusyQueryResponseSchema>;

--- a/packages/core/src/types/sync/busy.contracts.ts
+++ b/packages/core/src/types/sync/busy.contracts.ts
@@ -11,6 +11,9 @@ import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
 // which calendars block) here — that stays in the Compass booking module
 // (03-availability-and-booking.md).
 
+const isEndAfterStart = ({ start, end }: { start: string; end: string }) =>
+  Date.parse(end) > Date.parse(start);
+
 // Half-open [start, end) interval only: no calendar id, title, or other
 // event content ever appears on a busy interval (R-SEC-04 privacy).
 export const BusyIntervalSchema = z
@@ -18,7 +21,7 @@ export const BusyIntervalSchema = z
     start: DateTimeSchema,
     end: DateTimeSchema,
   })
-  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+  .refine(isEndAfterStart, {
     message: "Busy interval end must be after start",
     path: ["end"],
   });
@@ -46,7 +49,7 @@ export const BusyQuerySchema = z
     maxDataAgeSeconds: z.number().int().positive().optional(),
     purpose: BusyQueryPurposeSchema,
   })
-  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+  .refine(isEndAfterStart, {
     message: "Range end must be after start",
     path: ["end"],
   })

--- a/packages/core/src/types/sync/change-feed.contracts.test.ts
+++ b/packages/core/src/types/sync/change-feed.contracts.test.ts
@@ -1,0 +1,206 @@
+import { faker } from "@faker-js/faker";
+import {
+  ChangeFeedResponseSchema,
+  ChangeFeedResumeQuerySchema,
+  ImportProgressSchema,
+  InvalidationEnvelopeSchema,
+  SyncInvalidationSchema,
+} from "@core/types/sync/change-feed.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+describe("Sync change-feed contracts", () => {
+  describe("ImportProgressSchema", () => {
+    it("accepts a not-yet-started import", () => {
+      const progress = {
+        calendarsTotal: 0,
+        calendarsCompleted: 0,
+        complete: false,
+      };
+      expect(ImportProgressSchema.safeParse(progress).success).toBe(true);
+    });
+
+    it("accepts partial progress", () => {
+      const progress = {
+        calendarsTotal: 5,
+        calendarsCompleted: 2,
+        complete: false,
+      };
+      expect(ImportProgressSchema.safeParse(progress).success).toBe(true);
+    });
+
+    it("accepts complete once every calendar has finished", () => {
+      const progress = {
+        calendarsTotal: 5,
+        calendarsCompleted: 5,
+        complete: true,
+      };
+      expect(ImportProgressSchema.safeParse(progress).success).toBe(true);
+    });
+
+    it("rejects complete=true before every calendar finishes (R-CLIENT-05)", () => {
+      const progress = {
+        calendarsTotal: 5,
+        calendarsCompleted: 4,
+        complete: true,
+      };
+      expect(ImportProgressSchema.safeParse(progress).success).toBe(false);
+    });
+
+    it("rejects complete=true with zero discovered calendars", () => {
+      const progress = {
+        calendarsTotal: 0,
+        calendarsCompleted: 0,
+        complete: true,
+      };
+      expect(ImportProgressSchema.safeParse(progress).success).toBe(false);
+    });
+
+    it("rejects calendarsCompleted exceeding calendarsTotal", () => {
+      const progress = {
+        calendarsTotal: 2,
+        calendarsCompleted: 3,
+        complete: false,
+      };
+      expect(ImportProgressSchema.safeParse(progress).success).toBe(false);
+    });
+  });
+
+  describe("SyncInvalidationSchema", () => {
+    it("accepts a connection invalidation", () => {
+      const invalidation = { kind: "connection", connectionId: objectId() };
+      expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(true);
+    });
+
+    it("accepts a calendar invalidation", () => {
+      const invalidation = {
+        kind: "calendar",
+        connectionId: objectId(),
+        calendarId: objectId(),
+      };
+      expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(true);
+    });
+
+    it("accepts an event invalidation carrying only an id", () => {
+      const invalidation = { kind: "event", eventId: objectId() };
+      expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(true);
+    });
+
+    it("rejects an event invalidation carrying event content (privacy)", () => {
+      const invalidation = {
+        kind: "event",
+        eventId: objectId(),
+        title: "Therapy",
+      };
+      expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(
+        false,
+      );
+    });
+
+    it("accepts a command invalidation", () => {
+      const invalidation = { kind: "command", commandId: objectId() };
+      expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(true);
+    });
+
+    it("accepts an importProgress invalidation", () => {
+      const invalidation = {
+        kind: "importProgress",
+        connectionId: objectId(),
+        progress: {
+          calendarsTotal: 3,
+          calendarsCompleted: 1,
+          complete: false,
+        },
+      };
+      expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(true);
+    });
+
+    it("rejects an unrecognized kind", () => {
+      expect(
+        SyncInvalidationSchema.safeParse({ kind: "booking" }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("InvalidationEnvelopeSchema", () => {
+    it("accepts an envelope with no tenant/principal identifiers", () => {
+      const envelope = {
+        invalidation: { kind: "event", eventId: objectId() },
+        emittedAt: "2026-07-20T12:00:00.000Z",
+      };
+      expect(InvalidationEnvelopeSchema.safeParse(envelope).success).toBe(true);
+    });
+
+    it("rejects a leaked tenantId field", () => {
+      const envelope = {
+        invalidation: { kind: "event", eventId: objectId() },
+        emittedAt: "2026-07-20T12:00:00.000Z",
+        tenantId: objectId(),
+      };
+      expect(InvalidationEnvelopeSchema.safeParse(envelope).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("ChangeFeedResumeQuerySchema", () => {
+    it("accepts a null cursor to resume from now", () => {
+      expect(
+        ChangeFeedResumeQuerySchema.safeParse({ cursor: null }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a non-null cursor", () => {
+      expect(
+        ChangeFeedResumeQuerySchema.safeParse({ cursor: "token-1" }).success,
+      ).toBe(true);
+    });
+
+    it("rejects a missing cursor field", () => {
+      expect(ChangeFeedResumeQuerySchema.safeParse({}).success).toBe(false);
+    });
+
+    it("rejects principal scoping via the query body", () => {
+      const query = { cursor: null, principalId: objectId() };
+      expect(ChangeFeedResumeQuerySchema.safeParse(query).success).toBe(false);
+    });
+  });
+
+  describe("ChangeFeedResponseSchema", () => {
+    it("accepts an ok response with invalidations", () => {
+      const response = {
+        kind: "ok",
+        invalidations: [
+          {
+            invalidation: { kind: "event", eventId: objectId() },
+            emittedAt: "2026-07-20T12:00:00.000Z",
+          },
+        ],
+        nextCursor: "token-2",
+      };
+      expect(ChangeFeedResponseSchema.safeParse(response).success).toBe(true);
+    });
+
+    it("accepts an ok response with an empty page", () => {
+      const response = { kind: "ok", invalidations: [], nextCursor: "token-2" };
+      expect(ChangeFeedResponseSchema.safeParse(response).success).toBe(true);
+    });
+
+    it("accepts a bare resyncRequired response", () => {
+      expect(
+        ChangeFeedResponseSchema.safeParse({ kind: "resyncRequired" }).success,
+      ).toBe(true);
+    });
+
+    it("rejects a resyncRequired response carrying invalidations", () => {
+      const response = { kind: "resyncRequired", invalidations: [] };
+      expect(ChangeFeedResponseSchema.safeParse(response).success).toBe(false);
+    });
+
+    it("rejects an unrecognized kind", () => {
+      expect(
+        ChangeFeedResponseSchema.safeParse({ kind: "error" }).success,
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/types/sync/change-feed.contracts.ts
+++ b/packages/core/src/types/sync/change-feed.contracts.ts
@@ -1,0 +1,119 @@
+import { z } from "zod/v4";
+import { DateTimeSchema, EventIdSchema } from "@core/types/domain-primitives";
+import {
+  ConnectionIdSchema,
+  ProviderCalendarIdSchema,
+  SyncCommandIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Resumable internal change-feed contracts for Compass Sync (ledger S05).
+// Compass API consumes this feed and translates it into typed browser SSE;
+// it never appears in the browser directly (02-sync-lifecycle "Client
+// invalidation and recovery"). Invalidations carry only IDs and reasons,
+// never event content — a client always refetches canonical state.
+
+// Import progress must never imply completion from partial data
+// (R-CLIENT-05): `complete` can only be true once every discovered calendar
+// has finished, though the converse isn't required — a cursor-finalization
+// pass may still be pending even after every calendar's window fills.
+export const ImportProgressSchema = z
+  .strictObject({
+    calendarsTotal: z.number().int().min(0),
+    calendarsCompleted: z.number().int().min(0),
+    complete: z.boolean(),
+  })
+  .refine(
+    (progress) => progress.calendarsCompleted <= progress.calendarsTotal,
+    {
+      message: "calendarsCompleted cannot exceed calendarsTotal",
+      path: ["calendarsCompleted"],
+    },
+  )
+  .refine(
+    (progress) =>
+      !progress.complete ||
+      (progress.calendarsTotal > 0 &&
+        progress.calendarsCompleted === progress.calendarsTotal),
+    {
+      message: "complete requires every discovered calendar to have finished",
+      path: ["complete"],
+    },
+  );
+export type ImportProgress = z.infer<typeof ImportProgressSchema>;
+
+const ConnectionInvalidationSchema = z.strictObject({
+  kind: z.literal("connection"),
+  connectionId: ConnectionIdSchema,
+});
+
+const CalendarInvalidationSchema = z.strictObject({
+  kind: z.literal("calendar"),
+  connectionId: ConnectionIdSchema,
+  calendarId: ProviderCalendarIdSchema,
+});
+
+const EventInvalidationSchema = z.strictObject({
+  kind: z.literal("event"),
+  eventId: EventIdSchema,
+});
+
+const CommandInvalidationSchema = z.strictObject({
+  kind: z.literal("command"),
+  commandId: SyncCommandIdSchema,
+});
+
+const ImportProgressInvalidationSchema = z.strictObject({
+  kind: z.literal("importProgress"),
+  connectionId: ConnectionIdSchema,
+  progress: ImportProgressSchema,
+});
+
+export const SyncInvalidationSchema = z.discriminatedUnion("kind", [
+  ConnectionInvalidationSchema,
+  CalendarInvalidationSchema,
+  EventInvalidationSchema,
+  CommandInvalidationSchema,
+  ImportProgressInvalidationSchema,
+]);
+export type SyncInvalidation = z.infer<typeof SyncInvalidationSchema>;
+
+export const ChangeFeedCursorSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(1024)
+  .brand<"ChangeFeedCursor">();
+export type ChangeFeedCursor = z.infer<typeof ChangeFeedCursorSchema>;
+
+export const InvalidationEnvelopeSchema = z.strictObject({
+  invalidation: SyncInvalidationSchema,
+  emittedAt: DateTimeSchema,
+});
+export type InvalidationEnvelope = z.infer<typeof InvalidationEnvelopeSchema>;
+
+// null means "resume from now" (no prior cursor, e.g. a fresh SSE
+// connection). Tenant/principal scope always comes from the authenticated
+// caller context, never from this request body (R-SEC-03).
+export const ChangeFeedResumeQuerySchema = z.strictObject({
+  cursor: ChangeFeedCursorSchema.nullable(),
+});
+export type ChangeFeedResumeQuery = z.infer<typeof ChangeFeedResumeQuerySchema>;
+
+const ChangeFeedOkSchema = z.strictObject({
+  kind: z.literal("ok"),
+  invalidations: z.array(InvalidationEnvelopeSchema).readonly(),
+  nextCursor: ChangeFeedCursorSchema,
+});
+
+// Sent when a resume cursor is no longer valid; the caller must invalidate
+// all affected cached queries rather than trust a partial replay
+// (02-sync-lifecycle "Client invalidation and recovery").
+const ChangeFeedResyncRequiredSchema = z.strictObject({
+  kind: z.literal("resyncRequired"),
+});
+
+export const ChangeFeedResponseSchema = z.discriminatedUnion("kind", [
+  ChangeFeedOkSchema,
+  ChangeFeedResyncRequiredSchema,
+]);
+export type ChangeFeedResponse = z.infer<typeof ChangeFeedResponseSchema>;


### PR DESCRIPTION
## Summary

Adds the fifth provider-neutral Zod contract packet for Compass Sync, completing **Phase A** (additive shared contracts) of the internal architecture packet's ledger (item **S05** of `07-commit-ledger.md`):

- **`packages/core/src/types/sync/busy.contracts.ts`**: freshness-aware busy queries. `BusyIntervalSchema` is a half-open interval carrying only start/end — no calendar id or event content (R-SEC-04 privacy). `BusyQuerySchema` bounds the range to 366 days (R-AVAIL-06's "at least 12 months" is a floor this ceiling satisfies). `BusyQueryResponseSchema` couples completeness to bookability with two refines: `complete` must agree with an empty `incompleteCalendars` list, and `bookable` can only be true when `complete` is true — the fail-closed rule from R-AVAIL-04, enforced at the type level so a stale/incomplete result can't be marked bookable.
- **`packages/core/src/types/sync/change-feed.contracts.ts`**: the resumable internal change feed. A discriminated `SyncInvalidationSchema` (connection/calendar/event/command/importProgress) carries only ids — never event content — so the browser always refetches canonical state. `ImportProgressSchema` refuses to report `complete` before every discovered calendar finishes (R-CLIENT-05: no implying completion from partial data). `ChangeFeedResponseSchema` is either `ok` (invalidations + next cursor) or a bare `resyncRequired` for when a resume cursor is no longer valid.

Purely additive — nothing imports these yet, no runtime behavior changes.

An independent correctness review (code-reviewer agent) ran against the diff, specifically verifying the 366-day boundary arithmetic (2026 is a common year, so the accept/reject boundary tests land exactly on 366/367 days), the chained-refine composition on both busy schemas, the one-directional `ImportProgress` implication, and that the privacy `strictObject` rejections are genuine (not passing for the wrong reason). No findings.

## Simplicity

`BusyIntervalSchema` and `BusyQuerySchema` each repeated the same `Date.parse(end) > Date.parse(start)` predicate, so a follow-up commit extracts `isEndAfterStart` once and reuses it in both refines (2 occurrences → 1). Scoped to this file; the same pattern appears in five pre-existing sites across other contract files, which I deliberately left alone (out of this diff's scope, and unifying across files would be a separate change). No `useEffect`/`useRef`/`useState` — schema-only, no React.

## Manual Testing Steps

Not browser-observable (additive type contracts, no UI/route wiring). Equivalent CLI verification:

- [ ] `bun run test:core` — expect 254 pass, 0 fail
- [ ] `bun run type-check` — expect a clean exit
- [ ] `bunx biome check packages/core/src/types/sync/` — expect no errors

## Test plan

- [x] `bun run test:core` — 254 pass, 0 fail (259 expect() calls)
- [x] `bun run type-check` — clean
- [x] `bunx biome check` on touched files — clean
- [x] Independent correctness review (code-reviewer agent) — no findings at or above confidence threshold; refine composition, boundary math, and privacy-rejection test validity all verified
