### PR TITLE
feat(sync): deploy the sync service as a passive container

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -86,6 +86,8 @@ jobs:
           MONGO_REPLICA_SET_KEY: ${{ secrets.MONGO_REPLICA_SET_KEY }}
           MONGO_URI: ${{ secrets.MONGO_URI }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SYNC_INTERNAL_AUTH_TOKEN: ${{ secrets.SYNC_INTERNAL_AUTH_TOKEN }}
+          SYNC_MONGO_URI: ${{ secrets.SYNC_MONGO_URI }}
           SUPERTOKENS_KEY: ${{ secrets.SUPERTOKENS_KEY }}
           SUPERTOKENS_POSTGRES_PASSWORD: ${{ secrets.SUPERTOKENS_POSTGRES_PASSWORD }}
           SUPERTOKENS_URI: ${{ secrets.SUPERTOKENS_URI }}
@@ -145,6 +147,21 @@ jobs:
                 'email:' \
                 "  kitApiSecret: \"${KIT_API_SECRET}\""
             fi
+            # Sync runs only where its isolated database is provisioned. The
+            # scoped Atlas user there must be denied the API database, so
+            # least-privilege enforcement is on.
+            if [ -n "$SYNC_MONGO_URI" ]; then
+              if [ -z "$SYNC_INTERNAL_AUTH_TOKEN" ]; then
+                echo "Sync deploy requires SYNC_INTERNAL_AUTH_TOKEN when SYNC_MONGO_URI is set." >&2
+                exit 1
+              fi
+              printf '%s\n' \
+                'sync:' \
+                "  mongoUri: \"${SYNC_MONGO_URI}\"" \
+                "  internalAuthToken: \"${SYNC_INTERNAL_AUTH_TOKEN}\"" \
+                "  callbackBaseUrl: \"${FRONTEND_URL}\"" \
+                '  enforceLeastPrivilege: true'
+            fi
           } | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"
           COMPOSE_GIT_REF="${COMPOSE_GIT_REF:-${RELEASE_TAG}}"
@@ -155,9 +172,15 @@ jobs:
           fi
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
-          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml down 2>/dev/null || true"
-          if [ -n "$COMPOSE_PROFILES" ]; then
-            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES='${COMPOSE_PROFILES}' ./compass update"
+          # Enable the `sync` profile only where the isolated sync database is
+          # provisioned, so the sync container starts exactly there.
+          DEPLOY_PROFILES="$COMPOSE_PROFILES"
+          if [ -n "$SYNC_MONGO_URI" ]; then
+            DEPLOY_PROFILES="${DEPLOY_PROFILES:+${DEPLOY_PROFILES},}sync"
+          fi
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES=selfhosted,sync docker compose --project-name compass -f compose.yaml down 2>/dev/null || true"
+          if [ -n "$DEPLOY_PROFILES" ]; then
+            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES='${DEPLOY_PROFILES}' ./compass update"
           else
             ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update"
           fi

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -76,6 +76,17 @@ jobs:
             switchbacktech/compass-backend:${{ steps.version.outputs.minor_tag }}
             switchbacktech/compass-backend:latest
 
+      - name: Build and push compass-sync
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: self-host/Dockerfile.sync
+          push: ${{ github.event_name == 'push' || inputs.push_images }}
+          tags: |
+            switchbacktech/compass-sync:${{ steps.version.outputs.image_version }}
+            switchbacktech/compass-sync:${{ steps.version.outputs.minor_tag }}
+            switchbacktech/compass-sync:latest
+
       - name: Build and push compass-mongo
         uses: docker/build-push-action@v7
         with:

--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -58,3 +58,4 @@ supertokens:
 #   callbackBaseUrl: http://localhost:3010 # public base URL for provider OAuth/webhook callbacks
 #   execution: passive # passive | active
 #   maxConcurrency: 4
+#   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "type-check:web-tests": "bunx typescript@7.0.2 -p packages/web/tsconfig.test.json --noEmit",
     "verify": "bun packages/scripts/src/testing/verify.ts",
     "build:backend": "bun packages/scripts/src/commands/build.backend.ts",
+    "build:sync": "bun packages/scripts/src/commands/build.sync.ts",
     "build:web": "cd packages/web && bun run build.ts"
   },
   "dependencies": {

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -75,6 +75,7 @@ const CompassConfigSchema = z
         callbackBaseUrl: z.string(),
         execution: z.enum(["passive", "active"]).optional(),
         maxConcurrency: z.union([z.string(), z.number()]).optional(),
+        enforceLeastPrivilege: z.union([z.boolean(), z.string()]).optional(),
       })
       .nullish(),
   })

--- a/packages/scripts/src/commands/build.sync.ts
+++ b/packages/scripts/src/commands/build.sync.ts
@@ -1,0 +1,83 @@
+/**
+ * Sync service production build script.
+ *
+ * Bundles the Sync service into a single Bun-native file, mirroring the backend
+ * build. All JS/TS dependencies (including @compass/core) are inlined.
+ *
+ * Usage:
+ *   bun run build:sync
+ */
+
+import {
+  COMPASS_BUILD_DEV,
+  COMPASS_ROOT_DEV,
+} from "@scripts/common/cli.constants";
+import { $ } from "bun";
+import path from "node:path";
+import { styleText } from "node:util";
+
+const SYNC_BUILD = path.join(COMPASS_BUILD_DEV, "sync");
+
+const log = {
+  info: (msg: string) => console.log(styleText(["italic", "whiteBright"], msg)),
+  error: (msg: string) => console.log(styleText(["bold", "red"], msg)),
+  warning: (msg: string) => console.log(styleText("yellow", msg)),
+  success: (msg: string) => console.log(styleText("green", msg)),
+  tip: (msg: string) => console.log(styleText("yellowBright", msg)),
+};
+
+// 1. Clean old build
+log.info("Removing old sync build ...");
+await $`rm -rf ${SYNC_BUILD}`.quiet();
+log.success("Removed old sync build");
+
+// 2. Bundle — full bundle so @compass/core and all JS/TS deps are inlined.
+log.info("Bundling sync ...");
+const result = await Bun.build({
+  entrypoints: [path.join(COMPASS_ROOT_DEV, "packages/sync/src/app.ts")],
+  outdir: SYNC_BUILD,
+  target: "bun",
+  sourcemap: "inline",
+  minify: false,
+});
+
+if (!result.success) {
+  log.error("Sync bundle failed:");
+  for (const msg of result.logs) console.error(msg);
+  process.exit(1);
+}
+log.success(`Bundled → ${SYNC_BUILD}/app.js`);
+
+// 3. Copy config file when present for local bundled runs.
+const configPath = process.env["COMPASS_CONFIG_FILE"]
+  ? path.resolve(process.env["COMPASS_CONFIG_FILE"])
+  : path.join(COMPASS_ROOT_DEV, "compass.yaml");
+
+if (await Bun.file(configPath).exists()) {
+  await $`cp ${configPath} ${SYNC_BUILD}/compass.yaml`.quiet();
+  log.success("Copied Compass config file");
+} else {
+  log.warning(`Compass config file not found: ${configPath}`);
+}
+
+// 4. Write a minimal package.json. Everything is inlined in app.js.
+await Bun.write(
+  path.join(SYNC_BUILD, "package.json"),
+  JSON.stringify({ dependencies: {} }, null, 2),
+);
+
+// 5. Install an empty production dependency tree so Bun writes its runtime files.
+log.info("Installing production dependency metadata ...");
+const install = Bun.spawnSync({
+  cmd: ["bun", "install", "--production", "--ignore-scripts", "--no-progress"],
+  cwd: SYNC_BUILD,
+  stderr: "inherit",
+  stdout: "inherit",
+});
+if (install.exitCode !== 0) {
+  log.error("Dependency installation failed");
+  process.exit(install.exitCode);
+}
+
+log.success("Sync build complete");
+log.tip(`  Runtime: cd ${SYNC_BUILD} && bun app.js`);

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -66,24 +66,23 @@ async function start(): Promise<void> {
   const config = loadSyncConfig();
   const service = createSyncService(config);
 
-  // Connect storage before listening. Register the disconnect drain first so,
-  // under the coordinator's reverse-order teardown, storage closes LAST — after
-  // any workers that depend on it. Registering the readiness check means
-  // /health/ready stays 503 until the connection and indexes are verified.
+  // Register the disconnect drain first so, under the coordinator's
+  // reverse-order teardown, storage closes LAST — after any workers that
+  // depend on it. Readiness reflects storage state, so /health/ready stays 503
+  // until Mongo is connected and its indexes are installed.
   const mongo = new SyncMongoService();
   service.shutdown.register("mongo", () => mongo.disconnect());
-  await mongo.connect({
-    uri: config.MONGO_URI,
-    forbiddenDatabaseName: COMPASS_API_DATABASE,
-    enforceLeastPrivilege: config.ENFORCE_LEAST_PRIVILEGE,
-  });
   service.readiness.register("storage", async () => {
+    if (!mongo.isConnected) return false;
     await mongo.db.command({ ping: 1 });
     return true;
   });
 
   registerSignalHandlers(service, logger);
 
+  // Bind the port before connecting storage so liveness comes up regardless.
+  // A passive service must stay alive and report not-ready if Mongo is
+  // unreachable, rather than crash-loop under the restart policy.
   await new Promise<void>((resolve) =>
     service.httpServer.listen(config.PORT, () => {
       logger.info(
@@ -92,6 +91,23 @@ async function start(): Promise<void> {
       resolve();
     }),
   );
+
+  // Connect storage after the port is open. A failure — unreachable store, or
+  // a least-privilege violation — is logged and leaves readiness at 503; it
+  // does not take the process down. The passive service does no work until
+  // ready, so staying up-but-not-ready is safe and diagnosable.
+  try {
+    await mongo.connect({
+      uri: config.MONGO_URI,
+      forbiddenDatabaseName: COMPASS_API_DATABASE,
+      enforceLeastPrivilege: config.ENFORCE_LEAST_PRIVILEGE,
+    });
+  } catch (error) {
+    logger.error(
+      "Sync storage unavailable at startup; staying up as not-ready",
+      error,
+    );
+  }
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -59,7 +59,7 @@ function closeHttpServer(httpServer: Server): Promise<void> {
 }
 
 // The Compass API database Sync's least-privilege user must not be able to
-// read. Only enforced in staging/production, where the scoped Atlas user runs.
+// read. The check runs only where a scoped database user exists (config flag).
 const COMPASS_API_DATABASE = "prod_calendar";
 
 async function start(): Promise<void> {
@@ -75,7 +75,7 @@ async function start(): Promise<void> {
   await mongo.connect({
     uri: config.MONGO_URI,
     forbiddenDatabaseName: COMPASS_API_DATABASE,
-    nodeEnv: config.NODE_ENV,
+    enforceLeastPrivilege: config.ENFORCE_LEAST_PRIVILEGE,
   });
   service.readiness.register("storage", async () => {
     await mongo.db.command({ ping: 1 });

--- a/packages/sync/src/config/sync.config.test.ts
+++ b/packages/sync/src/config/sync.config.test.ts
@@ -50,6 +50,25 @@ describe("Sync service configuration", () => {
       const config = parseSyncConfig(compassConfigWithSync({ port: "4010" }));
       expect(config.PORT).toBe(4010);
     });
+
+    it("defaults the least-privilege check off when omitted", () => {
+      const config = parseSyncConfig(compassConfigWithSync());
+      expect(config.ENFORCE_LEAST_PRIVILEGE).toBe(false);
+    });
+
+    it("accepts a yaml boolean for the least-privilege flag", () => {
+      const config = parseSyncConfig(
+        compassConfigWithSync({ enforceLeastPrivilege: true }),
+      );
+      expect(config.ENFORCE_LEAST_PRIVILEGE).toBe(true);
+    });
+
+    it("coerces the string 'true' for the least-privilege flag", () => {
+      const config = parseSyncConfig(
+        compassConfigWithSync({ enforceLeastPrivilege: "true" }),
+      );
+      expect(config.ENFORCE_LEAST_PRIVILEGE).toBe(true);
+    });
   });
 
   describe("required fields", () => {

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -20,6 +20,11 @@ export type SyncExecutionMode = z.infer<typeof SyncExecutionModeSchema>;
 // Coerce yaml numbers-or-strings to a bounded positive integer.
 const PositiveIntFromInput = z.coerce.number().int().positive();
 
+// Accept a yaml boolean or the strings "true"/"false" (env vars are strings).
+const BooleanFromInput = z
+  .union([z.boolean(), z.enum(["true", "false"])])
+  .transform((value) => value === true || value === "true");
+
 export const SyncConfigSchema = z.strictObject({
   NODE_ENV: z.enum(NodeEnv),
   PORT: PositiveIntFromInput.default(SYNC_PORT_DEFAULT),
@@ -32,6 +37,10 @@ export const SyncConfigSchema = z.strictObject({
   CALLBACK_BASE_URL: z.url(),
   EXECUTION: SyncExecutionModeSchema.default("passive"),
   MAX_CONCURRENCY: PositiveIntFromInput.default(SYNC_MAX_CONCURRENCY_DEFAULT),
+  // On when a scoped `compass_sync` database user exists (managed cloud), so
+  // startup verifies it cannot read the API database. Off for a single-database
+  // self-host with no scoped user. Defaults off — enable it deliberately.
+  ENFORCE_LEAST_PRIVILEGE: BooleanFromInput.default(false),
 });
 export type SyncConfig = z.infer<typeof SyncConfigSchema>;
 
@@ -50,6 +59,7 @@ export function parseSyncConfig(config: CompassConfig): SyncConfig {
     CALLBACK_BASE_URL: config.sync.callbackBaseUrl,
     EXECUTION: config.sync.execution,
     MAX_CONCURRENCY: config.sync.maxConcurrency,
+    ENFORCE_LEAST_PRIVILEGE: config.sync.enforceLeastPrivilege,
   });
 }
 
@@ -64,6 +74,7 @@ export function parseSyncConfigFromEnv(
     CALLBACK_BASE_URL: rawEnv["SYNC_CALLBACK_BASE_URL"],
     EXECUTION: rawEnv["SYNC_EXECUTION"],
     MAX_CONCURRENCY: rawEnv["SYNC_MAX_CONCURRENCY"],
+    ENFORCE_LEAST_PRIVILEGE: rawEnv["SYNC_ENFORCE_LEAST_PRIVILEGE"],
   });
 }
 

--- a/packages/sync/src/storage/sync-mongo.service.test.ts
+++ b/packages/sync/src/storage/sync-mongo.service.test.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker";
-import { NodeEnv } from "@core/constants/core.constants";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
   assertForbiddenDatabaseUnreachable,
@@ -26,7 +25,7 @@ describe("SyncMongoService", () => {
       uri,
       databaseName: uniqueDbName(),
       forbiddenDatabaseName: "prod_calendar",
-      nodeEnv: NodeEnv.Test,
+      enforceLeastPrivilege: false,
     });
 
     expect(service.isConnected).toBe(true);
@@ -53,7 +52,7 @@ describe("SyncMongoService", () => {
         uri,
         databaseName: uniqueDbName(),
         forbiddenDatabaseName: "prod_calendar",
-        nodeEnv: NodeEnv.Staging,
+        enforceLeastPrivilege: true,
       }),
     ).rejects.toThrow(/excessive privileges/);
   });
@@ -65,7 +64,7 @@ describe("SyncMongoService", () => {
         // Reserved TEST-NET address; connection is refused quickly.
         uri: "mongodb://192.0.2.1:27017/compass_sync?serverSelectionTimeoutMS=500&connectTimeoutMS=500",
         forbiddenDatabaseName: "prod_calendar",
-        nodeEnv: NodeEnv.Test,
+        enforceLeastPrivilege: false,
       }),
     ).rejects.toThrow();
   });
@@ -76,7 +75,7 @@ describe("SyncMongoService", () => {
       uri,
       databaseName: uniqueDbName(),
       forbiddenDatabaseName: "prod_calendar",
-      nodeEnv: NodeEnv.Test,
+      enforceLeastPrivilege: false,
     });
 
     const collection = service.db.collection(SYNC_COLLECTIONS.jobs);

--- a/packages/sync/src/storage/sync-mongo.service.ts
+++ b/packages/sync/src/storage/sync-mongo.service.ts
@@ -1,5 +1,4 @@
 import { type Db, MongoClient } from "mongodb";
-import { NodeEnv } from "@core/constants/core.constants";
 import { Logger } from "@core/logger/winston.logger";
 import { installIndexManifest } from "@sync/storage/index-manifest";
 
@@ -16,7 +15,10 @@ export interface SyncMongoOptions {
   // A database Sync's least-privilege user must NOT be able to read (the
   // Compass API's database). Startup fails if Sync can reach it.
   readonly forbiddenDatabaseName: string;
-  readonly nodeEnv: NodeEnv;
+  // Enforce the least-privilege check only where a scoped database user exists
+  // (managed cloud). A single-database self-host has no scoped user, so its
+  // credentials can legitimately reach the API database and the check is off.
+  readonly enforceLeastPrivilege: boolean;
 }
 
 // Owns the connection to the isolated `compass_sync` database.
@@ -59,18 +61,13 @@ export class SyncMongoService {
     }
   }
 
-  // In staging/production the Sync user is scoped to `compass_sync`, so a read
-  // of the Compass API database must be denied. Local dev / in-memory tests
-  // have no auth, so the check would false-positive; skip it there and rely on
-  // the injectable unit test for the logic.
+  // Where a scoped `compass_sync` user exists, a read of the Compass API
+  // database must be denied. A self-host with one shared database has no scoped
+  // user, and dev / in-memory tests have no auth, so the check is off there and
+  // the logic is covered by the injectable unit test.
   private async verifyLeastPrivilege(options: SyncMongoOptions): Promise<void> {
-    const enforced =
-      options.nodeEnv === NodeEnv.Staging ||
-      options.nodeEnv === NodeEnv.Production;
-    if (!enforced) {
-      logger.info(
-        `Skipping least-privilege check in ${options.nodeEnv} (no scoped auth)`,
-      );
+    if (!options.enforceLeastPrivilege) {
+      logger.info("Skipping least-privilege check (no scoped database user)");
       return;
     }
 

--- a/self-host/Dockerfile.sync
+++ b/self-host/Dockerfile.sync
@@ -1,0 +1,22 @@
+FROM oven/bun:1.2.18 AS build
+
+WORKDIR /app
+COPY . .
+
+RUN bun install --frozen-lockfile
+RUN bun run build:sync
+
+FROM oven/bun:1.2.18-slim AS runtime
+
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 compass \
+ && adduser --system --uid 1001 --ingroup compass --no-create-home compass
+
+COPY --from=build --chown=compass:compass /app/build/sync ./
+
+USER compass
+
+ENV SYNC_PORT=3010
+EXPOSE 3010
+CMD ["bun", "app.js"]

--- a/self-host/Dockerfile.sync
+++ b/self-host/Dockerfile.sync
@@ -14,6 +14,7 @@ RUN addgroup --system --gid 1001 compass \
  && adduser --system --uid 1001 --ingroup compass --no-create-home compass
 
 COPY --from=build --chown=compass:compass /app/build/sync ./
+RUN mkdir -p /app/logs && chown compass:compass /app/logs
 
 USER compass
 

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -53,3 +53,4 @@ supertokens:
 #   callbackBaseUrl: https://cal.yourdomain.com # public base URL for provider OAuth/webhook callbacks
 #   execution: passive # passive | active
 #   maxConcurrency: 4
+#   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -50,6 +50,37 @@ services:
       retries: 5
       start_period: 20s
 
+  sync:
+    image: switchbacktech/compass-sync:${COMPASS_VERSION:-latest}
+    # Gated behind the `sync` profile: the deploy enables it only where an
+    # isolated sync database is provisioned, so environments without one never
+    # start a crash-looping container. Where enabled, Sync stays passive
+    # (serves health, does no provider work) until explicitly activated.
+    # No published host port and no Caddy route: reachable only on the internal
+    # compose network. No depends_on mongo: Atlas environments have no mongo
+    # container, and the service tolerates a not-yet-ready store (liveness stays
+    # up, readiness 503).
+    profiles: [sync]
+    environment:
+      COMPASS_CONFIG_FILE: /app/compass.yaml
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - ${COMPASS_CONFIG_FILE:-./compass.yaml}:/app/compass.yaml:ro
+    restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bun -e \"fetch('http://127.0.0.1:3010/health/live').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   mongo:
     image: switchbacktech/compass-mongo:${COMPASS_VERSION:-latest}
     profiles: [selfhosted]

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -69,6 +69,9 @@ services:
       - /tmp
     volumes:
       - ${COMPASS_CONFIG_FILE:-./compass.yaml}:/app/compass.yaml:ro
+      # The shared logger writes logs/app.log; the root fs is read-only, so
+      # give it a writable mount (same as the backend).
+      - compass_sync_logs:/app/logs
     restart: unless-stopped
     healthcheck:
       test:
@@ -147,6 +150,7 @@ services:
 
 volumes:
   compass_backend_logs:
+  compass_sync_logs:
   compass_mongo_configdb:
   compass_mongo_data:
   compass_supertokens_postgres_data:

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -121,12 +121,16 @@ describe("self-host docker compose", () => {
     expect(compose).toContain("switchbacktech/compass-sync:");
     // Liveness probe, not readiness: a store-less passive service stays up.
     expect(compose).toContain("http://127.0.0.1:3010/health/live");
-    // The `sync` profile lets a deploy start the container only where an
-    // isolated sync database is provisioned.
     const syncBlock = compose
       .slice(compose.indexOf("  sync:"))
       .split(/\n {2}\w/)[0];
+    // The `sync` profile lets a deploy start the container only where an
+    // isolated sync database is provisioned.
     expect(syncBlock).toContain("profiles: [sync]");
+    // The read-only root fs needs a writable mount for the logger's log file,
+    // or the container crashes on startup.
+    expect(syncBlock).toContain("compass_sync_logs:/app/logs");
+    expect(compose).toContain("compass_sync_logs:");
   });
 });
 

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -105,6 +105,29 @@ describe("self-host docker compose", () => {
       ),
     );
   });
+
+  it("builds the sync image without build-time Compass config", () => {
+    const dockerfile = readRepoFile("self-host/Dockerfile.sync");
+
+    expect(dockerfile).toContain("RUN bun run build:sync");
+    expect(dockerfile).not.toContain("--environment");
+  });
+
+  it("gates the passive sync service behind its own profile", () => {
+    const compose = readFileSync(join(import.meta.dir, "compose.yaml"), {
+      encoding: "utf8",
+    });
+
+    expect(compose).toContain("switchbacktech/compass-sync:");
+    // Liveness probe, not readiness: a store-less passive service stays up.
+    expect(compose).toContain("http://127.0.0.1:3010/health/live");
+    // The `sync` profile lets a deploy start the container only where an
+    // isolated sync database is provisioned.
+    const syncBlock = compose
+      .slice(compose.indexOf("  sync:"))
+      .split(/\n {2}\w/)[0];
+    expect(syncBlock).toContain("profiles: [sync]");
+  });
 });
 
 describe("self-host installer", () => {
@@ -147,10 +170,10 @@ describe("self-host helper", () => {
 });
 
 describe("staging deploy workflow", () => {
-  it("lets the self-host helper default compose profiles when the environment variable is unset", () => {
+  it("lets the self-host helper default compose profiles when none are set", () => {
     const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
 
-    expect(workflow).toContain('if [ -n "$COMPOSE_PROFILES" ]; then');
+    expect(workflow).toContain('if [ -n "$DEPLOY_PROFILES" ]; then');
     expect(workflow).toContain("cd ~/compass && ./compass update");
   });
 
@@ -188,6 +211,31 @@ describe("staging deploy workflow", () => {
     expect(dockerfile).toContain("ARG POSTHOG_KEY=");
     expect(dockerfile).toContain("ARG POSTHOG_HOST=");
     expect(dockerfile).toContain("'posthog:'");
+  });
+
+  it("writes the sync config and enables its profile only when provisioned", () => {
+    const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
+
+    expect(workflow).toContain(
+      "SYNC_MONGO_URI: $".concat("{{ secrets.SYNC_MONGO_URI }}"),
+    );
+    expect(workflow).toContain(
+      "SYNC_INTERNAL_AUTH_TOKEN: $".concat(
+        "{{ secrets.SYNC_INTERNAL_AUTH_TOKEN }}",
+      ),
+    );
+    expect(workflow).toContain('if [ -n "$SYNC_MONGO_URI" ]; then');
+    expect(workflow).toContain("Sync deploy requires SYNC_INTERNAL_AUTH_TOKEN");
+    expect(workflow).toContain("'sync:'");
+    expect(workflow).toContain('mongoUri: \\"$'.concat('{SYNC_MONGO_URI}\\"'));
+    expect(workflow).toContain("enforceLeastPrivilege: true");
+    // The sync profile is appended so the container starts where provisioned.
+    expect(workflow).toContain(
+      'DEPLOY_PROFILES="$'.concat(
+        "{DEPLOY_PROFILES:+$",
+        '{DEPLOY_PROFILES},}sync"',
+      ),
+    );
   });
 
   it("writes Kit email config whenever the deployment has a secret", () => {


### PR DESCRIPTION
## What

Deploys the Compass Sync service as a **passive** container across provisioned environments. The container starts, serves its health endpoints, and does no provider or calendar work — this proves the deployment path end to end without touching any live sync behavior.

## Changes

- **Build + image**: New Bun-native production build (`build:sync`) and `Dockerfile.sync`, mirroring the backend image. The `compass-sync` image is published alongside the other release images.
- **Compose service** (`self-host/compose.yaml`): A `sync` service gated behind a dedicated `sync` compose profile. The deploy enables that profile **only where an isolated sync database is provisioned**, so environments without one never start a crash-looping container. No published host port and no Caddy route — reachable only on the internal compose network. Liveness healthcheck on `/health/live:3010` so a store-less passive service is not killed.
- **Deploy wiring** (`.github/workflows/_deploy-environment.yml`): Generates the `sync:` config section from environment secrets (`SYNC_MONGO_URI`, `SYNC_INTERNAL_AUTH_TOKEN`, `callbackBaseUrl` from `FRONTEND_URL`), and appends `sync` to the active compose profiles when those secrets are present.
- **Least-privilege flag**: Replaced the `NODE_ENV`-based least-privilege gate with an explicit `ENFORCE_LEAST_PRIVILEGE` config flag (default off). `NODE_ENV` conflated *which environment* with *whether a scoped database user exists*; the flag names the actual precondition so a single-database self-host is not forced to enforce a check it cannot satisfy. Enabled (`true`) for provisioned Atlas environments.

## Why passive / profile-gated

A profile-less compose service runs everywhere, but the sync container fails config load without a `sync:` section, and self-hosted staging has no isolated `compass_sync` database. The `sync` profile lets the deploy start the container exactly where it is configured and keep it absent elsewhere. Provisioning the secret later auto-enables it.

## Test / verification

- `bun run test:sync` (155 pass), `bun run type-check` clean, `bun run lint` clean.
- `self-host/docker-compose.test.ts` extended to guard the sync image build, the profile gating, and the deploy-time config/profile wiring (25 pass).
- `bun run build:sync` produces a runnable bundle.
- Post-merge: deploy to staging and SSH-verify the sync container reports healthy with zero provider calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
