### PR TITLE
feat(sync): discover google calendars

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@compass/core": "1.0.0",
+        "@googleapis/calendar": "^14.1.0",
         "express": "^4.17.1",
         "google-auth-library": "^10.6.2",
         "mongodb": "^7.2.0",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -6,6 +6,7 @@
   "main": "build/src/app.js",
   "dependencies": {
     "@compass/core": "1.0.0",
+    "@googleapis/calendar": "^14.1.0",
     "express": "^4.17.1",
     "google-auth-library": "^10.6.2",
     "mongodb": "^7.2.0",

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -1,0 +1,361 @@
+import { type gSchema$CalendarListEntry } from "@core/types/gcal";
+import {
+  GoogleCalendarAdapter,
+  type GoogleCalendarListApi,
+  type GoogleCalendarListPage,
+} from "@sync/providers/google/google-calendar.adapter";
+import { ProviderCalendarError } from "@sync/providers/provider-calendar.port";
+
+// A fake calendar-list API that returns scripted pages in order, recording the
+// params it was called with so tests can assert pagination and cursor handling.
+class FakeCalendarListApi implements GoogleCalendarListApi {
+  calls: Array<{ pageToken?: string; syncToken?: string }> = [];
+  #pages: GoogleCalendarListPage[];
+  #error?: unknown;
+
+  constructor(pages: GoogleCalendarListPage[], error?: unknown) {
+    this.#pages = pages;
+    this.#error = error;
+  }
+
+  async listPage(params: {
+    pageToken?: string;
+    syncToken?: string;
+  }): Promise<GoogleCalendarListPage> {
+    this.calls.push(params);
+    if (this.#error) throw this.#error;
+    const page = this.#pages.shift();
+    if (!page) throw new Error("FakeCalendarListApi: no page scripted");
+    return page;
+  }
+}
+
+const entry = (
+  overrides: Partial<gSchema$CalendarListEntry>,
+): gSchema$CalendarListEntry => ({
+  kind: "calendar#calendarListEntry",
+  id: "cal@group.calendar.google.com",
+  summary: "A Calendar",
+  accessRole: "owner",
+  ...overrides,
+});
+
+const page = (
+  overrides: Partial<GoogleCalendarListPage>,
+): GoogleCalendarListPage => ({
+  items: [],
+  nextPageToken: null,
+  nextSyncToken: null,
+  ...overrides,
+});
+
+// A page factory that returns the given API for any access token, and remembers
+// which token it was built with.
+function adapterWith(api: GoogleCalendarListApi) {
+  const tokensSeen: string[] = [];
+  const adapter = new GoogleCalendarAdapter((accessToken) => {
+    tokensSeen.push(accessToken);
+    return api;
+  });
+  return { adapter, tokensSeen };
+}
+
+describe("GoogleCalendarAdapter", () => {
+  it("maps a single page and returns its sync token as the cursor", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({
+            id: "primary-cal",
+            summary: "Primary",
+            primary: true,
+            backgroundColor: "#112233",
+            accessRole: "owner",
+          }),
+        ],
+        nextSyncToken: "sync-token-1",
+      }),
+    ]);
+    const { adapter, tokensSeen } = adapterWith(api);
+
+    const result = await adapter.discoverCalendars({ accessToken: "at-1" });
+
+    expect(tokensSeen).toEqual(["at-1"]);
+    expect(result.cursor).toBe("sync-token-1");
+    expect(result.calendars).toEqual([
+      {
+        providerCalendarId: "primary-cal",
+        displayName: "Primary",
+        color: "#112233",
+        primary: true,
+        active: true,
+        accessRole: "owner",
+        capabilities: {
+          canReadEvents: true,
+          canWriteEvents: true,
+          canReadBusy: true,
+          canInviteAttendees: true,
+        },
+      },
+    ]);
+  });
+
+  it("follows pagination, accumulating items and taking the final sync token", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [entry({ id: "a", summary: "A" })],
+        nextPageToken: "page-2",
+      }),
+      page({
+        items: [entry({ id: "b", summary: "B" })],
+        nextSyncToken: "final-sync",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.discoverCalendars({ accessToken: "at" });
+
+    expect(result.calendars.map((c) => c.providerCalendarId)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(result.cursor).toBe("final-sync");
+    // First request has no pageToken; the second carries the first page's token.
+    expect(api.calls).toEqual([
+      { pageToken: undefined, syncToken: undefined },
+      { pageToken: "page-2", syncToken: undefined },
+    ]);
+  });
+
+  it("passes an incremental cursor on the first request only", async () => {
+    const api = new FakeCalendarListApi([
+      page({ items: [entry({ id: "a" })], nextPageToken: "p2" }),
+      page({ items: [entry({ id: "b" })], nextSyncToken: "s2" }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    await adapter.discoverCalendars({ accessToken: "at", cursor: "prev-sync" });
+
+    expect(api.calls[0]).toEqual({
+      pageToken: undefined,
+      syncToken: "prev-sync",
+    });
+    expect(api.calls[1]).toEqual({ pageToken: "p2", syncToken: undefined });
+  });
+
+  it("derives role and capabilities for each Google access role", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({ id: "owner", accessRole: "owner" }),
+          entry({ id: "writer", accessRole: "writer" }),
+          entry({ id: "reader", accessRole: "reader" }),
+          entry({ id: "fbr", accessRole: "freeBusyReader" }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+    const byId = Object.fromEntries(
+      calendars.map((c) => [c.providerCalendarId, c]),
+    );
+
+    expect(byId["owner"].accessRole).toBe("owner");
+    expect(byId["writer"].accessRole).toBe("editor");
+    expect(byId["reader"].accessRole).toBe("viewer");
+    expect(byId["fbr"].accessRole).toBe("busyOnly");
+
+    expect(byId["writer"].capabilities).toEqual({
+      canReadEvents: true,
+      canWriteEvents: true,
+      canReadBusy: true,
+      canInviteAttendees: true,
+    });
+    expect(byId["reader"].capabilities).toEqual({
+      canReadEvents: true,
+      canWriteEvents: false,
+      canReadBusy: true,
+      canInviteAttendees: false,
+    });
+    expect(byId["fbr"].capabilities).toEqual({
+      canReadEvents: false,
+      canWriteEvents: false,
+      canReadBusy: true,
+      canInviteAttendees: false,
+    });
+  });
+
+  it("falls back to busyOnly for an unknown or missing access role", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({ id: "weird", accessRole: "somethingNew" }),
+          entry({ id: "none", accessRole: undefined }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+
+    expect(calendars.every((c) => c.accessRole === "busyOnly")).toBe(true);
+  });
+
+  it("marks deleted and hidden calendars inactive but still reports them", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({ id: "live" }),
+          entry({ id: "gone", deleted: true }),
+          entry({ id: "hidden", hidden: true }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+    const active = Object.fromEntries(
+      calendars.map((c) => [c.providerCalendarId, c.active]),
+    );
+
+    expect(active).toEqual({ live: true, gone: false, hidden: false });
+  });
+
+  it("falls back through summaryOverride, summary, then id for the display name", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({
+            id: "renamed",
+            summary: "Original",
+            summaryOverride: "Mine",
+          }),
+          entry({
+            id: "shared",
+            summary: "Shared",
+            summaryOverride: undefined,
+          }),
+          entry({
+            id: "bare-id",
+            summary: undefined,
+            summaryOverride: undefined,
+          }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+    const names = Object.fromEntries(
+      calendars.map((c) => [c.providerCalendarId, c.displayName]),
+    );
+
+    expect(names).toEqual({
+      renamed: "Mine",
+      shared: "Shared",
+      "bare-id": "bare-id",
+    });
+  });
+
+  it("drops entries without an id and nulls a missing color", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({ id: undefined, summary: "no id" }),
+          entry({ id: "no-color", backgroundColor: undefined }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0].providerCalendarId).toBe("no-color");
+    expect(calendars[0].color).toBeNull();
+  });
+
+  it("returns a null cursor when the provider sends no sync token", async () => {
+    const api = new FakeCalendarListApi([
+      page({ items: [entry({ id: "a" })] }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { cursor } = await adapter.discoverCalendars({ accessToken: "at" });
+
+    expect(cursor).toBeNull();
+  });
+
+  it("keeps discovery independent per account (fresh api per access token)", async () => {
+    const tokensSeen: string[] = [];
+    const adapter = new GoogleCalendarAdapter((accessToken) => {
+      tokensSeen.push(accessToken);
+      return new FakeCalendarListApi([
+        page({ items: [entry({ id: accessToken })], nextSyncToken: "s" }),
+      ]);
+    });
+
+    const first = await adapter.discoverCalendars({ accessToken: "account-a" });
+    const second = await adapter.discoverCalendars({
+      accessToken: "account-b",
+    });
+
+    expect(tokensSeen).toEqual(["account-a", "account-b"]);
+    expect(first.calendars[0].providerCalendarId).toBe("account-a");
+    expect(second.calendars[0].providerCalendarId).toBe("account-b");
+  });
+
+  it("classifies an expired cursor (410) distinctly from a generic failure", async () => {
+    const expired = new FakeCalendarListApi([], {
+      response: { status: 410 },
+    });
+    const { adapter } = adapterWith(expired);
+
+    const error = (await adapter
+      .discoverCalendars({ accessToken: "at", cursor: "old" })
+      .catch((e) => e)) as ProviderCalendarError;
+
+    expect(error).toBeInstanceOf(ProviderCalendarError);
+    expect(error.reason).toBe("cursorExpired");
+  });
+
+  it("maps any other provider error to discoveryFailed and redacts the cause", async () => {
+    // A gaxios-shaped error whose config carries the bearer token must never
+    // survive onto the ProviderCalendarError cause chain.
+    const leaky = Object.assign(new Error("Request failed with status 403"), {
+      config: {
+        headers: { Authorization: "Bearer super-secret-access-token" },
+      },
+      response: { status: 403 },
+    });
+    const api = new FakeCalendarListApi([], leaky);
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .discoverCalendars({ accessToken: "at" })
+      .catch((e) => e)) as ProviderCalendarError;
+
+    expect(error.reason).toBe("discoveryFailed");
+    expect(error.cause).toBeInstanceOf(Error);
+    expect((error.cause as { config?: unknown }).config).toBeUndefined();
+    expect(JSON.stringify(error.cause)).not.toContain(
+      "super-secret-access-token",
+    );
+  });
+});

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -1,0 +1,201 @@
+import { calendar } from "@googleapis/calendar";
+import { OAuth2Client } from "google-auth-library";
+import {
+  type gCalendar,
+  type gSchema$CalendarListEntry,
+} from "@core/types/gcal";
+import {
+  type CalendarAccessRole,
+  type CalendarCapabilities,
+} from "@core/types/sync/connection.contracts";
+import {
+  type CalendarDiscovery,
+  type DiscoveredCalendar,
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
+
+// One page of a Google calendar-list read, narrowed to the fields discovery
+// needs. Google returns `nextSyncToken` only on the final page; intermediate
+// pages carry `nextPageToken` instead.
+export interface GoogleCalendarListPage {
+  readonly items: readonly gSchema$CalendarListEntry[];
+  readonly nextPageToken: string | null;
+  readonly nextSyncToken: string | null;
+}
+
+// The one Google call discovery makes. Depending on this narrow interface (not
+// the concrete googleapis client) lets tests supply scripted pages without a
+// network round-trip or module mocking.
+export interface GoogleCalendarListApi {
+  listPage(params: {
+    pageToken?: string;
+    syncToken?: string;
+  }): Promise<GoogleCalendarListPage>;
+}
+
+// Built per-connection from a short-lived access token minted by credential
+// custody; the token is set as the OAuth client's credential, never logged.
+export type GoogleCalendarListApiFactory = (
+  accessToken: string,
+) => GoogleCalendarListApi;
+
+const defaultApiFactory: GoogleCalendarListApiFactory = (accessToken) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal: gCalendar = calendar({ version: "v3", auth });
+  return {
+    async listPage({ pageToken, syncToken }) {
+      const { data } = await gcal.calendarList.list({ pageToken, syncToken });
+      return {
+        items: data.items ?? [],
+        nextPageToken: data.nextPageToken ?? null,
+        nextSyncToken: data.nextSyncToken ?? null,
+      };
+    },
+  };
+};
+
+// Google implementation of the calendar-discovery port. Maps Google's calendar
+// list to provider-neutral facts and follows pagination, surfacing an expired
+// incremental cursor distinctly so the caller can re-list in full.
+export class GoogleCalendarAdapter implements ProviderCalendarAdapter {
+  readonly provider = "google" as const;
+
+  #makeApi: GoogleCalendarListApiFactory;
+
+  constructor(makeApi: GoogleCalendarListApiFactory = defaultApiFactory) {
+    this.#makeApi = makeApi;
+  }
+
+  async discoverCalendars(input: {
+    accessToken: string;
+    cursor?: string;
+  }): Promise<CalendarDiscovery> {
+    const api = this.#makeApi(input.accessToken);
+    const calendars: DiscoveredCalendar[] = [];
+
+    // The incremental cursor applies only to the first request of a list; once
+    // paging begins Google identifies the sequence by pageToken alone.
+    let syncToken = input.cursor;
+    let pageToken: string | undefined;
+    let nextCursor: string | null = null;
+
+    do {
+      const page = await this.#listPage(api, { pageToken, syncToken });
+      for (const item of page.items) {
+        const mapped = mapCalendar(item);
+        if (mapped) calendars.push(mapped);
+      }
+      pageToken = page.nextPageToken ?? undefined;
+      // Only the final page carries the token; keep the newest non-null one.
+      nextCursor = page.nextSyncToken ?? nextCursor;
+      syncToken = undefined;
+    } while (pageToken);
+
+    return { calendars, cursor: nextCursor };
+  }
+
+  async #listPage(
+    api: GoogleCalendarListApi,
+    params: { pageToken?: string; syncToken?: string },
+  ): Promise<GoogleCalendarListPage> {
+    try {
+      return await api.listPage(params);
+    } catch (error) {
+      // An expired syncToken (410 Gone) is not retryable with the same token:
+      // the caller must drop it and re-list in full. Everything else is a
+      // generic discovery failure.
+      throw new ProviderCalendarError(
+        isCursorExpired(error) ? "cursorExpired" : "discoveryFailed",
+        "Google rejected the calendar list read",
+        { cause: redactedCause(error) },
+      );
+    }
+  }
+}
+
+// Google's per-calendar access role, collapsed onto the provider-neutral role.
+// An unknown or absent role falls back to the least authority we can assume.
+const ACCESS_ROLE_BY_GOOGLE: Record<string, CalendarAccessRole> = {
+  owner: "owner",
+  writer: "editor",
+  reader: "viewer",
+  freeBusyReader: "busyOnly",
+};
+
+// Operational capabilities implied by each role. Invite ability follows write
+// access — Google exposes no separate per-calendar attendee-invite flag.
+const CAPABILITIES_BY_ROLE: Record<CalendarAccessRole, CalendarCapabilities> = {
+  owner: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+  editor: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+  viewer: {
+    canReadEvents: true,
+    canWriteEvents: false,
+    canReadBusy: true,
+    canInviteAttendees: false,
+  },
+  busyOnly: {
+    canReadEvents: false,
+    canWriteEvents: false,
+    canReadBusy: true,
+    canInviteAttendees: false,
+  },
+};
+
+// Map one Google calendar-list entry to provider-neutral facts. An entry
+// without an id is unusable (it cannot be keyed or persisted), so it is dropped.
+function mapCalendar(
+  item: gSchema$CalendarListEntry,
+): DiscoveredCalendar | null {
+  if (!item.id) return null;
+
+  const accessRole = mapAccessRole(item.accessRole);
+  return {
+    providerCalendarId: item.id,
+    // summaryOverride is the user's rename; fall back to the shared summary,
+    // then the id so the required non-empty name always holds.
+    displayName: item.summaryOverride || item.summary || item.id,
+    color: item.backgroundColor || null,
+    primary: item.primary === true,
+    // deleted appears in incremental results; hidden means the user removed it
+    // from their list. Either makes the calendar inactive, not gone.
+    active: item.deleted !== true && item.hidden !== true,
+    accessRole,
+    capabilities: CAPABILITIES_BY_ROLE[accessRole],
+  };
+}
+
+function mapAccessRole(
+  googleRole: string | null | undefined,
+): CalendarAccessRole {
+  return (googleRole && ACCESS_ROLE_BY_GOOGLE[googleRole]) || "busyOnly";
+}
+
+// Google signals an expired calendar-list syncToken with HTTP 410 Gone. The
+// status lives on the response, so reading it does not touch the request.
+function isCursorExpired(error: unknown): boolean {
+  const status =
+    (error as { response?: { status?: number } })?.response?.status ??
+    (error as { code?: number })?.code;
+  return status === 410;
+}
+
+// Reduce a provider-SDK error to a bare message before attaching it as a cause.
+// A googleapis/gaxios error retains the full request config, whose headers carry
+// the bearer access token; propagating the raw object would leak that token the
+// moment any caller logs the cause chain. The message is response-derived, so it
+// is safe to keep for diagnostics. (Mirrors the auth adapter's redaction.)
+function redactedCause(error: unknown): Error | undefined {
+  return error instanceof Error ? new Error(error.message) : undefined;
+}

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -46,7 +46,15 @@ const defaultApiFactory: GoogleCalendarListApiFactory = (accessToken) => {
   const gcal: gCalendar = calendar({ version: "v3", auth });
   return {
     async listPage({ pageToken, syncToken }) {
-      const { data } = await gcal.calendarList.list({ pageToken, syncToken });
+      const { data } = await gcal.calendarList.list({
+        pageToken,
+        syncToken,
+        // Default false on a full list, which would silently omit hidden and
+        // deleted calendars rather than let us report them inactive. Opt in so
+        // discovery sees the same set an incremental (syncToken) list forces.
+        showHidden: true,
+        showDeleted: true,
+      });
       return {
         items: data.items ?? [],
         nextPageToken: data.nextPageToken ?? null,

--- a/packages/sync/src/providers/provider-calendar.port.ts
+++ b/packages/sync/src/providers/provider-calendar.port.ts
@@ -1,0 +1,65 @@
+import {
+  type CalendarAccessRole,
+  type CalendarCapabilities,
+} from "@core/types/sync/connection.contracts";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+
+// One calendar as the provider currently reports it, normalized to
+// provider-neutral facts. These map directly onto a persisted provider-calendar
+// record minus the Compass-owned ids; the discovery slice produces them, and a
+// later slice reconciles them into storage.
+export interface DiscoveredCalendar {
+  // The provider's own id for the calendar (opaque, scoped to the connection).
+  readonly providerCalendarId: string;
+  readonly displayName: string;
+  readonly color: string | null;
+  // The provider designates this as the account's default calendar.
+  readonly primary: boolean;
+  // The calendar is present and visible in the account's list. A deleted or
+  // hidden calendar is reported inactive so preferences survive its return.
+  readonly active: boolean;
+  readonly accessRole: CalendarAccessRole;
+  readonly capabilities: CalendarCapabilities;
+}
+
+// The result of one discovery pass: the full set of calendars the provider
+// returned across every page, plus the opaque cursor to resume incrementally.
+export interface CalendarDiscovery {
+  readonly calendars: readonly DiscoveredCalendar[];
+  // Opaque provider incremental cursor (Google's calendar-list nextSyncToken)
+  // for the next discovery. Null when the provider returned none.
+  readonly cursor: string | null;
+}
+
+// A provider-neutral calendar-discovery port. The domain lists an account's
+// calendars without knowing the provider; pagination, capability derivation,
+// and cursor handling stay inside the adapter.
+export interface ProviderCalendarAdapter {
+  readonly provider: ProviderKind;
+
+  // List every calendar the authorized account can see, following the
+  // provider's pagination. Pass `cursor` to resume incrementally from a prior
+  // pass; omit it for a full list. Rejects with a ProviderCalendarError.
+  discoverCalendars(input: {
+    readonly accessToken: string;
+    readonly cursor?: string;
+  }): Promise<CalendarDiscovery>;
+}
+
+// Why a discovery attempt could not complete. `cursorExpired` is distinct so the
+// caller can drop the stale cursor and re-list in full instead of retrying with
+// a token the provider will keep rejecting.
+export type ProviderCalendarErrorReason =
+  | "discoveryFailed" // the provider rejected or failed the calendar-list read
+  | "cursorExpired"; // the incremental cursor is too old; a full re-list is required
+
+export class ProviderCalendarError extends Error {
+  constructor(
+    readonly reason: ProviderCalendarErrorReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "ProviderCalendarError";
+  }
+}


### PR DESCRIPTION
## What

Adds a provider-neutral **calendar-discovery port** and its **Google adapter** to the sync service. Given a short-lived access token, the adapter lists an account's calendars — following Google's pagination — and maps each entry to provider-neutral facts.

## Mapping

- **Access role** `owner`/`writer`/`reader`/`freeBusyReader` collapses onto the neutral `owner`/`editor`/`viewer`/`busyOnly`; an unknown/absent role falls back to the least authority (`busyOnly`).
- **Capabilities** (read / write / busy / invite) derive from the role. Invite follows write access, since Google exposes no separate per-calendar invite flag.
- **Active**: a `deleted` or `hidden` calendar is reported inactive rather than dropped, so a calendar's preferences survive it leaving and returning.
- **Display name** falls back `summaryOverride → summary → id`; **color** is `backgroundColor` or null; entries without an id are dropped (unusable/unkeyable).

## Cursor

The final page's `nextSyncToken` is returned as an opaque cursor for later incremental discovery. An expired cursor (**410 Gone**) is surfaced as a distinct `cursorExpired` reason so a caller can drop it and re-list in full rather than retrying a dead token.

## Design

- The Google client is an **injected seam** (same pattern as the OAuth2Client factory in the auth adapter), so the whole adapter is unit-tested with scripted pages — no network, no module mocking.
- Provider-SDK error causes are reduced to a bare message before propagation: a googleapis/gaxios error retains the request config, whose headers carry the bearer token, and would leak it the moment any caller logged the cause chain. A regression test asserts a planted token never survives.

## Scope

Adapter capability only. Nothing drives discovery in production yet; the job that persists and reconciles discovered calendars (upsert + mark-removed-inactive + cursor storage) is a later slice — mirroring how the auth adapter landed before its HTTP callback ingress.

## Test plan

- [x] `bun run test:sync` (207 pass, incl. 12 new discovery tests)
- [x] `bun run type-check`
- [x] `bun run lint` (0 errors in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)