### PR TITLE
feat(web): handle week event querying more elegantly

### DIFF
--- a/docs/frontend/event-caching.md
+++ b/docs/frontend/event-caching.md
@@ -118,16 +118,27 @@ sides call the **same** predicate:
 
 ## Navigation: placeholder data + prefetch
 
-A small TanStack feature makes prev/next navigation feel instant:
+Two TanStack features make week navigation feel instant:
 
-- **The adjacent day/week is prefetched** as soon as the current one renders
-  (`usePrefetchAdjacentEvents`, wired into `useWeek`/`useDayEvents`). It calls
-  `queryClient.prefetchQuery` with the *same* options builder and date
-  formatting the real read hook uses, so the warmed entry lands under the
-  exact key a subsequent read looks up. `prefetchQuery` is a no-op for
-  entries that are already cached and fresh, so this adds no extra fetches on
-  repeat renders of the same range — only the next click resolves from cache
-  instead of paying a fetch.
+- **Stable fetch window.** `useWeek` always reads events for a 7-day window
+  from the anchor (`weekProps.query`), while the visible columns still clip
+  to `weekProps.component`. Resize-driven column changes no longer re-key the
+  query, so cached data survives layout changes.
+
+- **Overlap-based placeholder data.** `useWeekEventsQuery` supplies
+  `placeholderData` from `deriveOverlappingEventQueryData`, merging events
+  from any cached week entries whose stored range overlaps the requested
+  range. Shift+J/K can render overlapping events immediately while the
+  background fetch completes.
+
+- **Adjacent prefetch.** The previous and next paged windows are prefetched
+  as soon as the current one renders (`usePrefetchAdjacentEvents`, wired into
+  `useWeek`/`useDayEvents`). It calls `queryClient.prefetchQuery` with the
+  *same* options builder and date formatting the real read hook uses, so the
+  warmed entry lands under the exact key a subsequent read looks up.
+  `prefetchQuery` is a no-op for entries that are already cached and fresh,
+  so this adds no extra fetches on repeat renders of the same range — only
+  the next click resolves from cache instead of paying a fetch.
 
 ## What the cache is *not*
 

--- a/packages/web/src/events/queries/event.query.cache.test.ts
+++ b/packages/web/src/events/queries/event.query.cache.test.ts
@@ -3,6 +3,7 @@ import { CalendarIdSchema } from "@core/types/domain-primitives";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import {
+  deriveOverlappingEventQueryData,
   findEventInCache,
   getEventQueryEntries,
   insertEventIntoQueries,
@@ -11,6 +12,7 @@ import {
   removeEventsByCalendarFromQueries,
 } from "./event.query.cache";
 import { eventQueryKeys } from "./event.query.keys";
+import { normalizeEventList } from "./event.query.normalize";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
 const normalized = (
@@ -110,5 +112,38 @@ describe("event query cache", () => {
     expect(
       client.getQueryData<NormalizedEventQueryData>(keys.localWeek),
     ).toEqual(normalized(kept));
+  });
+
+  test("derives a subset from a cached superset range", () => {
+    const client = new QueryClient();
+    const event = createMockEvent({
+      schedule: {
+        kind: "timed",
+        start: "2026-07-03T09:00:00.000Z",
+        end: "2026-07-03T10:00:00.000Z",
+        timeZone: "UTC",
+      },
+    });
+    client.setQueryData(keys.localWeek, normalizeEventList([event]));
+
+    const result = deriveOverlappingEventQueryData(client, {
+      source: "local",
+      startDate: "2026-07-02T00:00:00.000Z",
+      endDate: "2026-07-04T23:59:59.999Z",
+    });
+
+    expect(result?.ids).toEqual([event.id]);
+  });
+
+  test("returns undefined when no cached range overlaps", () => {
+    const client = new QueryClient();
+
+    expect(
+      deriveOverlappingEventQueryData(client, {
+        source: "local",
+        startDate: "2026-07-01T00:00:00.000Z",
+        endDate: "2026-07-08T00:00:00.000Z",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/web/src/events/queries/event.query.cache.test.ts
+++ b/packages/web/src/events/queries/event.query.cache.test.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import {
@@ -117,12 +118,12 @@ describe("event query cache", () => {
   test("derives a subset from a cached superset range", () => {
     const client = new QueryClient();
     const event = createMockEvent({
-      schedule: {
+      schedule: EventScheduleSchema.parse({
         kind: "timed",
         start: "2026-07-03T09:00:00.000Z",
         end: "2026-07-03T10:00:00.000Z",
         timeZone: "UTC",
-      },
+      }),
     });
     client.setQueryData(keys.localWeek, normalizeEventList([event]));
 

--- a/packages/web/src/events/queries/event.query.cache.ts
+++ b/packages/web/src/events/queries/event.query.cache.ts
@@ -1,6 +1,7 @@
 import { type QueryClient, type QueryKey } from "@tanstack/react-query";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
+import { isDateRangeOverlapping } from "@core/util/date/date.util";
 import { type RecurringEditProjection } from "@web/events/recurrence/projectRecurringEdit";
 import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
 import { eventQueryKeys } from "./event.query.keys";
@@ -116,6 +117,53 @@ export function eventBelongsToEntry(
   if (entry.metadata.source !== source) return false;
 
   return eventMatchesRange(event, entry.metadata.start, entry.metadata.end);
+}
+
+/**
+ * Builds placeholder read data for a requested week range by merging events
+ * from any cached week entries whose stored range overlaps it. Returns
+ * `undefined` when nothing usable is cached so true first loads still show
+ * the loading state.
+ */
+export function deriveOverlappingEventQueryData(
+  queryClient: QueryClient,
+  args: {
+    source: EventRepositorySource;
+    startDate: string;
+    endDate: string;
+  },
+): NormalizedEventQueryData | undefined {
+  const { source, startDate, endDate } = args;
+  const entities: NormalizedEventQueryData["entities"] = {};
+  const ids: EventId[] = [];
+  const seenIds = new Set<string>();
+
+  for (const entry of getEventQueryEntries(queryClient, {
+    source,
+    scope: "week",
+  })) {
+    if (
+      !isDateRangeOverlapping(
+        entry.metadata.start,
+        entry.metadata.end,
+        startDate,
+        endDate,
+      )
+    ) {
+      continue;
+    }
+
+    for (const id of entry.data.ids) {
+      if (seenIds.has(id)) continue;
+      const event = entry.data.entities[id];
+      if (!event || !eventMatchesRange(event, startDate, endDate)) continue;
+      seenIds.add(id);
+      ids.push(id);
+      entities[id] = event;
+    }
+  }
+
+  return ids.length > 0 ? { ids, entities } : undefined;
 }
 
 // Shared by every writer below: find the matching cached query entries and

--- a/packages/web/src/events/queries/useWeekEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.test.ts
@@ -1,6 +1,10 @@
 import { waitFor } from "@testing-library/react";
 import { type EventId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { normalizeEventList } from "@web/events/queries/event.query.normalize";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const fetchWeekEvents = mock(async () => ({
@@ -88,5 +92,42 @@ describe("useWeekEventsQuery", () => {
     await waitFor(() => {
       expect(result.result.current.error?.message).toBe("boom");
     });
+  });
+
+  it("serves overlapping placeholder data from cache while fetching a shifted range", async () => {
+    const queryClient = createCompassQueryClient();
+    const start = dayjs.utc("2025-11-10T00:00:00Z");
+    const end = start.add(6, "day").endOf("day");
+    const event = createMockEvent({
+      schedule: {
+        kind: "timed",
+        start: "2025-11-11T09:00:00",
+        end: "2025-11-11T10:00:00",
+        timeZone: "UTC",
+      },
+    });
+    queryClient.setQueryData(
+      eventQueryKeys.week({
+        source: "local",
+        start: toUTCOffset(start),
+        end: toUTCOffset(end),
+      }),
+      normalizeEventList([event]),
+    );
+
+    const shiftedStart = start.add(1, "day");
+    const shiftedEnd = shiftedStart.add(6, "day").endOf("day");
+
+    const result = renderHook(
+      () =>
+        useWeekEventsQuery({
+          startOfView: shiftedStart,
+          endOfView: shiftedEnd,
+        }),
+      { queryClient },
+    );
+
+    expect(result.result.current.data?.ids).toEqual([event.id]);
+    expect(result.result.current.isPlaceholderData).toBe(true);
   });
 });

--- a/packages/web/src/events/queries/useWeekEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.test.ts
@@ -1,5 +1,6 @@
 import { waitFor } from "@testing-library/react";
 import { type EventId } from "@core/types/domain-primitives";
+import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
@@ -99,12 +100,12 @@ describe("useWeekEventsQuery", () => {
     const start = dayjs.utc("2025-11-10T00:00:00Z");
     const end = start.add(6, "day").endOf("day");
     const event = createMockEvent({
-      schedule: {
+      schedule: EventScheduleSchema.parse({
         kind: "timed",
-        start: "2025-11-11T09:00:00",
-        end: "2025-11-11T10:00:00",
+        start: "2025-11-11T09:00:00.000Z",
+        end: "2025-11-11T10:00:00.000Z",
         timeZone: "UTC",
-      },
+      }),
     });
     queryClient.setQueryData(
       eventQueryKeys.week({

--- a/packages/web/src/events/queries/useWeekEventsQuery.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.ts
@@ -1,8 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { handleError } from "@web/common/utils/event/event.util";
+import { deriveOverlappingEventQueryData } from "@web/events/queries/event.query.cache";
 import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { deriveCalendarEventViewModel } from "./event.view-model";
@@ -17,11 +18,20 @@ function useWeekEventsQueryInternal({
   startOfView,
   endOfView,
 }: WeekEventsQueryArgs) {
+  const queryClient = useQueryClient();
   const source = useEventRepositorySource();
   const startDate = toUTCOffset(startOfView);
   const endDate = toUTCOffset(endOfView);
 
-  return useQuery(weekEventsQueryOptions({ source, startDate, endDate }));
+  return useQuery({
+    ...weekEventsQueryOptions({ source, startDate, endDate }),
+    placeholderData: () =>
+      deriveOverlappingEventQueryData(queryClient, {
+        source,
+        startDate,
+        endDate,
+      }),
+  });
 }
 
 /**

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -97,6 +97,8 @@ export const WeekView = () => {
 
   const shortcutProps = {
     isCurrentWeek,
+    queryEndOfView: weekProps.query.endOfView,
+    queryStartOfView: weekProps.query.startOfView,
     startOfView: weekProps.component.startOfView,
     endOfView: weekProps.component.endOfView,
     weekDays: weekProps.component.weekDays,

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -26,8 +26,8 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   useGridMouseMove();
 
   const { allDayEvents, timedEvents } = useWeekEventViewModel({
-    startOfView: weekProps.component.startOfView,
-    endOfView: weekProps.component.endOfView,
+    startOfView: weekProps.query.startOfView,
+    endOfView: weekProps.query.endOfView,
   });
   const { state } = useDraftContext();
   const { draft } = state;

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -71,6 +71,10 @@ const createWeekProps = (): WeekProps =>
         dayjs("2026-05-24T00:00:00.000").add(index, "day"),
       ),
     },
+    query: {
+      endOfView: dayjs("2026-05-30T23:59:59.999"),
+      startOfView: dayjs("2026-05-24T00:00:00.000"),
+    },
   }) as WeekProps;
 
 const renderGridDraft = ({

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -25,14 +25,14 @@ import { isAllDayEventInVisibleDays } from "@web/views/Week/util/week-window.uti
 
 interface Props {
   measurements: Measurements_Grid;
-  startOfView: WeekProps["component"]["startOfView"];
-  endOfView: WeekProps["component"]["endOfView"];
+  queryEndOfView: WeekProps["query"]["endOfView"];
+  queryStartOfView: WeekProps["query"]["startOfView"];
   weekDays: WeekProps["component"]["weekDays"];
 }
 export const AllDayEvents = ({
   measurements,
-  startOfView,
-  endOfView,
+  queryEndOfView,
+  queryStartOfView,
   weekDays,
 }: Props) => {
   const draft = useDraftStore(selectDraft);
@@ -41,8 +41,8 @@ export const AllDayEvents = ({
     events: weekEvents,
     isPending: isLoadingWeekView,
   } = useWeekEventViewModel({
-    startOfView,
-    endOfView,
+    startOfView: queryStartOfView,
+    endOfView: queryEndOfView,
   });
 
   const draftId = useDraftStore(selectDraftId);

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayRow.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayRow.tsx
@@ -40,7 +40,7 @@ export const AllDayRow: FC<Props> = ({
   measurements,
   weekProps,
 }) => {
-  const { endOfView, startOfView } = weekProps.component;
+  const { endOfView, startOfView } = weekProps.query;
   const { rowCount: rowsCount } = useWeekEventViewModel({
     startOfView,
     endOfView,
@@ -156,16 +156,16 @@ const useAllDayEventsLayer = (
   useMemo(
     () => (
       <AllDayEvents
-        endOfView={weekProps.component.endOfView}
         measurements={measurements}
-        startOfView={weekProps.component.startOfView}
+        queryEndOfView={weekProps.query.endOfView}
+        queryStartOfView={weekProps.query.startOfView}
         weekDays={weekProps.component.weekDays}
       />
     ),
     [
       measurements,
-      weekProps.component.endOfView,
-      weekProps.component.startOfView,
       weekProps.component.weekDays,
+      weekProps.query.endOfView,
+      weekProps.query.startOfView,
     ],
   );

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -34,8 +34,8 @@ export const Grid: FC<Props> = ({
   // Subscribes to the same cache entry the event layers read, so this reports
   // their load without issuing a second fetch.
   const { isPending: isLoadingEvents } = useWeekEventsQueryStatus({
-    startOfView: weekProps.component.startOfView,
-    endOfView: weekProps.component.endOfView,
+    startOfView: weekProps.query.startOfView,
+    endOfView: weekProps.query.endOfView,
   });
 
   useDragEdgeNavigation(mainGridRef, weekProps);

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
@@ -171,6 +171,10 @@ const createWeekProps = () => ({
       startOfView.add(index, "day"),
     ),
   },
+  query: {
+    endOfView: startOfView.add(6, "day").endOf("day"),
+    startOfView,
+  },
   state: { goToDate: mock() },
   util: {
     decrementWeek: mock(),
@@ -587,9 +591,9 @@ describe("Week calendar accessibility", () => {
     render(
       <Provider>
         <AllDayEvents
-          endOfView={startOfView.endOf("week")}
           measurements={measurements}
-          startOfView={startOfView}
+          queryEndOfView={startOfView.add(6, "day").endOf("day")}
+          queryStartOfView={startOfView}
           weekDays={weekDaysInView}
         />
       </Provider>,
@@ -621,9 +625,9 @@ describe("Week calendar accessibility", () => {
     render(
       <Provider>
         <AllDayEvents
-          endOfView={startOfView.endOf("week")}
           measurements={measurements}
-          startOfView={startOfView}
+          queryEndOfView={startOfView.add(6, "day").endOf("day")}
+          queryStartOfView={startOfView}
           weekDays={weekDaysInView}
         />
       </Provider>,
@@ -774,9 +778,9 @@ describe("saved Week event ownership", () => {
     render(
       <Provider>
         <AllDayEvents
-          endOfView={startOfView.endOf("week")}
           measurements={measurements}
-          startOfView={startOfView}
+          queryEndOfView={startOfView.add(6, "day").endOf("day")}
+          queryStartOfView={startOfView}
           weekDays={weekDaysInView}
         />
       </Provider>,

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridBusyPeriods.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridBusyPeriods.test.tsx
@@ -46,6 +46,10 @@ const weekProps = {
       startOfView.add(index, "day"),
     ),
   },
+  query: {
+    endOfView: startOfView.add(6, "day").endOf("day"),
+    startOfView,
+  },
   state: { goToDate: mock() },
   util: {
     decrementWeek: mock(),

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -39,8 +39,8 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
     isPending: isLoadingWeekView,
     timedEvents,
   } = useWeekEventViewModel({
-    startOfView: weekProps.component.startOfView,
-    endOfView: weekProps.component.endOfView,
+    startOfView: weekProps.query.startOfView,
+    endOfView: weekProps.query.endOfView,
   });
   const draftId = useDraftStore(selectDraftId);
   const weekDays = weekProps.component.weekDays;

--- a/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
@@ -102,6 +102,10 @@ const createWeekProps = () => ({
       startOfView.add(index, "day"),
     ),
   },
+  query: {
+    endOfView: startOfView.add(6, "day").endOf("day"),
+    startOfView,
+  },
   state: { goToDate: mock() },
   util: {
     decrementWeek: mock(),
@@ -194,9 +198,9 @@ const renderAllDayEvents = () =>
         }
       >
         <AllDayEvents
-          endOfView={startOfView.endOf("week")}
           measurements={measurements}
-          startOfView={startOfView}
+          queryEndOfView={startOfView.add(6, "day").endOf("day")}
+          queryStartOfView={startOfView}
           weekDays={weekDaysInView}
         />
       </DraftContext.Provider>

--- a/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/keyboardEditForm.test.tsx
@@ -64,6 +64,10 @@ const weekProps = {
     week: startOfView.week(),
     weekDays,
   },
+  query: {
+    endOfView: startOfView.add(6, "day").endOf("day"),
+    startOfView,
+  },
   state: { goToDate: mock() },
   util: {
     decrementWeek: mock(),

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -195,6 +195,8 @@ const renderShortcuts = (options?: {
       useWeekShortcuts({
         endOfView: dayjs("2026-05-24T00:00:00.000"),
         isCurrentWeek: true,
+        queryEndOfView: dayjs("2026-05-24T23:59:59.999"),
+        queryStartOfView: dayjs("2026-05-18T00:00:00.000"),
         scrollUtil: { scrollToNow: mock() } as never,
         startOfView: dayjs("2026-05-18T00:00:00.000"),
         weekDays: Array.from({ length: 7 }, (_, index) =>

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -52,6 +52,8 @@ import {
 
 export interface ShortcutProps {
   isCurrentWeek: boolean;
+  queryEndOfView: Dayjs;
+  queryStartOfView: Dayjs;
   startOfView: Dayjs;
   endOfView: Dayjs;
   weekDays: Dayjs[];
@@ -67,6 +69,8 @@ const DRAFT_MOVEMENT_HOTKEY_OPTIONS = {
 
 export const useWeekShortcuts = ({
   isCurrentWeek,
+  queryEndOfView,
+  queryStartOfView,
   startOfView,
   endOfView,
   weekDays,
@@ -86,8 +90,8 @@ export const useWeekShortcuts = ({
 
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
   const { allDayEvents, entities, timedEvents } = useWeekEventViewModel({
-    startOfView,
-    endOfView,
+    startOfView: queryStartOfView,
+    endOfView: queryEndOfView,
   });
   const allDayEventsRef = useRef(allDayEvents);
   const timedEventsRef = useRef(timedEvents);

--- a/packages/web/src/views/Week/hooks/useWeek.test.tsx
+++ b/packages/web/src/views/Week/hooks/useWeek.test.tsx
@@ -223,4 +223,25 @@ describe("useWeek", () => {
       params: { dateString: "2026-05-23" },
     });
   });
+
+  it("keeps the query fetch window stable when visible day count changes", () => {
+    mockParams.dateString = "2026-05-20";
+    const today = dayjs("2026-05-20", DATE_FORMAT);
+    const { result, rerender } = renderHook(
+      ({ visibleDayCount }: { visibleDayCount: number }) =>
+        useWeek(today, visibleDayCount),
+      { initialProps: { visibleDayCount: 7 } },
+    );
+
+    const queryEndAtSeven = result.current.query.endOfView.format(DATE_FORMAT);
+
+    rerender({ visibleDayCount: 3 });
+
+    expect(result.current.query.endOfView.format(DATE_FORMAT)).toBe(
+      queryEndAtSeven,
+    );
+    expect(result.current.component.endOfView.format(DATE_FORMAT)).not.toBe(
+      queryEndAtSeven,
+    );
+  });
 });

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -49,6 +49,12 @@ export const useWeek = (
     () => start.add(visibleDayCount - 1, "day").endOf("day"),
     [start, visibleDayCount],
   );
+  // Fetch window is always WEEK_DAY_COUNT days from the anchor so resize-driven
+  // column changes reuse the same cache entry; display still clips to weekDays.
+  const queryEnd = useMemo(
+    () => start.add(WEEK_DAY_COUNT - 1, "day").endOf("day"),
+    [start],
+  );
 
   const week = useMemo(() => start.week(), [start]);
 
@@ -62,10 +68,9 @@ export const useWeek = (
     [start, visibleDayCount],
   );
 
-  // Changing the visible range re-keys the query; revisits use cached data.
-  useWeekEventsQuery({ startOfView: start, endOfView: end });
+  useWeekEventsQuery({ startOfView: start, endOfView: queryEnd });
 
-  // Warm the previous and next visible pages using the exact read-key format.
+  // Warm the previous and next paged windows (J/K) using 7-day read keys.
   const previousStart = useMemo(
     () => start.subtract(visibleDayCount, "day"),
     [start, visibleDayCount],
@@ -79,13 +84,13 @@ export const useWeek = (
     {
       startDate: toUTCOffset(previousStart),
       endDate: toUTCOffset(
-        previousStart.add(visibleDayCount - 1, "day").endOf("day"),
+        previousStart.add(WEEK_DAY_COUNT - 1, "day").endOf("day"),
       ),
     },
     {
       startDate: toUTCOffset(nextStart),
       endDate: toUTCOffset(
-        nextStart.add(visibleDayCount - 1, "day").endOf("day"),
+        nextStart.add(WEEK_DAY_COUNT - 1, "day").endOf("day"),
       ),
     },
   );
@@ -141,6 +146,10 @@ export const useWeek = (
       startOfView: start,
       week,
       weekDays,
+    },
+    query: {
+      endOfView: queryEnd,
+      startOfView: start,
     },
     state: { goToDate },
     util: {

--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -37,8 +37,8 @@ export const WeekInteractionCoordinator: FC<Props> = ({
   weekProps,
 }) => {
   const { allDayEvents, events, timedEvents } = useWeekEventViewModel({
-    startOfView: weekProps.component.startOfView,
-    endOfView: weekProps.component.endOfView,
+    startOfView: weekProps.query.startOfView,
+    endOfView: weekProps.query.endOfView,
   });
   const { actions, confirmation, setters, state } = useDraftContext();
   const mutations = useEventMutations();


### PR DESCRIPTION
## Summary
- Decouple week display range from fetch range: always query 7 days from the anchor so resize-driven column changes reuse the same TanStack Query cache entry.
- Add overlap-based `placeholderData` so Shift+J/K renders overlapping events instantly from cached week entries while the background fetch completes.
- Update week consumers, tests, and event-caching docs for the split `weekProps.query` / `weekProps.component` model.

## Test plan
- [x] `bun test` on affected web query/week files
- [x] Web app type-check (`packages/web/tsconfig.app.json`)
- [x] `bun lint`
- [ ] CI green


Made with [Cursor](https://cursor.com)