### PR TITLE
fix(web): repair repeat event display, delete, and styling

### DIFF
--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@core/types/calendar.contracts";
 import { type Event } from "@core/types/event.contracts";
 import {
+  applySchemaEventPatchToGridDraft,
   createGridEventDraft,
   duplicateGridEventDraft,
   editGridEventDraft,
@@ -26,6 +27,15 @@ const timedEvent = {
   recurrence: { kind: "single" as const },
   createdAt: "2026-07-01T00:00:00.000Z",
   updatedAt: null,
+} as unknown as Event;
+
+const SERIES_ID = "0123456789abcdefaaaaaaaa";
+const SERIES_RULES = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE"];
+
+const occurrenceEvent = {
+  ...(timedEvent as object),
+  id: "0123456789abcdef01234599",
+  recurrence: { kind: "occurrence" as const, seriesId: SERIES_ID },
 } as unknown as Event;
 
 test("creates an incomplete grid draft without manufacturing an Event", () => {
@@ -193,5 +203,66 @@ test("duplicating an all-day event round-trips the same calendar day through the
   expect(gridEventDraftToSchemaEvent(duplicate)).toMatchObject({
     startDate: "2026-07-20",
     endDate: "2026-07-21",
+  });
+});
+
+test("an occurrence projects with no rule when the series base isn't resolved", () => {
+  const draft = editGridEventDraft(occurrenceEvent);
+  if (!draft) throw new Error("Expected scheduled event draft");
+
+  const schemaEvent = gridEventDraftToSchemaEvent(draft);
+
+  expect(schemaEvent.recurrence).toEqual({ eventId: SERIES_ID });
+});
+
+test("an occurrence projects the resolved series rules when seriesRules is provided", () => {
+  const draft = editGridEventDraft(occurrenceEvent);
+  if (!draft) throw new Error("Expected scheduled event draft");
+
+  const schemaEvent = gridEventDraftToSchemaEvent(draft, SERIES_RULES);
+
+  expect(schemaEvent.recurrence).toEqual({
+    eventId: SERIES_ID,
+    rule: SERIES_RULES,
+  });
+});
+
+test("a patch that echoes the hydrated rule unchanged keeps the draft's recurrence as preserve", () => {
+  const draft = editGridEventDraft(occurrenceEvent);
+  if (!draft) throw new Error("Expected scheduled event draft");
+
+  const echoedPatch = {
+    ...gridEventDraftToSchemaEvent(draft, SERIES_RULES),
+    title: "Retitled mid-edit",
+  };
+  const updated = applySchemaEventPatchToGridDraft(
+    draft,
+    echoedPatch,
+    SERIES_RULES,
+  );
+
+  expect(updated.values).toMatchObject({
+    title: "Retitled mid-edit",
+    recurrence: { kind: "preserve" },
+  });
+});
+
+test("a patch with a genuinely different rule converts the draft to an explicit series edit", () => {
+  const draft = editGridEventDraft(occurrenceEvent);
+  if (!draft) throw new Error("Expected scheduled event draft");
+
+  const changedPatch = {
+    ...gridEventDraftToSchemaEvent(draft, SERIES_RULES),
+    recurrence: { rule: ["RRULE:FREQ=DAILY"], eventId: SERIES_ID },
+  };
+  const updated = applySchemaEventPatchToGridDraft(
+    draft,
+    changedPatch,
+    SERIES_RULES,
+  );
+
+  expect(updated.values.recurrence).toEqual({
+    kind: "series",
+    rules: ["RRULE:FREQ=DAILY"],
   });
 });

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -1,3 +1,4 @@
+import fastDeepEqual from "fast-deep-equal/react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
@@ -173,11 +174,22 @@ export function allDayGridSchedule(
 // Mirrors event.view-model.ts's scheduledEventToSchemaEvent recurrence
 // conversion (the now-deleted event.legacy-bridge.ts used the same mapping),
 // duplicated locally so this adapter has no dependency on that module.
-function legacyRecurrenceFromEvent(event: Event): CompassEvent["recurrence"] {
+//
+// An occurrence's own recurrence pointer carries no rule (only the series
+// base does), so opening one always reads as non-recurring unless the
+// caller resolves the base event and passes its rules through - see
+// EventForm.tsx's `seriesRules`.
+function legacyRecurrenceFromEvent(
+  event: Event,
+  seriesRules?: readonly string[],
+): CompassEvent["recurrence"] {
   return event.recurrence.kind === "series"
     ? { rule: [...event.recurrence.rules], eventId: event.id }
     : event.recurrence.kind === "occurrence"
-      ? { eventId: event.recurrence.seriesId }
+      ? {
+          eventId: event.recurrence.seriesId,
+          ...(seriesRules?.length ? { rule: [...seriesRules] } : {}),
+        }
       : undefined;
 }
 
@@ -187,11 +199,12 @@ function legacyRecurrenceFromEvent(event: Event): CompassEvent["recurrence"] {
 // back through the CompassEvent projection the form renders from.
 function legacyRecurrenceFromDraft(
   draft: GridEventDraft,
+  seriesRules?: readonly string[],
 ): CompassEvent["recurrence"] {
   const { recurrence } = draft.values;
 
   if (draft.kind === "edit" && recurrence.kind === "preserve") {
-    return legacyRecurrenceFromEvent(draft.source);
+    return legacyRecurrenceFromEvent(draft.source, seriesRules);
   }
 
   if (recurrence.kind === "series") {
@@ -227,6 +240,7 @@ function legacyRecurrenceFromDraft(
 // step 8).
 export function gridEventDraftToSchemaEvent(
   draft: GridEventDraft,
+  seriesRules?: readonly string[],
 ): CompassEvent & { calendarId?: CalendarId; isBusy?: boolean } {
   const { schedule } = draft.values;
 
@@ -240,7 +254,7 @@ export function gridEventDraftToSchemaEvent(
         : dayjs(schedule.end).format(),
     isAllDay: schedule.kind === "allDay",
     isBusy: draft.kind === "edit" && draft.source.content.kind === "busy",
-    recurrence: legacyRecurrenceFromDraft(draft),
+    recurrence: legacyRecurrenceFromDraft(draft, seriesRules),
     startDate:
       schedule.kind === "allDay"
         ? toDateOnlyString(schedule.start)
@@ -257,10 +271,23 @@ export function gridEventDraftToSchemaEvent(
 export function applySchemaEventPatchToGridDraft(
   current: GridEventDraft,
   patch: CompassEvent,
+  seriesRules?: readonly string[],
 ): GridEventDraft {
   const rule = patch.recurrence?.rule;
-  const recurrence =
-    Array.isArray(rule) && rule.length > 0
+  // A patch that merely echoes the draft's current projected rule (e.g. a
+  // title keystroke, which spreads the whole projected event through
+  // unchanged) must not flip the draft's recurrence away from "preserve" -
+  // otherwise every field edit on a recurring event would silently convert
+  // it into an explicit series-scope change. Only a rule that actually
+  // differs (the user edited recurrence) converts the draft.
+  const currentRule = legacyRecurrenceFromDraft(current, seriesRules)?.rule;
+  const ruleUnchanged =
+    Array.isArray(rule) &&
+    Array.isArray(currentRule) &&
+    fastDeepEqual(rule, currentRule);
+  const recurrence = ruleUnchanged
+    ? current.values.recurrence
+    : Array.isArray(rule) && rule.length > 0
       ? ({ kind: "series", rules: rule } as const)
       : current.kind === "edit"
         ? ({ kind: "preserve" } as const)

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -594,6 +594,114 @@ describe("useEventMutations", () => {
     context.pending.resolve();
   });
 
+  test("optimistically removes an entire series across day and week caches for an all-events delete", async () => {
+    const context = setup();
+    const seriesId = event().id;
+    const first = occurrence(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-02T16:00:00.000Z",
+        "2026-07-02T17:00:00.000Z",
+      ),
+    });
+    const second = occurrence(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-03T16:00:00.000Z",
+        "2026-07-03T17:00:00.000Z",
+      ),
+    });
+    const unrelated = event({
+      content: { kind: "details", title: "Unrelated", description: "" },
+    });
+    context.queryClient.setQueryData(
+      calendarKey,
+      normalized(first, second, unrelated),
+    );
+    context.queryClient.setQueryData(dayKey, normalized(first));
+
+    act(() =>
+      context.hook.result.current.mutations.delete({
+        id: first.id,
+        scope: "all",
+      }),
+    );
+
+    await waitFor(() => {
+      const week =
+        context.queryClient.getQueryData<NormalizedEventQueryData>(
+          calendarKey,
+        )!;
+      const day =
+        context.queryClient.getQueryData<NormalizedEventQueryData>(dayKey)!;
+      // Both instances leave both caches immediately - no waiting for a
+      // refetch to clear the rest of the series.
+      expect(week.ids).toEqual([unrelated.id]);
+      expect(day.ids).toEqual([]);
+    });
+
+    context.pending.resolve();
+  });
+
+  test("keeps earlier instances when an this-and-following delete targets a middle occurrence", async () => {
+    const context = setup();
+    const seriesId = event().id;
+    const instances = [1, 2, 3].map((day) =>
+      occurrence(seriesId, {
+        schedule: timedSchedule(
+          `2026-07-0${day}T16:00:00.000Z`,
+          `2026-07-0${day}T17:00:00.000Z`,
+        ),
+      }),
+    );
+    context.queryClient.setQueryData(calendarKey, normalized(...instances));
+
+    act(() =>
+      context.hook.result.current.mutations.delete({
+        id: instances[1].id,
+        scope: "thisAndFollowing",
+      }),
+    );
+
+    await waitFor(() => {
+      const cached =
+        context.queryClient.getQueryData<NormalizedEventQueryData>(
+          calendarKey,
+        )!;
+      expect(cached.ids).toEqual([instances[0].id]);
+    });
+
+    context.pending.resolve();
+  });
+
+  test("removes only the clicked instance for a this-scope delete on a recurring event", async () => {
+    const context = setup();
+    const seriesId = event().id;
+    const first = occurrence(seriesId);
+    const second = occurrence(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-03T16:00:00.000Z",
+        "2026-07-03T17:00:00.000Z",
+      ),
+    });
+    context.queryClient.setQueryData(calendarKey, normalized(first, second));
+
+    act(() =>
+      context.hook.result.current.mutations.delete({
+        id: first.id,
+        scope: "this",
+      }),
+    );
+
+    await waitFor(() => {
+      const cached =
+        context.queryClient.getQueryData<NormalizedEventQueryData>(
+          calendarKey,
+        )!;
+      expect(cached.ids).toEqual([second.id]);
+    });
+
+    context.pending.resolve();
+  });
+
   test("defers deletion until the in-flight create persists, then deletes server-side", async () => {
     const context = setup();
     context.queryClient.setQueryData(calendarKey, normalized());

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -25,7 +25,10 @@ import {
   upsertEventAcrossQueries,
 } from "@web/events/queries/event.query.cache";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
-import { projectRecurringEdit } from "@web/events/recurrence/projectRecurringEdit";
+import {
+  projectRecurringDelete,
+  projectRecurringEdit,
+} from "@web/events/recurrence/projectRecurringEdit";
 import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
@@ -315,7 +318,34 @@ export function useEventMutations(
           () => repository.delete(variables.id, variables.scope),
         );
       },
-      ({ id }) => removeEventFromQueries(queryClient, id, { source }),
+      ({ id, scope }) => {
+        const existing = findEventInCache(queryClient, id, source);
+        const seriesId =
+          existing?.recurrence.kind === "occurrence"
+            ? existing.recurrence.seriesId
+            : existing?.recurrence.kind === "series"
+              ? existing.id
+              : null;
+
+        if (existing && seriesId && scope !== "this") {
+          applyEventProjectionAcrossQueries(
+            queryClient,
+            projectRecurringDelete({
+              scope,
+              target: existing,
+              seriesId,
+              seriesEvents: findSeriesEventsInCache(
+                queryClient,
+                seriesId,
+                source,
+              ),
+            }),
+            source,
+          );
+          return;
+        }
+        removeEventFromQueries(queryClient, id, { source });
+      },
     ),
   );
 

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -53,6 +53,15 @@ import {
 
 const nowDateTime = () => DateTimeSchema.parse(new Date().toISOString());
 
+// An occurrence's series is its own recurrence pointer; the series base's
+// series is itself. Shared by the replace and delete optimistic callbacks,
+// which both need the series id to gather every cached instance.
+function seriesIdOf(event: Event | null): EventId | null {
+  if (event?.recurrence.kind === "occurrence") return event.recurrence.seriesId;
+  if (event?.recurrence.kind === "series") return event.id;
+  return null;
+}
+
 // A create's optimistic insert needs a full Event before the server response
 // lands; recurrence is a strict subset of EditableRecurrence ("single" |
 // "series"), so it's assignable as-is.
@@ -269,12 +278,7 @@ export function useEventMutations(
         const existing = findEventInCache(queryClient, id, source);
         if (!existing) return;
         const edited = mergeReplaceInput(existing, input);
-        const seriesId =
-          existing.recurrence.kind === "occurrence"
-            ? existing.recurrence.seriesId
-            : existing.recurrence.kind === "series"
-              ? existing.id
-              : null;
+        const seriesId = seriesIdOf(existing);
 
         if (seriesId && input.scope !== "this") {
           applyEventProjectionAcrossQueries(
@@ -320,12 +324,7 @@ export function useEventMutations(
       },
       ({ id, scope }) => {
         const existing = findEventInCache(queryClient, id, source);
-        const seriesId =
-          existing?.recurrence.kind === "occurrence"
-            ? existing.recurrence.seriesId
-            : existing?.recurrence.kind === "series"
-              ? existing.id
-              : null;
+        const seriesId = seriesIdOf(existing);
 
         if (existing && seriesId && scope !== "this") {
           applyEventProjectionAcrossQueries(

--- a/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
@@ -1,7 +1,10 @@
 import { type EventId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
-import { projectRecurringEdit } from "./projectRecurringEdit";
+import {
+  projectRecurringDelete,
+  projectRecurringEdit,
+} from "./projectRecurringEdit";
 import { describe, expect, test } from "bun:test";
 
 const SERIES_ID = "664e21f9a6b3f0b1c2d3e4f5" as EventId;
@@ -16,6 +19,19 @@ const occurrence = (day: number) =>
       timeZone: "UTC",
     } as never,
     recurrence: { kind: "occurrence", seriesId: SERIES_ID },
+  });
+
+const seriesBase = () =>
+  createMockEvent({
+    id: SERIES_ID,
+    content: { kind: "details", title: "Original", description: "" },
+    schedule: {
+      kind: "timed",
+      start: "2026-07-01T16:00:00.000Z",
+      end: "2026-07-01T17:00:00.000Z",
+      timeZone: "UTC",
+    } as never,
+    recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY"] },
   });
 
 describe("projectRecurringEdit", () => {
@@ -172,5 +188,58 @@ describe("projectRecurringEdit", () => {
 
     expect([...result.removeIds]).toEqual([events[0].id]);
     expect(result.upserts).toEqual([edited]);
+  });
+});
+
+describe("projectRecurringDelete", () => {
+  test("removes every occurrence and the series base for an all-events delete", () => {
+    const events = [occurrence(1), occurrence(2), occurrence(3)];
+    const target = events[1];
+
+    const result = projectRecurringDelete({
+      scope: "all",
+      target,
+      seriesId: SERIES_ID,
+      seriesEvents: events,
+    });
+
+    expect([...result.removeIds].sort()).toEqual(
+      [...events.map((event) => event.id), SERIES_ID].sort(),
+    );
+    expect(result.upserts).toEqual([]);
+  });
+
+  test("keeps earlier occurrences and the series base for a this-and-following delete", () => {
+    const events = [occurrence(1), occurrence(2), occurrence(3)];
+    const target = events[1];
+
+    const result = projectRecurringDelete({
+      scope: "thisAndFollowing",
+      target,
+      seriesId: SERIES_ID,
+      seriesEvents: events,
+    });
+
+    expect([...result.removeIds].sort()).toEqual(
+      [events[1].id, events[2].id].sort(),
+    );
+    expect(result.removeIds.has(events[0].id)).toBe(false);
+    expect(result.removeIds.has(SERIES_ID)).toBe(false);
+  });
+
+  test("removes every occurrence when an all-events delete is clicked on the series base", () => {
+    const base = seriesBase();
+    const events = [occurrence(1), occurrence(2)];
+
+    const result = projectRecurringDelete({
+      scope: "all",
+      target: base,
+      seriesId: SERIES_ID,
+      seriesEvents: events,
+    });
+
+    expect([...result.removeIds].sort()).toEqual(
+      [...events.map((event) => event.id), SERIES_ID].sort(),
+    );
   });
 });

--- a/packages/web/src/events/recurrence/projectRecurringEdit.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.ts
@@ -102,3 +102,32 @@ export function projectRecurringEdit({
 
   return { removeIds: new Set(), upserts };
 }
+
+type ProjectRecurringDeleteInput = {
+  scope: Exclude<RecurrenceScope, "this">;
+  target: Event;
+  seriesId: string;
+  seriesEvents: readonly Event[];
+};
+
+// `seriesEvents` (from findSeriesEventsInCache) holds occurrences only, so the
+// series base is added back explicitly. It's only removed for "all" — the
+// backend keeps the base's earlier instances (and the base itself) intact
+// when truncating a "thisAndFollowing" delete.
+export function projectRecurringDelete({
+  scope,
+  target,
+  seriesId,
+  seriesEvents,
+}: ProjectRecurringDeleteInput): RecurringEditProjection {
+  const affected =
+    scope === "all"
+      ? seriesEvents
+      : seriesEvents.filter((event) => isAtOrAfter(event, target.schedule));
+
+  const removeIds = new Set(affected.map((event) => event.id) as string[]);
+  removeIds.add(target.id);
+  if (scope === "all") removeIds.add(seriesId);
+
+  return { removeIds, upserts: [] };
+}

--- a/packages/web/src/events/recurrence/projectRecurringEdit.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.ts
@@ -125,7 +125,7 @@ export function projectRecurringDelete({
       ? seriesEvents
       : seriesEvents.filter((event) => isAtOrAfter(event, target.schedule));
 
-  const removeIds = new Set(affected.map((event) => event.id) as string[]);
+  const removeIds = new Set<string>(affected.map((event) => event.id));
   removeIds.add(target.id);
   if (scope === "all") removeIds.add(seriesId);
 

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -19,12 +19,26 @@ const baseEvent = (): GridEvent =>
     user: "user-1",
   });
 
+const recurringEvent = (): GridEvent =>
+  assembleGridEvent({
+    _id: "event-2",
+    title: "Standup",
+    description: "",
+    startDate: "2026-04-27T14:00:00.000Z",
+    endDate: "2026-04-27T15:00:00.000Z",
+    origin: Origin.COMPASS,
+    user: "user-1",
+    recurrence: { rule: ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE"] },
+  });
+
 function renderRecurrenceSection({
   authenticated,
   isBackendUnavailable = false,
+  initialEvent = baseEvent(),
 }: {
   authenticated: boolean;
   isBackendUnavailable?: boolean;
+  initialEvent?: GridEvent;
 }) {
   const setAuthenticated = mock();
   const setEventSpy = mock();
@@ -34,7 +48,7 @@ function renderRecurrenceSection({
   });
 
   function Harness() {
-    const [event, setEvent] = useState<CompassEvent | null>(baseEvent());
+    const [event, setEvent] = useState<CompassEvent | null>(initialEvent);
     const handleSetEvent = useCallback<typeof setEvent>((nextEvent) => {
       setEventSpy(nextEvent);
       setEvent(nextEvent);
@@ -42,13 +56,7 @@ function renderRecurrenceSection({
 
     if (!event) return null;
 
-    return (
-      <RecurrenceSection
-        bgColor="#f8d784"
-        event={event}
-        setEvent={handleSetEvent}
-      />
-    );
+    return <RecurrenceSection event={event} setEvent={handleSetEvent} />;
   }
 
   const view = render(<Harness />);
@@ -157,5 +165,32 @@ describe("RecurrenceSection", () => {
 
     expect(await screen.findByText("Every")).toBeInTheDocument();
     expect(screen.getByText("Ends on:")).toBeInTheDocument();
+  });
+
+  it("shows an existing recurring event's controls immediately, with the stored weekdays filled in", () => {
+    const { container } = renderRecurrenceSection({
+      authenticated: true,
+      initialEvent: recurringEvent(),
+    });
+
+    // No click on the Repeat toggle - an event that already has a rule must
+    // render its controls expanded from the first render.
+    expect(screen.getByText("Every")).toBeInTheDocument();
+    expect(screen.getByText("Ends on:")).toBeInTheDocument();
+
+    const selected = [...container.querySelectorAll("[data-selected]")].map(
+      (button) => button.getAttribute("data-selected"),
+    );
+    // WEEKDAYS order is [sun, mon, tue, wed, thu, fri, sat]; the stored rule
+    // is BYDAY=MO,TU,WE.
+    expect(selected).toEqual([
+      "false",
+      "true",
+      "true",
+      "true",
+      "false",
+      "false",
+      "false",
+    ]);
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.tsx
@@ -3,7 +3,6 @@ import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { isBackendUnavailable as getIsBackendUnavailable } from "@web/api/util/backend-unavailable-error.util";
 import { type CompassSession } from "@web/auth/compass/session/session.types";
 import { useSession } from "@web/auth/compass/session/useSession";
-import { useEventPalette } from "@web/common/styles/theme.util";
 import { EndsOnDate } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate";
 import { RecurrenceIntervalSelect } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect";
 import { RecurrenceToggle } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceToggle";
@@ -11,7 +10,6 @@ import { WeekDays } from "@web/views/Forms/EventForm/DateControlsSection/Recurre
 import { useRecurrence } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence";
 
 export interface RecurrenceSectionProps {
-  bgColor: string;
   event: CompassEvent;
   setEvent: Dispatch<SetStateAction<CompassEvent | null>>;
 }
@@ -26,12 +24,10 @@ export function createRecurrenceSection({
   useSession,
 }: RecurrenceSectionDependencies) {
   return function RecurrenceSection({
-    bgColor,
     event,
     setEvent,
   }: RecurrenceSectionProps) {
     const { authenticated } = useSession();
-    const { hover: inputColor } = useEventPalette();
     const recurrenceHook = useRecurrence(event, { setEvent });
     const { setInterval, setFreq, setWeekDays, setUntil } = recurrenceHook;
     const { weekDays, interval, freq, until, toggleRecurrence } =
@@ -53,7 +49,6 @@ export function createRecurrenceSection({
         {hasRecurrence && !isRecurrenceDisabled && (
           <>
             <RecurrenceIntervalSelect
-              bgColor={bgColor}
               initialValue={interval}
               frequency={freq}
               onChange={setInterval}
@@ -62,15 +57,9 @@ export function createRecurrenceSection({
               max={12}
             />
 
-            <WeekDays
-              bgColor={bgColor}
-              value={weekDays}
-              onChange={setWeekDays}
-            />
+            <WeekDays value={weekDays} onChange={setWeekDays} />
 
             <EndsOnDate
-              bgColor={bgColor}
-              inputColor={inputColor}
               until={until}
               minDate={event.endDate}
               setUntil={setUntil}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
@@ -1,13 +1,10 @@
 import type React from "react";
 import { useMemo, useState } from "react";
 import { parseCompassEventDate } from "@core/util/event/event.util";
-import { darken } from "@web/common/styles/color.utils";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 
 export interface EndsOnDateProps {
-  bgColor: string;
-  inputColor: string;
   minDate?: string;
   until?: Date | null;
   setUntil: React.Dispatch<React.SetStateAction<Date | null>>;
@@ -15,8 +12,6 @@ export interface EndsOnDateProps {
 
 export const EndsOnDate = ({
   until,
-  bgColor,
-  inputColor,
   setUntil,
   minDate = new Date().toISOString(),
 }: EndsOnDateProps) => {
@@ -25,7 +20,7 @@ export const EndsOnDate = ({
 
   return (
     <div className="mb-1 flex w-full basis-full items-center gap-2 p-0">
-      <span className="relative text-l">Ends on:</span>
+      <span className="relative text-m">Ends on:</span>
 
       <div
         className="flex items-start"
@@ -42,9 +37,7 @@ export const EndsOnDate = ({
         >
           <div id="portal">
             <DatePicker
-              bgColor={darken(bgColor, 15)}
               calendarClassName="recurrenceUntilDatePicker"
-              inputColor={inputColor}
               isOpen={open}
               minDate={miniDate.toDate()}
               onCalendarClose={() => setOpen(false)}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import ReactSelect from "react-select";
-import { brighten, darken } from "@web/common/styles/color.utils";
 import { colors } from "@web/common/styles/colors";
 import { theme } from "@web/common/styles/theme";
 import {
@@ -10,22 +9,18 @@ import {
 } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/constants/recurrence.constants";
 
 export interface FreqSelectProps {
-  bgColor: string;
   value: FrequencyValues;
   plural?: boolean;
   onFreqSelect: (option: FrequencyValues) => void;
 }
 
 export const FreqSelect = ({
-  bgColor,
   value,
   plural = false,
   onFreqSelect,
 }: FreqSelectProps) => {
   const options = useMemo(() => FREQUENCY_OPTIONS(plural ? "s" : ""), [plural]);
   const fontSize = theme.text.size.m;
-  const bgBright = brighten(bgColor);
-  const bgDark = darken(bgColor);
 
   const label = useMemo(
     () => `${FREQUENCY_MAP[value]}${plural ? "s" : ""}`,
@@ -44,19 +39,17 @@ export const FreqSelect = ({
         ...selectTheme,
         borderRadius: 4,
         primary: colors.borderStrong, // focus border color
-        primary25: darken(bgColor), // hover color
-        primary50: brighten(bgColor), // selected color
       })}
       styles={{
         control: (baseStyles, state) => ({
           ...baseStyles,
-          backgroundColor: bgColor,
+          backgroundColor: "var(--color-surface-overlay)",
           borderRadius: theme.shape.borderRadius,
           border: "none",
           transition: theme.transition.default,
           fontSize,
           "&:hover": {
-            filter: `brightness(95%)`,
+            backgroundColor: "hsl(0 0 100 / 12%)",
           },
           boxShadow: state.isFocused
             ? `0 0 0 2px ${colors.borderStrong}`
@@ -64,7 +57,17 @@ export const FreqSelect = ({
         }),
         singleValue: (baseStyles) => ({
           ...baseStyles,
-          color: theme.getContrastText(bgColor),
+          color: "var(--text)",
+        }),
+        // Matches CaretInput's stepper arrows, which inherit the ambient
+        // text color - without this react-select's default neutral gray
+        // caret visibly mismatches the sibling stepper.
+        dropdownIndicator: (baseStyles) => ({
+          ...baseStyles,
+          color: "var(--text)",
+          "&:hover": {
+            color: "var(--text)",
+          },
         }),
         indicatorSeparator: () => ({
           visibility: "hidden",
@@ -76,29 +79,24 @@ export const FreqSelect = ({
         menuList: (baseStyles) => ({
           ...baseStyles,
           fontSize,
-          backgroundColor: bgColor,
+          backgroundColor: "var(--surface)",
           maxHeight: "none",
           overflowY: "visible",
         }),
-        option: (styles, { isDisabled, isFocused, isSelected }) => {
-          const optionBg = isSelected ? bgBright : isFocused ? bgDark : bgColor;
-
-          return {
-            ...styles,
-            backgroundColor: isDisabled ? undefined : optionBg,
-            color: theme.getContrastText(optionBg),
-            opacity: isDisabled ? 0.5 : 1,
-            cursor: isDisabled ? "not-allowed" : "default",
-            ":active": {
-              ...styles[":active"],
-              backgroundColor: !isDisabled
-                ? isSelected
-                  ? bgColor
-                  : bgBright
-                : undefined,
-            },
-          };
-        },
+        // Same recipe as .timepicker__option--is-selected/--is-focused
+        // (index.css) - a translucent white overlay reads as a highlight on
+        // both themes' surfaces rather than needing per-theme tuning.
+        option: (styles, { isDisabled, isFocused, isSelected }) => ({
+          ...styles,
+          backgroundColor: isDisabled
+            ? undefined
+            : isSelected || isFocused
+              ? "hsl(0 0 100 / 10%)"
+              : "transparent",
+          color: "var(--text)",
+          opacity: isDisabled ? 0.5 : 1,
+          cursor: isDisabled ? "not-allowed" : "default",
+        }),
       }}
     />
   );

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/RecurrenceIntervalSelect.tsx
@@ -1,6 +1,4 @@
 import { useState } from "react";
-import { type CSSVariables } from "@web/common/styles/css.types";
-import { theme } from "@web/common/styles/theme";
 import { type FrequencyValues } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/constants/recurrence.constants";
 import { CaretInput } from "./CaretInput";
 import { FreqSelect } from "./FreqSelect";
@@ -8,7 +6,6 @@ import { FreqSelect } from "./FreqSelect";
 export interface RecurrenceIntervalSelectProps {
   frequency: FrequencyValues;
   onFreqSelect: (option: FrequencyValues) => void;
-  bgColor: string;
   initialValue: number;
   onChange: (repeatCount: number) => void;
   min: number;
@@ -18,7 +15,6 @@ export interface RecurrenceIntervalSelectProps {
 export const RecurrenceIntervalSelect = ({
   frequency,
   onFreqSelect,
-  bgColor,
   initialValue,
   onChange,
   min,
@@ -40,16 +36,10 @@ export const RecurrenceIntervalSelect = ({
 
   return (
     <div className="mb-1 flex w-full basis-full items-center gap-2 p-0">
-      <span className="relative text-l">Every</span>
+      <span className="relative text-m">Every</span>
 
       <input
-        className="ml-1 h-9.5 w-8 rounded-sm border border-transparent bg-[var(--recurrence-bg)] px-1 text-center text-[var(--recurrence-text)] text-s transition-all duration-300 hover:brightness-90 focus:shadow-[0_0_0_2px_var(--border-strong)] [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none [&[type=number]]:[appearance:textfield]"
-        style={
-          {
-            "--recurrence-bg": bgColor,
-            "--recurrence-text": theme.getContrastText(bgColor),
-          } as CSSVariables
-        }
+        className="ml-1 h-9.5 w-8 rounded-sm border border-transparent bg-surface-overlay px-1 text-center text-m text-text transition-all duration-300 focus:shadow-[0_0_0_2px_var(--border-strong)] [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none [&[type=number]]:[appearance:textfield]"
         type="number"
         max={max}
         min={min}
@@ -60,7 +50,6 @@ export const RecurrenceIntervalSelect = ({
       <CaretInput onChange={handleChange} />
 
       <FreqSelect
-        bgColor={bgColor}
         value={frequency}
         plural={value > 1}
         onFreqSelect={onFreqSelect}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/WeekDay.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/WeekDay.tsx
@@ -1,30 +1,17 @@
 import type React from "react";
-import { darken } from "@web/common/styles/color.utils";
-import { type CSSVariables } from "@web/common/styles/css.types";
-import { theme } from "@web/common/styles/theme";
 
 export interface WeekDayProps {
   day: string;
-  bgColor: string;
   onClick: () => void;
   selected: boolean;
 }
 
-export const WeekDay = ({ day, bgColor, onClick, selected }: WeekDayProps) => {
+export const WeekDay = ({ day, onClick, selected }: WeekDayProps) => {
   return (
     <button
       type="button"
-      className="size-6 cursor-pointer rounded-full border border-[var(--border-strong)] bg-[var(--weekday-bg)] text-[var(--weekday-text)] text-m transition-all duration-300 focus:shadow-[0_0_0_2px_var(--border-strong)] data-[selected=true]:bg-[var(--weekday-selected-bg)] data-[selected=true]:text-[var(--weekday-selected-text)] data-[selected=false]:hover:bg-background data-[selected=false]:hover:text-text-muted"
+      className="size-6 cursor-pointer rounded-full border border-[var(--border-strong)] bg-surface-overlay text-m text-text transition-all duration-300 focus:shadow-[0_0_0_2px_var(--border-strong)] data-[selected=true]:bg-accent data-[selected=true]:text-on-accent data-[selected=false]:hover:bg-background data-[selected=false]:hover:text-text-muted"
       data-selected={selected}
-      style={
-        {
-          "--weekday-bg": bgColor,
-          "--weekday-text": theme.getContrastText(bgColor),
-          "--weekday-selected-bg": darken(bgColor, 30),
-          // Contrast text for the actual (darkened) selected fill, not bgColor.
-          "--weekday-selected-text": theme.getContrastText(darken(bgColor, 30)),
-        } as CSSVariables
-      }
       onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         event.stopPropagation();

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/WeekDays.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/WeekDays.tsx
@@ -3,25 +3,19 @@ import { WEEKDAYS } from "@web/views/Forms/EventForm/DateControlsSection/Recurre
 import { WeekDay } from "./WeekDay";
 
 export interface WeekDaysProps {
-  bgColor: string;
   value: typeof WEEKDAYS;
   onChange: (days: typeof WEEKDAYS) => void;
 }
 
-export const WeekDays: React.FC<WeekDaysProps> = ({
-  bgColor,
-  value,
-  onChange,
-}) => {
+export const WeekDays: React.FC<WeekDaysProps> = ({ value, onChange }) => {
   return (
     <div className="mb-1 flex w-full basis-full items-center gap-2 p-0">
-      <span className="relative text-l">On: </span>
+      <span className="relative text-m">On: </span>
 
       {WEEKDAYS.map((day) => (
         <WeekDay
           key={day}
           day={day}
-          bgColor={bgColor}
           onClick={() => {
             if (value.includes(day)) {
               onChange(value.filter((weekday) => weekday !== day));

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -1,10 +1,15 @@
 import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act, type SetStateAction, useState } from "react";
+import { type EventId } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
-import { renderWithStore } from "@web/__tests__/render-with-store";
+import {
+  createStoreWrapper,
+  renderWithStore,
+} from "@web/__tests__/render-with-store";
+import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { Categories_Event } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
@@ -14,6 +19,7 @@ import {
   replaceGridDraftSchedule,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { type Props as DateTimeSectionProps } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -41,6 +47,23 @@ mock.module(
   () => ({
     DateControlsSection: (props: CapturedDateControlsSectionProps) => {
       capturedDateControlsSectionProps = props;
+      return null;
+    },
+  }),
+);
+
+interface CapturedRecurrenceSectionProps {
+  event: { recurrence?: { rule?: unknown; eventId?: unknown } };
+}
+
+let capturedRecurrenceSectionProps: CapturedRecurrenceSectionProps | null =
+  null;
+
+mock.module(
+  "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection",
+  () => ({
+    RecurrenceSection: (props: CapturedRecurrenceSectionProps) => {
+      capturedRecurrenceSectionProps = props;
       return null;
     },
   }),
@@ -168,6 +191,7 @@ describe("EventForm", () => {
   beforeEach(() => {
     HotkeyManager.resetInstance();
     capturedDateControlsSectionProps = null;
+    capturedRecurrenceSectionProps = null;
     document.body.removeAttribute("data-app-locked");
   });
 
@@ -732,5 +756,96 @@ describe("EventForm", () => {
     await user.keyboard("{Enter}");
 
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("hydrates an occurrence's recurrence from its cached series base, and keeps it preserved through a title edit", async () => {
+    const user = userEvent.setup();
+    const onSubmit = mock();
+    const seriesId = "0123456789abcdef11111111" as EventId;
+    const seriesRules = ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE"];
+    const seriesBase = createMockEvent({
+      id: seriesId,
+      content: { kind: "details", title: "Standup", description: "" },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-04-20T14:00:00.000Z",
+        end: "2026-04-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+      recurrence: { kind: "series", rules: seriesRules },
+    });
+    const occurrence = createMockEvent({
+      content: { kind: "details", title: "Standup", description: "" },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-04-27T14:00:00.000Z",
+        end: "2026-04-27T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+      recurrence: { kind: "occurrence", seriesId },
+    });
+    const draft = editGridEventDraft(occurrence);
+    if (!draft) throw new Error("expected an edit draft");
+
+    const { queryClient, wrapper } = createStoreWrapper();
+    // useEventById reads the cache synchronously on mount - the base must be
+    // present before the first render, not seeded after (setQueryDefaults'
+    // `initialData`, which seedEventQueries relies on, never materializes
+    // without a mounted query for that exact key).
+    queryClient.setQueryData(
+      eventQueryKeys.week({
+        source: "local",
+        start: "2026-04-20T00:00:00.000Z",
+        end: "2026-04-27T00:00:00.000Z",
+      }),
+      toNormalizedEventQueryData([seriesBase]),
+    );
+
+    function Harness() {
+      const [currentDraft, setDraft] = useState<GridEventDraft | null>(draft);
+      if (!currentDraft) return null;
+
+      return (
+        <EventForm
+          draft={currentDraft}
+          isDraft={false}
+          isExistingEvent={true}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={onSubmit}
+          setDraft={setDraft}
+        />
+      );
+    }
+
+    render(<Harness />, { wrapper });
+
+    // The occurrence's own recurrence pointer carries no rule - this only
+    // passes once EventForm resolves the series base and threads its rules
+    // through, which is what lets RecurrenceSection auto-expand with the
+    // real rule instead of reading the event as non-recurring.
+    expect(capturedRecurrenceSectionProps?.event.recurrence).toMatchObject({
+      eventId: seriesId,
+      rule: seriesRules,
+    });
+
+    const titleField = screen.getByPlaceholderText("Title");
+    await user.clear(titleField);
+    await user.type(titleField, "Standup (moved)");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // A field edit that never touches recurrence must not flip the draft
+    // from "preserve" to an explicit series conversion - the adapter's
+    // no-op guard compares the hydrated rule against what the patch echoes
+    // back, since every field patch spreads the whole projected event.
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({
+          title: "Standup (moved)",
+          recurrence: { kind: "preserve" },
+        }),
+      }),
+    );
   });
 });

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -44,6 +44,7 @@ import {
   replaceGridDraftSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { BUSY_EVENT_TITLE } from "@web/events/queries/event.view-model";
+import { useEventById } from "@web/events/queries/useEventById";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection";
@@ -145,11 +146,29 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     isExistingEvent,
     ...props
   }) => {
+    // An occurrence's own recurrence pointer carries no rule (only the
+    // series base does — see grid-event-draft.adapter.ts), so resolve the
+    // base from the cache and thread its rules through every CompassEvent
+    // projection below. This is what lets RecurrenceSection show an
+    // existing repeat event's real rule instead of reading as non-recurring.
+    const seriesBase = useEventById(
+      draft.kind === "edit" && draft.source.recurrence.kind === "occurrence"
+        ? draft.source.recurrence.seriesId
+        : undefined,
+    );
+    const seriesRules =
+      seriesBase?.recurrence.kind === "series"
+        ? seriesBase.recurrence.rules
+        : undefined;
+
     // CompassEvent-shaped projection of the canonical draft, for the
     // still-unconverted DatePickers field-patch API and RecurrenceSection's
     // CompassEvent contract — see grid-event-draft.adapter.ts's
     // gridEventDraftToSchemaEvent doc comment.
-    const event = useMemo(() => gridEventDraftToSchemaEvent(draft), [draft]);
+    const event = useMemo(
+      () => gridEventDraftToSchemaEvent(draft, seriesRules),
+      [draft, seriesRules],
+    );
     const { title } = event;
     const { base: eventColor } = useEventPalette();
     const category =
@@ -289,6 +308,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       (nextEvent: SetStateAction<CompassEvent | null>) => {
         const currentEvent = gridEventDraftToSchemaEvent(
           latestDraftRef.current,
+          seriesRules,
         );
         const resolvedEvent =
           typeof nextEvent === "function" ? nextEvent(currentEvent) : nextEvent;
@@ -299,10 +319,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           applySchemaEventPatchToGridDraft(
             latestDraftRef.current,
             resolvedEvent,
+            seriesRules,
           ),
         );
       },
-      [setLatestDraft],
+      [setLatestDraft, seriesRules],
     );
 
     useEffect(() => {
@@ -414,7 +435,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
     const onSetEventField: SetEventFormField = (field) => {
       setLatestEvent({
-        ...gridEventDraftToSchemaEvent(latestDraftRef.current),
+        ...gridEventDraftToSchemaEvent(latestDraftRef.current, seriesRules),
         ...field,
       });
     };
@@ -504,7 +525,6 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     };
 
     const recurrenceSectionProps = {
-      bgColor: eventColor,
       event,
       setEvent: setLatestEvent,
     };
@@ -631,7 +651,18 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 onToggleAllDay={onToggleAllDay}
               />
 
-              <RecurrenceSection {...recurrenceSectionProps} />
+              <RecurrenceSection
+                // Remount (not re-sync) when the rule appears/disappears -
+                // useRecurrence seeds its freq/interval/weekday state once,
+                // so a hydrated rule arriving after first render (or the
+                // user's own toggle) needs a fresh mount to re-seed from it.
+                key={
+                  (event.recurrence?.rule?.length ?? 0) > 0
+                    ? "recurring"
+                    : "single"
+                }
+                {...recurrenceSectionProps}
+              />
             </FormCard>
 
             <FormCard>


### PR DESCRIPTION
## Summary
- Opening a recurring event that's an *occurrence* (any instance shown on the grid) silently dropped its rule, since occurrences only carry a pointer to their series base, not the rule itself — recurrence controls stayed collapsed and custom weekday selections (e.g. Mon/Tue/Wed) never showed as filled in. The form now resolves the series base from the query cache and hydrates the occurrence's projection with its real rule.
- Deleting a recurring event with "All Events" only removed the clicked instance from the UI immediately; the rest of the series lingered until the next refetch. The delete mutation now projects the same series-wide optimistic removal the edit mutation already had, for both "All Events" and "This and Following Events".
- Recurrence field styling (interval input, weekday circles, frequency dropdown, "Ends on" date) used the event's accent color as a background, which was visually noisy and inconsistent with the rest of the form; now matches the subtle surface used by the time inputs, with consistent label sizing and a caret color that matches the stepper arrows.

## Simplicity
No new `useEffect`/`useRef`/`useState` — the fix threads an existing derived value (`seriesRules`, read via the existing `useEventById` hook) through existing memoized projections, plus one `key` prop to force a clean remount when a rule appears/disappears. A follow-up commit extracted a small `seriesIdOf()` helper to dedupe an occurrence/series ternary that would otherwise have been copy-pasted a second time in the delete path, and swapped a value-level cast for an explicit `Set<string>` type argument.

## Manual Testing Steps
- [ ] Open an existing recurring event with a custom weekly rule (e.g. repeats Mon/Tue/Wed) — the Repeat controls should show expanded immediately with the correct weekdays filled in, without needing to click "Repeat" first.
- [ ] Delete a recurring event and choose "All Events" — every instance visible in the week should disappear immediately, not just the one you clicked.
- [ ] Delete a recurring event and choose "This and Following Events" — only the clicked instance and later ones should disappear; earlier instances stay.
- [ ] Open the Repeat controls on any event (new or existing) and compare the field colors/sizes against the time inputs in both light and dark theme — they should look consistent, not noisy/mismatched.
- [ ] Edit the title of an existing recurring event without touching Repeat, then save — the recurrence should be unchanged, not silently altered.

**Known pre-existing issue found during testing (not fixed here, tracked separately):** clicking a weekday circle or changing the frequency dropdown while building a *new* custom rule from scratch crashes the app with a React "Maximum update depth exceeded" error. Confirmed reproducible on unmodified `main`, unrelated to this diff — it's a deeper Week-view draft-sync issue, out of scope for this PR.

## Test plan
- [x] `bun run test:web` — 203/203 files, 1319 tests passing
- [x] `bun run type-check` — clean
- [x] Manual verification in a real signed-in Chrome session: created a recurring event and confirmed the new styling live (subtle backgrounds, consistent label size, matching caret color, in both themes); deleted a 3-instance daily series with "All Events" and confirmed every instance vanished immediately and stayed gone after the settle-time refetch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recurrence draft/save semantics and optimistic multi-query cache deletes; wrong projection could mis-save recurrence or briefly show stale series instances, but behavior is heavily covered by new tests.
> 
> **Overview**
> Fixes recurring events in the event form and optimistic cache updates when deleting series.
> 
> **Occurrence editing:** Opening a series *occurrence* no longer looks non-recurring. `EventForm` loads the series base via `useEventById`, passes `seriesRules` into `gridEventDraftToSchemaEvent` / `applySchemaEventPatchToGridDraft`, and remounts `RecurrenceSection` when a rule appears. Patches that only echo the hydrated RRULE (e.g. title edits) keep draft recurrence at **preserve** instead of forcing a series edit (`fast-deep-equal` guard).
> 
> **Deletes:** `projectRecurringDelete` plus delete optimistic handling in `useEventMutations` remove the right cached instances for **all**, **this and following**, and **this** (single-instance unchanged path), including the series base on full-series delete.
> 
> **UI:** Recurrence controls drop per-event `bgColor` theming in favor of shared surface/accent tokens so interval, weekdays, frequency, and end-date match the rest of the form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fffada465b6086fe660fff4b51888cde1d50c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->