### PR TITLE
feat(sync): project occurrences for provider-linked events

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -3,13 +3,12 @@ import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
-import { syncHorizon } from "@sync/domain/horizon";
-import { projectOccurrences } from "@sync/domain/occurrence-projection";
 import {
   executeProviderCreate,
   executeProviderDelete,
   executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
+import { reprojectOccurrences } from "@sync/domain/reproject";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import {
   type CommandRecord,
@@ -87,6 +86,7 @@ export async function submitCloudCommand(
         {
           commands: deps.commands,
           events: deps.events,
+          occurrences: deps.occurrences,
           writer: deps.provider.writer,
           custody: deps.provider.custody,
         },
@@ -100,26 +100,8 @@ export async function submitCloudCommand(
 
   const record = buildCloudEventRecord(command, now());
   await deps.events.put(record);
-  await reprojectEvent(deps, record, now);
+  await reprojectOccurrences(deps.occurrences, record, now);
   return confirmCloud(deps, command);
-}
-
-// Rebuild an event's occurrence window after a cloud write. A cloud create or
-// single-event update carries no exceptions, so nothing is excluded here;
-// series-scope edits (which produce exceptions) pass their recurrenceIds once
-// that path lands. replaceForEvent is idempotent per (eventId, generation), so
-// a retry reprojects the same rows.
-async function reprojectEvent(
-  deps: CloudCommandDeps,
-  event: EventRecord,
-  now: () => Date,
-): Promise<void> {
-  const occurrences = projectOccurrences(event, syncHorizon(now()));
-  await deps.occurrences.replaceForEvent(
-    event._id,
-    event.generation,
-    occurrences,
-  );
 }
 
 // Apply a cloud-only update or delete to an existing event. Only single,
@@ -160,6 +142,7 @@ async function applyCloudMutation(
             {
               commands: deps.commands,
               events: deps.events,
+              occurrences: deps.occurrences,
               writer: deps.provider.writer,
               custody: deps.provider.custody,
               markers: deps.markers,
@@ -217,6 +200,7 @@ async function applyCloudMutation(
           {
             commands: deps.commands,
             events: deps.events,
+            occurrences: deps.occurrences,
             writer: deps.provider.writer,
             custody: deps.provider.custody,
           },
@@ -235,7 +219,7 @@ async function applyCloudMutation(
   const updated = applyCloudUpdate(existing, command, now());
   const applied = await deps.events.replaceExisting(updated);
   if (!applied) return command;
-  await reprojectEvent(deps, updated, now);
+  await reprojectOccurrences(deps.occurrences, updated, now);
   return confirmCloud(deps, command);
 }
 

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -13,6 +13,7 @@ import {
   executeProviderDelete,
   executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
+import { reprojectOccurrences } from "@sync/domain/reproject";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
@@ -24,10 +25,12 @@ import {
   ProviderWriteError,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 
@@ -73,6 +76,7 @@ describe("executeProviderCreate", () => {
   let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
   let calendars: ProviderCalendarRepository;
 
   const createInput = (
@@ -145,6 +149,7 @@ describe("executeProviderCreate", () => {
     });
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
+    occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     calendars = new ProviderCalendarRepository(mongo.db);
   });
 
@@ -160,7 +165,7 @@ describe("executeProviderCreate", () => {
     const writer = new FakeWriter();
 
     const result = await executeProviderCreate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       calendar,
       now,
@@ -185,6 +190,15 @@ describe("executeProviderCreate", () => {
     expect(stored?.providerEventId).toBe("g-evt-1");
     expect(stored?.providerVersion).toBe("etag-1");
     expect(stored?.deliveryState).toBe("confirmed");
+
+    // The provider-linked event is projected into the read model.
+    const occ = await mongo.db
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .find({ eventId: command.eventId })
+      .toArray();
+    expect(occ.map((o) => (o["startAt"] as Date).toISOString())).toEqual([
+      "2026-07-14T15:00:00.000Z",
+    ]);
   });
 
   it("passes the caller's invitation intent through to the writer", async () => {
@@ -192,7 +206,7 @@ describe("executeProviderCreate", () => {
     const writer = new FakeWriter();
 
     await executeProviderCreate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       calendar,
       now,
@@ -204,7 +218,13 @@ describe("executeProviderCreate", () => {
   it("converges on one event when executed twice (idempotent write)", async () => {
     const { tenantId, principalId, calendar, command } = await seed();
     const writer = new FakeWriter();
-    const deps = { commands, events, writer, custody: tokenSource() };
+    const deps = {
+      commands,
+      events,
+      occurrences,
+      writer,
+      custody: tokenSource(),
+    };
 
     await executeProviderCreate(deps, command, calendar, now);
     await executeProviderCreate(deps, command, calendar, now);
@@ -225,7 +245,7 @@ describe("executeProviderCreate", () => {
     writer.error = new ProviderWriteError("transient", "network blip");
 
     const result = await executeProviderCreate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       calendar,
       now,
@@ -243,7 +263,7 @@ describe("executeProviderCreate", () => {
     writer.error = new ProviderWriteError("readOnlyCalendar", "read only");
 
     const result = await executeProviderCreate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       calendar,
       now,
@@ -266,6 +286,7 @@ describe("executeProviderCreate", () => {
       {
         commands,
         events,
+        occurrences,
         writer,
         custody: failingTokenSource(
           new ProviderAuthError("authorizationRevoked", "revoked"),
@@ -291,6 +312,7 @@ describe("executeProviderCreate", () => {
       {
         commands,
         events,
+        occurrences,
         writer,
         custody: failingTokenSource(
           new ProviderAuthError("refreshFailed", "temporary"),
@@ -341,6 +363,7 @@ describe("executeProviderUpdate", () => {
   let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
   let calendars: ProviderCalendarRepository;
 
   const now = () => new Date("2026-07-10T00:00:00.000Z");
@@ -446,6 +469,7 @@ describe("executeProviderUpdate", () => {
     });
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
+    occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     calendars = new ProviderCalendarRepository(mongo.db);
   });
 
@@ -461,7 +485,7 @@ describe("executeProviderUpdate", () => {
     writer.fetched = providerEvent("Old", "etag-1");
 
     const result = await executeProviderUpdate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       event,
       calendar,
@@ -475,6 +499,14 @@ describe("executeProviderUpdate", () => {
     const stored = await events.findById(tenantId, principalId, event._id);
     expect(stored?.content.title).toBe("New");
     expect(stored?.providerVersion).toBe("etag-2");
+
+    // The occurrence projection is rebuilt with the edited title.
+    const occ = await mongo.db
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .find({ eventId: event._id })
+      .toArray();
+    expect(occ).toHaveLength(1);
+    expect(occ[0]?.["title"]).toBe("New");
   });
 
   it("confirms without re-patching when the edit already landed (replay)", async () => {
@@ -485,7 +517,7 @@ describe("executeProviderUpdate", () => {
     writer.fetched = providerEvent("New", "etag-2");
 
     const result = await executeProviderUpdate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       event,
       calendar,
@@ -531,7 +563,7 @@ describe("executeProviderUpdate", () => {
     };
 
     const result = await executeProviderUpdate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       event,
       calendar,
@@ -551,7 +583,7 @@ describe("executeProviderUpdate", () => {
     writer.patchError = new ProviderWriteError("versionConflict", "stale");
 
     const result = await executeProviderUpdate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       event,
       calendar,
@@ -570,7 +602,7 @@ describe("executeProviderUpdate", () => {
     writer.fetched = null;
 
     const result = await executeProviderUpdate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       event,
       calendar,
@@ -591,7 +623,7 @@ describe("executeProviderUpdate", () => {
     writer.patchError = new ProviderWriteError("transient", "blip");
 
     const result = await executeProviderUpdate(
-      { commands, events, writer, custody: tokenSource() },
+      { commands, events, occurrences, writer, custody: tokenSource() },
       command,
       event,
       calendar,
@@ -609,6 +641,7 @@ describe("executeProviderUpdate", () => {
       {
         commands,
         events,
+        occurrences,
         writer,
         custody: failingTokenSource(
           new ProviderAuthError("authorizationRevoked", "revoked"),
@@ -651,6 +684,7 @@ describe("executeProviderDelete", () => {
   let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
   let markers: DeletionMarkerRepository;
 
   const now = () => new Date("2026-07-10T00:00:00.000Z");
@@ -735,6 +769,7 @@ describe("executeProviderDelete", () => {
     });
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
+    occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     markers = new DeletionMarkerRepository(mongo.db);
   });
 
@@ -746,9 +781,23 @@ describe("executeProviderDelete", () => {
   it("deletes at the provider, tombstones, removes the local event, and confirms", async () => {
     const { tenantId, principalId, calendar, event, command } = await seed();
     const writer = new FakeDeleteWriter();
+    // Project the event first so the delete has occurrences to clear.
+    await reprojectOccurrences(occurrences, event, now);
+    const occurrenceCount = () =>
+      mongo.db
+        .collection(SYNC_COLLECTIONS.eventOccurrences)
+        .countDocuments({ eventId: event._id });
+    expect(await occurrenceCount()).toBe(1);
 
     const result = await executeProviderDelete(
-      { commands, events, writer, custody: tokenSource(), markers },
+      {
+        commands,
+        events,
+        occurrences,
+        writer,
+        custody: tokenSource(),
+        markers,
+      },
       command,
       event,
       calendar,
@@ -758,8 +807,9 @@ describe("executeProviderDelete", () => {
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.deleteCalls).toHaveLength(1);
     expect(writer.deleteCalls[0].invitation).toBe("all");
-    // Local content is gone, a content-free marker remains.
+    // Local content is gone, a content-free marker remains, occurrences cleared.
     expect(await events.findById(tenantId, principalId, event._id)).toBeNull();
+    expect(await occurrenceCount()).toBe(0);
     expect(
       await markers.exists(
         calendar.connectionId,
@@ -776,7 +826,14 @@ describe("executeProviderDelete", () => {
     await events.deleteById(tenantId, principalId, event._id);
 
     const result = await executeProviderDelete(
-      { commands, events, writer, custody: tokenSource(), markers },
+      {
+        commands,
+        events,
+        occurrences,
+        writer,
+        custody: tokenSource(),
+        markers,
+      },
       command,
       event,
       calendar,
@@ -794,7 +851,14 @@ describe("executeProviderDelete", () => {
     writer.deleteError = new ProviderWriteError("transient", "blip");
 
     const result = await executeProviderDelete(
-      { commands, events, writer, custody: tokenSource(), markers },
+      {
+        commands,
+        events,
+        occurrences,
+        writer,
+        custody: tokenSource(),
+        markers,
+      },
       command,
       event,
       calendar,
@@ -815,7 +879,14 @@ describe("executeProviderDelete", () => {
     );
 
     const result = await executeProviderDelete(
-      { commands, events, writer, custody: tokenSource(), markers },
+      {
+        commands,
+        events,
+        occurrences,
+        writer,
+        custody: tokenSource(),
+        markers,
+      },
       command,
       event,
       calendar,
@@ -839,6 +910,7 @@ describe("executeProviderDelete", () => {
       {
         commands,
         events,
+        occurrences,
         writer,
         custody: failingTokenSource(
           new ProviderAuthError("authorizationRevoked", "revoked"),

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -11,6 +11,7 @@ import {
   type ConnectionId,
   type ProviderEventId,
 } from "@core/types/sync/identity.contracts";
+import { reprojectOccurrences } from "@sync/domain/reproject";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
@@ -25,6 +26,7 @@ import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-ca
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
 import { type DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 
 // The slice of credential custody the executor needs — a valid access token for
 // a connection. Narrow so tests pass a plain fake; CredentialCustody satisfies
@@ -36,6 +38,9 @@ export interface AccessTokenSource {
 export interface ProviderMutationDeps {
   commands: CommandRepository;
   events: EventRepository;
+  // The derived occurrence projection, rebuilt (or cleared, on delete) so a
+  // provider-linked event appears in range queries.
+  occurrences: EventOccurrenceRepository;
   writer: ProviderEventWriter;
   custody: AccessTokenSource;
 }
@@ -101,10 +106,12 @@ export async function executeProviderCreate(
     throw error;
   }
 
-  // Commit the provider identity to the canonical event, then confirm.
-  await deps.events.put(
-    buildLinkedEventRecord(command, calendar, result, now()),
-  );
+  // Commit the provider identity to the canonical event and project its
+  // occurrences, then confirm. Both run before confirmation, so a crash leaves
+  // the command pending and a retry re-runs them idempotently.
+  const record = buildLinkedEventRecord(command, calendar, result, now());
+  await deps.events.put(record);
+  await reprojectOccurrences(deps.occurrences, record, now);
 
   const confirmed = await deps.commands.updateOutcome(
     command.tenantId,
@@ -307,7 +314,7 @@ async function commitProviderUpdate(
     throw new Error("commitProviderUpdate requires an update command");
   }
   const { input } = command;
-  const applied = await deps.events.replaceExisting({
+  const updated: EventRecord = {
     ...event,
     content: input.content,
     schedule: input.schedule,
@@ -315,8 +322,10 @@ async function commitProviderUpdate(
     providerUpdatedAt: null,
     deliveryState: "confirmed",
     updatedAt: now(),
-  });
+  };
+  const applied = await deps.events.replaceExisting(updated);
   if (!applied) return command;
+  await reprojectOccurrences(deps.occurrences, updated, now);
 
   const confirmed = await deps.commands.updateOutcome(
     command.tenantId,
@@ -445,8 +454,11 @@ export async function executeProviderDelete(
   }
 
   // The provider confirmed the deletion. Write the content-free tombstone first
-  // (so no window exists where the event is gone with no marker), then remove
-  // the local record, then confirm. All three are idempotent.
+  // (so no window exists where the event is gone with no marker), clear the
+  // occurrences, then remove the local record, then confirm. Clearing before the
+  // delete matters: a crash after deleteById would otherwise strand the
+  // occurrence rows, since the retry's already-gone (`!marked`) branch confirms
+  // without clearing them. All steps are idempotent.
   await deps.markers.record({
     tenantId: event.tenantId,
     principalId: event.principalId,
@@ -457,6 +469,7 @@ export async function executeProviderDelete(
     deletionSource: "compass",
     deletedAt: now(),
   });
+  await deps.occurrences.replaceForEvent(event._id, event.generation, []);
   await deps.events.deleteById(event.tenantId, event.principalId, event._id);
   return confirmDeletion(deps, command);
 }

--- a/packages/sync/src/domain/reproject.ts
+++ b/packages/sync/src/domain/reproject.ts
@@ -1,0 +1,19 @@
+import { type DateTime } from "@core/types/domain-primitives";
+import { syncHorizon } from "@sync/domain/horizon";
+import { projectOccurrences } from "@sync/domain/occurrence-projection";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+
+// Rebuild an event's occurrence window after a cloud or provider write, so range
+// queries stay current. Idempotent per (eventId, generation) — a retry
+// reprojects the same rows. A create or single-event edit carries no exceptions;
+// series-scope edits pass their exceptions' recurrenceIds once that path lands.
+export async function reprojectOccurrences(
+  occurrences: EventOccurrenceRepository,
+  event: EventRecord,
+  now: () => Date,
+  excludedInstants: readonly DateTime[] = [],
+): Promise<void> {
+  const rows = projectOccurrences(event, syncHorizon(now()), excludedInstants);
+  await occurrences.replaceForEvent(event._id, event.generation, rows);
+}


### PR DESCRIPTION
## What

Closes the read-path gap the cloud path left open: provider create/update/delete now rebuild (or clear) the occurrence projection, so **provider-linked events — single and series — appear in range queries**.

- **executeProviderCreate** → after committing the linked event, reproject its horizon.
- **executeProviderUpdate** (`commitProviderUpdate`) → after the conditional replace, reproject with the edited content.
- **executeProviderDelete** → clear the event's occurrences (before removing the local record).

Reprojection runs **before** the command confirms, so a crash leaves the command `pending` and a retry re-runs it idempotently — the same durability model as the cloud path.

## Delete ordering (same crash-safety fix as the cloud path)

The provider delete clears occurrences **before** `deleteById`. Deleting first would let a crash orphan the rows: the retry's already-gone (`!marked`) branch confirms without ever clearing them. Order is now `markers.record → clear occurrences → deleteById → confirm`, which satisfies both invariants (no window where the event is gone without a marker; no orphaned occurrences).

## DRY

Extracts the shared reprojection into `@sync/domain/reproject` (`reprojectOccurrences`), now used by both the cloud and provider command paths (4 call sites).

## Tests

Added projection assertions to the provider create (occurrence projected), update (reprojected with the new title), and delete (seeded occurrence cleared) success tests. Full sync suite: **390 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)