### PR TITLE
fix(web): show calendar sync status in all command palettes

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -40,7 +40,6 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
 
   const onRepairGoogle = useCallback(() => {
     const startRepair = async () => {
-      settingsActions.closeCmdPalette();
       setRepairingSyncIndicatorOverride();
 
       try {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -23,7 +23,7 @@ describe("getGoogleSyncStatus", () => {
   ] as const)("returns syncing copy for %s", (state) => {
     expect(getGoogleSyncStatus(state)).toEqual({
       variant: "syncing",
-      text: "Syncing calendar…",
+      text: "Syncing your calendar…",
     });
   });
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -53,7 +53,7 @@ export const getGoogleSyncStatus = (state: GoogleUiState): SyncStatus => {
     case "IMPORTING":
     case "repairing":
     case "checking":
-      return { variant: "syncing", text: "Syncing calendar…" };
+      return { variant: "syncing", text: "Syncing your calendar…" };
     case "ATTENTION":
       return { variant: "warning", text: "Calendar is out of date" };
     case "RECONNECT_REQUIRED":

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -78,7 +78,9 @@ mock.module("@web/auth/compass/user/hooks/useUser", () => ({
   useUser: () => ({}),
 }));
 
-const { CommandPalette, filterSections } = await import("./CommandPalette");
+const { CommandPalette, LifeCommandPalette, filterSections } = await import(
+  "./CommandPalette"
+);
 
 const onGoToToday = mock();
 const onShowShortcuts = mock();
@@ -345,6 +347,28 @@ describe("CommandPalette", () => {
     renderPalette();
 
     expect(screen.getByRole("status")).toHaveClass("c-sync-text-wave");
+  });
+});
+
+describe("LifeCommandPalette", () => {
+  beforeEach(() => {
+    mockSyncStatus = null;
+  });
+
+  it("renders the sync status line above the input", () => {
+    mockSyncStatus = {
+      variant: "healthy",
+      text: "Calendar up-to-date",
+    };
+
+    renderWithStore(
+      <LifeCommandPalette placeholder="Try: 'day', 'week', or 'feedback'" />,
+      { settings: { isCmdPaletteOpen: true } },
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Calendar up-to-date",
+    );
   });
 });
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -3,7 +3,6 @@ import { PlusIcon } from "@phosphor-icons/react";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
-import { type SyncStatus } from "@web/calendars/sync-status.types";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { type EventMutationDependencies } from "@web/events/mutations/useEventMutations";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
@@ -40,32 +39,20 @@ afterAll(() => {
   isNavigateMocked = false;
 });
 
-// The other Settings-section hooks (auth/logout/subscribe) hang off session
-// state that other suites mock globally (bun's mock.module leaks across
-// files), so their items are order-dependent and we don't assert on them
-// here — each has its own dedicated test. We stub only useCalendarSyncCmdItems
-// (no other importer, no dedicated test) to give the Settings section one
-// deterministic item and to skip its real async /config fetch. We
-// deliberately do NOT stub useSubscribeCmdItems: even a restorable stub would
-// still evaluate (and permanently cache) the real module the first time,
-// binding its `UserApi` import ahead of useSubscribeCmdItems.test.ts's own
-// mock and breaking that file's assertions instead.
-let mockSyncStatus: SyncStatus = null;
-mock.module(
-  "@web/components/CommandPalette/hooks/useCalendarSyncCmdItems",
-  () => ({
-    useCalendarSyncCmdItems: () => ({
-      items: [
-        {
-          id: "connect-google-calendar",
-          label: "Connect Google Calendar",
-          icon: PlusIcon,
-        },
-      ],
-      syncStatus: mockSyncStatus,
-    }),
-  }),
-);
+// The other Settings-section hooks (auth/logout/subscribe/calendar-sync) hang
+// off session or Google state that other suites mock globally (bun's
+// mock.module leaks across files), so their items are order-dependent and we
+// don't assert on them here — each has its own dedicated test. We stub only
+// useConnectGoogle (not useCalendarSyncCmdItems) so the real calendar-sync
+// hook runs while skipping async /config fetch. We deliberately do NOT stub
+// useSubscribeCmdItems: even a restorable stub would still evaluate (and
+// permanently cache) the real module the first time, binding its `UserApi`
+// import ahead of useSubscribeCmdItems.test.ts's own mock and breaking that
+// file's assertions instead.
+const mockUseConnectGoogle = mock();
+mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
+  useConnectGoogle: mockUseConnectGoogle,
+}));
 
 // useExportDataCmdItems calls useUser(), which throws outside a
 // UserProvider — this render tree doesn't have one (see renderWithStore).
@@ -84,6 +71,40 @@ const { CommandPalette, LifeCommandPalette, filterSections } = await import(
 
 const onGoToToday = mock();
 const onShowShortcuts = mock();
+const mockOnConnectGoogle = mock();
+
+const setMockGoogleConnection = (
+  state:
+    | "NOT_CONNECTED"
+    | "ATTENTION"
+    | "repairing"
+    | "IMPORTING"
+    | "checking"
+    | "HEALTHY" = "NOT_CONNECTED",
+) => {
+  const commandActionByState = {
+    NOT_CONNECTED: {
+      label: "Connect Google Calendar",
+      icon: PlusIcon,
+      onSelect: mockOnConnectGoogle,
+    },
+    ATTENTION: {
+      label: "Sync Google Calendar",
+      icon: PlusIcon,
+      onSelect: mockOnConnectGoogle,
+    },
+    repairing: null,
+    IMPORTING: null,
+    checking: null,
+    HEALTHY: null,
+  } as const;
+
+  mockUseConnectGoogle.mockReturnValue({
+    isAvailable: true,
+    commandAction: commandActionByState[state],
+    state,
+  });
+};
 
 const renderPalette = (
   mutationDependencies?: EventMutationDependencies,
@@ -118,7 +139,8 @@ describe("CommandPalette", () => {
     mockNavigate.mockClear();
     onGoToToday.mockClear();
     onShowShortcuts.mockClear();
-    mockSyncStatus = null;
+    mockOnConnectGoogle.mockClear();
+    setMockGoogleConnection("NOT_CONNECTED");
   });
 
   it("renders all sections with items and focuses the input on mount", () => {
@@ -324,10 +346,7 @@ describe("CommandPalette", () => {
   });
 
   it("renders the sync status line above the input with the variant color", () => {
-    mockSyncStatus = {
-      variant: "warning",
-      text: "Calendar is out of date",
-    };
+    setMockGoogleConnection("ATTENTION");
     renderPalette();
 
     const status = screen.getByRole("status");
@@ -343,24 +362,33 @@ describe("CommandPalette", () => {
   });
 
   it("shows the shimmer class for a syncing status", () => {
-    mockSyncStatus = { variant: "syncing", text: "Syncing calendar…" };
+    setMockGoogleConnection("repairing");
     renderPalette();
 
     expect(screen.getByRole("status")).toHaveClass("c-sync-text-wave");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Syncing your calendar…",
+    );
+  });
+
+  it("keeps the palette open when syncing Google Calendar", () => {
+    setMockGoogleConnection("ATTENTION");
+    renderPalette();
+
+    fireEvent.click(screen.getByText("Sync Google Calendar"));
+
+    expect(mockOnConnectGoogle).toHaveBeenCalledTimes(1);
+    expect(isOpen()).toBe(true);
   });
 });
 
 describe("LifeCommandPalette", () => {
   beforeEach(() => {
-    mockSyncStatus = null;
+    mockOnConnectGoogle.mockClear();
+    setMockGoogleConnection("HEALTHY");
   });
 
   it("renders the sync status line above the input", () => {
-    mockSyncStatus = {
-      variant: "healthy",
-      text: "Calendar up-to-date",
-    };
-
     renderWithStore(
       <LifeCommandPalette placeholder="Try: 'day', 'week', or 'feedback'" />,
       { settings: { isCmdPaletteOpen: true } },

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -394,9 +394,7 @@ describe("LifeCommandPalette", () => {
       { settings: { isCmdPaletteOpen: true } },
     );
 
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Calendar up-to-date",
-    );
+    expect(screen.getByRole("status")).toHaveTextContent("Calendar up-to-date");
   });
 });
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -222,7 +222,7 @@ const CommandPaletteContent = ({
                           onClick() {
                             if (item.disabled) return;
                             item.onClick?.();
-                            close();
+                            if (!item.keepOpen) close();
                           },
                         })}
                         type="button"

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -56,10 +56,6 @@ interface CommandPaletteProps {
 interface CommandPaletteContentProps {
   placeholder: string;
   sections: CommandSection[];
-  syncStatus?: {
-    text: string;
-    variant: SyncStatusVariant;
-  } | null;
 }
 
 /**
@@ -86,8 +82,8 @@ export function filterSections(
 const CommandPaletteContent = ({
   placeholder,
   sections,
-  syncStatus,
 }: CommandPaletteContentProps) => {
+  const { syncStatus } = useCalendarSyncCmdItems();
   const open = useSettingsStore(selectIsCmdPaletteOpen);
 
   const [search, setSearch] = useState("");
@@ -259,7 +255,7 @@ export const CommandPalette = ({
 }: CommandPaletteProps) => {
   const open = useSettingsStore(selectIsCmdPaletteOpen);
   const navigate = useNavigate();
-  const { items: calendarCmdItems, syncStatus } = useCalendarSyncCmdItems();
+  const { items: calendarCmdItems } = useCalendarSyncCmdItems();
   const subscribeCmdItems = useSubscribeCmdItems(open);
   const exportDataCmdItems = useExportDataCmdItems();
   const demoEventsCmdItems = useDemoEventsCmdItems();
@@ -321,11 +317,7 @@ export const CommandPalette = ({
   ];
 
   return (
-    <CommandPaletteContent
-      placeholder={placeholder}
-      sections={sections}
-      syncStatus={syncStatus}
-    />
+    <CommandPaletteContent placeholder={placeholder} sections={sections} />
   );
 };
 

--- a/packages/web/src/components/CommandPalette/command-palette.types.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.types.ts
@@ -7,6 +7,8 @@ export interface CommandItem {
   iconClassName?: string;
   onClick?: () => void;
   disabled?: boolean;
+  /** When true, selecting the item does not close the palette. */
+  keepOpen?: boolean;
   /** A single key (`"?"`) or one key per combo entry (`["Shift", "W"]`), rendered as keycap chips. */
   shortcut?: string | string[];
 }

--- a/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
@@ -1,0 +1,112 @@
+import { CloudArrowUpIcon } from "@phosphor-icons/react";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockUseConnectGoogle = mock();
+
+mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
+  useConnectGoogle: mockUseConnectGoogle,
+}));
+
+async function importHook() {
+  const moduleUrl = new URL(
+    `./useCalendarSyncCmdItems.ts?test=${Math.random().toString(36).slice(2)}`,
+    import.meta.url,
+  );
+
+  return import(moduleUrl.href) as Promise<
+    typeof import("./useCalendarSyncCmdItems")
+  >;
+}
+
+describe("useCalendarSyncCmdItems", () => {
+  beforeEach(() => {
+    mockUseConnectGoogle.mockReset();
+  });
+
+  it("returns no items when Google is unavailable", async () => {
+    mockUseConnectGoogle.mockReturnValue({
+      isAvailable: false,
+      commandAction: null,
+      state: "NOT_CONNECTED",
+    });
+
+    const { useCalendarSyncCmdItems } = await importHook();
+    const { result } = renderHook(() => useCalendarSyncCmdItems());
+
+    expect(result.current).toEqual({ items: [], syncStatus: null });
+  });
+
+  it("returns a keepOpen sync action when calendar needs attention", async () => {
+    const onSelect = mock();
+    mockUseConnectGoogle.mockReturnValue({
+      isAvailable: true,
+      commandAction: {
+        label: "Sync Google Calendar",
+        icon: CloudArrowUpIcon,
+        onSelect,
+      },
+      state: "ATTENTION",
+    });
+
+    const { useCalendarSyncCmdItems } = await importHook();
+    const { result } = renderHook(() => useCalendarSyncCmdItems());
+
+    expect(result.current.items).toEqual([
+      {
+        id: "connect-google-calendar",
+        label: "Sync Google Calendar",
+        icon: CloudArrowUpIcon,
+        onClick: onSelect,
+        keepOpen: true,
+      },
+    ]);
+    expect(result.current.syncStatus).toEqual({
+      variant: "warning",
+      text: "Calendar is out of date",
+    });
+  });
+
+  it("does not keep the palette open for connect actions", async () => {
+    const onSelect = mock();
+    mockUseConnectGoogle.mockReturnValue({
+      isAvailable: true,
+      commandAction: {
+        label: "Connect Google Calendar",
+        icon: CloudArrowUpIcon,
+        onSelect,
+      },
+      state: "NOT_CONNECTED",
+    });
+
+    const { useCalendarSyncCmdItems } = await importHook();
+    const { result } = renderHook(() => useCalendarSyncCmdItems());
+
+    expect(result.current.items[0]?.keepOpen).toBeUndefined();
+  });
+
+  it.each(["repairing", "IMPORTING", "checking"] as const)(
+    "returns a disabled syncing row for %s",
+    async (state) => {
+      mockUseConnectGoogle.mockReturnValue({
+        isAvailable: true,
+        commandAction: null,
+        state,
+      });
+
+      const { useCalendarSyncCmdItems } = await importHook();
+      const { result } = renderHook(() => useCalendarSyncCmdItems());
+
+      expect(result.current.items).toEqual([
+        {
+          id: "connect-google-calendar",
+          label: "Syncing your calendar…",
+          icon: CloudArrowUpIcon,
+          iconClassName: "c-sync-icon-wave",
+          disabled: true,
+        },
+      ]);
+      expect(result.current.syncStatus?.variant).toBe("syncing");
+    },
+  );
+});

--- a/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.ts
@@ -1,7 +1,14 @@
+import { CloudArrowUpIcon } from "@phosphor-icons/react";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
 import { type SyncStatus } from "@web/calendars/sync-status.types";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+
+const SYNCING_CALENDAR_LABEL = "Syncing your calendar…";
+
+const isCalendarSyncing = (state: GoogleUiState) =>
+  state === "repairing" || state === "IMPORTING" || state === "checking";
 
 export const useCalendarSyncCmdItems = (): {
   items: CommandItem[];
@@ -13,6 +20,21 @@ export const useCalendarSyncCmdItems = (): {
     return { items: [], syncStatus: null };
   }
 
+  if (isCalendarSyncing(state)) {
+    return {
+      items: [
+        {
+          id: "connect-google-calendar",
+          label: SYNCING_CALENDAR_LABEL,
+          icon: CloudArrowUpIcon,
+          iconClassName: "c-sync-icon-wave",
+          disabled: true,
+        },
+      ],
+      syncStatus: getGoogleSyncStatus(state),
+    };
+  }
+
   return {
     items: commandAction
       ? [
@@ -21,6 +43,7 @@ export const useCalendarSyncCmdItems = (): {
             label: commandAction.label,
             icon: commandAction.icon,
             onClick: commandAction.onSelect,
+            ...(state === "ATTENTION" ? { keepOpen: true } : {}),
           },
         ]
       : [],

--- a/packages/web/src/events/hooks/useDemoEventsPresent.ts
+++ b/packages/web/src/events/hooks/useDemoEventsPresent.ts
@@ -17,7 +17,8 @@ export function useDemoEventsPresent(): boolean {
       return;
     }
 
-    const generation = (refreshGenerationRef.current += 1);
+    refreshGenerationRef.current += 1;
+    const generation = refreshGenerationRef.current;
     void hasDemoEvents().then((result) => {
       if (generation === refreshGenerationRef.current) {
         setPresent(result);


### PR DESCRIPTION
## Summary
- Move calendar sync status fetching into the shared `CommandPaletteContent` shell
- Life view and any future palette variants now get the top status banner automatically
- Add a focused `LifeCommandPalette` test for sync status rendering

## Test plan
- [x] `bun test:web packages/web/src/components/CommandPalette/CommandPalette.test.tsx`
- [ ] Open command palette on day/week view and confirm calendar status still appears
- [ ] Open command palette on life view and confirm calendar status appears


Made with [Cursor](https://cursor.com)