### PR TITLE
feat(sync): ingest provider push notifications

### DIFF
--- a/packages/sync/src/server/notification.routes.test.ts
+++ b/packages/sync/src/server/notification.routes.test.ts
@@ -1,0 +1,188 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { createSyncService, type SyncService } from "@sync/app";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { type AddressInfo } from "node:net";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: uri,
+    INTERNAL_AUTH_TOKEN: "secret",
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "active",
+    MAX_CONCURRENCY: 4,
+    ...overrides,
+  }) as SyncConfig;
+
+const CHANNEL = "chan-1";
+const RESOURCE = "res-1";
+const TOKEN = "channel-secret-token";
+
+const googHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => ({
+  "x-goog-channel-id": CHANNEL,
+  "x-goog-channel-token": TOKEN,
+  "x-goog-resource-id": RESOURCE,
+  "x-goog-resource-state": "exists",
+  ...overrides,
+});
+
+describe("POST /oauth/google/notifications", () => {
+  let mongo: SyncMongoService;
+  let resources: SyncResourceRepository;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async (config: SyncConfig = testConfig()) => {
+    service = createSyncService(config, { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  // Seed a synced resource with an active push subscription for CHANNEL.
+  const seedSubscription = async (
+    expiresAt = new Date(Date.now() + 60 * 60 * 1000),
+    token = TOKEN,
+  ) => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: objectId() as ConnectionId,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.updateSubscription(tenantId, principalId, resource._id, {
+      subscriptionId: CHANNEL,
+      subscriptionResourceId: RESOURCE,
+      subscriptionToken: token,
+      subscriptionExpiresAt: expiresAt,
+    });
+    return resource._id;
+  };
+
+  const post = (headers: Record<string, string>) =>
+    fetch(`${base}${NOTIFICATIONS_PATH}`, { method: "POST", headers });
+
+  const jobCount = (coalescingKey: string) =>
+    mongo.db
+      .collection(SYNC_COLLECTIONS.jobs)
+      .countDocuments({ coalescingKey });
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `notif_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    resources = new SyncResourceRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("enqueues one pull for an authentic change, coalescing duplicates", async () => {
+    const resourceId = await seedSubscription();
+    await startService();
+
+    const first = await post(googHeaders());
+    const second = await post(googHeaders()); // duplicate delivery
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    // Both deliveries collapse to a single incrementalPull job.
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(1);
+  });
+
+  it("does not enqueue on the initial sync handshake", async () => {
+    const resourceId = await seedSubscription();
+    await startService();
+
+    const res = await post(googHeaders({ "x-goog-resource-state": "sync" }));
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
+  });
+
+  it("rejects a spoofed token: accepts the request but enqueues nothing", async () => {
+    const resourceId = await seedSubscription();
+    await startService();
+
+    const res = await post(googHeaders({ "x-goog-channel-token": "wrong" }));
+
+    // 200 so a spoofer learns nothing and triggers no retry — but no work.
+    expect(res.status).toBe(200);
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
+  });
+
+  it("enqueues nothing for an unknown channel", async () => {
+    await startService();
+
+    const res = await post(googHeaders({ "x-goog-channel-id": "unknown" }));
+
+    expect(res.status).toBe(200);
+    expect(
+      await mongo.db.collection(SYNC_COLLECTIONS.jobs).countDocuments({}),
+    ).toBe(0);
+  });
+
+  it("enqueues nothing for a resource-id that does not match the subscription", async () => {
+    const resourceId = await seedSubscription();
+    await startService();
+
+    const res = await post(googHeaders({ "x-goog-resource-id": "other-res" }));
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
+  });
+
+  it("enqueues nothing once the subscription has expired", async () => {
+    const resourceId = await seedSubscription(new Date(Date.now() - 1000));
+    await startService();
+
+    const res = await post(googHeaders());
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
+  });
+
+  it("rejects a request with no recognizable notification headers", async () => {
+    await startService();
+
+    const res = await post({ "x-goog-resource-state": "exists" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts and drops notifications in passive mode", async () => {
+    const resourceId = await seedSubscription();
+    await startService(testConfig({ EXECUTION: "passive" }));
+
+    const res = await post(googHeaders());
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
+  });
+});

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -1,0 +1,112 @@
+import { type Express } from "express";
+import { rateLimit } from "express-rate-limit";
+import { Status } from "@core/errors/status.codes";
+import { type SyncExecutionMode } from "@sync/config/sync.config";
+import { verifyNotification } from "@sync/notifications/notification-verification";
+import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
+import { type NotificationSubscription } from "@sync/providers/provider-notifications.port";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+export const NOTIFICATIONS_PATH = "/oauth/google/notifications";
+
+// Public callbacks arrive fast and in bursts (Google fans out per change); this
+// backstop bounds a flood or a spoof storm without shaping normal delivery.
+const notificationRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 600,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// Header parsing only — no network, no auth — so one shared instance is fine.
+const googleNotifications = new GoogleNotificationAdapter();
+
+export interface NotificationApiDeps {
+  mongo: SyncMongoService;
+  execution: SyncExecutionMode;
+  now?: () => number;
+}
+
+// The public provider push-notification callback. It carries no auth — the
+// per-channel token echoed in the headers, checked against the stored
+// subscription, is the only trust. A verified change ENQUEUES a pull; it never
+// pulls inline. Every recognizable notification is acknowledged with 200 so the
+// provider does not retry, and the verdict (spoofed/handshake/change) is never
+// revealed to the caller.
+export function registerNotificationRoutes(
+  app: Express,
+  deps: NotificationApiDeps,
+): void {
+  app.post(NOTIFICATIONS_PATH, notificationRateLimit, async (req, res) => {
+    const notification = googleNotifications.parseCallback(
+      req.headers as Record<string, string | undefined>,
+    );
+    if (!notification) {
+      res.status(Status.BAD_REQUEST).end();
+      return;
+    }
+
+    // A passive service has no subscriptions to match; accept and drop.
+    if (deps.execution === "passive" || !deps.mongo.isConnected) {
+      res.status(Status.OK).end();
+      return;
+    }
+
+    try {
+      const resources = new SyncResourceRepository(deps.mongo.db);
+      const resource = await resources.findBySubscriptionId(
+        notification.channelId,
+      );
+      const now = new Date((deps.now ?? Date.now)());
+      const verdict = verifyNotification(
+        notification,
+        toSubscription(resource),
+        now,
+      );
+
+      // Only an authentic change schedules work. Coalescing on the resource
+      // collapses duplicate deliveries of the same change into one job.
+      if (verdict.status === "process" && resource) {
+        await new JobRepository(deps.mongo.db).enqueue({
+          tenantId: resource.tenantId,
+          principalId: resource.principalId,
+          connectionId: resource.connectionId,
+          resourceId: resource._id,
+          commandId: null,
+          kind: "incrementalPull",
+          priority: 0,
+          runAfter: now,
+          coalescingKey: `incrementalPull:${resource._id}`,
+        });
+      }
+      res.status(Status.OK).end();
+    } catch {
+      // A storage failure is the one case worth a retry, so signal it.
+      res.status(Status.INTERNAL_SERVER).end();
+    }
+  });
+}
+
+// Build the stored subscription verifyNotification checks against, or null when
+// the channel is unknown or its subscription is not fully recorded.
+function toSubscription(
+  resource: SyncResourceRecord | null,
+): NotificationSubscription | null {
+  if (
+    !resource?.subscriptionId ||
+    !resource.subscriptionResourceId ||
+    !resource.subscriptionToken ||
+    !resource.subscriptionExpiresAt
+  ) {
+    return null;
+  }
+  return {
+    channelId: resource.subscriptionId,
+    resourceId: resource.subscriptionResourceId,
+    token: resource.subscriptionToken,
+    expiresAt: resource.subscriptionExpiresAt,
+  };
+}

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -5,6 +5,7 @@ import {
   registerConnectionRoutes,
 } from "@sync/server/connection.routes";
 import { registerHealthRoutes } from "@sync/server/health.routes";
+import { registerNotificationRoutes } from "@sync/server/notification.routes";
 import { type StructuredServiceIdentity } from "@sync/service-identity";
 
 // Builds the Sync service's HTTP application. Health probes are always public
@@ -22,6 +23,13 @@ export function buildSyncApp(deps: {
   registerHealthRoutes(app, deps);
   if (deps.connectionApi) {
     registerConnectionRoutes(app, deps.connectionApi);
+    // The public webhook ingress shares the connection API's storage; it needs
+    // no auth adapter or secrets, only the db and execution mode.
+    registerNotificationRoutes(app, {
+      mongo: deps.connectionApi.mongo,
+      execution: deps.connectionApi.execution,
+      now: deps.connectionApi.now,
+    });
   }
 
   return app;

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -32,10 +32,12 @@ export const SyncResourceRecordSchema = z.strictObject({
   importGeneration: z.number().int().min(0),
   lastAttemptAt: z.date().nullable(),
   lastSuccessAt: z.date().nullable(),
-  // Push subscription: the provider channel id, its opaque resource id, and
-  // when it expires. All null when no subscription is active.
+  // Push subscription: the provider channel id, its opaque resource id, the
+  // per-channel secret the provider echoes back on callbacks, and when it
+  // expires. All null when no subscription is active.
   subscriptionId: z.string().min(1).nullable(),
   subscriptionResourceId: z.string().min(1).nullable(),
+  subscriptionToken: z.string().min(1).nullable(),
   subscriptionExpiresAt: z.date().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -94,6 +94,13 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       key: { subscriptionExpiresAt: 1 },
       options: { sparse: true },
     },
+    {
+      // The public notification webhook looks a resource up by its channel id
+      // on every inbound callback; sparse because most resources have none.
+      name: "subscription_id",
+      key: { subscriptionId: 1 },
+      options: { sparse: true },
+    },
     { name: "last_success", key: { lastSuccessAt: 1 } },
   ],
   [SYNC_COLLECTIONS.commands]: [

--- a/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
@@ -84,6 +84,7 @@ describe("SyncResourceRepository", () => {
       {
         subscriptionId: "chan-1",
         subscriptionResourceId: "res-1",
+        subscriptionToken: "chan-token-1",
         subscriptionExpiresAt: new Date("2026-07-27T00:00:00.000Z"),
       },
     );
@@ -154,6 +155,7 @@ describe("SyncResourceRepository", () => {
       {
         subscriptionId: "chan-1",
         subscriptionResourceId: "res-1",
+        subscriptionToken: "chan-token-1",
         subscriptionExpiresAt: new Date("2026-07-27T00:00:00.000Z"),
       },
     );

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -15,6 +15,7 @@ import {
 interface SubscriptionInput {
   subscriptionId: string;
   subscriptionResourceId: string;
+  subscriptionToken: string;
   subscriptionExpiresAt: Date;
 }
 
@@ -54,6 +55,7 @@ export class SyncResourceRepository {
           lastSuccessAt: null,
           subscriptionId: null,
           subscriptionResourceId: null,
+          subscriptionToken: null,
           subscriptionExpiresAt: null,
           createdAt: now,
           updatedAt: now,
@@ -135,11 +137,23 @@ export class SyncResourceRepository {
         $set: {
           subscriptionId: null,
           subscriptionResourceId: null,
+          subscriptionToken: null,
           subscriptionExpiresAt: null,
           updatedAt: new Date(),
         },
       },
     );
+  }
+
+  // Find the resource a provider push channel belongs to. Keyed on the channel
+  // (subscription) id alone — an inbound callback carries no tenant/principal,
+  // and the channel id is unique — so authenticity is then checked against the
+  // stored token by verifyNotification, not by this lookup.
+  async findBySubscriptionId(
+    subscriptionId: string,
+  ): Promise<SyncResourceRecord | null> {
+    const record = await this.collection.findOne({ subscriptionId });
+    return record ? SyncResourceRecordSchema.parse(record) : null;
   }
 
   // Begin a fresh import generation for a non-destructive repair. The old


### PR DESCRIPTION
## What

Adds **`POST /oauth/google/notifications`** — the public webhook the provider calls when a watched resource changes. Completes S24's ingress surface.

## Flow

`parseCallback` (S23) → `findBySubscriptionId` → `verifyNotification` (S23) → on a verified change, **enqueue** an `incrementalPull` job.

- **No auth**: the per-channel token echoed in the headers, checked against the stored subscription, is the only trust.
- A verified change **enqueues** a pull, **coalesced per resource** — so duplicate deliveries of the same change collapse to one job. **It never pulls inline.**
- Every recognizable notification is acked with **200** so the provider doesn't retry, and the verdict (spoofed / handshake / real change) is **never revealed** to the caller. `400` only for an unparseable request; `500` on a storage error (so the provider retries).

## Storage

Stores the per-channel token as durable subscription evidence: `sync_resources` gains `subscriptionToken` (set/cleared with the rest of the subscription), and a `findBySubscriptionId` lookup keyed on the **channel id alone** — an inbound callback has no tenant/principal, so authenticity comes from the token check in `verifyNotification`, not the lookup.

## Security

Enqueue is strictly gated on `verdict.status === "process"`; a spoofed token, unknown channel, resource mismatch, or expired subscription all get `200` with **no work**. Rate-limited; refuses to act in passive mode.

## Test plan

- [x] `bun run test:sync` (308 pass, incl. 8 ingress tests: coalesced duplicate → 1 job, handshake, spoofed token, unknown channel, resource mismatch, expired, malformed → 400, passive)
- [x] `bun run type-check`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)