### PR TITLE
feat(sync): discover a connection's calendars and bootstrap their sync

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -11,6 +11,7 @@ import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
 import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
 import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
+import { GoogleCalendarAdapter } from "@sync/providers/google/google-calendar.adapter";
 import { GoogleEventReaderAdapter } from "@sync/providers/google/google-event-reader.adapter";
 import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
 import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
@@ -25,6 +26,7 @@ import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { randomUUID } from "node:crypto";
@@ -252,6 +254,8 @@ function buildSchedulers(
       occurrences: new EventOccurrenceRepository(db, mongo.client),
       resources,
       calendars: new ProviderCalendarRepository(db),
+      connections: new ProviderConnectionRepository(db),
+      discovery: new GoogleCalendarAdapter(),
       commands: new CommandRepository(db),
       jobs,
       reader: new GoogleEventReaderAdapter(),

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -1,0 +1,287 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
+import {
+  type CalendarDiscovery,
+  type DiscoveredCalendar,
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+const discovered = (
+  providerCalendarId: string,
+  active = true,
+): DiscoveredCalendar => ({
+  providerCalendarId,
+  displayName: providerCalendarId,
+  color: null,
+  primary: false,
+  active,
+  accessRole: "owner",
+  capabilities: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+});
+
+// Replays scripted discovery passes and records the cursor each call received.
+// `cursorExpiredFirst` throws cursorExpired on the first CURSORED call, so a test
+// exercises the full re-list fallback.
+class FakeDiscovery implements ProviderCalendarAdapter {
+  readonly provider = "google" as const;
+  cursors: Array<string | undefined> = [];
+  #passes: CalendarDiscovery[];
+  #cursorExpiredFirst: boolean;
+  #threw = false;
+
+  constructor(passes: CalendarDiscovery[], cursorExpiredFirst = false) {
+    this.#passes = [...passes];
+    this.#cursorExpiredFirst = cursorExpiredFirst;
+  }
+  discoverCalendars = async (input: {
+    accessToken: string;
+    cursor?: string;
+  }): Promise<CalendarDiscovery> => {
+    this.cursors.push(input.cursor);
+    if (
+      this.#cursorExpiredFirst &&
+      input.cursor !== undefined &&
+      !this.#threw
+    ) {
+      this.#threw = true;
+      throw new ProviderCalendarError("cursorExpired", "stale token");
+    }
+    return this.#passes.shift() ?? { calendars: [], cursor: null };
+  };
+}
+
+const custody = { getValidAccessToken: async () => "access-token" };
+
+describe("syncCalendarList", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let calendars: ProviderCalendarRepository;
+  let resources: SyncResourceRepository;
+  let jobs: JobRepository;
+
+  beforeEach(() => {
+    calendars = new ProviderCalendarRepository(storage.db());
+    resources = new SyncResourceRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+  });
+
+  const connection = (): ProviderConnectionRecord =>
+    ({
+      _id: objectId(),
+      tenantId: objectId(),
+      principalId: objectId(),
+    }) as ProviderConnectionRecord;
+
+  const deps = (discovery: FakeDiscovery) => ({
+    calendars,
+    resources,
+    jobs,
+    discovery,
+    custody,
+  });
+
+  const calendarDocs = (conn: ProviderConnectionRecord) =>
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.providerCalendars)
+      .find({ connectionId: conn._id })
+      .toArray();
+
+  const importJobs = () =>
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .find({ kind: "initialImport" })
+      .toArray();
+
+  const calendarListResource = (conn: ProviderConnectionRecord) =>
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ connectionId: conn._id, resourceKind: "calendarList" });
+
+  it("discovers calendars, persists them, and enqueues an import per active calendar", async () => {
+    const conn = connection();
+    const discovery = new FakeDiscovery([
+      {
+        calendars: [
+          discovered("primary"),
+          discovered("team"),
+          discovered("holidays", false),
+        ],
+        cursor: "cur-1",
+      },
+    ]);
+
+    const result = await syncCalendarList(deps(discovery), conn, now);
+
+    expect(result).toEqual({ discovered: 3, imported: 2 });
+    expect(await calendarDocs(conn)).toHaveLength(3);
+    // One initial import per ACTIVE calendar (2), none for the inactive one.
+    const enqueued = await importJobs();
+    expect(enqueued).toHaveLength(2);
+    // The discovery cursor is stored on the calendarList resource for next pass.
+    expect((await calendarListResource(conn))?.syncCursor).toBe("cur-1");
+    expect(discovery.cursors).toEqual([undefined]); // first pass is a full list
+  });
+
+  it("ensures an events resource for each active calendar so its import can run", async () => {
+    const conn = connection();
+    const discovery = new FakeDiscovery([
+      { calendars: [discovered("primary")], cursor: "c" },
+    ]);
+
+    await syncCalendarList(deps(discovery), conn, now);
+
+    const eventsResources = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .find({ connectionId: conn._id, resourceKind: "events" })
+      .toArray();
+    expect(eventsResources).toHaveLength(1);
+    // The enqueued import targets that events resource.
+    const [job] = await importJobs();
+    expect(job?.resourceId).toBe(eventsResources[0]?._id);
+    expect(job?.coalescingKey).toBe(`initialImport:${eventsResources[0]?._id}`);
+  });
+
+  it("retires a calendar no longer present on a full list", async () => {
+    const conn = connection();
+    // First full pass discovers two calendars.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [discovered("primary"), discovered("gone")],
+            cursor: null,
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    // Second full pass (no cursor stored, since first returned null) omits "gone".
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: null },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    const docs = await calendarDocs(conn);
+    const gone = docs.find((d) => d.providerCalendarId === "gone");
+    const primary = docs.find((d) => d.providerCalendarId === "primary");
+    expect(gone?.active).toBe(false);
+    expect(primary?.active).toBe(true);
+  });
+
+  it("does not retire absent calendars on an incremental pass", async () => {
+    const conn = connection();
+    // Seed a full pass that stores a cursor, so the next pass is incremental.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [discovered("primary"), discovered("team")],
+            cursor: "cur-1",
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    // Incremental pass returns only a changed calendar; "team" is absent but must
+    // stay active (absence means unchanged, not removed).
+    const incremental = new FakeDiscovery([
+      { calendars: [discovered("primary")], cursor: "cur-2" },
+    ]);
+    await syncCalendarList(deps(incremental), conn, now);
+
+    expect(incremental.cursors).toEqual(["cur-1"]); // resumed from the stored cursor
+    const team = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "team",
+    );
+    expect(team?.active).toBe(true);
+  });
+
+  it("re-lists in full when the incremental cursor has expired", async () => {
+    const conn = connection();
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [discovered("primary"), discovered("stale")],
+            cursor: "cur-1",
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    // The cursored call throws cursorExpired; the fallback full list omits "stale".
+    const expired = new FakeDiscovery(
+      [{ calendars: [discovered("primary")], cursor: "cur-2" }],
+      true,
+    );
+    await syncCalendarList(deps(expired), conn, now);
+
+    // It tried the stored cursor, then re-listed in full (undefined cursor).
+    expect(expired.cursors).toEqual(["cur-1", undefined]);
+    // Because the fallback was a full list, the absent "stale" calendar is retired.
+    const stale = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "stale",
+    );
+    expect(stale?.active).toBe(false);
+  });
+
+  it("throws on a non-cursor discovery failure so the worker retries", async () => {
+    const conn = connection();
+    const discovery = {
+      provider: "google" as const,
+      discoverCalendars: async () => {
+        throw new ProviderCalendarError("discoveryFailed", "boom");
+      },
+    };
+
+    await expect(
+      syncCalendarList(deps(discovery as unknown as FakeDiscovery), conn, now),
+    ).rejects.toThrow("boom");
+  });
+
+  it("is idempotent: a repeated pass coalesces into one import per calendar", async () => {
+    const conn = connection();
+    const pass = (): CalendarDiscovery => ({
+      calendars: [discovered("primary")],
+      cursor: "c",
+    });
+
+    await syncCalendarList(deps(new FakeDiscovery([pass()])), conn, now);
+    await syncCalendarList(deps(new FakeDiscovery([pass()])), conn, now);
+
+    // One events resource, one coalesced import job — not two.
+    const eventsResources = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .find({ connectionId: conn._id, resourceKind: "events" })
+      .toArray();
+    expect(eventsResources).toHaveLength(1);
+    expect(await importJobs()).toHaveLength(1);
+  });
+});

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -192,6 +192,32 @@ describe("syncCalendarList", () => {
     expect(primary?.active).toBe(true);
   });
 
+  it("does not retire everything when a full list comes back empty", async () => {
+    const conn = connection();
+    // First full pass discovers a calendar (cursor null keeps the next pass full).
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: null },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    // A full pass that returns zero calendars is a non-answer (a provider blip),
+    // not "all removed": the existing calendar must stay active.
+    await syncCalendarList(
+      deps(new FakeDiscovery([{ calendars: [], cursor: null }])),
+      conn,
+      now,
+    );
+
+    const primary = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "primary",
+    );
+    expect(primary?.active).toBe(true);
+  });
+
   it("does not retire absent calendars on an incremental pass", async () => {
     const conn = connection();
     // Seed a full pass that stores a cursor, so the next pass is incremental.

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -107,7 +107,12 @@ export async function syncCalendarList(
   // Only a full pass sees the complete set, so only then can a calendar's absence
   // mean it was removed. An incremental pass reports removals as active:false
   // entries (handled by the upsert above), so it must not retire the absent.
-  if (fullList) {
+  //
+  // Guard on a non-empty result: an account always has at least a primary
+  // calendar, so a full list of zero is treated as a non-answer (a provider
+  // hiccup that returned empty instead of throwing) rather than "all removed" —
+  // retiring every calendar on an empty blip would be user-visible damage.
+  if (fullList && discovery.calendars.length > 0) {
     await deps.calendars.deactivateAbsent(
       tenantId,
       principalId,

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -1,0 +1,162 @@
+import { type ProviderCalendarSourceId } from "@core/types/sync/identity.contracts";
+import { type AccessTokenSource } from "@sync/domain/provider-command.service";
+import {
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface CalendarListSyncDeps {
+  calendars: ProviderCalendarRepository;
+  resources: SyncResourceRepository;
+  jobs: JobRepository;
+  discovery: ProviderCalendarAdapter;
+  custody: AccessTokenSource;
+}
+
+export interface CalendarListSyncResult {
+  // How many calendars the provider returned this pass.
+  readonly discovered: number;
+  // How many active calendars had an initial import enqueued.
+  readonly imported: number;
+}
+
+// Discover a connection's calendars and bootstrap their sync. This is the front
+// of the sync chain: a fresh connection has no calendars and no events resource,
+// so nothing else can run until discovery populates them.
+//
+// Reconcile the provider's calendar list into `provider_calendars`, then for each
+// ACTIVE calendar ensure its events resource and enqueue an initial import (which
+// imports the events and, in turn, opens the push channel). The calendarList
+// resource carries the discovery cursor so a later pass lists incrementally.
+//
+// A cursored (incremental) pass returns only changed calendars, so absence does
+// NOT mean removal — only a FULL pass retires calendars no longer listed. An
+// expired cursor drops to a full re-list rather than retrying a dead token; any
+// other discovery failure throws so the worker retries with backoff.
+export async function syncCalendarList(
+  deps: CalendarListSyncDeps,
+  connection: ProviderConnectionRecord,
+  now: () => Date,
+): Promise<CalendarListSyncResult> {
+  const { tenantId, principalId, _id: connectionId } = connection;
+
+  // The calendarList resource (one per connection, null calendarId) holds the
+  // discovery cursor across passes.
+  const resource = await deps.resources.ensure({
+    tenantId,
+    principalId,
+    connectionId,
+    resourceKind: "calendarList",
+    calendarId: null,
+  });
+
+  const accessToken = await deps.custody.getValidAccessToken(connectionId);
+
+  // Resume incrementally from the stored cursor; a cursorExpired verdict means
+  // the token is too old, so re-list in full. Both leave `fullList` telling us
+  // whether absence implies removal below.
+  let fullList = resource.syncCursor === null;
+  let discovery: Awaited<
+    ReturnType<ProviderCalendarAdapter["discoverCalendars"]>
+  >;
+  try {
+    discovery = await deps.discovery.discoverCalendars({
+      accessToken,
+      cursor: resource.syncCursor ?? undefined,
+    });
+  } catch (error) {
+    if (
+      error instanceof ProviderCalendarError &&
+      error.reason === "cursorExpired"
+    ) {
+      fullList = true;
+      discovery = await deps.discovery.discoverCalendars({ accessToken });
+    } else {
+      // discoveryFailed or unexpected: transient, let the worker retry.
+      throw error;
+    }
+  }
+
+  // Upsert every discovered calendar (identity is the provider calendar id, so a
+  // rename keeps its Sync _id), keeping the persisted records to bootstrap the
+  // active ones below.
+  const upserted = [];
+  for (const calendar of discovery.calendars) {
+    const record = await deps.calendars.upsertByProviderCalendar({
+      tenantId,
+      principalId,
+      connectionId,
+      // The discovery port reports the provider's calendar id as a plain string;
+      // it is the provider source id, branded on the way into storage.
+      providerCalendarId:
+        calendar.providerCalendarId as ProviderCalendarSourceId,
+      displayName: calendar.displayName,
+      color: calendar.color,
+      active: calendar.active,
+      primary: calendar.primary,
+      accessRole: calendar.accessRole,
+      capabilities: calendar.capabilities,
+    });
+    upserted.push(record);
+  }
+
+  // Only a full pass sees the complete set, so only then can a calendar's absence
+  // mean it was removed. An incremental pass reports removals as active:false
+  // entries (handled by the upsert above), so it must not retire the absent.
+  if (fullList) {
+    await deps.calendars.deactivateAbsent(
+      tenantId,
+      principalId,
+      connectionId,
+      discovery.calendars.map(
+        (c) => c.providerCalendarId as ProviderCalendarSourceId,
+      ),
+    );
+  }
+
+  // Bootstrap events sync for each active calendar: ensure its events resource
+  // and enqueue an initial import. The import is coalesced (same key an import
+  // followup uses) and idempotent, so a re-discovery never double-imports.
+  let imported = 0;
+  for (const record of upserted) {
+    if (!record.active) continue;
+    const eventsResource = await deps.resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "events",
+      calendarId: record._id,
+    });
+    await deps.jobs.enqueue({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceId: eventsResource._id,
+      commandId: null,
+      kind: "initialImport",
+      priority: 0,
+      runAfter: now(),
+      coalescingKey: `initialImport:${eventsResource._id}`,
+    });
+    imported += 1;
+  }
+
+  // Record the new discovery cursor so the next pass lists incrementally. Google
+  // always returns a nextSyncToken on the final page; if a provider ever returns
+  // none, we simply full-list again next pass rather than store a null cursor.
+  if (discovery.cursor) {
+    await deps.resources.advanceCursor(
+      tenantId,
+      principalId,
+      resource._id,
+      discovery.cursor,
+      now(),
+    );
+  }
+
+  return { discovered: discovery.calendars.length, imported };
+}

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -14,12 +14,15 @@ import {
   type ProviderEventReader,
   type ProviderEventReadInput,
 } from "@sync/providers/provider-event-reader.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type JobRecord } from "@sync/storage/contracts/job.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -102,6 +105,31 @@ const notifications = {
   parseCallback: () => null,
 };
 
+// A calendar-discovery adapter that returns one active calendar, so a
+// calendarListSync dispatch runs without a network round-trip.
+const discovery = {
+  provider: "google" as const,
+  discoverCalendars: async () => ({
+    calendars: [
+      {
+        providerCalendarId: "primary@google.com",
+        displayName: "Google",
+        color: null,
+        primary: true,
+        active: true,
+        accessRole: "owner" as const,
+        capabilities: {
+          canReadEvents: true,
+          canWriteEvents: true,
+          canReadBusy: true,
+          canInviteAttendees: true,
+        },
+      },
+    ],
+    cursor: "cursor-1",
+  }),
+};
+
 describe("dispatchSyncJob", () => {
   const storage = setupSyncStorage(import.meta.url);
   let events: EventRepository;
@@ -109,6 +137,10 @@ describe("dispatchSyncJob", () => {
   let resources: SyncResourceRepository;
   let calendars: ProviderCalendarRepository;
   let commands: CommandRepository;
+  let jobs: JobRepository;
+  // Dispatch resolves the connection for a calendarListSync job; a test sets what
+  // findById returns without seeding a full connection record.
+  let stubbedConnection: ProviderConnectionRecord | null;
 
   beforeEach(() => {
     events = new EventRepository(storage.db());
@@ -116,13 +148,22 @@ describe("dispatchSyncJob", () => {
     resources = new SyncResourceRepository(storage.db());
     calendars = new ProviderCalendarRepository(storage.db());
     commands = new CommandRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+    stubbedConnection = null;
   });
+
+  const connections = {
+    findById: async () => stubbedConnection,
+  } as unknown as SyncJobDispatchDeps["connections"];
 
   const deps = (reader: FakeReader): SyncJobDispatchDeps => ({
     events,
     occurrences,
     resources,
     calendars,
+    connections,
+    discovery,
+    jobs,
     commands,
     reader,
     custody: tokenSource,
@@ -350,5 +391,76 @@ describe("dispatchSyncJob", () => {
       resource._id,
     );
     expect(saved?.subscriptionResourceId).toBe("provider-resource");
+  });
+
+  const calendarListJob = (
+    connectionId: string,
+    tenantId: string,
+    principalId: string,
+  ): JobRecord =>
+    ({
+      _id: objectId(),
+      tenantId,
+      principalId,
+      connectionId,
+      resourceId: null,
+      commandId: null,
+      kind: "calendarListSync",
+      priority: 0,
+      state: "claimed",
+      runAfter: now(),
+      attempt: 0,
+      coalescingKey: `calendarListSync:${connectionId}`,
+      leaseOwner: "worker-1",
+      leaseExpiresAt: now(),
+      failureClass: null,
+      createdAt: now(),
+      updatedAt: now(),
+    }) as JobRecord;
+
+  it("routes calendarListSync to discovery and settles done", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId();
+    stubbedConnection = {
+      _id: connectionId,
+      tenantId,
+      principalId,
+    } as ProviderConnectionRecord;
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([])),
+      calendarListJob(connectionId, tenantId, principalId),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    // Discovery persisted the calendar and enqueued its initial import.
+    const persisted = await calendars.listByConnection(
+      tenantId as ProviderCalendarRecord["tenantId"],
+      principalId as ProviderCalendarRecord["principalId"],
+      connectionId as ProviderCalendarRecord["connectionId"],
+    );
+    expect(persisted).toHaveLength(1);
+    const importCount = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .countDocuments({ kind: "initialImport" });
+    expect(importCount).toBe(1);
+  });
+
+  it("drops a calendarListSync whose connection no longer exists", async () => {
+    stubbedConnection = null; // findById returns nothing
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([])),
+      calendarListJob(objectId(), objectId(), objectId()),
+      now,
+    );
+
+    expect(outcome).toEqual({
+      result: "drop",
+      reason: "connection no longer exists",
+    });
   });
 });

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -1,8 +1,10 @@
 import { importCalendarEvents } from "@sync/domain/calendar-import.service";
+import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
 import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
 import { repairCalendar } from "@sync/domain/calendar-repair.service";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
+import { type ProviderCalendarAdapter } from "@sync/providers/provider-calendar.port";
 import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
 import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
 import {
@@ -15,7 +17,9 @@ import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.c
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 export interface SyncJobDispatchDeps {
@@ -23,6 +27,11 @@ export interface SyncJobDispatchDeps {
   occurrences: EventOccurrenceRepository;
   resources: SyncResourceRepository;
   calendars: ProviderCalendarRepository;
+  // syncCalendarList resolves the connection a calendarListSync job targets,
+  // discovers its calendars, and enqueues an initial import per active calendar.
+  connections: ProviderConnectionRepository;
+  discovery: ProviderCalendarAdapter;
+  jobs: JobRepository;
   // pullCalendarChanges consults pending commands before deleting an event.
   commands: CommandRepository;
   reader: ProviderEventReader;
@@ -53,16 +62,31 @@ export type SyncJobOutcome =
   // Dispatch here does not own it; the loop routes it.
   | { readonly result: "unsupported"; readonly kind: JobRecord["kind"] };
 
-// Run one claimed provider-calendar sync job (initialImport / incrementalPull /
-// repair / subscriptionMaintain) and report how to settle it. Resolves the job's
-// resource and calendar first; a job whose target no longer exists is dropped
-// rather than retried forever. All reads/writes inside the called services are
-// owner-scoped.
+// Run one claimed sync job (calendarListSync / initialImport / incrementalPull /
+// repair / subscriptionMaintain) and report how to settle it. calendarListSync
+// resolves the job's CONNECTION; the rest resolve its resource and calendar. A
+// job whose target no longer exists is dropped rather than retried forever. All
+// reads/writes inside the called services are owner-scoped.
 export async function dispatchSyncJob(
   deps: SyncJobDispatchDeps,
   job: JobRecord,
   now: () => Date,
 ): Promise<SyncJobOutcome> {
+  // Calendar-list discovery is keyed on the connection, not a calendar/resource,
+  // so it is resolved and handled before the resource-based family below.
+  if (job.kind === "calendarListSync") {
+    const connection = await deps.connections.findById(
+      job.tenantId,
+      job.principalId,
+      job.connectionId,
+    );
+    if (!connection) {
+      return { result: "drop", reason: "connection no longer exists" };
+    }
+    await syncCalendarList(deps, connection, now);
+    return { result: "done" };
+  }
+
   if (
     job.kind !== "initialImport" &&
     job.kind !== "incrementalPull" &&

--- a/packages/sync/src/storage/contracts/job.contracts.ts
+++ b/packages/sync/src/storage/contracts/job.contracts.ts
@@ -8,6 +8,7 @@ import {
 } from "@core/types/sync/identity.contracts";
 
 export const JobKindSchema = z.enum([
+  "calendarListSync",
   "initialImport",
   "incrementalPull",
   "commandApply",

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -3,6 +3,7 @@ import {
   type ConnectionId,
   type PrincipalId,
   type ProviderCalendarId,
+  type ProviderCalendarSourceId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -64,6 +65,31 @@ export class ProviderCalendarRepository {
       throw new Error("Upsert did not return a calendar record");
     }
     return ProviderCalendarRecordSchema.parse(result);
+  }
+
+  // Mark inactive every calendar of a connection whose provider id is NOT in
+  // `presentProviderCalendarIds`, and return how many were changed. Used after a
+  // FULL discovery pass to retire calendars the account no longer lists (an
+  // incremental pass must not call this — absence there means "unchanged", not
+  // "removed"). Marking inactive rather than deleting keeps a calendar's Sync _id
+  // (and any downstream preferences) if it later returns. Owner-scoped.
+  async deactivateAbsent(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+    presentProviderCalendarIds: readonly ProviderCalendarSourceId[],
+  ): Promise<number> {
+    const result = await this.collection.updateMany(
+      {
+        tenantId,
+        principalId,
+        connectionId,
+        active: true,
+        providerCalendarId: { $nin: [...presentProviderCalendarIds] },
+      },
+      { $set: { active: false, updatedAt: new Date() } },
+    );
+    return result.modifiedCount;
   }
 
   async listByConnection(


### PR DESCRIPTION
## What

The **front of the sync chain** — the piece that turns a fresh connection into discovered calendars and first imports.

A fresh OAuth connect creates only a connection record + credential. Nothing discovered calendars, created an events resource, or enqueued an import — so the whole S29–S33 machinery (import → channel → webhook → pull → serve) had no starting point. `syncCalendarList` closes that gap.

## Flow

Driven by a new `calendarListSync` job kind (connection-resolved in dispatch):

1. Ensure the `calendarList` sync_resource (one per connection) — it holds the discovery cursor.
2. Discover the account's calendars (resume from the stored cursor; on `cursorExpired` re-list in full; any other failure throws so the worker retries).
3. Upsert each into `provider_calendars` (identity is the provider calendar id, so a rename keeps its Sync `_id`).
4. On a **full** list only, retire calendars no longer present (`deactivateAbsent`). An incremental pass returns only changed calendars, so absence there means *unchanged*, not removed.
5. For each **active** calendar, ensure its events resource and enqueue a coalesced `initialImport` — which imports events and, via its existing followup, opens the push channel.
6. Store the discovery cursor so the next pass lists incrementally.

## Design notes

- **Full vs incremental** is the load-bearing distinction: `deactivateAbsent` runs only on a full pass (fresh connection, or a `cursorExpired` fallback). Getting this wrong would either retire live calendars or fail to retire removed ones.
- The engine **enqueues N import jobs directly** (one per calendar — can't be a single dispatch followup), so dispatch deps gained `jobs`. Crash-safe because ensure + enqueue are idempotent and coalesced.
- An unwatchable/never-active calendar is never re-imported: imports are coalesced and one-shot.

## Scope

Engine + dispatch + app deps. **Enqueuing `calendarListSync` on connect** is the next slice (this engine is dormant until that lands, the same handler-before-trigger split used throughout this arc).

## Tests

- `calendar-list-sync.service.db.test.ts`: persist + import-per-active-calendar, events-resource-per-active, retire-on-full-list, keep-on-incremental, cursor resume, cursorExpired full re-list, discoveryFailed throw, idempotent coalescing — asserting persisted DB state.
- `sync-job-dispatch.service.db.test.ts`: routes `calendarListSync` to discovery (settles done, persists + enqueues) / drops when the connection is gone.
- Full sync suite green (47 files). type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Calendar retirement logic on full vs incremental passes is subtle; mistakes could deactivate live calendars or leave stale ones active, though guards limit empty-list damage.
> 
> **Overview**
> Adds **`syncCalendarList`** as the first step after OAuth: a new **`calendarListSync`** job kind loads calendars from the provider, upserts **`provider_calendars`**, and for each active calendar ensures an events sync resource plus a coalesced **`initialImport`**.
> 
> Discovery uses a per-connection **`calendarList`** sync resource for incremental cursors. **Full** passes may call **`deactivateAbsent`** to retire removed calendars; **incremental** passes do not treat missing IDs as removals. **`cursorExpired`** triggers a full re-list; empty full lists are ignored so calendars are not mass-deactivated on provider blips.
> 
> **`dispatchSyncJob`** handles connection-scoped **`calendarListSync`** (drops if the connection is gone). The worker is wired with **`GoogleCalendarAdapter`**, **`ProviderConnectionRepository`**, and **`JobRepository`**. **`ProviderCalendarRepository.deactivateAbsent`** supports full-list reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 545d9ed95b663b123ac6ee572c686aa0e49a8c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->