### PR TITLE
fix(web): align calendar view controls

### DIFF
--- a/packages/web/src/common/constants/navigation.cmd.constants.test.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.test.ts
@@ -32,12 +32,19 @@ describe("getNavigationCommandItems", () => {
     expect(labels).toEqual(["Go to Day", "Go to Week", "Go to Life"]);
   });
 
-  it("advertises the Life shortcut in the command palette", () => {
-    const life = getNavigationCommandItems(noopHandlers).find(
-      (item) => item.id === "go-to-life",
+  it("advertises every view shortcut in the command palette", () => {
+    const shortcuts = Object.fromEntries(
+      getNavigationCommandItems(noopHandlers).map((item) => [
+        item.id,
+        item.shortcut,
+      ]),
     );
 
-    expect(life?.shortcut).toBe("l");
+    expect(shortcuts).toMatchObject({
+      "go-to-day": "d",
+      "go-to-week": "w",
+      "go-to-life": "l",
+    });
   });
 
   it("omits the current view from navigation", () => {

--- a/packages/web/src/common/constants/navigation.cmd.constants.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.ts
@@ -26,8 +26,18 @@ const commandPaletteViews: Record<
   CommandPaletteViewName,
   { icon: Icon; label: string; route: string; shortcut?: string }
 > = {
-  day: { ...VIEW_SHORTCUTS.day, icon: CalendarDotsIcon },
-  week: { ...VIEW_SHORTCUTS.week, icon: CalendarIcon },
+  day: {
+    icon: CalendarDotsIcon,
+    label: VIEW_SHORTCUTS.day.label,
+    route: VIEW_SHORTCUTS.day.route,
+    shortcut: VIEW_SHORTCUTS.day.key,
+  },
+  week: {
+    icon: CalendarIcon,
+    label: VIEW_SHORTCUTS.week.label,
+    route: VIEW_SHORTCUTS.week.route,
+    shortcut: VIEW_SHORTCUTS.week.key,
+  },
   life: {
     icon: HourglassSimpleIcon,
     label: LIFE_SHORTCUT.label,

--- a/packages/web/src/common/utils/draft/draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/draft.util.test.ts
@@ -1,9 +1,25 @@
 import dayjs from "@core/util/date/dayjs";
+import {
+  ID_GRID_EVENTS_ALLDAY,
+  ID_GRID_EVENTS_TIMED,
+} from "@web/common/constants/web.constants";
 import { Categories_Event } from "@web/common/types/web.event.types";
+import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useDraftStore } from "@web/events/stores/draft.store";
 import { assembleDefaultEvent } from "../event/event.util";
-import { createAlldayDraft, createTimedDraft } from "./draft.util";
-import { afterAll, describe, expect, it, setSystemTime } from "bun:test";
+import {
+  createAlldayDraft,
+  createTimedDraft,
+  getDraftContainer,
+} from "./draft.util";
+import {
+  afterAll,
+  afterEach,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+} from "bun:test";
 
 const expectSameTime = (actual: string, expected: string) => {
   expect(dayjs(actual).isSame(dayjs(expected))).toBe(true);
@@ -69,6 +85,28 @@ describe("shortcut draft creation", () => {
     expect(status?.eventType).toBe(Categories_Event.TIMED);
     expectSameTime(event?.startDate as string, "2026-06-01T10:15:00.000Z");
     expectSameTime(event?.endDate as string, "2026-06-01T11:15:00.000Z");
+  });
+});
+
+describe("getDraftContainer", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("uses the draft's live schedule instead of its original event category", () => {
+    const timedContainer = document.createElement("div");
+    timedContainer.id = ID_GRID_EVENTS_TIMED;
+    const allDayContainer = document.createElement("div");
+    allDayContainer.id = ID_GRID_EVENTS_ALLDAY;
+    document.body.append(timedContainer, allDayContainer);
+
+    const draft = createGridEventDraft({
+      kind: "allDay",
+      start: new Date("2026-05-20T00:00:00.000Z"),
+      end: new Date("2026-05-21T00:00:00.000Z"),
+    });
+
+    expect(getDraftContainer(draft)).toBe(allDayContainer);
   });
 });
 

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -3,9 +3,9 @@ import {
   ID_GRID_EVENTS_ALLDAY,
   ID_GRID_EVENTS_TIMED,
 } from "@web/common/constants/web.constants";
-import { Categories_Event } from "@web/common/types/web.event.types";
 import { getElemById } from "@web/common/utils/grid/grid.util";
 import { roundToNext } from "@web/common/utils/round/round.util";
+import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
   timedGridSchedule,
@@ -60,11 +60,7 @@ export const getDraftTimes = (isCurrentWeek: boolean, startOfWeek: Dayjs) => {
   return { startDate, endDate };
 };
 
-export const getDraftContainer = (category: Categories_Event) => {
-  switch (category) {
-    case Categories_Event.ALLDAY:
-      return getElemById(ID_GRID_EVENTS_ALLDAY);
-    case Categories_Event.TIMED:
-      return getElemById(ID_GRID_EVENTS_TIMED);
-  }
-};
+export const getDraftContainer = (draft: GridEventDraft) =>
+  draft.values.schedule.kind === "allDay"
+    ? getElemById(ID_GRID_EVENTS_ALLDAY)
+    : getElemById(ID_GRID_EVENTS_TIMED);

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -83,10 +83,13 @@ const { CommandPalette, filterSections } = await import("./CommandPalette");
 const onGoToToday = mock();
 const onShowShortcuts = mock();
 
-const renderPalette = (mutationDependencies?: EventMutationDependencies) =>
+const renderPalette = (
+  mutationDependencies?: EventMutationDependencies,
+  currentView: "day" | "week" = "week",
+) =>
   renderWithStore(
     <CommandPalette
-      currentView="week"
+      currentView={currentView}
       onGoToToday={onGoToToday}
       onShowShortcuts={onShowShortcuts}
       placeholder="Try: 'create', 'bug', or 'code'"
@@ -136,6 +139,23 @@ describe("CommandPalette", () => {
     expect(getInput()).toHaveFocus();
     // First option is active by default.
     expect(activeRowText(container)).toBe("Go to Today");
+  });
+
+  it("renders the Day and Week navigation shortcut tips", () => {
+    const { unmount } = renderPalette();
+    const dayRow = screen.getByText("Go to Day").closest("button");
+
+    expect(dayRow?.querySelector("[aria-hidden='true']")?.textContent).toBe(
+      "D",
+    );
+
+    unmount();
+    renderPalette(undefined, "day");
+    const weekRow = screen.getByText("Go to Week").closest("button");
+
+    expect(weekRow?.querySelector("[aria-hidden='true']")?.textContent).toBe(
+      "W",
+    );
   });
 
   it("filters case-insensitively, dropping empty sections, and shows a no-results row", () => {

--- a/packages/web/src/components/SelectView/SelectView.test.tsx
+++ b/packages/web/src/components/SelectView/SelectView.test.tsx
@@ -102,7 +102,7 @@ describe("SelectView", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders Day, Week, and This Week options with shortcut hints when dropdown is open", async () => {
+    it("orders This Week, Day, Week, and Life options with shortcut hints", async () => {
       await renderWithRouter("July 2026");
 
       await openDropdown();
@@ -114,13 +114,14 @@ describe("SelectView", () => {
         withinDropdown
           .getAllByRole("option")
           .map((option) => option.textContent),
-      ).toEqual(["DayD", "WeekW", "This WeekT"]);
+      ).toEqual(["This WeekT", "DayD", "WeekW", "LifeL"]);
 
       const shortcutHints = withinDropdown.getAllByTestId("shortcut-hint");
-      expect(shortcutHints).toHaveLength(3);
-      expect(shortcutHints[0]).toHaveTextContent("D");
-      expect(shortcutHints[1]).toHaveTextContent("W");
-      expect(shortcutHints[2]).toHaveTextContent("T");
+      expect(shortcutHints).toHaveLength(4);
+      expect(shortcutHints[0]).toHaveTextContent("T");
+      expect(shortcutHints[1]).toHaveTextContent("D");
+      expect(shortcutHints[2]).toHaveTextContent("W");
+      expect(shortcutHints[3]).toHaveTextContent("L");
     });
   });
 
@@ -169,8 +170,8 @@ describe("SelectView", () => {
       );
     });
 
-    it("shows Day, Week, and Today choices from the Life header", async () => {
-      await renderWithRouter("Life", ROOT_ROUTES.LIFE);
+    it("shows Day, Week, and Life choices from the Life header", async () => {
+      await renderWithRouter("Life", ROOT_ROUTES.LIFE, false);
 
       await openDropdown();
 
@@ -178,7 +179,7 @@ describe("SelectView", () => {
         within(screen.getByTestId("view-select-dropdown"))
           .getAllByRole("option")
           .map((option) => option.textContent),
-      ).toEqual(["DayD", "WeekW", expect.stringMatching(/^Today \(/)]);
+      ).toEqual(["DayD", "WeekW", "LifeL"]);
     });
 
     it("defaults to Week selected for unknown routes", async () => {
@@ -333,7 +334,7 @@ describe("SelectView", () => {
       });
     });
 
-    it("labels the today action 'Today (...)' and calls onToday on the day view", async () => {
+    it("labels the today action 'Today' and calls onToday on the day view", async () => {
       await renderWithRouter("Monday, July 20", ROOT_ROUTES.DAY);
 
       const { user } = await openDropdown();
@@ -444,6 +445,7 @@ describe("SelectView", () => {
       weekOption.focus();
 
       await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowDown}");
       await user.keyboard(" ");
 
       await waitFor(() => {
@@ -470,7 +472,7 @@ describe("SelectView", () => {
       });
     });
 
-    it("wraps navigation from last to first option", async () => {
+    it("moves from Today to Day", async () => {
       await renderWithRouter("July 2026", ROOT_ROUTES.WEEK);
 
       const { user } = await openDropdown();

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -10,10 +10,12 @@ import { CaretDownIcon } from "@phosphor-icons/react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import classNames from "classnames";
 import { useRef, useState } from "react";
-import dayjs from "@core/util/date/dayjs";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
-import { VIEW_SHORTCUTS } from "@web/shortcuts/shortcuts.constants";
+import {
+  LIFE_SHORTCUT,
+  VIEW_SHORTCUTS,
+} from "@web/shortcuts/shortcuts.constants";
 
 interface SelectViewProps {
   /** The date heading text, e.g. "July 2026" or "Monday, July 20". */
@@ -28,7 +30,7 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
   const navigate = useNavigate();
   const listRef = useRef<Array<HTMLElement | null>>([]);
 
-  const getCurrentView = () => {
+  const getCurrentView = (): "Day" | "Week" | "Life" => {
     const pathname = location.pathname;
     if (
       pathname === ROOT_ROUTES.DAY ||
@@ -45,21 +47,47 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
     return "Week";
   };
 
-  const getCurrentViewIndex = () => {
-    const currentView = getCurrentView();
-    if (currentView === "Day") return 0;
-    return 1;
-  };
-
   const currentView = getCurrentView();
+
+  const options = [
+    ...(onToday
+      ? [
+          {
+            label: currentView === "Week" ? "This Week" : "Today",
+            view: null,
+            key: "t",
+            onSelect: onToday,
+          },
+        ]
+      : []),
+    {
+      label: VIEW_SHORTCUTS.day.label,
+      view: "Day" as const,
+      key: VIEW_SHORTCUTS.day.key,
+      onSelect: () => navigate({ to: VIEW_SHORTCUTS.day.route }),
+    },
+    {
+      label: VIEW_SHORTCUTS.week.label,
+      view: "Week" as const,
+      key: VIEW_SHORTCUTS.week.key,
+      onSelect: () => navigate({ to: VIEW_SHORTCUTS.week.route }),
+    },
+    {
+      label: LIFE_SHORTCUT.label,
+      view: "Life" as const,
+      key: LIFE_SHORTCUT.key,
+      onSelect: () => navigate({ to: LIFE_SHORTCUT.route }),
+    },
+  ];
 
   const { refs, context } = useFloating({
     open: isOpen,
     onOpenChange: (open) => {
       setIsOpen(open);
       if (open) {
-        // Initialize activeIndex to current view when opening
-        setActiveIndex(getCurrentViewIndex());
+        setActiveIndex(
+          options.findIndex((option) => option.view === currentView),
+        );
       } else {
         setActiveIndex(null);
         listRef.current = [];
@@ -86,34 +114,6 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
     onSelect();
     setIsOpen(false);
   };
-
-  const options = [
-    {
-      label: VIEW_SHORTCUTS.day.label,
-      view: "Day" as const,
-      key: VIEW_SHORTCUTS.day.key,
-      onSelect: () => navigate({ to: VIEW_SHORTCUTS.day.route }),
-    },
-    {
-      label: VIEW_SHORTCUTS.week.label,
-      view: "Week" as const,
-      key: VIEW_SHORTCUTS.week.key,
-      onSelect: () => navigate({ to: VIEW_SHORTCUTS.week.route }),
-    },
-    ...(onToday
-      ? [
-          {
-            label:
-              currentView === "Week"
-                ? "This Week"
-                : `Today (${dayjs().locale("en").format("dddd, MMMM D")})`,
-            view: null,
-            key: "t",
-            onSelect: onToday,
-          },
-        ]
-      : []),
-  ];
 
   const dropdownId = "view-select-dropdown";
 

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -58,8 +58,12 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
     [allDayEvents, draftSchemaEvent],
   );
   const deckLayout = useMemo(
-    () => getActiveTimedDraftDeckLayout(draftSchemaEvent, timedEvents),
-    [draftSchemaEvent, timedEvents],
+    () =>
+      getActiveTimedDraftDeckLayout(draftSchemaEvent, [
+        ...timedEvents,
+        ...allDayEvents,
+      ]),
+    [allDayEvents, draftSchemaEvent, timedEvents],
   );
   const recurringPreviews = useMemo(
     () =>

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -1,18 +1,11 @@
 import { type FC, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { Origin } from "@core/constants/core.constants";
-import {
-  Categories_Event,
-  type GridEvent,
-} from "@web/common/types/web.event.types";
+import { type GridEvent } from "@web/common/types/web.event.types";
 import { getDraftContainer } from "@web/common/utils/draft/draft.util";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
-import {
-  selectDraftCategory,
-  useDraftStore,
-} from "@web/events/stores/draft.store";
 import { positionAllDayDraftEvent } from "@web/grid/layout/all-day-draft.position";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -32,7 +25,6 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   useGridMouseUp();
   useGridMouseMove();
 
-  const category = useDraftStore(selectDraftCategory);
   const { allDayEvents, timedEvents } = useWeekEventViewModel({
     startOfView: weekProps.component.startOfView,
     endOfView: weekProps.component.endOfView,
@@ -86,24 +78,18 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   if (!draft) {
     return null;
   }
-  if (!category) return null;
 
-  const container = getDraftContainer(category);
+  const container = getDraftContainer(draft);
   if (!container) return null;
 
-  const isGridDraft =
-    category === Categories_Event.ALLDAY || category === Categories_Event.TIMED;
-
   return createPortal(
-    isGridDraft && (
-      <GridDraft
-        activeAllDayDraftEvent={activeAllDayDraftEvent}
-        deckLayout={deckLayout}
-        measurements={measurements}
-        recurringPreviews={recurringPreviews}
-        weekProps={weekProps}
-      />
-    ),
+    <GridDraft
+      activeAllDayDraftEvent={activeAllDayDraftEvent}
+      deckLayout={deckLayout}
+      measurements={measurements}
+      recurringPreviews={recurringPreviews}
+      weekProps={weekProps}
+    />,
     container,
   );
 };

--- a/packages/web/src/views/Week/components/Draft/grid/activeTimedDraftDeckLayout.test.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/activeTimedDraftDeckLayout.test.ts
@@ -58,6 +58,27 @@ describe("getActiveTimedDraftDeckLayout", () => {
     expect(getActiveTimedDraftDeckLayout(draft, events)).toBeNull();
   });
 
+  it("lays out a saved all-day event converted to timed", () => {
+    const draft = createTimedEvent({
+      _id: "draft",
+      endDate: "2026-05-26T10:15:00.000Z",
+      startDate: "2026-05-26T09:15:00.000Z",
+    });
+    const events = [
+      createTimedEvent({ _id: "draft", isAllDay: true }),
+      createTimedEvent({
+        _id: "overlap",
+        endDate: "2026-05-26T10:30:00.000Z",
+        startDate: "2026-05-26T09:30:00.000Z",
+      }),
+    ];
+
+    expect(getActiveTimedDraftDeckLayout(draft, events)).toEqual({
+      groupSize: 2,
+      order: 0,
+    });
+  });
+
   it("ignores all-day drafts", () => {
     const draft = createTimedEvent({
       _id: "draft",

--- a/packages/web/src/views/Week/components/Draft/grid/activeTimedDraftDeckLayout.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/activeTimedDraftDeckLayout.ts
@@ -7,21 +7,22 @@ import {
 
 export const getActiveTimedDraftDeckLayout = (
   draft: GridEvent | null,
-  timedEvents: GridEvent[],
+  events: GridEvent[],
 ): TimedDeckLayout | null => {
   if (!draft?._id || draft.isAllDay) {
     return null;
   }
 
-  const draftIndex = timedEvents.findIndex((event) => event._id === draft._id);
+  const draftIndex = events.findIndex((event) => event._id === draft._id);
   if (draftIndex === -1) {
     return null;
   }
 
-  const eventsWithDraft = [...timedEvents];
+  const eventsWithDraft = [...events];
   eventsWithDraft[draftIndex] = draft;
-  const draftDayEvents = eventsWithDraft.filter((event) =>
-    dayjs(event.startDate).isSame(draft.startDate, "day"),
+  const draftDayEvents = eventsWithDraft.filter(
+    (event) =>
+      !event.isAllDay && dayjs(event.startDate).isSame(draft.startDate, "day"),
   );
 
   return (

--- a/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.test.tsx
@@ -1,12 +1,8 @@
 import { HotkeyManager } from "@tanstack/react-hotkeys";
 import userEvent from "@testing-library/user-event";
 import { cleanup, render, screen } from "@web/__tests__/__mocks__/mock.render";
-import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type GridEventDraft } from "@web/events/event-draft.types";
-import {
-  createGridEventDraft,
-  editGridEventDraft,
-} from "@web/events/grid-event-draft.adapter";
+import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import {
   draftActions,
   initialDraftState,
@@ -97,12 +93,11 @@ describe("WeekSidebarEventDetails", () => {
     );
   });
 
-  it("keeps an existing event's shared draft projection in sync with all-day changes", async () => {
+  it("keeps the shared draft projection in sync with all-day changes", async () => {
     const user = userEvent.setup();
-    const draft = editGridEventDraft(createMockEvent());
-    if (!draft) throw new Error("Expected an edit draft");
+    const draft = createDraft();
 
-    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    draftActions.startGridDraft({ activity: "gridClick", draft });
     renderPanel({ draft });
 
     await user.click(screen.getByRole("checkbox", { name: "All day?" }));

--- a/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.test.tsx
@@ -1,8 +1,17 @@
 import { HotkeyManager } from "@tanstack/react-hotkeys";
 import userEvent from "@testing-library/user-event";
 import { cleanup, render, screen } from "@web/__tests__/__mocks__/mock.render";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type GridEventDraft } from "@web/events/event-draft.types";
-import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import {
+  createGridEventDraft,
+  editGridEventDraft,
+} from "@web/events/grid-event-draft.adapter";
+import {
+  draftActions,
+  initialDraftState,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { WeekSidebarEventDetails } from "@web/views/Week/components/Draft/sidebar/WeekSidebarEventDetails";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -61,6 +70,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useDraftStore.setState(initialDraftState, true);
 });
 
 describe("WeekSidebarEventDetails", () => {
@@ -85,5 +95,21 @@ describe("WeekSidebarEventDetails", () => {
         values: expect.objectContaining({ title: "Planning" }),
       }),
     );
+  });
+
+  it("keeps an existing event's shared draft projection in sync with all-day changes", async () => {
+    const user = userEvent.setup();
+    const draft = editGridEventDraft(createMockEvent());
+    if (!draft) throw new Error("Expected an edit draft");
+
+    draftActions.startGridDraft({ activity: "keyboardEdit", draft });
+    renderPanel({ draft });
+
+    await user.click(screen.getByRole("checkbox", { name: "All day?" }));
+
+    expect(useDraftStore.getState().gridDraft?.values.schedule.kind).toBe(
+      "allDay",
+    );
+    expect(useDraftStore.getState().event).toMatchObject({ isAllDay: true });
   });
 });

--- a/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.test.tsx
@@ -9,7 +9,10 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
-import { WeekSidebarEventDetails } from "@web/views/Week/components/Draft/sidebar/WeekSidebarEventDetails";
+import {
+  syncWeekGridDraft,
+  WeekSidebarEventDetails,
+} from "@web/views/Week/components/Draft/sidebar/WeekSidebarEventDetails";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
 
@@ -93,18 +96,22 @@ describe("WeekSidebarEventDetails", () => {
     );
   });
 
-  it("keeps the shared draft projection in sync with all-day changes", async () => {
-    const user = userEvent.setup();
+  it("keeps the shared draft projection in sync with all-day changes", () => {
     const draft = createDraft();
+    const allDayDraft = createGridEventDraft({
+      kind: "allDay",
+      end: new Date("2026-05-27T00:00:00.000Z"),
+      start: new Date("2026-05-26T00:00:00.000Z"),
+    });
+    const setDraft = mock();
 
     draftActions.startGridDraft({ activity: "gridClick", draft });
-    renderPanel({ draft });
-
-    await user.click(screen.getByRole("checkbox", { name: "All day?" }));
+    syncWeekGridDraft(allDayDraft, setDraft);
 
     expect(useDraftStore.getState().gridDraft?.values.schedule.kind).toBe(
       "allDay",
     );
     expect(useDraftStore.getState().event).toMatchObject({ isAllDay: true });
+    expect(setDraft).toHaveBeenCalledWith(allDayDraft);
   });
 });

--- a/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
+++ b/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
@@ -1,4 +1,6 @@
-import { type FC } from "react";
+import { type Dispatch, type FC, type SetStateAction } from "react";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { draftActions } from "@web/events/stores/draft.store";
 import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
@@ -17,6 +19,16 @@ export const WeekSidebarEventDetails: FC = () => {
 
   if (!isFormOpen || !draft) return null;
 
+  const setFormDraft: Dispatch<SetStateAction<GridEventDraft | null>> = (
+    nextDraft,
+  ) => {
+    const resolvedDraft =
+      typeof nextDraft === "function" ? nextDraft(draft) : nextDraft;
+
+    draftActions.setGridDraft(resolvedDraft);
+    setDraft(resolvedDraft);
+  };
+
   return (
     <EventForm
       draft={draft}
@@ -28,7 +40,7 @@ export const WeekSidebarEventDetails: FC = () => {
       onSubmit={(nextDraft) => {
         if (nextDraft) void onSubmit(nextDraft);
       }}
-      setDraft={setDraft}
+      setDraft={setFormDraft}
     />
   );
 };

--- a/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
+++ b/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
@@ -4,6 +4,14 @@ import { draftActions } from "@web/events/stores/draft.store";
 import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
+export const syncWeekGridDraft = (
+  draft: GridEventDraft | null,
+  setDraft: Dispatch<SetStateAction<GridEventDraft | null>>,
+) => {
+  draftActions.setGridDraft(draft);
+  setDraft(draft);
+};
+
 /**
  * The Week view's event-details panel, docked in the sidebar. Wired
  * through DraftContext so it keeps Week's save/confirmation pipeline
@@ -25,8 +33,7 @@ export const WeekSidebarEventDetails: FC = () => {
     const resolvedDraft =
       typeof nextDraft === "function" ? nextDraft(draft) : nextDraft;
 
-    draftActions.setGridDraft(resolvedDraft);
-    setDraft(resolvedDraft);
+    syncWeekGridDraft(resolvedDraft, setDraft);
   };
 
   return (

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -53,10 +53,12 @@ export const AllDayEvents = ({
   // registry.
   const visibleAllDayEvents = useMemo(
     () =>
-      allDayEvents.filter((event: GridEvent) =>
-        isAllDayEventInVisibleDays(event, weekDays),
+      allDayEvents.filter(
+        (event: GridEvent) =>
+          isAllDayEventInVisibleDays(event, weekDays) &&
+          !(event._id === draftId && !draft?.isAllDay),
       ),
-    [allDayEvents, weekDays],
+    [allDayEvents, draft?.isAllDay, draftId, weekDays],
   );
   // Resolved once per event here (not inside each card) and kept referentially
   // stable across renders where neither the events nor the calendars changed,

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
@@ -500,6 +500,29 @@ describe("Week calendar accessibility", () => {
     ).toBeInTheDocument();
   });
 
+  it("removes a converted all-day draft from the timed grid", () => {
+    const savedEvent = createSavedEvent({ title: "Converted event" });
+    seedGrid([savedEvent], {
+      ...savedEvent,
+      endDate: "2024-01-16",
+      isAllDay: true,
+      startDate: "2024-01-15",
+    });
+
+    render(
+      <Provider>
+        <MainGridEvents
+          measurements={measurements}
+          weekProps={createWeekProps()}
+        />
+      </Provider>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /timed event: converted event/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps pending saved events fully interactive", () => {
     const event = createSavedEvent({
       title: "Pending save",

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -50,8 +50,12 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   // so off-window events never land in the DOM or the interaction registry.
   const visibleTimedEvents = useMemo(
     () =>
-      timedEvents.filter((event) => isTimedEventInVisibleDays(event, weekDays)),
-    [timedEvents, weekDays],
+      timedEvents.filter(
+        (event) =>
+          isTimedEventInVisibleDays(event, weekDays) &&
+          !(event._id === draftId && draft?.isAllDay),
+      ),
+    [draft?.isAllDay, draftId, timedEvents, weekDays],
   );
   const timedEventItems = useMemo(
     () => createTimedEventLayout(visibleTimedEvents),


### PR DESCRIPTION
## Summary
- Order header view options Today/This Week, Day, Week, Life, and simplify the Today label.
- Restore Day/Week command-palette shortcut hints.
- Keep Week draft placement and saved-event placeholders synchronized when converting between timed and all-day.

## Validation
- `bun test:web` (1307 passing)
- `bun type-check`
- `bun lint` (passes with five pre-existing unrelated warnings)
- Browser spot-check at `/week`: ordered dropdown, Life navigation, and clean console.

## Review
- Independent review found and verified fixes for both timed-to-all-day and all-day-to-timed existing-event layout cases; final follow-up found no actionable issues.