### PR TITLE
style(web): theme all-day checkbox to match event form surfaces

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -41,8 +41,25 @@ mock.module("@web/auth/compass/session/useSession", () => ({
     isSessionMocked ? mockUseSession(...args) : actualUseSession(...args),
 }));
 
+const actualUseConnectGoogle = (
+  await import("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle")
+).useConnectGoogle;
+let isConnectGoogleMocked = true;
+const mockUseConnectGoogle = mock(() => ({
+  commandAction: null,
+  isAvailable: true,
+  state: "NOT_CONNECTED" as const,
+}));
+mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
+  useConnectGoogle: (...args: Parameters<typeof actualUseConnectGoogle>) =>
+    isConnectGoogleMocked
+      ? mockUseConnectGoogle(...args)
+      : actualUseConnectGoogle(...args),
+}));
+
 afterAll(() => {
   isSessionMocked = false;
+  isConnectGoogleMocked = false;
 });
 
 // CalendarList.tsx is already cached by the time this file runs -

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -744,6 +744,33 @@
   }
 }
 
+@utility c-all-day-checkbox {
+  @apply size-4 shrink-0 cursor-pointer appearance-none rounded-sm border border-border-strong transition-all duration-300;
+  background-color: var(--surface-overlay);
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--accent);
+    outline: none;
+  }
+
+  &:checked {
+    background-color: var(--accent);
+    border-color: var(--accent);
+    background-size: 12px 12px;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+}
+
+:root .c-all-day-checkbox:checked,
+[data-theme="dark-abyss"] .c-all-day-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.5L6.5 11.5L12.5 4.5' stroke='%2305121a' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+[data-theme="light-beach"] .c-all-day-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.5L6.5 11.5L12.5 4.5' stroke='%23f6f3ea' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
 /*
  * Keep this unlayered so it can override react-select's unlayered CSS.
  * Rules inside a Tailwind @utility lose to unlayered library defaults.

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.tsx
@@ -7,7 +7,7 @@ export const AllDayToggle = ({ checked, onChange }: Props) => (
   <label className="flex w-fit cursor-pointer items-center gap-2 text-sm text-text-muted">
     <input
       checked={checked}
-      className="size-4 accent-accent"
+      className="c-all-day-checkbox"
       onChange={(event) => onChange(event.target.checked)}
       type="checkbox"
     />


### PR DESCRIPTION
## Summary
- Replace the native All day? checkbox styling that rendered with a stark white background in light-beach
- Add a themed `c-all-day-checkbox` utility that uses surface-overlay and border-strong to match adjacent time pickers
- Checked state uses accent fill with theme-aware checkmark colors

## Test plan
- [x] `bun test packages/web/src/views/Forms/EventForm/DateControlsSection/AllDayToggle.test.tsx` (1 pass)


Made with [Cursor](https://cursor.com)