### PR TITLE
feat(sync): expose the busy-availability query over an internal route

### DIFF
--- a/packages/core/src/types/sync/availability.contracts.ts
+++ b/packages/core/src/types/sync/availability.contracts.ts
@@ -1,0 +1,82 @@
+import { z } from "zod/v4";
+import { DateTimeSchema } from "@core/types/domain-primitives";
+import { ConnectionStateSchema } from "@core/types/sync/connection.contracts";
+import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
+import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
+
+// Why the caller wants the busy data. The caller sends its intent (and a
+// matching maxAge); Sync reports the same freshness facts either way — the
+// booking decision is the caller's.
+export const BusyQueryPurposeSchema = z.enum([
+  "display",
+  "booking_confirmation",
+]);
+export type BusyQueryPurpose = z.infer<typeof BusyQueryPurposeSchema>;
+
+// The longest window a single busy query may span, so no request can force an
+// unbounded scan.
+export const BUSY_QUERY_MAX_WINDOW_MS = 60 * 24 * 60 * 60 * 1000;
+
+// Request for the busy-availability query. The window is half-open [start, end)
+// and bounded to 60 days; calendarIds are the blocking calendars.
+export const BusyAvailabilityRequestSchema = z
+  .strictObject({
+    calendarIds: z.array(SyncEventCalendarIdSchema).min(1).max(100),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    // The oldest a calendar's last successful sync may be and still count fresh.
+    maxAgeMs: z.number().int().positive(),
+    purpose: BusyQueryPurposeSchema,
+  })
+  .refine((r) => Date.parse(r.end) > Date.parse(r.start), {
+    message: "end must be after start",
+    path: ["end"],
+  })
+  .refine(
+    (r) => Date.parse(r.end) - Date.parse(r.start) <= BUSY_QUERY_MAX_WINDOW_MS,
+    { message: "window must not exceed 60 days", path: ["end"] },
+  );
+export type BusyAvailabilityRequest = z.infer<
+  typeof BusyAvailabilityRequestSchema
+>;
+
+// A normalized half-open busy interval on the wire (ISO instants).
+export const BusyIntervalSchema = z.strictObject({
+  start: DateTimeSchema,
+  end: DateTimeSchema,
+});
+
+// Why a requested calendar's busy data could not be freshly included.
+export const CalendarFreshnessIssueReasonSchema = z.enum([
+  "notImported",
+  "neverSynced",
+  "stale",
+]);
+
+export const CalendarIssueSchema = z.strictObject({
+  calendarId: SyncEventCalendarIdSchema,
+  reason: CalendarFreshnessIssueReasonSchema,
+});
+
+// Freshness evidence for one connection backing a requested calendar. State and
+// timestamps are reported as-is; the caller decides how to use them.
+export const ConnectionFreshnessSchema = z.strictObject({
+  connectionId: ConnectionIdSchema,
+  state: ConnectionStateSchema,
+  lastSyncedAt: DateTimeSchema.nullable(),
+  lastHealthyAt: DateTimeSchema.nullable(),
+});
+
+// Busy intervals plus the freshness/completeness/bookability evidence. Event
+// titles, descriptions, locations, attendees, and conference links never appear.
+export const BusyAvailabilityResponseSchema = z.strictObject({
+  intervals: z.array(BusyIntervalSchema),
+  computedAt: DateTimeSchema,
+  connections: z.array(ConnectionFreshnessSchema),
+  complete: z.boolean(),
+  issues: z.array(CalendarIssueSchema),
+  bookable: z.boolean(),
+});
+export type BusyAvailabilityResponse = z.infer<
+  typeof BusyAvailabilityResponseSchema
+>;

--- a/packages/sync/src/server/availability.routes.db.test.ts
+++ b/packages/sync/src/server/availability.routes.db.test.ts
@@ -1,0 +1,219 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { createSyncService, type SyncService } from "@sync/app";
+import { signInternalRequest } from "@sync/auth/internal-auth";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { AVAILABILITY_BUSY_PATH } from "@sync/server/connection.routes";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { type AddressInfo } from "node:net";
+
+const storage = setupSyncStorage(import.meta.url);
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const objectId = () => faker.database.mongodbObjectId();
+const SECRET = "internal-secret";
+
+const testConfig = (): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: uri,
+    INTERNAL_AUTH_TOKEN: SECRET,
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+  }) as SyncConfig;
+
+const signedHeaders = (
+  tenantId: string,
+  principalId: string,
+): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "content-type": "application/json",
+    "x-sync-tenant": tenantId,
+    "x-sync-principal": principalId,
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signInternalRequest(SECRET, {
+      timestamp,
+      tenantId,
+      principalId,
+    }),
+  };
+};
+
+describe("POST /internal/availability/busy", () => {
+  let mongo: SyncMongoService;
+  let connections: ProviderConnectionRepository;
+  let resources: SyncResourceRepository;
+  let service: SyncService;
+  let base: string;
+  let accountSeq: number;
+
+  const startService = async () => {
+    service = createSyncService(testConfig(), { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    connections = new ProviderConnectionRepository(mongo.db);
+    resources = new SyncResourceRepository(mongo.db);
+    accountSeq = 0;
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  const seedConnection = async (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    state: "healthy" | "importing",
+  ) => {
+    accountSeq += 1;
+    const c = await connections.upsertByProviderAccount({
+      tenantId,
+      principalId,
+      provider: "google",
+      account: {
+        providerAccountId: `acct-${accountSeq}`,
+        email: `u${accountSeq}@gmail.com`,
+        displayName: "User",
+      },
+      capabilities: ["readEvents"],
+      state,
+      stateReason: null,
+      lastSyncedAt: new Date(),
+      lastHealthyAt: new Date(),
+    });
+    return c._id;
+  };
+
+  // Ensure a fresh events resource on a connection, plus busy occurrences.
+  const seedCalendar = async (
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: string,
+    intervals: Array<[string, string]>,
+  ) => {
+    const calendarId = objectId();
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: connectionId as never,
+      resourceKind: "events",
+      calendarId: calendarId as never,
+    });
+    await resources.advanceCursor(
+      tenantId,
+      principalId,
+      resource._id,
+      "cursor",
+      new Date(),
+    );
+    for (const [start, end] of intervals) {
+      const eventId = objectId();
+      await mongo.db.collection(SYNC_COLLECTIONS.eventOccurrences).insertOne({
+        _id: objectId(),
+        tenantId,
+        principalId,
+        eventId,
+        occurrenceKey: `${eventId}:${start}`,
+        calendarId,
+        generation: 0,
+        startAt: new Date(start),
+        endAt: new Date(end),
+        busy: true,
+        cancelled: false,
+        title: "secret meeting",
+      });
+    }
+    return calendarId;
+  };
+
+  const post = (headers: Record<string, string>, body: unknown) =>
+    fetch(`${base}${AVAILABILITY_BUSY_PATH}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+  const validBody = (calendarIds: string[]) => ({
+    calendarIds,
+    start: "2026-07-14T09:00:00.000Z",
+    end: "2026-07-14T17:00:00.000Z",
+    maxAgeMs: 15 * 60_000,
+    purpose: "booking_confirmation" as const,
+  });
+
+  it("rejects a request that is not signed", async () => {
+    await startService();
+    const res = await post(
+      { "content-type": "application/json" },
+      validBody([objectId()]),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a window longer than 60 days", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+    const res = await post(signedHeaders(tenantId, principalId), {
+      ...validBody([objectId()]),
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-10-01T00:00:00.000Z", // ~92 days
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an empty calendar list", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+    const res = await post(signedHeaders(tenantId, principalId), validBody([]));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns merged busy intervals with freshness evidence and no event content", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    await startService();
+    const conn = await seedConnection(tenantId, principalId, "healthy");
+    const cal = await seedCalendar(tenantId, principalId, conn, [
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T10:00:00.000Z"],
+      ["2026-07-14T09:30:00.000Z", "2026-07-14T11:00:00.000Z"],
+    ]);
+
+    const res = await post(
+      signedHeaders(tenantId, principalId),
+      validBody([cal]),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.intervals).toEqual([
+      {
+        start: "2026-07-14T09:00:00.000Z",
+        end: "2026-07-14T11:00:00.000Z",
+      },
+    ]);
+    expect(body.complete).toBe(true);
+    expect(body.bookable).toBe(true);
+    expect(body.issues).toEqual([]);
+    expect(body.connections).toHaveLength(1);
+    expect(body.connections[0].state).toBe("healthy");
+    // Event content must never leak into the availability response.
+    expect(JSON.stringify(body)).not.toContain("secret meeting");
+  });
+});

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -312,18 +312,6 @@ export function registerConnectionRoutes(
         new Date(query.end),
         dayjs(now).add(HORIZON_FUTURE_MONTHS, "month").toDate(),
       );
-      if (start >= end) {
-        const empty: BusyAvailabilityResponse = {
-          intervals: [],
-          computedAt: new Date(now).toISOString(),
-          connections: [],
-          complete: false,
-          issues: [],
-          bookable: false,
-        };
-        res.status(Status.OK).json(empty);
-        return;
-      }
 
       try {
         const availability = await computeBusyAvailability(

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -1,6 +1,11 @@
 import { type Express, type RequestHandler, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
 import {
+  BusyAvailabilityRequestSchema,
+  type BusyAvailabilityResponse,
+  BusyAvailabilityResponseSchema,
+} from "@core/types/sync/availability.contracts";
+import {
   type CalendarListResponse,
   type ConnectionListResponse,
   type ProviderCalendar,
@@ -23,6 +28,10 @@ import {
 import dayjs from "@core/util/date/dayjs";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import {
+  type BusyAvailability,
+  computeBusyAvailability,
+} from "@sync/domain/busy-query.service";
 import { deriveConnectionState } from "@sync/domain/connection-state";
 import {
   HORIZON_FUTURE_MONTHS,
@@ -52,6 +61,7 @@ import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 export const CONNECTIONS_PATH = "/internal/connections";
 export const CALENDARS_PATH = "/internal/calendars";
 export const EVENTS_PATH = "/internal/events";
+export const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 export const BEGIN_PATH = "/internal/connections/begin";
 // Where the provider redirects the browser after consent; `begin` builds the
 // redirect_uri from it and the public callback route below mounts on it.
@@ -263,6 +273,55 @@ export function registerConnectionRoutes(
               : null,
         };
         res.status(Status.OK).json(response);
+      } catch {
+        respondInternalError(res);
+      }
+    },
+  );
+
+  // Merged busy intervals for a set of blocking calendars over a bounded window,
+  // plus the freshness/completeness/bookability evidence the caller needs to
+  // decide whether to display or to confirm a booking against them. A POST
+  // because the query carries a structured body (calendar list + window +
+  // policy). Scoped to the signed principal; served in passive mode too (a read).
+  // The response carries intervals and freshness only — never event content.
+  app.post(
+    AVAILABILITY_BUSY_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+
+      const parsed = BusyAvailabilityRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_query" });
+        return;
+      }
+      const query = parsed.data;
+
+      try {
+        const availability = await computeBusyAvailability(
+          {
+            occurrences: new EventOccurrenceRepository(
+              deps.mongo.db,
+              deps.mongo.client,
+            ),
+            resources: new SyncResourceRepository(deps.mongo.db),
+            connections: new ProviderConnectionRepository(deps.mongo.db),
+          },
+          {
+            tenantId: auth.tenantId,
+            principalId: auth.principalId,
+            calendarIds: query.calendarIds,
+            start: new Date(query.start),
+            end: new Date(query.end),
+            maxAgeMs: query.maxAgeMs,
+            now: deps.now ? new Date(deps.now()) : new Date(),
+          },
+        );
+        res.status(Status.OK).json(toBusyAvailabilityResponse(availability));
       } catch {
         respondInternalError(res);
       }
@@ -565,6 +624,35 @@ async function linkConnection(
     priority: 0,
     runAfter: new Date(),
     coalescingKey: `calendarListSync:${connection._id}`,
+  });
+}
+
+// Map the busy-availability domain result (Date instants) to the wire contract
+// (ISO strings). The domain already excludes event content, so this only
+// reshapes timestamps.
+function toBusyAvailabilityResponse(
+  availability: BusyAvailability,
+): BusyAvailabilityResponse {
+  // Parse through the schema so ISO strings are validated and branded, and any
+  // shape drift fails loudly here rather than reaching the caller malformed.
+  return BusyAvailabilityResponseSchema.parse({
+    intervals: availability.intervals.map((i) => ({
+      start: i.start.toISOString(),
+      end: i.end.toISOString(),
+    })),
+    computedAt: availability.computedAt.toISOString(),
+    connections: availability.connections.map((c) => ({
+      connectionId: c.connectionId,
+      state: c.state,
+      lastSyncedAt: c.lastSyncedAt?.toISOString() ?? null,
+      lastHealthyAt: c.lastHealthyAt?.toISOString() ?? null,
+    })),
+    complete: availability.complete,
+    issues: availability.issues.map((issue) => ({
+      calendarId: issue.calendarId,
+      reason: issue.reason,
+    })),
+    bookable: availability.bookable,
   });
 }
 

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -313,15 +313,19 @@ export function registerConnectionRoutes(
         dayjs(now).add(HORIZON_FUTURE_MONTHS, "month").toDate(),
       );
       if (start >= end) {
-        const empty: BusyAvailabilityResponse = {
-          intervals: [],
-          computedAt: new Date(now).toISOString(),
-          connections: [],
-          complete: false,
-          issues: [],
-          bookable: false,
-        };
-        res.status(Status.OK).json(empty);
+        // The window collapsed entirely outside the horizon: nothing to read, and
+        // nothing verified, so fail closed. Build it through the mapper so the
+        // ISO timestamps are branded like every other response.
+        res.status(Status.OK).json(
+          toBusyAvailabilityResponse({
+            intervals: [],
+            computedAt: new Date(now),
+            connections: [],
+            complete: false,
+            issues: [],
+            bookable: false,
+          }),
+        );
         return;
       }
 

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -312,6 +312,18 @@ export function registerConnectionRoutes(
         new Date(query.end),
         dayjs(now).add(HORIZON_FUTURE_MONTHS, "month").toDate(),
       );
+      if (start >= end) {
+        const empty: BusyAvailabilityResponse = {
+          intervals: [],
+          computedAt: new Date(now).toISOString(),
+          connections: [],
+          complete: false,
+          issues: [],
+          bookable: false,
+        };
+        res.status(Status.OK).json(empty);
+        return;
+      }
 
       try {
         const availability = await computeBusyAvailability(

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -301,6 +301,30 @@ export function registerConnectionRoutes(
       }
       const query = parsed.data;
 
+      // Clamp the requested range to the horizon. A range that falls entirely
+      // outside it collapses to empty rather than scanning anything.
+      const now = deps.now ? deps.now() : Date.now();
+      const start = maxDate(
+        new Date(query.start),
+        dayjs(now).subtract(HORIZON_PAST_MONTHS, "month").toDate(),
+      );
+      const end = minDate(
+        new Date(query.end),
+        dayjs(now).add(HORIZON_FUTURE_MONTHS, "month").toDate(),
+      );
+      if (start >= end) {
+        const empty: BusyAvailabilityResponse = {
+          intervals: [],
+          computedAt: new Date(now).toISOString(),
+          connections: [],
+          complete: false,
+          issues: [],
+          bookable: false,
+        };
+        res.status(Status.OK).json(empty);
+        return;
+      }
+
       try {
         const availability = await computeBusyAvailability(
           {
@@ -315,10 +339,10 @@ export function registerConnectionRoutes(
             tenantId: auth.tenantId,
             principalId: auth.principalId,
             calendarIds: query.calendarIds,
-            start: new Date(query.start),
-            end: new Date(query.end),
+            start,
+            end,
             maxAgeMs: query.maxAgeMs,
-            now: deps.now ? new Date(deps.now()) : new Date(),
+            now: new Date(now),
           },
         );
         res.status(Status.OK).json(toBusyAvailabilityResponse(availability));


### PR DESCRIPTION
## What

The final S36 slice: **`POST /internal/availability/busy`** — the internal, authenticated endpoint the booking module will call to get merged busy intervals for a set of blocking calendars plus the freshness / completeness / bookability evidence.

It mirrors the existing events read route: `internalRateLimit` + auth (401 if unsigned), `ensureConnected` (503), validate the body (400), run `computeBusyAvailability` **scoped to the signed principal** (never the request body), map to the wire contract, 200. A POST because the query carries a structured body; served in passive mode too (it's a read).

## Privacy

Event titles, descriptions, locations, attendees, and conference links **never appear**. The domain read already projects to `{startAt, endAt}`, the response contract has no content fields, and a test asserts a seeded title is absent from the response JSON.

## Contract

New `@core/types/sync/availability.contracts.ts` — request (`calendarIds` 1–100, half-open window bounded to 60 days, `maxAgeMs`, `purpose`) and response (intervals, computedAt, per-connection freshness, complete, issues, bookable), all ISO. The mapper parses through the response schema so any shape drift fails loudly server-side rather than reaching the caller.

## Tests

- unsigned → 401, window > 60 days → 400, empty calendar list → 400
- happy path: merged intervals + `complete` + `bookable` + connection freshness, and **no leaked content**
- Full sync suite green (51 files, 552 tests). type-check + biome clean.

**This completes S36 end to end** — the busy-query domain (endAt, intervals, freshness/bookability) plus its callable HTTP surface. The backend booking client consumes it in a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New booking-facing internal API with privacy and fail-closed freshness semantics; domain logic is pre-existing but HTTP surface is new and security-sensitive (auth scoping, no event leakage).
> 
> **Overview**
> Adds **`POST /internal/availability/busy`** so booking (and other internal callers) can fetch **merged busy intervals** for up to 100 calendars over a bounded half-open window, along with **freshness, completeness, and bookability** signals.
> 
> New **`@core/types/sync/availability.contracts`** defines the Zod request/response shapes (60-day max window, `maxAgeMs`, `purpose`, intervals only—no event content). The route follows the same internal-read pattern as events: signed auth, rate limit, body validation, horizon clamping (fail-closed empty window → `complete: false`, `bookable: false`), then **`computeBusyAvailability`** scoped to the signed principal. Responses are mapped through the response schema for validation.
> 
> **`availability.routes.db.test.ts`** covers 401/400 cases and a happy path that asserts interval merge and that seeded event titles never appear in JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e989e0a907d3c17348b2d3d3259c8d7064cede16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->