### PR TITLE
feat(sync): give occurrences a normalized endAt for overlap queries

### DIFF
--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -76,6 +76,8 @@ describe("projectOccurrences", () => {
         generation: 0,
       });
       expect(occ?.startAt.toISOString()).toBe("2026-07-14T15:00:00.000Z");
+      // Half-open end: the timed end instant.
+      expect(occ?.endAt?.toISOString()).toBe("2026-07-14T16:00:00.000Z");
       expect(occ?.occurrenceKey).toBe(`${e._id}:2026-07-14T15:00:00.000Z`);
     });
 
@@ -84,6 +86,8 @@ describe("projectOccurrences", () => {
       const [occ] = projectOccurrences(e, HORIZON);
       expect(occ?.schedule).toEqual(allDay("2026-07-14", "2026-07-15"));
       expect(occ?.startAt.toISOString()).toBe("2026-07-14T00:00:00.000Z");
+      // The all-day end date is exclusive, so endAt is midnight UTC of it.
+      expect(occ?.endAt?.toISOString()).toBe("2026-07-15T00:00:00.000Z");
     });
 
     it("omits a single event whose start is before the horizon", () => {
@@ -153,6 +157,8 @@ describe("projectOccurrences", () => {
           new Date(o.schedule.end).getTime() -
           new Date(o.schedule.start).getTime();
         expect(durationMs).toBe(30 * 60 * 1000);
+        // endAt tracks the shifted duration on the normalized axis too.
+        expect(o.endAt?.getTime()).toBe(o.startAt.getTime() + 30 * 60 * 1000);
       }
     });
 

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -241,6 +241,7 @@ function toOccurrence(
     calendarId: event.calendarId,
     schedule,
     startAt,
+    endAt: scheduleEndAt(schedule),
     // Sync's content carries no free/busy transparency yet, so every occurrence
     // is busy. Transparency modeling lands with provider content mapping.
     busy: true,
@@ -256,6 +257,17 @@ function toOccurrence(
 export function scheduleStartAt(schedule: EventSchedule): Date {
   if (schedule.kind === "timed") return new Date(schedule.start);
   return new Date(`${schedule.start}T00:00:00.000Z`);
+}
+
+// The normalized EXCLUSIVE end instant, paired with scheduleStartAt to form a
+// half-open [startAt, endAt) interval on one coherent UTC axis — what a busy /
+// overlap query needs (a timed or all-day occurrence starting before a window
+// but ending inside it still overlaps it). The all-day end date is already
+// exclusive, so midnight UTC of it is the exclusive end. Both schedule kinds
+// guarantee end > start, so endAt is always strictly after startAt.
+export function scheduleEndAt(schedule: EventSchedule): Date {
+  if (schedule.kind === "timed") return new Date(schedule.end);
+  return new Date(`${schedule.end}T00:00:00.000Z`);
 }
 
 function withinHorizon(instant: Date, horizon: ProjectionHorizon): boolean {

--- a/packages/sync/src/storage/contracts/event-occurrence.contracts.ts
+++ b/packages/sync/src/storage/contracts/event-occurrence.contracts.ts
@@ -31,6 +31,14 @@ export const EventOccurrenceRecordSchema = z.strictObject({
   // occurrences compare on one coherent axis — string-comparing the union
   // schedule.start would be wrong across schedule kinds and offsets.
   startAt: z.date(),
+  // Normalized EXCLUSIVE end instant, paired with startAt as a half-open
+  // [startAt, endAt) interval so a busy/overlap query can find an occurrence
+  // that starts before a window but ends inside it. Optional ONLY during the
+  // rollout: the projection always sets it now, and existing occurrences pick it
+  // up on their next reprojection (every import/pull/repair rewrites them), so no
+  // read breaks on a doc that predates the field. Tighten to required once every
+  // occurrence carries it.
+  endAt: z.date().optional(),
   busy: z.boolean(),
   title: z.string(),
   cancelled: z.boolean(),


### PR DESCRIPTION
## What

The foundation for the freshness-aware busy query (S36).

Occurrences carry a normalized `startAt` but no end instant, so a range read can only match events that *start* in the window. A busy query needs interval **overlap** — an event that starts before the window but ends inside it is busy during it.

This adds `scheduleEndAt` (timed → the end instant; all-day → the exclusive end date at midnight UTC) and sets `endAt` on every projected occurrence, forming a half-open `[startAt, endAt)` interval on one coherent UTC axis — mirroring `scheduleStartAt`. Since both schedule kinds enforce `end > start`, `endAt` is always strictly after `startAt`.

## The endAt decision (why optional)

The schema field is `z.date().optional()` **only during rollout**:

- The occurrence record is a `strictObject`, so making `endAt` required would break parsing of any occurrence that predates the field — and staging may hold some now that connect → discovery → import is live.
- Occurrences are fully **derived and regenerated** on every import/pull/repair, so a pre-field occurrence picks up `endAt` on its next reprojection (within the normal sync cycle).
- Optional therefore avoids any read-break, needs no migration, and has no deploy-ordering hazard. A trivial follow-up tightens it to required once every occurrence carries it.

`toOccurrence` is the sole occurrence-construction site, so this covers single, exception, and series-expanded occurrences (the series path preserves the shifted duration).

## Tests

- exact `endAt` for a timed single (`16:00:00Z`) and an all-day single (exclusive `2026-07-15T00:00:00Z`)
- series occurrences: `endAt` tracks the shifted duration
- Full sync suite green (47 files, 527 tests). type-check + biome clean.

Next in S36: the busy-overlap read + `mergeBusyIntervals` algebra, then freshness/bookability, then the internal HTTP route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive derived-field change with optional schema rollout; no overlap query or read-path behavior changes yet, and occurrences are rewritten on normal sync cycles.
> 
> **Overview**
> Adds a normalized **`endAt`** on every projected occurrence so busy/range logic can use half-open **`[startAt, endAt)`** overlap, not only “starts in window.”
> 
> **`scheduleEndAt`** mirrors **`scheduleStartAt`**: timed events use the schedule end instant; all-day events use midnight UTC on the already-exclusive end date. **`toOccurrence`** always sets **`endAt`** from the occurrence’s schedule (singles, exceptions, and series-expanded rows keep duration on the normalized axis).
> 
> The **`EventOccurrenceRecord`** schema gains **`endAt`** as **optional** during rollout so existing stored occurrences without the field still parse; reprojection on import/pull/repair backfills it without a migration.
> 
> Tests assert **`endAt`** for timed and all-day singles and that weekly series **`endAt`** equals **`startAt` + duration**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dbe8c8fe22a0fb299d1fd8ab7d7b015f636d07b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->