### PR TITLE
feat(sync): derive connection health from evidence

### DIFF
--- a/packages/sync/src/domain/connection-state.test.ts
+++ b/packages/sync/src/domain/connection-state.test.ts
@@ -1,0 +1,161 @@
+import {
+  type ConnectionStateEvidence,
+  DELAYED_THRESHOLD_MS,
+  deriveConnectionState,
+} from "@sync/domain/connection-state";
+
+const NOW = new Date("2026-07-20T12:00:00.000Z");
+const agoMs = (ms: number) => new Date(NOW.getTime() - ms);
+
+// A fully healthy connection; each test overrides the one axis it exercises.
+const healthy = (
+  overrides: Partial<ConnectionStateEvidence> = {},
+): ConnectionStateEvidence => ({
+  disconnectedAt: null,
+  credential: "valid",
+  permanentConflict: false,
+  accountIdentified: true,
+  initialImportComplete: true,
+  catchingUp: false,
+  oldestDueWorkAt: null,
+  recentProviderErrors: false,
+  ...overrides,
+});
+
+const derive = (overrides: Partial<ConnectionStateEvidence> = {}) =>
+  deriveConnectionState(healthy(overrides), NOW);
+
+describe("deriveConnectionState", () => {
+  it("is healthy with valid authority, no catch-up, and no overdue work", () => {
+    expect(derive()).toEqual({ state: "healthy", reason: null });
+  });
+
+  it("is disconnected when the user ended the connection", () => {
+    expect(derive({ disconnectedAt: agoMs(1000) })).toEqual({
+      state: "disconnected",
+      reason: null,
+    });
+  });
+
+  it.each([
+    ["revoked", "authorizationRevoked"],
+    ["expired", "authorizationExpired"],
+    ["insufficientScopes", "insufficientScopes"],
+  ] as const)("is actionRequired for a %s credential", (credential, reason) => {
+    expect(derive({ credential })).toEqual({ state: "actionRequired", reason });
+  });
+
+  it("is actionRequired for a permanent conflict", () => {
+    expect(derive({ permanentConflict: true })).toEqual({
+      state: "actionRequired",
+      reason: "permanentConflict",
+    });
+  });
+
+  it("is connecting before the provider account is identified", () => {
+    expect(derive({ accountIdentified: false })).toEqual({
+      state: "connecting",
+      reason: null,
+    });
+  });
+
+  it("is importing until the first in-horizon import completes", () => {
+    expect(derive({ initialImportComplete: false })).toEqual({
+      state: "importing",
+      reason: null,
+    });
+  });
+
+  it("is catchingUp while a repair or reconciliation runs", () => {
+    expect(derive({ catchingUp: true })).toEqual({
+      state: "catchingUp",
+      reason: null,
+    });
+  });
+
+  it("is delayed when work is overdue by the threshold (workOverdue)", () => {
+    expect(derive({ oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS) })).toEqual({
+      state: "delayed",
+      reason: "workOverdue",
+    });
+  });
+
+  it("is delayed with providerErrors when recent provider errors caused the backlog", () => {
+    expect(
+      derive({
+        oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 5000),
+        recentProviderErrors: true,
+      }),
+    ).toEqual({ state: "delayed", reason: "providerErrors" });
+  });
+
+  it("stays healthy when overdue work is under the threshold", () => {
+    expect(
+      derive({ oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS - 1) }),
+    ).toEqual({ state: "healthy", reason: null });
+  });
+
+  it("becomes delayed exactly at the threshold boundary", () => {
+    const justUnder = derive({
+      oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS - 1),
+    });
+    const atThreshold = derive({
+      oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS),
+    });
+    expect(justUnder.state).toBe("healthy");
+    expect(atThreshold.state).toBe("delayed");
+  });
+
+  describe("priority ordering", () => {
+    it("disconnected dominates a revoked credential", () => {
+      expect(
+        derive({ disconnectedAt: agoMs(1000), credential: "revoked" }).state,
+      ).toBe("disconnected");
+    });
+
+    it("a bad credential dominates connecting/importing/catchingUp", () => {
+      expect(
+        derive({
+          credential: "revoked",
+          accountIdentified: false,
+          initialImportComplete: false,
+          catchingUp: true,
+        }).state,
+      ).toBe("actionRequired");
+    });
+
+    it("credential is checked before a permanent conflict", () => {
+      expect(
+        derive({ credential: "expired", permanentConflict: true }).reason,
+      ).toBe("authorizationExpired");
+    });
+
+    it("connecting dominates importing and overdue work", () => {
+      expect(
+        derive({
+          accountIdentified: false,
+          initialImportComplete: false,
+          oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 1000),
+        }).state,
+      ).toBe("connecting");
+    });
+
+    it("importing dominates overdue work (no delayed during first import)", () => {
+      expect(
+        derive({
+          initialImportComplete: false,
+          oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 1000),
+        }).state,
+      ).toBe("importing");
+    });
+
+    it("catchingUp dominates overdue work", () => {
+      expect(
+        derive({
+          catchingUp: true,
+          oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 1000),
+        }).state,
+      ).toBe("catchingUp");
+    });
+  });
+});

--- a/packages/sync/src/domain/connection-state.ts
+++ b/packages/sync/src/domain/connection-state.ts
@@ -1,0 +1,101 @@
+import {
+  type ConnectionState,
+  type ConnectionStateReason,
+} from "@core/types/sync/connection.contracts";
+
+// The single source of truth for a connection's user-facing state. It is a PURE
+// function of persisted evidence — no repository or adapter may set "healthy"
+// (or any state) directly. Health is earned: valid authority, no overdue
+// required work, and a recently verified path.
+
+// Work overdue by at least this long stops a connection from looking healthy.
+export const DELAYED_THRESHOLD_MS = 2 * 60 * 1000;
+
+export type CredentialState =
+  | "valid"
+  | "revoked"
+  | "expired"
+  | "insufficientScopes";
+
+export interface ConnectionStateEvidence {
+  // The user ended this connection; nothing else matters.
+  readonly disconnectedAt: Date | null;
+  readonly credential: CredentialState;
+  // A permanent conflict the user must resolve (e.g. an unsafe version clash).
+  readonly permanentConflict: boolean;
+  // The provider account identity has been resolved.
+  readonly accountIdentified: boolean;
+  // The first complete in-horizon import has finished.
+  readonly initialImportComplete: boolean;
+  // A non-destructive repair or post-gap reconciliation is running while
+  // existing data stays queryable.
+  readonly catchingUp: boolean;
+  // The oldest piece of due-but-incomplete work, or null when none is overdue.
+  readonly oldestDueWorkAt: Date | null;
+  // Recent provider errors are the cause of overdue work (vs. plain backlog).
+  readonly recentProviderErrors: boolean;
+}
+
+export interface DerivedConnectionState {
+  readonly state: ConnectionState;
+  // Present only for delayed and actionRequired; null otherwise.
+  readonly reason: ConnectionStateReason | null;
+}
+
+const CREDENTIAL_REASON: Record<
+  Exclude<CredentialState, "valid">,
+  ConnectionStateReason
+> = {
+  revoked: "authorizationRevoked",
+  expired: "authorizationExpired",
+  insufficientScopes: "insufficientScopes",
+};
+
+// Priority order matters: earlier conditions dominate later ones. A revoked
+// credential is action-required even mid-import; a disconnected connection is
+// disconnected regardless of anything else.
+export function deriveConnectionState(
+  evidence: ConnectionStateEvidence,
+  now: Date,
+): DerivedConnectionState {
+  if (evidence.disconnectedAt) {
+    return { state: "disconnected", reason: null };
+  }
+
+  if (evidence.credential !== "valid") {
+    return {
+      state: "actionRequired",
+      reason: CREDENTIAL_REASON[evidence.credential],
+    };
+  }
+
+  if (evidence.permanentConflict) {
+    return { state: "actionRequired", reason: "permanentConflict" };
+  }
+
+  if (!evidence.accountIdentified) {
+    return { state: "connecting", reason: null };
+  }
+
+  if (!evidence.initialImportComplete) {
+    return { state: "importing", reason: null };
+  }
+
+  if (evidence.catchingUp) {
+    return { state: "catchingUp", reason: null };
+  }
+
+  if (isOverdue(evidence.oldestDueWorkAt, now)) {
+    return {
+      state: "delayed",
+      reason: evidence.recentProviderErrors ? "providerErrors" : "workOverdue",
+    };
+  }
+
+  return { state: "healthy", reason: null };
+}
+
+function isOverdue(oldestDueWorkAt: Date | null, now: Date): boolean {
+  if (!oldestDueWorkAt) return false;
+  return now.getTime() - oldestDueWorkAt.getTime() >= DELAYED_THRESHOLD_MS;
+}


### PR DESCRIPTION
## Summary

Adds the single pure derivation of a connection's user-facing state (`connecting`/`importing`/`catchingUp`/`healthy`/`delayed`/`actionRequired`/`disconnected`) from persisted evidence. This is the one place a connection's state — especially `healthy` — is decided; no repository or adapter sets it directly. **Health is earned:** the function only returns `healthy` when authority is valid, no import or catch-up is pending, and no required work is overdue past the two-minute threshold.

Priority ordering is explicit and total: `disconnected` > `actionRequired` (bad credential, then permanent conflict) > `connecting` > `importing` > `catchingUp` > `delayed` > `healthy`. The `delayed` reason distinguishes plain backlog (`workOverdue`) from provider errors (`providerErrors`).

**Design note:** the domain's "path recently verified" condition for healthy is captured by the overdue-work axis rather than a separate one — scheduled reconciliation is *required work*, so a connection whose verification has gone stale surfaces as overdue reconciliation (→ `delayed`), not a silently-healthy stale connection. One axis instead of two, same guarantee.

Pure function, no I/O; nothing wires it in yet. No existing behavior changes.

I skipped a separate correctness-review pass on this one: it's a ~90-line pure priority-ordered function whose exhaustive table tests already exercise every state, reason, the threshold boundary, and each precedence rule (reserving the deeper review agent for the concurrency/storage code where it's been catching real bugs).

## Simplicity

A single pure function plus a typed evidence input — no state, no I/O, no duplication. No React.

## Manual Testing Steps

Not browser-observable (pure derivation). CLI verification:

- [ ] `bun run test:sync` — expect 152 pass, 0 fail
- [ ] `bun run type-check` — clean

## Test plan

- [x] `bun run test:sync` — 152 pass, 0 fail (19 new: every state, each credential→reason mapping, permanent conflict, the 2-minute threshold just-under/at boundary, workOverdue vs providerErrors, and six precedence tests)
- [x] `bun run type-check` — clean
- [x] `bun run lint` — exit 0 (5 pre-existing web warnings, unrelated)