### PR TITLE
feat(web): share bookmarkable life variations

### DIFF
--- a/packages/web/src/components/NumberInput/NumberInput.tsx
+++ b/packages/web/src/components/NumberInput/NumberInput.tsx
@@ -32,7 +32,7 @@ export function NumberInput({
     <div className="relative w-32">
       <input
         aria-label={ariaLabel}
-        className="c-number-input h-12 w-full rounded-lg border border-border bg-surface px-3 pr-10 text-center text-lg text-text outline-none transition-colors focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent/30"
+        className="c-number-input h-12 w-full rounded-lg border border-border bg-surface px-3 pr-10 text-center text-sm text-text outline-none transition-colors focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent/30"
         id={id}
         inputMode="numeric"
         max={max}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -561,12 +561,12 @@
     margin-bottom: 6px;
   }
 
-  & .react-datepicker__day--selected {
+  & .react-datepicker__day.react-datepicker__day--selected {
     background-color: var(--date-picker-selected-bg);
     color: var(--date-picker-selected-text);
   }
 
-  & .react-datepicker__day--selected:hover {
+  & .react-datepicker__day.react-datepicker__day--selected:hover {
     color: var(--date-picker-selected-text);
   }
 
@@ -586,8 +586,12 @@
     text-decoration-color: var(--date-picker-hover-text);
   }
 
-  & .react-datepicker__day--keyboard-selected {
-    background-color: var(--background);
+  &
+    .react-datepicker__day--keyboard-selected:not(
+      .react-datepicker__day--selected
+    ) {
+    background-color: var(--date-picker-hover-bg);
+    color: var(--date-picker-hover-text);
   }
 
   &[data-view="sidebar"] .react-datepicker__day--keyboard-selected {
@@ -641,6 +645,15 @@
 .c-number-input::-webkit-outer-spin-button {
   appearance: none;
   margin: 0;
+}
+
+.c-life-input + .react-datepicker__close-icon::after {
+  background-color: var(--text-muted);
+  color: var(--surface);
+}
+
+.c-life-input + .react-datepicker__close-icon:hover::after {
+  background-color: var(--text);
 }
 
 @utility c-scroll {

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -14,6 +14,7 @@ import {
   validateDayDateParam,
   validateWeekDateParam,
 } from "@web/routers/loaders";
+import { validateLifeSearch } from "@web/views/Life/life-search";
 import { NotFoundView } from "@web/views/NotFound";
 
 export const rootRoute = createRootRoute({
@@ -33,6 +34,7 @@ export const rootRoute = createRootRoute({
 export const lifeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: ROOT_ROUTES.LIFE,
+  validateSearch: validateLifeSearch,
   component: lazyRouteComponent(
     () => import("@web/views/Life/LifeView"),
     "LifeView",

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -64,6 +64,8 @@ describe("shortcuts.data", () => {
         "other",
       ]);
       expect(sections[0]?.shortcuts).toEqual([
+        { keys: ["j"], label: "Previous life variation" },
+        { keys: ["k"], label: "Next life variation" },
         { keys: ["t"], label: "Focus current week" },
         { keys: ["d"], label: "Go to Day view" },
         { keys: ["w"], label: "Go to Week view" },

--- a/packages/web/src/shortcuts/data/shortcuts.data.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.ts
@@ -19,6 +19,8 @@ const getNavigateShortcuts = ({
 
   if (view === "life") {
     return [
+      { keys: ["j"], label: "Previous life variation" },
+      { keys: ["k"], label: "Next life variation" },
       { keys: ["t"], label: "Focus current week" },
       { keys: [VIEW_SHORTCUTS.day.key], label: "Go to Day view" },
       { keys: [VIEW_SHORTCUTS.week.key], label: "Go to Week view" },

--- a/packages/web/src/views/Life/LifeShareButtons.tsx
+++ b/packages/web/src/views/Life/LifeShareButtons.tsx
@@ -1,0 +1,81 @@
+import {
+  FacebookLogoIcon,
+  InstagramLogoIcon,
+  XLogoIcon,
+} from "@phosphor-icons/react";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import {
+  downloadLifeShareImage,
+  getSocialShareUrl,
+  type LifeShareData,
+  shareLifeImage,
+} from "./life-share";
+
+interface LifeShareButtonsProps extends LifeShareData {}
+
+const iconButtonClassName =
+  "flex size-8 items-center justify-center rounded-full text-text-muted transition-colors hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent";
+
+export function LifeShareButtons({
+  lifespan,
+  totalDots,
+  weeksLived,
+}: LifeShareButtonsProps) {
+  const shareData = { lifespan, totalDots, weeksLived };
+
+  const openShare = (platform: "facebook" | "x") => {
+    const pageUrl = window.location.href;
+    window.open(
+      getSocialShareUrl(platform, pageUrl, lifespan),
+      "_blank",
+      "noopener,noreferrer",
+    );
+    void downloadLifeShareImage(shareData);
+  };
+
+  const shareToInstagram = async () => {
+    const didShare = await shareLifeImage(shareData, window.location.href);
+    if (didShare) return;
+
+    await downloadLifeShareImage(shareData);
+    window.open("https://www.instagram.com/", "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <section className="flex flex-col gap-2 text-text-muted">
+      <h2 className="font-semibold text-text">Share</h2>
+      <div className="flex items-center gap-1">
+        <TooltipWrapper description="Share on X (downloads image)">
+          <button
+            aria-label="Share on X"
+            className={iconButtonClassName}
+            onClick={() => openShare("x")}
+            type="button"
+          >
+            <XLogoIcon aria-hidden="true" size={17} />
+          </button>
+        </TooltipWrapper>
+        <TooltipWrapper description="Share on Facebook (downloads image)">
+          <button
+            aria-label="Share on Facebook"
+            className={iconButtonClassName}
+            onClick={() => openShare("facebook")}
+            type="button"
+          >
+            <FacebookLogoIcon aria-hidden="true" size={17} />
+          </button>
+        </TooltipWrapper>
+        <TooltipWrapper description="Share on Instagram">
+          <button
+            aria-label="Share on Instagram"
+            className={iconButtonClassName}
+            onClick={() => void shareToInstagram()}
+            type="button"
+          >
+            <InstagramLogoIcon aria-hidden="true" size={17} />
+          </button>
+        </TooltipWrapper>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/views/Life/LifeSidebarContent.tsx
+++ b/packages/web/src/views/Life/LifeSidebarContent.tsx
@@ -1,10 +1,14 @@
+import { ShuffleIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
+import { ArrowButton } from "@web/components/Button/ArrowButton";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
 import { NumberInput } from "@web/components/NumberInput/NumberInput";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import { LifeShareButtons } from "./LifeShareButtons";
 import {
   clampLifespan,
   formatDateInputValue,
+  getLifeVariationDescription,
   getRandomLifespan,
   LIFE_VARIATIONS,
   MAX_LIFESPAN,
@@ -14,18 +18,26 @@ import {
 import { type LifePreferences } from "./life-preferences.storage";
 
 interface LifeSidebarContentProps {
+  onCycleVariation: (direction: -1 | 1) => void;
   preferences: LifePreferences;
+  onShuffleAge: () => void;
   summary: string;
+  totalDots: number;
   today: Date;
+  weeksLived: number;
   onPreferencesChange: (
     update: (current: LifePreferences) => LifePreferences,
   ) => void;
 }
 
 export function LifeSidebarContent({
+  onCycleVariation,
   preferences,
+  onShuffleAge,
   summary,
+  totalDots,
   today,
+  weeksLived,
   onPreferencesChange,
 }: LifeSidebarContentProps) {
   const [isBirthDatePickerOpen, setIsBirthDatePickerOpen] = useState(false);
@@ -70,8 +82,24 @@ export function LifeSidebarContent({
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-8 overflow-y-auto px-5 pb-5 text-sm">
       <section className="flex flex-col gap-2 text-text-muted">
-        <h2 className="font-semibold text-text">{variation.label}</h2>
-        <p>{variation.description}</p>
+        <div className="flex items-center gap-1">
+          <h2 className="font-semibold text-text">{variation.label}</h2>
+          <TooltipWrapper description="Previous life variation" shortcut="J">
+            <ArrowButton
+              direction="left"
+              label="Previous life variation in sidebar"
+              onClick={() => onCycleVariation(-1)}
+            />
+          </TooltipWrapper>
+          <TooltipWrapper description="Next life variation" shortcut="K">
+            <ArrowButton
+              direction="right"
+              label="Next life variation in sidebar"
+              onClick={() => onCycleVariation(1)}
+            />
+          </TooltipWrapper>
+        </div>
+        <p>{getLifeVariationDescription(preferences.lifespan)}</p>
       </section>
 
       <section className="flex flex-col gap-2 text-center">
@@ -119,15 +147,25 @@ export function LifeSidebarContent({
             selected={birthDate ?? undefined}
             title="Date of birth"
             view="grid"
+            withTodayButton={false}
             withUnderline={false}
           />
         </div>
 
-        <label
-          className="flex w-full flex-col items-center gap-1 text-text-muted"
-          htmlFor="life-age-of-death"
-        >
-          Age of Death
+        <div className="flex w-full flex-col items-center gap-1 text-text-muted">
+          <span className="flex items-center gap-1">
+            Age of Death
+            <TooltipWrapper description="Choose a random age">
+              <button
+                aria-label="Shuffle life variation"
+                className="flex size-6 items-center justify-center rounded-full text-text-muted transition-colors hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                onClick={onShuffleAge}
+                type="button"
+              >
+                <ShuffleIcon aria-hidden="true" size={14} />
+              </button>
+            </TooltipWrapper>
+          </span>
           <NumberInput
             ariaLabel="Age of Death"
             id="life-age-of-death"
@@ -146,7 +184,7 @@ export function LifeSidebarContent({
             }}
             value={lifespanInput}
           />
-        </label>
+        </div>
       </section>
 
       <section className="flex flex-col gap-3 text-text-muted">
@@ -156,6 +194,12 @@ export function LifeSidebarContent({
           week of your life, and each row represents one year.
         </p>
       </section>
+
+      <LifeShareButtons
+        lifespan={preferences.lifespan}
+        totalDots={totalDots}
+        weeksLived={weeksLived}
+      />
     </div>
   );
 }

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -35,6 +35,7 @@ async function renderLifeViewWithSidebar() {
 const mockNavigate = mock();
 const actualTanstackRouter = { ...(await import("@tanstack/react-router")) };
 let isRouterMocked = true;
+let mockedLifeSearch: Record<string, unknown> = {};
 
 mock.module("@tanstack/react-router", () => ({
   ...actualTanstackRouter,
@@ -49,6 +50,7 @@ mock.module("@tanstack/react-router", () => ({
       : // biome-ignore lint/correctness/useHookAtTopLevel: this is a mock.module factory, not a component - the flag is stable for the lifetime of this suite.
         actualTanstackRouter.useNavigate(...(args as [])),
   useLocation: () => ({ pathname: "/life" }),
+  useSearch: () => mockedLifeSearch,
 }));
 
 afterAll(() => {
@@ -81,6 +83,8 @@ function getGrid(region: HTMLElement) {
 }
 
 beforeEach(() => {
+  mockedLifeSearch = {};
+  mockNavigate.mockClear();
   localStorage.setItem(STORAGE_KEYS.SIDEBAR_OPEN, "true");
   viewActions.setSidebarOpen(true);
   mockViewport(false);
@@ -241,6 +245,51 @@ describe("LifeView", () => {
     );
     expect(randomAge).toBeGreaterThanOrEqual(1);
     expect(randomAge).toBeLessThanOrEqual(100);
+  });
+
+  it("cycles life variations with J and K", async () => {
+    await renderLifeViewWithSidebar();
+
+    fireEvent.keyUp(document, { key: "k" });
+    expect(screen.getByText("Long")).toBeInTheDocument();
+    expect(
+      screen.getByText("This is your life if you live to 100"),
+    ).toBeInTheDocument();
+
+    fireEvent.keyUp(document, { key: "j" });
+    expect(screen.getByText("Average")).toBeInTheDocument();
+    expect(
+      screen.getByText("This is your life if you live to 77"),
+    ).toBeInTheDocument();
+  });
+
+  it("restores a bookmarkable Life variation", async () => {
+    mockedLifeSearch = { age: 100, variation: "long" };
+    await renderLifeViewWithSidebar();
+
+    expect(screen.getByText("Long")).toBeInTheDocument();
+    expect(
+      screen.getByText("This is your life if you live to 100"),
+    ).toBeInTheDocument();
+    expect(
+      (screen.getByLabelText(/age of death/i) as HTMLInputElement).value,
+    ).toBe("100");
+  });
+
+  it("shuffles to a random Life variation", async () => {
+    const user = userEvent.setup();
+    await renderLifeViewWithSidebar();
+
+    await user.click(
+      screen.getByRole("button", { name: "Shuffle life variation" }),
+    );
+
+    expect(screen.getByText("Random")).toBeInTheDocument();
+    const lifespan = Number(
+      (screen.getByLabelText(/age of death/i) as HTMLInputElement).value,
+    );
+    expect(lifespan).toBeGreaterThanOrEqual(1);
+    expect(lifespan).toBeLessThanOrEqual(100);
   });
 
   it("keeps the 52-week row on mobile without horizontal scroll or dot buttons", () => {

--- a/packages/web/src/views/Life/LifeView.tsx
+++ b/packages/web/src/views/Life/LifeView.tsx
@@ -1,5 +1,7 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getCommandPalettePlaceholder } from "@web/common/constants/more.cmd.constants";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useResponsiveLayout } from "@web/components/AuthenticatedLayout/useResponsiveLayout";
 import { CalendarHeader } from "@web/components/CalendarHeader/CalendarHeader";
@@ -30,6 +32,7 @@ import {
   readLifePreferences,
   writeLifePreferences,
 } from "./life-preferences.storage";
+import { applyLifeSearch } from "./life-search";
 
 interface LifeViewProps {
   today?: Date;
@@ -41,9 +44,13 @@ function formatWeeks(value: number) {
 
 export function LifeView({ today }: LifeViewProps) {
   const currentDate = useMemo(() => today ?? new Date(), [today]);
+  const navigate = useNavigate();
+  const search = useSearch({ from: ROOT_ROUTES.LIFE });
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
   const currentWeekRef = useRef<HTMLButtonElement>(null);
-  const [preferences, setPreferences] = useState(readLifePreferences);
+  const [preferences, setPreferences] = useState(() =>
+    applyLifeSearch(readLifePreferences(), search, currentDate),
+  );
   const totalDots = useMemo(
     () => getTotalLifeDots(preferences.lifespan),
     [preferences.lifespan],
@@ -65,6 +72,28 @@ export function LifeView({ today }: LifeViewProps) {
   useEffect(() => {
     writeLifePreferences(preferences);
   }, [preferences]);
+
+  useEffect(() => {
+    setPreferences((current) => {
+      const next = applyLifeSearch(current, search, currentDate);
+      return current.variation === next.variation &&
+        current.lifespan === next.lifespan
+        ? current
+        : next;
+    });
+  }, [currentDate, search]);
+
+  useEffect(() => {
+    navigate({
+      to: ROOT_ROUTES.LIFE,
+      replace: true,
+      search: (currentSearch) => ({
+        ...currentSearch,
+        age: preferences.lifespan,
+        variation: preferences.variation,
+      }),
+    });
+  }, [navigate, preferences.lifespan, preferences.variation]);
 
   const toggleSidebar = useCallback(() => {
     viewActions.toggleSidebar();
@@ -110,8 +139,17 @@ export function LifeView({ today }: LifeViewProps) {
     },
     [currentDate],
   );
+  const shuffleAge = useCallback(() => {
+    setPreferences((current) => ({
+      ...current,
+      lifespan: getRandomLifespan(current.birthDate, currentDate),
+      variation: "random",
+    }));
+  }, [currentDate]);
 
   useAppShortcutUp("T", focusCurrentWeek);
+  useAppShortcutUp("J", () => cycleVariation(-1));
+  useAppShortcutUp("K", () => cycleVariation(1));
 
   return (
     <div className="flex h-screen w-screen overflow-hidden">
@@ -152,9 +190,13 @@ export function LifeView({ today }: LifeViewProps) {
           shortcutsViewLabel="Life"
         >
           <LifeSidebarContent
+            onCycleVariation={cycleVariation}
             preferences={preferences}
+            onShuffleAge={shuffleAge}
             summary={summary}
+            totalDots={totalDots}
             today={currentDate}
+            weeksLived={weeksLived}
             onPreferencesChange={onPreferencesChange}
           />
         </SidebarShell>

--- a/packages/web/src/views/Life/life-search.test.ts
+++ b/packages/web/src/views/Life/life-search.test.ts
@@ -1,0 +1,31 @@
+import { applyLifeSearch, validateLifeSearch } from "./life-search";
+import { describe, expect, it } from "bun:test";
+
+describe("life search", () => {
+  it("accepts bookmarkable variation and age params", () => {
+    expect(validateLifeSearch({ age: "83", variation: "random" })).toEqual({
+      age: 83,
+      variation: "random",
+    });
+    expect(
+      validateLifeSearch({ age: "not-a-number", variation: "other" }),
+    ).toEqual({
+      age: undefined,
+      variation: undefined,
+    });
+  });
+
+  it("uses a URL age for the selected variation", () => {
+    const preferences = applyLifeSearch(
+      { birthDate: "1993-09-14", lifespan: 77, variation: "average" },
+      { age: 83, variation: "random" },
+      new Date(2026, 6, 21),
+    );
+
+    expect(preferences).toEqual({
+      birthDate: "1993-09-14",
+      lifespan: 83,
+      variation: "random",
+    });
+  });
+});

--- a/packages/web/src/views/Life/life-search.ts
+++ b/packages/web/src/views/Life/life-search.ts
@@ -1,0 +1,49 @@
+import {
+  clampLifespan,
+  getRandomLifespan,
+  LIFE_VARIATION_ORDER,
+  LIFE_VARIATIONS,
+  type LifeVariation,
+} from "./life.utils";
+import { type LifePreferences } from "./life-preferences.storage";
+
+export interface LifeSearch {
+  age?: number;
+  variation?: LifeVariation;
+}
+
+export function validateLifeSearch(
+  search: Record<string, unknown>,
+): LifeSearch {
+  const variation = LIFE_VARIATION_ORDER.find(
+    (value) => value === search.variation,
+  );
+  const rawAge =
+    typeof search.age === "number"
+      ? search.age
+      : typeof search.age === "string"
+        ? Number(search.age)
+        : Number.NaN;
+
+  return {
+    age: Number.isFinite(rawAge) ? clampLifespan(rawAge) : undefined,
+    variation,
+  };
+}
+
+export function applyLifeSearch(
+  preferences: LifePreferences,
+  search: LifeSearch,
+  today: Date,
+): LifePreferences {
+  if (!search.variation) return preferences;
+
+  const variation = search.variation;
+  const lifespan =
+    search.age ??
+    (variation === "random"
+      ? getRandomLifespan(preferences.birthDate, today)
+      : LIFE_VARIATIONS[variation].defaultLifespan);
+
+  return { ...preferences, lifespan, variation };
+}

--- a/packages/web/src/views/Life/life-share.test.ts
+++ b/packages/web/src/views/Life/life-share.test.ts
@@ -1,0 +1,23 @@
+import { getLifeShareText, getSocialShareUrl } from "./life-share";
+import { describe, expect, it } from "bun:test";
+
+describe("life sharing", () => {
+  it("creates a share message without personal date data", () => {
+    expect(getLifeShareText(83)).toBe("This is my life if I live to 83.");
+  });
+
+  it("prefills X and Facebook links with the current Life URL", () => {
+    const pageUrl = "https://compasscalendar.com/life?variation=random&age=83";
+    const xShare = new URL(getSocialShareUrl("x", pageUrl, 83));
+    const facebookShare = new URL(getSocialShareUrl("facebook", pageUrl, 83));
+
+    expect(xShare.searchParams.get("text")).toBe(
+      "This is my life if I live to 83.",
+    );
+    expect(xShare.searchParams.get("url")).toBe(pageUrl);
+    expect(facebookShare.searchParams.get("quote")).toBe(
+      "This is my life if I live to 83.",
+    );
+    expect(facebookShare.searchParams.get("url")).toBe(pageUrl);
+  });
+});

--- a/packages/web/src/views/Life/life-share.ts
+++ b/packages/web/src/views/Life/life-share.ts
@@ -1,0 +1,131 @@
+import { WEEKS_PER_ROW } from "./life.utils";
+
+export interface LifeShareData {
+  lifespan: number;
+  totalDots: number;
+  weeksLived: number;
+}
+
+type SocialPlatform = "facebook" | "x";
+
+const SHARE_TITLE = "Life in Weeks";
+
+export function getLifeShareText(lifespan: number) {
+  return `This is my life if I live to ${lifespan}.`;
+}
+
+export function getSocialShareUrl(
+  platform: SocialPlatform,
+  pageUrl: string,
+  lifespan: number,
+) {
+  const url = new URL(
+    platform === "x"
+      ? "https://x.com/intent/post"
+      : "https://www.facebook.com/sharer/sharer.php",
+  );
+
+  if (platform === "x") {
+    url.searchParams.set("text", getLifeShareText(lifespan));
+  } else {
+    url.searchParams.set("quote", getLifeShareText(lifespan));
+  }
+  url.searchParams.set("url", pageUrl);
+  return url.toString();
+}
+
+function createCanvas(data: LifeShareData) {
+  const canvas = document.createElement("canvas");
+  const rows = Math.ceil(data.totalDots / WEEKS_PER_ROW);
+  const dotSize = 10;
+  const dotGap = 7;
+  const gridWidth = WEEKS_PER_ROW * (dotSize + dotGap) - dotGap;
+  const width = 1080;
+  const left = Math.round((width - gridWidth) / 2);
+  const top = 230;
+
+  canvas.width = width;
+  canvas.height = Math.max(640, top + rows * (dotSize + 4) + 96);
+
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("Unable to create share image");
+
+  context.fillStyle = "#f3eee2";
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.fillStyle = "#403a2f";
+  context.font = "600 44px system-ui, sans-serif";
+  context.fillText(SHARE_TITLE, left, 82);
+  context.font = "32px system-ui, sans-serif";
+  context.fillStyle = "#5e5847";
+  context.fillText(getLifeShareText(data.lifespan), left, 132);
+  context.font = "24px system-ui, sans-serif";
+  context.fillText(
+    `${data.weeksLived.toLocaleString()} weeks lived`,
+    left,
+    174,
+  );
+
+  for (let dotIndex = 0; dotIndex < data.totalDots; dotIndex += 1) {
+    const row = Math.floor(dotIndex / WEEKS_PER_ROW);
+    const column = dotIndex % WEEKS_PER_ROW;
+    context.fillStyle =
+      dotIndex === data.weeksLived && dotIndex < data.totalDots
+        ? "#7a7771"
+        : dotIndex < data.weeksLived
+          ? "#2b2a27"
+          : "#d8d0c0";
+    context.fillRect(
+      left + column * (dotSize + dotGap),
+      top + row * (dotSize + 4),
+      dotSize,
+      dotSize,
+    );
+  }
+
+  return canvas;
+}
+
+export async function createLifeShareImage(data: LifeShareData) {
+  const canvas = createCanvas(data);
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((image) => {
+      if (image) {
+        resolve(image);
+      } else {
+        reject(new Error("Unable to create share image"));
+      }
+    }, "image/png");
+  });
+
+  return new File([blob], "my-life-in-weeks.png", { type: "image/png" });
+}
+
+export async function downloadLifeShareImage(data: LifeShareData) {
+  const image = await createLifeShareImage(data);
+  const url = URL.createObjectURL(image);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = image.name;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export async function shareLifeImage(data: LifeShareData, pageUrl: string) {
+  if (!navigator.share || !navigator.canShare) return false;
+
+  const image = await createLifeShareImage(data);
+  const shareData = {
+    files: [image],
+    text: getLifeShareText(data.lifespan),
+    title: SHARE_TITLE,
+    url: pageUrl,
+  };
+  if (!navigator.canShare(shareData)) return false;
+
+  try {
+    await navigator.share(shareData);
+    return true;
+  } catch (error) {
+    return error instanceof DOMException && error.name === "AbortError";
+  }
+}

--- a/packages/web/src/views/Life/life.utils.ts
+++ b/packages/web/src/views/Life/life.utils.ts
@@ -8,24 +8,20 @@ export type LifeVariation = "average" | "long" | "random";
 
 export interface LifeVariationDetails {
   label: string;
-  description: string;
   defaultLifespan: number;
 }
 
 export const LIFE_VARIATIONS: Record<LifeVariation, LifeVariationDetails> = {
   average: {
     label: "Average",
-    description: "A grounded view using an average lifespan of 77 years.",
     defaultLifespan: 77,
   },
   long: {
     label: "Long",
-    description: "A longer horizon gives you 100 years of weeks to explore.",
     defaultLifespan: 100,
   },
   random: {
     label: "Random",
-    description: "A playful unknown chooses an age between now and 100.",
     defaultLifespan: RANDOM_LIFESPAN_MAX,
   },
 };
@@ -35,6 +31,10 @@ export const LIFE_VARIATION_ORDER: LifeVariation[] = [
   "long",
   "random",
 ];
+
+export function getLifeVariationDescription(lifespan: number) {
+  return `This is your life if you live to ${lifespan}`;
+}
 
 const MS_PER_WEEK = 1000 * 60 * 60 * 24 * 7;
 


### PR DESCRIPTION
## Summary

- Add bookmarkable Life variation URLs, J/K cycling, shuffle controls, and themed Life-specific date selection.
- Add privacy-preserving X, Facebook, and Instagram sharing with a generated Life image and download fallback where direct media attachment is unavailable.

## Simplicity

- The simplification pass found no behavior-preserving reduction worth adding. URL validation, image generation, and platform sharing remain isolated in small Life utilities. The two effects in `LifeView` respectively synchronize external URL changes and persist the current variation URL.

## Automated validation

- Local browser: opened `http://localhost:9086/life?variation=long&age=100`; confirmed the Long variation and age restore. Pressing K moved to a randomized variation and updated the URL.
- Local browser: opened the DOB picker; confirmed themed selected-day contrast, neutral clear control, no Today action, and no console errors.

## Independent review

- Fresh read-only review against `origin/main`: no actionable findings.

## Test plan

- `bun test:web` (1,298 passing)
- `bun type-check`
- `bun lint` (five existing warning-only class-order findings)
- `git diff --check`