### PR TITLE
feat(sync): persist connections and calendars

### DIFF
--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -26,7 +26,14 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
   [SYNC_COLLECTIONS.providerConnections]: [
     {
       name: "provider_account_identity",
-      key: { tenantId: 1, principalId: 1, provider: 1, providerAccountId: 1 },
+      // account.providerAccountId is nested in the record — the index path must
+      // match where the field actually lives, or every document keys on null.
+      key: {
+        tenantId: 1,
+        principalId: 1,
+        provider: 1,
+        "account.providerAccountId": 1,
+      },
       options: { unique: true },
     },
     { name: "principal_state", key: { principalId: 1, state: 1 } },

--- a/packages/sync/src/storage/provider-calendar.record.ts
+++ b/packages/sync/src/storage/provider-calendar.record.ts
@@ -1,0 +1,52 @@
+import { z } from "zod/v4";
+import {
+  CalendarAccessRoleSchema,
+  CalendarCapabilitiesSchema,
+} from "@core/types/sync/connection.contracts";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  ProviderCalendarIdSchema,
+  ProviderCalendarSourceIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Persistence record for `provider_calendars` (ledger S12). Provider FACTS
+// only — `active`/`primary`/`accessRole`/`capabilities` reflect what the
+// provider reports. Product preferences (visible, blocksAvailability,
+// bookingTarget) are owned by the Compass booking module, never stored here
+// (R-CAL-02; ledger S12 "do not store product visibility or booking prefs").
+export const ProviderCalendarRecordSchema = z.strictObject({
+  _id: ProviderCalendarIdSchema,
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  providerCalendarId: ProviderCalendarSourceIdSchema,
+  displayName: z.string().trim().min(1).max(1024),
+  color: z.string().trim().min(1).max(64).nullable(),
+  active: z.boolean(),
+  primary: z.boolean(),
+  accessRole: CalendarAccessRoleSchema,
+  capabilities: CalendarCapabilitiesSchema,
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type ProviderCalendarRecord = z.infer<
+  typeof ProviderCalendarRecordSchema
+>;
+
+export const ProviderCalendarUpsertSchema = z.strictObject({
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  providerCalendarId: ProviderCalendarSourceIdSchema,
+  displayName: z.string().trim().min(1).max(1024),
+  color: z.string().trim().min(1).max(64).nullable(),
+  active: z.boolean(),
+  primary: z.boolean(),
+  accessRole: CalendarAccessRoleSchema,
+  capabilities: CalendarCapabilitiesSchema,
+});
+export type ProviderCalendarUpsert = z.infer<
+  typeof ProviderCalendarUpsertSchema
+>;

--- a/packages/sync/src/storage/provider-calendar.repository.test.ts
+++ b/packages/sync/src/storage/provider-calendar.repository.test.ts
@@ -1,0 +1,145 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+import { type ProviderCalendarUpsert } from "@sync/storage/provider-calendar.record";
+import { ProviderCalendarRepository } from "@sync/storage/provider-calendar.repository";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const baseUpsert = (
+  overrides: Partial<ProviderCalendarUpsert> = {},
+): ProviderCalendarUpsert =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    connectionId: objectId(),
+    providerCalendarId: "primary",
+    displayName: "Personal",
+    color: "#9fe1e7",
+    active: true,
+    primary: true,
+    accessRole: "owner",
+    capabilities: {
+      canReadEvents: true,
+      canWriteEvents: true,
+      canReadBusy: true,
+      canInviteAttendees: true,
+    },
+    ...overrides,
+  }) as ProviderCalendarUpsert;
+
+describe("ProviderCalendarRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: ProviderCalendarRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`cal_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new ProviderCalendarRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("assigns a stable id on first upsert", async () => {
+    const created = await repo.upsertByProviderCalendar(baseUpsert());
+    expect(created._id).toMatch(/^[0-9a-f]{24}$/);
+    expect(created.primary).toBe(true);
+  });
+
+  it("keeps the Sync id stable when the calendar is renamed", async () => {
+    const connectionId = objectId();
+    const first = await repo.upsertByProviderCalendar(
+      baseUpsert({ connectionId, displayName: "Personal" }),
+    );
+    const renamed = await repo.upsertByProviderCalendar(
+      baseUpsert({ connectionId, displayName: "Personal (renamed)" }),
+    );
+    expect(renamed._id).toBe(first._id);
+    expect(renamed.displayName).toBe("Personal (renamed)");
+  });
+
+  it("stores multiple calendars for one connection", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId();
+    await repo.upsertByProviderCalendar(
+      baseUpsert({
+        tenantId,
+        principalId,
+        connectionId,
+        providerCalendarId: "primary",
+      }),
+    );
+    await repo.upsertByProviderCalendar(
+      baseUpsert({
+        tenantId,
+        principalId,
+        connectionId,
+        providerCalendarId: "work@group",
+      }),
+    );
+    const all = await repo.listByConnection(
+      tenantId,
+      principalId,
+      connectionId,
+    );
+    expect(all).toHaveLength(2);
+  });
+
+  it("updates provider facts and capabilities on re-discovery", async () => {
+    const connectionId = objectId();
+    await repo.upsertByProviderCalendar(
+      baseUpsert({ connectionId, active: true, accessRole: "owner" }),
+    );
+    const updated = await repo.upsertByProviderCalendar(
+      baseUpsert({
+        connectionId,
+        active: false,
+        accessRole: "viewer",
+        capabilities: {
+          canReadEvents: true,
+          canWriteEvents: false,
+          canReadBusy: true,
+          canInviteAttendees: false,
+        },
+      }),
+    );
+    expect(updated.active).toBe(false);
+    expect(updated.accessRole).toBe("viewer");
+    expect(updated.capabilities.canWriteEvents).toBe(false);
+  });
+
+  it("does not leak calendars across principals", async () => {
+    const tenantId = objectId();
+    const connectionId = objectId();
+    const mine = objectId();
+    const theirs = objectId();
+    await repo.upsertByProviderCalendar(
+      baseUpsert({ tenantId, principalId: mine, connectionId }),
+    );
+    expect(
+      await repo.listByConnection(tenantId, theirs, connectionId),
+    ).toHaveLength(0);
+  });
+
+  it("rejects a duplicate (connection, provider-calendar) identity", async () => {
+    const shared = {
+      tenantId: objectId(),
+      principalId: objectId(),
+      connectionId: objectId(),
+      providerCalendarId: "primary",
+    };
+    const collection = db.collection("provider_calendars");
+    await collection.insertOne({ _id: objectId(), ...shared } as never);
+    await expect(
+      collection.insertOne({ _id: objectId(), ...shared } as never),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/sync/src/storage/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/provider-calendar.repository.ts
@@ -1,0 +1,92 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type ProviderCalendarId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type ProviderCalendarRecord,
+  ProviderCalendarRecordSchema,
+  type ProviderCalendarUpsert,
+  ProviderCalendarUpsertSchema,
+} from "@sync/storage/provider-calendar.record";
+
+// Repository for `provider_calendars` (ledger S12). Upserts are keyed on
+// (connection, provider-calendar id) so re-discovering a calendar updates one
+// document; a renamed calendar keeps its Sync _id because identity is the
+// provider's calendar id, not its display name (R-CAL-07). Queries are scoped
+// to the owning tenant/principal (R-SEC-03).
+export class ProviderCalendarRepository {
+  private readonly collection: Collection<ProviderCalendarRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<ProviderCalendarRecord>(
+      SYNC_COLLECTIONS.providerCalendars,
+    );
+  }
+
+  async upsertByProviderCalendar(
+    input: ProviderCalendarUpsert,
+  ): Promise<ProviderCalendarRecord> {
+    const fields = ProviderCalendarUpsertSchema.parse(input);
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      {
+        connectionId: fields.connectionId,
+        providerCalendarId: fields.providerCalendarId,
+      },
+      {
+        $set: {
+          displayName: fields.displayName,
+          color: fields.color,
+          active: fields.active,
+          primary: fields.primary,
+          accessRole: fields.accessRole,
+          capabilities: fields.capabilities,
+          updatedAt: now,
+        },
+        $setOnInsert: {
+          _id: new ObjectId().toHexString() as ProviderCalendarId,
+          tenantId: fields.tenantId,
+          principalId: fields.principalId,
+          connectionId: fields.connectionId,
+          providerCalendarId: fields.providerCalendarId,
+          createdAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+
+    if (!result) {
+      throw new Error("Upsert did not return a calendar record");
+    }
+    return ProviderCalendarRecordSchema.parse(result);
+  }
+
+  async listByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<ProviderCalendarRecord[]> {
+    const records = await this.collection
+      .find({ tenantId, principalId, connectionId })
+      .toArray();
+    return records.map((r) => ProviderCalendarRecordSchema.parse(r));
+  }
+
+  async findById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: ProviderCalendarId,
+  ): Promise<ProviderCalendarRecord | null> {
+    const record = await this.collection.findOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return record ? ProviderCalendarRecordSchema.parse(record) : null;
+  }
+}

--- a/packages/sync/src/storage/provider-connection.record.ts
+++ b/packages/sync/src/storage/provider-connection.record.ts
@@ -12,6 +12,22 @@ import {
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 
+// A connection may only carry an actionRequired state with a reason attached
+// (mirrors the wire contract's derivation invariant). Shared by the record and
+// upsert schemas so the two cannot drift.
+function refineActionRequiredReason(
+  connection: { state: string; stateReason: string | null },
+  ctx: z.RefinementCtx,
+): void {
+  if (connection.state === "actionRequired" && !connection.stateReason) {
+    ctx.addIssue({
+      code: "custom",
+      message: "actionRequired state requires a stateReason",
+      path: ["stateReason"],
+    });
+  }
+}
+
 // Persistence record for `provider_connections` (ledger S12). This is the
 // stored shape: string ids (Mongo accepts a string _id, and the ids are the
 // same opaque 24-hex values as the wire contracts) and Date timestamps for
@@ -33,32 +49,29 @@ export const ProviderConnectionRecordSchema = z
     createdAt: z.date(),
     updatedAt: z.date(),
   })
-  .superRefine((connection, ctx) => {
-    if (connection.state === "actionRequired" && !connection.stateReason) {
-      ctx.addIssue({
-        code: "custom",
-        message: "actionRequired state requires a stateReason",
-        path: ["stateReason"],
-      });
-    }
-  });
+  .superRefine(refineActionRequiredReason);
 export type ProviderConnectionRecord = z.infer<
   typeof ProviderConnectionRecordSchema
 >;
 
 // The fields a caller provides to create-or-update a connection by its stable
-// provider-account identity. Sync owns _id, createdAt, and updatedAt.
-export const ProviderConnectionUpsertSchema = z.strictObject({
-  tenantId: TenantIdSchema,
-  principalId: PrincipalIdSchema,
-  provider: ProviderKindSchema,
-  account: ProviderAccountFactsSchema,
-  capabilities: ProviderCapabilitySetSchema,
-  state: ConnectionStateSchema,
-  stateReason: ConnectionStateReasonSchema.nullable(),
-  lastSyncedAt: z.date().nullable(),
-  lastHealthyAt: z.date().nullable(),
-});
+// provider-account identity. Sync owns _id, createdAt, and updatedAt. It shares
+// the record's actionRequired->stateReason invariant so an invalid state can be
+// rejected BEFORE the write lands — otherwise the write succeeds but every
+// later read of that row fails to parse, bricking it.
+export const ProviderConnectionUpsertSchema = z
+  .strictObject({
+    tenantId: TenantIdSchema,
+    principalId: PrincipalIdSchema,
+    provider: ProviderKindSchema,
+    account: ProviderAccountFactsSchema,
+    capabilities: ProviderCapabilitySetSchema,
+    state: ConnectionStateSchema,
+    stateReason: ConnectionStateReasonSchema.nullable(),
+    lastSyncedAt: z.date().nullable(),
+    lastHealthyAt: z.date().nullable(),
+  })
+  .superRefine(refineActionRequiredReason);
 export type ProviderConnectionUpsert = z.infer<
   typeof ProviderConnectionUpsertSchema
 >;

--- a/packages/sync/src/storage/provider-connection.record.ts
+++ b/packages/sync/src/storage/provider-connection.record.ts
@@ -1,0 +1,64 @@
+import { z } from "zod/v4";
+import {
+  ConnectionStateReasonSchema,
+  ConnectionStateSchema,
+  ProviderAccountFactsSchema,
+} from "@core/types/sync/connection.contracts";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  ProviderCapabilitySetSchema,
+  ProviderKindSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Persistence record for `provider_connections` (ledger S12). This is the
+// stored shape: string ids (Mongo accepts a string _id, and the ids are the
+// same opaque 24-hex values as the wire contracts) and Date timestamps for
+// indexable range queries. The API layer (S24) maps this to the ISO-string
+// ProviderConnection wire contract. Credential material is added in S19; product
+// preferences (visibility, blocking, booking target) are NOT stored here.
+export const ProviderConnectionRecordSchema = z
+  .strictObject({
+    _id: ConnectionIdSchema,
+    tenantId: TenantIdSchema,
+    principalId: PrincipalIdSchema,
+    provider: ProviderKindSchema,
+    account: ProviderAccountFactsSchema,
+    capabilities: ProviderCapabilitySetSchema,
+    state: ConnectionStateSchema,
+    stateReason: ConnectionStateReasonSchema.nullable(),
+    lastSyncedAt: z.date().nullable(),
+    lastHealthyAt: z.date().nullable(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+  })
+  .superRefine((connection, ctx) => {
+    if (connection.state === "actionRequired" && !connection.stateReason) {
+      ctx.addIssue({
+        code: "custom",
+        message: "actionRequired state requires a stateReason",
+        path: ["stateReason"],
+      });
+    }
+  });
+export type ProviderConnectionRecord = z.infer<
+  typeof ProviderConnectionRecordSchema
+>;
+
+// The fields a caller provides to create-or-update a connection by its stable
+// provider-account identity. Sync owns _id, createdAt, and updatedAt.
+export const ProviderConnectionUpsertSchema = z.strictObject({
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  provider: ProviderKindSchema,
+  account: ProviderAccountFactsSchema,
+  capabilities: ProviderCapabilitySetSchema,
+  state: ConnectionStateSchema,
+  stateReason: ConnectionStateReasonSchema.nullable(),
+  lastSyncedAt: z.date().nullable(),
+  lastHealthyAt: z.date().nullable(),
+});
+export type ProviderConnectionUpsert = z.infer<
+  typeof ProviderConnectionUpsertSchema
+>;

--- a/packages/sync/src/storage/provider-connection.repository.test.ts
+++ b/packages/sync/src/storage/provider-connection.repository.test.ts
@@ -1,0 +1,147 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+import { type ProviderConnectionUpsert } from "@sync/storage/provider-connection.record";
+import { ProviderConnectionRepository } from "@sync/storage/provider-connection.repository";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const baseUpsert = (
+  overrides: Partial<ProviderConnectionUpsert> = {},
+): ProviderConnectionUpsert =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    provider: "google",
+    account: {
+      providerAccountId: "acct-1",
+      email: "user@gmail.com",
+      displayName: "User",
+    },
+    capabilities: ["readEvents"],
+    state: "importing",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+    ...overrides,
+  }) as ProviderConnectionUpsert;
+
+describe("ProviderConnectionRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: ProviderConnectionRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`conn_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new ProviderConnectionRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("assigns a stable id and timestamps on first upsert", async () => {
+    const created = await repo.upsertByProviderAccount(baseUpsert());
+    expect(created._id).toMatch(/^[0-9a-f]{24}$/);
+    expect(created.createdAt).toBeInstanceOf(Date);
+    expect(created.state).toBe("importing");
+  });
+
+  it("reconnecting the same account updates one document, not two", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const first = await repo.upsertByProviderAccount(
+      baseUpsert({ tenantId, principalId }),
+    );
+    const second = await repo.upsertByProviderAccount(
+      baseUpsert({ tenantId, principalId, state: "healthy" }),
+    );
+
+    expect(second._id).toBe(first._id);
+    expect(second.createdAt).toEqual(first.createdAt);
+    expect(second.state).toBe("healthy");
+    const all = await repo.listByPrincipal(tenantId, principalId);
+    expect(all).toHaveLength(1);
+  });
+
+  it("keeps multiple accounts for one principal isolated", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await repo.upsertByProviderAccount(
+      baseUpsert({
+        tenantId,
+        principalId,
+        account: {
+          providerAccountId: "acct-1",
+          email: "a@x.com",
+          displayName: null,
+        },
+      }),
+    );
+    await repo.upsertByProviderAccount(
+      baseUpsert({
+        tenantId,
+        principalId,
+        account: {
+          providerAccountId: "acct-2",
+          email: "b@x.com",
+          displayName: null,
+        },
+      }),
+    );
+    const all = await repo.listByPrincipal(tenantId, principalId);
+    expect(all).toHaveLength(2);
+  });
+
+  it("updates capabilities on reconnect", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await repo.upsertByProviderAccount(
+      baseUpsert({ tenantId, principalId, capabilities: ["readEvents"] }),
+    );
+    const updated = await repo.upsertByProviderAccount(
+      baseUpsert({
+        tenantId,
+        principalId,
+        capabilities: ["readEvents", "writeEvents", "changeNotifications"],
+      }),
+    );
+    expect(updated.capabilities).toEqual([
+      "readEvents",
+      "writeEvents",
+      "changeNotifications",
+    ]);
+  });
+
+  it("does not leak one principal's connections to another", async () => {
+    const tenantId = objectId();
+    const mine = objectId();
+    const theirs = objectId();
+    const created = await repo.upsertByProviderAccount(
+      baseUpsert({ tenantId, principalId: mine }),
+    );
+
+    expect(await repo.listByPrincipal(tenantId, theirs)).toHaveLength(0);
+    expect(await repo.findById(tenantId, theirs, created._id)).toBeNull();
+    expect(await repo.findById(tenantId, mine, created._id)).not.toBeNull();
+  });
+
+  it("rejects a raw duplicate insert violating the unique account identity", async () => {
+    const shared = {
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: { providerAccountId: "dup", email: null, displayName: null },
+    };
+    const collection = db.collection("provider_connections");
+    await collection.insertOne({ _id: objectId(), ...shared } as never);
+    await expect(
+      collection.insertOne({ _id: objectId(), ...shared } as never),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/sync/src/storage/provider-connection.repository.test.ts
+++ b/packages/sync/src/storage/provider-connection.repository.test.ts
@@ -131,6 +131,23 @@ describe("ProviderConnectionRepository", () => {
     expect(await repo.findById(tenantId, mine, created._id)).not.toBeNull();
   });
 
+  it("rejects an actionRequired upsert with no reason before any write lands", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await expect(
+      repo.upsertByProviderAccount(
+        baseUpsert({
+          tenantId,
+          principalId,
+          state: "actionRequired",
+          stateReason: null,
+        }),
+      ),
+    ).rejects.toThrow();
+    // Nothing was persisted — the invalid state never reached Mongo.
+    expect(await repo.listByPrincipal(tenantId, principalId)).toHaveLength(0);
+  });
+
   it("rejects a raw duplicate insert violating the unique account identity", async () => {
     const shared = {
       tenantId: objectId(),

--- a/packages/sync/src/storage/provider-connection.repository.ts
+++ b/packages/sync/src/storage/provider-connection.repository.ts
@@ -1,0 +1,94 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type ProviderConnectionRecord,
+  ProviderConnectionRecordSchema,
+  type ProviderConnectionUpsert,
+  ProviderConnectionUpsertSchema,
+} from "@sync/storage/provider-connection.record";
+
+// Repository for `provider_connections` (ledger S12). Upserts are keyed on the
+// stable provider-account identity so reconnecting the same account updates one
+// document instead of creating a duplicate (R-CONN-02). Every query is scoped
+// to a tenant/principal — one principal can never read another's connections
+// (R-SEC-03).
+export class ProviderConnectionRepository {
+  private readonly collection: Collection<ProviderConnectionRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<ProviderConnectionRecord>(
+      SYNC_COLLECTIONS.providerConnections,
+    );
+  }
+
+  // Atomically create-or-update by (tenant, principal, provider, account). On
+  // first sight Sync assigns _id and createdAt; on reconnect it updates the
+  // mutable facts and leaves identity/creation untouched.
+  async upsertByProviderAccount(
+    input: ProviderConnectionUpsert,
+  ): Promise<ProviderConnectionRecord> {
+    const fields = ProviderConnectionUpsertSchema.parse(input);
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      {
+        tenantId: fields.tenantId,
+        principalId: fields.principalId,
+        provider: fields.provider,
+        "account.providerAccountId": fields.account.providerAccountId,
+      },
+      {
+        $set: {
+          account: fields.account,
+          capabilities: fields.capabilities,
+          state: fields.state,
+          stateReason: fields.stateReason,
+          lastSyncedAt: fields.lastSyncedAt,
+          lastHealthyAt: fields.lastHealthyAt,
+          updatedAt: now,
+        },
+        $setOnInsert: {
+          _id: new ObjectId().toHexString() as ConnectionId,
+          tenantId: fields.tenantId,
+          principalId: fields.principalId,
+          provider: fields.provider,
+          createdAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+
+    if (!result) {
+      throw new Error("Upsert did not return a connection record");
+    }
+    return ProviderConnectionRecordSchema.parse(result);
+  }
+
+  async findById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: ConnectionId,
+  ): Promise<ProviderConnectionRecord | null> {
+    const record = await this.collection.findOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return record ? ProviderConnectionRecordSchema.parse(record) : null;
+  }
+
+  async listByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<ProviderConnectionRecord[]> {
+    const records = await this.collection
+      .find({ tenantId, principalId })
+      .toArray();
+    return records.map((r) => ProviderConnectionRecordSchema.parse(r));
+  }
+}


### PR DESCRIPTION
## Summary

Continues **Phase B** of the Compass Sync design packet (ledger item **S12** of `07-commit-ledger.md`): persistence for connections and calendars.

- **`provider-connection.record.ts` / `provider-calendar.record.ts`**: zod record schemas (stored shape — string `_id`, `Date` timestamps) plus `Upsert` input schemas for the mutable fields a caller provides. Provider facts only; no credentials (S19) and no product preferences (visibility/blocking/booking target).
- **`provider-connection.repository.ts` / `provider-calendar.repository.ts`**: repositories with **atomic upserts keyed on stable identity** — reconnecting the same provider account (or re-discovering a renamed calendar) updates one document instead of duplicating, preserving the Sync `_id` and `createdAt` (R-CONN-02, R-CAL-07). Identity fields are insert-only (`$setOnInsert`), so a reconnect can never rewrite them. Every read (`findById`, `list…`) is scoped to `tenantId` + `principalId`, so one principal can't see another's data (R-SEC-03).
- **`index-manifest.ts` fix**: the S11 provider-account unique index keyed on top-level `providerAccountId`, but the record nests it as `account.providerAccountId` — so the index saw `null` for every connection and collided the second insert. Repointed the index to the nested path. (My own multiple-accounts test caught this.)

Purely additive to the inert service; no existing behavior changes.

**Correctness-review fix (third commit):** `ProviderConnectionUpsertSchema` lacked the `actionRequired → stateReason` invariant that the record schema enforces. A caller could persist `{state: "actionRequired", stateReason: null}` — the write lands, then `RecordSchema.parse` throws *after* the fact, and every later read of that row also throws, bricking it. Now both schemas share one refine predicate (can't drift), so bad input is rejected before any write. Regression test added.

**Known follow-up (not fixed here, low-priority):** two concurrent *first* upserts of the same brand-new identity can both miss and one throws `E11000` from the unique index (clean error, no corruption). If reconnect can genuinely double-fire (e.g. webhook + user-initiated), S24 should catch-and-retry-as-update; noted for the connection API.

## Simplicity

Considered a shared `ScopedRepository` base for the identical `findById`/scoped-list, but left the two repos concrete: the identical surface is ~8 lines, and S13–S14 add four more repositories whose shapes will reveal the real common surface — extracting speculatively at 2 risks the wrong abstraction. No React.

## Manual Testing Steps

Not browser-observable (backend Mongo repositories). CLI verification:

- [ ] `bun install` then `bun run test:sync` — expect 83 pass, 0 fail (real in-memory Mongo)
- [ ] `bun run type-check` — clean

## Test plan

- [x] `bun run test:sync` — 83 pass, 0 fail (stable id + timestamps, reconnect dedup, multiple accounts, capability update, rename stability, cross-principal isolation, unique-index duplicate rejection, actionRequired-reason regression)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — one confirmed bug (upsert-schema invariant gap) fixed and re-verified; upsert atomicity, insert-only identity, scoping, and dotted-path index match all confirmed correct
