### PR TITLE
feat(backend): add sync beginConnection client + core contracts

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -3,6 +3,7 @@ import { type BusyAvailabilityRequest } from "@core/types/sync/availability.cont
 import { verifyInternalRequest } from "@sync/auth/internal-auth";
 import {
   AVAILABILITY_BUSY_PATH,
+  BEGIN_PATH,
   CONNECTIONS_PATH,
 } from "@sync/server/connection.routes";
 import {
@@ -143,6 +144,65 @@ describe("SyncServiceClient", () => {
     }));
 
     const result = await client(fn).listConnections(principal());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
+  });
+
+  it("begins a connection with a signed POST the real Sync verifier accepts", async () => {
+    const who = principal();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({
+        authorizationUrl:
+          "https://accounts.google.com/o/oauth2/v2/auth?state=x",
+      }),
+    }));
+
+    const result = await client(fn).beginConnection(who);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.authorizationUrl).toContain("accounts.google.com");
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${BEGIN_PATH}`);
+    expect(sent?.method).toBe("POST");
+    // No connectionId given: a fresh connection sends an empty body.
+    expect(JSON.parse(sent?.body ?? "{}")).toEqual({});
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("forwards a connectionId for reconnect", async () => {
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({
+        authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      }),
+    }));
+
+    const connectionId = objectId();
+    await client(fn).beginConnection(principal(), {
+      connectionId: connectionId as never,
+    });
+
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({ connectionId });
+  });
+
+  it("rejects a begin body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ authorizationUrl: "not-a-url" }),
+    }));
+
+    const result = await client(fn).beginConnection(principal());
 
     expect(result.ok).toBe(false);
     if (result.ok) return;

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type BusyAvailabilityRequest } from "@core/types/sync/availability.contracts";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { verifyInternalRequest } from "@sync/auth/internal-auth";
 import {
   AVAILABILITY_BUSY_PATH,
@@ -190,7 +191,7 @@ describe("SyncServiceClient", () => {
 
     const connectionId = objectId();
     await client(fn).beginConnection(principal(), {
-      connectionId: connectionId as never,
+      connectionId: connectionId as ConnectionId,
     });
 
     expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({ connectionId });

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -5,6 +5,9 @@ import {
   BusyAvailabilityResponseSchema,
 } from "@core/types/sync/availability.contracts";
 import {
+  type ConnectionBeginRequest,
+  type ConnectionBeginResponse,
+  ConnectionBeginResponseSchema,
   type ConnectionListResponse,
   ConnectionListResponseSchema,
 } from "@core/types/sync/connection.contracts";
@@ -14,6 +17,7 @@ import { createHmac, randomUUID } from "node:crypto";
 // route paths; a contract test asserts they match.
 const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 const CONNECTIONS_PATH = "/internal/connections";
+const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -121,6 +125,26 @@ export class SyncServiceClient {
       path: CONNECTIONS_PATH,
       principal,
       schema: ConnectionListResponseSchema,
+      correlationId,
+    });
+  }
+
+  // Start an OAuth authorization flow and return the provider consent URL the
+  // browser should be sent to. Pass a connectionId to reconnect an existing
+  // connection; omit it for a fresh one. The Sync service only mints the URL
+  // here (and requires active execution mode, else it returns a 409 mapped to
+  // `unexpectedStatus`); the connection is created when the provider calls back.
+  beginConnection(
+    principal: SyncPrincipal,
+    request: ConnectionBeginRequest = {},
+    correlationId?: string,
+  ): Promise<SyncClientResult<ConnectionBeginResponse>> {
+    return this.#request({
+      method: "POST",
+      path: CONNECTIONS_BEGIN_PATH,
+      principal,
+      body: request,
+      schema: ConnectionBeginResponseSchema,
       correlationId,
     });
   }

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -136,6 +136,26 @@ export type ConnectionListResponse = z.infer<
   typeof ConnectionListResponseSchema
 >;
 
+// Start an OAuth authorization flow for the caller's principal. An optional
+// connectionId means reconnect (rebind consent to that existing connection);
+// omit it for a fresh connection. Principal scope always comes from the
+// authenticated context, never the body.
+export const ConnectionBeginRequestSchema = z.strictObject({
+  connectionId: ConnectionIdSchema.optional(),
+});
+export type ConnectionBeginRequest = z.infer<
+  typeof ConnectionBeginRequestSchema
+>;
+
+// The provider consent URL the browser is sent to. `begin` only mints the URL;
+// the connection is created/updated when the provider calls back.
+export const ConnectionBeginResponseSchema = z.strictObject({
+  authorizationUrl: z.string().url(),
+});
+export type ConnectionBeginResponse = z.infer<
+  typeof ConnectionBeginResponseSchema
+>;
+
 export const CalendarListQuerySchema = z.strictObject({
   // Optional narrowing; principal scope always comes from authenticated
   // context, never from the request body.


### PR DESCRIPTION
## What

The backend building block for delegating provider **connect** to the sync service — the next step of connection-route delegation after status (#2336).

## Changes

- **core** `ConnectionBeginRequest`/`ConnectionBeginResponse` schemas (`{ connectionId? }` → `{ authorizationUrl }`), shared by the client and asserted against the real sync route in a contract test.
- **`SyncServiceClient.beginConnection()`** — a signed POST to `/internal/connections/begin` returning the provider consent URL, with an optional `connectionId` for reconnect. Same typed result/error path as the other client methods.

## Context: why connect is different

Legacy connect (`POST /api/auth/google/connect`) is a one-shot **server-side code exchange** returning `{status:"OK"}` — the web app already holds the auth code. The sync flow is **redirect-based**: `begin` mints an `authorizationUrl`, the browser navigates to Google, and Google calls back to the *sync service's* `/oauth/google/callback`, which links the connection. It also requires the sync service in **active** execution mode (a passive service returns 409, mapped here to `unexpectedStatus`).

Because the browser UX differs (navigate-to-URL vs popup-and-post) and the callback lands on the sync service, wiring an actual browser-facing route is a coordinated backend + web change with real deployment prerequisites (public callback reachability, active mode). This PR deliberately lands **only the client capability** so that follow-up can build on a tested seam.

## Not in this PR

No route, no web change. Nothing consumes `beginConnection` yet.

## Tests

Contract test: signed POST hits the real `BEGIN_PATH`, signature verifies against the real internal-auth verifier, empty body for a fresh connect, `connectionId` forwarded for reconnect, and an off-contract 200 body → `invalidResponse`. Core schema tests: 51 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client and schema changes with no production callers; OAuth wiring is deferred to follow-up PRs.
> 
> **Overview**
> Adds the **backend seam** for redirect-based OAuth connect via the sync service, without wiring any HTTP route or web UI yet.
> 
> **Core** introduces shared Zod contracts: `ConnectionBeginRequest` (optional `connectionId` for reconnect) and `ConnectionBeginResponse` (`authorizationUrl`).
> 
> **`SyncServiceClient`** gains `beginConnection()` — a signed POST to `/internal/connections/begin` that returns the provider consent URL, using the same typed result/error handling as `listConnections` and `queryBusyAvailability`.
> 
> **Tests** extend the sync client contract suite: path matches sync `BEGIN_PATH`, internal auth verifies, empty body for new connect vs `{ connectionId }` for reconnect, and invalid `authorizationUrl` responses map to `invalidResponse`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f6e6e5405532a701e240d4d1176c8bd70a6122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->