### PR TITLE
feat(sync): dispatch a claimed sync job to the right engine

### DIFF
--- a/packages/sync/src/domain/sync-job-dispatch.service.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.test.ts
@@ -1,0 +1,305 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import {
+  dispatchSyncJob,
+  type SyncJobDispatchDeps,
+} from "@sync/domain/sync-job-dispatch.service";
+import {
+  type ProviderEvent,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+import { type JobRecord } from "@sync/storage/contracts/job.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+const schedule = {
+  kind: "timed" as const,
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const single = (id: string): ProviderEvent => ({
+  kind: "event",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  providerUpdatedAt: null,
+  content: {
+    title: id,
+    description: "",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  },
+  schedule,
+  busy: true,
+  recurrence: { kind: "single" },
+});
+const page = (
+  events: ProviderEventRead[],
+  nextSyncToken: string | null = null,
+): ProviderEventPage => ({
+  events,
+  skipped: 0,
+  nextPageToken: null,
+  nextSyncToken,
+});
+
+// A reader that replays scripted pages, or throws a scripted error (e.g. an
+// expired cursor) on the next read.
+class FakeReader implements ProviderEventReader {
+  readonly provider = "google" as const;
+  #pages: ProviderEventPage[];
+  #error: ProviderEventReadError | null;
+
+  constructor(
+    pages: ProviderEventPage[],
+    error: ProviderEventReadError | null = null,
+  ) {
+    this.#pages = [...pages];
+    this.#error = error;
+  }
+  async listEventPage(
+    _input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    if (this.#error) throw this.#error;
+    const next = this.#pages.shift();
+    if (!next) throw new Error("FakeReader: no page scripted");
+    return next;
+  }
+}
+
+const tokenSource = { getValidAccessToken: async () => "access-token" };
+
+describe("dispatchSyncJob", () => {
+  const storage = setupSyncStorage();
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let resources: SyncResourceRepository;
+  let calendars: ProviderCalendarRepository;
+  let commands: CommandRepository;
+
+  beforeEach(() => {
+    events = new EventRepository(storage.db());
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    resources = new SyncResourceRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+    commands = new CommandRepository(storage.db());
+  });
+
+  const deps = (reader: FakeReader): SyncJobDispatchDeps => ({
+    events,
+    occurrences,
+    resources,
+    calendars,
+    commands,
+    reader,
+    custody: tokenSource,
+  });
+
+  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+    calendars.upsertByProviderCalendar({
+      tenantId: objectId() as ProviderCalendarRecord["tenantId"],
+      principalId: objectId() as ProviderCalendarRecord["principalId"],
+      connectionId: objectId() as ProviderCalendarRecord["connectionId"],
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  // Ensure the calendar's events resource, optionally already imported (holding
+  // a cursor), as a prior import/pull would have left it.
+  const seedResource = async (
+    calendar: ProviderCalendarRecord,
+    cursor: string | null,
+  ): Promise<SyncResourceRecord> => {
+    const resource = await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+    if (cursor) {
+      await resources.advanceCursor(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+        cursor,
+        now(),
+      );
+    }
+    return resource;
+  };
+
+  const jobFor = (
+    resource: SyncResourceRecord,
+    kind: JobRecord["kind"],
+  ): JobRecord =>
+    ({
+      _id: objectId(),
+      tenantId: resource.tenantId,
+      principalId: resource.principalId,
+      connectionId: resource.connectionId,
+      resourceId: resource._id,
+      commandId: null,
+      kind,
+      priority: 0,
+      state: "claimed",
+      runAfter: now(),
+      attempt: 0,
+      coalescingKey: `${kind}:${resource._id}`,
+      leaseOwner: "worker-1",
+      leaseExpiresAt: now(),
+      failureClass: null,
+      createdAt: now(),
+      updatedAt: now(),
+    }) as JobRecord;
+
+  it("settles an applied incremental pull as done with no followup", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reader = new FakeReader([page([single("new-1")], "cursor-1")]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    expect(outcome).toEqual({ result: "done" });
+  });
+
+  it("hands off an expired-cursor pull to a repair followup", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "stale-cursor");
+    const reader = new FakeReader(
+      [],
+      new ProviderEventReadError("cursorExpired", "gone"),
+    );
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    if (outcome.result !== "done" || !outcome.followup) {
+      throw new Error("expected a followup");
+    }
+    expect(outcome.followup.kind).toBe("repair");
+    expect(outcome.followup.coalescingKey).toBe(`repair:${resource._id}`);
+    expect(outcome.followup.resourceId).toBe(resource._id);
+  });
+
+  it("hands off a pull on a never-imported resource to an initial import", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null); // no cursor
+    const reader = new FakeReader([]); // pull returns notImported before reading
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    if (outcome.result !== "done" || !outcome.followup) {
+      throw new Error("expected a followup");
+    }
+    expect(outcome.followup.kind).toBe("initialImport");
+  });
+
+  it("settles a completed repair as done", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    const reader = new FakeReader([page([single("keep")], "cursor-1")]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "repair"),
+      now,
+    );
+    expect(outcome).toEqual({ result: "done" });
+  });
+
+  it("retries a repair that did not complete", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    // A page with no nextSyncToken leaves the repair unable to trust the rebuild.
+    const reader = new FakeReader([page([single("keep")], null)]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "repair"),
+      now,
+    );
+    expect(outcome).toEqual({
+      result: "retry",
+      failureClass: "retryableTransient",
+      reason: "repair did not complete",
+    });
+  });
+
+  it("runs an initial import for an already-imported resource as an idempotent no-op", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0"); // already imported
+    const reader = new FakeReader([]); // import no-ops on an existing cursor
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "initialImport"),
+      now,
+    );
+    expect(outcome).toEqual({ result: "done" });
+  });
+
+  it("drops a job whose resource no longer exists", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const ghost = { ...resource, _id: objectId() };
+    const reader = new FakeReader([]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(ghost, "incrementalPull"),
+      now,
+    );
+    expect(outcome).toEqual({
+      result: "drop",
+      reason: "resource no longer exists",
+    });
+  });
+
+  it("does not own a non-sync job kind", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reader = new FakeReader([]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "reconcile"),
+      now,
+    );
+    expect(outcome).toEqual({ result: "unsupported", kind: "reconcile" });
+  });
+});

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -1,0 +1,155 @@
+import { importCalendarEvents } from "@sync/domain/calendar-import.service";
+import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
+import { repairCalendar } from "@sync/domain/calendar-repair.service";
+import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
+import {
+  type JobEnqueue,
+  type JobFailureClass,
+  type JobRecord,
+} from "@sync/storage/contracts/job.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface SyncJobDispatchDeps {
+  events: EventRepository;
+  occurrences: EventOccurrenceRepository;
+  resources: SyncResourceRepository;
+  calendars: ProviderCalendarRepository;
+  // pullCalendarChanges consults pending commands before deleting an event.
+  commands: CommandRepository;
+  reader: ProviderEventReader;
+  custody: AccessTokenSource;
+}
+
+// The decision a dispatch makes about a claimed job. The worker loop (a later
+// slice) owns the lease and turns this into a JobRepository call; keeping the
+// decision pure keeps dispatch trivially testable without a queue.
+export type SyncJobOutcome =
+  // The work is done; settle the job complete. `followup`, when present, is a
+  // new job to enqueue (coalesced) — e.g. an expired pull hands off to a repair.
+  | { readonly result: "done"; readonly followup?: JobEnqueue }
+  // A transient, self-correcting condition; return the job to pending to retry.
+  | {
+      readonly result: "retry";
+      readonly failureClass: JobFailureClass;
+      readonly reason: string;
+    }
+  // Nothing to act on — the job's target vanished (resource/calendar deleted) or
+  // the job is malformed for its kind. Settle complete; retrying can't help.
+  | { readonly result: "drop"; readonly reason: string }
+  // This kind is not a provider-calendar sync job (commandApply, reconcile,
+  // subscriptionMaintain). Dispatch here does not own it; the loop routes it.
+  | { readonly result: "unsupported"; readonly kind: JobRecord["kind"] };
+
+// Run one claimed provider-calendar sync job (initialImport / incrementalPull /
+// repair) and report how to settle it. Resolves the job's resource and calendar
+// first; a job whose target no longer exists is dropped rather than retried
+// forever. All reads/writes inside the called services are owner-scoped.
+export async function dispatchSyncJob(
+  deps: SyncJobDispatchDeps,
+  job: JobRecord,
+  now: () => Date,
+): Promise<SyncJobOutcome> {
+  if (
+    job.kind !== "initialImport" &&
+    job.kind !== "incrementalPull" &&
+    job.kind !== "repair"
+  ) {
+    return { result: "unsupported", kind: job.kind };
+  }
+
+  if (!job.resourceId) {
+    return { result: "drop", reason: "job has no resourceId" };
+  }
+  const resource = await deps.resources.findById(
+    job.tenantId,
+    job.principalId,
+    job.resourceId,
+  );
+  if (!resource) {
+    return { result: "drop", reason: "resource no longer exists" };
+  }
+  if (!resource.calendarId) {
+    return { result: "drop", reason: "resource has no calendar" };
+  }
+  const calendar = await deps.calendars.findById(
+    job.tenantId,
+    job.principalId,
+    resource.calendarId as ProviderCalendarRecord["_id"],
+  );
+  if (!calendar) {
+    return { result: "drop", reason: "calendar no longer exists" };
+  }
+
+  switch (job.kind) {
+    case "initialImport": {
+      // Idempotent: a resource that already holds a cursor no-ops inside.
+      await importCalendarEvents(deps, calendar, now);
+      return { result: "done" };
+    }
+    case "incrementalPull": {
+      const pull = await pullCalendarChanges(deps, calendar, now);
+      if (pull.status === "applied") {
+        return { result: "done" };
+      }
+      if (pull.status === "notImported") {
+        // A pull before the initial import ever ran: hand off to an import.
+        return { result: "done", followup: importFollowup(resource, now) };
+      }
+      // cursorExpired: the provider cursor is unusable; a repair rebuilds.
+      return { result: "done", followup: repairFollowup(resource, now) };
+    }
+    case "repair": {
+      const repair = await repairCalendar(deps, calendar, now);
+      // An incomplete repair (the pass yielded no durable cursor) left the old
+      // generation intact; retry the whole rebuild later rather than settle.
+      return repair.status === "repaired"
+        ? { result: "done" }
+        : {
+            result: "retry",
+            failureClass: "retryableTransient",
+            reason: "repair did not complete",
+          };
+    }
+  }
+}
+
+function repairFollowup(
+  resource: SyncResourceRecord,
+  now: () => Date,
+): JobEnqueue {
+  return {
+    tenantId: resource.tenantId,
+    principalId: resource.principalId,
+    connectionId: resource.connectionId,
+    resourceId: resource._id,
+    commandId: null,
+    kind: "repair",
+    priority: 0,
+    runAfter: now(),
+    coalescingKey: `repair:${resource._id}`,
+  };
+}
+
+function importFollowup(
+  resource: SyncResourceRecord,
+  now: () => Date,
+): JobEnqueue {
+  return {
+    tenantId: resource.tenantId,
+    principalId: resource.principalId,
+    connectionId: resource.connectionId,
+    resourceId: resource._id,
+    commandId: null,
+    kind: "initialImport",
+    priority: 0,
+    runAfter: now(),
+    coalescingKey: `initialImport:${resource._id}`,
+  };
+}


### PR DESCRIPTION
## What

Adds `dispatchSyncJob` — the decision layer that turns a claimed sync job into
the right engine call. The webhook fast path (#2245) already enqueues
`incrementalPull` jobs and `JobRepository` already has claim/lease/complete/fail,
but nothing yet decides what a claimed job should *do*. This is that piece.

## Design

`dispatchSyncJob(deps, job, now)` resolves the job's resource and calendar, runs
the matching engine, and returns a **pure settlement outcome** — it does not
touch the lease or the queue. The worker loop (next slice) owns claim →
heartbeat → settle and turns the outcome into a `JobRepository` call. Keeping the
decision pure makes it exhaustively testable without a running worker.

Outcomes capture the real control flow:

| Job / result | Outcome |
| --- | --- |
| `incrementalPull` applied | `done` |
| `incrementalPull` on a never-imported resource | `done` + followup `initialImport` |
| `incrementalPull` with expired cursor | `done` + followup `repair` |
| `repair` completed | `done` |
| `repair` incomplete | `retry` (retryableTransient) |
| `initialImport` | `done` (idempotent; no-ops if already imported) |
| resource / calendar vanished, or no `resourceId` | `drop` (settle, don't retry) |
| `commandApply` / `reconcile` / `subscriptionMaintain` | `unsupported` (loop routes it) |

Followups are coalesced (`repair:<resourceId>`, `initialImport:<resourceId>`), so
a storm of expiries collapses to one repair.

## Not in this slice

The poll loop (claim due jobs, heartbeat, settle, lease recovery, process-start
scheduling) and periodic reconciliation / subscription renewal are the following
slices. Dispatch of `commandApply` (applying a pending command) is also deferred.

## Tests

`sync-job-dispatch.service.test.ts` covers every outcome above against real
repositories with a scripted provider reader. `bun run test:sync` — 478 pass.
