### PR TITLE
fix(self-host): prune unused images on compass update

### DIFF
--- a/self-host/compass
+++ b/self-host/compass
@@ -266,11 +266,22 @@ case $command_name in
     ;;
   update)
     require_stack
+    # Release deploys leave every prior tag on the host. Prune unused images
+    # before pulling so a full disk cannot block the upgrade, then again after
+    # recreate so the just-replaced tags do not accumulate.
+    docker image prune -af >/dev/null 2>&1 || true
     compose pull || fail "Could not pull updated Compass images from Docker Hub."
-    compose up -d --remove-orphans --wait || fail "Docker Compose failed to start updated Compass."
+    if ! compose up -d --remove-orphans --wait; then
+      compose ps -a >&2 || true
+      compose logs --tail=100 mongo backend >&2 || true
+      fail "Docker Compose failed to start updated Compass."
+    fi
+    docker image prune -af >/dev/null 2>&1 || true
     if wait_for_health; then
       info "Compass updated and running at $APP_URL"
     else
+      compose ps -a >&2 || true
+      compose logs --tail=100 mongo backend >&2 || true
       fail "Compass updated, but the backend health check did not pass. Run './compass logs' for details."
     fi
     ;;

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -219,6 +219,14 @@ describe("self-host helper", () => {
     expect(helper).toContain("compose up -d --remove-orphans --wait");
   });
 
+  it("prunes unused images around update so release tags cannot fill the disk", () => {
+    const helper = readRepoFile("self-host/compass");
+    const updateBlock = helper.slice(helper.indexOf("\n  update)"));
+
+    expect(updateBlock).toContain("docker image prune -af");
+    expect(updateBlock).toContain("compose logs --tail=100 mongo backend");
+  });
+
   it("applies the selfhosted mongo overlay when the selfhosted profile is active", () => {
     const helper = readRepoFile("self-host/compass");
 


### PR DESCRIPTION
## Summary
- Staging-selfhosted filled its 38G disk with ~1400 historical release images, which crashed mongo (`No space left on device`) and blocked deploys.
- `compass update` now prunes unused images before and after upgrading, and dumps mongo/backend logs when startup fails.
- Also deleted the stale staging `COMPOSE_GIT_REF=ci/deploy-health-checks` environment variables (ops change) so deploys stop 404-falling-back every run.

## Simplicity
No simplification opportunities found. One focused change in the update path; no React hooks involved.

## Manual Testing Steps
- [ ] On a selfhosted host with spare unused images, run `./compass update` and confirm unused images are removed while running containers stay healthy
- [ ] Confirm a failed `compose up` prints `compose ps` and recent mongo/backend logs before exiting
- [ ] After merge, confirm the next staging-selfhosted release no longer 404s on `ci/deploy-health-checks` and completes health checks

## Test plan
- [x] `bun test self-host/docker-compose.test.ts` (33 pass)
- [x] `bun run lint`
- [x] Deleted `COMPOSE_GIT_REF` from staging-selfhosted and staging-cloud via `gh variable delete`


Made with [Cursor](https://cursor.com)