### PR TITLE
fix(web): align toast keycap hints with active theme

### DIFF
--- a/packages/web/src/auth/google/util/google.auth.util.factory.ts
+++ b/packages/web/src/auth/google/util/google.auth.util.factory.ts
@@ -1,7 +1,7 @@
 import { type toast } from "react-toastify";
 import { Status } from "@core/errors/status.codes";
 import { type ApiError } from "@web/api/api.types";
-import { toastDefaultOptions } from "@web/common/constants/toast.constants";
+import { getToastDefaultOptions } from "@web/common/constants/toast.constants";
 export interface SyncLocalEventsResult {
   syncedCount: number;
   success: boolean;
@@ -69,7 +69,7 @@ export function createGoogleAuthUtil({
         ? LOCAL_EVENTS_SYNC_SESSION_EXPIRED_MESSAGE
         : LOCAL_EVENTS_SYNC_ERROR_MESSAGE;
 
-    toastError(message, toastDefaultOptions);
+    toastError(message, getToastDefaultOptions());
     console.error(error);
   };
 

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -1,5 +1,7 @@
 import { type Id, type ToastOptions } from "react-toastify";
-import { colors } from "@web/common/styles/colors";
+import { colors, lightColors } from "@web/common/styles/colors";
+import { type ThemeName } from "@web/settings/theme/theme.constants";
+import { useThemeStore } from "@web/settings/theme/theme.store";
 
 export const EVENT_DELETED_TOAST_ID: Id = "event-deleted";
 export const GOOGLE_REVOKED_TOAST_ID: Id = "google-revoked-api";
@@ -7,17 +9,46 @@ export const GOOGLE_REPAIR_FAILED_TOAST_ID: Id = "google-repair-failed";
 export const SUBSCRIBE_TO_UPDATES_TOAST_ID: Id = "subscribe-to-updates";
 export const EXPORT_MY_DATA_TOAST_ID: Id = "export-my-data";
 
-export const toastDefaultOptions: ToastOptions = {
-  autoClose: 5000,
-  position: "bottom-left",
-  closeOnClick: true,
-  theme: "dark",
-  style: {
-    backgroundColor: colors.background,
-    color: colors.text,
-    boxShadow: "0 4px 12px hsl(0 0 0 / 50%)",
+const toastPalette: Record<
+  ThemeName,
+  { background: string; text: string; textMuted: string; shadow: string }
+> = {
+  "dark-abyss": {
+    background: colors.background,
+    text: colors.text,
+    textMuted: colors.textMuted,
+    shadow: "0 4px 12px hsl(0 0 0 / 50%)",
   },
-  progressStyle: {
-    background: colors.textMuted,
+  "light-beach": {
+    background: lightColors.background,
+    text: lightColors.text,
+    textMuted: lightColors.textMuted,
+    shadow: "0 4px 12px hsl(40 25% 25% / 18%)",
   },
 };
+
+/** Theme-aware toast defaults. Read the store at call time so toasts match the active palette. */
+export function getToastDefaultOptions(
+  theme: ThemeName = useThemeStore.getState().theme,
+): ToastOptions {
+  const palette = toastPalette[theme];
+
+  return {
+    autoClose: 5000,
+    position: "bottom-left",
+    closeOnClick: true,
+    theme: theme === "dark-abyss" ? "dark" : "light",
+    style: {
+      backgroundColor: palette.background,
+      color: palette.text,
+      boxShadow: palette.shadow,
+    },
+    progressStyle: {
+      background: palette.textMuted,
+    },
+  };
+}
+
+/** @deprecated Prefer getToastDefaultOptions() so toasts follow the active theme. */
+export const toastDefaultOptions: ToastOptions =
+  getToastDefaultOptions("dark-abyss");

--- a/packages/web/src/common/styles/colors.ts
+++ b/packages/web/src/common/styles/colors.ts
@@ -37,5 +37,6 @@ export const colors = {
 export const lightColors = {
   background: "#F3EEE2",
   text: "#403A2F",
+  textMuted: "#5E5847",
   onAccent: "#F6F3EA",
 };

--- a/packages/web/src/common/styles/theme-css.test.ts
+++ b/packages/web/src/common/styles/theme-css.test.ts
@@ -140,6 +140,7 @@ describe("Tailwind theme CSS", () => {
       {
         background: "background",
         text: "text",
+        textMuted: "text-muted",
         onAccent: "on-accent",
       };
 

--- a/packages/web/src/common/utils/toast/deleted-toast.util.tsx
+++ b/packages/web/src/common/utils/toast/deleted-toast.util.tsx
@@ -1,6 +1,6 @@
 import {
   EVENT_DELETED_TOAST_ID,
-  toastDefaultOptions,
+  getToastDefaultOptions,
 } from "@web/common/constants/toast.constants";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { getToast } from "@web/common/utils/toast/toast.port";
@@ -35,6 +35,6 @@ export function showDeletedToast(withUndoHint: boolean): void {
 export function showRestoredToast(): void {
   getToast().update(EVENT_DELETED_TOAST_ID, {
     render: "Restored",
-    autoClose: toastDefaultOptions.autoClose,
+    autoClose: getToastDefaultOptions().autoClose,
   });
 }

--- a/packages/web/src/common/utils/toast/error-toast.util.ts
+++ b/packages/web/src/common/utils/toast/error-toast.util.ts
@@ -1,6 +1,6 @@
 import { createElement } from "react";
 import { type Id, type ToastContent, type ToastOptions } from "react-toastify";
-import { toastDefaultOptions } from "@web/common/constants/toast.constants";
+import { getToastDefaultOptions } from "@web/common/constants/toast.constants";
 import { SessionExpiredToast } from "@web/common/utils/toast/session-expired.toast";
 import { getToast } from "@web/common/utils/toast/toast.port";
 
@@ -38,7 +38,7 @@ export function showErrorToast(
     severity === ErrorToastSeverity.CRITICAL ? criticalErrorToastOptions : {};
 
   return toast.error(message, {
-    ...toastDefaultOptions,
+    ...getToastDefaultOptions(),
     ...severityOptions,
     ...options,
     ...(toastId ? { toastId } : {}),

--- a/packages/web/src/common/utils/toast/status-toast.util.ts
+++ b/packages/web/src/common/utils/toast/status-toast.util.ts
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { type Id } from "react-toastify";
-import { toastDefaultOptions } from "@web/common/constants/toast.constants";
+import { getToastDefaultOptions } from "@web/common/constants/toast.constants";
 import { getToast } from "@web/common/utils/toast/toast.port";
 
 /**
@@ -13,14 +13,15 @@ import { getToast } from "@web/common/utils/toast/toast.port";
  */
 export function showStatusToast(toastId: Id, message: ReactNode): void {
   const toast = getToast();
+  const options = getToastDefaultOptions();
   toast(message, {
-    ...toastDefaultOptions,
+    ...options,
     toastId,
     closeButton: false,
     hideProgressBar: true,
   });
   toast.update(toastId, {
     render: message,
-    autoClose: toastDefaultOptions.autoClose,
+    autoClose: options.autoClose,
   });
 }

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -15,6 +15,7 @@ import { DeleteAccountConfirmationProvider } from "@web/components/DeleteAccount
 import { FeedbackDialogHost } from "@web/components/Feedback/FeedbackDialogHost";
 import { IconProvider } from "@web/components/IconProvider/IconProvider";
 import { LogoutConfirmationProvider } from "@web/components/LogoutConfirmation/LogoutConfirmationProvider";
+import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
 import { useUndoRedoShortcuts } from "@web/views/Week/hooks/shortcuts/useUndoRedoShortcuts";
 
 /**
@@ -24,6 +25,27 @@ import { useUndoRedoShortcuts } from "@web/views/Week/hooks/shortcuts/useUndoRed
 export function GlobalShortcutsHost() {
   useUndoRedoShortcuts();
   return null;
+}
+
+function ThemeAwareToastContainer() {
+  const theme = useThemeStore(selectTheme);
+
+  return (
+    <ToastContainer
+      position="bottom-left"
+      autoClose={5000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+      theme={theme === "dark-abyss" ? "dark" : "light"}
+      limit={1}
+      transition={Slide}
+    />
+  );
 }
 
 interface CompassRequiredProvidersProps extends PropsWithChildren {
@@ -46,20 +68,7 @@ export const CompassRequiredProviders = ({
                 <DeleteAccountConfirmationProvider>
                   {children}
                 </DeleteAccountConfirmationProvider>
-                <ToastContainer
-                  position="bottom-left"
-                  autoClose={5000}
-                  hideProgressBar={false}
-                  newestOnTop={false}
-                  closeOnClick
-                  rtl={false}
-                  pauseOnFocusLoss
-                  draggable
-                  pauseOnHover
-                  theme="dark"
-                  limit={1}
-                  transition={Slide}
-                />
+                <ThemeAwareToastContainer />
               </LogoutConfirmationProvider>
             </IconProvider>
           </GoogleOAuthProvider>

--- a/packages/web/src/components/Shortcuts/ShortcutKeys.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutKeys.tsx
@@ -56,7 +56,7 @@ export function ShortcutKeys({ keys, title, className }: Props) {
     >
       {cleaned.map((key) => (
         <ShortcutHint key={key} variant="keycap">
-          <ShortCutLabel k={normalizeKeyToken(key)} size={13} />
+          <ShortCutLabel k={normalizeKeyToken(key)} />
         </ShortcutHint>
       ))}
     </span>

--- a/packages/web/src/components/Shortcuts/ShortcutLabel.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutLabel.tsx
@@ -32,14 +32,7 @@ export function ShortCutLabel({ k }: { k: string; size?: number }) {
     const IconComponent = keyIconMap[key];
 
     if (IconComponent) {
-      return (
-        <IconComponent
-          key={key}
-          data-testid={testId}
-          weight="regular"
-          aria-hidden
-        />
-      );
+      return <IconComponent key={key} data-testid={testId} weight="regular" />;
     }
 
     return (

--- a/packages/web/src/components/Shortcuts/ShortcutLabel.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutLabel.tsx
@@ -23,7 +23,7 @@ const keyIconMap: Record<string, Icon> = {
   ArrowLeft: ArrowLeftIcon,
   ArrowRight: ArrowRightIcon,
 };
-export function ShortCutLabel({ k, size = 14 }: { k: string; size?: number }) {
+export function ShortCutLabel({ k }: { k: string; size?: number }) {
   const display = expandModInShortcutDisplay(k);
 
   return display.split("+").map((_key) => {
@@ -32,11 +32,18 @@ export function ShortCutLabel({ k, size = 14 }: { k: string; size?: number }) {
     const IconComponent = keyIconMap[key];
 
     if (IconComponent) {
-      return <IconComponent key={key} size={size} data-testid={testId} />;
+      return (
+        <IconComponent
+          key={key}
+          data-testid={testId}
+          weight="regular"
+          aria-hidden
+        />
+      );
     }
 
     return (
-      <span key={key} data-testid={testId}>
+      <span key={key} data-testid={testId} className="leading-none">
         {key}
       </span>
     );

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -412,8 +412,15 @@
 }
 
 @utility c-keycap {
-  @apply inline-flex items-center rounded border border-border bg-surface-panel px-1.5 py-0.5 font-medium text-text-muted leading-none;
+  @apply inline-flex min-h-4.5 items-center justify-center rounded border border-border bg-surface-panel px-1.5 py-0.5 font-medium text-text-muted leading-none;
+
   font-size: var(--font-size-s);
+
+  & svg {
+    width: 1em;
+    height: 1em;
+    flex-shrink: 0;
+  }
 }
 
 @utility c-context-menu-item {


### PR DESCRIPTION
## Summary
- Make toast colors theme-aware so status toasts match Dark Abyss and Light Beach instead of always using hardcoded dark palette values
- Normalize keycap chip sizing so modifier icons and letter keys render at the same scale inside shortcut hints (e.g. the Deleted + Mod+Z undo toast)

## Test plan
- [x] `bun test:web -- packages/web/src/components/Shortcuts/ShortcutKeys.test.tsx packages/web/src/common/utils/toast/status-toast.util.test.ts packages/web/src/common/styles/theme-css.test.ts`
- [x] `bun type-check`
- [ ] Delete an event and confirm the undo keycap hint looks consistent in both themes
- [ ] Switch themes and confirm toast background and keycap colors stay aligned


Made with [Cursor](https://cursor.com)