### PR TITLE
fix(web): let useEventListener accept a null element

### DIFF
--- a/packages/web/src/views/Week/hooks/mouse/useEventListener.ts
+++ b/packages/web/src/views/Week/hooks/mouse/useEventListener.ts
@@ -7,7 +7,10 @@ type MouseEventHandler = {
 export const useEventListener = (
   eventName: "mouseup" | "mousemove",
   handler: MouseEventHandler,
-  element: HTMLElement | Window = window,
+  // Accept null so a fail-soft element lookup (getElemById returns null when
+  // the element is absent) can pass through — the effect already no-ops when
+  // the element can't receive listeners.
+  element: HTMLElement | Window | null = window,
 ) => {
   const savedHandler = useRef<(e: MouseEvent) => void>(handler);
   // Update ref.current value if handler changes.
@@ -20,9 +23,9 @@ export const useEventListener = (
   }, [handler]);
 
   useEffect(() => {
-    const isSupported = element?.addEventListener;
-
-    if (!isSupported) return;
+    // Inline the guard on `element` (not a separate `isSupported` const) so
+    // TypeScript narrows `element` to non-null for the calls below.
+    if (!element?.addEventListener) return;
 
     const listener = (event: Event) => {
       savedHandler.current(event as MouseEvent);


### PR DESCRIPTION
## Summary

**Unblocks a type-check-red `main`.** PR #2196 changed `getElemById` to return `HTMLDivElement | null` (fail-soft when the grid element is absent), but the `useGridMouseUp` call site passes that result straight to `useEventListener`, whose `element` param was typed `HTMLElement | Window` — so `main` is currently failing `type-check` (confirmed by type-checking `origin/main` directly).

`useEventListener` already no-ops at runtime when the element can't receive listeners (`element?.addEventListener` guard), so this widens the `element` param to accept `null` and inlines the guard so TypeScript narrows `element` to non-null for the `addEventListener`/`removeEventListener` calls. **Behavior-preserving** — same boolean guard, same `window` default.

Found while a sync-service PR's CI surfaced the failure on the merge-with-main.

## Test plan

- [x] `bun run type-check` — clean (was red on `origin/main`)
- [x] `bun test --cwd packages/web src/views/Week` — 198 pass, 0 fail
- [x] `bunx biome check` on the file — clean

## Manual Testing Steps

- [ ] On the Week view, click-drag on the grid to create a draft event and release — mouseup still completes the draft (the listener attaches to `#root` as before)