### PR TITLE
feat(sync): add google event mutations

### DIFF
--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -174,6 +174,26 @@ describe("GoogleEventWriter", () => {
     expect(result.providerVersion).toBe('"vGet"');
   });
 
+  it("classifies (and redacts) a failed read-back after a duplicate-id create", async () => {
+    // The 409 recovery lookup itself fails: the error must be classified, not
+    // leaked as a raw provider error carrying the bearer token.
+    const api = new FakeEventsApi({
+      insert: gError(409, "duplicate"),
+      get: gError(503),
+    });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .createEvent(baseCreate)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error).toBeInstanceOf(ProviderWriteError);
+    expect(error.reason).toBe("transient");
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+
   it("conditions a patch on the expected version via If-Match", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -1,0 +1,430 @@
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type gSchema$Event } from "@core/types/gcal";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import {
+  deriveGoogleEventId,
+  type GoogleEventsApi,
+  GoogleEventWriter,
+} from "@sync/providers/google/google-event-writer.adapter";
+import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
+
+// A gaxios-shaped error: a numeric HTTP status on `response`, an optional
+// Google reason, and a request config that carries a bearer token (so tests can
+// assert the token never survives onto a thrown error's cause).
+const gError = (status: number, reason?: string) =>
+  Object.assign(new Error(`google error ${status}`), {
+    response: {
+      status,
+      data: reason ? { error: { errors: [{ reason }] } } : undefined,
+    },
+    config: { headers: { Authorization: "Bearer super-secret-token" } },
+  });
+
+const scriptedEvent = (id: string, etag = '"v1"'): gSchema$Event => ({
+  kind: "calendar#event",
+  id,
+  etag,
+  status: "confirmed",
+  summary: "T",
+  start: {
+    dateTime: "2025-01-15T09:00:00-05:00",
+    timeZone: "America/New_York",
+  },
+  end: { dateTime: "2025-01-15T10:00:00-05:00", timeZone: "America/New_York" },
+});
+
+type Behavior = gSchema$Event | Error | undefined;
+
+// A scriptable fake for the four Google event calls. Each method records its
+// params and either returns its scripted result or throws its scripted error.
+class FakeEventsApi implements GoogleEventsApi {
+  calls = {
+    insert: [] as Parameters<GoogleEventsApi["insert"]>[0][],
+    patch: [] as Parameters<GoogleEventsApi["patch"]>[0][],
+    delete: [] as Parameters<GoogleEventsApi["delete"]>[0][],
+    get: [] as Parameters<GoogleEventsApi["get"]>[0][],
+  };
+
+  constructor(
+    private readonly behavior: {
+      insert?: Behavior;
+      patch?: Behavior;
+      delete?: Behavior;
+      get?: Behavior;
+    } = {},
+  ) {}
+
+  async insert(
+    params: Parameters<GoogleEventsApi["insert"]>[0],
+  ): Promise<gSchema$Event> {
+    this.calls.insert.push(params);
+    return this.#settle("insert", () =>
+      scriptedEvent(params.requestBody.id as string),
+    );
+  }
+
+  async patch(
+    params: Parameters<GoogleEventsApi["patch"]>[0],
+  ): Promise<gSchema$Event> {
+    this.calls.patch.push(params);
+    return this.#settle("patch", () => scriptedEvent(params.eventId, '"v2"'));
+  }
+
+  async delete(
+    params: Parameters<GoogleEventsApi["delete"]>[0],
+  ): Promise<void> {
+    this.calls.delete.push(params);
+    if (this.behavior.delete instanceof Error) throw this.behavior.delete;
+  }
+
+  async get(
+    params: Parameters<GoogleEventsApi["get"]>[0],
+  ): Promise<gSchema$Event> {
+    this.calls.get.push(params);
+    return this.#settle("get", () => scriptedEvent(params.eventId, '"vGet"'));
+  }
+
+  #settle(
+    method: "insert" | "patch" | "get",
+    fallback: () => gSchema$Event,
+  ): gSchema$Event {
+    const scripted = this.behavior[method];
+    if (scripted instanceof Error) throw scripted;
+    return (scripted as gSchema$Event) ?? fallback();
+  }
+}
+
+const writerWith = (api: GoogleEventsApi) => {
+  const tokens: string[] = [];
+  const writer = new GoogleEventWriter((accessToken) => {
+    tokens.push(accessToken);
+    return api;
+  });
+  return { writer, tokens };
+};
+
+const content = (overrides: Partial<SyncEventContent> = {}): SyncEventContent =>
+  ({
+    title: "Title",
+    description: "Desc",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+    ...overrides,
+  }) as SyncEventContent;
+
+const timedSchedule = {
+  kind: "timed",
+  start: "2025-01-15T09:00:00-05:00",
+  end: "2025-01-15T10:00:00-05:00",
+  timeZone: "America/New_York",
+} as unknown as EventSchedule;
+
+const allDaySchedule = {
+  kind: "allDay",
+  start: "2025-01-15",
+  end: "2025-01-16",
+} as unknown as EventSchedule;
+
+const baseCreate = {
+  accessToken: "at",
+  calendarId: "cal@group.calendar.google.com",
+  providerEventId: "abc12deadbeef00000000000",
+  content: content(),
+  schedule: timedSchedule,
+  recurrence: { kind: "single" } as const,
+  invitation: "none" as const,
+};
+
+const basePatch = {
+  accessToken: "at",
+  calendarId: "cal@group.calendar.google.com",
+  providerEventId: "abc12deadbeef00000000000",
+  expectedVersion: null,
+  content: content(),
+  schedule: timedSchedule,
+  recurrence: { kind: "single" } as const,
+  invitation: "none" as const,
+};
+
+describe("GoogleEventWriter", () => {
+  it("creates at the caller's deterministic id and returns provider identity", async () => {
+    const api = new FakeEventsApi();
+    const { writer, tokens } = writerWith(api);
+
+    const result = await writer.createEvent(baseCreate);
+
+    expect(tokens).toEqual(["at"]);
+    expect(api.calls.insert[0].requestBody.id).toBe("abc12deadbeef00000000000");
+    expect(result).toEqual({
+      providerEventId: "abc12deadbeef00000000000",
+      providerVersion: '"v1"',
+    });
+  });
+
+  it("treats a duplicate-id create as success by reading the event back", async () => {
+    // 409 => a prior attempt already created it; the retry must not fail.
+    const api = new FakeEventsApi({ insert: gError(409, "duplicate") });
+    const { writer } = writerWith(api);
+
+    const result = await writer.createEvent(baseCreate);
+
+    expect(api.calls.get[0].eventId).toBe("abc12deadbeef00000000000");
+    expect(result.providerVersion).toBe('"vGet"');
+  });
+
+  it("conditions a patch on the expected version via If-Match", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    const result = await writer.patchEvent({
+      ...basePatch,
+      expectedVersion: '"v1"',
+    });
+
+    expect(api.calls.patch[0].ifMatch).toBe('"v1"');
+    expect(result.providerVersion).toBe('"v2"');
+  });
+
+  it("patches unconditionally when no version is known", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent(basePatch);
+
+    expect(api.calls.patch[0].ifMatch).toBeNull();
+  });
+
+  it("maps a precondition failure to versionConflict", async () => {
+    const api = new FakeEventsApi({ patch: gError(412) });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .patchEvent({ ...basePatch, expectedVersion: '"stale"' })
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error).toBeInstanceOf(ProviderWriteError);
+    expect(error.reason).toBe("versionConflict");
+  });
+
+  it("maps a non-quota 403 to readOnlyCalendar", async () => {
+    const api = new FakeEventsApi({ patch: gError(403, "forbidden") });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("readOnlyCalendar");
+  });
+
+  it("maps a quota 403 to transient (retryable)", async () => {
+    const api = new FakeEventsApi({ patch: gError(403, "rateLimitExceeded") });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("transient");
+  });
+
+  it("maps a 401 to authorizationRevoked", async () => {
+    const api = new FakeEventsApi({ patch: gError(401) });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("authorizationRevoked");
+  });
+
+  it("maps a 5xx and a networkless failure to transient", async () => {
+    const server = new FakeEventsApi({ patch: gError(503) });
+    const network = new FakeEventsApi({ patch: new Error("ECONNRESET") });
+
+    const a = (await writerWith(server)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+    const b = (await writerWith(network)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(a.reason).toBe("transient");
+    expect(b.reason).toBe("transient");
+  });
+
+  it("deletes with the invitation intent and version precondition", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.deleteEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "abc12deadbeef00000000000",
+      expectedVersion: '"v9"',
+      invitation: "all",
+    });
+
+    expect(api.calls.delete[0]).toMatchObject({
+      eventId: "abc12deadbeef00000000000",
+      sendUpdates: "all",
+      ifMatch: '"v9"',
+    });
+  });
+
+  it("treats deleting an already-absent event as success", async () => {
+    const gone = new FakeEventsApi({ delete: gError(410) });
+    const missing = new FakeEventsApi({ delete: gError(404) });
+
+    await writerWith(gone).writer.deleteEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "id00000",
+      expectedVersion: null,
+      invitation: "none",
+    });
+    await writerWith(missing).writer.deleteEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "id00000",
+      expectedVersion: null,
+      invitation: "none",
+    });
+    // Neither rejected; both no-op deletes resolved.
+    expect(gone.calls.delete).toHaveLength(1);
+    expect(missing.calls.delete).toHaveLength(1);
+  });
+
+  it("still surfaces a precondition failure on delete", async () => {
+    const api = new FakeEventsApi({ delete: gError(412) });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .deleteEvent({
+        accessToken: "at",
+        calendarId: "cal",
+        providerEventId: "id00000",
+        expectedVersion: '"stale"',
+        invitation: "none",
+      })
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("versionConflict");
+  });
+
+  it("writes series rules and clears them for a single edit", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({
+      ...baseCreate,
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY"] },
+    });
+    await writer.patchEvent({ ...basePatch, recurrence: { kind: "single" } });
+
+    expect(api.calls.insert[0].requestBody.recurrence).toEqual([
+      "RRULE:FREQ=DAILY",
+    ]);
+    // A series-to-single edit must clear the rules, not omit the key.
+    expect(api.calls.patch[0].requestBody.recurrence).toBeNull();
+  });
+
+  it("nulls the unused schedule keys so Google never sees both a date and a dateTime", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({ ...baseCreate, schedule: timedSchedule });
+    await writer.patchEvent({ ...basePatch, schedule: allDaySchedule });
+
+    expect(api.calls.insert[0].requestBody.start).toEqual({
+      date: null,
+      dateTime: "2025-01-15T09:00:00-05:00",
+      timeZone: "America/New_York",
+    });
+    expect(api.calls.patch[0].requestBody.start).toEqual({
+      date: "2025-01-15",
+      dateTime: null,
+      timeZone: null,
+    });
+  });
+
+  it("maps each invitation intent straight to sendUpdates", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({ ...baseCreate, invitation: "all" });
+    await writer.createEvent({ ...baseCreate, invitation: "externalOnly" });
+    await writer.createEvent({ ...baseCreate, invitation: "none" });
+
+    expect(api.calls.insert.map((c) => c.sendUpdates)).toEqual([
+      "all",
+      "externalOnly",
+      "none",
+    ]);
+  });
+
+  it("fetches an event back as a normalized read, or null when absent", async () => {
+    const present = new FakeEventsApi();
+    const absent = new FakeEventsApi({ get: gError(404) });
+
+    const read = await writerWith(present).writer.fetchEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "abc12deadbeef00000000000",
+    });
+    const missing = await writerWith(absent).writer.fetchEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "missing0",
+    });
+
+    expect(read?.kind).toBe("event");
+    expect(read?.providerEventId).toBe("abc12deadbeef00000000000");
+    expect(missing).toBeNull();
+  });
+
+  it("never leaks the bearer token onto a thrown error's cause", async () => {
+    const api = new FakeEventsApi({ patch: gError(500) });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.cause).toBeInstanceOf(Error);
+    expect((error.cause as { config?: unknown }).config).toBeUndefined();
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+
+  it("rejects a create whose returned event lacks identity", async () => {
+    const api = new FakeEventsApi({
+      insert: { kind: "calendar#event", id: "x" } as gSchema$Event,
+    });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .createEvent(baseCreate)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("permanentProviderError");
+  });
+});
+
+describe("deriveGoogleEventId", () => {
+  it("lowercases a Compass ObjectId hex into a valid Google id", () => {
+    expect(deriveGoogleEventId("ABC123DEADBEEF0000000000")).toBe(
+      "abc123deadbeef0000000000",
+    );
+  });
+
+  it("rejects an id outside the base32hex charset", () => {
+    // 'z' is outside 0-9a-v.
+    expect(() => deriveGoogleEventId("zzz")).toThrow();
+    expect(() => deriveGoogleEventId("has-dashes-0000")).toThrow();
+  });
+});

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -1,0 +1,335 @@
+import { calendar, type calendar_v3 } from "@googleapis/calendar";
+import { OAuth2Client } from "google-auth-library";
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
+import { type ProviderEventRead } from "@sync/providers/provider-event.port";
+import {
+  type InvitationIntent,
+  type ProviderCreateInput,
+  type ProviderDeleteInput,
+  type ProviderEventWriter,
+  type ProviderFetchInput,
+  type ProviderPatchInput,
+  ProviderWriteError,
+  type ProviderWriteRecurrence,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+
+// The Google event calls the writer makes. Depending on this narrow interface
+// (not the concrete googleapis client) lets tests script results and errors
+// without a network round-trip or module mocking. `get` throws on 404 like the
+// real client; the adapter turns that into a null/idempotent result.
+export interface GoogleEventsApi {
+  insert(params: {
+    calendarId: string;
+    requestBody: calendar_v3.Schema$Event;
+    sendUpdates: string;
+  }): Promise<gSchema$Event>;
+  patch(params: {
+    calendarId: string;
+    eventId: string;
+    requestBody: calendar_v3.Schema$Event;
+    sendUpdates: string;
+    ifMatch: string | null;
+  }): Promise<gSchema$Event>;
+  delete(params: {
+    calendarId: string;
+    eventId: string;
+    sendUpdates: string;
+    ifMatch: string | null;
+  }): Promise<void>;
+  get(params: { calendarId: string; eventId: string }): Promise<gSchema$Event>;
+}
+
+export type GoogleEventsApiFactory = (accessToken: string) => GoogleEventsApi;
+
+const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal: gCalendar = calendar({ version: "v3", auth });
+  // An If-Match precondition is passed as a request header; googleapis takes
+  // per-call gaxios options as the second argument.
+  const ifMatchOptions = (ifMatch: string | null) =>
+    ifMatch ? { headers: { "If-Match": ifMatch } } : undefined;
+  return {
+    async insert({ calendarId, requestBody, sendUpdates }) {
+      const { data } = await gcal.events.insert({
+        calendarId,
+        requestBody,
+        sendUpdates,
+      });
+      return data;
+    },
+    async patch({ calendarId, eventId, requestBody, sendUpdates, ifMatch }) {
+      const { data } = await gcal.events.patch(
+        { calendarId, eventId, requestBody, sendUpdates },
+        ifMatchOptions(ifMatch),
+      );
+      return data;
+    },
+    async delete({ calendarId, eventId, sendUpdates, ifMatch }) {
+      await gcal.events.delete(
+        { calendarId, eventId, sendUpdates },
+        ifMatchOptions(ifMatch),
+      );
+    },
+    async get({ calendarId, eventId }) {
+      const { data } = await gcal.events.get({ calendarId, eventId });
+      return data;
+    },
+  };
+};
+
+// Google implementation of the event mutation port. Create is idempotent at a
+// caller-chosen id, patch and delete can be conditioned on a version, and
+// provider errors are classified into neutral, caller-actionable reasons.
+export class GoogleEventWriter implements ProviderEventWriter {
+  readonly provider = "google" as const;
+
+  #makeApi: GoogleEventsApiFactory;
+
+  constructor(makeApi: GoogleEventsApiFactory = defaultApiFactory) {
+    this.#makeApi = makeApi;
+  }
+
+  async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    const api = this.#makeApi(input.accessToken);
+    const requestBody: calendar_v3.Schema$Event = {
+      id: input.providerEventId,
+      ...toGoogleBody(input.content, input.schedule, input.recurrence),
+    };
+
+    try {
+      const created = await api.insert({
+        calendarId: input.calendarId,
+        requestBody,
+        sendUpdates: toSendUpdates(input.invitation),
+      });
+      return toResult(created);
+    } catch (error) {
+      // A duplicate id means a prior attempt already created it: read it back
+      // and report success so a retry is a no-op, not a failure.
+      if (googleStatus(error) === 409) {
+        const existing = await api.get({
+          calendarId: input.calendarId,
+          eventId: input.providerEventId,
+        });
+        return toResult(existing);
+      }
+      throw classifyWriteError(error);
+    }
+  }
+
+  async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    const api = this.#makeApi(input.accessToken);
+    try {
+      const patched = await api.patch({
+        calendarId: input.calendarId,
+        eventId: input.providerEventId,
+        requestBody: toGoogleBody(
+          input.content,
+          input.schedule,
+          input.recurrence,
+        ),
+        sendUpdates: toSendUpdates(input.invitation),
+        ifMatch: input.expectedVersion,
+      });
+      return toResult(patched);
+    } catch (error) {
+      throw classifyWriteError(error);
+    }
+  }
+
+  async deleteEvent(input: ProviderDeleteInput): Promise<void> {
+    const api = this.#makeApi(input.accessToken);
+    try {
+      await api.delete({
+        calendarId: input.calendarId,
+        eventId: input.providerEventId,
+        sendUpdates: toSendUpdates(input.invitation),
+        ifMatch: input.expectedVersion,
+      });
+    } catch (error) {
+      // Already gone: a delete of an absent event is a success, so retries and
+      // races converge instead of surfacing a spurious failure.
+      if (isNotFound(error)) return;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async fetchEvent(
+    input: ProviderFetchInput,
+  ): Promise<ProviderEventRead | null> {
+    const api = this.#makeApi(input.accessToken);
+    try {
+      const event = await api.get({
+        calendarId: input.calendarId,
+        eventId: input.providerEventId,
+      });
+      return normalizeGoogleEvent(event);
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw classifyWriteError(error);
+    }
+  }
+}
+
+function toResult(event: gSchema$Event): ProviderWriteResult {
+  if (!event.id || !event.etag) {
+    throw new ProviderWriteError(
+      "permanentProviderError",
+      "Google returned an event without an id or etag",
+    );
+  }
+  return { providerEventId: event.id, providerVersion: event.etag };
+}
+
+// Map neutral content/schedule/recurrence to a Google event body. Because
+// events.patch merges by key, keys that must be cleared are set to null rather
+// than omitted — an omitted key is left unchanged on Google, and leaving the
+// other schedule kind's keys behind makes Google reject a start holding both a
+// date and a dateTime.
+function toGoogleBody(
+  content: SyncEventContent,
+  schedule: EventSchedule,
+  recurrence: ProviderWriteRecurrence,
+): calendar_v3.Schema$Event {
+  return {
+    summary: content.title,
+    description: content.description,
+    location: content.location,
+    ...scheduleFields(schedule),
+    recurrence: recurrence.kind === "series" ? [...recurrence.rules] : null,
+  };
+}
+
+function scheduleFields(
+  schedule: EventSchedule,
+): Pick<calendar_v3.Schema$Event, "start" | "end"> {
+  if (schedule.kind === "timed") {
+    return {
+      start: {
+        date: null,
+        dateTime: schedule.start,
+        timeZone: schedule.timeZone,
+      },
+      end: { date: null, dateTime: schedule.end, timeZone: schedule.timeZone },
+    };
+  }
+  return {
+    start: { date: schedule.start, dateTime: null, timeZone: null },
+    end: { date: schedule.end, dateTime: null, timeZone: null },
+  };
+}
+
+// Google's sendUpdates values are exactly the neutral invitation intents.
+function toSendUpdates(invitation: InvitationIntent): string {
+  return invitation;
+}
+
+// Google 403 reasons that mean "slow down", not "forbidden" — retryable.
+const RETRYABLE_403_REASONS = new Set([
+  "rateLimitExceeded",
+  "userRateLimitExceeded",
+  "quotaExceeded",
+  "dailyLimitExceeded",
+]);
+
+function classifyWriteError(error: unknown): ProviderWriteError {
+  // An already-classified error (e.g. a missing-identity result) must not be
+  // re-wrapped as transient just because it carries no HTTP status.
+  if (error instanceof ProviderWriteError) return error;
+
+  const status = googleStatus(error);
+  const cause = redactedCause(error);
+
+  if (status === 412) {
+    return new ProviderWriteError(
+      "versionConflict",
+      "The event was modified since the expected version",
+      { cause },
+    );
+  }
+  if (status === 401) {
+    return new ProviderWriteError(
+      "authorizationRevoked",
+      "Google rejected the credential",
+      { cause },
+    );
+  }
+  if (status === 403) {
+    // A quota 403 is retryable; any other 403 means the calendar is not
+    // writable with this authorization.
+    if (hasRetryable403Reason(error)) {
+      return new ProviderWriteError(
+        "transient",
+        "Google rate limited the write",
+        { cause },
+      );
+    }
+    return new ProviderWriteError(
+      "readOnlyCalendar",
+      "The calendar cannot be written",
+      { cause },
+    );
+  }
+  // No status (network failure) or 429/5xx are transient and safe to retry.
+  if (status === undefined || status === 429 || status >= 500) {
+    return new ProviderWriteError("transient", "The write failed transiently", {
+      cause,
+    });
+  }
+  return new ProviderWriteError(
+    "permanentProviderError",
+    "Google rejected the write",
+    { cause },
+  );
+}
+
+function isNotFound(error: unknown): boolean {
+  const status = googleStatus(error);
+  return status === 404 || status === 410;
+}
+
+function googleStatus(error: unknown): number | undefined {
+  return (
+    (error as { response?: { status?: number } })?.response?.status ??
+    (error as { code?: number })?.code
+  );
+}
+
+function hasRetryable403Reason(error: unknown): boolean {
+  const errors = (
+    error as {
+      response?: { data?: { error?: { errors?: Array<{ reason?: string }> } } };
+    }
+  )?.response?.data?.error?.errors;
+  return Boolean(
+    errors?.some((e) => e.reason && RETRYABLE_403_REASONS.has(e.reason)),
+  );
+}
+
+// Reduce a provider-SDK error to a bare message before attaching it as a cause.
+// A googleapis/gaxios error retains the request config, whose headers carry the
+// bearer access token; propagating the raw object would leak it the moment any
+// caller logged the cause chain. The message is response-derived, so it is safe.
+function redactedCause(error: unknown): Error | undefined {
+  return error instanceof Error ? new Error(error.message) : undefined;
+}
+
+// Google event ids must be base32hex (0-9, a-v), 5-1024 chars. A Compass
+// ObjectId hex string is a strict subset, so it is a valid, deterministic id
+// as-is — using it makes a create idempotent without a separate mapping.
+const BASE32HEX_ID = /^[0-9a-v]{5,1024}$/;
+
+export function deriveGoogleEventId(compassEventId: string): string {
+  const id = compassEventId.toLowerCase();
+  if (!BASE32HEX_ID.test(id)) {
+    throw new Error(
+      "Compass event id is not a valid Google event id (base32hex, 5-1024 chars)",
+    );
+  }
+  return id;
+}

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -110,13 +110,19 @@ export class GoogleEventWriter implements ProviderEventWriter {
       return toResult(created);
     } catch (error) {
       // A duplicate id means a prior attempt already created it: read it back
-      // and report success so a retry is a no-op, not a failure.
+      // and report success so a retry is a no-op, not a failure. The read-back
+      // has its own try so a failed lookup is classified (and redacted) too,
+      // never leaked as a raw provider error.
       if (googleStatus(error) === 409) {
-        const existing = await api.get({
-          calendarId: input.calendarId,
-          eventId: input.providerEventId,
-        });
-        return toResult(existing);
+        try {
+          const existing = await api.get({
+            calendarId: input.calendarId,
+            eventId: input.providerEventId,
+          });
+          return toResult(existing);
+        } catch (getError) {
+          throw classifyWriteError(getError);
+        }
       }
       throw classifyWriteError(error);
     }
@@ -191,6 +197,14 @@ function toResult(event: gSchema$Event): ProviderWriteResult {
 // than omitted — an omitted key is left unchanged on Google, and leaving the
 // other schedule kind's keys behind makes Google reject a start holding both a
 // date and a dateTime.
+//
+// organizer, attendees, and conference are deliberately NOT written. Compass is
+// not authoritative for a provider event's guest list (organizer is fixed by
+// the provider at creation, and attendee/conference management is a separate
+// concern), so those are read-reflected only. Patch's merge-by-key semantics
+// leave the provider's own values untouched, which is the intended behavior.
+// sendUpdates still notifies existing attendees of the title/time changes we do
+// write.
 function toGoogleBody(
   content: SyncEventContent,
   schedule: EventSchedule,

--- a/packages/sync/src/providers/provider-event-writer.port.ts
+++ b/packages/sync/src/providers/provider-event-writer.port.ts
@@ -1,0 +1,100 @@
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type ProviderEventRead } from "@sync/providers/provider-event.port";
+
+// Whether the provider should notify attendees of a mutation.
+export type InvitationIntent = "all" | "externalOnly" | "none";
+
+// Recurrence to write: a standalone or single occurrence, or a series carrying
+// its rules. "this and following" is not a primitive — the caller composes it
+// from a series truncation plus a new create — so it is deliberately absent.
+export type ProviderWriteRecurrence =
+  | { readonly kind: "single" }
+  | { readonly kind: "series"; readonly rules: readonly string[] };
+
+interface ProviderWriteBody {
+  readonly content: SyncEventContent;
+  readonly schedule: EventSchedule;
+  readonly recurrence: ProviderWriteRecurrence;
+  readonly invitation: InvitationIntent;
+}
+
+export interface ProviderCreateInput extends ProviderWriteBody {
+  readonly accessToken: string;
+  readonly calendarId: string;
+  // Caller-supplied deterministic id — makes create idempotent across retries:
+  // a replay hits the same id and the provider reports it already exists.
+  readonly providerEventId: string;
+}
+
+export interface ProviderPatchInput extends ProviderWriteBody {
+  readonly accessToken: string;
+  readonly calendarId: string;
+  readonly providerEventId: string;
+  // The version to condition the write on. Non-null sends an If-Match
+  // precondition, so a stale caller loses to a concurrent change instead of
+  // overwriting it. Null writes unconditionally (no known prior version).
+  readonly expectedVersion: string | null;
+}
+
+export interface ProviderDeleteInput {
+  readonly accessToken: string;
+  readonly calendarId: string;
+  readonly providerEventId: string;
+  readonly expectedVersion: string | null;
+  readonly invitation: InvitationIntent;
+}
+
+export interface ProviderFetchInput {
+  readonly accessToken: string;
+  readonly calendarId: string;
+  readonly providerEventId: string;
+}
+
+export interface ProviderWriteResult {
+  readonly providerEventId: string;
+  readonly providerVersion: string;
+}
+
+// A provider-neutral event mutation port. Neutral inputs in, provider identity
+// out; Google request/response shapes never cross this boundary.
+export interface ProviderEventWriter {
+  readonly provider: ProviderKind;
+
+  // Create at a caller-chosen id. A replay that finds the id already present
+  // returns the existing identity rather than failing, so retries are safe.
+  createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult>;
+
+  // Merge-patch an existing event, optionally conditioned on its version.
+  patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult>;
+
+  // Delete an event, optionally conditioned on its version. Idempotent: a
+  // delete of an already-absent event resolves rather than failing.
+  deleteEvent(input: ProviderDeleteInput): Promise<void>;
+
+  // Read one event back — the reconciliation step after an ambiguous create,
+  // to learn whether the write actually landed. Null when no such event exists.
+  fetchEvent(input: ProviderFetchInput): Promise<ProviderEventRead | null>;
+}
+
+// Why a mutation could not be applied. The terminal reasons mirror the sync
+// command failure classes so a caller maps them straight to an outcome;
+// `transient` is a retryable network/provider failure that is not terminal.
+export type ProviderWriteErrorReason =
+  | "versionConflict" // precondition failed — the caller's version is stale
+  | "readOnlyCalendar" // the target calendar cannot be written
+  | "authorizationRevoked" // the credential is no longer valid
+  | "transient" // network / 5xx / rate limit — safe to retry
+  | "permanentProviderError"; // an unrecoverable provider rejection
+
+export class ProviderWriteError extends Error {
+  constructor(
+    readonly reason: ProviderWriteErrorReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "ProviderWriteError";
+  }
+}


### PR DESCRIPTION
## What

Adds a provider-neutral **event mutation port** and its **Google adapter** — the primitives a sync workflow needs to write events back to a provider.

## Primitives

- **create** at a caller-chosen **deterministic id**: a retried create hits the same id, and a duplicate (409) is read back as success rather than failing — idempotent.
- **patch** (merge, never full update), optionally conditioned on the event's version via **If-Match**: a stale writer loses to a concurrent change (`versionConflict`) instead of silently overwriting. Keys are cleared with explicit `null` since patch merges by key.
- **delete**, optionally conditioned, and **idempotent**: deleting an already-absent event resolves rather than failing; a precondition failure still surfaces.
- **fetch** one event back — the reconciliation step after an ambiguous create — reusing the read normalizer.

## Error classification

Provider errors map to neutral reasons that mirror the sync command failure classes: `versionConflict` (412), `authorizationRevoked` (401), `readOnlyCalendar` (non-quota 403), `transient` (quota 403 / 429 / 5xx / network), `permanentProviderError` (everything else). Invitation intent maps to the provider's notify setting.

## Boundaries

Google request/response shapes stay inside the adapter (injected `GoogleEventsApi` seam, so the whole thing is unit-tested with no network). SDK error causes are reduced to a bare message so the bearer token can't leak. The Compass ObjectId hex is a valid Google event id (base32hex superset), so it doubles as the deterministic create id.

## Scope

Primitives only — nothing drives them in production yet. "This and following" is deliberately not a primitive (the caller composes it from a series truncation plus a create).

## Test plan

- [x] `bun run test:sync` (241 pass, incl. 20 new: idempotent retry, precondition conflict, read-only, recurrence scope, invitation intent, delete idempotency, token-leak redaction, id derivation)
- [x] `bun run type-check`
- [x] `bun run lint` (clean on changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)