### PR TITLE
test(web): sync WelcomeModal FAQ assertion to updated copy

### DIFF
--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -138,9 +138,7 @@ describe("WelcomeModal", () => {
     expect(answer).toHaveAttribute("aria-hidden", "false");
     expect(answer).toHaveAttribute("data-state", "open");
     expect(
-      screen.getByText(
-        /Compass is designed for minimalists who value efficiency/,
-      ),
+      screen.getByText(/Compass is for busy minimalists who value focus/),
     ).toBeTruthy();
 
     await user.click(questionButton);


### PR DESCRIPTION
## What

#2232 updated the "Who is Compass for?" FAQ answer copy but left the `WelcomeModal` test asserting the old wording, turning `unit (web)` red on `main` (and on every branch cut from it). This points the assertion at the current answer text.

## Test plan

- [x] `bun test --cwd packages/web src/components/WelcomeModal/WelcomeModal.test.tsx` (4 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)