### PR TITLE
feat(sync): begin provider oauth with a signed csrf state

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -3,6 +3,7 @@ import { createInternalAuthMiddleware } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
+import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
 import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { buildSyncApp } from "@sync/server/sync.server";
@@ -56,9 +57,10 @@ export function createSyncService(
         // The provider adapter is db-free, so it is built once here (gated on
         // provider config); the per-request custody/repos build from the db.
         authAdapter: deps.authAdapter ?? buildAuthAdapter(config),
-        // The OAuth CSRF state is signed with the service secret and the
-        // callback resolves against the public base URL.
-        stateSecret: config.INTERNAL_AUTH_TOKEN,
+        // The OAuth CSRF state is signed with a key derived from the service
+        // secret (domain-separated from internal-auth signing); the callback
+        // resolves against the public base URL.
+        stateSecret: deriveOAuthStateSecret(config.INTERNAL_AUTH_TOKEN),
         callbackBaseUrl: config.CALLBACK_BASE_URL,
       }
     : undefined;

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -56,6 +56,10 @@ export function createSyncService(
         // The provider adapter is db-free, so it is built once here (gated on
         // provider config); the per-request custody/repos build from the db.
         authAdapter: deps.authAdapter ?? buildAuthAdapter(config),
+        // The OAuth CSRF state is signed with the service secret and the
+        // callback resolves against the public base URL.
+        stateSecret: config.INTERNAL_AUTH_TOKEN,
+        callbackBaseUrl: config.CALLBACK_BASE_URL,
       }
     : undefined;
 

--- a/packages/sync/src/oauth/oauth-state.test.ts
+++ b/packages/sync/src/oauth/oauth-state.test.ts
@@ -1,0 +1,109 @@
+import { faker } from "@faker-js/faker";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
+  type OAuthStatePayload,
+  signOAuthState,
+  verifyOAuthState,
+} from "@sync/oauth/oauth-state";
+import { Buffer } from "node:buffer";
+import { createHmac } from "node:crypto";
+
+const SECRET = "state-secret";
+const objectId = () => faker.database.mongodbObjectId();
+
+const payload = (
+  overrides: Partial<OAuthStatePayload> = {},
+): OAuthStatePayload => ({
+  tenantId: objectId() as TenantId,
+  principalId: objectId() as PrincipalId,
+  connectionId: null,
+  issuedAt: 1_000_000,
+  ...overrides,
+});
+
+describe("oauth-state", () => {
+  it("round-trips a signed payload", () => {
+    const original = payload();
+    const token = signOAuthState(SECRET, original);
+
+    const result = verifyOAuthState(SECRET, token, original.issuedAt);
+
+    expect(result).toEqual({ ok: true, payload: original });
+  });
+
+  it("round-trips a reconnect payload carrying a connection id", () => {
+    const original = payload({ connectionId: objectId() as ConnectionId });
+    const token = signOAuthState(SECRET, original);
+
+    const result = verifyOAuthState(SECRET, token, original.issuedAt);
+
+    expect(result.ok && result.payload.connectionId).toBe(
+      original.connectionId,
+    );
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const token = signOAuthState("other-secret", payload());
+    expect(verifyOAuthState(SECRET, token, 1_000_000)).toEqual({
+      ok: false,
+      reason: "invalidSignature",
+    });
+  });
+
+  it("rejects a tampered payload even though the signature is stale", () => {
+    const token = signOAuthState(SECRET, payload());
+    const [, signature] = token.split(".");
+    // Swap the payload for a different principal but keep the old signature.
+    const forged = Buffer.from(
+      JSON.stringify({ t: objectId(), p: objectId(), c: null, i: 1_000_000 }),
+    ).toString("base64url");
+
+    expect(
+      verifyOAuthState(SECRET, `${forged}.${signature}`, 1_000_000),
+    ).toEqual({ ok: false, reason: "invalidSignature" });
+  });
+
+  it("rejects a correctly-signed but structurally invalid payload", () => {
+    // A payload the attacker got signed somehow but that is not a valid state.
+    const encoded = Buffer.from("not the expected shape").toString("base64url");
+    const signature = createHmac("sha256", SECRET)
+      .update(encoded)
+      .digest("hex");
+
+    expect(
+      verifyOAuthState(SECRET, `${encoded}.${signature}`, 1_000_000),
+    ).toEqual({ ok: false, reason: "malformed" });
+  });
+
+  it("rejects an expired token", () => {
+    const original = payload({ issuedAt: 1_000_000 });
+    const token = signOAuthState(SECRET, original);
+
+    // 11 minutes later, past the 10-minute default ttl.
+    const result = verifyOAuthState(SECRET, token, 1_000_000 + 11 * 60 * 1000);
+
+    expect(result).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("rejects a token issued in the future (clock skew guard)", () => {
+    const original = payload({ issuedAt: 2_000_000 });
+    const token = signOAuthState(SECRET, original);
+
+    expect(verifyOAuthState(SECRET, token, 1_000_000)).toEqual({
+      ok: false,
+      reason: "expired",
+    });
+  });
+
+  it("rejects a structurally malformed token", () => {
+    expect(verifyOAuthState(SECRET, "no-dot-here", 1).reason).toBe("malformed");
+    expect(verifyOAuthState(SECRET, ".onlysig", 1).reason).toBe("malformed");
+    expect(verifyOAuthState(SECRET, "onlypayload.", 1).reason).toBe(
+      "malformed",
+    );
+  });
+});

--- a/packages/sync/src/oauth/oauth-state.ts
+++ b/packages/sync/src/oauth/oauth-state.ts
@@ -29,6 +29,16 @@ export interface OAuthStatePayload {
 // consent, short enough to bound replay of a leaked callback URL.
 export const DEFAULT_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 
+// Derive a purpose-specific signing key from the service root secret, so the
+// OAuth state and internal-auth request signatures never share a key. Domain
+// separation: even though the two message formats are already structurally
+// distinct, a distinct key removes any cross-protocol coupling for free.
+export function deriveOAuthStateSecret(rootSecret: string): string {
+  return createHmac("sha256", rootSecret)
+    .update("compass-sync/oauth-state")
+    .digest("hex");
+}
+
 // A signed token is `<base64url(payload json)>.<hmac hex>`. The payload is
 // public (it rides in a URL); the signature is what makes it unforgeable.
 export function signOAuthState(

--- a/packages/sync/src/oauth/oauth-state.ts
+++ b/packages/sync/src/oauth/oauth-state.ts
@@ -1,0 +1,127 @@
+import {
+  type ConnectionId,
+  ConnectionIdSchema,
+  type PrincipalId,
+  PrincipalIdSchema,
+  type TenantId,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+import { Buffer } from "node:buffer";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// The CSRF state carried through a provider OAuth round-trip. The service signs
+// it at `begin`, the provider echoes it back on the callback, and the service
+// verifies the signature to recover WHO the flow was for — without any
+// server-side session store. The state is the only trust on the public
+// callback, so it is HMAC-signed and time-bounded, exactly like internal-auth.
+
+export interface OAuthStatePayload {
+  readonly tenantId: TenantId;
+  readonly principalId: PrincipalId;
+  // Present when re-authorizing a specific existing connection (reconnect),
+  // absent for a first-time connect.
+  readonly connectionId: ConnectionId | null;
+  // Milliseconds since the epoch when the state was issued.
+  readonly issuedAt: number;
+}
+
+// Default lifetime of a state token: long enough for a human to complete
+// consent, short enough to bound replay of a leaked callback URL.
+export const DEFAULT_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+// A signed token is `<base64url(payload json)>.<hmac hex>`. The payload is
+// public (it rides in a URL); the signature is what makes it unforgeable.
+export function signOAuthState(
+  secret: string,
+  payload: OAuthStatePayload,
+): string {
+  const encoded = encodePayload(payload);
+  return `${encoded}.${sign(secret, encoded)}`;
+}
+
+export type OAuthStateFailure = "malformed" | "invalidSignature" | "expired";
+
+export type OAuthStateResult =
+  | { readonly ok: true; readonly payload: OAuthStatePayload }
+  | { readonly ok: false; readonly reason: OAuthStateFailure };
+
+export function verifyOAuthState(
+  secret: string,
+  token: string,
+  now: number,
+  ttlMs: number = DEFAULT_OAUTH_STATE_TTL_MS,
+): OAuthStateResult {
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) {
+    return { ok: false, reason: "malformed" };
+  }
+  const encoded = token.slice(0, dot);
+  const signature = token.slice(dot + 1);
+
+  // Verify the signature before trusting any byte of the payload.
+  if (!signaturesMatch(sign(secret, encoded), signature)) {
+    return { ok: false, reason: "invalidSignature" };
+  }
+
+  const payload = decodePayload(encoded);
+  if (!payload) return { ok: false, reason: "malformed" };
+
+  if (now - payload.issuedAt > ttlMs || payload.issuedAt > now) {
+    return { ok: false, reason: "expired" };
+  }
+  return { ok: true, payload };
+}
+
+function sign(secret: string, encoded: string): string {
+  return createHmac("sha256", secret).update(encoded).digest("hex");
+}
+
+function signaturesMatch(expected: string, provided: string): boolean {
+  if (expected.length !== provided.length) return false;
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(provided));
+}
+
+function encodePayload(payload: OAuthStatePayload): string {
+  const json = JSON.stringify({
+    t: payload.tenantId,
+    p: payload.principalId,
+    c: payload.connectionId,
+    i: payload.issuedAt,
+  });
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+// Decode and re-validate every field through the branded schemas, so a tampered
+// (but somehow correctly-signed) or malformed payload can never yield a usable
+// identity. Returns null on any structural problem.
+function decodePayload(encoded: string): OAuthStatePayload | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof raw !== "object" || raw === null) return null;
+
+  const record = raw as Record<string, unknown>;
+  const tenantId = TenantIdSchema.safeParse(record["t"]);
+  const principalId = PrincipalIdSchema.safeParse(record["p"]);
+  const issuedAt = record["i"];
+  if (!tenantId.success || !principalId.success) return null;
+  if (typeof issuedAt !== "number" || !Number.isFinite(issuedAt)) return null;
+
+  // connectionId is optional; when present it must be a valid connection id.
+  let connectionId: ConnectionId | null = null;
+  if (record["c"] !== null && record["c"] !== undefined) {
+    const parsed = ConnectionIdSchema.safeParse(record["c"]);
+    if (!parsed.success) return null;
+    connectionId = parsed.data;
+  }
+
+  return {
+    tenantId: tenantId.data,
+    principalId: principalId.data,
+    connectionId,
+    issuedAt,
+  };
+}

--- a/packages/sync/src/server/connection.routes.test.ts
+++ b/packages/sync/src/server/connection.routes.test.ts
@@ -8,11 +8,16 @@ import {
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
+import { verifyOAuthState } from "@sync/oauth/oauth-state";
 import {
   type ProviderAuthAdapter,
   type RefreshedCredential,
 } from "@sync/providers/provider-auth.port";
-import { CONNECTIONS_PATH } from "@sync/server/connection.routes";
+import {
+  BEGIN_PATH,
+  CONNECTIONS_PATH,
+  OAUTH_CALLBACK_PATH,
+} from "@sync/server/connection.routes";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -34,13 +39,16 @@ const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
     ...overrides,
   }) as SyncConfig;
 
-// A minimal provider auth adapter: disconnect only exercises revoke, which
-// records the token instead of hitting the network.
+// A minimal provider auth adapter: disconnect exercises revoke and begin
+// exercises buildAuthorizationUrl; both record their inputs instead of hitting
+// the network.
 class FakeAuthAdapter implements ProviderAuthAdapter {
   readonly provider = "google" as const;
   revoked: string[] = [];
-  buildAuthorizationUrl(): string {
-    return "https://example.com/consent";
+  authorizations: Array<{ state: string; redirectUri: string }> = [];
+  buildAuthorizationUrl(input: { state: string; redirectUri: string }): string {
+    this.authorizations.push(input);
+    return `https://consent.example.com/?state=${input.state}`;
   }
   exchangeAuthorizationCode(): Promise<never> {
     throw new Error("unused");
@@ -349,6 +357,147 @@ describe("DELETE /internal/connections/:id", () => {
       `${base}${CONNECTIONS_PATH}/${objectId() as ConnectionId}`,
       { method: "DELETE" },
     );
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /internal/connections/begin", () => {
+  let mongo: SyncMongoService;
+  let connections: ProviderConnectionRepository;
+  let service: SyncService;
+  let base: string;
+  let adapter: FakeAuthAdapter;
+
+  const activeConfig = () => testConfig({ EXECUTION: "active" });
+
+  const startService = async (
+    config: SyncConfig,
+    authAdapter?: ProviderAuthAdapter,
+  ) => {
+    service = createSyncService(config, { mongo, authAdapter });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  const begin = (
+    tenantId: string,
+    principalId: string,
+    body?: Record<string, unknown>,
+  ) =>
+    fetch(`${base}${BEGIN_PATH}`, {
+      method: "POST",
+      headers: {
+        ...signedHeaders(tenantId, principalId),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body ?? {}),
+    });
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `begin_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    connections = new ProviderConnectionRepository(mongo.db);
+    adapter = new FakeAuthAdapter();
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("returns a consent url whose state binds the flow to the caller", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService(activeConfig(), adapter);
+
+    const res = await begin(tenantId, principalId);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { authorizationUrl: string };
+    const { state, redirectUri } = adapter.authorizations[0];
+    expect(body.authorizationUrl).toContain(state);
+    expect(redirectUri).toBe(`http://localhost:3010${OAUTH_CALLBACK_PATH}`);
+
+    const verified = verifyOAuthState(SECRET, state, Date.now());
+    expect(verified.ok && verified.payload.principalId).toBe(principalId);
+    expect(verified.ok && verified.payload.tenantId).toBe(tenantId);
+    expect(verified.ok && verified.payload.connectionId).toBeNull();
+  });
+
+  it("binds the state to an owned connection for reconnect", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const existing = await seedConnection(
+      connections,
+      tenantId,
+      principalId,
+      "reconnect@example.com",
+    );
+    await startService(activeConfig(), adapter);
+
+    const res = await begin(tenantId, principalId, {
+      connectionId: existing._id,
+    });
+
+    expect(res.status).toBe(200);
+    const { state } = adapter.authorizations[0];
+    const verified = verifyOAuthState(SECRET, state, Date.now());
+    expect(verified.ok && verified.payload.connectionId).toBe(existing._id);
+  });
+
+  it("refuses to reconnect a connection the principal does not own", async () => {
+    const tenantId = objectId();
+    const owner = objectId();
+    const stranger = objectId();
+    const existing = await seedConnection(
+      connections,
+      tenantId,
+      owner,
+      "owner@example.com",
+    );
+    await startService(activeConfig(), adapter);
+
+    const res = await begin(tenantId, stranger, {
+      connectionId: existing._id,
+    });
+
+    expect(res.status).toBe(404);
+    expect(adapter.authorizations).toHaveLength(0);
+  });
+
+  it("rejects a malformed reconnect connection id", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService(activeConfig(), adapter);
+
+    const res = await begin(tenantId, principalId, { connectionId: "nope" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("refuses to begin in passive mode", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService(testConfig({ EXECUTION: "passive" }), adapter);
+
+    const res = await begin(tenantId, principalId);
+
+    expect(res.status).toBe(409);
+    expect(adapter.authorizations).toHaveLength(0);
+  });
+
+  it("rejects an unsigned begin", async () => {
+    await startService(activeConfig(), adapter);
+
+    const res = await fetch(`${base}${BEGIN_PATH}`, { method: "POST" });
 
     expect(res.status).toBe(401);
   });

--- a/packages/sync/src/server/connection.routes.test.ts
+++ b/packages/sync/src/server/connection.routes.test.ts
@@ -8,7 +8,10 @@ import {
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
-import { verifyOAuthState } from "@sync/oauth/oauth-state";
+import {
+  deriveOAuthStateSecret,
+  verifyOAuthState,
+} from "@sync/oauth/oauth-state";
 import {
   type ProviderAuthAdapter,
   type RefreshedCredential,
@@ -26,6 +29,8 @@ import { type AddressInfo } from "node:net";
 const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 const SECRET = "internal-secret";
+// The service signs OAuth state with a key derived from the root secret.
+const STATE_SECRET = deriveOAuthStateSecret(SECRET);
 
 const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
   ({
@@ -426,7 +431,7 @@ describe("POST /internal/connections/begin", () => {
     expect(body.authorizationUrl).toContain(state);
     expect(redirectUri).toBe(`http://localhost:3010${OAUTH_CALLBACK_PATH}`);
 
-    const verified = verifyOAuthState(SECRET, state, Date.now());
+    const verified = verifyOAuthState(STATE_SECRET, state, Date.now());
     expect(verified.ok && verified.payload.principalId).toBe(principalId);
     expect(verified.ok && verified.payload.tenantId).toBe(tenantId);
     expect(verified.ok && verified.payload.connectionId).toBeNull();
@@ -449,7 +454,7 @@ describe("POST /internal/connections/begin", () => {
 
     expect(res.status).toBe(200);
     const { state } = adapter.authorizations[0];
-    const verified = verifyOAuthState(SECRET, state, Date.now());
+    const verified = verifyOAuthState(STATE_SECRET, state, Date.now());
     expect(verified.ok && verified.payload.connectionId).toBe(existing._id);
   });
 

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -15,6 +15,7 @@ import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
 import { type InternalAuthedRequest } from "@sync/auth/internal-auth";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { signOAuthState } from "@sync/oauth/oauth-state";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
@@ -22,15 +23,25 @@ import { ProviderConnectionRepository } from "@sync/storage/repositories/provide
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
 export const CONNECTIONS_PATH = "/internal/connections";
+export const BEGIN_PATH = "/internal/connections/begin";
+// Where the provider redirects the browser after consent. The callback route
+// mounts here in a later slice; `begin` builds the redirect_uri from it now.
+export const OAUTH_CALLBACK_PATH = "/oauth/google/callback";
 
 export interface ConnectionApiDeps {
   authMiddleware: RequestHandler;
   mongo: SyncMongoService;
-  // Disconnect makes provider calls, so it is gated on execution mode.
+  // Disconnect and begin make provider calls, so they are gated on execution.
   execution: SyncExecutionMode;
   // The provider authorization adapter, present only when the provider is
   // configured. Absent (or passive mode) means no provider work is possible.
   authAdapter?: ProviderAuthAdapter;
+  // Secret the OAuth CSRF state is signed with, and the public base URL the
+  // provider callback resolves against.
+  stateSecret: string;
+  callbackBaseUrl: string;
+  // Injectable clock so state issuance is deterministic in tests.
+  now?: () => number;
 }
 
 // A generous backstop, not a throttle: the only caller is the trusted Compass
@@ -75,6 +86,67 @@ export function registerConnectionRoutes(
         // Never surface storage internals or identity to the caller.
         respondInternalError(res);
       }
+    },
+  );
+
+  // Start an OAuth authorization: return the provider consent URL carrying a
+  // signed CSRF state that binds the flow to this principal (and, for reconnect,
+  // to one existing connection). Completing consent creates/updates the
+  // connection in the callback slice; begin itself only mints the URL.
+  app.post(
+    BEGIN_PATH,
+    connectionRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps, res)) return;
+      // Authorizing touches the provider, so a passive or unconfigured service
+      // refuses rather than handing back a URL it could never complete.
+      if (deps.execution === "passive" || !deps.authAdapter) {
+        res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+        return;
+      }
+
+      // Optional connectionId means reconnect: validate it is a real id owned by
+      // this principal, so the state cannot bind a flow to a foreign connection.
+      let connectionId = null;
+      const rawConnectionId = (req.body as { connectionId?: unknown })
+        ?.connectionId;
+      if (rawConnectionId !== undefined && rawConnectionId !== null) {
+        const parsed = ConnectionIdSchema.safeParse(rawConnectionId);
+        if (!parsed.success) {
+          res
+            .status(Status.BAD_REQUEST)
+            .json({ error: "invalid_connection_id" });
+          return;
+        }
+        try {
+          const owned = await new ProviderConnectionRepository(
+            deps.mongo.db,
+          ).findById(auth.tenantId, auth.principalId, parsed.data);
+          if (!owned) {
+            res.status(Status.NOT_FOUND).json({ error: "not_found" });
+            return;
+          }
+        } catch {
+          respondInternalError(res);
+          return;
+        }
+        connectionId = parsed.data;
+      }
+
+      const state = signOAuthState(deps.stateSecret, {
+        tenantId: auth.tenantId,
+        principalId: auth.principalId,
+        connectionId,
+        issuedAt: (deps.now ?? Date.now)(),
+      });
+      const authorizationUrl = deps.authAdapter.buildAuthorizationUrl({
+        state,
+        redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
+      });
+      res.status(Status.OK).json({ authorizationUrl });
     },
   );
 


### PR DESCRIPTION
## What

The OAuth authorization **start**: `POST /internal/connections/begin` returns the provider consent URL, carrying an HMAC-signed CSRF **state** that binds the flow to the caller's principal (and, for reconnect, to one owned connection). Plus the signed-state module the (next-slice) public callback will verify.

## Security

The state is the only trust carried through the provider round-trip to the public callback, so it's signed and time-bounded exactly like `internal-auth`:

- **Signature verified before the payload is trusted** (constant-time compare); the token is `base64url(json).hmac`, and base64url contains no `.` so the split is unambiguous.
- **Decoded fields re-validated through the branded id schemas** — a tampered or malformed payload can never yield a usable principal/connection id.
- **Expiry rejects both stale and future-issued** tokens (10-min default).
- The payload holds only opaque ObjectId identities (tenant/principal/connection) — nothing sensitive rides in the URL.

## Authorization

- Tenant/principal come only from the signed internal-auth context.
- A reconnect `connectionId` is validated to be a real id **owned by the caller** (scoped `findById`) before the state binds it — the state can never bind a flow to a foreign connection.
- Gated like disconnect: passive or unconfigured → **409** (never mint a URL it couldn't complete). Rate-limited.
- `redirect_uri` is server-built from config (`callbackBaseUrl` + a fixed path), never from the request.

## Scope

`begin` only mints the URL. The public callback (verify state → exchange code → create/update connection + store credential) is the next slice, along with its post-consent redirect target.

## Test plan

- [x] `bun run test:sync` (289 pass, incl. 8 state-module security tests — forge/tamper/replay/expiry — and 6 begin HTTP tests)
- [x] `bun run type-check`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)