### PR TITLE
refactor(sync): extract the provider page applier shared by import and pull

### DIFF
--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -1,19 +1,10 @@
-import { type DateTime, type EventId } from "@core/types/domain-primitives";
-import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { syncHorizon } from "@sync/domain/horizon";
-import { occurrenceScheduleAt } from "@sync/domain/occurrence-projection";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
-import { reprojectOccurrences } from "@sync/domain/reproject";
-import {
-  type ProviderEvent,
-  type ProviderEventCancellation,
-  type ProviderEventRead,
-} from "@sync/providers/provider-event.port";
+import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
 import {
   type EventWindow,
   type ProviderEventReader,
 } from "@sync/providers/provider-event-reader.port";
-import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
@@ -142,37 +133,40 @@ export async function importCalendarEvents(
   };
 }
 
-// One import run's working state: the masters seen so far (to link instances),
-// the series members still waiting for their master, and the running counts.
+// Drives the reader through one import's passes over one calendar. The shared
+// ProviderPageApplier does the per-page content work (upsert, link, project);
+// this run owns import-specific control: the checkpointed page loop, the
+// windowed-vs-full distinction, reader-drop counting, and the final flush.
+// A standalone cancellation has no local event to tombstone on a first import,
+// so the applier's returned deletions are ignored.
 class ImportRun {
-  // Distinct provider event ids written, so the windowed and full passes (the
-  // full pass is a superset of the windowed one) and a crash-resumed page never
-  // inflate the count by re-upserting the same idempotent row.
-  #importedIds = new Set<string>();
-  // Per-event reads the reader dropped as unusable, plus series members whose
-  // master never appeared. Only the full pass contributes reader-dropped counts
-  // (the windowed pass's are re-seen and re-counted by the superset full pass).
-  #skipped = 0;
-
-  get imported(): number {
-    return this.#importedIds.size;
-  }
-  get skipped(): number {
-    return this.#skipped;
-  }
-
-  // Local master by the PROVIDER's series id, for linking instances.
-  #masters = new Map<string, EventRecord>();
-  // Series members (modified instances and cancelled occurrences) read before
-  // their master, awaiting it.
-  #pending: ProviderEventRead[] = [];
+  #applier: ProviderPageApplier;
+  // Reader-dropped reads on the full pass only; the windowed pass sees a subset
+  // the full pass re-reads, so counting both double-counts.
+  #readerSkipped = 0;
+  #orphans = 0;
 
   constructor(
     private readonly deps: CalendarImportDeps,
     private readonly calendar: ProviderCalendarRecord,
     private readonly resource: SyncResourceRecord,
-    private readonly now: () => Date,
-  ) {}
+    now: () => Date,
+  ) {
+    this.#applier = new ProviderPageApplier(
+      deps.events,
+      deps.occurrences,
+      calendar,
+      resource.importGeneration,
+      now,
+    );
+  }
+
+  get imported(): number {
+    return this.#applier.importedCount;
+  }
+  get skipped(): number {
+    return this.#readerSkipped + this.#orphans;
+  }
 
   // Drive the reader through one pass. Returns the provider's sync cursor when
   // the pass produced one (only an unwindowed pass can).
@@ -192,10 +186,10 @@ class ImportRun {
         window: options.window ?? null,
         pageToken,
       });
-      // Count reader-dropped events on the full pass only; the windowed pass
-      // sees a subset the full pass re-reads, so counting both double-counts.
-      if (options.checkpointed) this.#skipped += page.skipped;
-      await this.#applyPage(page.events);
+      if (options.checkpointed) this.#readerSkipped += page.skipped;
+      // A first import has no local events to delete, so standalone
+      // cancellations the applier returns are discarded.
+      await this.#applier.applyPage(page.events);
 
       pageToken = page.nextPageToken;
       syncCursor = page.nextSyncToken ?? syncCursor;
@@ -215,235 +209,10 @@ class ImportRun {
     return syncCursor;
   }
 
-  // Give every still-buffered series member one final chance to link,
-  // projecting the masters that gain an exception, then count the rest as
-  // skipped provider anomalies (a member whose master never appeared).
+  // Flush any series members still waiting for a master, counting the ones that
+  // never linked as skipped provider anomalies.
   async resolveRemainingInstances(): Promise<void> {
-    for (const master of await this.#drainPending()) {
-      await this.#projectSeries(master);
-    }
-    this.#skipped += this.#pending.length;
-    this.#pending = [];
-  }
-
-  // Upsert and project one page. Masters first so same-page members link
-  // without a buffer round-trip. A cancelled occurrence of a series is written
-  // as a cancelled exception (so the master's expansion excludes its instant);
-  // a standalone cancellation has no local event to tombstone on a first
-  // import, so it is ignored.
-  async #applyPage(events: readonly ProviderEventRead[]): Promise<void> {
-    const touchedSeries = new Map<EventId, EventRecord>();
-
-    for (const read of events) {
-      if (read.kind === "event" && read.recurrence.kind === "seriesMaster") {
-        const master = await this.#upsertRead(read, {
-          kind: "seriesMaster",
-          rules: read.recurrence.rules,
-        });
-        this.#masters.set(read.providerEventId, master);
-        touchedSeries.set(master._id, master);
-      }
-    }
-    for (const read of events) {
-      if (read.kind === "event" && read.recurrence.kind === "single") {
-        const single = await this.#upsertRead(read, { kind: "single" });
-        await reprojectOccurrences(this.deps.occurrences, single, this.now);
-      } else if (this.#needsMaster(read)) {
-        const master = await this.#link(read);
-        if (master) touchedSeries.set(master._id, master);
-        else this.#pending.push(read);
-      }
-    }
-
-    // A buffered member's master may have arrived on this page.
-    for (const master of await this.#drainPending()) {
-      touchedSeries.set(master._id, master);
-    }
-
-    for (const master of touchedSeries.values()) {
-      await this.#projectSeries(master);
-    }
-  }
-
-  // Whether a read is a series member that must resolve to a master before it
-  // can be stored: a modified instance, or a cancelled occurrence of a series.
-  #needsMaster(read: ProviderEventRead): boolean {
-    if (read.kind === "event") return read.recurrence.kind === "instance";
-    return read.series !== null;
-  }
-
-  // Try to link every still-buffered member to a now-available master. Returns
-  // the masters that gained an exception, deduped, so the caller reprojects
-  // each once. Projection is the caller's job, never done here.
-  async #drainPending(): Promise<EventRecord[]> {
-    const still: ProviderEventRead[] = [];
-    const relinked = new Map<EventId, EventRecord>();
-    for (const read of this.#pending) {
-      const master = await this.#link(read);
-      if (master) relinked.set(master._id, master);
-      else still.push(read);
-    }
-    this.#pending = still;
-    return [...relinked.values()];
-  }
-
-  // Store one series member as an exception of its locally stored master, or
-  // return null when the master is not resolvable yet. Every exception keeps
-  // its OWN provider identity (a provider instance/cancellation is its own
-  // provider event; reusing the master's id would violate the provider-identity
-  // index).
-  async #link(read: ProviderEventRead): Promise<EventRecord | null> {
-    if (read.kind === "event" && read.recurrence.kind === "instance") {
-      const master = await this.#resolveMaster(
-        read.recurrence.seriesProviderId,
-      );
-      if (!master) return null;
-      await this.#upsertRead(read, {
-        kind: "exception",
-        seriesId: master._id,
-        recurrenceId: read.recurrence.recurrenceId as DateTime,
-        cancelled: false,
-      });
-      return master;
-    }
-    if (read.kind === "cancellation" && read.series) {
-      const master = await this.#resolveMaster(read.series.seriesProviderId);
-      if (!master) return null;
-      await this.#upsertCancelledException(read, master);
-      return master;
-    }
-    throw new Error("#link requires a series instance or series cancellation");
-  }
-
-  // Store a cancelled series occurrence as a cancelled exception. A cancellation
-  // read carries no content or schedule (providers strip them), so the tombstone
-  // mirrors the master's content and derives its schedule from the cancelled
-  // instant — the same shape a Compass-side scope-"this" delete writes.
-  async #upsertCancelledException(
-    read: ProviderEventCancellation,
-    master: EventRecord,
-  ): Promise<void> {
-    if (!read.series) {
-      throw new Error(
-        "upsertCancelledException requires a series cancellation",
-      );
-    }
-    const recurrenceId = read.series.recurrenceId as DateTime;
-    const record = await this.deps.events.upsertByProviderIdentity({
-      tenantId: this.calendar.tenantId,
-      principalId: this.calendar.principalId,
-      origin: "provider",
-      calendarId: this.calendar._id,
-      clientEventId: null,
-      connectionId: this.calendar.connectionId,
-      providerEventId: read.providerEventId as NonNullable<
-        EventRecord["providerEventId"]
-      >,
-      providerVersion: read.providerVersion as NonNullable<
-        EventRecord["providerVersion"]
-      >,
-      providerUpdatedAt: null,
-      deliveryState: null,
-      providerMetadata: null,
-      content: master.content,
-      schedule: occurrenceScheduleAt(master.schedule, recurrenceId),
-      recurrence: {
-        kind: "exception",
-        seriesId: master._id,
-        recurrenceId,
-        cancelled: true,
-      },
-      lifecycleState: "active",
-      generation: this.resource.importGeneration,
-      confirmedAt: this.now(),
-    });
-    this.#importedIds.add(record.providerEventId as string);
-  }
-
-  // The locally stored master for a provider series id: seen this run, or
-  // imported by an earlier page/run and read back by provider identity.
-  async #resolveMaster(seriesProviderId: string): Promise<EventRecord | null> {
-    const seen = this.#masters.get(seriesProviderId);
-    if (seen) return seen;
-    const stored = await this.deps.events.findByProviderIdentity(
-      this.calendar.tenantId,
-      this.calendar.principalId,
-      {
-        connectionId: this.calendar.connectionId,
-        calendarId: this.calendar._id,
-        providerEventId: seriesProviderId as NonNullable<
-          EventRecord["providerEventId"]
-        >,
-      },
-    );
-    if (stored && stored.recurrence.kind === "seriesMaster") {
-      this.#masters.set(seriesProviderId, stored);
-      return stored;
-    }
-    return null;
-  }
-
-  // Reproject a master from a fresh read of its exceptions (excluding their
-  // instants), then each exception's own row. Fresh reads keep this correct
-  // regardless of the order pages delivered the series.
-  async #projectSeries(master: EventRecord): Promise<void> {
-    const exceptions = await this.deps.events.findSeriesExceptions(
-      master.tenantId,
-      master.principalId,
-      master._id,
-    );
-    const instants = exceptions.map((exception) => {
-      if (exception.recurrence.kind !== "exception") {
-        throw new Error("findSeriesExceptions returned a non-exception");
-      }
-      return exception.recurrence.recurrenceId;
-    });
-    await reprojectOccurrences(
-      this.deps.occurrences,
-      master,
-      this.now,
-      instants,
-    );
-    for (const exception of exceptions) {
-      await reprojectOccurrences(this.deps.occurrences, exception, this.now);
-    }
-  }
-
-  async #upsertRead(
-    read: ProviderEvent,
-    recurrence: SyncEventRecurrence,
-  ): Promise<EventRecord> {
-    const record = await this.deps.events.upsertByProviderIdentity({
-      tenantId: this.calendar.tenantId,
-      principalId: this.calendar.principalId,
-      origin: "provider",
-      calendarId: this.calendar._id,
-      clientEventId: null,
-      connectionId: this.calendar.connectionId,
-      providerEventId: read.providerEventId as NonNullable<
-        EventRecord["providerEventId"]
-      >,
-      providerVersion: read.providerVersion as NonNullable<
-        EventRecord["providerVersion"]
-      >,
-      providerUpdatedAt: read.providerUpdatedAt
-        ? new Date(read.providerUpdatedAt)
-        : null,
-      // Imported provider events carry no Compass delivery intent.
-      deliveryState: null,
-      // Busy is the overwhelming default; only a free ("transparent") event
-      // records its transparency, so the fact survives until the busy-query
-      // slice decides how to read it.
-      providerMetadata: read.busy ? null : { transparency: "transparent" },
-      content: read.content,
-      schedule: read.schedule,
-      recurrence,
-      lifecycleState: "active",
-      generation: this.resource.importGeneration,
-      confirmedAt: this.now(),
-    });
-    this.#importedIds.add(record.providerEventId as string);
-    return record;
+    this.#orphans += await this.#applier.finish();
   }
 }
 

--- a/packages/sync/src/domain/provider-page-applier.test.ts
+++ b/packages/sync/src/domain/provider-page-applier.test.ts
@@ -1,0 +1,160 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
+import {
+  type ProviderEvent,
+  type ProviderEventCancellation,
+} from "@sync/providers/provider-event.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+
+// The applier's happy-path content behavior (upsert, link, project, series
+// ordering, dedup) is exercised end to end by calendar-import.service.test.ts,
+// which drives it. These tests pin the one thing the import path does NOT
+// exercise: the standalone-cancellation seam applyPage exposes for the pull
+// path's deletion policy.
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+const schedule = {
+  kind: "timed" as const,
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const content = (title: string) => ({
+  title,
+  description: "",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+});
+const single = (id: string): ProviderEvent => ({
+  kind: "event",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  providerUpdatedAt: null,
+  content: content(id),
+  schedule,
+  busy: true,
+  recurrence: { kind: "single" },
+});
+const master = (id: string): ProviderEvent => ({
+  ...single(id),
+  recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+});
+const standaloneCancellation = (id: string): ProviderEventCancellation => ({
+  kind: "cancellation",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  series: null,
+});
+const seriesCancellation = (
+  id: string,
+  seriesProviderId: string,
+  recurrenceId: string,
+): ProviderEventCancellation => ({
+  kind: "cancellation",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  series: { seriesProviderId, recurrenceId },
+});
+
+describe("ProviderPageApplier", () => {
+  const storage = setupSyncStorage();
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let calendars: ProviderCalendarRepository;
+
+  beforeEach(() => {
+    events = new EventRepository(storage.db());
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    calendars = new ProviderCalendarRepository(storage.db());
+  });
+
+  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+    calendars.upsertByProviderCalendar({
+      tenantId: objectId() as ProviderCalendarRecord["tenantId"],
+      principalId: objectId() as ProviderCalendarRecord["principalId"],
+      connectionId: objectId() as ProviderCalendarRecord["connectionId"],
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  const applier = (calendar: ProviderCalendarRecord) =>
+    new ProviderPageApplier(events, occurrences, calendar, 0, now);
+
+  it("returns standalone cancellations unconsumed and writes nothing for them", async () => {
+    const calendar = await seedCalendar();
+    const run = applier(calendar);
+
+    const returned = await run.applyPage([
+      single("a"),
+      standaloneCancellation("gone"),
+    ]);
+
+    expect(returned.map((c) => c.providerEventId)).toEqual(["gone"]);
+    // The live event was written; the cancellation left no record.
+    expect(run.importedCount).toBe(1);
+    expect(
+      await events.findByProviderIdentity(
+        calendar.tenantId,
+        calendar.principalId,
+        {
+          connectionId: calendar.connectionId,
+          calendarId: calendar._id,
+          providerEventId: "gone",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("consumes a series cancellation as a tombstone rather than returning it", async () => {
+    const calendar = await seedCalendar();
+    const run = applier(calendar);
+
+    const returned = await run.applyPage([
+      master("m"),
+      seriesCancellation("m_c", "m", "2026-07-21T09:00:00-06:00"),
+    ]);
+
+    // Not returned — it was consumed as a cancelled exception.
+    expect(returned).toHaveLength(0);
+    // master + cancelled exception written.
+    expect(run.importedCount).toBe(2);
+    const occ = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .countDocuments({ calendarId: calendar._id });
+    // 3 series occurrences minus the excepted instant, plus the cancelled row.
+    expect(occ).toBe(3);
+  });
+
+  it("reports members that never found a master as orphans on finish", async () => {
+    const calendar = await seedCalendar();
+    const run = applier(calendar);
+
+    await run.applyPage([
+      seriesCancellation("orphan_c", "ghost", "2026-07-21T09:00:00-06:00"),
+    ]);
+    const orphans = await run.finish();
+
+    expect(orphans).toBe(1);
+    expect(run.importedCount).toBe(0);
+  });
+});

--- a/packages/sync/src/domain/provider-page-applier.ts
+++ b/packages/sync/src/domain/provider-page-applier.ts
@@ -1,0 +1,285 @@
+import { type DateTime, type EventId } from "@core/types/domain-primitives";
+import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
+import { occurrenceScheduleAt } from "@sync/domain/occurrence-projection";
+import { reprojectOccurrences } from "@sync/domain/reproject";
+import {
+  type ProviderEvent,
+  type ProviderEventCancellation,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+
+// Applies pages of provider event reads to the canonical store, shared by
+// initial import and incremental pull. It owns the parts both paths do
+// identically: upserting masters/singles, linking series members (modified
+// instances and cancelled occurrences) to their master as exceptions with their
+// OWN provider identity, buffering members that arrive before their master,
+// and reprojecting each touched series from a fresh exception read so the
+// master's expansion excludes every excepted instant. All writes are idempotent
+// provider-identity upserts, so replaying a page converges.
+//
+// It deliberately does NOT decide what a standalone cancellation means — a
+// cancelled read with no series link is a whole-event deletion, which import
+// ignores (no local event yet) but a pull must apply. `applyPage` returns those
+// unconsumed so each caller applies its own deletion policy.
+export class ProviderPageApplier {
+  // Distinct provider event ids written, so replays (an overlapping windowed
+  // pass, a crash-resumed page) never inflate the count.
+  #importedIds = new Set<string>();
+  // Local master by the PROVIDER's series id, for linking members without a
+  // store round-trip once seen.
+  #masters = new Map<string, EventRecord>();
+  // Series members read before their master, awaiting it.
+  #pending: ProviderEventRead[] = [];
+
+  constructor(
+    private readonly events: EventRepository,
+    private readonly occurrences: EventOccurrenceRepository,
+    private readonly calendar: ProviderCalendarRecord,
+    private readonly generation: number,
+    private readonly now: () => Date,
+  ) {}
+
+  // Distinct events written so far (masters, singles, override and cancelled
+  // exceptions).
+  get importedCount(): number {
+    return this.#importedIds.size;
+  }
+
+  // Apply one page's content and series-scoped cancellations. Masters are
+  // upserted first so same-page members link without a buffer round-trip;
+  // members whose master has not been seen are buffered and retried. Returns the
+  // standalone (non-series) cancellations it did not consume, for the caller's
+  // deletion policy.
+  async applyPage(
+    reads: readonly ProviderEventRead[],
+  ): Promise<ProviderEventCancellation[]> {
+    const touchedSeries = new Map<EventId, EventRecord>();
+    const standaloneCancellations: ProviderEventCancellation[] = [];
+
+    for (const read of reads) {
+      if (read.kind === "event" && read.recurrence.kind === "seriesMaster") {
+        const master = await this.#upsertRead(read, {
+          kind: "seriesMaster",
+          rules: read.recurrence.rules,
+        });
+        this.#masters.set(read.providerEventId, master);
+        touchedSeries.set(master._id, master);
+      }
+    }
+    for (const read of reads) {
+      if (read.kind === "event" && read.recurrence.kind === "single") {
+        const single = await this.#upsertRead(read, { kind: "single" });
+        await reprojectOccurrences(this.occurrences, single, this.now);
+      } else if (this.#needsMaster(read)) {
+        const master = await this.#link(read);
+        if (master) touchedSeries.set(master._id, master);
+        else this.#pending.push(read);
+      } else if (read.kind === "cancellation") {
+        // series === null: a whole-event deletion the caller resolves.
+        standaloneCancellations.push(read);
+      }
+    }
+
+    // A buffered member's master may have arrived on this page.
+    for (const master of await this.#drainPending()) {
+      touchedSeries.set(master._id, master);
+    }
+    for (const master of touchedSeries.values()) {
+      await this.#projectSeries(master);
+    }
+
+    return standaloneCancellations;
+  }
+
+  // Final pass: link any still-buffered member to a now-available master,
+  // project the masters that gained one, and return how many members never
+  // linked (a provider anomaly — an instant with no master in any page).
+  async finish(): Promise<number> {
+    for (const master of await this.#drainPending()) {
+      await this.#projectSeries(master);
+    }
+    const orphans = this.#pending.length;
+    this.#pending = [];
+    return orphans;
+  }
+
+  // Whether a read is a series member that must resolve to a master before it
+  // can be stored: a modified instance, or a cancelled occurrence of a series.
+  #needsMaster(read: ProviderEventRead): boolean {
+    if (read.kind === "event") return read.recurrence.kind === "instance";
+    return read.series !== null;
+  }
+
+  // Try to link every still-buffered member to a now-available master. Returns
+  // the masters that gained an exception, deduped, so the caller reprojects
+  // each once. Projection is the caller's job, never done here.
+  async #drainPending(): Promise<EventRecord[]> {
+    const still: ProviderEventRead[] = [];
+    const relinked = new Map<EventId, EventRecord>();
+    for (const read of this.#pending) {
+      const master = await this.#link(read);
+      if (master) relinked.set(master._id, master);
+      else still.push(read);
+    }
+    this.#pending = still;
+    return [...relinked.values()];
+  }
+
+  // Store one series member as an exception of its locally stored master, or
+  // return null when the master is not resolvable yet. Every exception keeps
+  // its OWN provider identity (a provider instance/cancellation is its own
+  // provider event; reusing the master's id would violate the provider-identity
+  // index).
+  async #link(read: ProviderEventRead): Promise<EventRecord | null> {
+    if (read.kind === "event" && read.recurrence.kind === "instance") {
+      const master = await this.#resolveMaster(
+        read.recurrence.seriesProviderId,
+      );
+      if (!master) return null;
+      await this.#upsertRead(read, {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId: read.recurrence.recurrenceId as DateTime,
+        cancelled: false,
+      });
+      return master;
+    }
+    if (read.kind === "cancellation" && read.series) {
+      const master = await this.#resolveMaster(read.series.seriesProviderId);
+      if (!master) return null;
+      await this.#upsertCancelledException(read, master);
+      return master;
+    }
+    throw new Error("#link requires a series instance or series cancellation");
+  }
+
+  // Store a cancelled series occurrence as a cancelled exception. A cancellation
+  // read carries no content or schedule (providers strip them), so the tombstone
+  // mirrors the master's content and derives its schedule from the cancelled
+  // instant — the same shape a Compass-side scope-"this" delete writes.
+  async #upsertCancelledException(
+    read: ProviderEventCancellation,
+    master: EventRecord,
+  ): Promise<void> {
+    if (!read.series) {
+      throw new Error(
+        "upsertCancelledException requires a series cancellation",
+      );
+    }
+    const recurrenceId = read.series.recurrenceId as DateTime;
+    const record = await this.events.upsertByProviderIdentity({
+      tenantId: this.calendar.tenantId,
+      principalId: this.calendar.principalId,
+      origin: "provider",
+      calendarId: this.calendar._id,
+      clientEventId: null,
+      connectionId: this.calendar.connectionId,
+      providerEventId: read.providerEventId as NonNullable<
+        EventRecord["providerEventId"]
+      >,
+      providerVersion: read.providerVersion as NonNullable<
+        EventRecord["providerVersion"]
+      >,
+      providerUpdatedAt: null,
+      deliveryState: null,
+      providerMetadata: null,
+      content: master.content,
+      schedule: occurrenceScheduleAt(master.schedule, recurrenceId),
+      recurrence: {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId,
+        cancelled: true,
+      },
+      lifecycleState: "active",
+      generation: this.generation,
+      confirmedAt: this.now(),
+    });
+    this.#importedIds.add(record.providerEventId as string);
+  }
+
+  // The locally stored master for a provider series id: seen this run, or
+  // written by an earlier page/run and read back by provider identity.
+  async #resolveMaster(seriesProviderId: string): Promise<EventRecord | null> {
+    const seen = this.#masters.get(seriesProviderId);
+    if (seen) return seen;
+    const stored = await this.events.findByProviderIdentity(
+      this.calendar.tenantId,
+      this.calendar.principalId,
+      {
+        connectionId: this.calendar.connectionId,
+        calendarId: this.calendar._id,
+        providerEventId: seriesProviderId as NonNullable<
+          EventRecord["providerEventId"]
+        >,
+      },
+    );
+    if (stored && stored.recurrence.kind === "seriesMaster") {
+      this.#masters.set(seriesProviderId, stored);
+      return stored;
+    }
+    return null;
+  }
+
+  // Reproject a master from a fresh read of its exceptions (excluding their
+  // instants), then each exception's own row. Fresh reads keep this correct
+  // regardless of the order pages delivered the series.
+  async #projectSeries(master: EventRecord): Promise<void> {
+    const exceptions = await this.events.findSeriesExceptions(
+      master.tenantId,
+      master.principalId,
+      master._id,
+    );
+    const instants = exceptions.map((exception) => {
+      if (exception.recurrence.kind !== "exception") {
+        throw new Error("findSeriesExceptions returned a non-exception");
+      }
+      return exception.recurrence.recurrenceId;
+    });
+    await reprojectOccurrences(this.occurrences, master, this.now, instants);
+    for (const exception of exceptions) {
+      await reprojectOccurrences(this.occurrences, exception, this.now);
+    }
+  }
+
+  async #upsertRead(
+    read: ProviderEvent,
+    recurrence: SyncEventRecurrence,
+  ): Promise<EventRecord> {
+    const record = await this.events.upsertByProviderIdentity({
+      tenantId: this.calendar.tenantId,
+      principalId: this.calendar.principalId,
+      origin: "provider",
+      calendarId: this.calendar._id,
+      clientEventId: null,
+      connectionId: this.calendar.connectionId,
+      providerEventId: read.providerEventId as NonNullable<
+        EventRecord["providerEventId"]
+      >,
+      providerVersion: read.providerVersion as NonNullable<
+        EventRecord["providerVersion"]
+      >,
+      providerUpdatedAt: read.providerUpdatedAt
+        ? new Date(read.providerUpdatedAt)
+        : null,
+      // Imported provider events carry no Compass delivery intent.
+      deliveryState: null,
+      // Busy is the overwhelming default; only a free ("transparent") event
+      // records its transparency, so the fact survives until the busy-query
+      // slice decides how to read it.
+      providerMetadata: read.busy ? null : { transparency: "transparent" },
+      content: read.content,
+      schedule: read.schedule,
+      recurrence,
+      lifecycleState: "active",
+      generation: this.generation,
+      confirmedAt: this.now(),
+    });
+    this.#importedIds.add(record.providerEventId as string);
+    return record;
+  }
+}


### PR DESCRIPTION
## What

Extract the per-page content work from the import engine's `ImportRun` into a reusable `ProviderPageApplier`, in preparation for the incremental-pull slice which needs the same logic.

## Why

Initial import and incremental pull apply provider event pages to the canonical store **identically**: upsert masters/singles, link series members (modified instances and cancelled occurrences) to their master as exceptions with their own provider identity, buffer members that arrive before their master, and reproject each touched series from a fresh exception read. That's ~200 lines of subtle crash-safe series logic. Duplicating it across two files would let the paths drift; sharing it in one applier keeps them honest.

## The seam

The applier deliberately does **not** decide what a standalone (non-series) cancellation means — that's the one place import and pull diverge. A cancelled read with no series link is a whole-event deletion: import ignores it (no local event exists yet on a first import), but a pull must apply it. `applyPage` returns those unconsumed so each caller owns its deletion policy. `ImportRun` becomes a thin driver keeping only import-specific control (the checkpointed page loop, windowed-vs-full passes, reader-drop counting).

## Behavior-preserving

The extracted logic is identical, and the **import test suite is unchanged and green** (15 tests) — the proof this refactor changes no behavior. New focused tests pin the applier's standalone-cancellation seam that the import path doesn't exercise (returned unconsumed, series cancellations consumed as tombstones, orphan members counted on finish).

## Testing

`bun run test:sync` — 450 pass / 37 files, 16.9s. Type-check and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)