### PR TITLE
refactor(web): extract shared EventFormPanel for day and week sidebars

### DIFF
--- a/packages/backend/src/__tests__/helpers/mock.setup.ts
+++ b/packages/backend/src/__tests__/helpers/mock.setup.ts
@@ -7,13 +7,11 @@ import {
   type VerifySessionOptions,
 } from "supertokens-node/lib/build/recipe/session/types";
 import {
-  LoggerFactory,
   type LoggerFactoryFn,
   registerLoggerFactory,
   resetLoggerFactory,
 } from "@core/logger/logger.factory";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
-import { type UserMetadata } from "@core/types/user.types";
 import { getTestIsolationKey } from "@backend/__tests__/helpers/test-file-context";
 import { getTestGcalFixture } from "@backend/__tests__/helpers/test-gcal-fixture";
 import {

--- a/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
+++ b/packages/backend/src/__tests__/mocks.gcal/factories/gcal.factory.ts
@@ -33,7 +33,7 @@ import {
 } from "@backend/__tests__/helpers/test-gcal-fixture";
 import { generateGcalId } from "@backend/__tests__/mocks.gcal/factories/gcal.event.factory";
 import { GcalEventRRule } from "@backend/event/classes/gcal.event.rrule";
-import { mock, spyOn } from "bun:test";
+import { mock } from "bun:test";
 
 /**
  * Creates a mock GaxiosResponse object with all required Response properties

--- a/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
@@ -1,6 +1,5 @@
 import { faker } from "@faker-js/faker";
 import { type Credentials, type TokenPayload } from "google-auth-library";
-import { LoggerFactory } from "@core/logger/logger.factory";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import {
   cleanupCollections,
@@ -27,7 +26,6 @@ import {
   describe,
   expect,
   it,
-  mock,
   spyOn,
 } from "bun:test";
 
@@ -68,16 +66,6 @@ describe("googleAuthService", () => {
       ({
         access_token: faker.internet.jwt(),
       }) as Pick<Credentials, "refresh_token" | "access_token">;
-    // LoggerFactory returns one stable mock logger per name in tests, so this
-    // is the instance the service captured at import.
-    const getMockLogger = () =>
-      authServiceLogger as unknown as {
-        debug: Mock;
-        error: Mock;
-        info: Mock;
-        verbose: Mock;
-        warn: Mock;
-      };
 
     beforeEach(() => {
       mockDetermineGoogleAuthMode().mockReset();

--- a/packages/backend/src/auth/services/google/google.auth.success.utils.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.success.utils.test.ts
@@ -3,7 +3,7 @@ import { ObjectId } from "mongodb";
 import * as syncRecords from "@backend/sync/services/records/sync-records.repository";
 import * as userQueries from "@backend/user/queries/user.queries";
 import { determineGoogleAuthMode } from "./util/google.auth.util";
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 function makeCompassUser(overrides?: {
   googleId?: string;

--- a/packages/backend/src/auth/services/google/util/google.auth.util.test.ts
+++ b/packages/backend/src/auth/services/google/util/google.auth.util.test.ts
@@ -7,7 +7,7 @@ import {
   determineGoogleAuthMode,
   parseReconnectGoogleParams,
 } from "./google.auth.util";
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 function makeCompassUser(overrides?: {
   googleId?: string;

--- a/packages/backend/src/calendar/services/calendar.service.db.test.ts
+++ b/packages/backend/src/calendar/services/calendar.service.db.test.ts
@@ -12,16 +12,7 @@ import calendarService from "@backend/calendar/services/calendar.service";
 import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("CalendarService", () => {
   beforeEach(() => setupTestDb(import.meta.url));

--- a/packages/backend/src/common/guards/google.guard.test.ts
+++ b/packages/backend/src/common/guards/google.guard.test.ts
@@ -5,7 +5,7 @@ import { type Schema_User } from "@core/types/user.types";
 import { UserError } from "@backend/common/errors/user/user.errors";
 import { requireGoogleConnection } from "@backend/common/guards/google.guard";
 import * as userQueries from "@backend/user/queries/user.queries";
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const isGoogleConnected = async (userId: string): Promise<boolean> => {
   if (!IDSchema.safeParse(userId).success) {

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -21,15 +21,7 @@ import {
   getFormFieldValue,
 } from "@backend/common/middleware/supertokens.middleware.util";
 import userService from "@backend/user/services/user.service";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 type MockCallSource = { mock: { calls: unknown[][] } };
 

--- a/packages/backend/src/common/services/gcal/gcal.service.test.ts
+++ b/packages/backend/src/common/services/gcal/gcal.service.test.ts
@@ -1,6 +1,5 @@
 import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
-import * as googleWatchToken from "@backend/sync/services/watch/google-watch-token";
-import { beforeAll, describe, expect, it, mock, spyOn } from "bun:test";
+import { beforeAll, describe, expect, it, mock } from "bun:test";
 
 beforeAll(() => {
   mockEnv({ GCAL_WEBHOOK_BASEURL: "https://example.trycloudflare.com/api" });

--- a/packages/backend/src/event/google-event-sync.service.test.ts
+++ b/packages/backend/src/event/google-event-sync.service.test.ts
@@ -7,7 +7,7 @@ import gcalService from "@backend/common/services/gcal/gcal.service";
 import { type EventRecord } from "@backend/event/event.record";
 import { eventRepository } from "@backend/event/event.repository";
 import { GoogleEventSync } from "@backend/event/google-event-sync.service";
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const calendar: CalendarRecord = {
   _id: new ObjectId(),

--- a/packages/backend/src/event/services/event.service.db.test.ts
+++ b/packages/backend/src/event/services/event.service.db.test.ts
@@ -14,16 +14,7 @@ import {
   buildEventRecord,
   seedGoogleCalendar,
 } from "@backend/sync/services/event-propagation/__tests__/event-propagation.test-helpers";
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const seedLocalCalendar = async (userId: ObjectId) => {
   const record = CalendarRecordSchema.parse({

--- a/packages/backend/src/events/controllers/events.controller.db.test.ts
+++ b/packages/backend/src/events/controllers/events.controller.db.test.ts
@@ -14,7 +14,6 @@ import { GoogleWatchStateStatus } from "@backend/sync/services/watch/google-watc
 import userService from "@backend/user/services/user.service";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,

--- a/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.db.test.ts
+++ b/packages/backend/src/sync/services/calendarlist/google-calendarlist.service.db.test.ts
@@ -25,7 +25,6 @@ import * as syncImportService from "@backend/sync/services/import/google-import.
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google-backfill.db.test.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google-backfill.db.test.ts
@@ -13,13 +13,11 @@ import { type EventRecord } from "@backend/event/event.record";
 import compassToGoogleBackfill from "@backend/sync/services/event-propagation/compass-to-google/compass-to-google-backfill";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,
   expect,
   it,
-  mock,
   spyOn,
 } from "bun:test";
 

--- a/packages/backend/src/sync/services/google-sync/gcal.client.test.ts
+++ b/packages/backend/src/sync/services/google-sync/gcal.client.test.ts
@@ -5,7 +5,7 @@ import { type Schema_User } from "@core/types/user.types";
 import { UserError } from "@backend/common/errors/user/user.errors";
 import { getGcalClient } from "@backend/sync/services/google-sync/gcal.client";
 import * as userQueries from "@backend/user/queries/user.queries";
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 describe("getGcalClient", () => {
   it("throws UserError.MissingGoogleRefreshToken when user exists but has no google", async () => {

--- a/packages/backend/src/sync/services/google-sync/google-sync.health.db.test.ts
+++ b/packages/backend/src/sync/services/google-sync/google-sync.health.db.test.ts
@@ -13,7 +13,6 @@ import * as googleWatchConfig from "@backend/sync/services/watch/google-watch-co
 import { isGoogleCalendarSyncHealthy } from "./google-sync.health";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,

--- a/packages/backend/src/sync/services/watch/google-watch-config.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-config.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from "@core/logger/winston.logger";
 import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
 import { warnIfWebhookNotPublicHttps } from "@backend/sync/services/watch/google-watch-config";
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("warnIfWebhookNotPublicHttps (packet 09 ops: self-host webhook check)", () => {
   afterEach(() => {});

--- a/packages/backend/src/sync/services/watch/google-watch-maintenance.service.db.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-maintenance.service.db.test.ts
@@ -24,13 +24,11 @@ import { googleWatchRepairService } from "@backend/sync/services/watch/google-wa
 import userService from "@backend/user/services/user.service";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,
   expect,
   it,
-  mock,
   spyOn,
 } from "bun:test";
 

--- a/packages/backend/src/sync/services/watch/google-watch-repair.service.db.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-repair.service.db.test.ts
@@ -28,13 +28,11 @@ import { googleWatchService } from "@backend/sync/services/watch/google-watch.se
 import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,
   expect,
   it,
-  mock,
   spyOn,
 } from "bun:test";
 

--- a/packages/backend/src/sync/services/watch/google-watch-state.db.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch-state.db.test.ts
@@ -22,7 +22,6 @@ import {
 } from "@backend/sync/services/watch/google-watch-state";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,

--- a/packages/backend/src/sync/services/watch/google-watch.service.db.test.ts
+++ b/packages/backend/src/sync/services/watch/google-watch.service.db.test.ts
@@ -32,7 +32,6 @@ import {
 } from "@backend/sync/services/watch/google-watch-state";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,

--- a/packages/backend/src/user/controllers/user.controller.db.test.ts
+++ b/packages/backend/src/user/controllers/user.controller.db.test.ts
@@ -17,7 +17,6 @@ import EmailService from "@backend/email/email.service";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,

--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
@@ -83,7 +83,9 @@ export function SidebarEventDetails() {
             setRecurrenceUpdateScopeDialogOpen={(isOpen) => {
               if (!isOpen) closeScopeDialog();
             }}
-            title={pendingAction.type === "delete" ? "Delete events" : undefined}
+            title={
+              pendingAction.type === "delete" ? "Delete events" : undefined
+            }
           />
         ) : null
       }

--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
@@ -1,9 +1,4 @@
-import {
-  type Dispatch,
-  type SetStateAction,
-  useCallback,
-  useState,
-} from "react";
+import { useCallback, useState } from "react";
 import { type RecurringEventUpdateScope } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
@@ -15,8 +10,8 @@ import {
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { RecurringEventUpdateScopeDialogContent } from "@web/views/Forms/EventForm/RecurrenceScopeDialog";
+import { EventFormPanel } from "@web/views/Forms/EventFormPanel/EventFormPanel";
 import { useCloseEventForm } from "@web/views/Forms/hooks/useCloseEventForm";
 import { useDeleteEvent } from "@web/views/Forms/hooks/useDeleteEvent";
 import { useDuplicateEvent } from "@web/views/Forms/hooks/useDuplicateEvent";
@@ -45,15 +40,9 @@ export function SidebarEventDetails() {
     existingEvent && existingEvent.recurrence.kind !== "single",
   );
 
-  const setDraft: Dispatch<SetStateAction<GridEventDraft | null>> = useCallback(
-    (next) => {
-      const resolved = typeof next === "function" ? next(draft) : next;
-      draftActions.setGridDraft(resolved);
-    },
-    [draft],
-  );
-
-  if (!isFormOpen || !draft) return null;
+  const syncDraft = useCallback((resolved: GridEventDraft | null) => {
+    draftActions.setGridDraft(resolved);
+  }, []);
 
   const closeScopeDialog = () => setPendingAction(null);
   const submitWithScope = (applyTo: RecurringEventUpdateScope) => {
@@ -64,8 +53,8 @@ export function SidebarEventDetails() {
     }
     setPendingAction(null);
   };
-  const submit = (nextDraft: GridEventDraft | null) => {
-    if (nextDraft && needsRecurrenceScope) {
+  const submit = (nextDraft: GridEventDraft) => {
+    if (needsRecurrenceScope) {
       setPendingAction({ draft: nextDraft, type: "save" });
       return;
     }
@@ -80,31 +69,31 @@ export function SidebarEventDetails() {
   };
 
   return (
-    <>
-      <EventForm
-        draft={draft}
-        isDraft={!existing}
-        isExistingEvent={existing}
-        onClose={onClose}
-        onDelete={deleteEvent}
-        onDuplicate={onDuplicate}
-        onSubmit={submit}
-        setDraft={setDraft}
-      />
-      {pendingAction && (
-        <RecurringEventUpdateScopeDialogContent
-          draft={
-            pendingAction.type === "save"
-              ? gridEventDraftToSchemaEvent(pendingAction.draft)
-              : gridEventDraftToSchemaEvent(draft)
-          }
-          onUpdateScopeChange={submitWithScope}
-          setRecurrenceUpdateScopeDialogOpen={(isOpen) => {
-            if (!isOpen) closeScopeDialog();
-          }}
-          title={pendingAction.type === "delete" ? "Delete events" : undefined}
-        />
-      )}
-    </>
+    <EventFormPanel
+      confirmation={{ onDelete: deleteEvent, onSubmit: submit }}
+      confirmationUi={
+        pendingAction && draft ? (
+          <RecurringEventUpdateScopeDialogContent
+            draft={
+              pendingAction.type === "save"
+                ? gridEventDraftToSchemaEvent(pendingAction.draft)
+                : gridEventDraftToSchemaEvent(draft)
+            }
+            onUpdateScopeChange={submitWithScope}
+            setRecurrenceUpdateScopeDialogOpen={(isOpen) => {
+              if (!isOpen) closeScopeDialog();
+            }}
+            title={pendingAction.type === "delete" ? "Delete events" : undefined}
+          />
+        ) : null
+      }
+      draft={draft}
+      isDraft={!existing}
+      isExistingEvent={existing}
+      isFormOpen={isFormOpen}
+      onClose={onClose}
+      onDuplicate={onDuplicate}
+      syncDraft={syncDraft}
+    />
   );
 }

--- a/packages/web/src/views/Forms/EventFormPanel/EventFormPanel.tsx
+++ b/packages/web/src/views/Forms/EventFormPanel/EventFormPanel.tsx
@@ -1,0 +1,70 @@
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useCallback,
+} from "react";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { EventForm } from "@web/views/Forms/EventForm/EventForm";
+
+export type EventFormPanelConfirmation = {
+  onDelete: () => void;
+  onSubmit: (draft: GridEventDraft) => void | Promise<void>;
+};
+
+export type EventFormPanelProps = {
+  confirmation: EventFormPanelConfirmation;
+  confirmationUi?: ReactNode;
+  draft: GridEventDraft | null;
+  isDraft: boolean;
+  isExistingEvent: boolean;
+  isFormOpen: boolean;
+  onClose: () => void;
+  onDuplicate?: (draft: GridEventDraft) => void;
+  syncDraft: (draft: GridEventDraft | null) => void;
+};
+
+/**
+ * Shared sidebar wiring for Day and Week event forms: resolves functional
+ * setDraft updates, guards on open state, and delegates save/delete through
+ * the caller's confirmation strategy.
+ */
+export function EventFormPanel({
+  confirmation,
+  confirmationUi,
+  draft,
+  isDraft,
+  isExistingEvent,
+  isFormOpen,
+  onClose,
+  onDuplicate,
+  syncDraft,
+}: EventFormPanelProps) {
+  const setDraft: Dispatch<SetStateAction<GridEventDraft | null>> = useCallback(
+    (next) => {
+      const resolved = typeof next === "function" ? next(draft) : next;
+      syncDraft(resolved);
+    },
+    [draft, syncDraft],
+  );
+
+  if (!isFormOpen || !draft) return null;
+
+  return (
+    <>
+      <EventForm
+        draft={draft}
+        isDraft={isDraft}
+        isExistingEvent={isExistingEvent}
+        onClose={onClose}
+        onDelete={confirmation.onDelete}
+        onDuplicate={onDuplicate}
+        onSubmit={(nextDraft) => {
+          if (nextDraft) void confirmation.onSubmit(nextDraft);
+        }}
+        setDraft={setDraft}
+      />
+      {confirmationUi}
+    </>
+  );
+}

--- a/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
+++ b/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
@@ -1,4 +1,9 @@
-import { type Dispatch, type FC, type SetStateAction, useCallback } from "react";
+import {
+  type Dispatch,
+  type FC,
+  type SetStateAction,
+  useCallback,
+} from "react";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { draftActions } from "@web/events/stores/draft.store";
 import { EventFormPanel } from "@web/views/Forms/EventFormPanel/EventFormPanel";

--- a/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
+++ b/packages/web/src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.tsx
@@ -1,7 +1,7 @@
-import { type Dispatch, type FC, type SetStateAction } from "react";
+import { type Dispatch, type FC, type SetStateAction, useCallback } from "react";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { draftActions } from "@web/events/stores/draft.store";
-import { EventForm } from "@web/views/Forms/EventForm/EventForm";
+import { EventFormPanel } from "@web/views/Forms/EventFormPanel/EventFormPanel";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
 export const syncWeekGridDraft = (
@@ -25,29 +25,23 @@ export const WeekSidebarEventDetails: FC = () => {
   const { draft, isFormOpen } = state;
   const { onSubmit, onDelete } = confirmation;
 
-  if (!isFormOpen || !draft) return null;
-
-  const setFormDraft: Dispatch<SetStateAction<GridEventDraft | null>> = (
-    nextDraft,
-  ) => {
-    const resolvedDraft =
-      typeof nextDraft === "function" ? nextDraft(draft) : nextDraft;
-
-    syncWeekGridDraft(resolvedDraft, setDraft);
-  };
+  const syncDraft = useCallback(
+    (resolved: GridEventDraft | null) => {
+      syncWeekGridDraft(resolved, setDraft);
+    },
+    [setDraft],
+  );
 
   return (
-    <EventForm
+    <EventFormPanel
+      confirmation={{ onDelete, onSubmit }}
       draft={draft}
-      isDraft={draft.kind === "create"}
-      isExistingEvent={draft.kind === "edit"}
+      isDraft={draft?.kind === "create"}
+      isExistingEvent={draft?.kind === "edit"}
+      isFormOpen={isFormOpen}
       onClose={discard}
-      onDelete={onDelete}
       onDuplicate={duplicateEvent}
-      onSubmit={(nextDraft) => {
-        if (nextDraft) void onSubmit(nextDraft);
-      }}
-      setDraft={setFormDraft}
+      syncDraft={syncDraft}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Extract `EventFormPanel` with shared EventForm wiring (draft sync, open guard, submit wrapper)
- Refactor `SidebarEventDetails` (Day) and `WeekSidebarEventDetails` (Week) to delegate through the panel
- Day passes store-only sync + inline recurrence scope dialog; Week passes `syncWeekGridDraft` + DraftContext confirmation

## Simplicity
Net complexity reduction: duplicated EventForm wiring removed from both sidebar components. `EventFormPanel` uses one `useCallback` for functional `setDraft` resolution — needed so EventForm receives a stable setter that always resolves against the current draft. `SidebarEventDetails` keeps its existing `useState` for pending recurrence scope actions (Day-specific confirmation UI). No simplification follow-up commit needed.

## Manual Testing Steps
- [ ] Open Day view, click an existing timed event — sidebar event form opens with title focused and event details populated
- [ ] Press Escape in the Day sidebar form — form closes
- [ ] Open Week view, click an existing timed event — sidebar event form opens with title focused and event details populated
- [ ] In Week view, edit the title and press Enter — form submits (save path via DraftContext confirmation)

## Test plan
- [x] `bun test src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx src/views/Week/components/Draft/sidebar/WeekSidebarEventDetails.test.tsx` — 8 pass, 0 fail
- [x] `bun run type-check` — pass
- [x] Manual browser smoke on local dev server (Day + Week event form open via Playwright)


Made with [Cursor](https://cursor.com)