### PR TITLE
feat(sync): persist sync resources and deletion markers

### DIFF
--- a/packages/sync/src/storage/deletion-marker.record.ts
+++ b/packages/sync/src/storage/deletion-marker.record.ts
@@ -1,0 +1,48 @@
+import { z } from "zod/v4";
+import {
+  ProviderEventVersionSchema,
+  SyncEventCalendarIdSchema,
+} from "@core/types/sync/event.contracts";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  ProviderEventIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+export const DeletionSourceSchema = z.enum(["compass", "provider"]);
+export type DeletionSource = z.infer<typeof DeletionSourceSchema>;
+
+// Persistence record for `deletion_markers` — the content-free memory of a
+// confirmed deletion, kept only long enough to stop delayed sync work from
+// resurrecting the event. A TTL index removes it after the retention window.
+// Only provider identity and version are retained: no title, description,
+// attendees, location, or conference data.
+export const DeletionMarkerRecordSchema = z.strictObject({
+  _id: z.string().regex(/^[0-9a-f]{24}$/i),
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  calendarId: SyncEventCalendarIdSchema,
+  providerEventId: ProviderEventIdSchema,
+  providerVersion: ProviderEventVersionSchema.nullable(),
+  deletionSource: DeletionSourceSchema,
+  deletedAt: z.date(),
+  // When the TTL index removes this marker (deletedAt + retention window).
+  expiresAt: z.date(),
+});
+export type DeletionMarkerRecord = z.infer<typeof DeletionMarkerRecordSchema>;
+
+export const DeletionMarkerRecordInputSchema = z.strictObject({
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  calendarId: SyncEventCalendarIdSchema,
+  providerEventId: ProviderEventIdSchema,
+  providerVersion: ProviderEventVersionSchema.nullable(),
+  deletionSource: DeletionSourceSchema,
+  deletedAt: z.date(),
+});
+export type DeletionMarkerRecordInput = z.infer<
+  typeof DeletionMarkerRecordInputSchema
+>;

--- a/packages/sync/src/storage/deletion-marker.repository.test.ts
+++ b/packages/sync/src/storage/deletion-marker.repository.test.ts
@@ -1,0 +1,116 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { type DeletionMarkerRecordInput } from "@sync/storage/deletion-marker.record";
+import {
+  DELETION_MARKER_RETENTION_MS,
+  DeletionMarkerRepository,
+} from "@sync/storage/deletion-marker.repository";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const markerInput = (
+  overrides: Partial<DeletionMarkerRecordInput> = {},
+): DeletionMarkerRecordInput =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    connectionId: objectId(),
+    calendarId: objectId(),
+    providerEventId: "evt-deleted",
+    providerVersion: "etag-9",
+    deletionSource: "compass",
+    deletedAt: new Date("2026-07-20T12:00:00.000Z"),
+    ...overrides,
+  }) as DeletionMarkerRecordInput;
+
+describe("DeletionMarkerRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: DeletionMarkerRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`del_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new DeletionMarkerRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("records a content-free marker with a 30-day expiry", async () => {
+    const marker = await repo.record(markerInput());
+    expect(marker.expiresAt.getTime()).toBe(
+      marker.deletedAt.getTime() + DELETION_MARKER_RETENTION_MS,
+    );
+    // No event content is stored — only identity/version/source/timestamps.
+    const doc = await db
+      .collection("deletion_markers")
+      .findOne({ _id: marker._id });
+    expect(Object.keys(doc ?? {}).sort()).toEqual(
+      [
+        "_id",
+        "calendarId",
+        "connectionId",
+        "deletedAt",
+        "deletionSource",
+        "expiresAt",
+        "principalId",
+        "providerEventId",
+        "providerVersion",
+        "tenantId",
+      ].sort(),
+    );
+  });
+
+  it("is idempotent on provider identity (re-confirmation refreshes, not duplicates)", async () => {
+    const identity = {
+      connectionId: objectId(),
+      calendarId: objectId(),
+      providerEventId: "evt-1",
+    };
+    const first = await repo.record(
+      markerInput({ ...identity, providerVersion: "v1" }),
+    );
+    const second = await repo.record(
+      markerInput({
+        ...identity,
+        providerVersion: "v2",
+        deletedAt: new Date("2026-07-21T12:00:00.000Z"),
+      }),
+    );
+    expect(second._id).toBe(first._id);
+    expect(second.providerVersion).toBe("v2");
+    expect(await db.collection("deletion_markers").countDocuments()).toBe(1);
+  });
+
+  it("reports whether a deletion marker exists for a provider event", async () => {
+    const marker = await repo.record(markerInput());
+    expect(
+      await repo.exists(
+        marker.connectionId,
+        marker.calendarId,
+        marker.providerEventId,
+      ),
+    ).toBe(true);
+    expect(
+      await repo.exists(
+        marker.connectionId,
+        marker.calendarId,
+        "never-deleted" as typeof marker.providerEventId,
+      ),
+    ).toBe(false);
+  });
+
+  it("has a TTL index that expires markers by expiresAt", async () => {
+    const indexes = await db.collection("deletion_markers").indexes();
+    const ttl = indexes.find((i) => i.name === "ttl_expiry");
+    expect(ttl?.expireAfterSeconds).toBe(0);
+    expect(ttl?.key).toEqual({ expiresAt: 1 });
+  });
+});

--- a/packages/sync/src/storage/deletion-marker.repository.ts
+++ b/packages/sync/src/storage/deletion-marker.repository.ts
@@ -1,0 +1,78 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
+import {
+  type ConnectionId,
+  type ProviderEventId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type DeletionMarkerRecord,
+  type DeletionMarkerRecordInput,
+  DeletionMarkerRecordInputSchema,
+  DeletionMarkerRecordSchema,
+} from "@sync/storage/deletion-marker.record";
+
+// Confirmed deletions are remembered for 30 days, after which the TTL index
+// removes the marker.
+export const DELETION_MARKER_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Repository for `deletion_markers`. Recording a deletion is idempotent on the
+// provider event identity, so a re-confirmed deletion refreshes rather than
+// duplicates. `exists` lets delayed sync work skip re-creating a deleted event.
+export class DeletionMarkerRepository {
+  private readonly collection: Collection<DeletionMarkerRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<DeletionMarkerRecord>(
+      SYNC_COLLECTIONS.deletionMarkers,
+    );
+  }
+
+  async record(
+    input: DeletionMarkerRecordInput,
+  ): Promise<DeletionMarkerRecord> {
+    const fields = DeletionMarkerRecordInputSchema.parse(input);
+    const expiresAt = new Date(
+      fields.deletedAt.getTime() + DELETION_MARKER_RETENTION_MS,
+    );
+
+    const result = await this.collection.findOneAndUpdate(
+      {
+        connectionId: fields.connectionId,
+        calendarId: fields.calendarId,
+        providerEventId: fields.providerEventId,
+      },
+      {
+        $set: {
+          providerVersion: fields.providerVersion,
+          deletionSource: fields.deletionSource,
+          deletedAt: fields.deletedAt,
+          expiresAt,
+        },
+        $setOnInsert: {
+          _id: new ObjectId().toHexString(),
+          tenantId: fields.tenantId,
+          principalId: fields.principalId,
+          connectionId: fields.connectionId,
+          calendarId: fields.calendarId,
+          providerEventId: fields.providerEventId,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    if (!result) throw new Error("record did not return a deletion marker");
+    return DeletionMarkerRecordSchema.parse(result);
+  }
+
+  async exists(
+    connectionId: ConnectionId,
+    calendarId: SyncEventCalendarId,
+    providerEventId: ProviderEventId,
+  ): Promise<boolean> {
+    const count = await this.collection.countDocuments(
+      { connectionId, calendarId, providerEventId },
+      { limit: 1 },
+    );
+    return count > 0;
+  }
+}

--- a/packages/sync/src/storage/sync-resource.record.ts
+++ b/packages/sync/src/storage/sync-resource.record.ts
@@ -1,0 +1,51 @@
+import { z } from "zod/v4";
+import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// A connection's calendar list, or one calendar's event collection — each an
+// independently synchronized unit of work.
+export const ResourceKindSchema = z.enum(["calendarList", "events"]);
+export type ResourceKind = z.infer<typeof ResourceKindSchema>;
+
+// Persistence record for `sync_resources` — one independently synchronized
+// provider resource with its cursors, import generation, timing, and push
+// subscription. A calendar-list resource has no calendarId (there is one per
+// connection); an events resource is keyed to one provider calendar. Holds no
+// event content.
+export const SyncResourceRecordSchema = z.strictObject({
+  _id: z.string().regex(/^[0-9a-f]{24}$/i),
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  resourceKind: ResourceKindSchema,
+  calendarId: SyncEventCalendarIdSchema.nullable(),
+  // Opaque provider incremental cursor. Advances only after every page in a
+  // batch has committed.
+  syncCursor: z.string().min(1).nullable(),
+  // Mid-batch page checkpoint for resumable pulls; null between batches.
+  pageCursor: z.string().min(1).nullable(),
+  importGeneration: z.number().int().min(0),
+  lastAttemptAt: z.date().nullable(),
+  lastSuccessAt: z.date().nullable(),
+  // Push subscription: the provider channel id, its opaque resource id, and
+  // when it expires. All null when no subscription is active.
+  subscriptionId: z.string().min(1).nullable(),
+  subscriptionResourceId: z.string().min(1).nullable(),
+  subscriptionExpiresAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type SyncResourceRecord = z.infer<typeof SyncResourceRecordSchema>;
+
+export const SyncResourceUpsertSchema = z.strictObject({
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  connectionId: ConnectionIdSchema,
+  resourceKind: ResourceKindSchema,
+  calendarId: SyncEventCalendarIdSchema.nullable(),
+});
+export type SyncResourceUpsert = z.infer<typeof SyncResourceUpsertSchema>;

--- a/packages/sync/src/storage/sync-resource.repository.test.ts
+++ b/packages/sync/src/storage/sync-resource.repository.test.ts
@@ -56,6 +56,51 @@ describe("SyncResourceRepository", () => {
     expect(await db.collection("sync_resources").countDocuments()).toBe(1);
   });
 
+  it("ensures one calendar-list resource per connection", async () => {
+    const key = {
+      connectionId: objectId(),
+      resourceKind: "calendarList" as const,
+      calendarId: null,
+    };
+    const first = await repo.ensure(upsert(key));
+    const second = await repo.ensure(upsert(key));
+    expect(second._id).toBe(first._id);
+    expect(await db.collection("sync_resources").countDocuments()).toBe(1);
+  });
+
+  it("re-ensuring an in-progress resource does not wipe its cursors or subscription", async () => {
+    const resource = await repo.ensure(upsert());
+    await repo.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "sync-token-1",
+      new Date("2026-07-20T12:00:00.000Z"),
+    );
+    await repo.updateSubscription(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      {
+        subscriptionId: "chan-1",
+        subscriptionResourceId: "res-1",
+        subscriptionExpiresAt: new Date("2026-07-27T00:00:00.000Z"),
+      },
+    );
+
+    // A later ensure() for the same key must return the advanced state intact.
+    const again = await repo.ensure(
+      upsert({
+        connectionId: resource.connectionId,
+        resourceKind: resource.resourceKind,
+        calendarId: resource.calendarId,
+      }),
+    );
+    expect(again._id).toBe(resource._id);
+    expect(again.syncCursor).toBe("sync-token-1");
+    expect(again.subscriptionId).toBe("chan-1");
+  });
+
   it("keeps the calendar-list resource distinct from event resources", async () => {
     const connectionId = objectId();
     await repo.ensure(
@@ -69,7 +114,12 @@ describe("SyncResourceRepository", () => {
 
   it("advancing the cursor clears the mid-batch page checkpoint", async () => {
     const resource = await repo.ensure(upsert());
-    await repo.setPageCheckpoint(resource._id, "page-token-2");
+    await repo.setPageCheckpoint(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "page-token-2",
+    );
     const mid = await repo.findById(
       resource.tenantId,
       resource.principalId,
@@ -78,7 +128,13 @@ describe("SyncResourceRepository", () => {
     expect(mid?.pageCursor).toBe("page-token-2");
 
     const succeededAt = new Date("2026-07-20T12:00:00.000Z");
-    await repo.advanceCursor(resource._id, "sync-token-final", succeededAt);
+    await repo.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "sync-token-final",
+      succeededAt,
+    );
     const done = await repo.findById(
       resource.tenantId,
       resource.principalId,
@@ -91,11 +147,16 @@ describe("SyncResourceRepository", () => {
 
   it("updates and clears the push subscription", async () => {
     const resource = await repo.ensure(upsert());
-    await repo.updateSubscription(resource._id, {
-      subscriptionId: "chan-1",
-      subscriptionResourceId: "res-1",
-      subscriptionExpiresAt: new Date("2026-07-27T00:00:00.000Z"),
-    });
+    await repo.updateSubscription(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      {
+        subscriptionId: "chan-1",
+        subscriptionResourceId: "res-1",
+        subscriptionExpiresAt: new Date("2026-07-27T00:00:00.000Z"),
+      },
+    );
     let read = await repo.findById(
       resource.tenantId,
       resource.principalId,
@@ -103,7 +164,11 @@ describe("SyncResourceRepository", () => {
     );
     expect(read?.subscriptionId).toBe("chan-1");
 
-    await repo.clearSubscription(resource._id);
+    await repo.clearSubscription(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
     read = await repo.findById(
       resource.tenantId,
       resource.principalId,
@@ -115,8 +180,31 @@ describe("SyncResourceRepository", () => {
 
   it("starts a new import generation for a repair", async () => {
     const resource = await repo.ensure(upsert());
-    expect(await repo.startNewGeneration(resource._id)).toBe(1);
-    expect(await repo.startNewGeneration(resource._id)).toBe(2);
+    const scope = [
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    ] as const;
+    expect(await repo.startNewGeneration(...scope)).toBe(1);
+    expect(await repo.startNewGeneration(...scope)).toBe(2);
+  });
+
+  it("does not let another principal advance the cursor (tenant isolation)", async () => {
+    const resource = await repo.ensure(upsert());
+    await repo.advanceCursor(
+      resource.tenantId,
+      objectId() as SyncResourceUpsert["principalId"],
+      resource._id,
+      "leaked-token",
+      new Date(),
+    );
+    const read = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    // The write against the wrong principal matched nothing.
+    expect(read?.syncCursor).toBeNull();
   });
 
   it("scopes findById to the owning principal", async () => {

--- a/packages/sync/src/storage/sync-resource.repository.test.ts
+++ b/packages/sync/src/storage/sync-resource.repository.test.ts
@@ -1,0 +1,132 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+import { type SyncResourceUpsert } from "@sync/storage/sync-resource.record";
+import { SyncResourceRepository } from "@sync/storage/sync-resource.repository";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const upsert = (
+  overrides: Partial<SyncResourceUpsert> = {},
+): SyncResourceUpsert =>
+  ({
+    tenantId: objectId(),
+    principalId: objectId(),
+    connectionId: objectId(),
+    resourceKind: "events",
+    calendarId: objectId(),
+    ...overrides,
+  }) as SyncResourceUpsert;
+
+describe("SyncResourceRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: SyncResourceRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`res_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new SyncResourceRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("creates a resource with empty cursors and generation 0", async () => {
+    const resource = await repo.ensure(upsert());
+    expect(resource.syncCursor).toBeNull();
+    expect(resource.pageCursor).toBeNull();
+    expect(resource.importGeneration).toBe(0);
+  });
+
+  it("ensures one resource per (connection, kind, calendar)", async () => {
+    const key = {
+      connectionId: objectId(),
+      resourceKind: "events" as const,
+      calendarId: objectId(),
+    };
+    const first = await repo.ensure(upsert(key));
+    const second = await repo.ensure(upsert(key));
+    expect(second._id).toBe(first._id);
+    expect(await db.collection("sync_resources").countDocuments()).toBe(1);
+  });
+
+  it("keeps the calendar-list resource distinct from event resources", async () => {
+    const connectionId = objectId();
+    await repo.ensure(
+      upsert({ connectionId, resourceKind: "calendarList", calendarId: null }),
+    );
+    await repo.ensure(
+      upsert({ connectionId, resourceKind: "events", calendarId: objectId() }),
+    );
+    expect(await db.collection("sync_resources").countDocuments()).toBe(2);
+  });
+
+  it("advancing the cursor clears the mid-batch page checkpoint", async () => {
+    const resource = await repo.ensure(upsert());
+    await repo.setPageCheckpoint(resource._id, "page-token-2");
+    const mid = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(mid?.pageCursor).toBe("page-token-2");
+
+    const succeededAt = new Date("2026-07-20T12:00:00.000Z");
+    await repo.advanceCursor(resource._id, "sync-token-final", succeededAt);
+    const done = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(done?.syncCursor).toBe("sync-token-final");
+    expect(done?.pageCursor).toBeNull();
+    expect(done?.lastSuccessAt).toEqual(succeededAt);
+  });
+
+  it("updates and clears the push subscription", async () => {
+    const resource = await repo.ensure(upsert());
+    await repo.updateSubscription(resource._id, {
+      subscriptionId: "chan-1",
+      subscriptionResourceId: "res-1",
+      subscriptionExpiresAt: new Date("2026-07-27T00:00:00.000Z"),
+    });
+    let read = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(read?.subscriptionId).toBe("chan-1");
+
+    await repo.clearSubscription(resource._id);
+    read = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(read?.subscriptionId).toBeNull();
+    expect(read?.subscriptionExpiresAt).toBeNull();
+  });
+
+  it("starts a new import generation for a repair", async () => {
+    const resource = await repo.ensure(upsert());
+    expect(await repo.startNewGeneration(resource._id)).toBe(1);
+    expect(await repo.startNewGeneration(resource._id)).toBe(2);
+  });
+
+  it("scopes findById to the owning principal", async () => {
+    const resource = await repo.ensure(upsert());
+    expect(
+      await repo.findById(
+        resource.tenantId,
+        objectId() as SyncResourceUpsert["principalId"],
+        resource._id,
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/sync/src/storage/sync-resource.repository.ts
+++ b/packages/sync/src/storage/sync-resource.repository.ts
@@ -65,17 +65,27 @@ export class SyncResourceRepository {
     return SyncResourceRecordSchema.parse(result);
   }
 
-  async markAttempt(id: string, at: Date): Promise<void> {
+  async markAttempt(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    at: Date,
+  ): Promise<void> {
     await this.collection.updateOne(
-      { _id: id },
+      { _id: id, tenantId, principalId },
       { $set: { lastAttemptAt: at, updatedAt: new Date() } },
     );
   }
 
   // Save mid-batch page progress without moving the incremental cursor.
-  async setPageCheckpoint(id: string, pageCursor: string): Promise<void> {
+  async setPageCheckpoint(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    pageCursor: string,
+  ): Promise<void> {
     await this.collection.updateOne(
-      { _id: id },
+      { _id: id, tenantId, principalId },
       { $set: { pageCursor, updatedAt: new Date() } },
     );
   }
@@ -83,12 +93,14 @@ export class SyncResourceRepository {
   // Advance the incremental cursor after a batch fully commits, clearing the
   // mid-batch checkpoint and recording success.
   async advanceCursor(
+    tenantId: TenantId,
+    principalId: PrincipalId,
     id: string,
     syncCursor: string,
     succeededAt: Date,
   ): Promise<void> {
     await this.collection.updateOne(
-      { _id: id },
+      { _id: id, tenantId, principalId },
       {
         $set: {
           syncCursor,
@@ -101,18 +113,24 @@ export class SyncResourceRepository {
   }
 
   async updateSubscription(
+    tenantId: TenantId,
+    principalId: PrincipalId,
     id: string,
     subscription: SubscriptionInput,
   ): Promise<void> {
     await this.collection.updateOne(
-      { _id: id },
+      { _id: id, tenantId, principalId },
       { $set: { ...subscription, updatedAt: new Date() } },
     );
   }
 
-  async clearSubscription(id: string): Promise<void> {
+  async clearSubscription(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+  ): Promise<void> {
     await this.collection.updateOne(
-      { _id: id },
+      { _id: id, tenantId, principalId },
       {
         $set: {
           subscriptionId: null,
@@ -126,9 +144,13 @@ export class SyncResourceRepository {
 
   // Begin a fresh import generation for a non-destructive repair. The old
   // generation's data stays queryable until the replacement completes.
-  async startNewGeneration(id: string): Promise<number> {
+  async startNewGeneration(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+  ): Promise<number> {
     const result = await this.collection.findOneAndUpdate(
-      { _id: id },
+      { _id: id, tenantId, principalId },
       { $inc: { importGeneration: 1 }, $set: { updatedAt: new Date() } },
       { returnDocument: "after" },
     );

--- a/packages/sync/src/storage/sync-resource.repository.ts
+++ b/packages/sync/src/storage/sync-resource.repository.ts
@@ -1,0 +1,162 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type SyncResourceRecord,
+  SyncResourceRecordSchema,
+  type SyncResourceUpsert,
+  SyncResourceUpsertSchema,
+} from "@sync/storage/sync-resource.record";
+
+interface SubscriptionInput {
+  subscriptionId: string;
+  subscriptionResourceId: string;
+  subscriptionExpiresAt: Date;
+}
+
+// Repository for `sync_resources`. Each resource is created once per
+// (connection, resourceKind, calendar) and then advanced as sync progresses.
+// The incremental cursor is only moved after a whole batch succeeds; the page
+// cursor holds mid-batch progress so an interrupted pull resumes rather than
+// restarts.
+export class SyncResourceRepository {
+  private readonly collection: Collection<SyncResourceRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<SyncResourceRecord>(
+      SYNC_COLLECTIONS.syncResources,
+    );
+  }
+
+  async ensure(input: SyncResourceUpsert): Promise<SyncResourceRecord> {
+    const fields = SyncResourceUpsertSchema.parse(input);
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      {
+        connectionId: fields.connectionId,
+        resourceKind: fields.resourceKind,
+        calendarId: fields.calendarId,
+      },
+      {
+        $setOnInsert: {
+          _id: new ObjectId().toHexString(),
+          tenantId: fields.tenantId,
+          principalId: fields.principalId,
+          syncCursor: null,
+          pageCursor: null,
+          importGeneration: 0,
+          lastAttemptAt: null,
+          lastSuccessAt: null,
+          subscriptionId: null,
+          subscriptionResourceId: null,
+          subscriptionExpiresAt: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    if (!result) throw new Error("Ensure did not return a sync resource");
+    return SyncResourceRecordSchema.parse(result);
+  }
+
+  async markAttempt(id: string, at: Date): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id },
+      { $set: { lastAttemptAt: at, updatedAt: new Date() } },
+    );
+  }
+
+  // Save mid-batch page progress without moving the incremental cursor.
+  async setPageCheckpoint(id: string, pageCursor: string): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id },
+      { $set: { pageCursor, updatedAt: new Date() } },
+    );
+  }
+
+  // Advance the incremental cursor after a batch fully commits, clearing the
+  // mid-batch checkpoint and recording success.
+  async advanceCursor(
+    id: string,
+    syncCursor: string,
+    succeededAt: Date,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id },
+      {
+        $set: {
+          syncCursor,
+          pageCursor: null,
+          lastSuccessAt: succeededAt,
+          updatedAt: new Date(),
+        },
+      },
+    );
+  }
+
+  async updateSubscription(
+    id: string,
+    subscription: SubscriptionInput,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id },
+      { $set: { ...subscription, updatedAt: new Date() } },
+    );
+  }
+
+  async clearSubscription(id: string): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id },
+      {
+        $set: {
+          subscriptionId: null,
+          subscriptionResourceId: null,
+          subscriptionExpiresAt: null,
+          updatedAt: new Date(),
+        },
+      },
+    );
+  }
+
+  // Begin a fresh import generation for a non-destructive repair. The old
+  // generation's data stays queryable until the replacement completes.
+  async startNewGeneration(id: string): Promise<number> {
+    const result = await this.collection.findOneAndUpdate(
+      { _id: id },
+      { $inc: { importGeneration: 1 }, $set: { updatedAt: new Date() } },
+      { returnDocument: "after" },
+    );
+    if (!result) throw new Error("startNewGeneration: resource not found");
+    return SyncResourceRecordSchema.parse(result).importGeneration;
+  }
+
+  async findById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+  ): Promise<SyncResourceRecord | null> {
+    const record = await this.collection.findOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return record ? SyncResourceRecordSchema.parse(record) : null;
+  }
+
+  async listByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<SyncResourceRecord[]> {
+    const records = await this.collection
+      .find({ tenantId, principalId, connectionId })
+      .toArray();
+    return records.map((r) => SyncResourceRecordSchema.parse(r));
+  }
+}


### PR DESCRIPTION
## Summary

Adds `sync_resources` and `deletion_markers` record schemas and repositories, completing the sync service's storage layer.

- **Sync resources**: `ensure` creates one resource per `(connection, kind, calendar)` — the single calendar-list resource (null `calendarId`) stays distinct from event resources. Each tracks its incremental cursor, a mid-batch page checkpoint, import generation, timing, and push subscription. The incremental cursor only advances after a batch fully commits (`advanceCursor`, which also clears the checkpoint), while `setPageCheckpoint` saves mid-batch progress *without* moving the cursor — so a crash resumes rather than skips uncommitted data. `startNewGeneration` bumps the generation for a non-destructive repair.
- **Deletion markers**: content-free (only provider identity, version, source, timestamps — no titles/attendees/etc.), recorded idempotently on provider identity, with a computed 30-day expiry the TTL index enforces. `exists()` lets delayed sync work skip resurrecting a deleted event.

Purely additive to the inert service; no existing behavior changes.

**Correctness-review fix (second commit):** the sync-resource mutation methods filtered by `_id` alone, unlike the command repository's `updateOutcome` which scopes by `(id, tenant, principal)`. All six write paths are now tenant/principal-scoped so one principal can't affect another's sync status (defense-in-depth, matching the established convention). Also added the two coverage tests the design turns on: a second `ensure()` of an in-progress resource preserves its advanced cursor and subscription, and one calendar-list resource per connection collapses under the null-`calendarId` unique index.

## Simplicity

Repositories stay concrete (small identical `findById` surface). No React.

## Manual Testing Steps

Not browser-observable (backend Mongo repositories). CLI verification:

- [ ] `bun install` then `bun run test:sync` — expect 124 pass, 0 fail
- [ ] `bun run type-check` — clean

## Test plan

- [x] `bun run test:sync` — 124 pass, 0 fail (resource ensure/idempotency incl. in-flight preservation, calendarList-per-connection collapse, cursor-advance-clears-checkpoint, subscription lifecycle, generation bump, cross-principal isolation; marker content-free key set, provider-identity idempotency, exists, TTL index spec)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent correctness review (code-reviewer agent) — no functional bugs; the recommended tenant-scoping and two coverage gaps are addressed