### PR TITLE
fix(web): isolate test files by process

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Run web tests
         if: matrix.project == 'web'
-        timeout-minutes: 2
+        timeout-minutes: 5
         env:
           TZ: Etc/UTC
         run: |

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Run web tests
         if: matrix.project == 'web'
-        timeout-minutes: 1
+        timeout-minutes: 2
         env:
           TZ: Etc/UTC
         run: |

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -104,7 +104,7 @@ Use this document to find the first files to inspect for common Compass changes.
 
 ## Test Anchors
 
-- Mongo-backed test launcher (per-file isolation over one in-memory replica set): `packages/scripts/src/testing/run-tests.ts`
+- Per-file test launcher (optional shared in-memory Mongo replica set): `packages/scripts/src/testing/run-tests.ts`
 - Bun/Jest compatibility shim used by every package's tests: `packages/scripts/src/testing/apply-bun-jest-compat.cjs`
 - Core test setup: `packages/core/src/__tests__`
 - Web test setup: `packages/web/src/__tests__`

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -47,8 +47,8 @@ E2E workflow (`test-e2e.yml`) is separate and runs on pull requests to `main` vi
 Every package now runs on Bun's test runner; Jest has been removed.
 
 - `bun run test:core` uses `bun test` with a small compatibility preload for the core BSON mock setup.
-- `bun run test:web` runs `bun test --cwd packages/web` directly. Web tests should be isolated enough to run in one Bun process without batching.
-- `bun run test:backend` and `bun run test:scripts` use `packages/scripts/src/testing/run-tests.ts`, a launcher that boots one in-memory MongoDB replica set and runs each test file in its own `bun test` process (Jest-like per-file isolation) against the shared server, in parallel. This keeps the isolation Jest gave us without its per-file startup cost.
+- `bun run test:web` uses `packages/scripts/src/testing/run-tests.ts` to run each file in its own `bun test` process. This prevents Bun's process-wide module mocks from leaking between files while keeping the files parallel.
+- `bun run test:backend`, `bun run test:scripts`, and `bun run test:sync` use the same launcher with one shared in-memory MongoDB replica set and distinct per-file databases.
 - Test files import lifecycle/assertion APIs from `bun:test` (never `jest` -- the ambient `jest` global is a compatibility shim from `packages/scripts/src/testing/apply-bun-jest-compat.cjs` that maps `jest.mock`/`jest.requireActual`/etc. onto `bun:test`).
 
 ### Test tiers
@@ -114,12 +114,12 @@ Avoid:
 
 Isolation rules:
 
-- Do not use top-level `mock.module` for shared production modules unless the test imports the subject through a local factory and the mock cannot affect later files. Prefer provider wrappers, real stores, explicit dependency factories, or `spyOn` with teardown.
-- Avoid mocking shared UI primitives such as `TooltipWrapper`, `@floating-ui/react`, or session hooks in broad component tests. A mock that only helps one file can change unrelated tests later in the same Bun process.
+- Prefer provider wrappers, real stores, explicit dependency factories, or `spyOn` with teardown over top-level `mock.module`. Module mocks remain process-wide within their test file and can affect every later import in that file.
+- Avoid mocking shared UI primitives such as `TooltipWrapper`, `@floating-ui/react`, or session hooks in broad component tests. Even with per-file isolation, broad mocks can hide integration behavior inside that file.
 - If a test replaces globals (`fetch`, `document.getElementById`, storage, timers, console methods), restore the original value in teardown.
 - Prefer `renderWithStore`, `createStoreWrapper`, or a focused provider harness over mocking `@web/store` or `store.hooks`.
-- `bun test --cwd packages/web` is the acceptance check for web test isolation. A focused test can pass while still leaking into the direct suite.
-- `mock.module` is process-global, not per-file: the preload's `afterAll(() => mock.restore())` (`packages/web/src/__tests__/web.preload.ts`) runs once at the very end of the whole run, so a `mock.module(...)` in one test file replaces that module for every file that imports it afterward — an order-dependent failure. Only mock a module if it has a single importer with no dedicated test of its own; if it has a dedicated test elsewhere, mocking it here will break that test instead.
+- `bun run test:web` is the acceptance check for web test isolation. It runs every file in a fresh process through the same path CI uses; a focused test can still miss interactions within its own file.
+- `mock.module` is process-global, not test-scoped. The per-file runner prevents cross-file leaks, and the web preload restores mocks when each file finishes, but tests within one file still share that file's module registry.
 - To focus an element on mount in this jsdom setup, use React's `autoFocus` prop or a stable callback ref (`ref={useCallback(n => n?.focus(), [])}`) — both fire in the commit phase. A `useEffect(() => ref.current?.focus())` does **not** make the element `document.activeElement` in tests. `autoFocus` trips biome's `lint/a11y/noAutofocus` (error) and a JSX-attribute `biome-ignore` comment breaks the formatter, so prefer the callback ref.
 - `FloatingFocusManager` fights virtual-focus combobox palettes: for a component that keeps real focus in one input while using `useListNavigation({ virtual: true })` + `aria-activedescendant` (a command-palette style pattern), `FloatingFocusManager` asynchronously grabs focus to the panel container and steals it back from the input. Drop it — `useDismiss` still handles Escape/outside-press without it. It belongs on anchored forms with a real reference element instead (e.g. `FloatingEventForm`).
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:backend:db": "bun packages/scripts/src/testing/run-tests.ts backend --tier db",
     "test:core": "bun test packages/core/src --preload ./packages/scripts/src/testing/core.preload.ts",
     "test:sync": "bun packages/scripts/src/testing/run-tests.ts sync",
-    "test:web": "bun test --cwd packages/web",
+    "test:web": "bun packages/scripts/src/testing/run-tests.ts web",
     "test:scripts": "bun packages/scripts/src/testing/run-tests.ts scripts",
     "test:scripts:fast": "bun packages/scripts/src/testing/run-tests.ts scripts --tier fast",
     "test:scripts:db": "bun packages/scripts/src/testing/run-tests.ts scripts --tier db",

--- a/packages/scripts/src/testing/run-tests.ts
+++ b/packages/scripts/src/testing/run-tests.ts
@@ -108,7 +108,7 @@ const server = usesMongo
   : undefined;
 
 // Mongo needs CPU headroom to stay responsive while its test files run. Web
-// has no shared service, so use every available core for its larger suite.
+// has no shared service, so it can use every CI core up to the safety cap.
 const reservedCpus = usesMongo ? 1 : 0;
 const concurrency = Math.max(1, Math.min(cpus().length - reservedCpus, 8));
 

--- a/packages/scripts/src/testing/run-tests.ts
+++ b/packages/scripts/src/testing/run-tests.ts
@@ -1,19 +1,19 @@
 /**
- * Test runner for the Mongo-backed packages (backend, scripts, sync).
+ * Isolated test runner for packages whose tests need a fresh module registry.
  *
  * Bun runs every file in a package inside ONE process, sharing the module
  * registry -- singletons, open handles and mock state leak between files, which
  * Jest avoided by giving each file its own registry. To get that isolation back
  * without paying Jest's per-file overhead, this launcher:
  *
- *   1. Boots one in-memory Mongo replica set for the whole run.
+ *   1. Boots one in-memory Mongo replica set when the package needs it.
  *   2. Runs each test file in its own `bun test` process (fresh modules =
- *      isolation), pointed at the shared server with a per-file database name so
- *      files can run in parallel without colliding.
+ *      isolation). Mongo-backed packages share the server through distinct
+ *      per-file databases so their files can run in parallel without colliding.
  *   3. Bounds parallelism to the core count and streams a compact summary.
  *
  * Usage:
- *   bun run-tests.ts <backend|scripts|sync> [--filter substring] [--tier fast|db]
+ *   bun run-tests.ts <backend|scripts|sync|web> [--filter substring] [--tier fast|db]
  *
  * Tiers are classified automatically (no hand-maintained allowlist): a file is
  * "db" if it touches the Mongo test harness (setupTestDb), otherwise "fast".
@@ -24,27 +24,38 @@ import { readFileSync } from "node:fs";
 import { cpus } from "node:os";
 import { resolve } from "node:path";
 
-type PackageName = "backend" | "scripts" | "sync";
+type PackageName = "backend" | "scripts" | "sync" | "web";
 
-const PACKAGES: Record<PackageName, { root: string; preload: string }> = {
+const PACKAGES: Record<
+  PackageName,
+  { root: string; preload: string; usesMongo: boolean }
+> = {
   backend: {
     root: "packages/backend/src",
     preload: "packages/backend/src/__tests__/backend.preload.ts",
+    usesMongo: true,
   },
   scripts: {
     root: "packages/scripts/src",
     preload: "packages/scripts/src/testing/scripts.preload.ts",
+    usesMongo: true,
   },
   sync: {
     root: "packages/sync/src",
     preload: "packages/sync/src/__tests__/sync.preload.ts",
+    usesMongo: true,
+  },
+  web: {
+    root: "packages/web/src",
+    preload: "packages/web/src/__tests__/web.preload.ts",
+    usesMongo: false,
   },
 };
 
 const pkg = process.argv[2] as PackageName;
 if (!pkg || !PACKAGES[pkg]) {
   console.error(
-    "Usage: run-tests.ts <backend|scripts|sync> [--filter substring]",
+    "Usage: run-tests.ts <backend|scripts|sync|web> [--filter substring]",
   );
   process.exit(2);
 }
@@ -59,7 +70,7 @@ if (tier && tier !== "fast" && tier !== "db") {
   process.exit(2);
 }
 
-const { root, preload: preloadRel } = PACKAGES[pkg];
+const { root, preload: preloadRel, usesMongo } = PACKAGES[pkg];
 const preload = resolve(preloadRel);
 
 // A file is "db" if it touches a Mongo test harness; otherwise "fast".
@@ -88,13 +99,13 @@ if (files.length === 0) {
 }
 
 const started = Date.now();
-console.log(
-  `Booting in-memory Mongo replica set for ${files.length} ${pkg} test files...`,
-);
+console.log(`Running ${files.length} isolated ${pkg} test files...`);
 
-const server = await MongoMemoryReplSet.create({
-  replSet: { count: 1, name: "compass-test", storageEngine: "wiredTiger" },
-});
+const server = usesMongo
+  ? await MongoMemoryReplSet.create({
+      replSet: { count: 1, name: "compass-test", storageEngine: "wiredTiger" },
+    })
+  : undefined;
 
 const concurrency = Math.max(1, Math.min(cpus().length - 1, 8));
 
@@ -109,11 +120,17 @@ const countRe = /^\s*(\d+)\s+(pass|fail|skip)\b/gm;
 
 async function runOne(index: number): Promise<void> {
   const file = files[index]!;
-  const uri = server.getUri(`testdb_${index}`);
   const label = file.replace(`${root}/`, "");
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    TZ: "Etc/UTC",
+  };
+  if (server) {
+    env["COMPASS_TEST_MONGO_URI"] = server.getUri(`testdb_${index}`);
+  }
 
   const proc = Bun.spawn(["bun", "test", file, "--preload", preload], {
-    env: { ...process.env, TZ: "Etc/UTC", COMPASS_TEST_MONGO_URI: uri },
+    env,
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -162,7 +179,7 @@ try {
 } finally {
   // Always tear the server down, even if a worker threw (e.g. a failed
   // spawn) -- otherwise the mongod process would be orphaned.
-  await server.stop();
+  await server?.stop();
 }
 
 const seconds = ((Date.now() - started) / 1000).toFixed(1);

--- a/packages/scripts/src/testing/run-tests.ts
+++ b/packages/scripts/src/testing/run-tests.ts
@@ -107,7 +107,10 @@ const server = usesMongo
     })
   : undefined;
 
-const concurrency = Math.max(1, Math.min(cpus().length - 1, 8));
+// Mongo needs CPU headroom to stay responsive while its test files run. Web
+// has no shared service, so use every available core for its larger suite.
+const reservedCpus = usesMongo ? 1 : 0;
+const concurrency = Math.max(1, Math.min(cpus().length - reservedCpus, 8));
 
 let nextIndex = 0;
 let passedFiles = 0;


### PR DESCRIPTION
## Summary

- run every web test file in its own Bun process so process-wide `mock.module` state cannot leak between files
- reuse the bounded per-file runner already used by backend, sync, and scripts
- skip Mongo startup for web, use all CI CPUs up to the safety cap, and retain Mongo CPU headroom for existing packages

## Simplicity

- extends the existing runner with one package entry and one explicit `usesMongo` flag
- avoids a second web-only process orchestrator; no separate simplification commit was needed

## Automated validation

- AuthModal-focused isolated run: 2 files, 41 tests passed in 2.7s
- six complete isolated web runs: 203/203 files and 1,307/1,307 tests each, 17.4–18.5s locally
- existing runner paths passed: backend 682 tests, sync 478 tests, scripts 40 tests
- core passed 496 tests; type-check and lint passed
- first CI run confirmed the two-core runner was serial; follow-up uses both web CPUs and keeps the five-minute suite ceiling above the runner's 90-second per-file diagnostic timeout

## Independent review

- final clean review found no confirmed defects
- earlier review findings fixed: stale shared-process documentation, insufficient CI CPU use, nested timeout headroom, and a stale Mongo-only runner description

## Test plan

- `bun packages/scripts/src/testing/run-tests.ts web --filter AuthModal`
- `bun test:web` (six complete runs)
- `bun test:backend`
- `bun test:sync`
- `bun test:scripts`
- `bun test:core`
- `bun type-check`
- `bun lint`
- `git diff --check`