### PR TITLE
fix(web): let event descriptions grow with content in sidebar

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -250,6 +250,32 @@ describe("EventForm", () => {
     ).toBeTruthy();
   });
 
+  it("lets long descriptions grow with content instead of capping height", () => {
+    const longDescription = Array.from(
+      { length: 12 },
+      (_, index) => `Paragraph ${index + 1}: event details that should remain visible without an inner scroll trap.`,
+    ).join("\n\n");
+
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft({ description: longDescription })}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const description = screen.getByPlaceholderText("Description");
+
+    expect(description.className).not.toContain("max-h-45");
+    expect(description.className).not.toContain("overflow-y-auto");
+    expect(description).toHaveValue(longDescription);
+  });
+
   it("duplicates the event with Mod+D while the title field is focused", async () => {
     const draft = createEditDraft();
     const onDuplicate = mock();

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -253,7 +253,8 @@ describe("EventForm", () => {
   it("lets long descriptions grow with content instead of capping height", () => {
     const longDescription = Array.from(
       { length: 12 },
-      (_, index) => `Paragraph ${index + 1}: event details that should remain visible without an inner scroll trap.`,
+      (_, index) =>
+        `Paragraph ${index + 1}: event details that should remain visible without an inner scroll trap.`,
     ).join("\n\n");
 
     renderWithStore(

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -685,7 +685,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 onKeyDown={handleIgnoredKeys}
                 placeholder="Description"
                 value={event.description || ""}
-                className="relative max-h-45 w-full overflow-y-auto border-hidden bg-transparent"
+                className="relative w-full border-hidden bg-transparent"
               />
             </FormCard>
           </fieldset>


### PR DESCRIPTION
## Summary
- Remove the `max-h-45` cap and inner scroll on the event form description field
- Long descriptions now autosize to their content; the sidebar body scrolls when the full form exceeds the viewport
- Add a regression test to prevent reintroducing the height cap

## Test plan
- [x] `bun test:web packages/web/src/views/Forms/EventForm/EventForm.test.tsx packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx`
- [ ] Open a read-only event with a long description in the sidebar and confirm more text is visible without focusing the field
- [ ] Confirm short descriptions stay compact


Made with [Cursor](https://cursor.com)