### PR TITLE
feat(backend): wire the sync service client from config

### DIFF
--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -1,6 +1,23 @@
-import { parseConfigFromEnv } from "@backend/common/constants/config.constants";
+import { type CompassConfig } from "@core/config/compass.config";
+import {
+  parseConfigFromEnv,
+  parseRawConfig,
+} from "@backend/common/constants/config.constants";
 import { isGoogleConfigured } from "@backend/common/constants/config.util";
 import { describe, expect, it } from "bun:test";
+
+// A minimal valid compass config file, mirroring the required fields
+// parseRawConfig reads. Tests spread a `sync` section onto it.
+const baseRawConfig: CompassConfig = {
+  web: { url: "http://localhost:9080" },
+  backend: {
+    apiUrl: "http://localhost:3000/api",
+    compassToken: "compass-token",
+  },
+  runtime: { nodeEnv: "development", timezone: "Etc/UTC" },
+  mongo: { uri: "mongodb://localhost:27017/compass" },
+  supertokens: { uri: "http://localhost:3567", key: "supertokens-key" },
+};
 
 const validEnv = {
   BASEURL: "http://localhost:3000/api",
@@ -188,5 +205,37 @@ describe("config.constants", () => {
 
     expect(env.SYNC_SERVICE_URL).toBeUndefined();
     expect(env.SYNC_INTERNAL_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it("does not enable Sync delegation for a standalone Sync deployment without a serviceUrl", () => {
+    // A config running the standalone Sync service always sets internalAuthToken
+    // (it is required in the sync section) but need not set serviceUrl. That must
+    // NOT trip the backend's both-or-neither check and refuse to start.
+    const env = parseRawConfig({
+      ...baseRawConfig,
+      sync: {
+        mongoUri: "mongodb://localhost:27017/compass_sync",
+        internalAuthToken: "sync-internal-secret",
+        callbackBaseUrl: "http://localhost:3010",
+      },
+    });
+
+    expect(env.SYNC_SERVICE_URL).toBeUndefined();
+    expect(env.SYNC_INTERNAL_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it("enables delegation when the config sets a Sync serviceUrl", () => {
+    const env = parseRawConfig({
+      ...baseRawConfig,
+      sync: {
+        mongoUri: "mongodb://localhost:27017/compass_sync",
+        internalAuthToken: "sync-internal-secret",
+        callbackBaseUrl: "http://localhost:3010",
+        serviceUrl: "http://localhost:3010",
+      },
+    });
+
+    expect(env.SYNC_SERVICE_URL).toBe("http://localhost:3010");
+    expect(env.SYNC_INTERNAL_AUTH_TOKEN).toBe("sync-internal-secret");
   });
 });

--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -178,4 +178,15 @@ describe("config.constants", () => {
       "Sync delegation requires both SYNC_SERVICE_URL and SYNC_INTERNAL_AUTH_TOKEN",
     );
   });
+
+  it("treats blank Sync env vars as unconfigured rather than failing", () => {
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      SYNC_SERVICE_URL: "",
+      SYNC_INTERNAL_AUTH_TOKEN: "",
+    });
+
+    expect(env.SYNC_SERVICE_URL).toBeUndefined();
+    expect(env.SYNC_INTERNAL_AUTH_TOKEN).toBeUndefined();
+  });
 });

--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -138,4 +138,44 @@ describe("config.constants", () => {
       "Google Calendar webhook notifications require TOKEN_GCAL_NOTIFICATION",
     );
   });
+
+  it("leaves Sync delegation unconfigured by default", () => {
+    const env = parseConfigFromEnv(validEnv);
+
+    expect(env.SYNC_SERVICE_URL).toBeUndefined();
+    expect(env.SYNC_INTERNAL_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it("parses a fully configured Sync delegation", () => {
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      SYNC_SERVICE_URL: "http://localhost:3010",
+      SYNC_INTERNAL_AUTH_TOKEN: "sync-internal-secret",
+    });
+
+    expect(env.SYNC_SERVICE_URL).toBe("http://localhost:3010");
+    expect(env.SYNC_INTERNAL_AUTH_TOKEN).toBe("sync-internal-secret");
+  });
+
+  it("rejects a Sync service URL without the internal auth token", () => {
+    expect(() =>
+      parseConfigFromEnv({
+        ...validEnv,
+        SYNC_SERVICE_URL: "http://localhost:3010",
+      }),
+    ).toThrow(
+      "Sync delegation requires both SYNC_SERVICE_URL and SYNC_INTERNAL_AUTH_TOKEN",
+    );
+  });
+
+  it("rejects a Sync auth token without the service URL", () => {
+    expect(() =>
+      parseConfigFromEnv({
+        ...validEnv,
+        SYNC_INTERNAL_AUTH_TOKEN: "sync-internal-secret",
+      }),
+    ).toThrow(
+      "Sync delegation requires both SYNC_SERVICE_URL and SYNC_INTERNAL_AUTH_TOKEN",
+    );
+  });
 });

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -160,8 +160,11 @@ export function parseConfigFromEnv(
     SUPERTOKENS_KEY: rawEnv["SUPERTOKENS_KEY"],
     TOKEN_GCAL_NOTIFICATION: rawEnv["TOKEN_GCAL_NOTIFICATION"],
     TOKEN_COMPASS_SYNC: rawEnv["TOKEN_COMPASS_SYNC"],
-    SYNC_SERVICE_URL: rawEnv["SYNC_SERVICE_URL"],
-    SYNC_INTERNAL_AUTH_TOKEN: rawEnv["SYNC_INTERNAL_AUTH_TOKEN"],
+    // nonEmpty so a var set to "" reads as unset (not-configured) rather than
+    // failing url()/nonempty(); mirrors the config-file path and keeps the
+    // both-or-neither check honest.
+    SYNC_SERVICE_URL: nonEmpty(rawEnv["SYNC_SERVICE_URL"]),
+    SYNC_INTERNAL_AUTH_TOKEN: nonEmpty(rawEnv["SYNC_INTERNAL_AUTH_TOKEN"]),
     POSTHOG_KEY: rawEnv["POSTHOG_KEY"],
     POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || DEFAULT_POSTHOG_HOST,
   });

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -105,7 +105,7 @@ const toStr = (
 const nonEmpty = (value: string | null | undefined): string | undefined =>
   value?.trim() ? value : undefined;
 
-function parseRawConfig(config: CompassConfig): Config {
+export function parseRawConfig(config: CompassConfig): Config {
   const nodeEnv = config.runtime.nodeEnv as NodeEnv;
 
   return ConfigSchema.parse({
@@ -129,8 +129,16 @@ function parseRawConfig(config: CompassConfig): Config {
     SUPERTOKENS_KEY: config.supertokens.key,
     TOKEN_GCAL_NOTIFICATION: nonEmpty(config.google?.notificationToken) ?? "",
     TOKEN_COMPASS_SYNC: config.backend.compassToken,
+    // `serviceUrl` is the sole delegation signal: a deployment running the
+    // standalone Sync service always sets `internalAuthToken`, but that alone
+    // must NOT enable backend delegation (it would trip the both-or-neither
+    // check and refuse to start). Only inherit the shared secret once a
+    // serviceUrl is present, so the backend targets the same secret Sync
+    // verifies with.
     SYNC_SERVICE_URL: nonEmpty(config.sync?.serviceUrl),
-    SYNC_INTERNAL_AUTH_TOKEN: nonEmpty(config.sync?.internalAuthToken),
+    SYNC_INTERNAL_AUTH_TOKEN: nonEmpty(config.sync?.serviceUrl)
+      ? nonEmpty(config.sync?.internalAuthToken)
+      : undefined,
     POSTHOG_KEY: nonEmpty(config.posthog?.key),
     POSTHOG_HOST: nonEmpty(config.posthog?.host) || DEFAULT_POSTHOG_HOST,
   });

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -35,6 +35,11 @@ const ConfigSchema = z
     SUPERTOKENS_KEY: z.string().nonempty(),
     TOKEN_GCAL_NOTIFICATION: z.string().default(""),
     TOKEN_COMPASS_SYNC: z.string().nonempty(),
+    // Base URL + shared secret for the Sync service's internal API. Both present
+    // (delegation configured) or both absent (legacy-only deployment); a partial
+    // configuration is a mistake.
+    SYNC_SERVICE_URL: z.string().url().optional(),
+    SYNC_INTERNAL_AUTH_TOKEN: z.string().nonempty().optional(),
     POSTHOG_KEY: z.string().nonempty().optional(),
     POSTHOG_HOST: z.string().url().optional(),
   })
@@ -73,6 +78,22 @@ const ConfigSchema = z
         path: ["TOKEN_GCAL_NOTIFICATION"],
       });
     }
+
+    // Sync delegation needs both the service URL and the shared secret; one
+    // without the other cannot make an authenticated call, so fail loudly.
+    if (
+      Boolean(env.SYNC_SERVICE_URL) !== Boolean(env.SYNC_INTERNAL_AUTH_TOKEN)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        fatal: true,
+        message:
+          "Sync delegation requires both SYNC_SERVICE_URL and SYNC_INTERNAL_AUTH_TOKEN, or neither",
+        path: env.SYNC_SERVICE_URL
+          ? ["SYNC_INTERNAL_AUTH_TOKEN"]
+          : ["SYNC_SERVICE_URL"],
+      });
+    }
   });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -108,6 +129,8 @@ function parseRawConfig(config: CompassConfig): Config {
     SUPERTOKENS_KEY: config.supertokens.key,
     TOKEN_GCAL_NOTIFICATION: nonEmpty(config.google?.notificationToken) ?? "",
     TOKEN_COMPASS_SYNC: config.backend.compassToken,
+    SYNC_SERVICE_URL: nonEmpty(config.sync?.serviceUrl),
+    SYNC_INTERNAL_AUTH_TOKEN: nonEmpty(config.sync?.internalAuthToken),
     POSTHOG_KEY: nonEmpty(config.posthog?.key),
     POSTHOG_HOST: nonEmpty(config.posthog?.host) || DEFAULT_POSTHOG_HOST,
   });
@@ -137,6 +160,8 @@ export function parseConfigFromEnv(
     SUPERTOKENS_KEY: rawEnv["SUPERTOKENS_KEY"],
     TOKEN_GCAL_NOTIFICATION: rawEnv["TOKEN_GCAL_NOTIFICATION"],
     TOKEN_COMPASS_SYNC: rawEnv["TOKEN_COMPASS_SYNC"],
+    SYNC_SERVICE_URL: rawEnv["SYNC_SERVICE_URL"],
+    SYNC_INTERNAL_AUTH_TOKEN: rawEnv["SYNC_INTERNAL_AUTH_TOKEN"],
     POSTHOG_KEY: rawEnv["POSTHOG_KEY"],
     POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || DEFAULT_POSTHOG_HOST,
   });

--- a/packages/backend/src/common/services/sync-service/sync-service.factory.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.factory.test.ts
@@ -1,0 +1,23 @@
+import { SyncServiceClient } from "./sync-service.client";
+import {
+  buildSyncServiceClient,
+  getSyncServiceClient,
+} from "./sync-service.factory";
+import { describe, expect, it } from "bun:test";
+
+describe("sync-service factory", () => {
+  it("builds a client from an explicit url and secret", () => {
+    const client = buildSyncServiceClient({
+      serviceUrl: "http://localhost:3010",
+      secret: "sync-internal-secret",
+    });
+
+    expect(client).toBeInstanceOf(SyncServiceClient);
+  });
+
+  it("returns null when Sync delegation is not configured", () => {
+    // The backend test env sets no SYNC_SERVICE_URL / SYNC_INTERNAL_AUTH_TOKEN,
+    // so a legacy-only deployment never routes to Sync.
+    expect(getSyncServiceClient()).toBeNull();
+  });
+});

--- a/packages/backend/src/common/services/sync-service/sync-service.factory.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.factory.ts
@@ -1,0 +1,33 @@
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { SyncServiceClient } from "./sync-service.client";
+
+// Build a client from an explicit URL + secret. Kept separate from the config
+// singleton so it is testable without the global CONFIG.
+export function buildSyncServiceClient(options: {
+  serviceUrl: string;
+  secret: string;
+  timeoutMs?: number;
+}): SyncServiceClient {
+  return new SyncServiceClient({
+    baseUrl: options.serviceUrl,
+    secret: options.secret,
+    timeoutMs: options.timeoutMs,
+  });
+}
+
+let cached: SyncServiceClient | null | undefined;
+
+// The process-wide client, built once from config. Returns null when Sync
+// delegation is not configured (SYNC_SERVICE_URL / SYNC_INTERNAL_AUTH_TOKEN
+// absent) — callers gate on it, so a legacy-only deployment simply never routes
+// to Sync. Config validation guarantees the two values are present together.
+export function getSyncServiceClient(): SyncServiceClient | null {
+  if (cached !== undefined) return cached;
+  const serviceUrl = CONFIG.SYNC_SERVICE_URL;
+  const secret = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
+  cached =
+    serviceUrl && secret
+      ? buildSyncServiceClient({ serviceUrl, secret })
+      : null;
+  return cached;
+}

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -72,6 +72,10 @@ const CompassConfigSchema = z
         port: z.union([z.string(), z.number()]).optional(),
         mongoUri: z.string(),
         internalAuthToken: z.string(),
+        // The base URL the backend uses to reach the Sync service (e.g.
+        // http://localhost:3010 in dev, an internal service URL in prod). Optional
+        // so a deployment that does not delegate to Sync omits it.
+        serviceUrl: z.string().optional(),
         callbackBaseUrl: z.string(),
         // Where the OAuth callback redirects the browser after connecting;
         // defaults to callbackBaseUrl when omitted.


### PR DESCRIPTION
## What

Makes the `SyncServiceClient` (merged in #2324) usable from real backend code — config + a factory, no route delegation yet (S38/S39).

- **compass config**: adds a backend-facing `sync.serviceUrl` (the URL the backend uses to reach Sync; optional).
- **backend config**: exposes `SYNC_SERVICE_URL` + `SYNC_INTERNAL_AUTH_TOKEN` (reusing the sync service's own `internalAuthToken` — same shared secret). Validated **both-present or both-absent** (one without the other can't authenticate). Blank env vars read as unconfigured, consistent across the config-file and env parse paths.
- **factory**: `buildSyncServiceClient` (explicit construction) and `getSyncServiceClient` — returns the config-built client, or `null` when Sync delegation isn't configured, so a legacy-only deployment simply never routes to Sync.

## Tests

- config: both-present (parsed), neither (undefined), only-url (throws), only-token (throws), blank-vars (unconfigured).
- factory: builds a client; returns null when unconfigured.
- Backend + core suites green; type-check + biome clean.

Prerequisite for connection/event route delegation (S38/S39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared-secret and service URL configuration with startup validation; behavior stays opt-in until routes use `getSyncServiceClient`, but misconfiguration now fails fast at boot.
> 
> **Overview**
> Wires the backend to optionally call the Sync service by adding **`SYNC_SERVICE_URL`** and **`SYNC_INTERNAL_AUTH_TOKEN`** to config (env and `compass.yaml`), with **both-or-neither** validation and blank env vars treated as unset.
> 
> **`sync.serviceUrl`** in the shared Compass config is the delegation switch: standalone Sync deployments that only set `internalAuthToken` no longer incorrectly enable backend delegation or fail startup. The internal auth token is only copied into backend config when `serviceUrl` is present.
> 
> Adds **`buildSyncServiceClient`** / **`getSyncServiceClient`** (cached singleton, **`null`** when delegation is off) and exports **`parseRawConfig`** for tests. No route delegation in this PR—callers will gate on the factory later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27759105084a88f743f18852ae44a15b3a61d35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->