### PR TITLE
feat(sync): reconcile sweep to enqueue pulls for stale calendars

### DIFF
--- a/packages/sync/src/domain/reconcile.service.test.ts
+++ b/packages/sync/src/domain/reconcile.service.test.ts
@@ -1,0 +1,127 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+// Resources not synced since this instant are stale.
+const staleBefore = new Date("2026-07-09T00:00:00.000Z");
+
+describe("reconcileStaleCalendars", () => {
+  const storage = setupSyncStorage();
+  let resources: SyncResourceRepository;
+  let jobs: JobRepository;
+
+  beforeEach(() => {
+    resources = new SyncResourceRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+  });
+
+  const deps = () => ({ resources, jobs });
+
+  // Ensure an events resource and set its last success to `lastSuccessAt`
+  // (omit for a never-synced resource). Each gets a distinct calendar so the
+  // unique (connection, kind, calendar) identity never collides.
+  const seedResource = async (
+    lastSuccessAt: Date | null,
+  ): Promise<SyncResourceRecord> => {
+    const tenantId = objectId() as SyncResourceRecord["tenantId"];
+    const principalId = objectId() as SyncResourceRecord["principalId"];
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      resourceKind: "events",
+      calendarId: objectId() as SyncResourceRecord["calendarId"],
+    });
+    if (lastSuccessAt) {
+      await resources.advanceCursor(
+        tenantId,
+        principalId,
+        resource._id,
+        "cursor",
+        lastSuccessAt,
+      );
+    }
+    return resource;
+  };
+
+  const jobByKey = (coalescingKey: string) =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).findOne({ coalescingKey });
+
+  const jobCount = () =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).countDocuments({});
+
+  it("enqueues an incremental pull for a stale resource", async () => {
+    const stale = await seedResource(new Date("2026-07-01T00:00:00.000Z"));
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now);
+
+    expect(enqueued).toBe(1);
+    const job = await jobByKey(`incrementalPull:${stale._id}`);
+    expect(job?.kind).toBe("incrementalPull");
+    expect(job?.resourceId).toBe(stale._id);
+    expect(job?.tenantId).toBe(stale.tenantId);
+  });
+
+  it("skips a resource synced more recently than the threshold", async () => {
+    await seedResource(new Date("2026-07-09T12:00:00.000Z")); // after staleBefore
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now);
+
+    expect(enqueued).toBe(0);
+    expect(await jobCount()).toBe(0);
+  });
+
+  it("enqueues a pull for a never-synced resource (bootstrap)", async () => {
+    const fresh = await seedResource(null);
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now);
+
+    expect(enqueued).toBe(1);
+    expect(await jobByKey(`incrementalPull:${fresh._id}`)).not.toBeNull();
+  });
+
+  it("coalesces repeated sweeps into one job per resource", async () => {
+    const stale = await seedResource(new Date("2026-07-01T00:00:00.000Z"));
+
+    await reconcileStaleCalendars(deps(), staleBefore, now);
+    await reconcileStaleCalendars(deps(), staleBefore, now);
+
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({ coalescingKey: `incrementalPull:${stale._id}` }),
+    ).toBe(1);
+  });
+
+  it("bounds the sweep and takes the oldest first", async () => {
+    await seedResource(new Date("2026-07-05T00:00:00.000Z"));
+    await seedResource(new Date("2026-07-02T00:00:00.000Z")); // oldest
+    await seedResource(new Date("2026-07-06T00:00:00.000Z"));
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now, 1);
+
+    expect(enqueued).toBe(1);
+    // The single job is for the oldest (2026-07-02) resource.
+    const jobs2 = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .find({})
+      .toArray();
+    expect(jobs2).toHaveLength(1);
+    const resourceId = jobs2[0]?.resourceId as string;
+    const resource = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resourceId });
+    expect(resource?.lastSuccessAt).toEqual(
+      new Date("2026-07-02T00:00:00.000Z"),
+    );
+  });
+});

--- a/packages/sync/src/domain/reconcile.service.ts
+++ b/packages/sync/src/domain/reconcile.service.ts
@@ -1,0 +1,45 @@
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface ReconcileDeps {
+  resources: SyncResourceRepository;
+  jobs: JobRepository;
+}
+
+// The reconcile sweep — the missed-webhook fallback. Find events resources that
+// have not synced since `before` (or never did) and enqueue an incremental pull
+// for each; the worker drains them like any other job. Returns how many it
+// enqueued.
+//
+// The pull job's coalescing key matches the webhook's (`incrementalPull:<id>`),
+// so a reconcile that races a live notification collapses into one job rather
+// than double-pulling. A never-imported resource enqueues a pull too: dispatch
+// turns that into an initial import (its `notImported` -> import followup), so
+// this one sweep both bootstraps new calendars and refreshes stale ones.
+//
+// A GLOBAL scan across owners (reconcile is system liveness, not a user
+// request); each enqueued job carries the resource's own owner ids. The periodic
+// trigger that calls this on a jittered interval is a separate slice — this is
+// the sweep it drives.
+export async function reconcileStaleCalendars(
+  deps: ReconcileDeps,
+  before: Date,
+  now: () => Date,
+  limit = 100,
+): Promise<number> {
+  const stale = await deps.resources.listStaleEvents(before, limit);
+  for (const resource of stale) {
+    await deps.jobs.enqueue({
+      tenantId: resource.tenantId,
+      principalId: resource.principalId,
+      connectionId: resource.connectionId,
+      resourceId: resource._id,
+      commandId: null,
+      kind: "incrementalPull",
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `incrementalPull:${resource._id}`,
+    });
+  }
+  return stale.length;
+}

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -235,4 +235,26 @@ export class SyncResourceRepository {
       .toArray();
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
+
+  // Events resources whose last successful sync is older than `before` (or which
+  // never succeeded), oldest first, bounded. This is the reconcile sweep's input
+  // — a missed-webhook fallback — so it is a GLOBAL scan across owners, not
+  // owner-scoped: each returned resource carries its own (tenantId, principalId)
+  // for the job the caller enqueues. A never-synced resource (lastSuccessAt
+  // null) sorts first so bootstrapping a new calendar is not starved by the
+  // stale ones. Uses the last_success index.
+  async listStaleEvents(
+    before: Date,
+    limit: number,
+  ): Promise<SyncResourceRecord[]> {
+    const records = await this.collection
+      .find({
+        resourceKind: "events",
+        $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
+      })
+      .sort({ lastSuccessAt: 1 })
+      .limit(limit)
+      .toArray();
+    return records.map((r) => SyncResourceRecordSchema.parse(r));
+  }
 }


### PR DESCRIPTION
## What

The missed-webhook fallback. A dropped push notification would leave a calendar silently un-synced; this sweep catches it.

`reconcileStaleCalendars(deps, before, now, limit)` finds `events` resources not synced since `before` (or never synced) via a new `SyncResourceRepository.listStaleEvents`, and enqueues an incremental pull for each. The worker (#2285) drains them like any other job.

## Design

- **Coalesced** on the webhook's key (`incrementalPull:<resourceId>`), so a reconcile that races a live notification collapses into one job, not a double pull.
- **Bootstraps too**: a never-synced resource enqueues a pull, which dispatch (#2284) turns into an initial import via its `notImported` → import followup. One sweep both bootstraps new calendars and refreshes stale ones.
- **Global scan** across owners (system liveness, not a user request); each enqueued job carries its resource's own `(tenantId, principalId)`. Never-synced resources sort first so bootstrapping isn't starved.

## Not in this slice

The jittered ~10-minute periodic **trigger** that calls this (and subscription renewal) is the next slice — this is the sweep it drives, kept pure so it tests without a timer.

## Tests

`reconcile.service.test.ts`: enqueues for a stale resource, skips a fresh one, bootstraps a never-synced one, coalesces repeated sweeps, and bounds + orders oldest-first. `bun run test:sync` — 43/43 files, 494 pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds global sync-resource scanning and background job enqueueing that affects calendar freshness across tenants; coalescing limits duplicate work but incorrect thresholds or queries could over-pull or miss stale calendars.
> 
> **Overview**
> Introduces **`reconcileStaleCalendars`**, a missed-webhook fallback that scans event sync resources not successfully synced since a cutoff (or never synced) and enqueues **`incrementalPull`** jobs for the worker.
> 
> **`SyncResourceRepository.listStaleEvents`** supports the sweep with a **global**, bounded query (oldest first; never-synced resources sort first so bootstrap isn’t starved behind stale calendars).
> 
> Jobs use the same **`incrementalPull:<resourceId>`** coalescing key as webhooks so reconcile races collapse to one pull; never-synced resources still get a pull, which existing dispatch can turn into an initial import. A configurable **`limit`** caps how many resources are processed per sweep.
> 
> Unit tests cover stale vs fresh resources, bootstrap, coalescing on repeated sweeps, and limit/ordering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea72a1fab377282b2c8cbe9b193c99a6b57c2d6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->