### PR TITLE
feat(sync): kick off calendar discovery when a connection links

### DIFF
--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -27,6 +27,7 @@ import {
   EVENTS_PATH,
   OAUTH_CALLBACK_PATH,
 } from "@sync/server/connection.routes";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
   type EventOccurrenceRecord,
   EventOccurrenceRecordSchema,
@@ -587,6 +588,29 @@ describe("GET /oauth/google/callback", () => {
 
     const stored = await credentials.findByConnection(linked[0]._id);
     expect(stored?.refreshToken).toBe("granted-refresh-token");
+  });
+
+  it("enqueues calendar-list discovery to bootstrap the new connection", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService(activeConfig(), adapter);
+
+    await hitCallback(
+      `code=auth-code&state=${encodeURIComponent(validState(tenantId, principalId))}`,
+    );
+
+    const [linked] = await connections.listByPrincipal(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+    );
+    // The connect enqueues one calendarListSync job for the new connection; it is
+    // the only trigger that starts the sync chain.
+    const job = await mongo.db
+      .collection(SYNC_COLLECTIONS.jobs)
+      .findOne({ coalescingKey: `calendarListSync:${linked._id}` });
+    expect(job?.kind).toBe("calendarListSync");
+    expect(job?.connectionId).toBe(linked._id);
+    expect(job?.resourceId).toBeNull();
   });
 
   it("redirects with an error and links nothing when the state is invalid", async () => {

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -43,6 +43,7 @@ import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-ca
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -545,6 +546,26 @@ async function linkConnection(
       .catch(() => undefined);
     throw error;
   }
+
+  // Bootstrap the connection's sync: enqueue a calendar-list discovery, which
+  // discovers the account's calendars and, per active calendar, enqueues the
+  // initial import (whose followup opens the push channel). This is the ONLY
+  // trigger that starts the sync chain for a new connection. Coalesced per
+  // connection, so a reconnect (which re-links) collapses into one discovery
+  // rather than piling up. A failure throws so the connect is reported failed and
+  // retried, rather than silently leaving a connection that never syncs.
+  const jobs = new JobRepository(deps.mongo.db);
+  await jobs.enqueue({
+    tenantId: state.tenantId,
+    principalId: state.principalId,
+    connectionId: connection._id,
+    resourceId: null,
+    commandId: null,
+    kind: "calendarListSync",
+    priority: 0,
+    runAfter: new Date(),
+    coalescingKey: `calendarListSync:${connection._id}`,
+  });
 }
 
 // Map a stored connection record (string ids, Date timestamps) to the wire


### PR DESCRIPTION
## What

The trigger that makes calendar discovery live. `linkConnection` now enqueues a `calendarListSync` job once a connection and its credential are persisted.

Before this, connecting an account created only the connection record + credential and then nothing happened — no calendars discovered, no imports, no channels. This is the single trigger that starts the sync chain for a new (or reconnected) account.

## End to end (finally closed)

connect → **enqueue calendarListSync** → discovery upserts calendars + enqueues an import per active calendar → import opens the push channel → provider pushes hit the webhook fast path → coalesced pull → reads serve. Reconcile and subscription sweeps keep it live.

## Notes

- **Gated already**: the OAuth callback runs only on an active, provider-configured deployment, so the enqueue never fires in passive mode.
- **Coalesced per connection** (`calendarListSync:<connectionId>`): a reconnect re-links the same connection and collapses into one discovery.
- **Not best-effort**: if the enqueue throws, the connect is reported failed and retried (re-link is idempotent, re-enqueue coalesces) rather than leaving a connection that's persisted but never syncs.

## Tests

- `connection.routes.db.test.ts`: a valid callback enqueues one `calendarListSync` job for the new connection with the right kind, coalescing key, connectionId, and null resourceId.
- Full sync suite green (47 files). type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OAuth success path and job queue; misbehavior could block connects or leave accounts unsynced, but scope is narrow and covered by a new integration test.
> 
> **Overview**
> **OAuth connect now starts sync** by enqueueing a `calendarListSync` job at the end of `linkConnection`, after the connection and credential are stored. That job is the only entry point into calendar discovery → per-calendar import → push channels; without it, a linked account never progressed.
> 
> Jobs are **coalesced** with `calendarListSync:<connectionId>` so reconnects collapse to one discovery. **Enqueue is not best-effort**: a failed write propagates so the callback reports failure and the client can retry, instead of leaving a persisted connection that never syncs.
> 
> A DB integration test asserts a successful Google callback creates exactly one job with the expected kind, `connectionId`, null `resourceId`, and coalescing key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c66727dd75b725e2d24e708ce0f8199e6100d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->