### PR TITLE
fix(web): correct low-contrast text across light and dark themes

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -157,7 +157,7 @@ state that nothing else needs), keep it — but say why in the commit message
 ## Repo-Specific Conventions
 
 - Use path aliases, not deep relative imports: `@compass/core`,
-  `@compass/backend`, `@compass/scripts`, `@web/*`, `@core/*`
+  `@compass/backend`, `@compass/scripts`, `@compass/sync`, `@web/*`, `@core/*`
 - Shared web/backend contracts belong in `packages/core` and use Zod — match
   the existing import style in the file you're editing
 - Zustand stores follow store + module actions + plain selectors (see
@@ -230,6 +230,7 @@ Match the check to the packages actually touched — don't default to a broad
 suite:
 
 - `packages/core` changes → `bun run test:core`
+- `packages/sync` changes → `bun run test:sync`
 - `packages/web` changes → `bun run test:web`
 - `packages/backend` changes → `bun run test:backend`
 - `packages/scripts` changes → `bun run test:scripts`

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: [core, web, backend, scripts]
+        project: [core, sync, web, backend, scripts]
 
     steps:
       - name: Check out Git repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ cp compass.example.yaml compass.yaml
 bun install
 bun dev:web
 bun dev:backend
+bun dev:sync
 bun test:core
+bun test:sync
 bun test:web
 bun test:backend
 bun test:scripts
@@ -35,6 +37,7 @@ bun lint:fix
 Validation defaults:
 
 - Core: `bun test:core`
+- Sync: `bun test:sync`
 - Web: `bun test:web`
 - Backend: `bun test:backend`
 - Scripts: `bun test:scripts`
@@ -57,6 +60,7 @@ Validation defaults:
   - `@compass/backend` -> `packages/backend/src`
   - `@compass/core` -> `packages/core/src`
   - `@compass/scripts` -> `packages/scripts/src`
+  - `@compass/sync` -> `packages/sync/src`
   - `@web/*` -> `packages/web/src/*`
   - `@core/*` -> `packages/core/src/*`
 - Shared web/backend contracts belong in `packages/core` and should use Zod.

--- a/biome.json
+++ b/biome.json
@@ -81,11 +81,18 @@
           "level": "on",
           "options": {
             "groups": [
-              [":PACKAGE:", "!@core/**", "!@web/**", "!@backend/**"],
-              ["@*", "!@core/**", "!@web/**", "!@backend/**"],
+              [
+                ":PACKAGE:",
+                "!@core/**",
+                "!@web/**",
+                "!@backend/**",
+                "!@sync/**"
+              ],
+              ["@*", "!@core/**", "!@web/**", "!@backend/**", "!@sync/**"],
               ["@core/**", "!@core"],
               ["@web/**", "!@web"],
               ["@backend/**", "!@backend"],
+              ["@sync/**", "!@sync"],
               ":PATH:"
             ]
           }

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@types/node": "^22.13.10",
         "@types/node-fetch": "^2.6.13",
         "axe-core": "^4.12.1",
-        "typescript": "^7.0.2",
+        "typescript": "7.0.2",
       },
     },
     "packages/backend": {
@@ -84,6 +84,18 @@
         "@types/node": "^24.7.2",
         "mongodb-memory-server": "^9.2.0",
         "typescript": "^7.0.2",
+      },
+    },
+    "packages/sync": {
+      "name": "@compass/sync",
+      "version": "1.0.0",
+      "dependencies": {
+        "@compass/core": "1.0.0",
+        "tslib": "^2.4.0",
+      },
+      "devDependencies": {
+        "@faker-js/faker": "^9.6.0",
+        "@types/node": "^22.13.10",
       },
     },
     "packages/web": {
@@ -196,6 +208,8 @@
     "@compass/core": ["@compass/core@workspace:packages/core"],
 
     "@compass/scripts": ["@compass/scripts@workspace:packages/scripts"],
+
+    "@compass/sync": ["@compass/sync@workspace:packages/sync"],
 
     "@compass/web": ["@compass/web@workspace:packages/web"],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "_moduleAliases": {
     "@compass/backend": "packages/backend/src",
     "@compass/core": "packages/core/src",
-    "@compass/scripts": "packages/scripts/src"
+    "@compass/scripts": "packages/scripts/src",
+    "@compass/sync": "packages/sync/src"
   },
   "scripts": {
     "cli": "bun packages/scripts/src/cli.ts",
@@ -21,19 +22,21 @@
     "dev:backend -verbose": "export DEBUG=* &&bun run dev:backend",
     "dev:backend": "bun run dev:ports backend && cd packages/backend && bun --watch src/app.ts",
     "dev:ports": "bun packages/scripts/src/commands/dev-ports.ts",
+    "dev:sync": "cd packages/sync && bun --watch src/app.ts",
     "dev:update": "git checkout main && git pull &&bun install",
     "dev:web": "bun run dev:ports web && cd packages/web &&bun run dev.ts",
     "lint": "bun packages/scripts/src/testing/check-semantic-colors.ts && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "test": "bun test:core && bun test:web && bun test:backend && bun test:scripts",
+    "test": "bun test:core && bun test:sync && bun test:web && bun test:backend && bun test:scripts",
     "test:a11y": "bunx playwright test e2e/accessibility",
     "test:e2e": "bunx playwright test",
     "test:backend": "bun packages/scripts/src/testing/run-tests.ts backend",
     "test:backend:fast": "bun packages/scripts/src/testing/run-tests.ts backend --tier fast",
     "test:backend:db": "bun packages/scripts/src/testing/run-tests.ts backend --tier db",
     "test:core": "bun test packages/core/src --preload ./packages/scripts/src/testing/core.preload.ts",
+    "test:sync": "bun test packages/sync/src --preload ./packages/sync/src/__tests__/sync.preload.ts",
     "test:web": "bun test --cwd packages/web",
     "test:scripts": "bun packages/scripts/src/testing/run-tests.ts scripts",
     "test:scripts:fast": "bun packages/scripts/src/testing/run-tests.ts scripts --tier fast",

--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -1,0 +1,375 @@
+import { faker } from "@faker-js/faker";
+import {
+  AttendeeSchema,
+  ConferenceSchema,
+  EventOccurrenceListQuerySchema,
+  EventOccurrenceListResponseSchema,
+  OrganizerSchema,
+  SyncEventOccurrenceSchema,
+  SyncEventOwnershipSchema,
+  SyncEventRecurrenceSchema,
+  SyncEventSchema,
+} from "@core/types/sync/event.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const timedSchedule = {
+  kind: "timed",
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+
+// 2026-03-08 is the US spring-forward transition; 09:00-10:00 local crosses
+// it in wall-clock time while the UTC offset itself changes (R-EVENT-04).
+const dstCrossingSchedule = {
+  kind: "timed",
+  start: "2026-03-08T01:30:00-07:00",
+  end: "2026-03-08T03:30:00-06:00",
+  timeZone: "America/Denver",
+};
+
+const allDaySchedule = {
+  kind: "allDay",
+  start: "2026-07-14",
+  end: "2026-07-15",
+};
+
+const unlinkedOwnership = { kind: "unlinked" };
+
+const linkedOwnership = () => ({
+  kind: "linked",
+  connectionId: objectId(),
+  calendarId: objectId(),
+  providerEventId: "abc123@google.com",
+  providerVersion: "etag-1",
+  providerUpdatedAt: "2026-07-20T12:00:00.000Z",
+  deliveryState: "confirmed",
+});
+
+const baseContent = {
+  title: "Standup",
+  description: "Daily sync",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+};
+
+const baseEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: objectId(),
+  clientEventId: null,
+  origin: "compass",
+  ownership: unlinkedOwnership,
+  content: baseContent,
+  schedule: timedSchedule,
+  recurrence: { kind: "single" },
+  lifecycleState: "active",
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+  confirmedAt: null,
+  ...overrides,
+});
+
+describe("Sync event contracts", () => {
+  describe("SyncEventSchema", () => {
+    it("accepts a timed, unlinked, single event", () => {
+      expect(SyncEventSchema.safeParse(baseEvent()).success).toBe(true);
+    });
+
+    it("accepts an all-day event", () => {
+      const event = baseEvent({ schedule: allDaySchedule });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("round-trips a DST-crossing timed schedule unchanged", () => {
+      const event = baseEvent({ schedule: dstCrossingSchedule });
+      const parsed = SyncEventSchema.parse(event);
+      expect(
+        SyncEventSchema.parse(JSON.parse(JSON.stringify(parsed))).schedule,
+      ).toEqual(dstCrossingSchedule);
+    });
+
+    it("accepts a linked event with full ownership evidence", () => {
+      const event = baseEvent({
+        origin: "provider",
+        ownership: linkedOwnership(),
+      });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("accepts a linked event carrying opaque provider metadata", () => {
+      const event = baseEvent({
+        ownership: {
+          ...linkedOwnership(),
+          providerMetadata: { iCalUID: "abc@google.com", sequence: "3" },
+        },
+      });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("rejects a linked event missing providerVersion", () => {
+      const { providerVersion: _dropped, ...incomplete } = linkedOwnership();
+      const event = baseEvent({ ownership: incomplete });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+
+    it("accepts a deletionPending event", () => {
+      const event = baseEvent({ lifecycleState: "deletionPending" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(true);
+    });
+
+    it("accepts a null confirmedAt before provider confirmation", () => {
+      expect(SyncEventSchema.safeParse(baseEvent()).success).toBe(true);
+    });
+
+    it("rejects a raw provider payload field", () => {
+      const event = baseEvent({ googleEventId: "leak" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+
+    it("rejects an unknown lifecycle state", () => {
+      const event = baseEvent({ lifecycleState: "deleted" });
+      expect(SyncEventSchema.safeParse(event).success).toBe(false);
+    });
+  });
+
+  describe("SyncEventOwnershipSchema", () => {
+    it("accepts unlinked", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse(unlinkedOwnership).success,
+      ).toBe(true);
+    });
+
+    it("accepts linked with full evidence", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse(linkedOwnership()).success,
+      ).toBe(true);
+    });
+
+    it("accepts a null providerUpdatedAt before the provider has reported one", () => {
+      const ownership = { ...linkedOwnership(), providerUpdatedAt: null };
+      expect(SyncEventOwnershipSchema.safeParse(ownership).success).toBe(true);
+    });
+
+    it("rejects an unrecognized kind", () => {
+      expect(
+        SyncEventOwnershipSchema.safeParse({ kind: "mirrored" }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("SyncEventRecurrenceSchema", () => {
+    it("accepts single", () => {
+      expect(
+        SyncEventRecurrenceSchema.safeParse({ kind: "single" }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a series master with rules", () => {
+      const recurrence = { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects a series master with empty rules", () => {
+      const recurrence = { kind: "seriesMaster", rules: [] };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+
+    it("accepts a cancelled exception overriding one occurrence", () => {
+      const recurrence = {
+        kind: "exception",
+        seriesId: objectId(),
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: true,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a non-cancelled override exception", () => {
+      const recurrence = {
+        kind: "exception",
+        seriesId: objectId(),
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: false,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an exception missing seriesId", () => {
+      const recurrence = {
+        kind: "exception",
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+        cancelled: false,
+      };
+      expect(SyncEventRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("OrganizerSchema and AttendeeSchema", () => {
+    it("accepts an organizer with a display name", () => {
+      const organizer = {
+        email: "founder@compasscalendar.com",
+        displayName: "Tyler",
+      };
+      expect(OrganizerSchema.safeParse(organizer).success).toBe(true);
+    });
+
+    it("accepts an organizer with a null display name", () => {
+      const organizer = {
+        email: "founder@compasscalendar.com",
+        displayName: null,
+      };
+      expect(OrganizerSchema.safeParse(organizer).success).toBe(true);
+    });
+
+    it.each([
+      "needsAction",
+      "accepted",
+      "declined",
+      "tentative",
+    ] as const)("accepts attendee response status %s", (responseStatus) => {
+      const attendee = {
+        email: "guest@example.com",
+        displayName: null,
+        responseStatus,
+      };
+      expect(AttendeeSchema.safeParse(attendee).success).toBe(true);
+    });
+
+    it("rejects an unknown response status", () => {
+      const attendee = {
+        email: "guest@example.com",
+        displayName: null,
+        responseStatus: "maybe",
+      };
+      expect(AttendeeSchema.safeParse(attendee).success).toBe(false);
+    });
+  });
+
+  describe("ConferenceSchema", () => {
+    it("accepts a conference URL with a label", () => {
+      const conference = {
+        url: "https://meet.google.com/abc-defg-hij",
+        label: "Google Meet",
+      };
+      expect(ConferenceSchema.safeParse(conference).success).toBe(true);
+    });
+
+    it("rejects a non-URL value", () => {
+      const conference = { url: "not-a-url", label: null };
+      expect(ConferenceSchema.safeParse(conference).success).toBe(false);
+    });
+  });
+
+  describe("SyncEventOccurrenceSchema", () => {
+    const baseOccurrence = () => ({
+      occurrenceKey: "event-id:2026-07-21T09:00:00.000Z",
+      eventId: objectId(),
+      calendarId: objectId(),
+      schedule: timedSchedule,
+      busy: true,
+      title: "Standup",
+      cancelled: false,
+    });
+
+    it("accepts a busy timed occurrence", () => {
+      expect(
+        SyncEventOccurrenceSchema.safeParse(baseOccurrence()).success,
+      ).toBe(true);
+    });
+
+    it("accepts a cancelled occurrence", () => {
+      const occurrence = { ...baseOccurrence(), cancelled: true };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a free (non-blocking) occurrence", () => {
+      const occurrence = { ...baseOccurrence(), busy: false };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts an all-day occurrence", () => {
+      const occurrence = { ...baseOccurrence(), schedule: allDaySchedule };
+      expect(SyncEventOccurrenceSchema.safeParse(occurrence).success).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("EventOccurrenceListQuerySchema", () => {
+    const baseQuery = () => ({
+      calendarIds: [objectId()],
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-08-01T00:00:00.000Z",
+    });
+
+    it("accepts a bounded range with at least one calendar", () => {
+      expect(
+        EventOccurrenceListQuerySchema.safeParse(baseQuery()).success,
+      ).toBe(true);
+    });
+
+    it("accepts an optional cursor and limit", () => {
+      const query = { ...baseQuery(), cursor: "page-2", limit: 100 };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an empty calendarIds array", () => {
+      const query = { ...baseQuery(), calendarIds: [] };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects end before start", () => {
+      const query = {
+        ...baseQuery(),
+        start: baseQuery().end,
+        end: baseQuery().start,
+      };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+
+    it("rejects a limit above the bound", () => {
+      const query = { ...baseQuery(), limit: 501 };
+      expect(EventOccurrenceListQuerySchema.safeParse(query).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("EventOccurrenceListResponseSchema", () => {
+    it("accepts an empty page with no next cursor", () => {
+      const response = { occurrences: [], nextCursor: null };
+      expect(
+        EventOccurrenceListResponseSchema.safeParse(response).success,
+      ).toBe(true);
+    });
+
+    it("accepts a page with a next cursor", () => {
+      const response = { occurrences: [], nextCursor: "page-2" };
+      expect(
+        EventOccurrenceListResponseSchema.safeParse(response).success,
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -1,0 +1,204 @@
+import { z } from "zod/v4";
+import {
+  DateTimeSchema,
+  EventIdSchema,
+  RRuleSchema,
+} from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import {
+  ConnectionIdSchema,
+  ProviderCalendarIdSchema,
+  ProviderEventIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Canonical, provider-neutral event contracts for Compass Sync (ledger S03).
+// This is the logical record Sync persists per event/series (01-domain-model
+// "Event"); Google/Microsoft SDK shapes stay inside provider adapters and
+// never appear here. Schedule reuses the app-facing EventScheduleSchema
+// (event.contracts.ts) since timed-vs-all-day/DST semantics are identical.
+
+export const ClientEventIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .brand<"ClientEventId">();
+export type ClientEventId = z.infer<typeof ClientEventIdSchema>;
+
+export const ProviderEventVersionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(1024)
+  .brand<"ProviderEventVersion">();
+export type ProviderEventVersion = z.infer<typeof ProviderEventVersionSchema>;
+
+export const SyncEventOriginSchema = z.enum(["compass", "provider"]);
+export type SyncEventOrigin = z.infer<typeof SyncEventOriginSchema>;
+
+export const ProviderDeliveryStateSchema = z.enum([
+  "pending",
+  "confirmed",
+  "failed",
+]);
+export type ProviderDeliveryState = z.infer<typeof ProviderDeliveryStateSchema>;
+
+// Present only once an event is linked to exactly one owning provider
+// calendar (R-EVENT-01, R-EVENT-02). Unlinked events have no provider truth.
+export const SyncEventOwnershipSchema = z.discriminatedUnion("kind", [
+  z.strictObject({ kind: z.literal("unlinked") }),
+  z.strictObject({
+    kind: z.literal("linked"),
+    connectionId: ConnectionIdSchema,
+    calendarId: ProviderCalendarIdSchema,
+    providerEventId: ProviderEventIdSchema,
+    providerVersion: ProviderEventVersionSchema,
+    // Provider's own last-update timestamp; null until the provider has
+    // reported one (e.g. immediately after an ambiguous create).
+    providerUpdatedAt: DateTimeSchema.nullable(),
+    deliveryState: ProviderDeliveryStateSchema,
+    // Minimal opaque bag for adapter-internal identity/concurrency facts
+    // (e.g. a recurring-instance fingerprint), never the full provider
+    // payload (01-domain-model.md). Preserves what R-EVENT-05 needs without
+    // duplicating provider state Sync doesn't otherwise model.
+    providerMetadata: z.record(z.string(), z.string()).readonly().optional(),
+  }),
+]);
+export type SyncEventOwnership = z.infer<typeof SyncEventOwnershipSchema>;
+
+export const OrganizerSchema = z.strictObject({
+  email: z.string().trim().min(1).max(320),
+  displayName: z.string().trim().min(1).max(256).nullable(),
+});
+export type Organizer = z.infer<typeof OrganizerSchema>;
+
+export const AttendeeResponseStatusSchema = z.enum([
+  "needsAction",
+  "accepted",
+  "declined",
+  "tentative",
+]);
+export type AttendeeResponseStatus = z.infer<
+  typeof AttendeeResponseStatusSchema
+>;
+
+export const AttendeeSchema = z.strictObject({
+  email: z.string().trim().min(1).max(320),
+  displayName: z.string().trim().min(1).max(256).nullable(),
+  responseStatus: AttendeeResponseStatusSchema,
+});
+export type Attendee = z.infer<typeof AttendeeSchema>;
+
+export const ConferenceSchema = z.strictObject({
+  url: z.url(),
+  label: z.string().trim().min(1).max(256).nullable(),
+});
+export type Conference = z.infer<typeof ConferenceSchema>;
+
+export const SyncEventContentSchema = z.strictObject({
+  title: z.string(),
+  description: z.string(),
+  location: z.string().nullable(),
+  organizer: OrganizerSchema.nullable(),
+  attendees: z.array(AttendeeSchema).readonly(),
+  conference: ConferenceSchema.nullable(),
+});
+export type SyncEventContent = z.infer<typeof SyncEventContentSchema>;
+
+const SingleRecurrenceSchema = z.strictObject({ kind: z.literal("single") });
+
+const SeriesMasterRecurrenceSchema = z.strictObject({
+  kind: z.literal("seriesMaster"),
+  rules: RRuleSchema,
+});
+
+// One overridden or cancelled instance of a recurring series (R-EVENT-06).
+// recurrenceId is the instance's original scheduled start before override —
+// the standard identity providers use to address one occurrence.
+const RecurrenceExceptionSchema = z.strictObject({
+  kind: z.literal("exception"),
+  seriesId: EventIdSchema,
+  recurrenceId: DateTimeSchema,
+  cancelled: z.boolean(),
+});
+
+export const SyncEventRecurrenceSchema = z.discriminatedUnion("kind", [
+  SingleRecurrenceSchema,
+  SeriesMasterRecurrenceSchema,
+  RecurrenceExceptionSchema,
+]);
+export type SyncEventRecurrence = z.infer<typeof SyncEventRecurrenceSchema>;
+
+// Visible while a Compass-initiated deletion has not yet been provider
+// confirmed (R-EVENT-09). The record is removed, and a content-free
+// deletion marker takes its place, only after confirmation.
+export const SyncEventLifecycleStateSchema = z.enum([
+  "active",
+  "deletionPending",
+]);
+export type SyncEventLifecycleState = z.infer<
+  typeof SyncEventLifecycleStateSchema
+>;
+
+export const SyncEventSchema = z.strictObject({
+  id: EventIdSchema,
+  // Caller-generated id used to make anonymous-to-cloud promotion and retry
+  // idempotent (R-LIFE-02); null once no longer needed for that purpose.
+  clientEventId: ClientEventIdSchema.nullable(),
+  origin: SyncEventOriginSchema,
+  ownership: SyncEventOwnershipSchema,
+  content: SyncEventContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: SyncEventRecurrenceSchema,
+  lifecycleState: SyncEventLifecycleStateSchema,
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+  confirmedAt: DateTimeSchema.nullable(),
+});
+export type SyncEvent = z.infer<typeof SyncEventSchema>;
+
+// One derived, display-ready instance within the rolling sync horizon (12
+// months past / 18 months future). Never expand a non-ending series to
+// completion; project only the bounded window a query needs (R-AVAIL-06).
+export const OccurrenceKeySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(512)
+  .brand<"OccurrenceKey">();
+export type OccurrenceKey = z.infer<typeof OccurrenceKeySchema>;
+
+export const SyncEventOccurrenceSchema = z.strictObject({
+  occurrenceKey: OccurrenceKeySchema,
+  eventId: EventIdSchema,
+  calendarId: ProviderCalendarIdSchema,
+  schedule: EventScheduleSchema,
+  busy: z.boolean(),
+  title: z.string(),
+  cancelled: z.boolean(),
+});
+export type SyncEventOccurrence = z.infer<typeof SyncEventOccurrenceSchema>;
+
+export const EventOccurrenceListQuerySchema = z
+  .strictObject({
+    calendarIds: z.array(ProviderCalendarIdSchema).min(1).readonly(),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    cursor: z.string().trim().min(1).max(1024).optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Range end must be after start",
+    path: ["end"],
+  });
+export type EventOccurrenceListQuery = z.infer<
+  typeof EventOccurrenceListQuerySchema
+>;
+
+export const EventOccurrenceListResponseSchema = z.strictObject({
+  occurrences: z.array(SyncEventOccurrenceSchema).readonly(),
+  nextCursor: z.string().trim().min(1).max(1024).nullable(),
+});
+export type EventOccurrenceListResponse = z.infer<
+  typeof EventOccurrenceListResponseSchema
+>;

--- a/packages/scripts/src/testing/verify.ts
+++ b/packages/scripts/src/testing/verify.ts
@@ -26,11 +26,12 @@ type BunRuntime = {
 
 const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
 
-const VALID_PACKAGES = ["core", "web", "backend", "scripts"] as const;
+const VALID_PACKAGES = ["core", "sync", "web", "backend", "scripts"] as const;
 type Package = (typeof VALID_PACKAGES)[number];
 
 const PACKAGE_PREFIXES: Record<string, Package> = {
   "packages/core/": "core",
+  "packages/sync/": "sync",
   "packages/web/": "web",
   "packages/backend/": "backend",
   "packages/scripts/": "scripts",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@compass/sync",
+  "description": "Compass Sync service — provider state, sync work, and connection health",
+  "license": "MIT",
+  "version": "1.0.0",
+  "main": "build/src/app.js",
+  "dependencies": {
+    "@compass/core": "1.0.0",
+    "tslib": "^2.4.0"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^9.6.0",
+    "@types/node": "^22.13.10"
+  }
+}

--- a/packages/sync/src/__tests__/sync.preload.ts
+++ b/packages/sync/src/__tests__/sync.preload.ts
@@ -1,0 +1,8 @@
+// sort-imports-ignore
+// Test preload for @compass/sync. Mirrors the core preload: apply the
+// bun:test → jest API compatibility shim so sync tests may use jest.fn/spyOn
+// like the other packages, and pin the test environment.
+import "@scripts/testing/core.jest-compat";
+
+process.env["NODE_ENV"] = "test";
+process.env["LOG_LEVEL"] = "debug";

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,0 +1,18 @@
+import { syncServiceIdentity } from "@sync/service-identity";
+
+// Entry point for the Compass Sync service (ledger S07). Intentionally inert:
+// the scaffold builds and starts but does no provider, storage, or HTTP work
+// yet. Configuration (S08), process lifecycle/health (S09), internal auth
+// (S10), and isolated Mongo storage (S11) land in later commits. This keeps
+// the standalone package deployable and type-checked before it does anything
+// user-facing (00-architecture-overview.md "Deployment and scaling").
+
+export function describeSyncService(): string {
+  return `${syncServiceIdentity.name} scaffold ready`;
+}
+
+// Only run when invoked directly (bun packages/sync/src/app.ts), not on import
+// from tests.
+if (import.meta.main) {
+  console.log(describeSyncService());
+}

--- a/packages/sync/src/service-identity.test.ts
+++ b/packages/sync/src/service-identity.test.ts
@@ -1,0 +1,13 @@
+import { describeSyncService } from "@sync/app";
+import { SYNC_SERVICE_NAME, syncServiceIdentity } from "@sync/service-identity";
+
+describe("Sync service scaffold", () => {
+  it("exposes the canonical service name", () => {
+    expect(SYNC_SERVICE_NAME).toBe("compass-sync");
+    expect(syncServiceIdentity.name).toBe(SYNC_SERVICE_NAME);
+  });
+
+  it("loads and describes itself without side effects", () => {
+    expect(describeSyncService()).toBe("compass-sync scaffold ready");
+  });
+});

--- a/packages/sync/src/service-identity.ts
+++ b/packages/sync/src/service-identity.ts
@@ -1,0 +1,13 @@
+// Stable identity for the Compass Sync service (ledger S07). Kept as a plain
+// constant so health telemetry (S44) and internal-auth (S10) can reference one
+// canonical service name rather than string literals. PostHog's `service.name`
+// dimension uses this value (04-security-and-observability.md).
+export const SYNC_SERVICE_NAME = "compass-sync";
+
+export interface SyncServiceIdentity {
+  readonly name: string;
+}
+
+export const syncServiceIdentity: SyncServiceIdentity = {
+  name: SYNC_SERVICE_NAME,
+};

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**"],
+  "compilerOptions": {
+    "composite": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "inlineSourceMap": true
+  }
+}

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -35,7 +35,11 @@ const buildEventPalette = (theme: ThemeName): EventPalette => {
     base,
     hover: brighten(base),
     gradient: `linear-gradient(90deg, ${darken(base, 15)}, ${darken(base, 30)})`,
-    saveButtonBg: darken(base),
+    // Undarkened: darken(base) sat right at the mid-tone dead zone (see
+    // getContrastText above), leaving Save's text only ~5:1 against its own
+    // fill. The plain base clears 6.5:1+ in both themes; saveButtonShadow
+    // still carries the "elevated" depth cue.
+    saveButtonBg: base,
     saveButtonShadow: darken(base, 25),
   };
 };

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -57,7 +57,7 @@ export const GoogleReconnectToast = ({
         safe in Google. Reconnect and Compass will re-import them.
       </p>
       <button
-        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-accent-secondary-hover"
+        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-on-accent text-sm transition-colors hover:bg-accent-secondary-hover"
         onClick={() => void handleReconnect()}
         type="button"
       >

--- a/packages/web/src/common/utils/toast/session-expired.toast.tsx
+++ b/packages/web/src/common/utils/toast/session-expired.toast.tsx
@@ -40,7 +40,7 @@ export const SessionExpiredToast = ({ toastId }: SessionExpiredToastProps) => {
         You've been signed out. Please sign in again.
       </p>
       <button
-        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-accent-secondary-hover"
+        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-on-accent text-sm transition-colors hover:bg-accent-secondary-hover"
         onClick={handleSignIn}
         type="button"
       >

--- a/packages/web/src/components/AuthModal/components/AuthButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AuthButton.tsx
@@ -36,7 +36,7 @@ export const AuthButton: FC<AuthButtonProps> = ({
         isDisabled ? "cursor-not-allowed" : "cursor-pointer",
         {
           // Primary variant
-          "h-10 w-full bg-accent px-4 text-text focus:ring-accent":
+          "h-10 w-full bg-accent px-4 text-on-accent focus:ring-accent":
             variant === "primary",
           "c-button-elevated": variant === "primary" && !isDisabled,
           "hover:brightness-110": variant === "primary" && !isDisabled,

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -226,7 +226,7 @@ export const CommandPalette = ({
             value={search}
             placeholder={placeholder}
             aria-label="Command palette search"
-            className="w-full border-border border-b bg-transparent px-4 py-3 text-text-muted outline-none placeholder:text-text focus-visible:border-accent"
+            className="w-full border-border border-b bg-transparent px-4 py-3 text-text outline-none placeholder:text-text-muted focus-visible:border-accent"
             onChange={(event) => {
               setSearch(event.target.value);
               setActiveIndex(0);

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -6,6 +6,7 @@ import dayjs from "@core/util/date/dayjs";
 import { darken, isDark } from "@web/common/styles/color.utils";
 import { colors, lightColors } from "@web/common/styles/colors";
 import { type CSSVariables } from "@web/common/styles/css.types";
+import { theme } from "@web/common/styles/theme";
 import { resolveDefaultExport } from "@web/common/utils/resolve-default-export.util";
 import { MonthNavButton } from "@web/components/DatePicker/MonthNavButton";
 import { ChevronLeftIcon } from "@web/components/Icons/ChevronLeftIcon";
@@ -95,7 +96,10 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
             INPUT_RESET_CLASSNAME,
             "w-28 transition-colors duration-300",
           )}
-          style={{ backgroundColor: inputColor }}
+          style={{
+            backgroundColor: inputColor,
+            color: inputColor ? theme.getContrastText(inputColor) : undefined,
+          }}
           underlineColor={darken(resolvedBgColor, -15)}
           withUnderline
         />

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
@@ -47,7 +47,7 @@ export function DeleteAccountConfirmationDialog({
           type="text"
           value={typedPhrase}
           autoComplete="off"
-          className="w-full rounded border border-border bg-transparent px-3 py-2 text-text-muted outline-none placeholder:text-text focus-visible:border-accent"
+          className="w-full rounded border border-border bg-transparent px-3 py-2 text-text outline-none placeholder:text-text-muted focus-visible:border-accent"
           onChange={(event) => setTypedPhrase(event.target.value)}
           // Typing the phrase out is the whole point of the confirmation,
           // so it can't be pasted or dragged in.

--- a/packages/web/src/components/MobileGate/MobileGate.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.tsx
@@ -20,7 +20,7 @@ export const MobileGate: React.FC = () => {
         <button
           type="button"
           onClick={handleJoinWaitlist}
-          className="min-h-[44px] cursor-pointer rounded border-none bg-accent px-8 py-2 font-medium font-sans text-base text-text transition-opacity duration-300 hover:opacity-90 focus:outline focus:outline-2 focus:outline-accent focus:outline-offset-2"
+          className="min-h-[44px] cursor-pointer rounded border-none bg-accent px-8 py-2 font-medium font-sans text-base text-on-accent transition-opacity duration-300 hover:opacity-90 focus:outline focus:outline-2 focus:outline-accent focus:outline-offset-2"
         >
           Join Mobile Waitlist
         </button>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -513,7 +513,7 @@
   }
 
   &[data-dark="true"] .react-datepicker__day-name {
-    color: var(--text-muted);
+    color: var(--text);
   }
 
   &[data-view="sidebar"] .react-datepicker__day-name {

--- a/packages/web/src/views/BackendDown/BackendDown.tsx
+++ b/packages/web/src/views/BackendDown/BackendDown.tsx
@@ -50,7 +50,7 @@ export const BackendDownView = () => {
         type="button"
         onClick={handleRetry}
         aria-disabled={isChecking}
-        className="mt-5 cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-text transition-all duration-200 ease-in-out hover:brightness-120 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 aria-disabled:cursor-wait aria-disabled:opacity-70"
+        className="mt-5 cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-on-accent transition-all duration-200 ease-in-out hover:brightness-120 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 aria-disabled:cursor-wait aria-disabled:opacity-70"
       >
         {isChecking ? "Scanning the horizon..." : "Try again"}
       </button>

--- a/packages/web/src/views/Cleanup/Cleanup.tsx
+++ b/packages/web/src/views/Cleanup/Cleanup.tsx
@@ -61,7 +61,7 @@ export const CleanupView = () => {
           <button
             type="button"
             onClick={handleRedirect}
-            className="rounded-sm bg-accent px-6 py-3 text-text transition-colors hover:bg-accent/90"
+            className="rounded-sm bg-accent px-6 py-3 text-on-accent transition-colors hover:bg-accent/90"
           >
             Continue to Home
           </button>

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -62,6 +62,10 @@ export const FreqSelect = ({
             ? `0 0 0 2px ${colors.borderStrong}`
             : "none",
         }),
+        singleValue: (baseStyles) => ({
+          ...baseStyles,
+          color: theme.getContrastText(bgColor),
+        }),
         indicatorSeparator: () => ({
           visibility: "hidden",
         }),
@@ -76,26 +80,31 @@ export const FreqSelect = ({
           maxHeight: "none",
           overflowY: "visible",
         }),
-        option: (styles, { isDisabled, isFocused, isSelected }) => ({
-          ...styles,
-          backgroundColor: isDisabled
-            ? undefined
-            : isSelected
-              ? bgBright
-              : isFocused
-                ? bgDark
+        option: (styles, { isDisabled, isFocused, isSelected }) => {
+          const optionBg = isSelected ? bgBright : isFocused ? bgDark : bgColor;
+
+          return {
+            ...styles,
+            backgroundColor: isDisabled
+              ? undefined
+              : isSelected
+                ? bgBright
+                : isFocused
+                  ? bgDark
+                  : undefined,
+            color: theme.getContrastText(optionBg),
+            opacity: isDisabled ? 0.5 : 1,
+            cursor: isDisabled ? "not-allowed" : "default",
+            ":active": {
+              ...styles[":active"],
+              backgroundColor: !isDisabled
+                ? isSelected
+                  ? bgColor
+                  : bgBright
                 : undefined,
-          color: isDisabled ? colors.textMuted : colors.onAccent,
-          cursor: isDisabled ? "not-allowed" : "default",
-          ":active": {
-            ...styles[":active"],
-            backgroundColor: !isDisabled
-              ? isSelected
-                ? bgColor
-                : bgBright
-              : undefined,
-          },
-        }),
+            },
+          };
+        },
       }}
     />
   );

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -85,13 +85,7 @@ export const FreqSelect = ({
 
           return {
             ...styles,
-            backgroundColor: isDisabled
-              ? undefined
-              : isSelected
-                ? bgBright
-                : isFocused
-                  ? bgDark
-                  : undefined,
+            backgroundColor: isDisabled ? undefined : optionBg,
             color: theme.getContrastText(optionBg),
             opacity: isDisabled ? 0.5 : 1,
             cursor: isDisabled ? "not-allowed" : "default",

--- a/packages/web/src/views/NotFound/NotFound.tsx
+++ b/packages/web/src/views/NotFound/NotFound.tsx
@@ -16,7 +16,7 @@ export const NotFoundView = () => {
 
       <Link
         to={ROOT_ROUTES.ROOT}
-        className="mt-5 mb-5 inline-block cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-text transition-all duration-200 ease-in-out hover:brightness-120"
+        className="mt-5 mb-5 inline-block cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-on-accent transition-all duration-200 ease-in-out hover:brightness-120"
       >
         Go back to your booty
       </Link>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "include": [
     "packages/core/src/**/*.ts",
     "packages/backend/src/**/*.ts",
+    "packages/sync/src/**/*.ts",
     "packages/scripts/src/**/*.ts",
     "packages/scripts/src/**/*.d.ts",
     "packages/scripts/src/commands/dev.js"
@@ -64,6 +65,7 @@
       "@core/*": ["./packages/core/src/*"],
       "@web/*": ["./packages/web/src/*"],
       "@backend/*": ["./packages/backend/src/*"],
+      "@sync/*": ["./packages/sync/src/*"],
       "@scripts/*": ["./packages/scripts/src/*"]
     },
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
## Summary

Several surfaces paired text against a background with insufficient contrast in one or both themes:

- The recurrence mini-calendar's weekday header (`S M T W T F S`) used `--text-muted`, a token only calibrated against the app's fixed near-black/cream surfaces, against a dynamic event-colored popup background — landing around 1.9:1. Fixed to match the identical, already-correct sibling rule used for the day numbers.
- The recurrence "Ends on" date input never had a text `color` set, so it fell back to a browser default that was invisible against its background in one theme. Now uses the existing `theme.getContrastText()` helper.
- The Save button's background was darkened into contrast's "mid-tone dead zone," leaving its text at a marginal ~5:1. Removed the extra darken step; now 6.9–8.8:1 in both themes.
- Several buttons used `bg-accent`/`bg-accent-secondary` with `text-text` instead of `text-on-accent` (MobileGate, AuthButton's primary CTA, Cleanup, BackendDown, NotFound, and two toast components) — in one theme both colors are dark, making the label nearly invisible.
- The recurrence frequency dropdown (`Day`/`Week`/`Month`/`Year`) had a hardcoded dark-theme-only hex for its closed-state label (no override at all — fell back to react-select's default `#333`) and its open-menu options used another hardcoded hex instead of the theme-aware contrast helper.
- Two inputs (delete-account confirmation, command palette search) had their typed-text and placeholder colors inverted from every other input in the app.

All fixes reuse the app's existing token system (`--on-accent`, `--text`, `theme.getContrastText()`) — no new colors were introduced.

## Simplicity

Net reduction: `FreqSelect.tsx`'s `option` style function computed the same `isSelected ? bgBright : isFocused ? bgDark : ...` background twice (once for the new contrast calculation, once for the existing `backgroundColor` field) — the two were consolidated into one `optionBg` value. No `useEffect`, `useRef`, or `useState` was added, removed, or touched by this change.

## Manual Testing Steps

- [ ] Open the app, start a session, and open an existing timed event's edit form. Confirm the "Save" button's label is clearly legible (dark text on a light blue button).
- [ ] In that same form, click "Repeat" to enable recurrence. Confirm the "Day" frequency dropdown's label is clearly legible, then open the dropdown and confirm all four options (Day/Week/Month/Year) have legible text against their backgrounds, including on hover.
- [ ] Click the "Ends on" date field. Confirm the weekday header row (S M T W T F S) in the popup calendar is clearly legible, then pick a date and confirm the typed date text in the field is clearly legible.
- [ ] Visit the app with `?auth=login` appended to the URL (or otherwise open the login modal). Confirm the "Log in" button's text is clearly legible.
- [ ] Switch the app to the light theme (via local storage key `compass.theme` = `light-beach`, or the in-app theme switcher if available) and repeat the above checks — all should remain legible.
- [ ] On a mobile device or with a mobile user agent, confirm the "Join Mobile Waitlist" button text is clearly legible against its dark button.

## Test plan

- [x] `bun run lint` — passes (5 pre-existing warnings, none in touched files)
- [x] `bunx typescript@7.0.2 -p packages/web/tsconfig.app.json --noEmit` — passes with no errors
- [x] `bun run test:web` — 1266 passed, 1 failed (`handleErrorResponse > still signs the user out on an unauthorized data-endpoint response`); confirmed this failure pre-exists on this branch before these changes and is unrelated to the diff
- [x] Manually verified all fixes render correctly in Chrome (both the isolated preview browser and a real Chrome profile), checked console/network for errors — none found