### PR TITLE
feat(sync): initialize isolated mongo storage

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -120,7 +120,7 @@ jobs:
       # backend and scripts boot an in-memory MongoDB; cache the downloaded
       # mongod binary so each run doesn't re-fetch it.
       - name: Cache MongoDB binaries
-        if: matrix.project == 'backend' || matrix.project == 'scripts'
+        if: matrix.project == 'backend' || matrix.project == 'scripts' || matrix.project == 'sync'
         uses: actions/cache@v5
         with:
           path: ~/.cache/mongodb-binaries

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
       "dependencies": {
         "@compass/core": "1.0.0",
         "express": "^4.17.1",
+        "mongodb": "^7.2.0",
         "tslib": "^2.4.0",
         "zod": "^3.25.76",
       },
@@ -99,6 +100,7 @@
         "@faker-js/faker": "^9.6.0",
         "@types/express": "^4.17.13",
         "@types/node": "^22.13.10",
+        "mongodb-memory-server": "^9.2.0",
       },
     },
     "packages/web": {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -7,12 +7,14 @@
   "dependencies": {
     "@compass/core": "1.0.0",
     "express": "^4.17.1",
+    "mongodb": "^7.2.0",
     "tslib": "^2.4.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
     "@types/express": "^4.17.13",
-    "@types/node": "^22.13.10"
+    "@types/node": "^22.13.10",
+    "mongodb-memory-server": "^9.2.0"
   }
 }

--- a/packages/sync/src/__tests__/helpers/mongo-memory.ts
+++ b/packages/sync/src/__tests__/helpers/mongo-memory.ts
@@ -1,0 +1,30 @@
+import { MongoMemoryReplSet } from "mongodb-memory-server";
+
+// In-memory Mongo for the sync test suite. Mirrors the backend helper's two
+// modes: in launcher mode (run-tests.ts) each worker reuses the shared
+// per-file URI from COMPASS_TEST_MONGO_URI; standalone, a single file starts
+// its own throwaway replica set. A replica set (not standalone) is required
+// because Sync uses multi-document transactions in later commits.
+
+let server: MongoMemoryReplSet | undefined;
+
+export async function startMemoryMongo(): Promise<string> {
+  const shared = process.env["COMPASS_TEST_MONGO_URI"];
+  if (shared) return shared;
+  if (server) return server.getUri();
+
+  server = await MongoMemoryReplSet.create({
+    replSet: {
+      count: 1,
+      name: "compass-sync-test",
+      storageEngine: "wiredTiger",
+    },
+  });
+  return server.getUri();
+}
+
+export async function stopMemoryMongo(): Promise<void> {
+  if (!server) return;
+  await server.stop();
+  server = undefined;
+}

--- a/packages/sync/src/__tests__/sync.preload.ts
+++ b/packages/sync/src/__tests__/sync.preload.ts
@@ -1,8 +1,21 @@
 // sort-imports-ignore
-// Test preload for @compass/sync. Mirrors the core preload: apply the
-// bun:test → jest API compatibility shim so sync tests may use jest.fn/spyOn
-// like the other packages, and pin the test environment.
+// Test preload for @compass/sync. Applies the bun:test -> jest API shim so
+// sync tests may use jest.fn/spyOn like the other packages, pins the test
+// environment, and starts one in-memory Mongo replica set for the process.
+// Storage tests isolate themselves with per-test database names.
 import "@scripts/testing/core.jest-compat";
+import {
+  startMemoryMongo,
+  stopMemoryMongo,
+} from "@sync/__tests__/helpers/mongo-memory";
+import { afterAll } from "bun:test";
 
 process.env["NODE_ENV"] = "test";
 process.env["LOG_LEVEL"] = "debug";
+
+const uri = await startMemoryMongo();
+process.env["SYNC_MONGO_URI"] = uri;
+
+afterAll(async () => {
+  await stopMemoryMongo();
+});

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -4,6 +4,7 @@ import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
 import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { createServer, type Server } from "node:http";
 
 const logger = Logger("sync:app");
@@ -57,9 +58,29 @@ function closeHttpServer(httpServer: Server): Promise<void> {
   );
 }
 
+// The Compass API database Sync's least-privilege user must not be able to
+// read. Only enforced in staging/production, where the scoped Atlas user runs.
+const COMPASS_API_DATABASE = "prod_calendar";
+
 async function start(): Promise<void> {
   const config = loadSyncConfig();
   const service = createSyncService(config);
+
+  // Connect storage before listening. Register the disconnect drain first so,
+  // under the coordinator's reverse-order teardown, storage closes LAST — after
+  // any workers that depend on it (S33). Registering the readiness check means
+  // /health/ready stays 503 until the connection and indexes are verified.
+  const mongo = new SyncMongoService();
+  service.shutdown.register("mongo", () => mongo.disconnect());
+  await mongo.connect({
+    uri: config.MONGO_URI,
+    forbiddenDatabaseName: COMPASS_API_DATABASE,
+    nodeEnv: config.NODE_ENV,
+  });
+  service.readiness.register("storage", async () => {
+    await mongo.db.command({ ping: 1 });
+    return true;
+  });
 
   registerSignalHandlers(service, logger);
 

--- a/packages/sync/src/storage/collections.ts
+++ b/packages/sync/src/storage/collections.ts
@@ -1,0 +1,18 @@
+// Collection names for the isolated `compass_sync` database (ledger S11).
+// One document per connection, calendar, event, occurrence, resource, command,
+// job, and deletion marker — never growing per-user arrays (01-domain-model.md
+// "Collections and essential indexes"). Repositories for these land in S12-S14;
+// S11 owns the bootstrap that creates them with their indexes.
+export const SYNC_COLLECTIONS = {
+  providerConnections: "provider_connections",
+  providerCalendars: "provider_calendars",
+  events: "events",
+  eventOccurrences: "event_occurrences",
+  syncResources: "sync_resources",
+  commands: "commands",
+  jobs: "jobs",
+  deletionMarkers: "deletion_markers",
+} as const;
+
+export type SyncCollectionName =
+  (typeof SYNC_COLLECTIONS)[keyof typeof SYNC_COLLECTIONS];

--- a/packages/sync/src/storage/index-manifest.test.ts
+++ b/packages/sync/src/storage/index-manifest.test.ts
@@ -83,4 +83,35 @@ describe("installIndexManifest", () => {
       Object.values(SYNC_COLLECTIONS).sort(),
     );
   });
+
+  it("allows many unlinked events while still rejecting duplicate provider identities", async () => {
+    await installIndexManifest(db);
+    const events = db.collection(SYNC_COLLECTIONS.events);
+
+    // Multiple unlinked events store provider fields as null; the partial
+    // unique index must not collide them (regression for the sparse hazard).
+    await events.insertOne({
+      principalId: "p",
+      connectionId: null,
+      calendarId: null,
+      providerEventId: null,
+    });
+    await events.insertOne({
+      principalId: "p",
+      connectionId: null,
+      calendarId: null,
+      providerEventId: null,
+    });
+    expect(await events.countDocuments()).toBe(2);
+
+    // Two genuinely linked events with the same provider identity DO collide.
+    const linked = {
+      principalId: "p",
+      connectionId: "c",
+      calendarId: "cal",
+      providerEventId: "evt-1",
+    };
+    await events.insertOne(linked);
+    await expect(events.insertOne({ ...linked })).rejects.toThrow();
+  });
 });

--- a/packages/sync/src/storage/index-manifest.test.ts
+++ b/packages/sync/src/storage/index-manifest.test.ts
@@ -1,0 +1,86 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  installIndexManifest,
+  SYNC_INDEX_MANIFEST,
+} from "@sync/storage/index-manifest";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+
+describe("installIndexManifest", () => {
+  let client: MongoClient;
+  let db: Db;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    // Unique database per test so files/tests never collide on the shared server.
+    db = client.db(`manifest_${faker.database.mongodbObjectId()}`);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("creates every declared collection", async () => {
+    await installIndexManifest(db);
+    const names = new Set(
+      (await db.listCollections({}, { nameOnly: true }).toArray()).map(
+        (c) => c.name,
+      ),
+    );
+    for (const collection of Object.values(SYNC_COLLECTIONS)) {
+      expect(names.has(collection)).toBe(true);
+    }
+  });
+
+  it("creates the declared indexes for a collection", async () => {
+    await installIndexManifest(db);
+    const indexes = await db.collection(SYNC_COLLECTIONS.commands).indexes();
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain("idempotency_key");
+    const idempotency = indexes.find((i) => i.name === "idempotency_key");
+    expect(idempotency?.unique).toBe(true);
+  });
+
+  it("is idempotent — running twice does not throw", async () => {
+    await installIndexManifest(db);
+    await installIndexManifest(db);
+    const indexes = await db
+      .collection(SYNC_COLLECTIONS.providerConnections)
+      .indexes();
+    // The unique provider-account identity index exists exactly once.
+    expect(
+      indexes.filter((i) => i.name === "provider_account_identity"),
+    ).toHaveLength(1);
+  });
+
+  it("installs a TTL index on deletion markers", async () => {
+    await installIndexManifest(db);
+    const indexes = await db
+      .collection(SYNC_COLLECTIONS.deletionMarkers)
+      .indexes();
+    const ttl = indexes.find((i) => i.name === "ttl_expiry");
+    expect(ttl?.expireAfterSeconds).toBe(0);
+  });
+
+  it("enforces the unique command idempotency key", async () => {
+    await installIndexManifest(db);
+    const commands = db.collection(SYNC_COLLECTIONS.commands);
+    const key = {
+      tenantId: "t",
+      principalId: "p",
+      idempotencyKey: "k",
+    };
+    await commands.insertOne(key);
+    await expect(commands.insertOne(key)).rejects.toThrow();
+  });
+
+  it("covers every collection in the manifest", () => {
+    expect(Object.keys(SYNC_INDEX_MANIFEST).sort()).toEqual(
+      Object.values(SYNC_COLLECTIONS).sort(),
+    );
+  });
+});

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -44,8 +44,16 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
     {
       name: "provider_event_identity",
       key: { connectionId: 1, calendarId: 1, providerEventId: 1 },
-      // Sparse: unlinked Compass events have no provider identity.
-      options: { unique: true, sparse: true },
+      // partialFilterExpression, not sparse: uniqueness must apply only to
+      // genuinely provider-linked events. A sparse index would index an
+      // unlinked event stored with providerEventId=null and then collide all
+      // such events on (null,null,null) — allowing only one unlinked event.
+      // Filtering on a real string providerEventId is robust whether the
+      // repository stores unlinked provider fields as null or absent.
+      options: {
+        unique: true,
+        partialFilterExpression: { providerEventId: { $type: "string" } },
+      },
     },
     { name: "principal_calendar", key: { principalId: 1, calendarId: 1 } },
     {
@@ -105,7 +113,12 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
     {
       name: "provider_event_identity",
       key: { connectionId: 1, calendarId: 1, providerEventId: 1 },
-      options: { unique: true },
+      // Markers are always provider-linked, but filter on a real providerEventId
+      // for the same robustness as the events index (never collide on nulls).
+      options: {
+        unique: true,
+        partialFilterExpression: { providerEventId: { $type: "string" } },
+      },
     },
     // TTL: content-free markers expire 30 days after deletion (R-EVENT-10).
     {

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -1,0 +1,151 @@
+import {
+  type CreateIndexesOptions,
+  type Db,
+  type IndexSpecification,
+} from "mongodb";
+import {
+  SYNC_COLLECTIONS,
+  type SyncCollectionName,
+} from "@sync/storage/collections";
+
+// Declarative index manifests for the `compass_sync` collections (ledger S11),
+// drawn from the essential-index table in 01-domain-model.md. Installation is
+// idempotent: MongoDB createIndex is a no-op when an identical index already
+// exists, so re-running startup never errors. Repositories (S12-S14) rely on
+// these unique identities for atomic upserts and coalescing.
+
+export interface IndexManifestEntry {
+  readonly name: string;
+  readonly key: IndexSpecification;
+  readonly options?: CreateIndexesOptions;
+}
+
+export type IndexManifest = Record<SyncCollectionName, IndexManifestEntry[]>;
+
+export const SYNC_INDEX_MANIFEST: IndexManifest = {
+  [SYNC_COLLECTIONS.providerConnections]: [
+    {
+      name: "provider_account_identity",
+      key: { tenantId: 1, principalId: 1, provider: 1, providerAccountId: 1 },
+      options: { unique: true },
+    },
+    { name: "principal_state", key: { principalId: 1, state: 1 } },
+    { name: "health_age", key: { lastHealthyAt: 1 } },
+  ],
+  [SYNC_COLLECTIONS.providerCalendars]: [
+    {
+      name: "connection_provider_calendar",
+      key: { connectionId: 1, providerCalendarId: 1 },
+      options: { unique: true },
+    },
+    { name: "principal_active", key: { principalId: 1, active: 1 } },
+  ],
+  [SYNC_COLLECTIONS.events]: [
+    {
+      name: "provider_event_identity",
+      key: { connectionId: 1, calendarId: 1, providerEventId: 1 },
+      // Sparse: unlinked Compass events have no provider identity.
+      options: { unique: true, sparse: true },
+    },
+    { name: "principal_calendar", key: { principalId: 1, calendarId: 1 } },
+    {
+      name: "client_event_id",
+      key: { principalId: 1, clientEventId: 1 },
+      options: { sparse: true },
+    },
+  ],
+  [SYNC_COLLECTIONS.eventOccurrences]: [
+    {
+      name: "event_occurrence",
+      key: { eventId: 1, occurrenceKey: 1 },
+      options: { unique: true },
+    },
+    { name: "calendar_start", key: { calendarId: 1, "schedule.start": 1 } },
+    { name: "principal_start", key: { principalId: 1, "schedule.start": 1 } },
+  ],
+  [SYNC_COLLECTIONS.syncResources]: [
+    {
+      name: "connection_resource_calendar",
+      key: { connectionId: 1, resourceKind: 1, calendarId: 1 },
+      options: { unique: true },
+    },
+    {
+      name: "subscription_expiry",
+      key: { subscriptionExpiresAt: 1 },
+      options: { sparse: true },
+    },
+    { name: "last_success", key: { lastSuccessAt: 1 } },
+  ],
+  [SYNC_COLLECTIONS.commands]: [
+    {
+      name: "idempotency_key",
+      key: { tenantId: 1, principalId: 1, idempotencyKey: 1 },
+      options: { unique: true },
+    },
+    { name: "event_state", key: { eventId: 1, "outcome.state": 1 } },
+    { name: "pending_age", key: { createdAt: 1 } },
+  ],
+  [SYNC_COLLECTIONS.jobs]: [
+    {
+      name: "coalescing_key",
+      key: { coalescingKey: 1 },
+      options: { unique: true },
+    },
+    {
+      name: "state_runafter_priority",
+      key: { state: 1, runAfter: 1, priority: -1 },
+    },
+    {
+      name: "lease_expiry",
+      key: { leaseExpiresAt: 1 },
+      options: { sparse: true },
+    },
+  ],
+  [SYNC_COLLECTIONS.deletionMarkers]: [
+    {
+      name: "provider_event_identity",
+      key: { connectionId: 1, calendarId: 1, providerEventId: 1 },
+      options: { unique: true },
+    },
+    // TTL: content-free markers expire 30 days after deletion (R-EVENT-10).
+    {
+      name: "ttl_expiry",
+      key: { expiresAt: 1 },
+      options: { expireAfterSeconds: 0 },
+    },
+  ],
+};
+
+// Creates every collection and its indexes idempotently. Safe to run on every
+// startup and safe to run concurrently across replicas (Mongo serializes
+// index/collection creation and treats an identical spec as a no-op).
+export async function installIndexManifest(
+  db: Db,
+  manifest: IndexManifest = SYNC_INDEX_MANIFEST,
+): Promise<void> {
+  const existing = new Set(
+    (await db.listCollections({}, { nameOnly: true }).toArray()).map(
+      (c) => c.name,
+    ),
+  );
+
+  for (const [collectionName, entries] of Object.entries(manifest)) {
+    if (!existing.has(collectionName)) {
+      // createCollection races harmlessly across replicas: a NamespaceExists
+      // (48) from a concurrent creator is equivalent to success.
+      await db
+        .createCollection(collectionName)
+        .catch((error: { code?: number }) => {
+          if (error?.code !== 48) throw error;
+        });
+    }
+
+    const collection = db.collection(collectionName);
+    for (const entry of entries) {
+      await collection.createIndex(entry.key, {
+        name: entry.name,
+        ...entry.options,
+      });
+    }
+  }
+}

--- a/packages/sync/src/storage/sync-mongo.service.test.ts
+++ b/packages/sync/src/storage/sync-mongo.service.test.ts
@@ -1,0 +1,111 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  assertForbiddenDatabaseUnreachable,
+  SyncMongoService,
+} from "@sync/storage/sync-mongo.service";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+
+const uniqueDbName = () => `svc_${faker.database.mongodbObjectId()}`;
+
+describe("SyncMongoService", () => {
+  let service: SyncMongoService;
+
+  afterEach(async () => {
+    if (service?.isConnected) {
+      await service.db.dropDatabase();
+    }
+    await service?.disconnect();
+  });
+
+  it("connects, installs manifests, and exposes the db", async () => {
+    service = new SyncMongoService();
+    await service.connect({
+      uri,
+      databaseName: uniqueDbName(),
+      forbiddenDatabaseName: "prod_calendar",
+      nodeEnv: NodeEnv.Test,
+    });
+
+    expect(service.isConnected).toBe(true);
+    const names = new Set(
+      (await service.db.listCollections({}, { nameOnly: true }).toArray()).map(
+        (c) => c.name,
+      ),
+    );
+    expect(names.has(SYNC_COLLECTIONS.providerConnections)).toBe(true);
+  });
+
+  it("throws when db is accessed before connecting", () => {
+    service = new SyncMongoService();
+    expect(() => service.db).toThrow(/not connected/);
+  });
+
+  it("fails to connect against an unreachable server", async () => {
+    service = new SyncMongoService();
+    await expect(
+      service.connect({
+        // Reserved TEST-NET address; connection is refused quickly.
+        uri: "mongodb://192.0.2.1:27017/compass_sync?serverSelectionTimeoutMS=500&connectTimeoutMS=500",
+        forbiddenDatabaseName: "prod_calendar",
+        nodeEnv: NodeEnv.Test,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("supports multi-document transactions (replica set)", async () => {
+    service = new SyncMongoService();
+    await service.connect({
+      uri,
+      databaseName: uniqueDbName(),
+      forbiddenDatabaseName: "prod_calendar",
+      nodeEnv: NodeEnv.Test,
+    });
+
+    const collection = service.db.collection(SYNC_COLLECTIONS.jobs);
+    const session = service.client.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await collection.insertOne({ coalescingKey: "a" }, { session });
+        await collection.insertOne({ coalescingKey: "b" }, { session });
+      });
+    } finally {
+      await session.endSession();
+    }
+    expect(await collection.countDocuments()).toBe(2);
+  });
+});
+
+describe("assertForbiddenDatabaseUnreachable (least-privilege logic)", () => {
+  it("passes when the probe is denied with an authorization error", async () => {
+    await expect(
+      assertForbiddenDatabaseUnreachable(() =>
+        Promise.reject({ code: 13, message: "Unauthorized" }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes on an Atlas authorization error code", async () => {
+    await expect(
+      assertForbiddenDatabaseUnreachable(() =>
+        Promise.reject({ code: 8000, message: "AtlasError: not authorized" }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails when the probe SUCCEEDS (over-privileged user)", async () => {
+    await expect(
+      assertForbiddenDatabaseUnreachable(() => Promise.resolve({ ok: 1 })),
+    ).rejects.toThrow(/excessive privileges/);
+  });
+
+  it("rethrows a non-authorization error unchanged", async () => {
+    await expect(
+      assertForbiddenDatabaseUnreachable(() =>
+        Promise.reject(new Error("network down")),
+      ),
+    ).rejects.toThrow("network down");
+  });
+});

--- a/packages/sync/src/storage/sync-mongo.service.test.ts
+++ b/packages/sync/src/storage/sync-mongo.service.test.ts
@@ -43,6 +43,21 @@ describe("SyncMongoService", () => {
     expect(() => service.db).toThrow(/not connected/);
   });
 
+  it("refuses to start in staging when the forbidden database is readable", async () => {
+    // The in-memory server has no auth, so the forbidden database IS reachable.
+    // With enforcement on (staging), the least-privilege guard must detect the
+    // excessive access and abort startup rather than run over-privileged.
+    service = new SyncMongoService();
+    await expect(
+      service.connect({
+        uri,
+        databaseName: uniqueDbName(),
+        forbiddenDatabaseName: "prod_calendar",
+        nodeEnv: NodeEnv.Staging,
+      }),
+    ).rejects.toThrow(/excessive privileges/);
+  });
+
   it("fails to connect against an unreachable server", async () => {
     service = new SyncMongoService();
     await expect(

--- a/packages/sync/src/storage/sync-mongo.service.ts
+++ b/packages/sync/src/storage/sync-mongo.service.ts
@@ -1,0 +1,103 @@
+import { type Db, MongoClient } from "mongodb";
+import { NodeEnv } from "@core/constants/core.constants";
+import { Logger } from "@core/logger/winston.logger";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+
+const logger = Logger("sync:mongo");
+
+// Mongo codes that mean "the database user is not authorized" — the expected,
+// wanted outcome when Sync probes a database it must not reach.
+const UNAUTHORIZED_CODES = new Set([13, 8000]);
+
+export interface SyncMongoOptions {
+  readonly uri: string;
+  // Database Sync owns. Defaults to the database encoded in the URI.
+  readonly databaseName?: string;
+  // A database Sync's least-privilege user must NOT be able to read (the
+  // Compass API's database). Startup fails if Sync can reach it.
+  readonly forbiddenDatabaseName: string;
+  readonly nodeEnv: NodeEnv;
+}
+
+// Owns the connection to the isolated `compass_sync` database (ledger S11).
+// It installs index manifests, verifies the least-privilege user, and never
+// makes cross-database calls into the Compass API's data
+// (01-domain-model.md; 00-architecture ownership boundary).
+export class SyncMongoService {
+  #client?: MongoClient;
+  #db?: Db;
+
+  get db(): Db {
+    if (!this.#db) throw new Error("SyncMongoService is not connected");
+    return this.#db;
+  }
+
+  get client(): MongoClient {
+    if (!this.#client) throw new Error("SyncMongoService is not connected");
+    return this.#client;
+  }
+
+  get isConnected(): boolean {
+    return this.#db !== undefined;
+  }
+
+  async connect(options: SyncMongoOptions): Promise<void> {
+    const client = new MongoClient(options.uri);
+    await client.connect();
+    this.#client = client;
+    this.#db = options.databaseName
+      ? client.db(options.databaseName)
+      : client.db();
+
+    await this.verifyLeastPrivilege(options);
+    await installIndexManifest(this.#db);
+  }
+
+  // In staging/production the Sync user is scoped to `compass_sync`, so a read
+  // of the Compass API database must be denied. Local dev / in-memory tests
+  // have no auth, so the check would false-positive; skip it there and rely on
+  // the injectable unit test for the logic.
+  private async verifyLeastPrivilege(options: SyncMongoOptions): Promise<void> {
+    const enforced =
+      options.nodeEnv === NodeEnv.Staging ||
+      options.nodeEnv === NodeEnv.Production;
+    if (!enforced) {
+      logger.info(
+        `Skipping least-privilege check in ${options.nodeEnv} (no scoped auth)`,
+      );
+      return;
+    }
+
+    await assertForbiddenDatabaseUnreachable(() =>
+      this.#client!.db(options.forbiddenDatabaseName).command({ ping: 1 }),
+    );
+  }
+
+  async disconnect(): Promise<void> {
+    await this.#client?.close();
+    this.#client = undefined;
+    this.#db = undefined;
+  }
+}
+
+// Runs a probe that MUST be rejected for an authorization reason. If the probe
+// resolves, the user is over-privileged and startup must fail. A non-auth
+// rejection (network, etc.) is rethrown unchanged.
+export async function assertForbiddenDatabaseUnreachable(
+  probe: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    await probe();
+  } catch (error) {
+    if (isUnauthorizedError(error)) return;
+    throw error;
+  }
+  throw new Error(
+    "Sync database user can read the Compass API database; refusing to start with excessive privileges",
+  );
+}
+
+function isUnauthorizedError(error: unknown): boolean {
+  const code = (error as { code?: number } | null)?.code;
+  return code !== undefined && UNAUTHORIZED_CODES.has(code);
+}

--- a/packages/sync/src/storage/sync-mongo.service.ts
+++ b/packages/sync/src/storage/sync-mongo.service.ts
@@ -49,8 +49,14 @@ export class SyncMongoService {
       ? client.db(options.databaseName)
       : client.db();
 
-    await this.verifyLeastPrivilege(options);
-    await installIndexManifest(this.#db);
+    try {
+      await this.verifyLeastPrivilege(options);
+      await installIndexManifest(this.#db);
+    } catch (error) {
+      // A failed startup must not leave an open client behind.
+      await this.disconnect();
+      throw error;
+    }
   }
 
   // In staging/production the Sync user is scoped to `compass_sync`, so a read
@@ -68,8 +74,15 @@ export class SyncMongoService {
       return;
     }
 
+    // Use a resource-scoped operation, not `ping`: `ping` is handshake-exempt
+    // and MongoDB never authorization-checks it, so it resolves for any user
+    // and would make this guard fire even for a correctly-scoped user.
+    // `listCollections` requires the `listCollections` privilege on the target
+    // database, so a scoped Sync user is denied with code 13.
     await assertForbiddenDatabaseUnreachable(() =>
-      this.#client!.db(options.forbiddenDatabaseName).command({ ping: 1 }),
+      this.#client!.db(options.forbiddenDatabaseName)
+        .listCollections({}, { nameOnly: true })
+        .toArray(),
     );
   }
 


### PR DESCRIPTION
## Summary

Continues **Phase B** of the Compass Sync design packet (ledger item **S11** of `07-commit-ledger.md`): isolated MongoDB bootstrap.

- **`storage/collections.ts` + `storage/index-manifest.ts`**: the eight `compass_sync` collections and their declarative index manifests (the essential-index table from the domain model — unique provider-account/calendar/event/command/coalescing identities, a deletion-marker TTL, and query indexes). `installIndexManifest` creates collections and indexes **idempotently** (tolerates `NamespaceExists`, and identical `createIndex` is a no-op), safe to run on every startup and across replicas.
- **`storage/sync-mongo.service.ts`**: `SyncMongoService` connects to the isolated `compass_sync` database, installs the manifests, and **verifies the least-privilege user** — a probe that CAN read the Compass API database aborts startup with an excessive-privileges error (enforced in staging/production; skipped where in-memory Mongo has no auth). Cleans up the client if startup fails.
- **`app.ts`**: `start()` connects storage before listening, registers a storage readiness check (`/health/ready` stays 503 until the connection and indexes verify) and a disconnect drain (registered first → drains last, after workers).
- **Test infra**: sync tests now run against an in-memory replica set (multi-document transactions supported) with per-test database isolation; `mongodb` + `mongodb-memory-server` added; `sync` added to the CI MongoDB-binary cache.

Purely additive to the still-inert service; no existing behavior changes.

**Two correctness fixes from review (second commit), both verified:**
1. **Least-privilege probe (critical, reviewer-found):** the probe used `ping`, which MongoDB never authorization-checks — it resolves for any user, so the guard would *always* fire in staging/production and block a correctly-scoped Sync user from ever starting (the opposite of intent). Switched to `listCollections` (requires the `listCollections` privilege → code 13 for a scoped user). Added an integration test proving the guard aborts startup when the forbidden DB is readable.
2. **Event uniqueness (empirically confirmed):** switched the `events` and `deletion_markers` provider-identity unique indexes from `sparse` to a `partialFilterExpression` on a real-string `providerEventId`. A sparse unique index collides all unlinked events stored with `providerEventId: null` on `(null,null,null)` — allowing only one unlinked event; the partial index enforces uniqueness only on genuinely linked events regardless of null-vs-absent storage. Regression test added (many unlinked events coexist; linked duplicates still collide).

## Simplicity

The manifest is declarative data and the service is a thin connection/verification wrapper — no duplication to remove. No React.

## Manual Testing Steps

Not browser-observable (backend Mongo bootstrap). CLI verification:

- [ ] `bun install` then `bun run test:sync` — expect 70 pass, 0 fail (real in-memory Mongo)
- [ ] `bun run type-check` — clean
- [ ] Confirm the `unit (sync)` CI job installs the MongoDB binary and runs green

## Test plan

- [x] `bun run test:sync` — 70 pass, 0 fail (index creation, idempotency, TTL, unique-constraint enforcement, transactions on a replica set, least-privilege pass/fail + staging enforcement, unlinked-event regression)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — one critical finding (ping not authz-checked) fixed and re-verified; idempotency, startup ordering, and test isolation confirmed sound
