### PR TITLE
feat(sync): execute provider update commands with safe replay

### DIFF
--- a/packages/core/src/types/sync/command.contracts.test.ts
+++ b/packages/core/src/types/sync/command.contracts.test.ts
@@ -111,6 +111,25 @@ describe("Sync command contracts", () => {
       );
     });
 
+    it("defaults an update's invitation to none when absent", () => {
+      const parsed = SyncCommandInputSchema.safeParse(updateInput());
+      expect(parsed.success && parsed.data.kind === "update").toBe(true);
+      if (parsed.success && parsed.data.kind === "update") {
+        expect(parsed.data.invitation).toBe("none");
+      }
+    });
+
+    it("accepts an update carrying an explicit invitation", () => {
+      const parsed = SyncCommandInputSchema.safeParse({
+        ...updateInput(),
+        invitation: "all",
+      });
+      expect(parsed.success && parsed.data.kind === "update").toBe(true);
+      if (parsed.success && parsed.data.kind === "update") {
+        expect(parsed.data.invitation).toBe("all");
+      }
+    });
+
     it("accepts a move input", () => {
       expect(SyncCommandInputSchema.safeParse(moveInput()).success).toBe(true);
     });

--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -53,8 +53,11 @@ const CreateCommandInputSchema = z.strictObject({
 
 // update never changes the owning calendar — that is exclusively the "move"
 // operation's job, so the two stay independently retryable and idempotent.
+// invitation carries the user's choice of whether to notify attendees of the
+// edit, same as create; default is to notify no one.
 const UpdateCommandInputSchema = z.strictObject({
   kind: z.literal("update"),
+  invitation: InvitationIntentSchema,
   content: SyncEventContentSchema,
   schedule: EventScheduleSchema,
   recurrence: RecurrenceEditSchema,

--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -8,9 +8,11 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { submitCloudCommand } from "@sync/domain/cloud-command.service";
+import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
   type ProviderCreateInput,
   type ProviderEventWriter,
+  type ProviderPatchInput,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
 import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
@@ -26,18 +28,44 @@ const objectId = () => faker.database.mongodbObjectId();
 class FakeWriter implements ProviderEventWriter {
   readonly provider = "google" as const;
   calls: ProviderCreateInput[] = [];
+  patchCalls: ProviderPatchInput[] = [];
+  // A stub current provider event for the update path's replay-detection fetch;
+  // its content differs from any command's intent so an update always patches.
+  fetched: ProviderEvent | null = {
+    kind: "event",
+    providerEventId: "g-evt-1",
+    providerVersion: "etag-1",
+    providerUpdatedAt: null,
+    content: {
+      title: "Provider copy",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    },
+    schedule: {
+      kind: "timed",
+      start: "2026-07-14T09:00:00-06:00",
+      end: "2026-07-14T10:00:00-06:00",
+      timeZone: "America/Denver",
+    },
+    busy: true,
+    recurrence: { kind: "single" },
+  };
   async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
     this.calls.push(input);
     return { providerEventId: "g-evt-1", providerVersion: "etag-1" };
   }
-  patchEvent(): Promise<ProviderWriteResult> {
-    throw new Error("unused");
+  async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    this.patchCalls.push(input);
+    return { providerEventId: "g-evt-1", providerVersion: "etag-2" };
   }
   deleteEvent(): Promise<void> {
     throw new Error("unused");
   }
-  fetchEvent(): Promise<null> {
-    throw new Error("unused");
+  async fetchEvent(): Promise<ProviderEvent | null> {
+    return this.fetched;
   }
 }
 
@@ -310,5 +338,61 @@ describe("submitCloudCommand provider dispatch", () => {
     expect(
       await events.findById(tenantId, principalId, eventId),
     ).not.toBeNull();
+  });
+
+  it("routes a provider-linked update to the provider executor when active", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      calendarId: calendar._id,
+      connectionId: calendar.connectionId as never,
+      providerEventId: "g-evt-1" as never,
+      providerVersion: "etag-1" as never,
+      deliveryState: "confirmed",
+    });
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        execution: "active",
+        provider: provider(writer),
+      },
+      {
+        tenantId,
+        principalId,
+        idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+        eventId,
+        input: {
+          kind: "update",
+          invitation: "none",
+          content: {
+            title: "Renamed",
+            description: "",
+            location: null,
+            organizer: null,
+            attendees: [],
+            conference: null,
+          },
+          schedule: {
+            kind: "timed",
+            start: "2026-07-14T09:00:00-06:00",
+            end: "2026-07-14T10:00:00-06:00",
+            timeZone: "America/Denver",
+          },
+          recurrence: { kind: "preserve" },
+          scope: "all",
+        } as unknown as SyncCommandInput,
+        expectedVersion: "etag-1" as never,
+      },
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(1);
   });
 });

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -3,7 +3,10 @@ import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
-import { executeProviderCreate } from "@sync/domain/provider-command.service";
+import {
+  executeProviderCreate,
+  executeProviderUpdate,
+} from "@sync/domain/provider-command.service";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import {
   type CommandRecord,
@@ -125,17 +128,42 @@ async function applyCloudMutation(
   // update: the target must exist; a missing event can't be updated, so leave
   // the command pending rather than confirming a no-op.
   if (!existing) return command;
-  if (existing.connectionId !== null) return command;
+  // A recurring series needs scope handling (later slice), and converting a
+  // single event into a series is itself a series edit — defer both. Gating on
+  // the command's intent (not the event's post-write recurrence) keeps a retry
+  // converging: the applied update never changes recurrence.kind here.
   if (existing.recurrence.kind !== "single") return command;
-  // Converting a single event into a series is a series-scope edit — defer it.
-  // Gating on the command's intent (not the event's post-write recurrence) keeps
-  // a retry converging: applyCloudUpdate never changes recurrence.kind here, so
-  // the guards above still pass on the re-read.
   if (command.input.recurrence.kind === "series") return command;
 
-  // Conditional replace (no upsert): if a concurrent delete removed the event
-  // between the read and here, the write is a no-op and the command stays
-  // pending rather than resurrecting the deleted event.
+  // A provider-linked event goes to the provider when provider work is enabled;
+  // otherwise it stays pending for a later execution.
+  if (existing.connectionId !== null) {
+    if (deps.execution === "active" && deps.provider) {
+      const calendar = await deps.calendars.findById(
+        command.tenantId,
+        command.principalId,
+        existing.calendarId as ProviderCalendarId,
+      );
+      if (calendar) {
+        return executeProviderUpdate(
+          {
+            commands: deps.commands,
+            events: deps.events,
+            writer: deps.provider.writer,
+            custody: deps.provider.custody,
+          },
+          command,
+          existing,
+          calendar,
+          now,
+        );
+      }
+    }
+    return command;
+  }
+
+  // Cloud single event: conditional replace (no upsert), so a concurrent delete
+  // is not resurrected — a miss leaves the command pending.
   const applied = await deps.events.replaceExisting(
     applyCloudUpdate(existing, command, now()),
   );

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -10,11 +10,15 @@ import {
 import {
   type AccessTokenSource,
   executeProviderCreate,
+  executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
   type ProviderCreateInput,
   type ProviderEventWriter,
+  type ProviderFetchInput,
+  type ProviderPatchInput,
   ProviderWriteError,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
@@ -296,5 +300,282 @@ describe("executeProviderCreate", () => {
 
     expect(result.outcome.state).toBe("pending");
     expect(writer.calls).toHaveLength(0);
+  });
+});
+
+// A writer for the update path: configurable fetchEvent (replay detection) and
+// patchEvent (conditional write) results/errors, recording their inputs.
+class FakeUpdateWriter implements ProviderEventWriter {
+  readonly provider = "google" as const;
+  fetched: ProviderEvent | null = null;
+  fetchError?: unknown;
+  patchResult: ProviderWriteResult = {
+    providerEventId: "g-evt-1",
+    providerVersion: "etag-2",
+  };
+  patchError?: unknown;
+  fetchCalls: ProviderFetchInput[] = [];
+  patchCalls: ProviderPatchInput[] = [];
+  createEvent(): Promise<ProviderWriteResult> {
+    throw new Error("unused");
+  }
+  async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    this.patchCalls.push(input);
+    if (this.patchError) throw this.patchError;
+    return this.patchResult;
+  }
+  deleteEvent(): Promise<void> {
+    throw new Error("unused");
+  }
+  async fetchEvent(input: ProviderFetchInput): Promise<ProviderEvent | null> {
+    this.fetchCalls.push(input);
+    if (this.fetchError) throw this.fetchError;
+    return this.fetched;
+  }
+}
+
+describe("executeProviderUpdate", () => {
+  let mongo: SyncMongoService;
+  let commands: CommandRepository;
+  let events: EventRepository;
+  let calendars: ProviderCalendarRepository;
+
+  const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+  const schedule = {
+    kind: "timed" as const,
+    start: "2026-07-14T09:00:00-06:00",
+    end: "2026-07-14T10:00:00-06:00",
+    timeZone: "America/Denver",
+  };
+  const content = (title: string) => ({
+    title,
+    description: "",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  });
+  const providerEvent = (title: string, version: string): ProviderEvent => ({
+    kind: "event",
+    providerEventId: "g-evt-1",
+    providerVersion: version,
+    providerUpdatedAt: null,
+    content: content(title),
+    schedule,
+    busy: true,
+    recurrence: { kind: "single" },
+  });
+
+  // Seed a provider-linked event plus an update command that renames it to
+  // "New". The provider currently holds "Old" at etag-1.
+  const seed = async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId,
+      principalId,
+      connectionId,
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const eventId = objectId() as EventId;
+    await events.put({
+      _id: eventId,
+      tenantId,
+      principalId,
+      origin: "compass",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-evt-1" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: content("Old"),
+      schedule,
+      recurrence: { kind: "single" },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const event = await events.findById(tenantId, principalId, eventId);
+    if (!event) throw new Error("seed failed to read back the event");
+    const command = await commands.submit({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId,
+      input: {
+        kind: "update",
+        invitation: "all",
+        content: content("New"),
+        schedule,
+        recurrence: { kind: "preserve" },
+        scope: "all",
+      } as unknown as SyncCommandInput,
+      expectedVersion: "etag-1" as never,
+    });
+    return { tenantId, principalId, calendar, event, command };
+  };
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `provupd_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    commands = new CommandRepository(mongo.db);
+    events = new EventRepository(mongo.db);
+    calendars = new ProviderCalendarRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("patches the provider and commits the new version and content", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeUpdateWriter();
+    // The provider still holds the old content, so this is a real edit.
+    writer.fetched = providerEvent("Old", "etag-1");
+
+    const result = await executeProviderUpdate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(1);
+    expect(writer.patchCalls[0].expectedVersion).toBe("etag-1");
+    expect(writer.patchCalls[0].invitation).toBe("all");
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.content.title).toBe("New");
+    expect(stored?.providerVersion).toBe("etag-2");
+  });
+
+  it("confirms without re-patching when the edit already landed (replay)", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeUpdateWriter();
+    // The provider already holds this command's intended content at a new
+    // version — a prior attempt landed before the crash.
+    writer.fetched = providerEvent("New", "etag-2");
+
+    const result = await executeProviderUpdate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    // No second write — the replay is recognized from the fetch.
+    expect(writer.patchCalls).toHaveLength(0);
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.providerVersion).toBe("etag-2");
+  });
+
+  it("fails with a conflict on a genuine concurrent external edit", async () => {
+    const { calendar, event, command } = await seed();
+    const writer = new FakeUpdateWriter();
+    // The provider was edited externally (different content, and the
+    // conditional patch is rejected).
+    writer.fetched = providerEvent("Someone else's edit", "etag-9");
+    writer.patchError = new ProviderWriteError("versionConflict", "stale");
+
+    const result = await executeProviderUpdate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(
+      result.outcome.state === "failed" && result.outcome.failureReason,
+    ).toBe("versionConflict");
+  });
+
+  it("fails when the provider event no longer exists", async () => {
+    const { calendar, event, command } = await seed();
+    const writer = new FakeUpdateWriter();
+    writer.fetched = null;
+
+    const result = await executeProviderUpdate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(
+      result.outcome.state === "failed" && result.outcome.failureReason,
+    ).toBe("permanentProviderError");
+    expect(writer.patchCalls).toHaveLength(0);
+  });
+
+  it("leaves the command pending on a transient patch failure", async () => {
+    const { calendar, event, command } = await seed();
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerEvent("Old", "etag-1");
+    writer.patchError = new ProviderWriteError("transient", "blip");
+
+    const result = await executeProviderUpdate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("pending");
+  });
+
+  it("fails without touching the provider when the credential is revoked", async () => {
+    const { calendar, event, command } = await seed();
+    const writer = new FakeUpdateWriter();
+
+    const result = await executeProviderUpdate(
+      {
+        commands,
+        events,
+        writer,
+        custody: failingTokenSource(
+          new ProviderAuthError("authorizationRevoked", "revoked"),
+        ),
+      },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(writer.fetchCalls).toHaveLength(0);
+    expect(writer.patchCalls).toHaveLength(0);
   });
 });

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -496,6 +496,49 @@ describe("executeProviderUpdate", () => {
     expect(stored?.providerVersion).toBe("etag-2");
   });
 
+  it("recognizes a replay even when read-reflected fields drifted", async () => {
+    const { calendar, event, command } = await seed();
+    const writer = new FakeUpdateWriter();
+    // The written fields (title/description/location/schedule) match this
+    // command's edit, but an attendee RSVP'd after our patch landed — a field
+    // the patch never writes. This must still count as a replay, not a false
+    // conflict on an edit that already succeeded.
+    writer.fetched = {
+      kind: "event",
+      providerEventId: "g-evt-1",
+      providerVersion: "etag-2",
+      providerUpdatedAt: null,
+      content: {
+        title: "New",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [
+          {
+            email: "guest@example.com",
+            displayName: null,
+            responseStatus: "accepted",
+          },
+        ],
+        conference: null,
+      },
+      schedule,
+      busy: true,
+      recurrence: { kind: "single" },
+    };
+
+    const result = await executeProviderUpdate(
+      { commands, events, writer, custody: tokenSource() },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(0);
+  });
+
   it("fails with a conflict on a genuine concurrent external edit", async () => {
     const { calendar, event, command } = await seed();
     const writer = new FakeUpdateWriter();

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -1,11 +1,18 @@
-import { type EditableRecurrence } from "@core/types/event.contracts";
+import {
+  type EditableRecurrence,
+  type EventSchedule,
+} from "@core/types/event.contracts";
 import { type SyncCommandFailureReason } from "@core/types/sync/command.contracts";
-import { type ProviderEventVersion } from "@core/types/sync/event.contracts";
+import {
+  type ProviderEventVersion,
+  type SyncEventContent,
+} from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
   type ProviderEventId,
 } from "@core/types/sync/identity.contracts";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
   type ProviderEventWriter,
   ProviderWriteError,
@@ -25,7 +32,7 @@ export interface AccessTokenSource {
   getValidAccessToken(connectionId: ConnectionId): Promise<string>;
 }
 
-export interface ProviderCreateDeps {
+export interface ProviderMutationDeps {
   commands: CommandRepository;
   events: EventRepository;
   writer: ProviderEventWriter;
@@ -41,7 +48,7 @@ export interface ProviderCreateDeps {
 // and the command is never confirmed from a write we didn't record — the
 // executor confirms only from a definitive provider result.
 export async function executeProviderCreate(
-  deps: ProviderCreateDeps,
+  deps: ProviderMutationDeps,
   command: CommandRecord,
   calendar: ProviderCalendarRecord,
   now: () => Date,
@@ -108,7 +115,7 @@ export async function executeProviderCreate(
 }
 
 async function failCommand(
-  deps: ProviderCreateDeps,
+  deps: ProviderMutationDeps,
   command: CommandRecord,
   reason: SyncCommandFailureReason,
 ): Promise<CommandRecord> {
@@ -173,4 +180,183 @@ function toProviderWriteRecurrence(
   return recurrence.kind === "series"
     ? { kind: "series", rules: recurrence.rules }
     : { kind: "single" };
+}
+
+// Apply a Compass-initiated update to an existing provider-linked event.
+//
+// Replay safety is the hard part: a successful conditional patch changes the
+// provider version, so a naive crash-then-retry would re-send the now-stale
+// expected version and the provider would reject it as a conflict — misreporting
+// an edit that actually landed. So we FETCH the provider's current state first:
+// if it already carries this command's intended content, the edit landed on a
+// prior attempt and we simply confirm at the current version (no second write).
+// Otherwise we patch conditionally; the If-Match precondition turns a genuine
+// concurrent external edit into a versionConflict. The content check only gates
+// the replay shortcut, so a false miss falls through to the conditional patch
+// (a spurious conflict at worst — never a lost external edit).
+export async function executeProviderUpdate(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+  event: EventRecord,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "update") {
+    throw new Error("executeProviderUpdate requires an update command");
+  }
+  if (!event.connectionId || !event.providerEventId) {
+    throw new Error("executeProviderUpdate requires a linked event");
+  }
+  const { input } = command;
+  const providerEventId = event.providerEventId;
+  const connectionId = event.connectionId;
+
+  let accessToken: string;
+  try {
+    accessToken = await deps.custody.getValidAccessToken(connectionId);
+  } catch (error) {
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason === "refreshFailed"
+    ) {
+      return command;
+    }
+    return failCommand(deps, command, "authorizationRevoked");
+  }
+
+  const location = {
+    accessToken,
+    calendarId: calendar.providerCalendarId,
+    providerEventId,
+  };
+
+  // Fetch current provider state to detect a replay (our edit already landed)
+  // and to learn the version to commit.
+  let current: ProviderEvent | null;
+  try {
+    const read = await deps.writer.fetchEvent(location);
+    // A cancellation read means the event no longer exists as a content event —
+    // there is nothing to update.
+    current = read?.kind === "event" ? read : null;
+  } catch (error) {
+    if (error instanceof ProviderWriteError) {
+      if (error.reason === "transient") return command;
+      return failCommand(deps, command, error.reason);
+    }
+    throw error;
+  }
+  if (!current) return failCommand(deps, command, "permanentProviderError");
+
+  // Replay: the provider already holds this edit, so confirm at its version
+  // rather than writing again.
+  if (matchesIntendedEdit(current, input.content, input.schedule)) {
+    return commitProviderUpdate(
+      deps,
+      command,
+      event,
+      current.providerVersion,
+      now,
+    );
+  }
+
+  let result: ProviderWriteResult;
+  try {
+    result = await deps.writer.patchEvent({
+      ...location,
+      expectedVersion: command.expectedVersion,
+      content: input.content,
+      schedule: input.schedule,
+      recurrence: { kind: "single" },
+      invitation: input.invitation,
+    });
+  } catch (error) {
+    if (error instanceof ProviderWriteError) {
+      if (error.reason === "transient") return command;
+      return failCommand(deps, command, error.reason);
+    }
+    throw error;
+  }
+
+  return commitProviderUpdate(
+    deps,
+    command,
+    event,
+    result.providerVersion,
+    now,
+  );
+}
+
+// Commit an updated provider event: write the new content/version to the
+// canonical record (owner-scoped, non-upsert so a concurrent delete is not
+// resurrected), then confirm. A miss means the local event vanished mid-flight,
+// so leave the command pending to re-evaluate rather than confirm a gone event.
+async function commitProviderUpdate(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+  event: EventRecord,
+  providerVersion: string,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "update") {
+    throw new Error("commitProviderUpdate requires an update command");
+  }
+  const { input } = command;
+  const applied = await deps.events.replaceExisting({
+    ...event,
+    content: input.content,
+    schedule: input.schedule,
+    providerVersion: providerVersion as ProviderEventVersion,
+    providerUpdatedAt: null,
+    deliveryState: "confirmed",
+    updatedAt: now(),
+  });
+  if (!applied) return command;
+
+  const confirmed = await deps.commands.updateOutcome(
+    command.tenantId,
+    command.principalId,
+    command._id,
+    {
+      state: "confirmed",
+      providerEventId: event.providerEventId as ProviderEventId,
+      providerVersion: providerVersion as ProviderEventVersion,
+    },
+    command.attemptCount,
+  );
+  return confirmed ?? command;
+}
+
+// Whether the provider's current event already carries this command's intended
+// edit. A structural (key-order-independent) comparison of content and schedule;
+// used only to detect a safe replay, so a false negative is harmless.
+function matchesIntendedEdit(
+  current: ProviderEvent,
+  content: SyncEventContent,
+  schedule: EventSchedule,
+): boolean {
+  return (
+    deepEqual(current.content, content) && deepEqual(current.schedule, schedule)
+  );
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (
+    typeof a !== "object" ||
+    typeof b !== "object" ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) =>
+    deepEqual(
+      (a as Record<string, unknown>)[key],
+      (b as Record<string, unknown>)[key],
+    ),
+  );
 }

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -327,15 +327,24 @@ async function commitProviderUpdate(
 }
 
 // Whether the provider's current event already carries this command's intended
-// edit. A structural (key-order-independent) comparison of content and schedule;
-// used only to detect a safe replay, so a false negative is harmless.
+// edit — the signal that a prior attempt landed and this is a safe replay.
+// Compares ONLY the fields a patch actually writes (title, description,
+// location, schedule). organizer/attendees/conference are read-reflected, not
+// written by the provider adapter, so they drift independently (e.g. an
+// attendee RSVPs) — comparing them would turn a landed edit into a false miss,
+// then a stale-version patch, then a spurious versionConflict on a write that
+// already succeeded. Used only to detect a replay, so a false negative on the
+// compared fields is still safe (it falls through to the conditional patch).
 function matchesIntendedEdit(
   current: ProviderEvent,
   content: SyncEventContent,
   schedule: EventSchedule,
 ): boolean {
   return (
-    deepEqual(current.content, content) && deepEqual(current.schedule, schedule)
+    current.content.title === content.title &&
+    current.content.description === content.description &&
+    current.content.location === content.location &&
+    deepEqual(current.schedule, schedule)
   );
 }
 


### PR DESCRIPTION
## What

The provider-update half of S28: routes an `update` of a single, provider-linked event to the owning provider (Google) when provider work is active, with **replay-safe** conflict handling — the "one safe replay" the ledger calls for. Cloud updates (S28.1), and series/move/delete, are unchanged/deferred.

## The replay-safety problem

Unlike provider *create* (idempotent for free via a deterministic id + Google's 409 read-back), a **successful** `patchEvent` *changes* the version. So a crash-before-confirm retry would re-send the now-stale expected version → Google returns 412 → a naive executor reports `versionConflict` for an edit that **actually landed**. That's a false failure on a successful write.

## The design: fetch-first

`executeProviderUpdate`:
1. Resolve the access token (transient refresh → pending; revoked/missing → failed, no provider call).
2. **`fetchEvent`** the provider's current state.
   - Gone / cancelled → `failed{permanentProviderError}` (nothing to update).
   - **Already carries this command's intended content** → the edit landed on a prior attempt → **confirm at the current version, no second write** (the safe replay).
3. Otherwise **`patchEvent`** conditionally (`If-Match` = the command's expected version). A genuine concurrent external edit → 412 → `failed{versionConflict}`; transient → pending.
4. Commit the new content + version to the canonical record via owner-scoped, **non-upsert** `replaceExisting` (no resurrection of a concurrently-deleted event), then confirm.

The content comparison only gates the replay shortcut, so a **false miss fails safe**: it falls through to the conditional patch, whose `If-Match` yields a spurious conflict at worst — never a silently-lost external edit.

## Invitation

Per the decision, the `update` command carries the client-driven `invitation` (default `none`), passed straight to `patchEvent`.

## Tests

- Executor (6, fake writer): patch-and-commit happy path (asserts `If-Match` + invitation pass-through), **replay** (fetched content matches intent → confirm, **zero** patch calls), **genuine conflict** → `failed{versionConflict}`, provider-event-gone → `failed{permanentProviderError}`, transient patch → pending, revoked credential → failed with no provider call.
- Dispatch (1): a provider-linked update under active mode routes to the executor and patches.
- Core: update defaults `invitation` to `none`; accepts an explicit one.

All core (490) + sync (364) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)