### PR TITLE
fix(web): remove legacy feedback links

### DIFF
--- a/packages/web/src/common/constants/more.cmd.constants.test.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.test.ts
@@ -12,25 +12,15 @@ import { beforeEach, describe, expect, it } from "bun:test";
 describe("getMoreCommandPaletteSections", () => {
   beforeEach(feedbackActions.close);
 
-  it("keeps the existing GitHub feedback links without PostHog", () => {
+  it("omits feedback commands when PostHog is not enabled", () => {
     const [section] = getMoreCommandPaletteSections("week", false);
 
-    expect(section.items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "report-bug",
-          href: expect.stringContaining("issues/new"),
-          target: "_blank",
-        }),
-        expect.objectContaining({
-          id: "share-feedback",
-          href: expect.stringContaining("discussions"),
-          target: "_blank",
-        }),
-      ]),
+    expect(section.items).toHaveLength(1);
+    expect(section.items[0].label).toMatch(/^Version: /);
+    expect(getCommandPalettePlaceholder("day", false)).not.toContain("bug");
+    expect(getCommandPalettePlaceholder("week", false)).not.toContain(
+      "feedback",
     );
-    expect(getCommandPalettePlaceholder("day")).toContain("bug");
-    expect(getCommandPalettePlaceholder("week")).toContain("feedback");
   });
 
   it("opens a prefilled feedback request from each cloud command", () => {

--- a/packages/web/src/common/constants/more.cmd.constants.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.ts
@@ -5,12 +5,19 @@ import { type CommandSection } from "@web/components/CommandPalette/command-pale
 import { feedbackActions } from "@web/components/Feedback/feedback.store";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
 
-export function getCommandPalettePlaceholder(currentView: ViewName): string {
+export function getCommandPalettePlaceholder(
+  currentView: ViewName,
+  feedbackEnabled = isPosthogEnabled(),
+): string {
   if (currentView === "day") {
-    return "Try: 'week', 'today', 'bug', or 'feedback'";
+    return feedbackEnabled
+      ? "Try: 'week', 'today', 'bug', or 'feedback'"
+      : "Try: 'week' or 'today'";
   }
 
-  return "Try: 'create', 'bug', or 'feedback'";
+  return feedbackEnabled
+    ? "Try: 'create', 'bug', or 'feedback'"
+    : "Try: 'create'";
 }
 
 export function getMoreCommandPaletteSections(
@@ -32,22 +39,7 @@ export function getMoreCommandPaletteSections(
           onClick: () => feedbackActions.open("suggestion", currentView),
         },
       ]
-    : [
-        {
-          id: "report-bug",
-          label: "Report Bug",
-          icon: BugIcon,
-          href: "https://github.com/SwitchbackTech/compass/issues/new?assignees=&projects=&template=2-bug-report.yml",
-          target: "_blank" as const,
-        },
-        {
-          id: "share-feedback",
-          label: "Share Feedback",
-          icon: ChatsIcon,
-          href: "https://github.com/SwitchbackTech/compass/discussions",
-          target: "_blank" as const,
-        },
-      ];
+    : [];
 
   return [
     {

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -133,10 +133,6 @@ describe("CommandPalette", () => {
     expect(screen.getByText("Create all-day event")).toBeInTheDocument();
     // Settings surfaces the (stubbed) Google item.
     expect(screen.getByText("Connect Google Calendar")).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Report Bug" })).toHaveAttribute(
-      "href",
-      expect.stringContaining("issues/new"),
-    );
     expect(getInput()).toHaveFocus();
     // First option is active by default.
     expect(activeRowText(container)).toBe("Go to Day");

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -280,23 +280,6 @@ export const CommandPalette = ({
                       </>
                     );
 
-                    if (item.href) {
-                      return (
-                        <a
-                          key={item.id}
-                          {...commonProps}
-                          role="option"
-                          aria-selected={isActive}
-                          href={item.href}
-                          target={item.target}
-                          rel="noopener noreferrer"
-                          className={rowClassName}
-                        >
-                          {content}
-                        </a>
-                      );
-                    }
-
                     return (
                       <button
                         key={item.id}

--- a/packages/web/src/components/CommandPalette/command-palette.types.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.types.ts
@@ -6,8 +6,6 @@ export interface CommandItem {
   icon: Icon;
   iconClassName?: string;
   onClick?: () => void;
-  href?: string;
-  target?: "_blank";
   disabled?: boolean;
   /** A single key (`"?"`) or one key per combo entry (`["Shift", "W"]`), rendered as keycap chips. */
   shortcut?: string | string[];


### PR DESCRIPTION
## Summary

- removes the legacy GitHub bug-report and feedback links from the command palette
- keeps the new in-app PostHog dialogs for hosted builds
- hides feedback commands and feedback placeholder suggestions when PostHog is unavailable\

## Validation
- 38 focused command-palette tests passed
- bun type-check passed
- bun lint passed with 5 pre-existing unrelated warnings
- independent review: no findings