### PR TITLE
feat(sync): execute provider delete commands with deletion markers

### DIFF
--- a/packages/core/src/types/sync/command.contracts.test.ts
+++ b/packages/core/src/types/sync/command.contracts.test.ts
@@ -149,6 +149,14 @@ describe("Sync command contracts", () => {
       );
     });
 
+    it("defaults a delete's invitation to none when absent", () => {
+      const parsed = SyncCommandInputSchema.safeParse(deleteInput());
+      expect(parsed.success && parsed.data.kind === "delete").toBe(true);
+      if (parsed.success && parsed.data.kind === "delete") {
+        expect(parsed.data.invitation).toBe("none");
+      }
+    });
+
     it("rejects an update input carrying a calendarId", () => {
       const input = { ...updateInput(), calendarId: objectId() };
       expect(SyncCommandInputSchema.safeParse(input).success).toBe(false);

--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -71,6 +71,9 @@ const MoveCommandInputSchema = z.strictObject({
 
 const DeleteCommandInputSchema = z.strictObject({
   kind: z.literal("delete"),
+  // Whether to notify attendees of the cancellation, same as create/update;
+  // default is to notify no one.
+  invitation: InvitationIntentSchema,
   scope: RecurrenceScopeSchema,
 });
 

--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -18,6 +18,7 @@ import {
 import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -61,8 +62,9 @@ class FakeWriter implements ProviderEventWriter {
     this.patchCalls.push(input);
     return { providerEventId: "g-evt-1", providerVersion: "etag-2" };
   }
-  deleteEvent(): Promise<void> {
-    throw new Error("unused");
+  deleteCalls = 0;
+  async deleteEvent(): Promise<void> {
+    this.deleteCalls++;
   }
   async fetchEvent(): Promise<ProviderEvent | null> {
     return this.fetched;
@@ -79,6 +81,7 @@ describe("submitCloudCommand provider dispatch", () => {
   let commands: CommandRepository;
   let events: EventRepository;
   let calendars: ProviderCalendarRepository;
+  let markers: DeletionMarkerRepository;
 
   const now = () => new Date("2026-07-10T00:00:00.000Z");
 
@@ -144,6 +147,7 @@ describe("submitCloudCommand provider dispatch", () => {
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     calendars = new ProviderCalendarRepository(mongo.db);
+    markers = new DeletionMarkerRepository(mongo.db);
   });
 
   afterEach(async () => {
@@ -162,6 +166,7 @@ describe("submitCloudCommand provider dispatch", () => {
         commands,
         events,
         calendars,
+        markers,
         execution: "active",
         provider: provider(writer),
       },
@@ -184,6 +189,7 @@ describe("submitCloudCommand provider dispatch", () => {
         commands,
         events,
         calendars,
+        markers,
         execution: "passive",
         provider: provider(writer),
       },
@@ -201,7 +207,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const calendar = await seedProviderCalendar(tenantId, principalId);
 
     const command = await submitCloudCommand(
-      { commands, events, calendars, execution: "active" },
+      { commands, events, calendars, markers, execution: "active" },
       submitFor(tenantId, principalId, calendar._id),
       now,
     );
@@ -219,6 +225,7 @@ describe("submitCloudCommand provider dispatch", () => {
         commands,
         events,
         calendars,
+        markers,
         execution: "active",
         provider: provider(writer),
       },
@@ -292,6 +299,7 @@ describe("submitCloudCommand provider dispatch", () => {
     commands,
     events,
     calendars,
+    markers,
     execution: "passive" as const,
   });
 
@@ -359,6 +367,7 @@ describe("submitCloudCommand provider dispatch", () => {
         commands,
         events,
         calendars,
+        markers,
         execution: "active",
         provider: provider(writer),
       },
@@ -394,5 +403,45 @@ describe("submitCloudCommand provider dispatch", () => {
 
     expect(command.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
+  });
+
+  it("routes a provider-linked delete to the provider executor when active", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      calendarId: calendar._id,
+      connectionId: calendar.connectionId as never,
+      providerEventId: "g-evt-1" as never,
+      providerVersion: "etag-1" as never,
+      deliveryState: "confirmed",
+    });
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        markers,
+        execution: "active",
+        provider: provider(writer),
+      },
+      deleteFor(tenantId, principalId, eventId),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    expect(writer.deleteCalls).toBe(1);
+    // Local content removed only after the provider confirmed.
+    expect(await events.findById(tenantId, principalId, eventId)).toBeNull();
+    expect(
+      await markers.exists(
+        calendar.connectionId,
+        calendar._id,
+        "g-evt-1" as never,
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -5,6 +5,7 @@ import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
 import {
   executeProviderCreate,
+  executeProviderDelete,
   executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
@@ -14,6 +15,7 @@ import {
 } from "@sync/storage/contracts/command.contracts";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 
@@ -21,6 +23,8 @@ export interface CloudCommandDeps {
   commands: CommandRepository;
   events: EventRepository;
   calendars: ProviderCalendarRepository;
+  // The deletion-marker store, for the tombstone a provider delete leaves.
+  markers: DeletionMarkerRepository;
   execution: SyncExecutionMode;
   // Provider write capability, present only when a provider is configured and
   // provider work is enabled. Absent means provider-targeted commands stay
@@ -112,8 +116,37 @@ async function applyCloudMutation(
     // Absence is the desired end state, so a delete of an already-gone (or
     // never-created) event is confirmed rather than left hanging.
     if (!existing) return confirmCloud(deps, command);
-    if (existing.connectionId !== null) return command;
+    // A recurring series needs scope handling (later slice) — defer for both
+    // cloud and provider events.
     if (existing.recurrence.kind !== "single") return command;
+    // A provider-linked event goes to the provider delete path when provider
+    // work is enabled; otherwise it stays pending. It is never removed locally
+    // here — content is deleted only after the provider confirms.
+    if (existing.connectionId !== null) {
+      if (deps.execution === "active" && deps.provider) {
+        const calendar = await deps.calendars.findById(
+          command.tenantId,
+          command.principalId,
+          existing.calendarId as ProviderCalendarId,
+        );
+        if (calendar) {
+          return executeProviderDelete(
+            {
+              commands: deps.commands,
+              events: deps.events,
+              writer: deps.provider.writer,
+              custody: deps.provider.custody,
+              markers: deps.markers,
+            },
+            command,
+            existing,
+            calendar,
+            now,
+          );
+        }
+      }
+      return command;
+    }
     await deps.events.deleteById(
       command.tenantId,
       command.principalId,

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -10,12 +10,14 @@ import {
 import {
   type AccessTokenSource,
   executeProviderCreate,
+  executeProviderDelete,
   executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
   type ProviderCreateInput,
+  type ProviderDeleteInput,
   type ProviderEventWriter,
   type ProviderFetchInput,
   type ProviderPatchInput,
@@ -24,6 +26,7 @@ import {
 } from "@sync/providers/provider-event-writer.port";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -620,5 +623,237 @@ describe("executeProviderUpdate", () => {
     expect(result.outcome.state).toBe("failed");
     expect(writer.fetchCalls).toHaveLength(0);
     expect(writer.patchCalls).toHaveLength(0);
+  });
+});
+
+// A writer for the delete path: a configurable deleteEvent (success or a preset
+// error), recording its inputs.
+class FakeDeleteWriter implements ProviderEventWriter {
+  readonly provider = "google" as const;
+  deleteCalls: ProviderDeleteInput[] = [];
+  deleteError?: unknown;
+  createEvent(): Promise<ProviderWriteResult> {
+    throw new Error("unused");
+  }
+  patchEvent(): Promise<ProviderWriteResult> {
+    throw new Error("unused");
+  }
+  async deleteEvent(input: ProviderDeleteInput): Promise<void> {
+    this.deleteCalls.push(input);
+    if (this.deleteError) throw this.deleteError;
+  }
+  fetchEvent(): Promise<null> {
+    throw new Error("unused");
+  }
+}
+
+describe("executeProviderDelete", () => {
+  let mongo: SyncMongoService;
+  let commands: CommandRepository;
+  let events: EventRepository;
+  let markers: DeletionMarkerRepository;
+
+  const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+  const schedule = {
+    kind: "timed" as const,
+    start: "2026-07-14T09:00:00-06:00",
+    end: "2026-07-14T10:00:00-06:00",
+    timeZone: "America/Denver",
+  };
+
+  // Seed a provider-linked event plus a delete command for it.
+  const seed = async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar: ProviderCalendarRecord = {
+      _id: objectId() as never,
+      tenantId,
+      principalId,
+      connectionId,
+      providerCalendarId: "primary@google.com" as never,
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: [],
+      createdAt: now(),
+      updatedAt: now(),
+    } as never;
+    const eventId = objectId() as EventId;
+    await events.put({
+      _id: eventId,
+      tenantId,
+      principalId,
+      origin: "compass",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-evt-1" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: {
+        title: "Doomed",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule,
+      recurrence: { kind: "single" },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const event = await events.findById(tenantId, principalId, eventId);
+    if (!event) throw new Error("seed failed to read back the event");
+    const command = await commands.submit({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId,
+      input: { kind: "delete", invitation: "all", scope: "all" } as never,
+      expectedVersion: null,
+    });
+    return { tenantId, principalId, calendar, event, command };
+  };
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `provdel_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    commands = new CommandRepository(mongo.db);
+    events = new EventRepository(mongo.db);
+    markers = new DeletionMarkerRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  it("deletes at the provider, tombstones, removes the local event, and confirms", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeDeleteWriter();
+
+    const result = await executeProviderDelete(
+      { commands, events, writer, custody: tokenSource(), markers },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.deleteCalls).toHaveLength(1);
+    expect(writer.deleteCalls[0].invitation).toBe("all");
+    // Local content is gone, a content-free marker remains.
+    expect(await events.findById(tenantId, principalId, event._id)).toBeNull();
+    expect(
+      await markers.exists(
+        calendar.connectionId,
+        event.calendarId,
+        "g-evt-1" as never,
+      ),
+    ).toBe(true);
+  });
+
+  it("confirms idempotently when the local event is already gone (replay)", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeDeleteWriter();
+    // Simulate a prior attempt having already removed the local event.
+    await events.deleteById(tenantId, principalId, event._id);
+
+    const result = await executeProviderDelete(
+      { commands, events, writer, custody: tokenSource(), markers },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    // Nothing to re-delete at the provider — the local absence proves it landed.
+    expect(writer.deleteCalls).toHaveLength(0);
+  });
+
+  it("keeps the event deletionPending and stays pending on a transient failure", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeDeleteWriter();
+    writer.deleteError = new ProviderWriteError("transient", "blip");
+
+    const result = await executeProviderDelete(
+      { commands, events, writer, custody: tokenSource(), markers },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("pending");
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.lifecycleState).toBe("deletionPending");
+  });
+
+  it("reverts the event to active and fails on a terminal error", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeDeleteWriter();
+    writer.deleteError = new ProviderWriteError(
+      "readOnlyCalendar",
+      "read only",
+    );
+
+    const result = await executeProviderDelete(
+      { commands, events, writer, custody: tokenSource(), markers },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(
+      result.outcome.state === "failed" && result.outcome.failureReason,
+    ).toBe("readOnlyCalendar");
+    // The event is restored — a failed delete must not leave it "deleting".
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.lifecycleState).toBe("active");
+  });
+
+  it("reverts and fails without deleting when the credential is revoked", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeDeleteWriter();
+
+    const result = await executeProviderDelete(
+      {
+        commands,
+        events,
+        writer,
+        custody: failingTokenSource(
+          new ProviderAuthError("authorizationRevoked", "revoked"),
+        ),
+        markers,
+      },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(writer.deleteCalls).toHaveLength(0);
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.lifecycleState).toBe("active");
   });
 });

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -477,8 +477,12 @@ async function confirmDeletion(
   return confirmed ?? command;
 }
 
-// Restore a deletionPending event to active (best-effort) and fail the command.
-// A failed delete must not leave the event stuck reading as "deleting".
+// Restore a deletionPending event to active, then fail the command. A failed
+// delete must not leave the event stuck reading as "deleting". The revert write
+// is NOT wrapped in a catch: replaceExisting signals the benign "already gone"
+// case with a resolved false (not a throw), so a throw here is a real error —
+// letting it propagate keeps the command pending (not falsely failed) and
+// retryable, rather than marking it terminally failed with a stuck event.
 async function revertAndFail(
   deps: ProviderMutationDeps,
   command: CommandRecord,
@@ -486,8 +490,10 @@ async function revertAndFail(
   reason: SyncCommandFailureReason,
   now: () => Date,
 ): Promise<CommandRecord> {
-  await deps.events
-    .replaceExisting({ ...event, lifecycleState: "active", updatedAt: now() })
-    .catch(() => undefined);
+  await deps.events.replaceExisting({
+    ...event,
+    lifecycleState: "active",
+    updatedAt: now(),
+  });
   return failCommand(deps, command, reason);
 }

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -23,6 +23,7 @@ import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 
 // The slice of credential custody the executor needs — a valid access token for
@@ -37,6 +38,11 @@ export interface ProviderMutationDeps {
   events: EventRepository;
   writer: ProviderEventWriter;
   custody: AccessTokenSource;
+}
+
+// Delete also needs the deletion-marker store for the tombstone.
+export interface ProviderDeleteDeps extends ProviderMutationDeps {
+  markers: DeletionMarkerRepository;
 }
 
 // Execute a Compass-initiated create against the owning provider, then commit.
@@ -368,4 +374,120 @@ function deepEqual(a: unknown, b: unknown): boolean {
       (b as Record<string, unknown>)[key],
     ),
   );
+}
+
+// Delete a Compass-initiated provider event. The event is marked deletionPending
+// (so it reads as "deleting" while the command is in flight or retrying) BEFORE
+// the provider is asked, and its local content is removed only AFTER the
+// provider confirms — never delete content before provider confirmation. The
+// delete is unconditional: the user's intent to cancel does not hinge on a
+// version, and a routine attendee RSVP must not block it. Idempotent: the
+// adapter treats an already-absent event as deleted, and the marker + local
+// delete are both idempotent, so a retry after a crash converges.
+export async function executeProviderDelete(
+  deps: ProviderDeleteDeps,
+  command: CommandRecord,
+  event: EventRecord,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "delete") {
+    throw new Error("executeProviderDelete requires a delete command");
+  }
+  if (!event.connectionId || !event.providerEventId) {
+    throw new Error("executeProviderDelete requires a linked event");
+  }
+  const { input } = command;
+  const connectionId = event.connectionId;
+  const providerEventId = event.providerEventId;
+
+  // Mark the event as being deleted. If it is already gone locally, a prior
+  // attempt removed it (the marker was written first) — the delete converged.
+  const marked = await deps.events.replaceExisting({
+    ...event,
+    lifecycleState: "deletionPending",
+    updatedAt: now(),
+  });
+  if (!marked) return confirmDeletion(deps, command);
+
+  let accessToken: string;
+  try {
+    accessToken = await deps.custody.getValidAccessToken(connectionId);
+  } catch (error) {
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason === "refreshFailed"
+    ) {
+      return command;
+    }
+    return revertAndFail(deps, command, event, "authorizationRevoked", now);
+  }
+
+  try {
+    await deps.writer.deleteEvent({
+      accessToken,
+      calendarId: calendar.providerCalendarId,
+      providerEventId,
+      // Unconditional: a cancellation is not conditioned on the version, so an
+      // unrelated external change never blocks it.
+      expectedVersion: null,
+      invitation: input.invitation,
+    });
+  } catch (error) {
+    if (error instanceof ProviderWriteError) {
+      // Transient: keep the event deletionPending (visibly deleting) and retry.
+      if (error.reason === "transient") return command;
+      // Terminal: the delete failed, so restore the event to active rather than
+      // leaving it stuck showing "deleting".
+      return revertAndFail(deps, command, event, error.reason, now);
+    }
+    throw error;
+  }
+
+  // The provider confirmed the deletion. Write the content-free tombstone first
+  // (so no window exists where the event is gone with no marker), then remove
+  // the local record, then confirm. All three are idempotent.
+  await deps.markers.record({
+    tenantId: event.tenantId,
+    principalId: event.principalId,
+    connectionId,
+    calendarId: event.calendarId,
+    providerEventId,
+    providerVersion: event.providerVersion,
+    deletionSource: "compass",
+    deletedAt: now(),
+  });
+  await deps.events.deleteById(event.tenantId, event.principalId, event._id);
+  return confirmDeletion(deps, command);
+}
+
+// Confirm a completed deletion: the event has no live provider target anymore,
+// so the confirmed outcome carries no provider identity.
+async function confirmDeletion(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+): Promise<CommandRecord> {
+  const confirmed = await deps.commands.updateOutcome(
+    command.tenantId,
+    command.principalId,
+    command._id,
+    { state: "confirmed", providerEventId: null, providerVersion: null },
+    command.attemptCount,
+  );
+  return confirmed ?? command;
+}
+
+// Restore a deletionPending event to active (best-effort) and fail the command.
+// A failed delete must not leave the event stuck reading as "deleting".
+async function revertAndFail(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+  event: EventRecord,
+  reason: SyncCommandFailureReason,
+  now: () => Date,
+): Promise<CommandRecord> {
+  await deps.events
+    .replaceExisting({ ...event, lifecycleState: "active", updatedAt: now() })
+    .catch(() => undefined);
+  return failCommand(deps, command, reason);
 }

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -20,6 +20,7 @@ import {
 import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -89,6 +90,7 @@ export function registerCommandRoutes(
             commands: new CommandRepository(deps.mongo.db),
             events: new EventRepository(deps.mongo.db),
             calendars: new ProviderCalendarRepository(deps.mongo.db),
+            markers: new DeletionMarkerRepository(deps.mongo.db),
             execution: deps.execution,
             provider,
           },


### PR DESCRIPTION
## What

The provider-delete slice of S28: routes a `delete` of a single, provider-linked event to the owning provider (Google) when provider work is active, leaving a content-free tombstone. Cloud delete (S28.1) is unchanged; series delete is deferred.

## Behavior — "never delete content before provider confirmation"

`executeProviderDelete`:
1. Mark the event `lifecycleState: "deletionPending"` (owner-scoped `replaceExisting`) so it reads as **deleting** while the command is in flight or retrying. If it's already gone locally, a prior attempt removed it (marker written first) → the delete converged → confirm.
2. Resolve the access token (transient refresh → pending; revoked → revert to active + fail).
3. `deleteEvent` at the provider — **unconditional** (`expectedVersion: null`): a cancellation isn't gated on a version, so a routine attendee RSVP never blocks it. The adapter treats an already-absent event as deleted (idempotent).
   - transient → keep `deletionPending` + pending (retry);
   - terminal → **revert to active** + `failed{reason}` (a failed delete must not leave the event stuck "deleting").
4. On success: write the content-free deletion marker **first** (no window where the event is gone with no tombstone), then remove the local record, then confirm. All three are idempotent.

## Replay convergence (every crash point)

- after full success → command confirmed → short-circuited on retry;
- after marker+delete, before confirm → retry finds the event gone → confirm (marker already written);
- after delete, before marker → retry re-runs; adapter NotFound-as-success + idempotent marker/delete converge;
- after `deletionPending`, before delete → retry re-attempts the delete.

## Invitation

Per the decision, `delete` carries the client-driven `invitation` (default `none`), passed to `deleteEvent`.

## Tests

- Executor (5): delete+tombstone+remove+confirm (asserts marker exists, local row gone, invitation pass-through); idempotent replay when the local event is already gone (no provider call); transient → pending with the event still `deletionPending`; terminal → `failed` with the event reverted to `active`; revoked credential → fail + revert, no provider call.
- Dispatch (1): a provider-linked delete under active mode routes to the executor, removes local content only after the provider confirms, and leaves a marker.
- Core: delete defaults `invitation` to `none`.

All core (491) + sync (371) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)