### PR TITLE
feat(sync): compute merged busy intervals for a calendar set and window

### DIFF
--- a/packages/sync/src/domain/busy-query.service.db.test.ts
+++ b/packages/sync/src/domain/busy-query.service.db.test.ts
@@ -1,0 +1,185 @@
+import { faker } from "@faker-js/faker";
+import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { queryBusyIntervals } from "@sync/domain/busy-query.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const WINDOW_START = new Date("2026-07-14T09:00:00.000Z");
+const WINDOW_END = new Date("2026-07-14T17:00:00.000Z");
+
+describe("queryBusyIntervals", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let occurrences: EventOccurrenceRepository;
+  let tenantId: TenantId;
+  let principalId: PrincipalId;
+  let calendarA: SyncEventCalendarId;
+  let calendarB: SyncEventCalendarId;
+
+  beforeEach(() => {
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    tenantId = objectId() as TenantId;
+    principalId = objectId() as PrincipalId;
+    calendarA = objectId() as SyncEventCalendarId;
+    calendarB = objectId() as SyncEventCalendarId;
+  });
+
+  // Insert a raw occurrence doc with only the fields the busy read touches.
+  const seed = (input: {
+    calendarId: SyncEventCalendarId;
+    start: string;
+    end?: string;
+    generation?: number;
+    busy?: boolean;
+    cancelled?: boolean;
+  }) => {
+    // Unique eventId + occurrenceKey per doc: the collection has a unique index
+    // on (eventId, generation, occurrenceKey), so distinct seeds must not collide.
+    const eventId = objectId();
+    return storage
+      .db()
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .insertOne({
+        _id: objectId(),
+        tenantId,
+        principalId,
+        eventId,
+        occurrenceKey: `${eventId}:${input.start}`,
+        calendarId: input.calendarId,
+        generation: input.generation ?? 0,
+        startAt: new Date(input.start),
+        ...(input.end ? { endAt: new Date(input.end) } : {}),
+        busy: input.busy ?? true,
+        cancelled: input.cancelled ?? false,
+      });
+  };
+
+  const query = (
+    calendars: Array<{ calendarId: SyncEventCalendarId; generation: number }>,
+  ) =>
+    queryBusyIntervals(
+      { occurrences },
+      {
+        tenantId,
+        principalId,
+        calendars,
+        start: WINDOW_START,
+        end: WINDOW_END,
+      },
+    );
+
+  const iso = (intervals: { start: Date; end: Date }[]) =>
+    intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]);
+
+  it("merges busy occurrences across calendars and keeps disjoint ones separate", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T09:00Z",
+      end: "2026-07-14T10:00Z",
+    });
+    await seed({
+      calendarId: calendarB,
+      start: "2026-07-14T09:30Z",
+      end: "2026-07-14T11:00Z",
+    });
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T14:00Z",
+      end: "2026-07-14T15:00Z",
+    });
+
+    const result = await query([
+      { calendarId: calendarA, generation: 0 },
+      { calendarId: calendarB, generation: 0 },
+    ]);
+
+    expect(iso(result)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+      ["2026-07-14T14:00:00.000Z", "2026-07-14T15:00:00.000Z"],
+    ]);
+  });
+
+  it("includes and clamps an occurrence that overlaps the window start", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T08:00Z",
+      end: "2026-07-14T09:30Z",
+    });
+
+    const result = await query([{ calendarId: calendarA, generation: 0 }]);
+
+    // Clamped to the window start.
+    expect(iso(result)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T09:30:00.000Z"],
+    ]);
+  });
+
+  it("clamps an occurrence that overlaps the window end", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T16:30Z",
+      end: "2026-07-14T18:00Z",
+    });
+
+    const result = await query([{ calendarId: calendarA, generation: 0 }]);
+
+    expect(iso(result)).toEqual([
+      ["2026-07-14T16:30:00.000Z", "2026-07-14T17:00:00.000Z"],
+    ]);
+  });
+
+  it("reads each calendar only at its active generation", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T09:00Z",
+      end: "2026-07-14T10:00Z",
+      generation: 0,
+    });
+    // A newer generation being built by a repair must not be read.
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T12:00Z",
+      end: "2026-07-14T13:00Z",
+      generation: 1,
+    });
+
+    const result = await query([{ calendarId: calendarA, generation: 0 }]);
+
+    expect(iso(result)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T10:00:00.000Z"],
+    ]);
+  });
+
+  it("excludes cancelled occurrences", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T09:00Z",
+      end: "2026-07-14T10:00Z",
+      cancelled: true,
+    });
+
+    expect(await query([{ calendarId: calendarA, generation: 0 }])).toEqual([]);
+  });
+
+  it("excludes an occurrence that has no endAt yet", async () => {
+    // A pre-endAt occurrence (not yet reprojected) has no end to overlap on.
+    await seed({ calendarId: calendarA, start: "2026-07-14T09:00Z" });
+
+    expect(await query([{ calendarId: calendarA, generation: 0 }])).toEqual([]);
+  });
+
+  it("excludes an occurrence entirely outside the window", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T20:00Z",
+      end: "2026-07-14T21:00Z",
+    });
+
+    expect(await query([{ calendarId: calendarA, generation: 0 }])).toEqual([]);
+  });
+});

--- a/packages/sync/src/domain/busy-query.service.test.ts
+++ b/packages/sync/src/domain/busy-query.service.test.ts
@@ -1,0 +1,90 @@
+import { mergeBusyIntervals } from "@sync/domain/busy-query.service";
+
+const iv = (start: string, end: string) => ({
+  start: new Date(start),
+  end: new Date(end),
+});
+// Compare merged output as ISO pairs for readable assertions.
+const iso = (intervals: { start: Date; end: Date }[]) =>
+  intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]);
+
+describe("mergeBusyIntervals", () => {
+  it("returns nothing for no intervals", () => {
+    expect(mergeBusyIntervals([])).toEqual([]);
+  });
+
+  it("passes a single interval through", () => {
+    expect(
+      iso(mergeBusyIntervals([iv("2026-07-14T09:00Z", "2026-07-14T10:00Z")])),
+    ).toEqual([["2026-07-14T09:00:00.000Z", "2026-07-14T10:00:00.000Z"]]);
+  });
+
+  it("keeps disjoint intervals separate and sorted", () => {
+    const out = mergeBusyIntervals([
+      iv("2026-07-14T13:00Z", "2026-07-14T14:00Z"),
+      iv("2026-07-14T09:00Z", "2026-07-14T10:00Z"),
+    ]);
+    expect(iso(out)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T10:00:00.000Z"],
+      ["2026-07-14T13:00:00.000Z", "2026-07-14T14:00:00.000Z"],
+    ]);
+  });
+
+  it("merges overlapping intervals", () => {
+    const out = mergeBusyIntervals([
+      iv("2026-07-14T09:00Z", "2026-07-14T10:30Z"),
+      iv("2026-07-14T10:00Z", "2026-07-14T11:00Z"),
+    ]);
+    expect(iso(out)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+    ]);
+  });
+
+  it("merges touching intervals, leaving no free gap between them", () => {
+    const out = mergeBusyIntervals([
+      iv("2026-07-14T09:00Z", "2026-07-14T10:00Z"),
+      iv("2026-07-14T10:00Z", "2026-07-14T11:00Z"),
+    ]);
+    expect(iso(out)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+    ]);
+  });
+
+  it("absorbs a fully nested interval", () => {
+    const out = mergeBusyIntervals([
+      iv("2026-07-14T09:00Z", "2026-07-14T12:00Z"),
+      iv("2026-07-14T10:00Z", "2026-07-14T10:30Z"),
+    ]);
+    expect(iso(out)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T12:00:00.000Z"],
+    ]);
+  });
+
+  it("is independent of input order", () => {
+    const forward = mergeBusyIntervals([
+      iv("2026-07-14T09:00Z", "2026-07-14T10:00Z"),
+      iv("2026-07-14T09:30Z", "2026-07-14T11:00Z"),
+      iv("2026-07-14T13:00Z", "2026-07-14T14:00Z"),
+    ]);
+    const shuffled = mergeBusyIntervals([
+      iv("2026-07-14T13:00Z", "2026-07-14T14:00Z"),
+      iv("2026-07-14T09:30Z", "2026-07-14T11:00Z"),
+      iv("2026-07-14T09:00Z", "2026-07-14T10:00Z"),
+    ]);
+    expect(iso(forward)).toEqual(iso(shuffled));
+    expect(iso(forward)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+      ["2026-07-14T13:00:00.000Z", "2026-07-14T14:00:00.000Z"],
+    ]);
+  });
+
+  it("drops empty (zero-length) intervals", () => {
+    const out = mergeBusyIntervals([
+      iv("2026-07-14T09:00Z", "2026-07-14T09:00Z"),
+      iv("2026-07-14T10:00Z", "2026-07-14T11:00Z"),
+    ]);
+    expect(iso(out)).toEqual([
+      ["2026-07-14T10:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+    ]);
+  });
+});

--- a/packages/sync/src/domain/busy-query.service.ts
+++ b/packages/sync/src/domain/busy-query.service.ts
@@ -1,0 +1,86 @@
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
+  type CalendarGeneration,
+  type EventOccurrenceRepository,
+} from "@sync/storage/repositories/event-occurrence.repository";
+
+// A normalized, half-open [start, end) busy interval on the UTC instant axis.
+export interface BusyInterval {
+  start: Date;
+  end: Date;
+}
+
+// Merge half-open [start, end) intervals into the minimal set of
+// non-overlapping, non-adjacent intervals, sorted by start. Overlapping AND
+// touching intervals merge — [9,10) and [10,11) leave no free gap between them,
+// so availability must treat them as one busy block [9,11). Empty intervals
+// (start >= end) contribute no busy time and are dropped. Pure and input-order
+// independent.
+export function mergeBusyIntervals(
+  intervals: readonly BusyInterval[],
+): BusyInterval[] {
+  const sorted = intervals
+    .filter((i) => i.end.getTime() > i.start.getTime())
+    .sort(
+      (a, b) =>
+        a.start.getTime() - b.start.getTime() ||
+        a.end.getTime() - b.end.getTime(),
+    );
+
+  const merged: BusyInterval[] = [];
+  for (const current of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && current.start.getTime() <= last.end.getTime()) {
+      // Overlapping or touching: extend the open block if this one reaches
+      // further (a fully-nested interval leaves the end unchanged).
+      if (current.end.getTime() > last.end.getTime()) last.end = current.end;
+    } else {
+      merged.push({ start: current.start, end: current.end });
+    }
+  }
+  return merged;
+}
+
+export interface BusyQueryDeps {
+  occurrences: EventOccurrenceRepository;
+}
+
+export interface BusyQueryInput {
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  // The blocking calendars, each with the generation whose occurrences are live.
+  calendars: readonly CalendarGeneration[];
+  // Half-open query window [start, end).
+  start: Date;
+  end: Date;
+}
+
+// The merged busy intervals within [start, end) for the given calendars. Each
+// occurrence interval is clamped to the window before merging, so an event that
+// spills past either edge contributes only its in-window busy time. This returns
+// intervals only; freshness/completeness/bookability evidence is layered on by a
+// later slice.
+export async function queryBusyIntervals(
+  deps: BusyQueryDeps,
+  input: BusyQueryInput,
+): Promise<BusyInterval[]> {
+  const occurrences = await deps.occurrences.listBusyOverlapping({
+    tenantId: input.tenantId,
+    principalId: input.principalId,
+    calendars: input.calendars,
+    start: input.start,
+    end: input.end,
+  });
+
+  const windowStart = input.start.getTime();
+  const windowEnd = input.end.getTime();
+  const clamped = occurrences.map((o) => ({
+    start: o.startAt.getTime() > windowStart ? o.startAt : input.start,
+    end: o.endAt.getTime() < windowEnd ? o.endAt : input.end,
+  }));
+
+  return mergeBusyIntervals(clamped);
+}

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -37,6 +37,23 @@ export interface OccurrenceRangeQuery {
   after?: OccurrenceRangeCursor;
 }
 
+export interface BusyOverlapQuery {
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  calendars: readonly CalendarGeneration[];
+  // Half-open window [start, end); an occurrence overlaps it when it starts
+  // before `end` and ends after `start`.
+  start: Date;
+  end: Date;
+}
+
+// One busy occurrence's normalized half-open interval — the only fields a busy
+// query needs. Titles and other content are never read here.
+export interface OccurrenceInterval {
+  startAt: Date;
+  endAt: Date;
+}
+
 // Repository for `event_occurrences`. Rebuilding a series' window
 // replaces exactly that event's occurrences for the given generation, so a
 // series edit rebuilds only the affected horizon. The range query is the
@@ -143,5 +160,38 @@ export class EventOccurrenceRepository {
       .limit(query.limit)
       .toArray();
     return records.map((r) => EventOccurrenceRecordSchema.parse(r));
+  }
+
+  // The busy occurrences overlapping [start, end) for the given calendars, each
+  // read at its active generation, projected to just the interval. Overlap (not
+  // start-in-range) so an occurrence that began before the window but ends inside
+  // it is included. Cancelled occurrences are not busy and are excluded; one with
+  // no endAt (predating the field and not yet reprojected) is excluded until it
+  // reprojects — the `endAt > start` filter never matches a missing field.
+  async listBusyOverlapping(
+    query: BusyOverlapQuery,
+  ): Promise<OccurrenceInterval[]> {
+    if (query.calendars.length === 0) return [];
+    const filter = {
+      tenantId: query.tenantId,
+      principalId: query.principalId,
+      busy: true,
+      cancelled: false,
+      $and: [
+        {
+          $or: query.calendars.map((c) => ({
+            calendarId: c.calendarId,
+            generation: c.generation,
+          })),
+        },
+        { startAt: { $lt: query.end } },
+        { endAt: { $gt: query.start } },
+      ],
+    };
+    return this.collection
+      .find(filter)
+      .project<OccurrenceInterval>({ startAt: 1, endAt: 1, _id: 0 })
+      .sort({ startAt: 1 })
+      .toArray();
   }
 }


### PR DESCRIPTION
## What

The busy-interval core of the availability query (S36), built on the `endAt` added in #2303.

- **`listBusyOverlapping`** (repo) reads the busy, non-cancelled occurrences that *overlap* `[start, end)` for the given calendars, each at its **active generation** — `startAt < end AND endAt > start`, so an event that begins before the window but ends inside it is included. Projected to just the interval; a busy read never touches titles or other content.
- **`queryBusyIntervals`** (domain) clamps each occurrence to the window, then
- **`mergeBusyIntervals`** (pure) folds overlapping *and touching* intervals into the minimal non-overlapping set — `[9,10)` and `[10,11)` become one busy block `[9,11)` because there's no free gap for availability to offer.

## Notes

- **Privacy**: intervals only, never event content.
- **endAt transition**: an occurrence not yet reprojected (no `endAt`) is excluded by the `endAt > start` filter — conservatively incomplete, never wrong. Completeness/freshness evidence is the next slice.
- **Scope**: intervals only. Freshness, completeness, `bookable`, and the internal HTTP route are later S36 slices.

## Tests

- Pure merge: overlap, touching, nested, disjoint, order-independence, empty-drop.
- DB: cross-calendar merge, clamp at both window edges, generation isolation, cancelled excluded, missing-`endAt` excluded, fully-outside excluded.
- Full sync suite green (49 files, 542 tests). type-check + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New availability/scheduling read path; incorrect merge or overlap rules could show wrong free time, but behavior is heavily tested and conservatively excludes incomplete occurrences (no endAt).
> 
> **Overview**
> Adds the **busy-interval** slice of availability (S36): merged half-open busy blocks for a tenant/principal, a set of calendars (each at its **active generation**), and a query window.
> 
> **`EventOccurrenceRepository.listBusyOverlapping`** loads busy, non-cancelled occurrences that **overlap** `[start, end)` (`startAt < end` and `endAt > start`), projects only `startAt`/`endAt`, and skips docs without `endAt`. **`queryBusyIntervals`** clamps each interval to the window and passes them through **`mergeBusyIntervals`**, which folds overlapping and **touching** intervals so back-to-back busy time is one block.
> 
> Unit and DB tests cover merge edge cases, cross-calendar merge, window clamping, generation isolation, and exclusions (cancelled, missing `endAt`, outside window). HTTP route, freshness, and bookability are out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449a6f615a83d40d5e653ea12bb0e38f4ec7452d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->