### PR TITLE
refactor(web): fold grid draft resize into startResizing

### DIFF
--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx
@@ -93,12 +93,10 @@ const renderGridDraft = ({
       discard: mock(),
       repositionDraftByKeyboard: mock(() => true),
       startDragging: mock(),
+      startResizing: mock(),
     },
     setters: {
-      setDateBeingChanged: mock(),
       setDraft: mock(),
-      setDragOffset: mock(),
-      setIsResizing: mock(),
     },
     state: {
       draft,

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -37,9 +37,8 @@ export const GridDraft: FC<Props> = ({
   recurringPreviews = [],
   weekProps,
 }) => {
-  const { actions, setters, state } = useDraftContext();
-  const { startDragging } = actions;
-  const { setDragOffset, setDateBeingChanged, setIsResizing } = setters;
+  const { actions, state } = useDraftContext();
+  const { startDragging, startResizing } = actions;
   const { draft, dragOffset, isDragging, isResizing } = state;
 
   // GridEvent-shaped projection of the canonical GridEventDraft, for
@@ -61,8 +60,19 @@ export const GridDraft: FC<Props> = ({
   const handleDrag = (_: GridEventEntity, moveEvent: PartialMouseEvent) => {
     if (!draft) return; // TS Guard
 
-    setDragOffset(getEventDragOffset(draftAsGridEvent ?? undefined, moveEvent));
-    startDragging();
+    startDragging(
+      getEventDragOffset(draftAsGridEvent ?? undefined, moveEvent),
+    );
+  };
+
+  const handleScalerMouseDown = (
+    _event: GridEventEntity,
+    e: MouseEvent,
+    dateToChange: "startDate" | "endDate",
+  ) => {
+    e.stopPropagation();
+    e.preventDefault();
+    startResizing(dateToChange);
   };
 
   const motionMode = isResizing ? "resizing" : isDragging ? "dragging" : "idle";
@@ -108,16 +118,7 @@ export const GridDraft: FC<Props> = ({
             e.preventDefault();
             onMouseDown(e, event);
           }}
-          onScalerMouseDown={(
-            _event: GridEventEntity,
-            e: MouseEvent,
-            dateToChange: "startDate" | "endDate",
-          ) => {
-            e.stopPropagation();
-            e.preventDefault();
-            setDateBeingChanged(dateToChange);
-            setIsResizing(true);
-          }}
+          onScalerMouseDown={handleScalerMouseDown}
           weekDays={weekProps.component.weekDays}
         />
       ) : (
@@ -133,16 +134,7 @@ export const GridDraft: FC<Props> = ({
             onMouseDown(e, event);
           }}
           onEventKeyDown={focusEventFormTitle}
-          onScalerMouseDown={(
-            _event: GridEventEntity,
-            e: MouseEvent,
-            dateToChange: "startDate" | "endDate",
-          ) => {
-            e.stopPropagation();
-            e.preventDefault();
-            setDateBeingChanged(dateToChange);
-            setIsResizing(true);
-          }}
+          onScalerMouseDown={handleScalerMouseDown}
           weekProps={weekProps}
         />
       )}

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -60,9 +60,7 @@ export const GridDraft: FC<Props> = ({
   const handleDrag = (_: GridEventEntity, moveEvent: PartialMouseEvent) => {
     if (!draft) return; // TS Guard
 
-    startDragging(
-      getEventDragOffset(draftAsGridEvent ?? undefined, moveEvent),
-    );
+    startDragging(getEventDragOffset(draftAsGridEvent ?? undefined, moveEvent));
   };
 
   const handleScalerMouseDown = (

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -30,6 +30,7 @@ import {
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
 import { useDraftEffects } from "@web/views/Week/components/Draft/hooks/effects/useDraftEffects";
 import {
+  type DragOffset,
   type Setters_Draft,
   type State_Draft_Local,
   type Status_Drag,
@@ -80,6 +81,7 @@ export const useDraftActions = (
   const {
     setIsDragging,
     setIsResizing,
+    setDragOffset,
     setDragStatus,
     setResizeStatus,
     setDateBeingChanged,
@@ -88,14 +90,23 @@ export const useDraftActions = (
     setIsFormOpenBeforeDragging,
   } = setters;
 
-  const startDragging = useCallback(() => {
-    setIsDragging(true);
-  }, [setIsDragging]);
+  const startDragging = useCallback(
+    (offset?: DragOffset) => {
+      if (offset) {
+        setDragOffset(offset);
+      }
+      setIsDragging(true);
+    },
+    [setDragOffset, setIsDragging],
+  );
 
-  const startResizing = useCallback(() => {
-    setIsResizing(true);
-    setDateBeingChanged(dateToResize ?? null);
-  }, [setIsResizing, setDateBeingChanged, dateToResize]);
+  const startResizing = useCallback(
+    (dateBeingChanged: "startDate" | "endDate") => {
+      setIsResizing(true);
+      setDateBeingChanged(dateBeingChanged);
+    },
+    [setIsResizing, setDateBeingChanged],
+  );
 
   const stopDragging = useCallback(() => {
     setIsDragging(false);
@@ -587,12 +598,15 @@ export const useDraftActions = (
     }
     if (activity === "resizing") {
       if (gridDraftFromStore) setDraft(gridDraftFromStore);
-      startResizing();
+      if (dateToResize === "startDate" || dateToResize === "endDate") {
+        startResizing(dateToResize);
+      }
     }
   }, [
     isDrafting,
     activity,
     create,
+    dateToResize,
     setDraft,
     gridDraftFromStore,
     startResizing,
@@ -606,14 +620,15 @@ export const useDraftActions = (
     openForm,
     repositionDraftByKeyboard,
     resize,
-    startDragging: () => {
+    startDragging: (offset?: DragOffset) => {
       // Placing `setIsFormOpenBeforeDragging` here rather than inside `startDragging`
       // because `setIsFormOpenBeforeDragging` depends on `isFormOpen` and re-calculates
       // `startDragging` (due to it being a react callback) which causes issues.
       // This is a hacky solution to the issue.
       setIsFormOpenBeforeDragging(isFormOpen);
-      startDragging();
+      startDragging(offset);
     },
+    startResizing,
     stopDragging,
     stopResizing,
   };


### PR DESCRIPTION
## Summary
- Export `startResizing(dateBeingChanged)` on Week draft actions and accept an optional drag offset on `startDragging`.
- `GridDraft` starts drag/resize through those actions instead of raw `setDateBeingChanged` / `setIsResizing` / `setDragOffset` setters.
- Store-driven resize activity still passes `dateToResize` into `startResizing`.

## Simplicity
Net reduction: GridDraft no longer reaches into resize/drag setters; one shared `handleScalerMouseDown` replaces duplicated all-day/timed handlers. Hook complexity stayed flat — no new `useEffect`/`useRef`/`useState`. Public context `setters` still expose the low-level setters for effects/`setDraft` callers; narrowing that surface further is left for a later peel.

## Manual Testing Steps
- [ ] In Week view, create or open a timed draft → drag it by the body → event follows the pointer with the original grab offset.
- [ ] Resize a timed draft from the top edge → start time changes; from the bottom edge → end time changes.
- [ ] Resize an all-day draft from either edge → span updates.
- [ ] Drag-create a timed event from an empty grid cell (store resizing activity) → draft still grows from the end edge until mouse-up.

## Test plan
- [x] `bun test:web packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts` (13 pass)
- [x] `bun run type-check:web-tests` + web app `tsc --noEmit`

Made with [Cursor](https://cursor.com)