### PR TITLE
feat(sync): bound job retries and jitter their backoff

### DIFF
--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -116,6 +116,11 @@ describe("SyncJobWorker", () => {
   const worker = (reader: FakeReader) =>
     new SyncJobWorker(deps(reader), OWNER, { now });
 
+  const workerWith = (
+    reader: FakeReader,
+    options: { maxAttempts?: number; random?: () => number },
+  ) => new SyncJobWorker(deps(reader), OWNER, { now, ...options });
+
   const seedCalendar = (): Promise<ProviderCalendarRecord> =>
     calendars.upsertByProviderCalendar({
       tenantId: objectId() as ProviderCalendarRecord["tenantId"],
@@ -255,6 +260,68 @@ describe("SyncJobWorker", () => {
     );
     expect(after?.state).toBe("pending");
     expect(after!.runAfter.getTime()).toBeGreaterThan(now().getTime());
+  });
+
+  it("fails a transient job once its retries are exhausted", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const job = await enqueue(resource, "incrementalPull");
+
+    // maxAttempts: 1 means the first (attempt 1) transient failure is terminal.
+    await workerWith(
+      new FakeReader([], new ProviderEventReadError("transient", "flaky")),
+      { maxAttempts: 1 },
+    ).runOnce();
+
+    const after = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      job._id,
+    );
+    expect(after?.state).toBe("failed");
+    expect(after?.failureClass).toBe("retryableTransient");
+    expect(after?.leaseOwner).toBeNull();
+  });
+
+  it("keeps a failed job's coalescing key so enqueue does not replace it", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await enqueue(resource, "incrementalPull");
+
+    await workerWith(
+      new FakeReader([], new ProviderEventReadError("transient", "flaky")),
+      { maxAttempts: 1 },
+    ).runOnce();
+
+    // A fresh trigger for the same resource coalesces onto the failed job rather
+    // than creating a new pending one — the failure needs attention first.
+    const reenqueued = await enqueue(resource, "incrementalPull");
+    expect(reenqueued.state).toBe("failed");
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({ coalescingKey: `incrementalPull:${resource._id}` }),
+    ).toBe(1);
+  });
+
+  it("applies bounded jitter to the retry backoff", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    const job = await enqueue(resource, "repair");
+
+    // random 0 => the low end of the +/-20% jitter on the 10s base (attempt 1).
+    await workerWith(new FakeReader([pageOf([single("keep")], null)]), {
+      random: () => 0,
+    }).runOnce();
+
+    const after = await jobs.findById(
+      resource.tenantId,
+      resource.principalId,
+      job._id,
+    );
+    // base 10_000ms * (1 - 0.2) = 8_000ms after now.
+    expect(after?.runAfter).toEqual(new Date(now().getTime() + 8_000));
   });
 
   it("drops a job whose resource no longer exists", async () => {

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -16,34 +16,53 @@ export interface SyncJobWorkerOptions {
   // reclaimed and re-run — safe, because every engine is idempotent, just
   // wasteful.
   leaseMs?: number;
-  // When to retry a job that failed or asked to be retried, from its attempt
-  // count. The default is a capped exponential with no jitter; fair scheduling
-  // and jitter are S34's concern.
+  // When to retry a job that asked to be retried, from its attempt count. The
+  // default is a capped exponential with jitter (so a burst of jobs that failed
+  // together do not all retry in lockstep). Tests inject a deterministic one.
   backoff?: (attempt: number, now: Date) => Date;
+  // How many times a transient failure is retried before the job is marked a
+  // terminal failure needing attention. Bounds retries so a persistently-failing
+  // job cannot loop forever.
+  maxAttempts?: number;
+  // Injectable [0,1) source so a test can pin the backoff jitter; defaults to
+  // Math.random.
+  random?: () => number;
   now?: () => Date;
 }
 
 const DEFAULT_LEASE_MS = 5 * 60_000;
+const DEFAULT_MAX_ATTEMPTS = 20;
 const BACKOFF_BASE_MS = 10_000;
 const BACKOFF_CAP_MS = 10 * 60_000;
+const BACKOFF_JITTER_RATIO = 0.2;
 
-// Capped exponential backoff. attempt is >= 1 (claimDueJob increments it on
-// every claim), so the first retry waits BACKOFF_BASE_MS.
-function defaultBackoff(attempt: number, now: Date): Date {
+// Capped exponential backoff with jitter. attempt is >= 1 (claimDueJob increments
+// it on every claim), so the first retry waits ~BACKOFF_BASE_MS. The jitter
+// (delay * (1 ± ratio)) spreads jobs that failed together — e.g. a whole
+// provider outage — so they do not retry in a synchronized thundering herd.
+function jitteredBackoff(
+  attempt: number,
+  now: Date,
+  random: () => number,
+): Date {
   const exp = Math.min(attempt - 1, 6);
-  const delay = Math.min(BACKOFF_CAP_MS, BACKOFF_BASE_MS * 2 ** exp);
+  const base = Math.min(BACKOFF_CAP_MS, BACKOFF_BASE_MS * 2 ** exp);
+  const swing = BACKOFF_JITTER_RATIO * (random() * 2 - 1);
+  const delay = Math.max(0, Math.round(base * (1 + swing)));
   return new Date(now.getTime() + delay);
 }
 
 // Drains the job queue: claim a due job, run it through dispatch, and settle it
-// (delete on success, reschedule on retry). One worker owns a lease; several can
-// run concurrently and never both win the same job (claimDueJob is atomic). The
-// continuous poll timer, heartbeat, and lifecycle wiring are a later slice; this
-// is the claim -> dispatch -> settle core they drive.
+// (delete on success, reschedule on transient failure, mark failed once retries
+// are exhausted or the failure is permanent). One worker owns a lease; several
+// can run concurrently and never both win the same job (claimDueJob is atomic).
+// The lease heartbeat for a job outliving its lease is a later slice; this is the
+// claim -> dispatch -> settle core the scheduler drives.
 export class SyncJobWorker {
   readonly #deps: SyncJobWorkerDeps;
   readonly #owner: string;
   readonly #leaseMs: number;
+  readonly #maxAttempts: number;
   readonly #backoff: (attempt: number, now: Date) => Date;
   readonly #now: () => Date;
 
@@ -55,7 +74,11 @@ export class SyncJobWorker {
     this.#deps = deps;
     this.#owner = owner;
     this.#leaseMs = options.leaseMs ?? DEFAULT_LEASE_MS;
-    this.#backoff = options.backoff ?? defaultBackoff;
+    this.#maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    const random = options.random ?? Math.random;
+    this.#backoff =
+      options.backoff ??
+      ((attempt, now) => jitteredBackoff(attempt, now, random));
     this.#now = options.now ?? (() => new Date());
   }
 
@@ -89,14 +112,8 @@ export class SyncJobWorker {
       outcome = await dispatchSyncJob(this.#deps, job, this.#now);
     } catch {
       // An engine threw (a transient provider/storage error dispatch does not
-      // model as a status). Reschedule for a backed-off retry rather than lose
-      // the job; S34 refines the retryable/permanent classification.
-      await this.#deps.jobs.scheduleRetry(
-        job._id,
-        this.#owner,
-        this.#backoff(job.attempt, this.#now()),
-        "retryableTransient",
-      );
+      // model as a status). Treat it as retryable; the cap still bounds it.
+      await this.#settleFailure(job, "retryableTransient");
       return;
     }
 
@@ -114,25 +131,38 @@ export class SyncJobWorker {
         await this.#deps.jobs.complete(job._id, this.#owner);
         return;
       case "retry":
-        await this.#deps.jobs.scheduleRetry(
-          job._id,
-          this.#owner,
-          this.#backoff(job.attempt, this.#now()),
-          outcome.failureClass,
-        );
+        await this.#settleFailure(job, outcome.failureClass);
         return;
       case "unsupported":
         // No handler for this kind in this build (commandApply/reconcile arrive
-        // later). Hold it for a future build via a backed-off retry rather than
-        // hot-loop or drop unfinished work. No producer enqueues these kinds
-        // yet, so this is defensive.
-        await this.#deps.jobs.scheduleRetry(
-          job._id,
-          this.#owner,
-          this.#backoff(job.attempt, this.#now()),
-          "retryableTransient",
-        );
+        // later). Hold it via a backed-off retry rather than hot-loop or drop
+        // unfinished work; the cap eventually fails a job that no build claims.
+        // No producer enqueues these kinds yet, so this is defensive.
+        await this.#settleFailure(job, "retryableTransient");
         return;
     }
+  }
+
+  // Reschedule a failed job for a backed-off retry, OR mark it a terminal failure
+  // once retries are exhausted or the failure is permanent. A failed job keeps
+  // its coalescing key, so enqueue will not create a replacement until an
+  // operator clears it — deliberate backpressure: a persistently-broken resource
+  // stops and asks for attention rather than looping (or resurrecting on every
+  // sweep, which would be unlimited retries by another name).
+  async #settleFailure(
+    job: JobRecord,
+    failureClass: JobRecord["failureClass"],
+  ): Promise<void> {
+    const exhausted = job.attempt >= this.#maxAttempts;
+    if (failureClass === "permanent" || exhausted) {
+      await this.#deps.jobs.fail(job._id, this.#owner, failureClass);
+      return;
+    }
+    await this.#deps.jobs.scheduleRetry(
+      job._id,
+      this.#owner,
+      this.#backoff(job.attempt, this.#now()),
+      failureClass,
+    );
   }
 }


### PR DESCRIPTION
## What

The first slice of retry fairness (S34): stop retrying failed jobs forever.

Before this, a job whose engine kept failing was rescheduled indefinitely. Now the worker:

- Retries **transient** failures with a jittered capped-exponential backoff until `maxAttempts` (default 20), then marks the job a terminal **failure** (`JobRepository.fail`, previously unused) needing attention.
- Fails a **permanent** failure immediately (mechanism ready; no engine classifies permanent yet).
- Adds **±20% jitter** to the backoff so a batch of jobs that failed together (a provider outage) don't all retry in lockstep.

## Backpressure by design

A `failed` job keeps its coalescing key, and `enqueue` coalesces on that key regardless of state (unlike `complete()`, which deletes it). So a failed job is **not silently replaced** by the next webhook or sweep — a permanently-broken resource stops and asks for attention rather than resurrecting every cycle (which would be "unlimited retries" by another name). Sweeps use per-resource keys, so only the broken resource is blocked, never its neighbors.

## Tests

- fails a transient job once retries are exhausted (state `failed`, `failureClass`, cleared lease)
- a failed job's coalescing key blocks a replacement enqueue
- bounded jitter on the retry backoff (pinned `random` → exact `runAfter`)
- Full sync suite green (47 files). type-check + biome clean.

Concurrency limits, priority ordering, and tenant rotation are later S34 slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core job settlement in the sync worker (retry vs fail), which affects queue behavior under provider outages; scope is localized to `SyncJobWorker` with strong DB tests.
> 
> **Overview**
> **Sync job worker** no longer reschedules failures indefinitely. Failures flow through `#settleFailure`: transient errors still use capped exponential backoff, but only until `maxAttempts` (default **20**), then `JobRepository.fail` marks the job terminal with `failureClass` and a cleared lease. **Permanent** failures fail immediately (ready for engines that classify them later).
> 
> Default retry delay adds **±20% jitter** on the exponential base (injectable `random` for tests). Retry, dispatch throws, and unsupported job paths all use the same settlement logic instead of always calling `scheduleRetry`.
> 
> **Backpressure:** failed jobs keep their coalescing key, so a new `enqueue` for the same resource coalesces onto the failed row instead of spawning a fresh pending job until something clears the failure.
> 
> DB tests cover exhaustion, coalescing after fail, and pinned jitter (`runAfter` = 8s at `random() => 0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204c63f14489f3421d9faf0868d2b026a193f502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->