### PR TITLE
feat(sync): open and renew calendar push channels before expiry

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -12,8 +12,10 @@ import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
 import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
 import { GoogleEventReaderAdapter } from "@sync/providers/google/google-event-reader.adapter";
 import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
+import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
@@ -234,6 +236,10 @@ function buildSchedulers(
       jobs,
       reader: new GoogleEventReaderAdapter(),
       custody: new CredentialCustody(new CredentialRepository(db), authAdapter),
+      notifications: new GoogleNotificationAdapter(),
+      // Where the provider posts change notifications back; the callback route
+      // verifies them against the stored subscription.
+      callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
     },
     owner,
   );

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -1,0 +1,309 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
+import {
+  type NotificationChannel,
+  type ProviderNotification,
+  type ProviderNotificationAdapter,
+  ProviderNotificationError,
+} from "@sync/providers/provider-notifications.port";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+// Records watch/stop calls and replays a scripted channel or throws a scripted
+// error, so a test drives the adapter without a network round-trip.
+class FakeNotifications implements ProviderNotificationAdapter {
+  readonly provider = "google" as const;
+  watched: Array<{ channelId: string; token: string; calendarId: string }> = [];
+  stopped: Array<{ channelId: string; resourceId: string }> = [];
+  #channel: NotificationChannel | null;
+  #watchError: ProviderNotificationError | null;
+  #stopError: Error | null;
+
+  constructor(opts: {
+    channel?: NotificationChannel | null;
+    watchError?: ProviderNotificationError | null;
+    stopError?: Error | null;
+  }) {
+    this.#channel = opts.channel ?? null;
+    this.#watchError = opts.watchError ?? null;
+    this.#stopError = opts.stopError ?? null;
+  }
+
+  watchEvents = async (input: {
+    accessToken: string;
+    calendarId: string;
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+  }): Promise<NotificationChannel> => {
+    this.watched.push({
+      channelId: input.channelId,
+      token: input.token,
+      calendarId: input.calendarId,
+    });
+    if (this.#watchError) throw this.#watchError;
+    // Echo the caller's channel id, as the real adapter does.
+    return {
+      ...(this.#channel as NotificationChannel),
+      channelId: input.channelId,
+    };
+  };
+
+  stopChannel = async (input: {
+    accessToken: string;
+    channelId: string;
+    resourceId: string;
+  }): Promise<void> => {
+    this.stopped.push({
+      channelId: input.channelId,
+      resourceId: input.resourceId,
+    });
+    if (this.#stopError) throw this.#stopError;
+  };
+
+  parseCallback(): ProviderNotification | null {
+    return null;
+  }
+}
+
+const custody = { getValidAccessToken: async () => "access-token" };
+
+describe("maintainSubscription", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let resources: SyncResourceRepository;
+
+  beforeEach(() => {
+    resources = new SyncResourceRepository(storage.db());
+  });
+
+  // A calendar record maintainSubscription reads (connectionId + the provider's
+  // calendar id); only those two fields matter to the operation.
+  const calendar = (connectionId: string): ProviderCalendarRecord =>
+    ({
+      _id: objectId(),
+      tenantId: objectId(),
+      principalId: objectId(),
+      connectionId,
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+      createdAt: now(),
+      updatedAt: now(),
+    }) as ProviderCalendarRecord;
+
+  // Ensure an events resource for a calendar, optionally seeded with an existing
+  // subscription that expires at `expiresAt`.
+  const seedResource = async (
+    cal: ProviderCalendarRecord,
+    subscription?: { expiresAt: Date },
+  ): Promise<SyncResourceRecord> => {
+    const resource = await resources.ensure({
+      tenantId: cal.tenantId,
+      principalId: cal.principalId,
+      connectionId: cal.connectionId,
+      resourceKind: "events",
+      calendarId: cal._id,
+    });
+    if (subscription) {
+      await resources.updateSubscription(
+        cal.tenantId,
+        cal.principalId,
+        resource._id,
+        {
+          subscriptionId: "old-channel",
+          subscriptionResourceId: "old-resource",
+          subscriptionToken: "old-token",
+          subscriptionExpiresAt: subscription.expiresAt,
+        },
+      );
+    }
+    const fresh = await resources.findById(
+      cal.tenantId,
+      cal.principalId,
+      resource._id,
+    );
+    if (!fresh) throw new Error("seed: resource vanished");
+    return fresh;
+  };
+
+  const reload = (resource: SyncResourceRecord) =>
+    resources.findById(resource.tenantId, resource.principalId, resource._id);
+
+  it("opens a fresh channel when the resource has none", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal);
+    const expiresAt = new Date("2026-07-17T00:00:00.000Z");
+    const notifications = new FakeNotifications({
+      channel: { channelId: "", resourceId: "res-1", expiresAt },
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "watched" });
+    expect(notifications.stopped).toHaveLength(0);
+    const saved = await reload(resource);
+    // The stored channel/token are the ones the operation generated and passed
+    // to watch; the resource id and expiry come back from the provider.
+    expect(saved?.subscriptionId).toBe(notifications.watched[0]?.channelId);
+    expect(saved?.subscriptionToken).toBe(notifications.watched[0]?.token);
+    expect(saved?.subscriptionResourceId).toBe("res-1");
+    expect(saved?.subscriptionExpiresAt).toEqual(expiresAt);
+    expect(notifications.watched[0]?.calendarId).toBe("primary@google.com");
+  });
+
+  it("renews and stops the old channel when it is near expiry", async () => {
+    const cal = calendar(objectId());
+    // Expires in 1 hour: inside the default 24h renew window.
+    const resource = await seedResource(cal, {
+      expiresAt: new Date("2026-07-10T01:00:00.000Z"),
+    });
+    const expiresAt = new Date("2026-07-17T00:00:00.000Z");
+    const notifications = new FakeNotifications({
+      channel: { channelId: "", resourceId: "res-2", expiresAt },
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "renewed" });
+    // The OLD channel is stopped (by its stored id), not the new one.
+    expect(notifications.stopped).toEqual([
+      { channelId: "old-channel", resourceId: "old-resource" },
+    ]);
+    const saved = await reload(resource);
+    expect(saved?.subscriptionResourceId).toBe("res-2");
+    expect(saved?.subscriptionExpiresAt).toEqual(expiresAt);
+    expect(saved?.subscriptionId).not.toBe("old-channel");
+  });
+
+  it("leaves a healthy channel untouched", async () => {
+    const cal = calendar(objectId());
+    // Expires in 3 days: outside the 24h renew window.
+    const resource = await seedResource(cal, {
+      expiresAt: new Date("2026-07-13T00:00:00.000Z"),
+    });
+    const notifications = new FakeNotifications({
+      channel: { channelId: "", resourceId: "res-x", expiresAt: now() },
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "current" });
+    expect(notifications.watched).toHaveLength(0);
+    expect(notifications.stopped).toHaveLength(0);
+    const saved = await reload(resource);
+    expect(saved?.subscriptionId).toBe("old-channel");
+  });
+
+  it("clears the subscription and reports unsupported when the calendar cannot be watched", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal, {
+      expiresAt: new Date("2026-07-10T01:00:00.000Z"),
+    });
+    const notifications = new FakeNotifications({
+      watchError: new ProviderNotificationError("watchUnsupported", "nope"),
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "unsupported" });
+    const saved = await reload(resource);
+    expect(saved?.subscriptionId).toBeNull();
+    expect(saved?.subscriptionExpiresAt).toBeNull();
+  });
+
+  it("reports authRevoked without touching the stored subscription", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal, {
+      expiresAt: new Date("2026-07-10T01:00:00.000Z"),
+    });
+    const notifications = new FakeNotifications({
+      watchError: new ProviderNotificationError("authorizationRevoked", "gone"),
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "authRevoked" });
+    // Left as-is: a reconnect re-bootstraps; we do not clear a possibly-live one.
+    const saved = await reload(resource);
+    expect(saved?.subscriptionId).toBe("old-channel");
+  });
+
+  it("throws on a transient watch failure so the worker retries", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal);
+    const notifications = new FakeNotifications({
+      watchError: new ProviderNotificationError("watchFailed", "try later"),
+    });
+
+    await expect(
+      maintainSubscription(
+        { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+        cal,
+        resource,
+        now,
+      ),
+    ).rejects.toThrow("try later");
+  });
+
+  it("persists the new channel even when stopping the old one fails", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal, {
+      expiresAt: new Date("2026-07-10T01:00:00.000Z"),
+    });
+    const expiresAt = new Date("2026-07-17T00:00:00.000Z");
+    const notifications = new FakeNotifications({
+      channel: { channelId: "", resourceId: "res-3", expiresAt },
+      stopError: new Error("stop blew up"),
+    });
+
+    const outcome = await maintainSubscription(
+      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "renewed" });
+    const saved = await reload(resource);
+    expect(saved?.subscriptionResourceId).toBe("res-3");
+  });
+});

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -1,0 +1,153 @@
+import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import {
+  type ProviderNotificationAdapter,
+  ProviderNotificationError,
+} from "@sync/providers/provider-notifications.port";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { randomUUID } from "node:crypto";
+
+export interface SubscriptionMaintenanceDeps {
+  resources: SyncResourceRepository;
+  notifications: ProviderNotificationAdapter;
+  custody: AccessTokenSource;
+  // The absolute URL provider callbacks post back to (config's callback base +
+  // the notifications route). Passed to the provider on watch; the callback then
+  // arrives here and is matched to the stored subscription.
+  callbackUrl: string;
+}
+
+export interface SubscriptionMaintenanceOptions {
+  // Replace a subscription once it is within this window of expiring, so a
+  // channel is renewed before it lapses and pushes never gap. A subscription
+  // with more than this much life left is left alone.
+  renewBeforeMs?: number;
+}
+
+export type SubscriptionMaintenanceOutcome =
+  // A first channel was opened for a resource that had none.
+  | { readonly status: "watched" }
+  // An existing channel near expiry was replaced (and the old one stopped).
+  | { readonly status: "renewed" }
+  // The existing channel still has ample life; nothing was changed.
+  | { readonly status: "current" }
+  // The provider cannot push for this calendar; any stale channel was cleared
+  // and the caller must rely on polling (the reconcile sweep) instead.
+  | { readonly status: "unsupported" }
+  // The credential is no longer valid; a reconnect re-bootstraps the channel, so
+  // there is nothing to do here and retrying will not help.
+  | { readonly status: "authRevoked" };
+
+// One day. Google event channels last about a week, so renewing a full day
+// ahead leaves generous margin over any reasonable maintenance cadence.
+const DEFAULT_RENEW_BEFORE_MS = 24 * 60 * 60 * 1000;
+
+// Ensure a calendar's events resource has a live push channel: open one if it
+// has none, or replace one that is near expiry. The new channel is persisted
+// BEFORE the old one is stopped, so a callback is always matchable — the reverse
+// order would open a window where neither the old nor the new channel delivers.
+//
+// Idempotent enough to run twice: a resource whose channel still has plenty of
+// life reports "current" and touches nothing, so a redundant maintain job (a
+// racing sweep, a re-run after a crash) does not churn the channel.
+//
+// A transient watch failure throws so the worker retries with backoff. Only the
+// terminal provider verdicts are folded into an outcome: an unwatchable resource
+// ("unsupported") falls back to polling, and a revoked credential ("authRevoked")
+// waits for a reconnect. Both settle the job rather than retry forever.
+export async function maintainSubscription(
+  deps: SubscriptionMaintenanceDeps,
+  calendar: ProviderCalendarRecord,
+  resource: SyncResourceRecord,
+  now: () => Date,
+  options: SubscriptionMaintenanceOptions = {},
+): Promise<SubscriptionMaintenanceOutcome> {
+  const renewBeforeMs = options.renewBeforeMs ?? DEFAULT_RENEW_BEFORE_MS;
+
+  // Skip a healthy channel with more than the renew window left. A channel with
+  // an id but no recorded expiry is treated as needing renewal (fail safe).
+  if (
+    resource.subscriptionId &&
+    resource.subscriptionExpiresAt &&
+    resource.subscriptionExpiresAt.getTime() - now().getTime() > renewBeforeMs
+  ) {
+    return { status: "current" };
+  }
+
+  const accessToken = await deps.custody.getValidAccessToken(
+    calendar.connectionId,
+  );
+
+  // The channel id and per-channel token are chosen here so the association is
+  // known before the provider can deliver the first callback. The token is a
+  // secret the provider echoes back and verifyNotification compares.
+  const channelId = randomUUID();
+  const channelToken = randomUUID();
+
+  let channel: Awaited<ReturnType<ProviderNotificationAdapter["watchEvents"]>>;
+  try {
+    channel = await deps.notifications.watchEvents({
+      accessToken,
+      calendarId: calendar.providerCalendarId,
+      channelId,
+      token: channelToken,
+      callbackUrl: deps.callbackUrl,
+    });
+  } catch (error) {
+    if (error instanceof ProviderNotificationError) {
+      if (error.reason === "watchUnsupported") {
+        // This calendar can never be watched; drop any stale channel so a
+        // lingering subscription id does not misroute a future callback, and let
+        // polling cover it.
+        if (resource.subscriptionId) {
+          await deps.resources.clearSubscription(
+            resource.tenantId,
+            resource.principalId,
+            resource._id,
+          );
+        }
+        return { status: "unsupported" };
+      }
+      if (error.reason === "authorizationRevoked") {
+        return { status: "authRevoked" };
+      }
+    }
+    // watchFailed or anything unexpected: transient, let the worker retry.
+    throw error;
+  }
+
+  const priorChannelId = resource.subscriptionId;
+  const priorResourceId = resource.subscriptionResourceId;
+
+  // Persist the new channel first so its callbacks verify immediately.
+  await deps.resources.updateSubscription(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    {
+      subscriptionId: channel.channelId,
+      subscriptionResourceId: channel.resourceId,
+      subscriptionToken: channelToken,
+      subscriptionExpiresAt: channel.expiresAt,
+    },
+  );
+
+  if (priorChannelId && priorResourceId) {
+    // Best effort: the new channel is already live and stored, so a failure to
+    // stop the old one is not fatal — it lapses on its own, and its callbacks no
+    // longer match the stored subscription so they are ignored meanwhile.
+    try {
+      await deps.notifications.stopChannel({
+        accessToken,
+        channelId: priorChannelId,
+        resourceId: priorResourceId,
+      });
+    } catch {
+      // Swallow: the stale channel expires without our help.
+    }
+    return { status: "renewed" };
+  }
+
+  return { status: "watched" };
+}

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -85,6 +85,23 @@ class FakeReader implements ProviderEventReader {
 
 const tokenSource = { getValidAccessToken: async () => "access-token" };
 
+// A notification adapter that records watch calls and returns a fixed channel,
+// so a subscriptionMaintain dispatch runs without a network round-trip.
+const notifications = {
+  provider: "google" as const,
+  watched: [] as string[],
+  watchEvents: async (input: { channelId: string }) => {
+    notifications.watched.push(input.channelId);
+    return {
+      channelId: input.channelId,
+      resourceId: "provider-resource",
+      expiresAt: new Date("2026-07-17T00:00:00.000Z"),
+    };
+  },
+  stopChannel: async () => {},
+  parseCallback: () => null,
+};
+
 describe("dispatchSyncJob", () => {
   const storage = setupSyncStorage(import.meta.url);
   let events: EventRepository;
@@ -109,6 +126,8 @@ describe("dispatchSyncJob", () => {
     commands,
     reader,
     custody: tokenSource,
+    notifications,
+    callbackUrl: "https://sync.example/oauth/google/notifications",
   });
 
   const seedCalendar = (): Promise<ProviderCalendarRecord> =>
@@ -301,5 +320,28 @@ describe("dispatchSyncJob", () => {
       now,
     );
     expect(outcome).toEqual({ result: "unsupported", kind: "reconcile" });
+  });
+
+  it("settles a subscriptionMaintain job as done, opening a channel", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0"); // no subscription
+    notifications.watched = [];
+    const reader = new FakeReader([]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "subscriptionMaintain"),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    // The channel was actually opened and persisted for the resource.
+    expect(notifications.watched).toHaveLength(1);
+    const saved = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(saved?.subscriptionResourceId).toBe("provider-resource");
   });
 });

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -2,7 +2,9 @@ import { importCalendarEvents } from "@sync/domain/calendar-import.service";
 import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
 import { repairCalendar } from "@sync/domain/calendar-repair.service";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
 import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
+import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
 import {
   type JobEnqueue,
   type JobFailureClass,
@@ -25,6 +27,10 @@ export interface SyncJobDispatchDeps {
   commands: CommandRepository;
   reader: ProviderEventReader;
   custody: AccessTokenSource;
+  // maintainSubscription opens/renews the calendar's push channel; the callback
+  // url is where the provider posts change notifications back to this service.
+  notifications: ProviderNotificationAdapter;
+  callbackUrl: string;
 }
 
 // The decision a dispatch makes about a claimed job. The worker loop (a later
@@ -43,14 +49,15 @@ export type SyncJobOutcome =
   // Nothing to act on — the job's target vanished (resource/calendar deleted) or
   // the job is malformed for its kind. Settle complete; retrying can't help.
   | { readonly result: "drop"; readonly reason: string }
-  // This kind is not a provider-calendar sync job (commandApply, reconcile,
-  // subscriptionMaintain). Dispatch here does not own it; the loop routes it.
+  // This kind is not a provider-calendar sync job (commandApply, reconcile).
+  // Dispatch here does not own it; the loop routes it.
   | { readonly result: "unsupported"; readonly kind: JobRecord["kind"] };
 
 // Run one claimed provider-calendar sync job (initialImport / incrementalPull /
-// repair) and report how to settle it. Resolves the job's resource and calendar
-// first; a job whose target no longer exists is dropped rather than retried
-// forever. All reads/writes inside the called services are owner-scoped.
+// repair / subscriptionMaintain) and report how to settle it. Resolves the job's
+// resource and calendar first; a job whose target no longer exists is dropped
+// rather than retried forever. All reads/writes inside the called services are
+// owner-scoped.
 export async function dispatchSyncJob(
   deps: SyncJobDispatchDeps,
   job: JobRecord,
@@ -59,7 +66,8 @@ export async function dispatchSyncJob(
   if (
     job.kind !== "initialImport" &&
     job.kind !== "incrementalPull" &&
-    job.kind !== "repair"
+    job.kind !== "repair" &&
+    job.kind !== "subscriptionMaintain"
   ) {
     return { result: "unsupported", kind: job.kind };
   }
@@ -116,6 +124,13 @@ export async function dispatchSyncJob(
             failureClass: "retryableTransient",
             reason: "repair did not complete",
           };
+    }
+    case "subscriptionMaintain": {
+      // Open or renew the push channel. Every terminal outcome (watched /
+      // renewed / current / unsupported / authRevoked) settles the job; a
+      // transient watch failure throws and the worker retries with backoff.
+      await maintainSubscription(deps, calendar, resource, now);
+      return { result: "done" };
     }
   }
 }

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -122,10 +122,10 @@ export class SyncJobWorker {
         );
         return;
       case "unsupported":
-        // No handler for this kind in this build (commandApply/reconcile/
-        // subscriptionMaintain arrive later). Hold it for a future build via a
-        // backed-off retry rather than hot-loop or drop unfinished work. No
-        // producer enqueues these kinds yet, so this is defensive.
+        // No handler for this kind in this build (commandApply/reconcile arrive
+        // later). Hold it for a future build via a backed-off retry rather than
+        // hot-loop or drop unfinished work. No producer enqueues these kinds
+        // yet, so this is defensive.
         await this.#deps.jobs.scheduleRetry(
           job._id,
           this.#owner,


### PR DESCRIPTION
## What

Adds `maintainSubscription` — the operation that gives a calendar's events resource a live provider push channel, and renews it before it lapses — and wires it in as the `subscriptionMaintain` job handler.

Until now the notification adapter, the `sync_resources` subscription fields, the `subscription_expiry` index, and the `subscriptionMaintain` job kind were all scaffolded but unwired: nothing opened or renewed a push channel, so near-real-time liveness rode entirely on the periodic reconcile pull sweep. This is the piece that turns webhooks on.

## How it behaves

- **No channel yet** -> open one, persist it (`watched`).
- **Near expiry** (within a 24h renew window by default) -> open a fresh channel, persist it, then stop the old one (`renewed`).
- **Still healthy** -> do nothing, so a redundant/racing job never churns the channel (`current`).
- **Provider can't watch this calendar** -> clear any stale channel and fall back to polling (`unsupported`).
- **Credential revoked** -> leave it for a reconnect to re-bootstrap (`authRevoked`).
- **Transient watch failure** -> throw, so the worker reschedules a backed-off retry.

### Ordering that matters

The new channel is persisted **before** the old one is stopped. The reverse would open a window where neither channel delivers. Stopping the old channel is best-effort: it is already superseded in storage (its callbacks no longer match), so if the stop call fails it simply lapses on its own.

## Scope

This is the handler + its dispatch wiring. The producer that finds near-expiry resources and enqueues `subscriptionMaintain` jobs, and the periodic trigger, are deliberately separate follow-ups (the same way the reconcile sweep shipped before its timer). So the dispatch path exists and is tested but is not yet driven end-to-end.

## Tests

- `subscription-maintenance.service.test.ts`: watch / renew+stop-old / healthy-skip / unsupported-clears / authRevoked-preserves / transient-throws / stop-failure-still-persists, asserting persisted DB state.
- `sync-job-dispatch.service.test.ts`: a `subscriptionMaintain` job settles `done` and actually opens+persists a channel.
- Full sync suite green (45 files, 505 tests). type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider watch/stop and persisted subscription state used for webhook verification; ordering is deliberate but misconfiguration of callback URL or renew behavior could gap or churn channels.
> 
> **Overview**
> Adds **`maintainSubscription`** so calendar events resources can get and keep live Google push channels, and wires it as the **`subscriptionMaintain`** job handler (previously scaffold-only).
> 
> The operation opens a channel when none exists, skips healthy subscriptions outside a **24h renew window**, renews near-expiry channels by **persisting the new subscription before best-effort stop of the old one**, and maps provider errors to terminal outcomes (`unsupported` clears stale state; `authRevoked` leaves storage alone; transient failures throw for worker retry).
> 
> **`dispatchSyncJob`** now owns `subscriptionMaintain` and always settles it `done` on terminal outcomes. The active worker in **`app.ts`** gets **`GoogleNotificationAdapter`** and a **`callbackUrl`** built from `CALLBACK_BASE_URL` + the notifications route. DB tests cover maintenance edge cases and dispatch opening a channel.
> 
> **Out of scope in this PR:** enqueueing or scheduling `subscriptionMaintain` jobs end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc9545146e6a2a1b82d53ff0cefd3aee4ec40d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->