### PR TITLE
feat(sync): apply cloud update and delete commands locally

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -14,6 +14,7 @@ import {
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
 import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
@@ -200,5 +201,114 @@ describe("submitCloudCommand provider dispatch", () => {
 
     expect(command.outcome.state).toBe("confirmed");
     expect(writer.calls).toHaveLength(0);
+  });
+
+  // Seed an existing event to mutate. Overrides let a test make it
+  // provider-linked or recurring to exercise the deferral guards.
+  const seedEvent = (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    eventId: EventId,
+    overrides: Partial<EventRecord> = {},
+  ) =>
+    events.put({
+      _id: eventId,
+      tenantId,
+      principalId,
+      origin: "compass",
+      calendarId: objectId(),
+      clientEventId: null,
+      connectionId: null,
+      providerEventId: null,
+      providerVersion: null,
+      providerUpdatedAt: null,
+      deliveryState: null,
+      providerMetadata: null,
+      content: {
+        title: "Existing",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T09:00:00-06:00",
+        end: "2026-07-14T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+      ...overrides,
+    } as EventRecord);
+
+  const deleteFor = (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    eventId: EventId,
+  ): CommandSubmit => ({
+    tenantId,
+    principalId,
+    idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+    eventId,
+    input: { kind: "delete", scope: "all" } as SyncCommandInput,
+    expectedVersion: null,
+  });
+
+  const deps = () => ({
+    commands,
+    events,
+    calendars,
+    execution: "passive" as const,
+  });
+
+  it("leaves a delete of a provider-linked event pending (provider path)", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      connectionId: objectId() as never,
+      providerEventId: "g-evt-1" as never,
+      providerVersion: "etag-1" as never,
+      deliveryState: "confirmed",
+    });
+
+    const command = await submitCloudCommand(
+      deps(),
+      deleteFor(tenantId, principalId, eventId),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("pending");
+    // The event is untouched — never delete a provider event without the
+    // provider's confirmation.
+    expect(
+      await events.findById(tenantId, principalId, eventId),
+    ).not.toBeNull();
+  });
+
+  it("leaves a delete of a recurring series pending (scope handling)", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+
+    const command = await submitCloudCommand(
+      deps(),
+      deleteFor(tenantId, principalId, eventId),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("pending");
+    expect(
+      await events.findById(tenantId, principalId, eventId),
+    ).not.toBeNull();
   });
 });

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -119,12 +119,27 @@ async function applyCloudMutation(
     return confirmCloud(deps, command);
   }
 
+  // Only update remains (applyCloudMutation is called for update/delete).
+  if (command.input.kind !== "update") return command;
+
   // update: the target must exist; a missing event can't be updated, so leave
   // the command pending rather than confirming a no-op.
   if (!existing) return command;
   if (existing.connectionId !== null) return command;
   if (existing.recurrence.kind !== "single") return command;
-  await deps.events.put(applyCloudUpdate(existing, command, now()));
+  // Converting a single event into a series is a series-scope edit — defer it.
+  // Gating on the command's intent (not the event's post-write recurrence) keeps
+  // a retry converging: applyCloudUpdate never changes recurrence.kind here, so
+  // the guards above still pass on the re-read.
+  if (command.input.recurrence.kind === "series") return command;
+
+  // Conditional replace (no upsert): if a concurrent delete removed the event
+  // between the read and here, the write is a no-op and the command stays
+  // pending rather than resurrecting the deleted event.
+  const applied = await deps.events.replaceExisting(
+    applyCloudUpdate(existing, command, now()),
+  );
+  if (!applied) return command;
   return confirmCloud(deps, command);
 }
 

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -51,6 +51,11 @@ export async function submitCloudCommand(
   // pending (a confirmed replay, or a kind we don't apply yet) is returned as
   // it stands, so a repeated submit never re-applies or overwrites an outcome.
   if (command.outcome.state !== "pending") return command;
+
+  // update/delete apply to an existing event; move is not handled yet.
+  if (command.input.kind === "update" || command.input.kind === "delete") {
+    return applyCloudMutation(deps, command, now);
+  }
   if (command.input.kind !== "create") return command;
 
   // A create whose target calendar is a connected provider calendar must go to
@@ -81,7 +86,56 @@ export async function submitCloudCommand(
   }
 
   await deps.events.put(buildCloudEventRecord(command, now()));
+  return confirmCloud(deps, command);
+}
 
+// Apply a cloud-only update or delete to an existing event. Only single,
+// unlinked events are handled here: a provider-linked event needs the provider
+// mutation path, and a recurring series needs scope handling — both land in
+// later slices, so those commands are left pending. Delete is idempotent (an
+// already-absent event confirms), so a retry after a crash converges.
+async function applyCloudMutation(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  const existing = await deps.events.findById(
+    command.tenantId,
+    command.principalId,
+    command.eventId,
+  );
+
+  if (command.input.kind === "delete") {
+    // Absence is the desired end state, so a delete of an already-gone (or
+    // never-created) event is confirmed rather than left hanging.
+    if (!existing) return confirmCloud(deps, command);
+    if (existing.connectionId !== null) return command;
+    if (existing.recurrence.kind !== "single") return command;
+    await deps.events.deleteById(
+      command.tenantId,
+      command.principalId,
+      command.eventId,
+    );
+    return confirmCloud(deps, command);
+  }
+
+  // update: the target must exist; a missing event can't be updated, so leave
+  // the command pending rather than confirming a no-op.
+  if (!existing) return command;
+  if (existing.connectionId !== null) return command;
+  if (existing.recurrence.kind !== "single") return command;
+  await deps.events.put(applyCloudUpdate(existing, command, now()));
+  return confirmCloud(deps, command);
+}
+
+// Confirm a cloud command with no provider identity — local persistence is the
+// only durability it needs. updateOutcome only misses if the command vanished
+// between submit and now (it cannot, within one request), so fall back to the
+// pending record rather than inventing an outcome.
+async function confirmCloud(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+): Promise<CommandRecord> {
   const confirmed = await deps.commands.updateOutcome(
     command.tenantId,
     command.principalId,
@@ -89,10 +143,33 @@ export async function submitCloudCommand(
     { state: "confirmed", providerEventId: null, providerVersion: null },
     command.attemptCount,
   );
-  // updateOutcome only misses if the command vanished between submit and now
-  // (it cannot, within one request); fall back to the pending record rather
-  // than inventing an outcome.
   return confirmed ?? command;
+}
+
+// Apply an update command's content/schedule/recurrence to an existing cloud
+// event, preserving its identity and provider fields. "preserve" keeps the
+// current recurrence; "single"/"series" set it.
+function applyCloudUpdate(
+  existing: EventRecord,
+  command: CommandRecord,
+  now: Date,
+): EventRecord {
+  if (command.input.kind !== "update") {
+    throw new Error("applyCloudUpdate requires an update command");
+  }
+  const { input } = command;
+  return {
+    ...existing,
+    content: input.content,
+    schedule: input.schedule,
+    recurrence:
+      input.recurrence.kind === "preserve"
+        ? existing.recurrence
+        : input.recurrence.kind === "series"
+          ? { kind: "seriesMaster", rules: input.recurrence.rules }
+          : { kind: "single" },
+    updatedAt: now,
+  };
 }
 
 // Build the canonical event for a cloud-only create. All provider fields are

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -265,14 +265,12 @@ describe("POST /internal/commands", () => {
     expect(await mongo.db.collection("events").countDocuments()).toBe(0);
   });
 
-  it("persists a non-create command as durable pending intent", async () => {
+  it("persists an unhandled command kind as durable pending intent", async () => {
     const tenantId = objectId();
     const principalId = objectId();
+    // move is not applied locally yet, so it is recorded pending.
     const request = createRequest({
-      input: {
-        kind: "delete",
-        scope: "this",
-      },
+      input: { kind: "move", calendarId: objectId() },
     });
     await startService();
 
@@ -285,6 +283,121 @@ describe("POST /internal/commands", () => {
     // No event is written for a command that was only recorded, not applied.
     expect(await mongo.db.collection("events").countDocuments()).toBe(0);
     expect(await mongo.db.collection("commands").countDocuments()).toBe(1);
+  });
+
+  it("updates a cloud event's content and confirms", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    // Create the event, then update it (both keyed on the same event id).
+    const created = createRequest();
+    await startService();
+    await submit(tenantId, principalId, created);
+
+    const update = {
+      idempotencyKey: `idem-${objectId()}`,
+      eventId: created.eventId,
+      input: {
+        kind: "update",
+        content: {
+          title: "Renamed",
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+        },
+        schedule: created.input.schedule,
+        recurrence: { kind: "preserve" },
+        scope: "all",
+      },
+      expectedVersion: null,
+    };
+    const res = await submit(tenantId, principalId, update);
+
+    const body = (await res.json()) as {
+      command: { outcome: { state: string } };
+    };
+    expect(body.command.outcome.state).toBe("confirmed");
+    const events = new EventRepository(mongo.db);
+    const stored = await events.findById(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+      created.eventId as never,
+    );
+    expect(stored?.content.title).toBe("Renamed");
+  });
+
+  it("deletes a cloud event and confirms", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const created = createRequest();
+    await startService();
+    await submit(tenantId, principalId, created);
+
+    const del = {
+      idempotencyKey: `idem-${objectId()}`,
+      eventId: created.eventId,
+      input: { kind: "delete", scope: "all" },
+      expectedVersion: null,
+    };
+    const res = await submit(tenantId, principalId, del);
+
+    const body = (await res.json()) as {
+      command: { outcome: { state: string } };
+    };
+    expect(body.command.outcome.state).toBe("confirmed");
+    expect(await mongo.db.collection("events").countDocuments()).toBe(0);
+  });
+
+  it("confirms an idempotent delete of an already-absent event", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+
+    const del = {
+      idempotencyKey: `idem-${objectId()}`,
+      eventId: objectId(),
+      input: { kind: "delete", scope: "all" },
+      expectedVersion: null,
+    };
+    const res = await submit(tenantId, principalId, del);
+
+    const body = (await res.json()) as {
+      command: { outcome: { state: string } };
+    };
+    expect(body.command.outcome.state).toBe("confirmed");
+  });
+
+  it("leaves an update of a missing event pending", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+
+    const update = {
+      idempotencyKey: `idem-${objectId()}`,
+      eventId: objectId(),
+      input: {
+        kind: "update",
+        content: {
+          title: "Nope",
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+        },
+        schedule: createRequest().input.schedule,
+        recurrence: { kind: "preserve" },
+        scope: "all",
+      },
+      expectedVersion: null,
+    };
+    const res = await submit(tenantId, principalId, update);
+
+    const body = (await res.json()) as {
+      command: { outcome: { state: string } };
+    };
+    expect(body.command.outcome.state).toBe("pending");
   });
 
   it("promotes an anonymous device event, preserving its clientEventId", async () => {

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -327,6 +327,42 @@ describe("POST /internal/commands", () => {
     expect(stored?.content.title).toBe("Renamed");
   });
 
+  it("defers an update that converts a single event into a series", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const created = createRequest();
+    await startService();
+    await submit(tenantId, principalId, created);
+
+    const update = {
+      idempotencyKey: `idem-${objectId()}`,
+      eventId: created.eventId,
+      input: {
+        kind: "update",
+        content: created.input.content,
+        schedule: created.input.schedule,
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+        scope: "all",
+      },
+      expectedVersion: null,
+    };
+    const res = await submit(tenantId, principalId, update);
+
+    const body = (await res.json()) as {
+      command: { outcome: { state: string } };
+    };
+    // Converting to a series is a scope edit, deferred — the event stays single
+    // so a retry re-reads a single event and stays consistently pending.
+    expect(body.command.outcome.state).toBe("pending");
+    const events = new EventRepository(mongo.db);
+    const stored = await events.findById(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+      created.eventId as never,
+    );
+    expect(stored?.recurrence).toEqual({ kind: "single" });
+  });
+
   it("deletes a cloud event and confirms", async () => {
     const tenantId = objectId();
     const principalId = objectId();

--- a/packages/sync/src/storage/repositories/event.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.test.ts
@@ -176,6 +176,45 @@ describe("EventRepository", () => {
     ).not.toBeNull();
   });
 
+  it("deleteById removes only the owner's event and is idempotent", async () => {
+    const saved = await repo.put(compassRecord());
+    const other = objectId() as EventRecord["principalId"];
+    // A foreign principal cannot delete it.
+    expect(await repo.deleteById(saved.tenantId, other, saved._id)).toBe(false);
+    expect(
+      await repo.findById(saved.tenantId, saved.principalId, saved._id),
+    ).not.toBeNull();
+    // The owner deletes it; a repeated delete is a no-op.
+    expect(
+      await repo.deleteById(saved.tenantId, saved.principalId, saved._id),
+    ).toBe(true);
+    expect(
+      await repo.deleteById(saved.tenantId, saved.principalId, saved._id),
+    ).toBe(false);
+  });
+
+  it("replaceExisting updates a present event but never resurrects an absent one", async () => {
+    const record = compassRecord();
+    // No document exists yet: a conditional replace must not insert one.
+    expect(await repo.replaceExisting(record)).toBe(false);
+    expect(
+      await repo.findById(record.tenantId, record.principalId, record._id),
+    ).toBeNull();
+    // Once it exists, the replace matches and updates it.
+    await repo.put(record);
+    const updated = {
+      ...record,
+      content: { ...record.content, title: "Changed" },
+    };
+    expect(await repo.replaceExisting(updated)).toBe(true);
+    const read = await repo.findById(
+      record.tenantId,
+      record.principalId,
+      record._id,
+    );
+    expect(read?.content.title).toBe("Changed");
+  });
+
   describe("listByCalendar keyset pagination", () => {
     const tenantId = objectId();
     const principalId = objectId();

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -100,6 +100,22 @@ export class EventRepository {
     return record ? EventRecordSchema.parse(record) : null;
   }
 
+  // Remove one event by id, scoped to its owner so a caller can only delete its
+  // own event. Idempotent: deleting an already-absent event is a no-op, so a
+  // retried delete converges. Returns whether a document was removed.
+  async deleteById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: EventId,
+  ): Promise<boolean> {
+    const result = await this.collection.deleteOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return result.deletedCount > 0;
+  }
+
   // Bounded, keyset-paginated canonical events for one calendar/generation,
   // ordered by _id so a cursor never skips or repeats a row.
   async listByCalendar(query: EventListQuery): Promise<EventRecord[]> {

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -116,6 +116,24 @@ export class EventRepository {
     return result.deletedCount > 0;
   }
 
+  // Replace an existing event, owner-scoped and WITHOUT upsert, so a write can
+  // never resurrect a document a concurrent delete already removed. Returns
+  // whether a document was matched; false means the event vanished since it was
+  // read, and the caller should re-evaluate rather than treat it as applied.
+  async replaceExisting(record: EventRecord): Promise<boolean> {
+    const parsed = EventRecordSchema.parse(record);
+    const result = await this.collection.replaceOne(
+      {
+        _id: parsed._id,
+        tenantId: parsed.tenantId,
+        principalId: parsed.principalId,
+      },
+      parsed,
+      { upsert: false },
+    );
+    return result.matchedCount > 0;
+  }
+
   // Bounded, keyset-paginated canonical events for one calendar/generation,
   // ordered by _id so a cursor never skips or repeats a row.
   async listByCalendar(query: EventListQuery): Promise<EventRecord[]> {


### PR DESCRIPTION
## What

First slice of S28. Handles `update` and `delete` commands for **single, unlinked (cloud) events** — the local-only mutation path, mirroring how S26.1 handled cloud create. Provider-linked events, recurring series, and `move` are deliberately deferred (see below).

## Behavior

`submitCloudCommand` now dispatches `update`/`delete` to `applyCloudMutation`:

- **delete** — load the owner-scoped event. Absence is the desired end state, so a delete of an already-gone (or never-created) event **confirms idempotently** (a retry after a crash converges). A present cloud single event is removed via the new owner-scoped `EventRepository.deleteById` and confirmed.
- **update** — the target must exist; a missing event leaves the command **pending** rather than confirming a no-op. A present cloud single event has its content/schedule/recurrence applied (`preserve` keeps the current recurrence; `single`/`series` set it) and is confirmed.

## Deferred (left pending, with guard tests)

- **Provider-linked events** → the provider mutation path (a later slice). For delete this enforces the S28 invariant *"do not delete content before provider confirmation"* — the event is left untouched.
- **Recurring series** → scope handling (`this`/`thisAndFollowing`/`all`) is a later slice.
- **move** → not handled yet; recorded pending.

## Tests

- Route: update-cloud-event → confirmed + content changed; delete-cloud-event → confirmed + row gone; idempotent delete of an absent event → confirmed; update of a missing event → pending. The old "non-create stays pending" test now uses `move` (still unhandled).
- Service guards: delete of a provider-linked event → pending + event untouched; delete of a recurring series → pending + event untouched.

All core + sync (354) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)