### PR TITLE
fix(web): fix contrast and focus-ring clipping in auth and date pickers

### DIFF
--- a/packages/web/src/components/AuthModal/components/AuthButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AuthButton.tsx
@@ -36,11 +36,11 @@ export const AuthButton: FC<AuthButtonProps> = ({
         isDisabled ? "cursor-not-allowed" : "cursor-pointer",
         {
           // Primary variant
-          "h-10 w-full bg-accent px-4 text-text focus:ring-accent":
+          "h-10 w-full bg-accent px-4 text-on-accent focus:ring-accent":
             variant === "primary",
           "c-button-elevated": variant === "primary" && !isDisabled,
           "hover:brightness-110": variant === "primary" && !isDisabled,
-          "opacity-50": variant === "primary" && isDisabled,
+          "opacity-70": variant === "primary" && isDisabled,
 
           // Secondary variant
           "h-10 w-full bg-surface px-4 text-text": variant === "secondary",

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -51,7 +51,7 @@ export const GoogleButton = ({
       disabled={disabled}
       aria-label={label}
       className={clsx(
-        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-text px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
         disabled
           ? "cursor-not-allowed opacity-60"
           : "c-button-elevated cursor-pointer hover:bg-[#f8f8f8]",

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -45,8 +45,8 @@ export const MonthPicker: FC<Props> = ({
 
     return dateKey ===
       focusedDate.format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT)
-      ? "!rounded-default !font-semibold"
-      : "!rounded-default !font-light";
+      ? "!font-semibold"
+      : "!font-light";
   };
 
   return (

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -476,7 +476,10 @@
 
   &[data-view="sidebar"] .react-datepicker__month-container {
     height: 252px;
-    padding: 0;
+    /* Leave room for the 2px focus outline + 1px offset on the leftmost/
+       rightmost day (Sun/Sat), otherwise it's clipped by .calendar's
+       overflow:hidden. */
+    padding: 0 3px;
   }
 
   & .react-datepicker__month {
@@ -563,26 +566,15 @@
     color: var(--date-picker-selected-text);
   }
 
+  /* --accent is chosen per-theme to stand out against the app's normal
+     surfaces (not just accent-filled ones), so it stays readable regardless
+     of theme or of an arbitrary event-color picker background — one rule for
+     both the sidebar and form/grid pickers, no data-dark branching needed. */
   & .react-datepicker__day--today:not(.react-datepicker__day--selected) {
-    color: var(--on-accent);
-    text-decoration: underline;
-    text-decoration-color: var(--on-accent);
-    text-underline-offset: 3px;
-  }
-
-  /* data-dark means "bg matches the theme's surface polarity", so today needs
-     the theme's standard text + accent underline to stay readable. Must sit
-     before the sidebar override below (equal specificity, source order). */
-  &[data-dark="true"]
-    .react-datepicker__day--today:not(.react-datepicker__day--selected) {
-    color: var(--text);
-    text-decoration-color: var(--accent);
-  }
-
-  &[data-view="sidebar"]
-    .react-datepicker__day--today:not(.react-datepicker__day--selected) {
     color: var(--accent);
+    text-decoration: underline;
     text-decoration-color: var(--accent);
+    text-underline-offset: 3px;
   }
 
   & .react-datepicker__day--today:hover {
@@ -802,7 +794,7 @@
     position: absolute;
     inset: -2px;
     z-index: -1;
-    border-radius: var(--radius-default);
+    border-radius: 50%;
     background: var(--date-picker-selected-bg);
     content: "";
   }

--- a/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
+++ b/packages/web/src/views/Week/components/Grid/WeekGridScrollArea.tsx
@@ -5,14 +5,16 @@ export const WeekGridScrollArea: FC<PropsWithChildren> = ({ children }) => {
   return (
     <div className="relative min-h-0 w-full flex-1">
       <section
-        className="h-full w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] [scrollbar-width:none] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--accent)] focus-visible:[outline-offset:-1px] [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0"
+        className="peer h-full w-full overflow-x-auto overflow-y-hidden [overscroll-behavior-x:contain] [scrollbar-width:none] focus-visible:outline-none [&::-webkit-scrollbar]:hidden [&::-webkit-scrollbar]:h-0 [&::-webkit-scrollbar]:w-0"
         aria-label="Week calendar horizontal scroll area"
         id={ID_WEEK_GRID_SCROLLER}
-        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); the focus-visible outline above was already styled for this, tabIndex={-1} just made it unreachable by Tab.
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); the focus-visible overlay below is already styled for this, tabIndex={-1} just made it unreachable by Tab.
         tabIndex={0}
       >
         {children}
       </section>
+      {/* Rendered as a sibling overlay, not an outline on the section itself, so the ring isn't clipped by the section's own overflow-y-hidden (which cuts off the top edge behind the all-day row). */}
+      <div className="pointer-events-none absolute inset-0 hidden outline outline-1 outline-[var(--accent)] peer-focus-visible:block" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Auth modal primary button (Log in / Sign up) used `--text` for its label color against a `bg-accent` fill, which is near-invisible in both enabled and disabled states in dark-abyss; switched to `--on-accent` (the token designed for accent-filled surfaces) and raised the disabled opacity from 50% to 70% so contrast holds once dimmed.
- "Continue with Google" button repurposed the theme's `--text` token as a fake white background, which flips dark in light-beach and produces dark-on-dark text; replaced with a fixed white background so the button's contrast no longer depends on theme.
- Week grid's keyboard focus ring was painted as an inset outline directly on the scrollable, `overflow-y-hidden` section, so its top edge got clipped/painted-over by the all-day row; moved the ring to a sibling overlay `div` (toggled via `peer-focus-visible`) so it's never subject to the scroll container's own clipping.
- Sidebar month picker: zero horizontal padding on the month grid left no room for the day cells' focus ring on Sunday/Saturday, clipped by the calendar's `overflow: hidden`; added minimal padding to match. The sidebar also forced every day into a `rounded-default` rectangle via `dayClassName`, diverging from the form picker's circular days; removed that override. The sidebar's "selected day" pill separately used a `border-radius: var(--radius-default)` rectangle; changed to a circle to match. "Today" text color was duplicated across three CSS rules (base / `[data-dark]` / `[data-view="sidebar"]`) with a fragile heuristic that broke for the recurrence "Ends on" picker's event-color background; collapsed to one rule using `--accent`, which is chosen per-theme to contrast against normal surfaces.

## Simplicity
Net reduction: the "today" text-color logic went from three overlapping CSS rules (with a `[data-dark]` JS-computed heuristic) to one. No `useEffect`/`useRef`/`useState` were added or touched — every fix here is a className/CSS change.

## Manual Testing Steps
- [ ] Open the app while logged out, click "Log in" — with the email/password fields empty, confirm the "Log in" button text is clearly legible against its light-blue disabled background (not near-invisible).
- [ ] Fill in an email and password — confirm the enabled "Log in" button shows dark text on the light-blue background.
- [ ] Switch to light theme (command palette → theme, or however the app currently switches) and view the "Continue with Google" button — confirm its dark text stays readable against a white button background.
- [ ] In Week view, click into the calendar grid to give it keyboard focus (e.g. click the scrollable grid area) — confirm a continuous blue focus outline wraps the entire grid, including a visible top edge above/around the all-day event row (not cut off).
- [ ] Open the sidebar month picker, use arrow keys to move keyboard focus onto a Saturday or Sunday (rightmost/leftmost column) — confirm the focus ring renders as a full circle, not clipped at the edge.
- [ ] In the sidebar month picker, confirm the selected day and today's date render as circles (not rounded rectangles), and that today's date number is clearly visible against its background in both light and dark theme.

## Test plan
- [x] `bun run lint` — no new warnings in changed files
- [x] `bun run type-check` — passes (re-verified after rebasing onto latest main)
- [x] `bun test --cwd packages/web src/components/Sidebar/MonthPicker/MonthPicker.test.tsx` — 1 pass
- [x] `bun run test:web` — 1266 pass, 1 pre-existing unrelated failure (`handleErrorResponse > still signs the user out on an unauthorized data-endpoint response`, confirmed failing on base branch via `git stash`)
- [x] Manually verified all five fixes live via the local dev server (temp account, both themes) — contrast computed numerically (disabled button ~4.9:1, up from ~1.2:1) and focus rings/circles confirmed via DOM inspection + screenshots

(Supersedes #2211, which had unrelated merge conflicts from in-progress `packages/sync` scaffolding on its base branch — this is the same diff rebased cleanly onto current `main`.)