### PR TITLE
fix(web): correct low-contrast text across light and dark themes

### DIFF
--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -35,7 +35,11 @@ const buildEventPalette = (theme: ThemeName): EventPalette => {
     base,
     hover: brighten(base),
     gradient: `linear-gradient(90deg, ${darken(base, 15)}, ${darken(base, 30)})`,
-    saveButtonBg: darken(base),
+    // Undarkened: darken(base) sat right at the mid-tone dead zone (see
+    // getContrastText above), leaving Save's text only ~5:1 against its own
+    // fill. The plain base clears 6.5:1+ in both themes; saveButtonShadow
+    // still carries the "elevated" depth cue.
+    saveButtonBg: base,
     saveButtonShadow: darken(base, 25),
   };
 };

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -57,7 +57,7 @@ export const GoogleReconnectToast = ({
         safe in Google. Reconnect and Compass will re-import them.
       </p>
       <button
-        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-accent-secondary-hover"
+        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-on-accent text-sm transition-colors hover:bg-accent-secondary-hover"
         onClick={() => void handleReconnect()}
         type="button"
       >

--- a/packages/web/src/common/utils/toast/session-expired.toast.tsx
+++ b/packages/web/src/common/utils/toast/session-expired.toast.tsx
@@ -40,7 +40,7 @@ export const SessionExpiredToast = ({ toastId }: SessionExpiredToastProps) => {
         You've been signed out. Please sign in again.
       </p>
       <button
-        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-accent-secondary-hover"
+        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-on-accent text-sm transition-colors hover:bg-accent-secondary-hover"
         onClick={handleSignIn}
         type="button"
       >

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -221,7 +221,7 @@ export const CommandPalette = ({
             value={search}
             placeholder={placeholder}
             aria-label="Command palette search"
-            className="w-full border-border border-b bg-transparent px-4 py-3 text-text-muted outline-none placeholder:text-text focus-visible:border-accent"
+            className="w-full border-border border-b bg-transparent px-4 py-3 text-text outline-none placeholder:text-text-muted focus-visible:border-accent"
             onChange={(event) => {
               setSearch(event.target.value);
               setActiveIndex(0);

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -6,6 +6,7 @@ import dayjs from "@core/util/date/dayjs";
 import { darken, isDark } from "@web/common/styles/color.utils";
 import { colors, lightColors } from "@web/common/styles/colors";
 import { type CSSVariables } from "@web/common/styles/css.types";
+import { theme } from "@web/common/styles/theme";
 import { resolveDefaultExport } from "@web/common/utils/resolve-default-export.util";
 import { MonthNavButton } from "@web/components/DatePicker/MonthNavButton";
 import { ChevronLeftIcon } from "@web/components/Icons/ChevronLeftIcon";
@@ -95,7 +96,10 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
             INPUT_RESET_CLASSNAME,
             "w-28 transition-colors duration-300",
           )}
-          style={{ backgroundColor: inputColor }}
+          style={{
+            backgroundColor: inputColor,
+            color: inputColor ? theme.getContrastText(inputColor) : undefined,
+          }}
           underlineColor={darken(resolvedBgColor, -15)}
           withUnderline
         />

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
@@ -47,7 +47,7 @@ export function DeleteAccountConfirmationDialog({
           type="text"
           value={typedPhrase}
           autoComplete="off"
-          className="w-full rounded border border-border bg-transparent px-3 py-2 text-text-muted outline-none placeholder:text-text focus-visible:border-accent"
+          className="w-full rounded border border-border bg-transparent px-3 py-2 text-text outline-none placeholder:text-text-muted focus-visible:border-accent"
           onChange={(event) => setTypedPhrase(event.target.value)}
           // Typing the phrase out is the whole point of the confirmation,
           // so it can't be pasted or dragged in.

--- a/packages/web/src/components/MobileGate/MobileGate.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.tsx
@@ -20,7 +20,7 @@ export const MobileGate: React.FC = () => {
         <button
           type="button"
           onClick={handleJoinWaitlist}
-          className="min-h-[44px] cursor-pointer rounded border-none bg-accent px-8 py-2 font-medium font-sans text-base text-text transition-opacity duration-300 hover:opacity-90 focus:outline focus:outline-2 focus:outline-accent focus:outline-offset-2"
+          className="min-h-[44px] cursor-pointer rounded border-none bg-accent px-8 py-2 font-medium font-sans text-base text-on-accent transition-opacity duration-300 hover:opacity-90 focus:outline focus:outline-2 focus:outline-accent focus:outline-offset-2"
         >
           Join Mobile Waitlist
         </button>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -516,7 +516,7 @@
   }
 
   &[data-dark="true"] .react-datepicker__day-name {
-    color: var(--text-muted);
+    color: var(--text);
   }
 
   &[data-view="sidebar"] .react-datepicker__day-name {

--- a/packages/web/src/views/BackendDown/BackendDown.tsx
+++ b/packages/web/src/views/BackendDown/BackendDown.tsx
@@ -50,7 +50,7 @@ export const BackendDownView = () => {
         type="button"
         onClick={handleRetry}
         aria-disabled={isChecking}
-        className="mt-5 cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-text transition-all duration-200 ease-in-out hover:brightness-120 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 aria-disabled:cursor-wait aria-disabled:opacity-70"
+        className="mt-5 cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-on-accent transition-all duration-200 ease-in-out hover:brightness-120 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 aria-disabled:cursor-wait aria-disabled:opacity-70"
       >
         {isChecking ? "Scanning the horizon..." : "Try again"}
       </button>

--- a/packages/web/src/views/Cleanup/Cleanup.tsx
+++ b/packages/web/src/views/Cleanup/Cleanup.tsx
@@ -61,7 +61,7 @@ export const CleanupView = () => {
           <button
             type="button"
             onClick={handleRedirect}
-            className="rounded-sm bg-accent px-6 py-3 text-text transition-colors hover:bg-accent/90"
+            className="rounded-sm bg-accent px-6 py-3 text-on-accent transition-colors hover:bg-accent/90"
           >
             Continue to Home
           </button>

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -62,6 +62,10 @@ export const FreqSelect = ({
             ? `0 0 0 2px ${colors.borderStrong}`
             : "none",
         }),
+        singleValue: (baseStyles) => ({
+          ...baseStyles,
+          color: theme.getContrastText(bgColor),
+        }),
         indicatorSeparator: () => ({
           visibility: "hidden",
         }),
@@ -76,26 +80,31 @@ export const FreqSelect = ({
           maxHeight: "none",
           overflowY: "visible",
         }),
-        option: (styles, { isDisabled, isFocused, isSelected }) => ({
-          ...styles,
-          backgroundColor: isDisabled
-            ? undefined
-            : isSelected
-              ? bgBright
-              : isFocused
-                ? bgDark
+        option: (styles, { isDisabled, isFocused, isSelected }) => {
+          const optionBg = isSelected ? bgBright : isFocused ? bgDark : bgColor;
+
+          return {
+            ...styles,
+            backgroundColor: isDisabled
+              ? undefined
+              : isSelected
+                ? bgBright
+                : isFocused
+                  ? bgDark
+                  : undefined,
+            color: theme.getContrastText(optionBg),
+            opacity: isDisabled ? 0.5 : 1,
+            cursor: isDisabled ? "not-allowed" : "default",
+            ":active": {
+              ...styles[":active"],
+              backgroundColor: !isDisabled
+                ? isSelected
+                  ? bgColor
+                  : bgBright
                 : undefined,
-          color: isDisabled ? colors.textMuted : colors.onAccent,
-          cursor: isDisabled ? "not-allowed" : "default",
-          ":active": {
-            ...styles[":active"],
-            backgroundColor: !isDisabled
-              ? isSelected
-                ? bgColor
-                : bgBright
-              : undefined,
-          },
-        }),
+            },
+          };
+        },
       }}
     />
   );

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -85,13 +85,7 @@ export const FreqSelect = ({
 
           return {
             ...styles,
-            backgroundColor: isDisabled
-              ? undefined
-              : isSelected
-                ? bgBright
-                : isFocused
-                  ? bgDark
-                  : undefined,
+            backgroundColor: isDisabled ? undefined : optionBg,
             color: theme.getContrastText(optionBg),
             opacity: isDisabled ? 0.5 : 1,
             cursor: isDisabled ? "not-allowed" : "default",

--- a/packages/web/src/views/NotFound/NotFound.tsx
+++ b/packages/web/src/views/NotFound/NotFound.tsx
@@ -16,7 +16,7 @@ export const NotFoundView = () => {
 
       <Link
         to={ROOT_ROUTES.ROOT}
-        className="mt-5 mb-5 inline-block cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-text transition-all duration-200 ease-in-out hover:brightness-120"
+        className="mt-5 mb-5 inline-block cursor-pointer rounded border-2 border-border bg-accent-secondary px-4 py-2 font-semibold text-[16px] text-on-accent transition-all duration-200 ease-in-out hover:brightness-120"
       >
         Go back to your booty
       </Link>


### PR DESCRIPTION
Replaces #2230 with the same web contrast fixes on top of current `main`.

## What changed
- Use semantic on-accent text colors for accent-filled controls.
- Correct input and placeholder contrast.
- Derive DatePicker and recurrence-select text colors from their dynamic backgrounds.
- Preserve the simplified recurrence option background calculation.

## Why
#2230 branched before sync/core work that later landed on `main` under different commit IDs. Updating it with a normal merge produces unrelated add/add conflicts in sync contracts and package wiring. Cherry-picking only its two web commits keeps this fix focused and avoids resolving unrelated history.

## Validation
- `bun test:web` — 1,280 passing
- `bun type-check`
- `bun lint` — passes with five pre-existing class-order warnings outside this diff
- `git diff --check origin/main...HEAD`