### PR TITLE
feat(backend): add submitCommand to SyncServiceClient

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1,8 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type BusyAvailabilityRequest } from "@core/types/sync/availability.contracts";
+import { type CommandSubmitRequest } from "@core/types/sync/command.contracts";
 import { type EventOccurrenceListQuery } from "@core/types/sync/event.contracts";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { verifyInternalRequest } from "@sync/auth/internal-auth";
+import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
   AVAILABILITY_BUSY_PATH,
   BEGIN_PATH,
@@ -230,6 +232,96 @@ describe("SyncServiceClient", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.kind).toBe("invalidResponse");
+  });
+
+  it("submits a command with a signed POST the real Sync verifier accepts", async () => {
+    const who = principal();
+    const eventId = objectId();
+    const submitRequest = {
+      idempotencyKey: "client-generated-key-1",
+      eventId,
+      input: { kind: "move", calendarId: objectId() },
+      expectedVersion: null,
+    } as CommandSubmitRequest;
+    // A minimal valid command envelope the Sync service would return.
+    const commandBody = {
+      id: objectId(),
+      tenantId: who.tenantId,
+      principalId: who.principalId,
+      idempotencyKey: "client-generated-key-1",
+      eventId,
+      input: submitRequest.input,
+      expectedVersion: null,
+      outcome: { state: "pending" },
+      attemptCount: 0,
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    };
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ command: commandBody }),
+    }));
+
+    const result = await client(fn).submitCommand(who, submitRequest);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.command.outcome.state).toBe("pending");
+    expect(result.value.command.eventId).toBe(eventId);
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${COMMANDS_PATH}`);
+    expect(sent?.method).toBe("POST");
+    // The body is the request verbatim: tenant/principal are signed, never sent.
+    const body = JSON.parse(sent?.body ?? "{}");
+    expect(body.idempotencyKey).toBe("client-generated-key-1");
+    expect(body.input.kind).toBe("move");
+    expect(body).not.toHaveProperty("tenantId");
+    expect(body).not.toHaveProperty("principalId");
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("rejects a command-submit body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ command: { bogus: true } }),
+    }));
+
+    const result = await client(fn).submitCommand(principal(), {
+      idempotencyKey: "client-generated-key-2",
+      eventId: objectId(),
+      input: { kind: "move", calendarId: objectId() },
+      expectedVersion: null,
+    } as CommandSubmitRequest);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
+  });
+
+  it("maps a 400 command rejection to badRequest without throwing", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 400,
+      json: async () => ({ error: "invalid_command" }),
+    }));
+
+    const result = await client(fn).submitCommand(principal(), {
+      idempotencyKey: "client-generated-key-3",
+      eventId: objectId(),
+      input: { kind: "move", calendarId: objectId() },
+      expectedVersion: null,
+    } as CommandSubmitRequest);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("badRequest");
   });
 
   it("begins a connection with a signed POST the real Sync verifier accepts", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -5,6 +5,11 @@ import {
   BusyAvailabilityResponseSchema,
 } from "@core/types/sync/availability.contracts";
 import {
+  type CommandSubmitRequest,
+  type CommandSubmitResponse,
+  CommandSubmitResponseSchema,
+} from "@core/types/sync/command.contracts";
+import {
   type ConnectionBeginRequest,
   type ConnectionBeginResponse,
   ConnectionBeginResponseSchema,
@@ -24,6 +29,7 @@ const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const EVENTS_PATH = "/internal/events";
+const COMMANDS_PATH = "/internal/commands";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -180,6 +186,27 @@ export class SyncServiceClient {
       query: params,
       principal,
       schema: EventOccurrenceListResponseSchema,
+      correlationId,
+    });
+  }
+
+  // Durably record one event-mutation command (create/update/move/delete),
+  // scoped to the signed principal. Idempotent on the request's idempotencyKey:
+  // a retry with the same key maps to the same command rather than duplicating
+  // it. Because Sync may have already accepted a submission whose response we
+  // never saw (timeout/unavailable), a caller MUST retry with the SAME key and
+  // never fall back to a legacy write.
+  submitCommand(
+    principal: SyncPrincipal,
+    request: CommandSubmitRequest,
+    correlationId?: string,
+  ): Promise<SyncClientResult<CommandSubmitResponse>> {
+    return this.#request({
+      method: "POST",
+      path: COMMANDS_PATH,
+      principal,
+      body: request,
+      schema: CommandSubmitResponseSchema,
       correlationId,
     });
   }


### PR DESCRIPTION
## What

Adds `SyncServiceClient.submitCommand(principal, request, correlationId?)` — a signed, principal-scoped `POST /internal/commands` that durably records one event-mutation command (create/update/move/delete) and returns the command envelope. Backend building block for **S39 event-write delegation**; no route/consumer wired yet (byte-identical behavior).

## How

- Reuses the shared `#request` POST path (same as `queryBusyAvailability`/`beginConnection`). Body is the `CommandSubmitRequest` verbatim; tenant/principal come from the signed headers, never the body.
- Idempotent on the request's `idempotencyKey`. The doc comment records the **load-bearing rule for the future write-route consumer**: because Sync may have accepted a submission whose response we never saw (timeout/unavailable), a caller MUST retry with the *same key* and never fall back to a legacy write. The client itself never retries — it maps every outcome to a typed result.
- Response `{command}` parsed with `CommandSubmitResponseSchema`; a bad body → `invalidResponse`.

## Testing

Contract tests import the real `@sync` `COMMANDS_PATH` + `verifyInternalRequest` to prove:
- path parity + signed-POST acceptance by the real Sync verifier for the same principal,
- the body carries the request verbatim and does **not** include tenant/principal,
- a schema-valid `SyncCommand` response parses (`outcome.state`/`eventId` asserted),
- `invalidResponse` on a bad body and `400 → badRequest` mapping.

19 pass in the client test file. `bun run type-check`: zero new errors vs `origin/main`. Lint clean via pinned biome.

## Context: the read fork is a separate decision

This is the *write*-path building block. Note that wiring the actual event routes (both read and write) is deferred pending a design decision: the sync occurrence-read endpoint is lossy for the browser's full event contract (no per-instance id, no recurrence/description), so `GET /api/event → /internal/events` needs a contract call before wiring. The write path via commands is more tractable, but both route-wirings await that design pass. This PR just lands the reusable client method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client API and tests only; no production routes or behavior changes until a future consumer is wired.
> 
> **Overview**
> Adds **`SyncServiceClient.submitCommand`**, a signed `POST` to `/internal/commands` that records event-mutation commands (create/update/move/delete) via the shared `#request` path. The body is the `CommandSubmitRequest` as-is; **tenant/principal stay in signed headers**, not the JSON. Responses are validated with `CommandSubmitResponseSchema`; outcomes map to the existing typed `SyncClientResult` errors (including **`400 → badRequest`** and bad bodies → **`invalidResponse`**).
> 
> Contract tests assert path parity with Sync’s `COMMANDS_PATH`, that the real internal-auth verifier accepts the POST, that identity fields are omitted from the body, and success/error parsing. **No API routes or callers are wired yet**—this is the write-delegation client building block for later S39 work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 502869fbb6cc341a56a8b9983b12d472e9717d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->