### PR TITLE
fix(self-host): hard-wait for mongo on selfhosted deploys

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -175,6 +175,7 @@ jobs:
             COMPOSE_GIT_REF="${RELEASE_TAG}"
           fi
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.yaml -o ~/compass/compose.yaml"
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.selfhosted.yaml -o ~/compass/compose.selfhosted.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
           # Enable the `sync` profile only when sync is fully configured, so the
           # container starts exactly where its config was written (never against

--- a/self-host/compass
+++ b/self-host/compass
@@ -16,6 +16,7 @@ fi
 
 CONFIG_FILE=${COMPASS_CONFIG_FILE:-"$INSTALL_DIR/compass.yaml"}
 COMPOSE_FILE=$INSTALL_DIR/compose.yaml
+COMPOSE_SELFHOSTED_FILE=$INSTALL_DIR/compose.selfhosted.yaml
 ENV_LOADED=0
 PROJECT_NAME=$(basename "$INSTALL_DIR")
 APP_URL=http://localhost:9080
@@ -155,6 +156,20 @@ require_stack() {
 compose() {
   require_stack
   set_compose_env
+  # Cloud/Atlas (no selfhosted profile) uses only the base file. Selfhosted
+  # adds the overlay that hard-waits for healthy mongo before backend. Putting
+  # that dependency in the base file breaks profile-less cloud deploys, and
+  # `required: false` is not a substitute — Compose treats an unhealthy
+  # optional dependency as satisfied and starts backend early.
+  case ",${COMPOSE_PROFILES}," in
+    *,selfhosted,*)
+      if [ -f "$COMPOSE_SELFHOSTED_FILE" ]; then
+        docker compose --project-name "$PROJECT_NAME" \
+          -f "$COMPOSE_FILE" -f "$COMPOSE_SELFHOSTED_FILE" "$@"
+        return
+      fi
+      ;;
+  esac
   docker compose --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
 }
 

--- a/self-host/compose.selfhosted.yaml
+++ b/self-host/compose.selfhosted.yaml
@@ -1,0 +1,9 @@
+# Overlay applied when COMPOSE_PROFILES includes `selfhosted`.
+# Keeps the backend gated on a healthy local mongo without breaking
+# profile-less cloud/Atlas deploys that have no mongo service in the
+# base compose.yaml.
+services:
+  backend:
+    depends_on:
+      mongo:
+        condition: service_healthy

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -24,17 +24,14 @@ services:
 
   backend:
     image: switchbacktech/compass-backend:${COMPASS_VERSION:-latest}
-    depends_on:
-      mongo:
-        condition: service_healthy
-        # `mongo` is gated behind the `selfhosted` profile. Atlas/cloud
-        # environments run without a mongo container (the backend reads
-        # mongo.uri from compass.yaml), so with the profile off there is no
-        # mongo service to depend on. `required: false` keeps the health-gated
-        # wait where mongo is present (selfhosted) while treating its absence as
-        # satisfied instead of an "undefined service mongo" invalid-project
-        # error (same reasoning the sync service documents below).
-        required: false
+    # No depends_on mongo here: mongo is gated behind the `selfhosted` profile,
+    # and cloud/Atlas deploys run without a local mongo service. A hard
+    # dependency in this base file makes those projects invalid ("depends on
+    # undefined service mongo"). `required: false` is not a substitute — Compose
+    # treats an unhealthy optional dependency as satisfied and starts backend
+    # before mongo is ready. The selfhosted wait lives in
+    # compose.selfhosted.yaml and is applied by the compass helper when the
+    # selfhosted profile is active.
     environment:
       COMPASS_CONFIG_FILE: /app/compass.yaml
       # Default to info so health-check requests stay out of the tail. Reveal

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -133,36 +133,37 @@ describe("self-host docker compose", () => {
     expect(compose).toContain("compass_sync_logs:");
   });
 
-  it("waits for mongo before starting backend when the selfhosted profile is active", () => {
-    const compose = readFileSync(join(import.meta.dir, "compose.yaml"), {
-      encoding: "utf8",
-    });
-
-    expect(compose).toContain("depends_on:");
-    expect(compose).toContain("condition: service_healthy");
-    expect(compose).toContain("stop_grace_period: 30s");
-    expect(compose).toContain("start_period: 90s");
-  });
-
-  it("keeps the backend mongo dependency optional so cloud/Atlas deploys stay a valid project", () => {
+  it("omits the backend mongo dependency from the base compose file", () => {
     const compose = readFileSync(join(import.meta.dir, "compose.yaml"), {
       encoding: "utf8",
     });
 
     // mongo is gated behind the `selfhosted` profile, so a profile-less
-    // cloud/Atlas deploy has no mongo container. Without `required: false` the
-    // backend's dependency on the (absent) mongo service makes the compose
-    // project invalid ("depends on undefined service mongo"), which breaks the
-    // staging-cloud/production deploy.
+    // cloud/Atlas deploy has no mongo container. A hard depends_on in the base
+    // file makes that project invalid ("depends on undefined service mongo").
+    // `required: false` is the wrong fix: Compose treats an unhealthy optional
+    // dependency as satisfied and starts backend before mongo is ready.
     // Match the top-level service definition ("\n  backend:\n", exactly two
     // spaces of indent), not the x-local-bindings anchor ("  backend:
     // &backend-port ...") nor the web service's nested "depends_on: backend:".
     const backendBlock = compose
       .slice(compose.indexOf("\n  backend:\n") + 1)
       .split(/\n {2}\w/)[0];
-    expect(backendBlock).toContain("mongo:");
-    expect(backendBlock).toContain("condition: service_healthy");
-    expect(backendBlock).toMatch(/^\s+required: false\s*$/m);
+    expect(backendBlock).not.toContain("mongo:");
+    expect(backendBlock).toContain("start_period: 90s");
+    expect(compose).toContain("stop_grace_period: 30s");
+  });
+
+  it("waits for mongo before starting backend via the selfhosted overlay", () => {
+    const overlay = readFileSync(
+      join(import.meta.dir, "compose.selfhosted.yaml"),
+      { encoding: "utf8" },
+    );
+
+    expect(overlay).toContain("depends_on:");
+    expect(overlay).toContain("mongo:");
+    expect(overlay).toContain("condition: service_healthy");
+    expect(overlay).not.toContain("required: false");
   });
 });
 
@@ -186,6 +187,14 @@ describe("self-host installer", () => {
       "I found existing Compass Docker data, but $CONFIG_FILE is missing.",
     );
   });
+
+  it("downloads the selfhosted mongo overlay with the base compose file", () => {
+    const installer = readRepoFile("self-host/install.sh");
+    const manual = readRepoFile("self-host/install-manual.sh");
+
+    expect(installer).toContain("self-host/compose.selfhosted.yaml");
+    expect(manual).toContain("self-host/compose.selfhosted.yaml");
+  });
 });
 
 describe("self-host helper", () => {
@@ -208,6 +217,13 @@ describe("self-host helper", () => {
     const helper = readRepoFile("self-host/compass");
 
     expect(helper).toContain("compose up -d --remove-orphans --wait");
+  });
+
+  it("applies the selfhosted mongo overlay when the selfhosted profile is active", () => {
+    const helper = readRepoFile("self-host/compass");
+
+    expect(helper).toContain("compose.selfhosted.yaml");
+    expect(helper).toContain("*,selfhosted,*)");
   });
 });
 
@@ -233,6 +249,14 @@ describe("staging deploy workflow", () => {
 
     expect(workflow).not.toContain(
       "docker compose --project-name compass -f compose.yaml down",
+    );
+  });
+
+  it("deploys the selfhosted mongo overlay alongside the base compose file", () => {
+    const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
+
+    expect(workflow).toContain(
+      "self-host/compose.selfhosted.yaml -o ~/compass/compose.selfhosted.yaml",
     );
   });
 

--- a/self-host/install-manual.sh
+++ b/self-host/install-manual.sh
@@ -47,6 +47,7 @@ CONFIG_FILE=$COMPASS_HOME/compass.yaml      # Your configuration (secrets, ports
 MARKER_FILE=$COMPASS_HOME/.compass-self-host # Marks this as a Compass install directory
 HELPER_FILE=$COMPASS_HOME/compass            # CLI helper script for day-to-day management
 COMPOSE_FILE=$COMPASS_HOME/compose.yaml      # Docker Compose configuration
+COMPOSE_SELFHOSTED_FILE=$COMPASS_HOME/compose.selfhosted.yaml
 
 # The project name is derived from the install directory name.
 # Docker Compose uses this to namespace containers and volumes.
@@ -364,6 +365,19 @@ export SUPERTOKENS_POSTGRES_DB="$(strip_quotes "$(read_config_value supertokens.
 
 echo "  ✓ Environment variables exported"
 
+compose_base() {
+  case ",${COMPOSE_PROFILES}," in
+    *,selfhosted,*)
+      if [ -f "$COMPOSE_SELFHOSTED_FILE" ]; then
+        docker compose --project-name "$PROJECT_NAME" \
+          -f "$COMPOSE_FILE" -f "$COMPOSE_SELFHOSTED_FILE" "$@"
+        return
+      fi
+      ;;
+  esac
+  docker compose --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
+}
+
 # ── Section 10: Start Stack ───────────────────────────────────────────────────
 # Start all Compass services using Docker Compose.
 # On first run, this will download container images (may take a few minutes).
@@ -378,7 +392,7 @@ echo "  ✓ Environment variables exported"
 echo "Starting Compass..."
 echo "  (First run will download images - this may take a few minutes)"
 
-docker compose --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d \
+compose_base up -d \
   || { echo "ERROR: Docker Compose failed to start Compass"; exit 1; }
 
 echo "  ✓ Compass containers started"

--- a/self-host/install-manual.sh
+++ b/self-host/install-manual.sh
@@ -265,6 +265,12 @@ curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_GIT_REF}/self-host/compose.yaml" -o "$C
   || { echo "ERROR: Could not download compose.yaml"; exit 1; }
 echo "  ✓ Downloaded compose.yaml"
 
+# Selfhosted overlay hard-waits for healthy mongo before starting backend.
+curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_GIT_REF}/self-host/compose.selfhosted.yaml" \
+  -o "$COMPASS_HOME/compose.selfhosted.yaml" \
+  || { echo "ERROR: Could not download compose.selfhosted.yaml"; exit 1; }
+echo "  ✓ Downloaded compose.selfhosted.yaml"
+
 # Download the compass helper script - provides commands like "compass logs", "compass restart"
 curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_GIT_REF}/self-host/compass" -o "$HELPER_FILE" \
   || { echo "ERROR: Could not download compass helper"; exit 1; }

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -13,6 +13,7 @@ CONFIG_FILE=$COMPASS_HOME/compass.yaml
 MARKER_FILE=$COMPASS_HOME/.compass-self-host
 HELPER_FILE=$COMPASS_HOME/compass
 COMPOSE_FILE=$COMPASS_HOME/compose.yaml
+COMPOSE_SELFHOSTED_FILE=$COMPASS_HOME/compose.selfhosted.yaml
 
 PROJECT_NAME=$(basename "$COMPASS_HOME")
 WEB_PORT_VALUE=9080
@@ -502,6 +503,15 @@ set_compose_env() {
 
 compose_base() {
   set_compose_env
+  case ",${COMPOSE_PROFILES}," in
+    *,selfhosted,*)
+      if [ -f "$COMPOSE_SELFHOSTED_FILE" ]; then
+        docker compose --project-name "$PROJECT_NAME" \
+          -f "$COMPOSE_FILE" -f "$COMPOSE_SELFHOSTED_FILE" "$@"
+        return
+      fi
+      ;;
+  esac
   docker compose --project-name "$PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
 }
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -452,15 +452,20 @@ EOF
 
 download_compose_file() {
   tmp_compose=$COMPASS_HOME/compose.yaml.$$
+  tmp_selfhosted=$COMPASS_HOME/compose.selfhosted.yaml.$$
   info "Downloading compose.yaml for Compass ${COMPASS_VERSION}."
   curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_GIT_REF}/self-host/compose.yaml" -o "$tmp_compose" \
     || fail "Could not download compose.yaml for version ${COMPASS_VERSION}. Check that the version exists."
+  curl -fsSL "${COMPASS_RAW_URL}/${COMPASS_GIT_REF}/self-host/compose.selfhosted.yaml" -o "$tmp_selfhosted" \
+    || fail "Could not download compose.selfhosted.yaml for version ${COMPASS_VERSION}. Check that the version exists."
 
   if [ -f "$COMPOSE_FILE" ]; then
     cp "$COMPOSE_FILE" "${COMPASS_HOME}/.compose.yaml.bak" || true
   fi
 
   mv "$tmp_compose" "$COMPOSE_FILE" || fail "Could not install compose.yaml."
+  mv "$tmp_selfhosted" "$COMPASS_HOME/compose.selfhosted.yaml" \
+    || fail "Could not install compose.selfhosted.yaml."
 }
 
 download_helper() {


### PR DESCRIPTION
## Summary
- Staging-selfhosted deploys were failing because `required: false` on backend→mongo lets Compose treat an unhealthy mongo as satisfied and start backend early, racing the health window.
- Keep mongo out of the base `compose.yaml` so cloud/Atlas stays a valid project, and apply a required `service_healthy` overlay (`compose.selfhosted.yaml`) when the selfhosted profile is active.
- Install and deploy paths download the overlay with the base compose file.

## Simplicity
No simplification opportunities found beyond clarifying the compass helper comment. Complexity is about the same: one small overlay file replaces an incorrect `required: false` flag. No React hooks involved.

## Manual Testing Steps
- [ ] Confirm `docker compose -f self-host/compose.yaml config` succeeds with empty `COMPOSE_PROFILES` (cloud) and does not list a mongo service dependency on backend
- [ ] Confirm `COMPOSE_PROFILES=selfhosted docker compose -f self-host/compose.yaml -f self-host/compose.selfhosted.yaml config` lists backend `depends_on.mongo.condition: service_healthy` without `required: false`
- [ ] After merge, confirm the next `Release on main` staging-selfhosted deploy no longer logs `optional dependency "mongo" failed to start` and reaches healthy backend/mongo

## Test plan
- [x] `bun test self-host/docker-compose.test.ts` (32 pass)
- [x] `bun run lint`
- [x] `docker compose ... config` for empty profiles and `selfhosted` + overlay


Made with [Cursor](https://cursor.com)