### PR TITLE
fix(self-host): make backend mongo dependency optional for Atlas/cloud

### DIFF
--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -27,6 +27,14 @@ services:
     depends_on:
       mongo:
         condition: service_healthy
+        # `mongo` is gated behind the `selfhosted` profile. Atlas/cloud
+        # environments run without a mongo container (the backend reads
+        # mongo.uri from compass.yaml), so with the profile off there is no
+        # mongo service to depend on. `required: false` keeps the health-gated
+        # wait where mongo is present (selfhosted) while treating its absence as
+        # satisfied instead of an "undefined service mongo" invalid-project
+        # error (same reasoning the sync service documents below).
+        required: false
     environment:
       COMPASS_CONFIG_FILE: /app/compass.yaml
       # Default to info so health-check requests stay out of the tail. Reveal

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -143,6 +143,27 @@ describe("self-host docker compose", () => {
     expect(compose).toContain("stop_grace_period: 30s");
     expect(compose).toContain("start_period: 90s");
   });
+
+  it("keeps the backend mongo dependency optional so cloud/Atlas deploys stay a valid project", () => {
+    const compose = readFileSync(join(import.meta.dir, "compose.yaml"), {
+      encoding: "utf8",
+    });
+
+    // mongo is gated behind the `selfhosted` profile, so a profile-less
+    // cloud/Atlas deploy has no mongo container. Without `required: false` the
+    // backend's dependency on the (absent) mongo service makes the compose
+    // project invalid ("depends on undefined service mongo"), which breaks the
+    // staging-cloud/production deploy.
+    // Match the top-level service definition ("\n  backend:\n", exactly two
+    // spaces of indent), not the x-local-bindings anchor ("  backend:
+    // &backend-port ...") nor the web service's nested "depends_on: backend:".
+    const backendBlock = compose
+      .slice(compose.indexOf("\n  backend:\n") + 1)
+      .split(/\n {2}\w/)[0];
+    expect(backendBlock).toContain("mongo:");
+    expect(backendBlock).toContain("condition: service_healthy");
+    expect(backendBlock).toContain("required: false");
+  });
 });
 
 describe("self-host installer", () => {

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -162,7 +162,7 @@ describe("self-host docker compose", () => {
       .split(/\n {2}\w/)[0];
     expect(backendBlock).toContain("mongo:");
     expect(backendBlock).toContain("condition: service_healthy");
-    expect(backendBlock).toContain("required: false");
+    expect(backendBlock).toMatch(/^\s+required: false\s*$/m);
   });
 });
 


### PR DESCRIPTION
## Problem

`Release on main` deploys were failing at **Deploy release to staging-cloud** (exit 1), while build, publish, and staging-selfhosted all passed:

```
service "backend" depends on undefined service "mongo": invalid compose project
Compass: Could not pull updated Compass images from Docker Hub.
```

In `self-host/compose.yaml`, `backend` depends unconditionally on `mongo` (`condition: service_healthy`), but `mongo` is gated behind `profiles: [selfhosted]`. staging-selfhosted sets `COMPOSE_PROFILES=selfhosted` so mongo exists and it works; **staging-cloud runs with empty `COMPOSE_PROFILES`** (mongo lives in Atlas, no local container), so the dependency points at an undefined service and the whole project is invalid.

This was exposed when the `COMPOSE_GIT_REF` deploy variable's branch (`ci/deploy-health-checks`) was merged and deleted: the deploy's compose fetch started 404ing and falling back to the release-tag compose, which has this latent bug for the cloud profile.

## Fix

Add `required: false` to the backend's mongo dependency. Where mongo is present (selfhosted profile) the backend still waits for it to be `service_healthy`; where the profile is off (cloud/Atlas) compose treats the absent dependency as satisfied instead of erroring. This mirrors the reasoning the `sync` service already documents for omitting its own mongo dependency.

## Verification

`docker compose config` (v2/spec, run locally):
- **empty profiles (cloud)** → resolves to `backend` + `web`, no error (previously: invalid project)
- **`COMPOSE_PROFILES=selfhosted`** → still includes `mongo` with backend waiting on it

Reverting the one-line change reproduces the exact `undefined service "mongo"` error. Adds a regression test to `self-host/docker-compose.test.ts` (29 pass).

## Follow-up (not in this PR, needs repo-settings access)

The `COMPOSE_GIT_REF` environment variable for the staging environments still points to the deleted `ci/deploy-health-checks` branch, so each deploy 404s and falls back. Worth repointing it to a live ref (or unsetting it to use the release tag) so the deploy stops relying on the fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single compose dependency flag plus a static compose-file test; selfhosted behavior is unchanged when mongo is present.
> 
> **Overview**
> Fixes **staging-cloud** and **production** deploy failures where `docker compose` rejected the project with `service "backend" depends on undefined service "mongo"`.
> 
> The **backend** still declares a health-gated `depends_on: mongo`, but adds **`required: false`** so profile-less cloud/Atlas stacks (no `selfhosted` profile, no local `mongo` service) validate and start. Self-hosted deploys with `COMPOSE_PROFILES=selfhosted` keep waiting for `mongo` to be healthy.
> 
> Adds a **regression test** in `docker-compose.test.ts` that asserts the backend service block includes `mongo`, `service_healthy`, and `required: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6510936f30f2c50c7a43dbd823fb7f11e937b937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->