### PR TITLE
feat(sync): serve reads from a calendar's active generation

### DIFF
--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -45,6 +45,7 @@ import { CredentialRepository } from "@sync/storage/repositories/credential.repo
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
 export const CONNECTIONS_PATH = "/internal/connections";
@@ -228,10 +229,23 @@ export function registerConnectionRoutes(
           deps.mongo.db,
           deps.mongo.client,
         );
+        // Resolve the active generation for each requested calendar so a repair
+        // in progress is never read; a calendar with no events resource yet
+        // (cloud-only, or not imported) reads generation 0.
+        const resources = new SyncResourceRepository(deps.mongo.db);
+        const activeByCalendar = await resources.activeGenerationByCalendar(
+          auth.tenantId,
+          auth.principalId,
+          [...query.calendarIds],
+        );
+        const calendars = [...query.calendarIds].map((calendarId) => ({
+          calendarId,
+          generation: activeByCalendar.get(calendarId) ?? 0,
+        }));
         const records = await repo.listByCalendarRange({
           tenantId: auth.tenantId,
           principalId: auth.principalId,
-          calendarIds: [...query.calendarIds],
+          calendars,
           start,
           end,
           limit,

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -29,7 +29,15 @@ export const SyncResourceRecordSchema = z.strictObject({
   syncCursor: z.string().min(1).nullable(),
   // Mid-batch page checkpoint for resumable pulls; null between batches.
   pageCursor: z.string().min(1).nullable(),
+  // The generation import and pull WRITE into. A non-destructive repair bumps
+  // this to build a fresh generation alongside the queryable one.
   importGeneration: z.number().int().min(0),
+  // The generation reads SERVE. Equal to importGeneration in steady state; a
+  // repair holds it back at the old generation until the new one completes,
+  // then activates it atomically, so reads never see a half-built repair.
+  // Defaults to 0 so a resource written before this field existed reads as the
+  // single generation it has.
+  activeGeneration: z.number().int().min(0).default(0),
   lastAttemptAt: z.date().nullable(),
   lastSuccessAt: z.date().nullable(),
   // Push subscription: the provider channel id, its opaque resource id, the

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -94,10 +94,16 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       key: { eventId: 1, occurrenceKey: 1 },
       options: { unique: true },
     },
-    // Index the normalized start instant (startAt), not the schedule.start
-    // union path — range queries compare all-day and timed occurrences on one
-    // coherent axis.
-    { name: "calendar_start", key: { calendarId: 1, startAt: 1 } },
+    // The range read filters each calendar to its active generation, then
+    // sorts/paginates by (startAt, _id). Leading with (calendarId, generation)
+    // keeps the query index-covered even while a repair keeps two generations of
+    // a calendar's occurrences resident. Index the normalized start instant
+    // (startAt), not the schedule.start union path, so all-day and timed
+    // occurrences compare on one coherent axis.
+    {
+      name: "calendar_gen_start",
+      key: { calendarId: 1, generation: 1, startAt: 1, _id: 1 },
+    },
     { name: "principal_start", key: { principalId: 1, startAt: 1 } },
   ],
   [SYNC_COLLECTIONS.syncResources]: [

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
@@ -142,7 +142,10 @@ describe("EventOccurrenceRepository", () => {
       const page = await repo.listByCalendarRange({
         tenantId: tenantId as OccurrenceInput["tenantId"],
         principalId: principalId as OccurrenceInput["principalId"],
-        calendarIds: [calA, calB],
+        calendars: [
+          { calendarId: calA, generation: 0 },
+          { calendarId: calB, generation: 0 },
+        ],
         start: new Date("2026-07-01T00:00:00-06:00"),
         end: new Date("2026-07-16T00:00:00-06:00"),
         limit: 100,
@@ -156,7 +159,10 @@ describe("EventOccurrenceRepository", () => {
       const query = {
         tenantId: tenantId as OccurrenceInput["tenantId"],
         principalId: principalId as OccurrenceInput["principalId"],
-        calendarIds: [calA, calB],
+        calendars: [
+          { calendarId: calA, generation: 0 },
+          { calendarId: calB, generation: 0 },
+        ],
         start: new Date("2026-07-01T00:00:00-06:00"),
         end: new Date("2026-07-16T00:00:00-06:00"),
       };
@@ -199,7 +205,9 @@ describe("EventOccurrenceRepository", () => {
       const query = {
         tenantId: tenant2,
         principalId: principal2,
-        calendarIds: [cal] as OccurrenceInput["calendarId"][],
+        calendars: [
+          { calendarId: cal as OccurrenceInput["calendarId"], generation: 0 },
+        ],
         start: new Date("2026-07-01T00:00:00-06:00"),
         end: new Date("2026-07-16T00:00:00-06:00"),
       };
@@ -219,6 +227,52 @@ describe("EventOccurrenceRepository", () => {
       }
       expect(seen).toHaveLength(5);
       expect(new Set(seen).size).toBe(5);
+    });
+
+    it("reads only the requested generation, hiding a repair's new one", async () => {
+      const tenant = objectId() as OccurrenceInput["tenantId"];
+      const principal = objectId() as OccurrenceInput["principalId"];
+      const cal = objectId() as OccurrenceInput["calendarId"];
+      const at = new Date("2026-07-14T09:00:00-06:00");
+      const mk = (eventId: string, gen: number, key: string) =>
+        repo.replaceForEvent(eventId as OccurrenceInput["eventId"], gen, [
+          occurrence({
+            tenantId: tenant,
+            principalId: principal,
+            eventId: eventId as OccurrenceInput["eventId"],
+            occurrenceKey: key,
+            calendarId: cal,
+            startAt: at,
+            generation: gen,
+          }),
+        ]);
+      // The live generation 0 and a repair building generation 1 coexist.
+      await mk(objectId(), 0, `${cal}:live`);
+      await mk(objectId(), 1, `${cal}:repair`);
+
+      const range = {
+        start: new Date("2026-07-01T00:00:00-06:00"),
+        end: new Date("2026-07-16T00:00:00-06:00"),
+        limit: 100,
+      };
+      // Reading the active generation shows only the live row, never the repair.
+      const live = await repo.listByCalendarRange({
+        tenantId: tenant,
+        principalId: principal,
+        calendars: [{ calendarId: cal, generation: 0 }],
+        ...range,
+      });
+      expect(live).toHaveLength(1);
+      expect(live[0]?.occurrenceKey).toBe(`${cal}:live`);
+      // Reading generation 1 (post-activation) shows only the repair's row.
+      const repaired = await repo.listByCalendarRange({
+        tenantId: tenant,
+        principalId: principal,
+        calendars: [{ calendarId: cal, generation: 1 }],
+        ...range,
+      });
+      expect(repaired).toHaveLength(1);
+      expect(repaired[0]?.occurrenceKey).toBe(`${cal}:repair`);
     });
   });
 });

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -18,10 +18,18 @@ export interface OccurrenceRangeCursor {
   id: string;
 }
 
+// One calendar to read, paired with the generation whose occurrences are
+// currently active for it — so a repair building a new generation alongside the
+// live one is never read until it activates.
+export interface CalendarGeneration {
+  calendarId: SyncEventCalendarId;
+  generation: number;
+}
+
 export interface OccurrenceRangeQuery {
   tenantId: TenantId;
   principalId: PrincipalId;
-  calendarIds: SyncEventCalendarId[];
+  calendars: readonly CalendarGeneration[];
   // Half-open [start, end) over the normalized start instant.
   start: Date;
   end: Date;
@@ -81,30 +89,34 @@ export class EventOccurrenceRepository {
   async listByCalendarRange(
     query: OccurrenceRangeQuery,
   ): Promise<EventOccurrenceRecord[]> {
-    const scope = {
-      tenantId: query.tenantId,
-      principalId: query.principalId,
-      calendarId: { $in: query.calendarIds },
+    if (query.calendars.length === 0) return [];
+    const base = { tenantId: query.tenantId, principalId: query.principalId };
+    // Read each calendar only at its active generation, so occurrences of a
+    // repair building a newer generation for that calendar stay invisible until
+    // it activates.
+    const activeCalendars = {
+      $or: query.calendars.map((c) => ({
+        calendarId: c.calendarId,
+        generation: c.generation,
+      })),
     };
     const inRange = { startAt: { $gte: query.start, $lt: query.end } };
 
     // Composite keyset over the (startAt, _id) sort: a later instant, or the
     // same instant with a greater _id. startAt is a top-level Date and _id a
     // string, so this is fully typeable — no cast needed.
-    const filter = query.after
-      ? {
-          ...scope,
-          $and: [
-            inRange,
-            {
-              $or: [
-                { startAt: { $gt: query.after.startAt } },
-                { startAt: query.after.startAt, _id: { $gt: query.after.id } },
-              ],
-            },
-          ],
-        }
-      : { ...scope, ...inRange };
+    const keyset = query.after
+      ? [
+          {
+            $or: [
+              { startAt: { $gt: query.after.startAt } },
+              { startAt: query.after.startAt, _id: { $gt: query.after.id } },
+            ],
+          },
+        ]
+      : [];
+
+    const filter = { ...base, $and: [activeCalendars, inRange, ...keyset] };
 
     const records = await this.collection
       .find(filter)

--- a/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.test.ts
@@ -33,6 +33,62 @@ describe("SyncResourceRepository", () => {
     expect(resource.syncCursor).toBeNull();
     expect(resource.pageCursor).toBeNull();
     expect(resource.importGeneration).toBe(0);
+    expect(resource.activeGeneration).toBe(0);
+  });
+
+  it("activates a generation without moving the import generation", async () => {
+    const tenantId = objectId() as never;
+    const principalId = objectId() as never;
+    const resource = await repo.ensure(
+      upsert({ tenantId, principalId }) as SyncResourceUpsert,
+    );
+    // A repair builds a new import generation, leaving reads on the old one.
+    const importGen = await repo.startNewGeneration(
+      tenantId,
+      principalId,
+      resource._id,
+    );
+    expect(importGen).toBe(1);
+    let after = await repo.findById(tenantId, principalId, resource._id);
+    expect(after?.activeGeneration).toBe(0);
+
+    // Activation flips reads to the new generation.
+    await repo.activateGeneration(
+      tenantId,
+      principalId,
+      resource._id,
+      importGen,
+    );
+    after = await repo.findById(tenantId, principalId, resource._id);
+    expect(after?.activeGeneration).toBe(1);
+    expect(after?.importGeneration).toBe(1);
+  });
+
+  it("resolves the active generation for each event calendar, defaulting absent ones", async () => {
+    const tenantId = objectId() as never;
+    const principalId = objectId() as never;
+    const calA = objectId() as never;
+    const calB = objectId() as never;
+    const absent = objectId() as never;
+    const a = await repo.ensure(
+      upsert({ tenantId, principalId, calendarId: calA }) as SyncResourceUpsert,
+    );
+    await repo.ensure(
+      upsert({ tenantId, principalId, calendarId: calB }) as SyncResourceUpsert,
+    );
+    // calA has been repaired and activated to generation 1; calB stays at 0.
+    await repo.startNewGeneration(tenantId, principalId, a._id);
+    await repo.activateGeneration(tenantId, principalId, a._id, 1);
+
+    const map = await repo.activeGenerationByCalendar(tenantId, principalId, [
+      calA,
+      calB,
+      absent,
+    ]);
+    expect(map.get(calA)).toBe(1);
+    expect(map.get(calB)).toBe(0);
+    // A calendar with no events resource is absent — the caller reads gen 0.
+    expect(map.has(absent)).toBe(false);
   });
 
   it("ensures one resource per (connection, kind, calendar)", async () => {

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -1,4 +1,5 @@
 import { type Collection, type Db, ObjectId } from "mongodb";
+import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
   type PrincipalId,
@@ -51,6 +52,7 @@ export class SyncResourceRepository {
           syncCursor: null,
           pageCursor: null,
           importGeneration: 0,
+          activeGeneration: 0,
           lastAttemptAt: null,
           lastSuccessAt: null,
           subscriptionId: null,
@@ -170,6 +172,44 @@ export class SyncResourceRepository {
     );
     if (!result) throw new Error("startNewGeneration: resource not found");
     return SyncResourceRecordSchema.parse(result).importGeneration;
+  }
+
+  // Serve reads from the generation a repair just finished building. The flip is
+  // a single field update, so reads switch from the old generation to the new
+  // one atomically; the old generation's rows are cleaned up afterward.
+  async activateGeneration(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    generation: number,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id, tenantId, principalId },
+      { $set: { activeGeneration: generation, updatedAt: new Date() } },
+    );
+  }
+
+  // The active generation to read for each of the given event calendars. A
+  // calendar with no events resource yet (a cloud-only calendar, or one not
+  // imported) is absent from the result; callers read generation 0 for those.
+  async activeGenerationByCalendar(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    calendarIds: readonly SyncEventCalendarId[],
+  ): Promise<Map<SyncEventCalendarId, number>> {
+    const records = await this.collection
+      .find({
+        tenantId,
+        principalId,
+        resourceKind: "events",
+        calendarId: { $in: [...calendarIds] },
+      })
+      .project<{ calendarId: SyncEventCalendarId; activeGeneration: number }>({
+        calendarId: 1,
+        activeGeneration: 1,
+      })
+      .toArray();
+    return new Map(records.map((r) => [r.calendarId, r.activeGeneration]));
   }
 
   async findById(


### PR DESCRIPTION
## What

Make the occurrence read path generation-aware — the foundation for S31 non-destructive repair. A repair builds a fresh occurrence generation alongside the one reads currently serve; reads must not see the half-built generation until it activates.

## How

- New `activeGeneration` on each events sync resource, distinct from the `importGeneration` that import/pull write into. Equal in steady state; a repair holds `activeGeneration` at the old generation while building a new `importGeneration`, then flips it in one field update (atomic activation).
- The events route resolves the active generation per requested calendar (`SyncResourceRepository.activeGenerationByCalendar`; a calendar with no events resource — cloud-only or not yet imported — reads generation 0) and `listByCalendarRange` scopes occurrences to those `(calendarId, generation)` pairs.
- `activeGeneration` defaults to 0 so a resource written before the field existed reads as its single generation.

## Behavior-preserving

Every calendar sits at generation 0 today, so reads return exactly the same set. Proven by the unchanged existing occurrence/route tests, plus a new test that a repair's generation-1 rows are hidden while generation 0 is served and vice-versa.

## Testing

`bun run test:sync` — 463 pass / 38 files, 14.2s. Type-check and biome clean. New coverage: generation-filtered reads, `activateGeneration` (doesn't move importGeneration), `activeGenerationByCalendar` (per-calendar, absent→default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)