### PR TITLE
feat(web): add all-day event toggle

### DIFF
--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithStore } from "@web/__tests__/render-with-store";
+import { AllDayToggle } from "./AllDayToggle";
+import { describe, expect, it, mock } from "bun:test";
+
+describe("AllDayToggle", () => {
+  it("labels and reports its checked state", async () => {
+    const user = userEvent.setup();
+    const onChange = mock();
+
+    renderWithStore(<AllDayToggle checked={false} onChange={onChange} />);
+
+    const toggle = screen.getByRole("checkbox", { name: "All day?" });
+    expect(toggle).not.toBeChecked();
+
+    await user.click(toggle);
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export const AllDayToggle = ({ checked, onChange }: Props) => (
+  <label className="flex w-fit cursor-pointer items-center gap-2 text-sm text-text-muted">
+    <input
+      checked={checked}
+      className="size-4 accent-accent"
+      onChange={(event) => onChange(event.target.checked)}
+      type="checkbox"
+    />
+    All day?
+  </label>
+);

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection.tsx
@@ -1,4 +1,5 @@
-import { type Categories_Event } from "@web/common/types/web.event.types";
+import { Categories_Event } from "@web/common/types/web.event.types";
+import { AllDayToggle } from "../AllDayToggle";
 import {
   DateTimeSection,
   type Props as DateTimeSectionProps,
@@ -7,12 +8,21 @@ import {
 interface Props {
   dateTimeSectionProps: DateTimeSectionProps;
   eventCategory: Categories_Event;
+  onToggleAllDay: (checked: boolean) => void;
 }
 
-export const DateControlsSection = ({ dateTimeSectionProps }: Props) => {
+export const DateControlsSection = ({
+  dateTimeSectionProps,
+  eventCategory,
+  onToggleAllDay,
+}: Props) => {
   return (
-    <div className="flex flex-wrap">
+    <div className="flex flex-col gap-2">
       <DateTimeSection {...dateTimeSectionProps} />
+      <AllDayToggle
+        checked={eventCategory === Categories_Event.ALLDAY}
+        onChange={onToggleAllDay}
+      />
     </div>
   );
 };

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -455,6 +455,49 @@ describe("EventForm", () => {
     );
   });
 
+  it("keeps every day covered by a cross-day timed draft when switching to all day", async () => {
+    const user = userEvent.setup();
+    const onSubmit = mock();
+
+    function Harness() {
+      const [draft, setDraft] = useState<GridEventDraft | null>(
+        createNewDraft({
+          startDate: "2026-04-24T14:00:00.000Z",
+          endDate: "2026-04-25T15:00:00.000Z",
+        }),
+      );
+
+      if (!draft) return null;
+
+      return (
+        <EventForm
+          draft={draft}
+          isDraft
+          isExistingEvent={false}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={onSubmit}
+          setDraft={setDraft}
+        />
+      );
+    }
+
+    renderWithStore(<Harness />);
+
+    act(() => capturedDateControlsSectionProps?.onToggleAllDay(true));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    const savedDraft = onSubmit.mock.calls[0]?.[0] as GridEventDraft;
+    expect(savedDraft.values.schedule).toMatchObject({ kind: "allDay" });
+    if (savedDraft.values.schedule.kind !== "allDay") {
+      throw new Error("expected an all-day schedule");
+    }
+    expect(dayjs(savedDraft.values.schedule.end).toYearMonthDayString()).toBe(
+      "2026-04-26",
+    );
+  });
+
   it("changes an all-day draft to a timed event that can be saved", async () => {
     const user = userEvent.setup();
     const onSubmit = mock();

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -6,6 +6,7 @@ import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { Categories_Event } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
@@ -28,6 +29,8 @@ type CapturedDateTimeSectionProps = Pick<
 
 interface CapturedDateControlsSectionProps {
   dateTimeSectionProps: CapturedDateTimeSectionProps;
+  eventCategory: Categories_Event;
+  onToggleAllDay: (checked: boolean) => void;
 }
 
 let capturedDateControlsSectionProps: CapturedDateControlsSectionProps | null =
@@ -55,7 +58,11 @@ mock.module("@web/views/Forms/EventForm/EventActionMenu", () => ({
 }));
 
 mock.module("@web/views/Forms/EventForm/SaveSection", () => ({
-  SaveSection: () => <button type="button">Save</button>,
+  SaveSection: ({ onSubmit }: { onSubmit: () => void }) => (
+    <button type="button" onClick={onSubmit}>
+      Save
+    </button>
+  ),
 }));
 
 const { EventForm } = require("./EventForm") as typeof import("./EventForm");
@@ -149,6 +156,13 @@ const createNewDraft = (
 
   return { ...draft, values: { ...draft.values, title } };
 };
+
+const createAllDayDraft = (): GridEventDraft =>
+  createGridEventDraft({
+    kind: "allDay",
+    start: new Date("2026-04-24T00:00:00"),
+    end: new Date("2026-04-25T00:00:00"),
+  });
 
 describe("EventForm", () => {
   beforeEach(() => {
@@ -395,6 +409,96 @@ describe("EventForm", () => {
     expect(props?.displayEndDate).toEqual(
       dayjs(expected.displayEndDate).toDate(),
     );
+  });
+
+  it("changes a draft to all day immediately and saves it as all day", async () => {
+    const user = userEvent.setup();
+    const onSubmit = mock();
+
+    function Harness() {
+      const [draft, setDraft] = useState<GridEventDraft | null>(
+        createNewDraft(),
+      );
+
+      if (!draft) return null;
+
+      return (
+        <EventForm
+          draft={draft}
+          isDraft
+          isExistingEvent={false}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={onSubmit}
+          setDraft={setDraft}
+        />
+      );
+    }
+
+    renderWithStore(<Harness />);
+
+    act(() => capturedDateControlsSectionProps?.onToggleAllDay(true));
+
+    expect(capturedDateControlsSectionProps?.eventCategory).toBe(
+      Categories_Event.ALLDAY,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({
+          schedule: expect.objectContaining({ kind: "allDay" }),
+        }),
+      }),
+    );
+  });
+
+  it("changes an all-day draft to a timed event that can be saved", async () => {
+    const user = userEvent.setup();
+    const onSubmit = mock();
+
+    function Harness() {
+      const [draft, setDraft] = useState<GridEventDraft | null>(
+        createAllDayDraft(),
+      );
+
+      if (!draft) return null;
+
+      return (
+        <EventForm
+          draft={draft}
+          isDraft
+          isExistingEvent={false}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={onSubmit}
+          setDraft={setDraft}
+        />
+      );
+    }
+
+    renderWithStore(<Harness />);
+
+    act(() => capturedDateControlsSectionProps?.onToggleAllDay(false));
+
+    expect(capturedDateControlsSectionProps?.eventCategory).toBe(
+      Categories_Event.TIMED,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    const savedDraft = onSubmit.mock.calls[0]?.[0] as GridEventDraft;
+    expect(savedDraft.values.schedule).toMatchObject({ kind: "timed" });
+    if (savedDraft.values.schedule.kind !== "timed") {
+      throw new Error("expected a timed schedule");
+    }
+    expect(
+      savedDraft.values.schedule.end.getTime() -
+        savedDraft.values.schedule.start.getTime(),
+    ).toBe(60 * 60 * 1000);
   });
 
   it("lets an untouched empty draft title keep normal arrow-key behavior", () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -426,10 +426,15 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       if (isAllDay === isCurrentlyAllDay) return;
 
       if (isAllDay) {
+        const endsAtMidnight = dayjs(currentDraft.values.schedule.end).isSame(
+          dayjs(currentDraft.values.schedule.end).startOf("day"),
+        );
         const schedule = mapToBackend({
           startDate: selectedStartDate,
           startTime,
-          endDate: selectedEndDate,
+          endDate: endsAtMidnight
+            ? selectedEndDate
+            : dayjs(selectedEndDate).add(1, "day").toDate(),
           endTime,
           isAllDay: true,
         });

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -23,7 +23,10 @@ import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
 import { useEventPalette } from "@web/common/styles/theme.util";
 import { type SelectOption } from "@web/common/types/component.types";
 import { Categories_Event } from "@web/common/types/web.event.types";
-import { mapToBackend } from "@web/common/utils/datetime/web.date.util";
+import {
+  getTimeOptionByValue,
+  mapToBackend,
+} from "@web/common/utils/datetime/web.date.util";
 import {
   isComboboxInteraction,
   isDeleteTextEditingTarget,
@@ -416,6 +419,64 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       });
     };
 
+    const onToggleAllDay = (isAllDay: boolean) => {
+      const currentDraft = latestDraftRef.current;
+      const isCurrentlyAllDay = currentDraft.values.schedule.kind === "allDay";
+
+      if (isAllDay === isCurrentlyAllDay) return;
+
+      if (isAllDay) {
+        const schedule = mapToBackend({
+          startDate: selectedStartDate,
+          startTime,
+          endDate: selectedEndDate,
+          endTime,
+          isAllDay: true,
+        });
+
+        if (schedule.kind !== "allDay") return;
+
+        setLatestDraft(
+          replaceGridDraftSchedule(currentDraft, {
+            kind: "allDay",
+            start: dayjs(schedule.start).toDate(),
+            end: dayjs(schedule.end).toDate(),
+          }),
+        );
+        return;
+      }
+
+      const timedStart = dayjs(selectedStartDate).hour(9).minute(0);
+      const timedEnd = timedStart.add(1, "hour");
+      const nextStartTime = getTimeOptionByValue(timedStart);
+      const nextEndTime = getTimeOptionByValue(timedEnd);
+      const schedule = mapToBackend({
+        startDate: timedStart.toDate(),
+        startTime: nextStartTime,
+        endDate: timedEnd.toDate(),
+        endTime: nextEndTime,
+        isAllDay: false,
+      });
+
+      if (schedule.kind !== "timed") return;
+
+      updateDateTimeState({
+        displayEndDate: timedStart.toDate(),
+        endTime: nextEndTime,
+        selectedEndDate: timedEnd.toDate(),
+        selectedStartDate: timedStart.toDate(),
+        startTime: nextStartTime,
+      });
+      setLatestDraft(
+        replaceGridDraftSchedule(currentDraft, {
+          kind: "timed",
+          start: dayjs(schedule.start).toDate(),
+          end: dayjs(schedule.end).toDate(),
+          timeZone: schedule.timeZone,
+        }),
+      );
+    };
+
     const dateTimeSectionProps = {
       displayEndDate,
       draft,
@@ -562,6 +623,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
               <DateControlsSection
                 dateTimeSectionProps={dateTimeSectionProps}
                 eventCategory={category}
+                onToggleAllDay={onToggleAllDay}
               />
 
               <RecurrenceSection {...recurrenceSectionProps} />


### PR DESCRIPTION
## Summary

Adds an accessible All day? checkbox to the event form. It immediately moves the draft between the timed grid and all-day row, persists the selected schedule type, defaults all-day-to-timed conversions to 9–10 AM, and preserves every covered day for cross-day timed events.

## Simplicity

No separate simplification commit was needed. The conversion stays inline with the form state it updates; extracting single-use logic would add indirection. No new effects, refs, or state were introduced.

## Automated validation

Browser validation at http://localhost:9084/week: changed a saved timed event to all-day and saved it; changed it back to timed and saved it; the draft moved immediately to the matching grid row each time, and no console errors occurred. After the cross-day fix, reloaded the app and reconfirmed the timed-to-all-day draft transition.

## Independent review

Initial independent review found and prompted a fix for cross-day timed events losing their final partially covered day. A fresh confirmation review found no remaining actionable defects.

## Test plan

- `bun test --cwd packages/web src/views/Forms/EventForm/EventForm.test.tsx src/views/Forms/EventForm/DateControlsSection/AllDayToggle.test.tsx`
- `bun test:web`
- `bun type-check`
- `bun test:a11y`
- `bunx biome check packages/web/src/views/Forms/EventForm/EventForm.tsx packages/web/src/views/Forms/EventForm/EventForm.test.tsx packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.tsx packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.test.tsx packages/web/src/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection.tsx`
- `bun lint` (reports five existing unrelated class-order warnings)
