### PR TITLE
feat(sync): import a provider calendar's events into the canonical store

### DIFF
--- a/packages/sync/src/domain/calendar-import.service.test.ts
+++ b/packages/sync/src/domain/calendar-import.service.test.ts
@@ -1,0 +1,526 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import {
+  type CalendarImportDeps,
+  importCalendarEvents,
+} from "@sync/domain/calendar-import.service";
+import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import {
+  type ProviderEvent,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type ProviderEventPage,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+// A reader serving scripted pages, one script for the windowed (fast) pass and
+// one for the full (cursor-earning) pass. Records every call.
+class FakeReader implements ProviderEventReader {
+  readonly provider = "google" as const;
+  calls: ProviderEventReadInput[] = [];
+  #window: ProviderEventPage[];
+  #full: ProviderEventPage[];
+
+  constructor(opts: {
+    window?: ProviderEventPage[];
+    full: ProviderEventPage[];
+  }) {
+    this.#window = [...(opts.window ?? [emptyPage()])];
+    this.#full = [...opts.full];
+  }
+
+  async listEventPage(
+    input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    this.calls.push(input);
+    const queue = input.window ? this.#window : this.#full;
+    const page = queue.shift();
+    if (!page) throw new Error("FakeReader: no page scripted");
+    return page;
+  }
+}
+
+const tokenSource: AccessTokenSource = {
+  getValidAccessToken: async () => "access-token",
+};
+
+const schedule = {
+  kind: "timed" as const,
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+
+const content = (title: string) => ({
+  title,
+  description: "",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+});
+
+const single = (id: string, title = id): ProviderEvent => ({
+  kind: "event",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  providerUpdatedAt: null,
+  content: content(title),
+  schedule,
+  busy: true,
+  recurrence: { kind: "single" },
+});
+
+const master = (
+  id: string,
+  rules = ["RRULE:FREQ=WEEKLY;COUNT=3"],
+): ProviderEvent => ({
+  ...single(id),
+  recurrence: { kind: "seriesMaster", rules },
+});
+
+const instance = (
+  id: string,
+  seriesProviderId: string,
+  recurrenceId: string,
+  title = id,
+): ProviderEvent => ({
+  ...single(id, title),
+  recurrence: { kind: "instance", seriesProviderId, recurrenceId },
+});
+
+const cancellation = (id: string): ProviderEventRead => ({
+  kind: "cancellation",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  series: null,
+});
+
+const page = (
+  events: ProviderEventRead[],
+  opts: {
+    nextPageToken?: string | null;
+    nextSyncToken?: string | null;
+    skipped?: number;
+  } = {},
+): ProviderEventPage => ({
+  events,
+  skipped: opts.skipped ?? 0,
+  nextPageToken: opts.nextPageToken ?? null,
+  nextSyncToken: opts.nextSyncToken ?? null,
+});
+
+const emptyPage = () => page([]);
+
+describe("importCalendarEvents", () => {
+  const storage = setupSyncStorage();
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let resources: SyncResourceRepository;
+  let calendars: ProviderCalendarRepository;
+
+  beforeEach(() => {
+    events = new EventRepository(storage.db());
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    resources = new SyncResourceRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+  });
+
+  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+    calendars.upsertByProviderCalendar({
+      tenantId: objectId() as ProviderCalendarRecord["tenantId"],
+      principalId: objectId() as ProviderCalendarRecord["principalId"],
+      connectionId: objectId() as ProviderCalendarRecord["connectionId"],
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  const deps = (reader: FakeReader): CalendarImportDeps => ({
+    events,
+    occurrences,
+    resources,
+    reader,
+    custody: tokenSource,
+  });
+
+  const occCount = (calendarId: string) =>
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .countDocuments({ calendarId });
+
+  const occStarts = async (eventId: string) =>
+    (
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.eventOccurrences)
+        .find({ eventId })
+        .sort({ startAt: 1 })
+        .toArray()
+    ).map((o) => (o["startAt"] as Date).toISOString());
+
+  it("imports singles, projects them, and advances the cursor from the full pass", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [page([single("a"), single("b")], { nextSyncToken: "cursor-1" })],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(result.resource.syncCursor).toBe("cursor-1");
+    expect(result.resource.pageCursor).toBeNull();
+    expect(await occCount(calendar._id)).toBe(2);
+  });
+
+  it("runs the windowed pass before the full pass", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      window: [page([single("w")])],
+      full: [page([single("a")], { nextSyncToken: "cursor-1" })],
+    });
+
+    await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(reader.calls[0].window).not.toBeNull();
+    expect(reader.calls.at(-1)?.window).toBeNull();
+  });
+
+  it("projects every occurrence of an imported series master", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [page([master("m")], { nextSyncToken: "cursor-1" })],
+    });
+
+    await importCalendarEvents(deps(reader), calendar, now);
+
+    const stored = await events.findByProviderIdentity(
+      calendar.tenantId,
+      calendar.principalId,
+      {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId: "m",
+      },
+    );
+    expect(stored?.recurrence.kind).toBe("seriesMaster");
+    expect(await occStarts(stored?._id as string)).toHaveLength(3);
+  });
+
+  it("links an instance that arrives before its master on the same page", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [
+        page(
+          [
+            instance("m_i1", "m", "2026-07-21T09:00:00-06:00", "Moved"),
+            master("m"),
+          ],
+          { nextSyncToken: "cursor-1" },
+        ),
+      ],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(2);
+    expect(result.skipped).toBe(0);
+    const exceptions = await events.findSeriesExceptions(
+      calendar.tenantId,
+      calendar.principalId,
+      (await masterId(events, calendar, "m")) as never,
+    );
+    expect(exceptions).toHaveLength(1);
+  });
+
+  it("links an instance whose master arrives on a later page", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [
+        page([instance("m_i1", "m", "2026-07-21T09:00:00-06:00")], {
+          nextPageToken: "p2",
+        }),
+        page([master("m")], { nextSyncToken: "cursor-1" }),
+      ],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(2);
+    expect(result.skipped).toBe(0);
+    // The master's projection excludes the exception's instant (3 rules - 1
+    // excepted instant = 2 master rows), and the exception projects its own.
+    const mId = (await masterId(events, calendar, "m")) as string;
+    expect(await occStarts(mId)).toHaveLength(2);
+  });
+
+  it("writes a cancelled series occurrence as a tombstone that excludes its instant", async () => {
+    const calendar = await seedCalendar();
+    // A deleted occurrence of an active weekly series (3 occurrences) comes back
+    // as a cancellation carrying the series link. Its instant must not resurface.
+    const cancelled = "2026-07-21T09:00:00-06:00";
+    const reader = new FakeReader({
+      full: [
+        page(
+          [
+            master("m"),
+            {
+              kind: "cancellation",
+              providerEventId: "m_c1",
+              providerVersion: "etag-c",
+              series: { seriesProviderId: "m", recurrenceId: cancelled },
+            },
+          ],
+          { nextSyncToken: "cursor-1" },
+        ),
+      ],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(2); // master + cancelled exception
+    const mId = (await masterId(events, calendar, "m")) as string;
+    // The master projects 2 live rows (its excepted instant excluded).
+    expect(await occStarts(mId)).toEqual([
+      "2026-07-14T15:00:00.000Z",
+      "2026-07-28T15:00:00.000Z",
+    ]);
+    // The tombstone exists and its own occurrence row is cancelled.
+    const exceptions = await events.findSeriesExceptions(
+      calendar.tenantId,
+      calendar.principalId,
+      mId as never,
+    );
+    expect(exceptions).toHaveLength(1);
+    expect(
+      exceptions[0]?.recurrence.kind === "exception" &&
+        exceptions[0]?.recurrence.cancelled,
+    ).toBe(true);
+  });
+
+  it("links a cancelled occurrence that arrives before its master", async () => {
+    const calendar = await seedCalendar();
+    const cancelled = "2026-07-21T09:00:00-06:00";
+    const reader = new FakeReader({
+      full: [
+        page(
+          [
+            {
+              kind: "cancellation",
+              providerEventId: "m_c1",
+              providerVersion: "etag-c",
+              series: { seriesProviderId: "m", recurrenceId: cancelled },
+            },
+          ],
+          { nextPageToken: "p2" },
+        ),
+        page([master("m")], { nextSyncToken: "cursor-1" }),
+      ],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.skipped).toBe(0);
+    const mId = (await masterId(events, calendar, "m")) as string;
+    expect(await occStarts(mId)).toHaveLength(2);
+  });
+
+  it("counts an instance whose master never appears as skipped", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [
+        page([instance("orphan_i", "ghost", "2026-07-21T09:00:00-06:00")], {
+          nextSyncToken: "cursor-1",
+        }),
+      ],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await occCount(calendar._id)).toBe(0);
+  });
+
+  it("carries the reader's per-event skip count into the result", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [page([single("a")], { nextSyncToken: "cursor-1", skipped: 3 })],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.skipped).toBe(3);
+  });
+
+  it("keeps a cancellation from importing anything", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [
+        page([cancellation("gone"), single("a")], {
+          nextSyncToken: "cursor-1",
+        }),
+      ],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(1);
+    expect(await occCount(calendar._id)).toBe(1);
+  });
+
+  it("dedupes an event that appears on two pages", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({
+      full: [
+        page([single("a")], { nextPageToken: "p2" }),
+        page([single("a")], { nextSyncToken: "cursor-1" }),
+      ],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(await occCount(calendar._id)).toBe(1);
+    expect(result.imported).toBe(1);
+    expect(result.resource.syncCursor).toBe("cursor-1");
+  });
+
+  it("counts an event once when both passes import it", async () => {
+    const calendar = await seedCalendar();
+    // The same event is in the windowed range and the full pass. It must be
+    // counted once (distinct id), and per-event skips counted only once too.
+    const reader = new FakeReader({
+      window: [page([single("a")], { skipped: 1 })],
+      full: [page([single("a")], { nextSyncToken: "cursor-1", skipped: 1 })],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(await occCount(calendar._id)).toBe(1);
+  });
+
+  it("is a no-op once the resource already has a cursor", async () => {
+    const calendar = await seedCalendar();
+    await importCalendarEvents(
+      deps(
+        new FakeReader({
+          full: [page([single("a")], { nextSyncToken: "cursor-1" })],
+        }),
+      ),
+      calendar,
+      now,
+    );
+    const reader = new FakeReader({
+      full: [page([single("b")], { nextSyncToken: "cursor-2" })],
+    });
+
+    const result = await importCalendarEvents(deps(reader), calendar, now);
+
+    expect(result.imported).toBe(0);
+    expect(reader.calls).toHaveLength(0);
+    expect(result.resource.syncCursor).toBe("cursor-1");
+  });
+
+  it("throws rather than finishing without a cursor", async () => {
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({ full: [page([single("a")])] });
+
+    await expect(
+      importCalendarEvents(deps(reader), calendar, now),
+    ).rejects.toThrow(/no sync cursor/);
+    // The event still imported, but the cursor is not advanced, so a retry
+    // re-imports idempotently rather than going incremental on partial data.
+    const resource = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      (await resourceId(resources, calendar)) as string,
+    );
+    expect(resource?.syncCursor).toBeNull();
+  });
+
+  it("skips the windowed pass when resuming from a page checkpoint", async () => {
+    const calendar = await seedCalendar();
+    // Prime the resource with a mid-full-pass checkpoint.
+    const resource = await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+    await resources.setPageCheckpoint(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+      "resume-token",
+    );
+    const reader = new FakeReader({
+      window: [page([single("should-not-read")])],
+      full: [page([single("a")], { nextSyncToken: "cursor-1" })],
+    });
+
+    await importCalendarEvents(deps(reader), calendar, now);
+
+    // No windowed call at all; the first (and only) read resumes the full pass.
+    expect(reader.calls.every((c) => c.window === null)).toBe(true);
+    expect(reader.calls[0].pageToken).toBe("resume-token");
+  });
+});
+
+// --- small helpers to keep the tests readable ---
+
+async function masterId(
+  events: EventRepository,
+  calendar: ProviderCalendarRecord,
+  providerEventId: string,
+): Promise<string> {
+  const record = await events.findByProviderIdentity(
+    calendar.tenantId,
+    calendar.principalId,
+    {
+      connectionId: calendar.connectionId,
+      calendarId: calendar._id,
+      providerEventId,
+    },
+  );
+  if (!record)
+    throw new Error(`no local event for provider id ${providerEventId}`);
+  return record._id;
+}
+
+async function resourceId(
+  resources: SyncResourceRepository,
+  calendar: ProviderCalendarRecord,
+): Promise<string> {
+  const [resource] = await resources.listByConnection(
+    calendar.tenantId,
+    calendar.principalId,
+    calendar.connectionId,
+  );
+  if (!resource) throw new Error("no resource for connection");
+  return resource._id;
+}

--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -1,0 +1,457 @@
+import { type DateTime, type EventId } from "@core/types/domain-primitives";
+import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
+import { syncHorizon } from "@sync/domain/horizon";
+import { occurrenceScheduleAt } from "@sync/domain/occurrence-projection";
+import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { reprojectOccurrences } from "@sync/domain/reproject";
+import {
+  type ProviderEvent,
+  type ProviderEventCancellation,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type EventWindow,
+  type ProviderEventReader,
+} from "@sync/providers/provider-event-reader.port";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface CalendarImportDeps {
+  events: EventRepository;
+  occurrences: EventOccurrenceRepository;
+  resources: SyncResourceRepository;
+  reader: ProviderEventReader;
+  custody: AccessTokenSource;
+}
+
+export interface CalendarImportResult {
+  resource: SyncResourceRecord;
+  // Distinct events written this run (masters, singles, and linked exceptions —
+  // overrides and cancelled tombstones), counted once regardless of how many
+  // passes or retries touched each.
+  imported: number;
+  // Events dropped: unusable reads the reader skipped, plus series members whose
+  // master never appeared (a provider anomaly).
+  skipped: number;
+}
+
+// Import one provider calendar's events until the resource holds a durable
+// incremental cursor.
+//
+// Two passes drive the reader. A WINDOWED pass over the rolling horizon runs
+// first so the user's useful range appears quickly; it cannot yield a cursor
+// (providers forbid combining a window with one), so a FULL unwindowed pass
+// follows, checkpointing the page token in the sync resource after each page
+// commits — a crash resumes from the checkpoint instead of restarting. The
+// incremental cursor is committed only after the full pass and every projection
+// it implies have completed, so the cursor never advances past uncommitted
+// data. Every write is an idempotent provider-identity upsert and every
+// projection replaces per (event, generation), so re-running any prefix
+// converges.
+//
+// A deleted occurrence of an otherwise-active series comes back from a full
+// list (showDeleted) as a cancellation carrying its series link; it is written
+// as a cancelled exception so the master's expansion excludes that instant,
+// never resurrecting the deleted occurrence.
+//
+// Ordering hazards handled:
+// - A series MEMBER (a modified instance or a cancelled occurrence) can arrive
+//   before its master (providers return events in arbitrary order). Unresolved
+//   members are buffered and retried after each page and once more at the end
+//   of each pass; a member whose master never appears is counted skipped. Named
+//   wart: a buffered cross-page member is lost if the process crashes after its
+//   own page was checkpointed but before its master arrived — bounded to one
+//   exception, and repair or an incremental pull re-delivers it.
+// - A master's projection must exclude the instants its exceptions own, and an
+//   exception can land pages after its master. Masters therefore reproject
+//   from a fresh exception read every time one of their exceptions links, and
+//   projections for a page run BEFORE that page's checkpoint so a resumed run
+//   never skips them.
+export async function importCalendarEvents(
+  deps: CalendarImportDeps,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<CalendarImportResult> {
+  const resource = await deps.resources.ensure({
+    tenantId: calendar.tenantId,
+    principalId: calendar.principalId,
+    connectionId: calendar.connectionId,
+    resourceKind: "events",
+    calendarId: calendar._id,
+  });
+
+  // A cursor means the initial import already completed; incremental pulls own
+  // this resource from here.
+  if (resource.syncCursor !== null) {
+    return { resource, imported: 0, skipped: 0 };
+  }
+
+  const accessToken = await deps.custody.getValidAccessToken(
+    calendar.connectionId,
+  );
+  await deps.resources.markAttempt(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    now(),
+  );
+
+  const run = new ImportRun(deps, calendar, resource, now);
+
+  // The windowed fast pass only runs on a fresh start — a resume mid-full-pass
+  // already imported the window, and redoing it would only repeat work.
+  if (resource.pageCursor === null) {
+    await run.readPass({ accessToken, window: horizonWindow(now()) });
+  }
+
+  const syncCursor = await run.readPass({
+    accessToken,
+    checkpointed: true,
+    resumeFrom: resource.pageCursor,
+  });
+  await run.resolveRemainingInstances();
+
+  if (!syncCursor) {
+    // Without a cursor the resource can never go incremental; surfacing this
+    // loudly beats silently re-importing forever.
+    throw new Error(
+      "Provider returned no sync cursor after a full unwindowed pass",
+    );
+  }
+  await deps.resources.advanceCursor(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    syncCursor,
+    now(),
+  );
+
+  const updated = await deps.resources.findById(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+  );
+  return {
+    resource: updated ?? resource,
+    imported: run.imported,
+    skipped: run.skipped,
+  };
+}
+
+// One import run's working state: the masters seen so far (to link instances),
+// the series members still waiting for their master, and the running counts.
+class ImportRun {
+  // Distinct provider event ids written, so the windowed and full passes (the
+  // full pass is a superset of the windowed one) and a crash-resumed page never
+  // inflate the count by re-upserting the same idempotent row.
+  #importedIds = new Set<string>();
+  // Per-event reads the reader dropped as unusable, plus series members whose
+  // master never appeared. Only the full pass contributes reader-dropped counts
+  // (the windowed pass's are re-seen and re-counted by the superset full pass).
+  #skipped = 0;
+
+  get imported(): number {
+    return this.#importedIds.size;
+  }
+  get skipped(): number {
+    return this.#skipped;
+  }
+
+  // Local master by the PROVIDER's series id, for linking instances.
+  #masters = new Map<string, EventRecord>();
+  // Series members (modified instances and cancelled occurrences) read before
+  // their master, awaiting it.
+  #pending: ProviderEventRead[] = [];
+
+  constructor(
+    private readonly deps: CalendarImportDeps,
+    private readonly calendar: ProviderCalendarRecord,
+    private readonly resource: SyncResourceRecord,
+    private readonly now: () => Date,
+  ) {}
+
+  // Drive the reader through one pass. Returns the provider's sync cursor when
+  // the pass produced one (only an unwindowed pass can).
+  async readPass(options: {
+    accessToken: string;
+    window?: EventWindow;
+    checkpointed?: boolean;
+    resumeFrom?: string | null;
+  }): Promise<string | null> {
+    let pageToken: string | null = options.resumeFrom ?? null;
+    let syncCursor: string | null = null;
+
+    do {
+      const page = await this.deps.reader.listEventPage({
+        accessToken: options.accessToken,
+        calendarId: this.calendar.providerCalendarId,
+        window: options.window ?? null,
+        pageToken,
+      });
+      // Count reader-dropped events on the full pass only; the windowed pass
+      // sees a subset the full pass re-reads, so counting both double-counts.
+      if (options.checkpointed) this.#skipped += page.skipped;
+      await this.#applyPage(page.events);
+
+      pageToken = page.nextPageToken;
+      syncCursor = page.nextSyncToken ?? syncCursor;
+      // The checkpoint is the durability barrier: it moves only after the
+      // page's upserts AND projections committed, so a crash-resume re-reads
+      // at most one already-applied (idempotent) page.
+      if (options.checkpointed && pageToken) {
+        await this.deps.resources.setPageCheckpoint(
+          this.resource.tenantId,
+          this.resource.principalId,
+          this.resource._id,
+          pageToken,
+        );
+      }
+    } while (pageToken);
+
+    return syncCursor;
+  }
+
+  // Give every still-buffered series member one final chance to link,
+  // projecting the masters that gain an exception, then count the rest as
+  // skipped provider anomalies (a member whose master never appeared).
+  async resolveRemainingInstances(): Promise<void> {
+    for (const master of await this.#drainPending()) {
+      await this.#projectSeries(master);
+    }
+    this.#skipped += this.#pending.length;
+    this.#pending = [];
+  }
+
+  // Upsert and project one page. Masters first so same-page members link
+  // without a buffer round-trip. A cancelled occurrence of a series is written
+  // as a cancelled exception (so the master's expansion excludes its instant);
+  // a standalone cancellation has no local event to tombstone on a first
+  // import, so it is ignored.
+  async #applyPage(events: readonly ProviderEventRead[]): Promise<void> {
+    const touchedSeries = new Map<EventId, EventRecord>();
+
+    for (const read of events) {
+      if (read.kind === "event" && read.recurrence.kind === "seriesMaster") {
+        const master = await this.#upsertRead(read, {
+          kind: "seriesMaster",
+          rules: read.recurrence.rules,
+        });
+        this.#masters.set(read.providerEventId, master);
+        touchedSeries.set(master._id, master);
+      }
+    }
+    for (const read of events) {
+      if (read.kind === "event" && read.recurrence.kind === "single") {
+        const single = await this.#upsertRead(read, { kind: "single" });
+        await reprojectOccurrences(this.deps.occurrences, single, this.now);
+      } else if (this.#needsMaster(read)) {
+        const master = await this.#link(read);
+        if (master) touchedSeries.set(master._id, master);
+        else this.#pending.push(read);
+      }
+    }
+
+    // A buffered member's master may have arrived on this page.
+    for (const master of await this.#drainPending()) {
+      touchedSeries.set(master._id, master);
+    }
+
+    for (const master of touchedSeries.values()) {
+      await this.#projectSeries(master);
+    }
+  }
+
+  // Whether a read is a series member that must resolve to a master before it
+  // can be stored: a modified instance, or a cancelled occurrence of a series.
+  #needsMaster(read: ProviderEventRead): boolean {
+    if (read.kind === "event") return read.recurrence.kind === "instance";
+    return read.series !== null;
+  }
+
+  // Try to link every still-buffered member to a now-available master. Returns
+  // the masters that gained an exception, deduped, so the caller reprojects
+  // each once. Projection is the caller's job, never done here.
+  async #drainPending(): Promise<EventRecord[]> {
+    const still: ProviderEventRead[] = [];
+    const relinked = new Map<EventId, EventRecord>();
+    for (const read of this.#pending) {
+      const master = await this.#link(read);
+      if (master) relinked.set(master._id, master);
+      else still.push(read);
+    }
+    this.#pending = still;
+    return [...relinked.values()];
+  }
+
+  // Store one series member as an exception of its locally stored master, or
+  // return null when the master is not resolvable yet. Every exception keeps
+  // its OWN provider identity (a provider instance/cancellation is its own
+  // provider event; reusing the master's id would violate the provider-identity
+  // index).
+  async #link(read: ProviderEventRead): Promise<EventRecord | null> {
+    if (read.kind === "event" && read.recurrence.kind === "instance") {
+      const master = await this.#resolveMaster(
+        read.recurrence.seriesProviderId,
+      );
+      if (!master) return null;
+      await this.#upsertRead(read, {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId: read.recurrence.recurrenceId as DateTime,
+        cancelled: false,
+      });
+      return master;
+    }
+    if (read.kind === "cancellation" && read.series) {
+      const master = await this.#resolveMaster(read.series.seriesProviderId);
+      if (!master) return null;
+      await this.#upsertCancelledException(read, master);
+      return master;
+    }
+    throw new Error("#link requires a series instance or series cancellation");
+  }
+
+  // Store a cancelled series occurrence as a cancelled exception. A cancellation
+  // read carries no content or schedule (providers strip them), so the tombstone
+  // mirrors the master's content and derives its schedule from the cancelled
+  // instant — the same shape a Compass-side scope-"this" delete writes.
+  async #upsertCancelledException(
+    read: ProviderEventCancellation,
+    master: EventRecord,
+  ): Promise<void> {
+    if (!read.series) {
+      throw new Error(
+        "upsertCancelledException requires a series cancellation",
+      );
+    }
+    const recurrenceId = read.series.recurrenceId as DateTime;
+    const record = await this.deps.events.upsertByProviderIdentity({
+      tenantId: this.calendar.tenantId,
+      principalId: this.calendar.principalId,
+      origin: "provider",
+      calendarId: this.calendar._id,
+      clientEventId: null,
+      connectionId: this.calendar.connectionId,
+      providerEventId: read.providerEventId as NonNullable<
+        EventRecord["providerEventId"]
+      >,
+      providerVersion: read.providerVersion as NonNullable<
+        EventRecord["providerVersion"]
+      >,
+      providerUpdatedAt: null,
+      deliveryState: null,
+      providerMetadata: null,
+      content: master.content,
+      schedule: occurrenceScheduleAt(master.schedule, recurrenceId),
+      recurrence: {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId,
+        cancelled: true,
+      },
+      lifecycleState: "active",
+      generation: this.resource.importGeneration,
+      confirmedAt: this.now(),
+    });
+    this.#importedIds.add(record.providerEventId as string);
+  }
+
+  // The locally stored master for a provider series id: seen this run, or
+  // imported by an earlier page/run and read back by provider identity.
+  async #resolveMaster(seriesProviderId: string): Promise<EventRecord | null> {
+    const seen = this.#masters.get(seriesProviderId);
+    if (seen) return seen;
+    const stored = await this.deps.events.findByProviderIdentity(
+      this.calendar.tenantId,
+      this.calendar.principalId,
+      {
+        connectionId: this.calendar.connectionId,
+        calendarId: this.calendar._id,
+        providerEventId: seriesProviderId as NonNullable<
+          EventRecord["providerEventId"]
+        >,
+      },
+    );
+    if (stored && stored.recurrence.kind === "seriesMaster") {
+      this.#masters.set(seriesProviderId, stored);
+      return stored;
+    }
+    return null;
+  }
+
+  // Reproject a master from a fresh read of its exceptions (excluding their
+  // instants), then each exception's own row. Fresh reads keep this correct
+  // regardless of the order pages delivered the series.
+  async #projectSeries(master: EventRecord): Promise<void> {
+    const exceptions = await this.deps.events.findSeriesExceptions(
+      master.tenantId,
+      master.principalId,
+      master._id,
+    );
+    const instants = exceptions.map((exception) => {
+      if (exception.recurrence.kind !== "exception") {
+        throw new Error("findSeriesExceptions returned a non-exception");
+      }
+      return exception.recurrence.recurrenceId;
+    });
+    await reprojectOccurrences(
+      this.deps.occurrences,
+      master,
+      this.now,
+      instants,
+    );
+    for (const exception of exceptions) {
+      await reprojectOccurrences(this.deps.occurrences, exception, this.now);
+    }
+  }
+
+  async #upsertRead(
+    read: ProviderEvent,
+    recurrence: SyncEventRecurrence,
+  ): Promise<EventRecord> {
+    const record = await this.deps.events.upsertByProviderIdentity({
+      tenantId: this.calendar.tenantId,
+      principalId: this.calendar.principalId,
+      origin: "provider",
+      calendarId: this.calendar._id,
+      clientEventId: null,
+      connectionId: this.calendar.connectionId,
+      providerEventId: read.providerEventId as NonNullable<
+        EventRecord["providerEventId"]
+      >,
+      providerVersion: read.providerVersion as NonNullable<
+        EventRecord["providerVersion"]
+      >,
+      providerUpdatedAt: read.providerUpdatedAt
+        ? new Date(read.providerUpdatedAt)
+        : null,
+      // Imported provider events carry no Compass delivery intent.
+      deliveryState: null,
+      // Busy is the overwhelming default; only a free ("transparent") event
+      // records its transparency, so the fact survives until the busy-query
+      // slice decides how to read it.
+      providerMetadata: read.busy ? null : { transparency: "transparent" },
+      content: read.content,
+      schedule: read.schedule,
+      recurrence,
+      lifecycleState: "active",
+      generation: this.resource.importGeneration,
+      confirmedAt: this.now(),
+    });
+    this.#importedIds.add(record.providerEventId as string);
+    return record;
+  }
+}
+
+// The rolling horizon as an RFC3339 window for the fast first pass.
+function horizonWindow(now: Date): EventWindow {
+  const horizon = syncHorizon(now);
+  return {
+    timeMin: horizon.start.toISOString(),
+    timeMax: horizon.end.toISOString(),
+  };
+}

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -100,6 +100,28 @@ export class EventRepository {
     return record ? EventRecordSchema.parse(record) : null;
   }
 
+  // Look up one provider-linked event by its provider identity, owner-scoped.
+  // Import uses this to resolve a series instance's provider parent to the
+  // locally stored master when the master arrived in an earlier page or run.
+  async findByProviderIdentity(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    identity: {
+      connectionId: NonNullable<EventRecord["connectionId"]>;
+      calendarId: EventRecord["calendarId"];
+      providerEventId: NonNullable<EventRecord["providerEventId"]>;
+    },
+  ): Promise<EventRecord | null> {
+    const record = await this.collection.findOne({
+      tenantId,
+      principalId,
+      connectionId: identity.connectionId,
+      calendarId: identity.calendarId,
+      providerEventId: identity.providerEventId,
+    });
+    return record ? EventRecordSchema.parse(record) : null;
+  }
+
   // Remove one event by id, scoped to its owner so a caller can only delete its
   // own event. Idempotent: deleting an already-absent event is a no-op, so a
   // retried delete converges. Returns whether a document was removed.


### PR DESCRIPTION
## What

The engine that drives the event-read port (PR #2274) to import one Google calendar into the canonical event store + occurrence projection, until the calendar holds a durable incremental cursor. This is the core of S29 initial import.

## How

- **Two passes.** A windowed pass over the rolling horizon runs first so the user's useful range appears fast; a full unwindowed pass then earns the sync cursor. The page token is checkpointed in the sync resource **after** each page's writes and projections commit, so a crash resumes from the checkpoint. The cursor advances only after the whole full pass succeeds — never past uncommitted data.
- **Idempotent throughout.** Every write is a provider-identity upsert; every projection replaces per (event, generation). Re-running any prefix converges. `imported` counts distinct provider ids so the windowed/full overlap and resume re-reads don't inflate it.
- **Series ordering** (providers return events in arbitrary order): a master is upserted before same-page members; a member seen before its master is buffered and retried after each page and at end of pass; a member whose master never appears is counted skipped. Each imported instance is stored as an exception with its **own** provider identity (never the master's, which would collide on the provider-identity index). A master reprojects from a fresh exception read each time one of its exceptions links, excluding those instants.

## Review-caught fixes (included)

The adversarial review found two real issues, both fixed with regression tests:
1. **(Critical) A cancelled series occurrence was dropped** — a deleted occurrence of an active recurring series comes back from a `showDeleted` list as a cancellation carrying its series link. Dropping it let the master's RRULE expand straight through the deleted instant → a phantom occurrence. Now written as a cancelled-exception tombstone (with the same buffering as instances, since it can precede its master) so the master's expansion excludes that instant.
2. **(Important) `imported`/`skipped` double-counted** across the windowed and full passes (the full pass is a superset) and on resume. Now `imported` is a distinct-id set and `skipped` counts the full pass only.

## Known limitation (documented in-code)

A buffered cross-page series member is lost if the process crashes after its own page checkpoints but before its master arrives — bounded to one exception, and repair or the next incremental pull re-delivers it. Named a wart rather than reaching for a distributed transaction that would fight the worker-less design.

## Testing

`bun run test:sync` — 447 pass / 36 files, 16.8s. Type-check and biome clean. 15 engine tests cover: single/master import + projection + cursor, windowed-before-full ordering, instance-before-master (same page and cross-page), cancelled-occurrence tombstone (in order and out of order), orphan member skipped, per-event skip propagation, dedup + count-once, resume-from-checkpoint (skips the windowed pass), and the no-cursor throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)