### PR TITLE
feat(sync): delete a provider-linked series at the provider on an all-scope delete

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -445,6 +445,83 @@ describe("submitCloudCommand provider dispatch", () => {
     ).toBe(true);
   });
 
+  it("deletes a provider-linked series at the provider on an all-scope delete", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      calendarId: calendar._id,
+      connectionId: calendar.connectionId as never,
+      providerEventId: "g-series-1" as never,
+      providerVersion: "etag-1" as never,
+      deliveryState: "confirmed",
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: provider(writer),
+      },
+      deleteFor(tenantId, principalId, eventId, "all"),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    expect(writer.deleteCalls).toBe(1);
+    expect(await events.findById(tenantId, principalId, eventId)).toBeNull();
+  });
+
+  it("leaves a provider-linked series this-scope delete pending", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      calendarId: calendar._id,
+      connectionId: calendar.connectionId as never,
+      providerEventId: "g-series-1" as never,
+      providerVersion: "etag-1" as never,
+      deliveryState: "confirmed",
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: provider(writer),
+      },
+      deleteFor(
+        tenantId,
+        principalId,
+        eventId,
+        "this",
+        "2026-07-21T09:00:00-06:00",
+      ),
+      now,
+    );
+
+    // Provider per-occurrence deletes need provider exception ops (deferred).
+    expect(command.outcome.state).toBe("pending");
+    expect(writer.deleteCalls).toBe(0);
+    expect(
+      await events.findById(tenantId, principalId, eventId),
+    ).not.toBeNull();
+  });
+
   // The occurrence projection is the read model, so a cloud command must leave
   // it consistent with the event it just wrote.
   const occurrenceStartsFor = async (eventId: EventId): Promise<string[]> => {

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -132,11 +132,16 @@ async function applyCloudMutation(
     // Absence is the desired end state, so a delete of an already-gone (or
     // never-created) event is confirmed rather than left hanging.
     if (!existing) return confirmCloud(deps, command);
-    // A cloud series master: scope "all" removes the whole series, scope "this"
-    // cancels one occurrence. thisAndFollowing (series split) and provider series
-    // stay pending for later slices.
+    // A series master: for a provider series, only scope "all" is handled here
+    // (delete the whole series at the provider); this/thisAndFollowing need
+    // provider exception ops and stay pending. For a cloud series, scope "all"
+    // removes the whole series, "this" cancels one occurrence, thisAndFollowing
+    // splits it.
     if (existing.recurrence.kind === "seriesMaster") {
-      if (existing.connectionId !== null) return command;
+      if (existing.connectionId !== null) {
+        if (command.input.scope !== "all") return command;
+        return dispatchProviderDelete(deps, command, existing, now);
+      }
       if (command.input.scope === "all") {
         return deleteCloudSeries(deps, command, existing);
       }
@@ -147,34 +152,10 @@ async function applyCloudMutation(
     }
     // A bare exception target (this/thisAndFollowing) also stays pending.
     if (existing.recurrence.kind !== "single") return command;
-    // A provider-linked event goes to the provider delete path when provider
-    // work is enabled; otherwise it stays pending. It is never removed locally
-    // here — content is deleted only after the provider confirms.
+    // A provider-linked event goes to the provider delete path; a cloud event is
+    // removed locally below. Content is removed only after the provider confirms.
     if (existing.connectionId !== null) {
-      if (deps.execution === "active" && deps.provider) {
-        const calendar = await deps.calendars.findById(
-          command.tenantId,
-          command.principalId,
-          existing.calendarId as ProviderCalendarId,
-        );
-        if (calendar) {
-          return executeProviderDelete(
-            {
-              commands: deps.commands,
-              events: deps.events,
-              occurrences: deps.occurrences,
-              writer: deps.provider.writer,
-              custody: deps.provider.custody,
-              markers: deps.markers,
-            },
-            command,
-            existing,
-            calendar,
-            now,
-          );
-        }
-      }
-      return command;
+      return dispatchProviderDelete(deps, command, existing, now);
     }
     // Clear the derived occurrences BEFORE removing the event. If this crashes
     // before the delete, a retry still finds the event and re-runs both steps;
@@ -254,6 +235,40 @@ async function applyCloudMutation(
   if (!applied) return command;
   await reprojectOccurrences(deps.occurrences, updated, now);
   return confirmCloud(deps, command);
+}
+
+// Route a delete of a provider-linked event to the provider executor when
+// provider work is enabled and the owning calendar resolves; otherwise leave the
+// command pending. Content is removed only after the provider confirms. Deleting
+// a series master here cancels the whole series at the provider. Shared by the
+// single-event and provider-series-all delete paths.
+async function dispatchProviderDelete(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  event: EventRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (deps.execution !== "active" || !deps.provider) return command;
+  const calendar = await deps.calendars.findById(
+    command.tenantId,
+    command.principalId,
+    event.calendarId as ProviderCalendarId,
+  );
+  if (!calendar) return command;
+  return executeProviderDelete(
+    {
+      commands: deps.commands,
+      events: deps.events,
+      occurrences: deps.occurrences,
+      writer: deps.provider.writer,
+      custody: deps.provider.custody,
+      markers: deps.markers,
+    },
+    command,
+    event,
+    calendar,
+    now,
+  );
 }
 
 // Apply a scope-"all" edit to a cloud series. An edit-all discards per-instance


### PR DESCRIPTION
## What

An `all`-scope delete of a **provider-linked** series master now routes to the provider delete executor instead of staying pending. `executeProviderDelete` on the master id cancels the whole series at the provider (Google's `events.delete` on a recurring event id removes it and all instances), writes the content-free tombstone, and removes the local record only after the provider confirms.

`this` and `thisAndFollowing` on a provider series still stay `pending` — they need per-occurrence provider exception operations (Google `recurringEventId` / `originalStartTime`), which are better tackled alongside import (provider exceptions only arise from import anyway).

## DRY

Extracts `dispatchProviderDelete` — the "active + provider + calendar resolves → executeProviderDelete, else pending" logic — shared by the single-event delete path and the new provider-series-all path, so the gating and executor wiring live in one place.

## Tests

Provider series all-scope delete (routes to the provider, deletes at the provider, removes local); provider series `this`-scope delete stays pending (no provider call). The existing passive-mode "provider series all stays pending" test still holds. Full sync suite: **409 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)