### PR TITLE
feat(sync): apply scope-this edits and deletes to a cloud series

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -302,12 +302,13 @@ describe("submitCloudCommand provider dispatch", () => {
     principalId: PrincipalId,
     eventId: EventId,
     scope = "all",
+    recurrenceId: string | null = null,
   ): CommandSubmit => ({
     tenantId,
     principalId,
     idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
     eventId,
-    input: { kind: "delete", scope } as SyncCommandInput,
+    input: { kind: "delete", scope, recurrenceId } as SyncCommandInput,
     expectedVersion: null,
   });
 
@@ -345,10 +346,7 @@ describe("submitCloudCommand provider dispatch", () => {
     ).not.toBeNull();
   });
 
-  it.each([
-    "this",
-    "thisAndFollowing",
-  ] as const)("leaves a series delete pending for scope %s (needs occurrence identity)", async (scope) => {
+  it("leaves a thisAndFollowing series delete pending (split not built yet)", async () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
     const eventId = objectId() as EventId;
@@ -358,7 +356,13 @@ describe("submitCloudCommand provider dispatch", () => {
 
     const command = await submitCloudCommand(
       deps(),
-      deleteFor(tenantId, principalId, eventId, scope),
+      deleteFor(
+        tenantId,
+        principalId,
+        eventId,
+        "thisAndFollowing",
+        "2026-07-21T09:00:00-06:00",
+      ),
       now,
     );
 
@@ -828,5 +832,134 @@ describe("submitCloudCommand provider dispatch", () => {
     expect(
       await events.findById(tenantId, principalId, masterId),
     ).not.toBeNull();
+  });
+
+  const updateThisFor = (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    eventId: EventId,
+    recurrenceId: string,
+    title: string,
+  ): CommandSubmit => ({
+    tenantId,
+    principalId,
+    idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+    eventId,
+    input: {
+      kind: "update",
+      invitation: "none",
+      content: {
+        title,
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-21T11:00:00-06:00",
+        end: "2026-07-21T12:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "preserve" },
+      scope: "this",
+      recurrenceId,
+    } as unknown as SyncCommandInput,
+    expectedVersion: null,
+  });
+
+  const EXCEPTED = "2026-07-21T09:00:00-06:00";
+  const EXCEPTED_START = "2026-07-21T15:00:00.000Z";
+
+  it("cancels one occurrence of a cloud series with scope this", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    await reprojectOccurrences(occurrences, master, now);
+    expect(await occurrenceStartsFor(masterId)).toHaveLength(3);
+
+    const command = await submitCloudCommand(
+      deps(),
+      deleteFor(tenantId, principalId, masterId, "this", EXCEPTED),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    const starts = await occurrenceStartsFor(masterId);
+    expect(starts).not.toContain(EXCEPTED_START);
+    expect(starts).toHaveLength(2);
+    const exceptions = await events.findSeriesExceptions(
+      tenantId,
+      principalId,
+      masterId,
+    );
+    expect(exceptions).toHaveLength(1);
+    const only = exceptions[0];
+    expect(
+      only?.recurrence.kind === "exception" && only.recurrence.cancelled,
+    ).toBe(true);
+  });
+
+  it("overrides one occurrence of a cloud series with scope this", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    await reprojectOccurrences(occurrences, master, now);
+
+    const command = await submitCloudCommand(
+      deps(),
+      updateThisFor(tenantId, principalId, masterId, EXCEPTED, "Moved"),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    const exceptions = await events.findSeriesExceptions(
+      tenantId,
+      principalId,
+      masterId,
+    );
+    expect(exceptions).toHaveLength(1);
+    const only = exceptions[0];
+    expect(only?.content.title).toBe("Moved");
+    expect(
+      only?.recurrence.kind === "exception" && !only.recurrence.cancelled,
+    ).toBe(true);
+    // The master no longer owns the instant; the override occurrence does.
+    const masterStarts = await occurrenceStartsFor(masterId);
+    expect(masterStarts).not.toContain(EXCEPTED_START);
+    expect(masterStarts).toHaveLength(2);
+    if (only) {
+      expect(await occurrenceStartsFor(only._id)).toHaveLength(1);
+    }
+  });
+
+  it("upserts a single exception across two deletes of the same occurrence", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    await reprojectOccurrences(occurrences, master, now);
+
+    // Two distinct commands (fresh idempotency keys) targeting one instant.
+    await submitCloudCommand(
+      deps(),
+      deleteFor(tenantId, principalId, masterId, "this", EXCEPTED),
+      now,
+    );
+    await submitCloudCommand(
+      deps(),
+      deleteFor(tenantId, principalId, masterId, "this", EXCEPTED),
+      now,
+    );
+
+    const exceptions = await events.findSeriesExceptions(
+      tenantId,
+      principalId,
+      masterId,
+    );
+    expect(exceptions).toHaveLength(1);
   });
 });

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -4,6 +4,7 @@ import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { occurrenceScheduleAt } from "@sync/domain/occurrence-projection";
 import {
   executeProviderCreate,
   executeProviderDelete,
@@ -125,14 +126,18 @@ async function applyCloudMutation(
     // Absence is the desired end state, so a delete of an already-gone (or
     // never-created) event is confirmed rather than left hanging.
     if (!existing) return confirmCloud(deps, command);
-    // A series master: only scope "all" on a cloud series is handled here.
-    // this/thisAndFollowing (which need occurrence identity + exception/split)
-    // and provider series stay pending for later slices.
+    // A cloud series master: scope "all" removes the whole series, scope "this"
+    // cancels one occurrence. thisAndFollowing (series split) and provider series
+    // stay pending for later slices.
     if (existing.recurrence.kind === "seriesMaster") {
-      if (command.input.scope !== "all" || existing.connectionId !== null) {
-        return command;
+      if (existing.connectionId !== null) return command;
+      if (command.input.scope === "all") {
+        return deleteCloudSeries(deps, command, existing);
       }
-      return deleteCloudSeries(deps, command, existing);
+      if (command.input.scope === "this") {
+        return deleteCloudOccurrence(deps, command, existing, now);
+      }
+      return command;
     }
     // A bare exception target (this/thisAndFollowing) also stays pending.
     if (existing.recurrence.kind !== "single") return command;
@@ -188,13 +193,18 @@ async function applyCloudMutation(
   // update: the target must exist; a missing event can't be updated, so leave
   // the command pending rather than confirming a no-op.
   if (!existing) return command;
-  // A series master: only scope "all" on a cloud series is handled here;
-  // this/thisAndFollowing and provider series stay pending for later slices.
+  // A cloud series master: scope "all" edits the whole series, scope "this"
+  // overrides one occurrence. thisAndFollowing (series split) and provider series
+  // stay pending for later slices.
   if (existing.recurrence.kind === "seriesMaster") {
-    if (command.input.scope !== "all" || existing.connectionId !== null) {
-      return command;
+    if (existing.connectionId !== null) return command;
+    if (command.input.scope === "all") {
+      return updateCloudSeries(deps, command, existing, now);
     }
-    return updateCloudSeries(deps, command, existing, now);
+    if (command.input.scope === "this") {
+      return updateCloudOccurrence(deps, command, existing, now);
+    }
+    return command;
   }
   // A bare exception target stays pending, and converting a single event into a
   // series is itself a series edit — defer both. Gating on the command's intent
@@ -344,6 +354,87 @@ function exceptionInstant(event: EventRecord): DateTime {
     throw new Error("exceptionInstant requires an exception event");
   }
   return event.recurrence.recurrenceId;
+}
+
+// Cancel one occurrence of a cloud series (scope "this"): upsert a cancelled
+// exception tombstone at the target instant, reproject the master to exclude
+// that instant, then project the tombstone's own (cancelled) row. The exception
+// upsert is keyed on (series, recurrenceId), so a retry lands on the same
+// tombstone instead of duplicating it.
+async function deleteCloudOccurrence(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  // The contract guarantees a this-scope delete carries a recurrenceId.
+  if (command.input.kind !== "delete" || command.input.recurrenceId === null) {
+    return command;
+  }
+  const recurrenceId = command.input.recurrenceId;
+  const exception = await deps.events.upsertException(
+    master,
+    recurrenceId,
+    {
+      content: master.content,
+      schedule: occurrenceScheduleAt(master.schedule, recurrenceId),
+      cancelled: true,
+    },
+    now(),
+  );
+  await reprojectMaster(deps, command, master, now);
+  await reprojectOccurrences(deps.occurrences, exception, now);
+  return confirmCloud(deps, command);
+}
+
+// Override one occurrence of a cloud series (scope "this"): upsert an exception
+// carrying the edit at the target instant, reproject the master to exclude that
+// instant, then project the exception's own occurrence. Idempotent on the same
+// (series, recurrenceId) key.
+async function updateCloudOccurrence(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "update" || command.input.recurrenceId === null) {
+    return command;
+  }
+  const exception = await deps.events.upsertException(
+    master,
+    command.input.recurrenceId,
+    {
+      content: command.input.content,
+      schedule: command.input.schedule,
+      cancelled: false,
+    },
+    now(),
+  );
+  await reprojectMaster(deps, command, master, now);
+  await reprojectOccurrences(deps.occurrences, exception, now);
+  return confirmCloud(deps, command);
+}
+
+// Reproject a series master excluding every instant one of its exceptions owns,
+// so the master never projects an occurrence at an excepted instant. Fetches the
+// exceptions fresh, so it picks up the one a scope-"this" edit just wrote.
+async function reprojectMaster(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  now: () => Date,
+): Promise<void> {
+  const exceptions = await deps.events.findSeriesExceptions(
+    command.tenantId,
+    command.principalId,
+    master._id,
+  );
+  await reprojectOccurrences(
+    deps.occurrences,
+    master,
+    now,
+    exceptions.map(exceptionInstant),
+  );
 }
 
 // Confirm a cloud command with no provider identity — local persistence is the

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -159,6 +159,17 @@ function localizeInstant(floating: Date, schedule: EventSchedule): Date {
   return dayjs.tz(wall, schedule.timeZone).toDate();
 }
 
+// The schedule one occurrence of a series has at a given recurrence instant —
+// the master's schedule shifted to that instant, preserving duration and zone.
+// Used when materializing an exception event for a scope-"this" edit/delete so
+// its instance sits at the right instant.
+export function occurrenceScheduleAt(
+  masterSchedule: EventSchedule,
+  recurrenceId: DateTime,
+): EventSchedule {
+  return shiftSchedule(masterSchedule, new Date(recurrenceId));
+}
+
 // Builds one occurrence's schedule from the master's, at the given original
 // start instant, preserving duration and (for timed) the zone.
 function shiftSchedule(

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -70,6 +70,23 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       key: { principalId: 1, clientEventId: 1 },
       options: { sparse: true },
     },
+    {
+      // At most one exception per (owner, series, instant), so a scope-"this"
+      // edit/delete upserts the same tombstone/override instead of racing two
+      // in. Partial on the exception kind: only exception events carry a
+      // recurrence.seriesId, and a non-exception would index as (null,null).
+      name: "series_exception_identity",
+      key: {
+        tenantId: 1,
+        principalId: 1,
+        "recurrence.seriesId": 1,
+        "recurrence.recurrenceId": 1,
+      },
+      options: {
+        unique: true,
+        partialFilterExpression: { "recurrence.kind": "exception" },
+      },
+    },
   ],
   [SYNC_COLLECTIONS.eventOccurrences]: [
     {

--- a/packages/sync/src/storage/repositories/event.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.test.ts
@@ -219,22 +219,26 @@ describe("EventRepository", () => {
     const tenantId = objectId();
     const principalId = objectId();
     const seriesId = objectId();
-    const exception = (overrides: Partial<EventRecord>) =>
+    const exception = (
+      recurrenceId: string,
+      overrides: Partial<EventRecord> = {},
+    ) =>
       compassRecord({
         tenantId,
         principalId,
         recurrence: {
           kind: "exception",
           seriesId,
-          recurrenceId: "2026-07-21T09:00:00-06:00",
+          recurrenceId,
           cancelled: false,
         } as EventRecord["recurrence"],
         ...overrides,
       });
 
-    const mine = await repo.put(exception({}));
-    // Same series, another instance — also mine.
-    await repo.put(exception({}));
+    const mine = await repo.put(exception("2026-07-21T09:00:00-06:00"));
+    // Same series, a different instance — also mine (distinct recurrenceId, per
+    // the unique series_exception_identity index).
+    await repo.put(exception("2026-07-28T09:00:00-06:00"));
     // A different series' exception, a plain single, the master itself, and
     // another principal's exception must all be excluded.
     await repo.put(
@@ -261,7 +265,9 @@ describe("EventRepository", () => {
         } as EventRecord["recurrence"],
       }),
     );
-    await repo.put(exception({ principalId: objectId() }));
+    await repo.put(
+      exception("2026-07-21T09:00:00-06:00", { principalId: objectId() }),
+    );
 
     const found = await repo.findSeriesExceptions(
       tenantId,
@@ -271,6 +277,52 @@ describe("EventRepository", () => {
     expect(found).toHaveLength(2);
     expect(found.every((e) => e.recurrence.kind === "exception")).toBe(true);
     expect(found.some((e) => e._id === mine._id)).toBe(true);
+  });
+
+  it("upserts one exception per (series, instant), mirroring the master", async () => {
+    const master = await repo.put(
+      compassRecord({
+        recurrence: {
+          kind: "seriesMaster",
+          rules: ["RRULE:FREQ=WEEKLY"],
+        } as EventRecord["recurrence"],
+      }),
+    );
+    const recurrenceId = "2026-07-21T09:00:00-06:00" as never;
+    const override = {
+      content: { ...master.content, title: "Overridden" },
+      schedule: master.schedule,
+      cancelled: false,
+    };
+
+    const first = await repo.upsertException(
+      master,
+      recurrenceId,
+      override,
+      new Date(),
+    );
+    // A second upsert for the same instant updates in place — same id, no dupe.
+    const second = await repo.upsertException(
+      master,
+      recurrenceId,
+      { ...override, cancelled: true },
+      new Date(),
+    );
+
+    expect(second._id).toBe(first._id);
+    expect(second.tenantId).toBe(master.tenantId);
+    expect(second.calendarId).toBe(master.calendarId);
+    if (second.recurrence.kind === "exception") {
+      expect(second.recurrence.seriesId).toBe(master._id);
+      expect(second.recurrence.recurrenceId).toBe(recurrenceId);
+      expect(second.recurrence.cancelled).toBe(true);
+    }
+    const exceptions = await repo.findSeriesExceptions(
+      master.tenantId,
+      master.principalId,
+      master._id,
+    );
+    expect(exceptions).toHaveLength(1);
   });
 
   describe("listByCalendar keyset pagination", () => {

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -1,5 +1,5 @@
 import { type Collection, type Db, ObjectId } from "mongodb";
-import { type EventId } from "@core/types/domain-primitives";
+import { type DateTime, type EventId } from "@core/types/domain-primitives";
 import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
   type PrincipalId,
@@ -132,6 +132,64 @@ export class EventRepository {
       { upsert: false },
     );
     return result.matchedCount > 0;
+  }
+
+  // Create or update the one exception (overridden or cancelled instance) of a
+  // series at a given recurrence instant, mirroring the master's calendar and
+  // provider identity. Keyed on (owner, seriesId, recurrenceId) and race-safe
+  // via the unique series_exception_identity index, so a scope-"this" edit or
+  // delete is idempotent — a retry lands on the same exception rather than a
+  // duplicate. Returns the stored exception (with its assigned _id).
+  async upsertException(
+    master: EventRecord,
+    recurrenceId: DateTime,
+    override: {
+      content: EventRecord["content"];
+      schedule: EventRecord["schedule"];
+      cancelled: boolean;
+    },
+    now: Date,
+  ): Promise<EventRecord> {
+    const result = await this.collection.findOneAndUpdate(
+      {
+        tenantId: master.tenantId,
+        principalId: master.principalId,
+        "recurrence.kind": "exception",
+        "recurrence.seriesId": master._id,
+        "recurrence.recurrenceId": recurrenceId,
+      },
+      {
+        // Mirror the master's ownership/calendar/provider identity; set the
+        // instance's own content, schedule, and cancelled flag. recurrence.kind
+        // /seriesId/recurrenceId are seeded from the filter on insert, so only
+        // cancelled is set here (setting the whole recurrence would conflict).
+        $set: {
+          origin: master.origin,
+          calendarId: master.calendarId,
+          clientEventId: null,
+          connectionId: master.connectionId,
+          providerEventId: master.providerEventId,
+          providerVersion: master.providerVersion,
+          providerUpdatedAt: master.providerUpdatedAt,
+          deliveryState: master.deliveryState,
+          providerMetadata: master.providerMetadata,
+          content: override.content,
+          schedule: override.schedule,
+          "recurrence.cancelled": override.cancelled,
+          lifecycleState: "active",
+          generation: master.generation,
+          updatedAt: now,
+        },
+        $setOnInsert: {
+          _id: new ObjectId().toHexString() as EventId,
+          createdAt: now,
+          confirmedAt: now,
+        },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+    if (!result) throw new Error("Exception upsert did not return a record");
+    return EventRecordSchema.parse(result);
   }
 
   // Every exception event of a series (overridden or cancelled instances),


### PR DESCRIPTION
## What

A cloud series command with `scope: "this"` now applies to **one occurrence** (using the `recurrenceId` added in #2265), instead of staying pending:

- **delete-this** — writes a `cancelled` exception tombstone at the target instant.
- **update-this** — writes an override exception carrying the edit.

Both then reproject the master to **exclude** that instant (so it no longer projects an occurrence there) and project the exception's own row.

## Idempotency

The exception is upserted on `(tenantId, principalId, seriesId, recurrenceId)` via a new unique `series_exception_identity` partial index, so:
- a retry lands on the **same** exception rather than duplicating it, and
- a concurrent pair can't both insert.

`EventRepository.upsertException` mirrors the master's calendar/provider identity and assigns `_id` on first write (same pattern as `upsertByProviderIdentity`). The new index immediately caught a latent same-instant duplicate in a pre-existing test.

## Crash-safety

Both executors run before `confirmCloud`, so a crash leaves the command `pending` and a retry re-runs the idempotent upsert + reprojection. Reprojecting the master **before** the exception's row means the worst transient state is a momentary gap at that instant, never a duplicate.

## Scope

`thisAndFollowing` (series split) and provider series stay `pending` for their own slices.

## Tests

delete-this (cancelled + master excludes instant), update-this (override + exception owns the instant), two-deletes-one-exception idempotency, `upsertException` repo test, plus the `thisAndFollowing`-still-pending case. Full sync suite: **400 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)