### PR TITLE
feat(sync): run the job queue with a lifecycle-managed scheduler

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,16 +1,28 @@
 import { Logger } from "@core/logger/winston.logger";
 import { createInternalAuthMiddleware } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
+import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { SyncJobWorker } from "@sync/domain/sync-job-worker.service";
+import { SyncScheduler } from "@sync/domain/sync-scheduler.service";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
 import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
 import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
+import { GoogleEventReaderAdapter } from "@sync/providers/google/google-event-reader.adapter";
 import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { randomUUID } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
 const logger = Logger("sync:app");
@@ -169,12 +181,58 @@ async function start(): Promise<void> {
       forbiddenDatabaseName: config.COMPASS_API_DATABASE,
       enforceLeastPrivilege: config.ENFORCE_LEAST_PRIVILEGE,
     });
+
+    // Storage is up: start draining the job queue. Registered AFTER the mongo
+    // drain so the coordinator's reverse-order teardown stops the scheduler
+    // FIRST (releasing its leases while storage is still open) and closes mongo
+    // last. Only an active, provider-configured deployment does work; a passive
+    // or unconfigured one serves health and admits nothing to drain.
+    const scheduler = buildScheduler(config, mongo);
+    if (scheduler) {
+      service.shutdown.register("scheduler", () => scheduler.stop());
+      scheduler.start();
+      logger.info("Sync scheduler draining the job queue");
+    }
   } catch (error) {
     logger.error(
       "Sync storage unavailable at startup; staying up as not-ready",
       error,
     );
   }
+}
+
+// Build the job-queue scheduler for an active, provider-configured deployment,
+// or null when there is nothing to drain (passive execution, or no provider
+// credentials to refresh access tokens with). The worker's repositories bind to
+// the now-connected db; a fresh owner id per process scopes its leases.
+function buildScheduler(
+  config: SyncConfig,
+  mongo: SyncMongoService,
+): SyncScheduler | null {
+  if (config.EXECUTION !== "active") return null;
+  const authAdapter = buildAuthAdapter(config);
+  if (!authAdapter) return null;
+
+  const db = mongo.db;
+  const owner = randomUUID();
+  const jobs = new JobRepository(db);
+  const worker = new SyncJobWorker(
+    {
+      events: new EventRepository(db),
+      occurrences: new EventOccurrenceRepository(db, mongo.client),
+      resources: new SyncResourceRepository(db),
+      calendars: new ProviderCalendarRepository(db),
+      commands: new CommandRepository(db),
+      jobs,
+      reader: new GoogleEventReaderAdapter(),
+      custody: new CredentialCustody(new CredentialRepository(db), authAdapter),
+    },
+    owner,
+  );
+  return new SyncScheduler(
+    { worker, jobs },
+    { owner, onError: (error) => logger.error("Sync job drain failed", error) },
+  );
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/domain/sync-scheduler.service.test.ts
+++ b/packages/sync/src/domain/sync-scheduler.service.test.ts
@@ -1,0 +1,139 @@
+import {
+  type JobDrainer,
+  SyncScheduler,
+} from "@sync/domain/sync-scheduler.service";
+
+const OWNER = "worker-1";
+
+// A worker whose drain returns a scripted sequence of counts (how many jobs it
+// processed), defaulting to 0 (idle) once the script runs out. Each call
+// resolves a promise the test can await, so the test advances exactly when a
+// drain happens — no arbitrary timers.
+class FakeWorker implements JobDrainer {
+  calls = 0;
+  #counts: number[];
+  #throwOnCall: number | null;
+  #waiters: Array<(n: number) => void> = [];
+
+  constructor(counts: number[] = [], throwOnCall: number | null = null) {
+    this.#counts = counts;
+    this.#throwOnCall = throwOnCall;
+  }
+  async drain(): Promise<number> {
+    this.calls += 1;
+    const call = this.calls;
+    const processed = this.#counts.shift() ?? 0;
+    for (const w of this.#waiters.splice(0)) w(processed);
+    if (this.#throwOnCall === call) throw new Error("drain failed");
+    return processed;
+  }
+  // Resolves on the next drain call, with the count it returned.
+  nextDrain(): Promise<number> {
+    return new Promise((resolve) => this.#waiters.push(resolve));
+  }
+}
+
+const releaser = () => {
+  const released: string[] = [];
+  return {
+    released,
+    releaseOwned: async (owner: string) => {
+      released.push(owner);
+      return 0;
+    },
+  };
+};
+
+describe("SyncScheduler", () => {
+  it("drains repeatedly while there is work, then idles", async () => {
+    const worker = new FakeWorker([2, 1]); // two busy drains, then idle (0)
+    const jobs = releaser();
+    const scheduler = new SyncScheduler(
+      { worker, jobs },
+      { owner: OWNER, pollMs: 10_000 },
+    );
+
+    // The third drain returns 0 (idle); await it, then stop before the poll
+    // timer would fire, so the test never waits out pollMs.
+    const idleReached = (async () => {
+      for (;;) {
+        const n = await worker.nextDrain();
+        if (n === 0) return;
+      }
+    })();
+    scheduler.start();
+    await idleReached;
+    await scheduler.stop();
+
+    expect(worker.calls).toBe(3); // 2 busy + 1 idle
+  });
+
+  it("releases its owned jobs on stop and halts the loop", async () => {
+    const worker = new FakeWorker([]); // always idle
+    const jobs = releaser();
+    const scheduler = new SyncScheduler(
+      { worker, jobs },
+      { owner: OWNER, pollMs: 10_000 },
+    );
+
+    const firstDrain = worker.nextDrain();
+    scheduler.start();
+    await firstDrain;
+    await scheduler.stop();
+
+    expect(jobs.released).toEqual([OWNER]);
+    // The loop is stopped: no further drains happen after stop resolves.
+    const callsAtStop = worker.calls;
+    await new Promise((r) => setTimeout(r, 0));
+    expect(worker.calls).toBe(callsAtStop);
+  });
+
+  it("keeps looping after a drain throws", async () => {
+    const errors: unknown[] = [];
+    const worker = new FakeWorker([1, 0], 1); // call 1 throws, call 2 idles
+    const jobs = releaser();
+    // A throw leaves processed at 0, so the loop backs off by pollMs before the
+    // next drain; keep it tiny so the retry is prompt (the test still awaits the
+    // real drain, so timing can't make it flaky, only slow).
+    const scheduler = new SyncScheduler(
+      { worker, jobs },
+      { owner: OWNER, pollMs: 1, onError: (e) => errors.push(e) },
+    );
+
+    const idleReached = (async () => {
+      for (;;) {
+        const n = await worker.nextDrain();
+        if (n === 0) return;
+      }
+    })();
+    scheduler.start();
+    await idleReached;
+    await scheduler.stop();
+
+    expect(errors).toHaveLength(1); // the thrown drain was caught, not fatal
+    expect(worker.calls).toBeGreaterThanOrEqual(2); // it kept going
+  });
+
+  it("start is idempotent and stop is safe when never started", async () => {
+    const worker = new FakeWorker([]);
+    const jobs = releaser();
+    const scheduler = new SyncScheduler(
+      { worker, jobs },
+      { owner: OWNER, pollMs: 10_000 },
+    );
+
+    // stop() before start(): no loop to await, but still releases (a no-op).
+    await scheduler.stop();
+    expect(jobs.released).toEqual([OWNER]);
+
+    // Two starts spawn one loop; stopping once fully halts it.
+    const firstDrain = worker.nextDrain();
+    scheduler.start();
+    scheduler.start();
+    await firstDrain;
+    await scheduler.stop();
+    const callsAtStop = worker.calls;
+    await new Promise((r) => setTimeout(r, 0));
+    expect(worker.calls).toBe(callsAtStop); // not double-looping
+  });
+});

--- a/packages/sync/src/domain/sync-scheduler.service.ts
+++ b/packages/sync/src/domain/sync-scheduler.service.ts
@@ -1,0 +1,108 @@
+// The scheduler drains the job queue continuously: it repeatedly asks a worker
+// to drain, sleeping a poll interval only when the queue is empty so a busy
+// queue is worked without idle latency. It owns no sync logic — that lives in
+// the worker/dispatch — only the loop and its graceful lifecycle.
+
+// The slice of the worker the loop drives. Kept minimal so the scheduler is
+// testable with a fake and never reaches into sync internals.
+export interface JobDrainer {
+  drain(max?: number): Promise<number>;
+}
+
+// The slice of the job store the scheduler needs to release its lease on stop.
+export interface OwnedJobReleaser {
+  releaseOwned(owner: string): Promise<number>;
+}
+
+export interface SyncSchedulerDeps {
+  worker: JobDrainer;
+  jobs: OwnedJobReleaser;
+}
+
+export interface SyncSchedulerOptions {
+  // The lease owner this scheduler's worker claims under; its held jobs are
+  // released back to pending on stop so a restart picks them up immediately.
+  owner: string;
+  // How long to wait between drains when the queue is empty. A busy drain loops
+  // with no wait, so this only bounds idle-poll latency (the missed-webhook
+  // fallback cadence is a separate, longer reconcile — a later slice).
+  pollMs?: number;
+  // Where a drain error goes. The loop never dies on one; it logs and continues.
+  onError?: (error: unknown) => void;
+}
+
+const DEFAULT_POLL_MS = 5_000;
+
+export class SyncScheduler {
+  readonly #worker: JobDrainer;
+  readonly #jobs: OwnedJobReleaser;
+  readonly #owner: string;
+  readonly #pollMs: number;
+  readonly #onError: (error: unknown) => void;
+
+  #running = false;
+  #loop: Promise<void> | null = null;
+  #wake: (() => void) | null = null;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(deps: SyncSchedulerDeps, options: SyncSchedulerOptions) {
+    this.#worker = deps.worker;
+    this.#jobs = deps.jobs;
+    this.#owner = options.owner;
+    this.#pollMs = options.pollMs ?? DEFAULT_POLL_MS;
+    this.#onError = options.onError ?? (() => {});
+  }
+
+  // Begin draining. Idempotent: a second call while running is a no-op, so one
+  // scheduler never spawns two loops.
+  start(): void {
+    if (this.#running) return;
+    this.#running = true;
+    this.#loop = this.#run();
+  }
+
+  // Stop draining and release this worker's held jobs. Waits for an in-flight
+  // drain to finish BEFORE releasing (releaseOwned's precondition: no handler
+  // may still be running, or a just-finished job could be flipped back to
+  // pending and reprocessed). Idempotent and safe to call when never started.
+  async stop(): Promise<void> {
+    this.#running = false;
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+    // Resolve a pending idle wait so the loop notices #running is false at once
+    // instead of sleeping out the poll interval.
+    this.#wake?.();
+    this.#wake = null;
+    if (this.#loop) await this.#loop;
+    this.#loop = null;
+    await this.#jobs.releaseOwned(this.#owner);
+  }
+
+  async #run(): Promise<void> {
+    while (this.#running) {
+      let processed = 0;
+      try {
+        processed = await this.#worker.drain();
+      } catch (error) {
+        // A drain failure must never kill the loop; surface it and keep going.
+        this.#onError(error);
+      }
+      if (!this.#running) break;
+      // Loop immediately while there is work; otherwise wait a poll interval.
+      await this.#idle(processed > 0 ? 0 : this.#pollMs);
+    }
+  }
+
+  #idle(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.#wake = resolve;
+      this.#timer = setTimeout(() => {
+        this.#wake = null;
+        this.#timer = null;
+        resolve();
+      }, ms);
+    });
+  }
+}


### PR DESCRIPTION
## What

Makes the sync job queue actually **run**. #2285 added a worker that can drain
the queue; nothing drove it. `SyncScheduler` is that driver, plus the app wiring
that starts it.

## SyncScheduler

A continuous poll loop that asks the worker to `drain()`, looping immediately
while there is work and sleeping a poll interval only when the queue is empty.

- **Never dies on an error** — a thrown drain is logged via `onError` and the
  loop continues.
- **`start()` is idempotent** — one scheduler never spawns two loops.
- **`stop()` is graceful** — it waits for an in-flight `drain()` to finish
  *before* calling `releaseOwned`, honoring that method's precondition (releasing
  while a handler still runs could flip a just-finished job back to pending). It
  then returns the worker's held leases so a restart picks them up immediately
  rather than waiting out the lease.

It depends only on minimal interfaces (`drain`, `releaseOwned`), so it is tested
deterministically with fakes that resolve on each drain call — no arbitrary
timers, no flakiness.

## App wiring

`start()` builds a worker (repositories on the connected db, the Google event
reader, credential custody) and a scheduler with a fresh owner id per process,
starts it once storage connects, and registers its shutdown drain **after** the
mongo drain — so reverse-order teardown stops the scheduler (releasing leases
while storage is still open) before closing mongo. Gated on `EXECUTION=active`
and provider credentials being present; a passive or unconfigured deployment
builds no scheduler and just serves health.

## Not in this slice

The lease **heartbeat** for a job that outlives its lease (meanwhile a reclaim +
re-run is safe because every engine is idempotent) and jittered periodic
reconciliation / subscription renewal are later slices.

## Tests

`sync-scheduler.service.test.ts`: drains while busy then idles, releases owned
jobs on stop and halts, survives a thrown drain, and `start` idempotency /
`stop`-when-never-started. `bun run test:sync` — 489 pass.
