### PR TITLE
feat(sync): add service health and shutdown

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,11 +91,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@compass/core": "1.0.0",
+        "express": "^4.17.1",
         "tslib": "^2.4.0",
         "zod": "^3.25.76",
       },
       "devDependencies": {
         "@faker-js/faker": "^9.6.0",
+        "@types/express": "^4.17.13",
         "@types/node": "^22.13.10",
       },
     },

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -6,11 +6,13 @@
   "main": "build/src/app.js",
   "dependencies": {
     "@compass/core": "1.0.0",
+    "express": "^4.17.1",
     "tslib": "^2.4.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
+    "@types/express": "^4.17.13",
     "@types/node": "^22.13.10"
   }
 }

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,18 +1,90 @@
-import { syncServiceIdentity } from "@sync/service-identity";
+import { Logger } from "@core/logger/winston.logger";
+import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
+import { ReadinessRegistry } from "@sync/lifecycle/readiness";
+import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
+import { buildSyncApp } from "@sync/server/sync.server";
+import { buildServiceIdentity } from "@sync/service-identity";
+import { createServer, type Server } from "node:http";
 
-// Entry point for the Compass Sync service (ledger S07). Intentionally inert:
-// the scaffold builds and starts but does no provider, storage, or HTTP work
-// yet. Configuration (S08), process lifecycle/health (S09), internal auth
-// (S10), and isolated Mongo storage (S11) land in later commits. This keeps
-// the standalone package deployable and type-checked before it does anything
-// user-facing (00-architecture-overview.md "Deployment and scaling").
+const logger = Logger("sync:app");
 
-export function describeSyncService(): string {
-  return `${syncServiceIdentity.name} scaffold ready`;
+export interface SyncService {
+  readonly identity: ReturnType<typeof buildServiceIdentity>;
+  readonly readiness: ReadinessRegistry;
+  readonly shutdown: ShutdownCoordinator;
+  readonly httpServer: Server;
 }
 
-// Only run when invoked directly (bun packages/sync/src/app.ts), not on import
-// from tests.
+// Wires the service's lifecycle pieces from a validated config without binding
+// a port or reading a file — so tests can drive it directly. Later commits
+// register storage/scheduler readiness checks and drain tasks against the
+// returned registries (S11+).
+export function createSyncService(config: SyncConfig): SyncService {
+  const identity = buildServiceIdentity({
+    environment: config.NODE_ENV,
+    execution: config.EXECUTION,
+  });
+  const readiness = new ReadinessRegistry();
+  const shutdown = new ShutdownCoordinator();
+
+  const app = buildSyncApp({ identity, readiness });
+  const httpServer = createServer(app);
+
+  shutdown.register("http-server", () => closeHttpServer(httpServer));
+
+  return { identity, readiness, shutdown, httpServer };
+}
+
+function closeHttpServer(httpServer: Server): Promise<void> {
+  if (!httpServer.listening) return Promise.resolve();
+  return new Promise((resolve, reject) =>
+    httpServer.close((error) => (error ? reject(error) : resolve())),
+  );
+}
+
+async function start(): Promise<void> {
+  const config = loadSyncConfig();
+  const service = createSyncService(config);
+
+  registerSignalHandlers(service.shutdown, logger);
+
+  await new Promise<void>((resolve) =>
+    service.httpServer.listen(config.PORT, () => {
+      logger.info(
+        `${service.identity.name} listening on ${config.PORT} (${service.identity.environment}, execution=${service.identity.execution})`,
+      );
+      resolve();
+    }),
+  );
+}
+
+function registerSignalHandlers(
+  shutdown: ShutdownCoordinator,
+  log: ReturnType<typeof Logger>,
+): void {
+  const handle = (signal: NodeJS.Signals) => {
+    if (shutdown.isShuttingDown) return;
+    log.info(`Received ${signal}, draining Sync service`);
+    void shutdown.shutdown().then((errors) => {
+      for (const { name, error } of errors) {
+        log.error(`Shutdown task "${name}" failed`, error);
+      }
+    });
+  };
+
+  process.on("SIGTERM", () => handle("SIGTERM"));
+  process.on("SIGINT", () => handle("SIGINT"));
+  process.on("SIGQUIT", () => handle("SIGQUIT"));
+}
+
+// Retained for the scaffold identity test and quick manual smoke checks.
+export function describeSyncService(): string {
+  return "compass-sync scaffold ready";
+}
+
 if (import.meta.main) {
-  console.log(describeSyncService());
+  start().catch((error) => {
+    logger.error("Sync service failed to start", error);
+    process.exit(1);
+  });
 }

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -13,6 +13,10 @@ export interface SyncService {
   readonly readiness: ReadinessRegistry;
   readonly shutdown: ShutdownCoordinator;
   readonly httpServer: Server;
+  // Graceful stop: close the HTTP front door first (stop admitting new work),
+  // then drain background dependencies in reverse order (workers -> storage).
+  // Idempotent — safe to call from repeated signals or test cleanup.
+  readonly stop: () => Promise<void>;
 }
 
 // Wires the service's lifecycle pieces from a validated config without binding
@@ -30,9 +34,20 @@ export function createSyncService(config: SyncConfig): SyncService {
   const app = buildSyncApp({ identity, readiness });
   const httpServer = createServer(app);
 
-  shutdown.register("http-server", () => closeHttpServer(httpServer));
+  const stop = async (): Promise<void> => {
+    // Phase 1: stop accepting new connections before anything drains, so no
+    // new request can hit a dependency that is about to close.
+    await closeHttpServer(httpServer);
+    // Phase 2: reverse-order teardown of background dependencies. The
+    // coordinator is idempotent, so a second stop() (repeated signal, test
+    // cleanup) does not re-run drains.
+    const errors = await shutdown.shutdown();
+    for (const { name, error } of errors) {
+      logger.error(`Shutdown task "${name}" failed`, error);
+    }
+  };
 
-  return { identity, readiness, shutdown, httpServer };
+  return { identity, readiness, shutdown, httpServer, stop };
 }
 
 function closeHttpServer(httpServer: Server): Promise<void> {
@@ -46,7 +61,7 @@ async function start(): Promise<void> {
   const config = loadSyncConfig();
   const service = createSyncService(config);
 
-  registerSignalHandlers(service.shutdown, logger);
+  registerSignalHandlers(service, logger);
 
   await new Promise<void>((resolve) =>
     service.httpServer.listen(config.PORT, () => {
@@ -59,17 +74,13 @@ async function start(): Promise<void> {
 }
 
 function registerSignalHandlers(
-  shutdown: ShutdownCoordinator,
+  service: SyncService,
   log: ReturnType<typeof Logger>,
 ): void {
   const handle = (signal: NodeJS.Signals) => {
-    if (shutdown.isShuttingDown) return;
+    if (service.shutdown.isShuttingDown) return;
     log.info(`Received ${signal}, draining Sync service`);
-    void shutdown.shutdown().then((errors) => {
-      for (const { name, error } of errors) {
-        log.error(`Shutdown task "${name}" failed`, error);
-      }
-    });
+    void service.stop();
   };
 
   process.on("SIGTERM", () => handle("SIGTERM"));

--- a/packages/sync/src/lifecycle/readiness.test.ts
+++ b/packages/sync/src/lifecycle/readiness.test.ts
@@ -1,0 +1,65 @@
+import { ReadinessRegistry } from "@sync/lifecycle/readiness";
+
+describe("ReadinessRegistry", () => {
+  it("reports not ready when no checks are registered (readiness must be earned)", async () => {
+    const registry = new ReadinessRegistry();
+    const report = await registry.report();
+    expect(report.ready).toBe(false);
+    expect(report.checks).toEqual([]);
+  });
+
+  it("reports ready when the only check passes", async () => {
+    const registry = new ReadinessRegistry();
+    registry.register("storage", () => true);
+    const report = await registry.report();
+    expect(report.ready).toBe(true);
+    expect(report.checks).toEqual([{ name: "storage", ready: true }]);
+  });
+
+  it("reports ready only when every check passes", async () => {
+    const registry = new ReadinessRegistry();
+    registry.register("storage", () => true);
+    registry.register("indexes", () => true);
+    registry.register("scheduler", () => false);
+    const report = await registry.report();
+    expect(report.ready).toBe(false);
+    expect(report.checks.find((c) => c.name === "scheduler")?.ready).toBe(
+      false,
+    );
+  });
+
+  it("awaits async checks", async () => {
+    const registry = new ReadinessRegistry();
+    registry.register("storage", async () => true);
+    const report = await registry.report();
+    expect(report.ready).toBe(true);
+  });
+
+  it("treats a throwing check as not ready and captures the message", async () => {
+    const registry = new ReadinessRegistry();
+    registry.register("storage", () => {
+      throw new Error("mongo unreachable");
+    });
+    const report = await registry.report();
+    expect(report.ready).toBe(false);
+    expect(report.checks[0]?.detail).toBe("mongo unreachable");
+  });
+
+  it("treats a rejected async check as not ready", async () => {
+    const registry = new ReadinessRegistry();
+    registry.register("storage", async () => {
+      throw new Error("timed out");
+    });
+    const report = await registry.report();
+    expect(report.ready).toBe(false);
+    expect(report.checks[0]?.detail).toBe("timed out");
+  });
+
+  it("rejects a duplicate check name", () => {
+    const registry = new ReadinessRegistry();
+    registry.register("storage", () => true);
+    expect(() => registry.register("storage", () => true)).toThrow(
+      /already registered/,
+    );
+  });
+});

--- a/packages/sync/src/lifecycle/readiness.ts
+++ b/packages/sync/src/lifecycle/readiness.ts
@@ -1,0 +1,65 @@
+// Readiness tracking for the Compass Sync service (ledger S09).
+//
+// Liveness answers "is the process running" (always true once we respond).
+// Readiness answers "are all required dependencies verified" — storage
+// connectivity, index installation, scheduler, change-feed init. Later commits
+// register real checks; S09 provides the registry and proves a failing check
+// makes the service not-ready. The service must never report ready before its
+// dependencies and indexes are verified (07-commit-ledger.md S09).
+
+export interface ReadinessCheckResult {
+  readonly name: string;
+  readonly ready: boolean;
+  readonly detail?: string;
+}
+
+export interface ReadinessReport {
+  readonly ready: boolean;
+  readonly checks: readonly ReadinessCheckResult[];
+}
+
+// A check returns true (ready) / false (not ready), or throws — a thrown
+// error is treated as not-ready with the error message as detail, so a
+// dependency that blows up can never be mistaken for ready.
+export type ReadinessCheck = () => boolean | Promise<boolean>;
+
+export class ReadinessRegistry {
+  private readonly checks = new Map<string, ReadinessCheck>();
+
+  register(name: string, check: ReadinessCheck): void {
+    if (this.checks.has(name)) {
+      throw new Error(`Readiness check "${name}" is already registered`);
+    }
+    this.checks.set(name, check);
+  }
+
+  async report(): Promise<ReadinessReport> {
+    const results = await Promise.all(
+      [...this.checks].map(([name, check]) => runCheck(name, check)),
+    );
+
+    // With no registered checks the service is not yet ready: readiness must
+    // be earned by verifying at least one dependency, never assumed.
+    const ready = results.length > 0 && results.every((result) => result.ready);
+
+    return { ready, checks: results };
+  }
+}
+
+async function runCheck(
+  name: string,
+  check: ReadinessCheck,
+): Promise<ReadinessCheckResult> {
+  try {
+    const ready = await check();
+    return ready
+      ? { name, ready: true }
+      : { name, ready: false, detail: "check reported not ready" };
+  } catch (error) {
+    return {
+      name,
+      ready: false,
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/sync/src/lifecycle/shutdown.test.ts
+++ b/packages/sync/src/lifecycle/shutdown.test.ts
@@ -1,0 +1,66 @@
+import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
+
+describe("ShutdownCoordinator", () => {
+  it("runs tasks in reverse registration order", async () => {
+    const order: string[] = [];
+    const coordinator = new ShutdownCoordinator();
+    coordinator.register("storage", () => {
+      order.push("storage");
+    });
+    coordinator.register("workers", () => {
+      order.push("workers");
+    });
+    coordinator.register("http", () => {
+      order.push("http");
+    });
+
+    await coordinator.shutdown();
+
+    // Last registered (http) drains first, storage (registered first) last.
+    expect(order).toEqual(["http", "workers", "storage"]);
+  });
+
+  it("awaits async tasks", async () => {
+    const order: string[] = [];
+    const coordinator = new ShutdownCoordinator();
+    coordinator.register("slow", async () => {
+      await Promise.resolve();
+      order.push("slow");
+    });
+    coordinator.register("fast", () => {
+      order.push("fast");
+    });
+
+    await coordinator.shutdown();
+    expect(order).toEqual(["fast", "slow"]);
+  });
+
+  it("runs every task even when one throws, and collects the failures", async () => {
+    const order: string[] = [];
+    const coordinator = new ShutdownCoordinator();
+    coordinator.register("storage", () => {
+      order.push("storage");
+    });
+    coordinator.register("broken", () => {
+      throw new Error("drain failed");
+    });
+    coordinator.register("http", () => {
+      order.push("http");
+    });
+
+    const errors = await coordinator.shutdown();
+
+    // http (last) drains, broken throws but does not strand storage (first).
+    expect(order).toEqual(["http", "storage"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.name).toBe("broken");
+  });
+
+  it("flips isShuttingDown once shutdown begins", async () => {
+    const coordinator = new ShutdownCoordinator();
+    expect(coordinator.isShuttingDown).toBe(false);
+    const pending = coordinator.shutdown();
+    expect(coordinator.isShuttingDown).toBe(true);
+    await pending;
+  });
+});

--- a/packages/sync/src/lifecycle/shutdown.test.ts
+++ b/packages/sync/src/lifecycle/shutdown.test.ts
@@ -63,4 +63,18 @@ describe("ShutdownCoordinator", () => {
     expect(coordinator.isShuttingDown).toBe(true);
     await pending;
   });
+
+  it("is idempotent — a second shutdown does not re-run tasks", async () => {
+    let runs = 0;
+    const coordinator = new ShutdownCoordinator();
+    coordinator.register("mongo", () => {
+      runs += 1;
+    });
+
+    await coordinator.shutdown();
+    const secondErrors = await coordinator.shutdown();
+
+    expect(runs).toBe(1);
+    expect(secondErrors).toEqual([]);
+  });
 });

--- a/packages/sync/src/lifecycle/shutdown.ts
+++ b/packages/sync/src/lifecycle/shutdown.ts
@@ -1,0 +1,46 @@
+// Graceful-shutdown coordination for the Compass Sync service (ledger S09).
+//
+// Registered drain tasks run in REVERSE registration order (last started,
+// first stopped), so higher-level work (job claims) drains before the
+// resources it depends on (storage, HTTP). Later commits register real drains:
+// stop claiming new work, then complete or release in-flight leases, then
+// close storage. S09 provides the ordering guarantee and proves one failing
+// drain does not prevent the others from running.
+
+export type ShutdownTask = () => void | Promise<void>;
+
+export interface ShutdownTaskError {
+  readonly name: string;
+  readonly error: unknown;
+}
+
+export class ShutdownCoordinator {
+  private readonly tasks: Array<{ name: string; task: ShutdownTask }> = [];
+  private shuttingDown = false;
+
+  register(name: string, task: ShutdownTask): void {
+    this.tasks.push({ name, task });
+  }
+
+  get isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  // Runs every registered task, in reverse order, even if some throw. Returns
+  // the collected failures so the caller can log them; one broken drain must
+  // never strand the resources registered before it.
+  async shutdown(): Promise<ShutdownTaskError[]> {
+    this.shuttingDown = true;
+    const errors: ShutdownTaskError[] = [];
+
+    for (const { name, task } of [...this.tasks].reverse()) {
+      try {
+        await task();
+      } catch (error) {
+        errors.push({ name, error });
+      }
+    }
+
+    return errors;
+  }
+}

--- a/packages/sync/src/lifecycle/shutdown.ts
+++ b/packages/sync/src/lifecycle/shutdown.ts
@@ -1,11 +1,16 @@
-// Graceful-shutdown coordination for the Compass Sync service (ledger S09).
+// Dependency-drain coordination for the Compass Sync service (ledger S09).
 //
-// Registered drain tasks run in REVERSE registration order (last started,
-// first stopped), so higher-level work (job claims) drains before the
-// resources it depends on (storage, HTTP). Later commits register real drains:
-// stop claiming new work, then complete or release in-flight leases, then
-// close storage. S09 provides the ordering guarantee and proves one failing
-// drain does not prevent the others from running.
+// This coordinator drains BACKGROUND DEPENDENCIES only — job-claim workers,
+// schedulers, and storage clients registered by later commits. It runs tasks
+// in REVERSE registration order so higher-level work (job claims) drains
+// before the storage it depends on: startup acquires storage first, then
+// starts workers, so LIFO teardown stops workers first and closes storage
+// last (04-security-and-observability.md "stops claims ... then closes").
+//
+// The HTTP listener is deliberately NOT a task here. Stopping the front door
+// must happen FIRST (before dependencies drain), so `createSyncService`
+// closes the HTTP server as an explicit first phase, ahead of this coordinator
+// (see app.ts `stop`).
 
 export type ShutdownTask = () => void | Promise<void>;
 
@@ -26,13 +31,15 @@ export class ShutdownCoordinator {
     return this.shuttingDown;
   }
 
-  // Runs every registered task, in reverse order, even if some throw. Returns
-  // the collected failures so the caller can log them; one broken drain must
-  // never strand the resources registered before it.
+  // Runs every registered task once, in reverse order, even if some throw.
+  // Idempotent: a second call is a no-op returning no errors, so a repeated
+  // signal or a double stop() never re-runs a non-idempotent drain (e.g.
+  // closing a Mongo client twice).
   async shutdown(): Promise<ShutdownTaskError[]> {
+    if (this.shuttingDown) return [];
     this.shuttingDown = true;
-    const errors: ShutdownTaskError[] = [];
 
+    const errors: ShutdownTaskError[] = [];
     for (const { name, task } of [...this.tasks].reverse()) {
       try {
         await task();

--- a/packages/sync/src/server/health.routes.ts
+++ b/packages/sync/src/server/health.routes.ts
@@ -1,0 +1,43 @@
+import { type Express, type Request, type Response } from "express";
+import { Status } from "@core/errors/status.codes";
+import { type ReadinessRegistry } from "@sync/lifecycle/readiness";
+import { type StructuredServiceIdentity } from "@sync/service-identity";
+
+// Liveness and readiness endpoints for the Compass Sync service (ledger S09).
+// These are content-free operational probes: they expose service identity and
+// dependency readiness, never user, tenant, or provider data
+// (04-security-and-observability.md — public health routes stay content-free).
+
+export const LIVENESS_PATH = "/health/live";
+export const READINESS_PATH = "/health/ready";
+
+export function registerHealthRoutes(
+  app: Express,
+  deps: {
+    identity: StructuredServiceIdentity;
+    readiness: ReadinessRegistry;
+  },
+): void {
+  // Liveness: the process is up and the event loop is responsive. It does not
+  // check dependencies — a live-but-not-ready service should not be killed,
+  // only kept out of rotation.
+  app.get(LIVENESS_PATH, (_req: Request, res: Response) => {
+    res.status(Status.OK).json({
+      status: "alive",
+      service: deps.identity.name,
+      environment: deps.identity.environment,
+      execution: deps.identity.execution,
+    });
+  });
+
+  // Readiness: every registered dependency check passes. Returns 503 while any
+  // check fails so orchestration keeps traffic away until the service is
+  // genuinely ready (storage connected, indexes installed, etc.).
+  app.get(READINESS_PATH, async (_req: Request, res: Response) => {
+    const report = await deps.readiness.report();
+    res.status(report.ready ? Status.OK : Status.SERVICE_UNAVAILABLE).json({
+      status: report.ready ? "ready" : "not_ready",
+      checks: report.checks,
+    });
+  });
+}

--- a/packages/sync/src/server/sync.server.test.ts
+++ b/packages/sync/src/server/sync.server.test.ts
@@ -1,0 +1,84 @@
+import { NodeEnv } from "@core/constants/core.constants";
+import { createSyncService, type SyncService } from "@sync/app";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { type AddressInfo } from "node:net";
+
+const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: "mongodb://localhost:27017/compass_sync",
+    INTERNAL_AUTH_TOKEN: "token",
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+    ...overrides,
+  }) as SyncConfig;
+
+async function listen(service: SyncService): Promise<string> {
+  await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+  const { port } = service.httpServer.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+describe("Sync HTTP server health endpoints", () => {
+  let service: SyncService;
+
+  afterEach(async () => {
+    await service.shutdown.shutdown();
+  });
+
+  it("serves liveness with structured, content-free identity", async () => {
+    service = createSyncService(testConfig({ EXECUTION: "passive" }));
+    const base = await listen(service);
+
+    const res = await fetch(`${base}/health/live`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "alive",
+      service: "compass-sync",
+      environment: NodeEnv.Test,
+      execution: "passive",
+    });
+  });
+
+  it("reports not-ready with 503 while no dependency checks are registered", async () => {
+    service = createSyncService(testConfig());
+    const base = await listen(service);
+
+    const res = await fetch(`${base}/health/ready`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("not_ready");
+  });
+
+  it("reports ready with 200 once a registered dependency check passes", async () => {
+    service = createSyncService(testConfig());
+    service.readiness.register("storage", () => true);
+    const base = await listen(service);
+
+    const res = await fetch(`${base}/health/ready`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ready");
+  });
+
+  it("reflects the active execution mode on liveness", async () => {
+    service = createSyncService(testConfig({ EXECUTION: "active" }));
+    const base = await listen(service);
+
+    const res = await fetch(`${base}/health/live`);
+    const body = (await res.json()) as { execution: string };
+    expect(body.execution).toBe("active");
+  });
+
+  it("closes the HTTP server on graceful shutdown", async () => {
+    service = createSyncService(testConfig());
+    await listen(service);
+    expect(service.httpServer.listening).toBe(true);
+
+    const errors = await service.shutdown.shutdown();
+    expect(errors).toEqual([]);
+    expect(service.httpServer.listening).toBe(false);
+  });
+});

--- a/packages/sync/src/server/sync.server.test.ts
+++ b/packages/sync/src/server/sync.server.test.ts
@@ -25,7 +25,7 @@ describe("Sync HTTP server health endpoints", () => {
   let service: SyncService;
 
   afterEach(async () => {
-    await service.shutdown.shutdown();
+    await service.stop();
   });
 
   it("serves liveness with structured, content-free identity", async () => {
@@ -72,13 +72,43 @@ describe("Sync HTTP server health endpoints", () => {
     expect(body.execution).toBe("active");
   });
 
-  it("closes the HTTP server on graceful shutdown", async () => {
+  it("closes the HTTP front door on graceful stop", async () => {
     service = createSyncService(testConfig());
     await listen(service);
     expect(service.httpServer.listening).toBe(true);
 
-    const errors = await service.shutdown.shutdown();
-    expect(errors).toEqual([]);
+    await service.stop();
     expect(service.httpServer.listening).toBe(false);
+  });
+
+  it("closes the HTTP listener before draining dependencies", async () => {
+    service = createSyncService(testConfig());
+    await listen(service);
+
+    const events: string[] = [];
+    // A dependency drain (as S11+ will register) records when it runs; the
+    // HTTP listener must already be closed by then.
+    service.shutdown.register("dependency", () => {
+      events.push(
+        service.httpServer.listening ? "http-still-open" : "http-closed",
+      );
+    });
+
+    await service.stop();
+    expect(events).toEqual(["http-closed"]);
+  });
+
+  it("is idempotent — a second stop does not re-run dependency drains", async () => {
+    service = createSyncService(testConfig());
+    await listen(service);
+
+    let drains = 0;
+    service.shutdown.register("dependency", () => {
+      drains += 1;
+    });
+
+    await service.stop();
+    await service.stop();
+    expect(drains).toBe(1);
   });
 });

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -1,0 +1,21 @@
+import express, { type Express } from "express";
+import { type ReadinessRegistry } from "@sync/lifecycle/readiness";
+import { registerHealthRoutes } from "@sync/server/health.routes";
+import { type StructuredServiceIdentity } from "@sync/service-identity";
+
+// Builds the Sync service's HTTP application (ledger S09). S09 mounts only the
+// content-free health probes; internal-auth middleware (S10), connection/OAuth
+// ingress (S24), webhook ingress (S32), and query routes (S25) mount here in
+// later commits. JSON body parsing is enabled now so those routes compose
+// without re-wiring the app.
+export function buildSyncApp(deps: {
+  identity: StructuredServiceIdentity;
+  readiness: ReadinessRegistry;
+}): Express {
+  const app = express();
+  app.use(express.json());
+
+  registerHealthRoutes(app, deps);
+
+  return app;
+}

--- a/packages/sync/src/service-identity.ts
+++ b/packages/sync/src/service-identity.ts
@@ -1,4 +1,6 @@
-// Stable identity for the Compass Sync service (ledger S07). Kept as a plain
+import { type NodeEnv } from "@core/constants/core.constants";
+
+// Stable identity for the Compass Sync service (ledger S07/S09). Kept as a plain
 // constant so health telemetry (S44) and internal-auth (S10) can reference one
 // canonical service name rather than string literals. PostHog's `service.name`
 // dimension uses this value (04-security-and-observability.md).
@@ -11,3 +13,23 @@ export interface SyncServiceIdentity {
 export const syncServiceIdentity: SyncServiceIdentity = {
   name: SYNC_SERVICE_NAME,
 };
+
+// Structured identity surfaced on liveness responses and (later) health
+// telemetry. Environment and execution mode let an operator confirm which
+// deployment and rollout state answered a probe.
+export interface StructuredServiceIdentity {
+  readonly name: string;
+  readonly environment: NodeEnv;
+  readonly execution: "passive" | "active";
+}
+
+export function buildServiceIdentity(input: {
+  environment: NodeEnv;
+  execution: "passive" | "active";
+}): StructuredServiceIdentity {
+  return {
+    name: SYNC_SERVICE_NAME,
+    environment: input.environment,
+    execution: input.execution,
+  };
+}


### PR DESCRIPTION
## Summary

Continues **Phase B** of the Compass Sync design packet (ledger item **S09** of `07-commit-ledger.md`): the service's process-lifecycle machinery — the first commit with real runtime behavior (an Express HTTP server, async readiness, signal handling, graceful shutdown).

- **`lifecycle/readiness.ts`** — a `ReadinessRegistry`: readiness must be *earned* by passing dependency checks. Zero registered checks reports **not** ready; a check that returns false or throws makes the service not-ready (a thrown error can never be mistaken for ready). Storage/index/scheduler checks register here in S11+.
- **`lifecycle/shutdown.ts`** — a `ShutdownCoordinator` that drains background dependencies (workers → storage) in reverse registration order (LIFO teardown: workers stop first, storage closes last), runs every task even if one throws, and is idempotent.
- **`server/health.routes.ts` + `server/sync.server.ts`** — content-free `GET /health/live` (200, structured identity) and `GET /health/ready` (200 ready / 503 not-ready). No user, tenant, or provider data on the probes.
- **`app.ts`** — `createSyncService(config)` wires identity/readiness/shutdown/HTTP server and exposes a graceful `stop()`; `start()` loads config, listens, and registers SIGTERM/SIGINT/SIGQUIT. The file-loading bootstrap runs only under `import.meta.main`, so tests drive the service directly.

Verified by booting the real service against a config file: it logs its listening line, `/health/live` returns `{status:"alive", service:"compass-sync", environment, execution:"passive"}`, and `/health/ready` correctly returns 503 (honest — no dependencies verified yet). Purely additive; nothing else imports this and no existing behavior changes.

**Graceful-shutdown ordering (correctness-review finding, fixed in the second commit):** the independent review caught that folding the HTTP listener into the reverse-order dependency coordinator would, once S11+ registers storage/worker drains, close the front door *last* — letting new requests arrive while the storage they depend on is already torn down. Restructured into two explicit phases in `stop()`: **(1)** close the HTTP listener first (stop admitting new work), **(2)** run the reverse-order dependency drains. Also made the coordinator idempotent so a repeated signal or double `stop()` never re-runs a non-idempotent drain (e.g. closing a Mongo client twice). New tests assert the HTTP listener is closed before any dependency drain runs, and that a second `stop()` is a no-op.

## Simplicity

The two registries have genuinely different semantics (readiness = parallel + aggregate; shutdown = sequential reverse + idempotent), so they stay separate rather than being force-unified. Each file is single-responsibility; no duplication introduced. No React.

## Manual Testing Steps

Not browser-observable (backend service). CLI verification a reviewer can run:

- [ ] `bun install` then `bun run test:sync` — expect 38 pass, 0 fail
- [ ] Boot it against a config: write a `compass.yaml` with a `sync:` section, then `COMPASS_CONFIG_FILE=./compass.yaml bun packages/sync/src/app.ts` — expect a "listening on 3010" log line
- [ ] `curl localhost:3010/health/live` — expect `{"status":"alive",...,"execution":"passive"}`
- [ ] `curl -o /dev/null -w "%{http_code}" localhost:3010/health/ready` — expect `503` (no dependency checks registered yet)
- [ ] `bun run type-check` — clean

## Test plan

- [x] `bun run test:sync` — 38 pass, 0 fail (readiness semantics, reverse-order + idempotent shutdown, two-phase stop ordering, real HTTP liveness/readiness on an ephemeral port)
- [x] Manual boot + curl of both health endpoints (liveness 200, readiness 503) — verified
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — one high-confidence finding (shutdown ordering) fixed and re-verified before push; signal-handler re-entrancy, readiness semantics, and health routes confirmed correct
