### PR TITLE
feat(sync): drain the job queue through a claim-dispatch-settle worker

### DIFF
--- a/packages/sync/src/domain/sync-job-worker.service.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.test.ts
@@ -1,0 +1,300 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import {
+  SyncJobWorker,
+  type SyncJobWorkerDeps,
+} from "@sync/domain/sync-job-worker.service";
+import {
+  type ProviderEvent,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type JobRecord } from "@sync/storage/contracts/job.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+const OWNER = "worker-under-test";
+
+const schedule = {
+  kind: "timed" as const,
+  start: "2026-07-14T09:00:00-06:00",
+  end: "2026-07-14T10:00:00-06:00",
+  timeZone: "America/Denver",
+};
+const single = (id: string): ProviderEvent => ({
+  kind: "event",
+  providerEventId: id,
+  providerVersion: `etag-${id}`,
+  providerUpdatedAt: null,
+  content: {
+    title: id,
+    description: "",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  },
+  schedule,
+  busy: true,
+  recurrence: { kind: "single" },
+});
+const pageOf = (
+  events: ProviderEventRead[],
+  nextSyncToken: string | null = null,
+): ProviderEventPage => ({
+  events,
+  skipped: 0,
+  nextPageToken: null,
+  nextSyncToken,
+});
+
+// Replays scripted pages, or throws a scripted error on the next read.
+class FakeReader implements ProviderEventReader {
+  readonly provider = "google" as const;
+  #pages: ProviderEventPage[];
+  #error: Error | null;
+
+  constructor(pages: ProviderEventPage[], error: Error | null = null) {
+    this.#pages = [...pages];
+    this.#error = error;
+  }
+  async listEventPage(
+    _input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    if (this.#error) throw this.#error;
+    const next = this.#pages.shift();
+    if (!next) throw new Error("FakeReader: no page scripted");
+    return next;
+  }
+}
+
+const tokenSource = { getValidAccessToken: async () => "access-token" };
+
+describe("SyncJobWorker", () => {
+  const storage = setupSyncStorage();
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let resources: SyncResourceRepository;
+  let calendars: ProviderCalendarRepository;
+  let commands: CommandRepository;
+  let jobs: JobRepository;
+
+  beforeEach(() => {
+    events = new EventRepository(storage.db());
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    resources = new SyncResourceRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+    commands = new CommandRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+  });
+
+  const deps = (reader: FakeReader): SyncJobWorkerDeps => ({
+    events,
+    occurrences,
+    resources,
+    calendars,
+    commands,
+    jobs,
+    reader,
+    custody: tokenSource,
+  });
+
+  const worker = (reader: FakeReader) =>
+    new SyncJobWorker(deps(reader), OWNER, { now });
+
+  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+    calendars.upsertByProviderCalendar({
+      tenantId: objectId() as ProviderCalendarRecord["tenantId"],
+      principalId: objectId() as ProviderCalendarRecord["principalId"],
+      connectionId: objectId() as ProviderCalendarRecord["connectionId"],
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+  const seedResource = async (
+    calendar: ProviderCalendarRecord,
+    cursor: string | null,
+  ): Promise<SyncResourceRecord> => {
+    const resource = await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+    if (cursor) {
+      await resources.advanceCursor(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+        cursor,
+        now(),
+      );
+    }
+    return resource;
+  };
+
+  const enqueue = (
+    resource: Pick<
+      SyncResourceRecord,
+      "tenantId" | "principalId" | "connectionId" | "_id"
+    >,
+    kind: JobRecord["kind"],
+  ) =>
+    jobs.enqueue({
+      tenantId: resource.tenantId,
+      principalId: resource.principalId,
+      connectionId: resource.connectionId,
+      resourceId: resource._id,
+      commandId: null,
+      kind,
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `${kind}:${resource._id}`,
+    });
+
+  const jobByKey = (coalescingKey: string) =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).findOne({ coalescingKey });
+
+  it("is idle when no job is due", async () => {
+    const outcome = await worker(new FakeReader([])).runOnce();
+    expect(outcome).toBe("idle");
+  });
+
+  it("completes an applied incremental pull, removing the job", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const job = await enqueue(resource, "incrementalPull");
+
+    const result = await worker(
+      new FakeReader([pageOf([single("new-1")], "cursor-1")]),
+    ).runOnce();
+
+    expect(result).toBe("processed");
+    expect(
+      await jobs.findById(resource.tenantId, resource.principalId, job._id),
+    ).toBeNull();
+  });
+
+  it("hands an expired-cursor pull off by enqueuing a repair and completing the pull", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "stale");
+    const pull = await enqueue(resource, "incrementalPull");
+
+    await worker(
+      new FakeReader([], new ProviderEventReadError("cursorExpired", "gone")),
+    ).runOnce();
+
+    // The pull job is gone; a coalesced repair job now waits.
+    expect(
+      await jobs.findById(resource.tenantId, resource.principalId, pull._id),
+    ).toBeNull();
+    const repair = await jobByKey(`repair:${resource._id}`);
+    expect(repair?.kind).toBe("repair");
+    expect(repair?.state).toBe("pending");
+  });
+
+  it("reschedules a repair that did not complete instead of deleting it", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    const job = await enqueue(resource, "repair");
+
+    // A page with no nextSyncToken makes the repair report incomplete.
+    await worker(new FakeReader([pageOf([single("keep")], null)])).runOnce();
+
+    const after = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      job._id,
+    );
+    expect(after?.state).toBe("pending");
+    expect(after?.leaseOwner).toBeNull();
+    // Backed off to a future runAfter, and its failure class recorded.
+    expect(after!.runAfter.getTime()).toBeGreaterThan(now().getTime());
+    expect(after?.failureClass).toBe("retryableTransient");
+  });
+
+  it("reschedules a job whose engine throws a transient error", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const job = await enqueue(resource, "incrementalPull");
+
+    // A non-cursorExpired read error propagates out of dispatch.
+    await worker(
+      new FakeReader([], new ProviderEventReadError("transient", "flaky")),
+    ).runOnce();
+
+    const after = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      job._id,
+    );
+    expect(after?.state).toBe("pending");
+    expect(after!.runAfter.getTime()).toBeGreaterThan(now().getTime());
+  });
+
+  it("drops a job whose resource no longer exists", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    // Enqueue against the resource, then remove the resource so dispatch drops.
+    const job = await enqueue(resource, "incrementalPull");
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .deleteOne({ _id: resource._id });
+
+    await worker(new FakeReader([])).runOnce();
+
+    expect(
+      await jobs.findById(resource.tenantId, resource.principalId, job._id),
+    ).toBeNull();
+  });
+
+  it("drains every due job and then reports how many it processed", async () => {
+    const calendarA = await seedCalendar();
+    const calendarB = await seedCalendar();
+    const resourceA = await seedResource(calendarA, "cursor-a");
+    const resourceB = await seedResource(calendarB, "cursor-b");
+    await enqueue(resourceA, "incrementalPull");
+    await enqueue(resourceB, "incrementalPull");
+
+    const processed = await worker(
+      new FakeReader([
+        pageOf([single("a")], "cursor-a1"),
+        pageOf([single("b")], "cursor-b1"),
+      ]),
+    ).drain();
+
+    expect(processed).toBe(2);
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({ state: "pending", runAfter: { $lte: now() } }),
+    ).toBe(0);
+  });
+});

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -1,0 +1,138 @@
+import {
+  dispatchSyncJob,
+  type SyncJobDispatchDeps,
+} from "@sync/domain/sync-job-dispatch.service";
+import { type JobRecord } from "@sync/storage/contracts/job.contracts";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+
+export interface SyncJobWorkerDeps extends SyncJobDispatchDeps {
+  jobs: JobRepository;
+}
+
+export interface SyncJobWorkerOptions {
+  // How long a claimed job's lease lasts. Generous by default: a heartbeat that
+  // extends the lease of a long-running job is a later slice, so the lease alone
+  // must outlast a normal import/pull/repair. A job that outlives its lease is
+  // reclaimed and re-run — safe, because every engine is idempotent, just
+  // wasteful.
+  leaseMs?: number;
+  // When to retry a job that failed or asked to be retried, from its attempt
+  // count. The default is a capped exponential with no jitter; fair scheduling
+  // and jitter are S34's concern.
+  backoff?: (attempt: number, now: Date) => Date;
+  now?: () => Date;
+}
+
+const DEFAULT_LEASE_MS = 5 * 60_000;
+const BACKOFF_BASE_MS = 10_000;
+const BACKOFF_CAP_MS = 10 * 60_000;
+
+// Capped exponential backoff. attempt is >= 1 (claimDueJob increments it on
+// every claim), so the first retry waits BACKOFF_BASE_MS.
+function defaultBackoff(attempt: number, now: Date): Date {
+  const exp = Math.min(attempt - 1, 6);
+  const delay = Math.min(BACKOFF_CAP_MS, BACKOFF_BASE_MS * 2 ** exp);
+  return new Date(now.getTime() + delay);
+}
+
+// Drains the job queue: claim a due job, run it through dispatch, and settle it
+// (delete on success, reschedule on retry). One worker owns a lease; several can
+// run concurrently and never both win the same job (claimDueJob is atomic). The
+// continuous poll timer, heartbeat, and lifecycle wiring are a later slice; this
+// is the claim -> dispatch -> settle core they drive.
+export class SyncJobWorker {
+  readonly #deps: SyncJobWorkerDeps;
+  readonly #owner: string;
+  readonly #leaseMs: number;
+  readonly #backoff: (attempt: number, now: Date) => Date;
+  readonly #now: () => Date;
+
+  constructor(
+    deps: SyncJobWorkerDeps,
+    owner: string,
+    options: SyncJobWorkerOptions = {},
+  ) {
+    this.#deps = deps;
+    this.#owner = owner;
+    this.#leaseMs = options.leaseMs ?? DEFAULT_LEASE_MS;
+    this.#backoff = options.backoff ?? defaultBackoff;
+    this.#now = options.now ?? (() => new Date());
+  }
+
+  // Claim and process at most one due job. Returns "idle" when nothing is due.
+  async runOnce(): Promise<"idle" | "processed"> {
+    const job = await this.#deps.jobs.claimDueJob(
+      this.#owner,
+      this.#now(),
+      this.#leaseMs,
+    );
+    if (!job) return "idle";
+    await this.#process(job);
+    return "processed";
+  }
+
+  // Drain due jobs up to a bound (a safety valve against a self-refilling queue
+  // starving the caller). Returns how many were processed.
+  async drain(max = 100): Promise<number> {
+    let processed = 0;
+    while (processed < max) {
+      const outcome = await this.runOnce();
+      if (outcome === "idle") break;
+      processed += 1;
+    }
+    return processed;
+  }
+
+  async #process(job: JobRecord): Promise<void> {
+    let outcome: Awaited<ReturnType<typeof dispatchSyncJob>>;
+    try {
+      outcome = await dispatchSyncJob(this.#deps, job, this.#now);
+    } catch {
+      // An engine threw (a transient provider/storage error dispatch does not
+      // model as a status). Reschedule for a backed-off retry rather than lose
+      // the job; S34 refines the retryable/permanent classification.
+      await this.#deps.jobs.scheduleRetry(
+        job._id,
+        this.#owner,
+        this.#backoff(job.attempt, this.#now()),
+        "retryableTransient",
+      );
+      return;
+    }
+
+    switch (outcome.result) {
+      case "done":
+        // Enqueue the followup (if any) BEFORE completing this job: the enqueue
+        // is idempotent (coalesced), so a crash between the two re-runs this
+        // idempotent job and re-enqueues the same followup, whereas completing
+        // first then crashing would drop the followup.
+        if (outcome.followup) await this.#deps.jobs.enqueue(outcome.followup);
+        await this.#deps.jobs.complete(job._id, this.#owner);
+        return;
+      case "drop":
+        // Nothing to do (target vanished); settle so it never retries.
+        await this.#deps.jobs.complete(job._id, this.#owner);
+        return;
+      case "retry":
+        await this.#deps.jobs.scheduleRetry(
+          job._id,
+          this.#owner,
+          this.#backoff(job.attempt, this.#now()),
+          outcome.failureClass,
+        );
+        return;
+      case "unsupported":
+        // No handler for this kind in this build (commandApply/reconcile/
+        // subscriptionMaintain arrive later). Hold it for a future build via a
+        // backed-off retry rather than hot-loop or drop unfinished work. No
+        // producer enqueues these kinds yet, so this is defensive.
+        await this.#deps.jobs.scheduleRetry(
+          job._id,
+          this.#owner,
+          this.#backoff(job.attempt, this.#now()),
+          "retryableTransient",
+        );
+        return;
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `SyncJobWorker` — the piece that actually **drains** the job queue. The
webhook fast path (#2245) enqueues jobs and dispatch (#2284) decides what a
claimed job should do, but nothing yet claims one. This closes the loop.

## How it works

`runOnce()` claims the highest-priority due job (`claimDueJob` is atomic, so
concurrent workers never both win), runs it through `dispatchSyncJob`, and
settles the outcome:

| Outcome | Settle |
| --- | --- |
| `done` | enqueue followup (if any) **then** delete the job |
| `drop` | delete the job (target vanished; never retry) |
| `retry` | reschedule with capped exponential backoff |
| engine throws | reschedule (retryableTransient) |
| `unsupported` | reschedule (defensive; no producer emits these kinds yet) |

`drain(max)` empties the due queue up to a bound (a safety valve against a
self-refilling queue).

**Crash-safety ordering:** on `done` with a followup, the followup is enqueued
*before* the job is completed. The enqueue is idempotent (coalesced), so a crash
between the two re-runs this idempotent job and re-enqueues the same followup —
whereas completing first then crashing would drop the followup.

## Not in this slice

The continuous poll timer, a lease **heartbeat** for long-running jobs, and
app-lifecycle wiring (`releaseOwned` on shutdown, process-start scheduling) are
the next slice. A generous lease covers a normal import/pull/repair without a
heartbeat; a job that outlives its lease is reclaimed and re-run, which is safe
because every engine is idempotent (wasteful, not corrupting). Backoff here is a
capped exponential with no jitter — fair scheduling and jitter are S34.

There is also **no production producer of jobs yet** (subscriptions and periodic
reconciliation come later), so this worker runs against test-enqueued jobs today.

## Tests

`sync-job-worker.service.test.ts`: idle when nothing due, completes an applied
pull, hands an expired-cursor pull to a repair followup, reschedules an
incomplete repair / a thrown transient error, drops a vanished-resource job, and
drains multiple due jobs. `bun run test:sync` — 485 pass.
