### PR TITLE
ci: give the mongo-backed unit suites a longer step timeout

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -136,7 +136,11 @@ jobs:
 
       - name: Run ${{ matrix.project }} tests
         if: matrix.project != 'web'
-        timeout-minutes: 5
+        # backend/scripts/sync each boot an in-memory MongoDB, so they run far
+        # longer than the web suite and grow with the sync service. A slow runner
+        # pushed the sync suite past a 5-minute wall clock even with every test
+        # passing; give the mongo-backed suites real headroom (web stays 1m above).
+        timeout-minutes: 10
         env:
           TZ: Etc/UTC
         run: |


### PR DESCRIPTION
## What

Raise the CI step timeout for the mongo-backed unit suites (backend, scripts, sync) from 5 to 10 minutes. The web suite keeps its 1-minute timeout.

## Why

Those three suites each boot an in-memory MongoDB and run far longer than the web suite. The sync suite has grown enough that a slow CI runner can exceed the shared 5-minute step wall clock **even when every test passes** — the job then fails with `The action 'Run … tests' has timed out after 5 minutes` rather than a real test failure (observed on #2271, where the suite ran 311s with 0 failures and its sibling job passed). This will only get worse as more sync slices land, so the timeout gets real headroom now.

## Testing

Workflow-only change; no product code touched. CI on this PR exercises the new value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)