### PR TITLE
feat(sync): execute provider create commands

### DIFF
--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -27,6 +27,15 @@ import {
 // work begins. This file adds contracts only — nothing here executes a command
 // or reads/writes the existing Compass API event endpoints.
 
+// Whether writing this event to a provider should notify attendees. The choice
+// is the user's (made in the UI when they created the event), carried on the
+// command so Sync honors it rather than deciding. Defaults to notifying no one
+// — the safe choice for a create with no attendees or no provider target.
+export const InvitationIntentSchema = z
+  .enum(["all", "externalOnly", "none"])
+  .default("none");
+export type InvitationIntent = z.infer<typeof InvitationIntentSchema>;
+
 // create has no calendar to move within and no prior scope to preserve, so
 // its recurrence input reuses the existing single/series edit shape.
 // clientEventId carries the stable device-event identity when an anonymous
@@ -36,6 +45,7 @@ const CreateCommandInputSchema = z.strictObject({
   kind: z.literal("create"),
   calendarId: SyncEventCalendarIdSchema,
   clientEventId: ClientEventIdSchema.nullable().default(null),
+  invitation: InvitationIntentSchema,
   content: SyncEventContentSchema,
   schedule: EventScheduleSchema,
   recurrence: EditableRecurrenceSchema,

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -5,7 +5,9 @@ import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
 import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
 import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
+import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -35,6 +37,9 @@ export function createSyncService(
     // Override the provider adapter (tests inject a fake to avoid the network);
     // production builds it from config.
     authAdapter?: ProviderAuthAdapter;
+    // Override the provider event writer (tests inject a fake); production
+    // builds it from config.
+    writer?: ProviderEventWriter;
   } = {},
 ): SyncService {
   const identity = buildServiceIdentity({
@@ -57,6 +62,9 @@ export function createSyncService(
         // The provider adapter is db-free, so it is built once here (gated on
         // provider config); the per-request custody/repos build from the db.
         authAdapter: deps.authAdapter ?? buildAuthAdapter(config),
+        // The event writer is likewise db-free and gated on provider config;
+        // the command routes use it for provider-targeted creates.
+        writer: deps.writer ?? buildEventWriter(config),
         // The OAuth CSRF state is signed with a key derived from the service
         // secret (domain-separated from internal-auth signing); the callback
         // resolves against the public base URL.
@@ -98,6 +106,16 @@ function buildAuthAdapter(config: SyncConfig): ProviderAuthAdapter | undefined {
     config.GOOGLE_CLIENT_ID,
     config.GOOGLE_CLIENT_SECRET,
   );
+}
+
+// Build the provider event writer when the provider is configured. Gated on the
+// same credentials as the auth adapter: a passive/unconfigured deployment
+// returns undefined, and provider-targeted commands stay pending.
+function buildEventWriter(config: SyncConfig): ProviderEventWriter | undefined {
+  if (!config.GOOGLE_CLIENT_ID || !config.GOOGLE_CLIENT_SECRET) {
+    return undefined;
+  }
+  return new GoogleEventWriter();
 }
 
 function closeHttpServer(httpServer: Server): Promise<void> {

--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -1,0 +1,204 @@
+import { faker } from "@faker-js/faker";
+import { type SyncCommandInput } from "@core/types/sync/command.contracts";
+import {
+  type ConnectionId,
+  type EventId,
+  type IdempotencyKey,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { submitCloudCommand } from "@sync/domain/cloud-command.service";
+import {
+  type ProviderCreateInput,
+  type ProviderEventWriter,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+class FakeWriter implements ProviderEventWriter {
+  readonly provider = "google" as const;
+  calls: ProviderCreateInput[] = [];
+  async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    this.calls.push(input);
+    return { providerEventId: "g-evt-1", providerVersion: "etag-1" };
+  }
+  patchEvent(): Promise<ProviderWriteResult> {
+    throw new Error("unused");
+  }
+  deleteEvent(): Promise<void> {
+    throw new Error("unused");
+  }
+  fetchEvent(): Promise<null> {
+    throw new Error("unused");
+  }
+}
+
+const provider = (writer: ProviderEventWriter) => ({
+  writer,
+  custody: { getValidAccessToken: async () => "access-token" },
+});
+
+describe("submitCloudCommand provider dispatch", () => {
+  let mongo: SyncMongoService;
+  let commands: CommandRepository;
+  let events: EventRepository;
+  let calendars: ProviderCalendarRepository;
+
+  const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+  const seedProviderCalendar = (tenantId: TenantId, principalId: PrincipalId) =>
+    calendars.upsertByProviderCalendar({
+      tenantId,
+      principalId,
+      connectionId: objectId() as ConnectionId,
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  const submitFor = (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    calendarId: string,
+  ): CommandSubmit => ({
+    tenantId,
+    principalId,
+    idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+    eventId: objectId() as EventId,
+    input: {
+      kind: "create",
+      calendarId,
+      invitation: "none",
+      content: {
+        title: "T",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T09:00:00-06:00",
+        end: "2026-07-14T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+    } as unknown as SyncCommandInput,
+    expectedVersion: null,
+  });
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `cloudcmd_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    commands = new CommandRepository(mongo.db);
+    events = new EventRepository(mongo.db);
+    calendars = new ProviderCalendarRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("executes a provider-targeted create when active and provider-capable", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        execution: "active",
+        provider: provider(writer),
+      },
+      submitFor(tenantId, principalId, calendar._id),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    expect(writer.calls).toHaveLength(1);
+  });
+
+  it("leaves a provider-targeted create pending when passive", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        execution: "passive",
+        provider: provider(writer),
+      },
+      submitFor(tenantId, principalId, calendar._id),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("pending");
+    expect(writer.calls).toHaveLength(0);
+  });
+
+  it("leaves a provider-targeted create pending when no provider is configured", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+
+    const command = await submitCloudCommand(
+      { commands, events, calendars, execution: "active" },
+      submitFor(tenantId, principalId, calendar._id),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("pending");
+  });
+
+  it("still confirms a cloud (non-provider) create locally when active", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        execution: "active",
+        provider: provider(writer),
+      },
+      // A calendar id with no provider_calendars row is a Compass cloud calendar.
+      submitFor(tenantId, principalId, objectId()),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    expect(writer.calls).toHaveLength(0);
+  });
+});

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -1,6 +1,10 @@
 import { type EditableRecurrence } from "@core/types/event.contracts";
 import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
+import { type SyncExecutionMode } from "@sync/config/sync.config";
+import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { executeProviderCreate } from "@sync/domain/provider-command.service";
+import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import {
   type CommandRecord,
   type CommandSubmit,
@@ -10,10 +14,18 @@ import { type CommandRepository } from "@sync/storage/repositories/command.repos
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 
-export interface CloudCommandRepos {
+export interface CloudCommandDeps {
   commands: CommandRepository;
   events: EventRepository;
   calendars: ProviderCalendarRepository;
+  execution: SyncExecutionMode;
+  // Provider write capability, present only when a provider is configured and
+  // provider work is enabled. Absent means provider-targeted commands stay
+  // pending instead of executing.
+  provider?: {
+    writer: ProviderEventWriter;
+    custody: CredentialCustody;
+  };
 }
 
 // Durably record a command and, for a cloud-only create, apply it to the
@@ -29,11 +41,11 @@ export interface CloudCommandRepos {
 // command is likewise persisted as durable pending intent and returned
 // unchanged; applying update/move/delete locally lands in a later slice.
 export async function submitCloudCommand(
-  repos: CloudCommandRepos,
+  deps: CloudCommandDeps,
   submit: CommandSubmit,
   now: () => Date,
 ): Promise<CommandRecord> {
-  const command = await repos.commands.submit(submit);
+  const command = await deps.commands.submit(submit);
 
   // Only a freshly-persisted create is applied here. A command already past
   // pending (a confirmed replay, or a kind we don't apply yet) is returned as
@@ -42,19 +54,35 @@ export async function submitCloudCommand(
   if (command.input.kind !== "create") return command;
 
   // A create whose target calendar is a connected provider calendar must go to
-  // the provider, not be confirmed as a local cloud event. Leave it pending for
-  // the provider path. A calendar id that resolves to no provider calendar is a
-  // Compass cloud calendar, so it is applied locally below.
-  const providerCalendar = await repos.calendars.findById(
+  // the provider, not be confirmed as a local cloud event. Execute it now when
+  // provider work is enabled; otherwise leave it pending for a later execution.
+  // A calendar id that resolves to no provider calendar is a Compass cloud
+  // calendar, so it is applied locally below.
+  const providerCalendar = await deps.calendars.findById(
     command.tenantId,
     command.principalId,
     command.input.calendarId as ProviderCalendarId,
   );
-  if (providerCalendar) return command;
+  if (providerCalendar) {
+    if (deps.execution === "active" && deps.provider) {
+      return executeProviderCreate(
+        {
+          commands: deps.commands,
+          events: deps.events,
+          writer: deps.provider.writer,
+          custody: deps.provider.custody,
+        },
+        command,
+        providerCalendar,
+        now,
+      );
+    }
+    return command;
+  }
 
-  await repos.events.put(buildCloudEventRecord(command, now()));
+  await deps.events.put(buildCloudEventRecord(command, now()));
 
-  const confirmed = await repos.commands.updateOutcome(
+  const confirmed = await deps.commands.updateOutcome(
     command.tenantId,
     command.principalId,
     command._id,

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -1,0 +1,300 @@
+import { faker } from "@faker-js/faker";
+import { type SyncCommandInput } from "@core/types/sync/command.contracts";
+import {
+  type ConnectionId,
+  type EventId,
+  type IdempotencyKey,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
+  type AccessTokenSource,
+  executeProviderCreate,
+} from "@sync/domain/provider-command.service";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import {
+  type ProviderCreateInput,
+  type ProviderEventWriter,
+  ProviderWriteError,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+
+// A writer that records its calls and returns a fixed identity, or throws a
+// preset error. No network.
+class FakeWriter implements ProviderEventWriter {
+  readonly provider = "google" as const;
+  calls: ProviderCreateInput[] = [];
+  result: ProviderWriteResult = {
+    providerEventId: "g-evt-1",
+    providerVersion: "etag-1",
+  };
+  error?: unknown;
+  async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    this.calls.push(input);
+    if (this.error) throw this.error;
+    return this.result;
+  }
+  patchEvent(): Promise<ProviderWriteResult> {
+    throw new Error("unused");
+  }
+  deleteEvent(): Promise<void> {
+    throw new Error("unused");
+  }
+  fetchEvent(): Promise<null> {
+    throw new Error("unused");
+  }
+}
+
+const tokenSource = (token = "access-token"): AccessTokenSource => ({
+  getValidAccessToken: async () => token,
+});
+const failingTokenSource = (error: unknown): AccessTokenSource => ({
+  getValidAccessToken: async () => {
+    throw error;
+  },
+});
+
+describe("executeProviderCreate", () => {
+  let mongo: SyncMongoService;
+  let commands: CommandRepository;
+  let events: EventRepository;
+  let calendars: ProviderCalendarRepository;
+
+  const createInput = (
+    calendarId: string,
+    invitation = "none",
+  ): SyncCommandInput =>
+    ({
+      kind: "create",
+      calendarId,
+      invitation,
+      content: {
+        title: "Sync me",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T09:00:00-06:00",
+        end: "2026-07-14T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+    }) as unknown as SyncCommandInput;
+
+  // Seed a pending create command plus its target provider calendar, and return
+  // both with the fake dependencies wired up.
+  const seed = async (invitation = "none") => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar: ProviderCalendarRecord =
+      await calendars.upsertByProviderCalendar({
+        tenantId,
+        principalId,
+        connectionId,
+        providerCalendarId: "primary@group.calendar.google.com",
+        displayName: "Google",
+        color: null,
+        active: true,
+        primary: true,
+        accessRole: "owner",
+        capabilities: {
+          canReadEvents: true,
+          canWriteEvents: true,
+          canReadBusy: true,
+          canInviteAttendees: true,
+        },
+      });
+    const command = await commands.submit({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId: objectId() as EventId,
+      input: createInput(calendar._id, invitation),
+      expectedVersion: null,
+    });
+    return { tenantId, principalId, calendar, command };
+  };
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `provcmd_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    commands = new CommandRepository(mongo.db);
+    events = new EventRepository(mongo.db);
+    calendars = new ProviderCalendarRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+  it("writes to the provider, commits its identity, and confirms", async () => {
+    const { tenantId, principalId, calendar, command } = await seed();
+    const writer = new FakeWriter();
+
+    const result = await executeProviderCreate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(
+      result.outcome.state === "confirmed" && result.outcome.providerEventId,
+    ).toBe("g-evt-1");
+
+    // Called with the raw provider calendar id and the deterministic event id.
+    expect(writer.calls).toHaveLength(1);
+    expect(writer.calls[0].calendarId).toBe(calendar.providerCalendarId);
+    expect(writer.calls[0].providerEventId).toBe(command.eventId);
+
+    const stored = await events.findById(
+      tenantId,
+      principalId,
+      command.eventId,
+    );
+    expect(stored?.connectionId).toBe(calendar.connectionId);
+    expect(stored?.providerEventId).toBe("g-evt-1");
+    expect(stored?.providerVersion).toBe("etag-1");
+    expect(stored?.deliveryState).toBe("confirmed");
+  });
+
+  it("passes the caller's invitation intent through to the writer", async () => {
+    const { calendar, command } = await seed("all");
+    const writer = new FakeWriter();
+
+    await executeProviderCreate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      calendar,
+      now,
+    );
+
+    expect(writer.calls[0].invitation).toBe("all");
+  });
+
+  it("converges on one event when executed twice (idempotent write)", async () => {
+    const { tenantId, principalId, calendar, command } = await seed();
+    const writer = new FakeWriter();
+    const deps = { commands, events, writer, custody: tokenSource() };
+
+    await executeProviderCreate(deps, command, calendar, now);
+    await executeProviderCreate(deps, command, calendar, now);
+
+    const owned = await events.listByCalendar({
+      tenantId,
+      principalId,
+      calendarId: calendar._id,
+      generation: 0,
+      limit: 10,
+    });
+    expect(owned).toHaveLength(1);
+  });
+
+  it("leaves the command pending on a transient write failure", async () => {
+    const { tenantId, principalId, calendar, command } = await seed();
+    const writer = new FakeWriter();
+    writer.error = new ProviderWriteError("transient", "network blip");
+
+    const result = await executeProviderCreate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("pending");
+    expect(
+      await events.findById(tenantId, principalId, command.eventId),
+    ).toBeNull();
+  });
+
+  it("fails the command on a terminal write error", async () => {
+    const { tenantId, principalId, calendar, command } = await seed();
+    const writer = new FakeWriter();
+    writer.error = new ProviderWriteError("readOnlyCalendar", "read only");
+
+    const result = await executeProviderCreate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(
+      result.outcome.state === "failed" && result.outcome.failureReason,
+    ).toBe("readOnlyCalendar");
+    expect(
+      await events.findById(tenantId, principalId, command.eventId),
+    ).toBeNull();
+  });
+
+  it("fails the command when the credential is revoked, without writing", async () => {
+    const { calendar, command } = await seed();
+    const writer = new FakeWriter();
+
+    const result = await executeProviderCreate(
+      {
+        commands,
+        events,
+        writer,
+        custody: failingTokenSource(
+          new ProviderAuthError("authorizationRevoked", "revoked"),
+        ),
+      },
+      command,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(
+      result.outcome.state === "failed" && result.outcome.failureReason,
+    ).toBe("authorizationRevoked");
+    expect(writer.calls).toHaveLength(0);
+  });
+
+  it("leaves the command pending on a transient refresh failure", async () => {
+    const { calendar, command } = await seed();
+    const writer = new FakeWriter();
+
+    const result = await executeProviderCreate(
+      {
+        commands,
+        events,
+        writer,
+        custody: failingTokenSource(
+          new ProviderAuthError("refreshFailed", "temporary"),
+        ),
+      },
+      command,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("pending");
+    expect(writer.calls).toHaveLength(0);
+  });
+});

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -1,0 +1,176 @@
+import { type EditableRecurrence } from "@core/types/event.contracts";
+import { type SyncCommandFailureReason } from "@core/types/sync/command.contracts";
+import { type ProviderEventVersion } from "@core/types/sync/event.contracts";
+import {
+  type ConnectionId,
+  type ProviderEventId,
+} from "@core/types/sync/identity.contracts";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import {
+  type ProviderEventWriter,
+  ProviderWriteError,
+  type ProviderWriteRecurrence,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+
+// The slice of credential custody the executor needs — a valid access token for
+// a connection. Narrow so tests pass a plain fake; CredentialCustody satisfies
+// it structurally.
+export interface AccessTokenSource {
+  getValidAccessToken(connectionId: ConnectionId): Promise<string>;
+}
+
+export interface ProviderCreateDeps {
+  commands: CommandRepository;
+  events: EventRepository;
+  writer: ProviderEventWriter;
+  custody: AccessTokenSource;
+}
+
+// Execute a Compass-initiated create against the owning provider, then commit.
+// The deterministic providerEventId (= the command's event id) makes the
+// provider create idempotent: a replay finds the id already present and the
+// adapter reads it back, so a retry after a crash converges without a separate
+// reconciliation step. Provider identity is committed to the canonical event
+// BEFORE the command is confirmed, so a crash between the two re-runs harmlessly
+// and the command is never confirmed from a write we didn't record — the
+// executor confirms only from a definitive provider result.
+export async function executeProviderCreate(
+  deps: ProviderCreateDeps,
+  command: CommandRecord,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "create") {
+    throw new Error("executeProviderCreate requires a create command");
+  }
+  const { input } = command;
+
+  let accessToken: string;
+  try {
+    accessToken = await deps.custody.getValidAccessToken(calendar.connectionId);
+  } catch (error) {
+    // A transient refresh failure is retryable, so leave the command pending; a
+    // revoked or missing credential is terminal.
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason === "refreshFailed"
+    ) {
+      return command;
+    }
+    return failCommand(deps, command, "authorizationRevoked");
+  }
+
+  let result: ProviderWriteResult;
+  try {
+    result = await deps.writer.createEvent({
+      accessToken,
+      calendarId: calendar.providerCalendarId,
+      providerEventId: command.eventId,
+      content: input.content,
+      schedule: input.schedule,
+      recurrence: toProviderWriteRecurrence(input.recurrence),
+      invitation: input.invitation,
+    });
+  } catch (error) {
+    if (error instanceof ProviderWriteError) {
+      // Transient failures are safe to retry — the deterministic id keeps the
+      // eventual retry idempotent. Every other reason is terminal and maps
+      // straight to a command failure class.
+      if (error.reason === "transient") return command;
+      return failCommand(deps, command, error.reason);
+    }
+    throw error;
+  }
+
+  // Commit the provider identity to the canonical event, then confirm.
+  await deps.events.put(
+    buildLinkedEventRecord(command, calendar, result, now()),
+  );
+
+  const confirmed = await deps.commands.updateOutcome(
+    command.tenantId,
+    command.principalId,
+    command._id,
+    {
+      state: "confirmed",
+      providerEventId: result.providerEventId as ProviderEventId,
+      providerVersion: result.providerVersion as ProviderEventVersion,
+    },
+    command.attemptCount,
+  );
+  return confirmed ?? command;
+}
+
+async function failCommand(
+  deps: ProviderCreateDeps,
+  command: CommandRecord,
+  reason: SyncCommandFailureReason,
+): Promise<CommandRecord> {
+  const failed = await deps.commands.updateOutcome(
+    command.tenantId,
+    command.principalId,
+    command._id,
+    { state: "failed", failureReason: reason },
+    command.attemptCount,
+  );
+  return failed ?? command;
+}
+
+// Build the canonical event for a provider-linked create: same shape as a cloud
+// event but with the provider identity the write returned. calendarId stays the
+// Sync provider-calendar id (how the command addressed it); the raw provider
+// calendar id is only used for the API call.
+function buildLinkedEventRecord(
+  command: CommandRecord,
+  calendar: ProviderCalendarRecord,
+  result: ProviderWriteResult,
+  now: Date,
+): EventRecord {
+  if (command.input.kind !== "create") {
+    throw new Error("buildLinkedEventRecord requires a create command");
+  }
+  const { input } = command;
+  return {
+    _id: command.eventId,
+    tenantId: command.tenantId,
+    principalId: command.principalId,
+    origin: "compass",
+    calendarId: input.calendarId,
+    clientEventId: input.clientEventId,
+    connectionId: calendar.connectionId,
+    providerEventId: result.providerEventId as ProviderEventId,
+    providerVersion: result.providerVersion as ProviderEventVersion,
+    // The write result carries no provider update time; a later read sets it.
+    providerUpdatedAt: null,
+    deliveryState: "confirmed",
+    providerMetadata: null,
+    content: input.content,
+    schedule: input.schedule,
+    recurrence:
+      input.recurrence.kind === "series"
+        ? { kind: "seriesMaster", rules: input.recurrence.rules }
+        : { kind: "single" },
+    lifecycleState: "active",
+    generation: 0,
+    createdAt: now,
+    updatedAt: now,
+    confirmedAt: now,
+  };
+}
+
+// The provider write port takes the same single|series shape the editable
+// recurrence already carries (unlike the stored form, which renames series to
+// seriesMaster), so this is a near-identity mapping kept explicit for clarity.
+function toProviderWriteRecurrence(
+  recurrence: EditableRecurrence,
+): ProviderWriteRecurrence {
+  return recurrence.kind === "series"
+    ? { kind: "series", rules: recurrence.rules }
+    : { kind: "single" };
+}

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -6,7 +6,11 @@ import {
   type SyncCommand,
   SyncCommandSchema,
 } from "@core/types/sync/command.contracts";
+import { type SyncExecutionMode } from "@sync/config/sync.config";
+import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { submitCloudCommand } from "@sync/domain/cloud-command.service";
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import {
   ensureConnected,
   internalRateLimit,
@@ -15,6 +19,7 @@ import {
 } from "@sync/server/internal-http";
 import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -24,6 +29,15 @@ export const COMMANDS_PATH = "/internal/commands";
 export interface CommandApiDeps {
   authMiddleware: RequestHandler;
   mongo: SyncMongoService;
+  // Whether provider work is enabled. A provider-targeted create executes only
+  // when active; otherwise it is recorded pending.
+  execution: SyncExecutionMode;
+  // Provider write + auth adapters, present only when a provider is configured.
+  // Both are needed to execute a provider create (the writer performs it, the
+  // auth adapter backs the per-request credential custody). Absent leaves
+  // provider-targeted commands pending.
+  writer?: ProviderEventWriter;
+  authAdapter?: ProviderAuthAdapter;
   // Injectable clock so local confirmation timestamps are deterministic in
   // tests.
   now?: () => number;
@@ -56,11 +70,27 @@ export function registerCommandRoutes(
       const request = parsed.data;
 
       try {
+        // Build the provider write capability only when both adapters exist;
+        // custody is per-request (it holds the request's db-backed credential
+        // repo), the writer is shared.
+        const provider =
+          deps.writer && deps.authAdapter
+            ? {
+                writer: deps.writer,
+                custody: new CredentialCustody(
+                  new CredentialRepository(deps.mongo.db),
+                  deps.authAdapter,
+                ),
+              }
+            : undefined;
+
         const command = await submitCloudCommand(
           {
             commands: new CommandRepository(deps.mongo.db),
             events: new EventRepository(deps.mongo.db),
             calendars: new ProviderCalendarRepository(deps.mongo.db),
+            execution: deps.execution,
+            provider,
           },
           {
             tenantId: auth.tenantId,

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -27,6 +27,7 @@ import { deriveConnectionState } from "@sync/domain/connection-state";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
 import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import {
   ensureConnected,
   internalRateLimit,
@@ -66,6 +67,10 @@ export interface ConnectionApiDeps {
   // The provider authorization adapter, present only when the provider is
   // configured. Absent (or passive mode) means no provider work is possible.
   authAdapter?: ProviderAuthAdapter;
+  // The provider event writer, present only when the provider is configured.
+  // Not used by the connection routes themselves; carried here because this is
+  // the shared bag the command routes are wired from.
+  writer?: ProviderEventWriter;
   // Secret the OAuth CSRF state is signed with, and the public base URL the
   // provider callback resolves against.
   stateSecret: string;

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -24,12 +24,15 @@ export function buildSyncApp(deps: {
   registerHealthRoutes(app, deps);
   if (deps.connectionApi) {
     registerConnectionRoutes(app, deps.connectionApi);
-    // The command ingress shares the connection API's storage and auth; it makes
-    // no provider call for a cloud-only command, so it needs no adapter or
-    // secrets.
+    // The command ingress shares the connection API's storage and auth. A
+    // cloud-only command needs no provider adapter; a provider-targeted create
+    // uses the writer + auth adapter when provider work is enabled.
     registerCommandRoutes(app, {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
+      execution: deps.connectionApi.execution,
+      writer: deps.connectionApi.writer,
+      authAdapter: deps.connectionApi.authAdapter,
       now: deps.connectionApi.now,
     });
     // The public webhook ingress shares the connection API's storage; it needs


### PR DESCRIPTION
## What

The provider-side of S27: when a `create` command targets a connected provider calendar and provider work is active, Sync now writes the event to the owning provider and confirms the command from the result — instead of leaving it pending (the S27.1 placeholder). Cloud-only creates are unchanged.

## Executor (`domain/provider-command.service.ts`)

1. Resolve a valid access token for the calendar's connection (`CredentialCustody.getValidAccessToken`).
2. `writer.createEvent` with a **deterministic** `providerEventId` = the command's event id. This is what makes the create idempotent: a replay hits the Google adapter's 409 duplicate-id read-back and returns the same identity, so a crash+retry converges with **no separate `fetchEvent` reconciliation step**.
3. Commit the returned provider identity/version to the canonical `EventRecord` (owner-scoped `put`), **then** confirm the command. Committing before confirming means a crash between the two re-runs harmlessly and the command is never confirmed from a write we didn't record.

### Error handling (dictated by the port types, not guessed)
- **Transient** provider write (`ProviderWriteError` reason `transient`) or **transient refresh** (`ProviderAuthError` reason `refreshFailed`) → leave the command **pending** for retry; the deterministic id keeps the retry idempotent.
- **Terminal** write errors (`versionConflict` / `readOnlyCalendar` / `authorizationRevoked` / `permanentProviderError`) map 1:1 to a typed command **failure**; a revoked/missing credential fails without ever calling the writer.

## Invitation intent

Per the product decision, the invitation choice (whether attendees are emailed: `all` / `externalOnly` / `none`) is **client-driven** — carried on the create command (`CreateCommandInputSchema.invitation`, default `none`) and passed straight through to the writer. Sync honors the user's UI choice rather than deciding.

## Wiring

`submitCloudCommand` dispatches a provider-targeted create to the executor only when `execution === "active"` **and** a provider writer + auth adapter are configured; otherwise it stays pending (passive/unconfigured deployments are unaffected). The writer is built in `app.ts` on the same gate as the auth adapter and threaded through the command routes. The executor depends on a narrow `AccessTokenSource` interface so tests use plain fakes.

## Tests

- Executor (7, fake writer + fake token source): commit-and-confirm happy path, invitation pass-through, idempotent double-execute → one event, transient-write → pending, terminal-write → failed, revoked-credential → failed (no write), transient-refresh → pending.
- Dispatch (4): active+provider executes, passive stays pending, no-provider-configured stays pending, cloud create still confirms locally under active.

No worker triggers the executor yet; it runs inline on a provider-targeted create request, consistent with the current worker-less architecture. All core (488) + sync (348) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)