### PR TITLE
feat(sync): preserve device identity when promoting a cloud event

### DIFF
--- a/packages/core/src/types/sync/command.contracts.test.ts
+++ b/packages/core/src/types/sync/command.contracts.test.ts
@@ -84,6 +84,23 @@ describe("Sync command contracts", () => {
       );
     });
 
+    it("defaults a create's clientEventId to null when absent", () => {
+      const parsed = SyncCommandInputSchema.safeParse(createInput());
+      expect(parsed.success && parsed.data.kind === "create").toBe(true);
+      if (parsed.success && parsed.data.kind === "create") {
+        expect(parsed.data.clientEventId).toBeNull();
+      }
+    });
+
+    it("accepts a create carrying a clientEventId for promotion", () => {
+      const promoted = { ...createInput(), clientEventId: objectId() };
+      const parsed = SyncCommandInputSchema.safeParse(promoted);
+      expect(parsed.success).toBe(true);
+      if (parsed.success && parsed.data.kind === "create") {
+        expect(parsed.data.clientEventId).toBe(promoted.clientEventId);
+      }
+    });
+
     it.each([
       "this",
       "thisAndFollowing",

--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -9,6 +9,7 @@ import {
   RecurrenceScopeSchema,
 } from "@core/types/event-command.contracts";
 import {
+  ClientEventIdSchema,
   ProviderEventVersionSchema,
   SyncEventCalendarIdSchema,
   SyncEventContentSchema,
@@ -28,9 +29,13 @@ import {
 
 // create has no calendar to move within and no prior scope to preserve, so
 // its recurrence input reuses the existing single/series edit shape.
+// clientEventId carries the stable device-event identity when an anonymous
+// event is promoted to a cloud account, so the same device event stays
+// traceable across promotion; it is absent (null) for a plain cloud create.
 const CreateCommandInputSchema = z.strictObject({
   kind: z.literal("create"),
   calendarId: SyncEventCalendarIdSchema,
+  clientEventId: ClientEventIdSchema.nullable().default(null),
   content: SyncEventContentSchema,
   schedule: EventScheduleSchema,
   recurrence: EditableRecurrenceSchema,

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -65,7 +65,9 @@ function buildCloudEventRecord(command: CommandRecord, now: Date): EventRecord {
     principalId: command.principalId,
     origin: "compass",
     calendarId: input.calendarId,
-    clientEventId: null,
+    // Preserve the device-event identity when this create is a promotion of an
+    // anonymous event; null for a plain cloud create.
+    clientEventId: input.clientEventId,
     connectionId: null,
     providerEventId: null,
     providerVersion: null,

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -267,25 +267,37 @@ describe("POST /internal/commands", () => {
     expect(stored?.clientEventId).toBe(clientEventId);
   });
 
-  it("promoting the same device event twice yields one cloud event", async () => {
+  it("converges a resumed promotion to one cloud event via the stable id", async () => {
     const tenantId = objectId();
     const principalId = objectId();
     const clientEventId = `device-${objectId()}`;
-    // A stable eventId is what keeps a resumed/repeated promotion idempotent.
-    const request = createRequest({
-      input: { ...createRequest().input, clientEventId },
-    });
+    const eventId = objectId();
+    const input = { ...createRequest().input, clientEventId };
     await startService();
 
-    await submit(tenantId, principalId, request);
-    await submit(tenantId, principalId, request);
+    // A resumed promotion is a fresh attempt (new idempotency key) for the same
+    // device event. Two separate commands result, but the stable event id keeps
+    // them converging on exactly one cloud event.
+    await submit(tenantId, principalId, {
+      idempotencyKey: `idem-${objectId()}`,
+      eventId,
+      input,
+      expectedVersion: null,
+    });
+    await submit(tenantId, principalId, {
+      idempotencyKey: `idem-${objectId()}`,
+      eventId,
+      input,
+      expectedVersion: null,
+    });
 
+    expect(await mongo.db.collection("commands").countDocuments()).toBe(2);
     expect(await mongo.db.collection("events").countDocuments()).toBe(1);
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
       tenantId as TenantId,
       principalId as PrincipalId,
-      request.eventId as never,
+      eventId as never,
     );
     expect(stored?.clientEventId).toBe(clientEventId);
   });

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -246,6 +246,50 @@ describe("POST /internal/commands", () => {
     expect(await mongo.db.collection("commands").countDocuments()).toBe(1);
   });
 
+  it("promotes an anonymous device event, preserving its clientEventId", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const clientEventId = `device-${objectId()}`;
+    const request = createRequest({
+      input: { ...createRequest().input, clientEventId },
+    });
+    await startService();
+
+    const res = await submit(tenantId, principalId, request);
+
+    expect(res.status).toBe(200);
+    const events = new EventRepository(mongo.db);
+    const stored = await events.findById(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+      request.eventId as never,
+    );
+    expect(stored?.clientEventId).toBe(clientEventId);
+  });
+
+  it("promoting the same device event twice yields one cloud event", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const clientEventId = `device-${objectId()}`;
+    // A stable eventId is what keeps a resumed/repeated promotion idempotent.
+    const request = createRequest({
+      input: { ...createRequest().input, clientEventId },
+    });
+    await startService();
+
+    await submit(tenantId, principalId, request);
+    await submit(tenantId, principalId, request);
+
+    expect(await mongo.db.collection("events").countDocuments()).toBe(1);
+    const events = new EventRepository(mongo.db);
+    const stored = await events.findById(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+      request.eventId as never,
+    );
+    expect(stored?.clientEventId).toBe(clientEventId);
+  });
+
   it("refuses to overwrite another principal's event with a reused id", async () => {
     const tenantId = objectId();
     const owner = objectId();


### PR DESCRIPTION
## What

Carries an anonymous device event's stable `clientEventId` through a cloud `create`, so an anonymous-to-cloud account promotion (R-LIFE-02 / A-01) stays traceable and duplicate-free. This is the promotion slice of S26; the create + idempotency + local-confirm machinery landed in #2249.

## Behavior

- The `create` command input gains an optional `clientEventId` (defaults to `null` for a plain cloud create). It is persisted on the canonical `EventRecord` (which already had the field and a `(principalId, clientEventId)` index).
- Promotion idempotency rides on the **stable event id** the client supplies per device event (R-LIFE-02's "stable event identity preserved"): a repeated or resumed promotion replaces the same document, so exactly one cloud event exists per device event with its `clientEventId` intact.

## Scope note

This makes the sync store promotion-*ready* — it accepts and preserves the device identity. The promotion *orchestration* (draining IndexedDB, resuming interrupted uploads) is the web-side driver in a later slice (S42), which owns the client's id-assignment contract. I deliberately did not add speculative `clientEventId`-based reconciliation (looking up and re-homing an event under a different proposed id) against that not-yet-built client — if S42 needs it, it's a targeted follow-up. Update/move/delete of cloud events is out of scope here: per the commit ledger's evidence lists, those (with expected-version conditioning, deletion markers, and recurrence-scope) belong to S28.

## Tests

- Core: create defaults `clientEventId` to null when absent; accepts it when present.
- Route: promotes a device event preserving its `clientEventId`; promoting the same device event twice yields exactly one cloud event with the id intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)