### PR TITLE
feat(sync): read a page of a provider calendar's events

### DIFF
--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -1,0 +1,230 @@
+import { type gSchema$Event } from "@core/types/gcal";
+import {
+  type GoogleEventListApi,
+  type GoogleEventListPage,
+  GoogleEventReaderAdapter,
+} from "@sync/providers/google/google-event-reader.adapter";
+import { ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
+
+// A fake events.list API returning scripted pages in order, recording the
+// params it was called with so tests can assert window/cursor/pagination.
+class FakeEventListApi implements GoogleEventListApi {
+  calls: Array<Parameters<GoogleEventListApi["listPage"]>[0]> = [];
+  #pages: GoogleEventListPage[];
+  #error?: unknown;
+
+  constructor(pages: GoogleEventListPage[], error?: unknown) {
+    this.#pages = pages;
+    this.#error = error;
+  }
+
+  async listPage(
+    params: Parameters<GoogleEventListApi["listPage"]>[0],
+  ): Promise<GoogleEventListPage> {
+    this.calls.push(params);
+    if (this.#error) throw this.#error;
+    const page = this.#pages.shift();
+    if (!page) throw new Error("FakeEventListApi: no page scripted");
+    return page;
+  }
+}
+
+const gEvent = (overrides: Partial<gSchema$Event>): gSchema$Event => ({
+  kind: "calendar#event",
+  id: "evt-id",
+  etag: '"v1"',
+  status: "confirmed",
+  summary: "Title",
+  start: {
+    dateTime: "2025-01-15T09:00:00-05:00",
+    timeZone: "America/New_York",
+  },
+  end: { dateTime: "2025-01-15T10:00:00-05:00", timeZone: "America/New_York" },
+  ...overrides,
+});
+
+const page = (
+  overrides: Partial<GoogleEventListPage>,
+): GoogleEventListPage => ({
+  items: [],
+  nextPageToken: null,
+  nextSyncToken: null,
+  ...overrides,
+});
+
+function adapterWith(api: GoogleEventListApi) {
+  const tokensSeen: string[] = [];
+  const adapter = new GoogleEventReaderAdapter((accessToken) => {
+    tokensSeen.push(accessToken);
+    return api;
+  });
+  return { adapter, tokensSeen };
+}
+
+describe("GoogleEventReaderAdapter", () => {
+  it("normalizes a page's events and returns its page/sync tokens", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          gEvent({ id: "a", summary: "A" }),
+          gEvent({ id: "b", summary: "B" }),
+        ],
+        nextSyncToken: "sync-1",
+      }),
+    ]);
+    const { adapter, tokensSeen } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
+
+    expect(tokensSeen).toEqual(["tok"]);
+    expect(result.events.map((e) => e.providerEventId)).toEqual(["a", "b"]);
+    expect(result.skipped).toBe(0);
+    expect(result.nextPageToken).toBeNull();
+    expect(result.nextSyncToken).toBe("sync-1");
+  });
+
+  it("passes the working window through and forwards no cursor", async () => {
+    const api = new FakeEventListApi([page({ nextSyncToken: null })]);
+    const { adapter } = adapterWith(api);
+
+    await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+      window: {
+        timeMin: "2026-06-01T00:00:00Z",
+        timeMax: "2026-09-01T00:00:00Z",
+      },
+    });
+
+    expect(api.calls[0].window).toEqual({
+      timeMin: "2026-06-01T00:00:00Z",
+      timeMax: "2026-09-01T00:00:00Z",
+    });
+    expect(api.calls[0].syncToken).toBeUndefined();
+  });
+
+  it("forwards the stored cursor and page token for a resumed full pass", async () => {
+    const api = new FakeEventListApi([page({})]);
+    const { adapter } = adapterWith(api);
+
+    await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+      cursor: "sync-token-0",
+      pageToken: "page-2",
+    });
+
+    expect(api.calls[0].syncToken).toBe("sync-token-0");
+    expect(api.calls[0].pageToken).toBe("page-2");
+  });
+
+  it("keeps cancellations in the page (an incremental deletion)", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          gEvent({ id: "live", summary: "Live" }),
+          gEvent({ id: "gone", status: "cancelled" }),
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
+
+    expect(result.events.map((e) => e.kind)).toEqual(["event", "cancellation"]);
+  });
+
+  it("drops and counts a structurally unusable event without failing the page", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          gEvent({ id: "ok", summary: "OK" }),
+          // No etag: the normalizer rejects it as missingIdentity.
+          gEvent({ id: "no-etag", etag: undefined }),
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
+
+    expect(result.events.map((e) => e.providerEventId)).toEqual(["ok"]);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("maps an expired sync token (410) to cursorExpired", async () => {
+    const api = new FakeEventListApi([], { response: { status: 410 } });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "primary@google.com",
+        cursor: "stale",
+      }),
+    ).rejects.toMatchObject({ reason: "cursorExpired" });
+  });
+
+  it("maps a rate limit and a server error to transient", async () => {
+    for (const status of [429, 503]) {
+      const api = new FakeEventListApi([], { response: { status } });
+      const { adapter } = adapterWith(api);
+      await expect(
+        adapter.listEventPage({
+          accessToken: "tok",
+          calendarId: "primary@google.com",
+        }),
+      ).rejects.toMatchObject({ reason: "transient" });
+    }
+  });
+
+  it("maps a networkless failure to transient", async () => {
+    const api = new FakeEventListApi([], new Error("socket hang up"));
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "primary@google.com",
+      }),
+    ).rejects.toMatchObject({ reason: "transient" });
+  });
+
+  it("maps an unrecoverable 4xx to readFailed", async () => {
+    const api = new FakeEventListApi([], { response: { status: 404 } });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "primary@google.com",
+      }),
+    ).rejects.toMatchObject({ reason: "readFailed" });
+  });
+
+  it("never leaks the access token onto a thrown error's cause", async () => {
+    const leaky = new Error("boom") as Error & { config?: unknown };
+    leaky.config = { headers: { Authorization: "Bearer super-secret-token" } };
+    const api = new FakeEventListApi([], leaky);
+    const { adapter } = adapterWith(api);
+
+    const error = await adapter
+      .listEventPage({ accessToken: "tok", calendarId: "primary@google.com" })
+      .catch((e) => e as ProviderEventReadError);
+
+    expect(error).toBeInstanceOf(ProviderEventReadError);
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+    expect((error.cause as Error)?.message).toBe("boom");
+  });
+});

--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -161,6 +161,34 @@ describe("GoogleEventReaderAdapter", () => {
     expect(result.skipped).toBe(1);
   });
 
+  it("skips a content-oversized event instead of failing the whole page", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          gEvent({ id: "ok", summary: "OK" }),
+          // Google does not cap attendee names; the neutral contract does. This
+          // event must be skipped, not throw out of the page.
+          gEvent({
+            id: "poison",
+            attendees: [
+              { email: "guest@example.com", displayName: "x".repeat(300) },
+            ],
+          }),
+          gEvent({ id: "ok2", summary: "OK2" }),
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
+
+    expect(result.events.map((e) => e.providerEventId)).toEqual(["ok", "ok2"]);
+    expect(result.skipped).toBe(1);
+  });
+
   it("maps an expired sync token (410) to cursorExpired", async () => {
     const api = new FakeEventListApi([], { response: { status: 410 } });
     const { adapter } = adapterWith(api);

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -1,0 +1,172 @@
+import { calendar } from "@googleapis/calendar";
+import { OAuth2Client } from "google-auth-library";
+import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
+import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
+import { ProviderEventError } from "@sync/providers/provider-event.port";
+import {
+  type EventWindow,
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+
+// One page of a Google events.list read, narrowed to the fields import needs.
+// Google returns `nextSyncToken` only on the final page of a pass entitled to
+// one; intermediate pages carry `nextPageToken` instead.
+export interface GoogleEventListPage {
+  readonly items: readonly gSchema$Event[];
+  readonly nextPageToken: string | null;
+  readonly nextSyncToken: string | null;
+}
+
+// The one Google call the reader makes. Depending on this narrow interface (not
+// the concrete googleapis client) lets tests supply scripted pages without a
+// network round-trip or module mocking.
+export interface GoogleEventListApi {
+  listPage(params: {
+    calendarId: string;
+    window?: EventWindow | null;
+    syncToken?: string;
+    pageToken?: string;
+  }): Promise<GoogleEventListPage>;
+}
+
+// Built per-connection from a short-lived access token minted by credential
+// custody; the token is set as the OAuth client's credential, never logged.
+export type GoogleEventListApiFactory = (
+  accessToken: string,
+) => GoogleEventListApi;
+
+const defaultApiFactory: GoogleEventListApiFactory = (accessToken) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal: gCalendar = calendar({ version: "v3", auth });
+  return {
+    async listPage({ calendarId, window, syncToken, pageToken }) {
+      const { data } = await gcal.events.list({
+        calendarId,
+        pageToken,
+        syncToken,
+        timeMin: window?.timeMin,
+        timeMax: window?.timeMax,
+        // Read masters and exceptions as distinct entities, not provider-
+        // expanded instances — the canonical store keeps them separable and
+        // projects occurrences itself.
+        singleEvents: false,
+        // Include cancellations so an incremental pass can carry deletions; an
+        // initial import simply ignores them.
+        showDeleted: true,
+        // The largest page Google allows, to minimize round-trips on a large
+        // calendar.
+        maxResults: 2500,
+      });
+      return {
+        items: data.items ?? [],
+        nextPageToken: data.nextPageToken ?? null,
+        nextSyncToken: data.nextSyncToken ?? null,
+      };
+    },
+  };
+};
+
+// Google implementation of the event-read port. Reads one page of a calendar's
+// events and normalizes each into a provider-neutral read, dropping (and
+// counting) any that are structurally unusable rather than failing the page.
+export class GoogleEventReaderAdapter implements ProviderEventReader {
+  readonly provider = "google" as const;
+
+  #makeApi: GoogleEventListApiFactory;
+
+  constructor(makeApi: GoogleEventListApiFactory = defaultApiFactory) {
+    this.#makeApi = makeApi;
+  }
+
+  async listEventPage(
+    input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    const api = this.#makeApi(input.accessToken);
+    const page = await this.#listPage(api, {
+      calendarId: input.calendarId,
+      window: input.window ?? null,
+      syncToken: input.cursor ?? undefined,
+      pageToken: input.pageToken ?? undefined,
+    });
+
+    const events = [];
+    let skipped = 0;
+    for (const item of page.items) {
+      try {
+        events.push(normalizeGoogleEvent(item));
+      } catch (error) {
+        // A structurally unusable event (no id/etag, unmappable schedule) is
+        // dropped so one bad row never fails the whole page or the import.
+        if (error instanceof ProviderEventError) {
+          skipped++;
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return {
+      events,
+      skipped,
+      nextPageToken: page.nextPageToken,
+      nextSyncToken: page.nextSyncToken,
+    };
+  }
+
+  async #listPage(
+    api: GoogleEventListApi,
+    params: {
+      calendarId: string;
+      window: EventWindow | null;
+      syncToken?: string;
+      pageToken?: string;
+    },
+  ): Promise<GoogleEventListPage> {
+    try {
+      return await api.listPage(params);
+    } catch (error) {
+      throw new ProviderEventReadError(
+        classifyReadError(error),
+        "Google rejected the events list read",
+        { cause: redactedCause(error) },
+      );
+    }
+  }
+}
+
+// Map a Google events.list failure to a read-error reason. An expired syncToken
+// (410 Gone) forces a full re-import; a rate limit or server/network error is
+// retryable; anything else is an unrecoverable read failure.
+function classifyReadError(
+  error: unknown,
+): "cursorExpired" | "transient" | "readFailed" {
+  const status = httpStatus(error);
+  if (status === 410) return "cursorExpired";
+  if (status === 429 || status === undefined || status >= 500) {
+    return "transient";
+  }
+  return "readFailed";
+}
+
+// The HTTP status of a googleapis/gaxios error, from the response or the error
+// code. Reading it does not touch the request. Undefined means no HTTP response
+// reached us (a network failure), which classifies as transient.
+function httpStatus(error: unknown): number | undefined {
+  const status =
+    (error as { response?: { status?: number } })?.response?.status ??
+    (error as { code?: number })?.code;
+  return typeof status === "number" ? status : undefined;
+}
+
+// Reduce a provider-SDK error to a bare message before attaching it as a cause.
+// A googleapis/gaxios error retains the full request config, whose headers carry
+// the bearer access token; propagating the raw object would leak that token the
+// moment any caller logs the cause chain. The message is response-derived, so it
+// is safe to keep for diagnostics. (Mirrors the other Google adapters.)
+function redactedCause(error: unknown): Error | undefined {
+  return error instanceof Error ? new Error(error.message) : undefined;
+}

--- a/packages/sync/src/providers/google/google-event.normalizer.test.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.test.ts
@@ -268,4 +268,26 @@ describe("normalizeGoogleEvent", () => {
     expect(error).toBeInstanceOf(ProviderEventError);
     expect(error.reason).toBe("unmappableSchedule");
   });
+
+  it("throws a skippable ProviderEventError when content exceeds the contract", () => {
+    // Google does not cap attendee display names; the neutral contract does. An
+    // over-long one must surface as a skippable ProviderEventError, never a raw
+    // ZodError that would escape a batch reader's per-event skip boundary.
+    const error = (() => {
+      try {
+        normalizeGoogleEvent(
+          gEvent({
+            attendees: [
+              { email: "guest@example.com", displayName: "x".repeat(300) },
+            ],
+          }),
+        );
+      } catch (e) {
+        return e;
+      }
+    })() as ProviderEventError;
+
+    expect(error).toBeInstanceOf(ProviderEventError);
+    expect(error.reason).toBe("unmappableContent");
+  });
 });

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -72,7 +72,12 @@ function cancellationSeries(
 }
 
 function mapContent(item: gSchema$Event) {
-  return SyncEventContentSchema.parse({
+  // safeParse, not parse: a provider can report a field the neutral contract
+  // caps but the provider does not (e.g. an attendee displayName longer than
+  // the contract's max). That makes one event unusable, so it must surface as a
+  // ProviderEventError the reader can skip — never a raw ZodError that would
+  // escape the per-event skip boundary and fail a whole import page.
+  const parsed = SyncEventContentSchema.safeParse({
     // Google omits summary/description for untitled/empty events; the neutral
     // contract models those as empty strings, not absence.
     title: item.summary ?? "",
@@ -82,6 +87,14 @@ function mapContent(item: gSchema$Event) {
     attendees: mapAttendees(item.attendees),
     conference: mapConference(item),
   });
+  if (!parsed.success) {
+    throw new ProviderEventError(
+      "unmappableContent",
+      "Event content failed the neutral contract",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
 }
 
 function mapOrganizer(
@@ -141,7 +154,7 @@ function mapSchedule(item: gSchema$Event) {
 
   if (start.date && end.date) {
     // Google's all-day end date is already exclusive, matching the contract.
-    return EventScheduleSchema.parse({
+    return parseSchedule({
       kind: "allDay",
       start: start.date,
       end: end.date,
@@ -158,7 +171,7 @@ function mapSchedule(item: gSchema$Event) {
     }
     // Re-anchor to the IANA zone so the emitted offset is correct for that
     // date's DST rules rather than trusting the stored offset.
-    return EventScheduleSchema.parse({
+    return parseSchedule({
       kind: "timed",
       start: toOffsetIso(start),
       end: toOffsetIso(end),
@@ -170,6 +183,21 @@ function mapSchedule(item: gSchema$Event) {
     "unmappableSchedule",
     "Event start/end mixes date and dateTime",
   );
+}
+
+// safeParse the neutral schedule so a value the contract rejects surfaces as a
+// skippable ProviderEventError, not a raw ZodError that would escape the
+// reader's per-event skip boundary and fail a whole import page.
+function parseSchedule(candidate: unknown) {
+  const parsed = EventScheduleSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "Event start/end could not be resolved to a schedule",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
 }
 
 function mapRecurrence(item: gSchema$Event): ProviderEventRecurrence {

--- a/packages/sync/src/providers/provider-event-reader.port.ts
+++ b/packages/sync/src/providers/provider-event-reader.port.ts
@@ -1,0 +1,67 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type ProviderEventRead } from "@sync/providers/provider-event.port";
+
+// A half-open working window over an event's time, as RFC3339 timestamps. The
+// first import pass windows to the user's current range so the useful part of a
+// large calendar becomes available quickly; the full pass omits the window.
+export interface EventWindow {
+  readonly timeMin: string;
+  readonly timeMax: string;
+}
+
+// One page of a calendar's events, normalized to provider-neutral reads.
+// Cancellations are included (an incremental page reports deletions this way),
+// so a caller that only wants live events filters them out. `skipped` counts
+// raw events dropped as structurally unusable, for observability. A provider
+// returns `nextSyncToken` only on the final page of a pass that is allowed to
+// produce one (a windowed pass never is).
+export interface ProviderEventPage {
+  readonly events: readonly ProviderEventRead[];
+  readonly skipped: number;
+  readonly nextPageToken: string | null;
+  readonly nextSyncToken: string | null;
+}
+
+export interface ProviderEventReadInput {
+  readonly accessToken: string;
+  readonly calendarId: string;
+  // Bounds the fast first pass. Omit (or null) for the full pass that earns a
+  // durable incremental cursor — providers forbid combining a window with a
+  // cursor, and a windowed list cannot yield a sync token.
+  readonly window?: EventWindow | null;
+  // The stored incremental cursor (sync token). Applies only to the first
+  // request of a pass; paging afterward is identified by pageToken alone.
+  readonly cursor?: string | null;
+  readonly pageToken?: string | null;
+}
+
+// A provider-neutral event read port. One call reads one page; the caller
+// follows pagination and checkpoints between pages so a large import resumes
+// where it left off. Reads masters and exceptions as distinct entities (never
+// provider-expanded instances) so the canonical store keeps them separable.
+export interface ProviderEventReader {
+  readonly provider: ProviderKind;
+
+  listEventPage(input: ProviderEventReadInput): Promise<ProviderEventPage>;
+}
+
+// Why a page read could not complete. `cursorExpired` (the stored sync token is
+// too old) is not retryable with the same token — the caller must re-import in
+// full. `transient` is a retryable network/provider failure; `readFailed` is an
+// unrecoverable rejection. Distinct from ProviderEventError, which is a
+// per-event normalization failure the reader absorbs into `skipped`.
+export type ProviderEventReadErrorReason =
+  | "cursorExpired"
+  | "transient"
+  | "readFailed";
+
+export class ProviderEventReadError extends Error {
+  constructor(
+    readonly reason: ProviderEventReadErrorReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "ProviderEventReadError";
+  }
+}

--- a/packages/sync/src/providers/provider-event.port.ts
+++ b/packages/sync/src/providers/provider-event.port.ts
@@ -56,7 +56,9 @@ export type ProviderEventRead = ProviderEvent | ProviderEventCancellation;
 // (e.g. a timed event with no start), not merely unusual.
 export type ProviderEventErrorReason =
   | "missingIdentity" // the event carried no id/version to key it by
-  | "unmappableSchedule"; // start/end could not be resolved to a schedule
+  | "unmappableSchedule" // start/end could not be resolved to a schedule
+  | "unmappableContent"; // content failed the neutral contract (e.g. an
+// out-of-bounds attendee/organizer field the provider does not cap)
 
 export class ProviderEventError extends Error {
   constructor(


### PR DESCRIPTION
## What

The first piece of Google calendar import: a provider-neutral event-read port (`ProviderEventReader.listEventPage`) and its Google adapter. One call reads one page of a calendar's events and normalizes each into a provider-neutral read; the (later) import engine follows pagination and checkpoints between pages so a large calendar imports resumably.

## Design

- **Window-first import shape**: a `timeMin/timeMax` windowed pass fetches the user's useful range fast; the full pass omits the window and earns the durable incremental cursor (`nextSyncToken` — Google only issues one on the final page of an unwindowed pass). Mutual exclusivity of window+cursor is a documented caller contract.
- **Masters and exceptions stay distinct** (`singleEvents: false`): the canonical store keeps them separable and projects occurrences itself.
- **Cancellations stay in the page** (`showDeleted: true`) so an incremental pass can carry deletions; an initial import ignores them.
- **Per-event skip boundary**: a structurally unusable event is dropped and counted (`skipped`), never failing the page. Error classification mirrors the sibling adapters: 410 → `cursorExpired` (re-import in full), 429/5xx/network → `transient`, else `readFailed`. Provider-SDK errors are reduced to a bare message before use so the bearer token can never ride along on a logged cause.
- Injected client seam (same factory pattern as the calendar-discovery and event-writer adapters) — fully unit-tested with scripted pages, no network.

## Review-caught fix (included)

An adversarial review found a real poison-pill hazard: the shared normalizer parsed event content/schedule with a hard schema parse, so a provider value our contract caps but Google does not (e.g. an over-long attendee display name) threw a raw validation error — which the reader's skip boundary (correctly narrow, `ProviderEventError` only) would rethrow, failing the entire page forever at that spot. The normalizer now converts its own validation failures into a skippable `ProviderEventError` (new reason `unmappableContent`); a genuine code bug still propagates loudly. Regression tests at both the normalizer and reader layers.

## Testing

`bun run test:sync` — 432 pass / 35 files, 15.8s. Type-check and biome clean. New coverage: page normalization + tokens, window pass-through, resumed cursor+pageToken, cancellations kept, unusable event skipped, content-oversized event skipped (poison-pill regression), 410/429/5xx/network/4xx classification, token-redaction on error causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)