### PR TITLE
feat(sync): add credential storage

### DIFF
--- a/packages/sync/src/storage/collections.ts
+++ b/packages/sync/src/storage/collections.ts
@@ -5,6 +5,7 @@
 // indexes.
 export const SYNC_COLLECTIONS = {
   providerConnections: "provider_connections",
+  credentials: "credentials",
   providerCalendars: "provider_calendars",
   events: "events",
   eventOccurrences: "event_occurrences",

--- a/packages/sync/src/storage/credential.record.ts
+++ b/packages/sync/src/storage/credential.record.ts
@@ -1,0 +1,64 @@
+import { z } from "zod/v4";
+import {
+  ConnectionIdSchema,
+  ProviderKindSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Persistence record for `credentials`. Credentials live in their OWN
+// collection, keyed 1:1 by connection id, so no normal connection projection
+// can ever return credential material — reading a connection never touches this
+// collection. Only the Sync database user can read it.
+//
+// The refresh token is the durable secret; the access token is a short-lived
+// cache re-minted from it on demand. Both are token-shaped and must never reach
+// a log or error — use `redactCredential` for any diagnostic output.
+export const CredentialRecordSchema = z.strictObject({
+  // One credential document per connection; the connection id is the key.
+  _id: ConnectionIdSchema,
+  provider: ProviderKindSchema,
+  refreshToken: z.string().min(1),
+  // Cached access token and its absolute expiry. Null until first refresh, and
+  // whenever the cached token has been invalidated.
+  accessToken: z.string().min(1).nullable(),
+  accessTokenExpiresAt: z.date().nullable(),
+  // The scopes the credential was granted, for capability checks.
+  scopes: z.array(z.string()),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type CredentialRecord = z.infer<typeof CredentialRecordSchema>;
+
+// What a caller provides to store or replace a connection's credential. Sync
+// owns _id, createdAt, and updatedAt. Storing a fresh refresh token clears any
+// cached access token so a stale one can never be served after re-authorization.
+export const CredentialUpsertSchema = z.strictObject({
+  connectionId: ConnectionIdSchema,
+  provider: ProviderKindSchema,
+  refreshToken: z.string().min(1),
+  scopes: z.array(z.string()),
+});
+export type CredentialUpsert = z.infer<typeof CredentialUpsertSchema>;
+
+// A log-safe view of a credential. Token-shaped fields are reduced to presence
+// booleans so a diagnostic can say "has a refresh token, access token expired"
+// without ever emitting the secret. This is the ONLY shape that should be
+// logged for a credential.
+export interface RedactedCredential {
+  readonly connectionId: string;
+  readonly provider: string;
+  readonly hasRefreshToken: boolean;
+  readonly hasAccessToken: boolean;
+  readonly accessTokenExpiresAt: Date | null;
+  readonly scopeCount: number;
+}
+
+export function redactCredential(record: CredentialRecord): RedactedCredential {
+  return {
+    connectionId: record._id,
+    provider: record.provider,
+    hasRefreshToken: record.refreshToken.length > 0,
+    hasAccessToken: record.accessToken !== null,
+    accessTokenExpiresAt: record.accessTokenExpiresAt,
+    scopeCount: record.scopes.length,
+  };
+}

--- a/packages/sync/src/storage/credential.repository.test.ts
+++ b/packages/sync/src/storage/credential.repository.test.ts
@@ -1,0 +1,141 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type CredentialUpsert,
+  redactCredential,
+} from "@sync/storage/credential.record";
+import { CredentialRepository } from "@sync/storage/credential.repository";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const baseCredential = (
+  overrides: Partial<CredentialUpsert> = {},
+): CredentialUpsert => ({
+  connectionId: objectId() as ConnectionId,
+  provider: "google",
+  refreshToken: "refresh-token-secret",
+  scopes: ["https://www.googleapis.com/auth/calendar.events"],
+  ...overrides,
+});
+
+describe("CredentialRepository", () => {
+  let client: MongoClient;
+  let db: Db;
+  let repo: CredentialRepository;
+
+  beforeEach(async () => {
+    client = new MongoClient(uri);
+    await client.connect();
+    db = client.db(`cred_${objectId()}`);
+    await installIndexManifest(db);
+    repo = new CredentialRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  it("stores and reads back a credential keyed by connection id", async () => {
+    const input = baseCredential();
+    const stored = await repo.store(input);
+
+    expect(stored._id).toBe(input.connectionId);
+    expect(stored.refreshToken).toBe("refresh-token-secret");
+    expect(stored.accessToken).toBeNull();
+    expect(stored.createdAt).toBeInstanceOf(Date);
+
+    const read = await repo.findByConnection(input.connectionId);
+    expect(read?.refreshToken).toBe("refresh-token-secret");
+  });
+
+  it("returns null when no credential exists for the connection", async () => {
+    expect(await repo.findByConnection(objectId() as ConnectionId)).toBeNull();
+  });
+
+  it("caches an access token and clears it when a new refresh token is stored", async () => {
+    const input = baseCredential();
+    await repo.store(input);
+
+    const expiresAt = new Date(Date.now() + 3600_000);
+    const cached = await repo.cacheAccessToken(
+      input.connectionId,
+      "access-token-value",
+      expiresAt,
+    );
+    expect(cached?.accessToken).toBe("access-token-value");
+    expect(cached?.accessTokenExpiresAt).toEqual(expiresAt);
+
+    // Re-authorizing (new refresh token) must invalidate the cached access
+    // token so a token from the superseded grant is never served.
+    const reAuthed = await repo.store({
+      ...input,
+      refreshToken: "rotated-refresh-token",
+    });
+    expect(reAuthed.refreshToken).toBe("rotated-refresh-token");
+    expect(reAuthed.accessToken).toBeNull();
+    expect(reAuthed.accessTokenExpiresAt).toBeNull();
+  });
+
+  it("does not resurrect a credential that was deleted mid-refresh", async () => {
+    const input = baseCredential();
+    await repo.store(input);
+    await repo.deleteByConnection(input.connectionId);
+
+    const result = await repo.cacheAccessToken(
+      input.connectionId,
+      "access-token-value",
+      new Date(Date.now() + 3600_000),
+    );
+    expect(result).toBeNull();
+    expect(await repo.findByConnection(input.connectionId)).toBeNull();
+  });
+
+  it("reports whether a delete removed anything", async () => {
+    const input = baseCredential();
+    await repo.store(input);
+
+    expect(await repo.deleteByConnection(input.connectionId)).toBe(true);
+    expect(await repo.deleteByConnection(input.connectionId)).toBe(false);
+  });
+
+  it("keeps credentials out of the provider_connections collection", async () => {
+    const input = baseCredential();
+    await repo.store(input);
+
+    // Credentials live in their own collection; nothing about a connection
+    // read touches them.
+    const inConnections = await db
+      .collection(SYNC_COLLECTIONS.providerConnections)
+      .findOne({ _id: input.connectionId });
+    expect(inConnections).toBeNull();
+
+    const inCredentials = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: input.connectionId });
+    expect(inCredentials).not.toBeNull();
+  });
+
+  it("redacts token-shaped fields for logging", async () => {
+    const stored = await repo.store(baseCredential());
+    await repo.cacheAccessToken(
+      stored._id,
+      "access-token-value",
+      new Date(Date.now() + 3600_000),
+    );
+    const record = await repo.findByConnection(stored._id);
+    const redacted = redactCredential(record!);
+
+    expect(redacted.hasRefreshToken).toBe(true);
+    expect(redacted.hasAccessToken).toBe(true);
+    expect(redacted.scopeCount).toBe(1);
+    // No token value can appear anywhere in the log-safe view.
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain("refresh-token-secret");
+    expect(serialized).not.toContain("access-token-value");
+  });
+});

--- a/packages/sync/src/storage/credential.repository.ts
+++ b/packages/sync/src/storage/credential.repository.ts
@@ -1,0 +1,90 @@
+import { type Collection, type Db } from "mongodb";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type CredentialRecord,
+  CredentialRecordSchema,
+  type CredentialUpsert,
+  CredentialUpsertSchema,
+} from "@sync/storage/credential.record";
+
+// Repository for `credentials`. One document per connection, keyed by the
+// connection id. This is the ONLY place provider credentials are read or
+// written; no connection query touches this collection, so a connection read
+// can never surface a token. The repository never logs credential material.
+export class CredentialRepository {
+  private readonly collection: Collection<CredentialRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<CredentialRecord>(
+      SYNC_COLLECTIONS.credentials,
+    );
+  }
+
+  // Store or replace a connection's credential. A new refresh token clears any
+  // cached access token, so a token minted from a superseded grant can never be
+  // served after re-authorization.
+  async store(input: CredentialUpsert): Promise<CredentialRecord> {
+    const fields = CredentialUpsertSchema.parse(input);
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      { _id: fields.connectionId },
+      {
+        $set: {
+          provider: fields.provider,
+          refreshToken: fields.refreshToken,
+          scopes: fields.scopes,
+          accessToken: null,
+          accessTokenExpiresAt: null,
+          updatedAt: now,
+        },
+        // _id comes from the query filter on insert; setting it here too would
+        // touch the immutable field.
+        $setOnInsert: { createdAt: now },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+
+    if (!result) {
+      throw new Error("Credential store did not return a record");
+    }
+    return CredentialRecordSchema.parse(result);
+  }
+
+  async findByConnection(
+    connectionId: ConnectionId,
+  ): Promise<CredentialRecord | null> {
+    const record = await this.collection.findOne({ _id: connectionId });
+    return record ? CredentialRecordSchema.parse(record) : null;
+  }
+
+  // Cache a freshly-minted access token and its expiry. Returns null if the
+  // credential was deleted concurrently (e.g. a disconnect landed mid-refresh),
+  // so a caller never resurrects a revoked credential.
+  async cacheAccessToken(
+    connectionId: ConnectionId,
+    accessToken: string,
+    expiresAt: Date,
+  ): Promise<CredentialRecord | null> {
+    const result = await this.collection.findOneAndUpdate(
+      { _id: connectionId },
+      {
+        $set: {
+          accessToken,
+          accessTokenExpiresAt: expiresAt,
+          updatedAt: new Date(),
+        },
+      },
+      { returnDocument: "after" },
+    );
+    return result ? CredentialRecordSchema.parse(result) : null;
+  }
+
+  // Remove a connection's credential (disconnect / account deletion). Returns
+  // whether a credential existed to delete.
+  async deleteByConnection(connectionId: ConnectionId): Promise<boolean> {
+    const result = await this.collection.deleteOne({ _id: connectionId });
+    return result.deletedCount > 0;
+  }
+}

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -39,6 +39,8 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
     { name: "principal_state", key: { principalId: 1, state: 1 } },
     { name: "health_age", key: { lastHealthyAt: 1 } },
   ],
+  // Keyed 1:1 by connection id (the automatic _id index); no secondary indexes.
+  [SYNC_COLLECTIONS.credentials]: [],
   [SYNC_COLLECTIONS.providerCalendars]: [
     {
       name: "connection_provider_calendar",


### PR DESCRIPTION
## What

Adds the storage layer for provider credentials in the sync service — the first, self-contained part of credential custody. The store is **inert** until the credential lifecycle (refresh/revoke, next PR) wires it in.

## Design

- **Own collection**: credentials live in a dedicated `credentials` collection, keyed 1:1 by connection id. No `provider_connection` query touches it, so reading a connection can never surface a token — the isolation makes credential leakage into connection reads *structurally impossible*, not just avoided. (Test: `keeps credentials out of the provider_connections collection`.)
- **Cache invalidation on re-auth**: `store()` writes a new refresh token and nulls any cached access token in the same `$set`, so a token minted from a superseded grant is never served after re-authorization. (Test: `caches an access token and clears it when a new refresh token is stored`.)
- **No resurrection**: `cacheAccessToken()` returns `null` if the credential was deleted concurrently (e.g. a disconnect landed mid-refresh), so a caller can't re-create a revoked credential. (Test: `does not resurrect a credential that was deleted mid-refresh`.)
- **Log-safe redaction**: `redactCredential()` reduces token-shaped fields to presence booleans — the only shape that should ever be logged. (Test asserts no token value survives serialization.)

## Files

- `credential.record.ts` — record + upsert schemas, `redactCredential` helper
- `credential.repository.ts` — `store` / `findByConnection` / `cacheAccessToken` / `deleteByConnection`
- `collections.ts`, `index-manifest.ts` — register the `credentials` collection (keyed by `_id`, no secondary indexes)

## Tests

`bun run test:sync` — 7 new credential tests + the manifest coverage test pass; type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
