### PR TITLE
feat(backend): serve Google connection status from sync when delegated

### DIFF
--- a/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
+++ b/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type SyncClientResult,
+  type SyncPrincipal,
+} from "./sync-service.client";
+import { resolveGoogleConnectionStateFromSync } from "./google-connection-status";
+import { type ConnectionListResponse } from "@core/types/sync/connection.contracts";
+
+const principal: SyncPrincipal = {
+  tenantId: "64b7f9c2e1a2b3c4d5e6f7a8",
+  principalId: "64b7f9c2e1a2b3c4d5e6f7a8",
+};
+
+// A minimal client stub whose listConnections returns a scripted result.
+const clientReturning = (
+  result: SyncClientResult<ConnectionListResponse>,
+) => ({
+  listConnections: async () => result,
+});
+
+const connection = (
+  state: string,
+  stateReason: string | null = null,
+): ConnectionListResponse["connections"][number] =>
+  ({
+    id: "c1",
+    tenantId: principal.tenantId,
+    principalId: principal.principalId,
+    provider: "google",
+    account: { providerAccountId: "a1", email: null, displayName: null },
+    capabilities: [],
+    state,
+    stateReason,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+    createdAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T00:00:00.000Z",
+  }) as unknown as ConnectionListResponse["connections"][number];
+
+describe("resolveGoogleConnectionStateFromSync", () => {
+  it("translates a healthy connection to HEALTHY", async () => {
+    const client = clientReturning({
+      ok: true,
+      value: { connections: [connection("healthy")] },
+      correlationId: "corr-1",
+    });
+
+    expect(await resolveGoogleConnectionStateFromSync(client, principal)).toBe(
+      "HEALTHY",
+    );
+  });
+
+  it("reports NOT_CONNECTED when the principal has no connections", async () => {
+    const client = clientReturning({
+      ok: true,
+      value: { connections: [] },
+      correlationId: "corr-1",
+    });
+
+    expect(await resolveGoogleConnectionStateFromSync(client, principal)).toBe(
+      "NOT_CONNECTED",
+    );
+  });
+
+  it("surfaces ATTENTION when the sync service is unavailable", async () => {
+    const client = clientReturning({
+      ok: false,
+      error: { kind: "unavailable", correlationId: "corr-1" },
+    });
+
+    expect(await resolveGoogleConnectionStateFromSync(client, principal)).toBe(
+      "ATTENTION",
+    );
+  });
+
+  it("surfaces ATTENTION on any client error kind (timeout, unauthorized, ...)", async () => {
+    for (const kind of [
+      "timeout",
+      "unauthorized",
+      "badRequest",
+      "invalidResponse",
+      "unexpectedStatus",
+    ] as const) {
+      const client = clientReturning({
+        ok: false,
+        error: { kind, correlationId: "corr-1" },
+      });
+
+      expect(await resolveGoogleConnectionStateFromSync(client, principal)).toBe(
+        "ATTENTION",
+      );
+    }
+  });
+});

--- a/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
+++ b/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { type ConnectionListResponse } from "@core/types/sync/connection.contracts";
+import { resolveGoogleConnectionStateFromSync } from "./google-connection-status";
 import {
   type SyncClientResult,
   type SyncPrincipal,
 } from "./sync-service.client";
-import { resolveGoogleConnectionStateFromSync } from "./google-connection-status";
-import { type ConnectionListResponse } from "@core/types/sync/connection.contracts";
+import { describe, expect, it } from "bun:test";
 
 const principal: SyncPrincipal = {
   tenantId: "64b7f9c2e1a2b3c4d5e6f7a8",
@@ -12,9 +12,7 @@ const principal: SyncPrincipal = {
 };
 
 // A minimal client stub whose listConnections returns a scripted result.
-const clientReturning = (
-  result: SyncClientResult<ConnectionListResponse>,
-) => ({
+const clientReturning = (result: SyncClientResult<ConnectionListResponse>) => ({
   listConnections: async () => result,
 });
 
@@ -86,9 +84,9 @@ describe("resolveGoogleConnectionStateFromSync", () => {
         error: { kind, correlationId: "corr-1" },
       });
 
-      expect(await resolveGoogleConnectionStateFromSync(client, principal)).toBe(
-        "ATTENTION",
-      );
+      expect(
+        await resolveGoogleConnectionStateFromSync(client, principal),
+      ).toBe("ATTENTION");
     }
   });
 });

--- a/packages/backend/src/common/services/sync-service/google-connection-status.ts
+++ b/packages/backend/src/common/services/sync-service/google-connection-status.ts
@@ -1,0 +1,35 @@
+import { Logger } from "@core/logger/winston.logger";
+import { type GoogleConnectionState } from "@core/types/user.types";
+import { toGoogleConnectionState } from "./connection-state.translation";
+import {
+  type SyncPrincipal,
+  type SyncServiceClient,
+} from "./sync-service.client";
+
+const logger = Logger("app:google-connection-status");
+
+/**
+ * Resolve the browser-facing Google connection state from the sync service.
+ *
+ * On any client failure we cannot confirm the real state, so we surface
+ * ATTENTION (a soft "needs a look") rather than a confidently-wrong value or a
+ * failed metadata request. Wart: a sync outage flips every delegated user to
+ * ATTENTION until it recovers. That is acceptable for the opt-in first cut of
+ * status delegation, and a deployment that routes connections to sync is
+ * expected to monitor sync availability.
+ */
+export async function resolveGoogleConnectionStateFromSync(
+  client: Pick<SyncServiceClient, "listConnections">,
+  principal: SyncPrincipal,
+): Promise<GoogleConnectionState> {
+  const result = await client.listConnections(principal);
+  if (result.ok) {
+    return toGoogleConnectionState(result.value.connections);
+  }
+
+  logger.warn(
+    `Sync connection status unavailable (${result.error.kind}); reporting ATTENTION ` +
+      `[correlationId=${result.error.correlationId}]`,
+  );
+  return "ATTENTION";
+}

--- a/packages/backend/src/common/services/sync-service/sync-principal.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-principal.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { toSyncPrincipal } from "./sync-principal";
+
+describe("toSyncPrincipal", () => {
+  it("maps a Compass user id to a personal tenant + principal (both the user id)", () => {
+    const userId = "64b7f9c2e1a2b3c4d5e6f7a8";
+
+    expect(toSyncPrincipal(userId)).toEqual({
+      tenantId: userId,
+      principalId: userId,
+    });
+  });
+});

--- a/packages/backend/src/common/services/sync-service/sync-principal.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-principal.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
 import { toSyncPrincipal } from "./sync-principal";
+import { describe, expect, it } from "bun:test";
 
 describe("toSyncPrincipal", () => {
   it("maps a Compass user id to a personal tenant + principal (both the user id)", () => {

--- a/packages/backend/src/common/services/sync-service/sync-principal.ts
+++ b/packages/backend/src/common/services/sync-service/sync-principal.ts
@@ -1,0 +1,17 @@
+import { type SyncPrincipal } from "./sync-service.client";
+
+/**
+ * The v1 identity bridge from a Compass user to a sync principal.
+ *
+ * Compass runs one personal tenant with a single principal per user, so both the
+ * tenant and the principal are the user's own id. `userId` is the Compass Mongo
+ * `_id` (ObjectId-shaped), which is exactly what the sync service's TenantId and
+ * PrincipalId schemas require.
+ *
+ * This is the single place the mapping lives. A future multi-principal-per-tenant
+ * model (distinct generated ids with a stored lookup) changes only this function
+ * and its callers keep working unchanged.
+ */
+export function toSyncPrincipal(userId: string): SyncPrincipal {
+  return { tenantId: userId, principalId: userId };
+}

--- a/packages/backend/src/user/services/user-metadata.service.ts
+++ b/packages/backend/src/user/services/user-metadata.service.ts
@@ -4,6 +4,10 @@ import {
   type UserMetadata,
 } from "@core/types/user.types";
 import { getUserMetadataStore } from "@backend/auth/ports/supertokens.registry";
+import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
+import { resolveGoogleConnectionStateFromSync } from "@backend/common/services/sync-service/google-connection-status";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import { isGoogleSyncActive } from "@backend/sync/services/google-sync/google-sync.activity";
 import { isGoogleCalendarSyncHealthy } from "@backend/sync/services/google-sync/google-sync.health";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
@@ -49,6 +53,22 @@ class UserMetadataService {
     userId: string,
     metadata?: UserMetadata,
   ): Promise<GoogleMetadataAssessment> => {
+    // When this deployment routes provider connections to the sync service, the
+    // connection state is owned there, not by the legacy google sub-doc, so
+    // derive it from sync. getConnectionDelegation() only returns "sync" once a
+    // client is configured (it fails safe to "legacy" otherwise), so a client is
+    // present here; the guard keeps this defensive.
+    if (getConnectionDelegation() === "sync") {
+      const client = getSyncServiceClient();
+      if (client) {
+        const connectionState = await resolveGoogleConnectionStateFromSync(
+          client,
+          toSyncPrincipal(userId),
+        );
+        return { connectionState };
+      }
+    }
+
     const storedMetadata =
       metadata ?? (await this.getStoredUserMetadata(userId));
     const user = await findCompassUserBy("_id", userId);

--- a/packages/web/src/__tests__/__mocks__/mock.setup.ts
+++ b/packages/web/src/__tests__/__mocks__/mock.setup.ts
@@ -1,5 +1,3 @@
-import { mock } from "bun:test";
-
 type RestorableMock = {
   mockRestore: () => void;
 };

--- a/packages/web/src/events/hooks/useDemoEventsPresent.ts
+++ b/packages/web/src/events/hooks/useDemoEventsPresent.ts
@@ -17,7 +17,8 @@ export function useDemoEventsPresent(): boolean {
       return;
     }
 
-    const generation = (refreshGenerationRef.current += 1);
+    refreshGenerationRef.current += 1;
+    const generation = refreshGenerationRef.current;
     void hasDemoEvents().then((result) => {
       if (generation === refreshGenerationRef.current) {
         setPresent(result);


### PR DESCRIPTION
## What

Wires the connection-state translation (from the previous slice) into the browser-facing status path. When a deployment sets `SYNC_CONNECTION_ROUTING=sync`, `assessGoogleMetadata` derives `google.connectionState` from the sync service instead of the legacy google sub-doc. **Legacy remains the default and is untouched**, so every current deployment behaves identically.

## Changes

- **`toSyncPrincipal(userId)`** — the v1 identity bridge. Compass runs one personal tenant with a single principal per user (per the sync domain model), so both are the user's own id. `userId` is the Compass Mongo `_id`, which is ObjectId-shaped exactly as the sync `TenantId`/`PrincipalId` schemas require. This is the single place the mapping lives; a future multi-principal model changes only this function.
- **`resolveGoogleConnectionStateFromSync(client, principal)`** — lists the caller's sync connections and translates them via `toGoogleConnectionState`. On any client failure it fails safe to `ATTENTION` (we cannot confirm the real state) rather than a confidently-wrong value or a failed request.
- **`assessGoogleMetadata`** — delegates to the above when `getConnectionDelegation() === "sync"`, else runs the existing legacy derivation.

## Design notes / warts (called out for review)

- **Identity convention (`tenantId = principalId = userId`)** is a v1 decision realizing "one personal tenant + one principal per user." It's deterministic (no stored lookup) and encapsulated in one function. Flagged for confirmation — a future multi-principal-per-tenant model would change it.
- **Fail-safe = ATTENTION.** A sync outage flips every *delegated* user to ATTENTION until it recovers. Acceptable for the opt-in first cut (the switch is off by default and a sync-routing deployment should monitor sync uptime).
- The two `skipAssessment` callers (internal sync-flow reads, not the browser status path) are intentionally left on the legacy read.

## Tests

- `toSyncPrincipal` mapping
- `resolveGoogleConnectionStateFromSync`: healthy→HEALTHY, empty→NOT_CONNECTED, and every client error kind→ATTENTION
- Existing `user-metadata.service.db.test.ts` (legacy path) still passes 15/15 — in tests delegation defaults to legacy, so the new branch is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how connection status is computed for opt-in deployments and depends on sync availability (outages surface ATTENTION for all delegated users); legacy path is untouched.
> 
> **Overview**
> When **`SYNC_CONNECTION_ROUTING=sync`**, browser-facing **`google.connectionState`** in user metadata is derived from the sync service instead of the legacy Mongo/google sub-doc. **Legacy routing stays the default**, so existing deployments are unchanged.
> 
> **`toSyncPrincipal`** maps a Compass user id to sync `tenantId`/`principalId` (both the user id for v1). **`resolveGoogleConnectionStateFromSync`** calls `listConnections`, translates via existing `toGoogleConnectionState`, and on any sync client failure returns **`ATTENTION`** so metadata does not fail or lie. **`assessGoogleMetadata`** takes the sync branch only when delegation is `"sync"` and a client exists.
> 
> Unit tests cover principal mapping and sync resolution (healthy, empty, all error kinds → ATTENTION).
> 
> Unrelated small web tweaks: drop an unused `bun:test` import in test mocks, and fix demo-events refresh generation counting in **`useDemoEventsPresent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f014c297436f48432760349c765d96461c090061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->