### PR TITLE
feat(sync): apply a provider calendar's incremental changes

### DIFF
--- a/packages/sync/src/domain/calendar-pull.service.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.test.ts
@@ -1,0 +1,444 @@
+import { faker } from "@faker-js/faker";
+import { type SyncCommandInput } from "@core/types/sync/command.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import {
+  type CalendarPullDeps,
+  pullCalendarChanges,
+} from "@sync/domain/calendar-pull.service";
+import {
+  type ProviderEvent,
+  type ProviderEventCancellation,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+class FakeReader implements ProviderEventReader {
+  readonly provider = "google" as const;
+  calls: ProviderEventReadInput[] = [];
+  #pages: ProviderEventPage[];
+  #error?: unknown;
+
+  constructor(pages: ProviderEventPage[], error?: unknown) {
+    this.#pages = [...pages];
+    this.#error = error;
+  }
+
+  async listEventPage(
+    input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    this.calls.push(input);
+    if (this.#error) throw this.#error;
+    const page = this.#pages.shift();
+    if (!page) throw new Error("FakeReader: no page scripted");
+    return page;
+  }
+}
+
+const schedule = {
+  kind: "timed" as const,
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const content = (title: string) => ({
+  title,
+  description: "",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+});
+const single = (id: string, title = id): ProviderEvent => ({
+  kind: "event",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  providerUpdatedAt: null,
+  content: content(title),
+  schedule,
+  busy: true,
+  recurrence: { kind: "single" },
+});
+const master = (id: string): ProviderEvent => ({
+  ...single(id),
+  recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+});
+const cancellation = (id: string): ProviderEventCancellation => ({
+  kind: "cancellation",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  series: null,
+});
+const page = (
+  events: ProviderEventRead[],
+  opts: { nextPageToken?: string | null; nextSyncToken?: string | null } = {},
+): ProviderEventPage => ({
+  events,
+  skipped: 0,
+  nextPageToken: opts.nextPageToken ?? null,
+  nextSyncToken: opts.nextSyncToken ?? null,
+});
+
+const tokenSource = { getValidAccessToken: async () => "access-token" };
+
+describe("pullCalendarChanges", () => {
+  const storage = setupSyncStorage();
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let resources: SyncResourceRepository;
+  let commands: CommandRepository;
+  let calendars: ProviderCalendarRepository;
+
+  beforeEach(() => {
+    events = new EventRepository(storage.db());
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    resources = new SyncResourceRepository(storage.db());
+    commands = new CommandRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+  });
+
+  const deps = (reader: FakeReader): CalendarPullDeps => ({
+    events,
+    occurrences,
+    resources,
+    commands,
+    reader,
+    custody: tokenSource,
+  });
+
+  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+    calendars.upsertByProviderCalendar({
+      tenantId: objectId() as ProviderCalendarRecord["tenantId"],
+      principalId: objectId() as ProviderCalendarRecord["principalId"],
+      connectionId: objectId() as ProviderCalendarRecord["connectionId"],
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  // Put the calendar's events resource into the imported state at a cursor.
+  const seedImported = async (
+    calendar: ProviderCalendarRecord,
+    cursor = "cursor-0",
+  ) => {
+    const resource = await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+    await resources.advanceCursor(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+      cursor,
+      now(),
+    );
+    return resource;
+  };
+
+  // Seed a provider-linked local event (as import would leave it).
+  const seedEvent = (
+    calendar: ProviderCalendarRecord,
+    read: ProviderEvent,
+    recurrence: EventRecord["recurrence"] = { kind: "single" },
+  ): Promise<EventRecord> =>
+    events.upsertByProviderIdentity({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      origin: "provider",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId: calendar.connectionId,
+      providerEventId: read.providerEventId as never,
+      providerVersion: read.providerVersion as never,
+      providerUpdatedAt: null,
+      deliveryState: null,
+      providerMetadata: null,
+      content: read.content,
+      schedule: read.schedule,
+      recurrence,
+      lifecycleState: "active",
+      generation: 0,
+      confirmedAt: now(),
+    });
+
+  const eventCount = (calendarId: string) =>
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .countDocuments({ calendarId });
+
+  it("returns notImported and reads nothing when the resource has no cursor", async () => {
+    const calendar = await seedCalendar();
+    // ensure the resource exists but never advance a cursor onto it.
+    await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+    const reader = new FakeReader([]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    expect(result.status).toBe("notImported");
+    expect(reader.calls).toHaveLength(0);
+  });
+
+  it("reads from the stored cursor and advances to the new one", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar, "cursor-0");
+    const reader = new FakeReader([
+      page([single("new-1")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    expect(reader.calls[0].cursor).toBe("cursor-0");
+    expect(reader.calls[0].window ?? null).toBeNull();
+    if (result.status !== "applied") throw new Error("expected applied");
+    expect(result.resource.syncCursor).toBe("cursor-1");
+    expect(result.changed).toBe(1);
+  });
+
+  it("applies a provider deletion by removing the local event", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    await seedEvent(calendar, single("doomed"));
+    expect(await eventCount(calendar._id)).toBe(1);
+    const reader = new FakeReader([
+      page([cancellation("doomed")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    expect(result.deleted).toBe(1);
+    expect(await eventCount(calendar._id)).toBe(0);
+  });
+
+  it("deletes a whole series when its master is cancelled", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    const m = await seedEvent(calendar, master("m"), {
+      kind: "seriesMaster",
+      rules: ["RRULE:FREQ=WEEKLY;COUNT=3"],
+    });
+    // An exception of that series.
+    await events.upsertByProviderIdentity({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      origin: "provider",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId: calendar.connectionId,
+      providerEventId: "m-ex" as never,
+      providerVersion: "etag-ex" as never,
+      providerUpdatedAt: null,
+      deliveryState: null,
+      providerMetadata: null,
+      content: content("ex"),
+      schedule,
+      recurrence: {
+        kind: "exception",
+        seriesId: m._id,
+        recurrenceId: "2026-07-21T09:00:00-06:00" as never,
+        cancelled: false,
+      },
+      lifecycleState: "active",
+      generation: 0,
+      confirmedAt: now(),
+    });
+    expect(await eventCount(calendar._id)).toBe(2);
+    const reader = new FakeReader([
+      page([cancellation("m")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    // Master and its exception both gone.
+    expect(await eventCount(calendar._id)).toBe(0);
+  });
+
+  it("preserves a contested exception when its series is cancelled", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    const m = await seedEvent(calendar, master("m"), {
+      kind: "seriesMaster",
+      rules: ["RRULE:FREQ=WEEKLY;COUNT=3"],
+    });
+    const putException = (providerEventId: string, recurrenceId: string) =>
+      events.upsertByProviderIdentity({
+        tenantId: calendar.tenantId,
+        principalId: calendar.principalId,
+        origin: "provider",
+        calendarId: calendar._id,
+        clientEventId: null,
+        connectionId: calendar.connectionId,
+        providerEventId: providerEventId as never,
+        providerVersion: `etag-${providerEventId}` as never,
+        providerUpdatedAt: null,
+        deliveryState: null,
+        providerMetadata: null,
+        content: content(providerEventId),
+        schedule,
+        recurrence: {
+          kind: "exception",
+          seriesId: m._id,
+          recurrenceId: recurrenceId as never,
+          cancelled: false,
+        },
+        lifecycleState: "active",
+        generation: 0,
+        confirmedAt: now(),
+      });
+    const contested = await putException(
+      "ex-edit",
+      "2026-07-21T09:00:00-06:00",
+    );
+    await putException("ex-plain", "2026-07-28T09:00:00-06:00");
+    // A pending Compass edit still targets the contested occurrence.
+    await commands.submit({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      idempotencyKey: `idem-${objectId()}` as never,
+      eventId: contested._id,
+      input: {
+        kind: "update",
+        invitation: "all",
+        content: content("my local edit"),
+        schedule,
+        recurrence: { kind: "preserve" },
+        scope: "this",
+        recurrenceId: "2026-07-21T09:00:00-06:00",
+      } as unknown as SyncCommandInput,
+      expectedVersion: null,
+    });
+    const reader = new FakeReader([
+      page([cancellation("m")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    // Master and the uncontested exception are gone; the contested one survives
+    // for its in-flight edit to reconcile against the provider.
+    const remaining = await events.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      contested._id,
+    );
+    expect(remaining).not.toBeNull();
+    expect(await eventCount(calendar._id)).toBe(1);
+  });
+
+  it("keeps an event with an unacknowledged Compass command", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    const event = await seedEvent(calendar, single("contested"));
+    // A pending local command still targets this event.
+    await commands.submit({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      idempotencyKey: `idem-${objectId()}` as never,
+      eventId: event._id,
+      input: {
+        kind: "delete",
+        invitation: "all",
+        scope: "all",
+        recurrenceId: null,
+      } as unknown as SyncCommandInput,
+      expectedVersion: null,
+    });
+    const reader = new FakeReader([
+      page([cancellation("contested")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    // The provider deletion is withheld — the local intent survives.
+    expect(result.deleted).toBe(0);
+    expect(await eventCount(calendar._id)).toBe(1);
+  });
+
+  it("treats a deletion of an already-absent event as a no-op", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    const reader = new FakeReader([
+      page([cancellation("ghost")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    expect(result.deleted).toBe(0);
+    expect(result.resource.syncCursor).toBe("cursor-1");
+  });
+
+  it("hands off to repair on an expired cursor without touching it", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar, "stale");
+    const reader = new FakeReader(
+      [],
+      new ProviderEventReadError("cursorExpired", "410"),
+    );
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    expect(result.status).toBe("cursorExpired");
+    // The stored cursor is left untouched for the repair path.
+    const resource = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      result.resource._id,
+    );
+    expect(resource?.syncCursor).toBe("stale");
+  });
+
+  it("advances the cursor only after every page commits", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    const reader = new FakeReader([
+      page([single("a")], { nextPageToken: "p2" }),
+      page([single("b")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    // First page carried no sync token, so the cursor moves to the last page's.
+    expect(result.resource.syncCursor).toBe("cursor-1");
+    expect(result.resource.pageCursor).toBeNull();
+    expect(reader.calls[1].pageToken).toBe("p2");
+    expect(result.changed).toBe(2);
+  });
+});

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -1,0 +1,248 @@
+import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
+import { type ProviderEventCancellation } from "@sync/providers/provider-event.port";
+import {
+  ProviderEventReadError,
+  type ProviderEventReader,
+} from "@sync/providers/provider-event-reader.port";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface CalendarPullDeps {
+  events: EventRepository;
+  occurrences: EventOccurrenceRepository;
+  resources: SyncResourceRepository;
+  commands: CommandRepository;
+  reader: ProviderEventReader;
+  custody: AccessTokenSource;
+}
+
+export type CalendarPullResult =
+  | {
+      // The pull applied the provider's changes and advanced the cursor.
+      status: "applied";
+      resource: SyncResourceRecord;
+      changed: number;
+      deleted: number;
+    }
+  | {
+      // The stored cursor is too old (410 Gone). The caller starts a full
+      // repair (a later slice); this pull made no changes and left the cursor
+      // untouched so the repair path decides what to do.
+      status: "cursorExpired";
+      resource: SyncResourceRecord;
+    }
+  | {
+      // The resource has no cursor yet, so there is nothing to pull
+      // incrementally — initial import owns it until it produces one.
+      status: "notImported";
+      resource: SyncResourceRecord;
+    };
+
+// Apply the provider's incremental changes for one already-imported calendar.
+//
+// Reads from the stored sync cursor (never a window — an incremental read is
+// defined by the cursor alone), commits each page's writes and projections, and
+// only advances the cursor after every page has committed, so a crash re-pulls
+// from the old cursor rather than skipping changes. Every write is an idempotent
+// provider-identity upsert and every projection replaces per (event,
+// generation), so re-pulling a page converges.
+//
+// The shared ProviderPageApplier does the content work (upsert changed events,
+// link series members, reproject touched series). This path adds what import
+// does not: applying provider DELETIONS. A standalone cancellation (an event
+// removed at the provider) deletes the local event — UNLESS an unacknowledged
+// Compass command still targets it, in which case the local intent is preserved
+// and left to reconcile rather than silently dropped.
+export async function pullCalendarChanges(
+  deps: CalendarPullDeps,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<CalendarPullResult> {
+  const resource = await deps.resources.ensure({
+    tenantId: calendar.tenantId,
+    principalId: calendar.principalId,
+    connectionId: calendar.connectionId,
+    resourceKind: "events",
+    calendarId: calendar._id,
+  });
+  if (resource.syncCursor === null) {
+    return { status: "notImported", resource };
+  }
+
+  const accessToken = await deps.custody.getValidAccessToken(
+    calendar.connectionId,
+  );
+  await deps.resources.markAttempt(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    now(),
+  );
+
+  const applier = new ProviderPageApplier(
+    deps.events,
+    deps.occurrences,
+    calendar,
+    resource.importGeneration,
+    now,
+  );
+  // A pull resumes a mid-batch page from the stored page checkpoint; otherwise
+  // it starts the batch at the stored incremental cursor.
+  let pageToken = resource.pageCursor;
+  let cursor = resource.syncCursor;
+  let deleted = 0;
+
+  do {
+    let page: Awaited<ReturnType<ProviderEventReader["listEventPage"]>>;
+    try {
+      page = await deps.reader.listEventPage({
+        accessToken,
+        calendarId: calendar.providerCalendarId,
+        // The cursor applies only to the first request of a batch; paging then
+        // continues by pageToken alone.
+        cursor: pageToken === null ? cursor : null,
+        pageToken,
+      });
+    } catch (error) {
+      // An expired cursor cannot be resumed; hand off to repair without
+      // touching the stored cursor.
+      if (
+        error instanceof ProviderEventReadError &&
+        error.reason === "cursorExpired"
+      ) {
+        return { status: "cursorExpired", resource };
+      }
+      throw error;
+    }
+
+    const standalone = await applier.applyPage(page.events);
+    deleted += await applyDeletions(deps, calendar, standalone);
+
+    pageToken = page.nextPageToken;
+    cursor = page.nextSyncToken ?? cursor;
+    // Checkpoint only after the page's writes, projections, and deletions have
+    // committed, so a crash-resume re-reads at most one already-applied page.
+    if (pageToken) {
+      await deps.resources.setPageCheckpoint(
+        resource.tenantId,
+        resource.principalId,
+        resource._id,
+        pageToken,
+      );
+    }
+  } while (pageToken);
+
+  await applier.finish();
+  await deps.resources.advanceCursor(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    cursor,
+    now(),
+  );
+
+  const updated = await deps.resources.findById(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+  );
+  return {
+    status: "applied",
+    resource: updated ?? resource,
+    changed: applier.importedCount,
+    deleted,
+  };
+}
+
+// Apply the provider deletions a page reported (its standalone cancellations).
+// Each resolves to a local event by provider identity; a series master takes
+// the whole series with it. An event with an unacknowledged Compass command is
+// left alone — deleting it would drop a local edit still reconciling. Returns
+// how many local events were removed.
+async function applyDeletions(
+  deps: CalendarPullDeps,
+  calendar: ProviderCalendarRecord,
+  cancellations: readonly ProviderEventCancellation[],
+): Promise<number> {
+  let deleted = 0;
+  for (const cancellation of cancellations) {
+    const event = await deps.events.findByProviderIdentity(
+      calendar.tenantId,
+      calendar.principalId,
+      {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId: cancellation.providerEventId as NonNullable<
+          EventRecord["providerEventId"]
+        >,
+      },
+    );
+    // Already gone (a prior pull removed it) or never stored — nothing to do.
+    if (!event) continue;
+    // A local edit/create is still in flight for this event; keep it so the
+    // Compass intent reconciles against the provider rather than being lost.
+    if (
+      await deps.commands.hasNonterminalForEvent(
+        event.tenantId,
+        event.principalId,
+        event._id,
+      )
+    ) {
+      continue;
+    }
+
+    await deleteEventAndSeries(deps, event);
+    deleted += 1;
+  }
+  return deleted;
+}
+
+// Remove a provider event locally. For a series master this also removes each
+// exception (occurrences cleared before the record, so a crash never orphans
+// occurrence rows — the same ordering the cloud series delete uses). An
+// exception with an unacknowledged Compass command is preserved for the same
+// reason a standalone event is: a per-occurrence edit still in flight must
+// reconcile against the provider, not be silently dropped by the series cascade.
+// That leaves it briefly master-less, which is safe — it projects only its own
+// occurrence and its command resolves against the provider's now-gone series.
+async function deleteEventAndSeries(
+  deps: CalendarPullDeps,
+  event: EventRecord,
+): Promise<void> {
+  if (event.recurrence.kind === "seriesMaster") {
+    const exceptions = await deps.events.findSeriesExceptions(
+      event.tenantId,
+      event.principalId,
+      event._id,
+    );
+    for (const exception of exceptions) {
+      if (
+        await deps.commands.hasNonterminalForEvent(
+          exception.tenantId,
+          exception.principalId,
+          exception._id,
+        )
+      ) {
+        continue;
+      }
+      await deps.occurrences.replaceForEvent(
+        exception._id,
+        exception.generation,
+        [],
+      );
+      await deps.events.deleteById(
+        exception.tenantId,
+        exception.principalId,
+        exception._id,
+      );
+    }
+  }
+  await deps.occurrences.replaceForEvent(event._id, event.generation, []);
+  await deps.events.deleteById(event.tenantId, event.principalId, event._id);
+}

--- a/packages/sync/src/storage/repositories/command.repository.test.ts
+++ b/packages/sync/src/storage/repositories/command.repository.test.ts
@@ -137,6 +137,47 @@ describe("CommandRepository", () => {
     expect(pending[0]?.idempotencyKey).toBe("b");
   });
 
+  it("reports a nonterminal command for an event, and none once it terminates", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const eventId = objectId();
+    const command = await repo.submit(
+      submit({ tenantId, principalId, eventId }),
+    );
+
+    expect(
+      await repo.hasNonterminalForEvent(
+        tenantId,
+        principalId,
+        eventId as never,
+      ),
+    ).toBe(true);
+    // A different event has no in-flight command.
+    expect(
+      await repo.hasNonterminalForEvent(
+        tenantId,
+        principalId,
+        objectId() as never,
+      ),
+    ).toBe(false);
+
+    await repo.updateOutcome(
+      tenantId,
+      principalId,
+      command._id,
+      { state: "confirmed", providerEventId: null, providerVersion: null },
+      1,
+    );
+    // Terminal now — no longer in flight.
+    expect(
+      await repo.hasNonterminalForEvent(
+        tenantId,
+        principalId,
+        eventId as never,
+      ),
+    ).toBe(false);
+  });
+
   it("rejects a raw duplicate insert violating the idempotency index", async () => {
     const shared = {
       tenantId: objectId(),

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -1,4 +1,5 @@
 import { type Collection, type Db, ObjectId } from "mongodb";
+import { type EventId } from "@core/types/domain-primitives";
 import { type SyncCommandOutcome } from "@core/types/sync/command.contracts";
 import {
   type PrincipalId,
@@ -68,6 +69,27 @@ export class CommandRepository {
       principalId,
     });
     return record ? CommandRecordSchema.parse(record) : null;
+  }
+
+  // Whether an unacknowledged Compass command still targets this event. An
+  // incremental pull consults this before applying a provider deletion so it
+  // never drops an event with a local edit/create still in flight — the Compass
+  // intent reconciles against the provider rather than being silently lost.
+  async hasNonterminalForEvent(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    eventId: EventId,
+  ): Promise<boolean> {
+    const existing = await this.collection.findOne(
+      {
+        tenantId,
+        principalId,
+        eventId,
+        "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+      },
+      { projection: { _id: 1 } },
+    );
+    return existing !== null;
   }
 
   // Record a state transition (pending -> applying -> confirmed/failed/...) and


### PR DESCRIPTION
## What

Incremental pull (S30): apply an already-imported Google calendar's changes from its stored sync cursor, on the shared `ProviderPageApplier` extracted in #2277. This closes the read loop — after initial import, a calendar stays current by pulling deltas.

## How

- Read from the stored cursor (never a window — an incremental read is defined by the cursor alone), commit each page's writes, projections, and deletions, and **advance the cursor only after every page commits**, so a crash re-pulls from the old cursor rather than skipping changes. Mid-batch pages checkpoint their page token; a resume continues from it. Every write is an idempotent provider-identity upsert, so re-pulling a page converges.
- The shared applier does the content work (upsert changed events, link series members, reproject). The pull adds what import doesn't: **applying provider deletions**. A standalone (non-series) cancellation removes the local event; a series master takes its whole series with it.
- **"Never delete unacknowledged Compass intent":** an event (or a series exception) with a nonterminal Compass command is preserved so the local edit reconciles against the provider rather than being silently dropped. New `CommandRepository.hasNonterminalForEvent` backs the guard.
- An expired cursor (410) hands off to a full repair (a later slice) without touching the stored cursor; a resource with no cursor yet is left to initial import.

## Review-caught fix (included)

The adversarial review found a real gap (Critical): the series-master cascade delete removed **every** exception unconditionally, bypassing the pending-command guard that only covered the master. A user's in-flight scope-"this" edit on one occurrence would be lost when the whole series was deleted upstream. Fixed: the cascade now checks each exception and preserves a contested one (leaving it briefly master-less, which is safe — it projects only its own occurrence and its command reconciles against the provider's now-gone series). Regression test added.

## Testing

`bun run test:sync` — 460 pass / 38 files, 13.6s. Type-check and biome clean. Pull coverage: read-from-cursor + advance, provider deletion (single and whole-series), pending-intent guard (standalone and contested-exception), already-absent no-op, cursorExpired hand-off, multi-page cursor-advance-after-all-pages. Plus a direct `hasNonterminalForEvent` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)