### PR TITLE
chore(web): sort Tailwind classes to clear lint warnings

### DIFF
--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -175,7 +175,7 @@ export const AuthModal: FC = () => {
           />
         )}
         {showSubmitError ? (
-          <p className="text-center text-sm text-error" role="alert">
+          <p className="text-center text-error text-sm" role="alert">
             {submitError}
           </p>
         ) : null}

--- a/packages/web/src/components/AuthModal/components/AuthInput.tsx
+++ b/packages/web/src/components/AuthModal/components/AuthInput.tsx
@@ -54,7 +54,7 @@ export const AuthInput = forwardRef<HTMLInputElement, AuthInputProps>(
           {...inputProps}
         />
         {showError && (
-          <span id={errorId} className="text-sm text-error" role="alert">
+          <span id={errorId} className="text-error text-sm" role="alert">
             {error}
           </span>
         )}

--- a/packages/web/src/components/AuthModal/forms/ForgotPasswordForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/ForgotPasswordForm.tsx
@@ -88,7 +88,7 @@ export const ForgotPasswordForm: FC<ForgotPasswordFormProps> = ({
         autoComplete="email"
       />
       {submitError ? (
-        <p className="text-center text-sm text-error" role="alert">
+        <p className="text-center text-error text-sm" role="alert">
           {submitError}
         </p>
       ) : null}

--- a/packages/web/src/components/AuthModal/forms/ResetPasswordForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/ResetPasswordForm.tsx
@@ -45,7 +45,7 @@ export const ResetPasswordForm: FC<ResetPasswordFormProps> = ({
       />
 
       {error ? (
-        <p className="text-center text-sm text-error" role="alert">
+        <p className="text-center text-error text-sm" role="alert">
           {error}
         </p>
       ) : null}

--- a/packages/web/src/components/Sidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
+++ b/packages/web/src/components/Sidebar/TasksRemovalNotice/TasksRemovalNotice.tsx
@@ -76,7 +76,7 @@ export function createTasksRemovalNotice({
         </div>
 
         <button
-          className="c-focus-ring self-start rounded-xs bg-accent px-2 py-1 font-medium text-s text-on-accent hover:brightness-110 disabled:opacity-60"
+          className="c-focus-ring self-start rounded-xs bg-accent px-2 py-1 font-medium text-on-accent text-s hover:brightness-110 disabled:opacity-60"
           disabled={exportStatus === "exporting"}
           onClick={handleExport}
           type="button"

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -125,7 +125,7 @@ const AllDayEventCardBase = (
         "absolute min-h-2.5 select-none overflow-hidden rounded-xs bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
         {
           "hover:cursor-pointer": !isPlaceholder,
-          "outline outline-1 outline-dashed outline-text-muted/50":
+          "outline outline-dashed outline-1 outline-text-muted/50":
             event.isDemo,
         },
       )}

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -242,7 +242,7 @@ const TimedEventCardBase = (
         "bg-(--event-bg) hover:bg-(--event-hover-bg)",
         "hover:cursor-pointer",
         event.isDemo &&
-          "outline outline-1 outline-dashed outline-text-muted/50",
+          "outline outline-dashed outline-1 outline-text-muted/50",
       )}
       style={eventStyle}
       onBlur={onBlur}


### PR DESCRIPTION
## What

Applies biome's `useSortedClasses` fix to the 7 web files that were emitting lint **warnings**, so the repo lint board is fully clean (`bun run lint` → 0 errors, 0 warnings).

## Why

`main`'s lint had accumulated these nursery `useSortedClasses` warnings. They don't fail CI, but a mixed warning/error board made a recent CI failure hard to triage (warnings and errors interleave in biome output). Zeroing them out keeps the signal clean.

## Safety

Every change is pure Tailwind class **reordering** (e.g. `text-sm text-error` → `text-error text-sm`). The reordered utilities set distinct CSS properties (width vs style, size vs color), so there is no cascade conflict and no rendered-output change. Verified:
- `bun run lint` → 0/0
- `type-check` passes
- No test asserts any of these class strings (grep)

7 files, 1 line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class-string reordering only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Clears remaining **Biome `useSortedClasses`** nursery warnings in the web package so `bun run lint` reports zero errors and zero warnings.
> 
> Each touched line only **reorders** utilities in `className` strings (for example `text-sm text-error` → `text-error text-sm`, or `outline outline-1 outline-dashed` → `outline outline-dashed outline-1`). Coverage spans auth modal error text, sidebar export button typography, and demo-event outline classes on grid event cards. No logic, markup, or distinct CSS properties change—only canonical class order for the linter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a621884fde79638d829bece7daa15445578c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->