### PR TITLE
feat(backend): add sync-delegated Google connect-begin route

### DIFF
--- a/packages/backend/src/auth/auth.routes.config.ts
+++ b/packages/backend/src/auth/auth.routes.config.ts
@@ -34,6 +34,16 @@ export class AuthRoutes extends CommonRoutesConfig {
         authController.connectGoogle(req, res);
       });
 
+    // Sync-delegated connect: returns the provider consent URL for the browser
+    // to navigate to. Only meaningful where connections are delegated to the
+    // sync service; the legacy code-exchange flow uses /connect above.
+    this.app
+      .route(`/api/auth/google/connect/begin`)
+      .all(requireSession)
+      .post((req, res) => {
+        authController.beginGoogleConnection(req, res);
+      });
+
     return this.app;
   }
 }

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -5,6 +5,10 @@ import {
   GoogleAuthCodeRequestSchema,
   GoogleConnectResponseSchema,
 } from "@core/types/auth.types";
+import {
+  type ConnectionBeginRequest,
+  ConnectionBeginRequestSchema,
+} from "@core/types/sync/connection.contracts";
 import { zObjectId } from "@core/types/type.utils";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import { googleAuthService } from "@backend/auth/services/google/google.auth.service";
@@ -12,6 +16,10 @@ import { CONFIG } from "@backend/common/constants/config.constants";
 import { isGoogleConfigured } from "@backend/common/constants/config.util";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
+import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
+import { beginSyncConnection } from "@backend/common/services/sync-service/sync-connection-begin";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import {
   type ReqBody,
   type Res_Promise,
@@ -69,6 +77,31 @@ class AuthController {
         .connectGoogleToCurrentUser(userId, input)
         .then(() => GoogleConnectResponseSchema.parse({ status: "OK" })),
     );
+  };
+
+  // Start a sync-delegated Google connection: return the provider consent URL
+  // the browser should navigate to. Only applies where this deployment
+  // delegates provider connections to the sync service (the redirect flow); the
+  // legacy code-exchange flow uses connectGoogle above instead.
+  beginGoogleConnection = (
+    req: SReqBody<ConnectionBeginRequest>,
+    res: Res_Promise,
+  ): void => {
+    const client =
+      getConnectionDelegation() === "sync" ? getSyncServiceClient() : null;
+    if (!client) {
+      res.promise(
+        Promise.reject(
+          error(AuthError.ConnectNotDelegated, "Connect begin unavailable"),
+        ),
+      );
+      return;
+    }
+
+    const userId = zObjectId.parse(req.session?.getUserId()).toString();
+    const request = ConnectionBeginRequestSchema.parse(req.body ?? {});
+
+    res.promise(beginSyncConnection(client, toSyncPrincipal(userId), request));
   };
 }
 

--- a/packages/backend/src/common/errors/auth/auth.errors.ts
+++ b/packages/backend/src/common/errors/auth/auth.errors.ts
@@ -2,6 +2,7 @@ import { Status } from "@core/errors/status.codes";
 import { type ErrorMetadata } from "@backend/common/types/error.types";
 
 interface AuthErrors {
+  ConnectNotDelegated: ErrorMetadata;
   DevOnly: ErrorMetadata;
   GoogleAccountAlreadyConnected: ErrorMetadata;
   GoogleConnectEmailMismatch: ErrorMetadata;
@@ -11,9 +12,16 @@ interface AuthErrors {
   MissingRefreshToken: ErrorMetadata;
   NoUserId: ErrorMetadata;
   NoGAuthAccessToken: ErrorMetadata;
+  SyncConnectionUnavailable: ErrorMetadata;
 }
 
 export const AuthError: AuthErrors = {
+  ConnectNotDelegated: {
+    description:
+      "Provider connect is not delegated to the sync service on this deployment",
+    status: Status.CONFLICT,
+    isOperational: true,
+  },
   DevOnly: {
     description: "Only available during development",
     status: Status.FORBIDDEN,
@@ -61,6 +69,11 @@ export const AuthError: AuthErrors = {
   NoGAuthAccessToken: {
     description: "No gauth access token",
     status: Status.UNAUTHORIZED,
+    isOperational: true,
+  },
+  SyncConnectionUnavailable: {
+    description: "Could not reach the sync service to start a connection",
+    status: Status.SERVICE_UNAVAILABLE,
     isOperational: true,
   },
 };

--- a/packages/backend/src/common/services/sync-service/sync-connection-begin.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-begin.test.ts
@@ -1,0 +1,75 @@
+import { BaseError } from "@core/errors/errors.base";
+import { Status } from "@core/errors/status.codes";
+import { type ConnectionBeginResponse } from "@core/types/sync/connection.contracts";
+import { beginSyncConnection } from "./sync-connection-begin";
+import {
+  type SyncClientResult,
+  type SyncPrincipal,
+} from "./sync-service.client";
+import { describe, expect, it } from "bun:test";
+
+const principal: SyncPrincipal = {
+  tenantId: "64b7f9c2e1a2b3c4d5e6f7a8",
+  principalId: "64b7f9c2e1a2b3c4d5e6f7a8",
+};
+
+const clientReturning = (
+  result: SyncClientResult<ConnectionBeginResponse>,
+) => ({
+  beginConnection: async () => result,
+});
+
+describe("beginSyncConnection", () => {
+  it("returns the authorization url when the sync service succeeds", async () => {
+    const client = clientReturning({
+      ok: true,
+      value: {
+        authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      },
+      correlationId: "corr-1",
+    });
+
+    const result = await beginSyncConnection(client, principal, {});
+
+    expect(result.authorizationUrl).toContain("accounts.google.com");
+  });
+
+  it("throws a 503 when the sync service is unavailable", async () => {
+    const client = clientReturning({
+      ok: false,
+      error: { kind: "unavailable", correlationId: "corr-1" },
+    });
+
+    expect(beginSyncConnection(client, principal, {})).rejects.toMatchObject({
+      statusCode: Status.SERVICE_UNAVAILABLE,
+    });
+  });
+
+  it("maps every client error kind to a 503 without leaking sync internals", async () => {
+    for (const kind of [
+      "timeout",
+      "unauthorized",
+      "badRequest",
+      "invalidResponse",
+      "unexpectedStatus",
+    ] as const) {
+      const client = clientReturning({
+        ok: false,
+        error: { kind, status: 409, correlationId: "corr-1" },
+      });
+
+      let thrown: unknown;
+      try {
+        await beginSyncConnection(client, principal, {});
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeInstanceOf(BaseError);
+      expect((thrown as BaseError).statusCode).toBe(Status.SERVICE_UNAVAILABLE);
+      // The sync error kind/status must not reach the browser-facing message.
+      expect((thrown as BaseError).message).not.toContain(kind);
+      expect((thrown as BaseError).message).not.toContain("409");
+    }
+  });
+});

--- a/packages/backend/src/common/services/sync-service/sync-connection-begin.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-begin.ts
@@ -1,0 +1,42 @@
+import { Logger } from "@core/logger/winston.logger";
+import {
+  type ConnectionBeginRequest,
+  type ConnectionBeginResponse,
+} from "@core/types/sync/connection.contracts";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import {
+  type SyncPrincipal,
+  type SyncServiceClient,
+} from "./sync-service.client";
+
+const logger = Logger("app:sync-connection-begin");
+
+/**
+ * Ask the sync service to start an OAuth authorization flow and return the
+ * consent URL the browser should be sent to.
+ *
+ * Any client failure surfaces as a single 503 (SyncConnectionUnavailable): the
+ * specific kind and correlation id are logged server-side, but nothing
+ * sync-internal (status codes, identity) reaches the browser. The distinctions
+ * the sync service makes (409 passive mode, 404 reconnect-not-found) are not yet
+ * actionable by the browser; when the reconnect UI is wired, this can grow more
+ * specific mappings.
+ */
+export async function beginSyncConnection(
+  client: Pick<SyncServiceClient, "beginConnection">,
+  principal: SyncPrincipal,
+  request: ConnectionBeginRequest,
+): Promise<ConnectionBeginResponse> {
+  const result = await client.beginConnection(principal, request);
+  if (result.ok) return result.value;
+
+  logger.warn(
+    `Sync begin-connection failed (${result.error.kind}) ` +
+      `[correlationId=${result.error.correlationId}]`,
+  );
+  throw error(
+    AuthError.SyncConnectionUnavailable,
+    "Failed to start Google connection",
+  );
+}


### PR DESCRIPTION
## What

Adds `POST /api/auth/google/connect/begin`. Under sync connection delegation, it returns the provider consent URL the browser should navigate to (the sync **redirect** flow), by calling the sync service's `beginConnection`. The legacy code-exchange flow (`POST /api/auth/google/connect`) is unchanged and remains the default.

This is the backend half of connect-route delegation (per the chosen "backend route first" approach). No web change.

## Changes

- **`beginSyncConnection()`** helper — calls the client and maps any failure to a single **503** (`SyncConnectionUnavailable`), logging the specific kind + correlation id server-side without leaking sync internals to the browser.
- **`auth.controller.beginGoogleConnection()`** — gates on `getConnectionDelegation() === "sync"` (else **409** `ConnectNotDelegated`), resolves the principal from the session (`zObjectId.parse`, same as the other auth routes → ObjectId-shaped), and forwards an optional `connectionId` for reconnect.
- **route** `POST /api/auth/google/connect/begin` (session-authed, sibling of `/connect`).
- Two new `AuthError` entries.

## Design notes

- **Only the redirect flow uses this.** Legacy connect is a one-shot server-side code exchange; the sync flow needs the browser to navigate to `authorizationUrl` and the provider to call back to the sync service. This route is the "give me the URL" step.
- **Error mapping is intentionally coarse for now** — every sync failure → 503. The sync service's finer distinctions (409 passive, 404 reconnect-not-found) aren't yet actionable by the browser; they can grow specific mappings when the reconnect UI is wired.
- **No rate limiter**, matching the existing `/connect` route and the backend's `CommonRoutesConfig` convention (the backend has no `express-rate-limit`; unlike the sync package, this route style doesn't trip CodeQL's rate-limit rule).

## Not in this PR

Nothing calls the route yet. The web redirect flow — and how the browser learns the deployment delegates connect to sync — is a follow-up.

## Tests

`beginSyncConnection`: success returns the URL; every client error kind → a 503 `BaseError` whose message leaks neither the kind nor the upstream status. Existing auth controller test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated OAuth connect paths and sync-service delegation; failures are coarse-mapped to 503/409 but the route is unused until the web flow lands.
> 
> **Overview**
> Adds **`POST /api/auth/google/connect/begin`** (session-required), a sibling of the existing code-exchange **`/connect`** route. When connection delegation is **`sync`**, it forwards to the sync service’s `beginConnection` and returns the provider **`authorizationUrl`** for the browser redirect OAuth flow; otherwise it responds with **409** `ConnectNotDelegated`.
> 
> Introduces **`beginSyncConnection()`**, which wraps the sync client and maps **all** client failures to a single **503** `SyncConnectionUnavailable` (kind/correlation id logged server-side only). Adds matching **`AuthError`** entries and unit tests for success and error sanitization. **No web caller yet**; legacy Google connect is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc90a6dda10cc08e1709e6842af6cef4ec36a6d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->