### PR TITLE
docs(sync): explain generation:0 on command-created events

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -716,6 +716,10 @@ function buildCloudEventRecord(command: CommandRecord, now: Date): EventRecord {
     schedule: input.schedule,
     recurrence: toStoredRecurrence(input.recurrence),
     lifecycleState: "active",
+    // Always correct here: a cloud event lives on a calendar with no provider
+    // sync resource, so nothing ever repairs it into a new generation and reads
+    // serve generation 0 for it unconditionally. (The provider-linked create
+    // path documents the one narrow, self-healing generation gap.)
     generation: 0,
     createdAt: now,
     updatedAt: now,

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -180,6 +180,16 @@ function buildLinkedEventRecord(
         ? { kind: "seriesMaster", rules: input.recurrence.rules }
         : { kind: "single" },
     lifecycleState: "active",
+    // generation 0 is correct in steady state (a calendar's active generation is
+    // 0 until a repair bumps it). The one gap it leaves is self-healing: if a
+    // repair has already advanced this calendar's active generation, a just-
+    // created event's occurrences land at generation 0 and reads (which serve
+    // the active generation) miss it — until the next incremental pull, which
+    // re-reads this event from the provider (it IS at the provider, linked here)
+    // and reprojects it at the active generation. Repairs are rare and pulls are
+    // frequent, so the window is small and closes on its own; resolving the
+    // active generation here would thread a resources dependency through the
+    // whole command path for a case that corrects itself.
     generation: 0,
     createdAt: now,
     updatedAt: now,


### PR DESCRIPTION
Comment-only. Documents the resolved analysis of why command-created events hardcode `generation: 0`, so a future reader (or reviewer) doesn't mistake it for an oversight.

- **Cloud creates**: on calendars with no sync resource, so never repaired — generation 0 is unconditionally correct.
- **Provider-linked creates**: one narrow, **self-healing** gap — if a repair already advanced the active generation, the event is briefly invisible until the next incremental pull re-reads it from the provider and reprojects at the active generation. Resolving the active generation at create time would thread a `resources` dependency through the whole command path for a case that corrects itself.

Also records that no unlinked Compass event ever exists on a provider calendar (provider creates are linked-from-write), so a repair has nothing local to strand — collapsing the previously-feared 'repair carry-forward' concern to a non-issue.

No behavior change. `bun run type-check` + `bunx biome check` clean.