### PR TITLE
feat(backend): add listEventOccurrences to SyncServiceClient

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1,11 +1,13 @@
 import { faker } from "@faker-js/faker";
 import { type BusyAvailabilityRequest } from "@core/types/sync/availability.contracts";
+import { type EventOccurrenceListQuery } from "@core/types/sync/event.contracts";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { verifyInternalRequest } from "@sync/auth/internal-auth";
 import {
   AVAILABILITY_BUSY_PATH,
   BEGIN_PATH,
   CONNECTIONS_PATH,
+  EVENTS_PATH,
 } from "@sync/server/connection.routes";
 import {
   SyncServiceClient,
@@ -145,6 +147,85 @@ describe("SyncServiceClient", () => {
     }));
 
     const result = await client(fn).listConnections(principal());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
+  });
+
+  it("lists event occurrences with a signed GET the real Sync verifier accepts", async () => {
+    const who = principal();
+    const calendarA = objectId();
+    const calendarB = objectId();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ occurrences: [], nextCursor: null }),
+    }));
+
+    const result = await client(fn).listEventOccurrences(who, {
+      calendarIds: [
+        calendarA,
+        calendarB,
+      ] as EventOccurrenceListQuery["calendarIds"],
+      start: "2026-07-14T09:00:00.000Z" as EventOccurrenceListQuery["start"],
+      end: "2026-07-14T17:00:00.000Z" as EventOccurrenceListQuery["end"],
+      limit: 100,
+    });
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.occurrences).toEqual([]);
+    expect(result.value.nextCursor).toBeNull();
+
+    const sent = calls[0];
+    expect(sent?.method).toBe("GET");
+    expect(sent?.body).toBeUndefined();
+    // Path parity with the Sync route, plus repeated calendarIds params (the
+    // Sync route parses them back into an array) and the range + limit.
+    expect(sent?.url.startsWith(`${BASE_URL}${EVENTS_PATH}?`)).toBe(true);
+    const query = new URL(sent?.url ?? "").searchParams;
+    expect(query.getAll("calendarIds")).toEqual([calendarA, calendarB]);
+    expect(query.get("start")).toBe("2026-07-14T09:00:00.000Z");
+    expect(query.get("end")).toBe("2026-07-14T17:00:00.000Z");
+    expect(query.get("limit")).toBe("100");
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("omits the cursor param when no cursor is given", async () => {
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ occurrences: [], nextCursor: null }),
+    }));
+
+    await client(fn).listEventOccurrences(principal(), {
+      calendarIds: [objectId()] as EventOccurrenceListQuery["calendarIds"],
+      start: "2026-07-14T09:00:00.000Z" as EventOccurrenceListQuery["start"],
+      end: "2026-07-14T17:00:00.000Z" as EventOccurrenceListQuery["end"],
+    });
+
+    const query = new URL(calls[0]?.url ?? "").searchParams;
+    expect(query.has("cursor")).toBe(false);
+    expect(query.has("limit")).toBe(false);
+  });
+
+  it("rejects an event-occurrence body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ occurrences: [{ bogus: true }], nextCursor: null }),
+    }));
+
+    const result = await client(fn).listEventOccurrences(principal(), {
+      calendarIds: [objectId()] as EventOccurrenceListQuery["calendarIds"],
+      start: "2026-07-14T09:00:00.000Z" as EventOccurrenceListQuery["start"],
+      end: "2026-07-14T17:00:00.000Z" as EventOccurrenceListQuery["end"],
+    });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -11,6 +11,11 @@ import {
   type ConnectionListResponse,
   ConnectionListResponseSchema,
 } from "@core/types/sync/connection.contracts";
+import {
+  type EventOccurrenceListQuery,
+  type EventOccurrenceListResponse,
+  EventOccurrenceListResponseSchema,
+} from "@core/types/sync/event.contracts";
 import { createHmac, randomUUID } from "node:crypto";
 
 // The internal endpoints this client calls. Kept in sync with the Sync service's
@@ -18,6 +23,7 @@ import { createHmac, randomUUID } from "node:crypto";
 const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
+const EVENTS_PATH = "/internal/events";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -149,6 +155,35 @@ export class SyncServiceClient {
     });
   }
 
+  // A page of canonical event occurrences for the given calendars and range,
+  // scoped to the signed principal. A read; served in the Sync service's passive
+  // mode too. `calendarIds` is serialized as repeated query params so the Sync
+  // route parses it back into an array; pass `query.cursor` from a prior
+  // response's `nextCursor` to page.
+  listEventOccurrences(
+    principal: SyncPrincipal,
+    query: EventOccurrenceListQuery,
+    correlationId?: string,
+  ): Promise<SyncClientResult<EventOccurrenceListResponse>> {
+    const params = new URLSearchParams();
+    for (const calendarId of query.calendarIds) {
+      params.append("calendarIds", calendarId);
+    }
+    params.set("start", query.start);
+    params.set("end", query.end);
+    if (query.cursor !== undefined) params.set("cursor", query.cursor);
+    if (query.limit !== undefined) params.set("limit", String(query.limit));
+
+    return this.#request({
+      method: "GET",
+      path: EVENTS_PATH,
+      query: params,
+      principal,
+      schema: EventOccurrenceListResponseSchema,
+      correlationId,
+    });
+  }
+
   // Merged busy intervals plus freshness/bookability evidence for a set of
   // blocking calendars.
   queryBusyAvailability(
@@ -169,6 +204,7 @@ export class SyncServiceClient {
   async #request<T>(input: {
     method: "GET" | "POST";
     path: string;
+    query?: URLSearchParams;
     principal: SyncPrincipal;
     body?: unknown;
     schema: z.ZodType<T>;
@@ -185,11 +221,17 @@ export class SyncServiceClient {
       "x-correlation-id": correlationId,
     };
 
+    const queryString = input.query?.toString();
+    const url =
+      queryString !== undefined && queryString.length > 0
+        ? `${this.#baseUrl}${input.path}?${queryString}`
+        : `${this.#baseUrl}${input.path}`;
+
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
     let response: { status: number; json: () => Promise<unknown> };
     try {
-      response = await this.#fetch(`${this.#baseUrl}${input.path}`, {
+      response = await this.#fetch(url, {
         method: input.method,
         headers,
         body: input.body === undefined ? undefined : JSON.stringify(input.body),


### PR DESCRIPTION
## What

Adds `SyncServiceClient.listEventOccurrences(principal, query, correlationId?)` — a signed, principal-scoped `GET /internal/events` returning a page of canonical event occurrences. Backend building block for **S39 event-read delegation**; no route/consumer wired yet (byte-identical behavior).

Also extends the private `#request` helper with minimal query-string support (previously path + body only).

## How

- `calendarIds` is serialized as **repeated query params** (`calendarIds=a&calendarIds=b`) so the Sync route's `toQueryArray` parses them back into an array; `start`/`end`/`cursor`/`limit` follow the `EventOccurrenceListQuery` contract. `cursor`/`limit` are omitted when unset.
- The request signature covers `timestamp.tenantId.principalId` only (not path/query/body), so the added query string needs no signing change — and ownership stays server-enforced by the Sync repo via the signed principal, never the query.
- Response parsed with `EventOccurrenceListResponseSchema`; a non-matching body → `invalidResponse`.

## Testing

Contract tests import the **real** `@sync` `EVENTS_PATH` + `verifyInternalRequest` to prove:
- path parity with the Sync route,
- repeated `calendarIds` params round-trip, plus `start`/`end`/`limit`,
- the signed headers verify against the real Sync internal-auth verifier for the same principal,
- `cursor`/`limit` omitted when unset,
- `invalidResponse` on a bad body.

16 pass in the client test file. `bun run type-check`: zero new errors vs `origin/main`. Lint clean via pinned biome.

## Manual Testing Steps

Not independently exercisable yet (no route). Verified via the contract tests that the client hits `/internal/events` with the correct signed GET and query shape the Sync service accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal HTTP client addition with no new routes or consumers; behavior is covered by contract tests and mirrors existing Sync client patterns.
> 
> **Overview**
> Adds **`SyncServiceClient.listEventOccurrences`**, a signed `GET` to `/internal/events` that returns paginated canonical event occurrences for a calendar range, scoped to the signed principal. Query params follow **`EventOccurrenceListQuery`**: repeated `calendarIds`, required `start`/`end`, and optional `cursor`/`limit` (omitted when unset). Responses are validated with **`EventOccurrenceListResponseSchema`**.
> 
> The private **`#request`** helper now accepts optional **`URLSearchParams`** and appends them to the URL; signing is unchanged (still `timestamp.tenantId.principalId`).
> 
> Contract tests assert path parity with the Sync **`EVENTS_PATH`**, query shape, internal-auth verification, optional-param omission, and **`invalidResponse`** on bad bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c0e853ad1c4a613e2250eed505da55e059dd19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->