### PR TITLE
feat(sync): split a cloud series on a this-and-following edit

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -346,51 +346,6 @@ describe("submitCloudCommand provider dispatch", () => {
     ).not.toBeNull();
   });
 
-  it("leaves a thisAndFollowing series update pending (split edit not built yet)", async () => {
-    const tenantId = objectId() as TenantId;
-    const principalId = objectId() as PrincipalId;
-    const eventId = objectId() as EventId;
-    await seedEvent(tenantId, principalId, eventId, {
-      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
-    });
-
-    const update: CommandSubmit = {
-      tenantId,
-      principalId,
-      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
-      eventId,
-      input: {
-        kind: "update",
-        invitation: "none",
-        content: {
-          title: "Later",
-          description: "",
-          location: null,
-          organizer: null,
-          attendees: [],
-          conference: null,
-        },
-        schedule: {
-          kind: "timed",
-          start: "2026-07-21T11:00:00-06:00",
-          end: "2026-07-21T12:00:00-06:00",
-          timeZone: "America/Denver",
-        },
-        recurrence: { kind: "preserve" },
-        scope: "thisAndFollowing",
-        recurrenceId: "2026-07-21T09:00:00-06:00",
-      } as unknown as SyncCommandInput,
-      expectedVersion: null,
-    };
-
-    const command = await submitCloudCommand(deps(), update, now);
-
-    expect(command.outcome.state).toBe("pending");
-    expect(
-      await events.findById(tenantId, principalId, eventId),
-    ).not.toBeNull();
-  });
-
   it("routes a provider-linked update to the provider executor when active", async () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
@@ -1016,6 +971,145 @@ describe("submitCloudCommand provider dispatch", () => {
     expect(
       await events.findById(tenantId, principalId, following._id),
     ).toBeNull();
+  });
+
+  const splitFor = (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    eventId: EventId,
+    recurrenceId: string,
+    title: string,
+  ): CommandSubmit => ({
+    tenantId,
+    principalId,
+    idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+    eventId,
+    input: {
+      kind: "update",
+      invitation: "none",
+      content: {
+        title,
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-21T09:00:00-06:00",
+        end: "2026-07-21T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=2"] },
+      scope: "thisAndFollowing",
+      recurrenceId,
+    } as unknown as SyncCommandInput,
+    expectedVersion: null,
+  });
+
+  const otherSeriesMaster = (principalId: PrincipalId, masterId: EventId) =>
+    mongo.db
+      .collection(SYNC_COLLECTIONS.events)
+      .find({
+        principalId,
+        "recurrence.kind": "seriesMaster",
+        _id: { $ne: masterId },
+      })
+      .toArray();
+
+  it("splits a cloud series into a truncated original and an edited remainder", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    // An override after the split — superseded by the new series, so dropped.
+    const following = await seriesException(
+      tenantId,
+      principalId,
+      masterId,
+      "2026-07-28T09:00:00-06:00",
+    );
+    await reprojectOccurrences(occurrences, master, now, [
+      "2026-07-28T09:00:00-06:00" as never,
+    ]);
+    await reprojectOccurrences(occurrences, following, now);
+
+    const command = await submitCloudCommand(
+      deps(),
+      splitFor(tenantId, principalId, masterId, EXCEPTED, "Split"),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    // The original keeps only the pre-split occurrence, with its old title.
+    const original = await events.findById(tenantId, principalId, masterId);
+    expect(original?.content.title).toBe("Existing");
+    expect(await occurrenceStartsFor(masterId)).toEqual([
+      "2026-07-14T15:00:00.000Z",
+    ]);
+    // The following exception is gone.
+    expect(
+      await events.findById(tenantId, principalId, following._id),
+    ).toBeNull();
+    // A remainder series carries the edit from the split point on.
+    const remainders = await otherSeriesMaster(principalId, masterId);
+    expect(remainders).toHaveLength(1);
+    const remainder = remainders[0];
+    expect(remainder?.["content"]).toMatchObject({ title: "Split" });
+    expect(await occurrenceStartsFor(remainder?.["_id"] as EventId)).toEqual([
+      "2026-07-21T15:00:00.000Z",
+      "2026-07-28T15:00:00.000Z",
+    ]);
+  });
+
+  it("upserts a single remainder master across two splits at the same point", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    await reprojectOccurrences(occurrences, master, now);
+
+    // Two distinct commands (fresh idempotency keys) splitting at one point.
+    await submitCloudCommand(
+      deps(),
+      splitFor(tenantId, principalId, masterId, EXCEPTED, "First"),
+      now,
+    );
+    await submitCloudCommand(
+      deps(),
+      splitFor(tenantId, principalId, masterId, EXCEPTED, "Second"),
+      now,
+    );
+
+    // The deterministic remainder id means one remainder, not two.
+    expect(await otherSeriesMaster(principalId, masterId)).toHaveLength(1);
+  });
+
+  it("collapses a thisAndFollowing edit at the first occurrence to editing the whole series", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const masterId = objectId() as EventId;
+    const master = await seriesMaster(tenantId, principalId, masterId);
+    await reprojectOccurrences(occurrences, master, now);
+
+    const command = await submitCloudCommand(
+      deps(),
+      splitFor(
+        tenantId,
+        principalId,
+        masterId,
+        "2026-07-14T09:00:00-06:00",
+        "Whole",
+      ),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    // Edited in place — no separate remainder series was created.
+    const original = await events.findById(tenantId, principalId, masterId);
+    expect(original?.content.title).toBe("Whole");
+    expect(await otherSeriesMaster(principalId, masterId)).toHaveLength(0);
   });
 
   it("collapses thisAndFollowing at the first occurrence to deleting the whole series", async () => {

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -1,4 +1,4 @@
-import { type DateTime } from "@core/types/domain-primitives";
+import { type DateTime, type EventId } from "@core/types/domain-primitives";
 import { type EditableRecurrence } from "@core/types/event.contracts";
 import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
@@ -7,6 +7,7 @@ import { type CredentialCustody } from "@sync/credentials/credential-custody.ser
 import {
   occurrenceScheduleAt,
   scheduleStartAt,
+  stripRuleBounds,
   truncateRulesBefore,
 } from "@sync/domain/occurrence-projection";
 import {
@@ -26,6 +27,7 @@ import { type DeletionMarkerRepository } from "@sync/storage/repositories/deleti
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { createHash } from "node:crypto";
 
 export interface CloudCommandDeps {
   commands: CommandRepository;
@@ -198,8 +200,8 @@ async function applyCloudMutation(
   // the command pending rather than confirming a no-op.
   if (!existing) return command;
   // A cloud series master: scope "all" edits the whole series, scope "this"
-  // overrides one occurrence. thisAndFollowing (series split) and provider series
-  // stay pending for later slices.
+  // overrides one occurrence, thisAndFollowing splits the series at the target.
+  // Provider series stay pending for later slices.
   if (existing.recurrence.kind === "seriesMaster") {
     if (existing.connectionId !== null) return command;
     if (command.input.scope === "all") {
@@ -208,7 +210,7 @@ async function applyCloudMutation(
     if (command.input.scope === "this") {
       return updateCloudOccurrence(deps, command, existing, now);
     }
-    return command;
+    return updateCloudSeriesFollowing(deps, command, existing, now);
   }
   // A bare exception target stays pending, and converting a single event into a
   // series is itself a series edit — defer both. Gating on the command's intent
@@ -494,6 +496,99 @@ async function deleteFollowingExceptions(
       new Date(exceptionInstant(exception)).getTime() >= splitAt.getTime(),
   );
   await deleteExceptions(deps, command, following);
+}
+
+// Edit one occurrence of a cloud series and every occurrence after it (scope
+// "thisAndFollowing") by SPLITTING the series: truncate the original master to
+// end before the split, drop the exceptions at or after it, and stand up a new
+// remainder master carrying the edit from the split point on. A split at the
+// series' first occurrence edits the whole series, so it collapses to edit-all.
+//
+// The remainder master's id is derived deterministically from (originalMaster,
+// split) so a retry upserts the SAME master instead of creating a second series.
+// The original is truncated (and reprojected) before the remainder is created,
+// so the worst transient state is a momentary gap at the split, never a
+// duplicate; every step is idempotent, so a retry converges.
+async function updateCloudSeriesFollowing(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "update" || command.input.recurrenceId === null) {
+    return command;
+  }
+  if (master.recurrence.kind !== "seriesMaster") return command;
+  const splitAt = new Date(command.input.recurrenceId);
+  if (splitAt.getTime() <= scheduleStartAt(master.schedule).getTime()) {
+    return updateCloudSeries(deps, command, master, now);
+  }
+
+  await deleteFollowingExceptions(deps, command, master._id, splitAt);
+  const truncated: EventRecord = {
+    ...master,
+    recurrence: {
+      kind: "seriesMaster",
+      rules: truncateRulesBefore(master.recurrence.rules, splitAt),
+    },
+    updatedAt: now(),
+  };
+  const applied = await deps.events.replaceExisting(truncated);
+  if (!applied) return command;
+  await reprojectMaster(deps, command, truncated, now);
+
+  const remainder = buildRemainderMaster(master, command, now());
+  await deps.events.put(remainder);
+  await reprojectOccurrences(deps.occurrences, remainder, now);
+  return confirmCloud(deps, command);
+}
+
+// Build the remainder series of a thisAndFollowing split: a fresh master at the
+// edit's schedule, carrying the edited content and recurrence, with a
+// deterministic id so a retry converges on one series. "preserve" continues the
+// original cadence (bounds stripped, so it runs open-ended from the split).
+function buildRemainderMaster(
+  master: EventRecord,
+  command: CommandRecord,
+  now: Date,
+): EventRecord {
+  if (command.input.kind !== "update") {
+    throw new Error("buildRemainderMaster requires an update command");
+  }
+  if (master.recurrence.kind !== "seriesMaster") {
+    throw new Error("buildRemainderMaster requires a series master");
+  }
+  const { input } = command;
+  const recurrence: SyncEventRecurrence =
+    input.recurrence.kind === "series"
+      ? { kind: "seriesMaster", rules: input.recurrence.rules }
+      : input.recurrence.kind === "single"
+        ? { kind: "single" }
+        : {
+            kind: "seriesMaster",
+            rules: stripRuleBounds(master.recurrence.rules),
+          };
+  return {
+    ...master,
+    _id: remainderMasterId(master._id, command.input.recurrenceId as DateTime),
+    clientEventId: null,
+    content: input.content,
+    schedule: input.schedule,
+    recurrence,
+    createdAt: now,
+    updatedAt: now,
+    confirmedAt: now,
+  };
+}
+
+// A deterministic event id for the remainder series, so the same split always
+// resolves to the same master and a retry never duplicates it. A 24-hex prefix
+// of a SHA-256 over (seriesId, split) is a valid event id and collision-safe.
+function remainderMasterId(seriesId: EventId, splitAt: DateTime): EventId {
+  return createHash("sha256")
+    .update(`${seriesId}:${splitAt}`)
+    .digest("hex")
+    .slice(0, 24) as EventId;
 }
 
 // Confirm a cloud command with no provider identity — local persistence is the

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -175,13 +175,19 @@ export function truncateRulesBefore(
     .replace(/\.\d{3}/, "");
   // Drop any existing COUNT/UNTIL first: COUNT and UNTIL are mutually exclusive
   // per RFC 5545, and a stale UNTIL would otherwise survive alongside the new one.
-  return rules.map((rule) => {
-    const cleaned = rule
+  return stripRuleBounds(rules).map((rule) => `${rule};UNTIL=${until}`);
+}
+
+// Removes COUNT and UNTIL from each rule, leaving an open-ended pattern. Used to
+// derive the remainder series of a thisAndFollowing split (it continues the
+// original cadence from the split point, unbounded).
+export function stripRuleBounds(rules: readonly string[]): string[] {
+  return rules.map((rule) =>
+    rule
       .split(";")
       .filter((part) => !/^COUNT=/i.test(part) && !/^UNTIL=/i.test(part))
-      .join(";");
-    return `${cleaned};UNTIL=${until}`;
-  });
+      .join(";"),
+  );
 }
 
 // The schedule one occurrence of a series has at a given recurrence instant —


### PR DESCRIPTION
## What

A cloud series update with `scope: "thisAndFollowing"` now **splits** the series instead of staying pending:
- truncates the original master to end before the split,
- drops the exceptions at or after the split, and
- stands up a **new remainder master** carrying the edit from the split point on.

A split at the series' **first** occurrence edits the whole series, so it collapses to edit-all. This completes cloud recurrence-scope: `this` / `thisAndFollowing` / `all` for both edit and delete.

## Deterministic remainder id (idempotency)

The remainder master's `_id` is derived deterministically — a SHA-256 over `originalSeriesId + ":" + splitInstant`, sliced to a 24-hex event id — so a crash-retry upserts the **same** master rather than creating a second series (a random id would duplicate on retry). Verified by a "two splits at the same point → one remainder" test.

## Ordering / crash-safety

The original is truncated and reprojected **before** the remainder is created, so the worst transient state is a momentary gap at the split, never a duplicate. Every step (truncate, following-exception cleanup, remainder upsert, reprojections) is idempotent and runs before `confirmCloud`, so a crash leaves the command pending and a retry converges.

## Remainder recurrence

- `preserve` → continues the original cadence with bounds stripped (open-ended from the split),
- `series` → adopts the command's rules,
- `single` → the remainder is a lone event at the split.

Adds `stripRuleBounds` to the projection engine (shared with `truncateRulesBefore`). Provider series stay `pending` for their own slice.

## Tests

Split (original truncated with old title + remainder with new title + following exception dropped), deterministic-id idempotency, earliest-occurrence collapse to edit-all. Full sync suite: **407 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)