### PR TITLE
feat(sync): project event occurrences from masters and exceptions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
         "express-rate-limit": "^7.5.0",
         "google-auth-library": "^10.6.2",
         "mongodb": "^7.2.0",
+        "rrule": "^2.7.2",
         "tslib": "^2.4.0",
         "zod": "^3.25.76",
       },

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -11,6 +11,7 @@
     "express-rate-limit": "^7.5.0",
     "google-auth-library": "^10.6.2",
     "mongodb": "^7.2.0",
+    "rrule": "^2.7.2",
     "tslib": "^2.4.0",
     "zod": "^3.25.76"
   },

--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -1,0 +1,235 @@
+import { faker } from "@faker-js/faker";
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
+import {
+  type ProjectionHorizon,
+  projectOccurrences,
+} from "@sync/domain/occurrence-projection";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+// A wide horizon so most cases aren't clipped; individual tests narrow it.
+const HORIZON: ProjectionHorizon = {
+  start: new Date("2026-01-01T00:00:00.000Z"),
+  end: new Date("2027-07-01T00:00:00.000Z"),
+};
+
+const timed = (start: string, end: string, timeZone = "America/Denver") =>
+  ({ kind: "timed", start, end, timeZone }) as EventSchedule;
+
+const allDay = (start: string, end: string) =>
+  ({ kind: "allDay", start, end }) as EventSchedule;
+
+const event = (
+  schedule: EventSchedule,
+  recurrence: SyncEventRecurrence,
+  overrides: Partial<EventRecord> = {},
+): EventRecord =>
+  ({
+    _id: objectId(),
+    tenantId: objectId(),
+    principalId: objectId(),
+    origin: "compass",
+    calendarId: objectId(),
+    clientEventId: null,
+    connectionId: null,
+    providerEventId: null,
+    providerVersion: null,
+    providerUpdatedAt: null,
+    deliveryState: null,
+    providerMetadata: null,
+    content: {
+      title: "Standup",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    },
+    schedule,
+    recurrence,
+    lifecycleState: "active",
+    generation: 0,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    confirmedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  }) as EventRecord;
+
+describe("projectOccurrences", () => {
+  describe("single events", () => {
+    it("projects one occurrence for a timed single event in range", () => {
+      const e = event(
+        timed("2026-07-14T09:00:00-06:00", "2026-07-14T10:00:00-06:00"),
+        { kind: "single" },
+      );
+      const [occ, ...rest] = projectOccurrences(e, HORIZON);
+      expect(rest).toHaveLength(0);
+      expect(occ).toMatchObject({
+        eventId: e._id,
+        calendarId: e.calendarId,
+        title: "Standup",
+        busy: true,
+        cancelled: false,
+        generation: 0,
+      });
+      expect(occ?.startAt.toISOString()).toBe("2026-07-14T15:00:00.000Z");
+      expect(occ?.occurrenceKey).toBe(`${e._id}:2026-07-14T15:00:00.000Z`);
+    });
+
+    it("projects one occurrence for an all-day single event", () => {
+      const e = event(allDay("2026-07-14", "2026-07-15"), { kind: "single" });
+      const [occ] = projectOccurrences(e, HORIZON);
+      expect(occ?.schedule).toEqual(allDay("2026-07-14", "2026-07-15"));
+      expect(occ?.startAt.toISOString()).toBe("2026-07-14T00:00:00.000Z");
+    });
+
+    it("omits a single event whose start is before the horizon", () => {
+      const e = event(
+        timed("2025-06-01T09:00:00-06:00", "2025-06-01T10:00:00-06:00"),
+        { kind: "single" },
+      );
+      expect(projectOccurrences(e, HORIZON)).toHaveLength(0);
+    });
+
+    it("omits a single event whose start is at or after the horizon end", () => {
+      const e = event(
+        timed("2027-07-01T00:00:00+00:00", "2027-07-01T01:00:00+00:00"),
+        { kind: "single" },
+      );
+      expect(projectOccurrences(e, HORIZON)).toHaveLength(0);
+    });
+  });
+
+  describe("exceptions", () => {
+    it("projects an active exception as one occurrence", () => {
+      const e = event(
+        timed("2026-07-14T11:00:00-06:00", "2026-07-14T12:00:00-06:00"),
+        {
+          kind: "exception",
+          seriesId: objectId() as EventRecord["_id"],
+          recurrenceId: "2026-07-14T09:00:00-06:00" as never,
+          cancelled: false,
+        },
+      );
+      const [occ] = projectOccurrences(e, HORIZON);
+      expect(occ?.cancelled).toBe(false);
+      expect(occ?.startAt.toISOString()).toBe("2026-07-14T17:00:00.000Z");
+    });
+
+    it("projects a cancelled exception as a cancelled occurrence", () => {
+      const e = event(
+        timed("2026-07-14T09:00:00-06:00", "2026-07-14T10:00:00-06:00"),
+        {
+          kind: "exception",
+          seriesId: objectId() as EventRecord["_id"],
+          recurrenceId: "2026-07-14T09:00:00-06:00" as never,
+          cancelled: true,
+        },
+      );
+      const [occ, ...rest] = projectOccurrences(e, HORIZON);
+      expect(rest).toHaveLength(0);
+      expect(occ?.cancelled).toBe(true);
+    });
+  });
+
+  describe("series masters", () => {
+    it("expands a weekly series and preserves duration", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+      );
+      const occ = projectOccurrences(e, HORIZON);
+      expect(occ.map((o) => o.startAt.toISOString())).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-13T15:00:00.000Z",
+        "2026-07-20T15:00:00.000Z",
+      ]);
+      for (const o of occ) {
+        if (o.schedule.kind !== "timed") throw new Error("expected timed");
+        const durationMs =
+          new Date(o.schedule.end).getTime() -
+          new Date(o.schedule.start).getTime();
+        expect(durationMs).toBe(30 * 60 * 1000);
+      }
+    });
+
+    it("clamps expansion to the horizon window", () => {
+      const e = event(
+        timed("2026-01-01T09:00:00-07:00", "2026-01-01T10:00:00-07:00"),
+        { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
+      );
+      const narrow: ProjectionHorizon = {
+        start: new Date("2026-06-01T00:00:00.000Z"),
+        end: new Date("2026-07-01T00:00:00.000Z"),
+      };
+      const occ = projectOccurrences(e, narrow);
+      expect(occ.length).toBeGreaterThan(0);
+      for (const o of occ) {
+        expect(o.startAt.getTime()).toBeGreaterThanOrEqual(
+          narrow.start.getTime(),
+        );
+        expect(o.startAt.getTime()).toBeLessThan(narrow.end.getTime());
+      }
+    });
+
+    it("skips instants owned by an exception", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T10:00:00-06:00"),
+        { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+      );
+      // The second occurrence (2026-07-13T09:00-06:00) is excepted.
+      const occ = projectOccurrences(e, HORIZON, [
+        "2026-07-13T09:00:00-06:00" as never,
+      ]);
+      expect(occ.map((o) => o.startAt.toISOString())).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-20T15:00:00.000Z",
+      ]);
+    });
+
+    it("expands an all-day weekly series preserving the multi-day span", () => {
+      const e = event(allDay("2026-07-06", "2026-07-08"), {
+        kind: "seriesMaster",
+        rules: ["RRULE:FREQ=WEEKLY;COUNT=2"],
+      });
+      const occ = projectOccurrences(e, HORIZON);
+      expect(occ.map((o) => o.schedule)).toEqual([
+        allDay("2026-07-06", "2026-07-08"),
+        allDay("2026-07-13", "2026-07-15"),
+      ]);
+    });
+
+    it("keeps wall-clock time across a DST spring-forward transition", () => {
+      // US DST 2026 begins 2026-03-08. A weekly 09:00 Denver series should read
+      // 09:00 local on both sides, with the civil offset changing -07 -> -06.
+      const e = event(
+        timed("2026-03-01T09:00:00-07:00", "2026-03-01T10:00:00-07:00"),
+        { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+      );
+      const occ = projectOccurrences(e, HORIZON);
+      const starts = occ.map((o) =>
+        o.schedule.kind === "timed" ? o.schedule.start : "",
+      );
+      expect(starts).toEqual([
+        "2026-03-01T09:00:00-07:00",
+        "2026-03-08T09:00:00-06:00",
+        "2026-03-15T09:00:00-06:00",
+      ]);
+    });
+
+    it("bounds a non-ending daily rule to the horizon rather than expanding forever", () => {
+      const e = event(
+        timed("2026-06-01T09:00:00-06:00", "2026-06-01T09:15:00-06:00"),
+        { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+      );
+      const narrow: ProjectionHorizon = {
+        start: new Date("2026-06-01T00:00:00.000Z"),
+        end: new Date("2026-06-11T00:00:00.000Z"),
+      };
+      const occ = projectOccurrences(e, narrow);
+      expect(occ).toHaveLength(10);
+    });
+  });
+});

--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -231,5 +231,45 @@ describe("projectOccurrences", () => {
       const occ = projectOccurrences(e, narrow);
       expect(occ).toHaveLength(10);
     });
+
+    it("honors a UTC UNTIL west of UTC without a phantom trailing occurrence", () => {
+      // Google encodes "ends June 9 (America/Denver)" as UNTIL=20260610T055959Z.
+      // A real-UTC UNTIL compared against floating candidates would leak one
+      // extra occurrence on June 10; the boundary must land on June 9.
+      const e = event(
+        timed("2026-06-01T03:00:00-06:00", "2026-06-01T03:15:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: ["RRULE:FREQ=DAILY;UNTIL=20260610T055959Z"],
+        },
+      );
+      const starts = projectOccurrences(e, HORIZON).map((o) =>
+        o.startAt.toISOString(),
+      );
+      expect(starts).toHaveLength(9);
+      expect(starts.at(-1)).toBe("2026-06-09T09:00:00.000Z");
+    });
+
+    it("honors a UTC UNTIL east of UTC without dropping the final occurrence", () => {
+      // "ends June 5 (Asia/Kolkata, +05:30)" is UNTIL=20260605T182959Z. A
+      // real-UTC UNTIL would drop the true June 5 occurrence (20:00 IST is
+      // 14:30Z, past the naive 18:29:59 boundary in the floating frame).
+      const e = event(
+        timed(
+          "2026-06-01T20:00:00+05:30",
+          "2026-06-01T20:30:00+05:30",
+          "Asia/Kolkata",
+        ),
+        {
+          kind: "seriesMaster",
+          rules: ["RRULE:FREQ=DAILY;UNTIL=20260605T182959Z"],
+        },
+      );
+      const starts = projectOccurrences(e, HORIZON).map((o) =>
+        o.startAt.toISOString(),
+      );
+      expect(starts).toHaveLength(5);
+      expect(starts.at(-1)).toBe("2026-06-05T14:30:00.000Z");
+    });
   });
 });

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -79,7 +79,7 @@ function expandInstants(
   rules: readonly string[],
   horizon: ProjectionHorizon,
 ): Date[] {
-  const rule = rrulestr(rules.join("\n"), {
+  const rule = rrulestr(floatingRules(rules, schedule), {
     dtstart: floatingAnchor(schedule),
   });
 
@@ -92,6 +92,43 @@ function expandInstants(
   });
 
   return wallInstants.map((date) => localizeInstant(date, schedule));
+}
+
+// Rewrites a rule's UNTIL into the same floating frame as the dtstart. rrule
+// parses UNTIL as an absolute UTC instant (Google always emits ...Z) but
+// compares it against the floating candidates we expand from floatingAnchor, so
+// a real-UTC UNTIL would mis-bound the series by the zone's offset — projecting
+// a phantom trailing occurrence west of UTC, or dropping the true final one east
+// of it. Reinterpreting UNTIL's instant as wall time in the event's zone, then
+// relabeling it UTC, makes the boundary comparison apples-to-apples. All-day
+// series already expand in real UTC, so their UNTIL needs no rewrite.
+function floatingRules(
+  rules: readonly string[],
+  schedule: EventSchedule,
+): string {
+  const joined = rules.join("\n");
+  if (schedule.kind !== "timed") return joined;
+  const { timeZone } = schedule;
+  return joined.replace(/UNTIL=(\d{8}T\d{6})Z?/g, (_match, basic: string) => {
+    const wall = dayjs(basicUtcToDate(basic))
+      .tz(timeZone)
+      .format("YYYYMMDD[T]HHmmss");
+    return `UNTIL=${wall}Z`;
+  });
+}
+
+// Parses a basic-format UTC datetime ("20260610T055959") to its instant.
+function basicUtcToDate(basic: string): Date {
+  return new Date(
+    Date.UTC(
+      Number(basic.slice(0, 4)),
+      Number(basic.slice(4, 6)) - 1,
+      Number(basic.slice(6, 8)),
+      Number(basic.slice(9, 11)),
+      Number(basic.slice(11, 13)),
+      Number(basic.slice(13, 15)),
+    ),
+  );
 }
 
 // The rule's dtstart: the master's wall-clock start expressed as a naive UTC

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -1,0 +1,197 @@
+import { rrulestr } from "rrule";
+import { GCAL_MAX_RECURRENCES } from "@core/constants/core.constants";
+import { type DateTime, type EventId } from "@core/types/domain-primitives";
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type OccurrenceKey } from "@core/types/sync/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type OccurrenceInput } from "@sync/storage/repositories/event-occurrence.repository";
+
+// Derives the bounded occurrence projection for one event. Sync stores masters
+// and exceptions canonically and materializes occurrences only for the rolling
+// horizon, so this never expands a series to completion — it stops at the
+// horizon end (and caps at GCAL_MAX_RECURRENCES as a defensive bound against a
+// pathological high-frequency rule).
+//
+// The projection is per-event: a seriesMaster expands its rule but omits any
+// instant an exception owns (passed as `excludedInstants`, the exceptions'
+// recurrenceIds); each exception or single event projects its own one
+// occurrence under its own id. So no event's projection ever writes another
+// event's occurrence rows, and a series edit rebuilds only that event's window.
+
+export interface ProjectionHorizon {
+  // Half-open [start, end) over an occurrence's normalized start instant.
+  start: Date;
+  end: Date;
+}
+
+export function projectOccurrences(
+  event: EventRecord,
+  horizon: ProjectionHorizon,
+  excludedInstants: readonly DateTime[] = [],
+): OccurrenceInput[] {
+  if (event.recurrence.kind === "seriesMaster") {
+    return projectSeriesMaster(
+      event,
+      event.recurrence.rules,
+      horizon,
+      excludedInstants,
+    );
+  }
+
+  // A single or exception event is one occurrence at its own schedule. A
+  // cancelled exception still projects a row (cancelled) so the gap it carves
+  // in the series is visible and reprojection stays deterministic.
+  const startAt = scheduleStartAt(event.schedule);
+  if (!withinHorizon(startAt, horizon)) return [];
+  const cancelled =
+    event.recurrence.kind === "exception" && event.recurrence.cancelled;
+  return [toOccurrence(event, event.schedule, startAt, cancelled)];
+}
+
+function projectSeriesMaster(
+  event: EventRecord,
+  rules: readonly string[],
+  horizon: ProjectionHorizon,
+  excludedInstants: readonly DateTime[],
+): OccurrenceInput[] {
+  const excluded = new Set(
+    excludedInstants.map((instant) => new Date(instant).getTime()),
+  );
+  const occurrences: OccurrenceInput[] = [];
+
+  for (const originalStart of expandInstants(event.schedule, rules, horizon)) {
+    if (excluded.has(originalStart.getTime())) continue;
+    const schedule = shiftSchedule(event.schedule, originalStart);
+    occurrences.push(toOccurrence(event, schedule, originalStart, false));
+  }
+
+  return occurrences;
+}
+
+// Expands a series to its occurrence START instants within the horizon.
+// Timed rules expand on floating wall time and re-localize, so a series that
+// crosses a DST transition keeps its wall-clock time (matching how the app
+// already materializes series). Iteration is bounded by the horizon end and
+// the recurrence cap.
+function expandInstants(
+  schedule: EventSchedule,
+  rules: readonly string[],
+  horizon: ProjectionHorizon,
+): Date[] {
+  const rule = rrulestr(rules.join("\n"), {
+    dtstart: floatingAnchor(schedule),
+  });
+
+  const wallInstants: Date[] = [];
+  rule.all((date) => {
+    const instant = localizeInstant(date, schedule);
+    if (instant.getTime() >= horizon.end.getTime()) return false;
+    if (instant.getTime() >= horizon.start.getTime()) wallInstants.push(date);
+    return wallInstants.length < GCAL_MAX_RECURRENCES;
+  });
+
+  return wallInstants.map((date) => localizeInstant(date, schedule));
+}
+
+// The rule's dtstart: the master's wall-clock start expressed as a naive UTC
+// instant, so rrule expands on floating wall time regardless of zone.
+function floatingAnchor(schedule: EventSchedule): Date {
+  if (schedule.kind === "allDay") {
+    return new Date(`${schedule.start}T00:00:00.000Z`);
+  }
+  const local = dayjs(schedule.start).tz(schedule.timeZone);
+  return new Date(
+    Date.UTC(
+      local.year(),
+      local.month(),
+      local.date(),
+      local.hour(),
+      local.minute(),
+      local.second(),
+    ),
+  );
+}
+
+// Re-anchors one floating expansion date back onto the real timeline: the
+// occurrence's civil wall time in the event's zone (DST-aware). For an all-day
+// series the floating date is already the occurrence's midnight-UTC instant.
+function localizeInstant(floating: Date, schedule: EventSchedule): Date {
+  if (schedule.kind === "allDay") return floating;
+  const wall = dayjs(floating).utc().format("YYYY-MM-DDTHH:mm:ss");
+  return dayjs.tz(wall, schedule.timeZone).toDate();
+}
+
+// Builds one occurrence's schedule from the master's, at the given original
+// start instant, preserving duration and (for timed) the zone.
+function shiftSchedule(
+  master: EventSchedule,
+  originalStart: Date,
+): EventSchedule {
+  if (master.kind === "allDay") {
+    const days = dayOnlyDiff(master.start, master.end);
+    const start = dayjs(originalStart).utc();
+    return {
+      kind: "allDay",
+      start: start.format("YYYY-MM-DD"),
+      end: start.add(days, "day").format("YYYY-MM-DD"),
+    } as EventSchedule;
+  }
+  const durationMs =
+    new Date(master.end).getTime() - new Date(master.start).getTime();
+  const start = dayjs(originalStart).tz(master.timeZone);
+  return {
+    kind: "timed",
+    start: start.format(),
+    end: start.add(durationMs, "millisecond").format(),
+    timeZone: master.timeZone,
+  } as EventSchedule;
+}
+
+function toOccurrence(
+  event: EventRecord,
+  schedule: EventSchedule,
+  startAt: Date,
+  cancelled: boolean,
+): OccurrenceInput {
+  return {
+    tenantId: event.tenantId,
+    principalId: event.principalId,
+    eventId: event._id,
+    occurrenceKey: occurrenceKey(event._id, startAt),
+    calendarId: event.calendarId,
+    schedule,
+    startAt,
+    // Sync's content carries no free/busy transparency yet, so every occurrence
+    // is busy. Transparency modeling lands with provider content mapping.
+    busy: true,
+    title: event.content.title,
+    cancelled,
+    generation: event.generation,
+  };
+}
+
+// The normalized start instant used by range queries and the start-time index:
+// the timed instant itself, or midnight UTC of an all-day date.
+function scheduleStartAt(schedule: EventSchedule): Date {
+  if (schedule.kind === "timed") return new Date(schedule.start);
+  return new Date(`${schedule.start}T00:00:00.000Z`);
+}
+
+function withinHorizon(instant: Date, horizon: ProjectionHorizon): boolean {
+  return (
+    instant.getTime() >= horizon.start.getTime() &&
+    instant.getTime() < horizon.end.getTime()
+  );
+}
+
+function occurrenceKey(eventId: EventId, startAt: Date): OccurrenceKey {
+  return `${eventId}:${startAt.toISOString()}` as OccurrenceKey;
+}
+
+function dayOnlyDiff(start: string, end: string): number {
+  return dayjs(`${end}T00:00:00.000Z`).diff(
+    dayjs(`${start}T00:00:00.000Z`),
+    "day",
+  );
+}


### PR DESCRIPTION
## What

Adds the **occurrence-projection engine** — the missing producer for the occurrence read path (S25b). Until now `EventOccurrenceRepository.replaceForEvent` had no caller and there was no RRULE expansion anywhere in `packages/sync`, so every event (single *or* series) projected zero occurrences.

`projectOccurrences(event, horizon, excludedInstants?)` derives the bounded occurrence window for:
- a **single** event — one occurrence at its schedule (horizon-clamped),
- an **exception** — one occurrence at its overridden schedule; a cancelled exception still projects a `cancelled` row so the gap it carves is visible,
- a **series master** — expands the RRULE across the rolling horizon only (never to completion; capped at `GCAL_MAX_RECURRENCES`), omitting any instant an exception owns.

## Why per-event

The projection is keyed per event (matching `replaceForEvent(eventId, gen, …)`): no event's projection ever writes another event's rows, so a series edit rebuilds only the affected window. This is the foundation recurrence-scope (S28 tail) needs to reproject after `all`/`this`/`thisAndFollowing` edits.

## DST correctness

Timed series expand on **floating wall time** and re-localize to the event's zone, so a series crossing a DST transition keeps its wall-clock time while the civil offset follows the zone (e.g. a weekly 09:00 Denver series reads `09:00-07:00` then `09:00-06:00` across the spring-forward). This matches how the app already materializes series.

## Tests

12 unit tests: single timed/all-day, horizon exclusion (before/after), active + cancelled exceptions, weekly expansion with duration preservation, horizon clamping, exception-instant skipping, all-day multi-day span, **DST spring-forward wall-clock stability**, and non-ending-rule horizon bounding.

Pure engine, no DB — not browser-observable. Wiring into the command path lands in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)