### PR TITLE
feat(sync): heartbeat a running job's lease so long work is not re-run

### DIFF
--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -324,6 +324,90 @@ describe("SyncJobWorker", () => {
     expect(after?.runAfter).toEqual(new Date(now().getTime() + 8_000));
   });
 
+  it("schedules a heartbeat per job and stops it once the job settles", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await enqueue(resource, "incrementalPull");
+
+    let everyMs = 0;
+    let stopped = false;
+    const w = new SyncJobWorker(
+      deps(new FakeReader([pageOf([single("a")], "cursor-1")])),
+      OWNER,
+      {
+        now,
+        leaseMs: 30_000,
+        heartbeatMs: 10_000,
+        scheduleHeartbeat: (_beat, ms) => {
+          everyMs = ms;
+          return () => {
+            stopped = true;
+          };
+        },
+      },
+    );
+
+    await w.runOnce();
+
+    expect(everyMs).toBe(10_000);
+    expect(stopped).toBe(true); // cleaned up in the finally, even on success
+  });
+
+  it("extends the lease of a running job through the heartbeat", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await enqueue(resource, "incrementalPull");
+
+    // A mutable clock so a heartbeat's new expiry differs from the claim's.
+    let clock = now().getTime();
+    const movingNow = () => new Date(clock);
+
+    // A reader that blocks the pull mid-flight until released, so the job stays
+    // claimed while we fire a heartbeat.
+    let releaseRead: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const gatedReader = {
+      provider: "google" as const,
+      async listEventPage() {
+        await gate;
+        return pageOf([single("x")], "cursor-1");
+      },
+    } as unknown as FakeReader;
+
+    let beat: (() => void | Promise<void>) | null = null;
+    const w = new SyncJobWorker(deps(gatedReader), OWNER, {
+      now: movingNow,
+      leaseMs: 300_000,
+      scheduleHeartbeat: (b) => {
+        beat = b;
+        return () => {};
+      },
+    });
+
+    const run = w.runOnce();
+    // Wait until the worker has claimed the job and scheduled its heartbeat
+    // (claimDueJob is a real round-trip, so a bare setTimeout(0) can beat it).
+    while (!beat) await new Promise((r) => setTimeout(r, 5));
+
+    const claimed = await jobByKey(`incrementalPull:${resource._id}`);
+    const claimedLease = (claimed?.leaseExpiresAt as Date).getTime();
+
+    // Advance time and fire one heartbeat; the lease must move forward.
+    clock += 60_000;
+    await beat?.();
+
+    const beaten = await jobByKey(`incrementalPull:${resource._id}`);
+    expect((beaten?.leaseExpiresAt as Date).getTime()).toBe(clock + 300_000);
+    expect((beaten?.leaseExpiresAt as Date).getTime()).toBeGreaterThan(
+      claimedLease,
+    );
+
+    releaseRead();
+    await run;
+  });
+
   it("drops a job whose resource no longer exists", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -76,8 +76,8 @@ function jitteredBackoff(
 // (delete on success, reschedule on transient failure, mark failed once retries
 // are exhausted or the failure is permanent). One worker owns a lease; several
 // can run concurrently and never both win the same job (claimDueJob is atomic).
-// The lease heartbeat for a job outliving its lease is a later slice; this is the
-// claim -> dispatch -> settle core the scheduler drives.
+// A heartbeat keeps a long-running job's lease alive while it works (see
+// #process), so it is not reclaimed and re-run mid-flight.
 export class SyncJobWorker {
   readonly #deps: SyncJobWorkerDeps;
   readonly #owner: string;

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -10,12 +10,20 @@ export interface SyncJobWorkerDeps extends SyncJobDispatchDeps {
 }
 
 export interface SyncJobWorkerOptions {
-  // How long a claimed job's lease lasts. Generous by default: a heartbeat that
-  // extends the lease of a long-running job is a later slice, so the lease alone
-  // must outlast a normal import/pull/repair. A job that outlives its lease is
-  // reclaimed and re-run — safe, because every engine is idempotent, just
-  // wasteful.
+  // How long a claimed job's lease lasts. A job still making progress keeps its
+  // lease alive via the heartbeat below, so this only needs to outlast the gap
+  // between heartbeats. A job that outlives its lease anyway (its worker stalled
+  // or crashed) is reclaimed and re-run — safe, because every engine is
+  // idempotent, just wasteful.
   leaseMs?: number;
+  // How often to extend a claimed job's lease while it is still running. Must be
+  // comfortably shorter than leaseMs so the lease never lapses under a long
+  // import/repair. Defaults to a third of the lease.
+  heartbeatMs?: number;
+  // Injectable timer so tests can drive the heartbeat deterministically. Given a
+  // callback and an interval, it returns a function that stops the timer.
+  // Defaults to setInterval/clearInterval.
+  scheduleHeartbeat?: (beat: () => void, everyMs: number) => () => void;
   // When to retry a job that asked to be retried, from its attempt count. The
   // default is a capped exponential with jitter (so a burst of jobs that failed
   // together do not all retry in lockstep). Tests inject a deterministic one.
@@ -31,7 +39,19 @@ export interface SyncJobWorkerOptions {
 }
 
 const DEFAULT_LEASE_MS = 5 * 60_000;
+// A third of the lease: up to two heartbeats can be missed before the lease
+// lapses, so a single hiccup does not trigger a spurious reclaim.
+const DEFAULT_HEARTBEAT_DIVISOR = 3;
 const DEFAULT_MAX_ATTEMPTS = 20;
+
+// Real timer used when the caller injects none.
+const setIntervalHeartbeat = (
+  beat: () => void,
+  everyMs: number,
+): (() => void) => {
+  const id = setInterval(beat, everyMs);
+  return () => clearInterval(id);
+};
 const BACKOFF_BASE_MS = 10_000;
 const BACKOFF_CAP_MS = 10 * 60_000;
 const BACKOFF_JITTER_RATIO = 0.2;
@@ -62,6 +82,11 @@ export class SyncJobWorker {
   readonly #deps: SyncJobWorkerDeps;
   readonly #owner: string;
   readonly #leaseMs: number;
+  readonly #heartbeatMs: number;
+  readonly #scheduleHeartbeat: (
+    beat: () => void,
+    everyMs: number,
+  ) => () => void;
   readonly #maxAttempts: number;
   readonly #backoff: (attempt: number, now: Date) => Date;
   readonly #now: () => Date;
@@ -74,6 +99,10 @@ export class SyncJobWorker {
     this.#deps = deps;
     this.#owner = owner;
     this.#leaseMs = options.leaseMs ?? DEFAULT_LEASE_MS;
+    this.#heartbeatMs =
+      options.heartbeatMs ??
+      Math.floor(this.#leaseMs / DEFAULT_HEARTBEAT_DIVISOR);
+    this.#scheduleHeartbeat = options.scheduleHeartbeat ?? setIntervalHeartbeat;
     this.#maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
     const random = options.random ?? Math.random;
     this.#backoff =
@@ -107,6 +136,29 @@ export class SyncJobWorker {
   }
 
   async #process(job: JobRecord): Promise<void> {
+    // Keep the lease alive while the job runs, so a long import/repair that
+    // outlasts a single lease is not reclaimed and redundantly re-run (wasting
+    // provider quota) by another worker. A heartbeat failure is non-fatal — the
+    // lease simply lapses and the job is reclaimed, same as before this existed.
+    // The beat returns the heartbeat promise (so a test can await one tick); the
+    // default setInterval ignores it. A heartbeat rejection is swallowed here so
+    // an unhandled rejection can never crash the worker.
+    const stopHeartbeat = this.#scheduleHeartbeat(
+      () =>
+        this.#deps.jobs
+          .heartbeat(job._id, this.#owner, this.#now(), this.#leaseMs)
+          .then(() => {})
+          .catch(() => {}),
+      this.#heartbeatMs,
+    );
+    try {
+      await this.#runJob(job);
+    } finally {
+      stopHeartbeat();
+    }
+  }
+
+  async #runJob(job: JobRecord): Promise<void> {
     let outcome: Awaited<ReturnType<typeof dispatchSyncJob>>;
     try {
       outcome = await dispatchSyncJob(this.#deps, job, this.#now);


### PR DESCRIPTION
## What

A long initial import or repair can exceed the 5-minute job lease, at which point another worker reclaims it and redundantly re-runs the same work — wasting provider API quota (and risking rate limits) even though every engine is idempotent.

Now, while a job runs, the worker periodically extends its lease (every `leaseMs / 3` by default) so a job still making progress keeps its claim.

## Notes

- **Best-effort**: a heartbeat failure is swallowed; if the lease lapses anyway, the job is reclaimed and re-run — exactly the prior behavior, just now the common case (steady progress) avoids it.
- **Owner + state scoped**: `heartbeat()` only extends a job that is still `claimed` by this worker, so a beat that races a `complete`/`fail`/`scheduleRetry` no-ops — it can't resurrect a settled job's lease.
- **Injectable timer**: `scheduleHeartbeat` lets tests drive beats deterministically; the default is `setInterval`/`clearInterval`, stopped in a `finally` so it never leaks.
- `#process` now wraps `#runJob` (the former dispatch+settle body) with the heartbeat start/stop.

## Tests

- schedules a heartbeat per job with the configured interval and stops it once the job settles
- extends the lease of a running job through the heartbeat (gated reader holds the job claimed + a moving clock proves the expiry advances to an exact value)
- Full sync suite green (47 files, run twice). type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core job-claim concurrency and lease timing; failures degrade to prior reclaim behavior, but bugs could cause duplicate work or stuck claims under load.
> 
> **Overview**
> **Long-running sync jobs** (imports/repairs) can now keep their claim instead of expiring the 5-minute lease and being picked up again by another worker.
> 
> While a job is processing, `SyncJobWorker` starts a **periodic heartbeat** (default every `leaseMs / 3`) that calls `jobs.heartbeat()` to push `leaseExpiresAt` forward. The timer is stopped in a `finally` when the job finishes. Heartbeat errors are swallowed so behavior falls back to the previous reclaim-and-re-run model.
> 
> New worker options include **`heartbeatMs`**, **`scheduleHeartbeat`** (for deterministic tests), and updated docs that frame **`leaseMs`** as covering the gap between beats rather than the whole job duration. Dispatch/settle logic moves into **`#runJob`**, wrapped by **`#process`** for heartbeat lifecycle.
> 
> DB tests cover that the heartbeat uses the configured interval and is cleaned up on success, and that a manual beat extends the lease while the job stays claimed mid-pull.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb058f53978258c0c0aab3e57dd4097d6c5fe773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->