### PR TITLE
feat(backend): expose connect-delegation flag on /api/config

### DIFF
--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -21,6 +21,7 @@ describe("GET /api/config", () => {
       expect(response.body).toEqual({
         google: {
           isConfigured: false,
+          connectDelegatedToSync: false,
         },
       });
     } finally {
@@ -44,11 +45,23 @@ describe("GET /api/config", () => {
       expect(response.body).toEqual({
         google: {
           isConfigured: false,
+          connectDelegatedToSync: false,
         },
       });
     } finally {
       CONFIG.GOOGLE_CLIENT_ID = originalClientId;
       CONFIG.GOOGLE_CLIENT_SECRET = originalClientSecret;
     }
+  });
+
+  it("reports connect as not delegated to sync on a legacy deployment", async () => {
+    // The test config has no sync service configured, so the global routing
+    // switch resolves to "legacy" and the browser keeps the code-exchange flow.
+    const response = await baseDriver
+      .getServer()
+      .get("/api/config")
+      .expect(Status.OK);
+
+    expect(response.body.google.connectDelegatedToSync).toBe(false);
   });
 });

--- a/packages/backend/src/config/controllers/config.controller.test.ts
+++ b/packages/backend/src/config/controllers/config.controller.test.ts
@@ -1,0 +1,47 @@
+import { type Request, type Response } from "express";
+import { type AppConfig } from "@core/types/config.types";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import configController from "./config.controller";
+import { afterEach, describe, expect, it } from "bun:test";
+
+// Capture what the controller writes via res.json without a real HTTP round-trip.
+const invokeGet = (): AppConfig => {
+  let captured: AppConfig | undefined;
+  const res = {
+    json: (body: AppConfig) => {
+      captured = body;
+    },
+  } as unknown as Response;
+
+  configController.get({} as Request<never, AppConfig, never, never>, res);
+
+  if (!captured) {
+    throw new Error("config controller did not respond");
+  }
+
+  return captured;
+};
+
+describe("ConfigController.get connectDelegatedToSync", () => {
+  const originalRouting = CONFIG.SYNC_CONNECTION_ROUTING;
+  const originalServiceUrl = CONFIG.SYNC_SERVICE_URL;
+  const originalToken = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
+
+  afterEach(() => {
+    CONFIG.SYNC_CONNECTION_ROUTING = originalRouting;
+    CONFIG.SYNC_SERVICE_URL = originalServiceUrl;
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = originalToken;
+  });
+
+  it("reports true when routing is sync and a sync client is configured", () => {
+    // A sync client is built lazily from these two values; with routing=sync
+    // and a client present, getConnectionDelegation() resolves to "sync".
+    // This test file gets its own process, so the client singleton is primed
+    // here rather than left null by an earlier legacy-path call.
+    CONFIG.SYNC_SERVICE_URL = "http://sync.internal:4000";
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
+    CONFIG.SYNC_CONNECTION_ROUTING = "sync";
+
+    expect(invokeGet().google.connectDelegatedToSync).toBe(true);
+  });
+});

--- a/packages/backend/src/config/controllers/config.controller.ts
+++ b/packages/backend/src/config/controllers/config.controller.ts
@@ -2,6 +2,7 @@ import { type Request, type Response } from "express";
 import { type AppConfig, AppConfigSchema } from "@core/types/config.types";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { isGoogleConfigured } from "@backend/common/constants/config.util";
+import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
 
 class ConfigController {
   get = (_req: Request<never, AppConfig, never, never>, res: Response) => {
@@ -9,6 +10,7 @@ class ConfigController {
       AppConfigSchema.parse({
         google: {
           isConfigured: isGoogleConfigured(CONFIG),
+          connectDelegatedToSync: getConnectionDelegation() === "sync",
         },
       }),
     );

--- a/packages/core/src/types/config.types.ts
+++ b/packages/core/src/types/config.types.ts
@@ -3,6 +3,14 @@ import { z } from "zod";
 export const AppConfigSchema = z.object({
   google: z.object({
     isConfigured: z.boolean(),
+    /**
+     * True when this deployment delegates Google connections to the sync
+     * service (the redirect-based begin flow) instead of the legacy in-backend
+     * code-exchange. Deployment-level, not per-user: it mirrors the global
+     * SYNC_CONNECTION_ROUTING switch so the browser can pick the connect UX
+     * before authenticating. Absent/false everywhere delegation is off.
+     */
+    connectDelegatedToSync: z.boolean().default(false),
   }),
 });
 


### PR DESCRIPTION
## What

Adds `google.connectDelegatedToSync` to the public `AppConfig` returned by `GET /api/config`, populated from the global `SYNC_CONNECTION_ROUTING` switch via `getConnectionDelegation()`.

This is the **enabling half** of web connect delegation (S38). The browser currently has no way to learn whether a deployment delegates Google connections to the sync service. Because the routing switch is a *deployment-level* posture (not per-user), the public, already-early-fetched `/api/config` is the least-invasive signal — as opposed to the session-authed, per-user `/api/user/metadata`.

The web consumer (fork the connect UX to the redirect flow when this is true) follows in a separate PR. Legacy stays the default; the field defaults to `false`, so legacy deployments are byte-compatible.

## How it's fail-safe

- `getConnectionDelegation()` already fails safe to `"legacy"` unless an operator selected `"sync"` **and** a sync client is configured.
- The zod field uses `.default(false)`, so a web client parsing an older backend response (field absent) reads it as `false` → legacy. No coordination window where the web breaks.

## Testing

- `bun packages/scripts/src/testing/test-mongo-env.ts backend -- './packages/backend/src/config/config.route.test.ts'` → 3 pass.
- `bun run type-check`: zero new errors vs. `origin/main` (verified by set-difference against the pre-existing local baseline).
- Lint: `./node_modules/.bin/biome check` clean on changed files.

## Manual Testing Steps

1. `GET /api/config` on a default deployment → `google.connectDelegatedToSync: false`.
2. On a deployment with `SYNC_CONNECTION_ROUTING=sync` + `SYNC_SERVICE_URL` set → `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public config field defaulting to false; no auth or connection behavior changes, only surfacing existing routing state.
> 
> **Overview**
> **`GET /api/config`** now includes **`google.connectDelegatedToSync`**, set when the deployment’s global sync connection routing resolves to the sync service (redirect-based connect) rather than legacy in-backend code exchange.
> 
> The field is added to **`AppConfigSchema`** with **`z.boolean().default(false)`** so older responses without it still read as legacy. **`ConfigController.get`** derives the value from existing **`getConnectionDelegation()`** logic (same fail-safe as auth: sync only when routing is sync and a sync client exists).
> 
> Tests assert **`false`** on legacy/default deployments and route expectations, plus a unit test that **`true`** when sync routing and client config are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35cdb968e1cbc47a995e99005a0f0f7b80dd118b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->