### PR TITLE
chore(sync): remove private design-doc references from public comments

### DIFF
--- a/packages/core/src/types/sync/busy.contracts.test.ts
+++ b/packages/core/src/types/sync/busy.contracts.test.ts
@@ -112,7 +112,7 @@ describe("Sync busy contracts", () => {
       expect(BusyQuerySchema.safeParse(query).success).toBe(true);
     });
 
-    it("rejects a range exceeding the 366-day ceiling (R-AVAIL-06 stays a floor, not unbounded)", () => {
+    it("rejects a range exceeding the 366-day ceiling (12 months is a floor, not unbounded)", () => {
       const query = {
         ...baseQuery(),
         start: "2026-01-01T00:00:00.000Z",
@@ -195,7 +195,7 @@ describe("Sync busy contracts", () => {
       expect(BusyQueryResponseSchema.safeParse(response).success).toBe(false);
     });
 
-    it("rejects bookable=true when complete is false (fail-closed, R-AVAIL-04)", () => {
+    it("rejects bookable=true when complete is false (fail-closed)", () => {
       const response = {
         ...baseResponse(),
         complete: false,

--- a/packages/core/src/types/sync/busy.contracts.ts
+++ b/packages/core/src/types/sync/busy.contracts.ts
@@ -3,19 +3,18 @@ import { DateTimeSchema } from "@core/types/domain-primitives";
 import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
 import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
 
-// Busy-query contracts for Compass Sync (ledger S05). Availability results
+// Busy-query contracts for Compass Sync. Availability results
 // must disclose freshness/completeness rather than presenting stale or
-// incomplete data as known-current (R-PRINCIPLE-02, R-AVAIL-03), and a
-// booking must fail closed when any required blocker cannot be freshly
-// verified (R-AVAIL-04). Do not add booking policy (working hours, buffers,
-// which calendars block) here — that stays in the Compass booking module
-// (03-availability-and-booking.md).
+// incomplete data as known-current, and a booking must fail closed when any
+// required blocker cannot be freshly verified. Do not add booking policy
+// (working hours, buffers, which calendars block) here — that stays in the
+// Compass booking module.
 
 const isEndAfterStart = ({ start, end }: { start: string; end: string }) =>
   Date.parse(end) > Date.parse(start);
 
 // Half-open [start, end) interval only: no calendar id, title, or other
-// event content ever appears on a busy interval (R-SEC-04 privacy).
+// event content ever appears on a busy interval, for privacy.
 export const BusyIntervalSchema = z
   .strictObject({
     start: DateTimeSchema,
@@ -33,9 +32,9 @@ export const BusyQueryPurposeSchema = z.enum([
 ]);
 export type BusyQueryPurpose = z.infer<typeof BusyQueryPurposeSchema>;
 
-// R-AVAIL-06 requires supporting at least 12 months into the future; this is
+// Availability must support at least 12 months into the future; this is
 // the Sync-level ceiling. The booking module further narrows this to its own
-// 60-day window when it calls in (03-availability-and-booking.md).
+// 60-day window when it calls in.
 const MAX_BUSY_QUERY_RANGE_DAYS = 366;
 const MAX_BUSY_QUERY_RANGE_MS = MAX_BUSY_QUERY_RANGE_DAYS * 24 * 60 * 60 * 1000;
 
@@ -95,9 +94,9 @@ export const BusyQueryResponseSchema = z
     connections: z.array(BusyConnectionEvidenceSchema).readonly(),
     complete: z.boolean(),
     incompleteCalendars: z.array(IncompleteCalendarSchema).readonly(),
-    // True only when every blocker meets confirmation freshness
-    // (R-AVAIL-04). Correct fail-closed responses still count as available
-    // service behavior for R-QUALITY-02, not as a failed query.
+    // True only when every blocker meets confirmation freshness.
+    // Correct fail-closed responses still count as available service
+    // behavior, not as a failed query.
     bookable: z.boolean(),
   })
   .refine(

--- a/packages/core/src/types/sync/change-feed.contracts.test.ts
+++ b/packages/core/src/types/sync/change-feed.contracts.test.ts
@@ -38,7 +38,7 @@ describe("Sync change-feed contracts", () => {
       expect(ImportProgressSchema.safeParse(progress).success).toBe(true);
     });
 
-    it("rejects complete=true before every calendar finishes (R-CLIENT-05)", () => {
+    it("rejects complete=true before every calendar finishes", () => {
       const progress = {
         calendarsTotal: 5,
         calendarsCompleted: 4,

--- a/packages/core/src/types/sync/change-feed.contracts.ts
+++ b/packages/core/src/types/sync/change-feed.contracts.ts
@@ -6,14 +6,13 @@ import {
   SyncCommandIdSchema,
 } from "@core/types/sync/identity.contracts";
 
-// Resumable internal change-feed contracts for Compass Sync (ledger S05).
+// Resumable internal change-feed contracts for Compass Sync.
 // Compass API consumes this feed and translates it into typed browser SSE;
-// it never appears in the browser directly (02-sync-lifecycle "Client
-// invalidation and recovery"). Invalidations carry only IDs and reasons,
-// never event content — a client always refetches canonical state.
+// it never appears in the browser directly. Invalidations carry only IDs and
+// reasons, never event content — a client always refetches canonical state.
 
-// Import progress must never imply completion from partial data
-// (R-CLIENT-05): `complete` can only be true once every discovered calendar
+// Import progress must never imply completion from partial data:
+// `complete` can only be true once every discovered calendar
 // has finished, though the converse isn't required — a cursor-finalization
 // pass may still be pending even after every calendar's window fills.
 export const ImportProgressSchema = z
@@ -93,7 +92,7 @@ export type InvalidationEnvelope = z.infer<typeof InvalidationEnvelopeSchema>;
 
 // null means "resume from now" (no prior cursor, e.g. a fresh SSE
 // connection). Tenant/principal scope always comes from the authenticated
-// caller context, never from this request body (R-SEC-03).
+// caller context, never from this request body.
 export const ChangeFeedResumeQuerySchema = z.strictObject({
   cursor: ChangeFeedCursorSchema.nullable(),
 });
@@ -106,8 +105,7 @@ const ChangeFeedOkSchema = z.strictObject({
 });
 
 // Sent when a resume cursor is no longer valid; the caller must invalidate
-// all affected cached queries rather than trust a partial replay
-// (02-sync-lifecycle "Client invalidation and recovery").
+// all affected cached queries rather than trust a partial replay.
 const ChangeFeedResyncRequiredSchema = z.strictObject({
   kind: z.literal("resyncRequired"),
 });

--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -21,12 +21,10 @@ import {
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 
-// Durable event command contracts for Compass Sync (ledger S04). A command
-// records acknowledged user intent (01-domain-model "Command") and is
-// persisted before any asynchronous work begins (R-SYNC-05). This file adds
-// contracts only — nothing here executes a command or reads/writes the
-// existing Compass API event endpoints (02-sync-lifecycle "Durable event
-// commands").
+// Durable event command contracts for Compass Sync. A command
+// records acknowledged user intent and is persisted before any asynchronous
+// work begins. This file adds contracts only — nothing here executes a command
+// or reads/writes the existing Compass API event endpoints.
 
 // create has no calendar to move within and no prior scope to preserve, so
 // its recurrence input reuses the existing single/series edit shape.
@@ -67,9 +65,8 @@ export const SyncCommandInputSchema = z.discriminatedUnion("kind", [
 export type SyncCommandInput = z.infer<typeof SyncCommandInputSchema>;
 
 // Provider-side rejection classes a command outcome can carry. These map to
-// the failure classification table in 02-sync-lifecycle.md; "capability"
-// failures are typed rather than a silently degraded write (01-domain-model
-// "Provider adapter contract").
+// the sync failure classification; "capability" failures are typed rather than
+// a silently degraded write in the provider adapter contract.
 export const SyncCommandFailureReasonSchema = z.enum([
   "versionConflict",
   "readOnlyCalendar",
@@ -83,7 +80,7 @@ export type SyncCommandFailureReason = z.infer<
 
 // Nonterminal: pending (persisted, not yet attempted), applying (in flight
 // at the provider), reconciling (response was ambiguous; identity must be
-// confirmed before another attempt — 02-sync-lifecycle "Create" step 6).
+// confirmed before another attempt).
 // Terminal: confirmed, failed, cancelled.
 const PendingOutcomeSchema = z.strictObject({ state: z.literal("pending") });
 const ApplyingOutcomeSchema = z.strictObject({ state: z.literal("applying") });
@@ -95,7 +92,7 @@ const ConfirmedOutcomeSchema = z
   .strictObject({
     state: z.literal("confirmed"),
     // Both null when the event has no provider target: confirmation is
-    // durable cloud persistence only (02-sync-lifecycle "Create" step 3).
+    // durable cloud persistence only.
     // Otherwise both present together — a provider identity without a
     // version (or vice versa) is not a coherent confirmed state.
     providerEventId: ProviderEventIdSchema.nullable(),
@@ -136,7 +133,7 @@ export const SyncCommandSchema = z
     tenantId: TenantIdSchema,
     principalId: PrincipalIdSchema,
     // Unique per (tenantId, principalId, idempotencyKey) — the same key
-    // always refers to the same command (01-domain-model "Command").
+    // always refers to the same command.
     idempotencyKey: IdempotencyKeySchema,
     eventId: EventIdSchema,
     input: SyncCommandInputSchema,

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -196,7 +196,7 @@ describe("Sync connection contracts", () => {
     });
 
     // Every capability combination is representable: facts describe what the
-    // provider permits, and no combination is privileged (R-CAL-05).
+    // provider permits, and no combination is privileged.
     it.each(
       Array.from({ length: 16 }, (_, mask) => [
         {

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -11,12 +11,12 @@ import {
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 
-// Connection and calendar contracts for Compass Sync (ledger S02).
-// R-CONN-01..06, R-CAL-01..05: provider facts only — no credentials, and no
-// product preferences (visibility, blocking, booking target) which belong to
-// the Compass product layer.
+// Connection and calendar contracts for Compass Sync.
+// Provider facts only — no credentials, and no product preferences
+// (visibility, blocking, booking target) which belong to the Compass product
+// layer.
 
-// The one user-facing connection state (R-CONN-03). Only the shared health
+// The one user-facing connection state. Only the shared health
 // derivation may produce these values; no code path reports healthy because a
 // single operation succeeded.
 export const ConnectionStateSchema = z.enum([
@@ -43,7 +43,7 @@ export type ConnectionStateReason = z.infer<typeof ConnectionStateReasonSchema>;
 
 // Display facts about the authorized provider account. The stable
 // providerAccountId is the only ownership proof; email is display data and
-// may change without changing identity (R-CONN-02).
+// may change without changing identity.
 export const ProviderAccountFactsSchema = z.strictObject({
   providerAccountId: ProviderAccountIdSchema,
   email: z.string().trim().min(1).max(320).nullable(),
@@ -67,7 +67,7 @@ export const ProviderConnectionSchema = z
     state: ConnectionStateSchema,
     // Present exactly when the state needs a user-facing explanation.
     stateReason: ConnectionStateReasonSchema.nullable(),
-    // Evidence timestamps (R-CONN-04): data sync vs verified health are
+    // Evidence timestamps: data sync vs verified health are
     // distinct facts. Null until the first successful pass.
     lastSyncedAt: DateTimeSchema.nullable(),
     lastHealthyAt: DateTimeSchema.nullable(),
@@ -118,7 +118,7 @@ export const ProviderCalendarSchema = z.strictObject({
   providerCalendarId: ProviderCalendarSourceIdSchema,
   displayName: z.string().trim().min(1).max(1024),
   color: z.string().trim().min(1).max(64).nullable(),
-  // Provider facts (R-CAL-02): active reflects the provider/calendar-list
+  // Provider facts: active reflects the provider/calendar-list
   // state, primary the provider's default-calendar designation.
   active: z.boolean(),
   primary: z.boolean(),
@@ -138,7 +138,7 @@ export type ConnectionListResponse = z.infer<
 
 export const CalendarListQuerySchema = z.strictObject({
   // Optional narrowing; principal scope always comes from authenticated
-  // context, never from the request body (R-SEC-03).
+  // context, never from the request body.
   connectionId: ConnectionIdSchema.optional(),
   activeOnly: z.boolean().optional(),
 });

--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -22,7 +22,7 @@ const timedSchedule = {
 };
 
 // 2026-03-08 is the US spring-forward transition; 09:00-10:00 local crosses
-// it in wall-clock time while the UTC offset itself changes (R-EVENT-04).
+// it in wall-clock time while the UTC offset itself changes.
 const dstCrossingSchedule = {
   kind: "timed",
   start: "2026-03-08T01:30:00-07:00",
@@ -314,7 +314,7 @@ describe("Sync event contracts", () => {
 
     // An occurrence must be groupable by calendar whether its source event is
     // still unlinked (Compass's own calendar id) or provider-linked (the
-    // provider calendar id) — Sync is the store of record for both (R-LIFE-03).
+    // provider calendar id) — Sync is the store of record for both.
     it("accepts a Compass calendar id for an unlinked event's occurrence", () => {
       expect(SyncEventCalendarIdSchema.safeParse(objectId()).success).toBe(
         true,

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -12,9 +12,9 @@ import {
   ProviderEventIdSchema,
 } from "@core/types/sync/identity.contracts";
 
-// Canonical, provider-neutral event contracts for Compass Sync (ledger S03).
-// This is the logical record Sync persists per event/series (01-domain-model
-// "Event"); Google/Microsoft SDK shapes stay inside provider adapters and
+// Canonical, provider-neutral event contracts for Compass Sync.
+// This is the logical record Sync persists per event/series;
+// Google/Microsoft SDK shapes stay inside provider adapters and
 // never appear here. Schedule reuses the app-facing EventScheduleSchema
 // (event.contracts.ts) since timed-vs-all-day/DST semantics are identical.
 
@@ -45,7 +45,7 @@ export const ProviderDeliveryStateSchema = z.enum([
 export type ProviderDeliveryState = z.infer<typeof ProviderDeliveryStateSchema>;
 
 // Present only once an event is linked to exactly one owning provider
-// calendar (R-EVENT-01, R-EVENT-02). Unlinked events have no provider truth.
+// calendar. Unlinked events have no provider truth.
 export const SyncEventOwnershipSchema = z.discriminatedUnion("kind", [
   z.strictObject({ kind: z.literal("unlinked") }),
   z.strictObject({
@@ -60,7 +60,7 @@ export const SyncEventOwnershipSchema = z.discriminatedUnion("kind", [
     deliveryState: ProviderDeliveryStateSchema,
     // Minimal opaque bag for adapter-internal identity/concurrency facts
     // (e.g. a recurring-instance fingerprint), never the full provider
-    // payload (01-domain-model.md). Preserves what R-EVENT-05 needs without
+    // payload. Preserves the adapter-internal facts Sync needs without
     // duplicating provider state Sync doesn't otherwise model.
     providerMetadata: z.record(z.string(), z.string()).readonly().optional(),
   }),
@@ -113,7 +113,7 @@ const SeriesMasterRecurrenceSchema = z.strictObject({
   rules: RRuleSchema,
 });
 
-// One overridden or cancelled instance of a recurring series (R-EVENT-06).
+// One overridden or cancelled instance of a recurring series.
 // recurrenceId is the instance's original scheduled start before override —
 // the standard identity providers use to address one occurrence.
 const RecurrenceExceptionSchema = z.strictObject({
@@ -131,7 +131,7 @@ export const SyncEventRecurrenceSchema = z.discriminatedUnion("kind", [
 export type SyncEventRecurrence = z.infer<typeof SyncEventRecurrenceSchema>;
 
 // Visible while a Compass-initiated deletion has not yet been provider
-// confirmed (R-EVENT-09). The record is removed, and a content-free
+// confirmed. The record is removed, and a content-free
 // deletion marker takes its place, only after confirmation.
 export const SyncEventLifecycleStateSchema = z.enum([
   "active",
@@ -144,7 +144,7 @@ export type SyncEventLifecycleState = z.infer<
 export const SyncEventSchema = z.strictObject({
   id: EventIdSchema,
   // Caller-generated id used to make anonymous-to-cloud promotion and retry
-  // idempotent (R-LIFE-02); null once no longer needed for that purpose.
+  // idempotent; null once no longer needed for that purpose.
   clientEventId: ClientEventIdSchema.nullable(),
   origin: SyncEventOriginSchema,
   ownership: SyncEventOwnershipSchema,
@@ -159,9 +159,9 @@ export const SyncEventSchema = z.strictObject({
 export type SyncEvent = z.infer<typeof SyncEventSchema>;
 
 // Sync is the store of record for both provider-linked and still-unlinked
-// Compass cloud events (S26), so an occurrence's calendar grouping key must
+// Compass cloud events, so an occurrence's calendar grouping key must
 // accept either identity space: Compass's own calendar id for an unlinked
-// event, or the provider calendar id once one exists (R-LIFE-03).
+// event, or the provider calendar id once one exists.
 export const SyncEventCalendarIdSchema = z.union([
   CalendarIdSchema,
   ProviderCalendarIdSchema,
@@ -170,7 +170,7 @@ export type SyncEventCalendarId = z.infer<typeof SyncEventCalendarIdSchema>;
 
 // One derived, display-ready instance within the rolling sync horizon (12
 // months past / 18 months future). Never expand a non-ending series to
-// completion; project only the bounded window a query needs (R-AVAIL-06).
+// completion; project only the bounded window a query needs.
 export const OccurrenceKeySchema = z
   .string()
   .trim()

--- a/packages/core/src/types/sync/identity.contracts.ts
+++ b/packages/core/src/types/sync/identity.contracts.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 import { OBJECT_ID_STRING_PATTERN } from "@core/types/type.utils";
 
-// Identity primitives for Compass Sync (internal design packet, ledger S01).
+// Identity primitives for Compass Sync.
 // Compass-issued ids are ObjectId-shaped; provider-issued ids are opaque
 // strings scoped beneath the connection that issued them and must never be
 // treated as globally unique or user-facing.

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -23,7 +23,7 @@ export interface SyncService {
 // Wires the service's lifecycle pieces from a validated config without binding
 // a port or reading a file — so tests can drive it directly. Later commits
 // register storage/scheduler readiness checks and drain tasks against the
-// returned registries (S11+).
+// returned registries.
 export function createSyncService(config: SyncConfig): SyncService {
   const identity = buildServiceIdentity({
     environment: config.NODE_ENV,
@@ -68,7 +68,7 @@ async function start(): Promise<void> {
 
   // Connect storage before listening. Register the disconnect drain first so,
   // under the coordinator's reverse-order teardown, storage closes LAST — after
-  // any workers that depend on it (S33). Registering the readiness check means
+  // any workers that depend on it. Registering the readiness check means
   // /health/ready stays 503 until the connection and indexes are verified.
   const mongo = new SyncMongoService();
   service.shutdown.register("mongo", () => mongo.disconnect());

--- a/packages/sync/src/auth/internal-auth.ts
+++ b/packages/sync/src/auth/internal-auth.ts
@@ -8,15 +8,15 @@ import {
 } from "@core/types/sync/identity.contracts";
 import { createHmac, timingSafeEqual } from "node:crypto";
 
-// Internal service authentication for the Compass Sync service (ledger S10).
+// Internal service authentication for the Compass Sync service.
 //
 // Only the trusted Compass API calls Sync's internal routes. Each request is
 // HMAC-signed with a shared, rotatable service secret over a timestamp and the
 // tenant/principal the request acts on behalf of. Sync derives the
 // tenant/principal context from those SIGNED headers — never from the request
 // body — so a caller cannot assert ownership of another tenant without the
-// secret (R-SEC-03; 04-security-and-observability.md "authenticated caller
-// identity", "authorizes every resource against tenant/principal").
+// secret. Every request is an authenticated caller identity, and every
+// resource is authorized against its tenant/principal.
 //
 // The signed timestamp bounds replay to a short freshness window rather than a
 // nonce store: on a private TLS network with a single trusted caller that is

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -5,12 +5,11 @@ import {
 } from "@core/config/compass.config";
 import { NodeEnv } from "@core/constants/core.constants";
 
-// Validated configuration for the Compass Sync service (ledger S08).
+// Validated configuration for the Compass Sync service.
 // Execution defaults to `passive`: the service starts, serves health, and
 // verifies storage read-only, but must not claim jobs, complete OAuth, accept
 // callbacks, or write to providers. Passive is enforced in code by later
-// commits; here it is the safe default when the field is omitted
-// (07-commit-ledger.md rollout controls).
+// commits; here it is the safe default when the field is omitted.
 
 const SYNC_PORT_DEFAULT = 3010;
 const SYNC_MAX_CONCURRENCY_DEFAULT = 4;

--- a/packages/sync/src/lifecycle/readiness.ts
+++ b/packages/sync/src/lifecycle/readiness.ts
@@ -1,11 +1,11 @@
-// Readiness tracking for the Compass Sync service (ledger S09).
+// Readiness tracking for the Compass Sync service.
 //
 // Liveness answers "is the process running" (always true once we respond).
 // Readiness answers "are all required dependencies verified" — storage
 // connectivity, index installation, scheduler, change-feed init. Later commits
-// register real checks; S09 provides the registry and proves a failing check
+// register real checks; this provides the registry and proves a failing check
 // makes the service not-ready. The service must never report ready before its
-// dependencies and indexes are verified (07-commit-ledger.md S09).
+// dependencies and indexes are verified.
 
 export interface ReadinessCheckResult {
   readonly name: string;

--- a/packages/sync/src/lifecycle/shutdown.ts
+++ b/packages/sync/src/lifecycle/shutdown.ts
@@ -1,11 +1,11 @@
-// Dependency-drain coordination for the Compass Sync service (ledger S09).
+// Dependency-drain coordination for the Compass Sync service.
 //
 // This coordinator drains BACKGROUND DEPENDENCIES only — job-claim workers,
 // schedulers, and storage clients registered by later commits. It runs tasks
 // in REVERSE registration order so higher-level work (job claims) drains
 // before the storage it depends on: startup acquires storage first, then
 // starts workers, so LIFO teardown stops workers first and closes storage
-// last (04-security-and-observability.md "stops claims ... then closes").
+// last: it stops claims before it closes the storage they depend on.
 //
 // The HTTP listener is deliberately NOT a task here. Stopping the front door
 // must happen FIRST (before dependencies drain), so `createSyncService`

--- a/packages/sync/src/server/health.routes.ts
+++ b/packages/sync/src/server/health.routes.ts
@@ -3,10 +3,10 @@ import { Status } from "@core/errors/status.codes";
 import { type ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { type StructuredServiceIdentity } from "@sync/service-identity";
 
-// Liveness and readiness endpoints for the Compass Sync service (ledger S09).
+// Liveness and readiness endpoints for the Compass Sync service.
 // These are content-free operational probes: they expose service identity and
-// dependency readiness, never user, tenant, or provider data
-// (04-security-and-observability.md — public health routes stay content-free).
+// dependency readiness, never user, tenant, or provider data. Public health
+// routes stay content-free.
 
 export const LIVENESS_PATH = "/health/live";
 export const READINESS_PATH = "/health/ready";

--- a/packages/sync/src/server/sync.server.test.ts
+++ b/packages/sync/src/server/sync.server.test.ts
@@ -86,8 +86,8 @@ describe("Sync HTTP server health endpoints", () => {
     await listen(service);
 
     const events: string[] = [];
-    // A dependency drain (as S11+ will register) records when it runs; the
-    // HTTP listener must already be closed by then.
+    // A dependency drain (as later commits will register) records when it
+    // runs; the HTTP listener must already be closed by then.
     service.shutdown.register("dependency", () => {
       events.push(
         service.httpServer.listening ? "http-still-open" : "http-closed",

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -3,11 +3,11 @@ import { type ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { registerHealthRoutes } from "@sync/server/health.routes";
 import { type StructuredServiceIdentity } from "@sync/service-identity";
 
-// Builds the Sync service's HTTP application (ledger S09). S09 mounts only the
-// content-free health probes; internal-auth middleware (S10), connection/OAuth
-// ingress (S24), webhook ingress (S32), and query routes (S25) mount here in
-// later commits. JSON body parsing is enabled now so those routes compose
-// without re-wiring the app.
+// Builds the Sync service's HTTP application. For now it mounts only the
+// content-free health probes; internal-auth middleware, connection/OAuth
+// ingress, webhook ingress, and query routes mount here in later commits.
+// JSON body parsing is enabled now so those routes compose without re-wiring
+// the app.
 export function buildSyncApp(deps: {
   identity: StructuredServiceIdentity;
   readiness: ReadinessRegistry;

--- a/packages/sync/src/service-identity.ts
+++ b/packages/sync/src/service-identity.ts
@@ -1,9 +1,9 @@
 import { type NodeEnv } from "@core/constants/core.constants";
 
-// Stable identity for the Compass Sync service (ledger S07/S09). Kept as a plain
-// constant so health telemetry (S44) and internal-auth (S10) can reference one
+// Stable identity for the Compass Sync service. Kept as a plain
+// constant so health telemetry and internal-auth can reference one
 // canonical service name rather than string literals. PostHog's `service.name`
-// dimension uses this value (04-security-and-observability.md).
+// dimension uses this value.
 export const SYNC_SERVICE_NAME = "compass-sync";
 
 export interface SyncServiceIdentity {

--- a/packages/sync/src/storage/collections.ts
+++ b/packages/sync/src/storage/collections.ts
@@ -1,8 +1,8 @@
-// Collection names for the isolated `compass_sync` database (ledger S11).
+// Collection names for the isolated `compass_sync` database.
 // One document per connection, calendar, event, occurrence, resource, command,
-// job, and deletion marker — never growing per-user arrays (01-domain-model.md
-// "Collections and essential indexes"). Repositories for these land in S12-S14;
-// S11 owns the bootstrap that creates them with their indexes.
+// job, and deletion marker — never growing per-user arrays. Repositories for
+// these land in later commits; the bootstrap here creates them with their
+// indexes.
 export const SYNC_COLLECTIONS = {
   providerConnections: "provider_connections",
   providerCalendars: "provider_calendars",

--- a/packages/sync/src/storage/event-occurrence.record.ts
+++ b/packages/sync/src/storage/event-occurrence.record.ts
@@ -10,9 +10,9 @@ import {
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 
-// Persistence record for `event_occurrences` (ledger S13) — a derived,
+// Persistence record for `event_occurrences` — a derived,
 // display-ready instance projected from an event/series within the rolling
-// horizon (R-AVAIL-06). Never expand a non-ending series to completion; only
+// horizon. Never expand a non-ending series to completion; only
 // the bounded window is materialized. tenantId/principalId are denormalized for
 // scoped queries and the principal_start index; generation ties an occurrence
 // to the import generation of its source event so a repair can rebuild in a new

--- a/packages/sync/src/storage/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/event-occurrence.repository.ts
@@ -29,10 +29,10 @@ export interface OccurrenceRangeQuery {
   after?: OccurrenceRangeCursor;
 }
 
-// Repository for `event_occurrences` (ledger S13). Rebuilding a series' window
+// Repository for `event_occurrences`. Rebuilding a series' window
 // replaces exactly that event's occurrences for the given generation, so a
-// series edit rebuilds only the affected horizon (02-sync-lifecycle). The
-// range query is the bounded, keyset-paginated display projection.
+// series edit rebuilds only the affected horizon. The range query is the
+// bounded, keyset-paginated display projection.
 export class EventOccurrenceRepository {
   private readonly collection: Collection<EventOccurrenceRecord>;
 

--- a/packages/sync/src/storage/event.record.ts
+++ b/packages/sync/src/storage/event.record.ts
@@ -18,12 +18,12 @@ import {
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 
-// Persistence record for `events` (ledger S13). Provider ownership is stored
-// FLAT at top level (not nested under `ownership` like the S03 wire contract)
+// Persistence record for `events`. Provider ownership is stored
+// FLAT at top level (not nested under `ownership` like the wire contract)
 // so the unique provider-identity index and the principal_calendar index match
 // where the fields live. Unlinked Compass events keep provider fields null; the
 // partialFilterExpression unique index only applies to a real providerEventId,
-// so many unlinked events coexist (R-LIFE-03). The query API (S25) maps this
+// so many unlinked events coexist. The query API maps this
 // flat record back to the nested ownership union.
 export const EventRecordSchema = z.strictObject({
   _id: EventIdSchema,
@@ -35,7 +35,7 @@ export const EventRecordSchema = z.strictObject({
   calendarId: SyncEventCalendarIdSchema,
   clientEventId: ClientEventIdSchema.nullable(),
   // Provider ownership: all null for an unlinked Compass event, all set once
-  // linked to exactly one provider calendar (R-EVENT-01).
+  // linked to exactly one provider calendar.
   connectionId: ConnectionIdSchema.nullable(),
   providerEventId: ProviderEventIdSchema.nullable(),
   providerVersion: ProviderEventVersionSchema.nullable(),
@@ -46,7 +46,7 @@ export const EventRecordSchema = z.strictObject({
   schedule: EventScheduleSchema,
   recurrence: SyncEventRecurrenceSchema,
   lifecycleState: SyncEventLifecycleStateSchema,
-  // Import generation. A non-destructive repair (S31) imports into a new
+  // Import generation. A non-destructive repair imports into a new
   // generation and only removes the old one after the replacement completes,
   // so both can coexist transiently.
   generation: z.number().int().min(0),

--- a/packages/sync/src/storage/event.repository.ts
+++ b/packages/sync/src/storage/event.repository.ts
@@ -13,7 +13,7 @@ import {
 
 // Fields for a provider-linked event upsert. Sync assigns _id/createdAt on
 // first sight and dedupes on the (connection, calendar, providerEventId)
-// identity so a repeated provider read never duplicates (R-EVENT-01).
+// identity so a repeated provider read never duplicates.
 export type ProviderEventUpsert = Omit<
   EventRecord,
   "_id" | "createdAt" | "updatedAt"

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -8,10 +8,10 @@ import {
   type SyncCollectionName,
 } from "@sync/storage/collections";
 
-// Declarative index manifests for the `compass_sync` collections (ledger S11),
-// drawn from the essential-index table in 01-domain-model.md. Installation is
+// Declarative index manifests for the `compass_sync` collections,
+// drawn from the domain model's essential indexes. Installation is
 // idempotent: MongoDB createIndex is a no-op when an identical index already
-// exists, so re-running startup never errors. Repositories (S12-S14) rely on
+// exists, so re-running startup never errors. Repositories rely on
 // these unique identities for atomic upserts and coalescing.
 
 export interface IndexManifestEntry {
@@ -130,7 +130,7 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
         partialFilterExpression: { providerEventId: { $type: "string" } },
       },
     },
-    // TTL: content-free markers expire 30 days after deletion (R-EVENT-10).
+    // TTL: content-free markers expire 30 days after deletion.
     {
       name: "ttl_expiry",
       key: { expiresAt: 1 },

--- a/packages/sync/src/storage/provider-calendar.record.ts
+++ b/packages/sync/src/storage/provider-calendar.record.ts
@@ -11,11 +11,11 @@ import {
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 
-// Persistence record for `provider_calendars` (ledger S12). Provider FACTS
+// Persistence record for `provider_calendars`. Provider FACTS
 // only — `active`/`primary`/`accessRole`/`capabilities` reflect what the
 // provider reports. Product preferences (visible, blocksAvailability,
-// bookingTarget) are owned by the Compass booking module, never stored here
-// (R-CAL-02; ledger S12 "do not store product visibility or booking prefs").
+// bookingTarget) are owned by the Compass booking module, never stored here —
+// do not store product visibility or booking prefs.
 export const ProviderCalendarRecordSchema = z.strictObject({
   _id: ProviderCalendarIdSchema,
   tenantId: TenantIdSchema,

--- a/packages/sync/src/storage/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/provider-calendar.repository.ts
@@ -13,11 +13,11 @@ import {
   ProviderCalendarUpsertSchema,
 } from "@sync/storage/provider-calendar.record";
 
-// Repository for `provider_calendars` (ledger S12). Upserts are keyed on
+// Repository for `provider_calendars`. Upserts are keyed on
 // (connection, provider-calendar id) so re-discovering a calendar updates one
 // document; a renamed calendar keeps its Sync _id because identity is the
-// provider's calendar id, not its display name (R-CAL-07). Queries are scoped
-// to the owning tenant/principal (R-SEC-03).
+// provider's calendar id, not its display name. Queries are scoped
+// to the owning tenant/principal.
 export class ProviderCalendarRepository {
   private readonly collection: Collection<ProviderCalendarRecord>;
 

--- a/packages/sync/src/storage/provider-connection.record.ts
+++ b/packages/sync/src/storage/provider-connection.record.ts
@@ -28,11 +28,11 @@ function refineActionRequiredReason(
   }
 }
 
-// Persistence record for `provider_connections` (ledger S12). This is the
+// Persistence record for `provider_connections`. This is the
 // stored shape: string ids (Mongo accepts a string _id, and the ids are the
 // same opaque 24-hex values as the wire contracts) and Date timestamps for
-// indexable range queries. The API layer (S24) maps this to the ISO-string
-// ProviderConnection wire contract. Credential material is added in S19; product
+// indexable range queries. The API layer maps this to the ISO-string
+// ProviderConnection wire contract. Credential material is added later; product
 // preferences (visibility, blocking, booking target) are NOT stored here.
 export const ProviderConnectionRecordSchema = z
   .strictObject({

--- a/packages/sync/src/storage/provider-connection.repository.ts
+++ b/packages/sync/src/storage/provider-connection.repository.ts
@@ -12,11 +12,10 @@ import {
   ProviderConnectionUpsertSchema,
 } from "@sync/storage/provider-connection.record";
 
-// Repository for `provider_connections` (ledger S12). Upserts are keyed on the
+// Repository for `provider_connections`. Upserts are keyed on the
 // stable provider-account identity so reconnecting the same account updates one
-// document instead of creating a duplicate (R-CONN-02). Every query is scoped
-// to a tenant/principal — one principal can never read another's connections
-// (R-SEC-03).
+// document instead of creating a duplicate. Every query is scoped
+// to a tenant/principal — one principal can never read another's connections.
 export class ProviderConnectionRepository {
   private readonly collection: Collection<ProviderConnectionRecord>;
 

--- a/packages/sync/src/storage/sync-mongo.service.ts
+++ b/packages/sync/src/storage/sync-mongo.service.ts
@@ -19,10 +19,10 @@ export interface SyncMongoOptions {
   readonly nodeEnv: NodeEnv;
 }
 
-// Owns the connection to the isolated `compass_sync` database (ledger S11).
+// Owns the connection to the isolated `compass_sync` database.
 // It installs index manifests, verifies the least-privilege user, and never
-// makes cross-database calls into the Compass API's data
-// (01-domain-model.md; 00-architecture ownership boundary).
+// makes cross-database calls into the Compass API's data — that ownership
+// boundary is enforced here.
 export class SyncMongoService {
   #client?: MongoClient;
   #db?: Db;


### PR DESCRIPTION
## Summary

The sync package and sync core-contract comments cited a private design repo — internal work-item ids, internal doc filenames, and requirement ids — which a public reader can't resolve and which read as confusing noise. This strips those citations from **comments and test titles only**, keeping the plain-English engineering rationale intact.

30 files under `packages/sync/src/` and `packages/core/src/types/sync/`. No code, identifiers, string literals used in logic, test assertions, or behavior changed — verified that every changed line is a comment or an `it()`/`describe()` title.

Examples of the rephrasing (meaning kept, opaque citation dropped):
- "reconnecting the same account updates one document instead of duplicating (R-CONN-02)." → "…instead of duplicating."
- "The query API (S25) maps this" → "The query API maps this"
- "drawn from the essential-index table in 01-domain-model.md" → "drawn from the domain model's essential indexes"

Genuine engineering constraints (Mongo idempotency, `partialFilterExpression` reasoning, LIFO teardown order, DST/timezone notes) were preserved — only the internal citations embedded in them were removed.

## Test plan

- [x] `bun run test:sync` — 98 pass, 0 fail
- [x] `bun run test:core` — 482 pass, 0 fail
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] `git diff` audited: only comment lines and test-title strings changed, no logic

## Manual Testing Steps

- [ ] None — comment-only change with no runtime effect. Confirm CI stays green.