### PR TITLE
feat(web): improve life onboarding and sharing

### DIFF
--- a/packages/web/src/common/constants/more.cmd.constants.test.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.test.ts
@@ -41,9 +41,15 @@ describe("getMoreCommandPaletteSections", () => {
     expect(getCommandPalettePlaceholder("day", true)).not.toContain("bug");
   });
 
-  it("uses a Life-specific placeholder", () => {
+  it("offers feedback from Life", () => {
+    const [section] = getMoreCommandPaletteSections("life", true);
+    section.items.find((item) => item.id === "share-feedback")?.onClick?.();
+
+    expect(selectFeedbackRequest(useFeedbackStore.getState())).toEqual({
+      view: "life",
+    });
     expect(getCommandPalettePlaceholder("life", true)).toBe(
-      "Try: 'day', 'week', or 'theme'",
+      "Try: 'day', 'week', or 'feedback'",
     );
   });
 });

--- a/packages/web/src/common/constants/more.cmd.constants.ts
+++ b/packages/web/src/common/constants/more.cmd.constants.ts
@@ -11,7 +11,9 @@ export function getCommandPalettePlaceholder(
   feedbackEnabled = isPosthogEnabled(),
 ): string {
   if (currentView === "life") {
-    return "Try: 'day', 'week', or 'theme'";
+    return feedbackEnabled
+      ? "Try: 'day', 'week', or 'feedback'"
+      : "Try: 'day', 'week', or 'theme'";
   }
 
   if (currentView === "day") {

--- a/packages/web/src/common/constants/navigation.cmd.constants.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.ts
@@ -13,7 +13,7 @@ import {
   type ViewName,
 } from "@web/shortcuts/shortcuts.constants";
 
-export type CommandPaletteViewName = ViewName | "life";
+export type CommandPaletteViewName = ViewName;
 
 interface GetNavigationCommandItemsArgs {
   currentView?: CommandPaletteViewName;

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -349,6 +349,7 @@ export const LifeCommandPalette = ({
           heading: "Appearance",
           items: themeCmdItems,
         },
+        ...getMoreCommandPaletteSections("life"),
       ]}
     />
   );

--- a/packages/web/src/shortcuts/shortcuts.constants.ts
+++ b/packages/web/src/shortcuts/shortcuts.constants.ts
@@ -15,4 +15,4 @@ export const LIFE_SHORTCUT = {
   route: ROOT_ROUTES.LIFE,
 } as const;
 
-export type ViewName = keyof typeof VIEW_SHORTCUTS;
+export type ViewName = keyof typeof VIEW_SHORTCUTS | "life";

--- a/packages/web/src/views/Life/LifeShareButtons.tsx
+++ b/packages/web/src/views/Life/LifeShareButtons.tsx
@@ -1,11 +1,15 @@
 import {
   FacebookLogoIcon,
   InstagramLogoIcon,
+  ShuffleIcon,
   XLogoIcon,
 } from "@phosphor-icons/react";
+import { useState } from "react";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import { getRandomLifeQuote } from "./life-quotes";
 import {
   downloadLifeShareImage,
+  getCleanLifeShareUrl,
   getSocialShareUrl,
   type LifeShareData,
   shareLifeImage,
@@ -22,9 +26,10 @@ export function LifeShareButtons({
   weeksLived,
 }: LifeShareButtonsProps) {
   const shareData = { lifespan, totalDots, weeksLived };
+  const [quote, setQuote] = useState(getRandomLifeQuote);
+  const pageUrl = getCleanLifeShareUrl(window.location.href);
 
   const openShare = (platform: "facebook" | "x") => {
-    const pageUrl = window.location.href;
     window.open(
       getSocialShareUrl(platform, pageUrl, lifespan),
       "_blank",
@@ -34,7 +39,7 @@ export function LifeShareButtons({
   };
 
   const shareToInstagram = async () => {
-    const didShare = await shareLifeImage(shareData, window.location.href);
+    const didShare = await shareLifeImage(shareData, pageUrl);
     if (didShare) return;
 
     await downloadLifeShareImage(shareData);
@@ -42,40 +47,60 @@ export function LifeShareButtons({
   };
 
   return (
-    <section className="flex flex-col gap-2 text-text-muted">
-      <h2 className="font-semibold text-text">Share</h2>
-      <div className="flex items-center gap-1">
-        <TooltipWrapper description="Share on X (downloads image)">
-          <button
-            aria-label="Share on X"
-            className={iconButtonClassName}
-            onClick={() => openShare("x")}
-            type="button"
-          >
-            <XLogoIcon aria-hidden="true" size={17} />
-          </button>
-        </TooltipWrapper>
-        <TooltipWrapper description="Share on Facebook (downloads image)">
-          <button
-            aria-label="Share on Facebook"
-            className={iconButtonClassName}
-            onClick={() => openShare("facebook")}
-            type="button"
-          >
-            <FacebookLogoIcon aria-hidden="true" size={17} />
-          </button>
-        </TooltipWrapper>
-        <TooltipWrapper description="Share on Instagram">
-          <button
-            aria-label="Share on Instagram"
-            className={iconButtonClassName}
-            onClick={() => void shareToInstagram()}
-            type="button"
-          >
-            <InstagramLogoIcon aria-hidden="true" size={17} />
-          </button>
-        </TooltipWrapper>
-      </div>
-    </section>
+    <>
+      <section className="flex flex-col gap-2 text-text-muted">
+        <div className="flex items-start gap-1">
+          <blockquote aria-live="polite" className="min-w-0 flex-1 italic">
+            {quote}
+          </blockquote>
+          <TooltipWrapper description="Show another quote">
+            <button
+              aria-label="Shuffle life quote"
+              className={iconButtonClassName}
+              onClick={() => setQuote((current) => getRandomLifeQuote(current))}
+              type="button"
+            >
+              <ShuffleIcon aria-hidden="true" size={17} />
+            </button>
+          </TooltipWrapper>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2 text-text-muted">
+        <h2 className="font-semibold text-text">Share</h2>
+        <div className="flex items-center gap-1">
+          <TooltipWrapper description="Share on X (downloads image)">
+            <button
+              aria-label="Share on X"
+              className={iconButtonClassName}
+              onClick={() => openShare("x")}
+              type="button"
+            >
+              <XLogoIcon aria-hidden="true" size={17} />
+            </button>
+          </TooltipWrapper>
+          <TooltipWrapper description="Share on Facebook (downloads image)">
+            <button
+              aria-label="Share on Facebook"
+              className={iconButtonClassName}
+              onClick={() => openShare("facebook")}
+              type="button"
+            >
+              <FacebookLogoIcon aria-hidden="true" size={17} />
+            </button>
+          </TooltipWrapper>
+          <TooltipWrapper description="Share on Instagram">
+            <button
+              aria-label="Share on Instagram"
+              className={iconButtonClassName}
+              onClick={() => void shareToInstagram()}
+              type="button"
+            >
+              <InstagramLogoIcon aria-hidden="true" size={17} />
+            </button>
+          </TooltipWrapper>
+        </div>
+      </section>
+    </>
   );
 }

--- a/packages/web/src/views/Life/LifeSidebarContent.tsx
+++ b/packages/web/src/views/Life/LifeSidebarContent.tsx
@@ -18,6 +18,7 @@ import {
 import { type LifePreferences } from "./life-preferences.storage";
 
 interface LifeSidebarContentProps {
+  autoFocusBirthDate: boolean;
   onCycleVariation: (direction: -1 | 1) => void;
   preferences: LifePreferences;
   onShuffleAge: () => void;
@@ -31,6 +32,7 @@ interface LifeSidebarContentProps {
 }
 
 export function LifeSidebarContent({
+  autoFocusBirthDate,
   onCycleVariation,
   preferences,
   onShuffleAge,
@@ -47,6 +49,11 @@ export function LifeSidebarContent({
   const previousLifespanRef = useRef(preferences.lifespan);
   const birthDate = parseLifeDate(preferences.birthDate);
   const variation = LIFE_VARIATIONS[preferences.variation];
+
+  useEffect(() => {
+    if (!autoFocusBirthDate) return;
+    document.getElementById("life-date-of-birth")?.focus();
+  }, [autoFocusBirthDate]);
 
   useEffect(() => {
     if (previousLifespanRef.current !== preferences.lifespan) {

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -107,19 +107,24 @@ describe("LifeView", () => {
 
     expect(screen.getByRole("heading", { name: "Life" })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Date of birth" })).toHaveValue(
-      "",
+      "Jan 1, 2000",
     );
+    expect(
+      screen.getByRole("textbox", { name: "Date of birth" }),
+    ).toHaveFocus();
     expect(
       (screen.getByLabelText(/age of death/i) as HTMLInputElement).value,
     ).toBe("77");
     expect(screen.getByText("Average")).toBeInTheDocument();
     expect(screen.getByText("About Life.")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toHaveTextContent("Birth date not set");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "1,356 weeks lived - 26 years - 34%",
+    );
     const region = screen.getByRole("region", {
       name: /life visualization/i,
     });
     expect(region).toBeInTheDocument();
-    expect(region.querySelector(".ring-1")).not.toBeInTheDocument();
+    expect(region.querySelector(".ring-1")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /zoom/i }),
     ).not.toBeInTheDocument();
@@ -202,7 +207,7 @@ describe("LifeView", () => {
           name: "Date of birth",
         }) as HTMLInputElement
       ).value,
-    ).toBe("");
+    ).toBe("Jan 1, 2000");
     expect(
       (screen.getByLabelText(/age of death/i) as HTMLInputElement).value,
     ).toBe("77");

--- a/packages/web/src/views/Life/LifeView.tsx
+++ b/packages/web/src/views/Life/LifeView.tsx
@@ -28,6 +28,7 @@ import {
   parseLifeDate,
 } from "./life.utils";
 import {
+  hasLifePreferences,
   type LifePreferences,
   readLifePreferences,
   writeLifePreferences,
@@ -48,6 +49,7 @@ export function LifeView({ today }: LifeViewProps) {
   const search = useSearch({ from: ROOT_ROUTES.LIFE });
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
   const currentWeekRef = useRef<HTMLButtonElement>(null);
+  const isNewLifeUser = useRef(!hasLifePreferences()).current;
   const [preferences, setPreferences] = useState(() =>
     applyLifeSearch(readLifePreferences(), search, currentDate),
   );
@@ -190,6 +192,7 @@ export function LifeView({ today }: LifeViewProps) {
           shortcutsViewLabel="Life"
         >
           <LifeSidebarContent
+            autoFocusBirthDate={isNewLifeUser}
             onCycleVariation={cycleVariation}
             preferences={preferences}
             onShuffleAge={shuffleAge}

--- a/packages/web/src/views/Life/life-preferences.storage.ts
+++ b/packages/web/src/views/Life/life-preferences.storage.ts
@@ -10,7 +10,7 @@ import {
 } from "./life.utils";
 
 const LifePreferencesSchema = z.object({
-  birthDate: z.string().default(""),
+  birthDate: z.string().default("2000-01-01"),
   lifespan: z.number().default(DEFAULT_LIFESPAN),
   variation: z.enum(["average", "long", "random"]).default("average"),
 });
@@ -22,7 +22,7 @@ export interface LifePreferences {
 }
 
 export const DEFAULT_LIFE_PREFERENCES: LifePreferences = {
-  birthDate: "",
+  birthDate: "2000-01-01",
   lifespan: LIFE_VARIATIONS.average.defaultLifespan,
   variation: "average",
 };
@@ -50,6 +50,10 @@ export function readLifePreferences(): LifePreferences {
   } catch {
     return DEFAULT_LIFE_PREFERENCES;
   }
+}
+
+export function hasLifePreferences() {
+  return persistentBrowserStore.get(STORAGE_KEYS.LIFE_PREFERENCES) !== null;
 }
 
 export function writeLifePreferences(preferences: LifePreferences) {

--- a/packages/web/src/views/Life/life-quotes.test.ts
+++ b/packages/web/src/views/Life/life-quotes.test.ts
@@ -1,0 +1,15 @@
+import { getRandomLifeQuote, LIFE_QUOTES } from "./life-quotes";
+import { describe, expect, it } from "bun:test";
+
+describe("life quotes", () => {
+  it("chooses from the supplied quotes", () => {
+    expect(getRandomLifeQuote(undefined, () => 0)).toBe(LIFE_QUOTES[0]);
+  });
+
+  it("chooses a different quote when shuffled", () => {
+    expect(getRandomLifeQuote(LIFE_QUOTES[0], () => 0)).toBe(LIFE_QUOTES[1]);
+    expect(getRandomLifeQuote(LIFE_QUOTES[0], () => 1)).not.toBe(
+      LIFE_QUOTES[0],
+    );
+  });
+});

--- a/packages/web/src/views/Life/life-quotes.ts
+++ b/packages/web/src/views/Life/life-quotes.ts
@@ -1,0 +1,66 @@
+export const LIFE_QUOTES = [
+  "“Teach us to number our days, that we may gain a heart of wisdom.” (Psalm 90:12)",
+  "“It is not that we have a short time to live, but that we waste a lot of it.” (Seneca)",
+  "“How we spend our days is, of course, how we spend our lives.” (Annie Dillard)",
+  "“How many more times will you watch the full moon rise? Perhaps twenty. And yet it all seems limitless.” (Paul Bowles)",
+  "“Tell me, what is it you plan to do with your one wild and precious life?” (Mary Oliver)",
+  "“You could leave life right now. Let that determine what you do and say and think.” (Marcus Aurelius)",
+  "“Dost thou love life? Then do not squander time, for that is the stuff life is made of.” (Benjamin Franklin)",
+  "“As if you could kill time without injuring eternity.” (Henry David Thoreau)",
+  "“Time is the coin of your life. It is the only coin you have, and only you can determine how it will be spent.” (Carl Sandburg)",
+  "“Life is long, if you know how to use it.” (Seneca)",
+  "“Your time is limited, so don’t waste it living someone else’s life.” (Steve Jobs)",
+  "“The average human lifespan is absurdly, terrifyingly, insultingly short.” (Oliver Burkeman)",
+  "“Forever is composed of nows.” (Emily Dickinson)",
+  "“Time is the substance I am made of. Time is a river which sweeps me along, but I am the river.” (Jorge Luis Borges)",
+  "“Begin at once to live, and count each separate day as a separate life.” (Seneca)",
+  "“While we are postponing, life speeds by.” (Seneca)",
+  "“Nothing is ours except time.” (Seneca)",
+  "“Do not act as if you were going to live ten thousand years. Death hangs over you. While you live, while it is in your power, be good.” (Marcus Aurelius)",
+  "“Think of yourself as dead. You have lived your life. Now take what’s left and live it properly.” (Marcus Aurelius)",
+  "“It is not death that a man should fear, but he should fear never beginning to live.” (Marcus Aurelius)",
+  "“Seize the day, put very little trust in tomorrow.” (Horace)",
+  "“The Moving Finger writes; and, having writ, moves on.” (Omar Khayyam)",
+  "“To every thing there is a season, and a time to every purpose under the heaven.” (Ecclesiastes 3:1)",
+  "“Life can only be understood backwards; but it must be lived forwards.” (Soren Kierkegaard)",
+  "“The unexamined life is not worth living.” (Socrates)",
+  "“We are always getting ready to live but never living.” (Ralph Waldo Emerson)",
+  "“Lost time is never found again.” (Benjamin Franklin)",
+  "“Time is what we want most, but what we use worst.” (William Penn)",
+  "“The days are long, but the years are short.” (Gretchen Rubin)",
+  "“Spend the afternoon. You can’t take it with you.” (Annie Dillard)",
+  "“The trouble is, you think you have time.” (Jack Kornfield)",
+  "“It passes on just like this, not ceasing day or night.” (Confucius, watching a river)",
+  "“The months and days are the travelers of eternity. The years that come and go are also voyagers.” (Matsuo Basho)",
+  "“If not now, when?” (Hillel the Elder)",
+  "“We are such stuff as dreams are made on, and our little life is rounded with a sleep.” (William Shakespeare)",
+  "“As a well-spent day brings happy sleep, so a life well spent brings happy death.” (Leonardo da Vinci)",
+  "“The value of life lies not in the length of days, but in the use we make of them.” (Michel de Montaigne)",
+  "“Time and tide wait for no man.” (English proverb)",
+  "“The best time to plant a tree was twenty years ago. The second best time is now.” (Proverb)",
+  "“A man who dares to waste one hour of time has not discovered the value of life.” (Charles Darwin)",
+  "“We are like butterflies who flutter for a day and think it is forever.” (Carl Sagan)",
+  "“Nobody sees a flower really; it is so small. We haven’t time, and to see takes time, like to have a friend takes time.” (Georgia O’Keeffe)",
+  "“How wonderful it is that nobody need wait a single moment before starting to improve the world.” (Anne Frank)",
+  "“The purpose of life is to live it, to taste experience to the utmost, to reach out eagerly and without fear for newer and richer experience.” (Eleanor Roosevelt)",
+  "“I took a deep breath and listened to the old brag of my heart. I am, I am, I am.” (Sylvia Plath)",
+  "“The time is always right to do what is right.” (Martin Luther King Jr.)",
+  "“Don’t count the days; make the days count.” (Muhammad Ali)",
+  "“I urge you to please notice when you are happy, and exclaim or murmur or think at some point, 'If this isn’t nice, I don’t know what is.'” (Kurt Vonnegut)",
+  "“It is good to have an end to journey toward; but it is the journey that matters, in the end.” (Ursula K. Le Guin)",
+  "“Life moves pretty fast. If you don’t stop and look around once in a while, you could miss it.” (Ferris Bueller’s Day Off)",
+] as const;
+
+export function getRandomLifeQuote(
+  currentQuote?: string,
+  random = Math.random,
+) {
+  const quotes = currentQuote
+    ? LIFE_QUOTES.filter((quote) => quote !== currentQuote)
+    : LIFE_QUOTES;
+  const index = Math.min(
+    quotes.length - 1,
+    Math.floor(random() * quotes.length),
+  );
+  return quotes[index] ?? LIFE_QUOTES[0];
+}

--- a/packages/web/src/views/Life/life-quotes.ts
+++ b/packages/web/src/views/Life/life-quotes.ts
@@ -1,3 +1,5 @@
+import { getSecureRandomNumber } from "./life.utils";
+
 export const LIFE_QUOTES = [
   "“Teach us to number our days, that we may gain a heart of wisdom.” (Psalm 90:12)",
   "“It is not that we have a short time to live, but that we waste a lot of it.” (Seneca)",
@@ -51,15 +53,9 @@ export const LIFE_QUOTES = [
   "“Life moves pretty fast. If you don’t stop and look around once in a while, you could miss it.” (Ferris Bueller’s Day Off)",
 ] as const;
 
-function getRandomNumber() {
-  const values = new Uint32Array(1);
-  crypto.getRandomValues(values);
-  return values[0] / 2 ** 32;
-}
-
 export function getRandomLifeQuote(
   currentQuote?: string,
-  random = getRandomNumber,
+  random = getSecureRandomNumber,
 ) {
   const quotes = currentQuote
     ? LIFE_QUOTES.filter((quote) => quote !== currentQuote)

--- a/packages/web/src/views/Life/life-quotes.ts
+++ b/packages/web/src/views/Life/life-quotes.ts
@@ -51,9 +51,15 @@ export const LIFE_QUOTES = [
   "“Life moves pretty fast. If you don’t stop and look around once in a while, you could miss it.” (Ferris Bueller’s Day Off)",
 ] as const;
 
+function getRandomNumber() {
+  const values = new Uint32Array(1);
+  crypto.getRandomValues(values);
+  return values[0] / 2 ** 32;
+}
+
 export function getRandomLifeQuote(
   currentQuote?: string,
-  random = Math.random,
+  random = getRandomNumber,
 ) {
   const quotes = currentQuote
     ? LIFE_QUOTES.filter((quote) => quote !== currentQuote)

--- a/packages/web/src/views/Life/life-share.test.ts
+++ b/packages/web/src/views/Life/life-share.test.ts
@@ -28,7 +28,7 @@ describe("life sharing", () => {
   it("shares only the canonical Life URL", () => {
     expect(
       getCleanLifeShareUrl(
-        "https://compasscalendar.com/life?auth=reset&token=secret&variation=random&age=83#token=secret",
+        "https://user:secret@compasscalendar.com/life?auth=reset&token=secret&variation=random&age=83#token=secret",
       ),
     ).toBe("https://compasscalendar.com/life");
   });

--- a/packages/web/src/views/Life/life-share.test.ts
+++ b/packages/web/src/views/Life/life-share.test.ts
@@ -1,4 +1,8 @@
-import { getLifeShareText, getSocialShareUrl } from "./life-share";
+import {
+  getCleanLifeShareUrl,
+  getLifeShareText,
+  getSocialShareUrl,
+} from "./life-share";
 import { describe, expect, it } from "bun:test";
 
 describe("life sharing", () => {
@@ -18,6 +22,14 @@ describe("life sharing", () => {
     expect(facebookShare.searchParams.get("quote")).toBe(
       "This is my life if I live to 83.",
     );
-    expect(facebookShare.searchParams.get("url")).toBe(pageUrl);
+    expect(facebookShare.searchParams.get("u")).toBe(pageUrl);
+  });
+
+  it("removes Life-specific state from shared links", () => {
+    expect(
+      getCleanLifeShareUrl(
+        "https://compasscalendar.com/life?variation=random&age=83&utm_source=x",
+      ),
+    ).toBe("https://compasscalendar.com/life?utm_source=x");
   });
 });

--- a/packages/web/src/views/Life/life-share.test.ts
+++ b/packages/web/src/views/Life/life-share.test.ts
@@ -28,7 +28,7 @@ describe("life sharing", () => {
   it("shares only the canonical Life URL", () => {
     expect(
       getCleanLifeShareUrl(
-        "https://compasscalendar.com/life?auth=reset&token=secret&variation=random&age=83",
+        "https://compasscalendar.com/life?auth=reset&token=secret&variation=random&age=83#token=secret",
       ),
     ).toBe("https://compasscalendar.com/life");
   });

--- a/packages/web/src/views/Life/life-share.test.ts
+++ b/packages/web/src/views/Life/life-share.test.ts
@@ -25,11 +25,11 @@ describe("life sharing", () => {
     expect(facebookShare.searchParams.get("u")).toBe(pageUrl);
   });
 
-  it("removes Life-specific state from shared links", () => {
+  it("shares only the canonical Life URL", () => {
     expect(
       getCleanLifeShareUrl(
-        "https://compasscalendar.com/life?variation=random&age=83&utm_source=x",
+        "https://compasscalendar.com/life?auth=reset&token=secret&variation=random&age=83",
       ),
-    ).toBe("https://compasscalendar.com/life?utm_source=x");
+    ).toBe("https://compasscalendar.com/life");
   });
 });

--- a/packages/web/src/views/Life/life-share.ts
+++ b/packages/web/src/views/Life/life-share.ts
@@ -38,9 +38,7 @@ export function getSocialShareUrl(
 
 export function getCleanLifeShareUrl(pageUrl: string) {
   const url = new URL(pageUrl);
-  url.search = "";
-  url.hash = "";
-  return url.toString();
+  return `${url.origin}${url.pathname}`;
 }
 
 function createCanvas(data: LifeShareData) {

--- a/packages/web/src/views/Life/life-share.ts
+++ b/packages/web/src/views/Life/life-share.ts
@@ -39,6 +39,7 @@ export function getSocialShareUrl(
 export function getCleanLifeShareUrl(pageUrl: string) {
   const url = new URL(pageUrl);
   url.search = "";
+  url.hash = "";
   return url.toString();
 }
 

--- a/packages/web/src/views/Life/life-share.ts
+++ b/packages/web/src/views/Life/life-share.ts
@@ -9,6 +9,7 @@ export interface LifeShareData {
 type SocialPlatform = "facebook" | "x";
 
 const SHARE_TITLE = "Life in Weeks";
+const SHARE_URL = "compasscalendar.com/life";
 
 export function getLifeShareText(lifespan: number) {
   return `This is my life if I live to ${lifespan}.`;
@@ -27,10 +28,18 @@ export function getSocialShareUrl(
 
   if (platform === "x") {
     url.searchParams.set("text", getLifeShareText(lifespan));
+    url.searchParams.set("url", pageUrl);
   } else {
     url.searchParams.set("quote", getLifeShareText(lifespan));
+    url.searchParams.set("u", pageUrl);
   }
-  url.searchParams.set("url", pageUrl);
+  return url.toString();
+}
+
+export function getCleanLifeShareUrl(pageUrl: string) {
+  const url = new URL(pageUrl);
+  url.searchParams.delete("age");
+  url.searchParams.delete("variation");
   return url.toString();
 }
 
@@ -58,12 +67,6 @@ function createCanvas(data: LifeShareData) {
   context.font = "32px system-ui, sans-serif";
   context.fillStyle = "#5e5847";
   context.fillText(getLifeShareText(data.lifespan), left, 132);
-  context.font = "24px system-ui, sans-serif";
-  context.fillText(
-    `${data.weeksLived.toLocaleString()} weeks lived`,
-    left,
-    174,
-  );
 
   for (let dotIndex = 0; dotIndex < data.totalDots; dotIndex += 1) {
     const row = Math.floor(dotIndex / WEEKS_PER_ROW);
@@ -81,6 +84,14 @@ function createCanvas(data: LifeShareData) {
       dotSize,
     );
   }
+
+  const linkY = canvas.height - 42;
+  context.font = "24px system-ui, sans-serif";
+  context.fillStyle = "#5e5847";
+  const linkWidth = context.measureText(SHARE_URL).width;
+  const linkX = Math.round((canvas.width - linkWidth) / 2);
+  context.fillText(SHARE_URL, linkX, linkY);
+  context.fillRect(linkX, linkY + 5, linkWidth, 1);
 
   return canvas;
 }

--- a/packages/web/src/views/Life/life-share.ts
+++ b/packages/web/src/views/Life/life-share.ts
@@ -38,8 +38,7 @@ export function getSocialShareUrl(
 
 export function getCleanLifeShareUrl(pageUrl: string) {
   const url = new URL(pageUrl);
-  url.searchParams.delete("age");
-  url.searchParams.delete("variation");
+  url.search = "";
   return url.toString();
 }
 

--- a/packages/web/src/views/Life/life.utils.ts
+++ b/packages/web/src/views/Life/life.utils.ts
@@ -99,10 +99,16 @@ export function getAgeInYears(birthDateValue: string, today = new Date()) {
   return Math.max(0, age);
 }
 
+export function getSecureRandomNumber() {
+  const values = new Uint32Array(1);
+  window.crypto.getRandomValues(values);
+  return values[0] / 2 ** 32;
+}
+
 export function getRandomLifespan(
   birthDateValue: string,
   today = new Date(),
-  random = Math.random,
+  random = getSecureRandomNumber,
 ) {
   const currentAge = getAgeInYears(birthDateValue, today) ?? MIN_LIFESPAN;
   const minimumAge = Math.max(


### PR DESCRIPTION
## Summary

- Give first-time Life visitors a focused Jan 1, 2000 date baseline, add the shared feedback action, and add reshufflable Life reflections.
- Refine shared images and social links: render the Life URL in the PNG, remove weeks-lived copy, use Facebook’s canonical `u` parameter, and share only the canonical `/life` URL.

## Simplicity

- No extra simplification commit was needed. The quote list and random selector are isolated, the first-visit focus effect is necessary because the third-party date picker does not forward focus to its custom input, and the URL-cleaning helper is the single privacy boundary for every share path.

## Automated validation

- Local browser: opened `http://localhost:9086/life?variation=long&age=100`; confirmed bookmark restoration, quote shuffle, J/K variation transition, URL update, and no console errors.
- Regression test: canonical share URLs remove `auth`, `token`, age, variation, and all other query parameters before any social or native share path.

## Independent review

- Initial fresh review found a confirmed reset-token exposure risk in shared query strings; fixed in `bfbe48f86`.
- Fresh confirmation review after the fix: no actionable findings.

## Test plan

- `bun test:web` (1,301 passing)
- `bun type-check`
- `bun lint` (five existing warning-only class-order findings)
- `git diff --check`