### PR TITLE
feat(sync): expose the internal calendar query

### DIFF
--- a/packages/sync/src/server/connection.routes.test.ts
+++ b/packages/sync/src/server/connection.routes.test.ts
@@ -896,6 +896,19 @@ describe("GET /internal/calendars", () => {
     expect(res.status).toBe(400);
   });
 
+  it("rejects a repeated connectionId that Express parses as an array", async () => {
+    await startService();
+    const conn = objectId();
+
+    const res = await get(
+      objectId(),
+      objectId(),
+      `?connectionId=${conn}&connectionId=${objectId()}`,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
   it("rejects an unsigned request", async () => {
     await startService();
 

--- a/packages/sync/src/server/connection.routes.test.ts
+++ b/packages/sync/src/server/connection.routes.test.ts
@@ -20,10 +20,12 @@ import {
 } from "@sync/providers/provider-auth.port";
 import {
   BEGIN_PATH,
+  CALENDARS_PATH,
   CONNECTIONS_PATH,
   OAUTH_CALLBACK_PATH,
 } from "@sync/server/connection.routes";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
@@ -753,5 +755,152 @@ describe("GET /oauth/google/callback", () => {
 
     expect(statusOf(res)).toBe("error");
     expect(adapter.exchanges).toHaveLength(0);
+  });
+});
+
+describe("GET /internal/calendars", () => {
+  let mongo: SyncMongoService;
+  let calendars: ProviderCalendarRepository;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async (config: SyncConfig = testConfig()) => {
+    service = createSyncService(config, { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  const seedCalendar = (
+    tenantId: string,
+    principalId: string,
+    overrides: {
+      connectionId?: string;
+      displayName?: string;
+      active?: boolean;
+    } = {},
+  ) =>
+    calendars.upsertByProviderCalendar({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: (overrides.connectionId ?? objectId()) as ConnectionId,
+      providerCalendarId: objectId(),
+      displayName: overrides.displayName ?? "My Calendar",
+      color: null,
+      active: overrides.active ?? true,
+      primary: false,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  const get = (tenantId: string, principalId: string, query = "") =>
+    fetch(`${base}${CALENDARS_PATH}${query}`, {
+      headers: signedHeaders(tenantId, principalId),
+    });
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `cal_api_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    calendars = new ProviderCalendarRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("returns the caller's calendars mapped to the wire contract", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedCalendar(tenantId, principalId, { displayName: "Work" });
+    await startService();
+
+    const res = await get(tenantId, principalId);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      calendars: Array<Record<string, unknown>>;
+    };
+    expect(body.calendars).toHaveLength(1);
+    expect(body.calendars[0]).toMatchObject({
+      principalId,
+      displayName: "Work",
+      accessRole: "owner",
+    });
+    expect(typeof body.calendars[0].createdAt).toBe("string");
+  });
+
+  it("scopes results to the authenticated principal", async () => {
+    const tenantId = objectId();
+    const mine = objectId();
+    const other = objectId();
+    await seedCalendar(tenantId, mine, { displayName: "Mine" });
+    await seedCalendar(tenantId, other, { displayName: "Theirs" });
+    await startService();
+
+    const body = (await (await get(tenantId, mine)).json()) as {
+      calendars: Array<{ displayName: string }>;
+    };
+    expect(body.calendars).toHaveLength(1);
+    expect(body.calendars[0].displayName).toBe("Mine");
+  });
+
+  it("narrows to one connection when connectionId is given", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const conn = objectId();
+    await seedCalendar(tenantId, principalId, { connectionId: conn });
+    await seedCalendar(tenantId, principalId, { connectionId: objectId() });
+    await startService();
+
+    const body = (await (
+      await get(tenantId, principalId, `?connectionId=${conn}`)
+    ).json()) as { calendars: unknown[] };
+    expect(body.calendars).toHaveLength(1);
+  });
+
+  it("returns only active calendars when activeOnly=true", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedCalendar(tenantId, principalId, { active: true });
+    await seedCalendar(tenantId, principalId, { active: false });
+    await startService();
+
+    const all = (await (await get(tenantId, principalId)).json()) as {
+      calendars: unknown[];
+    };
+    const activeOnly = (await (
+      await get(tenantId, principalId, "?activeOnly=true")
+    ).json()) as { calendars: unknown[] };
+
+    expect(all.calendars).toHaveLength(2);
+    expect(activeOnly.calendars).toHaveLength(1);
+  });
+
+  it("rejects a malformed connectionId filter", async () => {
+    await startService();
+
+    const res = await get(objectId(), objectId(), "?connectionId=nope");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unsigned request", async () => {
+    await startService();
+
+    const res = await fetch(`${base}${CALENDARS_PATH}`);
+
+    expect(res.status).toBe(401);
   });
 });

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -7,7 +7,10 @@ import {
 import { rateLimit } from "express-rate-limit";
 import { Status } from "@core/errors/status.codes";
 import {
+  type CalendarListResponse,
   type ConnectionListResponse,
+  type ProviderCalendar,
+  ProviderCalendarSchema,
   type ProviderConnection,
   ProviderConnectionSchema,
 } from "@core/types/sync/connection.contracts";
@@ -24,12 +27,15 @@ import { deriveConnectionState } from "@sync/domain/connection-state";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
 import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
 export const CONNECTIONS_PATH = "/internal/connections";
+export const CALENDARS_PATH = "/internal/calendars";
 export const BEGIN_PATH = "/internal/connections/begin";
 // Where the provider redirects the browser after consent; `begin` builds the
 // redirect_uri from it and the public callback route below mounts on it.
@@ -94,6 +100,49 @@ export function registerConnectionRoutes(
         res.status(Status.OK).json(response);
       } catch {
         // Never surface storage internals or identity to the caller.
+        respondInternalError(res);
+      }
+    },
+  );
+
+  // List the caller's provider calendars, optionally narrowed to one connection
+  // (?connectionId=) and/or active calendars only (?activeOnly=true). Scoped to
+  // the signed principal; a read, so it is served in passive mode too.
+  app.get(
+    CALENDARS_PATH,
+    connectionRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps, res)) return;
+
+      // A bad connectionId is a bad request, not an empty result.
+      const rawConnectionId = req.query["connectionId"];
+      let connectionId: ConnectionId | undefined;
+      if (typeof rawConnectionId === "string") {
+        const parsed = ConnectionIdSchema.safeParse(rawConnectionId);
+        if (!parsed.success) {
+          res
+            .status(Status.BAD_REQUEST)
+            .json({ error: "invalid_connection_id" });
+          return;
+        }
+        connectionId = parsed.data;
+      }
+
+      try {
+        const repo = new ProviderCalendarRepository(deps.mongo.db);
+        const records = await repo.listByPrincipal(
+          auth.tenantId,
+          auth.principalId,
+          { connectionId, activeOnly: req.query["activeOnly"] === "true" },
+        );
+        const response: CalendarListResponse = {
+          calendars: records.map(toProviderCalendar),
+        };
+        res.status(Status.OK).json(response);
+      } catch {
         respondInternalError(res);
       }
     },
@@ -418,6 +467,28 @@ export function toProviderConnection(
     stateReason: record.stateReason,
     lastSyncedAt: record.lastSyncedAt?.toISOString() ?? null,
     lastHealthyAt: record.lastHealthyAt?.toISOString() ?? null,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+  });
+}
+
+// Map a stored calendar record (string ids, Date timestamps) to the wire
+// contract (ISO-string timestamps), validated through the schema on the way out.
+export function toProviderCalendar(
+  record: ProviderCalendarRecord,
+): ProviderCalendar {
+  return ProviderCalendarSchema.parse({
+    id: record._id,
+    tenantId: record.tenantId,
+    principalId: record.principalId,
+    connectionId: record.connectionId,
+    providerCalendarId: record.providerCalendarId,
+    displayName: record.displayName,
+    color: record.color,
+    active: record.active,
+    primary: record.primary,
+    accessRole: record.accessRole,
+    capabilities: record.capabilities,
     createdAt: record.createdAt.toISOString(),
     updatedAt: record.updatedAt.toISOString(),
   });

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -117,12 +117,16 @@ export function registerConnectionRoutes(
       if (!auth) return;
       if (!ensureConnected(deps, res)) return;
 
-      // A bad connectionId is a bad request, not an empty result.
+      // A present-but-bad connectionId (malformed, or repeated so Express parses
+      // it as an array) is a bad request, not a silently-unfiltered result.
       const rawConnectionId = req.query["connectionId"];
       let connectionId: ConnectionId | undefined;
-      if (typeof rawConnectionId === "string") {
-        const parsed = ConnectionIdSchema.safeParse(rawConnectionId);
-        if (!parsed.success) {
+      if (rawConnectionId !== undefined) {
+        const parsed =
+          typeof rawConnectionId === "string"
+            ? ConnectionIdSchema.safeParse(rawConnectionId)
+            : null;
+        if (!parsed?.success) {
           res
             .status(Status.BAD_REQUEST)
             .json({ error: "invalid_connection_id" });

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -1,4 +1,4 @@
-import { type Collection, type Db, ObjectId } from "mongodb";
+import { type Collection, type Db, type Filter, ObjectId } from "mongodb";
 import {
   type ConnectionId,
   type PrincipalId,
@@ -88,5 +88,20 @@ export class ProviderCalendarRepository {
       principalId,
     });
     return record ? ProviderCalendarRecordSchema.parse(record) : null;
+  }
+
+  // List a principal's calendars, optionally narrowed to one connection and/or
+  // to active calendars only. Always scoped to the owning tenant/principal.
+  async listByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    filter: { connectionId?: ConnectionId; activeOnly?: boolean } = {},
+  ): Promise<ProviderCalendarRecord[]> {
+    const query: Filter<ProviderCalendarRecord> = { tenantId, principalId };
+    if (filter.connectionId) query.connectionId = filter.connectionId;
+    if (filter.activeOnly) query.active = true;
+
+    const records = await this.collection.find(query).toArray();
+    return records.map((r) => ProviderCalendarRecordSchema.parse(r));
   }
 }


### PR DESCRIPTION
## What

`GET /internal/calendars` lists the caller's provider calendars, optionally narrowed to one connection (`?connectionId=`) or to active calendars only (`?activeOnly=true`). First half of the S25 query surface (the bounded event/occurrence query is a follow-up).

## Behavior

- Tenant/principal come only from the signed internal-auth context, so a caller sees only its own principal's calendars. `listByPrincipal`'s Mongo filter is strictly tenant+principal scoped; the optional filters *narrow* it.
- A malformed `connectionId` is a **400**, not a silently-empty result.
- Records map to the ISO-string wire contract, validated through `ProviderCalendarSchema` on the way out.
- A read — served in passive mode, behind the shared rate limiter.

## Test plan

- [x] `bun run test:sync` (314 pass, incl. 6 new: wire mapping, principal scoping, connection filter, active-only filter, malformed-id 400, unsigned 401)
- [x] `bun run type-check`
- [x] `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)