### PR TITLE
test(sync): retry the shared-mongod connect to de-flake CI

### DIFF
--- a/packages/sync/src/__tests__/helpers/storage.ts
+++ b/packages/sync/src/__tests__/helpers/storage.ts
@@ -27,7 +27,7 @@ export function setupSyncStorage(): {
   const mongo = new SyncMongoService();
 
   beforeAll(async () => {
-    await mongo.connect({
+    await connectWithRetry(mongo, {
       uri: process.env["SYNC_MONGO_URI"] as string,
       databaseName: `synctest_${faker.database.mongodbObjectId()}`,
       forbiddenDatabaseName: "compass_api_unused",
@@ -53,4 +53,30 @@ export function setupSyncStorage(): {
     client: () => mongo.client,
     mongo: () => mongo,
   };
+}
+
+// Connect, retrying a few times on a transient failure. The whole sync suite
+// runs each test file in its own process against ONE shared in-memory mongod
+// (run-tests.ts); when many processes connect and install indexes at once, an
+// unlucky file can hit a transient server-selection timeout or refused
+// connection and fail its whole `beforeAll`. The server is alive (its neighbors
+// pass), so a short retry converges instead of flaking the run. The common path
+// connects on the first attempt with no delay; the backoff runs only on a retry.
+async function connectWithRetry(
+  mongo: SyncMongoService,
+  options: Parameters<SyncMongoService["connect"]>[0],
+  attempts = 4,
+): Promise<void> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await mongo.connect(options);
+      return;
+    } catch (error) {
+      // A half-open client from a connect that failed mid-way must be closed
+      // before retrying, or it leaks. disconnect() is safe when nothing opened.
+      await mongo.disconnect().catch(() => {});
+      if (attempt >= attempts) throw error;
+      await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+    }
+  }
 }

--- a/packages/sync/src/__tests__/helpers/storage.ts
+++ b/packages/sync/src/__tests__/helpers/storage.ts
@@ -28,7 +28,13 @@ export function setupSyncStorage(): {
 
   beforeAll(async () => {
     await connectWithRetry(mongo, {
-      uri: process.env["SYNC_MONGO_URI"] as string,
+      // A short server-selection timeout so a connect against a momentarily
+      // saturated shared mongod REJECTS fast enough to retry within the runner's
+      // per-file kill budget, instead of stalling on the driver's 30s default.
+      uri: withServerSelectionTimeout(
+        process.env["SYNC_MONGO_URI"] as string,
+        SERVER_SELECTION_TIMEOUT_MS,
+      ),
       databaseName: `synctest_${faker.database.mongodbObjectId()}`,
       forbiddenDatabaseName: "compass_api_unused",
       enforceLeastPrivilege: false,
@@ -55,17 +61,33 @@ export function setupSyncStorage(): {
   };
 }
 
+// A connect against the shared mongod must fail FAST when the server is
+// momentarily saturated, so the retry loop below fits inside run-tests.ts's 90s
+// per-file kill. The driver's 30s default would let a few retries blow past it
+// (and get the file killed mid-retry, which is worse than one clean failure).
+const SERVER_SELECTION_TIMEOUT_MS = 8_000;
+const CONNECT_ATTEMPTS = 5;
+
+// Append a serverSelectionTimeoutMS to the mongo URI, respecting an existing
+// query string.
+function withServerSelectionTimeout(uri: string, ms: number): string {
+  const separator = uri.includes("?") ? "&" : "?";
+  return `${uri}${separator}serverSelectionTimeoutMS=${ms}`;
+}
+
 // Connect, retrying a few times on a transient failure. The whole sync suite
 // runs each test file in its own process against ONE shared in-memory mongod
 // (run-tests.ts); when many processes connect and install indexes at once, an
 // unlucky file can hit a transient server-selection timeout or refused
 // connection and fail its whole `beforeAll`. The server is alive (its neighbors
-// pass), so a short retry converges instead of flaking the run. The common path
-// connects on the first attempt with no delay; the backoff runs only on a retry.
+// pass), so a bounded fast retry rides out the spike instead of flaking the run.
+// With an 8s selection timeout, 5 attempts cover a ~40s stall, well under the
+// 90s kill. The common path connects on the first attempt with no delay; the
+// backoff runs only on a retry.
 async function connectWithRetry(
   mongo: SyncMongoService,
   options: Parameters<SyncMongoService["connect"]>[0],
-  attempts = 4,
+  attempts = CONNECT_ATTEMPTS,
 ): Promise<void> {
   for (let attempt = 1; ; attempt += 1) {
     try {


### PR DESCRIPTION
## Problem

The sync suite runs each test file in its own process against **one shared** in-memory mongod (`run-tests.ts`). When many processes connect and install the ~25-index manifest at once, an unlucky file hits a transient server-selection timeout and its `beforeAll` connect **rejects**, failing that whole file with `SyncMongoService is not connected` while its neighbors pass. This has flaked `unit (sync)` on many PRs (the failing file varies: connection.routes, notification.routes, ...).

## Fix

Retry the connect a few times with a short backoff, **in the test helper only** (`setupSyncStorage`). The server is alive (neighbors succeed), so a transient refusal converges on retry.

- Production `connect()` semantics are untouched — a real startup failure there should still surface immediately.
- The common path connects on the first attempt with **no added delay**; backoff runs only on a retry.
- A half-open client from a failed attempt is disconnected before retrying, so nothing leaks.

Confirmed the observed CI failures are connect *rejects* (`not connected` from the getter = `beforeAll` threw), which is exactly what a retry addresses. `bun run test:sync` — 42/42 files, 489 pass, 16.3s.