### PR TITLE
feat: google auth adapter + command-palette nav

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
       "dependencies": {
         "@compass/core": "1.0.0",
         "express": "^4.17.1",
+        "google-auth-library": "^10.6.2",
         "mongodb": "^7.2.0",
         "tslib": "^2.4.0",
         "zod": "^3.25.76",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@compass/core": "1.0.0",
     "express": "^4.17.1",
+    "google-auth-library": "^10.6.2",
     "mongodb": "^7.2.0",
     "tslib": "^2.4.0",
     "zod": "^3.25.76"

--- a/packages/sync/src/config/sync.config.test.ts
+++ b/packages/sync/src/config/sync.config.test.ts
@@ -71,6 +71,40 @@ describe("Sync service configuration", () => {
     });
   });
 
+  describe("Google credentials (shared google config section)", () => {
+    const withGoogle = (google: Record<string, unknown> | undefined) =>
+      ({
+        runtime: { nodeEnv: "staging", timezone: "Etc/UTC" },
+        sync: baseSyncSection(),
+        google,
+      }) as unknown as CompassConfig;
+
+    it("leaves the Google client unset when the google section is absent", () => {
+      const config = parseSyncConfig(withGoogle(undefined));
+      expect(config.GOOGLE_CLIENT_ID).toBeUndefined();
+      expect(config.GOOGLE_CLIENT_SECRET).toBeUndefined();
+    });
+
+    it("reads the Google client id and secret from the google section", () => {
+      const config = parseSyncConfig(
+        withGoogle({
+          clientId: "id.apps.googleusercontent.com",
+          clientSecret: "secret",
+        }),
+      );
+      expect(config.GOOGLE_CLIENT_ID).toBe("id.apps.googleusercontent.com");
+      expect(config.GOOGLE_CLIENT_SECRET).toBe("secret");
+    });
+
+    it("treats an empty-string placeholder as unset", () => {
+      const config = parseSyncConfig(
+        withGoogle({ clientId: "", clientSecret: "" }),
+      );
+      expect(config.GOOGLE_CLIENT_ID).toBeUndefined();
+      expect(config.GOOGLE_CLIENT_SECRET).toBeUndefined();
+    });
+  });
+
   describe("required fields", () => {
     it("throws a clear error when the sync section is absent", () => {
       const config = { runtime: { nodeEnv: "staging", timezone: "Etc/UTC" } };

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -41,6 +41,11 @@ export const SyncConfigSchema = z.strictObject({
   // startup verifies it cannot read the API database. Off for a single-database
   // self-host with no scoped user. Defaults off — enable it deliberately.
   ENFORCE_LEAST_PRIVILEGE: BooleanFromInput.default(false),
+  // Google OAuth client, shared with the Compass API's `google` config section.
+  // Optional: a passive deployment without provider credentials still starts;
+  // the Google adapter refuses to construct when either is absent.
+  GOOGLE_CLIENT_ID: z.string().trim().min(1).optional(),
+  GOOGLE_CLIENT_SECRET: z.string().trim().min(1).optional(),
 });
 export type SyncConfig = z.infer<typeof SyncConfigSchema>;
 
@@ -60,6 +65,9 @@ export function parseSyncConfig(config: CompassConfig): SyncConfig {
     EXECUTION: config.sync.execution,
     MAX_CONCURRENCY: config.sync.maxConcurrency,
     ENFORCE_LEAST_PRIVILEGE: config.sync.enforceLeastPrivilege,
+    // Empty-string (unfilled deploy placeholder) or null coerces to absent.
+    GOOGLE_CLIENT_ID: config.google?.clientId || undefined,
+    GOOGLE_CLIENT_SECRET: config.google?.clientSecret || undefined,
   });
 }
 
@@ -75,6 +83,8 @@ export function parseSyncConfigFromEnv(
     EXECUTION: rawEnv["SYNC_EXECUTION"],
     MAX_CONCURRENCY: rawEnv["SYNC_MAX_CONCURRENCY"],
     ENFORCE_LEAST_PRIVILEGE: rawEnv["SYNC_ENFORCE_LEAST_PRIVILEGE"],
+    GOOGLE_CLIENT_ID: rawEnv["GOOGLE_CLIENT_ID"] || undefined,
+    GOOGLE_CLIENT_SECRET: rawEnv["GOOGLE_CLIENT_SECRET"] || undefined,
   });
 }
 

--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -201,6 +201,35 @@ describe("GoogleAuthAdapter", () => {
       expect((error as ProviderAuthError).reason).toBe("exchangeFailed");
     });
 
+    it("does not propagate the raw exchange error (which carries the client secret)", async () => {
+      // google-auth-library/gaxios errors retain the token-exchange request
+      // config, which includes the app's client_secret and the auth code.
+      const leaky = Object.assign(new Error("invalid_grant"), {
+        config: { data: "client_secret=SUPER_SECRET&code=auth-code" },
+        response: { data: { error: "invalid_grant" } },
+      });
+      const client = new FakeGoogleClient({ getTokenError: leaky });
+      const { adapter } = adapterWith(client);
+
+      const error = (await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://x/sync/google",
+        })
+        .catch((e) => e)) as ProviderAuthError;
+
+      const cause = error.cause as Error & { config?: unknown };
+      // The reason and a safe message survive; the raw object does not.
+      expect(cause).toBeInstanceOf(Error);
+      expect(cause.message).toBe("invalid_grant");
+      expect(cause).not.toBe(leaky);
+      expect(cause.config).toBeUndefined();
+      // Nothing reachable from the error may serialize the secret.
+      expect(
+        JSON.stringify({ message: error.message, cause: cause.message }),
+      ).not.toContain("SUPER_SECRET");
+    });
+
     it("requires a refresh token", async () => {
       const client = new FakeGoogleClient({
         tokens: { ...validTokens, refresh_token: undefined },

--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -1,0 +1,287 @@
+import { type Credentials, type TokenPayload } from "google-auth-library";
+import { GOOGLE_SCOPES } from "@sync/providers/google/google.scopes";
+import {
+  GoogleAuthAdapter,
+  type GoogleOAuthClient,
+} from "@sync/providers/google/google-auth.adapter";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+
+// A plain fake standing in for google-auth-library's OAuth2Client. Injected via
+// the adapter's client factory so no module mocking or network call is needed.
+class FakeGoogleClient implements GoogleOAuthClient {
+  authUrlOptions: Parameters<GoogleOAuthClient["generateAuthUrl"]>[0][] = [];
+
+  constructor(
+    private readonly behavior: {
+      tokens?: Credentials;
+      getTokenError?: unknown;
+      payload?: TokenPayload;
+      verifyError?: unknown;
+    } = {},
+  ) {}
+
+  generateAuthUrl(
+    options: Parameters<GoogleOAuthClient["generateAuthUrl"]>[0],
+  ): string {
+    this.authUrlOptions.push(options);
+    const scope = encodeURIComponent(options.scope.join(" "));
+    return `https://accounts.google.com/o/oauth2/v2/auth?state=${options.state}&scope=${scope}`;
+  }
+
+  async getToken(_code: string): Promise<{ tokens: Credentials }> {
+    if (this.behavior.getTokenError) throw this.behavior.getTokenError;
+    return { tokens: this.behavior.tokens ?? {} };
+  }
+
+  async verifyIdToken(_options: {
+    idToken: string;
+    audience: string;
+  }): Promise<{ getPayload(): TokenPayload | undefined }> {
+    if (this.behavior.verifyError) throw this.behavior.verifyError;
+    return { getPayload: () => this.behavior.payload };
+  }
+}
+
+const CLIENT_ID = "client-id.apps.googleusercontent.com";
+const CLIENT_SECRET = "client-secret";
+
+function makePayload(overrides: Partial<TokenPayload> = {}): TokenPayload {
+  return {
+    iss: "https://accounts.google.com",
+    aud: CLIENT_ID,
+    iat: 0,
+    exp: 0,
+    sub: "google-subject-123",
+    email: "user@example.com",
+    name: "Ada Lovelace",
+    ...overrides,
+  };
+}
+
+// Build an adapter whose client factory records the redirect URIs it is asked
+// for and always returns the given fake.
+function adapterWith(client: FakeGoogleClient) {
+  const redirectUris: string[] = [];
+  const adapter = new GoogleAuthAdapter(
+    CLIENT_ID,
+    CLIENT_SECRET,
+    (redirectUri) => {
+      redirectUris.push(redirectUri);
+      return client;
+    },
+  );
+  return { adapter, redirectUris };
+}
+
+describe("GoogleAuthAdapter", () => {
+  it("identifies as the google provider", () => {
+    const { adapter } = adapterWith(new FakeGoogleClient());
+    expect(adapter.provider).toBe("google");
+  });
+
+  it("refuses to construct without a client id and secret", () => {
+    expect(() => new GoogleAuthAdapter("", CLIENT_SECRET)).toThrow(
+      /client id and secret/,
+    );
+    expect(() => new GoogleAuthAdapter(CLIENT_ID, "")).toThrow(
+      /client id and secret/,
+    );
+  });
+
+  describe("buildAuthorizationUrl", () => {
+    it("requests offline access and consent for every configured scope", () => {
+      const client = new FakeGoogleClient();
+      const { adapter, redirectUris } = adapterWith(client);
+
+      const url = adapter.buildAuthorizationUrl({
+        state: "opaque-state",
+        redirectUri: "https://staging.example.com/sync/google",
+      });
+
+      // The redirect URI is passed through to the client that mints the URL.
+      expect(redirectUris).toEqual(["https://staging.example.com/sync/google"]);
+      const options = client.authUrlOptions[0];
+      expect(options.access_type).toBe("offline");
+      expect(options.prompt).toBe("consent");
+      expect(options.state).toBe("opaque-state");
+      expect(options.scope).toEqual([...GOOGLE_SCOPES]);
+      expect(url).toContain("state=opaque-state");
+    });
+  });
+
+  describe("exchangeAuthorizationCode", () => {
+    const validTokens: Credentials = {
+      refresh_token: "refresh-token-value",
+      access_token: "access-token-value",
+      id_token: "id-token-value",
+      scope:
+        "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar.readonly",
+    };
+
+    it("returns sub-keyed identity, the refresh token, and granted scopes", async () => {
+      const client = new FakeGoogleClient({
+        tokens: validTokens,
+        payload: makePayload(),
+      });
+      const { adapter, redirectUris } = adapterWith(client);
+
+      const result = await adapter.exchangeAuthorizationCode({
+        code: "auth-code",
+        redirectUri: "https://staging.example.com/sync/google",
+      });
+
+      expect(result.account.providerAccountId).toBe("google-subject-123");
+      expect(result.account.email).toBe("user@example.com");
+      expect(result.account.displayName).toBe("Ada Lovelace");
+      expect(result.refreshToken).toBe("refresh-token-value");
+      expect(result.grantedScopes).toEqual([
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/calendar.readonly",
+      ]);
+      expect(redirectUris).toEqual(["https://staging.example.com/sync/google"]);
+    });
+
+    it("preserves identity when the account email changes (keyed on sub)", async () => {
+      const first = await adapterWith(
+        new FakeGoogleClient({ tokens: validTokens, payload: makePayload() }),
+      ).adapter.exchangeAuthorizationCode({
+        code: "code-1",
+        redirectUri: "https://x/sync/google",
+      });
+
+      const second = await adapterWith(
+        new FakeGoogleClient({
+          tokens: { ...validTokens, refresh_token: "rotated-refresh" },
+          payload: makePayload({ email: "renamed@example.com" }),
+        }),
+      ).adapter.exchangeAuthorizationCode({
+        code: "code-2",
+        redirectUri: "https://x/sync/google",
+      });
+
+      // Same Google account -> same stable id, even though email + token moved.
+      expect(second.account.providerAccountId).toBe(
+        first.account.providerAccountId,
+      );
+      expect(second.account.email).toBe("renamed@example.com");
+      expect(second.refreshToken).toBe("rotated-refresh");
+    });
+
+    it("normalizes an absent email or name to null", async () => {
+      const client = new FakeGoogleClient({
+        tokens: validTokens,
+        payload: makePayload({ email: undefined, name: undefined }),
+      });
+      const { adapter } = adapterWith(client);
+
+      const result = await adapter.exchangeAuthorizationCode({
+        code: "auth-code",
+        redirectUri: "https://x/sync/google",
+      });
+
+      expect(result.account.providerAccountId).toBe("google-subject-123");
+      expect(result.account.email).toBeNull();
+      expect(result.account.displayName).toBeNull();
+    });
+
+    it("treats a failed code exchange as exchangeFailed", async () => {
+      const client = new FakeGoogleClient({
+        getTokenError: new Error("invalid_grant"),
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "bad-code",
+          redirectUri: "https://x/sync/google",
+        })
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(ProviderAuthError);
+      expect((error as ProviderAuthError).reason).toBe("exchangeFailed");
+    });
+
+    it("requires a refresh token", async () => {
+      const client = new FakeGoogleClient({
+        tokens: { ...validTokens, refresh_token: undefined },
+        payload: makePayload(),
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://x/sync/google",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("missingRefreshToken");
+    });
+
+    it("requires an id token to identify the account", async () => {
+      const client = new FakeGoogleClient({
+        tokens: { ...validTokens, id_token: undefined },
+        payload: makePayload(),
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://x/sync/google",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("invalidIdToken");
+    });
+
+    it("treats a failed id-token verification as invalidIdToken", async () => {
+      const client = new FakeGoogleClient({
+        tokens: validTokens,
+        verifyError: new Error("Wrong recipient"),
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://x/sync/google",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("invalidIdToken");
+    });
+
+    it("rejects a verified token that carries no subject", async () => {
+      const client = new FakeGoogleClient({
+        tokens: validTokens,
+        payload: makePayload({ sub: "" }),
+      });
+      const { adapter } = adapterWith(client);
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://x/sync/google",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("missingIdentity");
+    });
+
+    it("returns no granted scopes when the provider omits them", async () => {
+      const client = new FakeGoogleClient({
+        tokens: { ...validTokens, scope: undefined },
+        payload: makePayload(),
+      });
+      const { adapter } = adapterWith(client);
+
+      const result = await adapter.exchangeAuthorizationCode({
+        code: "auth-code",
+        redirectUri: "https://x/sync/google",
+      });
+
+      expect(result.grantedScopes).toEqual([]);
+    });
+  });
+});

--- a/packages/sync/src/providers/google/google-auth.adapter.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.ts
@@ -80,7 +80,7 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
       throw new ProviderAuthError(
         "exchangeFailed",
         "Google rejected the authorization code exchange",
-        { cause: error },
+        { cause: redactedCause(error) },
       );
     }
 
@@ -135,7 +135,7 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
       throw new ProviderAuthError(
         "invalidIdToken",
         "Google id token failed verification",
-        { cause: error },
+        { cause: redactedCause(error) },
       );
     }
     if (!payload) {
@@ -146,6 +146,16 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
     }
     return payload;
   }
+}
+
+// Reduce a provider-SDK error to a bare message before attaching it as a
+// cause. The google-auth-library/gaxios error retains the full token-exchange
+// request config, which includes the app's `client_secret` and the auth code;
+// propagating the raw object would leak that secret the moment any caller logs
+// the cause chain. The message is built from the response, not the request, so
+// it is safe to keep for diagnostics.
+function redactedCause(error: unknown): Error | undefined {
+  return error instanceof Error ? new Error(error.message) : undefined;
 }
 
 // Google returns granted scopes as a single space-delimited string. A subset of

--- a/packages/sync/src/providers/google/google-auth.adapter.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.ts
@@ -1,0 +1,156 @@
+import {
+  type Credentials,
+  OAuth2Client,
+  type TokenPayload,
+} from "google-auth-library";
+import { ProviderAccountFactsSchema } from "@core/types/sync/connection.contracts";
+import { GOOGLE_SCOPES } from "@sync/providers/google/google.scopes";
+import {
+  type ProviderAuthAdapter,
+  ProviderAuthError,
+  type ProviderAuthorization,
+} from "@sync/providers/provider-auth.port";
+
+// The subset of google-auth-library's OAuth2Client the adapter uses. Depending
+// on an interface (not the concrete client) lets tests supply a plain fake
+// without mocking the module or reaching across the network.
+export interface GoogleOAuthClient {
+  generateAuthUrl(options: {
+    access_type: string;
+    prompt?: string;
+    scope: string[];
+    state?: string;
+    include_granted_scopes?: boolean;
+  }): string;
+  getToken(code: string): Promise<{ tokens: Credentials }>;
+  verifyIdToken(options: { idToken: string; audience: string }): Promise<{
+    getPayload(): TokenPayload | undefined;
+  }>;
+}
+
+export type GoogleOAuthClientFactory = (
+  redirectUri: string,
+) => GoogleOAuthClient;
+
+// Google implementation of the provider authorization port. Identity is the
+// verified id-token `sub` — never the email, which is mutable and reassignable.
+export class GoogleAuthAdapter implements ProviderAuthAdapter {
+  readonly provider = "google" as const;
+
+  #clientId: string;
+  #makeClient: GoogleOAuthClientFactory;
+
+  constructor(
+    clientId: string,
+    clientSecret: string,
+    makeClient: GoogleOAuthClientFactory = (redirectUri) =>
+      new OAuth2Client(clientId, clientSecret, redirectUri),
+  ) {
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        "GoogleAuthAdapter requires a Google client id and secret",
+      );
+    }
+    this.#clientId = clientId;
+    this.#makeClient = makeClient;
+  }
+
+  buildAuthorizationUrl(input: { state: string; redirectUri: string }): string {
+    return this.#makeClient(input.redirectUri).generateAuthUrl({
+      // offline + consent guarantees a refresh token even on re-authorization,
+      // which Google otherwise omits after the first consent.
+      access_type: "offline",
+      prompt: "consent",
+      include_granted_scopes: true,
+      scope: [...GOOGLE_SCOPES],
+      state: input.state,
+    });
+  }
+
+  async exchangeAuthorizationCode(input: {
+    code: string;
+    redirectUri: string;
+  }): Promise<ProviderAuthorization> {
+    const client = this.#makeClient(input.redirectUri);
+
+    let tokens: Credentials;
+    try {
+      ({ tokens } = await client.getToken(input.code));
+    } catch (error) {
+      throw new ProviderAuthError(
+        "exchangeFailed",
+        "Google rejected the authorization code exchange",
+        { cause: error },
+      );
+    }
+
+    if (!tokens.refresh_token) {
+      throw new ProviderAuthError(
+        "missingRefreshToken",
+        "Google returned no refresh token; re-consent is required",
+      );
+    }
+    if (!tokens.id_token) {
+      throw new ProviderAuthError(
+        "invalidIdToken",
+        "Google returned no id token to identify the account",
+      );
+    }
+
+    const payload = await this.verifyIdToken(client, tokens.id_token);
+    if (!payload.sub) {
+      throw new ProviderAuthError(
+        "missingIdentity",
+        "Google id token carried no subject to identify the account",
+      );
+    }
+
+    // Parse through the shared contract so the branded id and nullable-field
+    // invariants hold at the boundary; empty strings normalize to null.
+    const account = ProviderAccountFactsSchema.parse({
+      providerAccountId: payload.sub,
+      email: payload.email || null,
+      displayName: payload.name || null,
+    });
+
+    return {
+      account,
+      refreshToken: tokens.refresh_token,
+      grantedScopes: parseGrantedScopes(tokens.scope),
+    };
+  }
+
+  private async verifyIdToken(
+    client: GoogleOAuthClient,
+    idToken: string,
+  ): Promise<TokenPayload> {
+    let payload: TokenPayload | undefined;
+    try {
+      const ticket = await client.verifyIdToken({
+        idToken,
+        audience: this.#clientId,
+      });
+      payload = ticket.getPayload();
+    } catch (error) {
+      throw new ProviderAuthError(
+        "invalidIdToken",
+        "Google id token failed verification",
+        { cause: error },
+      );
+    }
+    if (!payload) {
+      throw new ProviderAuthError(
+        "invalidIdToken",
+        "Google id token verification returned no payload",
+      );
+    }
+    return payload;
+  }
+}
+
+// Google returns granted scopes as a single space-delimited string. A subset of
+// the requested scopes is normal; callers derive capabilities from what is here.
+function parseGrantedScopes(scope: string | null | undefined): string[] {
+  if (!scope) return [];
+  return scope.split(/\s+/).filter(Boolean);
+}

--- a/packages/sync/src/providers/google/google.scopes.ts
+++ b/packages/sync/src/providers/google/google.scopes.ts
@@ -1,0 +1,8 @@
+// Scopes Sync requests from Google. These mirror the Compass API's existing
+// Google integration so a user's granted consent covers both. Email identifies
+// the account; the calendar scopes cover read and event read/write.
+export const GOOGLE_SCOPES: readonly string[] = [
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+];

--- a/packages/sync/src/providers/provider-auth.port.ts
+++ b/packages/sync/src/providers/provider-auth.port.ts
@@ -1,0 +1,60 @@
+import { type ProviderAccountFacts } from "@core/types/sync/connection.contracts";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+
+// The durable result of authorizing one provider account. It is the minimum a
+// caller needs to persist a connection: a stable, provider-assigned identity
+// (never email), the credential to store, and the scopes actually granted.
+export interface ProviderAuthorization {
+  // Stable account facts keyed on the provider's own account id (e.g. Google's
+  // `sub`). Identity is never inferred from email.
+  readonly account: ProviderAccountFacts;
+  // The long-lived credential to persist. Short-lived access tokens are minted
+  // on demand from this and are never stored.
+  readonly refreshToken: string;
+  // The scopes the user actually granted, which may be a subset of those
+  // requested. Callers derive capabilities from these rather than assuming.
+  readonly grantedScopes: readonly string[];
+}
+
+// A provider-neutral authorization port. The domain builds a consent URL and
+// exchanges the returned code without knowing which provider it is talking to;
+// provider-specific detail (endpoints, id-token verification, idempotency)
+// stays inside the adapter.
+export interface ProviderAuthAdapter {
+  readonly provider: ProviderKind;
+
+  // Build the URL to send the user to for consent. `state` is opaque here and
+  // is validated by the caller when the provider redirects back.
+  buildAuthorizationUrl(input: {
+    readonly state: string;
+    readonly redirectUri: string;
+  }): string;
+
+  // Exchange an authorization code for durable credentials and account
+  // identity. The `redirectUri` must match the one used to build the URL.
+  // Rejects with a ProviderAuthError when the grant is unusable.
+  exchangeAuthorizationCode(input: {
+    readonly code: string;
+    readonly redirectUri: string;
+  }): Promise<ProviderAuthorization>;
+}
+
+// Why an authorization attempt could not yield a usable connection. Callers map
+// these to connection states (e.g. a missing refresh token is a credential
+// problem the user must act on) instead of parsing provider error strings.
+export type ProviderAuthErrorReason =
+  | "exchangeFailed" // the provider rejected the code exchange
+  | "missingRefreshToken" // no refresh token returned (e.g. prior consent)
+  | "missingIdentity" // the account could not be identified from the grant
+  | "invalidIdToken"; // the id token was absent or failed verification
+
+export class ProviderAuthError extends Error {
+  constructor(
+    readonly reason: ProviderAuthErrorReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "ProviderAuthError";
+  }
+}

--- a/packages/web/src/common/constants/navigation.cmd.constants.test.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.test.ts
@@ -1,33 +1,22 @@
-import dayjs from "@core/util/date/dayjs";
 import { getNavigationCommandItems } from "@web/common/constants/navigation.cmd.constants";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
 import { describe, expect, it } from "bun:test";
 
 describe("getNavigationCommandItems", () => {
-  const today = dayjs("2026-05-28");
+  const noopHandlers = {
+    onGoToToday: () => {},
+    onNavigateToView: () => {},
+    onShowShortcuts: () => {},
+  };
 
-  function getItemLabels(currentView: ViewName) {
-    return getNavigationCommandItems({
-      currentView,
-      onGoToToday: () => {},
-      onNavigateToView: () => {},
-      onShowShortcuts: () => {},
-      today,
-    }).map((item) => item.label);
-  }
-
-  it("returns the other views, today, and shortcuts for the week palette", () => {
-    expect(getItemLabels("week")).toEqual([
+  it("lists Today first, then Day and Week, then shortcuts", () => {
+    const labels = getNavigationCommandItems(noopHandlers).map(
+      (item) => item.label,
+    );
+    expect(labels).toEqual([
+      "Go to Today",
       "Go to Day",
-      "Go to Today (Thursday, May 28)",
-      "Show Shortcuts",
-    ]);
-  });
-
-  it("returns the other views, today, and shortcuts for the day palette", () => {
-    expect(getItemLabels("day")).toEqual([
       "Go to Week",
-      "Go to Today (Thursday, May 28)",
       "Show Shortcuts",
     ]);
   });
@@ -37,7 +26,6 @@ describe("getNavigationCommandItems", () => {
     let didGoToToday = false;
     let didShowShortcuts = false;
     const items = getNavigationCommandItems({
-      currentView: "day",
       onGoToToday: () => {
         didGoToToday = true;
       },
@@ -47,14 +35,14 @@ describe("getNavigationCommandItems", () => {
       onShowShortcuts: () => {
         didShowShortcuts = true;
       },
-      today,
     });
 
+    items.find((item) => item.id === "go-to-day")?.onClick?.();
     items.find((item) => item.id === "go-to-week")?.onClick?.();
     items.find((item) => item.id === "today")?.onClick?.();
     items.find((item) => item.id === "show-shortcuts")?.onClick?.();
 
-    expect(navigatedViews).toEqual(["week"]);
+    expect(navigatedViews).toEqual(["day", "week"]);
     expect(didGoToToday).toBe(true);
     expect(didShowShortcuts).toBe(true);
   });

--- a/packages/web/src/common/constants/navigation.cmd.constants.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.ts
@@ -5,7 +5,6 @@ import {
   type Icon,
   KeyboardIcon,
 } from "@phosphor-icons/react";
-import { type Dayjs } from "@core/util/date/dayjs";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 import {
   VIEW_SHORTCUTS,
@@ -13,11 +12,9 @@ import {
 } from "@web/shortcuts/shortcuts.constants";
 
 interface GetNavigationCommandItemsArgs {
-  currentView: ViewName;
   onGoToToday: () => void;
   onNavigateToView: (viewName: ViewName) => void;
   onShowShortcuts: () => void;
-  today: Dayjs;
 }
 
 const viewIcons: Record<ViewName, Icon> = {
@@ -28,28 +25,24 @@ const viewIcons: Record<ViewName, Icon> = {
 const navigationViewOrder: ViewName[] = ["day", "week"];
 
 export const getNavigationCommandItems = ({
-  currentView,
   onGoToToday,
   onNavigateToView,
   onShowShortcuts,
-  today,
 }: GetNavigationCommandItemsArgs): CommandItem[] => [
-  ...navigationViewOrder
-    .filter((viewName) => viewName !== currentView)
-    .map((viewName) => ({
-      id: `go-to-${viewName}`,
-      label: `Go to ${VIEW_SHORTCUTS[viewName].label}`,
-      icon: viewIcons[viewName],
-      shortcut: VIEW_SHORTCUTS[viewName].key,
-      onClick: () => onNavigateToView(viewName),
-    })),
   {
     id: "today",
-    label: `Go to Today (${today.format("dddd, MMMM D")})`,
+    label: "Go to Today",
     icon: ArrowUDownLeftIcon,
     shortcut: "t",
     onClick: onGoToToday,
   },
+  ...navigationViewOrder.map((viewName) => ({
+    id: `go-to-${viewName}`,
+    label: `Go to ${VIEW_SHORTCUTS[viewName].label}`,
+    icon: viewIcons[viewName],
+    shortcut: VIEW_SHORTCUTS[viewName].key,
+    onClick: () => onNavigateToView(viewName),
+  })),
   {
     id: "show-shortcuts",
     label: "Show Shortcuts",

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -1,7 +1,6 @@
 import "@testing-library/jest-dom";
 import { PlusIcon } from "@phosphor-icons/react";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
-import dayjs from "@core/util/date/dayjs";
 import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type SyncStatus } from "@web/calendars/sync-status.types";
@@ -88,7 +87,6 @@ const renderPalette = (mutationDependencies?: EventMutationDependencies) =>
   renderWithStore(
     <CommandPalette
       currentView="week"
-      today={dayjs("2026-07-07")}
       onGoToToday={onGoToToday}
       onShowShortcuts={onShowShortcuts}
       placeholder="Try: 'create', 'bug', or 'code'"
@@ -126,16 +124,17 @@ describe("CommandPalette", () => {
     expect(screen.getByText("Settings")).toBeInTheDocument();
     expect(screen.getByText("More")).toBeInTheDocument();
 
-    // Week view hides its own nav item and surfaces the Day + Today entries.
+    // Navigation always lists Today first, then Day and Week.
+    expect(screen.getByText("Go to Today")).toBeInTheDocument();
     expect(screen.getByText("Go to Day")).toBeInTheDocument();
-    expect(screen.getByText(/Go to Today/)).toBeInTheDocument();
+    expect(screen.getByText("Go to Week")).toBeInTheDocument();
     expect(screen.getByText("Create event")).toBeInTheDocument();
     expect(screen.getByText("Create all-day event")).toBeInTheDocument();
     // Settings surfaces the (stubbed) Google item.
     expect(screen.getByText("Connect Google Calendar")).toBeInTheDocument();
     expect(getInput()).toHaveFocus();
     // First option is active by default.
-    expect(activeRowText(container)).toBe("Go to Day");
+    expect(activeRowText(container)).toBe("Go to Today");
   });
 
   it("filters case-insensitively, dropping empty sections, and shows a no-results row", () => {
@@ -165,16 +164,17 @@ describe("CommandPalette", () => {
     ).toBeDisabled();
 
     // First option active by default; ArrowUp wraps to the last (Version) row.
-    expect(activeRowText(container)).toBe("Go to Day");
+    expect(activeRowText(container)).toBe("Go to Today");
     fireEvent.keyDown(input, { key: "ArrowUp" });
     expect(activeRowText(container)).toMatch(/Version/);
     // ArrowDown from the last option wraps back to the first.
     fireEvent.keyDown(input, { key: "ArrowDown" });
-    expect(activeRowText(container)).toBe("Go to Day");
+    expect(activeRowText(container)).toBe("Go to Today");
 
     // Walk down to "Create all-day event", then the next ArrowDown skips the
     // disabled Undo row and lands on the Appearance section's theme toggle.
-    fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Today
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Day
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Week
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Show Shortcuts
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create event
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create all-day event
@@ -206,10 +206,10 @@ describe("CommandPalette", () => {
     const input = getInput();
 
     fireEvent.keyDown(input, { key: "ArrowDown" });
-    expect(activeRowText(container)).toMatch(/Go to Today/);
+    expect(activeRowText(container)).toBe("Go to Day");
 
     fireEvent.change(input, { target: { value: "go" } });
-    expect(activeRowText(container)).toBe("Go to Day");
+    expect(activeRowText(container)).toBe("Go to Today");
   });
 
   it("closes on Escape", () => {

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -10,7 +10,6 @@ import {
 import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useRef, useState } from "react";
-import { type Dayjs } from "@core/util/date/dayjs";
 import { type SyncStatusVariant } from "@web/calendars/sync-status.types";
 import { eventCommandPaletteItems } from "@web/common/constants/event.cmd.constants";
 import { getMoreCommandPaletteSections } from "@web/common/constants/more.cmd.constants";
@@ -46,7 +45,6 @@ const SYNC_STATUS_VARIANT_CLASSNAME: Record<SyncStatusVariant, string> = {
 
 interface CommandPaletteProps {
   currentView: ViewName;
-  today: Dayjs;
   onGoToToday: () => void;
   onShowShortcuts: () => void;
   placeholder: string;
@@ -76,7 +74,6 @@ export function filterSections(
 
 export const CommandPalette = ({
   currentView,
-  today,
   onGoToToday,
   onShowShortcuts,
   placeholder,
@@ -118,12 +115,10 @@ export const CommandPalette = ({
       id: "navigation",
       heading: "Navigation",
       items: getNavigationCommandItems({
-        currentView,
         onGoToToday,
         onNavigateToView: (viewName) =>
           navigate({ to: VIEW_SHORTCUTS[viewName].route }),
         onShowShortcuts,
-        today,
       }),
     },
     {

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -120,7 +120,6 @@ export const DayViewContent = memo(() => {
     <div id="day" className="flex h-screen w-screen overflow-hidden">
       <CommandPalette
         currentView="day"
-        today={dayjs()}
         onGoToToday={handleGoToToday}
         onShowShortcuts={toggleShortcuts}
         placeholder={getCommandPalettePlaceholder("day")}

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -139,7 +139,6 @@ export const WeekView = () => {
     <div id="cal" className="flex h-screen w-screen overflow-hidden">
       <CommandPalette
         currentView="week"
-        today={today}
         onGoToToday={goToTodayViaCmd}
         onShowShortcuts={toggleShortcuts}
         placeholder={getCommandPalettePlaceholder("week")}


### PR DESCRIPTION
This PR bundles two independent, self-contained commits.

## 1. `feat(sync): add google authorization adapter`

Introduces a provider-neutral authorization port and its Google adapter for the sync service:

- **Port** (`provider-auth.port.ts`): `ProviderAuthAdapter` (build consent URL, exchange code) returning a `ProviderAuthorization` (sub-keyed account facts, refresh token, granted scopes), plus a typed `ProviderAuthError`.
- **Google adapter** (`google/google-auth.adapter.ts`): builds the consent URL (offline + consent so a refresh token is always returned) and exchanges the code — verifying the id token and keying identity on the Google **`sub`**, never the email. Parses actually-granted scopes from the token response. Depends on an injected `OAuth2Client` interface so tests use a plain fake (no module mocking, no network).
- **Config**: plumbs the Google client id/secret into sync config from the shared `google` section (optional; the adapter refuses to construct without both). Adds `google-auth-library` as an explicit dependency.

Deliberately avoids the backend's email-fallback identity behavior (which can merge a Google login into a pre-existing email-matched account). The HTTP callback ingress is a later step; this is the adapter capability only.

## 2. `feat: update cmd palette`

Command-palette Navigation section now lists **Go to Today, Go to Day, Go to Week** (Today first), and drops the `(Monday, July 20)` date parenthetical from the Today entry for less noise. Removes the now-unused `today` prop threaded through the palette.

## Tests

- Sync: 170 pass (adapter scenarios: sub-keyed identity, email-change preserves identity, missing refresh/id token, failed exchange, granted-scope parsing; config plumbing).
- Web: navigation + CommandPalette tests updated for the new order (19 pass).
- `bun run type-check` and `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
