### PR TITLE
feat(web): improve first-run onboarding and setup discoverability

### DIFF
--- a/packages/web/src/auth/state/release-notes-prompt.store.ts
+++ b/packages/web/src/auth/state/release-notes-prompt.store.ts
@@ -8,7 +8,7 @@ export const useReleaseNotesPromptStore = create<ReleaseNotesPromptState>()(
   () => ({ isOpen: false }),
 );
 
-let scheduleOpenTimeoutId: ReturnType<typeof window.setTimeout> | undefined;
+let scheduleOpenTimeoutId: number | undefined;
 
 const clearScheduledOpen = () => {
   if (scheduleOpenTimeoutId !== undefined) {

--- a/packages/web/src/auth/state/release-notes-prompt.store.ts
+++ b/packages/web/src/auth/state/release-notes-prompt.store.ts
@@ -11,6 +11,11 @@ export const useReleaseNotesPromptStore = create<ReleaseNotesPromptState>()(
 export const releaseNotesPromptActions = {
   open: () => useReleaseNotesPromptStore.setState({ isOpen: true }),
   close: () => useReleaseNotesPromptStore.setState({ isOpen: false }),
+  scheduleOpen: (delayMs = 45_000) => {
+    window.setTimeout(() => {
+      useReleaseNotesPromptStore.setState({ isOpen: true });
+    }, delayMs);
+  },
 };
 
 export const selectReleaseNotesPromptOpen = (state: ReleaseNotesPromptState) =>

--- a/packages/web/src/auth/state/release-notes-prompt.store.ts
+++ b/packages/web/src/auth/state/release-notes-prompt.store.ts
@@ -8,11 +8,28 @@ export const useReleaseNotesPromptStore = create<ReleaseNotesPromptState>()(
   () => ({ isOpen: false }),
 );
 
+let scheduleOpenTimeoutId: ReturnType<typeof window.setTimeout> | undefined;
+
+const clearScheduledOpen = () => {
+  if (scheduleOpenTimeoutId !== undefined) {
+    window.clearTimeout(scheduleOpenTimeoutId);
+    scheduleOpenTimeoutId = undefined;
+  }
+};
+
 export const releaseNotesPromptActions = {
-  open: () => useReleaseNotesPromptStore.setState({ isOpen: true }),
-  close: () => useReleaseNotesPromptStore.setState({ isOpen: false }),
+  open: () => {
+    clearScheduledOpen();
+    useReleaseNotesPromptStore.setState({ isOpen: true });
+  },
+  close: () => {
+    clearScheduledOpen();
+    useReleaseNotesPromptStore.setState({ isOpen: false });
+  },
   scheduleOpen: (delayMs = 45_000) => {
-    window.setTimeout(() => {
+    clearScheduledOpen();
+    scheduleOpenTimeoutId = window.setTimeout(() => {
+      scheduleOpenTimeoutId = undefined;
       useReleaseNotesPromptStore.setState({ isOpen: true });
     }, delayMs);
   },

--- a/packages/web/src/auth/state/release-notes-prompt.store.ts
+++ b/packages/web/src/auth/state/release-notes-prompt.store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 
 export interface ReleaseNotesPromptState {
   isOpen: boolean;
@@ -8,7 +9,14 @@ export const useReleaseNotesPromptStore = create<ReleaseNotesPromptState>()(
   () => ({ isOpen: false }),
 );
 
+const SCHEDULED_OPEN_AT_STORAGE_KEY =
+  "compass.onboarding.release-notes-prompt-scheduled-at";
+
 let scheduleOpenTimeoutId: number | undefined;
+
+const clearScheduledOpenStorage = () => {
+  persistentBrowserStore.remove(SCHEDULED_OPEN_AT_STORAGE_KEY);
+};
 
 const clearScheduledOpen = () => {
   if (scheduleOpenTimeoutId !== undefined) {
@@ -17,21 +25,64 @@ const clearScheduledOpen = () => {
   }
 };
 
+const openPrompt = () => {
+  clearScheduledOpen();
+  clearScheduledOpenStorage();
+  useReleaseNotesPromptStore.setState({ isOpen: true });
+};
+
+const startScheduledOpenTimer = (delayMs: number) => {
+  clearScheduledOpen();
+  scheduleOpenTimeoutId = window.setTimeout(() => {
+    scheduleOpenTimeoutId = undefined;
+    openPrompt();
+  }, delayMs);
+};
+
+const resumeScheduledOpen = () => {
+  if (!persistentBrowserStore.isAvailable()) {
+    return;
+  }
+
+  const storedOpenAt = persistentBrowserStore.get(
+    SCHEDULED_OPEN_AT_STORAGE_KEY,
+  );
+  if (storedOpenAt === null) {
+    return;
+  }
+
+  const openAtMs = Number(storedOpenAt);
+  if (!Number.isFinite(openAtMs)) {
+    clearScheduledOpenStorage();
+    return;
+  }
+
+  const remainingMs = openAtMs - Date.now();
+  if (remainingMs <= 0) {
+    openPrompt();
+    return;
+  }
+
+  startScheduledOpenTimer(remainingMs);
+};
+
 export const releaseNotesPromptActions = {
   open: () => {
-    clearScheduledOpen();
-    useReleaseNotesPromptStore.setState({ isOpen: true });
+    openPrompt();
   },
   close: () => {
     clearScheduledOpen();
+    clearScheduledOpenStorage();
     useReleaseNotesPromptStore.setState({ isOpen: false });
   },
   scheduleOpen: (delayMs = 45_000) => {
-    clearScheduledOpen();
-    scheduleOpenTimeoutId = window.setTimeout(() => {
-      scheduleOpenTimeoutId = undefined;
-      useReleaseNotesPromptStore.setState({ isOpen: true });
-    }, delayMs);
+    if (persistentBrowserStore.isAvailable()) {
+      persistentBrowserStore.set(
+        SCHEDULED_OPEN_AT_STORAGE_KEY,
+        String(Date.now() + delayMs),
+      );
+    }
+    startScheduledOpenTimer(delayMs);
   },
 };
 
@@ -42,6 +93,8 @@ export const selectReleaseNotesPromptOpen = (state: ReleaseNotesPromptState) =>
 // raise the post-signup prompt without completing a real (backend-dependent)
 // signup. Merge (don't overwrite) so sibling stores' bridges survive.
 if (typeof window !== "undefined") {
+  resumeScheduledOpen();
+
   window.__COMPASS_E2E_STORE__ = {
     ...window.__COMPASS_E2E_STORE__,
     releaseNotesPrompt: {

--- a/packages/web/src/common/constants/navigation.cmd.constants.test.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.test.ts
@@ -20,7 +20,7 @@ describe("getNavigationCommandItems", () => {
       "Go to Day",
       "Go to Week",
       "Go to Life",
-      "Show Shortcuts",
+      "Show keyboard shortcuts",
     ]);
   });
 

--- a/packages/web/src/common/constants/navigation.cmd.constants.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.ts
@@ -2,10 +2,10 @@ import {
   ArrowUDownLeftIcon,
   CalendarDotsIcon,
   CalendarIcon,
+  CompassIcon,
   HourglassSimpleIcon,
   type Icon,
   KeyboardIcon,
-  CompassIcon,
 } from "@phosphor-icons/react";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 import {

--- a/packages/web/src/common/constants/navigation.cmd.constants.ts
+++ b/packages/web/src/common/constants/navigation.cmd.constants.ts
@@ -5,6 +5,7 @@ import {
   HourglassSimpleIcon,
   type Icon,
   KeyboardIcon,
+  CompassIcon,
 } from "@phosphor-icons/react";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 import {
@@ -20,6 +21,7 @@ interface GetNavigationCommandItemsArgs {
   onGoToToday?: () => void;
   onNavigateToView: (viewName: CommandPaletteViewName) => void;
   onShowShortcuts?: () => void;
+  onShowWelcomeGuide?: () => void;
 }
 
 const commandPaletteViews: Record<
@@ -56,6 +58,7 @@ export const getNavigationCommandItems = ({
   onGoToToday,
   onNavigateToView,
   onShowShortcuts,
+  onShowWelcomeGuide,
 }: GetNavigationCommandItemsArgs): CommandItem[] => {
   const calendarItems: CommandItem[] = [];
 
@@ -87,10 +90,19 @@ export const getNavigationCommandItems = ({
   if (onShowShortcuts) {
     calendarItems.push({
       id: "show-shortcuts",
-      label: "Show Shortcuts",
+      label: "Show keyboard shortcuts",
       icon: KeyboardIcon,
       shortcut: "?",
       onClick: onShowShortcuts,
+    });
+  }
+
+  if (onShowWelcomeGuide) {
+    calendarItems.push({
+      id: "show-welcome-guide",
+      label: "Show welcome guide",
+      icon: CompassIcon,
+      onClick: onShowWelcomeGuide,
     });
   }
 

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 export const StorageKeySchema = z.enum([
   "compass.auth",
   "compass.onboarding.has-seen-welcome",
+  "compass.onboarding.has-seen-cmd-palette-hint",
+  "compass.onboarding.has-seen-anonymous-save-toast",
+  "compass.onboarding.has-dismissed-demo-events-banner",
   "compass.onboarding.has-dismissed-tasks-removal-notice",
   "compass.sidebar.width",
   "compass.theme",
@@ -15,6 +18,9 @@ export type StorageKey = z.infer<typeof StorageKeySchema>;
 export const STORAGE_KEYS: Record<
   | "AUTH"
   | "HAS_SEEN_WELCOME"
+  | "HAS_SEEN_CMD_PALETTE_HINT"
+  | "HAS_SEEN_ANONYMOUS_SAVE_TOAST"
+  | "HAS_DISMISSED_DEMO_EVENTS_BANNER"
   | "HAS_DISMISSED_TASKS_REMOVAL_NOTICE"
   | "LIFE_PREFERENCES"
   | "SIDEBAR_WIDTH"
@@ -24,6 +30,11 @@ export const STORAGE_KEYS: Record<
 > = {
   AUTH: "compass.auth",
   HAS_SEEN_WELCOME: "compass.onboarding.has-seen-welcome",
+  HAS_SEEN_CMD_PALETTE_HINT: "compass.onboarding.has-seen-cmd-palette-hint",
+  HAS_SEEN_ANONYMOUS_SAVE_TOAST:
+    "compass.onboarding.has-seen-anonymous-save-toast",
+  HAS_DISMISSED_DEMO_EVENTS_BANNER:
+    "compass.onboarding.has-dismissed-demo-events-banner",
   HAS_DISMISSED_TASKS_REMOVAL_NOTICE:
     "compass.onboarding.has-dismissed-tasks-removal-notice",
   LIFE_PREFERENCES: "compass.life.preferences",

--- a/packages/web/src/common/storage/migrations/external/demo-data-seed.ts
+++ b/packages/web/src/common/storage/migrations/external/demo-data-seed.ts
@@ -75,7 +75,7 @@ function generateDemoData() {
     }),
     createEventRecord({
       title: "Try Compass",
-      description: `Welcome! Explore your calendar. When ready to bring in Google events, select 'Connect Google Calendar' from the command palette (${modKey}+K)`,
+      description: `Welcome! Click any empty time slot to create an event, or press C. When you're ready to sync Google Calendar, open the command palette (${modKey}+K) and choose Connect Google Calendar.`,
       schedule: {
         kind: "timed",
         start: todayAt(10, 0),
@@ -95,7 +95,8 @@ function generateDemoData() {
     }),
     createEventRecord({
       title: "Call a friend",
-      description: "Of all possessions, a friend is the most precious.",
+      description:
+        "Your calendar, your data. Sign up whenever you're ready to save across devices.",
       schedule: {
         kind: "timed",
         start: todayAt(17, 0),
@@ -116,7 +117,7 @@ function generateDemoData() {
     // Onboarding hints (previously seeded as tasks, now calendar events).
     createEventRecord({
       title: "Peek at your week",
-      description: `Press '${VIEW_SHORTCUTS.week.key}' to switch to Week view and see the whole week at a glance.`,
+      description: `Press '${VIEW_SHORTCUTS.week.key}' to switch to Week view and see the whole week at a glance. Press '?' anytime for all keyboard shortcuts.`,
       schedule: {
         kind: "timed",
         start: todayAt(14, 0),
@@ -126,7 +127,8 @@ function generateDemoData() {
     }),
     createEventRecord({
       title: "Create your daily plan",
-      description: "Block time for what matters most, then let the day flow.",
+      description:
+        "Press C to create an event, or drag across empty slots on the grid to block time for what matters most.",
       schedule: {
         kind: "timed",
         start: todayAt(15, 0),

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -51,6 +51,7 @@ export const GridEventSchema = WebEventSchema.extend({
   // calendars/useCalendarLookup.ts.
   calendarId: CalendarIdSchema.optional(),
   isBusy: z.boolean().optional(),
+  isDemo: z.boolean().optional(),
 });
 export type GridEvent = z.infer<typeof GridEventSchema>;
 

--- a/packages/web/src/common/utils/toast/anonymous-save.toast.tsx
+++ b/packages/web/src/common/utils/toast/anonymous-save.toast.tsx
@@ -1,0 +1,71 @@
+import { createElement } from "react";
+import { type Id } from "react-toastify";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { getToast } from "@web/common/utils/toast/toast.port";
+import { VIEW_TO_PARAM } from "@web/components/AuthModal/hooks/useAuthModal";
+
+const ANONYMOUS_SAVE_TOAST_ID: Id = "anonymous-save-toast";
+
+export function hasSeenAnonymousSaveToast(): boolean {
+  if (!persistentBrowserStore.isAvailable()) return true;
+  return (
+    persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_ANONYMOUS_SAVE_TOAST) ===
+    "true"
+  );
+}
+
+export function markAnonymousSaveToastSeen(): void {
+  persistentBrowserStore.set(
+    STORAGE_KEYS.HAS_SEEN_ANONYMOUS_SAVE_TOAST,
+    "true",
+  );
+}
+
+interface AnonymousSaveToastProps {
+  toastId: Id;
+}
+
+async function openSignUpFromOutsideRouter(): Promise<void> {
+  const { router } = await import("@web/routers");
+  router.navigate({
+    to: ".",
+    search: (prev: Record<string, unknown>) => ({
+      ...prev,
+      auth: VIEW_TO_PARAM.signUp,
+    }),
+  });
+}
+
+const AnonymousSaveToast = ({ toastId }: AnonymousSaveToastProps) => {
+  const handleSignUp = () => {
+    void openSignUpFromOutsideRouter();
+    getToast().dismiss(toastId);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <p className="text-sm text-text">
+        Sign up to save your calendar across devices.
+      </p>
+      <button
+        className="w-full rounded bg-accent-secondary px-3 py-2 font-medium text-on-accent text-sm transition-colors hover:bg-accent-secondary-hover"
+        onClick={handleSignUp}
+        type="button"
+      >
+        Sign up
+      </button>
+    </div>
+  );
+};
+
+export function maybeShowAnonymousSaveToast(): void {
+  if (hasSeenAnonymousSaveToast()) return;
+
+  markAnonymousSaveToastSeen();
+  showStatusToast(
+    ANONYMOUS_SAVE_TOAST_ID,
+    createElement(AnonymousSaveToast, { toastId: ANONYMOUS_SAVE_TOAST_ID }),
+  );
+}

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -74,7 +74,7 @@ export function useAuthFormHandlers({
               email: response.user.emails[0] ?? data.email,
             });
             closeModal();
-            releaseNotesPromptActions.open();
+            releaseNotesPromptActions.scheduleOpen();
             return;
           case "FIELD_ERROR":
             setSubmitError(response.formFields[0]?.error ?? "Sign up failed");

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -308,7 +308,7 @@ describe("CommandPalette", () => {
     // `[aria-hidden='true']` (not `.c-keycap`) because SelectView.test.tsx
     // mocks ShortcutHint process-wide (bun's mock.module leaks across
     // files); its stub keeps aria-hidden but drops the real class.
-    const row = screen.getByText("Show Shortcuts").closest("button");
+    const row = screen.getByText("Show keyboard shortcuts").closest("button");
     expect(row?.querySelector("[aria-hidden='true']")?.textContent).toBe("?");
 
     fireEvent.click(row as HTMLButtonElement);

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -21,6 +21,7 @@ import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthCmdItems } from "@web/components/CommandPalette/hooks/useAuthCmdItems";
 import { useCalendarSyncCmdItems } from "@web/components/CommandPalette/hooks/useCalendarSyncCmdItems";
 import { useDeleteAccountCmdItems } from "@web/components/CommandPalette/hooks/useDeleteAccountCmdItems";
+import { useDemoEventsCmdItems } from "@web/components/CommandPalette/hooks/useDemoEventsCmdItems";
 import { useExportDataCmdItems } from "@web/components/CommandPalette/hooks/useExportDataCmdItems";
 import { useLogoutCmdItems } from "@web/components/CommandPalette/hooks/useLogoutCmdItems";
 import { useSubscribeCmdItems } from "@web/components/CommandPalette/hooks/useSubscribeCmdItems";
@@ -47,6 +48,7 @@ interface CommandPaletteProps {
   currentView: ViewName;
   onGoToToday: () => void;
   onShowShortcuts: () => void;
+  onShowWelcomeGuide?: () => void;
   placeholder: string;
   mutationDependencies?: EventMutationDependencies;
 }
@@ -251,6 +253,7 @@ export const CommandPalette = ({
   currentView,
   onGoToToday,
   onShowShortcuts,
+  onShowWelcomeGuide,
   placeholder,
   mutationDependencies,
 }: CommandPaletteProps) => {
@@ -259,6 +262,7 @@ export const CommandPalette = ({
   const { items: calendarCmdItems, syncStatus } = useCalendarSyncCmdItems();
   const subscribeCmdItems = useSubscribeCmdItems(open);
   const exportDataCmdItems = useExportDataCmdItems();
+  const demoEventsCmdItems = useDemoEventsCmdItems();
   const authCmdItems = useAuthCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
   const deleteAccountCmdItems = useDeleteAccountCmdItems();
@@ -275,6 +279,7 @@ export const CommandPalette = ({
         onNavigateToView: (viewName) =>
           navigate({ to: getNavigationViewRoute(viewName) }),
         onShowShortcuts,
+        onShowWelcomeGuide,
       }),
     },
     {
@@ -282,6 +287,7 @@ export const CommandPalette = ({
       heading: "Common Tasks",
       items: [
         ...eventCommandPaletteItems,
+        ...demoEventsCmdItems,
         {
           id: "undo-last-change",
           label: "Undo last change",

--- a/packages/web/src/components/CommandPalette/hooks/useDemoEventsCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useDemoEventsCmdItems.ts
@@ -1,35 +1,21 @@
 import { EraserIcon } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useState } from "react";
-import { clearDemoEvents, hasDemoEvents } from "@web/events/demo-events.util";
-import { dismissDemoEventsBanner } from "@web/components/DemoEventsBanner/DemoEventsBanner";
+import { useCallback } from "react";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { dismissDemoEventsBanner } from "@web/components/DemoEventsBanner/DemoEventsBanner";
+import { clearDemoEvents } from "@web/events/demo-events.util";
+import { useDemoEventsPresent } from "@web/events/hooks/useDemoEventsPresent";
 import { type CommandItem } from "../command-palette.types";
 
 const CLEAR_DEMO_EVENTS_TOAST_ID = "clear-demo-events";
 
 export function useDemoEventsCmdItems(): CommandItem[] {
   const queryClient = useQueryClient();
-  const [demoEventsPresent, setDemoEventsPresent] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    void hasDemoEvents().then((present) => {
-      if (!cancelled) {
-        setDemoEventsPresent(present);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const demoEventsPresent = useDemoEventsPresent();
 
   const handleClearDemoEvents = useCallback(async () => {
     const removedCount = await clearDemoEvents(queryClient);
     dismissDemoEventsBanner();
-    setDemoEventsPresent(false);
 
     if (removedCount > 0) {
       showStatusToast(

--- a/packages/web/src/components/CommandPalette/hooks/useDemoEventsCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useDemoEventsCmdItems.ts
@@ -1,0 +1,58 @@
+import { EraserIcon } from "@phosphor-icons/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+import { clearDemoEvents, hasDemoEvents } from "@web/events/demo-events.util";
+import { dismissDemoEventsBanner } from "@web/components/DemoEventsBanner/DemoEventsBanner";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { type CommandItem } from "../command-palette.types";
+
+const CLEAR_DEMO_EVENTS_TOAST_ID = "clear-demo-events";
+
+export function useDemoEventsCmdItems(): CommandItem[] {
+  const queryClient = useQueryClient();
+  const [demoEventsPresent, setDemoEventsPresent] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void hasDemoEvents().then((present) => {
+      if (!cancelled) {
+        setDemoEventsPresent(present);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleClearDemoEvents = useCallback(async () => {
+    const removedCount = await clearDemoEvents(queryClient);
+    dismissDemoEventsBanner();
+    setDemoEventsPresent(false);
+
+    if (removedCount > 0) {
+      showStatusToast(
+        CLEAR_DEMO_EVENTS_TOAST_ID,
+        removedCount === 1
+          ? "Removed 1 sample event"
+          : `Removed ${removedCount} sample events`,
+      );
+    }
+  }, [queryClient]);
+
+  if (!demoEventsPresent) {
+    return [];
+  }
+
+  return [
+    {
+      id: "clear-sample-events",
+      label: "Clear sample events",
+      icon: EraserIcon,
+      onClick: () => {
+        void handleClearDemoEvents();
+      },
+    },
+  ];
+}

--- a/packages/web/src/components/DemoEventsBanner/DemoEventsBanner.tsx
+++ b/packages/web/src/components/DemoEventsBanner/DemoEventsBanner.tsx
@@ -1,0 +1,41 @@
+import { type FC } from "react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+export function hasDismissedDemoEventsBanner(): boolean {
+  if (!persistentBrowserStore.isAvailable()) return true;
+  return (
+    persistentBrowserStore.get(STORAGE_KEYS.HAS_DISMISSED_DEMO_EVENTS_BANNER) ===
+    "true"
+  );
+}
+
+export function dismissDemoEventsBanner(): void {
+  persistentBrowserStore.set(
+    STORAGE_KEYS.HAS_DISMISSED_DEMO_EVENTS_BANNER,
+    "true",
+  );
+}
+
+interface DemoEventsBannerProps {
+  onDismiss: () => void;
+}
+
+export const DemoEventsBanner: FC<DemoEventsBannerProps> = ({ onDismiss }) => (
+  <div
+    className="flex items-center justify-between gap-3 border-border border-b bg-surface-panel px-4 py-2 text-text-muted text-xs"
+    role="status"
+  >
+    <span>
+      Sample events to help you explore — edit or delete anytime, or clear them
+      from the command palette.
+    </span>
+    <button
+      className="c-focus-ring shrink-0 rounded-xs px-2 py-1 text-text hover:bg-surface-overlay"
+      onClick={onDismiss}
+      type="button"
+    >
+      Dismiss
+    </button>
+  </div>
+);

--- a/packages/web/src/components/DemoEventsBanner/DemoEventsBanner.tsx
+++ b/packages/web/src/components/DemoEventsBanner/DemoEventsBanner.tsx
@@ -5,8 +5,9 @@ import { persistentBrowserStore } from "@web/common/storage/browser-key-value.st
 export function hasDismissedDemoEventsBanner(): boolean {
   if (!persistentBrowserStore.isAvailable()) return true;
   return (
-    persistentBrowserStore.get(STORAGE_KEYS.HAS_DISMISSED_DEMO_EVENTS_BANNER) ===
-    "true"
+    persistentBrowserStore.get(
+      STORAGE_KEYS.HAS_DISMISSED_DEMO_EVENTS_BANNER,
+    ) === "true"
   );
 }
 

--- a/packages/web/src/components/DemoEventsBanner/DemoEventsBannerGate.tsx
+++ b/packages/web/src/components/DemoEventsBanner/DemoEventsBannerGate.tsx
@@ -1,0 +1,23 @@
+import { type FC, useCallback, useState } from "react";
+import {
+  DemoEventsBanner,
+  dismissDemoEventsBanner,
+  hasDismissedDemoEventsBanner,
+} from "@web/components/DemoEventsBanner/DemoEventsBanner";
+import { useDemoEventsPresent } from "@web/events/hooks/useDemoEventsPresent";
+
+export const DemoEventsBannerGate: FC = () => {
+  const hasDemoEvents = useDemoEventsPresent();
+  const [dismissed, setDismissed] = useState(hasDismissedDemoEventsBanner);
+
+  const handleDismiss = useCallback(() => {
+    dismissDemoEventsBanner();
+    setDismissed(true);
+  }, []);
+
+  if (!hasDemoEvents || dismissed) {
+    return null;
+  }
+
+  return <DemoEventsBanner onDismiss={handleDismiss} />;
+};

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -6,7 +6,12 @@ import {
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
 import { ReleaseNotesPrompt } from "@web/components/ReleaseNotesPrompt/ReleaseNotesPrompt";
+import { WelcomeGuideModal } from "@web/components/WelcomeModal/WelcomeGuideModal";
 import { WelcomeModal } from "@web/components/WelcomeModal/WelcomeModal";
+import {
+  selectWelcomeGuideOpen,
+  useWelcomeGuideStore,
+} from "@web/components/WelcomeModal/welcome.guide.store";
 import {
   useCalendarShellShortcuts,
   useNavigationShortcuts,
@@ -22,6 +27,7 @@ export function RootShell() {
   const isReleaseNotesPromptOpen = useReleaseNotesPromptStore(
     selectReleaseNotesPromptOpen,
   );
+  const isWelcomeGuideOpen = useWelcomeGuideStore(selectWelcomeGuideOpen);
   useNavigationShortcuts();
   useCalendarShellShortcuts();
 
@@ -30,6 +36,7 @@ export function RootShell() {
       <Outlet />
       <AuthModal />
       <WelcomeModal />
+      {isWelcomeGuideOpen && <WelcomeGuideModal />}
       {isReleaseNotesPromptOpen && <ReleaseNotesPrompt />}
     </AuthModalProvider>
   );

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -41,8 +41,25 @@ mock.module("@web/auth/compass/session/useSession", () => ({
     isSessionMocked ? mockUseSession(...args) : actualUseSession(...args),
 }));
 
+const actualUseConnectGoogle = (
+  await import("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle")
+).useConnectGoogle;
+let isConnectGoogleMocked = true;
+const mockUseConnectGoogle = mock(() => ({
+  commandAction: null,
+  isAvailable: true,
+  state: "NOT_CONNECTED" as const,
+}));
+mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
+  useConnectGoogle: (...args: Parameters<typeof actualUseConnectGoogle>) =>
+    isConnectGoogleMocked
+      ? mockUseConnectGoogle(...args)
+      : actualUseConnectGoogle(...args),
+}));
+
 afterAll(() => {
   isSessionMocked = false;
+  isConnectGoogleMocked = false;
 });
 
 // CalendarList.tsx is already cached by the time this file runs -

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -344,14 +344,6 @@ describe("CalendarList", () => {
     expect(screen.getByText(/no calendars yet/i)).toBeInTheDocument();
   });
 
-  it("prompts to connect Google when signed in without a linked calendar", () => {
-    renderCalendarList([]);
-
-    expect(
-      screen.getByText(/connect google to see your calendars/i),
-    ).toBeInTheDocument();
-  });
-
   it("shows an error state and recovers via retry", async () => {
     const calendar = makeCalendar({ name: "Work" });
     let shouldFail = true;

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -339,9 +339,17 @@ describe("CalendarList", () => {
   });
 
   it("shows an empty state when there are no calendars", () => {
-    renderCalendarList([]);
+    renderCalendarList([], { authenticated: false });
 
     expect(screen.getByText(/no calendars yet/i)).toBeInTheDocument();
+  });
+
+  it("prompts to connect Google when signed in without a linked calendar", () => {
+    renderCalendarList([]);
+
+    expect(
+      screen.getByText(/connect google to see your calendars/i),
+    ).toBeInTheDocument();
   });
 
   it("shows an error state and recovers via retry", async () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,6 +1,7 @@
 import { type FC } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
 import { CalendarListHeader } from "./CalendarListHeader";
@@ -30,6 +31,7 @@ export const CalendarList: FC<Props> = ({
   Header = CalendarListHeader,
 }) => {
   const { authenticated } = useSession();
+  const { isAvailable, state } = useConnectGoogle();
   const { data, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
     useCalendarVisibility(coalesceDelayMs);
@@ -56,7 +58,11 @@ export const CalendarList: FC<Props> = ({
           </button>
         </div>
       ) : calendars.length === 0 ? (
-        <p className="text-text-muted text-xs">No calendars yet.</p>
+        <p className="text-text-muted text-xs">
+          {authenticated && state === "NOT_CONNECTED" && isAvailable
+            ? "Connect Google to see your calendars."
+            : "No calendars yet."}
+        </p>
       ) : (
         <ul className="flex flex-col gap-1.5">
           {calendars.map((calendar) => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -10,8 +10,14 @@ const mockOpenModal = mock();
 let mockEmail: string | undefined;
 let mockGoogleState: GoogleUiState = "NOT_CONNECTED";
 let mockIsAnonymousDirty = false;
+const mockConnectGoogle = mock();
 const mockUseConnectGoogle = mock(() => ({
   state: mockGoogleState,
+  isAvailable: true,
+  commandAction:
+    mockGoogleState === "NOT_CONNECTED"
+      ? { label: "Connect Google Calendar", onSelect: mockConnectGoogle }
+      : null,
 }));
 
 mock.module("@web/auth/compass/state/auth.state.util", () => ({
@@ -90,23 +96,24 @@ describe("CalendarListHeader", () => {
     mockIsAnonymousDirty = false;
     mockOpenModal.mockClear();
     mockUseConnectGoogle.mockClear();
+    mockConnectGoogle.mockClear();
   });
 
-  it("shows a default-colored temporary account heading with a sign-up tooltip before any changes are made", async () => {
+  it("shows a default-colored not-saved-yet heading with a sign-up tooltip before any changes are made", async () => {
     const user = userEvent.setup();
 
     renderHeader();
 
     expect(
-      screen.getByRole("heading", { name: "Temporary account" }),
+      screen.getByRole("heading", { name: "Not saved yet" }),
     ).toBeInTheDocument();
-    const trigger = screen.getByRole("button", { name: "Temporary account" });
+    const trigger = screen.getByRole("button", { name: "Not saved yet" });
     expect(trigger).toHaveClass("text-text");
     expect(trigger).not.toHaveClass("c-sync-text-wave");
     expect(screen.queryByText("Sign up")).toBeNull();
 
     await user.hover(trigger);
-    await screen.findByText("Sign up to save your changes");
+    await screen.findByText("Sign up to save your changes across devices");
     const signUpButton = await screen.findByRole("button", { name: "Sign up" });
 
     await user.click(signUpButton);
@@ -114,26 +121,27 @@ describe("CalendarListHeader", () => {
     expect(mockUseConnectGoogle).not.toHaveBeenCalled();
   });
 
-  it("shows the wave shimmer on the temporary account label once the anonymous user makes a change", () => {
+  it("shows the wave shimmer on the not-saved-yet label once the anonymous user makes a change", () => {
     mockIsAnonymousDirty = true;
 
     renderHeader();
 
-    const trigger = screen.getByRole("button", { name: "Temporary account" });
+    const trigger = screen.getByRole("button", { name: "Not saved yet" });
     expect(trigger).toHaveClass("c-sync-text-wave");
     expect(trigger).not.toHaveClass("text-text");
   });
 
-  it("also opens sign up by clicking the temporary account label directly (keyboard path)", async () => {
+  it("also opens sign up by clicking the not-saved-yet label directly (keyboard path)", async () => {
     const user = userEvent.setup();
 
     renderHeader();
 
-    await user.click(screen.getByRole("button", { name: "Temporary account" }));
+    await user.click(screen.getByRole("button", { name: "Not saved yet" }));
     expect(mockOpenModal).toHaveBeenCalledWith("signUp");
   });
 
-  it("renders a plain, non-interactive email heading when Google is not connected", () => {
+  it("shows a connect Google button when authenticated and Google is not connected", async () => {
+    const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "NOT_CONNECTED";
 
@@ -142,15 +150,14 @@ describe("CalendarListHeader", () => {
     expect(
       screen.getByRole("heading", { name: "ahab@pequod.com" }),
     ).toBeInTheDocument();
-    const email = screen.getByText("ahab@pequod.com");
-    expect(email.tagName).toBe("SPAN");
-    expect(email).not.toHaveAttribute("tabindex");
-    expect(email).toHaveClass("text-text");
-    expect(screen.queryByRole("status")).toBeNull();
-    expect(screen.queryByRole("button")).toBeNull();
+    const connectButton = screen.getByRole("button", {
+      name: "Connect Google Calendar",
+    });
+    await user.click(connectButton);
+    expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
   });
 
-  it("renders a plain, neutral email heading with no tooltip when healthy", async () => {
+  it("renders a plain email heading without a connect button when Google is healthy", async () => {
     const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "HEALTHY";

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -15,7 +15,7 @@ import {
 } from "@web/components/Tooltip";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
 
-const TEMPORARY_ACCOUNT_MESSAGE = "Sign up to save your changes";
+const ANONYMOUS_SAVE_MESSAGE = "Sign up to save your changes across devices";
 
 const TOOLTIP_ACTION_BUTTON_CLASSNAME =
   "c-focus-ring self-start rounded-xs bg-accent px-2 py-1 font-medium text-s text-on-accent hover:brightness-110";
@@ -23,34 +23,36 @@ const TOOLTIP_ACTION_BUTTON_CLASSNAME =
 const HEADING_CLASSNAME =
   "mb-2 flex min-w-0 font-semibold text-sm leading-none";
 
-// Keeps the temporary-account label keyboard-focusable while looking like plain text.
-const TEMPORARY_ACCOUNT_TRIGGER_CLASSNAME =
+const ANONYMOUS_ACCOUNT_TRIGGER_CLASSNAME =
   "min-w-0 truncate appearance-none border-0 bg-transparent p-0 text-left font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent";
+
+const CONNECT_GOOGLE_BUTTON_CLASSNAME =
+  "c-focus-ring mb-2 w-full rounded-xs bg-accent px-2 py-1.5 text-left font-medium text-on-accent text-xs hover:brightness-110";
 
 /**
  * The calendar list's heading is the account identity (email, or the
- * temporary-account label when anonymous) rather than a generic "Calendars"
+ * not-saved-yet label when anonymous) rather than a generic "Calendars"
  * title, and carries the syncing wave shimmer plus the sign-up-to-save CTA
- * for anonymous users. Detailed sync status lives in the command palette.
+ * for anonymous users. Google connect is surfaced inline when not linked.
  */
 export const CalendarListHeader: FC = () => {
   const { email } = useUser();
 
   if (!email) {
-    return <TemporaryAccountHeader />;
+    return <AnonymousAccountHeader />;
   }
 
   return <AuthenticatedAccountHeader email={email} />;
 };
 
-const TemporaryAccountHeader: FC = () => {
+const AnonymousAccountHeader: FC = () => {
   const { openModal } = useAuthModal();
   const isDirty = useSyncExternalStore(
     subscribeToAuthState,
     shouldShowAnonymousCalendarChangeSignUpPrompt,
     shouldShowAnonymousCalendarChangeSignUpPrompt,
   );
-  const accountLabel = "Temporary account";
+  const accountLabel = "Not saved yet";
   const handleOpenSignUp = useCallback(() => {
     openModal("signUp");
   }, [openModal]);
@@ -61,7 +63,7 @@ const TemporaryAccountHeader: FC = () => {
         <TooltipTrigger asChild>
           <button
             className={classNames(
-              TEMPORARY_ACCOUNT_TRIGGER_CLASSNAME,
+              ANONYMOUS_ACCOUNT_TRIGGER_CLASSNAME,
               isDirty ? "c-sync-text-wave" : "text-text",
             )}
             onClick={handleOpenSignUp}
@@ -71,7 +73,7 @@ const TemporaryAccountHeader: FC = () => {
           </button>
         </TooltipTrigger>
         <TooltipContent className="flex max-w-55 flex-col gap-1.5">
-          <span>{TEMPORARY_ACCOUNT_MESSAGE}</span>
+          <span>{ANONYMOUS_SAVE_MESSAGE}</span>
           <button
             className={TOOLTIP_ACTION_BUTTON_CLASSNAME}
             onClick={handleOpenSignUp}
@@ -86,11 +88,13 @@ const TemporaryAccountHeader: FC = () => {
 };
 
 const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
-  const { state } = useConnectGoogle();
+  const { commandAction, isAvailable, state } = useConnectGoogle();
   const hasPendingEventMutations = useHasPendingEventMutations();
   const isSyncing =
     getGoogleSyncStatus(state)?.variant === "syncing" ||
     hasPendingEventMutations;
+  const showConnectGoogle =
+    state === "NOT_CONNECTED" && isAvailable && commandAction != null;
 
   return (
     <>
@@ -105,6 +109,15 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
           {email}
         </span>
       </h2>
+      {showConnectGoogle ? (
+        <button
+          className={CONNECT_GOOGLE_BUTTON_CLASSNAME}
+          onClick={commandAction.onSelect}
+          type="button"
+        >
+          Connect Google Calendar
+        </button>
+      ) : null}
       {isSyncing ? (
         <span
           aria-label="Syncing…"

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
@@ -84,7 +84,7 @@ describe("UpNextCard", () => {
     expect(screen.getByText("N")).toBeInTheDocument();
   });
 
-  it("renders nothing when today has no upcoming timed events", () => {
+  it("shows an empty-state hint when today has no upcoming timed events", () => {
     render(<UpNextCard />, {
       events: [
         // Already underway, so nothing is "up next".
@@ -101,7 +101,10 @@ describe("UpNextCard", () => {
       ],
     });
 
-    expect(screen.queryByRole("region", { name: "Up next" })).toBeNull();
+    expect(screen.getByRole("region", { name: "Up next" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Nothing scheduled — press C to add an event."),
+    ).toBeInTheDocument();
     expect(screen.queryByText("Past Event")).toBeNull();
     expect(screen.queryByText("All Day Event")).toBeNull();
   });

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
@@ -28,7 +28,11 @@ export function formatStartsIn(start: Dayjs, now: Dayjs): string {
  * for them.
  */
 export const UpNextCard: FC = () => {
-  const { now, openEventDetails, upNext } = useUpNextEvent();
+  const { now, openEventDetails, upNext, isPending } = useUpNextEvent();
+
+  if (isPending) {
+    return null;
+  }
 
   if (!upNext) {
     return (

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
@@ -30,7 +30,15 @@ export function formatStartsIn(start: Dayjs, now: Dayjs): string {
 export const UpNextCard: FC = () => {
   const { now, openEventDetails, upNext } = useUpNextEvent();
 
-  if (!upNext) return null;
+  if (!upNext) {
+    return (
+      <section aria-label="Up next">
+        <p className="text-text-muted text-xs">
+          Nothing scheduled — press C to add an event.
+        </p>
+      </section>
+    );
+  }
 
   const countdown = formatStartsIn(dayjs(upNext.startDate), now);
 

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
@@ -28,11 +28,7 @@ export function formatStartsIn(start: Dayjs, now: Dayjs): string {
  * for them.
  */
 export const UpNextCard: FC = () => {
-  const { now, openEventDetails, upNext, isPending } = useUpNextEvent();
-
-  if (isPending) {
-    return null;
-  }
+  const { now, openEventDetails, upNext } = useUpNextEvent();
 
   if (!upNext) {
     return (

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -1,0 +1,71 @@
+import { useId, useState } from "react";
+import { FAQ_ITEMS } from "./faq";
+
+export function WelcomeGuideBody() {
+  const disclosureIdPrefix = useId();
+  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleFaq = (question: string) => {
+    setExpandedFaqs((currentFaqs) => {
+      const nextFaqs = new Set(currentFaqs);
+
+      if (nextFaqs.has(question)) {
+        nextFaqs.delete(question);
+      } else {
+        nextFaqs.add(question);
+      }
+
+      return nextFaqs;
+    });
+  };
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <h2 className="font-bold text-2xl text-text leading-snug">
+          Compass Calendar helps you manage your time, simply.
+        </h2>
+        <p className="text-text-muted">
+          A small, but mighty calendar app. Built for busy minimalists who get
+          things done.
+        </p>
+      </div>
+
+      <div className="flex flex-col divide-y divide-border">
+        {FAQ_ITEMS.map((item, index) => {
+          const isExpanded = expandedFaqs.has(item.question);
+          const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
+          const state = isExpanded ? "open" : "closed";
+
+          return (
+            <div key={item.question} className="py-3">
+              <button
+                type="button"
+                aria-controls={answerId}
+                aria-expanded={isExpanded}
+                className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
+                onClick={() => toggleFaq(item.question)}
+              >
+                {item.question}
+              </button>
+              <div
+                id={answerId}
+                aria-hidden={!isExpanded}
+                className="c-disclosure-content"
+                data-state={state}
+              >
+                <div>
+                  <div className="mt-2 text-sm text-text-muted leading-relaxed">
+                    {item.answer}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
@@ -1,0 +1,76 @@
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  useCallback,
+  useState,
+} from "react";
+import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { WelcomeGuideBody } from "./WelcomeGuideBody";
+import { PixelPirate } from "./PixelPirate";
+import { welcomeGuideActions } from "./welcome.guide.store";
+
+export function WelcomeGuideModal() {
+  const [closing, setClosing] = useState(false);
+
+  const focusOnMount = useCallback((node: HTMLDivElement | null) => {
+    node?.focus();
+  }, []);
+
+  const dismiss = () => {
+    if (closing) return;
+    setClosing(true);
+    const reduceMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    window.setTimeout(
+      () => welcomeGuideActions.close(),
+      reduceMotion ? 0 : 400,
+    );
+  };
+
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      dismiss();
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      dismiss();
+    }
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the welcome guide.
+    <div
+      className="fixed inset-0 flex items-center justify-center overflow-y-auto bg-background/85 py-8 backdrop-blur-sm transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none"
+      data-closing={closing || undefined}
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      ref={focusOnMount}
+      role="presentation"
+      style={{ zIndex: Z_INDEX_MODAL }}
+      tabIndex={-1}
+    >
+      <div
+        role="dialog"
+        aria-modal
+        aria-label="Welcome to Compass Calendar"
+        data-closing={closing || undefined}
+        className="flex w-120 max-w-[90vw] flex-col gap-6 rounded-xl bg-surface-panel p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)] transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none"
+      >
+        <PixelPirate className="h-14 w-14 shrink-0" />
+        <WelcomeGuideBody />
+
+        <div className="flex justify-center">
+          <button
+            type="button"
+            onClick={dismiss}
+            className="c-button c-button-primary c-button-elevated rounded-full px-10"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
@@ -5,8 +5,8 @@ import {
   useState,
 } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
-import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { PixelPirate } from "./PixelPirate";
+import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { welcomeGuideActions } from "./welcome.guide.store";
 
 export function WelcomeGuideModal() {

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -55,11 +55,13 @@ export function WelcomeModal() {
 
   const handleLogIn = () => {
     markWelcomeSeen();
+    maybeShowCmdPaletteHint();
     openModal("login");
   };
 
   const handleSignUp = () => {
     markWelcomeSeen();
+    maybeShowCmdPaletteHint();
     openModal("signUp");
   };
 

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -8,26 +8,22 @@ import {
   type MouseEvent,
   useContext,
   useEffect,
-  useId,
   useRef,
   useState,
 } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
-import { FAQ_ITEMS } from "./faq";
+import { maybeShowCmdPaletteHint } from "./cmd-palette-hint.util";
+import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { PixelPirate } from "./PixelPirate";
 import { hasSeenWelcome, markWelcomeSeen } from "./welcome.modal.util";
 
 export function WelcomeModal() {
   const { authenticated } = useContext(SessionContext);
   const { openModal, isOpen: isAuthModalOpen } = useAuthModal();
-  const disclosureIdPrefix = useId();
   const [isOpen, setIsOpen] = useState(
     () => !authenticated && !hasSeenWelcome(),
-  );
-  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
-    () => new Set(),
   );
   const [closing, setClosing] = useState(false);
   const backdropRef = useRef<HTMLDivElement>(null);
@@ -50,6 +46,7 @@ export function WelcomeModal() {
   const dismiss = () => {
     if (closing) return;
     markWelcomeSeen();
+    maybeShowCmdPaletteHint();
     setClosing(true);
     const reduceMotion =
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
@@ -59,6 +56,11 @@ export function WelcomeModal() {
   const handleLogIn = () => {
     markWelcomeSeen();
     openModal("login");
+  };
+
+  const handleSignUp = () => {
+    markWelcomeSeen();
+    openModal("signUp");
   };
 
   const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -71,20 +73,6 @@ export function WelcomeModal() {
     if (event.key === "Escape") {
       dismiss();
     }
-  };
-
-  const toggleFaq = (question: string) => {
-    setExpandedFaqs((currentFaqs) => {
-      const nextFaqs = new Set(currentFaqs);
-
-      if (nextFaqs.has(question)) {
-        nextFaqs.delete(question);
-      } else {
-        nextFaqs.add(question);
-      }
-
-      return nextFaqs;
-    });
   };
 
   return (
@@ -106,11 +94,10 @@ export function WelcomeModal() {
         data-closing={closing || undefined}
         className="flex w-120 max-w-[90vw] flex-col gap-6 rounded-xl bg-surface-panel p-8 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)] transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none"
       >
-        {/* Top row: pirate top-left, log-in pill top-right */}
+        {/* Top row: pirate top-left, auth pills top-right */}
         <div className="flex items-center justify-between">
           <div className="group relative flex items-center">
             <PixelPirate className="h-14 w-14 shrink-0" />
-            {/* Speech bubble, revealed on hover; tail points at the pirate */}
             <div className="pointer-events-none absolute left-full ml-1 flex -translate-x-1 items-center opacity-0 transition-all duration-200 ease-out group-hover:translate-x-0 group-hover:opacity-100">
               <span
                 aria-hidden
@@ -121,26 +108,25 @@ export function WelcomeModal() {
               </span>
             </div>
           </div>
-          {/* bg matches the pirate's shirt gray (PixelPirate.tsx) */}
-          <button
-            type="button"
-            onClick={handleLogIn}
-            className="shrink-0 rounded-3xl bg-[#c2c6cc] px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#d1d5da]"
-          >
-            Log in
-          </button>
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              onClick={handleSignUp}
+              className="rounded-3xl bg-accent px-4 py-1.5 text-on-accent text-xs transition-all hover:brightness-110"
+            >
+              Sign up
+            </button>
+            <button
+              type="button"
+              onClick={handleLogIn}
+              className="rounded-3xl bg-[#c2c6cc] px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#d1d5da]"
+            >
+              Log in
+            </button>
+          </div>
         </div>
 
-        {/* Header */}
-        <div className="flex flex-col gap-2">
-          <h2 className="font-bold text-2xl text-text leading-snug">
-            Compass Calendar helps you manage your time, simply.
-          </h2>
-          <p className="text-text-muted">
-            A small, but mighty calendar app. Built for busy minimalists who get
-            things done.
-          </p>
-        </div>
+        <WelcomeGuideBody />
 
         {/* CTA */}
         <div className="flex justify-center">
@@ -151,55 +137,6 @@ export function WelcomeModal() {
           >
             Start Now
           </button>
-        </div>
-
-        {/* FAQ */}
-        <div className="flex flex-col divide-y divide-border">
-          {FAQ_ITEMS.map((item, index) => {
-            const isExpanded = expandedFaqs.has(item.question);
-            const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
-            const state = isExpanded ? "open" : "closed";
-
-            return (
-              <div key={item.question} className="py-3">
-                <button
-                  type="button"
-                  aria-controls={answerId}
-                  aria-expanded={isExpanded}
-                  className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
-                  onClick={() => toggleFaq(item.question)}
-                >
-                  {item.question}
-                </button>
-                <div
-                  id={answerId}
-                  aria-hidden={!isExpanded}
-                  className="c-disclosure-content"
-                  data-state={state}
-                >
-                  <div>
-                    <div className="mt-2 text-sm text-text-muted leading-relaxed">
-                      {item.answer !== null ? (
-                        item.answer
-                      ) : (
-                        <>
-                          Yes! The repo includes the API, frontend, CLI, and
-                          more. You can run it yourself too; read the{" "}
-                          <a
-                            href="/blog/self-host"
-                            className="c-focus-ring font-medium text-accent underline-offset-4 hover:underline"
-                          >
-                            self-hosting guide
-                          </a>{" "}
-                          to set up your own instance.
-                        </>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
         </div>
 
         {/* Footer: social + legal */}

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -15,8 +15,8 @@ import { SessionContext } from "@web/auth/compass/session/session.context";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { maybeShowCmdPaletteHint } from "./cmd-palette-hint.util";
-import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { PixelPirate } from "./PixelPirate";
+import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { hasSeenWelcome, markWelcomeSeen } from "./welcome.modal.util";
 
 export function WelcomeModal() {

--- a/packages/web/src/components/WelcomeModal/cmd-palette-hint.util.ts
+++ b/packages/web/src/components/WelcomeModal/cmd-palette-hint.util.ts
@@ -1,0 +1,29 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { getModifierKeyLabel } from "@web/shortcuts/shortcut.util";
+
+const CMD_PALETTE_HINT_TOAST_ID = "cmd-palette-hint";
+
+export function hasSeenCmdPaletteHint(): boolean {
+  if (!persistentBrowserStore.isAvailable()) return true;
+  return (
+    persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_CMD_PALETTE_HINT) ===
+    "true"
+  );
+}
+
+export function markCmdPaletteHintSeen(): void {
+  persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_CMD_PALETTE_HINT, "true");
+}
+
+export function maybeShowCmdPaletteHint(): void {
+  if (hasSeenCmdPaletteHint()) return;
+
+  markCmdPaletteHintSeen();
+  const modKey = getModifierKeyLabel();
+  showStatusToast(
+    CMD_PALETTE_HINT_TOAST_ID,
+    `Press ${modKey}+K for commands — create events, connect Google, switch views`,
+  );
+}

--- a/packages/web/src/components/WelcomeModal/welcome.guide.store.ts
+++ b/packages/web/src/components/WelcomeModal/welcome.guide.store.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+export interface WelcomeGuideState {
+  isOpen: boolean;
+}
+
+export const useWelcomeGuideStore = create<WelcomeGuideState>()(() => ({
+  isOpen: false,
+}));
+
+export const welcomeGuideActions = {
+  open: () => useWelcomeGuideStore.setState({ isOpen: true }),
+  close: () => useWelcomeGuideStore.setState({ isOpen: false }),
+};
+
+export const selectWelcomeGuideOpen = (state: WelcomeGuideState) =>
+  state.isOpen;

--- a/packages/web/src/events/demo-events.util.ts
+++ b/packages/web/src/events/demo-events.util.ts
@@ -7,14 +7,14 @@ export async function hasDemoEvents(): Promise<boolean> {
   return records.some((record) => record.isDemo);
 }
 
-export async function clearDemoEvents(queryClient: QueryClient): Promise<number> {
+export async function clearDemoEvents(
+  queryClient: QueryClient,
+): Promise<number> {
   const store = getOfflineDataStore();
   const records = await store.getAllEvents();
   const demoRecords = records.filter((record) => record.isDemo);
 
-  await Promise.all(
-    demoRecords.map((record) => store.deleteEvent(record.id)),
-  );
+  await Promise.all(demoRecords.map((record) => store.deleteEvent(record.id)));
 
   await queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
 

--- a/packages/web/src/events/demo-events.util.ts
+++ b/packages/web/src/events/demo-events.util.ts
@@ -1,0 +1,22 @@
+import { type QueryClient } from "@tanstack/react-query";
+import { getOfflineDataStore } from "@web/common/storage/offline-data/offline-data.store.registry";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+
+export async function hasDemoEvents(): Promise<boolean> {
+  const records = await getOfflineDataStore().getAllEvents();
+  return records.some((record) => record.isDemo);
+}
+
+export async function clearDemoEvents(queryClient: QueryClient): Promise<number> {
+  const store = getOfflineDataStore();
+  const records = await store.getAllEvents();
+  const demoRecords = records.filter((record) => record.isDemo);
+
+  await Promise.all(
+    demoRecords.map((record) => store.deleteEvent(record.id)),
+  );
+
+  await queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+
+  return demoRecords.length;
+}

--- a/packages/web/src/events/event-view.types.ts
+++ b/packages/web/src/events/event-view.types.ts
@@ -11,6 +11,8 @@ export type EventEntityMap = Record<EventId, Event>;
 export type NormalizedEvents = {
   ids: EventId[];
   entities: EventEntityMap;
+  /** Present when events are loaded from local IndexedDB records. */
+  demoEventIds?: readonly EventId[];
 };
 
 export type OptimisticEvent = {

--- a/packages/web/src/events/hooks/useDemoEventsPresent.ts
+++ b/packages/web/src/events/hooks/useDemoEventsPresent.ts
@@ -2,14 +2,21 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 import { hasDemoEvents } from "@web/events/demo-events.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 
 export function useDemoEventsPresent(): boolean {
   const queryClient = useQueryClient();
+  const source = useEventRepositorySource();
   const [present, setPresent] = useState(false);
 
   const refresh = useCallback(() => {
+    if (source !== "local") {
+      setPresent(false);
+      return;
+    }
+
     void hasDemoEvents().then(setPresent);
-  }, []);
+  }, [source]);
 
   useEffect(() => {
     refresh();

--- a/packages/web/src/events/hooks/useDemoEventsPresent.ts
+++ b/packages/web/src/events/hooks/useDemoEventsPresent.ts
@@ -1,0 +1,29 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+import { hasDemoEvents } from "@web/events/demo-events.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+
+export function useDemoEventsPresent(): boolean {
+  const queryClient = useQueryClient();
+  const [present, setPresent] = useState(false);
+
+  const refresh = useCallback(() => {
+    void hasDemoEvents().then(setPresent);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+
+    return queryClient.getQueryCache().subscribe((event) => {
+      if (
+        event.type === "updated" &&
+        Array.isArray(event.query.queryKey) &&
+        event.query.queryKey[0] === eventQueryKeys.all[0]
+      ) {
+        refresh();
+      }
+    });
+  }, [queryClient, refresh]);
+
+  return present;
+}

--- a/packages/web/src/events/hooks/useDemoEventsPresent.ts
+++ b/packages/web/src/events/hooks/useDemoEventsPresent.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { hasDemoEvents } from "@web/events/demo-events.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
@@ -8,14 +8,21 @@ export function useDemoEventsPresent(): boolean {
   const queryClient = useQueryClient();
   const source = useEventRepositorySource();
   const [present, setPresent] = useState(false);
+  const refreshGenerationRef = useRef(0);
 
   const refresh = useCallback(() => {
     if (source !== "local") {
+      refreshGenerationRef.current += 1;
       setPresent(false);
       return;
     }
 
-    void hasDemoEvents().then(setPresent);
+    const generation = (refreshGenerationRef.current += 1);
+    void hasDemoEvents().then((result) => {
+      if (generation === refreshGenerationRef.current) {
+        setPresent(result);
+      }
+    });
   }, [source]);
 
   useEffect(() => {

--- a/packages/web/src/events/mutations/event.mutation.runtime.ts
+++ b/packages/web/src/events/mutations/event.mutation.runtime.ts
@@ -5,12 +5,14 @@ import {
   markAnonymousCalendarChangeForSignUpPrompt,
 } from "@web/auth/compass/state/auth.state.util";
 import { isGoogleRevoked } from "@web/auth/google/state/google.auth.state";
+import { maybeShowAnonymousSaveToast } from "@web/common/utils/toast/anonymous-save.toast";
 import { eventMutationKeys } from "./event.mutation.keys";
 
 export async function markAnonymousEventWrite() {
   if (await session.doesSessionExist()) return;
   if (hasUserEverAuthenticated() || isGoogleRevoked()) return;
   markAnonymousCalendarChangeForSignUpPrompt();
+  maybeShowAnonymousSaveToast();
 }
 
 type AnyMutation = Mutation<unknown, Error, unknown, unknown>;

--- a/packages/web/src/events/mutations/event.mutation.runtime.ts
+++ b/packages/web/src/events/mutations/event.mutation.runtime.ts
@@ -12,6 +12,11 @@ export async function markAnonymousEventWrite() {
   if (await session.doesSessionExist()) return;
   if (hasUserEverAuthenticated() || isGoogleRevoked()) return;
   markAnonymousCalendarChangeForSignUpPrompt();
+}
+
+export async function showAnonymousSaveToastIfEligible(): Promise<void> {
+  if (await session.doesSessionExist()) return;
+  if (hasUserEverAuthenticated() || isGoogleRevoked()) return;
   maybeShowAnonymousSaveToast();
 }
 

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -43,6 +43,7 @@ import {
   type PrecedingEventWrites,
   precedingCreateOk,
   precedingDeleteOk,
+  showAnonymousSaveToastIfEligible,
   waitForPrecedingEventWrites,
 } from "./event.mutation.runtime";
 import {
@@ -148,6 +149,10 @@ export function useEventMutations(
     [dependencies.repository, source],
   );
   const markWrite = dependencies.markWrite ?? markAnonymousEventWrite;
+  const showAnonymousSaveToast =
+    dependencies.markWrite === undefined
+      ? showAnonymousSaveToastIfEligible
+      : undefined;
   const reportError = dependencies.reportError ?? handleError;
 
   // Backstop only - the real enforcement is the UI gates (cards, shortcuts,
@@ -235,8 +240,10 @@ export function useEventMutations(
       await markWrite();
       return;
     }
-    if (canWrite(preceding)) await write();
+    const wrote = canWrite(preceding);
+    if (wrote) await write();
     await markWrite();
+    if (wrote) await showAnonymousSaveToast?.();
   };
 
   const createMutation = useMutation(

--- a/packages/web/src/events/queries/day.event.query.ts
+++ b/packages/web/src/events/queries/day.event.query.ts
@@ -1,5 +1,7 @@
 import { EventListQuerySchema } from "@core/types/event-command.contracts";
+import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
+import { fetchLocalEventsRange } from "./event.query.local";
 import { normalizeEventList } from "./event.query.normalize";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
@@ -14,9 +16,14 @@ type FetchDayEventsPayload = { startDate: string; endDate: string };
 export async function fetchDayEvents(
   payload: FetchDayEventsPayload,
   repository: EventRepository,
+  source: EventRepositorySource = "remote",
 ): Promise<NormalizedEventQueryData> {
   if (!payload.startDate || !payload.endDate) {
     throw new Error("Event query requires startDate and endDate");
+  }
+
+  if (source === "local") {
+    return fetchLocalEventsRange(payload);
   }
 
   const query = EventListQuerySchema.parse({

--- a/packages/web/src/events/queries/event.query.local.ts
+++ b/packages/web/src/events/queries/event.query.local.ts
@@ -1,0 +1,23 @@
+import { EventListQuerySchema } from "@core/types/event-command.contracts";
+import { getOfflineDataStore } from "@web/common/storage/offline-data/offline-data.store.registry";
+import { normalizeLocalEventRecords } from "./event.query.normalize";
+import { type NormalizedEventQueryData } from "./event.query.types";
+
+type FetchLocalEventsPayload = { startDate: string; endDate: string };
+
+export async function fetchLocalEventsRange(
+  payload: FetchLocalEventsPayload,
+): Promise<NormalizedEventQueryData> {
+  if (!payload.startDate || !payload.endDate) {
+    throw new Error("Event query requires startDate and endDate");
+  }
+
+  const query = EventListQuerySchema.parse({
+    kind: "range",
+    start: payload.startDate,
+    end: payload.endDate,
+  });
+
+  const records = await getOfflineDataStore().getEvents(query);
+  return normalizeLocalEventRecords(records);
+}

--- a/packages/web/src/events/queries/event.query.normalize.ts
+++ b/packages/web/src/events/queries/event.query.normalize.ts
@@ -23,7 +23,9 @@ export const normalizeLocalEventRecords = (
   records: LocalEventRecord[],
 ): NormalizedEvents => ({
   ...normalizeEventList(records.map((record) => record.event)),
-  demoEventIds: records.filter((record) => record.isDemo).map((record) => record.id),
+  demoEventIds: records
+    .filter((record) => record.isDemo)
+    .map((record) => record.id),
 });
 
 /**

--- a/packages/web/src/events/queries/event.query.normalize.ts
+++ b/packages/web/src/events/queries/event.query.normalize.ts
@@ -1,4 +1,5 @@
 import { type Event } from "@core/types/event.contracts";
+import { type LocalEventRecord } from "@web/common/storage/types/local-event.record";
 import { type NormalizedEvents } from "@web/events/event-view.types";
 
 /**
@@ -12,6 +13,17 @@ export const normalizeEventList = (events: Event[]): NormalizedEvents => ({
     entities[event.id] = event;
     return entities;
   }, {}),
+});
+
+/**
+ * Normalize local IndexedDB records, preserving demo-event metadata for grid
+ * styling and onboarding affordances.
+ */
+export const normalizeLocalEventRecords = (
+  records: LocalEventRecord[],
+): NormalizedEvents => ({
+  ...normalizeEventList(records.map((record) => record.event)),
+  demoEventIds: records.filter((record) => record.isDemo).map((record) => record.id),
 });
 
 /**

--- a/packages/web/src/events/queries/event.query.options.ts
+++ b/packages/web/src/events/queries/event.query.options.ts
@@ -34,6 +34,7 @@ export function dayEventsQueryOptions({
       fetchDayEvents(
         { startDate, endDate },
         getEventRepositoryBySource(source),
+        source,
       ),
     ...EVENT_QUERY_CACHE_OPTIONS,
   });
@@ -50,6 +51,7 @@ export function weekEventsQueryOptions({
       fetchWeekEvents(
         { startDate, endDate },
         getEventRepositoryBySource(source),
+        source,
       ),
     ...EVENT_QUERY_CACHE_OPTIONS,
   });

--- a/packages/web/src/events/queries/event.view-model.test.ts
+++ b/packages/web/src/events/queries/event.view-model.test.ts
@@ -47,6 +47,22 @@ describe("Event query view models", () => {
     expect(result.events.map(({ id }) => id)).toEqual([base.id, occurrence.id]);
   });
 
+  test("marks demo events from normalized demoEventIds", () => {
+    const demo = createMockEvent();
+    const user = createMockEvent();
+    const data: NormalizedEventQueryData = {
+      ...normalized(demo, user),
+      demoEventIds: [demo.id],
+    };
+
+    const result = deriveCalendarEventViewModel(data);
+    const demoCard = result.timedEvents.find(({ _id }) => _id === demo.id);
+    const userCard = result.timedEvents.find(({ _id }) => _id === user.id);
+
+    expect(demoCard?.isDemo).toBe(true);
+    expect(userCard?.isDemo).toBe(false);
+  });
+
   test("returns stable empty shapes", () => {
     const week = deriveCalendarEventViewModel();
     expect(week).toEqual({
@@ -55,6 +71,7 @@ describe("Event query view models", () => {
       timedEvents: [],
       allDayEvents: [],
       rowCount: 1,
+      demoEventIds: undefined,
     });
   });
 });

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -1,3 +1,4 @@
+import { type EventId } from "@core/types/domain-primitives";
 import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type Event } from "@core/types/event.contracts";
@@ -79,7 +80,9 @@ const isValidScheduledEvent = (event: Event): boolean => {
 const withCalendarMetadata = (
   events: Event[],
   gridEvents: GridEvent[],
+  demoEventIds?: readonly EventId[],
 ): GridEvent[] => {
+  const demoEventIdSet = new Set(demoEventIds ?? []);
   const metadataByEventId = new Map<
     string,
     { calendarId: Event["calendarId"]; isBusy: boolean }
@@ -97,6 +100,9 @@ const withCalendarMetadata = (
       ...gridEvent,
       calendarId: metadata?.calendarId,
       isBusy: metadata?.isBusy ?? false,
+      isDemo: gridEvent._id
+        ? demoEventIdSet.has(gridEvent._id as EventId)
+        : false,
     };
   });
 };
@@ -105,7 +111,11 @@ const withCalendarMetadata = (
 // datetime (kept so the RRULE and series id are reachable for editing), but
 // the first occurrence itself is a separately materialized doc that renders
 // the actual card. Rendering the base too would double the first day.
-const gridEventsFrom = (events: Event[], kind: "timed" | "allDay") => {
+const gridEventsFrom = (
+  events: Event[],
+  kind: "timed" | "allDay",
+  demoEventIds?: readonly EventId[],
+) => {
   const scheduled = events
     .filter(isValidScheduledEvent)
     .filter((event) => event.schedule.kind === kind)
@@ -115,13 +125,18 @@ const gridEventsFrom = (events: Event[], kind: "timed" | "allDay") => {
     .filter((event): event is EventWithDates => hasEventDates(event))
     .map(assembleGridEvent);
 
-  return withCalendarMetadata(scheduled, assembled);
+  return withCalendarMetadata(scheduled, assembled, demoEventIds);
 };
 
-const timedEventsFrom = (events: Event[]) => gridEventsFrom(events, "timed");
+const timedEventsFrom = (
+  events: Event[],
+  demoEventIds?: readonly EventId[],
+) => gridEventsFrom(events, "timed", demoEventIds);
 
-const allDayEventsFrom = (events: Event[]) =>
-  assignEventsToRow(gridEventsFrom(events, "allDay")).allDayEvents;
+const allDayEventsFrom = (
+  events: Event[],
+  demoEventIds?: readonly EventId[],
+) => assignEventsToRow(gridEventsFrom(events, "allDay", demoEventIds)).allDayEvents;
 
 const rowCountFrom = (events: GridEvent[]) => {
   const rows = events
@@ -136,20 +151,23 @@ type CalendarEventViewModel = {
   timedEvents: GridEvent[];
   allDayEvents: GridEvent[];
   rowCount: number;
+  demoEventIds?: readonly EventId[];
 };
 
 const computeCalendarEventViewModel = (
   data?: NormalizedEventQueryData,
 ): CalendarEventViewModel => {
   const events = eventsFrom(data);
-  const timedEvents = timedEventsFrom(events);
-  const allDayEvents = allDayEventsFrom(events);
+  const demoEventIds = data?.demoEventIds;
+  const timedEvents = timedEventsFrom(events, demoEventIds);
+  const allDayEvents = allDayEventsFrom(events, demoEventIds);
   return {
     entities: data?.entities ?? {},
     events,
     timedEvents,
     allDayEvents,
     rowCount: rowCountFrom(allDayEvents),
+    demoEventIds,
   };
 };
 

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -1,6 +1,6 @@
-import { type EventId } from "@core/types/domain-primitives";
 import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
+import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -128,15 +128,12 @@ const gridEventsFrom = (
   return withCalendarMetadata(scheduled, assembled, demoEventIds);
 };
 
-const timedEventsFrom = (
-  events: Event[],
-  demoEventIds?: readonly EventId[],
-) => gridEventsFrom(events, "timed", demoEventIds);
+const timedEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
+  gridEventsFrom(events, "timed", demoEventIds);
 
-const allDayEventsFrom = (
-  events: Event[],
-  demoEventIds?: readonly EventId[],
-) => assignEventsToRow(gridEventsFrom(events, "allDay", demoEventIds)).allDayEvents;
+const allDayEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
+  assignEventsToRow(gridEventsFrom(events, "allDay", demoEventIds))
+    .allDayEvents;
 
 const rowCountFrom = (events: GridEvent[]) => {
   const rows = events

--- a/packages/web/src/events/queries/week.event.query.ts
+++ b/packages/web/src/events/queries/week.event.query.ts
@@ -1,5 +1,7 @@
 import { EventListQuerySchema } from "@core/types/event-command.contracts";
+import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
+import { fetchLocalEventsRange } from "./event.query.local";
 import { normalizeEventList } from "./event.query.normalize";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
@@ -20,9 +22,14 @@ type FetchWeekEventsPayload = { startDate: string; endDate: string };
 export async function fetchWeekEvents(
   payload: FetchWeekEventsPayload,
   repository: EventRepository,
+  source: EventRepositorySource = "remote",
 ): Promise<NormalizedEventQueryData> {
   if (!payload.startDate || !payload.endDate) {
     throw new Error("Event query requires startDate and endDate");
+  }
+
+  if (source === "local") {
+    return fetchLocalEventsRange(payload);
   }
 
   const query = EventListQuerySchema.parse({

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -104,7 +104,7 @@ const AllDayEventCardBase = (
     cursor: showResizeCursor ? "col-resize" : undefined,
     ...placement,
   });
-  const baseAccessibleLabel = `${isRecurring ? "Recurring " : ""}All-day event: ${event.title || "Untitled event"}`;
+  const baseAccessibleLabel = `${isRecurring ? "Recurring " : ""}${event.isDemo ? "Sample " : ""}All-day event: ${event.title || "Untitled event"}`;
   // Fill stays a flat neutral color; the accent + this suffix are the only
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
@@ -125,6 +125,8 @@ const AllDayEventCardBase = (
         "absolute min-h-2.5 select-none overflow-hidden rounded-xs bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
         {
           "hover:cursor-pointer": !isPlaceholder,
+          "outline outline-1 outline-dashed outline-text-muted/50":
+            event.isDemo,
         },
       )}
       style={eventStyle}

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { type RefCallback } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { afterEach, describe, expect, it, mock } from "bun:test";
@@ -62,6 +63,39 @@ describe("EventGrid", () => {
     expect(
       screen.getByRole("region", { name: "Timed events grid" }),
     ).toContainElement(screen.getByTestId("timed-events-layer"));
+  });
+
+  it("shows a grid-wide focus indicator when the timed grid is focused", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <button type="button">Before</button>
+        <EventGrid
+          allDayEventsLayer={<div />}
+          gridRefs={createGridRefs()}
+          onAllDayMouseDown={mock()}
+          onTimedMouseDown={mock()}
+          timedEventsLayer={<div />}
+          today={dayjs("2026-05-20T00:00:00.000")}
+          visibleDates={[
+            {
+              date: dayjs("2026-05-20T00:00:00.000"),
+              key: "date-0",
+            },
+          ]}
+        />
+      </div>,
+    );
+
+    await user.tab();
+    await user.tab();
+
+    const timedGrid = screen.getByRole("region", { name: "Timed events grid" });
+    expect(timedGrid).toHaveFocus();
+
+    const indicator = screen.getByTestId("grid-focus-indicator");
+    expect(getComputedStyle(indicator).display).not.toBe("none");
   });
 
   it("passes the all-day row count to the shared all-day surface", () => {

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -56,6 +56,12 @@ export const EventGrid: FC<EventGridProps> = ({
       today={today}
       visibleDates={visibleDates}
     />
+    {/* Sibling overlay, not an outline on TimedGrid itself, so the ring isn't clipped by overflow-y-auto and includes the all-day row above. */}
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 hidden outline outline-1 outline-[var(--accent)] peer-focus-visible:block"
+      data-testid="grid-focus-indicator"
+    />
     {isLoadingEvents && (
       // pointer-events-none: the loader is informational and covers the whole
       // grid, so without it the overlay swallows the mousedown that

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -220,12 +220,13 @@ const TimedEventCardBase = (
   const baseAccessibleLabel = event.isAllDay
     ? `${recurringPrefix}All-day event: ${eventTitle}`
     : `${recurringPrefix}Timed event: ${eventTitle}, ${timeRange ?? "time not set"}`;
+  const samplePrefix = event.isDemo ? "Sample " : "";
   // Fill stays a flat neutral color; the accent + this suffix are the only
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
   const accessibleLabel = calendarIdentity
-    ? `${baseAccessibleLabel}, ${calendarIdentity.name} calendar`
-    : baseAccessibleLabel;
+    ? `${samplePrefix}${baseAccessibleLabel}, ${calendarIdentity.name} calendar`
+    : `${samplePrefix}${baseAccessibleLabel}`;
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: Grid events are draggable/resizable blocks, not native buttons.
@@ -240,6 +241,8 @@ const TimedEventCardBase = (
         "absolute min-h-2.5 select-none overflow-hidden rounded-xs pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
         "bg-(--event-bg) hover:bg-(--event-hover-bg)",
         "hover:cursor-pointer",
+        event.isDemo &&
+          "outline outline-1 outline-dashed outline-text-muted/50",
       )}
       style={eventStyle}
       onBlur={onBlur}

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -56,10 +56,10 @@ export const TimedGrid: FC<TimedGridProps> = ({
   return (
     <section
       aria-label="Timed events grid"
-      // c-scroll sets `:focus-visible { outline: none }`; restore a visible
-      // indicator now that this is a real Tab stop (see tabIndex below), or
-      // keyboard users get a focusable-but-invisible region.
-      className="c-scroll relative min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden [--scrollbar-width:0px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[var(--accent)] focus-visible:[outline-offset:-1px]"
+      // EventGrid renders the visible focus ring as a sibling overlay so it
+      // wraps the all-day row and timed grid together and is not clipped by
+      // this section's overflow-y-auto.
+      className="peer c-scroll relative min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden [--scrollbar-width:0px] focus-visible:outline-none"
       id={timedGridId}
       ref={timedGridRef}
       // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 requires a scrollable region to be keyboard-focusable (axe's scrollable-region-focusable rule); tabIndex={-1} previously made a mouse click the only way in.

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -744,6 +744,33 @@
   }
 }
 
+@utility c-all-day-checkbox {
+  @apply size-4 shrink-0 cursor-pointer appearance-none rounded-sm border border-border-strong transition-all duration-300;
+  background-color: var(--surface-overlay);
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--accent);
+    outline: none;
+  }
+
+  &:checked {
+    background-color: var(--accent);
+    border-color: var(--accent);
+    background-size: 12px 12px;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+}
+
+:root .c-all-day-checkbox:checked,
+[data-theme="dark-abyss"] .c-all-day-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.5L6.5 11.5L12.5 4.5' stroke='%2305121a' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+[data-theme="light-beach"] .c-all-day-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.5L6.5 11.5L12.5 4.5' stroke='%23f6f3ea' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
 /*
  * Keep this unlayered so it can override react-select's unlayered CSS.
  * Rules inside a Tailwind @utility lose to unlayered library defaults.

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -6,13 +6,13 @@ import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigati
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { DemoEventsBannerGate } from "@web/components/DemoEventsBanner/DemoEventsBannerGate";
-import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import { SidebarEventDetails } from "@web/components/Sidebar/EventDetails/SidebarEventDetails";
 import { ResizableSidebarPanel } from "@web/components/Sidebar/ResizableSidebarPanel";
 import { Sidebar } from "@web/components/Sidebar/Sidebar";
 import { useUpNextEventShortcut } from "@web/components/Sidebar/UpNextCard/useUpNextEvent";
 import { useSidebarShortcuts } from "@web/components/Sidebar/useSidebarShortcuts";
 import { focusFirstSidebarItem } from "@web/components/Sidebar/util/sidebarFocus.util";
+import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import {
   selectIsEventFormOpen,
   useDraftStore,

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -5,6 +5,8 @@ import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
+import { DemoEventsBannerGate } from "@web/components/DemoEventsBanner/DemoEventsBannerGate";
+import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import { SidebarEventDetails } from "@web/components/Sidebar/EventDetails/SidebarEventDetails";
 import { ResizableSidebarPanel } from "@web/components/Sidebar/ResizableSidebarPanel";
 import { Sidebar } from "@web/components/Sidebar/Sidebar";
@@ -116,12 +118,17 @@ export const DayViewContent = memo(() => {
     onGoToToday: handleGoToToday,
   });
 
+  const openWelcomeGuide = useCallback(() => {
+    welcomeGuideActions.open();
+  }, []);
+
   return (
     <div id="day" className="flex h-screen w-screen overflow-hidden">
       <CommandPalette
         currentView="day"
         onGoToToday={handleGoToToday}
         onShowShortcuts={toggleShortcuts}
+        onShowWelcomeGuide={openWelcomeGuide}
         placeholder={getCommandPalettePlaceholder("day")}
       />
       <Dedication />
@@ -132,6 +139,7 @@ export const DayViewContent = memo(() => {
         className="flex h-screen flex-1 flex-col overflow-hidden bg-background pt-5 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
       >
         <Header />
+        <DemoEventsBannerGate />
 
         <div className="flex w-full flex-1 overflow-hidden">
           <DayCalendarGrid />

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.tsx
@@ -7,7 +7,7 @@ export const AllDayToggle = ({ checked, onChange }: Props) => (
   <label className="flex w-fit cursor-pointer items-center gap-2 text-sm text-text-muted">
     <input
       checked={checked}
-      className="size-4 accent-accent"
+      className="c-all-day-checkbox"
       onChange={(event) => onChange(event.target.checked)}
       type="checkbox"
     />

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -250,6 +250,33 @@ describe("EventForm", () => {
     ).toBeTruthy();
   });
 
+  it("lets long descriptions grow with content instead of capping height", () => {
+    const longDescription = Array.from(
+      { length: 12 },
+      (_, index) =>
+        `Paragraph ${index + 1}: event details that should remain visible without an inner scroll trap.`,
+    ).join("\n\n");
+
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft({ description: longDescription })}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const description = screen.getByPlaceholderText("Description");
+
+    expect(description.className).not.toContain("max-h-45");
+    expect(description.className).not.toContain("overflow-y-auto");
+    expect(description).toHaveValue(longDescription);
+  });
+
   it("duplicates the event with Mod+D while the title field is focused", async () => {
     const draft = createEditDraft();
     const onDuplicate = mock();

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -685,7 +685,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 onKeyDown={handleIgnoredKeys}
                 placeholder="Description"
                 value={event.description || ""}
-                className="relative max-h-45 w-full overflow-y-auto border-hidden bg-transparent"
+                className="relative w-full border-hidden bg-transparent"
               />
             </FormCard>
           </fieldset>

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.tsx
@@ -37,7 +37,7 @@ export async function completeGoogleAuthCallback({
   if (result.status === "failed") {
     showErrorToast(result.message);
   } else if (result.isNewUser) {
-    releaseNotesPromptActions.open();
+    releaseNotesPromptActions.scheduleOpen();
   }
 
   navigate(result.returnPath, { replace: true });

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -4,13 +4,13 @@ import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
-import { DemoEventsBannerGate } from "@web/components/DemoEventsBanner/DemoEventsBannerGate";
-import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuWrapper";
+import { DemoEventsBannerGate } from "@web/components/DemoEventsBanner/DemoEventsBannerGate";
 import { ResizableSidebarPanel } from "@web/components/Sidebar/ResizableSidebarPanel";
 import { Sidebar } from "@web/components/Sidebar/Sidebar";
 import { useUpNextEventShortcut } from "@web/components/Sidebar/UpNextCard/useUpNextEvent";
 import { useSidebarShortcuts } from "@web/components/Sidebar/useSidebarShortcuts";
+import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import {
   draftActions,
   selectIsEventFormOpen,

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -4,6 +4,8 @@ import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
+import { DemoEventsBannerGate } from "@web/components/DemoEventsBanner/DemoEventsBannerGate";
+import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuWrapper";
 import { ResizableSidebarPanel } from "@web/components/Sidebar/ResizableSidebarPanel";
 import { Sidebar } from "@web/components/Sidebar/Sidebar";
@@ -135,12 +137,17 @@ export const WeekView = () => {
     [gridRefs.allDayColumnsRef, gridRefs.mainGridRef, gridRefs.timedColumnsRef],
   );
 
+  const openWelcomeGuide = useCallback(() => {
+    welcomeGuideActions.open();
+  }, []);
+
   return (
     <div id="cal" className="flex h-screen w-screen overflow-hidden">
       <CommandPalette
         currentView="week"
         onGoToToday={goToTodayViaCmd}
         onShowShortcuts={toggleShortcuts}
+        onShowWelcomeGuide={openWelcomeGuide}
         placeholder={getCommandPalettePlaceholder("week")}
       />
       <Dedication />
@@ -153,6 +160,7 @@ export const WeekView = () => {
             className="flex h-screen flex-1 flex-col overflow-hidden bg-background pt-5 pr-0 pb-0 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
           >
             <Header scrollUtil={scrollUtil} weekProps={weekProps} />
+            <DemoEventsBannerGate />
 
             <WeekGridScrollArea>
               <div


### PR DESCRIPTION
## Summary
- Mark demo/sample events visually and add a dismissible banner plus a command-palette action to clear them.
- Surface Google Calendar connect in the sidebar for authenticated users who have not linked Google yet.
- Improve anonymous save messaging, defer the release-notes prompt after sign-up, and add one-time Cmd+K and welcome-guide help.

## Test plan
- [x] `bun test:web` for updated onboarding-related tests
- [x] `bun type-check`

Made with [Cursor](https://cursor.com)