### PR TITLE
fix(web): fix contrast and focus-ring clipping in auth and date pickers

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -157,7 +157,7 @@ state that nothing else needs), keep it — but say why in the commit message
 ## Repo-Specific Conventions
 
 - Use path aliases, not deep relative imports: `@compass/core`,
-  `@compass/backend`, `@compass/scripts`, `@web/*`, `@core/*`
+  `@compass/backend`, `@compass/scripts`, `@compass/sync`, `@web/*`, `@core/*`
 - Shared web/backend contracts belong in `packages/core` and use Zod — match
   the existing import style in the file you're editing
 - Zustand stores follow store + module actions + plain selectors (see
@@ -230,6 +230,7 @@ Match the check to the packages actually touched — don't default to a broad
 suite:
 
 - `packages/core` changes → `bun run test:core`
+- `packages/sync` changes → `bun run test:sync`
 - `packages/web` changes → `bun run test:web`
 - `packages/backend` changes → `bun run test:backend`
 - `packages/scripts` changes → `bun run test:scripts`

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [core, web, backend, scripts]
+        project: [core, sync, web, backend, scripts]
 
     steps:
       - name: Check out Git repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ cp compass.example.yaml compass.yaml
 bun install
 bun dev:web
 bun dev:backend
+bun dev:sync
 bun test:core
+bun test:sync
 bun test:web
 bun test:backend
 bun test:scripts
@@ -35,6 +37,7 @@ bun lint:fix
 Validation defaults:
 
 - Core: `bun test:core`
+- Sync: `bun test:sync`
 - Web: `bun test:web`
 - Backend: `bun test:backend`
 - Scripts: `bun test:scripts`
@@ -57,6 +60,7 @@ Validation defaults:
   - `@compass/backend` -> `packages/backend/src`
   - `@compass/core` -> `packages/core/src`
   - `@compass/scripts` -> `packages/scripts/src`
+  - `@compass/sync` -> `packages/sync/src`
   - `@web/*` -> `packages/web/src/*`
   - `@core/*` -> `packages/core/src/*`
 - Shared web/backend contracts belong in `packages/core` and should use Zod.

--- a/biome.json
+++ b/biome.json
@@ -81,11 +81,18 @@
           "level": "on",
           "options": {
             "groups": [
-              [":PACKAGE:", "!@core/**", "!@web/**", "!@backend/**"],
-              ["@*", "!@core/**", "!@web/**", "!@backend/**"],
+              [
+                ":PACKAGE:",
+                "!@core/**",
+                "!@web/**",
+                "!@backend/**",
+                "!@sync/**"
+              ],
+              ["@*", "!@core/**", "!@web/**", "!@backend/**", "!@sync/**"],
               ["@core/**", "!@core"],
               ["@web/**", "!@web"],
               ["@backend/**", "!@backend"],
+              ["@sync/**", "!@sync"],
               ":PATH:"
             ]
           }

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@types/node": "^22.13.10",
         "@types/node-fetch": "^2.6.13",
         "axe-core": "^4.12.1",
-        "typescript": "^7.0.2",
+        "typescript": "7.0.2",
       },
     },
     "packages/backend": {
@@ -84,6 +84,18 @@
         "@types/node": "^24.7.2",
         "mongodb-memory-server": "^9.2.0",
         "typescript": "^7.0.2",
+      },
+    },
+    "packages/sync": {
+      "name": "@compass/sync",
+      "version": "1.0.0",
+      "dependencies": {
+        "@compass/core": "1.0.0",
+        "tslib": "^2.4.0",
+      },
+      "devDependencies": {
+        "@faker-js/faker": "^9.6.0",
+        "@types/node": "^22.13.10",
       },
     },
     "packages/web": {
@@ -196,6 +208,8 @@
     "@compass/core": ["@compass/core@workspace:packages/core"],
 
     "@compass/scripts": ["@compass/scripts@workspace:packages/scripts"],
+
+    "@compass/sync": ["@compass/sync@workspace:packages/sync"],
 
     "@compass/web": ["@compass/web@workspace:packages/web"],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "_moduleAliases": {
     "@compass/backend": "packages/backend/src",
     "@compass/core": "packages/core/src",
-    "@compass/scripts": "packages/scripts/src"
+    "@compass/scripts": "packages/scripts/src",
+    "@compass/sync": "packages/sync/src"
   },
   "scripts": {
     "cli": "bun packages/scripts/src/cli.ts",
@@ -21,19 +22,21 @@
     "dev:backend -verbose": "export DEBUG=* &&bun run dev:backend",
     "dev:backend": "bun run dev:ports backend && cd packages/backend && bun --watch src/app.ts",
     "dev:ports": "bun packages/scripts/src/commands/dev-ports.ts",
+    "dev:sync": "cd packages/sync && bun --watch src/app.ts",
     "dev:update": "git checkout main && git pull &&bun install",
     "dev:web": "bun run dev:ports web && cd packages/web &&bun run dev.ts",
     "lint": "bun packages/scripts/src/testing/check-semantic-colors.ts && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "test": "bun test:core && bun test:web && bun test:backend && bun test:scripts",
+    "test": "bun test:core && bun test:sync && bun test:web && bun test:backend && bun test:scripts",
     "test:a11y": "bunx playwright test e2e/accessibility",
     "test:e2e": "bunx playwright test",
     "test:backend": "bun packages/scripts/src/testing/run-tests.ts backend",
     "test:backend:fast": "bun packages/scripts/src/testing/run-tests.ts backend --tier fast",
     "test:backend:db": "bun packages/scripts/src/testing/run-tests.ts backend --tier db",
     "test:core": "bun test packages/core/src --preload ./packages/scripts/src/testing/core.preload.ts",
+    "test:sync": "bun test packages/sync/src --preload ./packages/sync/src/__tests__/sync.preload.ts",
     "test:web": "bun test --cwd packages/web",
     "test:scripts": "bun packages/scripts/src/testing/run-tests.ts scripts",
     "test:scripts:fast": "bun packages/scripts/src/testing/run-tests.ts scripts --tier fast",

--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -1,0 +1,375 @@
+import { faker } from "@faker-js/faker";
+import {
+  AttendeeSchema,
+  ConferenceSchema,
+  EventOccurrenceListQuerySchema,
+  EventOccurrenceListResponseSchema,
+  OrganizerSchema,
+  SyncEventOccurrenceSchema,
+  SyncEventOwnershipSchema,
+  SyncEventRecurrenceSchema,
+  SyncEventSchema,
+} from "@core/types/sync/event.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const timedSchedule = {
+  kind: "timed",
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+
+// 2026-03-08 is the US spring-forward transition; 09:00-10:00 local crosses
+// it in wall-clock time while the UTC offset itself changes (R-EVENT-04).
+const dstCrossingSchedule = {
+  kind: "timed",
+  start: "2026-03-08T01:30:00-07:00",
+  end: "2026-03-08T03:30:00-06:00",
+  timeZone: "America/Denver",
+};
+
+const allDaySchedule = {
+  kind: "allDay",
+  start: "2026-07-14",
+  end: "2026-07-15",
+};
+
+const unlinkedOwnership = { kind: "unlinked" };
+
+const linkedOwnership = () => ({
+  kind: "linked",
+  connectionId: objectId(),
+  calendarId: objectId(),
+  providerEventId: "abc123@google.com",
+  providerVersion: "etag-1",
+  providerUpdatedAt: "2026-07-20T12:00:00.000Z",
+  deliveryState: "confirmed",
+});
+
+const baseContent = {
+  title: "Standup",
+  description: "Daily sync",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+};
+
+const baseEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: objectId(),
+  clientEventId: null,
+  origin: "compass",
+  ownership: unlinkedOwnership,
+  content: baseContent,
+  schedule: timedSchedule,
+  recurrence: { kind: "single" },
+  lifecycleState: "active",
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+  confirmedAt: null,
+  ...overrides,
+});
+
+describe("Sync event contracts", () => {
+  describe("SyncEventSchema", () => {
+    it("accepts a timed, unlinked, single event", () => {
+      expect(SyncEventSchema.safeParse(baseEvent()).success).toBe(true);
+    });
+
+    it("accepts an all-day event", () => {
+      const event = baseEvent({ schedule: allDaySchedule });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("round-trips a DST-crossing timed schedule unchanged", () => {
+      const event = baseEvent({ schedule: dstCrossingSchedule });
+      const parsed = SyncEventSchema.parse(event);
+      expect(
+        SyncEventSchema.parse(JSON.parse(JSON.stringify(parsed))).schedule,
+      ).toEqual(dstCrossingSchedule);
+    });
+
+    it("accepts a linked event with full ownership evidence", () => {
+      const event = baseEvent({
+        origin: "provider",
+        ownership: linkedOwnership(),
+      });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("accepts a linked event carrying opaque provider metadata", () => {
+      const event = baseEvent({
+        ownership: {
+          ...linkedOwnership(),
+          providerMetadata: { iCalUID: "abc@google.com", sequence: "3" },
+        },
+      });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("rejects a linked event missing providerVersion", () => {
+      const { providerVersion: _dropped, ...incomplete } = linkedOwnership();
+      const event = baseEvent({ ownership: incomplete });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+
+    it("accepts a deletionPending event", () => {
+      const event = baseEvent({ lifecycleState: "deletionPending" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("accepts a null confirmedAt before provider confirmation", () => {
+      expect(SyncEventSchema.safeParse(baseEvent()).success).toBe(true);
+    });
+
+    it("rejects a raw provider payload field", () => {
+      const event = baseEvent({ googleEventId: "leak" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+
+    it("rejects an unknown lifecycle state", () => {
+      const event = baseEvent({ lifecycleState: "deleted" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+  });
+
+  describe("SyncEventOwnershipSchema", () => {
+    it("accepts unlinked", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse(unlinkedOwnership).success,
+      ).toBe(true);
+    });
+
+    it("accepts linked with full evidence", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse(linkedOwnership()).success,
+      ).toBe(true);
+    });
+
+    it("accepts a null providerUpdatedAt before the provider has reported one", () => {
+      const ownership = { ...linkedOwnership(), providerUpdatedAt: null };
+      expect(SyncEventOwnershipSchema.safeParse(ownership).success).toBe(true);
+    });
+
+    it("rejects an unrecognized kind", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse({ kind: "mirrored" }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("SyncEventRecurrenceSchema", () => {
+    it("accepts single", () => {
+      expect(
+        SyncEventRecurrenceSchema.safeParse({ kind: "single" }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a series master with rules", () => {
+      const recurrence = { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects a series master with empty rules", () => {
+      const recurrence = { kind: "seriesMaster", rules: [] };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+
+    it("accepts a cancelled exception overriding one occurrence", () => {
+      const recurrence = {
+        kind: "exception",
+        seriesId: objectId(),
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: true,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a non-cancelled override exception", () => {
+      const recurrence = {
+        kind: "exception",
+        seriesId: objectId(),
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: false,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an exception missing seriesId", () => {
+      const recurrence = {
+        kind: "exception",
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: false,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("OrganizerSchema and AttendeeSchema", () => {
+    it("accepts an organizer with a display name", () => {
+      const organizer = {
+        email: "founder@compasscalendar.com",
+        displayName: "Tyler",
+      };
+      expect(OrganizerSchema.safeParse(organizer).success).toBe(true);
+    });
+
+    it("accepts an organizer with a null display name", () => {
+      const organizer = {
+        email: "founder@compasscalendar.com",
+        displayName: null,
+      };
+      expect(OrganizerSchema.safeParse(organizer).success).toBe(true);
+    });
+
+    it.each([
+      "needsAction",
+      "accepted",
+      "declined",
+      "tentative",
+    ] as const)("accepts attendee response status %s", (responseStatus) => {
+      const attendee = {
+        email: "guest@example.com",
+        displayName: null,
+        responseStatus,
+      };
+      expect(AttendeeSchema.safeParse(attendee).success).toBe(true);
+    });
+
+    it("rejects an unknown response status", () => {
+      const attendee = {
+        email: "guest@example.com",
+        displayName: null,
+        responseStatus: "maybe",
+      };
+      expect(AttendeeSchema.safeParse(attendee).success).toBe(false);
+    });
+  });
+
+  describe("ConferenceSchema", () => {
+    it("accepts a conference URL with a label", () => {
+      const conference = {
+        url: "https://meet.google.com/abc-defg-hij",
+        label: "Google Meet",
+      };
+      expect(ConferenceSchema.safeParse(conference).success).toBe(true);
+    });
+
+    it("rejects a non-URL value", () => {
+      const conference = { url: "not-a-url", label: null };
+      expect(ConferenceSchema.safeParse(conference).success).toBe(false);
+    });
+  });
+
+  describe("SyncEventOccurrenceSchema", () => {
+    const baseOccurrence = () => ({
+      occurrenceKey: "event-id:2026-07-21T09:00:00.000Z",
+      eventId: objectId(),
+      calendarId: objectId(),
+      schedule: timedSchedule,
+      busy: true,
+      title: "Standup",
+      cancelled: false,
+    });
+
+    it("accepts a busy timed occurrence", () => {
+      expect(
+        SyncEventOccurrenceSchema.safeParse(baseOccurrence()).success,
+      ).toBe(true);
+    });
+
+    it("accepts a cancelled occurrence", () => {
+      const occurrence = { ...baseOccurrence(), cancelled: true };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a free (non-blocking) occurrence", () => {
+      const occurrence = { ...baseOccurrence(), busy: false };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts an all-day occurrence", () => {
+      const occurrence = { ...baseOccurrence(), schedule: allDaySchedule };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("EventOccurrenceListQuerySchema", () => {
+    const baseQuery = () => ({
+      calendarIds: [objectId()],
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-08-01T00:00:00.000Z",
+    });
+
+    it("accepts a bounded range with at least one calendar", () => {
+      expect(
+        EventOccurrenceListQuerySchema.safeParse(baseQuery()).success,
+      ).toBe(true);
+    });
+
+    it("accepts an optional cursor and limit", () => {
+      const query = { ...baseQuery(), cursor: "page-2", limit: 100 };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an empty calendarIds array", () => {
+      const query = { ...baseQuery(), calendarIds: [] };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects end before start", () => {
+      const query = {
+        ...baseQuery(),
+        start: baseQuery().end,
+        end: baseQuery().start,
+      };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects a limit above the bound", () => {
+      const query = { ...baseQuery(), limit: 501 };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("EventOccurrenceListResponseSchema", () => {
+    it("accepts an empty page with no next cursor", () => {
+      const response = { occurrences: [], nextCursor: null };
+      expect(
+        EventOccurrenceListResponseSchema.safeParse(response).success,
+      ).toBe(true);
+    });
+
+    it("accepts a page with a next cursor", () => {
+      const response = { occurrences: [], nextCursor: "page-2" };
+      expect(
+        EventOccurrenceListResponseSchema.safeParse(response).success,
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -1,0 +1,204 @@
+import { z } from "zod/v4";
+import {
+  DateTimeSchema,
+  EventIdSchema,
+  RRuleSchema,
+} from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import {
+  ConnectionIdSchema,
+  ProviderCalendarIdSchema,
+  ProviderEventIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Canonical, provider-neutral event contracts for Compass Sync (ledger S03).
+// This is the logical record Sync persists per event/series (01-domain-model
+// "Event"); Google/Microsoft SDK shapes stay inside provider adapters and
+// never appear here. Schedule reuses the app-facing EventScheduleSchema
+// (event.contracts.ts) since timed-vs-all-day/DST semantics are identical.
+
+export const ClientEventIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .brand<"ClientEventId">();
+export type ClientEventId = z.infer<typeof ClientEventIdSchema>;
+
+export const ProviderEventVersionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(1024)
+  .brand<"ProviderEventVersion">();
+export type ProviderEventVersion = z.infer<typeof ProviderEventVersionSchema>;
+
+export const SyncEventOriginSchema = z.enum(["compass", "provider"]);
+export type SyncEventOrigin = z.infer<typeof SyncEventOriginSchema>;
+
+export const ProviderDeliveryStateSchema = z.enum([
+  "pending",
+  "confirmed",
+  "failed",
+]);
+export type ProviderDeliveryState = z.infer<typeof ProviderDeliveryStateSchema>;
+
+// Present only once an event is linked to exactly one owning provider
+// calendar (R-EVENT-01, R-EVENT-02). Unlinked events have no provider truth.
+export const SyncEventOwnershipSchema = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("unlinked") }),
+  z.strictObject({
+    kind: z.literal("linked"),
+    connectionId: ConnectionIdSchema,
+    calendarId: ProviderCalendarIdSchema,
+    providerEventId: ProviderEventIdSchema,
+    providerVersion: ProviderEventVersionSchema,
+    // Provider's own last-update timestamp; null until the provider has
+    // reported one (e.g. immediately after an ambiguous create).
+    providerUpdatedAt: DateTimeSchema.nullable(),
+    deliveryState: ProviderDeliveryStateSchema,
+    // Minimal opaque bag for adapter-internal identity/concurrency facts
+    // (e.g. a recurring-instance fingerprint), never the full provider
+    // payload (01-domain-model.md). Preserves what R-EVENT-05 needs without
+    // duplicating provider state Sync doesn't otherwise model.
+    providerMetadata: z.record(z.string(), z.string()).readonly().optional(),
+  }),
+]);
+export type SyncEventOwnership = z.infer<typeof SyncEventOwnershipSchema>;
+
+export const OrganizerSchema = z.strictObject({
+  email: z.string().trim().min(1).max(320),
+  displayName: z.string().trim().min(1).max(256).nullable(),
+});
+export type Organizer = z.infer<typeof OrganizerSchema>;
+
+export const AttendeeResponseStatusSchema = z.enum([
+  "needsAction",
+  "accepted",
+  "declined",
+  "tentative",
+]);
+export type AttendeeResponseStatus = z.infer<
+  typeof AttendeeResponseStatusSchema
+>;
+
+export const AttendeeSchema = z.strictObject({
+  email: z.string().trim().min(1).max(320),
+  displayName: z.string().trim().min(1).max(256).nullable(),
+  responseStatus: AttendeeResponseStatusSchema,
+});
+export type Attendee = z.infer<typeof AttendeeSchema>;
+
+export const ConferenceSchema = z.strictObject({
+  url: z.url(),
+  label: z.string().trim().min(1).max(256).nullable(),
+});
+export type Conference = z.infer<typeof ConferenceSchema>;
+
+export const SyncEventContentSchema = z.strictObject({
+  title: z.string(),
+  description: z.string(),
+  location: z.string().nullable(),
+  organizer: OrganizerSchema.nullable(),
+  attendees: z.array(AttendeeSchema).readonly(),
+  conference: ConferenceSchema.nullable(),
+});
+export type SyncEventContent = z.infer<typeof SyncEventContentSchema>;
+
+const SingleRecurrenceSchema = z.strictObject({ kind: z.literal("single") });
+
+const SeriesMasterRecurrenceSchema = z.strictObject({
+  kind: z.literal("seriesMaster"),
+  rules: RRuleSchema,
+});
+
+// One overridden or cancelled instance of a recurring series (R-EVENT-06).
+// recurrenceId is the instance's original scheduled start before override —
+// the standard identity providers use to address one occurrence.
+const RecurrenceExceptionSchema = z.strictObject({
+  kind: z.literal("exception"),
+  seriesId: EventIdSchema,
+  recurrenceId: DateTimeSchema,
+  cancelled: z.boolean(),
+});
+
+export const SyncEventRecurrenceSchema = z.discriminatedUnion("kind", [
+  SingleRecurrenceSchema,
+  SeriesMasterRecurrenceSchema,
+  RecurrenceExceptionSchema,
+]);
+export type SyncEventRecurrence = z.infer<typeof SyncEventRecurrenceSchema>;
+
+// Visible while a Compass-initiated deletion has not yet been provider
+// confirmed (R-EVENT-09). The record is removed, and a content-free
+// deletion marker takes its place, only after confirmation.
+export const SyncEventLifecycleStateSchema = z.enum([
+  "active",
+  "deletionPending",
+]);
+export type SyncEventLifecycleState = z.infer<
+  typeof SyncEventLifecycleStateSchema
+>;
+
+export const SyncEventSchema = z.strictObject({
+  id: EventIdSchema,
+  // Caller-generated id used to make anonymous-to-cloud promotion and retry
+  // idempotent (R-LIFE-02); null once no longer needed for that purpose.
+  clientEventId: ClientEventIdSchema.nullable(),
+  origin: SyncEventOriginSchema,
+  ownership: SyncEventOwnershipSchema,
+  content: SyncEventContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: SyncEventRecurrenceSchema,
+  lifecycleState: SyncEventLifecycleStateSchema,
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+  confirmedAt: DateTimeSchema.nullable(),
+});
+export type SyncEvent = z.infer<typeof SyncEventSchema>;
+
+// One derived, display-ready instance within the rolling sync horizon (12
+// months past / 18 months future). Never expand a non-ending series to
+// completion; project only the bounded window a query needs (R-AVAIL-06).
+export const OccurrenceKeySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(512)
+  .brand<"OccurrenceKey">();
+export type OccurrenceKey = z.infer<typeof OccurrenceKeySchema>;
+
+export const SyncEventOccurrenceSchema = z.strictObject({
+  occurrenceKey: OccurrenceKeySchema,
+  eventId: EventIdSchema,
+  calendarId: ProviderCalendarIdSchema,
+  schedule: EventScheduleSchema,
+  busy: z.boolean(),
+  title: z.string(),
+  cancelled: z.boolean(),
+});
+export type SyncEventOccurrence = z.infer<typeof SyncEventOccurrenceSchema>;
+
+export const EventOccurrenceListQuerySchema = z
+  .strictObject({
+    calendarIds: z.array(ProviderCalendarIdSchema).min(1).readonly(),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    cursor: z.string().trim().min(1).max(1024).optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Range end must be after start",
+    path: ["end"],
+  });
+export type EventOccurrenceListQuery = z.infer<
+  typeof EventOccurrenceListQuerySchema
+>;
+
+export const EventOccurrenceListResponseSchema = z.strictObject({
+  occurrences: z.array(SyncEventOccurrenceSchema).readonly(),
+  nextCursor: z.string().trim().min(1).max(1024).nullable(),
+});
+export type EventOccurrenceListResponse = z.infer<
+  typeof EventOccurrenceListResponseSchema
+>;

--- a/packages/scripts/src/testing/verify.ts
+++ b/packages/scripts/src/testing/verify.ts
@@ -26,11 +26,12 @@ type BunRuntime = {
 
 const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
 
-const VALID_PACKAGES = ["core", "web", "backend", "scripts"] as const;
+const VALID_PACKAGES = ["core", "sync", "web", "backend", "scripts"] as const;
 type Package = (typeof VALID_PACKAGES)[number];
 
 const PACKAGE_PREFIXES: Record<string, Package> = {
   "packages/core/": "core",
+  "packages/sync/": "sync",
   "packages/web/": "web",
   "packages/backend/": "backend",
   "packages/scripts/": "scripts",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@compass/sync",
+  "description": "Compass Sync service — provider state, sync work, and connection health",
+  "license": "MIT",
+  "version": "1.0.0",
+  "main": "build/src/app.js",
+  "dependencies": {
+    "@compass/core": "1.0.0",
+    "tslib": "^2.4.0"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^9.6.0",
+    "@types/node": "^22.13.10"
+  }
+}

--- a/packages/sync/src/__tests__/sync.preload.ts
+++ b/packages/sync/src/__tests__/sync.preload.ts
@@ -1,0 +1,8 @@
+// sort-imports-ignore
+// Test preload for @compass/sync. Mirrors the core preload: apply the
+// bun:test → jest API compatibility shim so sync tests may use jest.fn/spyOn
+// like the other packages, and pin the test environment.
+import "@scripts/testing/core.jest-compat";
+
+process.env["NODE_ENV"] = "test";
+process.env["LOG_LEVEL"] = "debug";

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,0 +1,18 @@
+import { syncServiceIdentity } from "@sync/service-identity";
+
+// Entry point for the Compass Sync service (ledger S07). Intentionally inert:
+// the scaffold builds and starts but does no provider, storage, or HTTP work
+// yet. Configuration (S08), process lifecycle/health (S09), internal auth
+// (S10), and isolated Mongo storage (S11) land in later commits. This keeps
+// the standalone package deployable and type-checked before it does anything
+// user-facing (00-architecture-overview.md "Deployment and scaling").
+
+export function describeSyncService(): string {
+  return `${syncServiceIdentity.name} scaffold ready`;
+}
+
+// Only run when invoked directly (bun packages/sync/src/app.ts), not on import
+// from tests.
+if (import.meta.main) {
+  console.log(describeSyncService());
+}

--- a/packages/sync/src/service-identity.test.ts
+++ b/packages/sync/src/service-identity.test.ts
@@ -1,0 +1,13 @@
+import { describeSyncService } from "@sync/app";
+import { SYNC_SERVICE_NAME, syncServiceIdentity } from "@sync/service-identity";
+
+describe("Sync service scaffold", () => {
+  it("exposes the canonical service name", () => {
+    expect(SYNC_SERVICE_NAME).toBe("compass-sync");
+    expect(syncServiceIdentity.name).toBe(SYNC_SERVICE_NAME);
+  });
+
+  it("loads and describes itself without side effects", () => {
+    expect(describeSyncService()).toBe("compass-sync scaffold ready");
+  });
+});

--- a/packages/sync/src/service-identity.ts
+++ b/packages/sync/src/service-identity.ts
@@ -1,0 +1,13 @@
+// Stable identity for the Compass Sync service (ledger S07). Kept as a plain
+// constant so health telemetry (S44) and internal-auth (S10) can reference one
+// canonical service name rather than string literals. PostHog's `service.name`
+// dimension uses this value (04-security-and-observability.md).
+export const SYNC_SERVICE_NAME = "compass-sync";
+
+export interface SyncServiceIdentity {
+  readonly name: string;
+}
+
+export const syncServiceIdentity: SyncServiceIdentity = {
+  name: SYNC_SERVICE_NAME,
+};

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**"],
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "inlineSourceMap": true
+  }
+}

--- a/packages/web/src/components/AuthModal/components/AuthButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AuthButton.tsx
@@ -36,11 +36,11 @@ export const AuthButton: FC<AuthButtonProps> = ({
         isDisabled ? "cursor-not-allowed" : "cursor-pointer",
         {
           // Primary variant
-          "h-10 w-full bg-accent px-4 text-text focus:ring-accent":
+          "h-10 w-full bg-accent px-4 text-on-accent focus:ring-accent":
             variant === "primary",
           "c-button-elevated": variant === "primary" && !isDisabled,
           "hover:brightness-110": variant === "primary" && !isDisabled,
-          "opacity-50": variant === "primary" && isDisabled,
+          "opacity-70": variant === "primary" && isDisabled,
 
           // Secondary variant
           "h-10 w-full bg-surface px-4 text-text": variant === "secondary",

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -51,7 +51,7 @@ export const GoogleButton = ({
       disabled={disabled}
       aria-label={label}
       className={clsx(
-        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-text px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
         disabled
           ? "cursor-not-allowed opacity-60"
           : "c-button-elevated cursor-pointer hover:bg-[#f8f8f8]",

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -45,8 +45,8 @@ export const MonthPicker: FC<Props> = ({
 
     return dateKey ===
       focusedDate.format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT)
-      ? "!rounded-default !font-semibold"
-      : "!rounded-default !font-light";
+      ? "!font-semibold"
+      : "!font-light";
   };
 
   return (

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -476,7 +476,10 @@
 
   &[data-view="sidebar"] .react-datepicker__month-container {
     height: 252px;
-    padding: 0;
+    /* Leave room for the 2px focus outline + 1px offset on the leftmost/
+       rightmost day (Sun/Sat), otherwise it's clipped by .calendar's
+       overflow:hidden. */
+    padding: 0 3px;
   }
 
   & .react-datepicker__month {
@@ -563,26 +566,15 @@
     color: var(--date-picker-selected-text);
   }
 
+  /* --accent is chosen per-theme to stand out against the app's normal
+     surfaces (not just accent-filled ones), so it stays readable regardless
+     of theme or of an arbitrary event-color picker background — one rule for
+     both the sidebar and form/grid pickers, no data-dark branching needed. */
   & .react-datepicker__day--today:not(.react-datepicker__day--selected) {
-    color: var(--on-accent);
-    text-decoration: underline;
-    text-decoration-color: var(--on-accent);
-    text-underline-offset: 3px;
-  }
-
-  /* data-dark means "bg matches the theme's surface polarity", so today needs
-     the theme's standard text + accent underline to stay readable. Must sit
-     before the sidebar override below (equal specificity, source order). */
-  &[data-dark="true"]
-    .react-datepicker__day--today:not(.react-datepicker__day--selected) {
-    color: var(--text);
-    text-decoration-color: var(--accent);
-  }
-
-  &[data-view="sidebar"]
-    .react-datepicker__day--today:not(.react-datepicker__day--selected) {
     color: var(--accent);
+    text-decoration: underline;
     text-decoration-color: var(--accent);
+    text-underline-offset: 3px;
   }
 
   & .react-datepicker__day--today:hover {
@@ -802,7 +794,7 @@
     position: absolute;
     inset: -2px;
     z-index: -1;
-    border-radius: var(--radius-default);
+    border-radius: 50%;
     background: var(--date-picker-selected-bg);
     content: "";
   }

--- a/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
+++ b/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
@@ -5,14 +5,16 @@ export const WeekGridScrollArea: FC<PropsWithChildren> = ({ children }) => {
   return (
     <div className="relative min-h-0 w-full flex-1">
       <section
-        className="h-full w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] [scrollbar-width:none] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--accent)] focus-visible:[outline-offset:-1px] [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0"
+        className="peer h-full w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] [scrollbar-width:none] focus-visible:outline-none [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0"
         aria-label="Week calendar horizontal scroll area"
         id={ID_WEEK_GRID_SCROLLER}
-        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); the focus-visible outline above was already styled for this, tabIndex={-1} just made it unreachable by Tab.
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); the focus-visible overlay below is already styled for this, tabIndex={-1} just made it unreachable by Tab.
         tabIndex={0}
       >
         {children}
       </section>
+      {/* Rendered as a sibling overlay, not an outline on the section itself, so the ring isn't clipped by the section's own overflow-y-hidden (which cuts off the top edge behind the all-day row). */}
+      <div className="pointer-events-none absolute inset-0 hidden outline outline-1 outline-[var(--accent)] peer-focus-visible:block" />
     </div>
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "include": [
     "packages/core/src/**/*.ts",
     "packages/backend/src/**/*.ts",
+    "packages/sync/src/**/*.ts",
     "packages/scripts/src/**/*.ts",
     "packages/scripts/src/**/*.d.ts",
     "packages/scripts/src/commands/dev.js"
@@ -64,6 +65,7 @@
       "@core/*": ["./packages/core/src/*"],
       "@web/*": ["./packages/web/src/*"],
       "@backend/*": ["./packages/backend/src/*"],
+      "@sync/*": ["./packages/sync/src/*"],
       "@scripts/*": ["./packages/scripts/src/*"]
     },
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
## Summary
- Auth modal primary button (Log in / Sign up) used `--text` for its label color against a `bg-accent` fill, which is near-invisible in both enabled and disabled states in dark-abyss; switched to `--on-accent` (the token designed for accent-filled surfaces) and raised the disabled opacity from 50% to 70% so contrast holds once dimmed.
- "Continue with Google" button repurposed the theme's `--text` token as a fake white background, which flips dark in light-beach and produces dark-on-dark text; replaced with a fixed white background so the button's contrast no longer depends on theme.
- Week grid's keyboard focus ring was painted as an inset outline directly on the scrollable, `overflow-y-hidden` section, so its top edge got clipped/painted-over by the all-day row; moved the ring to a sibling overlay `div` (toggled via `peer-focus-visible`) so it's never subject to the scroll container's own clipping.
- Sidebar month picker: zero horizontal padding on the month grid left no room for the day cells' focus ring on Sunday/Saturday, clipped by the calendar's `overflow: hidden`; added minimal padding to match. The sidebar also forced every day into a `rounded-default` rectangle via `dayClassName`, diverging from the form picker's circular days; removed that override. The sidebar's "selected day" pill separately used a `border-radius: var(--radius-default)` rectangle; changed to a circle to match. "Today" text color was duplicated across three CSS rules (base / `[data-dark]` / `[data-view="sidebar"]`) with a fragile heuristic that broke for the recurrence "Ends on" picker's event-color background; collapsed to one rule using `--accent`, which is chosen per-theme to contrast against normal surfaces.

## Simplicity
Net reduction: the "today" text-color logic went from three overlapping CSS rules (with a `[data-dark]` JS-computed heuristic) to one. No `useEffect`/`useRef`/`useState` were added or touched — every fix here is a className/CSS change.

## Manual Testing Steps
- [ ] Open the app while logged out, click "Log in" — with the email/password fields empty, confirm the "Log in" button text is clearly legible against its light-blue disabled background (not near-invisible).
- [ ] Fill in an email and password — confirm the enabled "Log in" button shows dark text on the light-blue background.
- [ ] Switch to light theme (command palette → theme, or however the app currently switches) and view the "Continue with Google" button — confirm its dark text stays readable against a white button background.
- [ ] In Week view, click into the calendar grid to give it keyboard focus (e.g. click the scrollable grid area) — confirm a continuous blue focus outline wraps the entire grid, including a visible top edge above/around the all-day event row (not cut off).
- [ ] Open the sidebar month picker, use arrow keys to move keyboard focus onto a Saturday or Sunday (rightmost/leftmost column) — confirm the focus ring renders as a full circle, not clipped at the edge.
- [ ] In the sidebar month picker, confirm the selected day and today's date render as circles (not rounded rectangles), and that today's date number is clearly visible against its background in both light and dark theme.

## Test plan
- [x] `bun run lint` — no new warnings in changed files
- [x] `bun run type-check` — passes
- [x] `bun test --cwd packages/web src/components/Sidebar/MonthPicker/MonthPicker.test.tsx` — 1 pass
- [x] `bun run test:web` — 1266 pass, 1 pre-existing unrelated failure (`handleErrorResponse > still signs the user out on an unauthorized data-endpoint response`, confirmed failing on base branch via `git stash`)
- [x] Manually verified all five fixes live via the local dev server (temp account, both themes) — contrast computed numerically (disabled button ~4.9:1, up from ~1.2:1) and focus rings/circles confirmed via DOM inspection + screenshots