### PR TITLE
feat(sync): validate service configuration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
       "dependencies": {
         "@compass/core": "1.0.0",
         "tslib": "^2.4.0",
+        "zod": "^3.25.76",
       },
       "devDependencies": {
         "@faker-js/faker": "^9.6.0",

--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -47,3 +47,15 @@ supertokens:
 # posthog:
 #   key: REPLACE_WITH_POSTHOG_KEY
 #   host: REPLACE_WITH_POSTHOG_HOST
+
+# Compass Sync service (optional; omit until you run the standalone service).
+# execution defaults to `passive` (health + read-only verification, no provider
+# calls or job claims). mongoUri MUST point at an isolated database/user that
+# cannot read the backend's database.
+# sync:
+#   port: 3010
+#   mongoUri: mongodb+srv://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@cluster/compass_sync?retryWrites=true&w=majority
+#   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
+#   callbackBaseUrl: http://localhost:3010 # public base URL for provider OAuth/webhook callbacks
+#   execution: passive # passive | active
+#   maxConcurrency: 4

--- a/packages/core/src/config/compass.config.test.ts
+++ b/packages/core/src/config/compass.config.test.ts
@@ -62,6 +62,28 @@ describe("compass config", () => {
     expect(config.google?.clientSecret).toBeUndefined();
     expect(config.email).toBeUndefined();
     expect(config.posthog).toBeUndefined();
+    expect(config.sync).toBeUndefined();
+  });
+
+  it("parses the optional sync section when provided", () => {
+    const config = parseCompassConfigText(
+      `${validYaml}
+sync:
+  port: 3010
+  mongoUri: mongodb://localhost:27017/compass_sync
+  internalAuthToken: internal-token
+  callbackBaseUrl: http://localhost:3010
+  execution: passive
+`,
+      "compass.yaml",
+    );
+
+    expect(config.sync?.mongoUri).toBe(
+      "mongodb://localhost:27017/compass_sync",
+    );
+    expect(config.sync?.internalAuthToken).toBe("internal-token");
+    expect(config.sync?.callbackBaseUrl).toBe("http://localhost:3010");
+    expect(config.sync?.execution).toBe("passive");
   });
 
   it("accepts optional sections that are empty because they only contain comments", () => {

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -61,6 +61,20 @@ const CompassConfigSchema = z
         host: optionalString,
       })
       .nullish(),
+    // Compass Sync service configuration. Optional so existing deployments
+    // (and the legacy backend) parse unchanged until Sync is provisioned.
+    // Sync owns its OWN isolated Mongo database (mongoUri) and never reads
+    // the backend's mongo.uri, per the sync-service ownership boundary.
+    sync: z
+      .object({
+        port: z.union([z.string(), z.number()]).optional(),
+        mongoUri: z.string(),
+        internalAuthToken: z.string(),
+        callbackBaseUrl: z.string(),
+        execution: z.enum(["passive", "active"]).optional(),
+        maxConcurrency: z.union([z.string(), z.number()]).optional(),
+      })
+      .nullish(),
   })
   .strict();
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -6,7 +6,8 @@
   "main": "build/src/app.js",
   "dependencies": {
     "@compass/core": "1.0.0",
-    "tslib": "^2.4.0"
+    "tslib": "^2.4.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",

--- a/packages/sync/src/config/sync.config.test.ts
+++ b/packages/sync/src/config/sync.config.test.ts
@@ -1,0 +1,148 @@
+import { type CompassConfig } from "@core/config/compass.config";
+import {
+  parseSyncConfig,
+  parseSyncConfigFromEnv,
+  SyncConfigSchema,
+} from "@sync/config/sync.config";
+
+const baseSyncSection = () => ({
+  mongoUri: "mongodb+srv://compass_sync:pw@cluster/compass_sync",
+  internalAuthToken: "internal-token",
+  callbackBaseUrl: "https://staging.compasscalendar.com",
+});
+
+const compassConfigWithSync = (
+  syncOverrides: Record<string, unknown> = {},
+): CompassConfig =>
+  ({
+    runtime: { nodeEnv: "staging", timezone: "Etc/UTC" },
+    sync: { ...baseSyncSection(), ...syncOverrides },
+  }) as unknown as CompassConfig;
+
+const baseEnv = () => ({
+  NODE_ENV: "test",
+  SYNC_MONGO_URI: "mongodb://localhost:27017/compass_sync",
+  SYNC_INTERNAL_AUTH_TOKEN: "internal-token",
+  SYNC_CALLBACK_BASE_URL: "http://localhost:3010",
+});
+
+describe("Sync service configuration", () => {
+  describe("SyncConfigSchema defaults", () => {
+    it("defaults execution to passive when omitted (safety default)", () => {
+      const config = parseSyncConfig(compassConfigWithSync());
+      expect(config.EXECUTION).toBe("passive");
+    });
+
+    it("defaults the port and concurrency when omitted", () => {
+      const config = parseSyncConfig(compassConfigWithSync());
+      expect(config.PORT).toBe(3010);
+      expect(config.MAX_CONCURRENCY).toBe(4);
+    });
+
+    it("accepts an explicit active execution mode", () => {
+      const config = parseSyncConfig(
+        compassConfigWithSync({ execution: "active" }),
+      );
+      expect(config.EXECUTION).toBe("active");
+    });
+
+    it("coerces a yaml numeric string port to a number", () => {
+      const config = parseSyncConfig(compassConfigWithSync({ port: "4010" }));
+      expect(config.PORT).toBe(4010);
+    });
+  });
+
+  describe("required fields", () => {
+    it("throws a clear error when the sync section is absent", () => {
+      const config = { runtime: { nodeEnv: "staging", timezone: "Etc/UTC" } };
+      expect(() => parseSyncConfig(config as unknown as CompassConfig)).toThrow(
+        /sync.*section/i,
+      );
+    });
+
+    it.each([
+      "mongoUri",
+      "internalAuthToken",
+      "callbackBaseUrl",
+    ])("rejects a config missing %s", (field) => {
+      const section = baseSyncSection() as Record<string, unknown>;
+      delete section[field];
+      const config = {
+        runtime: { nodeEnv: "staging", timezone: "Etc/UTC" },
+        sync: section,
+      };
+      expect(() =>
+        parseSyncConfig(config as unknown as CompassConfig),
+      ).toThrow();
+    });
+
+    it("rejects an empty mongoUri", () => {
+      expect(() =>
+        parseSyncConfig(compassConfigWithSync({ mongoUri: "   " })),
+      ).toThrow();
+    });
+  });
+
+  describe("invalid values", () => {
+    it("rejects a non-URL callbackBaseUrl", () => {
+      expect(() =>
+        parseSyncConfig(
+          compassConfigWithSync({ callbackBaseUrl: "not-a-url" }),
+        ),
+      ).toThrow();
+    });
+
+    it("rejects an unknown execution mode", () => {
+      expect(() =>
+        parseSyncConfig(compassConfigWithSync({ execution: "paused" })),
+      ).toThrow();
+    });
+
+    it("rejects a non-positive port", () => {
+      expect(() =>
+        parseSyncConfig(compassConfigWithSync({ port: 0 })),
+      ).toThrow();
+    });
+
+    it("rejects a fractional concurrency", () => {
+      expect(() =>
+        parseSyncConfig(compassConfigWithSync({ maxConcurrency: 2.5 })),
+      ).toThrow();
+    });
+  });
+
+  describe("unknown fields", () => {
+    it("rejects an unknown top-level config field", () => {
+      const result = SyncConfigSchema.safeParse({
+        NODE_ENV: "test",
+        MONGO_URI: "mongodb://localhost/compass_sync",
+        INTERNAL_AUTH_TOKEN: "t",
+        CALLBACK_BASE_URL: "http://localhost:3010",
+        SUPERTOKENS_KEY: "leak",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("parseSyncConfigFromEnv", () => {
+    it("parses a valid environment with the passive default", () => {
+      const config = parseSyncConfigFromEnv(baseEnv());
+      expect(config.EXECUTION).toBe("passive");
+      expect(config.MONGO_URI).toBe("mongodb://localhost:27017/compass_sync");
+    });
+
+    it("reads an explicit execution mode from the environment", () => {
+      const config = parseSyncConfigFromEnv({
+        ...baseEnv(),
+        SYNC_EXECUTION: "active",
+      });
+      expect(config.EXECUTION).toBe("active");
+    });
+
+    it("rejects an environment missing the internal auth token", () => {
+      const env = baseEnv() as Record<string, string | undefined>;
+      env["SYNC_INTERNAL_AUTH_TOKEN"] = undefined;
+      expect(() => parseSyncConfigFromEnv(env)).toThrow();
+    });
+  });
+});

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -1,0 +1,73 @@
+import { z } from "zod/v4";
+import {
+  type CompassConfig,
+  loadCompassConfig,
+} from "@core/config/compass.config";
+import { NodeEnv } from "@core/constants/core.constants";
+
+// Validated configuration for the Compass Sync service (ledger S08).
+// Execution defaults to `passive`: the service starts, serves health, and
+// verifies storage read-only, but must not claim jobs, complete OAuth, accept
+// callbacks, or write to providers. Passive is enforced in code by later
+// commits; here it is the safe default when the field is omitted
+// (07-commit-ledger.md rollout controls).
+
+const SYNC_PORT_DEFAULT = 3010;
+const SYNC_MAX_CONCURRENCY_DEFAULT = 4;
+
+export const SyncExecutionModeSchema = z.enum(["passive", "active"]);
+export type SyncExecutionMode = z.infer<typeof SyncExecutionModeSchema>;
+
+// Coerce yaml numbers-or-strings to a bounded positive integer.
+const PositiveIntFromInput = z.coerce.number().int().positive();
+
+export const SyncConfigSchema = z.strictObject({
+  NODE_ENV: z.enum(NodeEnv),
+  PORT: PositiveIntFromInput.default(SYNC_PORT_DEFAULT),
+  // Isolated `compass_sync` database URI — never the backend's mongo.uri.
+  MONGO_URI: z.string().trim().min(1),
+  // Shared secret authenticating trusted Compass API -> Sync requests.
+  INTERNAL_AUTH_TOKEN: z.string().trim().min(1),
+  // Public base URL provider OAuth redirects and webhooks resolve against
+  // (e.g. https://staging.compasscalendar.com). Must be a valid URL.
+  CALLBACK_BASE_URL: z.url(),
+  EXECUTION: SyncExecutionModeSchema.default("passive"),
+  MAX_CONCURRENCY: PositiveIntFromInput.default(SYNC_MAX_CONCURRENCY_DEFAULT),
+});
+export type SyncConfig = z.infer<typeof SyncConfigSchema>;
+
+export function parseSyncConfig(config: CompassConfig): SyncConfig {
+  if (!config.sync) {
+    throw new Error(
+      "Sync service configuration is missing: add a `sync` section to compass.yaml",
+    );
+  }
+
+  return SyncConfigSchema.parse({
+    NODE_ENV: config.runtime.nodeEnv,
+    PORT: config.sync.port,
+    MONGO_URI: config.sync.mongoUri,
+    INTERNAL_AUTH_TOKEN: config.sync.internalAuthToken,
+    CALLBACK_BASE_URL: config.sync.callbackBaseUrl,
+    EXECUTION: config.sync.execution,
+    MAX_CONCURRENCY: config.sync.maxConcurrency,
+  });
+}
+
+export function parseSyncConfigFromEnv(
+  rawEnv: Record<string, string | undefined>,
+): SyncConfig {
+  return SyncConfigSchema.parse({
+    NODE_ENV: rawEnv["NODE_ENV"],
+    PORT: rawEnv["SYNC_PORT"],
+    MONGO_URI: rawEnv["SYNC_MONGO_URI"],
+    INTERNAL_AUTH_TOKEN: rawEnv["SYNC_INTERNAL_AUTH_TOKEN"],
+    CALLBACK_BASE_URL: rawEnv["SYNC_CALLBACK_BASE_URL"],
+    EXECUTION: rawEnv["SYNC_EXECUTION"],
+    MAX_CONCURRENCY: rawEnv["SYNC_MAX_CONCURRENCY"],
+  });
+}
+
+export function loadSyncConfig(): SyncConfig {
+  return parseSyncConfig(loadCompassConfig());
+}

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -41,3 +41,15 @@ supertokens:
 #   channelExpirationMin: 10
 #   webhookUrl: REPLACE_WITH_GOOGLE_WEBHOOK_URL # e.g. https://cal.yourdomain.com/api
 #   notificationToken: REPLACE_WITH_NOTIFICATION_TOKEN
+
+# Compass Sync service (optional; omit until you run the standalone service).
+# execution defaults to `passive` (health + read-only verification, no provider
+# calls or job claims). mongoUri MUST point at an isolated database/user that
+# cannot read the backend's database.
+# sync:
+#   port: 3010
+#   mongoUri: mongodb://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
+#   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
+#   callbackBaseUrl: https://cal.yourdomain.com # public base URL for provider OAuth/webhook callbacks
+#   execution: passive # passive | active
+#   maxConcurrency: 4


### PR DESCRIPTION
## Summary

Continues **Phase B** of the Compass Sync design packet (ledger item **S08** of `07-commit-ledger.md`): validated configuration for the sync service.

- **`packages/sync/src/config/sync.config.ts`** (new): a strict `SyncConfigSchema` validating the sync service's config — `PORT` (default 3010), isolated `MONGO_URI`, `INTERNAL_AUTH_TOKEN`, `CALLBACK_BASE_URL` (URL-validated), `EXECUTION` (`passive`|`active`), and `MAX_CONCURRENCY`. **`EXECUTION` defaults to `passive`** — the rollout-safety default that later commits enforce in code; there is no input path (omitted key, null, empty, or malformed) that silently yields `active`, only an explicit valid `"active"` string does. Provides `parseSyncConfig` (from the shared config), `parseSyncConfigFromEnv` (test/env path, mirroring the backend's dual pattern), and `loadSyncConfig`.
- **`packages/core/src/config/compass.config.ts`**: registers an optional (`.nullish()`) `sync` section on the shared `CompassConfigSchema` so existing deployments and the legacy backend parse unchanged. The section documents that `mongoUri` must point at an isolated database the backend's user cannot read (enforcement lands with the Mongo bootstrap in S11).
- **`compass.example.yaml` / `self-host/compass.example.yaml`**: a commented `sync:` section, no secrets.

Purely additive — nothing imports the config module yet, and no runtime behavior changes.

An independent correctness review (code-reviewer agent) verified: the passive-default has no silent-unsafe path (every non-`active` input either defaults to passive or fails loudly); the `z.coerce.number().int().positive().default()` chains coerce/reject correctly and the tests genuinely exercise them; the `.nullish()` sync section can't break the backend's parse or the placeholder-detection walk; and `z.enum(NodeEnv)` is valid zod v4 native-enum usage. No findings. Its one sub-threshold note — declaring `zod` as a direct dependency of the new package rather than relying on workspace hoisting — is applied in this commit.

## Simplicity

No simplification opportunities — the config loader mirrors the established backend `parseRawConfig`/`parseConfigFromEnv` pattern rather than inventing a new one, and introduces no duplication. No React.

## Manual Testing Steps

Not browser-observable (backend service config, inert). CLI verification:

- [ ] `bun install` then `bun run test:sync` — expect 19 pass, 0 fail
- [ ] `bun run test:core` — expect a clean run (includes the new shared-config test)
- [ ] `bun run type-check` — clean
- [ ] Confirm a `compass.yaml` with no `sync:` section still loads (backend unaffected): `bun run test:backend` stays green

## Test plan

- [x] `bun run test:sync` — 19 pass, 0 fail (covers passive-default, coercion, missing/invalid/unknown fields, env parsing)
- [x] `bun run test:core` — 482 pass, 0 fail (includes the new sync-section parse test)
- [x] `bun run test:backend` — 677 pass, 0 fail (shared-config change is safe for the backend consumer)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — no findings; passive-default safety confirmed
