### PR TITLE
feat(core): add SyncEventInstance full-fidelity event-read contract

### DIFF
--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -474,11 +474,19 @@ describe("Sync event contracts", () => {
       expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(true);
     });
 
-    it("carries the full content the browser needs to render and edit", () => {
-      // Unlike the stripped occurrence feed (title only), an instance carries
-      // the description too — the whole point of the full-fidelity read.
-      const instance = baseInstance();
-      expect("description" in instance.content).toBe(true);
+    it("preserves the description through validation (full-fidelity read)", () => {
+      // Unlike the stripped occurrence feed (title only), the schema must keep
+      // the description — the whole point of the full-fidelity read. Assert on
+      // the PARSED output, not the input object, so this proves the schema.
+      const parsed = SyncEventInstanceSchema.safeParse(
+        baseInstance({
+          content: { title: "Standup", description: "Daily sync" },
+        }),
+      );
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.content.description).toBe("Daily sync");
+      }
     });
 
     it("rejects an instance whose content is missing the description", () => {

--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -2,14 +2,18 @@ import { faker } from "@faker-js/faker";
 import {
   AttendeeSchema,
   ConferenceSchema,
+  EventInstanceListQuerySchema,
+  EventInstanceListResponseSchema,
   EventOccurrenceListQuerySchema,
   EventOccurrenceListResponseSchema,
   OrganizerSchema,
   SyncEventCalendarIdSchema,
+  SyncEventInstanceSchema,
   SyncEventOccurrenceSchema,
   SyncEventOwnershipSchema,
   SyncEventRecurrenceSchema,
   SyncEventSchema,
+  SyncInstanceRecurrenceSchema,
 } from "@core/types/sync/event.contracts";
 
 const objectId = () => faker.database.mongodbObjectId();
@@ -388,6 +392,157 @@ describe("Sync event contracts", () => {
       expect(
         EventOccurrenceListResponseSchema.safeParse(response).success,
       ).toBe(true);
+    });
+  });
+
+  describe("SyncInstanceRecurrenceSchema", () => {
+    it("accepts a single row", () => {
+      expect(
+        SyncInstanceRecurrenceSchema.safeParse({ kind: "single" }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a series master row carrying the rule", () => {
+      const recurrence = { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] };
+      expect(SyncInstanceRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects a series master row with empty rules", () => {
+      const recurrence = { kind: "series", rules: [] };
+      expect(SyncInstanceRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+
+    it("accepts an occurrence row addressed by its recurrenceId", () => {
+      const recurrence = {
+        kind: "occurrence",
+        recurrenceId: "2026-07-21T09:00:00.000Z",
+      };
+      expect(SyncInstanceRecurrenceSchema.safeParse(recurrence).success).toBe(
+        true,
+      );
+    });
+
+    it("rejects an occurrence row missing its recurrenceId", () => {
+      const recurrence = { kind: "occurrence" };
+      expect(SyncInstanceRecurrenceSchema.safeParse(recurrence).success).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("SyncEventInstanceSchema", () => {
+    const baseInstance = (overrides: Record<string, unknown> = {}) => ({
+      eventId: objectId(),
+      calendarId: objectId(),
+      content: { title: "Standup", description: "Daily sync" },
+      schedule: timedSchedule,
+      recurrence: { kind: "single" },
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+      ...overrides,
+    });
+
+    it("accepts a single timed instance", () => {
+      expect(SyncEventInstanceSchema.safeParse(baseInstance()).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a series master row with a rule", () => {
+      const instance = baseInstance({
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(true);
+    });
+
+    it("accepts a projected occurrence row addressed by recurrenceId", () => {
+      const instance = baseInstance({
+        recurrence: {
+          kind: "occurrence",
+          recurrenceId: "2026-07-21T09:00:00.000Z",
+        },
+      });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(true);
+    });
+
+    it("accepts an all-day instance", () => {
+      const instance = baseInstance({ schedule: allDaySchedule });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(true);
+    });
+
+    it("carries the full content the browser needs to render and edit", () => {
+      // Unlike the stripped occurrence feed (title only), an instance carries
+      // the description too — the whole point of the full-fidelity read.
+      const instance = baseInstance();
+      expect("description" in instance.content).toBe(true);
+    });
+
+    it("rejects an instance whose content is missing the description", () => {
+      const instance = baseInstance({ content: { title: "Standup" } });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(false);
+    });
+
+    it("rejects a calendarId that isn't a 24-character hex id", () => {
+      const instance = baseInstance({ calendarId: "not-an-id" });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(false);
+    });
+  });
+
+  describe("EventInstanceListQuerySchema", () => {
+    const baseQuery = () => ({
+      calendarIds: [objectId()],
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-08-01T00:00:00.000Z",
+    });
+
+    it("accepts a bounded range with at least one calendar", () => {
+      expect(EventInstanceListQuerySchema.safeParse(baseQuery()).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts an optional cursor and limit", () => {
+      const query = { ...baseQuery(), cursor: "page-2", limit: 100 };
+      expect(EventInstanceListQuerySchema.safeParse(query).success).toBe(true);
+    });
+
+    it("rejects an empty calendarIds array", () => {
+      const query = { ...baseQuery(), calendarIds: [] };
+      expect(EventInstanceListQuerySchema.safeParse(query).success).toBe(false);
+    });
+
+    it("rejects end before start", () => {
+      const query = {
+        ...baseQuery(),
+        start: baseQuery().end,
+        end: baseQuery().start,
+      };
+      expect(EventInstanceListQuerySchema.safeParse(query).success).toBe(false);
+    });
+
+    it("rejects a limit above the bound", () => {
+      const query = { ...baseQuery(), limit: 501 };
+      expect(EventInstanceListQuerySchema.safeParse(query).success).toBe(false);
+    });
+  });
+
+  describe("EventInstanceListResponseSchema", () => {
+    it("accepts an empty page with no next cursor", () => {
+      const response = { instances: [], nextCursor: null };
+      expect(EventInstanceListResponseSchema.safeParse(response).success).toBe(
+        true,
+      );
+    });
+
+    it("accepts a page with a next cursor", () => {
+      const response = { instances: [], nextCursor: "page-2" };
+      expect(EventInstanceListResponseSchema.safeParse(response).success).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -213,3 +213,90 @@ export const EventOccurrenceListResponseSchema = z.strictObject({
 export type EventOccurrenceListResponse = z.infer<
   typeof EventOccurrenceListResponseSchema
 >;
+
+// A full-fidelity event row for the browser calendar read (distinct from the
+// stripped SyncEventOccurrence used by the busy/availability feed). It carries
+// everything the app needs to render AND edit an event: full content, the
+// projected instance schedule, and how the row relates to a series. The backend
+// translates one of these into an app-facing Event.
+//
+// Row kinds returned for a recurring series over a range, mirroring what the
+// legacy store materializes today:
+//   - one `series` master row (the app keeps it for edit-all-future, but
+//     suppresses it from rendering), plus
+//   - one `occurrence` row per projected instance in range.
+// A non-recurring event is a single `single` row.
+const SyncInstanceContentSchema = z.strictObject({
+  title: z.string(),
+  description: z.string(),
+});
+export type SyncInstanceContent = z.infer<typeof SyncInstanceContentSchema>;
+
+const SingleInstanceRecurrenceSchema = z.strictObject({
+  kind: z.literal("single"),
+});
+
+// The series master row: carries the recurrence rule the app needs to offer
+// "edit this and all following". Its schedule is the master's own schedule.
+const SeriesInstanceRecurrenceSchema = z.strictObject({
+  kind: z.literal("series"),
+  rules: RRuleSchema,
+});
+
+// One projected (or overridden) instance of a series. recurrenceId is the
+// instance's original scheduled start — the identity the write path uses to
+// address exactly this occurrence. The owning series is `eventId`.
+const OccurrenceInstanceRecurrenceSchema = z.strictObject({
+  kind: z.literal("occurrence"),
+  recurrenceId: DateTimeSchema,
+});
+
+export const SyncInstanceRecurrenceSchema = z.discriminatedUnion("kind", [
+  SingleInstanceRecurrenceSchema,
+  SeriesInstanceRecurrenceSchema,
+  OccurrenceInstanceRecurrenceSchema,
+]);
+export type SyncInstanceRecurrence = z.infer<
+  typeof SyncInstanceRecurrenceSchema
+>;
+
+export const SyncEventInstanceSchema = z.strictObject({
+  // The real id of the owning event: the single, or the series master that
+  // owns a `series`/`occurrence` row. Never a synthesized id — the backend
+  // composes any app-facing per-occurrence id from (eventId, recurrenceId).
+  eventId: EventIdSchema,
+  calendarId: SyncEventCalendarIdSchema,
+  content: SyncInstanceContentSchema,
+  schedule: EventScheduleSchema,
+  recurrence: SyncInstanceRecurrenceSchema,
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+});
+export type SyncEventInstance = z.infer<typeof SyncEventInstanceSchema>;
+
+// Query for the full-fidelity read. Identical range/paging shape to the
+// occurrence feed, kept as its own schema so the two endpoints stay
+// independently evolvable.
+export const EventInstanceListQuerySchema = z
+  .strictObject({
+    calendarIds: z.array(SyncEventCalendarIdSchema).min(1).readonly(),
+    start: DateTimeSchema,
+    end: DateTimeSchema,
+    cursor: z.string().trim().min(1).max(1024).optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+  })
+  .refine(({ start, end }) => Date.parse(end) > Date.parse(start), {
+    message: "Range end must be after start",
+    path: ["end"],
+  });
+export type EventInstanceListQuery = z.infer<
+  typeof EventInstanceListQuerySchema
+>;
+
+export const EventInstanceListResponseSchema = z.strictObject({
+  instances: z.array(SyncEventInstanceSchema).readonly(),
+  nextCursor: z.string().trim().min(1).max(1024).nullable(),
+});
+export type EventInstanceListResponse = z.infer<
+  typeof EventInstanceListResponseSchema
+>;


### PR DESCRIPTION
## What

The core wire contract for **S39 event-read delegation (option a)** — a full-fidelity event row that will back the browser's `GET /api/event` under sync delegation. Contract + schema tests only; no endpoint or consumer wired yet.

Unlike the stripped `SyncEventOccurrence` (busy/availability feed, title-only), a `SyncEventInstance` carries everything the browser needs to **render and edit**: full content (title + description), the projected instance schedule, and how the row relates to a series.

## Row model (mirrors what legacy materializes today, so the browser contract is unchanged)

- **`single`** — a non-recurring event.
- **`series`** — the master row carrying the RRULE. The web keeps it for "edit this and all following" but suppresses it from rendering (verified in `event.view-model.ts`).
- **`occurrence`** — one projected/overridden instance, addressed by its `recurrenceId` (original scheduled start) under the owning `eventId`.

## Key design choice: real ids on the wire, composed id in the backend

The contract carries **real domain ids only** (`eventId` + `recurrenceId`). The backend composes any app-facing per-occurrence id from those (Decision 1 = II, computed instance ids) and reverses it on write into a command's `eventId + recurrenceId + scope`. This keeps the sync wire clean and localizes the synthetic-id scheme in the backend translation layer.

`calendarId` is the sync calendar id directly (Decision 2 = option 2, sync-owned calendars) — no legacy translation layer.

## Testing

- Schema tests prove the union constraints, not tautologies: rejects `series` with empty rules, rejects `occurrence` missing `recurrenceId`, rejects content missing `description`, rejects a non-hex `calendarId`; accepts single / series / occurrence / all-day rows and the list query/response paging shape.
- 61 pass in the contract test file. `bun run type-check`: zero new errors vs `origin/main`. Lint clean via pinned biome.

## Where this sits

First slice of the option-a program (contract → sync endpoint → client → calendar-list delegation → read-route wiring → write wiring). All dormant behind the `SYNC_EVENT_ROUTING=legacy` default until the full stack lands and is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract and test-only changes with no production code paths; future API behavior depends on later endpoint wiring.
> 
> **Overview**
> Adds **Zod wire contracts** for a full-fidelity sync event read (ahead of browser `GET /api/event` delegation), separate from the title-only occurrence/busy feed.
> 
> **`SyncEventInstance`** rows carry `eventId`, sync `calendarId`, title+**required** `description`, instance `schedule`, timestamps, and a **`SyncInstanceRecurrence`** discriminant (`single`, `series` with RRULE, or `occurrence` with `recurrenceId`). **`EventInstanceListQuery` / `EventInstanceListResponse`** mirror the occurrence list’s calendar range, cursor, and limit paging but return `instances` instead of `occurrences`.
> 
> Contract tests cover union validation, full-fidelity content (description preserved), and list query bounds; **no endpoint or consumer is wired in this PR**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c9d8aca953fcd37d916e5b1d7d441bc699d7f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->