### PR TITLE
fix(sync): don't confirm a provider-targeted create as a local cloud event

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -1,5 +1,6 @@
 import { type EditableRecurrence } from "@core/types/event.contracts";
 import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
+import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
 import {
   type CommandRecord,
   type CommandSubmit,
@@ -7,10 +8,12 @@ import {
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 
 export interface CloudCommandRepos {
   commands: CommandRepository;
   events: EventRepository;
+  calendars: ProviderCalendarRepository;
 }
 
 // Durably record a command and, for a cloud-only create, apply it to the
@@ -20,7 +23,10 @@ export interface CloudCommandRepos {
 // runs while the command is still pending. So a retry after a crash at any
 // point converges on one confirmed command and one event.
 //
-// A non-create command is persisted as durable pending intent and returned
+// A command with a provider target (its calendar is a connected provider
+// calendar) is left pending here: confirming it locally would skip the provider
+// write. The provider execution path applies and confirms it. A non-create
+// command is likewise persisted as durable pending intent and returned
 // unchanged; applying update/move/delete locally lands in a later slice.
 export async function submitCloudCommand(
   repos: CloudCommandRepos,
@@ -34,6 +40,17 @@ export async function submitCloudCommand(
   // it stands, so a repeated submit never re-applies or overwrites an outcome.
   if (command.outcome.state !== "pending") return command;
   if (command.input.kind !== "create") return command;
+
+  // A create whose target calendar is a connected provider calendar must go to
+  // the provider, not be confirmed as a local cloud event. Leave it pending for
+  // the provider path. A calendar id that resolves to no provider calendar is a
+  // Compass cloud calendar, so it is applied locally below.
+  const providerCalendar = await repos.calendars.findById(
+    command.tenantId,
+    command.principalId,
+    command.input.calendarId as ProviderCalendarId,
+  );
+  if (providerCalendar) return command;
 
   await repos.events.put(buildCloudEventRecord(command, now()));
 

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
+  type ConnectionId,
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
@@ -10,6 +11,7 @@ import { type SyncConfig } from "@sync/config/sync.config";
 import { COMMANDS_PATH } from "@sync/server/command.routes";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
@@ -222,6 +224,45 @@ describe("POST /internal/commands", () => {
       kind: "seriesMaster",
       rules: ["RRULE:FREQ=WEEKLY"],
     });
+  });
+
+  it("leaves a create targeting a provider calendar pending for the provider path", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+
+    // A connected provider calendar; a create aimed at it must not be confirmed
+    // as a local cloud event.
+    const calendars = new ProviderCalendarRepository(mongo.db);
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: objectId() as ConnectionId,
+      providerCalendarId: objectId(),
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+    const request = createRequest({
+      input: { ...createRequest().input, calendarId: calendar._id },
+    });
+    const res = await submit(tenantId, principalId, request);
+
+    const body = (await res.json()) as {
+      command: { outcome: { state: string } };
+    };
+    expect(body.command.outcome.state).toBe("pending");
+    // No local cloud event is written for a provider-targeted create.
+    expect(await mongo.db.collection("events").countDocuments()).toBe(0);
   });
 
   it("persists a non-create command as durable pending intent", async () => {

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -16,6 +16,7 @@ import {
 import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
 export const COMMANDS_PATH = "/internal/commands";
@@ -59,6 +60,7 @@ export function registerCommandRoutes(
           {
             commands: new CommandRepository(deps.mongo.db),
             events: new EventRepository(deps.mongo.db),
+            calendars: new ProviderCalendarRepository(deps.mongo.db),
           },
           {
             tenantId: auth.tenantId,


### PR DESCRIPTION
## What

Corrects the cloud command path so a `create` aimed at a connected **provider** calendar is no longer confirmed as a local cloud event. This is the first, low-risk slice of S27 (provider create commands) — the discrimination that routes linked creates away from the cloud path.

## The gap

`submitCloudCommand` confirmed *every* create locally (`EventRepository.put` + `outcome: confirmed{providerEventId: null}`). For a create targeting a provider calendar, that would skip the provider write entirely and falsely report the command confirmed with no provider identity — an event that exists in Compass but was never written to Google.

It is latent today (no caller submits commands yet), but it's the wrong default and the precondition for the provider executor, so it's fixed here rather than layered over.

## Fix

Look the target calendar up via `ProviderCalendarRepository.findById` (scoped to the caller's tenant/principal). If it resolves to a provider calendar, leave the command **pending** for the provider execution path. A calendar id that resolves to nothing is a Compass cloud calendar, so it is applied and confirmed locally exactly as before.

## Follow-up (deliberately not here)

The provider **executor** itself (resolve credential → `writer.createEvent` with the deterministic id → commit provider identity → confirm, with `ProviderWriteError` mapping) is the next slice. It carries one genuine product decision I want to surface rather than guess: the **invitation intent** on a provider create (whether creating the event emails attendees — `all` / `externalOnly` / `none`), which is a real outward-facing side effect.

## Tests

Adds a route test: a create targeting a seeded provider calendar stays `pending` with no local cloud event written. All existing cloud-create, promotion, and idempotency tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)