### PR TITLE
feat(sync): edit a provider-linked series at the provider on an all-scope update

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -522,6 +522,117 @@ describe("submitCloudCommand provider dispatch", () => {
     ).not.toBeNull();
   });
 
+  const updateSeriesFor = (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    eventId: EventId,
+    scope: string,
+    recurrenceId: string | null = null,
+  ): CommandSubmit => ({
+    tenantId,
+    principalId,
+    idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+    eventId,
+    input: {
+      kind: "update",
+      invitation: "none",
+      content: {
+        title: "Renamed series",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T09:00:00-06:00",
+        end: "2026-07-14T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "preserve" },
+      scope,
+      recurrenceId,
+    } as unknown as SyncCommandInput,
+    expectedVersion: "etag-1" as never,
+  });
+
+  it("routes a provider-linked series all-scope update to the provider executor", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      calendarId: calendar._id,
+      connectionId: calendar.connectionId as never,
+      providerEventId: "g-series-1" as never,
+      providerVersion: "etag-1" as never,
+      deliveryState: "confirmed",
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: provider(writer),
+      },
+      updateSeriesFor(tenantId, principalId, eventId, "all"),
+      now,
+    );
+
+    expect(command.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(1);
+  });
+
+  it("leaves a provider-linked series this-scope update pending", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendar = await seedProviderCalendar(tenantId, principalId);
+    const eventId = objectId() as EventId;
+    await seedEvent(tenantId, principalId, eventId, {
+      calendarId: calendar._id,
+      connectionId: calendar.connectionId as never,
+      providerEventId: "g-series-1" as never,
+      providerVersion: "etag-1" as never,
+      deliveryState: "confirmed",
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const writer = new FakeWriter();
+
+    const command = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: provider(writer),
+      },
+      updateSeriesFor(
+        tenantId,
+        principalId,
+        eventId,
+        "this",
+        "2026-07-21T09:00:00-06:00",
+      ),
+      now,
+    );
+
+    // Provider per-occurrence edits need provider exception ops (deferred).
+    expect(command.outcome.state).toBe("pending");
+    expect(writer.patchCalls).toHaveLength(0);
+    expect(
+      await events.findById(tenantId, principalId, eventId),
+    ).not.toBeNull();
+  });
+
   // The occurrence projection is the read model, so a cloud command must leave
   // it consistent with the event it just wrote.
   const occurrenceStartsFor = async (eventId: EventId): Promise<string[]> => {

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   executeProviderCreate,
   executeProviderDelete,
+  executeProviderSeriesUpdate,
   executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
 import { reprojectOccurrences } from "@sync/domain/reproject";
@@ -180,11 +181,16 @@ async function applyCloudMutation(
   // update: the target must exist; a missing event can't be updated, so leave
   // the command pending rather than confirming a no-op.
   if (!existing) return command;
-  // A cloud series master: scope "all" edits the whole series, scope "this"
-  // overrides one occurrence, thisAndFollowing splits the series at the target.
-  // Provider series stay pending for later slices.
+  // A series master. For a cloud series, scope "all" edits the whole series,
+  // "this" overrides one occurrence, thisAndFollowing splits at the target. For
+  // a provider series, only scope "all" is handled here (edit the whole series
+  // at the provider); this/thisAndFollowing need provider exception ops and stay
+  // pending.
   if (existing.recurrence.kind === "seriesMaster") {
-    if (existing.connectionId !== null) return command;
+    if (existing.connectionId !== null) {
+      if (command.input.scope !== "all") return command;
+      return dispatchProviderSeriesUpdate(deps, command, existing, now);
+    }
     if (command.input.scope === "all") {
       return updateCloudSeries(deps, command, existing, now);
     }
@@ -266,6 +272,38 @@ async function dispatchProviderDelete(
     },
     command,
     event,
+    calendar,
+    now,
+  );
+}
+
+// Route a scope-"all" edit of a provider-linked series master to the provider
+// executor when provider work is enabled and the owning calendar resolves;
+// otherwise leave the command pending. This edits the whole series at the
+// provider (Google's edit-all).
+async function dispatchProviderSeriesUpdate(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (deps.execution !== "active" || !deps.provider) return command;
+  const calendar = await deps.calendars.findById(
+    command.tenantId,
+    command.principalId,
+    master.calendarId as ProviderCalendarId,
+  );
+  if (!calendar) return command;
+  return executeProviderSeriesUpdate(
+    {
+      commands: deps.commands,
+      events: deps.events,
+      occurrences: deps.occurrences,
+      writer: deps.provider.writer,
+      custody: deps.provider.custody,
+    },
+    command,
+    master,
     calendar,
     now,
   );

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { type RecurrenceEdit } from "@core/types/event-command.contracts";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
 import {
   type ConnectionId,
@@ -11,6 +12,7 @@ import {
   type AccessTokenSource,
   executeProviderCreate,
   executeProviderDelete,
+  executeProviderSeriesUpdate,
   executeProviderUpdate,
 } from "@sync/domain/provider-command.service";
 import { reprojectOccurrences } from "@sync/domain/reproject";
@@ -26,6 +28,7 @@ import {
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
@@ -927,5 +930,520 @@ describe("executeProviderDelete", () => {
     expect(writer.deleteCalls).toHaveLength(0);
     const stored = await events.findById(tenantId, principalId, event._id);
     expect(stored?.lifecycleState).toBe("active");
+  });
+});
+
+describe("executeProviderSeriesUpdate", () => {
+  let mongo: SyncMongoService;
+  let commands: CommandRepository;
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let calendars: ProviderCalendarRepository;
+
+  const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+  // A weekly series of four occurrences starting 2026-07-14 09:00 Denver.
+  const schedule = {
+    kind: "timed" as const,
+    start: "2026-07-14T09:00:00-06:00",
+    end: "2026-07-14T10:00:00-06:00",
+    timeZone: "America/Denver",
+  };
+  const weekly4 = ["RRULE:FREQ=WEEKLY;COUNT=4"];
+  const weekly2 = ["RRULE:FREQ=WEEKLY;COUNT=2"];
+  const content = (title: string) => ({
+    title,
+    description: "",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  });
+  // The provider's view of the series master, with its current rules.
+  const providerSeries = (
+    title: string,
+    version: string,
+    rules: readonly string[],
+  ): ProviderEvent => ({
+    kind: "event",
+    providerEventId: "g-evt-1",
+    providerVersion: version,
+    providerUpdatedAt: null,
+    content: content(title),
+    schedule,
+    busy: true,
+    recurrence: { kind: "seriesMaster", rules: [...rules] },
+  });
+
+  // Seed a provider-linked series master ("Old", weekly x4 at etag-1).
+  const seedMaster = async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId,
+      principalId,
+      connectionId,
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const eventId = objectId() as EventId;
+    await events.put({
+      _id: eventId,
+      tenantId,
+      principalId,
+      origin: "compass",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-evt-1" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: content("Old"),
+      schedule,
+      recurrence: { kind: "seriesMaster", rules: [...weekly4] },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const master = await events.findById(tenantId, principalId, eventId);
+    if (!master) throw new Error("seed failed to read back the master");
+    // Project the master so the read model starts with its four occurrences.
+    await reprojectOccurrences(occurrences, master, now);
+    return { tenantId, principalId, calendar, master };
+  };
+
+  // An edit-all update command for the seeded master.
+  const editAllCommand = async (
+    master: EventRecord,
+    edit: { title: string; recurrence: RecurrenceEdit },
+  ) =>
+    commands.submit({
+      tenantId: master.tenantId,
+      principalId: master.principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId: master._id,
+      input: {
+        kind: "update",
+        invitation: "all",
+        content: content(edit.title),
+        schedule,
+        recurrence: edit.recurrence,
+        scope: "all",
+        recurrenceId: null,
+      } as unknown as SyncCommandInput,
+      expectedVersion: "etag-1" as never,
+    });
+
+  const masterOccurrences = (eventId: EventId) =>
+    mongo.db
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .find({ eventId })
+      .sort({ startAt: 1 })
+      .toArray();
+
+  // Seed a provider-linked series exception. Real provider exceptions come from
+  // import (a later slice) and each carries its OWN provider event id, so this
+  // seeds a distinct providerEventId rather than reusing the master's — the
+  // provider-identity unique index forbids sharing it.
+  const putException = async (
+    master: EventRecord,
+    opts: {
+      providerEventId: string;
+      recurrenceId: string;
+      cancelled: boolean;
+      title: string;
+    },
+  ): Promise<EventRecord> => {
+    const id = objectId() as EventId;
+    await events.put({
+      _id: id,
+      tenantId: master.tenantId,
+      principalId: master.principalId,
+      origin: "compass",
+      calendarId: master.calendarId,
+      clientEventId: null,
+      connectionId: master.connectionId,
+      providerEventId: opts.providerEventId as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: content(opts.title),
+      schedule,
+      recurrence: {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId: opts.recurrenceId as never,
+        cancelled: opts.cancelled,
+      },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const stored = await events.findById(
+      master.tenantId,
+      master.principalId,
+      id,
+    );
+    if (!stored) throw new Error("seed failed to read back the exception");
+    return stored;
+  };
+
+  beforeEach(async () => {
+    mongo = new SyncMongoService();
+    await mongo.connect({
+      uri,
+      databaseName: `provseries_${objectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
+    commands = new CommandRepository(mongo.db);
+    events = new EventRepository(mongo.db);
+    occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
+    calendars = new ProviderCalendarRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
+  });
+
+  const deps = (writer: ProviderEventWriter) => ({
+    commands,
+    events,
+    occurrences,
+    writer,
+    custody: tokenSource(),
+  });
+
+  it("patches the whole series and reprojects with the edited content", async () => {
+    const { tenantId, principalId, calendar, master } = await seedMaster();
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+    writer.patchResult = {
+      providerEventId: "g-evt-1",
+      providerVersion: "etag-2",
+    };
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    // Preserve re-writes the master's own rules; the whole series is patched.
+    expect(writer.patchCalls).toHaveLength(1);
+    expect(writer.patchCalls[0].recurrence).toEqual({
+      kind: "series",
+      rules: [...weekly4],
+    });
+    const stored = await events.findById(tenantId, principalId, master._id);
+    expect(stored?.content.title).toBe("New");
+    expect(stored?.providerVersion).toBe("etag-2");
+    expect(stored?.recurrence).toEqual({
+      kind: "seriesMaster",
+      rules: [...weekly4],
+    });
+    // All four occurrences carry the edited title.
+    const occ = await masterOccurrences(master._id);
+    expect(occ).toHaveLength(4);
+    expect(occ.every((o) => o["title"] === "New")).toBe(true);
+  });
+
+  it("patches on a rules-only edit instead of treating it as a replay", async () => {
+    const { tenantId, principalId, calendar, master } = await seedMaster();
+    // Same title and schedule, only the recurrence rule shrinks 4 -> 2. Without
+    // comparing recurrence this would look identical to the provider's current
+    // state and be confirmed WITHOUT ever writing the new rule.
+    const command = await editAllCommand(master, {
+      title: "Old",
+      recurrence: { kind: "series", rules: weekly2 },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+    writer.patchResult = {
+      providerEventId: "g-evt-1",
+      providerVersion: "etag-2",
+    };
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(1);
+    expect(writer.patchCalls[0].recurrence).toEqual({
+      kind: "series",
+      rules: [...weekly2],
+    });
+    const stored = await events.findById(tenantId, principalId, master._id);
+    expect(stored?.recurrence).toEqual({
+      kind: "seriesMaster",
+      rules: [...weekly2],
+    });
+    // The horizon now holds only the two remaining occurrences.
+    expect(await masterOccurrences(master._id)).toHaveLength(2);
+  });
+
+  it("confirms without re-patching when the whole edit already landed", async () => {
+    const { calendar, master } = await seedMaster();
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "series", rules: weekly2 },
+    });
+    const writer = new FakeUpdateWriter();
+    // Provider already holds the edited content AND the new rules at a fresh
+    // version — a prior attempt landed before the crash.
+    writer.fetched = providerSeries("New", "etag-2", weekly2);
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(0);
+  });
+
+  it("treats a reformatted-but-equivalent rule echo as a replay", async () => {
+    const { calendar, master } = await seedMaster();
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: {
+        kind: "series",
+        rules: ["RRULE:FREQ=WEEKLY;COUNT=4;INTERVAL=1"],
+      },
+    });
+    const writer = new FakeUpdateWriter();
+    // The provider echoes the same rule reordered and lowercased at a new
+    // version — our edit landed on a prior attempt. A byte-for-byte compare
+    // would miss it and re-patch with a now-stale version, failing a write that
+    // already succeeded.
+    writer.fetched = providerSeries("New", "etag-2", [
+      "rrule:interval=1;count=4;freq=weekly",
+    ]);
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(0);
+  });
+
+  it("fails with a conflict on a genuine concurrent external edit", async () => {
+    const { calendar, master } = await seedMaster();
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Someone else", "etag-9", weekly4);
+    writer.patchError = new ProviderWriteError("versionConflict", "stale");
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(
+      result.outcome.state === "failed" && result.outcome.failureReason,
+    ).toBe("versionConflict");
+  });
+
+  it("discards override exceptions but keeps cancelled tombstones", async () => {
+    const { tenantId, principalId, calendar, master } = await seedMaster();
+    // An override on the 2nd instant and a cancellation on the 3rd.
+    const override = await putException(master, {
+      providerEventId: "g-inst-override",
+      recurrenceId: "2026-07-21T09:00:00-06:00",
+      cancelled: false,
+      title: "Moved",
+    });
+    await putException(master, {
+      providerEventId: "g-inst-cancelled",
+      recurrenceId: "2026-07-28T09:00:00-06:00",
+      cancelled: true,
+      title: "Old",
+    });
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    // The override is gone; the cancelled tombstone survives the edit.
+    expect(
+      await events.findById(tenantId, principalId, override._id),
+    ).toBeNull();
+    const remaining = await events.findSeriesExceptions(
+      tenantId,
+      principalId,
+      master._id,
+    );
+    expect(remaining).toHaveLength(1);
+    expect(
+      remaining[0]?.recurrence.kind === "exception" &&
+        remaining[0]?.recurrence.cancelled,
+    ).toBe(true);
+    // The reprojected master excludes the cancelled instant (2026-07-28 15:00Z)
+    // but re-covers the formerly-overridden instant, so three master rows remain.
+    const occ = await masterOccurrences(master._id);
+    const starts = occ.map((o) => (o["startAt"] as Date).toISOString());
+    expect(starts).toEqual([
+      "2026-07-14T15:00:00.000Z",
+      "2026-07-21T15:00:00.000Z",
+      "2026-08-04T15:00:00.000Z",
+    ]);
+  });
+
+  it("converts a series to a single event, dropping every exception", async () => {
+    const { tenantId, principalId, calendar, master } = await seedMaster();
+    await putException(master, {
+      providerEventId: "g-inst-cancelled",
+      recurrenceId: "2026-07-28T09:00:00-06:00",
+      cancelled: true,
+      title: "Old",
+    });
+    const command = await editAllCommand(master, {
+      title: "Just once",
+      recurrence: { kind: "single" },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    // The provider write removes recurrence.
+    expect(writer.patchCalls[0].recurrence).toEqual({ kind: "single" });
+    const stored = await events.findById(tenantId, principalId, master._id);
+    expect(stored?.recurrence).toEqual({ kind: "single" });
+    // No exceptions survive a conversion to a single event, and the master
+    // projects exactly one occurrence.
+    expect(
+      await events.findSeriesExceptions(tenantId, principalId, master._id),
+    ).toHaveLength(0);
+    expect(await masterOccurrences(master._id)).toHaveLength(1);
+  });
+
+  it("converges when executed twice (idempotent retry)", async () => {
+    const { tenantId, principalId, calendar, master } = await seedMaster();
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "series", rules: weekly2 },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+    writer.patchResult = {
+      providerEventId: "g-evt-1",
+      providerVersion: "etag-2",
+    };
+
+    await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+    // The provider now reflects the landed edit, so a retry is a replay.
+    writer.fetched = providerSeries("New", "etag-2", weekly2);
+    const second = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(second.outcome.state).toBe("confirmed");
+    // Only the first attempt wrote; the retry recognized the replay.
+    expect(writer.patchCalls).toHaveLength(1);
+    const owned = await events.listByCalendar({
+      tenantId,
+      principalId,
+      calendarId: calendar._id,
+      generation: 0,
+      limit: 10,
+    });
+    expect(owned).toHaveLength(1);
+    expect(await masterOccurrences(master._id)).toHaveLength(2);
+  });
+
+  it("leaves the command pending on a transient patch failure", async () => {
+    const { calendar, master } = await seedMaster();
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+    writer.patchError = new ProviderWriteError("transient", "blip");
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("pending");
   });
 });

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -1,11 +1,14 @@
+import { type DateTime } from "@core/types/domain-primitives";
 import {
   type EditableRecurrence,
   type EventSchedule,
 } from "@core/types/event.contracts";
+import { type RecurrenceEdit } from "@core/types/event-command.contracts";
 import { type SyncCommandFailureReason } from "@core/types/sync/command.contracts";
 import {
   type ProviderEventVersion,
   type SyncEventContent,
+  type SyncEventRecurrence,
 } from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
@@ -261,8 +264,13 @@ export async function executeProviderUpdate(
   if (!current) return failCommand(deps, command, "permanentProviderError");
 
   // Replay: the provider already holds this edit, so confirm at its version
-  // rather than writing again.
-  if (matchesIntendedEdit(current, input.content, input.schedule)) {
+  // rather than writing again. A single-event update always writes recurrence
+  // "single", so that is the intended recurrence to compare against.
+  if (
+    matchesIntendedEdit(current, input.content, input.schedule, {
+      kind: "single",
+    })
+  ) {
     return commitProviderUpdate(
       deps,
       command,
@@ -341,26 +349,328 @@ async function commitProviderUpdate(
   return confirmed ?? command;
 }
 
+// Apply a Compass-initiated scope-"all" edit to a provider-linked recurring
+// series — Google's "edit all events in the series". The master is patched with
+// the new content, schedule, AND recurrence rules, and its per-instance
+// overrides fall away. Kept separate from executeProviderUpdate because the
+// local commit is series-aware: it discards override exceptions but preserves
+// cancelled tombstones (a deletion must survive an edit) and reprojects the
+// master excluding their instants.
+//
+// Replay safety mirrors the single-event path: fetch the provider's current
+// master first; if it already carries this edit (content, schedule, and rules),
+// a prior attempt landed, so confirm at the current version without re-writing.
+// Otherwise patch conditionally on the command's expected version, turning a
+// genuine concurrent external edit into a versionConflict.
+export async function executeProviderSeriesUpdate(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "update") {
+    throw new Error("executeProviderSeriesUpdate requires an update command");
+  }
+  if (!master.connectionId || !master.providerEventId) {
+    throw new Error("executeProviderSeriesUpdate requires a linked event");
+  }
+  if (master.recurrence.kind !== "seriesMaster") {
+    throw new Error("executeProviderSeriesUpdate requires a series master");
+  }
+  const { input } = command;
+  const connectionId = master.connectionId;
+  const providerEventId = master.providerEventId;
+  const intendedRecurrence = intendedSeriesRecurrence(input.recurrence, master);
+
+  let accessToken: string;
+  try {
+    accessToken = await deps.custody.getValidAccessToken(connectionId);
+  } catch (error) {
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason === "refreshFailed"
+    ) {
+      return command;
+    }
+    return failCommand(deps, command, "authorizationRevoked");
+  }
+
+  const location = {
+    accessToken,
+    calendarId: calendar.providerCalendarId,
+    providerEventId,
+  };
+
+  // Fetch the master's current provider state to detect a replay and learn the
+  // version to commit. A cancellation read means the series no longer exists.
+  let current: ProviderEvent | null;
+  try {
+    const read = await deps.writer.fetchEvent(location);
+    current = read?.kind === "event" ? read : null;
+  } catch (error) {
+    if (error instanceof ProviderWriteError) {
+      if (error.reason === "transient") return command;
+      return failCommand(deps, command, error.reason);
+    }
+    throw error;
+  }
+  if (!current) return failCommand(deps, command, "permanentProviderError");
+
+  // Replay: the provider already holds this series edit (rules included), so
+  // confirm at its version rather than writing again.
+  if (
+    matchesIntendedEdit(
+      current,
+      input.content,
+      input.schedule,
+      intendedRecurrence,
+    )
+  ) {
+    return commitProviderSeriesUpdate(
+      deps,
+      command,
+      master,
+      current.providerVersion,
+      now,
+    );
+  }
+
+  let result: ProviderWriteResult;
+  try {
+    result = await deps.writer.patchEvent({
+      ...location,
+      expectedVersion: command.expectedVersion,
+      content: input.content,
+      schedule: input.schedule,
+      recurrence: intendedRecurrence,
+      invitation: input.invitation,
+    });
+  } catch (error) {
+    if (error instanceof ProviderWriteError) {
+      if (error.reason === "transient") return command;
+      return failCommand(deps, command, error.reason);
+    }
+    throw error;
+  }
+
+  return commitProviderSeriesUpdate(
+    deps,
+    command,
+    master,
+    result.providerVersion,
+    now,
+  );
+}
+
+// Commit a provider series edit-all locally after the provider write lands.
+// An edit-all discards per-instance content/time OVERRIDES (they revert to the
+// edited series) but KEEPS cancelled tombstones, whose instants are excluded
+// from the reprojected master so a deleted occurrence is not resurrected. A
+// conversion to a single event drops every exception.
+//
+// Overrides are deleted BEFORE the master is replaced, on purpose — the same
+// crash-safety ordering the cloud path uses. A convert-to-single edit changes
+// the master's recurrence kind, and a retry that read the converted single
+// master would take the single-event path, which never cleans exceptions;
+// clearing first closes that hole. Gating the kept/discarded split on the
+// command's immutable recurrence intent keeps a retry classifying identically.
+// A false from replaceExisting means the master vanished mid-flight, so leave
+// the command pending rather than confirm a gone series.
+async function commitProviderSeriesUpdate(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+  master: EventRecord,
+  providerVersion: string,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (command.input.kind !== "update") {
+    throw new Error("commitProviderSeriesUpdate requires an update command");
+  }
+  const { input } = command;
+  const convertsToSingle = input.recurrence.kind === "single";
+  const exceptions = await deps.events.findSeriesExceptions(
+    command.tenantId,
+    command.principalId,
+    master._id,
+  );
+  const kept = convertsToSingle ? [] : exceptions.filter(isCancelledException);
+  const discarded = convertsToSingle
+    ? exceptions
+    : exceptions.filter((exception) => !isCancelledException(exception));
+
+  // Clear each discarded override's occurrences, then remove it. (Twin of the
+  // cloud path's deleteExceptions — kept local so the working cloud path is
+  // untouched; both are a plain occurrence-clear-then-delete loop.)
+  //
+  // Deferred gap: for a provider-linked series this removes only the LOCAL copy
+  // of the override, not the override event at the provider — patching a Google
+  // master does not delete its instance overrides. That is harmless today
+  // because provider-linked exceptions are only ever created by import, which
+  // does not exist yet, so `discarded` is always empty here. Once import lands,
+  // an edit-all must also cancel the discarded overrides at the provider (the
+  // same gap already noted for the provider delete path), or a later pull would
+  // resurrect them.
+  for (const exception of discarded) {
+    await deps.occurrences.replaceForEvent(
+      exception._id,
+      exception.generation,
+      [],
+    );
+    await deps.events.deleteById(
+      command.tenantId,
+      command.principalId,
+      exception._id,
+    );
+  }
+
+  const updated: EventRecord = {
+    ...master,
+    content: input.content,
+    schedule: input.schedule,
+    recurrence: storedSeriesRecurrence(input.recurrence, master),
+    providerVersion: providerVersion as ProviderEventVersion,
+    providerUpdatedAt: null,
+    deliveryState: "confirmed",
+    updatedAt: now(),
+  };
+  const applied = await deps.events.replaceExisting(updated);
+  if (!applied) return command;
+  await reprojectOccurrences(
+    deps.occurrences,
+    updated,
+    now,
+    kept.map(exceptionInstant),
+  );
+
+  const confirmed = await deps.commands.updateOutcome(
+    command.tenantId,
+    command.principalId,
+    command._id,
+    {
+      state: "confirmed",
+      providerEventId: master.providerEventId as ProviderEventId,
+      providerVersion: providerVersion as ProviderEventVersion,
+    },
+    command.attemptCount,
+  );
+  return confirmed ?? command;
+}
+
+// The provider recurrence a series edit-all writes. "series" sets new rules;
+// "single" removes recurrence (converting the series to one event); "preserve"
+// re-writes the master's current rules unchanged (harmless, keeps the write
+// self-describing).
+function intendedSeriesRecurrence(
+  recurrence: RecurrenceEdit,
+  master: EventRecord,
+): ProviderWriteRecurrence {
+  if (recurrence.kind === "series") {
+    return { kind: "series", rules: recurrence.rules };
+  }
+  if (recurrence.kind === "single") return { kind: "single" };
+  return master.recurrence.kind === "seriesMaster"
+    ? { kind: "series", rules: master.recurrence.rules }
+    : { kind: "single" };
+}
+
+// The stored recurrence a series edit-all applies to the local master, mirroring
+// intendedSeriesRecurrence in the canonical event's own union.
+function storedSeriesRecurrence(
+  recurrence: RecurrenceEdit,
+  master: EventRecord,
+): SyncEventRecurrence {
+  if (recurrence.kind === "series") {
+    return { kind: "seriesMaster", rules: recurrence.rules };
+  }
+  if (recurrence.kind === "single") return { kind: "single" };
+  return master.recurrence;
+}
+
+// Whether a series exception is a cancelled tombstone (a per-instance deletion)
+// rather than a content override. Twin of the cloud path's helper.
+function isCancelledException(event: EventRecord): boolean {
+  return event.recurrence.kind === "exception" && event.recurrence.cancelled;
+}
+
+// The original instant a series exception overrides — its recurrence identity.
+function exceptionInstant(event: EventRecord): DateTime {
+  if (event.recurrence.kind !== "exception") {
+    throw new Error("exceptionInstant requires an exception event");
+  }
+  return event.recurrence.recurrenceId;
+}
+
 // Whether the provider's current event already carries this command's intended
 // edit — the signal that a prior attempt landed and this is a safe replay.
 // Compares ONLY the fields a patch actually writes (title, description,
-// location, schedule). organizer/attendees/conference are read-reflected, not
-// written by the provider adapter, so they drift independently (e.g. an
-// attendee RSVPs) — comparing them would turn a landed edit into a false miss,
-// then a stale-version patch, then a spurious versionConflict on a write that
-// already succeeded. Used only to detect a replay, so a false negative on the
-// compared fields is still safe (it falls through to the conditional patch).
+// location, schedule, recurrence). organizer/attendees/conference are
+// read-reflected, not written by the provider adapter, so they drift
+// independently (e.g. an attendee RSVPs) — comparing them would turn a landed
+// edit into a false miss, then a stale-version patch, then a spurious
+// versionConflict on a write that already succeeded. Recurrence IS written (a
+// series edit-all changes the rules), so it must be compared: a rules-only edit
+// leaves content and schedule identical, and without this a false replay would
+// confirm the command without ever writing the new rules. Used only to detect a
+// replay, so a false negative on the compared fields is still safe (it falls
+// through to the conditional patch).
 function matchesIntendedEdit(
   current: ProviderEvent,
   content: SyncEventContent,
   schedule: EventSchedule,
+  recurrence: ProviderWriteRecurrence,
 ): boolean {
   return (
     current.content.title === content.title &&
     current.content.description === content.description &&
     current.content.location === content.location &&
-    deepEqual(current.schedule, schedule)
+    deepEqual(current.schedule, schedule) &&
+    recurrenceMatches(current.recurrence, recurrence)
   );
+}
+
+// Whether the provider's reported recurrence matches the recurrence a write
+// would set. A single write expects a non-recurring event; a series write
+// expects the same rules the provider now reports on its master.
+//
+// Rules are compared canonically, not byte-for-byte. A provider can echo a rule
+// it stored in a reformatted-but-equivalent form (reordered components,
+// different casing), so an exact compare would false-miss a landed edit — and
+// because this gates a replay, that miss would re-patch with a now-stale
+// expected version and fail a write that already succeeded, leaving the local
+// event diverged from the provider. Canonicalizing absorbs that cosmetic drift;
+// genuinely different rules still differ, so this never widens a real change
+// into a false match. Named wart: an exotic reformatting the canonicalization
+// misses (e.g. a provider injecting a non-default WKST we never sent) can still
+// false-miss — acceptable because Compass emits simple rules and the only
+// consequence is a spurious conflict in the narrow landed-then-retried window.
+function recurrenceMatches(
+  current: ProviderEvent["recurrence"],
+  intended: ProviderWriteRecurrence,
+): boolean {
+  if (intended.kind === "single") return current.kind === "single";
+  if (current.kind !== "seriesMaster") return false;
+  if (current.rules.length !== intended.rules.length) return false;
+  const currentCanonical = current.rules.map(canonicalRule).sort();
+  const intendedCanonical = intended.rules.map(canonicalRule).sort();
+  return currentCanonical.every(
+    (rule, index) => rule === intendedCanonical[index],
+  );
+}
+
+// A rule normalized for equality: uppercased, its optional RRULE: prefix
+// dropped, and its ;-separated components sorted. This makes the comparison
+// order- and case-insensitive without a full RRULE parse (which would drag in
+// dtstart defaulting and reformatting of its own).
+function canonicalRule(rule: string): string {
+  return rule
+    .trim()
+    .toUpperCase()
+    .replace(/^RRULE:/, "")
+    .split(";")
+    .filter((part) => part.length > 0)
+    .sort()
+    .join(";");
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {


### PR DESCRIPTION
## What

A scope-`all` edit of a **provider-linked** recurring series master now runs at the provider (Google's "edit all events in the series") instead of staying pending. This completes the provider-side update for whole-series edits; per-occurrence provider edits (`this` / `thisAndFollowing`) remain pending until import lands.

## How

- A new `executeProviderSeriesUpdate` executor patches the master with the edited content, schedule, **and** recurrence rules, then commits locally the same way a cloud series edit-all does: discard per-instance overrides, keep cancelled tombstones, and reproject the master excluding their instants. A convert-to-single edit drops every exception. Kept as a separate executor from the single-event `executeProviderUpdate` because the local commit is series-aware.
- Replay detection (`matchesIntendedEdit`) now compares **recurrence** as well as content and schedule. Without this, a rules-only series edit (same title/time, different RRULE) looked identical to the provider's pre-edit state and was confirmed without ever writing the new rules.
- Rules are compared **canonically** (uppercased, `RRULE:` prefix dropped, components sorted), not byte-for-byte, so a provider that echoes an equivalent-but-reformatted rule on a retry doesn't false-miss a landed edit and then re-patch with a stale expected version.
- Dispatch: a provider series master + scope `all` routes to the new executor; `this`/`thisAndFollowing` still return pending.

## Correctness notes (independent review)

- **Recurrence-aware replay + canonical rule compare** — fixes both the original rules-only false-replay and a review-caught regression where raw-string rule comparison could false-miss a landed edit under provider reformatting, causing a terminal version conflict with local/provider divergence. Regression test added (reordered/lowercased rule echo treated as a replay).
- **Deferred gap (documented in code):** for a provider-linked series, discarding an override removes only the *local* copy, not the override event at the provider. Harmless today because provider-linked exceptions are only created by import (not built yet), so the discard set is always empty. Called out in-code alongside the matching gap already noted for the provider delete path.

## Testing

- `bun run test:sync` — 420 pass, 0 fail.
- `bun run type-check` clean; biome clean.
- New coverage: whole-series patch + reprojection, rules-only edit (not a false replay), reformatted-rule replay, version conflict, override-discard / cancelled-keep partition, convert-to-single, idempotent retry, plus cloud-dispatch routing (all-scope routes; this-scope stays pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)