### PR TITLE
perf(sync): cut the sync test suite from three minutes to sixteen seconds

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -136,11 +136,7 @@ jobs:
 
       - name: Run ${{ matrix.project }} tests
         if: matrix.project != 'web'
-        # backend/scripts/sync each boot an in-memory MongoDB, so they run far
-        # longer than the web suite and grow with the sync service. A slow runner
-        # pushed the sync suite past a 5-minute wall clock even with every test
-        # passing; give the mongo-backed suites real headroom (web stays 1m above).
-        timeout-minutes: 10
+        timeout-minutes: 5
         env:
           TZ: Etc/UTC
         run: |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:backend:fast": "bun packages/scripts/src/testing/run-tests.ts backend --tier fast",
     "test:backend:db": "bun packages/scripts/src/testing/run-tests.ts backend --tier db",
     "test:core": "bun test packages/core/src --preload ./packages/scripts/src/testing/core.preload.ts",
-    "test:sync": "bun test packages/sync/src --preload ./packages/sync/src/__tests__/sync.preload.ts",
+    "test:sync": "bun packages/scripts/src/testing/run-tests.ts sync",
     "test:web": "bun test --cwd packages/web",
     "test:scripts": "bun packages/scripts/src/testing/run-tests.ts scripts",
     "test:scripts:fast": "bun packages/scripts/src/testing/run-tests.ts scripts --tier fast",

--- a/packages/scripts/src/testing/run-tests.ts
+++ b/packages/scripts/src/testing/run-tests.ts
@@ -1,5 +1,5 @@
 /**
- * Test runner for the Mongo-backed packages (backend, scripts).
+ * Test runner for the Mongo-backed packages (backend, scripts, sync).
  *
  * Bun runs every file in a package inside ONE process, sharing the module
  * registry -- singletons, open handles and mock state leak between files, which
@@ -13,7 +13,7 @@
  *   3. Bounds parallelism to the core count and streams a compact summary.
  *
  * Usage:
- *   bun run-tests.ts <backend|scripts> [--filter substring] [--tier fast|db]
+ *   bun run-tests.ts <backend|scripts|sync> [--filter substring] [--tier fast|db]
  *
  * Tiers are classified automatically (no hand-maintained allowlist): a file is
  * "db" if it touches the Mongo test harness (setupTestDb), otherwise "fast".
@@ -24,7 +24,7 @@ import { readFileSync } from "node:fs";
 import { cpus } from "node:os";
 import { resolve } from "node:path";
 
-type PackageName = "backend" | "scripts";
+type PackageName = "backend" | "scripts" | "sync";
 
 const PACKAGES: Record<PackageName, { root: string; preload: string }> = {
   backend: {
@@ -35,11 +35,17 @@ const PACKAGES: Record<PackageName, { root: string; preload: string }> = {
     root: "packages/scripts/src",
     preload: "packages/scripts/src/testing/scripts.preload.ts",
   },
+  sync: {
+    root: "packages/sync/src",
+    preload: "packages/sync/src/__tests__/sync.preload.ts",
+  },
 };
 
 const pkg = process.argv[2] as PackageName;
 if (!pkg || !PACKAGES[pkg]) {
-  console.error("Usage: run-tests.ts <backend|scripts> [--filter substring]");
+  console.error(
+    "Usage: run-tests.ts <backend|scripts|sync> [--filter substring]",
+  );
   process.exit(2);
 }
 
@@ -56,11 +62,13 @@ if (tier && tier !== "fast" && tier !== "db") {
 const { root, preload: preloadRel } = PACKAGES[pkg];
 const preload = resolve(preloadRel);
 
-// A file is "db" if it touches the Mongo test harness; otherwise "fast".
+// A file is "db" if it touches a Mongo test harness; otherwise "fast".
 // Derived from the source, so the classification can never drift out of sync
 // with a hand-maintained list.
 const isDbFile = (path: string): boolean =>
-  /\bsetupTestDb\b/.test(readFileSync(path, "utf8"));
+  /\bsetupTestDb\b|\bsetupSyncStorage\b|\bSYNC_MONGO_URI\b/.test(
+    readFileSync(path, "utf8"),
+  );
 
 const files = Array.from(new Glob("**/*.{test,spec}.{ts,tsx}").scanSync(root))
   .map((rel) => `${root}/${rel}`)

--- a/packages/sync/src/__tests__/helpers/storage.ts
+++ b/packages/sync/src/__tests__/helpers/storage.ts
@@ -1,60 +1,56 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db, type MongoClient } from "mongodb";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
-import { installIndexManifest } from "@sync/storage/index-manifest";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { afterAll, beforeAll, beforeEach } from "bun:test";
 
 // Shared Mongo lifecycle for storage-backed sync tests.
 //
-// Connecting a client and installing the index manifest are the expensive parts
-// of test setup (hundreds of milliseconds against a replica set), so they run
-// ONCE per describe scope here; between tests only the collections are wiped,
-// which is a few milliseconds. The old pattern paid the full
-// connect/install/dropDatabase cycle in every beforeEach, which made a <30ms
-// test cost ~700ms of setup and pushed the whole suite past three minutes.
+// Connecting and installing the index manifest are the expensive parts of test
+// setup (hundreds of milliseconds against a replica set), so they run ONCE per
+// file here; between tests only the collections are wiped, which is a few
+// milliseconds. The old pattern paid the full connect/install/dropDatabase
+// cycle in every beforeEach, which made a <30ms test cost ~700ms of setup and
+// pushed the whole suite past three minutes.
 //
-// Each call gets its own randomly-named database, so test files running in
-// parallel launcher processes (run-tests.ts) never collide. Tests that
-// exercise connection or manifest behavior itself (sync-mongo.service.test.ts,
+// Holds a real SyncMongoService (not a bare client) so server tests can inject
+// it into createSyncService, whose routes gate on `mongo.isConnected`. Each
+// call gets its own randomly-named database, so test files running in parallel
+// launcher processes (run-tests.ts) never collide. Tests that exercise
+// connection or manifest behavior itself (sync-mongo.service.test.ts,
 // index-manifest.test.ts) keep their own bespoke setup instead of this helper.
-export function useSyncStorage(): {
+export function setupSyncStorage(): {
   db: () => Db;
   client: () => MongoClient;
+  mongo: () => SyncMongoService;
 } {
-  let client: MongoClient | undefined;
-  let db: Db | undefined;
+  const mongo = new SyncMongoService();
 
   beforeAll(async () => {
-    client = new MongoClient(process.env["SYNC_MONGO_URI"] as string);
-    await client.connect();
-    db = client.db(`synctest_${faker.database.mongodbObjectId()}`);
-    await installIndexManifest(db);
+    await mongo.connect({
+      uri: process.env["SYNC_MONGO_URI"] as string,
+      databaseName: `synctest_${faker.database.mongodbObjectId()}`,
+      forbiddenDatabaseName: "compass_api_unused",
+      enforceLeastPrivilege: false,
+    });
   });
 
   beforeEach(async () => {
-    const connected = requireDb(db);
     await Promise.all(
       Object.values(SYNC_COLLECTIONS).map((name) =>
-        connected.collection(name).deleteMany({}),
+        mongo.db.collection(name).deleteMany({}),
       ),
     );
   });
 
   afterAll(async () => {
-    await db?.dropDatabase();
-    await client?.close();
+    await mongo.db.dropDatabase();
+    await mongo.disconnect();
   });
 
   return {
-    db: () => requireDb(db),
-    client: () => {
-      if (!client) throw new Error("useSyncStorage: not connected yet");
-      return client;
-    },
+    db: () => mongo.db,
+    client: () => mongo.client,
+    mongo: () => mongo,
   };
-}
-
-function requireDb(db: Db | undefined): Db {
-  if (!db) throw new Error("useSyncStorage: not connected yet");
-  return db;
 }

--- a/packages/sync/src/__tests__/helpers/storage.ts
+++ b/packages/sync/src/__tests__/helpers/storage.ts
@@ -1,0 +1,60 @@
+import { faker } from "@faker-js/faker";
+import { type Db, MongoClient } from "mongodb";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { installIndexManifest } from "@sync/storage/index-manifest";
+import { afterAll, beforeAll, beforeEach } from "bun:test";
+
+// Shared Mongo lifecycle for storage-backed sync tests.
+//
+// Connecting a client and installing the index manifest are the expensive parts
+// of test setup (hundreds of milliseconds against a replica set), so they run
+// ONCE per describe scope here; between tests only the collections are wiped,
+// which is a few milliseconds. The old pattern paid the full
+// connect/install/dropDatabase cycle in every beforeEach, which made a <30ms
+// test cost ~700ms of setup and pushed the whole suite past three minutes.
+//
+// Each call gets its own randomly-named database, so test files running in
+// parallel launcher processes (run-tests.ts) never collide. Tests that
+// exercise connection or manifest behavior itself (sync-mongo.service.test.ts,
+// index-manifest.test.ts) keep their own bespoke setup instead of this helper.
+export function useSyncStorage(): {
+  db: () => Db;
+  client: () => MongoClient;
+} {
+  let client: MongoClient | undefined;
+  let db: Db | undefined;
+
+  beforeAll(async () => {
+    client = new MongoClient(process.env["SYNC_MONGO_URI"] as string);
+    await client.connect();
+    db = client.db(`synctest_${faker.database.mongodbObjectId()}`);
+    await installIndexManifest(db);
+  });
+
+  beforeEach(async () => {
+    const connected = requireDb(db);
+    await Promise.all(
+      Object.values(SYNC_COLLECTIONS).map((name) =>
+        connected.collection(name).deleteMany({}),
+      ),
+    );
+  });
+
+  afterAll(async () => {
+    await db?.dropDatabase();
+    await client?.close();
+  });
+
+  return {
+    db: () => requireDb(db),
+    client: () => {
+      if (!client) throw new Error("useSyncStorage: not connected yet");
+      return client;
+    },
+  };
+}
+
+function requireDb(db: Db | undefined): Db {
+  if (!db) throw new Error("useSyncStorage: not connected yet");
+  return db;
+}

--- a/packages/sync/src/credentials/credential-custody.service.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import {
   type ProviderAuthAdapter,
@@ -65,7 +65,7 @@ const baseCredential = (
 });
 
 describe("CredentialCustody", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: CredentialRepository;
 

--- a/packages/sync/src/credentials/credential-custody.service.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.test.ts
@@ -218,26 +218,45 @@ describe("CredentialCustody", () => {
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
+    // Resolves once the refresh has genuinely started — which proves custody
+    // already read the credential. Deleting only after this point pins the test
+    // to the mid-refresh race; deleting concurrently with the initial read
+    // could let the delete overtake it on a pooled connection and exercise the
+    // wrong path (the plain missing-credential throw).
+    let refreshStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      refreshStarted = resolve;
+    });
     const adapter = new FakeAdapter({
       refreshed: {
         accessToken: "orphan-token",
         expiresAt: new Date("2099-01-01T00:00:00Z"),
         grantedScopes: [],
       },
-      onRefresh: () => gate,
+      onRefresh: () => {
+        refreshStarted();
+        return gate;
+      },
     });
     const custody = new CredentialCustody(repo, adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
-    // Start a refresh, delete the credential while it is in flight, then let
-    // the refresh finish.
-    const inFlight = custody.getValidAccessToken(connectionId);
+    // Start a refresh; the rejection handler attaches immediately so the
+    // eventual rejection is never unhandled while later awaits are pending.
+    const inFlight = custody
+      .getValidAccessToken(connectionId)
+      .catch((e) => e as ProviderAuthError);
+    // Delete the credential while the refresh is in flight, then let it finish.
+    await started;
     await repo.deleteByConnection(connectionId);
     release();
 
-    const error = (await inFlight.catch((e) => e)) as ProviderAuthError;
+    const error = await inFlight;
     expect(error).toBeInstanceOf(ProviderAuthError);
-    expect(error.reason).toBe("missingRefreshToken");
+    expect((error as ProviderAuthError).reason).toBe("missingRefreshToken");
+    expect((error as ProviderAuthError).message).toBe(
+      "Credential was removed during refresh",
+    );
     // The token was never re-cached, so the deleted credential stays gone.
     expect(await repo.findByConnection(connectionId)).toBeNull();
   });

--- a/packages/sync/src/credentials/credential-custody.service.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import {
   type ProviderAuthAdapter,
@@ -8,10 +9,8 @@ import {
   type RefreshedCredential,
 } from "@sync/providers/provider-auth.port";
 import { type CredentialUpsert } from "@sync/storage/contracts/credential.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 // A configurable ProviderAuthAdapter fake that counts refresh/revoke calls.
@@ -66,21 +65,13 @@ const baseCredential = (
 });
 
 describe("CredentialCustody", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: CredentialRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`custody_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new CredentialRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   const fixedNow = () => new Date("2026-01-01T00:00:00Z");

--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker";
-import { type Db, type MongoClient } from "mongodb";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
 import {
   type ConnectionId,
@@ -8,7 +7,7 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { submitCloudCommand } from "@sync/domain/cloud-command.service";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
@@ -26,8 +25,9 @@ import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-ma
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
-const storage = useSyncStorage();
+const storage = setupSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 
 class FakeWriter implements ProviderEventWriter {
@@ -81,7 +81,7 @@ const provider = (writer: ProviderEventWriter) => ({
 });
 
 describe("submitCloudCommand provider dispatch", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -142,7 +142,7 @@ describe("submitCloudCommand provider dispatch", () => {
   });
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);

--- a/packages/sync/src/domain/cloud-command.service.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { type Db, type MongoClient } from "mongodb";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
 import {
   type ConnectionId,
@@ -7,6 +8,7 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { submitCloudCommand } from "@sync/domain/cloud-command.service";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
@@ -24,9 +26,8 @@ import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-ma
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
-import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = useSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 
 class FakeWriter implements ProviderEventWriter {
@@ -80,7 +81,7 @@ const provider = (writer: ProviderEventWriter) => ({
 });
 
 describe("submitCloudCommand provider dispatch", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -140,24 +141,13 @@ describe("submitCloudCommand provider dispatch", () => {
     expectedVersion: null,
   });
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `cloudcmd_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     calendars = new ProviderCalendarRepository(mongo.db);
     markers = new DeletionMarkerRepository(mongo.db);
-  });
-
-  afterEach(async () => {
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("executes a provider-targeted create when active and provider-capable", async () => {

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker";
-import { type Db, type MongoClient } from "mongodb";
 import { type RecurrenceEdit } from "@core/types/event-command.contracts";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
 import {
@@ -9,7 +8,7 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
   type AccessTokenSource,
   executeProviderCreate,
@@ -37,8 +36,9 @@ import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-ma
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
-const storage = useSyncStorage();
+const storage = setupSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 
 // A writer that records its calls and returns a fixed identity, or throws a
@@ -77,7 +77,7 @@ const failingTokenSource = (error: unknown): AccessTokenSource => ({
 });
 
 describe("executeProviderCreate", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -144,7 +144,7 @@ describe("executeProviderCreate", () => {
   };
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
@@ -353,7 +353,7 @@ class FakeUpdateWriter implements ProviderEventWriter {
 }
 
 describe("executeProviderUpdate", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -453,7 +453,7 @@ describe("executeProviderUpdate", () => {
   };
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
@@ -663,7 +663,7 @@ class FakeDeleteWriter implements ProviderEventWriter {
 }
 
 describe("executeProviderDelete", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -742,7 +742,7 @@ describe("executeProviderDelete", () => {
   };
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
@@ -902,7 +902,7 @@ describe("executeProviderDelete", () => {
 });
 
 describe("executeProviderSeriesUpdate", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -1075,7 +1075,7 @@ describe("executeProviderSeriesUpdate", () => {
   };
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);

--- a/packages/sync/src/domain/provider-command.service.test.ts
+++ b/packages/sync/src/domain/provider-command.service.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { type Db, type MongoClient } from "mongodb";
 import { type RecurrenceEdit } from "@core/types/event-command.contracts";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
 import {
@@ -8,6 +9,7 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
   type AccessTokenSource,
   executeProviderCreate,
@@ -35,9 +37,8 @@ import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-ma
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
-import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = useSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 
 // A writer that records its calls and returns a fixed identity, or throws a
@@ -76,7 +77,7 @@ const failingTokenSource = (error: unknown): AccessTokenSource => ({
 });
 
 describe("executeProviderCreate", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -142,23 +143,12 @@ describe("executeProviderCreate", () => {
     return { tenantId, principalId, calendar, command };
   };
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `provcmd_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     calendars = new ProviderCalendarRepository(mongo.db);
-  });
-
-  afterEach(async () => {
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   const now = () => new Date("2026-07-10T00:00:00.000Z");
@@ -363,7 +353,7 @@ class FakeUpdateWriter implements ProviderEventWriter {
 }
 
 describe("executeProviderUpdate", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -462,23 +452,12 @@ describe("executeProviderUpdate", () => {
     return { tenantId, principalId, calendar, event, command };
   };
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `provupd_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     calendars = new ProviderCalendarRepository(mongo.db);
-  });
-
-  afterEach(async () => {
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("patches the provider and commits the new version and content", async () => {
@@ -684,7 +663,7 @@ class FakeDeleteWriter implements ProviderEventWriter {
 }
 
 describe("executeProviderDelete", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -762,23 +741,12 @@ describe("executeProviderDelete", () => {
     return { tenantId, principalId, calendar, event, command };
   };
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `provdel_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     markers = new DeletionMarkerRepository(mongo.db);
-  });
-
-  afterEach(async () => {
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("deletes at the provider, tombstones, removes the local event, and confirms", async () => {
@@ -934,7 +902,7 @@ describe("executeProviderDelete", () => {
 });
 
 describe("executeProviderSeriesUpdate", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let commands: CommandRepository;
   let events: EventRepository;
   let occurrences: EventOccurrenceRepository;
@@ -1106,23 +1074,12 @@ describe("executeProviderSeriesUpdate", () => {
     return stored;
   };
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `provseries_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     commands = new CommandRepository(mongo.db);
     events = new EventRepository(mongo.db);
     occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
     calendars = new ProviderCalendarRepository(mongo.db);
-  });
-
-  afterEach(async () => {
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   const deps = (writer: ProviderEventWriter) => ({

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -1,10 +1,12 @@
 import { faker } from "@faker-js/faker";
+import { type Db, type MongoClient } from "mongodb";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
@@ -12,10 +14,9 @@ import { COMMANDS_PATH } from "@sync/server/command.routes";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
-import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = useSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 const SECRET = "internal-secret";
 
@@ -78,7 +79,7 @@ const createRequest = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe("POST /internal/commands", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let service: SyncService;
   let base: string;
 
@@ -96,20 +97,12 @@ describe("POST /internal/commands", () => {
       body: JSON.stringify(body),
     });
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `cmd_api_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
   });
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("confirms a cloud-only create and writes the canonical event", async () => {

--- a/packages/sync/src/server/command.routes.test.ts
+++ b/packages/sync/src/server/command.routes.test.ts
@@ -1,12 +1,11 @@
 import { faker } from "@faker-js/faker";
-import { type Db, type MongoClient } from "mongodb";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
@@ -14,9 +13,11 @@ import { COMMANDS_PATH } from "@sync/server/command.routes";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
-const storage = useSyncStorage();
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = setupSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 const SECRET = "internal-secret";
 
@@ -79,7 +80,7 @@ const createRequest = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe("POST /internal/commands", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let service: SyncService;
   let base: string;
 
@@ -98,7 +99,7 @@ describe("POST /internal/commands", () => {
     });
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
   });
 
   afterEach(async () => {

--- a/packages/sync/src/server/connection.routes.test.ts
+++ b/packages/sync/src/server/connection.routes.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { type Db, type MongoClient } from "mongodb";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
@@ -6,6 +7,7 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
@@ -33,10 +35,9 @@ import {
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
-import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = useSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 const SECRET = "internal-secret";
 // The service signs OAuth state with a key derived from the root secret.
@@ -136,7 +137,7 @@ const signedHeaders = (
 };
 
 describe("GET /internal/connections", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let repo: ProviderConnectionRepository;
   let service: SyncService;
   let base: string;
@@ -151,21 +152,13 @@ describe("GET /internal/connections", () => {
     base = `http://127.0.0.1:${port}`;
   };
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `conn_api_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     repo = new ProviderConnectionRepository(mongo.db);
   });
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("returns the caller's connections mapped to the wire contract", async () => {
@@ -262,7 +255,7 @@ describe("GET /internal/connections", () => {
 });
 
 describe("DELETE /internal/connections/:id", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let connections: ProviderConnectionRepository;
   let credentials: CredentialRepository;
   let service: SyncService;
@@ -281,14 +274,8 @@ describe("DELETE /internal/connections/:id", () => {
     base = `http://127.0.0.1:${port}`;
   };
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `disconnect_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     connections = new ProviderConnectionRepository(mongo.db);
     credentials = new CredentialRepository(mongo.db);
     adapter = new FakeAuthAdapter();
@@ -296,8 +283,6 @@ describe("DELETE /internal/connections/:id", () => {
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   const seedConnected = async (tenantId: string, principalId: string) => {
@@ -397,7 +382,7 @@ describe("DELETE /internal/connections/:id", () => {
 });
 
 describe("POST /internal/connections/begin", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let connections: ProviderConnectionRepository;
   let service: SyncService;
   let base: string;
@@ -429,22 +414,14 @@ describe("POST /internal/connections/begin", () => {
       body: JSON.stringify(body ?? {}),
     });
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `begin_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     connections = new ProviderConnectionRepository(mongo.db);
     adapter = new FakeAuthAdapter();
   });
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("returns a consent url whose state binds the flow to the caller", async () => {
@@ -538,7 +515,7 @@ describe("POST /internal/connections/begin", () => {
 });
 
 describe("GET /oauth/google/callback", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let connections: ProviderConnectionRepository;
   let credentials: CredentialRepository;
   let service: SyncService;
@@ -571,14 +548,8 @@ describe("GET /oauth/google/callback", () => {
   const statusOf = (res: Response) =>
     new URL(res.headers.get("location") as string).searchParams.get("status");
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `callback_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     connections = new ProviderConnectionRepository(mongo.db);
     credentials = new CredentialRepository(mongo.db);
     adapter = new FakeAuthAdapter();
@@ -586,8 +557,6 @@ describe("GET /oauth/google/callback", () => {
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("links the connection and stores the credential on a valid callback", async () => {
@@ -765,7 +734,7 @@ describe("GET /oauth/google/callback", () => {
 });
 
 describe("GET /internal/calendars", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let calendars: ProviderCalendarRepository;
   let service: SyncService;
   let base: string;
@@ -809,21 +778,13 @@ describe("GET /internal/calendars", () => {
       headers: signedHeaders(tenantId, principalId),
     });
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `cal_api_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     calendars = new ProviderCalendarRepository(mongo.db);
   });
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("returns the caller's calendars mapped to the wire contract", async () => {
@@ -925,7 +886,7 @@ describe("GET /internal/calendars", () => {
 });
 
 describe("GET /internal/events", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let service: SyncService;
   let base: string;
 
@@ -981,20 +942,12 @@ describe("GET /internal/events", () => {
       headers: signedHeaders(tenantId, principalId),
     });
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `events_api_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
   });
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("returns occurrences mapped to the strict wire contract", async () => {

--- a/packages/sync/src/server/connection.routes.test.ts
+++ b/packages/sync/src/server/connection.routes.test.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker";
-import { type Db, type MongoClient } from "mongodb";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
@@ -7,7 +6,7 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
@@ -35,9 +34,11 @@ import {
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
-const storage = useSyncStorage();
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = setupSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 const SECRET = "internal-secret";
 // The service signs OAuth state with a key derived from the root secret.
@@ -137,7 +138,7 @@ const signedHeaders = (
 };
 
 describe("GET /internal/connections", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let repo: ProviderConnectionRepository;
   let service: SyncService;
   let base: string;
@@ -153,7 +154,7 @@ describe("GET /internal/connections", () => {
   };
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     repo = new ProviderConnectionRepository(mongo.db);
   });
 
@@ -255,7 +256,7 @@ describe("GET /internal/connections", () => {
 });
 
 describe("DELETE /internal/connections/:id", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let connections: ProviderConnectionRepository;
   let credentials: CredentialRepository;
   let service: SyncService;
@@ -275,7 +276,7 @@ describe("DELETE /internal/connections/:id", () => {
   };
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     connections = new ProviderConnectionRepository(mongo.db);
     credentials = new CredentialRepository(mongo.db);
     adapter = new FakeAuthAdapter();
@@ -382,7 +383,7 @@ describe("DELETE /internal/connections/:id", () => {
 });
 
 describe("POST /internal/connections/begin", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let connections: ProviderConnectionRepository;
   let service: SyncService;
   let base: string;
@@ -415,7 +416,7 @@ describe("POST /internal/connections/begin", () => {
     });
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     connections = new ProviderConnectionRepository(mongo.db);
     adapter = new FakeAuthAdapter();
   });
@@ -515,7 +516,7 @@ describe("POST /internal/connections/begin", () => {
 });
 
 describe("GET /oauth/google/callback", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let connections: ProviderConnectionRepository;
   let credentials: CredentialRepository;
   let service: SyncService;
@@ -549,7 +550,7 @@ describe("GET /oauth/google/callback", () => {
     new URL(res.headers.get("location") as string).searchParams.get("status");
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     connections = new ProviderConnectionRepository(mongo.db);
     credentials = new CredentialRepository(mongo.db);
     adapter = new FakeAuthAdapter();
@@ -734,7 +735,7 @@ describe("GET /oauth/google/callback", () => {
 });
 
 describe("GET /internal/calendars", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let calendars: ProviderCalendarRepository;
   let service: SyncService;
   let base: string;
@@ -779,7 +780,7 @@ describe("GET /internal/calendars", () => {
     });
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     calendars = new ProviderCalendarRepository(mongo.db);
   });
 
@@ -886,7 +887,7 @@ describe("GET /internal/calendars", () => {
 });
 
 describe("GET /internal/events", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let service: SyncService;
   let base: string;
 
@@ -943,7 +944,7 @@ describe("GET /internal/events", () => {
     });
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
   });
 
   afterEach(async () => {

--- a/packages/sync/src/server/notification.routes.test.ts
+++ b/packages/sync/src/server/notification.routes.test.ts
@@ -1,19 +1,20 @@
 import { faker } from "@faker-js/faker";
+import { type Db, type MongoClient } from "mongodb";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { type SyncConfig } from "@sync/config/sync.config";
 import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
-import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = useSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 
 const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
@@ -43,7 +44,7 @@ const googHeaders = (
 });
 
 describe("POST /oauth/google/notifications", () => {
-  let mongo: SyncMongoService;
+  let mongo: { db: Db; client: MongoClient };
   let resources: SyncResourceRepository;
   let service: SyncService;
   let base: string;
@@ -86,21 +87,13 @@ describe("POST /oauth/google/notifications", () => {
       .collection(SYNC_COLLECTIONS.jobs)
       .countDocuments({ coalescingKey });
 
-  beforeEach(async () => {
-    mongo = new SyncMongoService();
-    await mongo.connect({
-      uri,
-      databaseName: `notif_${objectId()}`,
-      forbiddenDatabaseName: "compass_api_unused",
-      enforceLeastPrivilege: false,
-    });
+  beforeEach(() => {
+    mongo = { db: storage.db(), client: storage.client() };
     resources = new SyncResourceRepository(mongo.db);
   });
 
   afterEach(async () => {
     await service?.stop();
-    await mongo.db.dropDatabase();
-    await mongo.disconnect();
   });
 
   it("enqueues one pull for an authentic change, coalescing duplicates", async () => {

--- a/packages/sync/src/server/notification.routes.test.ts
+++ b/packages/sync/src/server/notification.routes.test.ts
@@ -1,20 +1,21 @@
 import { faker } from "@faker-js/faker";
-import { type Db, type MongoClient } from "mongodb";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { type SyncConfig } from "@sync/config/sync.config";
 import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
-const storage = useSyncStorage();
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = setupSyncStorage();
 const objectId = () => faker.database.mongodbObjectId();
 
 const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
@@ -44,7 +45,7 @@ const googHeaders = (
 });
 
 describe("POST /oauth/google/notifications", () => {
-  let mongo: { db: Db; client: MongoClient };
+  let mongo: SyncMongoService;
   let resources: SyncResourceRepository;
   let service: SyncService;
   let base: string;
@@ -88,7 +89,7 @@ describe("POST /oauth/google/notifications", () => {
       .countDocuments({ coalescingKey });
 
   beforeEach(() => {
-    mongo = { db: storage.db(), client: storage.client() };
+    mongo = storage.mongo();
     resources = new SyncResourceRepository(mongo.db);
   });
 

--- a/packages/sync/src/storage/repositories/command.repository.test.ts
+++ b/packages/sync/src/storage/repositories/command.repository.test.ts
@@ -1,10 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const timed = {
@@ -40,21 +39,13 @@ const submit = (overrides: Partial<CommandSubmit> = {}): CommandSubmit =>
   }) as CommandSubmit;
 
 describe("CommandRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: CommandRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`cmd_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new CommandRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("submits a new command as pending with zero attempts", async () => {

--- a/packages/sync/src/storage/repositories/command.repository.test.ts
+++ b/packages/sync/src/storage/repositories/command.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 
@@ -39,7 +39,7 @@ const submit = (overrides: Partial<CommandSubmit> = {}): CommandSubmit =>
   }) as CommandSubmit;
 
 describe("CommandRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: CommandRepository;
 

--- a/packages/sync/src/storage/repositories/credential.repository.test.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
   type CredentialUpsert,
@@ -22,7 +22,7 @@ const baseCredential = (
 });
 
 describe("CredentialRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: CredentialRepository;
 

--- a/packages/sync/src/storage/repositories/credential.repository.test.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.test.ts
@@ -1,15 +1,14 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
   type CredentialUpsert,
   redactCredential,
 } from "@sync/storage/contracts/credential.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const baseCredential = (
@@ -23,21 +22,13 @@ const baseCredential = (
 });
 
 describe("CredentialRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: CredentialRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`cred_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new CredentialRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("stores and reads back a credential keyed by connection id", async () => {

--- a/packages/sync/src/storage/repositories/deletion-marker.repository.test.ts
+++ b/packages/sync/src/storage/repositories/deletion-marker.repository.test.ts
@@ -1,13 +1,12 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type DeletionMarkerRecordInput } from "@sync/storage/contracts/deletion-marker.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import {
   DELETION_MARKER_RETENTION_MS,
   DeletionMarkerRepository,
 } from "@sync/storage/repositories/deletion-marker.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const markerInput = (
@@ -26,21 +25,13 @@ const markerInput = (
   }) as DeletionMarkerRecordInput;
 
 describe("DeletionMarkerRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: DeletionMarkerRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`del_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new DeletionMarkerRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("records a content-free marker with a 30-day expiry", async () => {

--- a/packages/sync/src/storage/repositories/deletion-marker.repository.test.ts
+++ b/packages/sync/src/storage/repositories/deletion-marker.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type DeletionMarkerRecordInput } from "@sync/storage/contracts/deletion-marker.contracts";
 import {
   DELETION_MARKER_RETENTION_MS,
@@ -25,7 +25,7 @@ const markerInput = (
   }) as DeletionMarkerRecordInput;
 
 describe("DeletionMarkerRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: DeletionMarkerRepository;
 

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurrence.contracts";
 import {
   EventOccurrenceRepository,
@@ -33,7 +33,7 @@ const occurrence = (
   }) as OccurrenceInput;
 
 describe("EventOccurrenceRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: EventOccurrenceRepository;
 

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
@@ -1,13 +1,12 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurrence.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import {
   EventOccurrenceRepository,
   type OccurrenceInput,
 } from "@sync/storage/repositories/event-occurrence.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const occurrence = (
@@ -34,21 +33,13 @@ const occurrence = (
   }) as OccurrenceInput;
 
 describe("EventOccurrenceRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: EventOccurrenceRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`occ_${objectId()}`);
-    await installIndexManifest(db);
-    repo = new EventOccurrenceRepository(db, client);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
+  beforeEach(() => {
+    db = storage.db();
+    repo = new EventOccurrenceRepository(db, storage.client());
   });
 
   it("materializes occurrences for an event", async () => {

--- a/packages/sync/src/storage/repositories/event.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.test.ts
@@ -1,13 +1,12 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import {
   EventRepository,
   type ProviderEventUpsert,
 } from "@sync/storage/repositories/event.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const timed = (start: string, end: string, timeZone = "America/Denver") => ({
@@ -76,21 +75,13 @@ const compassRecord = (overrides: Partial<EventRecord> = {}): EventRecord =>
   }) as EventRecord;
 
 describe("EventRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: EventRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`event_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new EventRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("dedupes a linked event on provider identity across repeated reads", async () => {

--- a/packages/sync/src/storage/repositories/event.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import {
   EventRepository,
@@ -75,7 +75,7 @@ const compassRecord = (overrides: Partial<EventRecord> = {}): EventRecord =>
   }) as EventRecord;
 
 describe("EventRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: EventRepository;
 

--- a/packages/sync/src/storage/repositories/job.repository.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.test.ts
@@ -1,10 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const enqueue = (overrides: Partial<JobEnqueue> = {}): JobEnqueue =>
@@ -22,21 +21,13 @@ const enqueue = (overrides: Partial<JobEnqueue> = {}): JobEnqueue =>
   }) as JobEnqueue;
 
 describe("JobRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: JobRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`job_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new JobRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("enqueues a new pending job", async () => {

--- a/packages/sync/src/storage/repositories/job.repository.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 
@@ -21,7 +21,7 @@ const enqueue = (overrides: Partial<JobEnqueue> = {}): JobEnqueue =>
   }) as JobEnqueue;
 
 describe("JobRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: JobRepository;
 

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.test.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.test.ts
@@ -1,10 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type ProviderCalendarUpsert } from "@sync/storage/contracts/provider-calendar.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const baseUpsert = (
@@ -30,21 +29,13 @@ const baseUpsert = (
   }) as ProviderCalendarUpsert;
 
 describe("ProviderCalendarRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: ProviderCalendarRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`cal_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new ProviderCalendarRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("assigns a stable id on first upsert", async () => {

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.test.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type ProviderCalendarUpsert } from "@sync/storage/contracts/provider-calendar.contracts";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 
@@ -29,7 +29,7 @@ const baseUpsert = (
   }) as ProviderCalendarUpsert;
 
 describe("ProviderCalendarRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: ProviderCalendarRepository;
 

--- a/packages/sync/src/storage/repositories/provider-connection.repository.test.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.test.ts
@@ -1,10 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type ProviderConnectionUpsert } from "@sync/storage/contracts/provider-connection.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const baseUpsert = (
@@ -28,21 +27,13 @@ const baseUpsert = (
   }) as ProviderConnectionUpsert;
 
 describe("ProviderConnectionRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: ProviderConnectionRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`conn_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new ProviderConnectionRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("assigns a stable id and timestamps on first upsert", async () => {

--- a/packages/sync/src/storage/repositories/provider-connection.repository.test.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type ProviderConnectionUpsert } from "@sync/storage/contracts/provider-connection.contracts";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 
@@ -27,7 +27,7 @@ const baseUpsert = (
   }) as ProviderConnectionUpsert;
 
 describe("ProviderConnectionRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: ProviderConnectionRepository;
 

--- a/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
@@ -1,10 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { type Db, MongoClient } from "mongodb";
+import { type Db } from "mongodb";
+import { useSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type SyncResourceUpsert } from "@sync/storage/contracts/sync-resource.contracts";
-import { installIndexManifest } from "@sync/storage/index-manifest";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
-const uri = process.env["SYNC_MONGO_URI"] as string;
 const objectId = () => faker.database.mongodbObjectId();
 
 const upsert = (
@@ -20,21 +19,13 @@ const upsert = (
   }) as SyncResourceUpsert;
 
 describe("SyncResourceRepository", () => {
-  let client: MongoClient;
+  const storage = useSyncStorage();
   let db: Db;
   let repo: SyncResourceRepository;
 
-  beforeEach(async () => {
-    client = new MongoClient(uri);
-    await client.connect();
-    db = client.db(`res_${objectId()}`);
-    await installIndexManifest(db);
+  beforeEach(() => {
+    db = storage.db();
     repo = new SyncResourceRepository(db);
-  });
-
-  afterEach(async () => {
-    await db.dropDatabase();
-    await client.close();
   });
 
   it("creates a resource with empty cursors and generation 0", async () => {

--- a/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { useSyncStorage } from "@sync/__tests__/helpers/storage";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type SyncResourceUpsert } from "@sync/storage/contracts/sync-resource.contracts";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -19,7 +19,7 @@ const upsert = (
   }) as SyncResourceUpsert;
 
 describe("SyncResourceRepository", () => {
-  const storage = useSyncStorage();
+  const storage = setupSyncStorage();
   let db: Db;
   let repo: SyncResourceRepository;
 


### PR DESCRIPTION
## What

The sync unit suite ran ~190s locally and 311s on CI — long enough to time out the CI step even with every test passing. It now runs in **16s** locally (420 tests, 34 files) and the CI step timeout goes back to 5 minutes.

## Why it was slow

Every Mongo-backed test's `beforeEach` paid a fresh `MongoClient` connect **plus a full index-manifest install** (~25 `createIndex` round-trips on a replica set), and every `afterEach` paid a `dropDatabase` + close. That's ~700ms of setup per test wrapping bodies that run in 6–30ms — ~97% of the suite's wall clock was setup. On top of that, `bun test` ran all 34 files serially in one process, while the backend and scripts suites had long since moved to the parallel per-file launcher.

## How

- **New `setupSyncStorage` helper** (`packages/sync/src/__tests__/helpers/storage.ts`): connects a real `SyncMongoService` and installs indexes ONCE per file into a randomly-named database, wipes the collections between tests (`deleteMany` — a few ms, and it keeps indexes so unique-constraint tests still exercise them), drops the database at the end. Holds a real `SyncMongoService` so server route tests can inject it into `createSyncService`, whose routes gate on `mongo.isConnected`.
- **14 test files converted** (repositories, domain command services, server routes, credential custody). Test bodies are untouched — each file's `db`/`mongo` variables now repoint at the shared connection in a cheap `beforeEach`. Files that test the connection/manifest machinery itself keep their bespoke setup.
- **Sync joins the parallel launcher** (`run-tests.ts`): per-file bun processes over one shared in-memory replica set, same as backend/scripts. The sync preload already honored the launcher's shared-server env var; only the package entry was missing. This also restores per-file module isolation that single-process `bun test` doesn't provide.
- **CI step timeout reverted 10 → 5 minutes** (#2272 had raised it as a stopgap for the slow suite).

## Numbers

| suite | before | after |
|---|---|---|
| sync (local) | ~190s | **16.0s** |
| sync (CI) | 311s (timed out the 5-min step) | this PR's CI run is the measurement |
| backend / scripts | 10.9s / 2.0s | unchanged, verified green |

## Correctness notes (independent review)

An adversarial review specifically hunted isolation regressions a green run can't disprove: wipe-vs-drop index-state masking on the duplicate-key tests, order-dependence in nested describes, hook ordering, double-teardown between the helper and the launcher's replset stop, cross-test state on the shared `SyncMongoService` in server files, and the launcher tier-classifier change. No findings — details verified per file.

## Testing

- `bun run test:sync` — 420 pass / 34 files, 16.0s via the launcher; also green serially (28.9s) for the standalone single-file workflow.
- `bun run test:backend` (682 pass, 10.9s) and `bun run test:scripts` (40 pass, 2.0s) — unaffected by the launcher change.
- `bun run type-check` and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)