### PR TITLE
feat(sync): claim durable work with leases

### DIFF
--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -116,8 +116,11 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       options: { unique: true },
     },
     {
-      name: "state_runafter_priority",
-      key: { state: 1, runAfter: 1, priority: -1 },
+      // Field order matches the due-job claim: filter on state, then sort by
+      // priority (desc) then runAfter (asc), so the claim is served from the
+      // index without a blocking in-memory sort.
+      name: "state_priority_runafter",
+      key: { state: 1, priority: -1, runAfter: 1 },
     },
     {
       name: "lease_expiry",

--- a/packages/sync/src/storage/job.repository.test.ts
+++ b/packages/sync/src/storage/job.repository.test.ts
@@ -102,4 +102,116 @@ describe("JobRepository", () => {
       collection.insertOne({ _id: objectId(), coalescingKey: "k" } as never),
     ).rejects.toThrow();
   });
+
+  describe("work leases", () => {
+    const NOW = new Date("2026-07-20T12:00:00.000Z");
+    const LEASE_MS = 60_000;
+    const past = (ms: number) => new Date(NOW.getTime() - ms);
+    const future = (ms: number) => new Date(NOW.getTime() + ms);
+
+    it("claims a due pending job and leases it to the worker", async () => {
+      await repo.enqueue(enqueue({ runAfter: past(1000) }));
+      const claimed = await repo.claimDueJob("worker-1", NOW, LEASE_MS);
+      expect(claimed?.state).toBe("claimed");
+      expect(claimed?.leaseOwner).toBe("worker-1");
+      expect(claimed?.attempt).toBe(1);
+      expect(claimed?.leaseExpiresAt).toEqual(future(LEASE_MS));
+    });
+
+    it("does not claim a job whose runAfter is still in the future", async () => {
+      await repo.enqueue(enqueue({ runAfter: future(60_000) }));
+      expect(await repo.claimDueJob("worker-1", NOW, LEASE_MS)).toBeNull();
+    });
+
+    it("lets only one of two racing workers claim a single due job", async () => {
+      await repo.enqueue(enqueue({ runAfter: past(1000) }));
+      const [a, b] = await Promise.all([
+        repo.claimDueJob("worker-a", NOW, LEASE_MS),
+        repo.claimDueJob("worker-b", NOW, LEASE_MS),
+      ]);
+      // Exactly one worker gets the job; the other gets nothing.
+      const claimed = [a, b].filter(Boolean);
+      expect(claimed).toHaveLength(1);
+    });
+
+    it("claims jobs in priority then age order", async () => {
+      await repo.enqueue(
+        enqueue({ coalescingKey: "low", priority: 1, runAfter: past(2000) }),
+      );
+      await repo.enqueue(
+        enqueue({ coalescingKey: "high", priority: 9, runAfter: past(1000) }),
+      );
+      const first = await repo.claimDueJob("w", NOW, LEASE_MS);
+      expect(first?.coalescingKey).toBe("high");
+    });
+
+    it("reclaims a job whose lease has expired (previous owner crashed)", async () => {
+      await repo.enqueue(enqueue({ runAfter: past(1000) }));
+      const first = await repo.claimDueJob("crashed-worker", NOW, LEASE_MS);
+      expect(first).not.toBeNull();
+
+      // A second worker claims well after the lease would have expired.
+      const later = future(LEASE_MS + 1000);
+      const reclaimed = await repo.claimDueJob("fresh-worker", later, LEASE_MS);
+      expect(reclaimed?._id).toBe(first?._id);
+      expect(reclaimed?.leaseOwner).toBe("fresh-worker");
+      expect(reclaimed?.attempt).toBe(2);
+    });
+
+    it("does not let a stale worker heartbeat, complete, retry, or fail", async () => {
+      await repo.enqueue(enqueue({ runAfter: past(1000) }));
+      const job = await repo.claimDueJob("owner", NOW, LEASE_MS);
+      const id = job?._id as NonNullable<typeof job>["_id"];
+
+      expect(await repo.heartbeat(id, "intruder", NOW, LEASE_MS)).toBe(false);
+      expect(await repo.complete(id, "intruder")).toBe(false);
+      expect(
+        await repo.scheduleRetry(
+          id,
+          "intruder",
+          future(5000),
+          "retryableTransient",
+        ),
+      ).toBe(false);
+      expect(await repo.fail(id, "intruder", "permanent")).toBe(false);
+      // The real owner still can.
+      expect(await repo.heartbeat(id, "owner", NOW, LEASE_MS)).toBe(true);
+    });
+
+    it("reschedules a retry back to the pending pool", async () => {
+      await repo.enqueue(enqueue({ runAfter: past(1000) }));
+      const job = await repo.claimDueJob("owner", NOW, LEASE_MS);
+      const id = job?._id as NonNullable<typeof job>["_id"];
+      const retryAt = future(30_000);
+      expect(
+        await repo.scheduleRetry(id, "owner", retryAt, "retryableTransient"),
+      ).toBe(true);
+
+      const after = await repo.findById(job!.tenantId, job!.principalId, id);
+      expect(after?.state).toBe("pending");
+      expect(after?.runAfter).toEqual(retryAt);
+      expect(after?.leaseOwner).toBeNull();
+      expect(after?.failureClass).toBe("retryableTransient");
+    });
+
+    it("completes a job the owner holds", async () => {
+      await repo.enqueue(enqueue({ runAfter: past(1000) }));
+      const job = await repo.claimDueJob("owner", NOW, LEASE_MS);
+      expect(await repo.complete(job!._id, "owner")).toBe(true);
+      expect(await db.collection("jobs").countDocuments()).toBe(0);
+    });
+
+    it("releases all of a worker's jobs to pending on graceful shutdown", async () => {
+      await repo.enqueue(enqueue({ coalescingKey: "a", runAfter: past(1000) }));
+      await repo.enqueue(enqueue({ coalescingKey: "b", runAfter: past(1000) }));
+      await repo.claimDueJob("leaving-worker", NOW, LEASE_MS);
+      await repo.claimDueJob("leaving-worker", NOW, LEASE_MS);
+
+      expect(await repo.releaseOwned("leaving-worker")).toBe(2);
+      const stillClaimed = await db
+        .collection("jobs")
+        .countDocuments({ state: "claimed" });
+      expect(stillClaimed).toBe(0);
+    });
+  });
 });

--- a/packages/sync/src/storage/job.repository.ts
+++ b/packages/sync/src/storage/job.repository.ts
@@ -79,4 +79,120 @@ export class JobRepository {
     const result = await this.collection.deleteOne({ _id: id, coalescingKey });
     return result.deletedCount === 1;
   }
+
+  // Atomically claim the highest-priority due job for one worker. A job is due
+  // when it's pending and its runAfter has passed, OR it's claimed but its
+  // lease has expired (the previous owner crashed). Because findOneAndUpdate is
+  // a single atomic operation, two workers racing for the same job can never
+  // both win — the loser simply gets the next job or null. Returns null when no
+  // job is due.
+  async claimDueJob(
+    owner: string,
+    now: Date,
+    leaseDurationMs: number,
+  ): Promise<JobRecord | null> {
+    const leaseExpiresAt = new Date(now.getTime() + leaseDurationMs);
+    const result = await this.collection.findOneAndUpdate(
+      {
+        $or: [
+          { state: "pending", runAfter: { $lte: now } },
+          { state: "claimed", leaseExpiresAt: { $lt: now } },
+        ],
+      },
+      {
+        $set: { state: "claimed", leaseOwner: owner, leaseExpiresAt },
+        $inc: { attempt: 1 },
+        $currentDate: { updatedAt: true },
+      },
+      { sort: { priority: -1, runAfter: 1 }, returnDocument: "after" },
+    );
+    return result ? JobRecordSchema.parse(result) : null;
+  }
+
+  // Extend the lease while a worker is still processing. Only the current owner
+  // can heartbeat; a job reclaimed by someone else returns false.
+  async heartbeat(
+    id: SyncJobId,
+    owner: string,
+    now: Date,
+    leaseDurationMs: number,
+  ): Promise<boolean> {
+    const result = await this.collection.updateOne(
+      { _id: id, leaseOwner: owner, state: "claimed" },
+      {
+        $set: { leaseExpiresAt: new Date(now.getTime() + leaseDurationMs) },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  // Finish a job the worker owns. Scoped to the owner so a job reclaimed after a
+  // stale lease isn't deleted out from under its new owner.
+  async complete(id: SyncJobId, owner: string): Promise<boolean> {
+    const result = await this.collection.deleteOne({
+      _id: id,
+      leaseOwner: owner,
+    });
+    return result.deletedCount === 1;
+  }
+
+  // Reschedule a job the worker owns for a later retry, returning it to the
+  // pending pool and releasing the lease.
+  async scheduleRetry(
+    id: SyncJobId,
+    owner: string,
+    runAfter: Date,
+    failureClass: JobRecord["failureClass"],
+  ): Promise<boolean> {
+    const result = await this.collection.updateOne(
+      { _id: id, leaseOwner: owner },
+      {
+        $set: {
+          state: "pending",
+          runAfter,
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          failureClass,
+        },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  // Mark a job the worker owns as a permanent failure needing attention.
+  async fail(
+    id: SyncJobId,
+    owner: string,
+    failureClass: JobRecord["failureClass"],
+  ): Promise<boolean> {
+    const result = await this.collection.updateOne(
+      { _id: id, leaseOwner: owner },
+      {
+        $set: {
+          state: "failed",
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          failureClass,
+        },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  // On graceful shutdown, return every job this worker still holds to the
+  // pending pool so another worker (or the restarted process) picks them up
+  // immediately instead of waiting for the lease to expire.
+  async releaseOwned(owner: string): Promise<number> {
+    const result = await this.collection.updateMany(
+      { leaseOwner: owner, state: "claimed" },
+      {
+        $set: { state: "pending", leaseOwner: null, leaseExpiresAt: null },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    return result.modifiedCount;
+  }
 }

--- a/packages/sync/src/storage/job.repository.ts
+++ b/packages/sync/src/storage/job.repository.ts
@@ -185,6 +185,12 @@ export class JobRepository {
   // On graceful shutdown, return every job this worker still holds to the
   // pending pool so another worker (or the restarted process) picks them up
   // immediately instead of waiting for the lease to expire.
+  //
+  // Precondition: the caller must drain all in-flight job handlers for this
+  // worker BEFORE calling releaseOwned. Running it concurrently with an
+  // in-flight complete()/scheduleRetry() can flip a just-finished job back to
+  // pending (the completion then no-ops because the lease is cleared), causing
+  // another worker to reprocess already-done work.
   async releaseOwned(owner: string): Promise<number> {
     const result = await this.collection.updateMany(
       { leaseOwner: owner, state: "claimed" },


### PR DESCRIPTION
## Summary

Adds distributed work-leasing to the job repository so multiple worker processes/replicas can claim and process jobs safely.

- **`claimDueJob`** atomically leases the highest-priority due job to one worker via a single `findOneAndUpdate`. A job is due when it's pending past its `runAfter`, or claimed with an expired lease (the previous owner crashed) — so a fresh worker reclaims abandoned work. Because the match+update is atomic and the filter is re-checked at update time, two workers racing for the same job can never both win; the loser gets the next job or null.
- **`heartbeat`** extends the lease during long processing. **`complete`/`scheduleRetry`/`fail`** act only on the job the caller still owns (`leaseOwner` filter), so a job reclaimed after a stale lease can't be mutated by its old owner. **`releaseOwned`** returns a worker's held jobs to the pending pool on graceful shutdown so a restart doesn't wait out the lease.

"One mutation/pull per resource" is enforced upstream by the unique coalescing key (one job per resource exists at a time). Failure classification is stored; provider-specific retry rules come later. Purely additive to the inert service.

**Correctness-review fixes (second commit):**
- **Perf:** the claim sorts by `(priority desc, runAfter asc)` but the index led with `runAfter` before `priority`, forcing a blocking in-memory sort. Reordered the index to `(state, priority, runAfter)` — confirmed via `explain` that the claim now serves from the index with no SORT stage.
- **Docs:** documented that `releaseOwned` must run only after in-flight handlers drain, so a shutdown can't flip a just-completed job back to pending and cause reprocessing.

The review confirmed the core claim atomicity is correct — no double-claim, no cross-owner corruption — and that the racing-workers test genuinely exercises the server's atomicity guarantee (real in-memory replica set, real connection pool).

## Simplicity

Lease mechanics live on the existing `JobRepository` (it owns the jobs collection) rather than a new class. No React.

## Manual Testing Steps

Not browser-observable (backend Mongo repository). CLI verification:

- [ ] `bun install` then `bun run test:sync` — expect 133 pass, 0 fail
- [ ] `bun run type-check` — clean

## Test plan

- [x] `bun run test:sync` — 133 pass, 0 fail (claim due/not-due, single-winner race, priority+age order, stale-lease reclaim after crash, owner-only heartbeat/complete/retry/fail, retry reschedule, graceful release)
- [x] `explain` check — the claim query uses the reordered index with no blocking SORT
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)
- [x] Independent concurrency review (code-reviewer agent) — no double-claim/corruption bugs; the index-order and release-drain items are addressed