### PR TITLE
feat(sync): add google notification adapter

### DIFF
--- a/packages/sync/src/notifications/notification-verification.test.ts
+++ b/packages/sync/src/notifications/notification-verification.test.ts
@@ -1,0 +1,93 @@
+import { verifyNotification } from "@sync/notifications/notification-verification";
+import {
+  type NotificationSubscription,
+  type ProviderNotification,
+} from "@sync/providers/provider-notifications.port";
+
+const now = new Date("2026-01-01T00:00:00Z");
+
+const subscription = (
+  overrides: Partial<NotificationSubscription> = {},
+): NotificationSubscription => ({
+  channelId: "chan-1",
+  resourceId: "res-1",
+  token: "secret-token",
+  expiresAt: new Date("2026-01-02T00:00:00Z"),
+  ...overrides,
+});
+
+const notification = (
+  overrides: Partial<ProviderNotification> = {},
+): ProviderNotification => ({
+  channelId: "chan-1",
+  resourceId: "res-1",
+  token: "secret-token",
+  state: "changed",
+  ...overrides,
+});
+
+describe("verifyNotification", () => {
+  it("accepts an authentic change and asks the caller to process it", () => {
+    const verdict = verifyNotification(notification(), subscription(), now);
+    expect(verdict).toEqual({ status: "process" });
+  });
+
+  it("accepts the initial handshake but marks it a no-op", () => {
+    const verdict = verifyNotification(
+      notification({ state: "initialSync" }),
+      subscription(),
+      now,
+    );
+    expect(verdict).toEqual({ status: "ignore" });
+  });
+
+  it("rejects a callback for a channel with no stored subscription", () => {
+    const verdict = verifyNotification(notification(), null, now);
+    expect(verdict).toEqual({ status: "rejected", reason: "unknownChannel" });
+  });
+
+  it("rejects when the subscription is for a different channel id", () => {
+    const verdict = verifyNotification(
+      notification({ channelId: "chan-other" }),
+      subscription(),
+      now,
+    );
+    expect(verdict).toEqual({ status: "rejected", reason: "unknownChannel" });
+  });
+
+  it("rejects a spoofed token", () => {
+    const verdict = verifyNotification(
+      notification({ token: "wrong-token" }),
+      subscription(),
+      now,
+    );
+    expect(verdict).toEqual({ status: "rejected", reason: "tokenMismatch" });
+  });
+
+  it("rejects a callback that carries no token at all", () => {
+    const verdict = verifyNotification(
+      notification({ token: null }),
+      subscription(),
+      now,
+    );
+    expect(verdict).toEqual({ status: "rejected", reason: "tokenMismatch" });
+  });
+
+  it("rejects a callback naming a different resource than was subscribed", () => {
+    const verdict = verifyNotification(
+      notification({ resourceId: "res-other" }),
+      subscription(),
+      now,
+    );
+    expect(verdict).toEqual({ status: "rejected", reason: "resourceMismatch" });
+  });
+
+  it("rejects a callback for a subscription that has already expired", () => {
+    const verdict = verifyNotification(
+      notification(),
+      subscription({ expiresAt: new Date("2025-12-31T23:59:59Z") }),
+      now,
+    );
+    expect(verdict).toEqual({ status: "rejected", reason: "expired" });
+  });
+});

--- a/packages/sync/src/notifications/notification-verification.ts
+++ b/packages/sync/src/notifications/notification-verification.ts
@@ -1,0 +1,61 @@
+import {
+  type NotificationSubscription,
+  type ProviderNotification,
+} from "@sync/providers/provider-notifications.port";
+
+// The outcome of checking one inbound callback against the stored association.
+// A rejected callback is dropped and never triggers work; an accepted one may
+// still be a no-op handshake rather than a real change.
+export type NotificationVerdict =
+  | { readonly status: "process" } // authentic change: the caller should sync
+  | { readonly status: "ignore" } // authentic, but nothing to do (handshake)
+  | { readonly status: "rejected"; readonly reason: NotificationRejectReason };
+
+export type NotificationRejectReason =
+  | "unknownChannel" // no stored subscription for this channel id
+  | "tokenMismatch" // the callback's token does not match the stored one
+  | "resourceMismatch" // the callback names a different resource than stored
+  | "expired"; // the subscription has lapsed; a fresh channel is required
+
+// Verify an inbound callback against the subscription the caller loaded for its
+// channel id (null if none was found). Every mismatch is a rejection, so a
+// spoofed or stale callback can never reach the sync path. The token is
+// compared in length-constant time so a mismatch reveals nothing by timing.
+export function verifyNotification(
+  notification: ProviderNotification,
+  subscription: NotificationSubscription | null,
+  now: Date = new Date(),
+): NotificationVerdict {
+  if (!subscription || subscription.channelId !== notification.channelId) {
+    return { status: "rejected", reason: "unknownChannel" };
+  }
+  if (
+    notification.token === null ||
+    !constantTimeEquals(notification.token, subscription.token)
+  ) {
+    return { status: "rejected", reason: "tokenMismatch" };
+  }
+  if (notification.resourceId !== subscription.resourceId) {
+    return { status: "rejected", reason: "resourceMismatch" };
+  }
+  if (subscription.expiresAt.getTime() <= now.getTime()) {
+    return { status: "rejected", reason: "expired" };
+  }
+
+  // The initial "sync" handshake fires once right after a watch and carries no
+  // change; only a real change should drive a pull.
+  return notification.state === "changed"
+    ? { status: "process" }
+    : { status: "ignore" };
+}
+
+// Compare two strings without short-circuiting on the first differing byte, so
+// a spoofed token cannot be recovered by measuring response time.
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/packages/sync/src/notifications/notification-verification.ts
+++ b/packages/sync/src/notifications/notification-verification.ts
@@ -2,6 +2,8 @@ import {
   type NotificationSubscription,
   type ProviderNotification,
 } from "@sync/providers/provider-notifications.port";
+import { Buffer } from "node:buffer";
+import { timingSafeEqual } from "node:crypto";
 
 // The outcome of checking one inbound callback against the stored association.
 // A rejected callback is dropped and never triggers work; an accepted one may
@@ -49,13 +51,11 @@ export function verifyNotification(
     : { status: "ignore" };
 }
 
-// Compare two strings without short-circuiting on the first differing byte, so
-// a spoofed token cannot be recovered by measuring response time.
+// Compare two tokens without short-circuiting on the first differing byte, so a
+// spoofed token cannot be recovered by measuring response time. Equal length is
+// a precondition of timingSafeEqual; a wrong-length token is trivially invalid
+// and its length is not itself a secret. Mirrors internal-auth's HMAC compare.
 function constantTimeEquals(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i += 1) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return diff === 0;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
 }

--- a/packages/sync/src/providers/google/google-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.test.ts
@@ -1,0 +1,257 @@
+import { type calendar_v3 } from "@googleapis/calendar";
+import {
+  type GoogleChannelsApi,
+  GoogleNotificationAdapter,
+} from "@sync/providers/google/google-notifications.adapter";
+import { ProviderNotificationError } from "@sync/providers/provider-notifications.port";
+
+const gError = (status: number, reason?: string) =>
+  Object.assign(new Error(`google error ${status}`), {
+    response: {
+      status,
+      data: reason ? { error: { errors: [{ reason }] } } : undefined,
+    },
+    config: { headers: { Authorization: "Bearer super-secret-token" } },
+  });
+
+type Behavior = calendar_v3.Schema$Channel | Error | undefined;
+
+class FakeChannelsApi implements GoogleChannelsApi {
+  watchCalls: Parameters<GoogleChannelsApi["watchEvents"]>[0][] = [];
+  stopCalls: Parameters<GoogleChannelsApi["stopChannel"]>[0][] = [];
+
+  constructor(
+    private readonly behavior: { watch?: Behavior; stop?: Error } = {},
+  ) {}
+
+  async watchEvents(
+    params: Parameters<GoogleChannelsApi["watchEvents"]>[0],
+  ): Promise<calendar_v3.Schema$Channel> {
+    this.watchCalls.push(params);
+    if (this.behavior.watch instanceof Error) throw this.behavior.watch;
+    return (
+      this.behavior.watch ?? {
+        resourceId: "res-1",
+        expiration: "1767312000000",
+      }
+    );
+  }
+
+  async stopChannel(
+    params: Parameters<GoogleChannelsApi["stopChannel"]>[0],
+  ): Promise<void> {
+    this.stopCalls.push(params);
+    if (this.behavior.stop) throw this.behavior.stop;
+  }
+}
+
+const adapterWith = (
+  api: GoogleChannelsApi,
+  now = () => new Date("2026-01-01T00:00:00Z"),
+) => {
+  const tokens: string[] = [];
+  const adapter = new GoogleNotificationAdapter((accessToken) => {
+    tokens.push(accessToken);
+    return api;
+  }, now);
+  return { adapter, tokens };
+};
+
+const watchInput = {
+  accessToken: "at",
+  calendarId: "cal@group.calendar.google.com",
+  channelId: "chan-1",
+  token: "chan-token",
+  callbackUrl: "https://sync.example.com/callbacks/google",
+};
+
+describe("GoogleNotificationAdapter watch/stop", () => {
+  it("opens a web_hook channel and returns the provider's expiry", async () => {
+    // 1767312000000 = 2026-01-02T00:00:00Z
+    const api = new FakeChannelsApi({
+      watch: { resourceId: "res-1", expiration: "1767312000000" },
+    });
+    const { adapter, tokens } = adapterWith(api);
+
+    const channel = await adapter.watchEvents(watchInput);
+
+    expect(tokens).toEqual(["at"]);
+    expect(api.watchCalls[0]).toEqual({
+      calendarId: "cal@group.calendar.google.com",
+      requestBody: {
+        id: "chan-1",
+        type: "web_hook",
+        address: "https://sync.example.com/callbacks/google",
+        token: "chan-token",
+        expiration: String(new Date("2026-01-08T00:00:00Z").getTime()),
+      },
+    });
+    expect(channel).toEqual({
+      channelId: "chan-1",
+      resourceId: "res-1",
+      expiresAt: new Date("2026-01-02T00:00:00Z"),
+    });
+  });
+
+  it("requests a caller-supplied ttl but lets the provider expiry win", async () => {
+    const api = new FakeChannelsApi({
+      watch: { resourceId: "res-1", expiration: "1767225600000" },
+    });
+    const { adapter } = adapterWith(api);
+
+    const channel = await adapter.watchEvents({
+      ...watchInput,
+      ttlMs: 3600_000,
+    });
+
+    // Requested one hour out...
+    expect(api.watchCalls[0].requestBody.expiration).toBe(
+      String(new Date("2026-01-01T01:00:00Z").getTime()),
+    );
+    // ...but the returned expiry (2026-01-01T00:00:00 + provider value) wins.
+    expect(channel.expiresAt).toEqual(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  it("falls back to the requested expiry when the provider omits one", async () => {
+    const api = new FakeChannelsApi({ watch: { resourceId: "res-1" } });
+    const { adapter } = adapterWith(api);
+
+    const channel = await adapter.watchEvents({
+      ...watchInput,
+      ttlMs: 3600_000,
+    });
+
+    expect(channel.expiresAt).toEqual(new Date("2026-01-01T01:00:00Z"));
+  });
+
+  it("fails when the provider returns no resource id", async () => {
+    const api = new FakeChannelsApi({ watch: { expiration: "1767312000000" } });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watchEvents(watchInput)
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("watchFailed");
+  });
+
+  it("classifies an unwatchable resource distinctly so the caller can poll", async () => {
+    const api = new FakeChannelsApi({
+      watch: gError(400, "pushNotSupportedForRequestedResource"),
+    });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watchEvents(watchInput)
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("watchUnsupported");
+  });
+
+  it("classifies a revoked credential and never leaks the bearer token", async () => {
+    const api = new FakeChannelsApi({ watch: gError(401) });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watchEvents(watchInput)
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("authorizationRevoked");
+    expect(error.cause).toBeInstanceOf(Error);
+    expect((error.cause as { config?: unknown }).config).toBeUndefined();
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+
+  it("stops a channel by id and resource id", async () => {
+    const api = new FakeChannelsApi();
+    const { adapter } = adapterWith(api);
+
+    await adapter.stopChannel({
+      accessToken: "at",
+      channelId: "chan-1",
+      resourceId: "res-1",
+    });
+
+    expect(api.stopCalls[0]).toEqual({
+      requestBody: { id: "chan-1", resourceId: "res-1" },
+    });
+  });
+
+  it("treats stopping an already-gone channel as success", async () => {
+    for (const status of [404, 401, 410]) {
+      const api = new FakeChannelsApi({ stop: gError(status) });
+      const { adapter } = adapterWith(api);
+
+      await adapter.stopChannel({
+        accessToken: "at",
+        channelId: "chan-1",
+        resourceId: "res-1",
+      });
+      expect(api.stopCalls).toHaveLength(1);
+    }
+  });
+
+  it("surfaces an unexpected stop failure", async () => {
+    const api = new FakeChannelsApi({ stop: gError(500) });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .stopChannel({
+        accessToken: "at",
+        channelId: "chan-1",
+        resourceId: "res-1",
+      })
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error).toBeInstanceOf(ProviderNotificationError);
+    expect(error.reason).toBe("watchFailed");
+  });
+});
+
+describe("GoogleNotificationAdapter parseCallback", () => {
+  const adapter = new GoogleNotificationAdapter();
+
+  it("normalizes a change callback from the Google headers", () => {
+    const notification = adapter.parseCallback({
+      "x-goog-channel-id": "chan-1",
+      "x-goog-channel-token": "chan-token",
+      "x-goog-resource-id": "res-1",
+      "x-goog-resource-state": "exists",
+    });
+
+    expect(notification).toEqual({
+      channelId: "chan-1",
+      resourceId: "res-1",
+      token: "chan-token",
+      state: "changed",
+    });
+  });
+
+  it("maps the initial sync handshake to initialSync", () => {
+    const notification = adapter.parseCallback({
+      "x-goog-channel-id": "chan-1",
+      "x-goog-channel-token": "chan-token",
+      "x-goog-resource-id": "res-1",
+      "x-goog-resource-state": "sync",
+    });
+
+    expect(notification?.state).toBe("initialSync");
+  });
+
+  it("carries a null token when the header is absent, for the verifier to reject", () => {
+    const notification = adapter.parseCallback({
+      "x-goog-channel-id": "chan-1",
+      "x-goog-resource-id": "res-1",
+      "x-goog-resource-state": "exists",
+    });
+
+    expect(notification?.token).toBeNull();
+  });
+
+  it("returns null when the channel or resource header is missing", () => {
+    expect(adapter.parseCallback({ "x-goog-resource-id": "res-1" })).toBeNull();
+    expect(adapter.parseCallback({ "x-goog-channel-id": "chan-1" })).toBeNull();
+  });
+});

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -1,0 +1,217 @@
+import { calendar, type calendar_v3 } from "@googleapis/calendar";
+import { OAuth2Client } from "google-auth-library";
+import { type gCalendar } from "@core/types/gcal";
+import {
+  type NotificationChannel,
+  type NotificationState,
+  type ProviderNotification,
+  type ProviderNotificationAdapter,
+  ProviderNotificationError,
+} from "@sync/providers/provider-notifications.port";
+
+// The two Google channel calls the adapter makes. Depending on this narrow
+// interface (not the concrete googleapis client) lets tests script results and
+// errors without a network round-trip or module mocking.
+export interface GoogleChannelsApi {
+  watchEvents(params: {
+    calendarId: string;
+    requestBody: calendar_v3.Schema$Channel;
+  }): Promise<calendar_v3.Schema$Channel>;
+  stopChannel(params: {
+    requestBody: calendar_v3.Schema$Channel;
+  }): Promise<void>;
+}
+
+export type GoogleChannelsApiFactory = (
+  accessToken: string,
+) => GoogleChannelsApi;
+
+const defaultApiFactory: GoogleChannelsApiFactory = (accessToken) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal: gCalendar = calendar({ version: "v3", auth });
+  return {
+    async watchEvents({ calendarId, requestBody }) {
+      const { data } = await gcal.events.watch({ calendarId, requestBody });
+      return data;
+    },
+    async stopChannel({ requestBody }) {
+      await gcal.channels.stop({ requestBody });
+    },
+  };
+};
+
+// A default channel lifetime when the caller requests none. Google caps event
+// channels near a week; it may return a shorter expiry, which is authoritative.
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Google callback headers, lower-cased (Node lower-cases request headers).
+const HEADER_CHANNEL_ID = "x-goog-channel-id";
+const HEADER_CHANNEL_TOKEN = "x-goog-channel-token";
+const HEADER_RESOURCE_ID = "x-goog-resource-id";
+const HEADER_RESOURCE_STATE = "x-goog-resource-state";
+
+// Google implementation of the notification port. Opens and stops push
+// channels and normalizes callback headers; the authenticity check against the
+// stored association is provider-neutral and lives in verifyNotification.
+export class GoogleNotificationAdapter implements ProviderNotificationAdapter {
+  readonly provider = "google" as const;
+
+  #makeApi: GoogleChannelsApiFactory;
+  #now: () => Date;
+
+  constructor(
+    makeApi: GoogleChannelsApiFactory = defaultApiFactory,
+    now: () => Date = () => new Date(),
+  ) {
+    this.#makeApi = makeApi;
+    this.#now = now;
+  }
+
+  async watchEvents(input: {
+    accessToken: string;
+    calendarId: string;
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+    ttlMs?: number;
+  }): Promise<NotificationChannel> {
+    const api = this.#makeApi(input.accessToken);
+    const expiration = this.#now().getTime() + (input.ttlMs ?? DEFAULT_TTL_MS);
+
+    let channel: calendar_v3.Schema$Channel;
+    try {
+      channel = await api.watchEvents({
+        calendarId: input.calendarId,
+        requestBody: {
+          id: input.channelId,
+          type: "web_hook",
+          address: input.callbackUrl,
+          token: input.token,
+          // Google expects an absolute expiration in epoch milliseconds.
+          expiration: String(expiration),
+        },
+      });
+    } catch (error) {
+      throw classifyWatchError(error);
+    }
+
+    if (!channel.resourceId) {
+      throw new ProviderNotificationError(
+        "watchFailed",
+        "Google returned a channel without a resource id",
+      );
+    }
+    return {
+      channelId: input.channelId,
+      resourceId: channel.resourceId,
+      // Google's returned expiration wins over the requested one; fall back to
+      // the requested expiry only if it omitted one.
+      expiresAt: parseExpiration(channel.expiration, expiration),
+    };
+  }
+
+  async stopChannel(input: {
+    accessToken: string;
+    channelId: string;
+    resourceId: string;
+  }): Promise<void> {
+    const api = this.#makeApi(input.accessToken);
+    try {
+      await api.stopChannel({
+        requestBody: { id: input.channelId, resourceId: input.resourceId },
+      });
+    } catch (error) {
+      // A channel that is already gone (or whose authority lapsed) cannot be
+      // stopped and needs no stopping — treat it as done. Other failures are
+      // surfaced so a caller can retry.
+      const status = googleStatus(error);
+      if (status === 404 || status === 401 || status === 410) return;
+      throw classifyWatchError(error);
+    }
+  }
+
+  parseCallback(
+    headers: Record<string, string | undefined>,
+  ): ProviderNotification | null {
+    const channelId = headers[HEADER_CHANNEL_ID];
+    const resourceId = headers[HEADER_RESOURCE_ID];
+    // Without a channel and resource to match, there is nothing to verify.
+    if (!channelId || !resourceId) return null;
+
+    return {
+      channelId,
+      resourceId,
+      token: headers[HEADER_CHANNEL_TOKEN] ?? null,
+      state: mapState(headers[HEADER_RESOURCE_STATE]),
+    };
+  }
+}
+
+// Google's initial post-watch delivery is "sync"; every other state ("exists",
+// "not_exists", ...) signals a change the caller should act on.
+function mapState(resourceState: string | undefined): NotificationState {
+  return resourceState === "sync" ? "initialSync" : "changed";
+}
+
+function parseExpiration(
+  expiration: string | null | undefined,
+  fallbackMs: number,
+): Date {
+  if (!expiration) return new Date(fallbackMs);
+  const parsed = Number(expiration);
+  return Number.isFinite(parsed) ? new Date(parsed) : new Date(fallbackMs);
+}
+
+function classifyWatchError(error: unknown): ProviderNotificationError {
+  if (error instanceof ProviderNotificationError) return error;
+  const cause = redactedCause(error);
+  if (googleStatus(error) === 401) {
+    return new ProviderNotificationError(
+      "authorizationRevoked",
+      "Google rejected the credential",
+      { cause },
+    );
+  }
+  if (isWatchUnsupported(error)) {
+    return new ProviderNotificationError(
+      "watchUnsupported",
+      "Google does not support watching this resource",
+      { cause },
+    );
+  }
+  return new ProviderNotificationError(
+    "watchFailed",
+    "Google refused to open the channel",
+    { cause },
+  );
+}
+
+// A 400 whose reason is pushNotSupportedForRequestedResource means the resource
+// can never be watched, so the caller should poll instead of retrying.
+function isWatchUnsupported(error: unknown): boolean {
+  if (googleStatus(error) !== 400) return false;
+  const errors = (
+    error as {
+      response?: { data?: { error?: { errors?: Array<{ reason?: string }> } } };
+    }
+  )?.response?.data?.error?.errors;
+  return Boolean(
+    errors?.some((e) => e.reason === "pushNotSupportedForRequestedResource"),
+  );
+}
+
+function googleStatus(error: unknown): number | undefined {
+  return (
+    (error as { response?: { status?: number } })?.response?.status ??
+    (error as { code?: number })?.code
+  );
+}
+
+// Reduce a provider-SDK error to a bare message before attaching it as a cause.
+// A googleapis/gaxios error retains the request config, whose headers carry the
+// bearer access token; propagating the raw object would leak it the moment any
+// caller logged the cause chain.
+function redactedCause(error: unknown): Error | undefined {
+  return error instanceof Error ? new Error(error.message) : undefined;
+}

--- a/packages/sync/src/providers/provider-notifications.port.ts
+++ b/packages/sync/src/providers/provider-notifications.port.ts
@@ -1,0 +1,86 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+
+// A live provider push channel, as the provider reports it after a watch. The
+// caller persists this association and matches inbound callbacks against it.
+export interface NotificationChannel {
+  // The channel id the caller chose and the provider echoes back on callbacks.
+  readonly channelId: string;
+  // The provider's opaque id for the watched resource, required to stop it.
+  readonly resourceId: string;
+  // When the channel stops delivering and must be renewed.
+  readonly expiresAt: Date;
+}
+
+// What one inbound callback tells us, normalized from provider headers. It is
+// untrusted until verified against the stored subscription. The provider's
+// initial post-watch handshake is `initialSync`; every other state is a change
+// the caller should act on.
+export type NotificationState = "initialSync" | "changed";
+
+export interface ProviderNotification {
+  readonly channelId: string;
+  readonly resourceId: string;
+  // The secret the provider echoes back; compared to the stored token.
+  readonly token: string | null;
+  readonly state: NotificationState;
+}
+
+// The stored channel association a callback is verified against. The token is
+// per-channel (not a shared secret), so a leak of one callback cannot forge
+// callbacks for another channel.
+export interface NotificationSubscription {
+  readonly channelId: string;
+  readonly resourceId: string;
+  readonly token: string;
+  readonly expiresAt: Date;
+}
+
+// A provider-neutral notification port. Channel lifecycle (watch/stop) and the
+// provider-specific callback header shapes stay inside the adapter; the domain
+// works with the normalized ProviderNotification and the verification verdict.
+export interface ProviderNotificationAdapter {
+  readonly provider: ProviderKind;
+
+  // Open a push channel for a calendar's events. `channelId` and `token` are
+  // caller-supplied so the association is known before the first callback can
+  // arrive. `ttlMs` requests a lifetime; the provider may shorten it, so the
+  // returned expiry is authoritative.
+  watchEvents(input: {
+    readonly accessToken: string;
+    readonly calendarId: string;
+    readonly channelId: string;
+    readonly token: string;
+    readonly callbackUrl: string;
+    readonly ttlMs?: number;
+  }): Promise<NotificationChannel>;
+
+  // Stop a channel. Idempotent: stopping an already-gone channel resolves.
+  stopChannel(input: {
+    readonly accessToken: string;
+    readonly channelId: string;
+    readonly resourceId: string;
+  }): Promise<void>;
+
+  // Normalize provider callback headers into a ProviderNotification, or null if
+  // the headers are not a recognizable notification at all.
+  parseCallback(
+    headers: Record<string, string | undefined>,
+  ): ProviderNotification | null;
+}
+
+// Why a mutation of a channel could not complete.
+export type ProviderNotificationErrorReason =
+  | "watchUnsupported" // the resource cannot be watched; the caller must poll
+  | "watchFailed" // the provider refused to open the channel
+  | "authorizationRevoked"; // the credential is no longer valid
+
+export class ProviderNotificationError extends Error {
+  constructor(
+    readonly reason: ProviderNotificationErrorReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "ProviderNotificationError";
+  }
+}


### PR DESCRIPTION
## What

Adds a provider-neutral **push-notification port** with its Google adapter and a neutral **callback verifier** — so the sync service can open, renew, and stop provider change-channels and authenticate the callbacks they deliver.

## Pieces

- **`watchEvents`** opens a `web_hook` channel for a calendar's events at a caller-supplied channel id and token, returning the resource id and the provider's authoritative expiry. Renewal is stop-then-recreate, composed by the caller.
- **`stopChannel`** is idempotent: an already-gone channel (404/401/410) resolves rather than failing.
- **`parseCallback`** normalizes the Google `X-Goog-*` callback headers into a neutral notification. The initial post-watch `sync` delivery is a handshake; every other state is a change.
- **`verifyNotification`** (pure) is the security boundary: it checks an inbound callback against the stored association and rejects anything spoofed or stale — `unknownChannel`, `tokenMismatch` (constant-time compare), `resourceMismatch`, or `expired`. An authentic change asks the caller to `process`; the handshake is `ignore`.

## Security choice

A **per-channel random token** (stored with the association), not a shared static secret. A callback must match *that channel's* token, so a leak from one callback can't forge callbacks for another channel. (This deviates from the backend's single shared secret — a deliberate hardening for the isolated sync service.)

## Boundaries

An unwatchable resource (`pushNotSupportedForRequestedResource`) is classified distinctly so the caller can fall back to polling. Google request/response shapes stay inside the adapter (injected `GoogleChannelsApi` seam), and SDK error causes are reduced to a bare message so the bearer token can't leak. **Nothing pulls changes here** — the callback path only validates.

## Test plan

- [x] `bun run test:sync` (263 pass, incl. 21 new: spoofed callback, missing association, expiration, token/resource mismatch, handshake-vs-change, watch/stop, unwatchable resource, token-leak redaction)
- [x] `bun run type-check`
- [x] `bun run lint` (clean on changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)