### PR TITLE
test(sync): stop reinstalling indexes and dropping databases per test

### DIFF
--- a/packages/sync/src/storage/index-manifest.test.ts
+++ b/packages/sync/src/storage/index-manifest.test.ts
@@ -12,20 +12,32 @@ describe("installIndexManifest", () => {
   let client: MongoClient;
   let db: Db;
 
-  beforeEach(async () => {
+  // Connect and install ONCE. Installing the manifest is ~25 createIndex
+  // round-trips; doing it per test made each test ~1s even uncontended, and the
+  // per-test dropDatabase serialized DDL on the shared mongod and raced the next
+  // test's writes ("database is in the process of being dropped") under the
+  // parallel runner. Install is deterministic, so one install serves every
+  // read-only assertion; the two write tests clear their own collections.
+  beforeAll(async () => {
     client = new MongoClient(uri);
     await client.connect();
-    // Unique database per test so files/tests never collide on the shared server.
     db = client.db(`manifest_${faker.database.mongodbObjectId()}`);
+    await installIndexManifest(db);
   });
 
-  afterEach(async () => {
+  beforeEach(async () => {
+    await Promise.all([
+      db.collection(SYNC_COLLECTIONS.commands).deleteMany({}),
+      db.collection(SYNC_COLLECTIONS.events).deleteMany({}),
+    ]);
+  });
+
+  afterAll(async () => {
     await db.dropDatabase();
     await client.close();
   });
 
   it("creates every declared collection", async () => {
-    await installIndexManifest(db);
     const names = new Set(
       (await db.listCollections({}, { nameOnly: true }).toArray()).map(
         (c) => c.name,
@@ -37,7 +49,6 @@ describe("installIndexManifest", () => {
   });
 
   it("creates the declared indexes for a collection", async () => {
-    await installIndexManifest(db);
     const indexes = await db.collection(SYNC_COLLECTIONS.commands).indexes();
     const names = indexes.map((i) => i.name);
     expect(names).toContain("idempotency_key");
@@ -58,7 +69,6 @@ describe("installIndexManifest", () => {
   });
 
   it("installs a TTL index on deletion markers", async () => {
-    await installIndexManifest(db);
     const indexes = await db
       .collection(SYNC_COLLECTIONS.deletionMarkers)
       .indexes();
@@ -67,7 +77,6 @@ describe("installIndexManifest", () => {
   });
 
   it("enforces the unique command idempotency key", async () => {
-    await installIndexManifest(db);
     const commands = db.collection(SYNC_COLLECTIONS.commands);
     const key = {
       tenantId: "t",
@@ -85,7 +94,6 @@ describe("installIndexManifest", () => {
   });
 
   it("allows many unlinked events while still rejecting duplicate provider identities", async () => {
-    await installIndexManifest(db);
     const events = db.collection(SYNC_COLLECTIONS.events);
 
     // Multiple unlinked events store provider fields as null; the partial

--- a/packages/sync/src/storage/sync-mongo.service.test.ts
+++ b/packages/sync/src/storage/sync-mongo.service.test.ts
@@ -9,17 +9,15 @@ const uri = process.env["SYNC_MONGO_URI"] as string;
 
 const uniqueDbName = () => `svc_${faker.database.mongodbObjectId()}`;
 
-describe("SyncMongoService", () => {
+// The tests that need a healthy connection share ONE — connecting installs the
+// ~25-index manifest, so connecting per test made this file needlessly slow and,
+// with a per-test dropDatabase, raced other files' DDL on the shared mongod.
+// The connection-failure tests connect their own (failed) service, which never
+// installs because connect() rejects before the install step.
+describe("SyncMongoService when connected", () => {
   let service: SyncMongoService;
 
-  afterEach(async () => {
-    if (service?.isConnected) {
-      await service.db.dropDatabase();
-    }
-    await service?.disconnect();
-  });
-
-  it("connects, installs manifests, and exposes the db", async () => {
+  beforeAll(async () => {
     service = new SyncMongoService();
     await service.connect({
       uri,
@@ -27,7 +25,13 @@ describe("SyncMongoService", () => {
       forbiddenDatabaseName: "prod_calendar",
       enforceLeastPrivilege: false,
     });
+  });
 
+  afterAll(async () => {
+    await service.disconnect();
+  });
+
+  it("connects, installs manifests, and exposes the db", async () => {
     expect(service.isConnected).toBe(true);
     const names = new Set(
       (await service.db.listCollections({}, { nameOnly: true }).toArray()).map(
@@ -37,47 +41,7 @@ describe("SyncMongoService", () => {
     expect(names.has(SYNC_COLLECTIONS.providerConnections)).toBe(true);
   });
 
-  it("throws when db is accessed before connecting", () => {
-    service = new SyncMongoService();
-    expect(() => service.db).toThrow(/not connected/);
-  });
-
-  it("refuses to start in staging when the forbidden database is readable", async () => {
-    // The in-memory server has no auth, so the forbidden database IS reachable.
-    // With enforcement on (staging), the least-privilege guard must detect the
-    // excessive access and abort startup rather than run over-privileged.
-    service = new SyncMongoService();
-    await expect(
-      service.connect({
-        uri,
-        databaseName: uniqueDbName(),
-        forbiddenDatabaseName: "prod_calendar",
-        enforceLeastPrivilege: true,
-      }),
-    ).rejects.toThrow(/excessive privileges/);
-  });
-
-  it("fails to connect against an unreachable server", async () => {
-    service = new SyncMongoService();
-    await expect(
-      service.connect({
-        // Reserved TEST-NET address; connection is refused quickly.
-        uri: "mongodb://192.0.2.1:27017/compass_sync?serverSelectionTimeoutMS=500&connectTimeoutMS=500",
-        forbiddenDatabaseName: "prod_calendar",
-        enforceLeastPrivilege: false,
-      }),
-    ).rejects.toThrow();
-  });
-
   it("supports multi-document transactions (replica set)", async () => {
-    service = new SyncMongoService();
-    await service.connect({
-      uri,
-      databaseName: uniqueDbName(),
-      forbiddenDatabaseName: "prod_calendar",
-      enforceLeastPrivilege: false,
-    });
-
     const collection = service.db.collection(SYNC_COLLECTIONS.jobs);
     const session = service.client.startSession();
     try {
@@ -89,6 +53,41 @@ describe("SyncMongoService", () => {
       await session.endSession();
     }
     expect(await collection.countDocuments()).toBe(2);
+  });
+});
+
+describe("SyncMongoService connection failures", () => {
+  it("throws when db is accessed before connecting", () => {
+    const service = new SyncMongoService();
+    expect(() => service.db).toThrow(/not connected/);
+  });
+
+  it("refuses to start in staging when the forbidden database is readable", async () => {
+    // The in-memory server has no auth, so the forbidden database IS reachable.
+    // With enforcement on (staging), the least-privilege guard must detect the
+    // excessive access and abort startup rather than run over-privileged. The
+    // guard rejects before the manifest install, so nothing is left connected.
+    const service = new SyncMongoService();
+    await expect(
+      service.connect({
+        uri,
+        databaseName: uniqueDbName(),
+        forbiddenDatabaseName: "prod_calendar",
+        enforceLeastPrivilege: true,
+      }),
+    ).rejects.toThrow(/excessive privileges/);
+  });
+
+  it("fails to connect against an unreachable server", async () => {
+    const service = new SyncMongoService();
+    await expect(
+      service.connect({
+        // Reserved TEST-NET address; connection is refused quickly.
+        uri: "mongodb://192.0.2.1:27017/compass_sync?serverSelectionTimeoutMS=500&connectTimeoutMS=500",
+        forbiddenDatabaseName: "prod_calendar",
+        enforceLeastPrivilege: false,
+      }),
+    ).rejects.toThrow();
   });
 });
 


### PR DESCRIPTION
## Problem

Two sync storage test files (`index-manifest.test.ts`, `sync-mongo.service.test.ts`) still did per-test connect + full manifest install (~25 `createIndex` round-trips) + `dropDatabase`. Fine when the sync suite ran single-process; but once it moved onto the parallel per-file launcher, that per-test DDL both dragged and **raced other files' writes** on the shared in-memory mongod — producing intermittent CI failures: `error: Cannot create collection … database is in the process of being dropped` and individual tests timing out at 5000ms. `index-manifest` alone ran ~1s **per test even uncontended** (it reinstalled the whole manifest in 6 of 7 tests).

## Fix

- **`index-manifest.test.ts`**: install the manifest **once** in `beforeAll` (it's deterministic — one install serves every read-only assertion), clear only the two collections the write tests touch in `beforeEach`, drop once in `afterAll`. No per-test `dropDatabase`.
- **`sync-mongo.service.test.ts`**: share one connected `SyncMongoService` across the two tests that need a healthy connection (connecting is what installs the manifest), and remove the per-test `dropDatabase` — every test already uses a unique database name, and the launcher tears the whole server down at the end.

No behavior under test changes. The connection-failure tests are unaffected (they reject before the install step).

## Result

| file | before | after |
|---|---|---|
| index-manifest | 7.0s | **2.1s** |
| sync-mongo | 4.0s | **2.9s** |

No sync test file does per-test `dropDatabase` anymore, so the drop/create race is gone suite-wide, and no test can approach the per-test timeout under contention. `bun run test:sync` — 450 pass, 13.9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)