### PR TITLE
feat(backend): add authenticated sync service client

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1,0 +1,228 @@
+import { faker } from "@faker-js/faker";
+import { type BusyAvailabilityRequest } from "@core/types/sync/availability.contracts";
+import { verifyInternalRequest } from "@sync/auth/internal-auth";
+import { AVAILABILITY_BUSY_PATH } from "@sync/server/connection.routes";
+import {
+  SyncServiceClient,
+  type SyncServiceClientOptions,
+} from "./sync-service.client";
+
+const objectId = () => faker.database.mongodbObjectId();
+const SECRET = "shared-internal-secret";
+const NOW = 1_800_000_000_000;
+const BASE_URL = "http://sync.internal:3010";
+
+// Records the last request the client made, so a test can inspect the signed
+// headers, and returns a scripted response.
+interface Captured {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+const fakeFetch = (
+  responder: (captured: Captured) => Promise<{
+    status: number;
+    json: () => Promise<unknown>;
+  }>,
+) => {
+  const calls: Captured[] = [];
+  const fn: SyncServiceClientOptions["fetch"] = async (url, init) => {
+    const captured: Captured = {
+      url,
+      method: init.method,
+      headers: init.headers,
+      body: init.body,
+    };
+    calls.push(captured);
+    return responder(captured);
+  };
+  return { fn, calls };
+};
+
+const client = (fetchFn: SyncServiceClientOptions["fetch"]) =>
+  new SyncServiceClient({
+    baseUrl: BASE_URL,
+    secret: SECRET,
+    timeoutMs: 20,
+    fetch: fetchFn,
+    now: () => NOW,
+    newCorrelationId: () => "corr-1",
+  });
+
+const principal = () => ({ tenantId: objectId(), principalId: objectId() });
+
+const request = (calendarIds: string[]): BusyAvailabilityRequest => ({
+  calendarIds: calendarIds as BusyAvailabilityRequest["calendarIds"],
+  start: "2026-07-14T09:00:00.000Z" as BusyAvailabilityRequest["start"],
+  end: "2026-07-14T17:00:00.000Z" as BusyAvailabilityRequest["end"],
+  maxAgeMs: 900_000,
+  purpose: "booking_confirmation",
+});
+
+const okBody = () => ({
+  intervals: [
+    { start: "2026-07-14T09:00:00.000Z", end: "2026-07-14T10:00:00.000Z" },
+  ],
+  computedAt: "2026-07-14T12:00:00.000Z",
+  connections: [],
+  complete: true,
+  issues: [],
+  bookable: true,
+});
+
+describe("SyncServiceClient", () => {
+  it("signs a request the real Sync verifier accepts, and returns the parsed body", async () => {
+    const who = principal();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => okBody(),
+    }));
+
+    const result = await client(fn).queryBusyAvailability(
+      who,
+      request([objectId()]),
+    );
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.bookable).toBe(true);
+    expect(result.value.intervals).toHaveLength(1);
+
+    // The URL and method are correct.
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${AVAILABILITY_BUSY_PATH}`);
+    expect(sent?.method).toBe("POST");
+
+    // The signed headers verify against the real Sync internal-auth verifier,
+    // for the same principal — cross-service auth compatibility.
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("maps a 401 to an unauthorized error", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 401,
+      json: async () => ({ error: "unauthorized" }),
+    }));
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "unauthorized", status: 401, correlationId: "corr-1" },
+    });
+  });
+
+  it("maps a 400 to a badRequest error", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 400,
+      json: async () => ({ error: "invalid_query" }),
+    }));
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("badRequest");
+  });
+
+  it("maps a 503 to unavailable", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 503,
+      json: async () => ({ error: "not_ready" }),
+    }));
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("unavailable");
+  });
+
+  it("maps a connection failure to unavailable", async () => {
+    const fn: SyncServiceClientOptions["fetch"] = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("unavailable");
+  });
+
+  it("times out a request that outlives the deadline", async () => {
+    // A fetch that only settles when aborted — the client's deadline fires first.
+    const fn: SyncServiceClientOptions["fetch"] = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        });
+      });
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("timeout");
+  });
+
+  it("rejects a 200 body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ not: "a busy response" }),
+    }));
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
+  });
+
+  it("never exposes the shared secret in the signature header or the result", async () => {
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 401,
+      json: async () => ({ error: "unauthorized" }),
+    }));
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    const signature = calls[0]?.headers["x-sync-signature"] ?? "";
+    // The header carries an HMAC (64 hex chars), never the raw secret.
+    expect(signature).toMatch(/^[0-9a-f]{64}$/);
+    expect(signature).not.toContain(SECRET);
+    // Nothing the caller receives contains the secret.
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+  });
+});

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -1,0 +1,199 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { type z } from "zod/v4";
+import {
+  type BusyAvailabilityRequest,
+  type BusyAvailabilityResponse,
+  BusyAvailabilityResponseSchema,
+} from "@core/types/sync/availability.contracts";
+
+// The internal endpoints this client calls. Kept in sync with the Sync service's
+// route paths; a contract test asserts they match.
+const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+// The identity a request acts on behalf of. Signed into the request so the Sync
+// service derives ownership from the signature, never the body.
+export interface SyncPrincipal {
+  tenantId: string;
+  principalId: string;
+}
+
+export type SyncClientErrorKind =
+  // The Sync service rejected our signature or identity (401).
+  | "unauthorized"
+  // The Sync service rejected the request shape (400) — a client/contract bug.
+  | "badRequest"
+  // The service is unreachable or not ready (network failure or 503).
+  | "unavailable"
+  // The request exceeded the deadline.
+  | "timeout"
+  // A 2xx body that did not match the expected contract.
+  | "invalidResponse"
+  // Any other, unexpected status.
+  | "unexpectedStatus";
+
+// Carries no response body, secret, or identity — only what a caller needs to
+// react and correlate. Safe to log.
+export interface SyncClientError {
+  kind: SyncClientErrorKind;
+  status?: number;
+  correlationId: string;
+}
+
+export type SyncClientResult<T> =
+  | { ok: true; value: T; correlationId: string }
+  | { ok: false; error: SyncClientError };
+
+type FetchFn = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{ status: number; json: () => Promise<unknown> }>;
+
+export interface SyncServiceClientOptions {
+  // Base URL of the Sync service (no trailing slash), e.g. http://localhost:3010.
+  baseUrl: string;
+  // The shared internal-auth secret. Never logged or returned to callers.
+  secret: string;
+  // Per-request deadline; a slow/hung service fails as `timeout` not a hang.
+  timeoutMs?: number;
+  // Injectable seams for tests.
+  fetch?: FetchFn;
+  now?: () => number;
+  newCorrelationId?: () => string;
+}
+
+// Sign a request the way the Sync service verifies it: an HMAC-SHA256 over
+// `timestamp.tenantId.principalId` with the shared secret. Reimplemented here
+// (rather than importing the Sync package) so the backend does not build-depend
+// on the independently-deployable Sync service; a contract test proves the
+// signature this produces is accepted by the real verifier.
+function signRequest(
+  secret: string,
+  timestamp: number,
+  principal: SyncPrincipal,
+): string {
+  return createHmac("sha256", secret)
+    .update(`${timestamp}.${principal.tenantId}.${principal.principalId}`)
+    .digest("hex");
+}
+
+// A typed, authenticated client for the Compass Sync service's internal API. It
+// signs each request, bounds it with a timeout, and maps every outcome to a
+// typed result — the caller never sees a thrown network error, a raw status, or
+// an unvalidated body.
+export class SyncServiceClient {
+  readonly #baseUrl: string;
+  readonly #secret: string;
+  readonly #timeoutMs: number;
+  readonly #fetch: FetchFn;
+  readonly #now: () => number;
+  readonly #newCorrelationId: () => string;
+
+  constructor(options: SyncServiceClientOptions) {
+    this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.#secret = options.secret;
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#fetch = options.fetch ?? (globalThis.fetch as unknown as FetchFn);
+    this.#now = options.now ?? Date.now;
+    this.#newCorrelationId = options.newCorrelationId ?? randomUUID;
+  }
+
+  // Merged busy intervals plus freshness/bookability evidence for a set of
+  // blocking calendars.
+  queryBusyAvailability(
+    principal: SyncPrincipal,
+    request: BusyAvailabilityRequest,
+    correlationId?: string,
+  ): Promise<SyncClientResult<BusyAvailabilityResponse>> {
+    return this.#request({
+      method: "POST",
+      path: AVAILABILITY_BUSY_PATH,
+      principal,
+      body: request,
+      schema: BusyAvailabilityResponseSchema,
+      correlationId,
+    });
+  }
+
+  async #request<T>(input: {
+    method: "GET" | "POST";
+    path: string;
+    principal: SyncPrincipal;
+    body?: unknown;
+    schema: z.ZodType<T>;
+    correlationId?: string;
+  }): Promise<SyncClientResult<T>> {
+    const correlationId = input.correlationId ?? this.#newCorrelationId();
+    const timestamp = this.#now();
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "x-sync-tenant": input.principal.tenantId,
+      "x-sync-principal": input.principal.principalId,
+      "x-sync-timestamp": String(timestamp),
+      "x-sync-signature": signRequest(this.#secret, timestamp, input.principal),
+      "x-correlation-id": correlationId,
+    };
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
+    let response: { status: number; json: () => Promise<unknown> };
+    try {
+      response = await this.#fetch(`${this.#baseUrl}${input.path}`, {
+        method: input.method,
+        headers,
+        body: input.body === undefined ? undefined : JSON.stringify(input.body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      // An abort is our deadline firing; anything else is a connection failure.
+      const kind =
+        error instanceof Error && error.name === "AbortError"
+          ? "timeout"
+          : "unavailable";
+      return { ok: false, error: { kind, correlationId } };
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (response.status === 200) {
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        return errorResult("invalidResponse", correlationId, 200);
+      }
+      const parsed = input.schema.safeParse(body);
+      if (!parsed.success) {
+        return errorResult("invalidResponse", correlationId, 200);
+      }
+      return { ok: true, value: parsed.data, correlationId };
+    }
+
+    return errorResult(
+      statusToKind(response.status),
+      correlationId,
+      response.status,
+    );
+  }
+}
+
+function statusToKind(status: number): SyncClientErrorKind {
+  if (status === 401) return "unauthorized";
+  if (status === 400) return "badRequest";
+  if (status === 503) return "unavailable";
+  return "unexpectedStatus";
+}
+
+function errorResult<T>(
+  kind: SyncClientErrorKind,
+  correlationId: string,
+  status?: number,
+): SyncClientResult<T> {
+  return { ok: false, error: { kind, status, correlationId } };
+}

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -1,10 +1,10 @@
-import { createHmac, randomUUID } from "node:crypto";
 import { type z } from "zod/v4";
 import {
   type BusyAvailabilityRequest,
   type BusyAvailabilityResponse,
   BusyAvailabilityResponseSchema,
 } from "@core/types/sync/availability.contracts";
+import { createHmac, randomUUID } from "node:crypto";
 
 // The internal endpoints this client calls. Kept in sync with the Sync service's
 // route paths; a contract test asserts they match.


### PR DESCRIPTION
## What

The backend's typed, authenticated HTTP client for the Compass Sync service's internal API (S37) — the consumer of the sync surface built in Phase D.

`SyncServiceClient`:
- **Signs** each request the way Sync verifies it — HMAC-SHA256 over `timestamp.tenantId.principalId`, sent as `x-sync-*` headers.
- **Bounds** each request with a timeout (AbortController), so a hung service fails as `timeout`, not a hang.
- **Propagates** a correlation id per request.
- **Maps every outcome to a typed result** — `unauthorized` (401), `badRequest` (400), `unavailable` (503 or network failure), `timeout`, `invalidResponse` (2xx body off-contract), `unexpectedStatus`. Callers never see a thrown error, a raw status, or an unvalidated body.
- **Never** logs or returns the secret.

First method: `queryBusyAvailability`.

## Design choices

- **Reimplements the signing** rather than importing `@sync`, so the backend doesn't build-depend on the independently-deployable Sync service. A **contract test** imports the real `@sync` `verifyInternalRequest` (test-only) and asserts the client's signature is accepted for the right principal — no drift.
- **Config-injected** (baseUrl, secret, timeout, fetch, now, correlation id) so it's testable without global config. The global-config factory and route delegation are later slices.

## Tests

Contract (real verifier accepts the signature + right tenant/principal), 401, 400, 503, network failure, deterministic timeout, off-contract body, and no-secret-leak. 8/8 pass; type-check + biome clean.

Client library only — nothing calls it yet; route delegation (S38/S39) and config wiring follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches internal service auth (HMAC + principal headers) and availability contracts, but the change is a standalone library with no production callers yet.
> 
> **Overview**
> Adds **`SyncServiceClient`**, a new backend HTTP client for the Sync service internal API, starting with **`queryBusyAvailability`** (POST busy availability). Each call is **HMAC-signed** (`x-sync-*` headers over `timestamp.tenantId.principalId`), **deadline-bounded** via `AbortController`, and returns a **discriminated `SyncClientResult`** (success with Zod-validated body, or errors like `unauthorized`, `badRequest`, `unavailable`, `timeout`, `invalidResponse`) instead of throwing.
> 
> Signing is **reimplemented locally** (no runtime `@sync` dependency); tests use the real **`verifyInternalRequest`** and assert the busy path matches Sync’s **`AVAILABILITY_BUSY_PATH`**. **Nothing in production wires this client yet**—config and route delegation are follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98168193dda281431af9fb0f7e96d1d056c6a938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->