### PR TITLE
fix(web): fix draft drag, trackpad swipe lock, and all-day duplicate date

### DIFF
--- a/packages/web/src/common/hooks/useHorizontalNavigation.test.tsx
+++ b/packages/web/src/common/hooks/useHorizontalNavigation.test.tsx
@@ -38,6 +38,50 @@ describe("useHorizontalNavigation", () => {
     expect(onPrevious).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores the decaying momentum tail after navigating", () => {
+    const onNext = mock();
+    render(<Harness onNext={onNext} onPrevious={mock()} />);
+
+    const calendar = screen.getByRole("region", { name: "Calendar" });
+    fireEvent.wheel(calendar, { deltaX: 70, deltaY: 0 });
+    // macOS momentum events: same direction, steadily decaying magnitude
+    for (const deltaX of [60, 45, 30, 20, 12, 6, 2]) {
+      fireEvent.wheel(calendar, { deltaX, deltaY: 0 });
+    }
+
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates again when a new swipe starts during the momentum tail", () => {
+    const onNext = mock();
+    render(<Harness onNext={onNext} onPrevious={mock()} />);
+
+    const calendar = screen.getByRole("region", { name: "Calendar" });
+    fireEvent.wheel(calendar, { deltaX: 70, deltaY: 0 });
+    for (const deltaX of [40, 25, 12, 5]) {
+      fireEvent.wheel(calendar, { deltaX, deltaY: 0 });
+    }
+    // Second swipe: magnitude jumps well above the dying tail
+    fireEvent.wheel(calendar, { deltaX: 45, deltaY: 0 });
+    fireEvent.wheel(calendar, { deltaX: 45, deltaY: 0 });
+
+    expect(onNext).toHaveBeenCalledTimes(2);
+  });
+
+  it("navigates the other way when the tail is interrupted by an opposite swipe", () => {
+    const onNext = mock();
+    const onPrevious = mock();
+    render(<Harness onNext={onNext} onPrevious={onPrevious} />);
+
+    const calendar = screen.getByRole("region", { name: "Calendar" });
+    fireEvent.wheel(calendar, { deltaX: 70, deltaY: 0 });
+    fireEvent.wheel(calendar, { deltaX: 30, deltaY: 0 });
+    fireEvent.wheel(calendar, { deltaX: -70, deltaY: 0 });
+
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
   it("does not hijack vertical scrolling or pinch zoom", () => {
     const onNext = mock();
     const onPrevious = mock();

--- a/packages/web/src/common/hooks/useHorizontalNavigation.ts
+++ b/packages/web/src/common/hooks/useHorizontalNavigation.ts
@@ -2,6 +2,8 @@ import { type RefObject, useEffect, useRef } from "react";
 
 const GESTURE_IDLE_MS = 180;
 const NAVIGATION_THRESHOLD_PX = 60;
+const NEW_SWIPE_DELTA_JUMP_PX = 10;
+const MOMENTUM_DEAD_PX = 8;
 
 type HorizontalNavigationOptions = {
   containerRef: RefObject<HTMLElement | null>;
@@ -47,11 +49,13 @@ export const useHorizontalNavigation = ({
 
     let accumulatedDelta = 0;
     let hasNavigated = false;
+    let lastDeltaX = 0;
     let resetTimer: ReturnType<typeof setTimeout> | undefined;
 
     const resetGesture = () => {
       accumulatedDelta = 0;
       hasNavigated = false;
+      lastDeltaX = 0;
     };
 
     const handleWheel = (event: WheelEvent) => {
@@ -67,6 +71,24 @@ export const useHorizontalNavigation = ({
       event.preventDefault();
       clearTimeout(resetTimer);
       resetTimer = setTimeout(resetGesture, GESTURE_IDLE_MS);
+
+      // Trackpad momentum events keep firing (< idle gap apart) long after the
+      // fingers lift, so the idle timer alone never releases the gesture lock.
+      // Momentum never reverses direction, so a sign flip is always a new
+      // swipe. A magnitude jump only counts as one once the tail has decayed
+      // to a crawl — a jump right after navigating is just the same swipe
+      // still accelerating. A re-swipe mid-tail in the same direction is
+      // indistinguishable from momentum and stays swallowed.
+      const isNewSwipe =
+        hasNavigated &&
+        (Math.sign(event.deltaX) !== Math.sign(lastDeltaX) ||
+          (Math.abs(lastDeltaX) <= MOMENTUM_DEAD_PX &&
+            Math.abs(event.deltaX) >
+              Math.abs(lastDeltaX) + NEW_SWIPE_DELTA_JUMP_PX));
+      if (isNewSwipe) {
+        resetGesture();
+      }
+      lastDeltaX = event.deltaX;
 
       if (hasNavigated) return;
 

--- a/packages/web/src/common/utils/grid/grid.util.ts
+++ b/packages/web/src/common/utils/grid/grid.util.ts
@@ -155,10 +155,14 @@ export const getBeforeTodayDiff = (
   const diff = yesterdayIndex + futureFactor;
   return diff;
 };
-export const getElemById = (id: string): HTMLDivElement | null => {
+// #mainGrid/#allDayRow are <section> elements, not <div>s, so an
+// HTMLDivElement-only check made every lookup on them return null and
+// silently no-op event listeners (drag never started). Widened to accept
+// any element.
+export const getElemById = (id: string): HTMLElement | null => {
   const element = document.getElementById(id);
 
-  return element instanceof HTMLDivElement ? element : null;
+  return element instanceof HTMLElement ? element : null;
 };
 
 export const getRelativePercentages = (todayIndex: number) => {

--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -138,3 +138,60 @@ test("duplicate falls back to no calendar when the source calendar isn't in the 
 
   expect(duplicate?.values.calendarId).toBeNull();
 });
+
+test("duplicating an all-day event round-trips the same calendar day through the full draft-to-save pipeline", () => {
+  // Guards the fix for a bug that landed all-day duplicates a day early in
+  // any timezone west of UTC: gridScheduleFromEvent parsed the date-only
+  // string as UTC midnight while toDateOnlyString re-serialized it in local
+  // time. Both now go through dayjs's local-parse/local-format, so this
+  // round trip holds regardless of timezone.
+  //
+  // bun test always runs with the ambient timezone pinned to UTC, where UTC
+  // parsing and local parsing produce the same instant - so this test can't
+  // reproduce the actual day-shift (verified manually instead, in a real
+  // America/Denver browser session: duplicate lands on the same day and
+  // survives a reload). It still guards the round trip itself, which would
+  // fail under any ambient timezone if the two conventions drifted apart
+  // again.
+  const allDayEvent = {
+    ...(timedEvent as object),
+    id: "0123456789abcdef01234568",
+    content: {
+      kind: "details" as const,
+      title: "Deep work day",
+      description: "",
+    },
+    schedule: {
+      kind: "allDay" as const,
+      start: "2026-07-20",
+      end: "2026-07-21",
+    },
+  } as unknown as Event;
+
+  const writableSourceCalendar = {
+    id: allDayEvent.calendarId,
+    capabilities: getCalendarCapabilities("owner"),
+  } as unknown as Calendar;
+
+  const duplicate = duplicateGridEventDraft(allDayEvent, [
+    writableSourceCalendar,
+  ]);
+  if (!duplicate) throw new Error("Expected duplicate draft");
+
+  const result = parseGridEventDraft(duplicate);
+
+  expect(result).toMatchObject({
+    ok: true,
+    mode: "create",
+    input: {
+      schedule: { kind: "allDay", start: "2026-07-20", end: "2026-07-21" },
+    },
+  });
+
+  // The grid projection the draft renders from must agree with what gets
+  // saved.
+  expect(gridEventDraftToSchemaEvent(duplicate)).toMatchObject({
+    startDate: "2026-07-20",
+    endDate: "2026-07-21",
+  });
+});

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -28,15 +28,7 @@ function gridScheduleFromEvent(event: Event): GridScheduleDraft | null {
   }
 
   if (schedule.kind === "allDay") {
-    // All-day draft Dates are local midnight everywhere (drag creation, form
-    // patches, shortcuts). new Date("YYYY-MM-DD") would parse as UTC midnight,
-    // which reads as the previous day when formatted back in local time west
-    // of UTC — dayjs parses date-only strings as local.
-    return {
-      kind: "allDay",
-      start: dayjs(schedule.start).toDate(),
-      end: dayjs(schedule.end).toDate(),
-    };
+    return allDayGridSchedule(schedule.start, schedule.end);
   }
 
   return null;
@@ -161,6 +153,21 @@ export function parseGridEventDraft(
 
 export function timedGridSchedule(start: Date, end: Date): GridScheduleDraft {
   return { kind: "timed", start, end, timeZone: getBrowserTimeZone() };
+}
+
+// All-day draft Dates are local midnight everywhere (drag creation, form
+// patches, shortcuts). new Date("YYYY-MM-DD") would parse as UTC midnight,
+// which reads as the previous day when formatted back in local time west of
+// UTC — dayjs parses date-only strings as local.
+export function allDayGridSchedule(
+  start: string,
+  end: string,
+): GridScheduleDraft {
+  return {
+    kind: "allDay",
+    start: dayjs(start).toDate(),
+    end: dayjs(end).toDate(),
+  };
 }
 
 // Mirrors event.view-model.ts's scheduledEventToSchemaEvent recurrence

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -28,10 +28,14 @@ function gridScheduleFromEvent(event: Event): GridScheduleDraft | null {
   }
 
   if (schedule.kind === "allDay") {
+    // All-day draft Dates are local midnight everywhere (drag creation, form
+    // patches, shortcuts). new Date("YYYY-MM-DD") would parse as UTC midnight,
+    // which reads as the previous day when formatted back in local time west
+    // of UTC — dayjs parses date-only strings as local.
     return {
       kind: "allDay",
-      start: new Date(schedule.start),
-      end: new Date(schedule.end),
+      start: dayjs(schedule.start).toDate(),
+      end: dayjs(schedule.end).toDate(),
     };
   }
 
@@ -306,4 +310,6 @@ export function applySchemaEventPatchToGridDraft(
   };
 }
 
-const toDateOnlyString = (date: Date) => date.toISOString().slice(0, 10);
+// Local, not toISOString: all-day draft Dates are local midnight, so a UTC
+// rendering would shift the day for any non-UTC viewer.
+const toDateOnlyString = (date: Date) => dayjs(date).toYearMonthDayString();

--- a/packages/web/src/grid/hooks/useAllDayDraftCreation.ts
+++ b/packages/web/src/grid/hooks/useAllDayDraftCreation.ts
@@ -49,11 +49,13 @@ export const useAllDayDraftCreation = ({
       .add(1, "day")
       .format(YEAR_MONTH_DAY_FORMAT);
 
+    // dayjs, not new Date(): date-only strings must parse as local midnight
+    // (the all-day draft convention), not UTC midnight.
     const draft = createGridEventDraft(
       {
         kind: "allDay",
-        start: new Date(startDate),
-        end: new Date(endDate),
+        start: dayjs(startDate).toDate(),
+        end: dayjs(endDate).toDate(),
       },
       undefined,
       calendarId,

--- a/packages/web/src/grid/hooks/useAllDayDraftCreation.ts
+++ b/packages/web/src/grid/hooks/useAllDayDraftCreation.ts
@@ -6,6 +6,7 @@ import dayjs from "@core/util/date/dayjs";
 import { isRightClick } from "@web/common/utils/mouse/mouse.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
+  allDayGridSchedule,
   createGridEventDraft,
   gridEventDraftToSchemaEvent,
 } from "@web/events/grid-event-draft.adapter";
@@ -49,14 +50,8 @@ export const useAllDayDraftCreation = ({
       .add(1, "day")
       .format(YEAR_MONTH_DAY_FORMAT);
 
-    // dayjs, not new Date(): date-only strings must parse as local midnight
-    // (the all-day draft convention), not UTC midnight.
     const draft = createGridEventDraft(
-      {
-        kind: "allDay",
-        start: dayjs(startDate).toDate(),
-        end: dayjs(endDate).toDate(),
-      },
+      allDayGridSchedule(startDate, endDate),
       undefined,
       calendarId,
     );

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -123,9 +123,11 @@ export function DayCalendarGrid() {
         : createGridEventDraft(
             event.isAllDay
               ? {
+                  // dayjs, not new Date(): date-only strings must parse as
+                  // local midnight (the all-day draft convention), not UTC.
                   kind: "allDay",
-                  start: new Date(event.startDate),
-                  end: new Date(event.endDate),
+                  start: dayjs(event.startDate).toDate(),
+                  end: dayjs(event.endDate).toDate(),
                 }
               : timedGridSchedule(
                   new Date(event.startDate),

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -23,6 +23,7 @@ import {
 } from "@web/common/utils/event/event.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import {
+  allDayGridSchedule,
   createGridEventDraft,
   editGridEventDraft,
   timedGridSchedule,
@@ -122,13 +123,7 @@ export function DayCalendarGrid() {
         ? editGridEventDraft(sourceEvent)
         : createGridEventDraft(
             event.isAllDay
-              ? {
-                  // dayjs, not new Date(): date-only strings must parse as
-                  // local midnight (the all-day draft convention), not UTC.
-                  kind: "allDay",
-                  start: dayjs(event.startDate).toDate(),
-                  end: dayjs(event.endDate).toDate(),
-                }
+              ? allDayGridSchedule(event.startDate, event.endDate)
               : timedGridSchedule(
                   new Date(event.startDate),
                   new Date(event.endDate),


### PR DESCRIPTION
## Summary
- Dragging an open draft's body did nothing (resize still worked): `getElemById` required an `HTMLDivElement`, but `#mainGrid`/`#allDayRow` are `<section>` elements (a repo-wide semantic-HTML pass changed them a while back), so the lookup threw and `useGridEventMouseDown`'s mousemove/mouseup listeners never attached. Widened the type guard to accept any `HTMLElement` — the actual root cause, not a symptom patch.
- Trackpad swipe navigated a week once, then stopped: the gesture lock only released after 180ms of wheel silence, but a trackpad's momentum tail keeps firing wheel events closer together than that, endlessly re-arming the timer. Mouse-wheel scroll has no momentum tail, so it kept working. A direction flip, or a magnitude jump once the tail has decayed to a crawl, now ends the gesture early so the lock releases for the next swipe.
- Duplicating an all-day event landed the copy a day earlier in any timezone west of UTC: the date-only string was parsed as UTC midnight (`new Date("2026-07-20")`) but re-serialized in local time on submit. Both directions now go through dayjs's local parse/format consistently.

## Simplicity
Net reduction: the three all-day fix sites each built the same `{ kind: "allDay", start: dayjs(x).toDate(), end: dayjs(y).toDate() }` shape with a near-identical comment explaining the local-parse convention. Extracted a single `allDayGridSchedule` helper alongside the existing sibling `timedGridSchedule` in `grid-event-draft.adapter.ts`, so the convention is documented and enforced in one place instead of three. No `useEffect`, `useRef`, or `useState` in this diff.

## Manual Testing Steps
- [ ] Go to the week view, create a timed event (e.g. "Focus block"), save it, then click it again to reopen the sidebar edit form. Drag the event's body (not its top/bottom edge) to a different time slot on the grid — it should move, keeping the same duration.
- [ ] On a Mac trackpad, swipe left/right over the week grid repeatedly — each swipe should navigate one week, and it should keep working on the second, third, etc. swipe, not just the first.
- [ ] Right-click an all-day event (e.g. "Deep work day" on a Wednesday) and choose Duplicate — the copy should land on the same day, not the day before. Reload the page and confirm it's still on the same day.
- [ ] Confirm resizing an event (dragging its top/bottom edge) still works as before, unaffected by the drag fix.

## Test plan
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean (0 errors; 5 pre-existing unrelated nursery warnings)
- [x] `bun run test:web` — 1270 pass, 1 pre-existing unrelated failure (`handleErrorResponse`, confirmed failing on `main` too via `git stash`)
- [x] Manually verified all three fixes in the user's real Chrome against the local dev server: draft body-drag moves the event and preserves duration; two trackpad-style swipes fired ~100ms apart (under the old 180ms lock-release threshold) both navigated a week; duplicating an all-day event landed on the same day and survived a reload; no console or network errors during any of this