### PR TITLE
feat(sync): persist commands and jobs

### DIFF
--- a/packages/sync/src/storage/command.record.ts
+++ b/packages/sync/src/storage/command.record.ts
@@ -1,0 +1,63 @@
+import { z } from "zod/v4";
+import { EventIdSchema } from "@core/types/domain-primitives";
+import {
+  SyncCommandInputSchema,
+  SyncCommandOutcomeSchema,
+} from "@core/types/sync/command.contracts";
+import { ProviderEventVersionSchema } from "@core/types/sync/event.contracts";
+import {
+  IdempotencyKeySchema,
+  PrincipalIdSchema,
+  SyncCommandIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// A create command has nothing prior to condition against, so it never carries
+// an expected version.
+function refineCreateHasNoExpectedVersion(
+  command: { input: { kind: string }; expectedVersion: string | null },
+  ctx: z.RefinementCtx,
+): void {
+  if (command.input.kind === "create" && command.expectedVersion !== null) {
+    ctx.addIssue({
+      code: "custom",
+      message: "A create command cannot carry an expectedVersion",
+      path: ["expectedVersion"],
+    });
+  }
+}
+
+// Persistence record for `commands` — acknowledged, durable user intent for one
+// event mutation. Unique per (tenant, principal, idempotencyKey) so a retried
+// submission maps to the same command. `outcome` is nested so its `state` is
+// indexable. No credentials or raw provider payloads are stored here.
+export const CommandRecordSchema = z
+  .strictObject({
+    _id: SyncCommandIdSchema,
+    tenantId: TenantIdSchema,
+    principalId: PrincipalIdSchema,
+    idempotencyKey: IdempotencyKeySchema,
+    eventId: EventIdSchema,
+    input: SyncCommandInputSchema,
+    expectedVersion: ProviderEventVersionSchema.nullable(),
+    outcome: SyncCommandOutcomeSchema,
+    attemptCount: z.number().int().min(0),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+  })
+  .superRefine(refineCreateHasNoExpectedVersion);
+export type CommandRecord = z.infer<typeof CommandRecordSchema>;
+
+// Fields a caller supplies to submit a command. Sync owns _id, attemptCount,
+// outcome (starts pending), createdAt, and updatedAt.
+export const CommandSubmitSchema = z
+  .strictObject({
+    tenantId: TenantIdSchema,
+    principalId: PrincipalIdSchema,
+    idempotencyKey: IdempotencyKeySchema,
+    eventId: EventIdSchema,
+    input: SyncCommandInputSchema,
+    expectedVersion: ProviderEventVersionSchema.nullable(),
+  })
+  .superRefine(refineCreateHasNoExpectedVersion);
+export type CommandSubmit = z.infer<typeof CommandSubmitSchema>;

--- a/packages/sync/src/storage/command.repository.test.ts
+++ b/packages/sync/src/storage/command.repository.test.ts
@@ -1,0 +1,161 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { type CommandSubmit } from "@sync/storage/command.record";
+import { CommandRepository } from "@sync/storage/command.repository";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const timed = {
+  kind: "timed",
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const content = {
+  title: "Standup",
+  description: "",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+};
+
+const submit = (overrides: Partial<CommandSubmit> = {}): CommandSubmit =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    idempotencyKey: "key-1",
+    eventId: objectId(),
+    input: {
+      kind: "create",
+      calendarId: objectId(),
+      content,
+      schedule: timed,
+      recurrence: { kind: "single" },
+    },
+    expectedVersion: null,
+    ...overrides,
+  }) as CommandSubmit;
+
+describe("CommandRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: CommandRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`cmd_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new CommandRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("submits a new command as pending with zero attempts", async () => {
+    const command = await repo.submit(submit());
+    expect(command.outcome).toEqual({ state: "pending" });
+    expect(command.attemptCount).toBe(0);
+    expect(command._id).toMatch(/^[0-9a-f]{24}$/);
+  });
+
+  it("returns the existing command for a repeated idempotency key", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const first = await repo.submit(
+      submit({ tenantId, principalId, idempotencyKey: "dup" }),
+    );
+    // A retried submit must not create a second command or reset progress.
+    await repo.updateOutcome(
+      tenantId,
+      principalId,
+      first._id,
+      { state: "applying" },
+      1,
+    );
+    const second = await repo.submit(
+      submit({ tenantId, principalId, idempotencyKey: "dup" }),
+    );
+
+    expect(second._id).toBe(first._id);
+    expect(second.outcome).toEqual({ state: "applying" });
+    expect(second.attemptCount).toBe(1);
+    expect(await db.collection("commands").countDocuments()).toBe(1);
+  });
+
+  it("transitions outcome through the command lifecycle", async () => {
+    const command = await repo.submit(submit());
+    const applying = await repo.updateOutcome(
+      command.tenantId,
+      command.principalId,
+      command._id,
+      { state: "applying" },
+      1,
+    );
+    expect(applying?.outcome).toEqual({ state: "applying" });
+
+    const confirmed = await repo.updateOutcome(
+      command.tenantId,
+      command.principalId,
+      command._id,
+      {
+        state: "confirmed",
+        providerEventId: "evt-1",
+        providerVersion: "etag-1",
+      },
+      1,
+    );
+    expect(confirmed?.outcome).toMatchObject({ state: "confirmed" });
+  });
+
+  it("rejects an outcome update from another principal", async () => {
+    const command = await repo.submit(submit());
+    const result = await repo.updateOutcome(
+      command.tenantId,
+      objectId() as CommandSubmit["principalId"],
+      command._id,
+      { state: "applying" },
+      1,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("lists only nonterminal commands, oldest first", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const a = await repo.submit(
+      submit({ tenantId, principalId, idempotencyKey: "a" }),
+    );
+    await repo.submit(submit({ tenantId, principalId, idempotencyKey: "b" }));
+    // Terminate one; it should drop out of the nonterminal list.
+    await repo.updateOutcome(
+      tenantId,
+      principalId,
+      a._id,
+      { state: "confirmed", providerEventId: null, providerVersion: null },
+      1,
+    );
+
+    const pending = await repo.listNonterminal(tenantId, principalId, 100);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.idempotencyKey).toBe("b");
+  });
+
+  it("rejects a raw duplicate insert violating the idempotency index", async () => {
+    const shared = {
+      tenantId: objectId(),
+      principalId: objectId(),
+      idempotencyKey: "same",
+    };
+    const collection = db.collection("commands");
+    await collection.insertOne({ _id: objectId(), ...shared } as never);
+    await expect(
+      collection.insertOne({ _id: objectId(), ...shared } as never),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/sync/src/storage/command.repository.ts
+++ b/packages/sync/src/storage/command.repository.ts
@@ -1,0 +1,109 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import { type SyncCommandOutcome } from "@core/types/sync/command.contracts";
+import {
+  type PrincipalId,
+  type SyncCommandId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type CommandRecord,
+  CommandRecordSchema,
+  type CommandSubmit,
+  CommandSubmitSchema,
+} from "@sync/storage/command.record";
+
+// Repository for `commands`. Submitting is idempotent on
+// (tenant, principal, idempotencyKey): a retried submission returns the
+// existing command rather than creating a duplicate, so an interrupted or
+// replayed submit is safe. Queries are scoped to the owning tenant/principal.
+export class CommandRepository {
+  private readonly collection: Collection<CommandRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<CommandRecord>(SYNC_COLLECTIONS.commands);
+  }
+
+  // Insert the command if its idempotency key is new; otherwise return the
+  // command already stored for that key unchanged. New commands start pending
+  // with a zero attempt count.
+  async submit(input: CommandSubmit): Promise<CommandRecord> {
+    const fields = CommandSubmitSchema.parse(input);
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      {
+        tenantId: fields.tenantId,
+        principalId: fields.principalId,
+        idempotencyKey: fields.idempotencyKey,
+      },
+      {
+        // Everything is set-on-insert: a repeated submit must not overwrite an
+        // in-flight command's outcome or attempt count.
+        $setOnInsert: {
+          _id: new ObjectId().toHexString() as SyncCommandId,
+          eventId: fields.eventId,
+          input: fields.input,
+          expectedVersion: fields.expectedVersion,
+          outcome: { state: "pending" } as SyncCommandOutcome,
+          attemptCount: 0,
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    if (!result) throw new Error("Submit did not return a command record");
+    return CommandRecordSchema.parse(result);
+  }
+
+  async findById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: SyncCommandId,
+  ): Promise<CommandRecord | null> {
+    const record = await this.collection.findOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return record ? CommandRecordSchema.parse(record) : null;
+  }
+
+  // Record a state transition (pending -> applying -> confirmed/failed/...) and
+  // the current attempt count. Returns the updated record, or null if the
+  // command doesn't exist for this principal.
+  async updateOutcome(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: SyncCommandId,
+    outcome: SyncCommandOutcome,
+    attemptCount: number,
+  ): Promise<CommandRecord | null> {
+    const result = await this.collection.findOneAndUpdate(
+      { _id: id, tenantId, principalId },
+      { $set: { outcome, attemptCount, updatedAt: new Date() } },
+      { returnDocument: "after" },
+    );
+    return result ? CommandRecordSchema.parse(result) : null;
+  }
+
+  // Commands still working (not in a terminal state), oldest first — the queue
+  // a worker drains. Terminal states are confirmed, failed, and cancelled.
+  async listNonterminal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    limit: number,
+  ): Promise<CommandRecord[]> {
+    const records = await this.collection
+      .find({
+        tenantId,
+        principalId,
+        "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+      })
+      .sort({ createdAt: 1 })
+      .limit(limit)
+      .toArray();
+    return records.map((r) => CommandRecordSchema.parse(r));
+  }
+}

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -102,6 +102,12 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
     },
     { name: "event_state", key: { eventId: 1, "outcome.state": 1 } },
     { name: "pending_age", key: { createdAt: 1 } },
+    // Covers the per-principal nonterminal queue drain (filter on state,
+    // ordered oldest-first) so it's an index scan, not a collection scan.
+    {
+      name: "principal_nonterminal",
+      key: { tenantId: 1, principalId: 1, "outcome.state": 1, createdAt: 1 },
+    },
   ],
   [SYNC_COLLECTIONS.jobs]: [
     {

--- a/packages/sync/src/storage/job.record.ts
+++ b/packages/sync/src/storage/job.record.ts
@@ -1,0 +1,68 @@
+import { z } from "zod/v4";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  SyncCommandIdSchema,
+  SyncJobIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+export const JobKindSchema = z.enum([
+  "initialImport",
+  "incrementalPull",
+  "commandApply",
+  "reconcile",
+  "subscriptionMaintain",
+  "repair",
+]);
+export type JobKind = z.infer<typeof JobKindSchema>;
+
+// pending: waiting to be claimed. claimed: leased by a worker. failed: a
+// terminal failure needing attention (retryable failures return to pending).
+export const JobStateSchema = z.enum(["pending", "claimed", "failed"]);
+export type JobState = z.infer<typeof JobStateSchema>;
+
+export const JobFailureClassSchema = z.enum([
+  "retryableTransient",
+  "permanent",
+]);
+export type JobFailureClass = z.infer<typeof JobFailureClassSchema>;
+
+// Persistence record for `jobs` — a small internal work item pointing at a
+// connection and (optionally) a resource or command. A unique coalescing key
+// collapses a storm of equivalent notifications into one job. Jobs hold no
+// credentials and no event content.
+export const JobRecordSchema = z.strictObject({
+  _id: SyncJobIdSchema,
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  // What the job acts on. Both null for connection-wide work.
+  resourceId: z.string().trim().min(1).nullable(),
+  commandId: SyncCommandIdSchema.nullable(),
+  kind: JobKindSchema,
+  priority: z.number().int(),
+  state: JobStateSchema,
+  runAfter: z.date(),
+  attempt: z.number().int().min(0),
+  coalescingKey: z.string().trim().min(1),
+  leaseOwner: z.string().trim().min(1).nullable(),
+  leaseExpiresAt: z.date().nullable(),
+  failureClass: JobFailureClassSchema.nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type JobRecord = z.infer<typeof JobRecordSchema>;
+
+export const JobEnqueueSchema = z.strictObject({
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  resourceId: z.string().trim().min(1).nullable(),
+  commandId: SyncCommandIdSchema.nullable(),
+  kind: JobKindSchema,
+  priority: z.number().int(),
+  runAfter: z.date(),
+  coalescingKey: z.string().trim().min(1),
+});
+export type JobEnqueue = z.infer<typeof JobEnqueueSchema>;

--- a/packages/sync/src/storage/job.repository.test.ts
+++ b/packages/sync/src/storage/job.repository.test.ts
@@ -1,0 +1,105 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+import { type JobEnqueue } from "@sync/storage/job.record";
+import { JobRepository } from "@sync/storage/job.repository";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const enqueue = (overrides: Partial<JobEnqueue> = {}): JobEnqueue =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    connectionId: objectId(),
+    resourceId: null,
+    commandId: null,
+    kind: "incrementalPull",
+    priority: 2,
+    runAfter: new Date("2026-07-20T12:00:00.000Z"),
+    coalescingKey: `pull:${objectId()}`,
+    ...overrides,
+  }) as JobEnqueue;
+
+describe("JobRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: JobRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`job_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new JobRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("enqueues a new pending job", async () => {
+    const job = await repo.enqueue(enqueue());
+    expect(job.state).toBe("pending");
+    expect(job.attempt).toBe(0);
+    expect(job.leaseOwner).toBeNull();
+  });
+
+  it("coalesces repeated enqueues of the same key into one job", async () => {
+    const coalescingKey = "pull:resource-1";
+    const first = await repo.enqueue(enqueue({ coalescingKey, priority: 2 }));
+    const second = await repo.enqueue(enqueue({ coalescingKey, priority: 9 }));
+
+    expect(second._id).toBe(first._id);
+    // The existing job is returned unchanged — a storm does not bump priority.
+    expect(second.priority).toBe(2);
+    expect(await db.collection("jobs").countDocuments()).toBe(1);
+  });
+
+  it("allows a fresh job under the same key after the previous one is removed", async () => {
+    const coalescingKey = "pull:resource-2";
+    const first = await repo.enqueue(enqueue({ coalescingKey }));
+    expect(await repo.remove(first._id, coalescingKey)).toBe(true);
+
+    const second = await repo.enqueue(enqueue({ coalescingKey }));
+    expect(second._id).not.toBe(first._id);
+    expect(await db.collection("jobs").countDocuments()).toBe(1);
+  });
+
+  it("does not remove a different job that reused the key", async () => {
+    const coalescingKey = "pull:resource-3";
+    const first = await repo.enqueue(enqueue({ coalescingKey }));
+    // Simulate: our job completes, a new one is enqueued under the same key.
+    await repo.remove(first._id, coalescingKey);
+    const second = await repo.enqueue(enqueue({ coalescingKey }));
+
+    // A late remove of the ORIGINAL id must not delete the new job.
+    expect(await repo.remove(first._id, coalescingKey)).toBe(false);
+    expect(
+      await repo.findById(second.tenantId, second.principalId, second._id),
+    ).not.toBeNull();
+  });
+
+  it("scopes findById to the owning principal", async () => {
+    const job = await repo.enqueue(enqueue());
+    expect(
+      await repo.findById(
+        job.tenantId,
+        objectId() as JobEnqueue["principalId"],
+        job._id,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a raw duplicate insert violating the coalescing index", async () => {
+    const collection = db.collection("jobs");
+    await collection.insertOne({
+      _id: objectId(),
+      coalescingKey: "k",
+    } as never);
+    await expect(
+      collection.insertOne({ _id: objectId(), coalescingKey: "k" } as never),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/sync/src/storage/job.repository.ts
+++ b/packages/sync/src/storage/job.repository.ts
@@ -1,0 +1,82 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import {
+  type PrincipalId,
+  type SyncJobId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type JobEnqueue,
+  JobEnqueueSchema,
+  type JobRecord,
+  JobRecordSchema,
+} from "@sync/storage/job.record";
+
+// Repository for `jobs`. Enqueue coalesces on a unique key so repeated
+// notifications for the same resource collapse into one pending job instead of
+// an unbounded queue. Terminal jobs are removed so a later notification can
+// re-enqueue the same coalescing key.
+export class JobRepository {
+  private readonly collection: Collection<JobRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<JobRecord>(SYNC_COLLECTIONS.jobs);
+  }
+
+  // Create the job if its coalescing key is new; otherwise return the existing
+  // job unchanged. A burst of equivalent notifications therefore yields one
+  // job, not many.
+  async enqueue(input: JobEnqueue): Promise<JobRecord> {
+    const fields = JobEnqueueSchema.parse(input);
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      { coalescingKey: fields.coalescingKey },
+      {
+        $setOnInsert: {
+          _id: new ObjectId().toHexString() as SyncJobId,
+          tenantId: fields.tenantId,
+          principalId: fields.principalId,
+          connectionId: fields.connectionId,
+          resourceId: fields.resourceId,
+          commandId: fields.commandId,
+          kind: fields.kind,
+          priority: fields.priority,
+          state: "pending",
+          runAfter: fields.runAfter,
+          attempt: 0,
+          coalescingKey: fields.coalescingKey,
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          failureClass: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    if (!result) throw new Error("Enqueue did not return a job record");
+    return JobRecordSchema.parse(result);
+  }
+
+  async findById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: SyncJobId,
+  ): Promise<JobRecord | null> {
+    const record = await this.collection.findOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return record ? JobRecordSchema.parse(record) : null;
+  }
+
+  // Remove a completed job. Deleting by _id AND coalescingKey guarantees we
+  // only remove the job we finished, never a fresh one another worker may have
+  // enqueued under the same key after ours completed.
+  async remove(id: SyncJobId, coalescingKey: string): Promise<boolean> {
+    const result = await this.collection.deleteOne({ _id: id, coalescingKey });
+    return result.deletedCount === 1;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `commands` and `jobs` record schemas and repositories for the sync service.

- **Commands**: `submit` is idempotent on `(tenant, principal, idempotencyKey)` via a `$setOnInsert`-only upsert — a retried or interrupted submission returns the existing command with its outcome and attempt count intact, never a duplicate or a progress reset. `updateOutcome` records state transitions (pending → applying → confirmed/failed/…) scoped to the owning principal. `listNonterminal` is the oldest-first queue drain. A shared refine keeps the create-can't-carry-expectedVersion invariant on both the record and submit schemas.
- **Jobs**: `enqueue` coalesces on a unique key so a burst of equivalent notifications collapses into one pending job (returned unchanged, not re-prioritized). `remove` deletes by `(id, coalescingKey)` so a late cleanup can't delete a *fresh* job that reused the key after the original completed (the key is unique, so a new job has a new `_id`). Jobs hold no credentials or event content.
- A compound index covers the `listNonterminal` drain so it's an index scan, not a collection scan (follow-up commit from review).

Purely additive to the inert service; no existing behavior changes.

An independent correctness review confirmed the `$setOnInsert`-only idempotency/coalescing semantics, the `remove(id, key)` safety reasoning, tenant/principal scoping, and the validation-before-write invariant. Its one actionable note — the missing index for the nonterminal drain — is applied here.

## Simplicity

The repositories stay concrete rather than sharing a base — the identical `findById` surface is small, and consolidating is better done once all the repository shapes settle. No React.

## Manual Testing Steps

Not browser-observable (backend Mongo repositories). CLI verification:

- [ ] `bun install` then `bun run test:sync` — expect 110 pass, 0 fail (real in-memory Mongo)
- [ ] `bun run type-check` — clean

## Test plan

- [x] `bun run test:sync` — 110 pass, 0 fail (idempotent submit incl. mid-flight non-reset, state transitions, cross-principal rejection, nonterminal listing, job coalescing, remove-by-key safety incl. reused-key case, unique-index duplicate rejection, new index installs)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — no findings; the recommended nonterminal-drain index is included