### PR TITLE
feat(sync): persist events and occurrences

### DIFF
--- a/packages/sync/src/storage/event-occurrence.record.ts
+++ b/packages/sync/src/storage/event-occurrence.record.ts
@@ -1,0 +1,38 @@
+import { z } from "zod/v4";
+import { EventIdSchema } from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import {
+  OccurrenceKeySchema,
+  SyncEventCalendarIdSchema,
+} from "@core/types/sync/event.contracts";
+import {
+  PrincipalIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Persistence record for `event_occurrences` (ledger S13) — a derived,
+// display-ready instance projected from an event/series within the rolling
+// horizon (R-AVAIL-06). Never expand a non-ending series to completion; only
+// the bounded window is materialized. tenantId/principalId are denormalized for
+// scoped queries and the principal_start index; generation ties an occurrence
+// to the import generation of its source event so a repair can rebuild in a new
+// generation before removing the old one.
+export const EventOccurrenceRecordSchema = z.strictObject({
+  _id: z.string().regex(/^[0-9a-f]{24}$/i),
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  eventId: EventIdSchema,
+  occurrenceKey: OccurrenceKeySchema,
+  calendarId: SyncEventCalendarIdSchema,
+  schedule: EventScheduleSchema,
+  // Normalized start instant for range queries and the start-time indexes.
+  // Computed by the projection layer (the caller) so all-day and timed
+  // occurrences compare on one coherent axis — string-comparing the union
+  // schedule.start would be wrong across schedule kinds and offsets.
+  startAt: z.date(),
+  busy: z.boolean(),
+  title: z.string(),
+  cancelled: z.boolean(),
+  generation: z.number().int().min(0),
+});
+export type EventOccurrenceRecord = z.infer<typeof EventOccurrenceRecordSchema>;

--- a/packages/sync/src/storage/event-occurrence.repository.test.ts
+++ b/packages/sync/src/storage/event-occurrence.repository.test.ts
@@ -43,7 +43,7 @@ describe("EventOccurrenceRepository", () => {
     await client.connect();
     db = client.db(`occ_${objectId()}`);
     await installIndexManifest(db);
-    repo = new EventOccurrenceRepository(db);
+    repo = new EventOccurrenceRepository(db, client);
   });
 
   afterEach(async () => {
@@ -180,6 +180,54 @@ describe("EventOccurrenceRepository", () => {
       expect(first).toHaveLength(2);
       expect(second).toHaveLength(1);
       expect(ids.size).toBe(3);
+    });
+
+    it("paginates correctly across occurrences that share the same startAt", async () => {
+      // Five occurrences at the SAME instant straddling page boundaries — the
+      // (_id) tie-break in the composite cursor must not skip or repeat any.
+      const tenant2 = objectId() as OccurrenceInput["tenantId"];
+      const principal2 = objectId() as OccurrenceInput["principalId"];
+      const cal = objectId();
+      const sameInstant = new Date("2026-07-14T09:00:00-06:00");
+      const eventId = objectId() as OccurrenceInput["eventId"];
+      await repo.replaceForEvent(
+        eventId,
+        0,
+        Array.from({ length: 5 }, (_, i) =>
+          occurrence({
+            tenantId: tenant2,
+            principalId: principal2,
+            eventId,
+            occurrenceKey: `${cal}:tie:${i}`,
+            calendarId: cal as OccurrenceInput["calendarId"],
+            startAt: sameInstant,
+          }),
+        ),
+      );
+
+      const query = {
+        tenantId: tenant2,
+        principalId: principal2,
+        calendarIds: [cal] as OccurrenceInput["calendarId"][],
+        start: new Date("2026-07-01T00:00:00-06:00"),
+        end: new Date("2026-07-16T00:00:00-06:00"),
+      };
+      const seen: string[] = [];
+      let after: { startAt: Date; id: string } | undefined;
+      for (let i = 0; i < 10; i += 1) {
+        const page = await repo.listByCalendarRange({
+          ...query,
+          limit: 2,
+          after,
+        });
+        if (page.length === 0) break;
+        for (const o of page) seen.push(o._id);
+        const lastRow = page[page.length - 1];
+        if (!lastRow) break;
+        after = { startAt: lastRow.startAt, id: lastRow._id };
+      }
+      expect(seen).toHaveLength(5);
+      expect(new Set(seen).size).toBe(5);
     });
   });
 });

--- a/packages/sync/src/storage/event-occurrence.repository.test.ts
+++ b/packages/sync/src/storage/event-occurrence.repository.test.ts
@@ -1,0 +1,185 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { type EventOccurrenceRecord } from "@sync/storage/event-occurrence.record";
+import {
+  EventOccurrenceRepository,
+  type OccurrenceInput,
+} from "@sync/storage/event-occurrence.repository";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const occurrence = (
+  overrides: Partial<OccurrenceInput> = {},
+): OccurrenceInput =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    eventId: objectId(),
+    occurrenceKey: `${objectId()}:2026-07-14T09:00:00-06:00`,
+    calendarId: objectId(),
+    schedule: {
+      kind: "timed",
+      start: "2026-07-14T09:00:00-06:00",
+      end: "2026-07-14T10:00:00-06:00",
+      timeZone: "America/Denver",
+    },
+    startAt: new Date("2026-07-14T09:00:00-06:00"),
+    busy: true,
+    title: "Standup",
+    cancelled: false,
+    generation: 0,
+    ...overrides,
+  }) as OccurrenceInput;
+
+describe("EventOccurrenceRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: EventOccurrenceRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`occ_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new EventOccurrenceRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("materializes occurrences for an event", async () => {
+    const eventId = objectId() as OccurrenceInput["eventId"];
+    await repo.replaceForEvent(eventId, 0, [
+      occurrence({ eventId, occurrenceKey: `${eventId}:a` }),
+      occurrence({ eventId, occurrenceKey: `${eventId}:b` }),
+    ]);
+    expect(await db.collection("event_occurrences").countDocuments()).toBe(2);
+  });
+
+  it("replaces only the target event's occurrences in that generation", async () => {
+    const target = objectId() as OccurrenceInput["eventId"];
+    const other = objectId() as OccurrenceInput["eventId"];
+    await repo.replaceForEvent(target, 0, [
+      occurrence({ eventId: target, occurrenceKey: `${target}:old` }),
+    ]);
+    await repo.replaceForEvent(other, 0, [
+      occurrence({ eventId: other, occurrenceKey: `${other}:x` }),
+    ]);
+
+    // Rebuild the target with new occurrences; the other event is untouched.
+    await repo.replaceForEvent(target, 0, [
+      occurrence({ eventId: target, occurrenceKey: `${target}:new1` }),
+      occurrence({ eventId: target, occurrenceKey: `${target}:new2` }),
+    ]);
+
+    const targetDocs = await db
+      .collection("event_occurrences")
+      .find({ eventId: target })
+      .toArray();
+    expect(targetDocs.map((d) => d.occurrenceKey).sort()).toEqual([
+      `${target}:new1`,
+      `${target}:new2`,
+    ]);
+    expect(
+      await db
+        .collection("event_occurrences")
+        .countDocuments({ eventId: other }),
+    ).toBe(1);
+  });
+
+  it("does not disturb another generation of the same event (non-destructive repair)", async () => {
+    const eventId = objectId() as OccurrenceInput["eventId"];
+    await repo.replaceForEvent(eventId, 0, [
+      occurrence({ eventId, occurrenceKey: `${eventId}:gen0` }),
+    ]);
+    // A repair builds generation 1 alongside generation 0.
+    await repo.replaceForEvent(eventId, 1, [
+      occurrence({ eventId, occurrenceKey: `${eventId}:gen1`, generation: 1 }),
+    ]);
+    expect(
+      await db.collection("event_occurrences").countDocuments({ eventId }),
+    ).toBe(2);
+  });
+
+  it("clears occurrences when replaced with an empty set", async () => {
+    const eventId = objectId() as OccurrenceInput["eventId"];
+    await repo.replaceForEvent(eventId, 0, [
+      occurrence({ eventId, occurrenceKey: `${eventId}:a` }),
+    ]);
+    await repo.replaceForEvent(eventId, 0, []);
+    expect(
+      await db.collection("event_occurrences").countDocuments({ eventId }),
+    ).toBe(0);
+  });
+
+  describe("listByCalendarRange", () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const calA = objectId();
+    const calB = objectId();
+
+    beforeEach(async () => {
+      const mk = (calendarId: string, day: number) =>
+        occurrence({
+          tenantId: tenantId as OccurrenceInput["tenantId"],
+          principalId: principalId as OccurrenceInput["principalId"],
+          eventId: objectId() as OccurrenceInput["eventId"],
+          occurrenceKey: `${calendarId}:${day}`,
+          calendarId: calendarId as OccurrenceInput["calendarId"],
+          schedule: {
+            kind: "timed",
+            start: `2026-07-${day}T09:00:00-06:00`,
+            end: `2026-07-${day}T10:00:00-06:00`,
+            timeZone: "America/Denver",
+          },
+          startAt: new Date(`2026-07-${day}T09:00:00-06:00`),
+        });
+      const eventId = objectId() as OccurrenceInput["eventId"];
+      await repo.replaceForEvent(eventId, 0, [
+        mk(calA, 10),
+        mk(calA, 14),
+        mk(calB, 12),
+        mk(calA, 20), // outside the query range below
+      ]);
+    });
+
+    it("returns occurrences across multiple calendars in range, ordered", async () => {
+      const page = await repo.listByCalendarRange({
+        tenantId: tenantId as OccurrenceInput["tenantId"],
+        principalId: principalId as OccurrenceInput["principalId"],
+        calendarIds: [calA, calB],
+        start: new Date("2026-07-01T00:00:00-06:00"),
+        end: new Date("2026-07-16T00:00:00-06:00"),
+        limit: 100,
+      });
+      expect(page).toHaveLength(3);
+      const starts = page.map((o) => o.startAt.getTime());
+      expect(starts).toEqual([...starts].sort((a, b) => a - b));
+    });
+
+    it("paginates with the composite cursor", async () => {
+      const query = {
+        tenantId: tenantId as OccurrenceInput["tenantId"],
+        principalId: principalId as OccurrenceInput["principalId"],
+        calendarIds: [calA, calB],
+        start: new Date("2026-07-01T00:00:00-06:00"),
+        end: new Date("2026-07-16T00:00:00-06:00"),
+      };
+      const first = await repo.listByCalendarRange({ ...query, limit: 2 });
+      const last = first[first.length - 1] as EventOccurrenceRecord;
+      const second = await repo.listByCalendarRange({
+        ...query,
+        limit: 2,
+        after: { startAt: last.startAt, id: last._id },
+      });
+      const ids = new Set([...first, ...second].map((o) => o._id));
+      expect(first).toHaveLength(2);
+      expect(second).toHaveLength(1);
+      expect(ids.size).toBe(3);
+    });
+  });
+});

--- a/packages/sync/src/storage/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/event-occurrence.repository.ts
@@ -1,4 +1,4 @@
-import { type Collection, type Db, ObjectId } from "mongodb";
+import { type Collection, type Db, type MongoClient, ObjectId } from "mongodb";
 import { type EventId } from "@core/types/domain-primitives";
 import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
@@ -36,31 +36,46 @@ export interface OccurrenceRangeQuery {
 export class EventOccurrenceRepository {
   private readonly collection: Collection<EventOccurrenceRecord>;
 
-  constructor(db: Db) {
+  // The client is needed to run the rebuild atomically in a transaction.
+  constructor(
+    db: Db,
+    private readonly client: MongoClient,
+  ) {
     this.collection = db.collection<EventOccurrenceRecord>(
       SYNC_COLLECTIONS.eventOccurrences,
     );
   }
 
-  // Replace all occurrences for one event within a generation. Delete-then-
-  // insert is scoped to (eventId, generation), so occurrences of other events —
-  // and of the same event in a different generation being built by a repair —
-  // are never touched (never delete an old generation before its replacement).
+  // Replace all occurrences for one event within a generation, atomically.
+  // The delete+insert runs in a transaction so a concurrent range query never
+  // observes the mid-rebuild empty window, and a failed insert rolls the delete
+  // back (no lost occurrences). Scoped to (eventId, generation), so occurrences
+  // of other events — and of the same event in another generation being built
+  // by a repair — are never touched (never delete an old generation before its
+  // replacement completes).
   async replaceForEvent(
     eventId: EventId,
     generation: number,
     occurrences: OccurrenceInput[],
   ): Promise<void> {
-    await this.collection.deleteMany({ eventId, generation });
-    if (occurrences.length === 0) return;
-
     const docs = occurrences.map((occurrence) =>
       EventOccurrenceRecordSchema.parse({
         _id: new ObjectId().toHexString(),
         ...occurrence,
       }),
     );
-    await this.collection.insertMany(docs);
+
+    const session = this.client.startSession();
+    try {
+      await session.withTransaction(async () => {
+        await this.collection.deleteMany({ eventId, generation }, { session });
+        if (docs.length > 0) {
+          await this.collection.insertMany(docs, { session });
+        }
+      });
+    } finally {
+      await session.endSession();
+    }
   }
 
   async listByCalendarRange(

--- a/packages/sync/src/storage/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/event-occurrence.repository.ts
@@ -1,0 +1,101 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import { type EventId } from "@core/types/domain-primitives";
+import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type EventOccurrenceRecord,
+  EventOccurrenceRecordSchema,
+} from "@sync/storage/event-occurrence.record";
+
+export type OccurrenceInput = Omit<EventOccurrenceRecord, "_id">;
+
+export interface OccurrenceRangeCursor {
+  startAt: Date;
+  id: string;
+}
+
+export interface OccurrenceRangeQuery {
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  calendarIds: SyncEventCalendarId[];
+  // Half-open [start, end) over the normalized start instant.
+  start: Date;
+  end: Date;
+  limit: number;
+  after?: OccurrenceRangeCursor;
+}
+
+// Repository for `event_occurrences` (ledger S13). Rebuilding a series' window
+// replaces exactly that event's occurrences for the given generation, so a
+// series edit rebuilds only the affected horizon (02-sync-lifecycle). The
+// range query is the bounded, keyset-paginated display projection.
+export class EventOccurrenceRepository {
+  private readonly collection: Collection<EventOccurrenceRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<EventOccurrenceRecord>(
+      SYNC_COLLECTIONS.eventOccurrences,
+    );
+  }
+
+  // Replace all occurrences for one event within a generation. Delete-then-
+  // insert is scoped to (eventId, generation), so occurrences of other events —
+  // and of the same event in a different generation being built by a repair —
+  // are never touched (never delete an old generation before its replacement).
+  async replaceForEvent(
+    eventId: EventId,
+    generation: number,
+    occurrences: OccurrenceInput[],
+  ): Promise<void> {
+    await this.collection.deleteMany({ eventId, generation });
+    if (occurrences.length === 0) return;
+
+    const docs = occurrences.map((occurrence) =>
+      EventOccurrenceRecordSchema.parse({
+        _id: new ObjectId().toHexString(),
+        ...occurrence,
+      }),
+    );
+    await this.collection.insertMany(docs);
+  }
+
+  async listByCalendarRange(
+    query: OccurrenceRangeQuery,
+  ): Promise<EventOccurrenceRecord[]> {
+    const scope = {
+      tenantId: query.tenantId,
+      principalId: query.principalId,
+      calendarId: { $in: query.calendarIds },
+    };
+    const inRange = { startAt: { $gte: query.start, $lt: query.end } };
+
+    // Composite keyset over the (startAt, _id) sort: a later instant, or the
+    // same instant with a greater _id. startAt is a top-level Date and _id a
+    // string, so this is fully typeable — no cast needed.
+    const filter = query.after
+      ? {
+          ...scope,
+          $and: [
+            inRange,
+            {
+              $or: [
+                { startAt: { $gt: query.after.startAt } },
+                { startAt: query.after.startAt, _id: { $gt: query.after.id } },
+              ],
+            },
+          ],
+        }
+      : { ...scope, ...inRange };
+
+    const records = await this.collection
+      .find(filter)
+      .sort({ startAt: 1, _id: 1 })
+      .limit(query.limit)
+      .toArray();
+    return records.map((r) => EventOccurrenceRecordSchema.parse(r));
+  }
+}

--- a/packages/sync/src/storage/event.record.ts
+++ b/packages/sync/src/storage/event.record.ts
@@ -1,0 +1,57 @@
+import { z } from "zod/v4";
+import { EventIdSchema } from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import {
+  ClientEventIdSchema,
+  ProviderDeliveryStateSchema,
+  ProviderEventVersionSchema,
+  SyncEventCalendarIdSchema,
+  SyncEventContentSchema,
+  SyncEventLifecycleStateSchema,
+  SyncEventOriginSchema,
+  SyncEventRecurrenceSchema,
+} from "@core/types/sync/event.contracts";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  ProviderEventIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Persistence record for `events` (ledger S13). Provider ownership is stored
+// FLAT at top level (not nested under `ownership` like the S03 wire contract)
+// so the unique provider-identity index and the principal_calendar index match
+// where the fields live. Unlinked Compass events keep provider fields null; the
+// partialFilterExpression unique index only applies to a real providerEventId,
+// so many unlinked events coexist (R-LIFE-03). The query API (S25) maps this
+// flat record back to the nested ownership union.
+export const EventRecordSchema = z.strictObject({
+  _id: EventIdSchema,
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  origin: SyncEventOriginSchema,
+  // The owning calendar — a Compass calendar id for an unlinked event or a
+  // provider calendar id once linked. Always present.
+  calendarId: SyncEventCalendarIdSchema,
+  clientEventId: ClientEventIdSchema.nullable(),
+  // Provider ownership: all null for an unlinked Compass event, all set once
+  // linked to exactly one provider calendar (R-EVENT-01).
+  connectionId: ConnectionIdSchema.nullable(),
+  providerEventId: ProviderEventIdSchema.nullable(),
+  providerVersion: ProviderEventVersionSchema.nullable(),
+  providerUpdatedAt: z.date().nullable(),
+  deliveryState: ProviderDeliveryStateSchema.nullable(),
+  providerMetadata: z.record(z.string(), z.string()).nullable(),
+  content: SyncEventContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: SyncEventRecurrenceSchema,
+  lifecycleState: SyncEventLifecycleStateSchema,
+  // Import generation. A non-destructive repair (S31) imports into a new
+  // generation and only removes the old one after the replacement completes,
+  // so both can coexist transiently.
+  generation: z.number().int().min(0),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+  confirmedAt: z.date().nullable(),
+});
+export type EventRecord = z.infer<typeof EventRecordSchema>;

--- a/packages/sync/src/storage/event.repository.test.ts
+++ b/packages/sync/src/storage/event.repository.test.ts
@@ -1,0 +1,236 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { type EventRecord } from "@sync/storage/event.record";
+import {
+  EventRepository,
+  type ProviderEventUpsert,
+} from "@sync/storage/event.repository";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const timed = (start: string, end: string, timeZone = "America/Denver") => ({
+  kind: "timed" as const,
+  start,
+  end,
+  timeZone,
+});
+
+const baseContent = {
+  title: "Standup",
+  description: "",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+};
+
+const linkedUpsert = (
+  overrides: Partial<ProviderEventUpsert> = {},
+): ProviderEventUpsert =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    origin: "provider",
+    calendarId: objectId(),
+    clientEventId: null,
+    connectionId: objectId(),
+    providerEventId: "evt-1",
+    providerVersion: "etag-1",
+    providerUpdatedAt: new Date("2026-07-20T12:00:00.000Z"),
+    deliveryState: "confirmed",
+    providerMetadata: null,
+    content: baseContent,
+    schedule: timed("2026-07-14T09:00:00-06:00", "2026-07-14T10:00:00-06:00"),
+    recurrence: { kind: "single" },
+    lifecycleState: "active",
+    generation: 0,
+    confirmedAt: new Date("2026-07-20T12:00:00.000Z"),
+    ...overrides,
+  }) as ProviderEventUpsert;
+
+const compassRecord = (overrides: Partial<EventRecord> = {}): EventRecord =>
+  ({
+    _id: objectId(),
+    tenantId: objectId(),
+    principalId: objectId(),
+    origin: "compass",
+    calendarId: objectId(),
+    clientEventId: null,
+    connectionId: null,
+    providerEventId: null,
+    providerVersion: null,
+    providerUpdatedAt: null,
+    deliveryState: null,
+    providerMetadata: null,
+    content: baseContent,
+    schedule: timed("2026-07-14T09:00:00-06:00", "2026-07-14T10:00:00-06:00"),
+    recurrence: { kind: "single" },
+    lifecycleState: "active",
+    generation: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    confirmedAt: null,
+    ...overrides,
+  }) as EventRecord;
+
+describe("EventRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: EventRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`event_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new EventRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("dedupes a linked event on provider identity across repeated reads", async () => {
+    const identity = {
+      connectionId: objectId(),
+      calendarId: objectId(),
+      providerEventId: "evt-42",
+    };
+    const first = await repo.upsertByProviderIdentity(
+      linkedUpsert({ ...identity, providerVersion: "etag-1" }),
+    );
+    const second = await repo.upsertByProviderIdentity(
+      linkedUpsert({ ...identity, providerVersion: "etag-2" }),
+    );
+    expect(second._id).toBe(first._id);
+    expect(second.providerVersion).toBe("etag-2");
+    expect(await db.collection("events").countDocuments()).toBe(1);
+  });
+
+  it("stores many unlinked Compass events (no provider identity collision)", async () => {
+    const principalId = objectId();
+    await repo.put(compassRecord({ principalId }));
+    await repo.put(compassRecord({ principalId }));
+    expect(await db.collection("events").countDocuments()).toBe(2);
+  });
+
+  it("round-trips an all-day event", async () => {
+    const record = compassRecord({
+      schedule: { kind: "allDay", start: "2026-07-14", end: "2026-07-15" },
+    });
+    const saved = await repo.put(record);
+    const read = await repo.findById(
+      saved.tenantId,
+      saved.principalId,
+      saved._id,
+    );
+    expect(read?.schedule).toEqual({
+      kind: "allDay",
+      start: "2026-07-14",
+      end: "2026-07-15",
+    });
+  });
+
+  it("round-trips a DST-crossing timed schedule", async () => {
+    const dst = timed("2026-03-08T01:30:00-07:00", "2026-03-08T03:30:00-06:00");
+    const saved = await repo.put(compassRecord({ schedule: dst }));
+    const read = await repo.findById(
+      saved.tenantId,
+      saved.principalId,
+      saved._id,
+    );
+    expect(read?.schedule).toEqual(dst);
+  });
+
+  it("round-trips a recurrence exception event", async () => {
+    const seriesId = objectId();
+    const record = compassRecord({
+      recurrence: {
+        kind: "exception",
+        seriesId: seriesId as EventRecord["_id"],
+        recurrenceId: "2026-07-21T09:00:00.000Z" as never,
+        cancelled: true,
+      },
+    });
+    const saved = await repo.put(record);
+    const read = await repo.findById(
+      saved.tenantId,
+      saved.principalId,
+      saved._id,
+    );
+    expect(read?.recurrence).toMatchObject({
+      kind: "exception",
+      cancelled: true,
+    });
+  });
+
+  it("scopes findById to the owning principal", async () => {
+    const saved = await repo.put(compassRecord());
+    const other = objectId() as EventRecord["principalId"];
+    expect(await repo.findById(saved.tenantId, other, saved._id)).toBeNull();
+    expect(
+      await repo.findById(saved.tenantId, saved.principalId, saved._id),
+    ).not.toBeNull();
+  });
+
+  describe("listByCalendar keyset pagination", () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const calendarId = objectId();
+
+    beforeEach(async () => {
+      for (let i = 0; i < 5; i += 1) {
+        await repo.put(
+          compassRecord({
+            tenantId: tenantId as EventRecord["tenantId"],
+            principalId: principalId as EventRecord["principalId"],
+            calendarId: calendarId as EventRecord["calendarId"],
+          }),
+        );
+      }
+      // An event in a different generation must be excluded by the query.
+      await repo.put(
+        compassRecord({
+          tenantId: tenantId as EventRecord["tenantId"],
+          principalId: principalId as EventRecord["principalId"],
+          calendarId: calendarId as EventRecord["calendarId"],
+          generation: 1,
+        }),
+      );
+    });
+
+    const baseQuery = {
+      tenantId: tenantId as EventRecord["tenantId"],
+      principalId: principalId as EventRecord["principalId"],
+      calendarId,
+      generation: 0,
+    };
+
+    it("returns only the requested generation, id-ordered", async () => {
+      const page = await repo.listByCalendar({ ...baseQuery, limit: 100 });
+      expect(page).toHaveLength(5);
+      const ids = page.map((e) => e._id);
+      expect(ids).toEqual([...ids].sort());
+    });
+
+    it("paginates without skipping or repeating via the id cursor", async () => {
+      const seen: string[] = [];
+      let afterId: EventRecord["_id"] | undefined;
+      for (let i = 0; i < 10; i += 1) {
+        const page = await repo.listByCalendar({
+          ...baseQuery,
+          limit: 2,
+          afterId,
+        });
+        if (page.length === 0) break;
+        for (const e of page) seen.push(e._id);
+        afterId = page[page.length - 1]?._id;
+      }
+      expect(seen).toHaveLength(5);
+      expect(new Set(seen).size).toBe(5);
+    });
+  });
+});

--- a/packages/sync/src/storage/event.repository.ts
+++ b/packages/sync/src/storage/event.repository.ts
@@ -1,0 +1,110 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import { type EventId } from "@core/types/domain-primitives";
+import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type EventRecord,
+  EventRecordSchema,
+} from "@sync/storage/event.record";
+
+// Fields for a provider-linked event upsert. Sync assigns _id/createdAt on
+// first sight and dedupes on the (connection, calendar, providerEventId)
+// identity so a repeated provider read never duplicates (R-EVENT-01).
+export type ProviderEventUpsert = Omit<
+  EventRecord,
+  "_id" | "createdAt" | "updatedAt"
+> & {
+  connectionId: NonNullable<EventRecord["connectionId"]>;
+  providerEventId: NonNullable<EventRecord["providerEventId"]>;
+};
+
+export interface EventListQuery {
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  calendarId: SyncEventCalendarId;
+  generation: number;
+  limit: number;
+  // Exclusive lower-bound _id for keyset pagination. Canonical events are
+  // listed by id, not time — the time-ordered display projection is the
+  // occurrence query. Uses the principal_calendar index.
+  afterId?: EventId;
+}
+
+export class EventRepository {
+  private readonly collection: Collection<EventRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<EventRecord>(SYNC_COLLECTIONS.events);
+  }
+
+  async upsertByProviderIdentity(
+    input: ProviderEventUpsert,
+  ): Promise<EventRecord> {
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      {
+        connectionId: input.connectionId,
+        calendarId: input.calendarId,
+        providerEventId: input.providerEventId,
+      },
+      {
+        // input already omits _id/createdAt/updatedAt (see ProviderEventUpsert).
+        $set: { ...input, updatedAt: now },
+        $setOnInsert: {
+          _id: new ObjectId().toHexString() as EventId,
+          createdAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    if (!result) throw new Error("Upsert did not return an event record");
+    return EventRecordSchema.parse(result);
+  }
+
+  // Full write of a Compass (or already-identified) event by its _id. Used for
+  // unlinked cloud events and for promoting/relinking an existing event.
+  async put(record: EventRecord): Promise<EventRecord> {
+    const parsed = EventRecordSchema.parse(record);
+    await this.collection.replaceOne({ _id: parsed._id }, parsed, {
+      upsert: true,
+    });
+    return parsed;
+  }
+
+  async findById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: EventId,
+  ): Promise<EventRecord | null> {
+    const record = await this.collection.findOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return record ? EventRecordSchema.parse(record) : null;
+  }
+
+  // Bounded, keyset-paginated canonical events for one calendar/generation,
+  // ordered by _id so a cursor never skips or repeats a row.
+  async listByCalendar(query: EventListQuery): Promise<EventRecord[]> {
+    const filter = {
+      tenantId: query.tenantId,
+      principalId: query.principalId,
+      calendarId: query.calendarId,
+      generation: query.generation,
+      ...(query.afterId ? { _id: { $gt: query.afterId } } : {}),
+    };
+
+    const records = await this.collection
+      .find(filter)
+      .sort({ _id: 1 })
+      .limit(query.limit)
+      .toArray();
+    return records.map((r) => EventRecordSchema.parse(r));
+  }
+}

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -75,8 +75,11 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       key: { eventId: 1, occurrenceKey: 1 },
       options: { unique: true },
     },
-    { name: "calendar_start", key: { calendarId: 1, "schedule.start": 1 } },
-    { name: "principal_start", key: { principalId: 1, "schedule.start": 1 } },
+    // Index the normalized start instant (startAt), not the schedule.start
+    // union path — range queries compare all-day and timed occurrences on one
+    // coherent axis.
+    { name: "calendar_start", key: { calendarId: 1, startAt: 1 } },
+    { name: "principal_start", key: { principalId: 1, startAt: 1 } },
   ],
   [SYNC_COLLECTIONS.syncResources]: [
     {


### PR DESCRIPTION
## Summary

Continues **Phase B** of the Compass Sync design packet (ledger item **S13** of `07-commit-ledger.md`): persistence for canonical events and their rolling occurrence projection.

- **`event.record.ts` / `event.repository.ts`**: the canonical `events` record stores provider ownership **flat at top level** (nullable — all null for an unlinked Compass event, all set for a linked one) so the S11 provider-identity and `principal_calendar` indexes match where the fields live. `upsertByProviderIdentity` dedupes linked events on `(connection, calendar, providerEventId)`; `put` persists Compass events by `_id`; `listByCalendar` is keyset-paginated by `_id`. Records carry a `generation` for non-destructive repair.
- **`event-occurrence.record.ts` / `event-occurrence.repository.ts`**: the rolling display projection. `replaceForEvent` rebuilds exactly one event's window in a generation **atomically** (see below), never touching other events or other generations. `listByCalendarRange` is a bounded, keyset-paginated time query over a normalized **`startAt` instant** — string-comparing the `schedule.start` discriminated union would be wrong across all-day/timed/offset, so the projection layer supplies a coherent instant, which also keeps the Mongo filters fully typed (no casts). The S11 occurrence start-time indexes moved from `schedule.start` to `startAt`.

Purely additive to the inert service; no existing behavior changes.

**Correctness-review fixes (second commit):**
1. **Atomic rebuild (critical).** `replaceForEvent`'s delete-then-insert exposed an empty window on *every* rebuild (a concurrent range query saw the event's occurrences vanish) and lost them permanently if `insertMany` failed after `deleteMany`. Now wrapped in a replica-set transaction — no mid-rebuild gap, and a failed insert rolls the delete back. The occurrence repository takes the `MongoClient` to run the transaction.
2. **Cursor tie-break test.** Added a pagination test with 5 occurrences sharing one `startAt` straddling page boundaries, exercising the `(_id)` tie-break in the composite cursor that no prior test covered.

## Simplicity

The mid-implementation refactor to `startAt` + `listByCalendar` removed two `as unknown as Filter` casts and a latent all-day-vs-timed comparison bug. The shared scoped-`findById` pattern across repositories stays concrete, still deferred to S14 once all six repo shapes exist. No React.

## Manual Testing Steps

Not browser-observable (backend Mongo repositories). CLI verification:

- [ ] `bun install` then `bun run test:sync` — expect 98 pass, 0 fail (real in-memory replica set)
- [ ] `bun run type-check` — clean

## Test plan

- [x] `bun run test:sync` — 98 pass, 0 fail (dedup, many-unlinked coexistence, all-day/DST/recurrence-exception round-trips, calendar id-keyset pagination + generation filter, atomic rebuild + generation isolation, empty-set clear, range query across calendars, composite-cursor pagination incl. same-`startAt` tie-break)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — critical non-atomic-rebuild finding fixed and re-verified; flat-ownership index match, upsert semantics, keyset correctness, and caller-provided `startAt` all confirmed correct
