### PR TITLE
fix(sync): only deploy sync when both its secrets are set

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -103,6 +103,15 @@ jobs:
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+          # Sync activates only when BOTH its secrets are present. Sync is an
+          # optional passive add-on, so a half-provisioned config must never
+          # block the web/backend deploy — skip it cleanly instead.
+          SYNC_ENABLED=""
+          if [ -n "$SYNC_MONGO_URI" ] && [ -n "$SYNC_INTERNAL_AUTH_TOKEN" ]; then
+            SYNC_ENABLED="1"
+          elif [ -n "$SYNC_MONGO_URI" ] || [ -n "$SYNC_INTERNAL_AUTH_TOKEN" ]; then
+            echo "Note: sync is only partially configured (need both SYNC_MONGO_URI and SYNC_INTERNAL_AUTH_TOKEN); skipping sync." >&2
+          fi
           {
             printf '%s\n' \
               'runtime:' \
@@ -147,14 +156,9 @@ jobs:
                 'email:' \
                 "  kitApiSecret: \"${KIT_API_SECRET}\""
             fi
-            # Sync runs only where its isolated database is provisioned. The
-            # scoped Atlas user there must be denied the API database, so
-            # least-privilege enforcement is on.
-            if [ -n "$SYNC_MONGO_URI" ]; then
-              if [ -z "$SYNC_INTERNAL_AUTH_TOKEN" ]; then
-                echo "Sync deploy requires SYNC_INTERNAL_AUTH_TOKEN when SYNC_MONGO_URI is set." >&2
-                exit 1
-              fi
+            # The scoped Atlas user for the isolated sync database must be
+            # denied the API database, so least-privilege enforcement is on.
+            if [ -n "$SYNC_ENABLED" ]; then
               printf '%s\n' \
                 'sync:' \
                 "  mongoUri: \"${SYNC_MONGO_URI}\"" \
@@ -172,10 +176,11 @@ jobs:
           fi
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
-          # Enable the `sync` profile only where the isolated sync database is
-          # provisioned, so the sync container starts exactly there.
+          # Enable the `sync` profile only when sync is fully configured, so the
+          # container starts exactly where its config was written (never against
+          # a compass.yaml that has no sync section).
           DEPLOY_PROFILES="$COMPOSE_PROFILES"
-          if [ -n "$SYNC_MONGO_URI" ]; then
+          if [ -n "$SYNC_ENABLED" ]; then
             DEPLOY_PROFILES="${DEPLOY_PROFILES:+${DEPLOY_PROFILES},}sync"
           fi
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES=selfhosted,sync docker compose --project-name compass -f compose.yaml down 2>/dev/null || true"

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -217,7 +217,7 @@ describe("staging deploy workflow", () => {
     expect(dockerfile).toContain("'posthog:'");
   });
 
-  it("writes the sync config and enables its profile only when provisioned", () => {
+  it("configures sync and enables its profile only when both secrets are set", () => {
     const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
 
     expect(workflow).toContain(
@@ -228,12 +228,21 @@ describe("staging deploy workflow", () => {
         "{{ secrets.SYNC_INTERNAL_AUTH_TOKEN }}",
       ),
     );
-    expect(workflow).toContain('if [ -n "$SYNC_MONGO_URI" ]; then');
-    expect(workflow).toContain("Sync deploy requires SYNC_INTERNAL_AUTH_TOKEN");
+    // Both secrets gate a single SYNC_ENABLED flag; a half-provisioned config
+    // must never abort the deploy, so there is no `exit` in the sync path.
+    expect(workflow).toContain(
+      'if [ -n "$SYNC_MONGO_URI" ] && [ -n "$SYNC_INTERNAL_AUTH_TOKEN" ]; then',
+    );
+    expect(workflow).toContain('SYNC_ENABLED="1"');
+    expect(workflow).not.toContain(
+      "Sync deploy requires SYNC_INTERNAL_AUTH_TOKEN",
+    );
+    // Both the config section and the profile gate on the same flag, so the
+    // container never starts against a compass.yaml with no sync section.
+    expect(workflow).toContain('if [ -n "$SYNC_ENABLED" ]; then');
     expect(workflow).toContain("'sync:'");
     expect(workflow).toContain('mongoUri: \\"$'.concat('{SYNC_MONGO_URI}\\"'));
     expect(workflow).toContain("enforceLeastPrivilege: true");
-    // The sync profile is appended so the container starts where provisioned.
     expect(workflow).toContain(
       'DEPLOY_PROFILES="$'.concat(
         "{DEPLOY_PROFILES:+$",


### PR DESCRIPTION
## Problem

Follow-up to #2221. The v1.0.306 staging-cloud deploy revealed two coupled defects in the sync deploy wiring (verified from the deploy job log):

1. **Profile activation and config emission used different conditions.** The `sync` compose profile was enabled whenever `SYNC_MONGO_URI` was set, but the `sync:` config section was written only when `SYNC_INTERNAL_AUTH_TOKEN` was *also* set. Staging-cloud has `SYNC_MONGO_URI` but not the token, so the deploy started `compass-sync-1` against a `compass.yaml` with **no `sync:` section** — a guaranteed crash-loop (the service's config load throws when the section is absent).

2. **The `exit 1` fail-fast didn't fail.** It ran on the producer side of `{ … ; exit 1; } | ssh …`. With the pipeline's status coming from the successful `ssh`, the step continued and wrote a **truncated** `compass.yaml` (everything before the `exit`, minus the sync section).

## Fix

Compute one `SYNC_ENABLED` flag that requires **both** secrets, and gate **both** the config section and the profile on it. Sync is an optional passive add-on, so a half-provisioned config now skips it cleanly (with a note to the log) rather than aborting the web/backend deploy or starting an unconfigurable container.

Behavior by provisioning state (simulated):

| `SYNC_MONGO_URI` | `SYNC_INTERNAL_AUTH_TOKEN` | sync section | profile | result |
|---|---|---|---|---|
| set | set | written | `…,sync` | sync deploys |
| set | unset | skipped | not added | note logged, no sync (current staging-cloud) |
| unset | unset | skipped | not added | clean (selfhosted) |

Redeploying from the current staging-cloud state also tears down the crash-looping `compass-sync-1` (the `down` covers the `sync` profile) without recreating it.

## Note for reviewers / ops

Sync stays **off** until `SYNC_INTERNAL_AUTH_TOKEN` is added to the staging-cloud (and production) environment. That is intentional and non-blocking — the web/backend deploy proceeds regardless.

## Test

- `bun run lint` clean; `self-host/docker-compose.test.ts` updated to assert the both-secrets gate and the absence of the `exit` path (25 pass).
- Gate logic simulated for all three provisioning states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
