### PR TITLE
fix(web): consolidate feedback commands

### DIFF
--- a/packages/web/src/common/constants/more.cmd.constants.test.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.test.ts
@@ -23,23 +23,21 @@ describe("getMoreCommandPaletteSections", () => {
     );
   });
 
-  it("opens a prefilled feedback request from each cloud command", () => {
+  it("opens the feedback request from the cloud command", () => {
     const [section] = getMoreCommandPaletteSections("day", true);
-    const reportBug = section.items.find((item) => item.id === "report-bug");
+    expect(section.items).toHaveLength(2);
+    expect(
+      section.items.find((item) => item.id === "report-bug"),
+    ).toBeUndefined();
     const shareFeedback = section.items.find(
       (item) => item.id === "share-feedback",
     );
 
-    reportBug?.onClick?.();
-    expect(selectFeedbackRequest(useFeedbackStore.getState())).toEqual({
-      kind: "bug",
-      view: "day",
-    });
-
     shareFeedback?.onClick?.();
     expect(selectFeedbackRequest(useFeedbackStore.getState())).toEqual({
-      kind: "suggestion",
       view: "day",
     });
+    expect(getCommandPalettePlaceholder("day", true)).toContain("feedback");
+    expect(getCommandPalettePlaceholder("day", true)).not.toContain("bug");
   });
 });

--- a/packages/web/src/common/constants/more.cmd.constants.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.ts
@@ -1,4 +1,4 @@
-import { BugIcon, ChatsIcon, InfoIcon } from "@phosphor-icons/react";
+import { ChatsIcon, InfoIcon } from "@phosphor-icons/react";
 import { isPosthogEnabled } from "@web/auth/posthog/posthog.util";
 import { APP_VERSION } from "@web/common/constants/version.constants";
 import { type CommandSection } from "@web/components/CommandPalette/command-palette.types";
@@ -11,13 +11,11 @@ export function getCommandPalettePlaceholder(
 ): string {
   if (currentView === "day") {
     return feedbackEnabled
-      ? "Try: 'week', 'today', 'bug', or 'feedback'"
+      ? "Try: 'week', 'today', or 'feedback'"
       : "Try: 'week' or 'today'";
   }
 
-  return feedbackEnabled
-    ? "Try: 'create', 'bug', or 'feedback'"
-    : "Try: 'create'";
+  return feedbackEnabled ? "Try: 'create' or 'feedback'" : "Try: 'create'";
 }
 
 export function getMoreCommandPaletteSections(
@@ -27,16 +25,10 @@ export function getMoreCommandPaletteSections(
   const feedbackItems = feedbackEnabled
     ? [
         {
-          id: "report-bug",
-          label: "Report Bug",
-          icon: BugIcon,
-          onClick: () => feedbackActions.open("bug", currentView),
-        },
-        {
           id: "share-feedback",
           label: "Share Feedback",
           icon: ChatsIcon,
-          onClick: () => feedbackActions.open("suggestion", currentView),
+          onClick: () => feedbackActions.open(currentView),
         },
       ]
     : [];

--- a/packages/web/src/components/Feedback/FeedbackDialog.test.tsx
+++ b/packages/web/src/components/Feedback/FeedbackDialog.test.tsx
@@ -7,67 +7,56 @@ import { restoreCommandPaletteFocus } from "@web/components/Feedback/FeedbackDia
 import { describe, expect, it, mock } from "bun:test";
 
 describe("FeedbackDialog", () => {
-  it("prefills the bug-report copy and submits trimmed details", async () => {
+  it("submits trimmed feedback details", async () => {
     const user = userEvent.setup();
     const onSubmit = mock();
 
     const { rerender } = render(
-      <FeedbackDialog kind="bug" onDismiss={mock()} onSubmit={onSubmit} />,
+      <FeedbackDialog onDismiss={mock()} onSubmit={onSubmit} />,
     );
 
     expect(
-      screen.getByRole("dialog", { name: "Report a bug" }),
+      screen.getByRole("dialog", { name: "Share feedback" }),
     ).toBeInTheDocument();
-    const details = screen.getByRole("textbox", { name: "What went wrong?" });
+    const details = screen.getByRole("textbox", {
+      name: "What would you like to share?",
+    });
     expect(details).toHaveFocus();
     expect(details).toHaveAccessibleDescription(
       "We'll include your account, app version, current view, and session details so we can follow up and troubleshoot.",
     );
     expect(
-      screen.getByRole("button", { name: "Send bug report" }),
+      screen.getByRole("button", { name: "Send feedback" }),
     ).toBeDisabled();
 
     await user.type(details, "  Events disappear after syncing.  ");
     rerender(
-      <FeedbackDialog
-        kind="bug"
-        isSubmitting
-        onDismiss={mock()}
-        onSubmit={onSubmit}
-      />,
+      <FeedbackDialog isSubmitting onDismiss={mock()} onSubmit={onSubmit} />,
     );
     expect(screen.getByRole("button", { name: "Sending…" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
     await user.keyboard("{Escape}");
     expect(
-      screen.getByRole("dialog", { name: "Report a bug" }),
+      screen.getByRole("dialog", { name: "Share feedback" }),
     ).toBeInTheDocument();
     expect(details).toHaveFocus();
 
-    rerender(
-      <FeedbackDialog kind="bug" onDismiss={mock()} onSubmit={onSubmit} />,
-    );
-    await user.click(screen.getByRole("button", { name: "Send bug report" }));
+    rerender(<FeedbackDialog onDismiss={mock()} onSubmit={onSubmit} />);
+    await user.click(screen.getByRole("button", { name: "Send feedback" }));
 
     expect(onSubmit).toHaveBeenCalledWith("Events disappear after syncing.");
   });
 
-  it("uses suggestion copy and dismisses without submitting", async () => {
+  it("dismisses without submitting", async () => {
     const user = userEvent.setup();
     const onDismiss = mock();
     const onSubmit = mock();
 
-    render(
-      <FeedbackDialog
-        kind="suggestion"
-        onDismiss={onDismiss}
-        onSubmit={onSubmit}
-      />,
-    );
+    render(<FeedbackDialog onDismiss={onDismiss} onSubmit={onSubmit} />);
 
     expect(
-      screen.getByRole("textbox", { name: "What would make Compass better?" }),
-    ).toHaveAttribute("placeholder", "Tell us what you'd like to see.");
+      screen.getByRole("textbox", { name: "What would you like to share?" }),
+    ).toHaveAttribute("placeholder", "Tell us what you think.");
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
@@ -88,7 +77,6 @@ describe("FeedbackDialog", () => {
           />
           {open ? (
             <FeedbackDialog
-              kind="bug"
               onDismiss={() => setOpen(false)}
               restoreFocus={() =>
                 document
@@ -127,7 +115,6 @@ describe("FeedbackDialog", () => {
           <button type="button" aria-label="Open sidebar" />
           {open ? (
             <FeedbackDialog
-              kind="suggestion"
               onDismiss={() => setOpen(false)}
               restoreFocus={restoreCommandPaletteFocus}
               onSubmit={mock()}

--- a/packages/web/src/components/Feedback/FeedbackDialog.tsx
+++ b/packages/web/src/components/Feedback/FeedbackDialog.tsx
@@ -1,36 +1,11 @@
 import { type FormEvent, useId, useState } from "react";
-import { type FeedbackKind } from "@web/components/Feedback/feedback.store";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
 
-const DIALOG_COPY = {
-  bug: {
-    title: "Report a bug",
-    label: "What went wrong?",
-    placeholder: "What happened? What did you expect instead?",
-    submitLabel: "Send bug report",
-  },
-  suggestion: {
-    title: "Share a suggestion",
-    label: "What would make Compass better?",
-    placeholder: "Tell us what you'd like to see.",
-    submitLabel: "Send suggestion",
-  },
-} satisfies Record<
-  FeedbackKind,
-  {
-    title: string;
-    label: string;
-    placeholder: string;
-    submitLabel: string;
-  }
->;
-
 interface FeedbackDialogProps {
-  kind: FeedbackKind;
   isSubmitting?: boolean;
   onDismiss: () => void;
   restoreFocus?: () => void;
@@ -38,7 +13,6 @@ interface FeedbackDialogProps {
 }
 
 export function FeedbackDialog({
-  kind,
   isSubmitting = false,
   onDismiss,
   restoreFocus,
@@ -47,7 +21,6 @@ export function FeedbackDialog({
   const [details, setDetails] = useState("");
   const textareaId = useId();
   const contextId = useId();
-  const copy = DIALOG_COPY[kind];
   const handleDismiss = () => {
     if (!isSubmitting) onDismiss();
   };
@@ -60,7 +33,7 @@ export function FeedbackDialog({
 
   return (
     <OverlayPanel
-      title={copy.title}
+      title="Share feedback"
       message="Send feedback without leaving Compass."
       onDismiss={handleDismiss}
       restoreFocus={restoreFocus}
@@ -71,7 +44,7 @@ export function FeedbackDialog({
       <form className="flex w-full flex-col gap-5" onSubmit={handleSubmit}>
         <div className="flex flex-col gap-2">
           <label className="text-sm text-text" htmlFor={textareaId}>
-            {copy.label}
+            What would you like to share?
           </label>
           <textarea
             id={textareaId}
@@ -80,7 +53,7 @@ export function FeedbackDialog({
             maxLength={5000}
             rows={6}
             aria-describedby={contextId}
-            placeholder={copy.placeholder}
+            placeholder="Tell us what you think."
             className="w-full resize-y rounded border border-border bg-transparent px-3 py-2 text-text outline-none placeholder:text-text-muted focus-visible:border-accent"
             onChange={(event) => setDetails(event.target.value)}
           />
@@ -102,7 +75,7 @@ export function FeedbackDialog({
             variant="primary"
             disabled={!details.trim() || isSubmitting}
           >
-            {isSubmitting ? "Sending…" : copy.submitLabel}
+            {isSubmitting ? "Sending…" : "Send feedback"}
           </OverlayPanelActionButton>
         </OverlayPanelActions>
       </form>

--- a/packages/web/src/components/Feedback/FeedbackDialogHost.tsx
+++ b/packages/web/src/components/Feedback/FeedbackDialogHost.tsx
@@ -44,7 +44,6 @@ export function FeedbackDialogHost() {
 
   return (
     <FeedbackDialog
-      kind={request.kind}
       isSubmitting={isSubmitting}
       onDismiss={feedbackActions.close}
       restoreFocus={restoreCommandPaletteFocus}

--- a/packages/web/src/components/Feedback/feedback.posthog.test.ts
+++ b/packages/web/src/components/Feedback/feedback.posthog.test.ts
@@ -21,7 +21,6 @@ describe("captureFeedback", () => {
       posthog,
       {
         details: "Keep completed events visible.",
-        kind: "suggestion",
         view: "week",
       },
       { apiKey: "test-key", host: "https://us.i.posthog.com", send },
@@ -50,7 +49,7 @@ describe("captureFeedback", () => {
         app_version: expect.any(String),
         app_view: "week",
         feedback_source: "command_palette",
-        feedback_type: "suggestion",
+        feedback_type: "feedback",
       },
     });
   });
@@ -61,7 +60,6 @@ describe("captureFeedback", () => {
         posthog,
         {
           details: "Keep my report open so I can retry.",
-          kind: "bug",
           view: "day",
         },
         {

--- a/packages/web/src/components/Feedback/feedback.posthog.ts
+++ b/packages/web/src/components/Feedback/feedback.posthog.ts
@@ -7,7 +7,7 @@ export const FEEDBACK_SURVEY = {
   name: "Open feedback",
   question: {
     id: "d0154ae2-c312-4d19-9d03-bb28eb56d6e3",
-    question: "What can we do to improve Compass?",
+    question: "What would you like to share?",
   },
 } as const;
 
@@ -33,7 +33,7 @@ interface FeedbackDeliveryOptions {
 
 export async function captureFeedback(
   posthog: PostHogFeedbackClient,
-  { details, kind, view }: FeedbackSubmission,
+  { details, view }: FeedbackSubmission,
   {
     apiKey = ENV_WEB.POSTHOG_KEY,
     host = ENV_WEB.POSTHOG_HOST,
@@ -60,7 +60,7 @@ export async function captureFeedback(
         app_version: APP_VERSION,
         app_view: view,
         feedback_source: "command_palette",
-        feedback_type: kind,
+        feedback_type: "feedback",
       },
     }),
   });

--- a/packages/web/src/components/Feedback/feedback.store.ts
+++ b/packages/web/src/components/Feedback/feedback.store.ts
@@ -1,10 +1,7 @@
 import { create } from "zustand";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
 
-export type FeedbackKind = "bug" | "suggestion";
-
 export interface FeedbackRequest {
-  kind: FeedbackKind;
   view: ViewName;
 }
 
@@ -17,8 +14,7 @@ export const useFeedbackStore = create<FeedbackState>()(() => ({
 }));
 
 export const feedbackActions = {
-  open: (kind: FeedbackKind, view: ViewName) =>
-    useFeedbackStore.setState({ request: { kind, view } }),
+  open: (view: ViewName) => useFeedbackStore.setState({ request: { view } }),
   close: () => useFeedbackStore.setState({ request: null }),
 };
 


### PR DESCRIPTION
## Summary

- Replace the separate **Report Bug** and **Share Feedback** palette entries with one **Share Feedback** command.
- Use one generic dialog and feedback type while retaining app/session context in PostHog.
- Keep the existing PostHog deployment gate: self-host installs still omit the cloud feedback command.

## Simplicity

- Removes `FeedbackKind` and the two-copy map rather than adding a new mode or flag.
- Reuses the existing dialog, store, survey response, and delivery path.

## Automated validation

- `bun test --cwd packages/web src/components/Feedback src/common/constants/more.cmd.constants.test.ts src/components/CommandPalette/CommandPalette.test.tsx` — 25 passing.
- `bun type-check` — passing.
- `bun lint` — passing with five pre-existing unrelated Tailwind class-order warnings.
- Validated staging delivery separately: the exact staging submission reached PostHog; the API survey is active and reports three responses today.

## Independent review

- Reviewed the final diff independently. The initial self-host fallback concern was invalid because `#2220` intentionally removed those legacy GitHub links on `main`; no remaining findings.

## Test plan

- Open the cloud command palette and confirm exactly one **Share Feedback** action is present.
- Open it and verify the generic feedback dialog copy, autofocus, disabled empty submit state, Escape dismissal, and focus restoration.
- Submit feedback and verify the `survey sent` response in PostHog.