### PR TITLE
feat(sync): add authenticated connection read api

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@core/logger/winston.logger";
+import { createInternalAuthMiddleware } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
@@ -24,7 +25,10 @@ export interface SyncService {
 // a port or reading a file — so tests can drive it directly. Later commits
 // register storage/scheduler readiness checks and drain tasks against the
 // returned registries.
-export function createSyncService(config: SyncConfig): SyncService {
+export function createSyncService(
+  config: SyncConfig,
+  deps: { mongo?: SyncMongoService } = {},
+): SyncService {
   const identity = buildServiceIdentity({
     environment: config.NODE_ENV,
     execution: config.EXECUTION,
@@ -32,7 +36,19 @@ export function createSyncService(config: SyncConfig): SyncService {
   const readiness = new ReadinessRegistry();
   const shutdown = new ShutdownCoordinator();
 
-  const app = buildSyncApp({ identity, readiness });
+  // The internal connection API mounts only when storage is provided. Its
+  // routes read the connected db per request, so the app is still built before
+  // Mongo connects (liveness-first startup).
+  const connectionApi = deps.mongo
+    ? {
+        authMiddleware: createInternalAuthMiddleware({
+          secret: config.INTERNAL_AUTH_TOKEN,
+        }),
+        mongo: deps.mongo,
+      }
+    : undefined;
+
+  const app = buildSyncApp({ identity, readiness, connectionApi });
   const httpServer = createServer(app);
 
   const stop = async (): Promise<void> => {
@@ -60,13 +76,17 @@ function closeHttpServer(httpServer: Server): Promise<void> {
 
 async function start(): Promise<void> {
   const config = loadSyncConfig();
-  const service = createSyncService(config);
+
+  // Build the mongo service before the app so the internal connection API can
+  // read from it. It is not connected yet; the app binds its port first and the
+  // routes access the db lazily, per request.
+  const mongo = new SyncMongoService();
+  const service = createSyncService(config, { mongo });
 
   // Register the disconnect drain first so, under the coordinator's
   // reverse-order teardown, storage closes LAST — after any workers that
   // depend on it. Readiness reflects storage state, so /health/ready stays 503
   // until Mongo is connected and its indexes are installed.
-  const mongo = new SyncMongoService();
   service.shutdown.register("mongo", () => mongo.disconnect());
   service.readiness.register("storage", async () => {
     if (!mongo.isConnected) return false;

--- a/packages/sync/src/server/connection.routes.test.ts
+++ b/packages/sync/src/server/connection.routes.test.ts
@@ -1,0 +1,192 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { createSyncService, type SyncService } from "@sync/app";
+import { signInternalRequest } from "@sync/auth/internal-auth";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { CONNECTIONS_PATH } from "@sync/server/connection.routes";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { type AddressInfo } from "node:net";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+const SECRET = "internal-secret";
+
+const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: uri,
+    INTERNAL_AUTH_TOKEN: SECRET,
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+    ...overrides,
+  }) as SyncConfig;
+
+const seedConnection = (
+  repo: ProviderConnectionRepository,
+  tenantId: string,
+  principalId: string,
+  email: string,
+) =>
+  repo.upsertByProviderAccount({
+    tenantId: tenantId as TenantId,
+    principalId: principalId as PrincipalId,
+    provider: "google",
+    account: {
+      providerAccountId: objectId(),
+      email,
+      displayName: null,
+    },
+    capabilities: ["readEvents"],
+    state: "healthy",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+  });
+
+// Sign like the trusted Compass API would, so the request clears internal auth.
+const signedHeaders = (
+  tenantId: string,
+  principalId: string,
+): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "x-sync-tenant": tenantId,
+    "x-sync-principal": principalId,
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signInternalRequest(SECRET, {
+      timestamp,
+      tenantId,
+      principalId,
+    }),
+  };
+};
+
+describe("GET /internal/connections", () => {
+  let mongo: SyncMongoService;
+  let repo: ProviderConnectionRepository;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async (config: SyncConfig = testConfig()) => {
+    service = createSyncService(config, { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `conn_api_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    repo = new ProviderConnectionRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("returns the caller's connections mapped to the wire contract", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedConnection(repo, tenantId, principalId, "me@example.com");
+    await startService();
+
+    const res = await fetch(`${base}${CONNECTIONS_PATH}`, {
+      headers: signedHeaders(tenantId, principalId),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      connections: Array<Record<string, unknown>>;
+    };
+    expect(body.connections).toHaveLength(1);
+    expect(body.connections[0]).toMatchObject({
+      principalId,
+      provider: "google",
+      state: "healthy",
+      account: { email: "me@example.com", displayName: null },
+    });
+    // Timestamps are ISO strings on the wire, not Dates.
+    expect(typeof body.connections[0].createdAt).toBe("string");
+  });
+
+  it("scopes results to the authenticated principal", async () => {
+    const tenantId = objectId();
+    const mine = objectId();
+    const other = objectId();
+    await seedConnection(repo, tenantId, mine, "mine@example.com");
+    await seedConnection(repo, tenantId, other, "other@example.com");
+    await startService();
+
+    const res = await fetch(`${base}${CONNECTIONS_PATH}`, {
+      headers: signedHeaders(tenantId, mine),
+    });
+
+    const body = (await res.json()) as {
+      connections: Array<{ account: { email: string } }>;
+    };
+    expect(body.connections).toHaveLength(1);
+    expect(body.connections[0].account.email).toBe("mine@example.com");
+  });
+
+  it("returns an empty list for a principal with no connections", async () => {
+    await startService();
+
+    const res = await fetch(`${base}${CONNECTIONS_PATH}`, {
+      headers: signedHeaders(objectId(), objectId()),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connections: [] });
+  });
+
+  it("rejects a request that is not signed", async () => {
+    await startService();
+
+    const res = await fetch(`${base}${CONNECTIONS_PATH}`);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a request whose signature does not match", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+
+    const headers = signedHeaders(tenantId, principalId);
+    headers["x-sync-signature"] = "deadbeef";
+
+    const res = await fetch(`${base}${CONNECTIONS_PATH}`, { headers });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("serves reads in passive mode (they touch no provider)", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedConnection(repo, tenantId, principalId, "passive@example.com");
+    await startService(testConfig({ EXECUTION: "passive" }));
+
+    const res = await fetch(`${base}${CONNECTIONS_PATH}`, {
+      headers: signedHeaders(tenantId, principalId),
+    });
+
+    expect(res.status).toBe(200);
+    expect(
+      ((await res.json()) as { connections: unknown[] }).connections,
+    ).toHaveLength(1);
+  });
+});

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -1,0 +1,79 @@
+import { type Express, type RequestHandler, type Response } from "express";
+import { Status } from "@core/errors/status.codes";
+import {
+  type ConnectionListResponse,
+  type ProviderConnection,
+  ProviderConnectionSchema,
+} from "@core/types/sync/connection.contracts";
+import { type InternalAuthedRequest } from "@sync/auth/internal-auth";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+export const CONNECTIONS_PATH = "/internal/connections";
+
+// Internal, authenticated connection endpoints. The tenant/principal comes from
+// the signed auth context, never the request, so every query is scoped to the
+// caller's own principal. Reads are allowed in passive mode — they touch no
+// provider. The record's stored state is authoritative (it was derived from
+// evidence at write time), so this layer only reshapes it to the wire contract.
+export function registerConnectionRoutes(
+  app: Express,
+  deps: { authMiddleware: RequestHandler; mongo: SyncMongoService },
+): void {
+  app.get(CONNECTIONS_PATH, deps.authMiddleware, async (req, res) => {
+    const auth = (req as InternalAuthedRequest).syncAuth;
+    // The middleware always sets this on success; treat its absence as a bug,
+    // not an authorization, and never fall through to an unscoped query.
+    if (!auth) {
+      res.status(Status.UNAUTHORIZED).json({ error: "unauthorized" });
+      return;
+    }
+    if (!deps.mongo.isConnected) {
+      res.status(Status.SERVICE_UNAVAILABLE).json({ error: "not_ready" });
+      return;
+    }
+
+    try {
+      const repo = new ProviderConnectionRepository(deps.mongo.db);
+      const records = await repo.listByPrincipal(
+        auth.tenantId,
+        auth.principalId,
+      );
+      const response: ConnectionListResponse = {
+        connections: records.map(toProviderConnection),
+      };
+      res.status(Status.OK).json(response);
+    } catch {
+      // Never surface storage internals or identity to the caller.
+      respondInternalError(res);
+    }
+  });
+}
+
+// Map a stored connection record (string ids, Date timestamps) to the wire
+// contract (ISO-string timestamps). Parsing through the schema validates and
+// brands the result, so a row that somehow violates the contract fails loudly
+// here rather than reaching the caller malformed.
+export function toProviderConnection(
+  record: ProviderConnectionRecord,
+): ProviderConnection {
+  return ProviderConnectionSchema.parse({
+    id: record._id,
+    tenantId: record.tenantId,
+    principalId: record.principalId,
+    provider: record.provider,
+    account: record.account,
+    capabilities: record.capabilities,
+    state: record.state,
+    stateReason: record.stateReason,
+    lastSyncedAt: record.lastSyncedAt?.toISOString() ?? null,
+    lastHealthyAt: record.lastHealthyAt?.toISOString() ?? null,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+  });
+}
+
+function respondInternalError(res: Response): void {
+  res.status(Status.INTERNAL_SERVER).json({ error: "internal_error" });
+}

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -1,21 +1,26 @@
-import express, { type Express } from "express";
+import express, { type Express, type RequestHandler } from "express";
 import { type ReadinessRegistry } from "@sync/lifecycle/readiness";
+import { registerConnectionRoutes } from "@sync/server/connection.routes";
 import { registerHealthRoutes } from "@sync/server/health.routes";
 import { type StructuredServiceIdentity } from "@sync/service-identity";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
-// Builds the Sync service's HTTP application. For now it mounts only the
-// content-free health probes; internal-auth middleware, connection/OAuth
-// ingress, webhook ingress, and query routes mount here in later commits.
-// JSON body parsing is enabled now so those routes compose without re-wiring
-// the app.
+// Builds the Sync service's HTTP application. Health probes are always public
+// and content-free. The internal connection API mounts only when its storage
+// dependency is supplied, so the health-only paths need no database. OAuth /
+// webhook ingress and query routes mount here in later commits.
 export function buildSyncApp(deps: {
   identity: StructuredServiceIdentity;
   readiness: ReadinessRegistry;
+  connectionApi?: { authMiddleware: RequestHandler; mongo: SyncMongoService };
 }): Express {
   const app = express();
   app.use(express.json());
 
   registerHealthRoutes(app, deps);
+  if (deps.connectionApi) {
+    registerConnectionRoutes(app, deps.connectionApi);
+  }
 
   return app;
 }


### PR DESCRIPTION
## What

The first internal, authenticated endpoint on the sync service: **`GET /internal/connections`** lists the caller's provider connections. Also lands the dependency-injection seam that the remaining connection endpoints and query routes will mount onto.

## Security / isolation

- The tenant/principal comes from the **signed internal-auth context** (`req.syncAuth`), never the request body/query — so a caller can only read its own principal's connections. `listByPrincipal` is already tenant+principal scoped.
- Behind `createInternalAuthMiddleware`; an unsigned or bad-signature request gets 401 with only a generic reason.
- Records (string ids, `Date` timestamps) are reshaped to the ISO-string wire contract and validated through `ProviderConnectionSchema` on the way out. Errors return a generic code — no storage internals or identity leak.

## Wiring

`buildSyncApp` gains an optional `connectionApi` dependency; `createSyncService` builds it (+ the internal-auth middleware) from a `SyncMongoService` when one is supplied. The service is passed **before** Mongo connects and the route reads the db lazily per request, so the app stays built port-first (liveness before storage) and the health-only paths need no database.

## Scope

Read-only first increment. `disconnect`, OAuth `begin`/callback, `reconnect`, and the notification-callback ingress are follow-up slices that mount onto this same seam. Reads are served in passive mode (they touch no provider).

## Test plan

- [x] `bun run test:sync` (269 pass, incl. 6 new HTTP-level: happy path + wire mapping, principal scoping, empty list, unsigned/bad-signature 401, passive-mode read)
- [x] `bun run type-check`
- [x] `bun run lint` (clean on changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)