### PR TITLE
refactor(web): open week event form via draft store

### DIFF
--- a/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { Categories_Event } from "@web/common/types/web.event.types";
 import { getElemById } from "@web/common/utils/grid/grid.util";
 import {
+  draftActions,
   selectDraftStatus,
   useDraftStore,
 } from "@web/events/stores/draft.store";
@@ -11,7 +12,7 @@ import { useDraftContext } from "../../context/useDraftContext";
 export const useGridMouseUp = () => {
   const { actions, state } = useDraftContext();
   const { draft, dragStatus, isDragging, isResizing, resizeStatus } = state;
-  const { discard, openForm, stopDragging, stopResizing, submit } = actions;
+  const { discard, stopDragging, stopResizing, submit } = actions;
 
   const draftStatus = useDraftStore(selectDraftStatus);
   const draftType = draftStatus?.eventType;
@@ -59,14 +60,14 @@ export const useGridMouseUp = () => {
     );
 
     if (shouldOpenForm) {
-      openForm();
+      draftActions.setFormOpen(true);
       return;
     }
 
     if (shouldSubmit) {
       submit(draft);
     }
-  }, [draft, getNextAction, stopMotion, openForm, submit]);
+  }, [draft, getNextAction, stopMotion, submit]);
 
   const handleMainGridMouseUp = useCallback(() => {
     if (!draft || !isDrafting) return;
@@ -83,7 +84,7 @@ export const useGridMouseUp = () => {
     );
 
     if (shouldOpenForm) {
-      openForm();
+      draftActions.setFormOpen(true);
       return;
     }
 
@@ -97,7 +98,6 @@ export const useGridMouseUp = () => {
     getNextAction,
     discard,
     stopMotion,
-    openForm,
     submit,
   ]);
 

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -144,10 +144,6 @@ export const useDraftActions = (
     setResizeStatus,
   ]);
 
-  const openForm = useCallback(() => {
-    setIsFormOpen(true);
-  }, [setIsFormOpen]);
-
   const determineSubmitAction = useCallback(
     (draft: GridEventDraft) => {
       if (draft.kind !== "edit") return "CREATE";
@@ -175,7 +171,7 @@ export const useDraftActions = (
       const action = determineSubmitAction(draft);
       switch (action) {
         case "OPEN_FORM":
-          openForm();
+          setIsFormOpen(true);
           return;
         case "DISCARD":
           discard();
@@ -218,7 +214,7 @@ export const useDraftActions = (
           }
 
           if (isFormOpenBeforeDragging) {
-            openForm();
+            setIsFormOpen(true);
           } else {
             discard();
           }
@@ -234,7 +230,7 @@ export const useDraftActions = (
       discard,
       isFormOpenBeforeDragging,
       mutations,
-      openForm,
+      setIsFormOpen,
     ],
   );
 
@@ -579,8 +575,8 @@ export const useDraftActions = (
     if (!gridDraftFromStore) return;
 
     setDraft(gridDraftFromStore);
-    openForm();
-  }, [openForm, gridDraftFromStore, setDraft]);
+    setIsFormOpen(true);
+  }, [gridDraftFromStore, setDraft, setIsFormOpen]);
 
   const handleChange = useCallback(async () => {
     if (!isDrafting) return;
@@ -589,7 +585,7 @@ export const useDraftActions = (
     }
     if (activity === "keyboardEdit") {
       if (gridDraftFromStore) setDraft(gridDraftFromStore);
-      openForm();
+      setIsFormOpen(true);
       return;
     }
     if (activity === "createShortcut" || activity === "gridClick") {
@@ -609,15 +605,14 @@ export const useDraftActions = (
     dateToResize,
     setDraft,
     gridDraftFromStore,
+    setIsFormOpen,
     startResizing,
-    openForm,
   ]);
 
   const actions = {
     submit,
     discard,
     drag,
-    openForm,
     repositionDraftByKeyboard,
     resize,
     setLocalDraft: setDraft,

--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -148,7 +148,7 @@ export const WeekInteractionCoordinator: FC<Props> = ({
         draftActions.setGridDraft(draft);
       }
 
-      actions.openForm();
+      draftActions.setFormOpen(true);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Remove Week draft `openForm` action from the public DraftContext surface.
- `useGridMouseUp` and `WeekInteractionCoordinator` open the form with `draftActions.setFormOpen(true)`.
- Internal create/submit/handleChange paths call `setIsFormOpen(true)` (already the store action).

## Simplicity
Net reduction: one fewer DraftContext action, no new hooks. Form-open was already store-owned; this deletes the redundant Week wrapper.

## Manual Testing Steps
- [ ] Click empty timed grid → release → form opens.
- [ ] Click an existing event → form opens with that event.
- [ ] Drag-create a timed event → form opens after release.
- [ ] Drag a saved event while its form was open, then release with a move → form reopens.

## Test plan
- [x] `bun test:web packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts` (9 pass)
- [x] `bun run type-check:web-tests` + web app `tsc --noEmit`
- [x] `bun lint` (pre-existing unused-import warning in `__tests__/render-with-store.tsx` from #2350)

Made with [Cursor](https://cursor.com)