### PR TITLE
refactor(web): share day/week interaction adapter helpers

### DIFF
--- a/packages/web/src/grid/interaction/adapter.helpers.ts
+++ b/packages/web/src/grid/interaction/adapter.helpers.ts
@@ -1,0 +1,100 @@
+import {
+  getSmartScrollFrame,
+  type SmartScrollCache,
+} from "@web/grid/interaction/math/smart-scroll";
+import {
+  type VisualPoint,
+  type VisualRect,
+} from "@web/grid/interaction/types/timed-drag.types";
+
+/** Shared smart-scroll tuning used by Day and Week layout caches. */
+export const SMART_SCROLL_BOTTOM_INSET_PX = 100;
+export const SMART_SCROLL_SPEED_PX = 10;
+
+export type SavedGridInteractionType =
+  | "allDayDrag"
+  | "allDayResize"
+  | "timedDrag"
+  | "timedResize";
+
+export const getSavedEventOwnershipReason = (
+  type: SavedGridInteractionType,
+) => {
+  switch (type) {
+    case "allDayDrag":
+      return "saved-all-day-drag";
+    case "allDayResize":
+      return "saved-all-day-resize";
+    case "timedResize":
+      return "saved-timed-resize";
+    case "timedDrag":
+      return "saved-timed-drag";
+  }
+};
+
+export const getSavedEventInteractionCursor = (
+  type: SavedGridInteractionType,
+) => {
+  switch (type) {
+    case "allDayResize":
+      return "col-resize";
+    case "timedResize":
+      return "row-resize";
+    case "allDayDrag":
+    case "timedDrag":
+      return "move";
+  }
+};
+
+export const readElementRect = (element: HTMLElement): VisualRect => {
+  const rect = element.getBoundingClientRect();
+
+  return {
+    height: rect.height,
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+  };
+};
+
+/**
+ * Applies one smart-scroll frame against a layout cache, mutating the scroll
+ * container when needed. Returns the updated scrollTop so the caller can keep
+ * its closed-over session state in sync.
+ */
+export const applySmartScroll = ({
+  layout,
+  pointer,
+  scrollTop,
+}: {
+  layout: { smartScroll?: SmartScrollCache | null } | null;
+  pointer: Pick<VisualPoint, "y">;
+  scrollTop: number | null;
+}): {
+  isScrolling: boolean;
+  scrollDeltaPx: number;
+  scrollTop: number | null;
+} => {
+  if (!layout?.smartScroll || scrollTop === null) {
+    return { isScrolling: false, scrollDeltaPx: 0, scrollTop };
+  }
+
+  let nextScrollTop = layout.smartScroll.element.scrollTop;
+
+  const frame = getSmartScrollFrame({
+    cache: layout.smartScroll,
+    pointerY: pointer.y,
+    scrollTop: nextScrollTop,
+  });
+
+  if (frame.scrollTop !== nextScrollTop) {
+    layout.smartScroll.element.scrollTop = frame.scrollTop;
+    nextScrollTop = frame.scrollTop;
+  }
+
+  return {
+    isScrolling: frame.velocityPx !== 0,
+    scrollDeltaPx: nextScrollTop - layout.smartScroll.initialScrollTop,
+    scrollTop: nextScrollTop,
+  };
+};

--- a/packages/web/src/grid/interaction/commit/timed-moved.ts
+++ b/packages/web/src/grid/interaction/commit/timed-moved.ts
@@ -1,0 +1,11 @@
+import { type TimedDragVisual } from "@web/grid/interaction/types/timed-drag.types";
+import { type TimedResizeVisual } from "@web/grid/interaction/types/timed-resize.types";
+
+export const hasTimedDragVisualMoved = (visual: TimedDragVisual) =>
+  visual.dayDate !== visual.initialDayDate ||
+  visual.startMinutes !== visual.initialStartMinutes ||
+  visual.endMinutes !== visual.initialEndMinutes;
+
+export const hasTimedResizeVisualMoved = (visual: TimedResizeVisual) =>
+  visual.startMinutes !== visual.initialStartMinutes ||
+  visual.endMinutes !== visual.initialEndMinutes;

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -640,11 +640,18 @@ describe("DayCalendarGrid", () => {
   it("opens the form for a new all-day draft", async () => {
     const { user } = renderDayCalendarGrid();
 
-    await user.pointer({
-      coords: { clientX: 100, clientY: 1 },
-      keys: "[MouseLeft>]",
-      target: getAllDayRegion(),
-    });
+    await user.pointer([
+      {
+        coords: { clientX: 100, clientY: 1 },
+        keys: "[MouseLeft>]",
+        target: getAllDayRegion(),
+      },
+      {
+        coords: { clientX: 100, clientY: 1 },
+        keys: "[/MouseLeft]",
+        target: getAllDayRegion(),
+      },
+    ]);
 
     await waitFor(() => {
       expect(
@@ -657,8 +664,6 @@ describe("DayCalendarGrid", () => {
         screen.getByRole("textbox", { name: "Event Title" }),
       ).toHaveFocus();
     });
-
-    await user.pointer({ keys: "[/MouseLeft]" });
   });
 
   it("creates an all-day draft in the clicked calendar column", async () => {

--- a/packages/web/src/views/Day/interaction/adapter/commit/all-day.commit.ts
+++ b/packages/web/src/views/Day/interaction/adapter/commit/all-day.commit.ts
@@ -1,0 +1,67 @@
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { type AllDayDragVisual } from "@web/grid/interaction/types/all-day-drag.types";
+import { type AllDayResizeVisual } from "@web/grid/interaction/types/all-day-resize.types";
+import {
+  type DayAllDayDragCommitResult,
+  type DayAllDayDragTarget,
+  type DayAllDayResizeCommitResult,
+  type DayAllDayResizeTarget,
+} from "../day-interaction.adapter.types";
+import { columnMoveCalendarId } from "./timed.commit";
+
+export const commitAllDayDragInteraction = (
+  target: DayAllDayDragTarget,
+  visual: AllDayDragVisual,
+): DayAllDayDragCommitResult => {
+  const hasMoved =
+    "dayDate" in visual ? visual.dayDate !== visual.initialDayDate : false;
+
+  // In the Day view every column shares the visible date, so an all-day drag
+  // that "moved" can only have changed COLUMN, i.e. calendar. Keep the
+  // event's own dates: rewriting them to the visible date would truncate a
+  // multi-day all-day event to a single day.
+  return {
+    event: hasMoved
+      ? {
+          ...target.event,
+          calendarId: columnMoveCalendarId(visual, target.event),
+        }
+      : target.event,
+    eventId: target.event._id!,
+    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
+    hasMoved,
+    type: "allDayDragEnd",
+  };
+};
+
+export const commitAllDayResizeInteraction = (
+  target: DayAllDayResizeTarget,
+  visual: AllDayResizeVisual,
+  visibleDate: Dayjs,
+): DayAllDayResizeCommitResult => {
+  const hasMoved =
+    visual.startDayIndex !== visual.initialStartDayIndex ||
+    visual.endDayIndex !== visual.initialEndDayIndex;
+
+  return {
+    event: hasMoved
+      ? allDayVisualToDayGridEvent(target.event, visibleDate)
+      : target.event,
+    eventId: target.event._id!,
+    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
+    hasMoved,
+    type: "allDayResizeEnd",
+  };
+};
+
+const allDayVisualToDayGridEvent = (
+  event: GridEvent,
+  visibleDate: Dayjs,
+): GridEvent => ({
+  ...event,
+  isAllDay: true,
+  endDate: visibleDate.add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
+  startDate: visibleDate.format(YEAR_MONTH_DAY_FORMAT),
+});

--- a/packages/web/src/views/Day/interaction/adapter/commit/timed.commit.ts
+++ b/packages/web/src/views/Day/interaction/adapter/commit/timed.commit.ts
@@ -1,0 +1,100 @@
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import {
+  hasTimedDragVisualMoved,
+  hasTimedResizeVisualMoved,
+} from "@web/grid/interaction/commit/timed-moved";
+import { type TimedDragVisual } from "@web/grid/interaction/types/timed-drag.types";
+import { type TimedResizeVisual } from "@web/grid/interaction/types/timed-resize.types";
+import {
+  type DayTimedDragCommitResult,
+  type DayTimedDragTarget,
+  type DayTimedResizeCommitResult,
+  type DayTimedResizeTarget,
+} from "../day-interaction.adapter.types";
+
+export const commitTimedDragInteraction = (
+  target: DayTimedDragTarget,
+  visual: TimedDragVisual,
+  visibleDate: Dayjs,
+): DayTimedDragCommitResult => {
+  const hasMoved = hasTimedDragVisualMoved(visual);
+
+  return {
+    event: hasMoved
+      ? timedDragVisualToDayGridEvent(target.event, visual, visibleDate)
+      : target.event,
+    eventId: target.event._id!,
+    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
+    hasMoved,
+    type: "timedDragEnd",
+  };
+};
+
+export const commitTimedResizeInteraction = (
+  target: DayTimedResizeTarget,
+  visual: TimedResizeVisual,
+  visibleDate: Dayjs,
+): DayTimedResizeCommitResult => {
+  const hasMoved = hasTimedResizeVisualMoved(visual);
+
+  return {
+    event: hasMoved
+      ? timedResizeVisualToDayGridEvent(target.event, visual, visibleDate)
+      : target.event,
+    eventId: target.event._id!,
+    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
+    hasMoved,
+    type: "timedResizeEnd",
+  };
+};
+
+export const timedDragVisualToDayGridEvent = (
+  event: GridEvent,
+  visual: TimedDragVisual,
+  visibleDate: Dayjs,
+): GridEvent => ({
+  ...event,
+  calendarId: columnMoveCalendarId(visual, event),
+  isAllDay: false,
+  endDate: visibleDate
+    .startOf("day")
+    .add(visual.endMinutes, "minutes")
+    .format(),
+  startDate: visibleDate
+    .startOf("day")
+    .add(visual.startMinutes, "minutes")
+    .format(),
+});
+
+/**
+ * Day-view drag column keys are calendar ids (see createVisual), so a drop
+ * on a different column is a cross-calendar move. Same-column drops (and the
+ * single-column fallback, whose one key is a date string that never changes)
+ * keep the event's own calendarId.
+ */
+export const columnMoveCalendarId = (
+  visual: Pick<TimedDragVisual, "dayDate" | "initialDayDate">,
+  event: GridEvent,
+): CalendarId | undefined =>
+  visual.dayDate !== visual.initialDayDate
+    ? (visual.dayDate as CalendarId)
+    : event.calendarId;
+
+export const timedResizeVisualToDayGridEvent = (
+  event: GridEvent,
+  visual: TimedResizeVisual,
+  visibleDate: Dayjs,
+): GridEvent => ({
+  ...event,
+  isAllDay: false,
+  endDate: visibleDate
+    .startOf("day")
+    .add(visual.endMinutes, "minutes")
+    .format(),
+  startDate: visibleDate
+    .startOf("day")
+    .add(visual.startMinutes, "minutes")
+    .format(),
+});

--- a/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.ts
+++ b/packages/web/src/views/Day/interaction/adapter/day-interaction.adapter.ts
@@ -1,25 +1,18 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
-import { type CalendarId } from "@core/types/domain-primitives";
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import dayjs from "@core/util/date/dayjs";
 import {
-  ID_ALLDAY_COLUMNS,
-  ID_GRID_COLUMNS_TIMED,
-  ID_GRID_MAIN,
-} from "@web/common/constants/web.constants";
-import { type GridEvent } from "@web/common/types/web.event.types";
-import { GRID_TIME_STEP, TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
+  applySmartScroll as applySmartScrollFrame,
+  getSavedEventInteractionCursor,
+  getSavedEventOwnershipReason,
+  readElementRect,
+} from "@web/grid/interaction/adapter.helpers";
 import { getLocalMinutes } from "@web/grid/interaction/date";
 import {
   createDraftEventMount,
   getResizeHandleEdge,
   updateDraftEventTimeLabel,
 } from "@web/grid/interaction/dom";
-import {
-  buildAllDayGridLayoutCache,
-  buildTimedGridLayoutCache,
-  type GridLayoutCache,
-  type GridLayoutCacheSources,
-} from "@web/grid/interaction/layout.cache";
+import { type GridLayoutCache } from "@web/grid/interaction/layout.cache";
 import {
   createAllDayDragVisual,
   updateAllDayDragVisual,
@@ -28,7 +21,6 @@ import {
   createAllDayResizeVisual,
   updateAllDayResizeVisual,
 } from "@web/grid/interaction/math/all-day.resize";
-import { getSmartScrollFrame } from "@web/grid/interaction/math/smart-scroll";
 import {
   createTimedDragVisual,
   updateTimedDragVisual,
@@ -37,13 +29,7 @@ import {
   createTimedResizeVisual,
   updateTimedResizeVisual,
 } from "@web/grid/interaction/math/timed.resize";
-import { type AllDayDragVisual } from "@web/grid/interaction/types/all-day-drag.types";
-import { type AllDayResizeVisual } from "@web/grid/interaction/types/all-day-resize.types";
-import {
-  type TimedDragVisual,
-  type VisualPoint,
-} from "@web/grid/interaction/types/timed-drag.types";
-import { type TimedResizeVisual } from "@web/grid/interaction/types/timed-resize.types";
+import { type VisualPoint } from "@web/grid/interaction/types/timed-drag.types";
 import { type InteractionAdapter } from "@web/interaction/interaction.adapter.types";
 import {
   createInteractionEngine,
@@ -56,9 +42,17 @@ import {
   dayEventRegistry,
 } from "../registry/day-event.registry";
 import {
-  type DayAllDayDragCommitResult,
+  commitAllDayDragInteraction,
+  commitAllDayResizeInteraction,
+} from "./commit/all-day.commit";
+import {
+  commitTimedDragInteraction,
+  commitTimedResizeInteraction,
+  timedDragVisualToDayGridEvent,
+  timedResizeVisualToDayGridEvent,
+} from "./commit/timed.commit";
+import {
   type DayAllDayDragTarget,
-  type DayAllDayResizeCommitResult,
   type DayAllDayResizeTarget,
   type DayInteractionAdapter,
   type DayInteractionAdapterOptions,
@@ -68,11 +62,13 @@ import {
   type DayInteractionTarget,
   type DayInteractionVisual,
   type DayResolvedEventTarget,
-  type DayTimedDragCommitResult,
   type DayTimedDragTarget,
-  type DayTimedResizeCommitResult,
   type DayTimedResizeTarget,
 } from "./day-interaction.adapter.types";
+import {
+  buildDayLayoutCacheForTarget,
+  isDayDragTarget,
+} from "./geometry/day-layout.cache";
 
 export type {
   DayAllDayDragCommitResult,
@@ -82,10 +78,6 @@ export type {
   DayTimedDragCommitResult,
   DayTimedResizeCommitResult,
 } from "./day-interaction.adapter.types";
-
-const DAY_SMART_SCROLL_EDGE_THRESHOLD_PX = 50;
-const SMART_SCROLL_BOTTOM_INSET_PX = 100;
-const SMART_SCROLL_SPEED_PX = 10;
 
 const inertRuntime: DayInteractionRuntime = {
   getTimedEventById: () => null,
@@ -147,7 +139,7 @@ export const createDayInteractionAdapter = ({
     }
 
     return {
-      reason: getOwnershipReason(target),
+      reason: getSavedEventOwnershipReason(target.type),
       shouldOwn: true,
     };
   }
@@ -259,7 +251,9 @@ export const createDayInteractionAdapter = ({
         // and events momentarily out of sync) also falls back to the single
         // column: anchoring it to column 0 would make a purely vertical drag
         // commit a calendar move the user never made.
-        const calendarColumnKeys = isDragTarget(target) ? getColumnKeys() : [];
+        const calendarColumnKeys = isDayDragTarget(target)
+          ? getColumnKeys()
+          : [];
         const eventColumnIndex = calendarColumnKeys.indexOf(
           target.event.calendarId ?? "",
         );
@@ -327,12 +321,12 @@ export const createDayInteractionAdapter = ({
       },
       getDraftEventMount: ({ sourceElement, target }) =>
         createDraftEventMount({
-          cursor: getInteractionCursor(target),
+          cursor: getSavedEventInteractionCursor(target.type),
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
       getSourceElementDraftEventMode: (target) =>
-        isDragTarget(target) ? "dim-source" : "hide-source",
+        isDayDragTarget(target) ? "dim-source" : "hide-source",
       getTarget: (event) => getInteractionTarget(event),
       updateVisual: ({ pointer, target, visual }) => {
         if (!layout) {
@@ -429,26 +423,11 @@ export const createDayInteractionAdapter = ({
   }
 
   function applySmartScroll(pointer: VisualPoint) {
-    if (!layout?.smartScroll || scrollTop === null) {
-      return { isScrolling: false, scrollDeltaPx: 0 };
-    }
-
-    scrollTop = layout.smartScroll.element.scrollTop;
-
-    const frame = getSmartScrollFrame({
-      cache: layout.smartScroll,
-      pointerY: pointer.y,
-      scrollTop,
-    });
-
-    if (frame.scrollTop !== scrollTop) {
-      layout.smartScroll.element.scrollTop = frame.scrollTop;
-      scrollTop = frame.scrollTop;
-    }
-
+    const result = applySmartScrollFrame({ layout, pointer, scrollTop });
+    scrollTop = result.scrollTop;
     return {
-      isScrolling: frame.velocityPx !== 0,
-      scrollDeltaPx: scrollTop - layout.smartScroll.initialScrollTop,
+      isScrolling: result.isScrolling,
+      scrollDeltaPx: result.scrollDeltaPx,
     };
   }
 
@@ -622,237 +601,7 @@ export const createDayInteractionAdapter = ({
   };
 };
 
-const buildDayTimedLayoutCache = (
-  sources: GridLayoutCacheSources,
-  visibleDates: string[],
-) =>
-  buildTimedGridLayoutCache({
-    ...sources,
-    edgeThresholdPx: DAY_SMART_SCROLL_EDGE_THRESHOLD_PX,
-    mainGridElementId: ID_GRID_MAIN,
-    smartScroll: {
-      bottomInsetPx: SMART_SCROLL_BOTTOM_INSET_PX,
-      speedPx: SMART_SCROLL_SPEED_PX,
-    },
-    snapMinutes: GRID_TIME_STEP,
-    timedColumnsElementId: ID_GRID_COLUMNS_TIMED,
-    timedVisibleHours: TIMED_VISIBLE_HOURS,
-    visibleDates,
-  });
-
-const buildDayAllDayLayoutCache = (
-  sources: GridLayoutCacheSources,
-  visibleDates: string[],
-) =>
-  buildAllDayGridLayoutCache({
-    ...sources,
-    allDayColumnsElementId: ID_ALLDAY_COLUMNS,
-    edgeThresholdPx: 0,
-    snapMinutes: GRID_TIME_STEP,
-    timedVisibleHours: TIMED_VISIBLE_HOURS,
-    visibleDates,
-  });
-
-const buildDayLayoutCacheForTarget = (
-  target: DayInteractionTarget,
-  sources: GridLayoutCacheSources,
-  visibleDates: string[],
-) =>
-  isAllDayTarget(target)
-    ? buildDayAllDayLayoutCache(sources, visibleDates)
-    : buildDayTimedLayoutCache(sources, visibleDates);
-
-const commitTimedDragInteraction = (
-  target: DayTimedDragTarget,
-  visual: TimedDragVisual,
-  visibleDate: Dayjs,
-): DayTimedDragCommitResult => {
-  const hasMoved = hasTimedDragVisualMoved(visual);
-
-  return {
-    event: hasMoved
-      ? timedDragVisualToDayGridEvent(target.event, visual, visibleDate)
-      : target.event,
-    eventId: target.event._id!,
-    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
-    hasMoved,
-    type: "timedDragEnd",
-  };
-};
-
-const commitTimedResizeInteraction = (
-  target: DayTimedResizeTarget,
-  visual: TimedResizeVisual,
-  visibleDate: Dayjs,
-): DayTimedResizeCommitResult => {
-  const hasMoved = hasTimedResizeVisualMoved(visual);
-
-  return {
-    event: hasMoved
-      ? timedResizeVisualToDayGridEvent(target.event, visual, visibleDate)
-      : target.event,
-    eventId: target.event._id!,
-    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
-    hasMoved,
-    type: "timedResizeEnd",
-  };
-};
-
-const commitAllDayDragInteraction = (
-  target: DayAllDayDragTarget,
-  visual: AllDayDragVisual,
-): DayAllDayDragCommitResult => {
-  const hasMoved =
-    "dayDate" in visual ? visual.dayDate !== visual.initialDayDate : false;
-
-  // In the Day view every column shares the visible date, so an all-day drag
-  // that "moved" can only have changed COLUMN, i.e. calendar. Keep the
-  // event's own dates: rewriting them to the visible date would truncate a
-  // multi-day all-day event to a single day.
-  return {
-    event: hasMoved
-      ? {
-          ...target.event,
-          calendarId: columnMoveCalendarId(visual, target.event),
-        }
-      : target.event,
-    eventId: target.event._id!,
-    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
-    hasMoved,
-    type: "allDayDragEnd",
-  };
-};
-
-const commitAllDayResizeInteraction = (
-  target: DayAllDayResizeTarget,
-  visual: AllDayResizeVisual,
-  visibleDate: Dayjs,
-): DayAllDayResizeCommitResult => {
-  const hasMoved =
-    visual.startDayIndex !== visual.initialStartDayIndex ||
-    visual.endDayIndex !== visual.initialEndDayIndex;
-
-  return {
-    event: hasMoved
-      ? allDayVisualToDayGridEvent(target.event, visibleDate)
-      : target.event,
-    eventId: target.event._id!,
-    hadFormOpenBeforeInteraction: target.hadFormOpenBeforeInteraction,
-    hasMoved,
-    type: "allDayResizeEnd",
-  };
-};
-
-const timedDragVisualToDayGridEvent = (
-  event: GridEvent,
-  visual: TimedDragVisual,
-  visibleDate: Dayjs,
-): GridEvent => ({
-  ...event,
-  calendarId: columnMoveCalendarId(visual, event),
-  isAllDay: false,
-  endDate: visibleDate
-    .startOf("day")
-    .add(visual.endMinutes, "minutes")
-    .format(),
-  startDate: visibleDate
-    .startOf("day")
-    .add(visual.startMinutes, "minutes")
-    .format(),
-});
-
-/**
- * Day-view drag column keys are calendar ids (see createVisual), so a drop
- * on a different column is a cross-calendar move. Same-column drops (and the
- * single-column fallback, whose one key is a date string that never changes)
- * keep the event's own calendarId.
- */
-const columnMoveCalendarId = (
-  visual: Pick<TimedDragVisual, "dayDate" | "initialDayDate">,
-  event: GridEvent,
-): CalendarId | undefined =>
-  visual.dayDate !== visual.initialDayDate
-    ? (visual.dayDate as CalendarId)
-    : event.calendarId;
-
-const timedResizeVisualToDayGridEvent = (
-  event: GridEvent,
-  visual: TimedResizeVisual,
-  visibleDate: Dayjs,
-): GridEvent => ({
-  ...event,
-  isAllDay: false,
-  endDate: visibleDate
-    .startOf("day")
-    .add(visual.endMinutes, "minutes")
-    .format(),
-  startDate: visibleDate
-    .startOf("day")
-    .add(visual.startMinutes, "minutes")
-    .format(),
-});
-
-const allDayVisualToDayGridEvent = (
-  event: GridEvent,
-  visibleDate: Dayjs,
-): GridEvent => ({
-  ...event,
-  isAllDay: true,
-  endDate: visibleDate.add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
-  startDate: visibleDate.format(YEAR_MONTH_DAY_FORMAT),
-});
-
-const hasTimedDragVisualMoved = (visual: TimedDragVisual) =>
-  visual.dayDate !== visual.initialDayDate ||
-  visual.startMinutes !== visual.initialStartMinutes ||
-  visual.endMinutes !== visual.initialEndMinutes;
-
-const hasTimedResizeVisualMoved = (visual: TimedResizeVisual) =>
-  visual.startMinutes !== visual.initialStartMinutes ||
-  visual.endMinutes !== visual.initialEndMinutes;
-
 const isAllDayTarget = (
   target: DayInteractionTarget,
 ): target is DayAllDayDragTarget | DayAllDayResizeTarget =>
   target.type === "allDayDrag" || target.type === "allDayResize";
-
-const isDragTarget = (
-  target: DayInteractionTarget,
-): target is DayAllDayDragTarget | DayTimedDragTarget =>
-  target.type === "allDayDrag" || target.type === "timedDrag";
-
-const getOwnershipReason = (target: DayInteractionTarget) => {
-  switch (target.type) {
-    case "allDayDrag":
-      return "saved-all-day-drag";
-    case "allDayResize":
-      return "saved-all-day-resize";
-    case "timedResize":
-      return "saved-timed-resize";
-    case "timedDrag":
-      return "saved-timed-drag";
-  }
-};
-
-const getInteractionCursor = (target: DayInteractionTarget) => {
-  switch (target.type) {
-    case "allDayResize":
-      return "col-resize";
-    case "timedResize":
-      return "row-resize";
-    case "allDayDrag":
-    case "timedDrag":
-      return "move";
-  }
-};
-
-const readElementRect = (element: HTMLElement) => {
-  const rect = element.getBoundingClientRect();
-
-  return {
-    height: rect.height,
-    left: rect.left,
-    top: rect.top,
-    width: rect.width,
-  };
-};

--- a/packages/web/src/views/Day/interaction/adapter/geometry/day-layout.cache.ts
+++ b/packages/web/src/views/Day/interaction/adapter/geometry/day-layout.cache.ts
@@ -1,0 +1,78 @@
+import {
+  ID_ALLDAY_COLUMNS,
+  ID_GRID_COLUMNS_TIMED,
+  ID_GRID_MAIN,
+} from "@web/common/constants/web.constants";
+import { GRID_TIME_STEP, TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
+import {
+  SMART_SCROLL_BOTTOM_INSET_PX,
+  SMART_SCROLL_SPEED_PX,
+} from "@web/grid/interaction/adapter.helpers";
+import {
+  buildAllDayGridLayoutCache,
+  buildTimedGridLayoutCache,
+  type GridLayoutCache,
+  type GridLayoutCacheSources,
+} from "@web/grid/interaction/layout.cache";
+import {
+  type DayAllDayDragTarget,
+  type DayAllDayResizeTarget,
+  type DayInteractionTarget,
+  type DayTimedDragTarget,
+} from "../day-interaction.adapter.types";
+
+/** Day timed smart-scroll edge threshold (Week uses edge-nav threshold instead). */
+const DAY_SMART_SCROLL_EDGE_THRESHOLD_PX = 50;
+
+export type DayLayoutCache = GridLayoutCache;
+export type DayLayoutCacheSources = GridLayoutCacheSources;
+
+export const buildDayTimedLayoutCache = (
+  sources: GridLayoutCacheSources,
+  visibleDates: string[],
+) =>
+  buildTimedGridLayoutCache({
+    ...sources,
+    edgeThresholdPx: DAY_SMART_SCROLL_EDGE_THRESHOLD_PX,
+    mainGridElementId: ID_GRID_MAIN,
+    smartScroll: {
+      bottomInsetPx: SMART_SCROLL_BOTTOM_INSET_PX,
+      speedPx: SMART_SCROLL_SPEED_PX,
+    },
+    snapMinutes: GRID_TIME_STEP,
+    timedColumnsElementId: ID_GRID_COLUMNS_TIMED,
+    timedVisibleHours: TIMED_VISIBLE_HOURS,
+    visibleDates,
+  });
+
+export const buildDayAllDayLayoutCache = (
+  sources: GridLayoutCacheSources,
+  visibleDates: string[],
+) =>
+  buildAllDayGridLayoutCache({
+    ...sources,
+    allDayColumnsElementId: ID_ALLDAY_COLUMNS,
+    edgeThresholdPx: 0,
+    snapMinutes: GRID_TIME_STEP,
+    timedVisibleHours: TIMED_VISIBLE_HOURS,
+    visibleDates,
+  });
+
+const isAllDayTarget = (
+  target: DayInteractionTarget,
+): target is DayAllDayDragTarget | DayAllDayResizeTarget =>
+  target.type === "allDayDrag" || target.type === "allDayResize";
+
+export const buildDayLayoutCacheForTarget = (
+  target: DayInteractionTarget,
+  sources: GridLayoutCacheSources,
+  visibleDates: string[],
+) =>
+  isAllDayTarget(target)
+    ? buildDayAllDayLayoutCache(sources, visibleDates)
+    : buildDayTimedLayoutCache(sources, visibleDates);
+
+export const isDayDragTarget = (
+  target: DayInteractionTarget,
+): target is DayAllDayDragTarget | DayTimedDragTarget =>
+  target.type === "allDayDrag" || target.type === "timedDrag";

--- a/packages/web/src/views/Week/interaction/adapter/commit/timed.commit.ts
+++ b/packages/web/src/views/Week/interaction/adapter/commit/timed.commit.ts
@@ -1,12 +1,13 @@
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import {
+  hasTimedDragVisualMoved,
+  hasTimedResizeVisualMoved,
+} from "@web/grid/interaction/commit/timed-moved";
 import { type TimedDragVisual } from "@web/grid/interaction/types/timed-drag.types";
 import { type TimedResizeVisual } from "@web/grid/interaction/types/timed-resize.types";
 
-export const hasTimedDragVisualMoved = (visual: TimedDragVisual) =>
-  visual.dayDate !== visual.initialDayDate ||
-  visual.startMinutes !== visual.initialStartMinutes ||
-  visual.endMinutes !== visual.initialEndMinutes;
+export { hasTimedDragVisualMoved, hasTimedResizeVisualMoved };
 
 export const timedDragVisualToGridEvent = (
   event: GridEvent,
@@ -22,10 +23,6 @@ export const timedDragVisualToGridEvent = (
     startDate: movedDay.add(visual.startMinutes, "minutes").format(),
   };
 };
-
-export const hasTimedResizeVisualMoved = (visual: TimedResizeVisual) =>
-  visual.startMinutes !== visual.initialStartMinutes ||
-  visual.endMinutes !== visual.initialEndMinutes;
 
 export const timedResizeVisualToGridEvent = (
   event: GridEvent,

--- a/packages/web/src/views/Week/interaction/adapter/geometry/week-layout.cache.ts
+++ b/packages/web/src/views/Week/interaction/adapter/geometry/week-layout.cache.ts
@@ -5,6 +5,10 @@ import {
 } from "@web/common/constants/web.constants";
 import { GRID_TIME_STEP, TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 import {
+  SMART_SCROLL_BOTTOM_INSET_PX,
+  SMART_SCROLL_SPEED_PX,
+} from "@web/grid/interaction/adapter.helpers";
+import {
   buildAllDayGridLayoutCache,
   buildDragGridLayoutCache,
   buildTimedGridLayoutCache,
@@ -16,9 +20,6 @@ import {
 } from "@web/grid/interaction/layout.cache";
 import { type DragRow } from "@web/grid/interaction/types/timed-drag.types";
 import { WEEK_EDGE_NAVIGATION_THRESHOLD_PX } from "../edge-navigation";
-
-const SMART_SCROLL_BOTTOM_INSET_PX = 100;
-const SMART_SCROLL_SPEED_PX = 10;
 
 export type WeekLayoutCacheSources = GridLayoutCacheSources;
 

--- a/packages/web/src/views/Week/interaction/adapter/week-interaction.adapter.ts
+++ b/packages/web/src/views/Week/interaction/adapter/week-interaction.adapter.ts
@@ -1,4 +1,10 @@
 import {
+  applySmartScroll as applySmartScrollFrame,
+  getSavedEventInteractionCursor,
+  getSavedEventOwnershipReason,
+  readElementRect,
+} from "@web/grid/interaction/adapter.helpers";
+import {
   createDraftEventMount,
   getResizeHandleEdge,
   hideDraftEventTimeLabel,
@@ -8,7 +14,6 @@ import {
   getDragRowLayouts,
   resolveDragRow,
 } from "@web/grid/interaction/math/cross-row.drag";
-import { getSmartScrollFrame } from "@web/grid/interaction/math/smart-scroll";
 import {
   type CrossRowSize,
   type VisualPoint,
@@ -163,7 +168,7 @@ export const createWeekInteractionAdapter = ({
     setWeekInteractionMotionActive(true);
 
     return {
-      reason: getOwnershipReason(target),
+      reason: getSavedEventOwnershipReason(target.type),
       shouldOwn: true,
     };
   }
@@ -321,7 +326,7 @@ export const createWeekInteractionAdapter = ({
       },
       getDraftEventMount: ({ sourceElement, target }) =>
         createDraftEventMount({
-          cursor: getInteractionCursor(target),
+          cursor: getSavedEventInteractionCursor(target.type),
           source: sourceElement,
         }),
       getSourceElement: (target) => target.registered.element,
@@ -637,26 +642,11 @@ export const createWeekInteractionAdapter = ({
   }
 
   function applySmartScroll(pointer: VisualPoint) {
-    if (!layout?.smartScroll || scrollTop === null) {
-      return { isScrolling: false, scrollDeltaPx: 0 };
-    }
-
-    scrollTop = layout.smartScroll.element.scrollTop;
-
-    const frame = getSmartScrollFrame({
-      cache: layout.smartScroll,
-      pointerY: pointer.y,
-      scrollTop,
-    });
-
-    if (frame.scrollTop !== scrollTop) {
-      layout.smartScroll.element.scrollTop = frame.scrollTop;
-      scrollTop = frame.scrollTop;
-    }
-
+    const result = applySmartScrollFrame({ layout, pointer, scrollTop });
+    scrollTop = result.scrollTop;
     return {
-      isScrolling: frame.velocityPx !== 0,
-      scrollDeltaPx: scrollTop - layout.smartScroll.initialScrollTop,
+      isScrolling: result.isScrolling,
+      scrollDeltaPx: result.scrollDeltaPx,
     };
   }
 
@@ -757,31 +747,6 @@ const isDragTarget = (
 ): target is WeekAllDayDragTarget | WeekTimedDragTarget =>
   target.type === "allDayDrag" || target.type === "timedDrag";
 
-const getOwnershipReason = (target: WeekInteractionTarget) => {
-  switch (target.type) {
-    case "allDayDrag":
-      return "saved-all-day-drag";
-    case "allDayResize":
-      return "saved-all-day-resize";
-    case "timedResize":
-      return "saved-timed-resize";
-    case "timedDrag":
-      return "saved-timed-drag";
-  }
-};
-
-const getInteractionCursor = (target: WeekInteractionTarget) => {
-  switch (target.type) {
-    case "allDayResize":
-      return "col-resize";
-    case "timedResize":
-      return "row-resize";
-    case "allDayDrag":
-    case "timedDrag":
-      return "move";
-  }
-};
-
 // Drags cache both rows so they can be dropped across them; resizes stay within
 // one row and only need their own.
 const buildWeekLayoutCacheForTarget = (
@@ -813,14 +778,3 @@ const getDraftEventSize = (visual: {
   };
 
 const isEligibleWeekPointerDown = isEligibleInteractionPointerDown;
-
-const readElementRect = (element: HTMLElement): VisualRect => {
-  const rect = element.getBoundingClientRect();
-
-  return {
-    height: rect.height,
-    left: rect.left,
-    top: rect.top,
-    width: rect.width,
-  };
-};


### PR DESCRIPTION
## Summary
- Lift identical Day/Week adapter helpers (`applySmartScroll`, ownership/cursor reasons, `readElementRect`, timed moved predicates, smart-scroll constants) into `@web/grid/interaction`
- Extract Day `commit/` + `geometry/` modules to match Week’s adapter layout; leave Day/Week adapters separate (calendar columns vs dates, edge nav, form-open policy stay view-specific)

## Test plan
- [ ] Day: timed/all-day drag + resize (including cross-calendar timed/all-day moves)
- [ ] Week: timed/all-day drag + resize, smart-scroll, edge dwell navigation
- [ ] CI green (`bun test:web` on Day/Week interaction + `grid/interaction`)


Made with [Cursor](https://cursor.com)