### PR TITLE
refactor(web): unify recurrence scope confirmation across day and week views

### DIFF
--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
@@ -1,25 +1,20 @@
-import {
-  type Dispatch,
-  type SetStateAction,
-  useCallback,
-  useState,
-} from "react";
-import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
+import { useCallback, useMemo } from "react";
 import { type GridEventDraft } from "@web/events/event-draft.types";
+import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { useEventById } from "@web/events/queries/useEventById";
 import { toRecurrenceScope } from "@web/events/recurrence/recurrence-scope";
 import {
-  resolveRecurrenceScopeOnSubmit,
-  shouldPromptForRecurrenceScopeOnDelete,
-} from "@web/events/recurrence/recurrence-scope-decision";
+  isExistingEventRecurring,
+  useRecurrenceScopeConfirmation,
+} from "@web/events/recurrence/useRecurrenceScopeConfirmation";
 import {
   draftActions,
   selectGridDraft,
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { EventForm } from "@web/views/Forms/EventForm/EventForm";
-import { RecurringEventUpdateScopeDialogContent } from "@web/views/Forms/EventForm/RecurrenceScopeDialog";
+import { RecurrenceScopeConfirmationDialog } from "@web/views/Forms/EventForm/RecurrenceScopeDialog";
+import { EventFormPanel } from "@web/views/Forms/EventFormPanel/EventFormPanel";
 import { useCloseEventForm } from "@web/views/Forms/hooks/useCloseEventForm";
 import { useDeleteEvent } from "@web/views/Forms/hooks/useDeleteEvent";
 import { useDuplicateEvent } from "@web/views/Forms/hooks/useDuplicateEvent";
@@ -35,98 +30,70 @@ export function SidebarEventDetails() {
   const draft = useDraftStore(selectGridDraft);
   const isFormOpen = useDraftStore(selectIsEventFormOpen);
   const _id = draft?.kind === "edit" ? draft.source.id : undefined;
-  const seriesId =
-    draft?.kind === "edit" && draft.source.recurrence.kind === "occurrence"
-      ? draft.source.recurrence.seriesId
-      : undefined;
-  const baseEvent = useEventById(seriesId);
-  const [pendingAction, setPendingAction] = useState<
-    { draft: GridEventDraft; type: "save" } | { type: "delete" } | null
-  >(null);
   const onSave = useSaveEventForm();
   const onDelete = useDeleteEvent(_id as string);
   const onDuplicate = useDuplicateEvent(_id as string);
   const onClose = useCloseEventForm();
   const existingEvent = useEventById(_id);
   const existing = Boolean(existingEvent);
+  const isRecurring = isExistingEventRecurring(existingEvent);
 
-  const setDraft: Dispatch<SetStateAction<GridEventDraft | null>> = useCallback(
-    (next) => {
-      const resolved = typeof next === "function" ? next(draft) : next;
-      draftActions.setGridDraft(resolved);
-    },
-    [draft],
+  const getSaveContext = useCallback(
+    () => ({
+      confirmAllRecurringEdits: true,
+      isInstance: false,
+      isRecurring,
+    }),
+    [isRecurring],
   );
 
-  if (!isFormOpen || !draft) return null;
+  const getDeleteContext = useCallback(() => ({ isRecurring }), [isRecurring]);
 
-  const closeScopeDialog = () => setPendingAction(null);
-  const submitWithScope = (applyTo: RecurringEventUpdateScope) => {
-    if (pendingAction?.type === "save") {
-      onSave(pendingAction.draft, applyTo);
-    } else if (pendingAction?.type === "delete") {
-      onDelete(toRecurrenceScope(applyTo));
-    }
-    setPendingAction(null);
-  };
-  const submit = (nextDraft: GridEventDraft | null) => {
-    if (!nextDraft) return;
+  const {
+    onDelete: deleteEvent,
+    onSubmit,
+    pendingAction,
+    setRecurrenceUpdateScopeDialogOpen,
+    onUpdateScopeChange,
+  } = useRecurrenceScopeConfirmation({
+    getDeleteContext,
+    getSaveContext,
+    onDelete: (applyTo) => onDelete(toRecurrenceScope(applyTo)),
+    onSave,
+  });
 
-    const decision = resolveRecurrenceScopeOnSubmit({
-      draft: nextDraft,
-      baseEvent,
-      isInstance:
-        nextDraft.kind === "edit" &&
-        nextDraft.source.recurrence.kind === "occurrence",
-      isRecurrence:
-        nextDraft.kind === "edit" &&
-        nextDraft.source.recurrence.kind === "series",
-    });
+  const syncDraft = useCallback((resolved: GridEventDraft | null) => {
+    draftActions.setGridDraft(resolved);
+  }, []);
 
-    if (decision.action === "prompt") {
-      setPendingAction({ draft: nextDraft, type: "save" });
-      return;
-    }
+  const scopeDialogDraft = useMemo(() => {
+    if (!pendingAction || !draft) return null;
 
-    if (decision.action === "standalone-confirm") {
-      // Day has no ConvertToStandaloneDialog; Week confirms then saves with
-      // ALL_EVENTS. Match that outcome here.
-      onSave(nextDraft, RecurringEventUpdateScope.ALL_EVENTS);
-      return;
-    }
-
-    onSave(nextDraft, decision.applyTo);
-  };
-  const deleteEvent = () => {
-    if (shouldPromptForRecurrenceScopeOnDelete(draft)) {
-      setPendingAction({ type: "delete" });
-      return;
-    }
-    onDelete();
-  };
+    return gridEventDraftToSchemaEvent(
+      pendingAction.type === "save" ? pendingAction.draft : draft,
+    );
+  }, [draft, pendingAction]);
 
   return (
-    <>
-      <EventForm
-        draft={draft}
-        isDraft={!existing}
-        isExistingEvent={existing}
-        onClose={onClose}
-        onDelete={deleteEvent}
-        onDuplicate={onDuplicate}
-        onSubmit={submit}
-        setDraft={setDraft}
-      />
-      {pendingAction && (
-        <RecurringEventUpdateScopeDialogContent
-          draft={pendingAction.type === "save" ? pendingAction.draft : draft}
-          onUpdateScopeChange={submitWithScope}
-          setRecurrenceUpdateScopeDialogOpen={(isOpen) => {
-            if (!isOpen) closeScopeDialog();
-          }}
-          title={pendingAction.type === "delete" ? "Delete events" : undefined}
+    <EventFormPanel
+      confirmation={{ onDelete: deleteEvent, onSubmit }}
+      confirmationUi={
+        <RecurrenceScopeConfirmationDialog
+          draft={scopeDialogDraft}
+          pendingAction={pendingAction}
+          setRecurrenceUpdateScopeDialogOpen={
+            setRecurrenceUpdateScopeDialogOpen
+          }
+          onUpdateScopeChange={onUpdateScopeChange}
         />
-      )}
-    </>
+      }
+      draft={draft}
+      isDraft={!existing}
+      isExistingEvent={existing}
+      isFormOpen={isFormOpen}
+      onClose={onClose}
+      onDuplicate={onDuplicate}
+      syncDraft={syncDraft}
+    />
   );
 }

--- a/packages/web/src/events/recurrence/recurrence-scope-decision.test.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-decision.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from "bson";
 import { EventIdSchema } from "@core/types/domain-primitives";
-import { EventScheduleSchema } from "@core/types/event.contracts";
+import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
 import {
@@ -13,9 +13,10 @@ import {
   editGridEventDraft,
 } from "@web/events/grid-event-draft.adapter";
 import {
-  resolveRecurrenceScopeOnSubmit,
-  shouldPromptForRecurrenceScopeOnDelete,
-} from "./recurrence-scope-decision";
+  getScopeDecisionRecurrenceRule,
+  hasMultipleRecurrenceOccurrences,
+  resolveRecurrenceScopeDecision,
+} from "@web/events/recurrence/recurrence-scope-decision";
 import { describe, expect, it } from "bun:test";
 
 const SCHEDULE = EventScheduleSchema.parse({
@@ -45,11 +46,8 @@ const buildEditDraft = ({
   liveRecurrence = { kind: "preserve" as const },
 }: {
   id?: string;
-  recurrence?: Extract<
-    GridEventDraft,
-    { kind: "edit" }
-  >["source"]["recurrence"];
   liveRecurrence?: EditEventRecurrenceDraft;
+  recurrence?: Event["recurrence"];
 } = {}): GridEventDraft => {
   const source = createMockEvent({
     id: EventIdSchema.parse(id),
@@ -63,27 +61,44 @@ const buildEditDraft = ({
   return { ...draft, values: { ...draft.values, recurrence: liveRecurrence } };
 };
 
-describe("resolveRecurrenceScopeOnSubmit", () => {
-  it("submits a new recurring draft without prompting", () => {
-    const draft = buildCreateDraft({
-      kind: "series",
-      rules: ["FREQ=WEEKLY;COUNT=4"],
-    });
+describe("hasMultipleRecurrenceOccurrences", () => {
+  it("returns false for a single-occurrence series", () => {
+    const schedule = {
+      start: new Date("2026-05-31T10:00:00.000Z"),
+      end: new Date("2026-05-31T11:00:00.000Z"),
+    };
 
     expect(
-      resolveRecurrenceScopeOnSubmit({
-        draft,
-        baseEvent: null,
-        isInstance: false,
-        isRecurrence: false,
-      }),
-    ).toEqual({
-      action: "submit",
-      applyTo: RecurringEventUpdateScope.THIS_EVENT,
-    });
+      hasMultipleRecurrenceOccurrences(schedule, ["RRULE:FREQ=WEEKLY;COUNT=1"]),
+    ).toBe(false);
   });
 
-  it("prompts for existing multi-occurrence recurring instances", () => {
+  it("returns true for a multi-occurrence series", () => {
+    const schedule = {
+      start: new Date("2026-05-31T10:00:00.000Z"),
+      end: new Date("2026-05-31T11:00:00.000Z"),
+    };
+
+    expect(
+      hasMultipleRecurrenceOccurrences(schedule, ["RRULE:FREQ=WEEKLY;COUNT=4"]),
+    ).toBe(true);
+  });
+});
+
+describe("getScopeDecisionRecurrenceRule", () => {
+  it("prefers an explicit series choice on the draft", () => {
+    const draft = buildEditDraft({
+      recurrence: { kind: "single" },
+      liveRecurrence: { kind: "series", rules: ["FREQ=DAILY;COUNT=3"] },
+    });
+    if (draft.kind !== "edit") throw new Error("Expected an edit draft");
+
+    expect(getScopeDecisionRecurrenceRule(draft, null)).toEqual([
+      "FREQ=DAILY;COUNT=3",
+    ]);
+  });
+
+  it("falls back to the series base rule for an occurrence", () => {
     const baseEventId = new ObjectId().toString();
     const baseEvent = createMockEvent({
       id: EventIdSchema.parse(baseEventId),
@@ -96,57 +111,210 @@ describe("resolveRecurrenceScopeOnSubmit", () => {
         seriesId: EventIdSchema.parse(baseEventId),
       },
     });
+    if (draft.kind !== "edit") throw new Error("Expected an edit draft");
 
-    expect(
-      resolveRecurrenceScopeOnSubmit({
-        draft,
-        baseEvent,
-        isInstance: false,
-        isRecurrence: false,
-      }),
-    ).toEqual({ action: "prompt" });
-  });
-
-  it("submits a single-occurrence recurring instance without prompting", () => {
-    const baseEventId = new ObjectId().toString();
-    const baseEvent = createMockEvent({
-      id: EventIdSchema.parse(baseEventId),
-      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=1"] },
-      schedule: SCHEDULE,
-    });
-    const draft = buildEditDraft({
-      recurrence: {
-        kind: "occurrence",
-        seriesId: EventIdSchema.parse(baseEventId),
-      },
-    });
-
-    expect(
-      resolveRecurrenceScopeOnSubmit({
-        draft,
-        baseEvent,
-        isInstance: false,
-        isRecurrence: false,
-      }),
-    ).toEqual({
-      action: "submit",
-      applyTo: RecurringEventUpdateScope.ALL_EVENTS,
-    });
+    expect(getScopeDecisionRecurrenceRule(draft, baseEvent)).toEqual([
+      "FREQ=WEEKLY;COUNT=4",
+    ]);
   });
 });
 
-describe("shouldPromptForRecurrenceScopeOnDelete", () => {
-  it("prompts before deleting recurring drafts", () => {
-    const draft = buildEditDraft({
-      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=4"] },
+describe("resolveRecurrenceScopeDecision", () => {
+  describe("delete", () => {
+    it("prompts before deleting recurring events", () => {
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "delete",
+          isRecurring: true,
+        }),
+      ).toEqual({ kind: "prompt" });
     });
 
-    expect(shouldPromptForRecurrenceScopeOnDelete(draft)).toBe(true);
+    it("deletes non-recurring events immediately", () => {
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "delete",
+          isRecurring: false,
+        }),
+      ).toEqual({
+        kind: "apply",
+        scope: RecurringEventUpdateScope.THIS_EVENT,
+      });
+    });
   });
 
-  it("does not prompt before deleting standalone drafts", () => {
-    const draft = buildEditDraft({ recurrence: { kind: "single" } });
+  describe("save (week heuristics)", () => {
+    it("applies THIS_EVENT for new recurring drafts", () => {
+      const draft = buildCreateDraft({
+        kind: "series",
+        rules: ["FREQ=WEEKLY;COUNT=4"],
+      });
 
-    expect(shouldPromptForRecurrenceScopeOnDelete(draft)).toBe(false);
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          draft,
+          isInstance: false,
+          isRecurring: false,
+        }),
+      ).toEqual({
+        kind: "apply",
+        scope: RecurringEventUpdateScope.THIS_EVENT,
+      });
+    });
+
+    it("prompts for existing multi-occurrence recurring instances", () => {
+      const baseEventId = new ObjectId().toString();
+      const baseEvent = createMockEvent({
+        id: EventIdSchema.parse(baseEventId),
+        recurrence: { kind: "series", rules: ["FREQ=WEEKLY;COUNT=4"] },
+        schedule: SCHEDULE,
+      });
+      const draft = buildEditDraft({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse(baseEventId),
+        },
+      });
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          baseEvent,
+          draft,
+          isInstance: true,
+          isRecurring: true,
+        }),
+      ).toEqual({ kind: "prompt" });
+    });
+
+    it("applies THIS_EVENT when a standalone draft is made recurring", () => {
+      const draft = buildEditDraft({
+        recurrence: { kind: "single" },
+        liveRecurrence: { kind: "series", rules: ["FREQ=WEEKLY;COUNT=4"] },
+      });
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          draft,
+          isInstance: false,
+          isRecurring: false,
+        }),
+      ).toEqual({
+        kind: "apply",
+        scope: RecurringEventUpdateScope.THIS_EVENT,
+      });
+    });
+
+    it("applies ALL_EVENTS for a single-occurrence recurring instance", () => {
+      const baseEventId = new ObjectId().toString();
+      const baseEvent = createMockEvent({
+        id: EventIdSchema.parse(baseEventId),
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=1"] },
+        schedule: SCHEDULE,
+      });
+      const draft = buildEditDraft({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse(baseEventId),
+        },
+      });
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          baseEvent,
+          draft,
+          isInstance: true,
+          isRecurring: true,
+        }),
+      ).toEqual({
+        kind: "apply",
+        scope: RecurringEventUpdateScope.ALL_EVENTS,
+      });
+    });
+
+    it("asks to convert an instance to standalone when recurrence is cleared", () => {
+      const baseEventId = new ObjectId().toString();
+      const baseEvent = createMockEvent({
+        id: EventIdSchema.parse(baseEventId),
+        recurrence: { kind: "series", rules: ["FREQ=WEEKLY;COUNT=4"] },
+        schedule: SCHEDULE,
+      });
+      const draft = buildEditDraft({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse(baseEventId),
+        },
+        liveRecurrence: { kind: "single" },
+      });
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          baseEvent,
+          draft,
+          isInstance: true,
+          isRecurring: true,
+        }),
+      ).toEqual({ kind: "convertToStandalone" });
+    });
+  });
+
+  describe("save (day confirm-all-recurring-edits)", () => {
+    it("prompts for any existing recurring edit", () => {
+      const draft = buildEditDraft({
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=4"] },
+      });
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          confirmAllRecurringEdits: true,
+          draft,
+          isInstance: false,
+          isRecurring: true,
+        }),
+      ).toEqual({ kind: "prompt" });
+    });
+
+    it("applies THIS_EVENT for non-recurring edits", () => {
+      const draft = buildEditDraft({ recurrence: { kind: "single" } });
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          confirmAllRecurringEdits: true,
+          draft,
+          isInstance: false,
+          isRecurring: false,
+        }),
+      ).toEqual({
+        kind: "apply",
+        scope: RecurringEventUpdateScope.THIS_EVENT,
+      });
+    });
+
+    it("still prompts when clearing recurrence on a day recurring instance", () => {
+      const baseEventId = new ObjectId().toString();
+      const draft = buildEditDraft({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse(baseEventId),
+        },
+        liveRecurrence: { kind: "single" },
+      });
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          confirmAllRecurringEdits: true,
+          draft,
+          isInstance: true,
+          isRecurring: true,
+        }),
+      ).toEqual({ kind: "prompt" });
+    });
   });
 });

--- a/packages/web/src/events/recurrence/recurrence-scope-decision.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-decision.ts
@@ -7,6 +7,33 @@ import { type GridEventDraft } from "@web/events/event-draft.types";
 
 type EditGridEventDraft = Extract<GridEventDraft, { kind: "edit" }>;
 
+export type RecurrenceScopeDecision =
+  | { kind: "prompt" }
+  | { kind: "apply"; scope: RecurringEventUpdateScope }
+  | { kind: "convertToStandalone" };
+
+export type ResolveRecurrenceScopeSaveInput = {
+  action: "save";
+  draft: GridEventDraft;
+  baseEvent?: Event | null;
+  isRecurring: boolean;
+  isInstance: boolean;
+  /**
+   * Day view always prompts before saving any edit to an existing recurring
+   * event. Week view applies occurrence-count and instance heuristics instead.
+   */
+  confirmAllRecurringEdits?: boolean;
+};
+
+export type ResolveRecurrenceScopeDeleteInput = {
+  action: "delete";
+  isRecurring: boolean;
+};
+
+export type ResolveRecurrenceScopeDecisionInput =
+  | ResolveRecurrenceScopeSaveInput
+  | ResolveRecurrenceScopeDeleteInput;
+
 export const hasMultipleRecurrenceOccurrences = (
   schedule: { start: Date; end: Date },
   rule: string[] | null | undefined,
@@ -29,6 +56,11 @@ export const hasMultipleRecurrenceOccurrences = (
   }
 };
 
+// Returns the recurrence rule that should decide the update-scope prompt:
+// an explicit "series"/"single" choice on the draft (the user toggled
+// recurrence in the form) always wins; otherwise ("preserve") falls back to
+// the source event's own rule, or — for an occurrence with no rule of its
+// own — the loaded series base's rule.
 export const getScopeDecisionRecurrenceRule = (
   draft: EditGridEventDraft,
   baseEvent: Event | null | undefined,
@@ -51,63 +83,62 @@ export const getScopeDecisionRecurrenceRule = (
   return undefined;
 };
 
-export type RecurrenceScopeSubmitDecision =
-  | { action: "submit"; applyTo: RecurringEventUpdateScope }
-  | { action: "prompt" }
-  | { action: "standalone-confirm" };
+export const resolveRecurrenceScopeDecision = (
+  input: ResolveRecurrenceScopeDecisionInput,
+): RecurrenceScopeDecision => {
+  if (input.action === "delete") {
+    if (input.isRecurring) {
+      return { kind: "prompt" };
+    }
 
-export function resolveRecurrenceScopeOnSubmit({
-  draft,
-  baseEvent,
-  isInstance,
-  isRecurrence,
-}: {
-  draft: GridEventDraft;
-  baseEvent: Event | null | undefined;
-  isInstance: boolean;
-  isRecurrence: boolean;
-}): RecurrenceScopeSubmitDecision {
+    return { kind: "apply", scope: RecurringEventUpdateScope.THIS_EVENT };
+  }
+
+  const {
+    draft,
+    baseEvent,
+    isRecurring,
+    isInstance,
+    confirmAllRecurringEdits = false,
+  } = input;
+
   if (draft.kind !== "edit") {
-    return {
-      action: "submit",
-      applyTo: RecurringEventUpdateScope.THIS_EVENT,
-    };
+    return { kind: "apply", scope: RecurringEventUpdateScope.THIS_EVENT };
+  }
+
+  if (confirmAllRecurringEdits) {
+    if (isRecurring) {
+      return { kind: "prompt" };
+    }
+
+    return { kind: "apply", scope: RecurringEventUpdateScope.THIS_EVENT };
   }
 
   const rule = getScopeDecisionRecurrenceRule(draft, baseEvent);
-  const draftIsInstance = draft.source.recurrence.kind === "occurrence";
-  const isRecurringEvent = isRecurrence || draftIsInstance;
-  const instanceEvent = isInstance || draftIsInstance;
-  const toStandAlone = instanceEvent && rule === null;
+  const toStandAlone = isInstance && rule === null;
   const hasMultipleOccurrences = hasMultipleRecurrenceOccurrences(
     draft.values.schedule,
     rule,
   );
   const isSingleOccurrenceInstance =
-    isRecurringEvent && instanceEvent && !hasMultipleOccurrences;
+    isRecurring && isInstance && !hasMultipleOccurrences;
   const shouldAskForUpdateScope =
-    !toStandAlone &&
-    isRecurringEvent &&
-    (hasMultipleOccurrences || !instanceEvent);
+    !toStandAlone && isRecurring && (hasMultipleOccurrences || !isInstance);
 
   if (shouldAskForUpdateScope) {
-    return { action: "prompt" };
+    return { kind: "prompt" };
   }
 
   if (toStandAlone) {
-    return { action: "standalone-confirm" };
+    return { kind: "convertToStandalone" };
   }
 
-  const applyTo =
-    toStandAlone || isSingleOccurrenceInstance
-      ? RecurringEventUpdateScope.ALL_EVENTS
-      : RecurringEventUpdateScope.THIS_EVENT;
+  const scope = isSingleOccurrenceInstance
+    ? RecurringEventUpdateScope.ALL_EVENTS
+    : RecurringEventUpdateScope.THIS_EVENT;
 
-  return { action: "submit", applyTo };
-}
+  return { kind: "apply", scope };
+};
 
-export function shouldPromptForRecurrenceScopeOnDelete(
-  draft: GridEventDraft,
-): boolean {
-  return draft.kind === "edit" && draft.source.recurrence.kind !== "single";
-}
+export const isExistingEventRecurring = (event: Event | null | undefined) =>
+  Boolean(event && event.recurrence.kind !== "single");

--- a/packages/web/src/events/recurrence/useRecurrenceScopeConfirmation.ts
+++ b/packages/web/src/events/recurrence/useRecurrenceScopeConfirmation.ts
@@ -1,0 +1,130 @@
+import { useCallback, useState } from "react";
+import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  type ResolveRecurrenceScopeSaveInput,
+  resolveRecurrenceScopeDecision,
+} from "@web/events/recurrence/recurrence-scope-decision";
+
+export type RecurrenceScopePendingAction =
+  | { draft: GridEventDraft; type: "save" }
+  | { type: "delete" };
+
+export type RecurrenceScopeSaveContext = Omit<
+  ResolveRecurrenceScopeSaveInput,
+  "action" | "draft"
+>;
+
+export type UseRecurrenceScopeConfirmationOptions = {
+  getDeleteContext: () => Pick<
+    Extract<
+      Parameters<typeof resolveRecurrenceScopeDecision>[0],
+      { action: "delete" }
+    >,
+    "isRecurring"
+  >;
+  getSaveContext: (draft: GridEventDraft) => RecurrenceScopeSaveContext;
+  onDelete: (scope: RecurringEventUpdateScope) => void;
+  onSave: (draft: GridEventDraft, scope: RecurringEventUpdateScope) => void;
+};
+
+export const useRecurrenceScopeConfirmation = ({
+  getDeleteContext,
+  getSaveContext,
+  onDelete,
+  onSave,
+}: UseRecurrenceScopeConfirmationOptions) => {
+  const [pendingAction, setPendingAction] =
+    useState<RecurrenceScopePendingAction | null>(null);
+  const [standaloneDraft, setStandaloneDraft] = useState<GridEventDraft | null>(
+    null,
+  );
+
+  const isRecurrenceUpdateScopeDialogOpen = pendingAction !== null;
+
+  const dismissScopeDialog = useCallback(() => {
+    setPendingAction(null);
+  }, []);
+
+  const onUpdateScopeChange = useCallback(
+    (applyTo: RecurringEventUpdateScope) => {
+      if (pendingAction?.type === "save") {
+        onSave(pendingAction.draft, applyTo);
+      } else if (pendingAction?.type === "delete") {
+        onDelete(applyTo);
+      }
+
+      setPendingAction(null);
+    },
+    [onDelete, onSave, pendingAction],
+  );
+
+  const onSubmit = useCallback(
+    (draft: GridEventDraft) => {
+      const decision = resolveRecurrenceScopeDecision({
+        action: "save",
+        draft,
+        ...getSaveContext(draft),
+      });
+
+      switch (decision.kind) {
+        case "prompt":
+          setPendingAction({ draft, type: "save" });
+          return;
+        case "convertToStandalone":
+          setStandaloneDraft(draft);
+          return;
+        case "apply":
+          onSave(draft, decision.scope);
+          return;
+      }
+    },
+    [getSaveContext, onSave],
+  );
+
+  const onDeleteRequest = useCallback(() => {
+    const decision = resolveRecurrenceScopeDecision({
+      action: "delete",
+      ...getDeleteContext(),
+    });
+
+    if (decision.kind === "prompt") {
+      setPendingAction({ type: "delete" });
+      return;
+    }
+
+    if (decision.kind === "apply") {
+      onDelete(decision.scope);
+    }
+  }, [getDeleteContext, onDelete]);
+
+  const onConfirmConvertToStandalone = useCallback(() => {
+    if (standaloneDraft) {
+      onSave(standaloneDraft, RecurringEventUpdateScope.ALL_EVENTS);
+    }
+
+    setStandaloneDraft(null);
+  }, [onSave, standaloneDraft]);
+
+  const onCancelConvertToStandalone = useCallback(() => {
+    setStandaloneDraft(null);
+  }, []);
+
+  return {
+    isRecurrenceUpdateScopeDialogOpen,
+    onCancelConvertToStandalone,
+    onConfirmConvertToStandalone,
+    onDelete: onDeleteRequest,
+    onSubmit,
+    onUpdateScopeChange,
+    pendingAction,
+    setRecurrenceUpdateScopeDialogOpen: (isOpen: boolean) => {
+      if (!isOpen) {
+        dismissScopeDialog();
+      }
+    },
+    standaloneDraft,
+  };
+};
+
+export { isExistingEventRecurring } from "@web/events/recurrence/recurrence-scope-decision";

--- a/packages/web/src/views/Forms/EventForm/RecurrenceScopeDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/RecurrenceScopeDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
 import { DirtyParser } from "@web/common/utils/parse/dirty.parser";
 import {
@@ -6,8 +7,9 @@ import {
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
-import { type GridEventDraft } from "@web/events/event-draft.types";
-import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
+import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
+import { type RecurrenceScopePendingAction } from "@web/events/recurrence/useRecurrenceScopeConfirmation";
+import { selectDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
 const UPDATE_SCOPE_OPTIONS: RecurringEventUpdateScope[] = [
@@ -36,22 +38,50 @@ export function RecurrenceScopeDialog() {
   } = useDraftContext();
   const {
     isRecurrenceUpdateScopeDialogOpen,
-    setRecurrenceUpdateScopeDialogOpen,
     onUpdateScopeChange,
+    pendingAction,
+    setRecurrenceUpdateScopeDialogOpen,
   } = confirmation;
+
   if (!isRecurrenceUpdateScopeDialogOpen) return null;
+
+  return (
+    <RecurrenceScopeConfirmationDialog
+      draft={draft ? gridEventDraftToSchemaEvent(draft) : null}
+      pendingAction={pendingAction}
+      setRecurrenceUpdateScopeDialogOpen={setRecurrenceUpdateScopeDialogOpen}
+      onUpdateScopeChange={onUpdateScopeChange}
+    />
+  );
+}
+
+type RecurrenceScopeConfirmationDialogProps = {
+  draft: CompassEvent | null;
+  onUpdateScopeChange: (applyTo: RecurringEventUpdateScope) => void;
+  pendingAction: RecurrenceScopePendingAction | null;
+  setRecurrenceUpdateScopeDialogOpen: (isOpen: boolean) => void;
+};
+
+export function RecurrenceScopeConfirmationDialog({
+  draft,
+  onUpdateScopeChange,
+  pendingAction,
+  setRecurrenceUpdateScopeDialogOpen,
+}: RecurrenceScopeConfirmationDialogProps) {
+  if (!pendingAction) return null;
 
   return (
     <RecurringEventUpdateScopeDialogContent
       draft={draft}
       onUpdateScopeChange={onUpdateScopeChange}
       setRecurrenceUpdateScopeDialogOpen={setRecurrenceUpdateScopeDialogOpen}
+      title={pendingAction.type === "delete" ? "Delete events" : undefined}
     />
   );
 }
 
 interface RecurringEventUpdateScopeDialogContentProps {
-  draft: GridEventDraft | null;
+  draft: CompassEvent | null;
   onUpdateScopeChange: (applyTo: RecurringEventUpdateScope) => void;
   recurrenceChanged?: boolean;
   setRecurrenceUpdateScopeDialogOpen: (isOpen: boolean) => void;
@@ -65,12 +95,12 @@ export function RecurringEventUpdateScopeDialogContent({
   setRecurrenceUpdateScopeDialogOpen,
   title = "Apply changes to",
 }: RecurringEventUpdateScopeDialogContentProps) {
-  const originalDraft = useDraftStore(selectGridDraft);
-  const currentDraft = draft ?? originalDraft;
+  const draftFromStore = useDraftStore(selectDraft);
+  const currentDraft = draft ?? draftFromStore;
   const recurrenceChanged =
     recurrenceChangedOverride ??
-    (currentDraft && originalDraft
-      ? DirtyParser.gridDraftRecurrenceChanged(currentDraft, originalDraft)
+    (currentDraft && draftFromStore
+      ? DirtyParser.recurrenceChanged(currentDraft, draftFromStore)
       : false);
   const options = recurrenceChanged
     ? RECURRENCE_CHANGED_UPDATE_SCOPE_OPTIONS
@@ -135,3 +165,5 @@ export function RecurringEventUpdateScopeDialogContent({
     </OverlayPanel>
   );
 }
+
+export type { RecurrenceScopePendingAction };

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.ts
@@ -1,11 +1,11 @@
-import { useCallback, useState } from "react";
-import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
+import { useCallback } from "react";
+import { type Event } from "@core/types/event.contracts";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { useEventById } from "@web/events/queries/useEventById";
 import {
-  resolveRecurrenceScopeOnSubmit,
-  shouldPromptForRecurrenceScopeOnDelete,
-} from "@web/events/recurrence/recurrence-scope-decision";
+  type UseRecurrenceScopeConfirmationOptions,
+  useRecurrenceScopeConfirmation,
+} from "@web/events/recurrence/useRecurrenceScopeConfirmation";
 import { type useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
 export const useDraftConfirmation = ({
@@ -21,89 +21,63 @@ export const useDraftConfirmation = ({
       : undefined;
   const baseEvent = useEventById(baseEventId);
 
-  const [
-    isRecurrenceUpdateScopeDialogOpen,
-    setRecurrenceUpdateScopeDialogOpen,
-  ] = useState<boolean>(false);
+  const getSaveContext = useCallback(
+    (_draft: GridEventDraft) => {
+      const isEditDraft = _draft.kind === "edit";
+      const draftIsInstance =
+        isEditDraft && _draft.source.recurrence.kind === "occurrence";
 
-  const [finalDraft, setFinalDraft] = useState<GridEventDraft | null>(null);
-
-  const [standaloneDraft, setStandaloneDraft] = useState<GridEventDraft | null>(
-    null,
+      return {
+        baseEvent: baseEvent as Event | null | undefined,
+        isInstance: isInstance() || draftIsInstance,
+        isRecurring: isEditDraft && (isRecurrence() || draftIsInstance),
+      };
+    },
+    [baseEvent, isInstance, isRecurrence],
   );
+
+  const getDeleteContext = useCallback(
+    () => ({ isRecurring: isRecurrence() }),
+    [isRecurrence],
+  );
+
+  const onSave = useCallback<UseRecurrenceScopeConfirmationOptions["onSave"]>(
+    (nextDraft, applyTo) => {
+      submit(nextDraft, applyTo);
+      discard();
+    },
+    [discard, submit],
+  );
+
+  const onDelete = useCallback<
+    UseRecurrenceScopeConfirmationOptions["onDelete"]
+  >(
+    (applyTo) => {
+      deleteEvent(applyTo);
+      discard();
+    },
+    [deleteEvent, discard],
+  );
+
+  const confirmation = useRecurrenceScopeConfirmation({
+    getDeleteContext,
+    getSaveContext,
+    onDelete,
+    onSave,
+  });
 
   const onConfirmConvertToStandalone = useCallback(() => {
-    if (standaloneDraft) {
-      submit(standaloneDraft, RecurringEventUpdateScope.ALL_EVENTS);
-      discard();
-    }
-
-    setStandaloneDraft(null);
-  }, [standaloneDraft, submit, discard]);
-
-  const onCancelConvertToStandalone = useCallback(() => {
-    setStandaloneDraft(null);
-  }, []);
-
-  const onUpdateScopeChange = useCallback(
-    (applyTo: RecurringEventUpdateScope) => {
-      if (finalDraft) {
-        submit(finalDraft, applyTo);
-      } else {
-        deleteEvent(applyTo);
-      }
-
-      setFinalDraft(null);
-      setRecurrenceUpdateScopeDialogOpen(false);
-      discard();
-    },
-    [finalDraft, submit, discard, deleteEvent],
-  );
-
-  const onSubmit = useCallback(
-    async (_draft: GridEventDraft) => {
-      const decision = resolveRecurrenceScopeOnSubmit({
-        draft: _draft,
-        baseEvent,
-        isInstance: isInstance(),
-        isRecurrence: isRecurrence(),
-      });
-
-      if (decision.action === "prompt") {
-        setFinalDraft(_draft);
-        return setRecurrenceUpdateScopeDialogOpen(true);
-      }
-
-      if (decision.action === "standalone-confirm") {
-        return setStandaloneDraft(_draft);
-      }
-
-      submit(_draft, decision.applyTo);
-      discard();
-    },
-    [submit, isRecurrence, isInstance, discard, baseEvent],
-  );
-
-  const onDelete = useCallback(async () => {
-    if (draft && shouldPromptForRecurrenceScopeOnDelete(draft)) {
-      setFinalDraft(null);
-      return setRecurrenceUpdateScopeDialogOpen(true);
-    }
-
-    deleteEvent(RecurringEventUpdateScope.THIS_EVENT);
+    confirmation.onConfirmConvertToStandalone();
     discard();
-  }, [deleteEvent, draft, discard]);
+  }, [confirmation, discard]);
 
   return {
-    isRecurrenceUpdateScopeDialogOpen,
-    setRecurrenceUpdateScopeDialogOpen,
+    ...confirmation,
     draft,
-    finalDraft,
-    standaloneDraft,
-    onSubmit,
-    onDelete,
-    onUpdateScopeChange,
+    finalDraft:
+      confirmation.pendingAction?.type === "save"
+        ? confirmation.pendingAction.draft
+        : null,
     onConfirmConvertToStandalone,
-    onCancelConvertToStandalone,
   };
 };


### PR DESCRIPTION
## Summary

- Extract `resolveRecurrenceScopeDecision()` as the shared save/delete decision helper for recurring events
- Add `useRecurrenceScopeConfirmation()` and `RecurrenceScopeConfirmationDialog` so Day and Week views share one confirmation wrapper
- Day view keeps `confirmAllRecurringEdits` behavior (always prompt for existing recurring edits); Week view keeps occurrence-count heuristics and standalone conversion

## Simplicity

Net-reduced complexity: three divergent decision paths (SidebarEventDetails, useDraftConfirmation, RecurrenceScopeDialog) collapse into one helper + one hook. `useState` in `useRecurrenceScopeConfirmation` tracks pending save/delete actions and standalone-conversion draft — necessary local UI state that neither view's store owns. Simplify found nothing further to change.

## Manual Testing Steps

- [ ] In Day view, open an existing weekly recurring event, change the title, save — expect the "Apply changes to" scope dialog with This Event / This and Following / All Events
- [ ] In Day view, open the same recurring event, press Delete — expect the "Delete events" scope dialog before the event is removed
- [ ] In Week view, open one instance of a multi-occurrence series, edit the title, save — expect the scope dialog (not an immediate save)
- [ ] In Week view, open the only instance of a single-occurrence series, edit the title, save — expect an immediate save with no scope dialog
- [ ] In Week view, open a series instance, clear recurrence to make it standalone, save — expect the "Convert to standalone event?" dialog

## Test plan

- [x] `bun test:web -- packages/web/src/events/recurrence/recurrence-scope-decision.test.ts packages/web/src/views/Week/components/Draft/hooks/state/useDraftConfirmation.test.tsx packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx` — 24 pass, 0 fail
- [x] Code review (medium effort) — no high-confidence correctness issues found


Made with [Cursor](https://cursor.com)