### PR TITLE
feat(sync): periodically reconcile stale calendars on a jittered timer

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -2,6 +2,8 @@ import { Logger } from "@core/logger/winston.logger";
 import { createInternalAuthMiddleware } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
+import { ReconcileScheduler } from "@sync/domain/reconcile-scheduler.service";
 import { SyncJobWorker } from "@sync/domain/sync-job-worker.service";
 import { SyncScheduler } from "@sync/domain/sync-scheduler.service";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
@@ -182,16 +184,19 @@ async function start(): Promise<void> {
       enforceLeastPrivilege: config.ENFORCE_LEAST_PRIVILEGE,
     });
 
-    // Storage is up: start draining the job queue. Registered AFTER the mongo
-    // drain so the coordinator's reverse-order teardown stops the scheduler
-    // FIRST (releasing its leases while storage is still open) and closes mongo
-    // last. Only an active, provider-configured deployment does work; a passive
-    // or unconfigured one serves health and admits nothing to drain.
-    const scheduler = buildScheduler(config, mongo);
-    if (scheduler) {
-      service.shutdown.register("scheduler", () => scheduler.stop());
-      scheduler.start();
-      logger.info("Sync scheduler draining the job queue");
+    // Storage is up: start draining the job queue and periodically reconciling
+    // stale calendars. Both drains register AFTER the mongo drain so the
+    // coordinator's reverse-order teardown stops them FIRST (reconcile before
+    // drain, so no new jobs are enqueued while the drain finishes and releases
+    // its leases) and closes mongo last. Only an active, provider-configured
+    // deployment does work; a passive or unconfigured one serves health.
+    const schedulers = buildSchedulers(config, mongo);
+    if (schedulers) {
+      service.shutdown.register("scheduler", () => schedulers.drain.stop());
+      service.shutdown.register("reconcile", () => schedulers.reconcile.stop());
+      schedulers.drain.start();
+      schedulers.reconcile.start();
+      logger.info("Sync scheduler draining and reconciling");
     }
   } catch (error) {
     logger.error(
@@ -201,26 +206,29 @@ async function start(): Promise<void> {
   }
 }
 
-// Build the job-queue scheduler for an active, provider-configured deployment,
-// or null when there is nothing to drain (passive execution, or no provider
-// credentials to refresh access tokens with). The worker's repositories bind to
-// the now-connected db; a fresh owner id per process scopes its leases.
-function buildScheduler(
+// Build the background schedulers for an active, provider-configured deployment:
+// the queue DRAIN (claims and runs jobs) and the RECONCILE sweep (the
+// missed-webhook fallback that enqueues pulls for stale calendars). Returns null
+// when there is nothing to run (passive execution, or no provider credentials to
+// refresh access tokens with). Repositories bind to the now-connected db; a
+// fresh owner id per process scopes the drain worker's leases.
+function buildSchedulers(
   config: SyncConfig,
   mongo: SyncMongoService,
-): SyncScheduler | null {
+): { drain: SyncScheduler; reconcile: ReconcileScheduler } | null {
   if (config.EXECUTION !== "active") return null;
   const authAdapter = buildAuthAdapter(config);
   if (!authAdapter) return null;
 
   const db = mongo.db;
   const owner = randomUUID();
+  const resources = new SyncResourceRepository(db);
   const jobs = new JobRepository(db);
   const worker = new SyncJobWorker(
     {
       events: new EventRepository(db),
       occurrences: new EventOccurrenceRepository(db, mongo.client),
-      resources: new SyncResourceRepository(db),
+      resources,
       calendars: new ProviderCalendarRepository(db),
       commands: new CommandRepository(db),
       jobs,
@@ -229,10 +237,18 @@ function buildScheduler(
     },
     owner,
   );
-  return new SyncScheduler(
+  const drain = new SyncScheduler(
     { worker, jobs },
     { owner, onError: (error) => logger.error("Sync job drain failed", error) },
   );
+  const reconcile = new ReconcileScheduler(
+    {
+      sweep: (before) =>
+        reconcileStaleCalendars({ resources, jobs }, before, () => new Date()),
+    },
+    { onError: (error) => logger.error("Sync reconcile sweep failed", error) },
+  );
+  return { drain, reconcile };
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/domain/reconcile-scheduler.service.test.ts
+++ b/packages/sync/src/domain/reconcile-scheduler.service.test.ts
@@ -1,0 +1,87 @@
+import { ReconcileScheduler } from "@sync/domain/reconcile-scheduler.service";
+
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+// Records each sweep's `before` argument and resolves a promise the test can
+// await, so the test advances exactly when a sweep happens — no arbitrary timers.
+class FakeSweeper {
+  calls: Date[] = [];
+  #waiters: Array<() => void> = [];
+  #throwOnCall: number | null;
+
+  constructor(throwOnCall: number | null = null) {
+    this.#throwOnCall = throwOnCall;
+  }
+  sweep = async (before: Date): Promise<number> => {
+    this.calls.push(before);
+    const call = this.calls.length;
+    for (const w of this.#waiters.splice(0)) w();
+    if (this.#throwOnCall === call) throw new Error("sweep failed");
+    return 0;
+  };
+  nextSweep(): Promise<void> {
+    return new Promise((resolve) => this.#waiters.push(resolve));
+  }
+}
+
+describe("ReconcileScheduler", () => {
+  it("sweeps immediately on start, then again after the interval", async () => {
+    const sweeper = new FakeSweeper();
+    const scheduler = new ReconcileScheduler(
+      { sweep: sweeper.sweep },
+      { intervalMs: 5, jitterRatio: 0, staleAfterMs: 60_000, now },
+    );
+
+    const secondSweep = (async () => {
+      await sweeper.nextSweep(); // first (immediate)
+      await sweeper.nextSweep(); // second (after the 5ms interval)
+    })();
+    scheduler.start();
+    await secondSweep;
+    await scheduler.stop();
+
+    expect(sweeper.calls.length).toBeGreaterThanOrEqual(2);
+    // The sweep is asked for resources stale as of now - staleAfterMs.
+    expect(sweeper.calls[0]).toEqual(new Date("2026-07-09T23:59:00.000Z"));
+  });
+
+  it("stops the loop and is safe to stop when never started", async () => {
+    const sweeper = new FakeSweeper();
+    const scheduler = new ReconcileScheduler(
+      { sweep: sweeper.sweep },
+      { intervalMs: 10_000, jitterRatio: 0, now },
+    );
+
+    await scheduler.stop(); // never started: no-op, no throw
+
+    const firstSweep = sweeper.nextSweep();
+    scheduler.start();
+    await firstSweep;
+    await scheduler.stop();
+
+    // No sweeps happen after stop resolves (the 10s next-interval timer is cleared).
+    const callsAtStop = sweeper.calls.length;
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sweeper.calls.length).toBe(callsAtStop);
+  });
+
+  it("keeps sweeping after one throws", async () => {
+    const errors: unknown[] = [];
+    const sweeper = new FakeSweeper(1); // first sweep throws
+    const scheduler = new ReconcileScheduler(
+      { sweep: sweeper.sweep },
+      { intervalMs: 1, jitterRatio: 0, now, onError: (e) => errors.push(e) },
+    );
+
+    const secondSweep = (async () => {
+      await sweeper.nextSweep();
+      await sweeper.nextSweep();
+    })();
+    scheduler.start();
+    await secondSweep;
+    await scheduler.stop();
+
+    expect(errors).toHaveLength(1);
+    expect(sweeper.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/sync/src/domain/reconcile-scheduler.service.ts
+++ b/packages/sync/src/domain/reconcile-scheduler.service.ts
@@ -1,0 +1,111 @@
+// Periodically runs the reconcile sweep (the missed-webhook fallback) on a
+// jittered interval. It owns only the timer and its lifecycle; the sweep itself
+// (find stale calendars, enqueue pulls) is injected, so this is testable without
+// repositories or real time.
+
+export interface ReconcileSchedulerDeps {
+  // Run one sweep for resources not synced since `before`; returns how many it
+  // enqueued. Bound to reconcileStaleCalendars + repositories by the caller.
+  sweep: (before: Date) => Promise<number>;
+}
+
+export interface ReconcileSchedulerOptions {
+  // Base gap between sweeps. The ledger's fallback cadence is ~10 minutes.
+  intervalMs?: number;
+  // Jitter as a fraction of the interval (each wait is interval * (1 ± this)),
+  // so replicas do not all sweep in lockstep and hammer the store together.
+  jitterRatio?: number;
+  // A resource is stale if it has not synced within this window; each sweep asks
+  // for resources whose last success is older than now - staleAfterMs.
+  staleAfterMs?: number;
+  now?: () => Date;
+  // Injectable [0,1) source so a test can pin the jitter; defaults to Math.random.
+  random?: () => number;
+  // A sweep error must never kill the loop; it is surfaced here and the loop
+  // continues to the next interval.
+  onError?: (error: unknown) => void;
+}
+
+const DEFAULT_INTERVAL_MS = 10 * 60_000;
+const DEFAULT_JITTER_RATIO = 0.2;
+const DEFAULT_STALE_AFTER_MS = 15 * 60_000;
+
+export class ReconcileScheduler {
+  readonly #sweep: (before: Date) => Promise<number>;
+  readonly #intervalMs: number;
+  readonly #jitterRatio: number;
+  readonly #staleAfterMs: number;
+  readonly #now: () => Date;
+  readonly #random: () => number;
+  readonly #onError: (error: unknown) => void;
+
+  #running = false;
+  #loop: Promise<void> | null = null;
+  #wake: (() => void) | null = null;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    deps: ReconcileSchedulerDeps,
+    options: ReconcileSchedulerOptions = {},
+  ) {
+    this.#sweep = deps.sweep;
+    this.#intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.#jitterRatio = options.jitterRatio ?? DEFAULT_JITTER_RATIO;
+    this.#staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    this.#now = options.now ?? (() => new Date());
+    this.#random = options.random ?? Math.random;
+    this.#onError = options.onError ?? (() => {});
+  }
+
+  // Begin sweeping. Runs a sweep immediately (so a restart promptly catches
+  // anything missed while down), then on jittered intervals. Idempotent.
+  start(): void {
+    if (this.#running) return;
+    this.#running = true;
+    this.#loop = this.#run();
+  }
+
+  // Stop sweeping. Waits for an in-flight sweep to finish so nothing is torn
+  // down mid-enqueue. Idempotent and safe when never started.
+  async stop(): Promise<void> {
+    this.#running = false;
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = null;
+    }
+    this.#wake?.();
+    this.#wake = null;
+    if (this.#loop) await this.#loop;
+    this.#loop = null;
+  }
+
+  async #run(): Promise<void> {
+    while (this.#running) {
+      try {
+        const before = new Date(this.#now().getTime() - this.#staleAfterMs);
+        await this.#sweep(before);
+      } catch (error) {
+        this.#onError(error);
+      }
+      if (!this.#running) break;
+      await this.#idle(this.#nextIntervalMs());
+    }
+  }
+
+  // interval * (1 ± jitterRatio).
+  #nextIntervalMs(): number {
+    const swing = this.#jitterRatio * (this.#random() * 2 - 1);
+    return Math.max(0, Math.round(this.#intervalMs * (1 + swing)));
+  }
+
+  #idle(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.#wake = resolve;
+      this.#timer = setTimeout(() => {
+        this.#wake = null;
+        this.#timer = null;
+        resolve();
+      }, ms);
+    });
+  }
+}


### PR DESCRIPTION
## What

The reconcile sweep (#2290) had no trigger. `ReconcileScheduler` runs it periodically — the actual missed-webhook fallback rhythm.

## How it works

- **Sweep immediately on start**, so a restart promptly catches anything missed while down; then wait `interval * (1 ± jitterRatio)` between sweeps (default ~10 min ± 20%) so replicas don't sweep in lockstep and hammer the store together.
- **Never dies on a sweep error** (logs via `onError`, continues), **`start()` idempotent**, **`stop()` waits for an in-flight sweep** before returning.
- Owns only the timer; the sweep is **injected** (`sweep: (before) => Promise<number>`), so it tests deterministically with a fake resolving on each sweep — no real time, no flakiness. Reuses the same lifecycle mechanics as `SyncScheduler`.

## App wiring

`buildSchedulers` now builds both the drain and reconcile schedulers (shared repositories, same active-and-configured gate), starts both after storage connects, and registers reconcile's shutdown drain **after** the drain scheduler's — so reverse-order teardown stops reconcile first (no new jobs enqueued while the drain finishes and releases its leases), then the drain, then mongo.

## Tests

`reconcile-scheduler.service.test.ts`: sweeps immediately then after the interval, computes `before = now - staleAfterMs`, halts on stop / safe when never started, and survives a thrown sweep. Validated in the full sync suite (44/44 files) locally.

Note: this branch was prepared in an isolated git worktree off clean `main` because a concurrent test-infra refactor was in flight in the shared checkout; the diff is exactly these 3 files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds continuous background enqueueing of sync jobs in active deployments; mis-tuned staleness/interval could increase load, but scope is limited to the existing reconcile sweep and mirrors `SyncScheduler` lifecycle patterns.
> 
> **Overview**
> Adds **`ReconcileScheduler`** so the existing `reconcileStaleCalendars` sweep actually runs in production—the missed-webhook fallback that enqueues incremental pulls for calendars that have not synced recently.
> 
> The scheduler runs a sweep **immediately on start**, then on a **~10 minute interval with ±20% jitter** (default **15 minute** staleness window via `before = now - staleAfterMs`). Sweep failures are logged and the loop continues; **`stop()`** waits for an in-flight sweep. The sweep is **injected** for tests.
> 
> **`app.ts`** refactors `buildScheduler` → **`buildSchedulers`**: active, provider-configured processes start both the job drain and reconcile loop, sharing `SyncResourceRepository` / `JobRepository`. Shutdown registers reconcile **before** the drain so teardown stops reconcile first (no new reconcile jobs while the drain finishes), then mongo last.
> 
> New unit tests cover interval behavior, `before` cutoff, stop semantics, and error resilience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caeb2bab571f753546e4a16733ad668d41c1f590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->