### PR TITLE
feat(sync): add freshness and bookability evidence to busy availability

### DIFF
--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -212,4 +212,22 @@ describe("computeBusyAvailability", () => {
     expect(result.bookable).toBe(false); // connection not healthy
     expect(result.connections[0]?.state).toBe("importing");
   });
+
+  it("fails closed when a resource references a missing connection record", async () => {
+    // A fresh, fully-imported calendar whose connection row is gone (e.g. hard
+    // deleted) leaves an orphaned resource. bookable must NOT be true — we cannot
+    // verify the connection's health, so booking would risk a double-book.
+    const ghostConnection = objectId() as ConnectionId; // never seeded
+    const cal = await seedCalendar({
+      connectionId: ghostConnection,
+      lastSuccessAt: fresh,
+      intervals: [["2026-07-14T09:00Z", "2026-07-14T10:00Z"]],
+    });
+
+    const result = await run([cal]);
+
+    expect(result.complete).toBe(true); // the data itself is fresh
+    expect(result.bookable).toBe(false); // but the connection cannot be verified
+    expect(result.connections).toEqual([]); // no record to report freshness for
+  });
 });

--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -1,0 +1,215 @@
+import { faker } from "@faker-js/faker";
+import { type ConnectionState } from "@core/types/sync/connection.contracts";
+import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { computeBusyAvailability } from "@sync/domain/busy-query.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const NOW = new Date("2026-07-14T12:00:00.000Z");
+const MAX_AGE_MS = 10 * 60_000; // 10 minutes
+const WINDOW_START = new Date("2026-07-14T09:00:00.000Z");
+const WINDOW_END = new Date("2026-07-14T17:00:00.000Z");
+
+describe("computeBusyAvailability", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+  let resources: SyncResourceRepository;
+  let occurrences: EventOccurrenceRepository;
+  let tenantId: TenantId;
+  let principalId: PrincipalId;
+  let accountSeq: number;
+
+  beforeEach(() => {
+    connections = new ProviderConnectionRepository(storage.db());
+    resources = new SyncResourceRepository(storage.db());
+    occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    tenantId = objectId() as TenantId;
+    principalId = objectId() as PrincipalId;
+    accountSeq = 0;
+  });
+
+  const seedConnection = async (
+    state: ConnectionState,
+    lastSyncedAt: Date | null,
+  ): Promise<ConnectionId> => {
+    accountSeq += 1;
+    const connection = await connections.upsertByProviderAccount({
+      tenantId,
+      principalId,
+      provider: "google",
+      account: {
+        providerAccountId: `acct-${accountSeq}`,
+        email: `user${accountSeq}@gmail.com`,
+        displayName: "User",
+      },
+      capabilities: ["readEvents"],
+      state,
+      stateReason: null,
+      lastSyncedAt,
+      lastHealthyAt: lastSyncedAt,
+    });
+    return connection._id;
+  };
+
+  // Seed a calendar with its events resource (optionally never-synced or with a
+  // given last-success time) and optional busy occurrences, on a connection of a
+  // given health. Returns the calendar id.
+  const seedCalendar = async (opts: {
+    connectionId: ConnectionId;
+    lastSuccessAt?: Date | null;
+    intervals?: Array<[string, string]>;
+  }): Promise<SyncEventCalendarId> => {
+    const calendarId = objectId() as SyncEventCalendarId;
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: opts.connectionId,
+      resourceKind: "events",
+      calendarId,
+    });
+    if (opts.lastSuccessAt) {
+      await resources.advanceCursor(
+        tenantId,
+        principalId,
+        resource._id,
+        "cursor",
+        opts.lastSuccessAt,
+      );
+    }
+    for (const [start, end] of opts.intervals ?? []) {
+      const eventId = objectId();
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.eventOccurrences)
+        .insertOne({
+          _id: objectId(),
+          tenantId,
+          principalId,
+          eventId,
+          occurrenceKey: `${eventId}:${start}`,
+          calendarId,
+          generation: 0,
+          startAt: new Date(start),
+          endAt: new Date(end),
+          busy: true,
+          cancelled: false,
+        });
+    }
+    return calendarId;
+  };
+
+  const run = (calendarIds: SyncEventCalendarId[]) =>
+    computeBusyAvailability(
+      { occurrences, resources, connections },
+      {
+        tenantId,
+        principalId,
+        calendarIds,
+        start: WINDOW_START,
+        end: WINDOW_END,
+        maxAgeMs: MAX_AGE_MS,
+        now: NOW,
+      },
+    );
+
+  const fresh = new Date(NOW.getTime() - 60_000); // 1 min ago
+  const old = new Date(NOW.getTime() - 60 * 60_000); // 1 hour ago (> maxAge)
+
+  it("is complete and bookable when every calendar is fresh and its connection is healthy", async () => {
+    const conn = await seedConnection("healthy", fresh);
+    const calA = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: fresh,
+      intervals: [["2026-07-14T09:00Z", "2026-07-14T10:00Z"]],
+    });
+    const calB = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: fresh,
+      intervals: [["2026-07-14T09:30Z", "2026-07-14T11:00Z"]],
+    });
+
+    const result = await run([calA, calB]);
+
+    expect(result.complete).toBe(true);
+    expect(result.bookable).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.computedAt).toEqual(NOW);
+    expect(
+      result.intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]),
+    ).toEqual([["2026-07-14T09:00:00.000Z", "2026-07-14T11:00:00.000Z"]]);
+    expect(result.connections).toHaveLength(1);
+    expect(result.connections[0]?.state).toBe("healthy");
+  });
+
+  it("flags a not-imported calendar and is neither complete nor bookable", async () => {
+    const conn = await seedConnection("healthy", fresh);
+    const calA = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: fresh,
+    });
+    const ghost = objectId() as SyncEventCalendarId; // no resource
+
+    const result = await run([calA, ghost]);
+
+    expect(result.complete).toBe(false);
+    expect(result.bookable).toBe(false);
+    expect(result.issues).toEqual([
+      { calendarId: ghost, reason: "notImported" },
+    ]);
+  });
+
+  it("flags a never-synced calendar", async () => {
+    const conn = await seedConnection("importing", null);
+    const cal = await seedCalendar({ connectionId: conn, lastSuccessAt: null });
+
+    const result = await run([cal]);
+
+    expect(result.issues).toEqual([{ calendarId: cal, reason: "neverSynced" }]);
+    expect(result.complete).toBe(false);
+    expect(result.bookable).toBe(false);
+  });
+
+  it("returns a stale calendar's intervals but flags it stale and not bookable", async () => {
+    const conn = await seedConnection("healthy", old);
+    const cal = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: old,
+      intervals: [["2026-07-14T13:00Z", "2026-07-14T14:00Z"]],
+    });
+
+    const result = await run([cal]);
+
+    // The busy data is still returned...
+    expect(
+      result.intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]),
+    ).toEqual([["2026-07-14T13:00:00.000Z", "2026-07-14T14:00:00.000Z"]]);
+    // ...but its staleness is disclosed and it is not bookable.
+    expect(result.issues).toEqual([{ calendarId: cal, reason: "stale" }]);
+    expect(result.complete).toBe(false);
+    expect(result.bookable).toBe(false);
+  });
+
+  it("is complete but not bookable when a backing connection is not healthy", async () => {
+    const conn = await seedConnection("importing", fresh);
+    const cal = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: fresh,
+      intervals: [["2026-07-14T09:00Z", "2026-07-14T10:00Z"]],
+    });
+
+    const result = await run([cal]);
+
+    expect(result.complete).toBe(true); // fresh data
+    expect(result.bookable).toBe(false); // connection not healthy
+    expect(result.connections[0]?.state).toBe("importing");
+  });
+});

--- a/packages/sync/src/domain/busy-query.service.ts
+++ b/packages/sync/src/domain/busy-query.service.ts
@@ -1,4 +1,7 @@
+import { type ConnectionState } from "@core/types/sync/connection.contracts";
+import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
+  type ConnectionId,
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
@@ -6,6 +9,8 @@ import {
   type CalendarGeneration,
   type EventOccurrenceRepository,
 } from "@sync/storage/repositories/event-occurrence.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 // A normalized, half-open [start, end) busy interval on the UTC instant axis.
 export interface BusyInterval {
@@ -83,4 +88,155 @@ export async function queryBusyIntervals(
   }));
 
   return mergeBusyIntervals(clamped);
+}
+
+// Why a requested calendar's busy data could not be freshly included.
+export type CalendarFreshnessIssue =
+  // No events resource for the calendar yet — it was never imported.
+  | "notImported"
+  // A resource exists but has not completed a successful sync yet.
+  | "neverSynced"
+  // Its last successful sync is older than the caller's acceptable age.
+  | "stale";
+
+export interface CalendarIssue {
+  calendarId: SyncEventCalendarId;
+  reason: CalendarFreshnessIssue;
+}
+
+// The freshness evidence for one connection backing a requested calendar. State
+// and timestamps are reported as-is so the caller (not Sync) decides how to use
+// them; `state === "healthy"` is the only state that permits booking.
+export interface ConnectionFreshness {
+  connectionId: ConnectionId;
+  state: ConnectionState;
+  lastSyncedAt: Date | null;
+  lastHealthyAt: Date | null;
+}
+
+export interface BusyAvailability {
+  // Merged busy intervals from every requested calendar that had data (including
+  // stale ones — their staleness is disclosed in `issues`, not hidden).
+  intervals: BusyInterval[];
+  // When this result was computed, so the caller can reason about its own age.
+  computedAt: Date;
+  // Per-connection freshness for the connections backing the requested calendars.
+  connections: ConnectionFreshness[];
+  // Every requested calendar was present and within the acceptable age.
+  complete: boolean;
+  // The calendars that were missing or stale, with the reason for each.
+  issues: CalendarIssue[];
+  // Fresh enough to confirm a booking: complete AND every backing connection is
+  // healthy. Fail-closed — anything unverified makes this false.
+  bookable: boolean;
+}
+
+export interface BusyAvailabilityDeps {
+  occurrences: EventOccurrenceRepository;
+  resources: SyncResourceRepository;
+  connections: ProviderConnectionRepository;
+}
+
+export interface BusyAvailabilityInput {
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  // The blocking calendars whose busy data is requested.
+  calendarIds: readonly SyncEventCalendarId[];
+  // Half-open query window [start, end).
+  start: Date;
+  end: Date;
+  // The oldest a calendar's last successful sync may be and still count as fresh.
+  maxAgeMs: number;
+  now: Date;
+}
+
+// The busy intervals for a set of calendars plus the freshness/completeness
+// evidence a caller needs to decide whether the result is safe to display or to
+// confirm a booking against. Sync reports the facts; the booking policy (which
+// calendars block, working hours, duration) is the caller's.
+//
+// A stale calendar's intervals are still returned (with its staleness disclosed)
+// rather than dropped, so a display can show what is known while flagging it; a
+// booking-confirmation caller sees `complete`/`bookable` go false and fails
+// closed rather than booking over possibly-missed conflicts.
+export async function computeBusyAvailability(
+  deps: BusyAvailabilityDeps,
+  input: BusyAvailabilityInput,
+): Promise<BusyAvailability> {
+  const now = input.now;
+  const freshness = await deps.resources.listEventResourceFreshnessByCalendar(
+    input.tenantId,
+    input.principalId,
+    input.calendarIds,
+  );
+
+  const present: CalendarGeneration[] = [];
+  const issues: CalendarIssue[] = [];
+  const backingConnectionIds = new Set<ConnectionId>();
+
+  for (const calendarId of input.calendarIds) {
+    const resource = freshness.get(calendarId);
+    if (!resource) {
+      issues.push({ calendarId, reason: "notImported" });
+      continue;
+    }
+    backingConnectionIds.add(resource.connectionId);
+    if (resource.lastSuccessAt === null) {
+      issues.push({ calendarId, reason: "neverSynced" });
+      continue;
+    }
+    // Include its data even when stale — disclose the staleness, do not hide it.
+    present.push({
+      calendarId,
+      generation: resource.activeGeneration,
+    });
+    const ageMs = now.getTime() - resource.lastSuccessAt.getTime();
+    if (ageMs > input.maxAgeMs) {
+      issues.push({ calendarId, reason: "stale" });
+    }
+  }
+
+  const intervals = present.length
+    ? await queryBusyIntervals(
+        { occurrences: deps.occurrences },
+        {
+          tenantId: input.tenantId,
+          principalId: input.principalId,
+          calendars: present,
+          start: input.start,
+          end: input.end,
+        },
+      )
+    : [];
+
+  // Freshness for exactly the connections backing the requested calendars.
+  const allConnections = await deps.connections.listByPrincipal(
+    input.tenantId,
+    input.principalId,
+  );
+  const connections: ConnectionFreshness[] = allConnections
+    .filter((c) => backingConnectionIds.has(c._id))
+    .map((c) => ({
+      connectionId: c._id,
+      state: c.state,
+      lastSyncedAt: c.lastSyncedAt,
+      lastHealthyAt: c.lastHealthyAt,
+    }));
+
+  const complete = issues.length === 0;
+  // Every backing connection must be present in storage AND healthy. A missing
+  // connection record (referenced by a resource but not found) fails closed.
+  const allBackingHealthy =
+    connections.length === backingConnectionIds.size &&
+    connections.every((c) => c.state === "healthy");
+  const bookable = complete && allBackingHealthy;
+
+  return {
+    intervals,
+    computedAt: now,
+    connections,
+    complete,
+    issues,
+    bookable,
+  };
 }

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -212,6 +212,55 @@ export class SyncResourceRepository {
     return new Map(records.map((r) => [r.calendarId, r.activeGeneration]));
   }
 
+  // The events resources backing the given calendars, projected to what a busy /
+  // availability query needs: the generation to read, the owning connection, and
+  // the freshness watermark. A calendar with no events resource yet is simply
+  // absent from the result (the caller reports it missing).
+  async listEventResourceFreshnessByCalendar(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    calendarIds: readonly SyncEventCalendarId[],
+  ): Promise<
+    Map<
+      SyncEventCalendarId,
+      {
+        connectionId: ConnectionId;
+        activeGeneration: number;
+        lastSuccessAt: Date | null;
+      }
+    >
+  > {
+    const records = await this.collection
+      .find({
+        tenantId,
+        principalId,
+        resourceKind: "events",
+        calendarId: { $in: [...calendarIds] },
+      })
+      .project<{
+        calendarId: SyncEventCalendarId;
+        connectionId: ConnectionId;
+        activeGeneration: number;
+        lastSuccessAt: Date | null;
+      }>({
+        calendarId: 1,
+        connectionId: 1,
+        activeGeneration: 1,
+        lastSuccessAt: 1,
+      })
+      .toArray();
+    return new Map(
+      records.map((r) => [
+        r.calendarId,
+        {
+          connectionId: r.connectionId,
+          activeGeneration: r.activeGeneration,
+          lastSuccessAt: r.lastSuccessAt,
+        },
+      ]),
+    );
+  }
+
   async findById(
     tenantId: TenantId,
     principalId: PrincipalId,


### PR DESCRIPTION
## What

The final domain slice of the freshness-aware busy query (S36). `computeBusyAvailability` wraps the busy-interval query with the evidence a caller needs to trust it.

For each requested calendar it resolves the events resource (generation, owning connection, last successful sync) and returns:

- **`intervals`** — merged busy intervals (from `queryBusyIntervals`)
- **`computedAt`**
- **`connections`** — per backing connection: `state`, `lastSyncedAt`, `lastHealthyAt`
- **`issues`** — per calendar: `notImported` / `neverSynced` / `stale` (vs `maxAgeMs`)
- **`complete`** — every requested calendar present and within the acceptable age
- **`bookable`** — `complete` AND every backing connection `healthy`

## Design

- **Fail-closed** (R-AVAIL-04): `bookable` requires every backing connection to be present in storage *and* `state === "healthy"`. A resource referencing a missing connection, a stale calendar, or a missing one all force `bookable = false` — never book over an unverified conflict.
- **Stale is disclosed, not hidden**: a stale calendar's intervals are still returned so a *display* shows what's known, while a *booking* caller sees `complete`/`bookable` go false.
- **Facts, not policy**: Sync reports evidence; the booking policy (which calendars block, hours, duration) is the caller's — so `purpose → maxAge` is mapped at the route, not here.

## Tests

- complete+bookable (multi-calendar merge), notImported, neverSynced, stale-with-intervals-still-returned, fresh-data-but-unhealthy-connection.
- Full sync suite green (50 files, 547 tests). type-check + biome clean.

Next (final S36): the internal authenticated HTTP route (maps `purpose`→`maxAge`, bounds the window to 60 days, and returns this evidence; content never appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes availability/booking safety semantics (fail-closed bookable); incorrect logic could block bookings or allow double-booking, though behavior is covered by targeted DB tests.
> 
> **Overview**
> Adds **`computeBusyAvailability`**, which layers on top of merged busy intervals the metadata callers need to trust the result: per-calendar **`issues`** (`notImported`, `neverSynced`, `stale` vs `maxAgeMs`), **`complete`**, per-connection freshness, and **`bookable`** (complete plus every backing connection present and `healthy`).
> 
> **Fail-closed booking**: missing resources, never-synced or stale calendars, unhealthy connections, or orphaned resources pointing at a deleted connection all force **`bookable`** false. Stale calendars still contribute **intervals** so UIs can show known busy time while flagging freshness.
> 
> **`SyncResourceRepository.listEventResourceFreshnessByCalendar`** supplies generation, `connectionId`, and `lastSuccessAt` for the requested calendars. New DB tests cover the happy path, each issue type, stale-with-data, unhealthy connection, and orphaned connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e51919fb2606c89e5660419766cc7c51246c6c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->