### PR TITLE
feat(backend): add validated connection-routing switch

### DIFF
--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -56,6 +56,8 @@ supertokens:
 #   mongoUri: mongodb+srv://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@cluster/compass_sync?retryWrites=true&w=majority
 #   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
 #   callbackBaseUrl: http://localhost:3010 # public base URL for provider OAuth/webhook callbacks
+#   serviceUrl: http://localhost:3010 # base URL the API uses to reach this service; set only when delegating to sync
+#   connectionRouting: legacy # legacy (default) | sync; sync delegates provider-connection routes here and requires serviceUrl
 #   execution: passive # passive | active
 #   maxConcurrency: 4
 #   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)

--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -238,4 +238,80 @@ describe("config.constants", () => {
     expect(env.SYNC_SERVICE_URL).toBe("http://localhost:3010");
     expect(env.SYNC_INTERNAL_AUTH_TOKEN).toBe("sync-internal-secret");
   });
+
+  it("defaults connection routing to legacy", () => {
+    const env = parseConfigFromEnv(validEnv);
+
+    expect(env.SYNC_CONNECTION_ROUTING).toBe("legacy");
+  });
+
+  it("treats a blank connection-routing env var as the legacy default", () => {
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      SYNC_CONNECTION_ROUTING: "",
+    });
+
+    expect(env.SYNC_CONNECTION_ROUTING).toBe("legacy");
+  });
+
+  it("rejects an unknown connection-routing value", () => {
+    expect(() =>
+      parseConfigFromEnv({
+        ...validEnv,
+        SYNC_CONNECTION_ROUTING: "both",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects connection routing = sync without a Sync service URL", () => {
+    expect(() =>
+      parseConfigFromEnv({
+        ...validEnv,
+        SYNC_CONNECTION_ROUTING: "sync",
+      }),
+    ).toThrow("SYNC_CONNECTION_ROUTING=sync requires SYNC_SERVICE_URL");
+  });
+
+  it("accepts connection routing = sync when a Sync client is configured", () => {
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      SYNC_CONNECTION_ROUTING: "sync",
+      SYNC_SERVICE_URL: "http://localhost:3010",
+      SYNC_INTERNAL_AUTH_TOKEN: "sync-internal-secret",
+    });
+
+    expect(env.SYNC_CONNECTION_ROUTING).toBe("sync");
+  });
+
+  it("rejects config-file connection routing = sync without a serviceUrl", () => {
+    // The config-file path couples connectionRouting to serviceUrl the same way
+    // the flat env path does; assert the coupling here too, since a required
+    // sibling field (internalAuthToken) alone must not satisfy it.
+    expect(() =>
+      parseRawConfig({
+        ...baseRawConfig,
+        sync: {
+          mongoUri: "mongodb://localhost:27017/compass_sync",
+          internalAuthToken: "sync-internal-secret",
+          callbackBaseUrl: "http://localhost:3010",
+          connectionRouting: "sync",
+        },
+      }),
+    ).toThrow("SYNC_CONNECTION_ROUTING=sync requires SYNC_SERVICE_URL");
+  });
+
+  it("enables sync connection routing from the config file with a serviceUrl", () => {
+    const env = parseRawConfig({
+      ...baseRawConfig,
+      sync: {
+        mongoUri: "mongodb://localhost:27017/compass_sync",
+        internalAuthToken: "sync-internal-secret",
+        callbackBaseUrl: "http://localhost:3010",
+        serviceUrl: "http://localhost:3010",
+        connectionRouting: "sync",
+      },
+    });
+
+    expect(env.SYNC_CONNECTION_ROUTING).toBe("sync");
+  });
 });

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -40,6 +40,9 @@ const ConfigSchema = z
     // configuration is a mistake.
     SYNC_SERVICE_URL: z.string().url().optional(),
     SYNC_INTERNAL_AUTH_TOKEN: z.string().nonempty().optional(),
+    // Which implementation serves the browser-facing provider-connection routes.
+    // Global, not per-request: legacy (default) or delegate to the Sync service.
+    SYNC_CONNECTION_ROUTING: z.enum(["legacy", "sync"]).default("legacy"),
     POSTHOG_KEY: z.string().nonempty().optional(),
     POSTHOG_HOST: z.string().url().optional(),
   })
@@ -94,6 +97,19 @@ const ConfigSchema = z
           : ["SYNC_SERVICE_URL"],
       });
     }
+
+    // Delegating connection routes to Sync is meaningless without a Sync client
+    // to reach, so refuse to start rather than silently fall back to legacy and
+    // hide an operator's misconfigured switch.
+    if (env.SYNC_CONNECTION_ROUTING === "sync" && !env.SYNC_SERVICE_URL) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        fatal: true,
+        message:
+          "SYNC_CONNECTION_ROUTING=sync requires SYNC_SERVICE_URL (and SYNC_INTERNAL_AUTH_TOKEN) to be configured",
+        path: ["SYNC_SERVICE_URL"],
+      });
+    }
   });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -139,6 +155,7 @@ export function parseRawConfig(config: CompassConfig): Config {
     SYNC_INTERNAL_AUTH_TOKEN: nonEmpty(config.sync?.serviceUrl)
       ? nonEmpty(config.sync?.internalAuthToken)
       : undefined,
+    SYNC_CONNECTION_ROUTING: config.sync?.connectionRouting,
     POSTHOG_KEY: nonEmpty(config.posthog?.key),
     POSTHOG_HOST: nonEmpty(config.posthog?.host) || DEFAULT_POSTHOG_HOST,
   });
@@ -173,6 +190,7 @@ export function parseConfigFromEnv(
     // both-or-neither check honest.
     SYNC_SERVICE_URL: nonEmpty(rawEnv["SYNC_SERVICE_URL"]),
     SYNC_INTERNAL_AUTH_TOKEN: nonEmpty(rawEnv["SYNC_INTERNAL_AUTH_TOKEN"]),
+    SYNC_CONNECTION_ROUTING: nonEmpty(rawEnv["SYNC_CONNECTION_ROUTING"]),
     POSTHOG_KEY: rawEnv["POSTHOG_KEY"],
     POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || DEFAULT_POSTHOG_HOST,
   });

--- a/packages/backend/src/common/services/sync-service/connection-routing.test.ts
+++ b/packages/backend/src/common/services/sync-service/connection-routing.test.ts
@@ -1,0 +1,27 @@
+import { resolveConnectionDelegation } from "./connection-routing";
+import { describe, expect, it } from "bun:test";
+
+describe("resolveConnectionDelegation", () => {
+  it("delegates to sync only when sync is selected and a client is configured", () => {
+    expect(
+      resolveConnectionDelegation({ routing: "sync", hasSyncClient: true }),
+    ).toBe("sync");
+  });
+
+  it("stays legacy when legacy is selected", () => {
+    expect(
+      resolveConnectionDelegation({ routing: "legacy", hasSyncClient: true }),
+    ).toBe("legacy");
+    expect(
+      resolveConnectionDelegation({ routing: "legacy", hasSyncClient: false }),
+    ).toBe("legacy");
+  });
+
+  it("fails safe to legacy when sync is selected but no client is configured", () => {
+    // Config validation should prevent this pairing, but the resolver must never
+    // route to a missing client even if that guard is somehow bypassed.
+    expect(
+      resolveConnectionDelegation({ routing: "sync", hasSyncClient: false }),
+    ).toBe("legacy");
+  });
+});

--- a/packages/backend/src/common/services/sync-service/connection-routing.ts
+++ b/packages/backend/src/common/services/sync-service/connection-routing.ts
@@ -1,0 +1,30 @@
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { getSyncServiceClient } from "./sync-service.factory";
+
+export type ConnectionDelegation = "legacy" | "sync";
+
+/**
+ * The single decision point for whether the browser-facing provider-connection
+ * routes delegate to the Sync service or run the legacy in-backend flow.
+ *
+ * Global, not per-request: the ledger requires one implementation to own a
+ * connection end-to-end, so this resolves from deployment config, never from
+ * the request or the user. It fails safe to "legacy" unless an operator both
+ * selected "sync" AND a Sync client is actually configured — config validation
+ * already enforces that pairing, but the resolver refuses to route to a missing
+ * client regardless, so a misconfiguration degrades to legacy rather than 500s.
+ */
+export function resolveConnectionDelegation(input: {
+  routing: ConnectionDelegation;
+  hasSyncClient: boolean;
+}): ConnectionDelegation {
+  return input.routing === "sync" && input.hasSyncClient ? "sync" : "legacy";
+}
+
+/** Resolve delegation from the process config + client singleton. */
+export function getConnectionDelegation(): ConnectionDelegation {
+  return resolveConnectionDelegation({
+    routing: CONFIG.SYNC_CONNECTION_ROUTING,
+    hasSyncClient: getSyncServiceClient() !== null,
+  });
+}

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -76,6 +76,12 @@ const CompassConfigSchema = z
         // http://localhost:3010 in dev, an internal service URL in prod). Optional
         // so a deployment that does not delegate to Sync omits it.
         serviceUrl: z.string().optional(),
+        // Which implementation serves the browser-facing provider-connection
+        // routes. "legacy" (default) keeps today's in-backend flow; "sync"
+        // delegates to the standalone Sync service. A single global switch, so
+        // every connection is owned end-to-end by one implementation. "sync"
+        // requires serviceUrl (validated backend-side).
+        connectionRouting: z.enum(["legacy", "sync"]).optional(),
         callbackBaseUrl: z.string(),
         // Where the OAuth callback redirects the browser after connecting;
         // defaults to callbackBaseUrl when omitted.

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -51,6 +51,8 @@ supertokens:
 #   mongoUri: mongodb://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
 #   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
 #   callbackBaseUrl: https://cal.yourdomain.com # public base URL for provider OAuth/webhook callbacks
+#   serviceUrl: http://sync:3010 # base URL the API uses to reach this service; set only when delegating to sync
+#   connectionRouting: legacy # legacy (default) | sync; sync delegates provider-connection routes here and requires serviceUrl
 #   execution: passive # passive | active
 #   maxConcurrency: 4
 #   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)


### PR DESCRIPTION
## What

Adds a single **global switch** that selects which implementation serves the browser-facing provider-connection routes (connect / status / reconnect / disconnect): the legacy in-backend flow (default) or the standalone sync service.

The decision is a deployment config value, resolved once, **never per-request or per-user** so one implementation owns a connection end-to-end.

## Changes

- **compass config** — `sync.connectionRouting` (`"legacy" | "sync"`, optional)
- **backend `Config`** — `SYNC_CONNECTION_ROUTING` (defaults to `"legacy"`). Selecting `"sync"` without a configured `SYNC_SERVICE_URL` **fails startup** rather than silently degrading, validated on both the env and config-file parse paths.
- **`resolveConnectionDelegation()`** — the single decision seam. Fails safe to `legacy` unless `"sync"` is selected *and* a sync client is configured, so a misconfiguration degrades to legacy rather than routing to a missing client.

## Not in this PR

No route behavior changes yet — the seam has no consumer until the connection routes are wired to it in a follow-up. Legacy remains the only live path, so behavior is byte-identical for every existing deployment.

## Tests

- Resolver fail-safe truth table (`connection-routing.test.ts`)
- Config validation on **both** parse paths: default legacy, blank-as-default, unknown-value rejection, and `sync`-without-`serviceUrl` rejection on the flat env path *and* the coupled config-file path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only and a unused resolver; default legacy preserves current behavior, with fail-fast validation for misconfigured sync routing.
> 
> **Overview**
> Introduces a **deployment-wide switch** (`legacy` | `sync`) for which implementation will serve browser-facing provider-connection routes, defaulting to **legacy** so existing deployments behave the same.
> 
> Config is exposed as `SYNC_CONNECTION_ROUTING` / `sync.connectionRouting`, with startup validation that **`sync` requires `SYNC_SERVICE_URL`** (env and config-file paths). Example YAML documents `serviceUrl` and `connectionRouting`.
> 
> Adds **`resolveConnectionDelegation` / `getConnectionDelegation`** as the single decision seam; it only returns `sync` when routing is `sync` and a Sync client exists, otherwise **fails safe to legacy**. **No routes call this yet**—follow-up will wire connection handlers; runtime behavior stays on the legacy path today.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2075ec07d8c0fa422ae1ba7f4d7f3607ec6dbb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->