### PR TITLE
refactor(web): open context-menu edit via draft store

### DIFF
--- a/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
@@ -24,12 +24,9 @@ import {
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockClose = mock();
-const mockOpenForm = mock();
-const mockSetDraft = mock();
 
 const EVENT_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -59,10 +56,9 @@ const createSourceEvent = (event: GridEvent) =>
     }),
   });
 
-// GridContextMenuWrapper.tsx (the real right-click flow, unconverted here)
-// already pushes a GridEventDraft into the store's `gridDraft` field before
-// ContextMenuItems mounts; seed the same field directly so edit has a
-// canonical draft to read.
+// GridContextMenuWrapper.tsx (the real right-click flow) already pushes a
+// GridEventDraft into the store's `gridDraft` field before ContextMenuItems
+// mounts; seed the same field so edit can open the store-owned form.
 const seedGridDraftForEvent = (event: GridEvent) => {
   const draft = editGridEventDraft(createSourceEvent(event));
   useDraftStore.setState({ gridDraft: draft });
@@ -98,24 +94,7 @@ const renderWithTheme = (
   }
 
   return {
-    ...render(
-      <DraftContext.Provider
-        value={
-          {
-            actions: {
-              openForm: mockOpenForm,
-              repositionDraftByKeyboard: mock(() => false),
-            },
-            setters: {
-              setDraft: mockSetDraft,
-            },
-          } as never
-        }
-      >
-        {ui}
-      </DraftContext.Provider>,
-      { queryClient },
-    ),
+    ...render(ui, { queryClient }),
     queryClient,
   };
 };
@@ -123,8 +102,6 @@ const renderWithTheme = (
 describe("ContextMenuItems", () => {
   beforeEach(() => {
     mockClose.mockClear();
-    mockOpenForm.mockClear();
-    mockSetDraft.mockClear();
     useDraftStore.setState({ gridDraft: null, status: null });
   });
 
@@ -156,8 +133,7 @@ describe("ContextMenuItems", () => {
     const editButton = screen.getByRole("menuitem", { name: "Edit" });
     await user.click(editButton);
 
-    expect(mockSetDraft).toHaveBeenCalled();
-    expect(mockOpenForm).toHaveBeenCalled();
+    expect(selectIsEventFormOpen(useDraftStore.getState())).toBe(true);
     expect(mockClose).toHaveBeenCalled();
   });
 
@@ -205,8 +181,7 @@ describe("ContextMenuItems", () => {
     const editButton = screen.getByRole("menuitem", { name: "Edit" });
     await user.click(editButton);
 
-    expect(mockSetDraft).toHaveBeenCalled();
-    expect(mockOpenForm).toHaveBeenCalled();
+    expect(selectIsEventFormOpen(useDraftStore.getState())).toBe(true);
     expect(mockClose).toHaveBeenCalled();
   });
 

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -7,10 +7,9 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { ID_CONTEXT_MENU_ITEMS } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
+import { draftActions } from "@web/events/stores/draft.store";
 import { useDeleteEvent } from "@web/views/Forms/hooks/useDeleteEvent";
 import { useDuplicateEvent } from "@web/views/Forms/hooks/useDuplicateEvent";
-import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 
 export interface ContextMenuAction {
   id: string;
@@ -126,17 +125,9 @@ export function ContextMenuItemsView({
 }
 
 export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
-  const { actions, setters } = useDraftContext();
-  const { openForm } = actions;
-  const { setDraft } = setters;
   const eventId = event._id ?? "";
   const deleteEvent = useDeleteEvent(eventId);
   const duplicateEvent = useDuplicateEvent(eventId);
-  // The right-click flow (GridContextMenuWrapper.tsx) already builds a
-  // GridEventDraft via editGridEventDraft and pushes it into the store, so
-  // this reads that canonical draft rather than re-deriving one from
-  // `event` (a GridEvent render projection with no strict source).
-  const gridDraft = useDraftStore(selectGridDraft);
 
   const menuActions: ContextMenuItemsActions = {
     delete: () => {
@@ -145,9 +136,11 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
     duplicate: () => {
       duplicateEvent();
     },
+    // Right-click already seeded `gridDraft` via startGridDraft. Form open is
+    // store-owned; Week's Draft hydrates the local portal draft from the store
+    // when isFormOpen flips (handleChange skips eventRightClick on purpose).
     edit: () => {
-      if (gridDraft) setDraft(gridDraft);
-      openForm();
+      draftActions.setFormOpen(true);
     },
   };
 

--- a/packages/web/src/components/ContextMenu/contextMenuLayering.test.tsx
+++ b/packages/web/src/components/ContextMenu/contextMenuLayering.test.tsx
@@ -1,4 +1,3 @@
-import { type PropsWithChildren } from "react";
 import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
 import {
   cleanup,
@@ -19,8 +18,7 @@ import { ContextMenuWrapper } from "@web/components/ContextMenu/GridContextMenuW
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { draftActions } from "@web/events/stores/draft.store";
 import { useDayCalendarContextMenu } from "@web/views/Day/components/Calendar/DayCalendarContextMenu";
-import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
 
 // The menu used to render inline with a hardcoded z-2, so any event card
@@ -66,21 +64,6 @@ const seedCacheEntry = () => {
   return queryClient;
 };
 
-// The menu's items read the draft context; this test is only about where the
-// menu renders, so a stub is enough.
-const DraftStub = ({ children }: PropsWithChildren) => (
-  <DraftContext.Provider
-    value={
-      {
-        actions: { openForm: mock() },
-        setters: { setDraft: mock() },
-      } as never
-    }
-  >
-    {children}
-  </DraftContext.Provider>
-);
-
 afterEach(() => {
   draftActions.discard();
   cleanup();
@@ -101,7 +84,7 @@ describe("context menu layering", () => {
             right-clicked element. */}
         <div {...{ [DATA_EVENT_ELEMENT_ID]: event.id }}>Stacked event</div>
       </ContextMenuWrapper>,
-      { queryClient: seedCacheEntry(), wrapper: DraftStub },
+      { queryClient: seedCacheEntry() },
     );
 
     fireEvent.contextMenu(screen.getByText("Stacked event"));
@@ -130,7 +113,6 @@ describe("context menu layering", () => {
 
     render(<DayHarness />, {
       queryClient: seedCacheEntry(),
-      wrapper: DraftStub,
     });
 
     fireEvent.contextMenu(screen.getByText("Stacked event"));

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -6,7 +6,11 @@ import { getDraftContainer } from "@web/common/utils/draft/draft.util";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
-import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
+import {
+  selectDraftActivity,
+  selectGridDraft,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { positionAllDayDraftEvent } from "@web/grid/layout/all-day-draft.position";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -34,18 +38,20 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   const { draft, isDragging, isFormOpen, isResizing } = state;
   const { setDraft } = setters;
   const gridDraftFromStore = useDraftStore(selectGridDraft);
+  const activity = useDraftStore(selectDraftActivity);
 
   // Context-menu Edit only flips store isFormOpen (handleChange skips
-  // eventRightClick), so hydrate local draft during render when it is still
-  // null — otherwise the portal would lag a frame behind the sidebar form.
-  // Do not overwrite a non-null local draft here: keyboard repositioning
-  // updates local only, and a render-time `draft !== store` sync would undo it.
+  // eventRightClick), so hydrate local draft during render — otherwise the
+  // portal would lag a frame behind the sidebar form. Allow a non-null
+  // overwrite only for eventRightClick: an earlier create/nudge can leave
+  // stale local state, but keyboard repositioning (other activities) updates
+  // local only and must not be undone here.
   if (
     !isDragging &&
     !isResizing &&
     isFormOpen &&
     gridDraftFromStore &&
-    draft === null
+    (draft === null || activity === "eventRightClick")
   ) {
     setDraft(gridDraftFromStore);
   }

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from "react";
+import { type FC, useEffect, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { Origin } from "@core/constants/core.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -35,21 +35,30 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   const { setDraft } = setters;
   const gridDraftFromStore = useDraftStore(selectGridDraft);
 
-  // Sidebar edits and context-menu Edit write the shared draft store.
-  // Mirror into Week local draft while the form is idle so the portal
-  // overlay stays in sync without ContextMenu/Sidebar depending on
-  // DraftContext. Adjust during render (not useEffect) so context-menu
-  // Edit — which only flips store isFormOpen — does not flash an empty
-  // portal for a frame before GridDraft can read local `draft`.
+  // Context-menu Edit only flips store isFormOpen (handleChange skips
+  // eventRightClick), so hydrate local draft during render when it is still
+  // null — otherwise the portal would lag a frame behind the sidebar form.
+  // Do not overwrite a non-null local draft here: keyboard repositioning
+  // updates local only, and a render-time `draft !== store` sync would undo it.
   if (
     !isDragging &&
     !isResizing &&
     isFormOpen &&
     gridDraftFromStore &&
-    draft !== gridDraftFromStore
+    draft === null
   ) {
     setDraft(gridDraftFromStore);
   }
+
+  // Sidebar edits write the shared draft store. Mirror into Week local draft
+  // when the store draft changes while the form is idle.
+  useEffect(() => {
+    if (isDragging || isResizing || !isFormOpen || !gridDraftFromStore) {
+      return;
+    }
+
+    setDraft(gridDraftFromStore);
+  }, [gridDraftFromStore, isDragging, isFormOpen, isResizing, setDraft]);
 
   // GridEvent-shaped projection of the canonical GridEventDraft, for
   // the still-unconverted grid-layout helpers below (deck layout, all-day

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo } from "react";
+import { type FC, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { Origin } from "@core/constants/core.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -35,16 +35,21 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   const { setDraft } = setters;
   const gridDraftFromStore = useDraftStore(selectGridDraft);
 
-  // Sidebar edits write the shared draft store. Mirror into Week local draft
-  // while the form is idle so the portal overlay stays in sync without
-  // SidebarEventDetails depending on DraftContext.
-  useEffect(() => {
-    if (isDragging || isResizing || !isFormOpen || !gridDraftFromStore) {
-      return;
-    }
-
+  // Sidebar edits and context-menu Edit write the shared draft store.
+  // Mirror into Week local draft while the form is idle so the portal
+  // overlay stays in sync without ContextMenu/Sidebar depending on
+  // DraftContext. Adjust during render (not useEffect) so context-menu
+  // Edit — which only flips store isFormOpen — does not flash an empty
+  // portal for a frame before GridDraft can read local `draft`.
+  if (
+    !isDragging &&
+    !isResizing &&
+    isFormOpen &&
+    gridDraftFromStore &&
+    draft !== gridDraftFromStore
+  ) {
     setDraft(gridDraftFromStore);
-  }, [gridDraftFromStore, isDragging, isFormOpen, isResizing, setDraft]);
+  }
 
   // GridEvent-shaped projection of the canonical GridEventDraft, for
   // the still-unconverted grid-layout helpers below (deck layout, all-day


### PR DESCRIPTION
## Summary
- `ContextMenuItems` Edit now calls `draftActions.setFormOpen(true)` instead of Week `DraftContext` (`openForm` / `setDraft`).
- Week `Draft` hydrates a null local portal draft during render when the form opens (avoids an empty-frame portal after context-menu Edit), and keeps the store→local effect for Sidebar edits without overwriting local-only keyboard moves.
- Context menu tests no longer mock `DraftProvider`.

## Simplicity
Net reduction: ContextMenu dropped a DraftContext dependency and DraftProvider test scaffolding. Hook complexity stayed flat — kept the existing store→local `useEffect` for Sidebar sync; added a render-time null-only hydrate so context-menu Edit does not flash an empty portal (`useEffect` alone would lag a frame; a blanket `draft !== store` render sync would undo keyboard nudges).

## Manual Testing Steps
- [ ] In Week view, right-click an event → menu opens without the event form.
- [ ] Choose Edit/View → sidebar form opens with that event; grid draft overlay appears without a blank flash.
- [ ] Close the form, right-click another event → Edit again → form shows the new event.
- [ ] Create or open a draft via keyboard shortcut/click, arrow-nudge it while the form is open → times stay moved (not snapped back).
- [ ] Edit title in the sidebar while the form is open → grid draft overlay updates.

## Test plan
- [x] `bun test:web packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx packages/web/src/components/ContextMenu/contextMenuLayering.test.tsx packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts` (20 pass)
- [x] `bun run type-check:web-tests` + web app `tsc --noEmit`

Made with [Cursor](https://cursor.com)