### PR TITLE
fix(self-host): bound image prune so ssh deploys cannot stall

### DIFF
--- a/self-host/compass
+++ b/self-host/compass
@@ -237,6 +237,19 @@ rebuild_stack() {
   fi
 }
 
+prune_unused_images() {
+  # Release deploys leave every prior tag on the host. Prune before pull so a
+  # full disk cannot block upgrades, and again after recreate so replaced tags
+  # do not accumulate. Keep stdout moving and bound runtime so a large prune
+  # cannot silently stall an SSH-based CI deploy.
+  info "Pruning unused Docker images..."
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 120 docker image prune -af || info "Image prune timed out or failed; continuing update."
+  else
+    docker image prune -af || info "Image prune failed; continuing update."
+  fi
+}
+
 command_name=${1:-}
 
 case $command_name in
@@ -266,17 +279,14 @@ case $command_name in
     ;;
   update)
     require_stack
-    # Release deploys leave every prior tag on the host. Prune unused images
-    # before pulling so a full disk cannot block the upgrade, then again after
-    # recreate so the just-replaced tags do not accumulate.
-    docker image prune -af >/dev/null 2>&1 || true
+    prune_unused_images
     compose pull || fail "Could not pull updated Compass images from Docker Hub."
     if ! compose up -d --remove-orphans --wait; then
       compose ps -a >&2 || true
       compose logs --tail=100 mongo backend >&2 || true
       fail "Docker Compose failed to start updated Compass."
     fi
-    docker image prune -af >/dev/null 2>&1 || true
+    prune_unused_images
     if wait_for_health; then
       info "Compass updated and running at $APP_URL"
     else

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -223,7 +223,8 @@ describe("self-host helper", () => {
     const helper = readRepoFile("self-host/compass");
     const updateBlock = helper.slice(helper.indexOf("\n  update)"));
 
-    expect(updateBlock).toContain("docker image prune -af");
+    expect(helper).toContain("prune_unused_images");
+    expect(helper).toContain("timeout 120 docker image prune -af");
     expect(updateBlock).toContain("compose logs --tail=100 mongo backend");
   });
 


### PR DESCRIPTION
## Summary
- Follow-up to #2345: silent unbounded `docker image prune -af` hung the staging-cloud SSH deploy after reclaiming disk.
- Cap prune at 120s, keep stdout so the session stays alive, and continue the update if prune times out.
- Staging-selfhosted already succeeded on v1.0.421; staging-cloud was updated manually to 1.0.421 and the stuck release run was cancelled.

## Simplicity
Extracted a small `prune_unused_images` helper. No React hooks involved.

## Manual Testing Steps
- [ ] Run `./compass update` on a host with unused images and confirm prune logs appear (not silent) and update completes
- [ ] Confirm a prune that would run longer than two minutes is cut off and the update still proceeds

## Test plan
- [x] `bun test self-host/docker-compose.test.ts` (33 pass)
- [x] `bun run lint`


Made with [Cursor](https://cursor.com)