### PR TITLE
feat(sync): scaffold standalone service package

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -157,7 +157,7 @@ state that nothing else needs), keep it — but say why in the commit message
 ## Repo-Specific Conventions
 
 - Use path aliases, not deep relative imports: `@compass/core`,
-  `@compass/backend`, `@compass/scripts`, `@web/*`, `@core/*`
+  `@compass/backend`, `@compass/scripts`, `@compass/sync`, `@web/*`, `@core/*`
 - Shared web/backend contracts belong in `packages/core` and use Zod — match
   the existing import style in the file you're editing
 - Zustand stores follow store + module actions + plain selectors (see
@@ -230,6 +230,7 @@ Match the check to the packages actually touched — don't default to a broad
 suite:
 
 - `packages/core` changes → `bun run test:core`
+- `packages/sync` changes → `bun run test:sync`
 - `packages/web` changes → `bun run test:web`
 - `packages/backend` changes → `bun run test:backend`
 - `packages/scripts` changes → `bun run test:scripts`

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [core, web, backend, scripts]
+        project: [core, sync, web, backend, scripts]
 
     steps:
       - name: Check out Git repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ cp compass.example.yaml compass.yaml
 bun install
 bun dev:web
 bun dev:backend
+bun dev:sync
 bun test:core
+bun test:sync
 bun test:web
 bun test:backend
 bun test:scripts
@@ -35,6 +37,7 @@ bun lint:fix
 Validation defaults:
 
 - Core: `bun test:core`
+- Sync: `bun test:sync`
 - Web: `bun test:web`
 - Backend: `bun test:backend`
 - Scripts: `bun test:scripts`
@@ -57,6 +60,7 @@ Validation defaults:
   - `@compass/backend` -> `packages/backend/src`
   - `@compass/core` -> `packages/core/src`
   - `@compass/scripts` -> `packages/scripts/src`
+  - `@compass/sync` -> `packages/sync/src`
   - `@web/*` -> `packages/web/src/*`
   - `@core/*` -> `packages/core/src/*`
 - Shared web/backend contracts belong in `packages/core` and should use Zod.

--- a/biome.json
+++ b/biome.json
@@ -81,11 +81,18 @@
           "level": "on",
           "options": {
             "groups": [
-              [":PACKAGE:", "!@core/**", "!@web/**", "!@backend/**"],
-              ["@*", "!@core/**", "!@web/**", "!@backend/**"],
+              [
+                ":PACKAGE:",
+                "!@core/**",
+                "!@web/**",
+                "!@backend/**",
+                "!@sync/**"
+              ],
+              ["@*", "!@core/**", "!@web/**", "!@backend/**", "!@sync/**"],
               ["@core/**", "!@core"],
               ["@web/**", "!@web"],
               ["@backend/**", "!@backend"],
+              ["@sync/**", "!@sync"],
               ":PATH:"
             ]
           }

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@types/node": "^22.13.10",
         "@types/node-fetch": "^2.6.13",
         "axe-core": "^4.12.1",
-        "typescript": "^7.0.2",
+        "typescript": "7.0.2",
       },
     },
     "packages/backend": {
@@ -84,6 +84,18 @@
         "@types/node": "^24.7.2",
         "mongodb-memory-server": "^9.2.0",
         "typescript": "^7.0.2",
+      },
+    },
+    "packages/sync": {
+      "name": "@compass/sync",
+      "version": "1.0.0",
+      "dependencies": {
+        "@compass/core": "1.0.0",
+        "tslib": "^2.4.0",
+      },
+      "devDependencies": {
+        "@faker-js/faker": "^9.6.0",
+        "@types/node": "^22.13.10",
       },
     },
     "packages/web": {
@@ -196,6 +208,8 @@
     "@compass/core": ["@compass/core@workspace:packages/core"],
 
     "@compass/scripts": ["@compass/scripts@workspace:packages/scripts"],
+
+    "@compass/sync": ["@compass/sync@workspace:packages/sync"],
 
     "@compass/web": ["@compass/web@workspace:packages/web"],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "_moduleAliases": {
     "@compass/backend": "packages/backend/src",
     "@compass/core": "packages/core/src",
-    "@compass/scripts": "packages/scripts/src"
+    "@compass/scripts": "packages/scripts/src",
+    "@compass/sync": "packages/sync/src"
   },
   "scripts": {
     "cli": "bun packages/scripts/src/cli.ts",
@@ -21,19 +22,21 @@
     "dev:backend -verbose": "export DEBUG=* &&bun run dev:backend",
     "dev:backend": "bun run dev:ports backend && cd packages/backend && bun --watch src/app.ts",
     "dev:ports": "bun packages/scripts/src/commands/dev-ports.ts",
+    "dev:sync": "cd packages/sync && bun --watch src/app.ts",
     "dev:update": "git checkout main && git pull &&bun install",
     "dev:web": "bun run dev:ports web && cd packages/web &&bun run dev.ts",
     "lint": "bun packages/scripts/src/testing/check-semantic-colors.ts && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "test": "bun test:core && bun test:web && bun test:backend && bun test:scripts",
+    "test": "bun test:core && bun test:sync && bun test:web && bun test:backend && bun test:scripts",
     "test:a11y": "bunx playwright test e2e/accessibility",
     "test:e2e": "bunx playwright test",
     "test:backend": "bun packages/scripts/src/testing/run-tests.ts backend",
     "test:backend:fast": "bun packages/scripts/src/testing/run-tests.ts backend --tier fast",
     "test:backend:db": "bun packages/scripts/src/testing/run-tests.ts backend --tier db",
     "test:core": "bun test packages/core/src --preload ./packages/scripts/src/testing/core.preload.ts",
+    "test:sync": "bun test packages/sync/src --preload ./packages/sync/src/__tests__/sync.preload.ts",
     "test:web": "bun test --cwd packages/web",
     "test:scripts": "bun packages/scripts/src/testing/run-tests.ts scripts",
     "test:scripts:fast": "bun packages/scripts/src/testing/run-tests.ts scripts --tier fast",

--- a/packages/scripts/src/testing/verify.ts
+++ b/packages/scripts/src/testing/verify.ts
@@ -26,11 +26,12 @@ type BunRuntime = {
 
 const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
 
-const VALID_PACKAGES = ["core", "web", "backend", "scripts"] as const;
+const VALID_PACKAGES = ["core", "sync", "web", "backend", "scripts"] as const;
 type Package = (typeof VALID_PACKAGES)[number];
 
 const PACKAGE_PREFIXES: Record<string, Package> = {
   "packages/core/": "core",
+  "packages/sync/": "sync",
   "packages/web/": "web",
   "packages/backend/": "backend",
   "packages/scripts/": "scripts",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@compass/sync",
+  "description": "Compass Sync service — provider state, sync work, and connection health",
+  "license": "MIT",
+  "version": "1.0.0",
+  "main": "build/src/app.js",
+  "dependencies": {
+    "@compass/core": "1.0.0",
+    "tslib": "^2.4.0"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^9.6.0",
+    "@types/node": "^22.13.10"
+  }
+}

--- a/packages/sync/src/__tests__/sync.preload.ts
+++ b/packages/sync/src/__tests__/sync.preload.ts
@@ -1,0 +1,8 @@
+// sort-imports-ignore
+// Test preload for @compass/sync. Mirrors the core preload: apply the
+// bun:test → jest API compatibility shim so sync tests may use jest.fn/spyOn
+// like the other packages, and pin the test environment.
+import "@scripts/testing/core.jest-compat";
+
+process.env["NODE_ENV"] = "test";
+process.env["LOG_LEVEL"] = "debug";

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,0 +1,18 @@
+import { syncServiceIdentity } from "@sync/service-identity";
+
+// Entry point for the Compass Sync service (ledger S07). Intentionally inert:
+// the scaffold builds and starts but does no provider, storage, or HTTP work
+// yet. Configuration (S08), process lifecycle/health (S09), internal auth
+// (S10), and isolated Mongo storage (S11) land in later commits. This keeps
+// the standalone package deployable and type-checked before it does anything
+// user-facing (00-architecture-overview.md "Deployment and scaling").
+
+export function describeSyncService(): string {
+  return `${syncServiceIdentity.name} scaffold ready`;
+}
+
+// Only run when invoked directly (bun packages/sync/src/app.ts), not on import
+// from tests.
+if (import.meta.main) {
+  console.log(describeSyncService());
+}

--- a/packages/sync/src/service-identity.test.ts
+++ b/packages/sync/src/service-identity.test.ts
@@ -1,0 +1,13 @@
+import { describeSyncService } from "@sync/app";
+import { SYNC_SERVICE_NAME, syncServiceIdentity } from "@sync/service-identity";
+
+describe("Sync service scaffold", () => {
+  it("exposes the canonical service name", () => {
+    expect(SYNC_SERVICE_NAME).toBe("compass-sync");
+    expect(syncServiceIdentity.name).toBe(SYNC_SERVICE_NAME);
+  });
+
+  it("loads and describes itself without side effects", () => {
+    expect(describeSyncService()).toBe("compass-sync scaffold ready");
+  });
+});

--- a/packages/sync/src/service-identity.ts
+++ b/packages/sync/src/service-identity.ts
@@ -1,0 +1,13 @@
+// Stable identity for the Compass Sync service (ledger S07). Kept as a plain
+// constant so health telemetry (S44) and internal-auth (S10) can reference one
+// canonical service name rather than string literals. PostHog's `service.name`
+// dimension uses this value (04-security-and-observability.md).
+export const SYNC_SERVICE_NAME = "compass-sync";
+
+export interface SyncServiceIdentity {
+  readonly name: string;
+}
+
+export const syncServiceIdentity: SyncServiceIdentity = {
+  name: SYNC_SERVICE_NAME,
+};

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**"],
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "inlineSourceMap": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "include": [
     "packages/core/src/**/*.ts",
     "packages/backend/src/**/*.ts",
+    "packages/sync/src/**/*.ts",
     "packages/scripts/src/**/*.ts",
     "packages/scripts/src/**/*.d.ts",
     "packages/scripts/src/commands/dev.js"
@@ -64,6 +65,7 @@
       "@core/*": ["./packages/core/src/*"],
       "@web/*": ["./packages/web/src/*"],
       "@backend/*": ["./packages/backend/src/*"],
+      "@sync/*": ["./packages/sync/src/*"],
       "@scripts/*": ["./packages/scripts/src/*"]
     },
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
## Summary

Begins **Phase B** (inert service and storage foundation) of the Compass Sync design packet (ledger item **S07** of `07-commit-ledger.md`): scaffolds `packages/sync` as a standalone monorepo workspace.

- **`packages/sync/`**: a new package with a minimal service-identity module (`SYNC_SERVICE_NAME = "compass-sync"`, referenced later by health telemetry and internal auth) and an inert `app.ts` entrypoint. The scaffold builds, type-checks, and starts (`bun packages/sync/src/app.ts` prints a readiness line), but does **no** provider, storage, or HTTP work yet — configuration (S08), lifecycle/health (S09), internal auth (S10), and isolated Mongo storage (S11) land in later commits. Concrete imports, no barrel files.
- **Full monorepo wiring** so the package is a first-class citizen alongside core/backend/scripts: `@sync/*` tsconfig path alias + `include`, `@compass/sync` module alias, `test:sync` and `dev:sync` scripts (plus `test:sync` in the aggregate `test` script), `sync` added to `verify.ts` package selection, the CI unit-test matrix, the `biome.json` import-organize groups, and the `AGENTS.md` / simplify-skill package enumerations.

Purely additive and inert — nothing imports `@sync/*` from other packages, and no existing behavior changes.

An independent correctness review (code-reviewer agent) audited the wiring against every place packages are enumerated in the repo (tsconfig, package.json, biome.json, CI workflows, verify.ts, run-tests.ts, Docker/deploy, AGENTS.md, skill docs). It confirmed the core wiring correct and flagged three enumeration sites initially missed — the CI test matrix, the biome import groups, and the AGENTS.md/skill docs — all three now fixed and included in this commit. It confirmed no build/type-check/CI-breaking issues and that Docker/deploy wiring correctly has no sync entry yet (deployment is S17).

## Simplicity

No simplification opportunities — a minimal scaffold with no duplication. No `useEffect`/`useRef`/`useState` (no React; this is a backend service package).

## Manual Testing Steps

Not browser-observable (a new backend service package, inert). CLI verification a reviewer can run:

- [ ] `bun install` then `bun run test:sync` — expect 2 pass, 0 fail
- [ ] `bun packages/sync/src/app.ts` — expect it to print `compass-sync scaffold ready` and exit 0
- [ ] `bun run type-check` — expect a clean exit (now includes `packages/sync/src`)
- [ ] `bun run lint` — expect exit 0 (only pre-existing `packages/web` class-sort warnings)

## Test plan

- [x] `bun run test:sync` — 2 pass, 0 fail
- [x] `bun packages/sync/src/app.ts` — prints readiness line, exits 0
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — wiring-completeness audit; three missed enumeration sites found and fixed before push, no build/CI-breaking issues
