### PR TITLE
feat(web): consolidate header into a clickable title and move sidebar right

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -1,6 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 import {
   ensureSidebarOpen,
+  getViewSwitcherButton,
   openTimedEventFormWithMouse,
 } from "../utils/event-test-utils";
 
@@ -293,10 +294,10 @@ async function setupCalendarExperiencePage(
   });
 
   await page.goto("/week", { waitUntil: "domcontentloaded" });
-  await page
-    .getByRole("button", { name: /select view, currently/i })
-    .first()
-    .waitFor({ state: "visible", timeout: 15000 });
+  await getViewSwitcherButton(page).waitFor({
+    state: "visible",
+    timeout: 15000,
+  });
 
   await page.waitForFunction(
     () => (window as CompassE2EWindow).__COMPASS_E2E_HOOKS__ !== undefined,
@@ -386,9 +387,7 @@ test("day view separates visible calendars into distinct columns", async ({
 }) => {
   await setupCalendarExperiencePage(page);
 
-  await page
-    .getByRole("button", { name: /select view, currently week/i })
-    .click();
+  await getViewSwitcherButton(page).click();
   await page.getByRole("option", { name: /^day/i }).click();
 
   const dayAgenda = page.getByRole("region", { name: "Calendar agenda" });

--- a/e2e/utils/event-test-utils.ts
+++ b/e2e/utils/event-test-utils.ts
@@ -91,27 +91,26 @@ const pressShortcut = async (page: Page, key: string) => {
   }, key);
 };
 
-const ensureWeekView = async (page: Page) => {
-  const weekViewButton = page.getByRole("button", {
-    name: /select view, currently week/i,
-  });
+/**
+ * The header's date title doubles as the Day/Week switcher trigger, so it's
+ * the sole button inside the page's one <h1> regardless of which view or
+ * date it displays.
+ */
+export const getViewSwitcherButton = (page: Page) =>
+  page.getByRole("heading", { level: 1 }).getByRole("button");
 
-  if (await weekViewButton.isVisible()) {
+const ensureWeekView = async (page: Page) => {
+  if (page.url().includes("/week")) {
     return;
   }
 
-  const viewButton = page
-    .getByRole("button", { name: /select view, currently/i })
-    .first();
+  const viewButton = getViewSwitcherButton(page);
   await viewButton.waitFor({ state: "visible", timeout: 5000 });
   await viewButton.click();
   await page.getByRole("option", { name: "Week" }).click();
   await page.waitForURL((url) => url.pathname.startsWith("/week"), {
     timeout: 10000,
   });
-
-  // Verify we actually switched to Week view
-  await weekViewButton.waitFor({ state: "visible", timeout: 5000 });
 };
 
 const blurActiveElement = async (page: Page) => {
@@ -127,13 +126,10 @@ const getFormTitleInput = (page: Page) =>
   page.getByRole("form").getByPlaceholder("Title");
 
 const waitForCalendarShell = async (page: Page) => {
-  await page
-    .getByRole("button", { name: /select view, currently/i })
-    .first()
-    .waitFor({
-      state: "visible",
-      timeout: 15000,
-    });
+  await getViewSwitcherButton(page).waitFor({
+    state: "visible",
+    timeout: 15000,
+  });
 };
 
 const clearClientAuthState = async (page: Page) => {

--- a/e2e/utils/event-test-utils.ts
+++ b/e2e/utils/event-test-utils.ts
@@ -232,7 +232,7 @@ export const ensureSidebarOpen = async (page: Page) => {
   if (!(await sidebar.isVisible())) {
     await blurActiveElement(page);
     await page.locator("#mainGrid").focus();
-    await pressShortcut(page, "[");
+    await pressShortcut(page, "]");
     await expect(sidebar).toBeVisible();
     await waitForMainGridWidthToSettle(page);
   }

--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -25,9 +25,9 @@ interface Props {
 }
 
 /**
- * Shared header for the Day and Week views: a left-aligned heading with the
- * prev/next arrows beside it, and a right-aligned control cluster (today, view
- * switcher).
+ * Shared header for the Day and Week views: a left-aligned cluster for
+ * orientation and navigation (view switcher, prev/next, today), and a
+ * right-aligned sidebar toggle.
  * Owns the heading markup, sidebar-toggle state, and the control layout so both
  * views stay consistent without re-wiring these concerns per caller.
  */
@@ -44,35 +44,29 @@ export const CalendarHeader: FC<Props> = ({
 
   return (
     <div className="flex h-12 w-full shrink-0 items-center gap-3 text-text-muted">
-      {!isSidebarOpen ? (
+      <SelectView label={label} />
+      <TooltipWrapper shortcut="J">
+        <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
+      </TooltipWrapper>
+      <TooltipWrapper shortcut="K">
+        <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
+      </TooltipWrapper>
+      <TodayButton navigateToToday={onToday} isToday={isToday} />
+
+      <div className="z-2 ml-auto flex items-center pr-5">
         <TooltipWrapper
-          description="Open sidebar"
+          description={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
           onClick={() => viewActions.toggleSidebar()}
-          shortcut="["
+          shortcut="]"
         >
           <button
             type="button"
-            aria-label="Open sidebar"
+            aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
             className="c-focus-ring flex h-6 w-6 cursor-pointer items-center justify-center"
           >
             <SidebarIcon color={colors.textMuted} size={21} />
           </button>
         </TooltipWrapper>
-      ) : null}
-
-      <h1 className="text-text" aria-live="polite">
-        <span className="relative text-xl">{label}</span>
-      </h1>
-
-      <div className="z-2 ml-auto flex items-center gap-3 pr-5">
-        <TodayButton navigateToToday={onToday} isToday={isToday} />
-        <TooltipWrapper shortcut="J">
-          <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
-        </TooltipWrapper>
-        <TooltipWrapper shortcut="K">
-          <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
-        </TooltipWrapper>
-        <SelectView />
       </div>
     </div>
   );

--- a/packages/web/src/components/Icons/Sidebar.tsx
+++ b/packages/web/src/components/Icons/Sidebar.tsx
@@ -1,6 +1,12 @@
-import { type IconProps, Sidebar } from "@phosphor-icons/react";
+import { type IconProps, SidebarSimpleIcon } from "@phosphor-icons/react";
 import { getInteractiveIconClassName } from "./icon.utils";
 
+// Mirrored so the panel glyph reads as sitting on the right, matching the
+// sidebar's position in the layout.
 export const SidebarIcon = ({ className, ...props }: IconProps) => (
-  <Sidebar className={getInteractiveIconClassName(className)} {...props} />
+  <SidebarSimpleIcon
+    mirrored
+    className={getInteractiveIconClassName(className)}
+    {...props}
+  />
 );

--- a/packages/web/src/components/SelectView/SelectView.test.tsx
+++ b/packages/web/src/components/SelectView/SelectView.test.tsx
@@ -80,33 +80,31 @@ describe("SelectView", () => {
   }
 
   describe("Component Rendering", () => {
-    it("renders button with current view label for Week view", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.WEEK);
+    it("renders the button with the date label", async () => {
+      await renderWithRouter(
+        <SelectView label="July 2026" />,
+        ROOT_ROUTES.WEEK,
+      );
 
       const button = screen.getByRole("button");
       expect(button).toBeInTheDocument();
-      expect(button).toHaveTextContent("Week");
+      expect(button.textContent).toBe("July 2026");
       expect(button).toHaveAttribute("aria-expanded", "false");
     });
 
-    it("renders button with current view label for Day view", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+    it("renders the label as the page heading", async () => {
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
-      const button = screen.getByRole("button");
-      expect(button).toBeInTheDocument();
-      expect(button).toHaveTextContent("Day");
-    });
-
-    it("renders button with current view label for Day view with date param", async () => {
-      await renderWithRouter(<SelectView />, `${ROOT_ROUTES.DAY}/2024-01-15`);
-
-      const button = screen.getByRole("button");
-      expect(button).toBeInTheDocument();
-      expect(button).toHaveTextContent("Day");
+      expect(
+        screen.getByRole("heading", { name: "Monday, July 20" }),
+      ).toBeInTheDocument();
     });
 
     it("renders Day and Week options with shortcut hints when dropdown is open", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       await openDropdown();
 
@@ -127,38 +125,74 @@ describe("SelectView", () => {
   });
 
   describe("Route Detection", () => {
-    it("detects Day view when on /day route", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+    it("marks Day selected when on /day route", async () => {
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
-      const button = screen.getByRole("button");
-      expect(button).toHaveTextContent("Day");
+      await openDropdown();
+
+      expect(screen.getByRole("option", { name: /day/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByRole("option", { name: /week/i })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
     });
 
-    it("detects Day view when on /day/:date route", async () => {
-      await renderWithRouter(<SelectView />, `${ROOT_ROUTES.DAY}/2024-01-15`);
+    it("marks Day selected when on /day/:date route", async () => {
+      await renderWithRouter(
+        <SelectView label="Monday, January 15" />,
+        `${ROOT_ROUTES.DAY}/2024-01-15`,
+      );
 
-      const button = screen.getByRole("button");
-      expect(button).toHaveTextContent("Day");
+      await openDropdown();
+
+      expect(screen.getByRole("option", { name: /day/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
     });
 
-    it("detects Week view when on /week route", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.WEEK);
+    it("marks Week selected when on /week route", async () => {
+      await renderWithRouter(
+        <SelectView label="July 2026" />,
+        ROOT_ROUTES.WEEK,
+      );
 
-      const button = screen.getByRole("button");
-      expect(button).toHaveTextContent("Week");
+      await openDropdown();
+
+      expect(screen.getByRole("option", { name: /week/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByRole("option", { name: /day/i })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
     });
 
-    it("defaults to Week view for unknown routes", async () => {
-      await renderWithRouter(<SelectView />, "/unknown-route");
+    it("defaults to Week selected for unknown routes", async () => {
+      await renderWithRouter(
+        <SelectView label="July 2026" />,
+        "/unknown-route",
+      );
 
-      const button = screen.getByRole("button");
-      expect(button).toHaveTextContent("Week");
+      await openDropdown();
+
+      expect(screen.getByRole("option", { name: /week/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
     });
   });
 
   describe("Dropdown Behavior", () => {
     it("opens dropdown when button is clicked", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       const button = screen.getByRole("button");
       expect(button).toHaveAttribute("aria-expanded", "false");
@@ -170,7 +204,7 @@ describe("SelectView", () => {
     });
 
     it("closes dropdown when clicking outside", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       const { button, user } = await openDropdown();
 
@@ -185,7 +219,7 @@ describe("SelectView", () => {
     });
 
     it("closes dropdown when ESC key is pressed", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       const { button, user } = await openDropdown();
 
@@ -200,7 +234,10 @@ describe("SelectView", () => {
     });
 
     it("highlights active view option in dropdown", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
       await openDropdown();
 
@@ -212,7 +249,7 @@ describe("SelectView", () => {
     });
 
     it("uses div elements for options instead of buttons", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       await openDropdown();
 
@@ -224,7 +261,7 @@ describe("SelectView", () => {
 
   describe("User Interactions", () => {
     it("navigates to Day route when Day option is clicked", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       const { user } = await openDropdown();
 
@@ -238,7 +275,10 @@ describe("SelectView", () => {
     });
 
     it("navigates to Week route when Week option is clicked", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
       const { user } = await openDropdown();
 
@@ -252,7 +292,7 @@ describe("SelectView", () => {
     });
 
     it("closes dropdown after option selection", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       const { button, user } = await openDropdown();
 
@@ -270,7 +310,7 @@ describe("SelectView", () => {
 
   describe("Shortcut Hints", () => {
     it("displays d shortcut hint for Day option", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       await openDropdown();
 
@@ -282,7 +322,7 @@ describe("SelectView", () => {
     });
 
     it("displays w shortcut hint for Week option", async () => {
-      await renderWithRouter(<SelectView />);
+      await renderWithRouter(<SelectView label="July 2026" />);
 
       await openDropdown();
 
@@ -296,7 +336,10 @@ describe("SelectView", () => {
 
   describe("Keyboard Navigation", () => {
     it("navigates to next option with ArrowDown", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
       const { user } = await openDropdown();
 
@@ -313,7 +356,10 @@ describe("SelectView", () => {
     });
 
     it("navigates to previous option with ArrowUp", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
       const { user } = await openDropdown();
 
@@ -330,7 +376,10 @@ describe("SelectView", () => {
     });
 
     it("selects highlighted option with Enter key", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
       const { user } = await openDropdown();
 
@@ -346,7 +395,10 @@ describe("SelectView", () => {
     });
 
     it("selects highlighted option with Space key", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.WEEK);
+      await renderWithRouter(
+        <SelectView label="July 2026" />,
+        ROOT_ROUTES.WEEK,
+      );
 
       const { user } = await openDropdown();
 
@@ -362,7 +414,10 @@ describe("SelectView", () => {
     });
 
     it("initializes highlight to current view when dropdown opens", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
       const { user } = await openDropdown();
 
@@ -381,7 +436,10 @@ describe("SelectView", () => {
     });
 
     it("wraps navigation from last to first option", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.WEEK);
+      await renderWithRouter(
+        <SelectView label="July 2026" />,
+        ROOT_ROUTES.WEEK,
+      );
 
       const { user } = await openDropdown();
 
@@ -398,7 +456,10 @@ describe("SelectView", () => {
     });
 
     it("wraps navigation from first to last option", async () => {
-      await renderWithRouter(<SelectView />, ROOT_ROUTES.DAY);
+      await renderWithRouter(
+        <SelectView label="Monday, July 20" />,
+        ROOT_ROUTES.DAY,
+      );
 
       const { user } = await openDropdown();
 

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -6,6 +6,7 @@ import {
   useListNavigation,
   useRole,
 } from "@floating-ui/react";
+import { CaretDownIcon } from "@phosphor-icons/react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import classNames from "classnames";
 import { useRef, useState } from "react";
@@ -14,14 +15,11 @@ import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { VIEW_SHORTCUTS } from "@web/shortcuts/shortcuts.constants";
 
 interface SelectViewProps {
-  displayLabel?: string;
-  buttonClassName?: string;
+  /** The date heading text, e.g. "July 2026" or "Monday, July 20". */
+  label: string;
 }
 
-export const SelectView = ({
-  displayLabel,
-  buttonClassName,
-}: SelectViewProps) => {
+export const SelectView = ({ label }: SelectViewProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const location = useLocation();
@@ -49,7 +47,6 @@ export const SelectView = ({
   };
 
   const currentView = getCurrentView();
-  const buttonLabel = displayLabel ?? currentView;
 
   const { refs, context } = useFloating({
     open: isOpen,
@@ -106,36 +103,20 @@ export const SelectView = ({
 
   return (
     <div className="relative">
-      <button
-        ref={refs.setReference}
-        {...getReferenceProps()}
-        className={
-          buttonClassName ??
-          "flex items-center gap-2 rounded px-3 py-1.5 text-sm text-text/90 transition-colors hover:bg-text/10"
-        }
-        aria-expanded={isOpen}
-        aria-haspopup="listbox"
-        aria-controls={isOpen ? dropdownId : undefined}
-        aria-label={`Select view, currently ${currentView}`}
-      >
-        {/* min-width fits the widest label ("Week") so the nav arrows to the
-            left of this button don't shift when the view changes */}
-        <span className="min-w-10 text-left">{buttonLabel}</span>
-        <svg
-          className="h-4 w-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
+      <h1 className="text-text" aria-live="polite">
+        <button
+          ref={refs.setReference}
+          {...getReferenceProps()}
+          type="button"
+          className="c-focus-ring flex cursor-pointer items-center gap-1.5 rounded px-1 text-xl transition-colors hover:bg-text/10"
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-controls={isOpen ? dropdownId : undefined}
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
-      </button>
+          <span>{label}</span>
+          <CaretDownIcon size={14} aria-hidden="true" />
+        </button>
+      </h1>
 
       {isOpen && (
         <div
@@ -156,7 +137,7 @@ export const SelectView = ({
           })}
           id={dropdownId}
           data-testid="view-select-dropdown"
-          className="absolute inset-inline-end-0 top-full z-50 mt-1 min-w-[140px] rounded border border-border bg-surface py-1 shadow-lg"
+          className="absolute inset-inline-start-0 top-full z-50 mt-1 min-w-[140px] rounded border border-border bg-surface py-1 shadow-lg"
           role="listbox"
         >
           {options.map((option, index) => {

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -2,12 +2,9 @@ import { type FC, useEffect, useRef, useState } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ID_DATEPICKER_SIDEBAR } from "@web/common/constants/web.constants";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
-import { SidebarIcon } from "@web/components/Icons/Sidebar";
-import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 
 interface Props {
   monthsShown?: number;
-  onToggleSidebar?: () => void;
   onSelectDate: (date: Dayjs) => void;
   selectedDate: Dayjs;
 }
@@ -20,7 +17,6 @@ const headerActionsClassName = "!ml-2.5";
 export const MonthPicker: FC<Props> = ({
   monthsShown,
   onSelectDate,
-  onToggleSidebar,
   selectedDate,
 }) => {
   const selectedDateKey = selectedDate.format(
@@ -60,19 +56,6 @@ export const MonthPicker: FC<Props> = ({
         calendarClassName={ID_DATEPICKER_SIDEBAR}
         dayClassName={getDayClassName}
         headerActionsClassName={headerActionsClassName}
-        headerEndContent={
-          onToggleSidebar ? (
-            <TooltipWrapper
-              description="Close sidebar"
-              onClick={onToggleSidebar}
-              shortcut="["
-            >
-              <span className="flex h-6 w-6 items-center justify-center text-text-muted">
-                <SidebarIcon size={21} />
-              </span>
-            </TooltipWrapper>
-          ) : null
-        }
         headerClassName="!relative !justify-start !px-0 !pb-3"
         inline
         isOpen={true}

--- a/packages/web/src/components/Sidebar/ResizableSidebarPanel.tsx
+++ b/packages/web/src/components/Sidebar/ResizableSidebarPanel.tsx
@@ -13,8 +13,8 @@ interface Props extends PropsWithChildren {
 }
 
 /**
- * Width-collapsing wrapper for the left sidebar that is also user-resizable via
- * a drag handle or the keyboard (arrows/Home/End/Enter). The panel and its
+ * Width-collapsing wrapper for the right sidebar that is also user-resizable
+ * via a drag handle or the keyboard (arrows/Home/End/Enter). The panel and its
  * divider share one collapse transition, and a live drag disables that
  * transition so the width tracks the pointer 1:1.
  */
@@ -29,21 +29,6 @@ export function ResizableSidebarPanel({ children, isOpen }: Props) {
 
   return (
     <>
-      <div
-        className={classNames("h-full min-w-0 shrink-0 overflow-hidden", {
-          "transition-[width] duration-200 ease-out motion-reduce:transition-none":
-            animatesWidth,
-        })}
-        onTransitionEnd={transition.onTransitionEnd}
-        style={{ width: transition.isExpanded ? width : 0 }}
-      >
-        {/* The content holds its full width even while the wrapper collapses to
-            0, so overflow-hidden slides it out of view. */}
-        <div className="h-full shrink-0" style={{ width }}>
-          {children}
-        </div>
-      </div>
-
       {/* biome-ignore lint/a11y/useSemanticElements: An hr cannot host the focusable, draggable window-splitter interaction. */}
       <div
         {...dividerProps}
@@ -65,12 +50,27 @@ export function ResizableSidebarPanel({ children, isOpen }: Props) {
       >
         <div
           className={classNames(
-            "absolute inset-y-1 left-0 w-px rounded-full bg-border transition-[width,background-color] duration-200 ease-out motion-reduce:transition-none",
+            "absolute inset-y-1 right-0 w-px rounded-full bg-border transition-[width,background-color] duration-200 ease-out motion-reduce:transition-none",
             "group-hover:w-0.5 group-hover:bg-text/60",
             "group-focus-visible:w-1 group-focus-visible:bg-accent",
             { "w-0.5 bg-text/60": isResizing },
           )}
         />
+      </div>
+
+      <div
+        className={classNames("h-full min-w-0 shrink-0 overflow-hidden", {
+          "transition-[width] duration-200 ease-out motion-reduce:transition-none":
+            animatesWidth,
+        })}
+        onTransitionEnd={transition.onTransitionEnd}
+        style={{ width: transition.isExpanded ? width : 0 }}
+      >
+        {/* The content holds its full width even while the wrapper collapses to
+            0, so overflow-hidden slides it out of view. */}
+        <div className="h-full shrink-0" style={{ width }}>
+          {children}
+        </div>
       </div>
     </>
   );

--- a/packages/web/src/components/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.tsx
@@ -23,7 +23,6 @@ export interface SidebarProps extends HTMLAttributes<HTMLDivElement> {
   onCloseShortcuts: () => void;
   onToggleShortcuts: () => void;
   onSelectDate: (date: Dayjs) => void;
-  onToggleSidebar?: () => void;
   shortcutSections: ShortcutOverlaySection[];
   shortcutsViewLabel?: string;
 }
@@ -54,7 +53,6 @@ export function createSidebar({
     onCloseShortcuts,
     onToggleShortcuts,
     onSelectDate,
-    onToggleSidebar,
     shortcutSections,
     shortcutsViewLabel,
     ...props
@@ -82,7 +80,6 @@ export function createSidebar({
             <MonthPickerComponent
               monthsShown={monthsShown}
               onSelectDate={onSelectDate}
-              onToggleSidebar={onToggleSidebar}
               selectedDate={calendarDate}
             />
             <UpNextCardComponent />

--- a/packages/web/src/components/Sidebar/hooks/useResizableSidebar.ts
+++ b/packages/web/src/components/Sidebar/hooks/useResizableSidebar.ts
@@ -57,7 +57,7 @@ export function useResizableSidebar() {
     if (!e.isPrimary) return;
     e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
-    // The sidebar is pinned to the left edge, so the room it can grow into is
+    // The sidebar is pinned to the right edge, so the room it can grow into is
     // the viewport minus the divider and the calendar's minimum width. Measured
     // once here since the viewport is stable for the duration of a drag.
     const dynamicMax =
@@ -75,7 +75,9 @@ export function useResizableSidebar() {
       const drag = dragRef.current;
       if (!drag) return;
 
-      const next = drag.startWidth + (e.clientX - drag.startX);
+      // The sidebar is pinned to the right edge, so dragging the divider
+      // toward the left (a decreasing clientX) grows it.
+      const next = drag.startWidth + (drag.startX - e.clientX);
       applyWidth(clampDragWidth(next, drag.dynamicMax));
     },
     [applyWidth],
@@ -93,8 +95,10 @@ export function useResizableSidebar() {
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // The divider is left of the sidebar, so ArrowLeft (moving the
+      // splitter toward the calendar) grows it and ArrowRight shrinks it.
       const direction =
-        e.key === "ArrowLeft" ? -1 : e.key === "ArrowRight" ? 1 : 0;
+        e.key === "ArrowLeft" ? 1 : e.key === "ArrowRight" ? -1 : 0;
       const next =
         direction !== 0
           ? widthRef.current + direction * KEYBOARD_STEP

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -165,7 +165,7 @@ describe("shortcuts.data", () => {
 
       expect(other?.title).toBe("Other");
       expect(other?.shortcuts).toContainEqual({
-        keys: ["["],
+        keys: ["]"],
         label: "Toggle sidebar",
       });
     });

--- a/packages/web/src/shortcuts/data/shortcuts.data.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.ts
@@ -83,7 +83,7 @@ const getEditShortcuts = (view: ShortcutMenuView): Shortcut[] =>
       ];
 
 const getOtherShortcuts = (): Shortcut[] => [
-  { keys: ["["], label: "Toggle sidebar" },
+  { keys: ["]"], label: "Toggle sidebar" },
   { keys: ["?"], label: "Toggle shortcuts" },
   { keys: ["Mod", "k"], label: "Command Palette" },
 ];

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -126,21 +126,6 @@ export const DayViewContent = memo(() => {
       />
       <Dedication />
 
-      <ResizableSidebarPanel isOpen={isSidebarOpen || isEventDetailsOpen}>
-        <Sidebar
-          calendarDate={dateInView}
-          eventDetails={<SidebarEventDetails />}
-          isEventDetailsOpen={isEventDetailsOpen}
-          isShortcutsOpen={isShortcutsOpen}
-          onCloseShortcuts={closeShortcuts}
-          onToggleShortcuts={toggleShortcuts}
-          onSelectDate={navigateToDate}
-          onToggleSidebar={toggleSidebar}
-          shortcutSections={shortcutSections}
-          shortcutsViewLabel="Day"
-        />
-      </ResizableSidebarPanel>
-
       <div
         id={ID_MAIN}
         ref={mainRef}
@@ -152,6 +137,20 @@ export const DayViewContent = memo(() => {
           <DayCalendarGrid />
         </div>
       </div>
+
+      <ResizableSidebarPanel isOpen={isSidebarOpen || isEventDetailsOpen}>
+        <Sidebar
+          calendarDate={dateInView}
+          eventDetails={<SidebarEventDetails />}
+          isEventDetailsOpen={isEventDetailsOpen}
+          isShortcutsOpen={isShortcutsOpen}
+          onCloseShortcuts={closeShortcuts}
+          onToggleShortcuts={toggleShortcuts}
+          onSelectDate={navigateToDate}
+          shortcutSections={shortcutSections}
+          shortcutsViewLabel="Day"
+        />
+      </ResizableSidebarPanel>
     </div>
   );
 });

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -147,23 +147,6 @@ export const WeekView = () => {
 
       <DraftProvider dateCalcs={dateCalcs} weekProps={weekProps}>
         <Shortcuts shortcutsProps={shortcutProps}>
-          <ContextMenuWrapper id="sidebar-context-menu">
-            <Draft measurements={measurements} weekProps={weekProps} />
-            <ResizableSidebarPanel isOpen={isSidebarOpen || isEventDetailsOpen}>
-              <Sidebar
-                calendarDate={calendarDate}
-                eventDetails={<WeekSidebarEventDetails />}
-                isEventDetailsOpen={isEventDetailsOpen}
-                isShortcutsOpen={isShortcutsOpen}
-                onCloseShortcuts={closeShortcuts}
-                onToggleShortcuts={toggleShortcuts}
-                onSelectDate={goToDateFromSidebar}
-                onToggleSidebar={toggleSidebar}
-                shortcutSections={shortcutSections}
-                shortcutsViewLabel="Week"
-              />
-            </ResizableSidebarPanel>
-          </ContextMenuWrapper>
           <div
             id={ID_MAIN}
             ref={mainRef}
@@ -200,6 +183,22 @@ export const WeekView = () => {
               </div>
             </WeekGridScrollArea>
           </div>
+          <ContextMenuWrapper id="sidebar-context-menu">
+            <Draft measurements={measurements} weekProps={weekProps} />
+            <ResizableSidebarPanel isOpen={isSidebarOpen || isEventDetailsOpen}>
+              <Sidebar
+                calendarDate={calendarDate}
+                eventDetails={<WeekSidebarEventDetails />}
+                isEventDetailsOpen={isEventDetailsOpen}
+                isShortcutsOpen={isShortcutsOpen}
+                onCloseShortcuts={closeShortcuts}
+                onToggleShortcuts={toggleShortcuts}
+                onSelectDate={goToDateFromSidebar}
+                shortcutSections={shortcutSections}
+                shortcutsViewLabel="Week"
+              />
+            </ResizableSidebarPanel>
+          </ContextMenuWrapper>
         </Shortcuts>
 
         <RecurrenceScopeDialog />

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.test.tsx
@@ -95,13 +95,13 @@ describe("useGlobalShortcuts", () => {
     });
   });
 
-  it("toggles and persists the sidebar when pressing [", async () => {
+  it("toggles and persists the sidebar when pressing ]", async () => {
     const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
 
     expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
 
     act(() => {
-      pressKey("[");
+      pressKey("]");
     });
 
     await waitFor(() => {
@@ -110,13 +110,29 @@ describe("useGlobalShortcuts", () => {
     expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("false");
 
     act(() => {
-      pressKey("[");
+      pressKey("]");
     });
 
     await waitFor(() => {
       expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
     });
     expect(localStorage.getItem(STORAGE_KEYS.SIDEBAR_OPEN)).toBe("true");
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("does not toggle the sidebar when pressing [", async () => {
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
+
+    act(() => {
+      pressKey("[");
+    });
+
+    expect(selectIsSidebarOpen(useViewStore.getState())).toBe(true);
 
     act(() => {
       unmount();

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
@@ -57,7 +57,7 @@ export function useGlobalShortcuts() {
     }
   });
 
-  useAppShortcutUp("[", () => viewActions.toggleSidebar());
+  useAppShortcutUp("]", () => viewActions.toggleSidebar());
 
   useAppShortcut(
     "Mod+K",


### PR DESCRIPTION
## Summary
- Merges the date title ("July 2026" / "Monday, July 20") and the Day/Week view selector into one clickable heading (`SelectView`) with an always-visible chevron, so clicking the title reveals the Day/Week dropdown.
- Regroups the header left-to-right: title dropdown, prev arrow, next arrow, today circle (left = orientation/navigation), and a single persistent sidebar toggle on the right (right = customization), using a mirrored `SidebarSimpleIcon` to visually match the sidebar's new side.
- Moves the sidebar itself from the left of the layout to the right in both Week and Day views, flipping the resize divider and its drag/keyboard directions to match.
- Rebinds the sidebar-toggle shortcut from `[` to `]`, and removes the now-redundant close button inside the sidebar's month picker.

## Simplicity
No simplification opportunities found — the diff is pure reordering (DOM order, resize-delta signs, prop removal) and a straightforward prop-shape change on `SelectView`. No `useEffect`, `useRef`, or `useState` were added, changed, or left behind; none are in play in this diff.

## Manual Testing Steps
- [ ] Go to `/week`. Click the "July 2026" title — a dropdown opens showing Day and Week options with their keyboard-shortcut hints, Week highlighted as current.
- [ ] Click "Day" in the dropdown — the view switches to Day and the title updates to the current day's date (e.g. "Monday, July 20").
- [ ] Confirm the left-to-right header order is: title, previous arrow, next arrow, then the "today" dot (only when not viewing today).
- [ ] Click the sidebar icon in the top-right of the header — the sidebar (calendar list, month picker, etc.) closes on the right and the calendar grid expands to fill the width.
- [ ] Press `]` — the sidebar reopens on the right; press `]` again — it closes. Press `[` — nothing happens (no longer bound).
- [ ] With the sidebar open, drag the divider between the calendar and the sidebar, or focus it and press the Left/Right arrow keys — dragging/pressing Left grows the sidebar, dragging/pressing Right shrinks it.
- [ ] Open the sidebar's month picker — its header shows only the month name and prev/next month arrows, with no leftover close-sidebar button.

## Test plan
- [x] `bun run type-check` — passes.
- [x] `bun test` (packages/web, full suite) — 1266 pass, 1 pre-existing unrelated flake in `api.util.test.ts` (confirmed to pass in isolation and on the base commit, unaffected by this change).
- [x] Targeted suites re-verified: `SelectView.test.tsx` (24/24), `useGlobalShortcuts.test.tsx`, `shortcuts.data.test.ts`, full `Sidebar` test directory — all passing.
- [x] `bun run lint` — clean (0 errors; 5 pre-existing warnings in unrelated files).
- [x] Manual verification in a real signed-in Chrome session: dropdown open/close/keyboard nav, Day/Week switching, sidebar toggle via icon and via `]` (both directions), keyboard resize (285px → 301px → 285px), today-circle show/hide, no console or network errors.