### PR TITLE
feat(sync): non-destructive calendar repair into a fresh generation

### DIFF
--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -152,11 +152,14 @@ class ImportRun {
     private readonly resource: SyncResourceRecord,
     now: () => Date,
   ) {
+    // Import writes the active (live) generation — the one reads serve. Only a
+    // repair stages a separate importGeneration; the first import runs with
+    // active and import both at 0, so it populates the generation reads serve.
     this.#applier = new ProviderPageApplier(
       deps.events,
       deps.occurrences,
       calendar,
-      resource.importGeneration,
+      resource.activeGeneration,
       now,
     );
   }

--- a/packages/sync/src/domain/calendar-pull.service.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.test.ts
@@ -228,6 +228,35 @@ describe("pullCalendarChanges", () => {
     expect(result.changed).toBe(1);
   });
 
+  it("writes into the active generation when a prior repair left one staged", async () => {
+    // A repair bumped importGeneration ahead of activeGeneration but never
+    // activated (crashed/incomplete). A pull must still write the live (active)
+    // generation, or its new events land in a generation reads never serve.
+    const calendar = await seedCalendar();
+    const resource = await seedImported(calendar, "cursor-0");
+    await resources.startNewGeneration(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    ); // importGeneration -> 1, activeGeneration stays 0
+
+    const reader = new FakeReader([
+      page([single("new-1")], { nextSyncToken: "cursor-1" }),
+    ]);
+    const result = await pullCalendarChanges(deps(reader), calendar, now);
+
+    if (result.status !== "applied") throw new Error("expected applied");
+    const occAt = (generation: number) =>
+      storage
+        .db()
+        .collection(SYNC_COLLECTIONS.eventOccurrences)
+        .countDocuments({ calendarId: calendar._id, generation });
+    // The pulled event is visible at the active generation, not stranded in the
+    // repair's staged one.
+    expect(await occAt(0)).toBe(1);
+    expect(await occAt(1)).toBe(0);
+  });
+
   it("applies a provider deletion by removing the local event", async () => {
     const calendar = await seedCalendar();
     await seedImported(calendar);

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -85,11 +85,16 @@ export async function pullCalendarChanges(
     now(),
   );
 
+  // Write into the active (live) generation, not importGeneration: an
+  // incremental pull edits what reads currently serve. Were it to target a
+  // repair's staged importGeneration (bumped ahead but not yet active), its
+  // occurrences would land in a generation reads ignore — new events would
+  // vanish and provider deletions would leave phantoms until a repair completed.
   const applier = new ProviderPageApplier(
     deps.events,
     deps.occurrences,
     calendar,
-    resource.importGeneration,
+    resource.activeGeneration,
     now,
   );
   // A pull resumes a mid-batch page from the stored page checkpoint; otherwise

--- a/packages/sync/src/domain/calendar-repair.service.test.ts
+++ b/packages/sync/src/domain/calendar-repair.service.test.ts
@@ -1,0 +1,332 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import {
+  type CalendarRepairDeps,
+  repairCalendar,
+} from "@sync/domain/calendar-repair.service";
+import {
+  type ProviderEvent,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type ProviderEventPage,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+class FakeReader implements ProviderEventReader {
+  readonly provider = "google" as const;
+  calls: ProviderEventReadInput[] = [];
+  #pages: ProviderEventPage[];
+
+  constructor(pages: ProviderEventPage[]) {
+    this.#pages = [...pages];
+  }
+  async listEventPage(
+    input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    this.calls.push(input);
+    const page = this.#pages.shift();
+    if (!page) throw new Error("FakeReader: no page scripted");
+    return page;
+  }
+}
+
+const schedule = {
+  kind: "timed" as const,
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const content = (title: string) => ({
+  title,
+  description: "",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+});
+const single = (id: string, title = id): ProviderEvent => ({
+  kind: "event",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  providerUpdatedAt: null,
+  content: content(title),
+  schedule,
+  busy: true,
+  recurrence: { kind: "single" },
+});
+const page = (
+  events: ProviderEventRead[],
+  opts: { nextPageToken?: string | null; nextSyncToken?: string | null } = {},
+): ProviderEventPage => ({
+  events,
+  skipped: 0,
+  nextPageToken: opts.nextPageToken ?? null,
+  nextSyncToken: opts.nextSyncToken ?? null,
+});
+
+const tokenSource = { getValidAccessToken: async () => "access-token" };
+
+describe("repairCalendar", () => {
+  const storage = setupSyncStorage();
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let resources: SyncResourceRepository;
+  let calendars: ProviderCalendarRepository;
+
+  beforeEach(() => {
+    events = new EventRepository(storage.db());
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    resources = new SyncResourceRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+  });
+
+  const deps = (reader: FakeReader): CalendarRepairDeps => ({
+    events,
+    occurrences,
+    resources,
+    reader,
+    custody: tokenSource,
+  });
+
+  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+    calendars.upsertByProviderCalendar({
+      tenantId: objectId() as ProviderCalendarRecord["tenantId"],
+      principalId: objectId() as ProviderCalendarRecord["principalId"],
+      connectionId: objectId() as ProviderCalendarRecord["connectionId"],
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  const seedImported = async (calendar: ProviderCalendarRecord) => {
+    const resource = await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+    await resources.advanceCursor(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+      "cursor-0",
+      now(),
+    );
+    return resource;
+  };
+
+  // Seed an event and one occurrence at the given generation, as a prior
+  // import/pull would have left them.
+  const seedEvent = async (
+    calendar: ProviderCalendarRecord,
+    providerEventId: string | null,
+    generation: number,
+  ): Promise<EventRecord> => {
+    const record = providerEventId
+      ? await events.upsertByProviderIdentity({
+          tenantId: calendar.tenantId,
+          principalId: calendar.principalId,
+          origin: "provider",
+          calendarId: calendar._id,
+          clientEventId: null,
+          connectionId: calendar.connectionId,
+          providerEventId: providerEventId as never,
+          providerVersion: `etag-${providerEventId}` as never,
+          providerUpdatedAt: null,
+          deliveryState: null,
+          providerMetadata: null,
+          content: content(providerEventId),
+          schedule,
+          recurrence: { kind: "single" },
+          lifecycleState: "active",
+          generation,
+          confirmedAt: now(),
+        })
+      : await events.put({
+          _id: objectId() as EventRecord["_id"],
+          tenantId: calendar.tenantId,
+          principalId: calendar.principalId,
+          origin: "compass",
+          calendarId: calendar._id,
+          clientEventId: null,
+          connectionId: calendar.connectionId,
+          providerEventId: null,
+          providerVersion: null,
+          providerUpdatedAt: null,
+          deliveryState: null,
+          providerMetadata: null,
+          content: content("local"),
+          schedule,
+          recurrence: { kind: "single" },
+          lifecycleState: "active",
+          generation,
+          createdAt: now(),
+          updatedAt: now(),
+          confirmedAt: now(),
+        } as EventRecord);
+    await occurrences.replaceForEvent(record._id, generation, [
+      {
+        tenantId: calendar.tenantId,
+        principalId: calendar.principalId,
+        eventId: record._id,
+        occurrenceKey: `${record._id}:0`,
+        calendarId: calendar._id,
+        schedule,
+        startAt: new Date("2026-07-14T15:00:00.000Z"),
+        busy: true,
+        title: providerEventId ?? "local",
+        cancelled: false,
+        generation,
+      } as never,
+    ]);
+    return record;
+  };
+
+  const occAtGeneration = (calendarId: string, generation: number) =>
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .countDocuments({ calendarId, generation });
+
+  const eventCountAt = (calendarId: string, generation: number) =>
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .countDocuments({ calendarId, generation });
+
+  it("rebuilds into a new generation, activates it, and clears the old one", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    await seedEvent(calendar, "keep", 0);
+    await seedEvent(calendar, "stale", 0);
+    expect(await occAtGeneration(calendar._id, 0)).toBe(2);
+
+    // The provider still has "keep" but not "stale".
+    const reader = new FakeReader([
+      page([single("keep")], { nextSyncToken: "cursor-1" }),
+    ]);
+    const result = await repairCalendar(deps(reader), calendar, now);
+
+    expect(result.status).toBe("repaired");
+    if (result.status !== "repaired") throw new Error("unreachable");
+    expect(result.generation).toBe(1);
+    expect(result.resource.activeGeneration).toBe(1);
+    expect(result.resource.syncCursor).toBe("cursor-1");
+    // The old generation's occurrences are gone; the new one holds "keep".
+    expect(await occAtGeneration(calendar._id, 0)).toBe(0);
+    expect(await occAtGeneration(calendar._id, 1)).toBe(1);
+    // "stale" (absent at the provider) is removed; "keep" moved to generation 1.
+    expect(await eventCountAt(calendar._id, 0)).toBe(0);
+    expect(await eventCountAt(calendar._id, 1)).toBe(1);
+  });
+
+  it("leaves the old generation active and intact when the pass yields no cursor", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    await seedEvent(calendar, "keep", 0);
+
+    const reader = new FakeReader([page([single("keep")])]); // no nextSyncToken
+    const result = await repairCalendar(deps(reader), calendar, now);
+
+    expect(result.status).toBe("incomplete");
+    // Reads stay on the old generation; the old data is untouched.
+    const resource = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      result.resource._id,
+    );
+    expect(resource?.activeGeneration).toBe(0);
+    expect(await occAtGeneration(calendar._id, 0)).toBe(1);
+  });
+
+  it("preserves a Compass-owned event across a repair", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    // A local (unlinked) event has no providerEventId, so the provider result
+    // can't speak to it; it must survive the stale-event cleanup.
+    const local = await seedEvent(calendar, null, 0);
+
+    const reader = new FakeReader([
+      page([single("keep")], { nextSyncToken: "cursor-1" }),
+    ]);
+    await repairCalendar(deps(reader), calendar, now);
+
+    const survived = await events.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      local._id,
+    );
+    expect(survived).not.toBeNull();
+  });
+
+  it("resumes an in-flight repair generation instead of bumping again", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedImported(calendar);
+    // Simulate a prior repair that bumped the import generation but crashed
+    // before activating (importGeneration 1 ahead of activeGeneration 0).
+    await resources.startNewGeneration(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+
+    const reader = new FakeReader([
+      page([single("keep")], { nextSyncToken: "cursor-1" }),
+    ]);
+    const result = await repairCalendar(deps(reader), calendar, now);
+
+    if (result.status !== "repaired") throw new Error("expected repaired");
+    // Reused generation 1, did not bump to 2.
+    expect(result.generation).toBe(1);
+    expect(result.resource.importGeneration).toBe(1);
+  });
+
+  it("converges when run twice (idempotent)", async () => {
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    await seedEvent(calendar, "keep", 0);
+
+    const first = new FakeReader([
+      page([single("keep")], { nextSyncToken: "cursor-1" }),
+    ]);
+    await repairCalendar(deps(first), calendar, now);
+    // A second repair rebuilds again into a further generation and cleans up.
+    const second = new FakeReader([
+      page([single("keep")], { nextSyncToken: "cursor-2" }),
+    ]);
+    const result = await repairCalendar(deps(second), calendar, now);
+
+    if (result.status !== "repaired") throw new Error("expected repaired");
+    // Exactly one live event and occurrence remain, at the active generation.
+    expect(await eventCountAt(calendar._id, result.generation)).toBe(1);
+    expect(await occAtGeneration(calendar._id, result.generation)).toBe(1);
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.eventOccurrences)
+        .countDocuments({ calendarId: calendar._id }),
+    ).toBe(1);
+  });
+});

--- a/packages/sync/src/domain/calendar-repair.service.ts
+++ b/packages/sync/src/domain/calendar-repair.service.ts
@@ -1,0 +1,159 @@
+import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
+import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface CalendarRepairDeps {
+  events: EventRepository;
+  occurrences: EventOccurrenceRepository;
+  resources: SyncResourceRepository;
+  reader: ProviderEventReader;
+  custody: AccessTokenSource;
+}
+
+export type CalendarRepairResult =
+  | {
+      // The rebuild completed: reads now serve the fresh generation and the old
+      // one has been cleaned up.
+      status: "repaired";
+      resource: SyncResourceRecord;
+      generation: number;
+    }
+  | {
+      // The provider pass finished without a cursor, so the rebuild cannot be
+      // trusted as complete. Reads stay on the old, intact generation; a later
+      // repair resumes the same in-flight generation.
+      status: "incomplete";
+      resource: SyncResourceRecord;
+    };
+
+// Rebuild a provider calendar into a fresh occurrence generation and activate it
+// atomically — a non-destructive repair for an invalid cursor or inconsistent
+// stored state.
+//
+// The old generation stays the one reads serve for the entire rebuild, so the
+// user never sees a half-built calendar; the new generation is built alongside
+// it and only becomes visible on a single-field activation. On any failure the
+// old generation is left active and intact — the repair simply does not
+// activate.
+//
+// Crash-safe and idempotent. The new generation is chosen so a retry resumes the
+// same in-flight one rather than bumping again (which would strand a partial
+// generation): if a prior repair already advanced importGeneration past the
+// active one, that generation is reused; otherwise a fresh generation starts.
+// Every write is an idempotent provider-identity upsert into the new generation,
+// so re-running the pass converges. Activation, cursor advance, and cleanup all
+// run after the pass and are each idempotent, so a crash between them re-runs
+// harmlessly.
+export async function repairCalendar(
+  deps: CalendarRepairDeps,
+  calendar: ProviderCalendarRecord,
+  now: () => Date,
+): Promise<CalendarRepairResult> {
+  const resource = await deps.resources.ensure({
+    tenantId: calendar.tenantId,
+    principalId: calendar.principalId,
+    connectionId: calendar.connectionId,
+    resourceKind: "events",
+    calendarId: calendar._id,
+  });
+
+  // Reuse an in-flight repair generation (a previous attempt bumped it but never
+  // activated) instead of starting yet another; otherwise begin a fresh one.
+  const newGeneration =
+    resource.importGeneration > resource.activeGeneration
+      ? resource.importGeneration
+      : await deps.resources.startNewGeneration(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+        );
+
+  const accessToken = await deps.custody.getValidAccessToken(
+    calendar.connectionId,
+  );
+  await deps.resources.markAttempt(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    now(),
+  );
+
+  // Rebuild the whole calendar into the new generation. A full unwindowed pass
+  // (no cursor, no window) so the new generation is the provider's authoritative
+  // current state; the final page yields the cursor incremental pulls resume
+  // from. Standalone cancellations (events absent at the provider) are simply
+  // not created in the new generation — their absence is the deletion.
+  const applier = new ProviderPageApplier(
+    deps.events,
+    deps.occurrences,
+    calendar,
+    newGeneration,
+    now,
+  );
+  let pageToken: string | null = null;
+  let cursor: string | null = null;
+  do {
+    const page = await deps.reader.listEventPage({
+      accessToken,
+      calendarId: calendar.providerCalendarId,
+      pageToken,
+    });
+    await applier.applyPage(page.events);
+    pageToken = page.nextPageToken;
+    cursor = page.nextSyncToken ?? cursor;
+  } while (pageToken);
+  await applier.finish();
+
+  if (!cursor) {
+    // No durable cursor means the rebuild can't be trusted complete. Leave the
+    // old generation active and intact; the bumped importGeneration lets a later
+    // repair resume this same generation.
+    return { status: "incomplete", resource };
+  }
+
+  // Activate the new generation, then advance the cursor — reads flip in one
+  // field update. Cleanup of the generations the repair replaced runs last, so a
+  // crash before it leaves stale rows that reads already ignore and the next
+  // cleanup removes.
+  await deps.resources.activateGeneration(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    newGeneration,
+  );
+  await deps.resources.advanceCursor(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    cursor,
+    now(),
+  );
+  await deps.occurrences.deleteByCalendarBelowGeneration(
+    calendar.tenantId,
+    calendar.principalId,
+    calendar._id,
+    newGeneration,
+  );
+  await deps.events.deleteStaleProviderEventsBelowGeneration(
+    calendar.tenantId,
+    calendar.principalId,
+    calendar._id,
+    newGeneration,
+  );
+
+  const updated = await deps.resources.findById(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+  );
+  return {
+    status: "repaired",
+    resource: updated ?? resource,
+    generation: newGeneration,
+  };
+}

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -29,14 +29,19 @@ export const SyncResourceRecordSchema = z.strictObject({
   syncCursor: z.string().min(1).nullable(),
   // Mid-batch page checkpoint for resumable pulls; null between batches.
   pageCursor: z.string().min(1).nullable(),
-  // The generation import and pull WRITE into. A non-destructive repair bumps
-  // this to build a fresh generation alongside the queryable one.
+  // A repair's STAGING generation. Only a non-destructive repair touches this:
+  // it bumps this ahead of activeGeneration to build a fresh generation
+  // alongside the queryable one, then sets activeGeneration to it on success.
+  // Equal to activeGeneration in steady state. Steady-state writers (import and
+  // pull) do NOT write into this — they write the active generation, so a repair
+  // left incomplete (this bumped ahead, never activated) never strands their
+  // writes in a generation reads ignore.
   importGeneration: z.number().int().min(0),
-  // The generation reads SERVE. Equal to importGeneration in steady state; a
-  // repair holds it back at the old generation until the new one completes,
-  // then activates it atomically, so reads never see a half-built repair.
-  // Defaults to 0 so a resource written before this field existed reads as the
-  // single generation it has.
+  // The generation reads SERVE and steady-state writers (import, pull) write
+  // into — the single live generation outside a repair. A repair holds this back
+  // at the old generation while it builds importGeneration, then activates the
+  // new one atomically, so reads never see a half-built repair. Defaults to 0 so
+  // a resource written before this field existed reads as its single generation.
   activeGeneration: z.number().int().min(0).default(0),
   lastAttemptAt: z.date().nullable(),
   lastSuccessAt: z.date().nullable(),

--- a/packages/sync/src/storage/index-manifest.test.ts
+++ b/packages/sync/src/storage/index-manifest.test.ts
@@ -87,6 +87,28 @@ describe("installIndexManifest", () => {
     await expect(commands.insertOne(key)).rejects.toThrow();
   });
 
+  it("drops an index the manifest no longer declares", async () => {
+    // A stray index (e.g. left by an older manifest) must be reconciled away so
+    // a renamed index can take a key the old same-named one would have blocked.
+    const events = db.collection(SYNC_COLLECTIONS.events);
+    await events.createIndex({ title: 1 }, { name: "stale_legacy_index" });
+    expect(
+      (await events.indexes()).some((i) => i.name === "stale_legacy_index"),
+    ).toBe(true);
+
+    await installIndexManifest(db);
+
+    expect(
+      (await events.indexes()).some((i) => i.name === "stale_legacy_index"),
+    ).toBe(false);
+    // A declared index is still present.
+    expect(
+      (await events.indexes()).some(
+        (i) => i.name === "provider_event_identity",
+      ),
+    ).toBe(true);
+  });
+
   it("covers every collection in the manifest", () => {
     expect(Object.keys(SYNC_INDEX_MANIFEST).sort()).toEqual(
       Object.values(SYNC_COLLECTIONS).sort(),

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -90,8 +90,13 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
   ],
   [SYNC_COLLECTIONS.eventOccurrences]: [
     {
-      name: "event_occurrence",
-      key: { eventId: 1, occurrenceKey: 1 },
+      // Unique per (event, instant) WITHIN a generation. The generation is part
+      // of the key so a non-destructive repair can hold the same occurrence in
+      // two generations at once (same event and occurrenceKey, different
+      // generation) without colliding — the old generation stays readable while
+      // the new one is built.
+      name: "event_occurrence_generation",
+      key: { eventId: 1, generation: 1, occurrenceKey: 1 },
       options: { unique: true },
     },
     // The range read filters each calendar to its active generation, then
@@ -205,6 +210,21 @@ export async function installIndexManifest(
     }
 
     const collection = db.collection(collectionName);
+
+    // Reconcile: the manifest is the source of truth, so drop any index it no
+    // longer declares before (re)creating the ones it does. This lets an index
+    // change its key under a new name — the old name is dropped here rather than
+    // lingering and enforcing a stale (e.g. unique) constraint. Never touch the
+    // built-in _id_ index. Safe while collections are empty (createIndex on a
+    // renamed key would otherwise conflict with the old same-named index).
+    const declared = new Set(entries.map((e) => e.name));
+    const present = await collection.indexes().catch(() => []);
+    for (const index of present) {
+      if (index.name && index.name !== "_id_" && !declared.has(index.name)) {
+        await collection.dropIndex(index.name);
+      }
+    }
+
     for (const entry of entries) {
       await collection.createIndex(entry.key, {
         name: entry.name,

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -217,6 +217,14 @@ export async function installIndexManifest(
     // lingering and enforcing a stale (e.g. unique) constraint. Never touch the
     // built-in _id_ index. Safe while collections are empty (createIndex on a
     // renamed key would otherwise conflict with the old same-named index).
+    //
+    // OPERATIONAL CAVEAT: against a LARGE, POPULATED collection this is unsafe to
+    // run inline at startup — dropping then rebuilding a unique index leaves a
+    // window with no uniqueness enforced and blocks readiness on a foreground
+    // build. Fine today: sync isn't serving production data yet, so collections
+    // are empty or tiny and no concurrent writer exists at connect time. Before
+    // sync carries real data, a key change on a populated collection must move to
+    // a rolling/online index migration instead of this inline drop-and-rebuild.
     const declared = new Set(entries.map((e) => e.name));
     const present = await collection.indexes().catch(() => []);
     for (const index of present) {

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.test.ts
@@ -84,12 +84,15 @@ describe("EventOccurrenceRepository", () => {
 
   it("does not disturb another generation of the same event (non-destructive repair)", async () => {
     const eventId = objectId() as OccurrenceInput["eventId"];
+    // The SAME occurrence (same eventId + occurrenceKey) in two generations: the
+    // unique index includes generation, so a repair building generation 1 does
+    // not collide with the live generation 0.
+    const key = `${eventId}:instant`;
     await repo.replaceForEvent(eventId, 0, [
-      occurrence({ eventId, occurrenceKey: `${eventId}:gen0` }),
+      occurrence({ eventId, occurrenceKey: key, generation: 0 }),
     ]);
-    // A repair builds generation 1 alongside generation 0.
     await repo.replaceForEvent(eventId, 1, [
-      occurrence({ eventId, occurrenceKey: `${eventId}:gen1`, generation: 1 }),
+      occurrence({ eventId, occurrenceKey: key, generation: 1 }),
     ]);
     expect(
       await db.collection("event_occurrences").countDocuments({ eventId }),

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -86,6 +86,25 @@ export class EventOccurrenceRepository {
     }
   }
 
+  // Drop every occurrence of a calendar below a generation. A completed repair
+  // uses this to garbage-collect the generations it replaced once reads have
+  // moved to the new one — including the previously-active generation and any
+  // orphaned intermediate generations left by earlier interrupted repairs.
+  // Owner-scoped and idempotent.
+  async deleteByCalendarBelowGeneration(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    calendarId: SyncEventCalendarId,
+    generation: number,
+  ): Promise<void> {
+    await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      calendarId,
+      generation: { $lt: generation },
+    });
+  }
+
   async listByCalendarRange(
     query: OccurrenceRangeQuery,
   ): Promise<EventOccurrenceRecord[]> {

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -234,6 +234,26 @@ export class EventRepository {
     return records.map((r) => EventRecordSchema.parse(r));
   }
 
+  // Remove a calendar's provider-linked events left below a generation — the
+  // ones a completed repair did NOT re-import (deleted at the provider), since a
+  // re-imported event's identity upsert bumped it to the new generation.
+  // Compass-owned events (no providerEventId) are preserved: they carry local
+  // intent the provider result can't speak to. Owner-scoped and idempotent.
+  async deleteStaleProviderEventsBelowGeneration(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    calendarId: EventRecord["calendarId"],
+    generation: number,
+  ): Promise<void> {
+    await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      calendarId,
+      generation: { $lt: generation },
+      providerEventId: { $ne: null },
+    });
+  }
+
   // Bounded, keyset-paginated canonical events for one calendar/generation,
   // ordered by _id so a cursor never skips or repeats a row.
   async listByCalendar(query: EventListQuery): Promise<EventRecord[]> {

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -41,6 +41,18 @@ export class EventRepository {
     this.collection = db.collection<EventRecord>(SYNC_COLLECTIONS.events);
   }
 
+  // Generation on the events store is a "last touched by" watermark, NOT an
+  // isolation key — deliberately unlike occurrences, which ARE generation-keyed
+  // (a doc per generation) because the range read serves them by generation.
+  // Nothing reads events by generation on any user path; the only reader is a
+  // repair's own bookkeeping. So exactly one canonical doc exists per provider
+  // identity, and re-importing it bumps its generation in place rather than
+  // inserting a second doc — which is what makes stale-detection work: a repair
+  // rebuilding into generation N leaves genuinely-deleted events stranded below
+  // N (deleteStaleProviderEventsBelowGeneration), while re-seen ones ride
+  // forward. Adding generation to the filter here (or to the unique
+  // provider_event_identity index) would collide the second import and defeat
+  // that signal. The filter therefore excludes generation on purpose.
   async upsertByProviderIdentity(
     input: ProviderEventUpsert,
   ): Promise<EventRecord> {
@@ -162,6 +174,10 @@ export class EventRepository {
   // via the unique series_exception_identity index, so a scope-"this" edit or
   // delete is idempotent — a retry lands on the same exception rather than a
   // duplicate. Returns the stored exception (with its assigned _id).
+  //
+  // Generation is a watermark here too (see upsertByProviderIdentity): a repair
+  // re-seeing an exception bumps it into the new generation in place, so the
+  // filter excludes generation and the index stays generation-free by design.
   async upsertException(
     master: EventRecord,
     recurrenceId: DateTime,


### PR DESCRIPTION
## What

Adds a non-destructive **calendar repair**: when a provider calendar's stored
state is untrustworthy (invalid sync cursor, inconsistent local rows), rebuild
it from scratch into a fresh occurrence *generation* and activate that
generation atomically, so reads never see a half-built calendar.

## How it works

- **Build alongside, then flip.** The old generation stays the one reads serve
  for the entire rebuild. A full unwindowed provider pass repopulates a new
  generation via the shared `ProviderPageApplier`. Only once the pass yields a
  durable cursor do we activate the new generation, advance the cursor, and
  clean up the old rows — a single-field flip (`activeGeneration`).
- **Fail safe.** If the pass finishes without a cursor, we return `incomplete`
  and leave the old generation active and untouched. Nothing is destroyed on a
  failed repair.
- **Crash-safe / resumable.** The new generation is chosen so a retry resumes
  the same in-flight one rather than stranding a partial generation each attempt.
  Every write is an idempotent provider-identity upsert, and activation, cursor
  advance, and cleanup each run after the pass and are individually idempotent.

## Two stores, two treatments (read before flagging)

Occurrences are **generation-isolated** — the unique index includes
`generation`, because the range read serves occurrences by generation and the
old and new sets must coexist during a repair.

Events are **generation-watermarked**, not isolated: no user read path filters
events by generation, so exactly one canonical doc exists per provider identity
and a repair bumps its generation *in place*. That in-place bump is precisely
the signal stale-detection uses — genuinely-deleted events strand below the new
generation and get cleaned up, while re-seen ones ride forward. Adding
generation to the events unique index would collide the second import and defeat
that signal. This asymmetry is documented at `upsertByProviderIdentity`.

## Tests

`calendar-repair.service.test.ts` covers: rebuild + activate + clear old,
`incomplete` leaves the old generation intact, a Compass-owned (unlinked) event
survives, an in-flight generation resumes instead of bumping again, and
convergence when run twice. Occurrence-store isolation and the index
reconciliation have their own repository/manifest tests.

`bun run test:sync` — 469 pass, 0 fail.
