### PR TITLE
feat(backend): translate sync connection state to the Google status enum

### DIFF
--- a/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
@@ -3,8 +3,8 @@ import {
   type ConnectionStateReason,
   type ProviderConnection,
 } from "@core/types/sync/connection.contracts";
-import { describe, expect, it } from "bun:test";
 import { toGoogleConnectionState } from "./connection-state.translation";
+import { describe, expect, it } from "bun:test";
 
 // A ProviderConnection is a rich record, but the translation reads only state +
 // stateReason; the rest is filled with valid-enough placeholders. Built as the
@@ -45,9 +45,9 @@ describe("toGoogleConnectionState", () => {
   });
 
   it("maps delayed to ATTENTION", () => {
-    expect(toGoogleConnectionState([connection("delayed", "workOverdue")])).toBe(
-      "ATTENTION",
-    );
+    expect(
+      toGoogleConnectionState([connection("delayed", "workOverdue")]),
+    ).toBe("ATTENTION");
   });
 
   it("maps a disconnected connection to RECONNECT_REQUIRED, not NOT_CONNECTED", () => {

--- a/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
@@ -1,0 +1,118 @@
+import {
+  type ConnectionState,
+  type ConnectionStateReason,
+  type ProviderConnection,
+} from "@core/types/sync/connection.contracts";
+import { describe, expect, it } from "bun:test";
+import { toGoogleConnectionState } from "./connection-state.translation";
+
+// A ProviderConnection is a rich record, but the translation reads only state +
+// stateReason; the rest is filled with valid-enough placeholders. Built as the
+// plain type (not schema-parsed) so a test can pose any state/reason pair,
+// including combinations the schema's refinements would reject.
+const connection = (
+  state: ConnectionState,
+  stateReason: ConnectionStateReason | null = null,
+): ProviderConnection =>
+  ({
+    id: "c1",
+    tenantId: "t1",
+    principalId: "p1",
+    provider: "google",
+    account: { providerAccountId: "a1", email: null, displayName: null },
+    capabilities: [],
+    state,
+    stateReason,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+    createdAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T00:00:00.000Z",
+  }) as unknown as ProviderConnection;
+
+describe("toGoogleConnectionState", () => {
+  it("reports NOT_CONNECTED when there are no connections", () => {
+    expect(toGoogleConnectionState([])).toBe("NOT_CONNECTED");
+  });
+
+  it("maps healthy to HEALTHY", () => {
+    expect(toGoogleConnectionState([connection("healthy")])).toBe("HEALTHY");
+  });
+
+  it("maps every in-progress state to IMPORTING", () => {
+    for (const state of ["connecting", "importing", "catchingUp"] as const) {
+      expect(toGoogleConnectionState([connection(state)])).toBe("IMPORTING");
+    }
+  });
+
+  it("maps delayed to ATTENTION", () => {
+    expect(toGoogleConnectionState([connection("delayed", "workOverdue")])).toBe(
+      "ATTENTION",
+    );
+  });
+
+  it("maps a disconnected connection to RECONNECT_REQUIRED, not NOT_CONNECTED", () => {
+    expect(toGoogleConnectionState([connection("disconnected")])).toBe(
+      "RECONNECT_REQUIRED",
+    );
+  });
+
+  it("maps actionRequired with a re-auth reason to RECONNECT_REQUIRED", () => {
+    for (const reason of [
+      "authorizationRevoked",
+      "authorizationExpired",
+      "insufficientScopes",
+    ] as const) {
+      expect(
+        toGoogleConnectionState([connection("actionRequired", reason)]),
+      ).toBe("RECONNECT_REQUIRED");
+    }
+  });
+
+  it("maps actionRequired with a non-re-auth reason to ATTENTION", () => {
+    for (const reason of [
+      "permanentConflict",
+      "providerErrors",
+      "workOverdue",
+    ] as const) {
+      expect(
+        toGoogleConnectionState([connection("actionRequired", reason)]),
+      ).toBe("ATTENTION");
+    }
+  });
+
+  describe("precedence across multiple connections", () => {
+    it("surfaces RECONNECT_REQUIRED over a healthy sibling", () => {
+      expect(
+        toGoogleConnectionState([
+          connection("healthy"),
+          connection("actionRequired", "authorizationRevoked"),
+        ]),
+      ).toBe("RECONNECT_REQUIRED");
+    });
+
+    it("surfaces ATTENTION over IMPORTING and HEALTHY", () => {
+      expect(
+        toGoogleConnectionState([
+          connection("healthy"),
+          connection("importing"),
+          connection("delayed", "providerErrors"),
+        ]),
+      ).toBe("ATTENTION");
+    });
+
+    it("surfaces IMPORTING over a healthy sibling", () => {
+      expect(
+        toGoogleConnectionState([
+          connection("healthy"),
+          connection("importing"),
+        ]),
+      ).toBe("IMPORTING");
+    });
+
+    it("reports HEALTHY only when every connection is healthy", () => {
+      expect(
+        toGoogleConnectionState([connection("healthy"), connection("healthy")]),
+      ).toBe("HEALTHY");
+    });
+  });
+});

--- a/packages/backend/src/common/services/sync-service/connection-state.translation.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.ts
@@ -1,0 +1,85 @@
+import {
+  type ConnectionState,
+  type ConnectionStateReason,
+  type ProviderConnection,
+} from "@core/types/sync/connection.contracts";
+import { type GoogleConnectionState } from "@core/types/user.types";
+
+/**
+ * Translate the sync service's multi-connection health model into the single
+ * `GoogleConnectionState` enum the browser already reads from `/user/metadata`.
+ *
+ * The two implementations model connections differently — sync tracks many
+ * connections each with a rich `state`/`stateReason`, while the legacy product
+ * exposes one derived Google enum — so delegating status to sync means
+ * translating here rather than passing a shape through. Keeping this a pure
+ * function makes the mapping exhaustively testable in isolation, independent of
+ * any route wiring.
+ */
+
+// actionRequired reasons that mean the user must re-authorize (re-run the
+// connect flow), as opposed to waiting out a transient problem or contacting
+// support. These map to RECONNECT_REQUIRED; other actionRequired reasons are
+// surfaced as the softer ATTENTION.
+const REAUTH_REASONS: ReadonlySet<ConnectionStateReason> = new Set([
+  "authorizationRevoked",
+  "authorizationExpired",
+  "insufficientScopes",
+]);
+
+function translateConnection(
+  state: ConnectionState,
+  reason: ConnectionStateReason | null,
+): GoogleConnectionState {
+  switch (state) {
+    case "healthy":
+      return "HEALTHY";
+    // Every "work in progress" state the UI shows as an importing spinner. The
+    // legacy app likewise reports an active sync as IMPORTING, so catchingUp
+    // (incremental backlog) is IMPORTING rather than HEALTHY.
+    case "connecting":
+    case "importing":
+    case "catchingUp":
+      return "IMPORTING";
+    // A connection record exists but its credential is gone: the user must
+    // reconnect. That is more actionable than NOT_CONNECTED, which the browser
+    // treats as never-connected.
+    case "disconnected":
+      return "RECONNECT_REQUIRED";
+    case "actionRequired":
+      return reason && REAUTH_REASONS.has(reason)
+        ? "RECONNECT_REQUIRED"
+        : "ATTENTION";
+    case "delayed":
+      return "ATTENTION";
+  }
+}
+
+// When a principal has more than one Google connection, surface the most
+// actionable state so a single broken account is never hidden behind a healthy
+// one. A user has one Google account today; this keeps the contract honest if
+// that changes.
+const PRECEDENCE: readonly GoogleConnectionState[] = [
+  "RECONNECT_REQUIRED",
+  "ATTENTION",
+  "IMPORTING",
+  "HEALTHY",
+];
+
+export function toGoogleConnectionState(
+  connections: readonly ProviderConnection[],
+): GoogleConnectionState {
+  // Google is the only provider today and this enum is Google-specific, so
+  // every connection maps directly.
+  if (connections.length === 0) return "NOT_CONNECTED";
+
+  const states = connections.map((connection) =>
+    translateConnection(connection.state, connection.stateReason),
+  );
+  for (const candidate of PRECEDENCE) {
+    if (states.includes(candidate)) return candidate;
+  }
+  // Unreachable: translateConnection never returns NOT_CONNECTED, so a non-empty
+  // list always matches a precedence value. Defensive only.
+  return "NOT_CONNECTED";
+}

--- a/packages/backend/src/common/services/sync-service/connection-state.translation.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.ts
@@ -43,9 +43,18 @@ function translateConnection(
       return "IMPORTING";
     // A connection record exists but its credential is gone: the user must
     // reconnect. That is more actionable than NOT_CONNECTED, which the browser
-    // treats as never-connected.
+    // treats as never-connected. NOTE for when this feeds the browser: today
+    // `disconnected` only results from a deliberate self-serve disconnect, so a
+    // user who intentionally disconnects would see a persistent "needs
+    // reconnecting" status rather than a neutral connect prompt. Confirm that
+    // intent before the status route ships.
     case "disconnected":
       return "RECONNECT_REQUIRED";
+    // actionRequired always needs the user to act. Re-auth reasons map to
+    // RECONNECT_REQUIRED; other reasons (today only permanentConflict) fall to
+    // the softer ATTENTION. NOTE: ATTENTION's browser affordance is a resync,
+    // which won't resolve a permanent conflict — revisit the remediation when
+    // the status route is wired.
     case "actionRequired":
       return reason && REAUTH_REASONS.has(reason)
         ? "RECONNECT_REQUIRED"

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1,7 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type BusyAvailabilityRequest } from "@core/types/sync/availability.contracts";
 import { verifyInternalRequest } from "@sync/auth/internal-auth";
-import { AVAILABILITY_BUSY_PATH } from "@sync/server/connection.routes";
+import {
+  AVAILABILITY_BUSY_PATH,
+  CONNECTIONS_PATH,
+} from "@sync/server/connection.routes";
 import {
   SyncServiceClient,
   type SyncServiceClientOptions,
@@ -104,6 +107,46 @@ describe("SyncServiceClient", () => {
     if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
     expect(verdict.context.tenantId).toBe(who.tenantId);
     expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("lists connections with a signed GET the real Sync verifier accepts", async () => {
+    const who = principal();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ connections: [] }),
+    }));
+
+    const result = await client(fn).listConnections(who);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.connections).toEqual([]);
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${CONNECTIONS_PATH}`);
+    expect(sent?.method).toBe("GET");
+    expect(sent?.body).toBeUndefined();
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("rejects a connections body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ connections: [{ bogus: true }] }),
+    }));
+
+    const result = await client(fn).listConnections(principal());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
   });
 
   it("maps a 401 to an unauthorized error", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -4,11 +4,16 @@ import {
   type BusyAvailabilityResponse,
   BusyAvailabilityResponseSchema,
 } from "@core/types/sync/availability.contracts";
+import {
+  type ConnectionListResponse,
+  ConnectionListResponseSchema,
+} from "@core/types/sync/connection.contracts";
 import { createHmac, randomUUID } from "node:crypto";
 
 // The internal endpoints this client calls. Kept in sync with the Sync service's
 // route paths; a contract test asserts they match.
 const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
+const CONNECTIONS_PATH = "/internal/connections";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -102,6 +107,22 @@ export class SyncServiceClient {
     this.#fetch = options.fetch ?? (globalThis.fetch as unknown as FetchFn);
     this.#now = options.now ?? Date.now;
     this.#newCorrelationId = options.newCorrelationId ?? randomUUID;
+  }
+
+  // The caller's provider connections, scoped to the signed principal. A read;
+  // served in the Sync service's passive mode too, so it is safe to call before
+  // any provider work has run.
+  listConnections(
+    principal: SyncPrincipal,
+    correlationId?: string,
+  ): Promise<SyncClientResult<ConnectionListResponse>> {
+    return this.#request({
+      method: "GET",
+      path: CONNECTIONS_PATH,
+      principal,
+      schema: ConnectionListResponseSchema,
+      correlationId,
+    });
   }
 
   // Merged busy intervals plus freshness/bookability evidence for a set of


### PR DESCRIPTION
## What

The building blocks for serving provider-connection **status** from the sync service without changing what the browser sees.

Today the browser learns Google connection health as a single `GoogleConnectionState` enum via `GET /api/user/metadata`. The sync service instead models many connections, each with a rich `state`/`stateReason`. Delegating status therefore requires **translating** the sync model into the legacy enum, not passing a shape through.

## Changes

- **`SyncServiceClient.listConnections()`** — a signed `GET /internal/connections`, scoped to the signed principal, mapped through the same typed result/error handling as the busy query. A contract test asserts it hits the real sync route path and that its signature verifies against the real internal-auth verifier.
- **`toGoogleConnectionState()`** — a pure translation from the sync multi-connection health model to `GoogleConnectionState`. Exhaustive over every sync connection state; distinguishes re-auth reasons (`RECONNECT_REQUIRED`) from softer problems (`ATTENTION`); surfaces the most actionable state when a principal has more than one connection.

## Mapping

| sync state | → legacy |
|---|---|
| `healthy` | `HEALTHY` |
| `connecting` / `importing` / `catchingUp` | `IMPORTING` |
| `delayed` | `ATTENTION` |
| `actionRequired` + revoked/expired/insufficientScopes | `RECONNECT_REQUIRED` |
| `actionRequired` + other reason | `ATTENTION` |
| `disconnected` | `RECONNECT_REQUIRED` |
| (no connections) | `NOT_CONNECTED` |

Multi-connection precedence: `RECONNECT_REQUIRED` > `ATTENTION` > `IMPORTING` > `HEALTHY`.

## Not in this PR

No route is wired to these yet — they are consumed by the status-delegation slice next. Legacy remains the only live path.

## Tests

Exhaustive translation truth table (every state, every re-auth vs non-re-auth reason, precedence across multiple connections) + client contract test (path, GET, no body, signature verifies, invalid-body rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New client and pure translation only—no production routes switched yet. Future wiring must validate UX for `disconnected` → `RECONNECT_REQUIRED` and `ATTENTION` on non-resyncable conflicts.
> 
> **Overview**
> Adds **building blocks** so Google connection health can eventually come from the sync service while the browser still reads the legacy `GoogleConnectionState` from user metadata.
> 
> **`SyncServiceClient.listConnections()`** performs a signed `GET` to `/internal/connections` for the signed principal, with the same typed success/error handling and response validation as the existing busy-availability call. Tests assert the route path, GET with no body, internal-auth verification, and rejection of invalid response bodies.
> 
> **`toGoogleConnectionState()`** collapses sync’s per-connection `state` / `stateReason` into the single Google enum: in-progress states → `IMPORTING`, re-auth `actionRequired` reasons → `RECONNECT_REQUIRED`, other problems → `ATTENTION`, empty list → `NOT_CONNECTED`, and `disconnected` → `RECONNECT_REQUIRED` (not neutral not-connected). With multiple connections, the worst actionable state wins (`RECONNECT_REQUIRED` > `ATTENTION` > `IMPORTING` > `HEALTHY`).
> 
> Nothing is wired to HTTP yet; legacy metadata remains the live path. Exhaustive unit tests cover the mapping and multi-connection precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ff84627af492ac39204e11b8f5b852b231ebd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->