### PR TITLE
feat(sync): renew expiring push channels on a periodic timer

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -3,7 +3,8 @@ import { createInternalAuthMiddleware } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
-import { ReconcileScheduler } from "@sync/domain/reconcile-scheduler.service";
+import { maintainExpiringSubscriptions } from "@sync/domain/subscription-sweep.service";
+import { SweepScheduler } from "@sync/domain/sweep-scheduler.service";
 import { SyncJobWorker } from "@sync/domain/sync-job-worker.service";
 import { SyncScheduler } from "@sync/domain/sync-scheduler.service";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
@@ -187,18 +188,25 @@ async function start(): Promise<void> {
     });
 
     // Storage is up: start draining the job queue and periodically reconciling
-    // stale calendars. Both drains register AFTER the mongo drain so the
-    // coordinator's reverse-order teardown stops them FIRST (reconcile before
-    // drain, so no new jobs are enqueued while the drain finishes and releases
-    // its leases) and closes mongo last. Only an active, provider-configured
-    // deployment does work; a passive or unconfigured one serves health.
+    // stale calendars and renewing expiring push channels. All three register
+    // AFTER the mongo drain so the coordinator's reverse-order teardown stops
+    // them FIRST (the producing sweeps before the drain, so no new jobs are
+    // enqueued while the drain finishes and releases its leases) and closes mongo
+    // last. Only an active, provider-configured deployment does work; a passive
+    // or unconfigured one serves health.
     const schedulers = buildSchedulers(config, mongo);
     if (schedulers) {
       service.shutdown.register("scheduler", () => schedulers.drain.stop());
       service.shutdown.register("reconcile", () => schedulers.reconcile.stop());
+      service.shutdown.register("subscription", () =>
+        schedulers.subscription.stop(),
+      );
       schedulers.drain.start();
       schedulers.reconcile.start();
-      logger.info("Sync scheduler draining and reconciling");
+      schedulers.subscription.start();
+      logger.info(
+        "Sync scheduler draining, reconciling, and renewing channels",
+      );
     }
   } catch (error) {
     logger.error(
@@ -208,16 +216,28 @@ async function start(): Promise<void> {
   }
 }
 
+// A resource not synced within this window is swept for a reconcile pull.
+const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
+// A push channel expiring within this window is swept for renewal. Matches
+// maintainSubscription's default renew guard so the sweep and the operation
+// agree on what "near expiry" means.
+const SUBSCRIPTION_RENEW_BEFORE_MS = 24 * 60 * 60_000;
+
 // Build the background schedulers for an active, provider-configured deployment:
-// the queue DRAIN (claims and runs jobs) and the RECONCILE sweep (the
-// missed-webhook fallback that enqueues pulls for stale calendars). Returns null
-// when there is nothing to run (passive execution, or no provider credentials to
-// refresh access tokens with). Repositories bind to the now-connected db; a
-// fresh owner id per process scopes the drain worker's leases.
+// the queue DRAIN (claims and runs jobs), the RECONCILE sweep (the missed-webhook
+// fallback that enqueues pulls for stale calendars), and the SUBSCRIPTION sweep
+// (that renews push channels before they expire). Returns null when there is
+// nothing to run (passive execution, or no provider credentials to refresh access
+// tokens with). Repositories bind to the now-connected db; a fresh owner id per
+// process scopes the drain worker's leases.
 function buildSchedulers(
   config: SyncConfig,
   mongo: SyncMongoService,
-): { drain: SyncScheduler; reconcile: ReconcileScheduler } | null {
+): {
+  drain: SyncScheduler;
+  reconcile: SweepScheduler;
+  subscription: SweepScheduler;
+} | null {
   if (config.EXECUTION !== "active") return null;
   const authAdapter = buildAuthAdapter(config);
   if (!authAdapter) return null;
@@ -247,14 +267,37 @@ function buildSchedulers(
     { worker, jobs },
     { owner, onError: (error) => logger.error("Sync job drain failed", error) },
   );
-  const reconcile = new ReconcileScheduler(
+  // The reconcile fallback looks BACK: enqueue a pull for any events resource not
+  // synced within the stale window (negative offset from now).
+  const reconcile = new SweepScheduler(
     {
       sweep: (before) =>
         reconcileStaleCalendars({ resources, jobs }, before, () => new Date()),
     },
-    { onError: (error) => logger.error("Sync reconcile sweep failed", error) },
+    {
+      windowMs: -RECONCILE_STALE_AFTER_MS,
+      onError: (error) => logger.error("Sync reconcile sweep failed", error),
+    },
   );
-  return { drain, reconcile };
+  // Subscription maintenance looks AHEAD: enqueue a renewal for any push channel
+  // expiring within the renew window (positive offset from now), so a channel is
+  // replaced before it lapses. Aligns with maintainSubscription's renew guard.
+  const subscription = new SweepScheduler(
+    {
+      sweep: (before) =>
+        maintainExpiringSubscriptions(
+          { resources, jobs },
+          before,
+          () => new Date(),
+        ),
+    },
+    {
+      windowMs: SUBSCRIPTION_RENEW_BEFORE_MS,
+      onError: (error) =>
+        logger.error("Sync subscription maintenance sweep failed", error),
+    },
+  );
+  return { drain, reconcile, subscription };
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/domain/sweep-scheduler.service.test.ts
+++ b/packages/sync/src/domain/sweep-scheduler.service.test.ts
@@ -1,4 +1,4 @@
-import { ReconcileScheduler } from "@sync/domain/reconcile-scheduler.service";
+import { SweepScheduler } from "@sync/domain/sweep-scheduler.service";
 
 const now = () => new Date("2026-07-10T00:00:00.000Z");
 
@@ -24,12 +24,12 @@ class FakeSweeper {
   }
 }
 
-describe("ReconcileScheduler", () => {
+describe("SweepScheduler", () => {
   it("sweeps immediately on start, then again after the interval", async () => {
     const sweeper = new FakeSweeper();
-    const scheduler = new ReconcileScheduler(
+    const scheduler = new SweepScheduler(
       { sweep: sweeper.sweep },
-      { intervalMs: 5, jitterRatio: 0, staleAfterMs: 60_000, now },
+      { intervalMs: 5, jitterRatio: 0, windowMs: -60_000, now },
     );
 
     const secondSweep = (async () => {
@@ -41,13 +41,29 @@ describe("ReconcileScheduler", () => {
     await scheduler.stop();
 
     expect(sweeper.calls.length).toBeGreaterThanOrEqual(2);
-    // The sweep is asked for resources stale as of now - staleAfterMs.
+    // A negative window looks BACK: cutoff is now - 60s (the reconcile shape).
     expect(sweeper.calls[0]).toEqual(new Date("2026-07-09T23:59:00.000Z"));
+  });
+
+  it("looks ahead when the window is positive (the subscription shape)", async () => {
+    const sweeper = new FakeSweeper();
+    const scheduler = new SweepScheduler(
+      { sweep: sweeper.sweep },
+      { intervalMs: 10_000, jitterRatio: 0, windowMs: 60_000, now },
+    );
+
+    const firstSweep = sweeper.nextSweep();
+    scheduler.start();
+    await firstSweep;
+    await scheduler.stop();
+
+    // A positive window looks AHEAD: cutoff is now + 60s (channels expiring soon).
+    expect(sweeper.calls[0]).toEqual(new Date("2026-07-10T00:01:00.000Z"));
   });
 
   it("stops the loop and is safe to stop when never started", async () => {
     const sweeper = new FakeSweeper();
-    const scheduler = new ReconcileScheduler(
+    const scheduler = new SweepScheduler(
       { sweep: sweeper.sweep },
       { intervalMs: 10_000, jitterRatio: 0, now },
     );
@@ -68,7 +84,7 @@ describe("ReconcileScheduler", () => {
   it("keeps sweeping after one throws", async () => {
     const errors: unknown[] = [];
     const sweeper = new FakeSweeper(1); // first sweep throws
-    const scheduler = new ReconcileScheduler(
+    const scheduler = new SweepScheduler(
       { sweep: sweeper.sweep },
       { intervalMs: 1, jitterRatio: 0, now, onError: (e) => errors.push(e) },
     );

--- a/packages/sync/src/domain/sweep-scheduler.service.ts
+++ b/packages/sync/src/domain/sweep-scheduler.service.ts
@@ -1,23 +1,25 @@
-// Periodically runs the reconcile sweep (the missed-webhook fallback) on a
-// jittered interval. It owns only the timer and its lifecycle; the sweep itself
-// (find stale calendars, enqueue pulls) is injected, so this is testable without
-// repositories or real time.
+// Periodically runs a sweep on a jittered interval. It owns only the timer and
+// its lifecycle; the sweep itself (find due resources, enqueue jobs) is injected,
+// so this is testable without repositories or real time. Both the reconcile
+// fallback and subscription maintenance drive their sweeps through it.
 
-export interface ReconcileSchedulerDeps {
-  // Run one sweep for resources not synced since `before`; returns how many it
-  // enqueued. Bound to reconcileStaleCalendars + repositories by the caller.
+export interface SweepSchedulerDeps {
+  // Run one sweep for the cutoff instant `before`; returns how many it enqueued.
+  // Bound to a concrete sweep (reconcileStaleCalendars, maintainExpiringSubscriptions)
+  // + repositories by the caller.
   sweep: (before: Date) => Promise<number>;
 }
 
-export interface ReconcileSchedulerOptions {
+export interface SweepSchedulerOptions {
   // Base gap between sweeps. The ledger's fallback cadence is ~10 minutes.
   intervalMs?: number;
   // Jitter as a fraction of the interval (each wait is interval * (1 ± this)),
   // so replicas do not all sweep in lockstep and hammer the store together.
   jitterRatio?: number;
-  // A resource is stale if it has not synced within this window; each sweep asks
-  // for resources whose last success is older than now - staleAfterMs.
-  staleAfterMs?: number;
+  // Signed offset from now that defines each sweep's cutoff: before = now + windowMs.
+  // NEGATIVE looks BACK (reconcile: resources not synced since now - 15m).
+  // POSITIVE looks AHEAD (subscription: channels expiring before now + 24h).
+  windowMs?: number;
   now?: () => Date;
   // Injectable [0,1) source so a test can pin the jitter; defaults to Math.random.
   random?: () => number;
@@ -28,13 +30,12 @@ export interface ReconcileSchedulerOptions {
 
 const DEFAULT_INTERVAL_MS = 10 * 60_000;
 const DEFAULT_JITTER_RATIO = 0.2;
-const DEFAULT_STALE_AFTER_MS = 15 * 60_000;
 
-export class ReconcileScheduler {
+export class SweepScheduler {
   readonly #sweep: (before: Date) => Promise<number>;
   readonly #intervalMs: number;
   readonly #jitterRatio: number;
-  readonly #staleAfterMs: number;
+  readonly #windowMs: number;
   readonly #now: () => Date;
   readonly #random: () => number;
   readonly #onError: (error: unknown) => void;
@@ -44,14 +45,11 @@ export class ReconcileScheduler {
   #wake: (() => void) | null = null;
   #timer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(
-    deps: ReconcileSchedulerDeps,
-    options: ReconcileSchedulerOptions = {},
-  ) {
+  constructor(deps: SweepSchedulerDeps, options: SweepSchedulerOptions = {}) {
     this.#sweep = deps.sweep;
     this.#intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
     this.#jitterRatio = options.jitterRatio ?? DEFAULT_JITTER_RATIO;
-    this.#staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    this.#windowMs = options.windowMs ?? 0;
     this.#now = options.now ?? (() => new Date());
     this.#random = options.random ?? Math.random;
     this.#onError = options.onError ?? (() => {});
@@ -82,7 +80,7 @@ export class ReconcileScheduler {
   async #run(): Promise<void> {
     while (this.#running) {
       try {
-        const before = new Date(this.#now().getTime() - this.#staleAfterMs);
+        const before = new Date(this.#now().getTime() + this.#windowMs);
         await this.#sweep(before);
       } catch (error) {
         this.#onError(error);


### PR DESCRIPTION
## What

The periodic trigger for subscription maintenance — the last piece before webhooks run themselves.

The reconcile timer (`ReconcileScheduler`) and a subscription-renewal timer differ only in *which direction they look*, so this generalizes it into a reusable **`SweepScheduler`** and wires a second instance for renewals.

## The one idea

A `SweepScheduler` runs a sweep on a jittered interval, computing each sweep's cutoff as `before = now + windowMs`:

- **Negative window looks back** — reconcile: `windowMs = -15m`, "resources not synced since `now - 15m`".
- **Positive window looks ahead** — subscription: `windowMs = +24h`, "channels expiring before `now + 24h`".

That sign is the whole correctness story, so the scheduler owns it and its unit test asserts both directions.

## Behavior parity

Reconcile is unchanged: it previously defaulted `staleAfterMs` to 15m; it now passes `windowMs = -RECONCILE_STALE_AFTER_MS` (15m) explicitly — same cutoff, same cadence. The subscription window (24h) matches `maintainSubscription`'s renew guard, so a swept job never no-ops as "current".

## Wiring

Both sweeps register in the shutdown coordinator after the mongo drain, so reverse-order teardown stops the producing sweeps first, then the drain, then mongo. All three (drain, reconcile, subscription) run only on an active, provider-configured deployment.

## End to end

With this, on an active deployment: import bootstraps a channel → the subscription sweep renews it before expiry → provider pushes hit the webhook fast path → a coalesced pull job runs → reads serve. The reconcile sweep remains the missed-webhook fallback.

## Tests

- `sweep-scheduler.service.test.ts`: immediate-on-start + interval, **look-back (negative window)** and **look-ahead (positive window)** cutoff assertions, stop-safety, and survives-a-throw.
- Full sync suite green (46 files). type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds background work that enqueues subscription maintenance jobs and changes scheduler naming/API; reconcile behavior is intended to be parity-preserving but affects core sync timing paths.
> 
> **Overview**
> Generalizes **`ReconcileScheduler`** into **`SweepScheduler`**, where each sweep cutoff is **`now + windowMs`**: a **negative** window keeps the reconcile “stale since” behavior (`-15m`), and a **positive** window drives subscription renewal (“expiring before `now + 24h`”).
> 
> On active, provider-configured deployments, a **second** `SweepScheduler` runs **`maintainExpiringSubscriptions`** on that 24h ahead window, with its own shutdown hook registered before the job drain (same teardown ordering as reconcile). Tests now assert both look-back and look-ahead cutoffs on the shared scheduler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b8dd4d5ece524dd4dd5b74513e4b9cd6bdc4daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->