### PR TITLE
feat(sync): enqueue channel renewals for expiring subscriptions

### DIFF
--- a/packages/sync/src/domain/subscription-sweep.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-sweep.service.db.test.ts
@@ -1,0 +1,144 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { maintainExpiringSubscriptions } from "@sync/domain/subscription-sweep.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+// Subscriptions expiring before this instant are due for renewal.
+const renewBefore = new Date("2026-07-10T12:00:00.000Z");
+
+describe("maintainExpiringSubscriptions", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let resources: SyncResourceRepository;
+  let jobs: JobRepository;
+
+  beforeEach(() => {
+    resources = new SyncResourceRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+  });
+
+  const deps = () => ({ resources, jobs });
+
+  // Ensure an events resource, optionally holding a subscription that expires at
+  // `expiresAt`. Each gets a distinct calendar so the unique (connection, kind,
+  // calendar) identity never collides.
+  const seedResource = async (
+    expiresAt: Date | null,
+  ): Promise<SyncResourceRecord> => {
+    const tenantId = objectId() as SyncResourceRecord["tenantId"];
+    const principalId = objectId() as SyncResourceRecord["principalId"];
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      resourceKind: "events",
+      calendarId: objectId() as SyncResourceRecord["calendarId"],
+    });
+    if (expiresAt) {
+      await resources.updateSubscription(tenantId, principalId, resource._id, {
+        subscriptionId: `channel-${resource._id}`,
+        subscriptionResourceId: `res-${resource._id}`,
+        subscriptionToken: "token",
+        subscriptionExpiresAt: expiresAt,
+      });
+    }
+    return resource;
+  };
+
+  const jobByKey = (coalescingKey: string) =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).findOne({ coalescingKey });
+
+  const jobCount = () =>
+    storage.db().collection(SYNC_COLLECTIONS.jobs).countDocuments({});
+
+  it("enqueues a maintain job for a subscription expiring before the threshold", async () => {
+    const expiring = await seedResource(new Date("2026-07-10T01:00:00.000Z"));
+
+    const enqueued = await maintainExpiringSubscriptions(
+      deps(),
+      renewBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    const job = await jobByKey(`subscriptionMaintain:${expiring._id}`);
+    expect(job?.kind).toBe("subscriptionMaintain");
+    expect(job?.resourceId).toBe(expiring._id);
+    expect(job?.tenantId).toBe(expiring.tenantId);
+  });
+
+  it("skips a subscription that expires after the threshold", async () => {
+    await seedResource(new Date("2026-07-11T00:00:00.000Z")); // after renewBefore
+
+    const enqueued = await maintainExpiringSubscriptions(
+      deps(),
+      renewBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(0);
+    expect(await jobCount()).toBe(0);
+  });
+
+  it("skips a resource with no subscription (bootstrap is the import followup's job)", async () => {
+    await seedResource(null);
+
+    const enqueued = await maintainExpiringSubscriptions(
+      deps(),
+      renewBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(0);
+    expect(await jobCount()).toBe(0);
+  });
+
+  it("coalesces repeated sweeps into one job per resource", async () => {
+    const expiring = await seedResource(new Date("2026-07-10T01:00:00.000Z"));
+
+    await maintainExpiringSubscriptions(deps(), renewBefore, now);
+    await maintainExpiringSubscriptions(deps(), renewBefore, now);
+
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({
+          coalescingKey: `subscriptionMaintain:${expiring._id}`,
+        }),
+    ).toBe(1);
+  });
+
+  it("bounds the sweep and takes the soonest-expiring first", async () => {
+    await seedResource(new Date("2026-07-10T05:00:00.000Z"));
+    await seedResource(new Date("2026-07-10T02:00:00.000Z")); // soonest
+    await seedResource(new Date("2026-07-10T08:00:00.000Z"));
+
+    const enqueued = await maintainExpiringSubscriptions(
+      deps(),
+      renewBefore,
+      now,
+      1,
+    );
+
+    expect(enqueued).toBe(1);
+    const enqueuedJobs = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .find({})
+      .toArray();
+    expect(enqueuedJobs).toHaveLength(1);
+    const resourceId = enqueuedJobs[0]?.resourceId as string;
+    const resource = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resourceId });
+    expect(resource?.subscriptionExpiresAt).toEqual(
+      new Date("2026-07-10T02:00:00.000Z"),
+    );
+  });
+});

--- a/packages/sync/src/domain/subscription-sweep.service.ts
+++ b/packages/sync/src/domain/subscription-sweep.service.ts
@@ -1,0 +1,47 @@
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface SubscriptionSweepDeps {
+  resources: SyncResourceRepository;
+  jobs: JobRepository;
+}
+
+// The subscription-maintenance sweep. Find events resources whose push channel
+// expires before `before` and enqueue a subscriptionMaintain job for each; the
+// worker renews them like any other job. Returns how many it enqueued.
+//
+// The job's coalescing key (`subscriptionMaintain:<id>`) matches the bootstrap
+// followup an initialImport enqueues, so a renewal that races a fresh import
+// collapses into one job rather than opening two channels. Only resources that
+// already hold a channel are swept (the finder filters on subscriptionId): a
+// never-watched calendar gets its first channel from the import followup, so an
+// unwatchable one is not re-enqueued here on every pass.
+//
+// A GLOBAL scan across owners (this is system liveness, not a user request);
+// each enqueued job carries the resource's own owner ids. The periodic trigger
+// that drives this on an interval is a separate slice.
+export async function maintainExpiringSubscriptions(
+  deps: SubscriptionSweepDeps,
+  before: Date,
+  now: () => Date,
+  limit = 100,
+): Promise<number> {
+  const expiring = await deps.resources.listExpiringSubscriptions(
+    before,
+    limit,
+  );
+  for (const resource of expiring) {
+    await deps.jobs.enqueue({
+      tenantId: resource.tenantId,
+      principalId: resource.principalId,
+      connectionId: resource.connectionId,
+      resourceId: resource._id,
+      commandId: null,
+      kind: "subscriptionMaintain",
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `subscriptionMaintain:${resource._id}`,
+    });
+  }
+  return expiring.length;
+}

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -279,7 +279,7 @@ describe("dispatchSyncJob", () => {
     });
   });
 
-  it("runs an initial import for an already-imported resource as an idempotent no-op", async () => {
+  it("runs an initial import and hands off to a subscription bootstrap", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0"); // already imported
     const reader = new FakeReader([]); // import no-ops on an existing cursor
@@ -289,7 +289,14 @@ describe("dispatchSyncJob", () => {
       jobFor(resource, "initialImport"),
       now,
     );
-    expect(outcome).toEqual({ result: "done" });
+    // Even an idempotent no-op import ensures the push channel gets opened.
+    if (outcome.result !== "done" || !outcome.followup) {
+      throw new Error("expected a followup");
+    }
+    expect(outcome.followup.kind).toBe("subscriptionMaintain");
+    expect(outcome.followup.coalescingKey).toBe(
+      `subscriptionMaintain:${resource._id}`,
+    );
   });
 
   it("drops a job whose resource no longer exists", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -99,7 +99,10 @@ export async function dispatchSyncJob(
     case "initialImport": {
       // Idempotent: a resource that already holds a cursor no-ops inside.
       await importCalendarEvents(deps, calendar, now);
-      return { result: "done" };
+      // Bootstrap the push channel once the calendar is imported. The followup
+      // is coalesced and maintainSubscription no-ops on an already-live channel,
+      // so a repeated import (a reclaimed lease, a re-import) never churns it.
+      return { result: "done", followup: subscriptionFollowup(resource, now) };
     }
     case "incrementalPull": {
       const pull = await pullCalendarChanges(deps, calendar, now);
@@ -166,5 +169,24 @@ function importFollowup(
     priority: 0,
     runAfter: now(),
     coalescingKey: `initialImport:${resource._id}`,
+  };
+}
+
+function subscriptionFollowup(
+  resource: SyncResourceRecord,
+  now: () => Date,
+): JobEnqueue {
+  return {
+    tenantId: resource.tenantId,
+    principalId: resource.principalId,
+    connectionId: resource.connectionId,
+    resourceId: resource._id,
+    commandId: null,
+    kind: "subscriptionMaintain",
+    priority: 0,
+    runAfter: now(),
+    // The same key the expiry sweep uses, so a bootstrap watch and a renewal
+    // never double up into two channels.
+    coalescingKey: `subscriptionMaintain:${resource._id}`,
   };
 }

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -257,4 +257,28 @@ export class SyncResourceRepository {
       .toArray();
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
+
+  // Events resources whose push subscription expires before `before` (soonest
+  // first, bounded). This is the subscription-maintenance sweep's input, so like
+  // listStaleEvents it is a GLOBAL scan across owners (system liveness, not a
+  // user request) — each returned resource carries its own (tenantId,
+  // principalId) for the job the caller enqueues. Only resources that ALREADY
+  // hold a channel are returned; a resource with no subscription is bootstrapped
+  // by the initialImport followup, not here, so an unwatchable calendar is not
+  // re-selected forever. Uses the subscription_expiry index.
+  async listExpiringSubscriptions(
+    before: Date,
+    limit: number,
+  ): Promise<SyncResourceRecord[]> {
+    const records = await this.collection
+      .find({
+        resourceKind: "events",
+        subscriptionId: { $ne: null },
+        subscriptionExpiresAt: { $lt: before },
+      })
+      .sort({ subscriptionExpiresAt: 1 })
+      .limit(limit)
+      .toArray();
+    return records.map((r) => SyncResourceRecordSchema.parse(r));
+  }
 }


### PR DESCRIPTION
## What

The producer for `subscriptionMaintain` jobs. Two paths, matching the two things that must happen:

- **Renewal** — `maintainExpiringSubscriptions` finds events resources whose push channel expires before a cutoff and enqueues a coalesced `subscriptionMaintain` job for each. Mirrors the reconcile sweep exactly.
- **Bootstrap** — an `initialImport` now hands off to a `subscriptionMaintain` followup, so a freshly imported calendar gets its first channel.

Until now the `maintainSubscription` handler (PR #2294) existed but nothing enqueued the jobs that drive it. This makes it live.

## Why the split

The finder returns only resources that **already hold a channel** (`subscriptionId != null`). So an unwatchable calendar (where `maintainSubscription` returns `unsupported` and clears the subscription to null) is **not re-selected by the sweep on every pass** — it only gets a bootstrap attempt per import, and imports are one-shot. The renewal sweep and the bootstrap followup share the coalescing key `subscriptionMaintain:<resourceId>`, so a bootstrap racing a renewal collapses into one job rather than opening two channels.

## Scope

Producer only. The periodic **trigger** (a scheduler timer that calls this sweep on an interval) is the next slice, the same way the reconcile sweep shipped before its timer.

## Tests

- `subscription-sweep.service.db.test.ts`: enqueues for an expiring subscription / skips one past the threshold / skips a resource with no subscription / coalesces repeated sweeps / bounds and takes soonest-expiring first — asserting the enqueued job's kind, key, and owner.
- `sync-job-dispatch.service.db.test.ts`: an initial import now hands off to a `subscriptionMaintain` followup.
- Full sync suite green (46 files). type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync job orchestration and global subscription queries; mis-filtering or missing coalescing could churn provider channels or miss renewals, but changes are narrow and well-tested.
> 
> **Overview**
> Wires up **producers** for `subscriptionMaintain` jobs so the existing handler can actually run—periodic scheduler wiring is still a follow-up slice.
> 
> **Renewal sweep:** Adds `maintainExpiringSubscriptions`, which globally finds events resources with an existing push channel expiring before a cutoff and enqueues coalesced `subscriptionMaintain` jobs (same pattern as the reconcile sweep). `SyncResourceRepository.listExpiringSubscriptions` drives the query (only `subscriptionId != null`, soonest expiry first, bounded limit).
> 
> **Bootstrap:** `initialImport` dispatch now always returns a `subscriptionMaintain` followup (including idempotent no-op imports), using the same `subscriptionMaintain:<resourceId>` coalescing key as the sweep so bootstrap and renewal cannot double-open channels.
> 
> DB tests cover sweep enqueue/skip/coalesce/priority behavior and the updated initial-import followup expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04d1a6178a2832198d745ef129d69bcee3514c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->