### PR TITLE
feat(sync): carry a target occurrence on scoped update and delete commands

### DIFF
--- a/packages/core/src/types/sync/command.contracts.test.ts
+++ b/packages/core/src/types/sync/command.contracts.test.ts
@@ -32,12 +32,17 @@ const createInput = () => ({
   recurrence: { kind: "single" },
 });
 
+// A this/thisAndFollowing scope must carry a recurrenceId; scope "all" must not.
+const recurrenceIdFor = (scope: string) =>
+  scope === "all" ? null : "2026-07-14T09:00:00-06:00";
+
 const updateInput = (scope: string = "this") => ({
   kind: "update",
   content: baseContent,
   schedule: timedSchedule,
   recurrence: { kind: "preserve" },
   scope,
+  recurrenceId: recurrenceIdFor(scope),
 });
 
 const moveInput = () => ({ kind: "move", calendarId: objectId() });
@@ -45,6 +50,7 @@ const moveInput = () => ({ kind: "move", calendarId: objectId() });
 const deleteInput = (scope: string = "this") => ({
   kind: "delete",
   scope,
+  recurrenceId: recurrenceIdFor(scope),
 });
 
 const pendingOutcome = { state: "pending" };
@@ -127,6 +133,15 @@ describe("Sync command contracts", () => {
       expect(parsed.success && parsed.data.kind === "update").toBe(true);
       if (parsed.success && parsed.data.kind === "update") {
         expect(parsed.data.invitation).toBe("all");
+      }
+    });
+
+    it("defaults recurrenceId to null when absent", () => {
+      const { recurrenceId: _omit, ...withoutTarget } = updateInput("all");
+      const parsed = SyncCommandInputSchema.safeParse(withoutTarget);
+      expect(parsed.success && parsed.data.kind === "update").toBe(true);
+      if (parsed.success && parsed.data.kind === "update") {
+        expect(parsed.data.recurrenceId).toBeNull();
       }
     });
 
@@ -286,6 +301,31 @@ describe("Sync command contracts", () => {
       expect(
         SyncCommandSchema.parse(JSON.parse(JSON.stringify(parsed))),
       ).toEqual(parsed);
+    });
+
+    it.each([
+      "this",
+      "thisAndFollowing",
+    ] as const)("rejects a %s-scope command that omits a recurrenceId", (scope) => {
+      const command = baseCommand({
+        input: { ...updateInput(scope), recurrenceId: null },
+      });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(false);
+    });
+
+    it("rejects an all-scope command that carries a recurrenceId", () => {
+      const command = baseCommand({
+        input: {
+          ...deleteInput("all"),
+          recurrenceId: "2026-07-14T09:00:00-06:00",
+        },
+      });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(false);
+    });
+
+    it("accepts a this-scope delete targeting one occurrence", () => {
+      const command = baseCommand({ input: deleteInput("this") });
+      expect(SyncCommandSchema.safeParse(command).success).toBe(true);
     });
   });
 });

--- a/packages/core/src/types/sync/command.contracts.ts
+++ b/packages/core/src/types/sync/command.contracts.ts
@@ -62,6 +62,10 @@ const UpdateCommandInputSchema = z.strictObject({
   schedule: EventScheduleSchema,
   recurrence: RecurrenceEditSchema,
   scope: RecurrenceScopeSchema,
+  // Which occurrence a this/thisAndFollowing scope targets: the instance's
+  // original scheduled start (its recurrence identity). Null for scope "all"
+  // and for a single event, which have no one occurrence to address.
+  recurrenceId: DateTimeSchema.nullable().default(null),
 });
 
 const MoveCommandInputSchema = z.strictObject({
@@ -75,6 +79,9 @@ const DeleteCommandInputSchema = z.strictObject({
   // default is to notify no one.
   invitation: InvitationIntentSchema,
   scope: RecurrenceScopeSchema,
+  // Which occurrence a this/thisAndFollowing scope targets (see update above).
+  // Null for scope "all" and for a single event.
+  recurrenceId: DateTimeSchema.nullable().default(null),
 });
 
 export const SyncCommandInputSchema = z.discriminatedUnion("kind", [
@@ -84,6 +91,17 @@ export const SyncCommandInputSchema = z.discriminatedUnion("kind", [
   DeleteCommandInputSchema,
 ]);
 export type SyncCommandInput = z.infer<typeof SyncCommandInputSchema>;
+
+// A this/thisAndFollowing scope targets one occurrence, so it must carry a
+// recurrenceId; scope "all" targets the whole series, so it must not. Enforced
+// on the request and command envelopes rather than the input union so the union
+// stays a clean discriminated union (a refined member can't discriminate).
+const recurrenceTargetIsCoherent = (input: SyncCommandInput): boolean => {
+  if (input.kind !== "update" && input.kind !== "delete") return true;
+  return (input.scope === "all") === (input.recurrenceId === null);
+};
+const RECURRENCE_TARGET_MESSAGE =
+  "recurrenceId is required for scope this/thisAndFollowing and must be null for scope all";
 
 // Provider-side rejection classes a command outcome can carry. These map to
 // the sync failure classification; "capability" failures are typed rather than
@@ -175,7 +193,11 @@ export const SyncCommandSchema = z
       message: "A create command cannot carry an expectedVersion",
       path: ["expectedVersion"],
     },
-  );
+  )
+  .refine((command) => recurrenceTargetIsCoherent(command.input), {
+    message: RECURRENCE_TARGET_MESSAGE,
+    path: ["input", "recurrenceId"],
+  });
 export type SyncCommand = z.infer<typeof SyncCommandSchema>;
 
 // What the trusted Compass API submits to durably record one command. The
@@ -197,7 +219,11 @@ export const CommandSubmitRequestSchema = z
       message: "A create command cannot carry an expectedVersion",
       path: ["expectedVersion"],
     },
-  );
+  )
+  .refine((request) => recurrenceTargetIsCoherent(request.input), {
+    message: RECURRENCE_TARGET_MESSAGE,
+    path: ["input", "recurrenceId"],
+  });
 export type CommandSubmitRequest = z.infer<typeof CommandSubmitRequestSchema>;
 
 export const CommandSubmitResponseSchema = z.strictObject({


### PR DESCRIPTION
## What

Adds `recurrenceId` to the update and delete command inputs so a `this`/`thisAndFollowing` scope can address **one occurrence** of a series — the instance's original scheduled start (its recurrence identity, matching the exception model's own `recurrenceId`). Scope `"all"` targets the whole series and carries no `recurrenceId`.

## Why the rule lives on the envelope

The pairing (`this`/`thisAndFollowing` ⟺ `recurrenceId` present; `all` ⟺ absent) is enforced on `CommandSubmitRequestSchema` and `SyncCommandSchema`, not on the input union — a discriminated-union member can't be a refined schema, so refining `SyncCommandInputSchema` would break discrimination. The envelopes already carry the analogous `expectedVersion` rule, so this is consistent.

## Scope

**Contract only.** Nothing consumes `recurrenceId` yet — the executor that creates the exception (`this`) or splits the series (`thisAndFollowing`) lands in the next PR. This mirrors the contracts-first slicing used for the earlier command work, and lets the trusted Compass API client start populating the field.

## Why now

Sync derives occurrences (only exceptions are events), so an un-exceptioned instance has no event id — only an `occurrenceKey`. `recurrenceId` is how a command names the target instant. Chosen over an `occurrenceKey` field because it matches the exception identity exactly and needs no server-side key parsing.

## Tests

Default-to-null, accept `this`/`thisAndFollowing` with a `recurrenceId`, reject them without, reject `all` with one. Core suite: **496 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)