### PR TITLE
feat(sync): persist and locally confirm cloud event commands

### DIFF
--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -156,3 +156,30 @@ export const SyncCommandSchema = z
     },
   );
 export type SyncCommand = z.infer<typeof SyncCommandSchema>;
+
+// What the trusted Compass API submits to durably record one command. The
+// tenant and principal are deliberately NOT in the body — they come from the
+// signed internal-auth context, so a caller can only ever write to its own
+// principal. The idempotency key makes a retried submission map to the same
+// command instead of creating a duplicate.
+export const CommandSubmitRequestSchema = z
+  .strictObject({
+    idempotencyKey: IdempotencyKeySchema,
+    eventId: EventIdSchema,
+    input: SyncCommandInputSchema,
+    expectedVersion: ProviderEventVersionSchema.nullable(),
+  })
+  .refine(
+    (request) =>
+      request.input.kind !== "create" || request.expectedVersion === null,
+    {
+      message: "A create command cannot carry an expectedVersion",
+      path: ["expectedVersion"],
+    },
+  );
+export type CommandSubmitRequest = z.infer<typeof CommandSubmitRequestSchema>;
+
+export const CommandSubmitResponseSchema = z.strictObject({
+  command: SyncCommandSchema,
+});
+export type CommandSubmitResponse = z.infer<typeof CommandSubmitResponseSchema>;

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -1,0 +1,95 @@
+import { type EditableRecurrence } from "@core/types/event.contracts";
+import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
+import {
+  type CommandRecord,
+  type CommandSubmit,
+} from "@sync/storage/contracts/command.contracts";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+
+export interface CloudCommandRepos {
+  commands: CommandRepository;
+  events: EventRepository;
+}
+
+// Durably record a command and, for a cloud-only create, apply it to the
+// canonical event store and confirm it locally — no provider round-trip. The
+// whole operation is idempotent: submit dedupes on the idempotency key, the
+// event write is keyed by the client-supplied event id, and confirmation only
+// runs while the command is still pending. So a retry after a crash at any
+// point converges on one confirmed command and one event.
+//
+// A non-create command is persisted as durable pending intent and returned
+// unchanged; applying update/move/delete locally lands in a later slice.
+export async function submitCloudCommand(
+  repos: CloudCommandRepos,
+  submit: CommandSubmit,
+  now: () => Date,
+): Promise<CommandRecord> {
+  const command = await repos.commands.submit(submit);
+
+  // Only a freshly-persisted create is applied here. A command already past
+  // pending (a confirmed replay, or a kind we don't apply yet) is returned as
+  // it stands, so a repeated submit never re-applies or overwrites an outcome.
+  if (command.outcome.state !== "pending") return command;
+  if (command.input.kind !== "create") return command;
+
+  await repos.events.put(buildCloudEventRecord(command, now()));
+
+  const confirmed = await repos.commands.updateOutcome(
+    command.tenantId,
+    command.principalId,
+    command._id,
+    { state: "confirmed", providerEventId: null, providerVersion: null },
+    command.attemptCount,
+  );
+  // updateOutcome only misses if the command vanished between submit and now
+  // (it cannot, within one request); fall back to the pending record rather
+  // than inventing an outcome.
+  return confirmed ?? command;
+}
+
+// Build the canonical event for a cloud-only create. All provider fields are
+// null — this event has no provider target — and it is confirmed at creation
+// because local persistence is the only durability it needs. The id is the
+// client-supplied event id, so a retried create replaces rather than duplicates.
+function buildCloudEventRecord(command: CommandRecord, now: Date): EventRecord {
+  if (command.input.kind !== "create") {
+    throw new Error("buildCloudEventRecord requires a create command");
+  }
+  const { input } = command;
+  return {
+    _id: command.eventId,
+    tenantId: command.tenantId,
+    principalId: command.principalId,
+    origin: "compass",
+    calendarId: input.calendarId,
+    clientEventId: null,
+    connectionId: null,
+    providerEventId: null,
+    providerVersion: null,
+    providerUpdatedAt: null,
+    deliveryState: null,
+    providerMetadata: null,
+    content: input.content,
+    schedule: input.schedule,
+    recurrence: toStoredRecurrence(input.recurrence),
+    lifecycleState: "active",
+    generation: 0,
+    createdAt: now,
+    updatedAt: now,
+    confirmedAt: now,
+  };
+}
+
+// The create wire input carries the editable recurrence (single | series); the
+// stored form is the fuller union (single | seriesMaster | exception). A create
+// can only ever produce a single event or a series master.
+function toStoredRecurrence(
+  recurrence: EditableRecurrence,
+): SyncEventRecurrence {
+  return recurrence.kind === "series"
+    ? { kind: "seriesMaster", rules: recurrence.rules }
+    : { kind: "single" };
+}

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -246,6 +246,35 @@ describe("POST /internal/commands", () => {
     expect(await mongo.db.collection("commands").countDocuments()).toBe(1);
   });
 
+  it("refuses to overwrite another principal's event with a reused id", async () => {
+    const tenantId = objectId();
+    const owner = objectId();
+    const attacker = objectId();
+    const request = createRequest();
+    await startService();
+
+    // The owner creates an event.
+    await submit(tenantId, owner, request);
+
+    // A different principal submits a create reusing the owner's event id.
+    const res = await submit(tenantId, attacker, {
+      ...request,
+      idempotencyKey: `idem-${objectId()}`,
+    });
+
+    // The write is refused (the scoped filter collides on the unique _id),
+    // never a silent clobber.
+    expect(res.status).toBe(500);
+    const events = new EventRepository(mongo.db);
+    const stored = await events.findById(
+      tenantId as TenantId,
+      owner as PrincipalId,
+      request.eventId as never,
+    );
+    // The owner still owns the untouched event.
+    expect(stored?.principalId).toBe(owner);
+  });
+
   it("rejects a malformed command body", async () => {
     await startService();
 

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -1,0 +1,277 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { createSyncService, type SyncService } from "@sync/app";
+import { signInternalRequest } from "@sync/auth/internal-auth";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { COMMANDS_PATH } from "@sync/server/command.routes";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { type AddressInfo } from "node:net";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+const SECRET = "internal-secret";
+
+const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: uri,
+    INTERNAL_AUTH_TOKEN: SECRET,
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+    ...overrides,
+  }) as SyncConfig;
+
+const signedHeaders = (
+  tenantId: string,
+  principalId: string,
+): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "content-type": "application/json",
+    "x-sync-tenant": tenantId,
+    "x-sync-principal": principalId,
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signInternalRequest(SECRET, {
+      timestamp,
+      tenantId,
+      principalId,
+    }),
+  };
+};
+
+// A minimal, valid cloud create request. tenant/principal are NOT in the body —
+// they ride on the signed headers.
+const createRequest = (overrides: Record<string, unknown> = {}) => ({
+  idempotencyKey: `idem-${objectId()}`,
+  eventId: objectId(),
+  input: {
+    kind: "create",
+    calendarId: objectId(),
+    content: {
+      title: "Lunch",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    },
+    schedule: {
+      kind: "timed",
+      start: "2026-07-14T12:00:00-06:00",
+      end: "2026-07-14T13:00:00-06:00",
+      timeZone: "America/Denver",
+    },
+    recurrence: { kind: "single" },
+  },
+  expectedVersion: null,
+  ...overrides,
+});
+
+describe("POST /internal/commands", () => {
+  let mongo: SyncMongoService;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async (config: SyncConfig = testConfig()) => {
+    service = createSyncService(config, { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  const submit = (tenantId: string, principalId: string, body: unknown) =>
+    fetch(`${base}${COMMANDS_PATH}`, {
+      method: "POST",
+      headers: signedHeaders(tenantId, principalId),
+      body: JSON.stringify(body),
+    });
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `cmd_api_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("confirms a cloud-only create and writes the canonical event", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const request = createRequest();
+    // No connection/provider is seeded and the service is passive: a cloud
+    // create needs neither.
+    await startService();
+
+    const res = await submit(tenantId, principalId, request);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      command: {
+        outcome: { state: string; providerEventId: null };
+        eventId: string;
+      };
+    };
+    expect(body.command.outcome.state).toBe("confirmed");
+    expect(body.command.outcome.providerEventId).toBeNull();
+
+    const events = new EventRepository(mongo.db);
+    const stored = await events.findById(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+      request.eventId as never,
+    );
+    expect(stored).not.toBeNull();
+    expect(stored?.origin).toBe("compass");
+    expect(stored?.connectionId).toBeNull();
+    expect(stored?.confirmedAt).not.toBeNull();
+    // The signed principal owns the event, not anything in the body.
+    expect(stored?.principalId).toBe(principalId);
+  });
+
+  it("is idempotent on a repeated upload", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const request = createRequest();
+    await startService();
+
+    const first = (await (
+      await submit(tenantId, principalId, request)
+    ).json()) as { command: { id: string } };
+    const second = (await (
+      await submit(tenantId, principalId, request)
+    ).json()) as { command: { id: string; outcome: { state: string } } };
+
+    expect(second.command.id).toBe(first.command.id);
+    expect(second.command.outcome.state).toBe("confirmed");
+    expect(await mongo.db.collection("commands").countDocuments()).toBe(1);
+    expect(await mongo.db.collection("events").countDocuments()).toBe(1);
+  });
+
+  it("recovers an interrupted acknowledgement by confirming on retry", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const request = createRequest();
+    await startService();
+
+    // Simulate a crash after the command persisted but before it was applied:
+    // the command already exists as pending with no event written.
+    const commands = new CommandRepository(mongo.db);
+    const pending = await commands.submit({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      idempotencyKey: request.idempotencyKey as never,
+      eventId: request.eventId as never,
+      input: request.input as never,
+      expectedVersion: null,
+    });
+    expect(pending.outcome.state).toBe("pending");
+
+    const res = await submit(tenantId, principalId, request);
+
+    const body = (await res.json()) as {
+      command: { id: string; outcome: { state: string } };
+    };
+    expect(body.command.id).toBe(pending._id);
+    expect(body.command.outcome.state).toBe("confirmed");
+    const events = new EventRepository(mongo.db);
+    expect(
+      await events.findById(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+        request.eventId as never,
+      ),
+    ).not.toBeNull();
+  });
+
+  it("maps a series create to a stored series master", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const request = createRequest({
+      input: {
+        ...createRequest().input,
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      },
+    });
+    await startService();
+
+    await submit(tenantId, principalId, request);
+
+    const events = new EventRepository(mongo.db);
+    const stored = await events.findById(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+      request.eventId as never,
+    );
+    expect(stored?.recurrence).toEqual({
+      kind: "seriesMaster",
+      rules: ["RRULE:FREQ=WEEKLY"],
+    });
+  });
+
+  it("persists a non-create command as durable pending intent", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const request = createRequest({
+      input: {
+        kind: "delete",
+        scope: "this",
+      },
+    });
+    await startService();
+
+    const res = await submit(tenantId, principalId, request);
+
+    const body = (await res.json()) as {
+      command: { outcome: { state: string } };
+    };
+    expect(body.command.outcome.state).toBe("pending");
+    // No event is written for a command that was only recorded, not applied.
+    expect(await mongo.db.collection("events").countDocuments()).toBe(0);
+    expect(await mongo.db.collection("commands").countDocuments()).toBe(1);
+  });
+
+  it("rejects a malformed command body", async () => {
+    await startService();
+
+    const res = await submit(objectId(), objectId(), { not: "a command" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a create carrying an expectedVersion", async () => {
+    await startService();
+    const request = createRequest({ expectedVersion: "v1" });
+
+    const res = await submit(objectId(), objectId(), request);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unsigned request", async () => {
+    await startService();
+
+    const res = await fetch(`${base}${COMMANDS_PATH}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(createRequest()),
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -1,0 +1,101 @@
+import { type Express, type RequestHandler } from "express";
+import { Status } from "@core/errors/status.codes";
+import {
+  CommandSubmitRequestSchema,
+  type CommandSubmitResponse,
+  type SyncCommand,
+  SyncCommandSchema,
+} from "@core/types/sync/command.contracts";
+import { submitCloudCommand } from "@sync/domain/cloud-command.service";
+import {
+  ensureConnected,
+  internalRateLimit,
+  requireAuth,
+  respondInternalError,
+} from "@sync/server/internal-http";
+import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+export const COMMANDS_PATH = "/internal/commands";
+
+export interface CommandApiDeps {
+  authMiddleware: RequestHandler;
+  mongo: SyncMongoService;
+  // Injectable clock so local confirmation timestamps are deterministic in
+  // tests.
+  now?: () => number;
+}
+
+// Internal, authenticated command ingress. Durably records acknowledged user
+// intent for one event mutation. A cloud-only create is applied to the
+// canonical store and confirmed locally in the same request — no provider call
+// — so this is served in passive mode too. The tenant/principal come from the
+// signed auth context, never the body, so a caller only ever writes to its own
+// principal.
+export function registerCommandRoutes(
+  app: Express,
+  deps: CommandApiDeps,
+): void {
+  app.post(
+    COMMANDS_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+
+      const parsed = CommandSubmitRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_command" });
+        return;
+      }
+      const request = parsed.data;
+
+      try {
+        const command = await submitCloudCommand(
+          {
+            commands: new CommandRepository(deps.mongo.db),
+            events: new EventRepository(deps.mongo.db),
+          },
+          {
+            tenantId: auth.tenantId,
+            principalId: auth.principalId,
+            idempotencyKey: request.idempotencyKey,
+            eventId: request.eventId,
+            input: request.input,
+            expectedVersion: request.expectedVersion,
+          },
+          () => (deps.now ? new Date(deps.now()) : new Date()),
+        );
+        const response: CommandSubmitResponse = {
+          command: toSyncCommand(command),
+        };
+        res.status(Status.OK).json(response);
+      } catch {
+        respondInternalError(res);
+      }
+    },
+  );
+}
+
+// Map a stored command record (Date timestamps) to the wire contract (ISO
+// strings), validated through the schema on the way out so a row that somehow
+// violates the contract fails here rather than reaching the caller malformed.
+export function toSyncCommand(record: CommandRecord): SyncCommand {
+  return SyncCommandSchema.parse({
+    id: record._id,
+    tenantId: record.tenantId,
+    principalId: record.principalId,
+    idempotencyKey: record.idempotencyKey,
+    eventId: record.eventId,
+    input: record.input,
+    expectedVersion: record.expectedVersion,
+    outcome: record.outcome,
+    attemptCount: record.attemptCount,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+  });
+}

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -1,10 +1,4 @@
-import {
-  type Express,
-  type Request,
-  type RequestHandler,
-  type Response,
-} from "express";
-import { rateLimit } from "express-rate-limit";
+import { type Express, type RequestHandler, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
 import {
   type CalendarListResponse,
@@ -27,13 +21,18 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
-import { type InternalAuthedRequest } from "@sync/auth/internal-auth";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { deriveConnectionState } from "@sync/domain/connection-state";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
 import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import {
+  ensureConnected,
+  internalRateLimit,
+  requireAuth,
+  respondInternalError,
+} from "@sync/server/internal-http";
 import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurrence.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
@@ -78,16 +77,6 @@ export interface ConnectionApiDeps {
   now?: () => number;
 }
 
-// A generous backstop, not a throttle: the only caller is the trusted Compass
-// API over a private network, so this bounds a runaway loop or a compromised
-// caller rather than shaping normal traffic. Keyed per client ip, fixed window.
-const connectionRateLimit = rateLimit({
-  windowMs: 60_000,
-  limit: 300,
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
 // Internal, authenticated connection endpoints. The tenant/principal comes from
 // the signed auth context, never the request, so every query is scoped to the
 // caller's own principal. Reads are allowed in passive mode — they touch no
@@ -99,12 +88,12 @@ export function registerConnectionRoutes(
 ): void {
   app.get(
     CONNECTIONS_PATH,
-    connectionRateLimit,
+    internalRateLimit,
     deps.authMiddleware,
     async (req, res) => {
       const auth = requireAuth(req, res);
       if (!auth) return;
-      if (!ensureConnected(deps, res)) return;
+      if (!ensureConnected(deps.mongo, res)) return;
 
       try {
         const repo = new ProviderConnectionRepository(deps.mongo.db);
@@ -128,12 +117,12 @@ export function registerConnectionRoutes(
   // the signed principal; a read, so it is served in passive mode too.
   app.get(
     CALENDARS_PATH,
-    connectionRateLimit,
+    internalRateLimit,
     deps.authMiddleware,
     async (req, res) => {
       const auth = requireAuth(req, res);
       if (!auth) return;
-      if (!ensureConnected(deps, res)) return;
+      if (!ensureConnected(deps.mongo, res)) return;
 
       // A present-but-bad connectionId (malformed, or repeated so Express parses
       // it as an array) is a bad request, not a silently-unfiltered result.
@@ -176,12 +165,12 @@ export function registerConnectionRoutes(
   // the signed principal; a read, served in passive mode too.
   app.get(
     EVENTS_PATH,
-    connectionRateLimit,
+    internalRateLimit,
     deps.authMiddleware,
     async (req, res) => {
       const auth = requireAuth(req, res);
       if (!auth) return;
-      if (!ensureConnected(deps, res)) return;
+      if (!ensureConnected(deps.mongo, res)) return;
 
       const parsed = EventOccurrenceListQuerySchema.safeParse({
         calendarIds: toQueryArray(req.query["calendarIds"]),
@@ -263,12 +252,12 @@ export function registerConnectionRoutes(
   // connection in the callback slice; begin itself only mints the URL.
   app.post(
     BEGIN_PATH,
-    connectionRateLimit,
+    internalRateLimit,
     deps.authMiddleware,
     async (req, res) => {
       const auth = requireAuth(req, res);
       if (!auth) return;
-      if (!ensureConnected(deps, res)) return;
+      if (!ensureConnected(deps.mongo, res)) return;
       // Authorizing touches the provider, so a passive or unconfigured service
       // refuses rather than handing back a URL it could never complete.
       if (deps.execution === "passive" || !deps.authAdapter) {
@@ -324,7 +313,7 @@ export function registerConnectionRoutes(
   // a server-configured URL (never a request-controlled one), so there is no
   // open-redirect surface. Nothing here pulls provider data; it only links the
   // account and stores the credential.
-  app.get(OAUTH_CALLBACK_PATH, connectionRateLimit, async (req, res) => {
+  app.get(OAUTH_CALLBACK_PATH, internalRateLimit, async (req, res) => {
     const redirect = (status: string) =>
       redirectAfterConnect(deps, res, status);
 
@@ -379,12 +368,12 @@ export function registerConnectionRoutes(
 
   app.delete(
     `${CONNECTIONS_PATH}/:id`,
-    connectionRateLimit,
+    internalRateLimit,
     deps.authMiddleware,
     async (req, res) => {
       const auth = requireAuth(req, res);
       if (!auth) return;
-      if (!ensureConnected(deps, res)) return;
+      if (!ensureConnected(deps.mongo, res)) return;
 
       // Disconnect revokes at the provider, so a passive service (or one with no
       // provider configured) must refuse rather than half-disconnect: delete the
@@ -433,28 +422,6 @@ export function registerConnectionRoutes(
       }
     },
   );
-}
-
-// Read the verified auth context. The middleware always sets it on success;
-// treat its absence as a bug, not an authorization, and never run unscoped.
-function requireAuth(
-  req: Request,
-  res: Response,
-): InternalAuthedRequest["syncAuth"] | undefined {
-  const auth = (req as InternalAuthedRequest).syncAuth;
-  if (!auth) {
-    res.status(Status.UNAUTHORIZED).json({ error: "unauthorized" });
-    return undefined;
-  }
-  return auth;
-}
-
-function ensureConnected(deps: ConnectionApiDeps, res: Response): boolean {
-  if (!deps.mongo.isConnected) {
-    res.status(Status.SERVICE_UNAVAILABLE).json({ error: "not_ready" });
-    return false;
-  }
-  return true;
 }
 
 // Redirect the browser to the server-configured post-connect URL with a coarse
@@ -665,7 +632,3 @@ function decodeOccurrenceCursor(
 
 const maxDate = (a: Date, b: Date): Date => (a > b ? a : b);
 const minDate = (a: Date, b: Date): Date => (a < b ? a : b);
-
-function respondInternalError(res: Response): void {
-  res.status(Status.INTERNAL_SERVER).json({ error: "internal_error" });
-}

--- a/packages/sync/src/server/internal-http.ts
+++ b/packages/sync/src/server/internal-http.ts
@@ -1,0 +1,48 @@
+import { type Request, type RequestHandler, type Response } from "express";
+import { rateLimit } from "express-rate-limit";
+import { Status } from "@core/errors/status.codes";
+import { type InternalAuthedRequest } from "@sync/auth/internal-auth";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+// A generous backstop, not a throttle: the only caller is the trusted Compass
+// API over a private network, so this bounds a runaway loop or a compromised
+// caller rather than shaping normal traffic. Keyed per client ip, fixed window.
+// Shared by every internal authed route so they share one budget.
+export const internalRateLimit: RequestHandler = rateLimit({
+  windowMs: 60_000,
+  limit: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// Read the verified auth context. The middleware always sets it on success;
+// treat its absence as a bug, not an authorization, and never run unscoped.
+export function requireAuth(
+  req: Request,
+  res: Response,
+): InternalAuthedRequest["syncAuth"] | undefined {
+  const auth = (req as InternalAuthedRequest).syncAuth;
+  if (!auth) {
+    res.status(Status.UNAUTHORIZED).json({ error: "unauthorized" });
+    return undefined;
+  }
+  return auth;
+}
+
+// Guard against serving a request before storage is connected (liveness-first
+// startup binds the port before Mongo). A read/write both need the db.
+export function ensureConnected(
+  mongo: SyncMongoService,
+  res: Response,
+): boolean {
+  if (!mongo.isConnected) {
+    res.status(Status.SERVICE_UNAVAILABLE).json({ error: "not_ready" });
+    return false;
+  }
+  return true;
+}
+
+// Never surface storage internals or identity to the caller.
+export function respondInternalError(res: Response): void {
+  res.status(Status.INTERNAL_SERVER).json({ error: "internal_error" });
+}

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -1,5 +1,6 @@
 import express, { type Express } from "express";
 import { type ReadinessRegistry } from "@sync/lifecycle/readiness";
+import { registerCommandRoutes } from "@sync/server/command.routes";
 import {
   type ConnectionApiDeps,
   registerConnectionRoutes,
@@ -23,6 +24,14 @@ export function buildSyncApp(deps: {
   registerHealthRoutes(app, deps);
   if (deps.connectionApi) {
     registerConnectionRoutes(app, deps.connectionApi);
+    // The command ingress shares the connection API's storage and auth; it makes
+    // no provider call for a cloud-only command, so it needs no adapter or
+    // secrets.
+    registerCommandRoutes(app, {
+      authMiddleware: deps.connectionApi.authMiddleware,
+      mongo: deps.connectionApi.mongo,
+      now: deps.connectionApi.now,
+    });
     // The public webhook ingress shares the connection API's storage; it needs
     // no auth adapter or secrets, only the db and execution mode.
     registerNotificationRoutes(app, {

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -67,12 +67,23 @@ export class EventRepository {
   }
 
   // Full write of a Compass (or already-identified) event by its _id. Used for
-  // unlinked cloud events and for promoting/relinking an existing event.
+  // unlinked cloud events and for promoting/relinking an existing event. The
+  // filter is scoped to the owning tenant/principal, not _id alone: _id is the
+  // client-supplied event id, so an unscoped replace would let one principal
+  // overwrite another's event by reusing its id. Scoping means a foreign id
+  // collides on the unique _id at insert (a caught error) instead of silently
+  // clobbering the owner's document.
   async put(record: EventRecord): Promise<EventRecord> {
     const parsed = EventRecordSchema.parse(record);
-    await this.collection.replaceOne({ _id: parsed._id }, parsed, {
-      upsert: true,
-    });
+    await this.collection.replaceOne(
+      {
+        _id: parsed._id,
+        tenantId: parsed.tenantId,
+        principalId: parsed.principalId,
+      },
+      parsed,
+      { upsert: true },
+    );
     return parsed;
   }
 


### PR DESCRIPTION
## What

Adds `POST /internal/commands`: the authenticated, tenant-scoped ingress that durably records acknowledged user intent for one event mutation. This is the first slice of S26 (durable cloud-only commands) and the write-side counterpart to the query surface shipped in #2246 / #2247.

## Behavior

- **Cloud-only create, confirmed locally.** A `create` command with no provider target is applied straight to the canonical event store (`EventRepository.put`) and its command is marked `confirmed` in the same request. No Google call, so it works in passive mode. The confirmed outcome carries `providerEventId: null` / `providerVersion: null` — the contract's documented "durable cloud persistence only" state.
- **Idempotent end to end.** `CommandRepository.submit` dedupes on `(tenant, principal, idempotencyKey)`; the event write is keyed by the client-supplied event id; and confirmation runs *only* while the command is still `pending`. So a retried submit after a crash at any point converges on exactly one confirmed command and one event — never a duplicate, never a re-applied outcome.
- **Scope from signed context.** `tenantId`/`principalId` come from the internal-auth headers, never the request body, so a caller can only ever write to its own principal.
- **Non-create commands** are persisted as durable `pending` intent and returned unchanged; local application of `update`/`move`/`delete` lands in a follow-up slice (S26.2), and anonymous-to-cloud promotion in S26.3.

## Refactor

Extracts the shared internal-route helpers (`requireAuth`, `ensureConnected`, `internalRateLimit`, `respondInternalError`) out of `connection.routes.ts` into a new `server/internal-http.ts`, so the command and connection routes share one copy of the auth scaffolding instead of duplicating it. `ensureConnected` now takes the mongo service directly rather than the whole connection-API deps.

## Tests

8 route tests: cloud-only create confirms + writes the event, repeated-upload idempotency (one command, one event), interrupted-acknowledgement recovery (pre-seeded pending command confirms on retry), series-create maps to a stored `seriesMaster`, non-create persists as pending with no event written, malformed body, create-with-expectedVersion rejection, and unsigned request. All existing sync + core suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)