### PR TITLE
feat(sync): delete this-and-following occurrences of a cloud series

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -346,7 +346,7 @@ describe("submitCloudCommand provider dispatch", () => {
     ).not.toBeNull();
   });
 
-  it("leaves a thisAndFollowing series delete pending (split not built yet)", async () => {
+  it("leaves a thisAndFollowing series update pending (split edit not built yet)", async () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
     const eventId = objectId() as EventId;
@@ -354,17 +354,36 @@ describe("submitCloudCommand provider dispatch", () => {
       recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
     });
 
-    const command = await submitCloudCommand(
-      deps(),
-      deleteFor(
-        tenantId,
-        principalId,
-        eventId,
-        "thisAndFollowing",
-        "2026-07-21T09:00:00-06:00",
-      ),
-      now,
-    );
+    const update: CommandSubmit = {
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId,
+      input: {
+        kind: "update",
+        invitation: "none",
+        content: {
+          title: "Later",
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+        },
+        schedule: {
+          kind: "timed",
+          start: "2026-07-21T11:00:00-06:00",
+          end: "2026-07-21T12:00:00-06:00",
+          timeZone: "America/Denver",
+        },
+        recurrence: { kind: "preserve" },
+        scope: "thisAndFollowing",
+        recurrenceId: "2026-07-21T09:00:00-06:00",
+      } as unknown as SyncCommandInput,
+      expectedVersion: null,
+    };
+
+    const command = await submitCloudCommand(deps(), update, now);
 
     expect(command.outcome.state).toBe("pending");
     expect(
@@ -635,7 +654,8 @@ describe("submitCloudCommand provider dispatch", () => {
       schedule: {
         kind: "timed",
         start: recurrenceId,
-        end: "2026-07-21T11:00:00-06:00",
+        // A valid end on the same day as the instance (09:00 starts -> 23:00).
+        end: recurrenceId.replace(/T\d{2}:/, "T23:"),
         timeZone: "America/Denver",
       } as never,
     });
@@ -961,5 +981,65 @@ describe("submitCloudCommand provider dispatch", () => {
       masterId,
     );
     expect(exceptions).toHaveLength(1);
+  });
+
+  it("deletes this and following occurrences of a cloud series", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    // Weekly x3 from 2026-07-14: 07-14, 07-21, 07-28 (all 09:00-06 = 15:00Z).
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    // An override on the last occurrence — it is at/after the split, so it goes.
+    const following = await seriesException(
+      tenantId,
+      principalId,
+      masterId,
+      "2026-07-28T09:00:00-06:00",
+    );
+    await reprojectOccurrences(occurrences, master, now, [
+      "2026-07-28T09:00:00-06:00" as never,
+    ]);
+    await reprojectOccurrences(occurrences, following, now);
+
+    const command = await submitCloudCommand(
+      deps(),
+      deleteFor(tenantId, principalId, masterId, "thisAndFollowing", EXCEPTED),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    // Only the occurrence before the split survives.
+    expect(await occurrenceStartsFor(masterId)).toEqual([
+      "2026-07-14T15:00:00.000Z",
+    ]);
+    // The following exception is gone.
+    expect(
+      await events.findById(tenantId, principalId, following._id),
+    ).toBeNull();
+  });
+
+  it("collapses thisAndFollowing at the first occurrence to deleting the whole series", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    await reprojectOccurrences(occurrences, master, now);
+
+    const command = await submitCloudCommand(
+      deps(),
+      // The split point is the series' own first occurrence.
+      deleteFor(
+        tenantId,
+        principalId,
+        masterId,
+        "thisAndFollowing",
+        "2026-07-14T09:00:00-06:00",
+      ),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    expect(await events.findById(tenantId, principalId, masterId)).toBeNull();
+    expect(await occurrenceStartsFor(masterId)).toHaveLength(0);
   });
 });

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -4,7 +4,11 @@ import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
-import { occurrenceScheduleAt } from "@sync/domain/occurrence-projection";
+import {
+  occurrenceScheduleAt,
+  scheduleStartAt,
+  truncateRulesBefore,
+} from "@sync/domain/occurrence-projection";
 import {
   executeProviderCreate,
   executeProviderDelete,
@@ -137,7 +141,7 @@ async function applyCloudMutation(
       if (command.input.scope === "this") {
         return deleteCloudOccurrence(deps, command, existing, now);
       }
-      return command;
+      return deleteCloudSeriesFollowing(deps, command, existing, now);
     }
     // A bare exception target (this/thisAndFollowing) also stays pending.
     if (existing.recurrence.kind !== "single") return command;
@@ -435,6 +439,61 @@ async function reprojectMaster(
     now,
     exceptions.map(exceptionInstant),
   );
+}
+
+// Delete one occurrence of a cloud series and every occurrence after it (scope
+// "thisAndFollowing"): truncate the master's rule to end before the split point,
+// drop the exceptions at or after it, and reproject the shortened master. A
+// split at the series' first occurrence removes the whole series, so it collapses
+// to delete-all. The master keeps its kind (still a series), so a retry re-enters
+// here; truncation and the following-exception cleanup are both idempotent.
+async function deleteCloudSeriesFollowing(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "delete" || command.input.recurrenceId === null) {
+    return command;
+  }
+  if (master.recurrence.kind !== "seriesMaster") return command;
+  const splitAt = new Date(command.input.recurrenceId);
+  if (splitAt.getTime() <= scheduleStartAt(master.schedule).getTime()) {
+    return deleteCloudSeries(deps, command, master);
+  }
+
+  await deleteFollowingExceptions(deps, command, master._id, splitAt);
+  const truncated: EventRecord = {
+    ...master,
+    recurrence: {
+      kind: "seriesMaster",
+      rules: truncateRulesBefore(master.recurrence.rules, splitAt),
+    },
+    updatedAt: now(),
+  };
+  const applied = await deps.events.replaceExisting(truncated);
+  if (!applied) return command;
+  await reprojectMaster(deps, command, truncated, now);
+  return confirmCloud(deps, command);
+}
+
+// Delete every exception at or after the split instant and clear its occurrences.
+async function deleteFollowingExceptions(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  seriesId: EventRecord["_id"],
+  splitAt: Date,
+): Promise<void> {
+  const exceptions = await deps.events.findSeriesExceptions(
+    command.tenantId,
+    command.principalId,
+    seriesId,
+  );
+  const following = exceptions.filter(
+    (exception) =>
+      new Date(exceptionInstant(exception)).getTime() >= splitAt.getTime(),
+  );
+  await deleteExceptions(deps, command, following);
 }
 
 // Confirm a cloud command with no provider identity — local persistence is the

--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -4,6 +4,7 @@ import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import {
   type ProjectionHorizon,
   projectOccurrences,
+  truncateRulesBefore,
 } from "@sync/domain/occurrence-projection";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 
@@ -270,6 +271,45 @@ describe("projectOccurrences", () => {
       );
       expect(starts).toHaveLength(5);
       expect(starts.at(-1)).toBe("2026-06-05T14:30:00.000Z");
+    });
+  });
+
+  describe("truncateRulesBefore", () => {
+    it("appends a strictly-before UNTIL (one second earlier, inclusive bound)", () => {
+      const [rule] = truncateRulesBefore(
+        ["RRULE:FREQ=WEEKLY"],
+        new Date("2026-07-21T15:00:00.000Z"),
+      );
+      expect(rule).toBe("RRULE:FREQ=WEEKLY;UNTIL=20260721T145959Z");
+    });
+
+    it("drops a COUNT (mutually exclusive with UNTIL) and replaces a stale UNTIL", () => {
+      const [rule] = truncateRulesBefore(
+        ["RRULE:FREQ=WEEKLY;COUNT=10;UNTIL=20270101T000000Z"],
+        new Date("2026-07-21T15:00:00.000Z"),
+      );
+      expect(rule).toBe("RRULE:FREQ=WEEKLY;UNTIL=20260721T145959Z");
+    });
+
+    it("truncates the projection to occurrences before the split point", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: truncateRulesBefore(
+            ["RRULE:FREQ=WEEKLY;COUNT=5"],
+            // Split at the third occurrence (2026-07-20 09:00 -06:00 = 15:00Z).
+            new Date("2026-07-20T15:00:00.000Z"),
+          ),
+        },
+      );
+      const starts = projectOccurrences(e, HORIZON).map((o) =>
+        o.startAt.toISOString(),
+      );
+      expect(starts).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-13T15:00:00.000Z",
+      ]);
     });
   });
 });

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -159,6 +159,31 @@ function localizeInstant(floating: Date, schedule: EventSchedule): Date {
   return dayjs.tz(wall, schedule.timeZone).toDate();
 }
 
+// Bounds a series' rules to end strictly before an instant, by setting (or
+// replacing) UNTIL. The UNTIL is a real-UTC instant, exactly as a provider
+// emits it — floatingRules re-frames it on expansion — so a thisAndFollowing
+// split truncates the master to just the occurrences before the split point.
+export function truncateRulesBefore(
+  rules: readonly string[],
+  instant: Date,
+): string[] {
+  // UNTIL is inclusive, so back off one second to end strictly before `instant`
+  // (the split occurrence itself is excluded). Sub-second cadence isn't modeled.
+  const until = new Date(instant.getTime() - 1000)
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}/, "");
+  // Drop any existing COUNT/UNTIL first: COUNT and UNTIL are mutually exclusive
+  // per RFC 5545, and a stale UNTIL would otherwise survive alongside the new one.
+  return rules.map((rule) => {
+    const cleaned = rule
+      .split(";")
+      .filter((part) => !/^COUNT=/i.test(part) && !/^UNTIL=/i.test(part))
+      .join(";");
+    return `${cleaned};UNTIL=${until}`;
+  });
+}
+
 // The schedule one occurrence of a series has at a given recurrence instant —
 // the master's schedule shifted to that instant, preserving duration and zone.
 // Used when materializing an exception event for a scope-"this" edit/delete so
@@ -220,8 +245,9 @@ function toOccurrence(
 }
 
 // The normalized start instant used by range queries and the start-time index:
-// the timed instant itself, or midnight UTC of an all-day date.
-function scheduleStartAt(schedule: EventSchedule): Date {
+// the timed instant itself, or midnight UTC of an all-day date. Exported so a
+// series split can compare its cut point against the master's first occurrence.
+export function scheduleStartAt(schedule: EventSchedule): Date {
   if (schedule.kind === "timed") return new Date(schedule.start);
   return new Date(`${schedule.start}T00:00:00.000Z`);
 }


### PR DESCRIPTION
## What

A cloud series delete with `scope: "thisAndFollowing"` now truncates the series at the split point instead of staying pending:
- drops the exceptions **at or after** the split,
- shortens the master's rule to end **strictly before** the split, and
- reprojects the shortened master.

A split at the series' **first** occurrence removes the whole series, so it collapses to delete-all (cf. backend `analyzeDelete` `isSeriesEarliestOccurrence`).

## RRULE truncation (composes with the projection's UNTIL handling)

`truncateRulesBefore` writes `UNTIL` as a real-UTC instant **one second before** the split (`UNTIL` is inclusive, so the split occurrence itself must be excluded) and **strips any COUNT** (mutually exclusive with `UNTIL` per RFC 5545, and drops any stale `UNTIL`). The projection's existing `floatingRules` reframes that real-UTC `UNTIL` into the floating expansion frame, so the split lands correctly excluded across time zones and DST — the write side and read side were designed to compose.

## Retry-safety

The master keeps its `seriesMaster` kind (still a series), so a retry re-enters the same branch; truncation (idempotent — same split → same `UNTIL`) and the following-exception cleanup (idempotent) both converge. Runs before `confirmCloud`, so a crash leaves the command pending.

## Scope

`update-thisAndFollowing` (the series *split* with a new remainder master) and provider series stay `pending` for their own slices — asserted by an update-thisAndFollowing-still-pending test.

## Tests

delete-thisAndFollowing (only pre-split survives + following exception dropped), earliest-occurrence collapse to delete-all, and `truncateRulesBefore` unit tests (strictly-before UNTIL, COUNT-strip, end-to-end projection truncation). Full sync suite: **405 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)