### PR TITLE
test(web): raise async-query timeout to stop CI contention flakes

### DIFF
--- a/packages/web/src/__tests__/web.preload.ts
+++ b/packages/web/src/__tests__/web.preload.ts
@@ -295,8 +295,17 @@ if (typeof globalThis.structuredClone === "undefined") {
 mockNodeModules();
 
 const sessionModule = await import("supertokens-web-js/recipe/session");
-const { cleanup } = await import("@testing-library/react");
+const { cleanup, configure } = await import("@testing-library/react");
 const { resetAllStores } = await import("./utils/state/reset-stores");
+
+// Give async queries (findBy*, waitFor) real headroom. The default 1000ms is
+// fine locally (the whole suite runs in ~16s) but too tight on CI, where every
+// matrix job shares the runner's cores: under that contention a component that
+// resolves in tens of ms locally can take past a second, timing out queries in
+// tests that are otherwise correct (AuthModal/SelectView flaked this way). A
+// genuinely stuck async never resolves regardless, so this only widens the
+// window for slow-but-correct ones — it cannot mask a real hang.
+configure({ asyncUtilTimeout: 5000 });
 
 function resetDocument() {
   document.body.innerHTML = "";


### PR DESCRIPTION
## What

Set testing-library's `asyncUtilTimeout` to 5s in the web test preload (default is 1000ms).

## Why

The `unit (web)` job has flaked on multiple recent unrelated PRs (sync-only changes) with ~48 `findBy`/`waitFor` timeouts in AuthModal and SelectView — each needing a rerun. The whole web suite passes locally in ~16s and completed on the flaking CI runs in ~58s: it isn't a step timeout, it's individual async queries exceeding their 1000ms default while the six-job CI matrix contends for the runner's cores. A component that renders in tens of ms locally can slip past a second under that load.

Raising the ceiling gives slow-but-correct async real headroom. It can't mask a real bug: a genuinely stuck async never resolves regardless of the ceiling, so a truly broken test still fails (just later). Passing tests are unaffected — the timeout is an upper bound, not a delay; the local suite runs in the same 16s.

## Testing

`bun run test:web` — 1307 pass, 15.87s (unchanged). Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)