### PR TITLE
feat(sync): assemble full-fidelity event instances + batch findByIds

### DIFF
--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -1,0 +1,255 @@
+import { faker } from "@faker-js/faker";
+import {
+  type EventRecord,
+  EventRecordSchema,
+} from "@sync/storage/contracts/event.contracts";
+import {
+  type EventOccurrenceRecord,
+  EventOccurrenceRecordSchema,
+} from "@sync/storage/contracts/event-occurrence.contracts";
+import { assembleEventInstances } from "./event-instance-assembly";
+import { describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const timed = (start: string, end: string) => ({
+  kind: "timed" as const,
+  start,
+  end,
+  timeZone: "America/Denver",
+});
+
+const makeEvent = (overrides: Partial<EventRecord> = {}): EventRecord =>
+  EventRecordSchema.parse({
+    _id: objectId(),
+    tenantId: objectId(),
+    principalId: objectId(),
+    origin: "compass",
+    calendarId: objectId(),
+    clientEventId: null,
+    connectionId: null,
+    providerEventId: null,
+    providerVersion: null,
+    providerUpdatedAt: null,
+    deliveryState: null,
+    providerMetadata: null,
+    content: {
+      title: "Standup",
+      description: "Daily sync",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    },
+    schedule: timed("2026-07-14T09:00:00-06:00", "2026-07-14T09:15:00-06:00"),
+    recurrence: { kind: "single" },
+    lifecycleState: "active",
+    generation: 0,
+    createdAt: new Date("2026-07-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-07-02T00:00:00.000Z"),
+    confirmedAt: null,
+    ...overrides,
+  });
+
+const makeOccurrence = (
+  overrides: Partial<EventOccurrenceRecord> = {},
+): EventOccurrenceRecord => {
+  const startAt = overrides.startAt ?? new Date("2026-07-14T15:00:00.000Z");
+  const eventId = overrides.eventId ?? objectId();
+  return EventOccurrenceRecordSchema.parse({
+    _id: objectId(),
+    tenantId: objectId(),
+    principalId: objectId(),
+    eventId,
+    occurrenceKey: `${eventId}:${startAt.toISOString()}`,
+    calendarId: objectId(),
+    schedule: timed("2026-07-14T09:00:00-06:00", "2026-07-14T09:15:00-06:00"),
+    startAt,
+    busy: true,
+    title: "Standup",
+    cancelled: false,
+    generation: 0,
+    ...overrides,
+  });
+};
+
+const byId = (...events: EventRecord[]) =>
+  new Map(events.map((event) => [event._id, event]));
+
+describe("assembleEventInstances", () => {
+  it("maps a single event to one single row carrying full content", () => {
+    const event = makeEvent({ recurrence: { kind: "single" } });
+    const occurrence = makeOccurrence({ eventId: event._id });
+
+    const [instance, ...rest] = assembleEventInstances(
+      [occurrence],
+      byId(event),
+    );
+
+    expect(rest).toHaveLength(0);
+    expect(instance?.eventId).toBe(event._id);
+    expect(instance?.recurrence).toEqual({ kind: "single" });
+    expect(instance?.content).toEqual({
+      title: "Standup",
+      description: "Daily sync",
+    });
+    // The instance schedule comes from the occurrence, timestamps from the event.
+    expect(instance?.schedule).toEqual(occurrence.schedule);
+    expect(instance?.createdAt).toBe("2026-07-01T00:00:00.000Z");
+    expect(instance?.updatedAt).toBe("2026-07-02T00:00:00.000Z");
+  });
+
+  it("maps plain series instances to occurrence rows plus one master row", () => {
+    const master = makeEvent({
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+    });
+    const monday = makeOccurrence({
+      eventId: master._id,
+      startAt: new Date("2026-07-13T15:00:00.000Z"),
+    });
+    const tuesday = makeOccurrence({
+      eventId: master._id,
+      startAt: new Date("2026-07-14T15:00:00.000Z"),
+    });
+
+    const result = assembleEventInstances([monday, tuesday], byId(master));
+
+    const occurrences = result.filter(
+      (r) => r.recurrence.kind === "occurrence",
+    );
+    const masters = result.filter((r) => r.recurrence.kind === "series");
+    expect(occurrences).toHaveLength(2);
+    // Exactly one master row, back-filled even though there were two instances.
+    expect(masters).toHaveLength(1);
+    expect(masters[0]?.eventId).toBe(master._id);
+    expect(masters[0]?.recurrence).toEqual({
+      kind: "series",
+      rules: ["RRULE:FREQ=DAILY"],
+    });
+    // Each occurrence is addressed by its own instant and owned by the master.
+    expect(occurrences.every((o) => o.eventId === master._id)).toBe(true);
+    expect(
+      occurrences.map((o) =>
+        o.recurrence.kind === "occurrence" ? o.recurrence.recurrenceId : null,
+      ),
+    ).toEqual(["2026-07-13T15:00:00.000Z", "2026-07-14T15:00:00.000Z"]);
+  });
+
+  it("addresses an overridden instance by its ORIGINAL start, linked to the master", () => {
+    const master = makeEvent({
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+    });
+    // The user moved Tuesday's instance from 15:00 to 18:00. The exception is its
+    // own event; its recurrenceId is the original 15:00 slot.
+    const exception = makeEvent({
+      content: {
+        title: "Standup (moved)",
+        description: "rescheduled",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      recurrence: {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId: "2026-07-14T15:00:00.000Z",
+        cancelled: false,
+      },
+    });
+    // The occurrence row for the override points at the exception, and its
+    // startAt is the MOVED time — which must NOT become the recurrenceId.
+    const movedOccurrence = makeOccurrence({
+      eventId: exception._id,
+      startAt: new Date("2026-07-14T18:00:00.000Z"),
+      schedule: timed("2026-07-14T12:00:00-06:00", "2026-07-14T12:15:00-06:00"),
+    });
+
+    const result = assembleEventInstances(
+      [movedOccurrence],
+      byId(master, exception),
+    );
+
+    const override = result.find((r) => r.recurrence.kind === "occurrence");
+    expect(override?.eventId).toBe(master._id);
+    expect(
+      override?.recurrence.kind === "occurrence"
+        ? override.recurrence.recurrenceId
+        : null,
+    ).toBe("2026-07-14T15:00:00.000Z");
+    // Content is the override's, schedule is the moved occurrence's.
+    expect(override?.content.title).toBe("Standup (moved)");
+    expect(override?.schedule).toEqual(movedOccurrence.schedule);
+  });
+
+  it("back-fills the master even when its only in-range row is an exception", () => {
+    // Subtlety: the occurrence points at the exception, not the master. A back-
+    // fill that only looked at seriesMaster events in the page would miss it.
+    const master = makeEvent({
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const exception = makeEvent({
+      recurrence: {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId: "2026-07-14T15:00:00.000Z",
+        cancelled: false,
+      },
+    });
+    const occurrence = makeOccurrence({ eventId: exception._id });
+
+    const result = assembleEventInstances(
+      [occurrence],
+      byId(master, exception),
+    );
+
+    expect(result.filter((r) => r.recurrence.kind === "series")).toHaveLength(
+      1,
+    );
+    expect(result.find((r) => r.recurrence.kind === "series")?.eventId).toBe(
+      master._id,
+    );
+  });
+
+  it("omits a cancelled occurrence entirely", () => {
+    const master = makeEvent({
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+    });
+    const cancelled = makeOccurrence({
+      eventId: master._id,
+      cancelled: true,
+    });
+
+    const result = assembleEventInstances([cancelled], byId(master));
+
+    // No instance row for the deleted slot; no orphan master back-filled from it.
+    expect(result).toEqual([]);
+  });
+
+  it("skips an occurrence whose owning event is missing, without throwing", () => {
+    const orphan = makeOccurrence({ eventId: objectId() });
+
+    expect(assembleEventInstances([orphan], byId())).toEqual([]);
+  });
+
+  it("de-duplicates the master row across many instances of one series", () => {
+    const master = makeEvent({
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+    });
+    const occurrences = Array.from({ length: 5 }, (_, i) =>
+      makeOccurrence({
+        eventId: master._id,
+        startAt: new Date(`2026-07-1${i}T15:00:00.000Z`),
+      }),
+    );
+
+    const result = assembleEventInstances(occurrences, byId(master));
+
+    expect(result.filter((r) => r.recurrence.kind === "series")).toHaveLength(
+      1,
+    );
+    expect(
+      result.filter((r) => r.recurrence.kind === "occurrence"),
+    ).toHaveLength(5);
+  });
+});

--- a/packages/sync/src/domain/event-instance-assembly.ts
+++ b/packages/sync/src/domain/event-instance-assembly.ts
@@ -1,0 +1,129 @@
+import {
+  type SyncEventInstance,
+  SyncEventInstanceSchema,
+} from "@core/types/sync/event.contracts";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurrence.contracts";
+
+// Assemble the full-fidelity event rows the browser read returns, from a page of
+// materialized occurrence rows joined to their owning event records. Pure: all
+// I/O (occurrence range read, batch event hydration) happens in the caller, so
+// every recurring-event subtlety is unit-testable without a database.
+//
+// `eventsById` must contain every event referenced by an occurrence's `eventId`
+// AND, for any exception among those, the master named by its `seriesId` — the
+// caller does both fetch hops. Rows whose owning event is missing are skipped
+// defensively rather than throwing (an occurrence transiently orphaned from its
+// event should not fail the whole page).
+//
+// Row model (mirrors what the legacy store materializes, so the browser contract
+// is unchanged):
+//   - single event            -> one `single` row
+//   - plain series instance    -> one `occurrence` row (recurrenceId = its start)
+//   - overridden instance      -> one `occurrence` row (recurrenceId = the
+//                                 exception's ORIGINAL start, not its moved start)
+//   - each referenced series    -> one `series` master row, appended out-of-band
+//                                 (the app keeps it for edit-all-future but
+//                                 suppresses it from rendering)
+// Cancelled instances are omitted entirely: a deleted occurrence simply must not
+// appear, exactly as it wouldn't in the legacy store.
+export function assembleEventInstances(
+  occurrences: readonly EventOccurrenceRecord[],
+  eventsById: ReadonlyMap<string, EventRecord>,
+): SyncEventInstance[] {
+  const instances: SyncEventInstance[] = [];
+  // Series masters referenced by any instance row, back-filled once at the end.
+  const seriesMasterIds = new Set<string>();
+
+  for (const occurrence of occurrences) {
+    // A cancelled exception still emits an occurrence row so reprojection is
+    // deterministic; for display it means "this instance was deleted" — drop it.
+    if (occurrence.cancelled) continue;
+
+    const event = eventsById.get(occurrence.eventId);
+    if (!event) continue;
+
+    const content = {
+      title: event.content.title,
+      description: event.content.description,
+    };
+    const timestamps = {
+      createdAt: event.createdAt.toISOString(),
+      updatedAt: event.updatedAt.toISOString(),
+    };
+
+    if (event.recurrence.kind === "single") {
+      instances.push(
+        SyncEventInstanceSchema.parse({
+          eventId: event._id,
+          calendarId: occurrence.calendarId,
+          content,
+          schedule: occurrence.schedule,
+          recurrence: { kind: "single" },
+          ...timestamps,
+        }),
+      );
+      continue;
+    }
+
+    if (event.recurrence.kind === "seriesMaster") {
+      // A plain projected instance: its owning event IS the master.
+      instances.push(
+        SyncEventInstanceSchema.parse({
+          eventId: event._id,
+          calendarId: occurrence.calendarId,
+          content,
+          schedule: occurrence.schedule,
+          recurrence: {
+            kind: "occurrence",
+            recurrenceId: occurrence.startAt.toISOString(),
+          },
+          ...timestamps,
+        }),
+      );
+      seriesMasterIds.add(event._id);
+      continue;
+    }
+
+    // An exception (overridden instance): its owning event is a separate doc, so
+    // the app-facing row must link to the MASTER (its seriesId) and address the
+    // slot by the exception's ORIGINAL scheduled start — never the moved
+    // occurrence.startAt, which would target the wrong slot on a subsequent edit.
+    const { seriesId, recurrenceId } = event.recurrence;
+    instances.push(
+      SyncEventInstanceSchema.parse({
+        eventId: seriesId,
+        calendarId: occurrence.calendarId,
+        content,
+        schedule: occurrence.schedule,
+        recurrence: { kind: "occurrence", recurrenceId },
+        ...timestamps,
+      }),
+    );
+    seriesMasterIds.add(seriesId);
+  }
+
+  // Back-fill one master row per referenced series, appended after the instance
+  // page (never interleaved into the keyset-ordered occurrence stream — a
+  // master's own schedule may fall entirely outside the queried range).
+  for (const masterId of seriesMasterIds) {
+    const master = eventsById.get(masterId);
+    if (!master || master.recurrence.kind !== "seriesMaster") continue;
+    instances.push(
+      SyncEventInstanceSchema.parse({
+        eventId: master._id,
+        calendarId: master.calendarId,
+        content: {
+          title: master.content.title,
+          description: master.content.description,
+        },
+        schedule: master.schedule,
+        recurrence: { kind: "series", rules: master.recurrence.rules },
+        createdAt: master.createdAt.toISOString(),
+        updatedAt: master.updatedAt.toISOString(),
+      }),
+    );
+  }
+
+  return instances;
+}

--- a/packages/sync/src/storage/repositories/event.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.db.test.ts
@@ -167,6 +167,56 @@ describe("EventRepository", () => {
     ).not.toBeNull();
   });
 
+  describe("findByIds", () => {
+    it("batch-hydrates several events by id, owner-scoped", async () => {
+      const tenantId = objectId() as EventRecord["tenantId"];
+      const principalId = objectId() as EventRecord["principalId"];
+      const a = await repo.put(compassRecord({ tenantId, principalId }));
+      const b = await repo.put(compassRecord({ tenantId, principalId }));
+
+      const found = await repo.findByIds(tenantId, principalId, [a._id, b._id]);
+
+      expect(found.map((e) => e._id).sort()).toEqual([a._id, b._id].sort());
+    });
+
+    it("excludes ids owned by a different principal", async () => {
+      const tenantId = objectId() as EventRecord["tenantId"];
+      const mine = objectId() as EventRecord["principalId"];
+      const theirs = objectId() as EventRecord["principalId"];
+      const own = await repo.put(
+        compassRecord({ tenantId, principalId: mine }),
+      );
+      const foreign = await repo.put(
+        compassRecord({ tenantId, principalId: theirs }),
+      );
+
+      const found = await repo.findByIds(tenantId, mine, [
+        own._id,
+        foreign._id,
+      ]);
+
+      expect(found.map((e) => e._id)).toEqual([own._id]);
+    });
+
+    it("returns an empty array for an empty id list without querying", async () => {
+      const tenantId = objectId() as EventRecord["tenantId"];
+      const principalId = objectId() as EventRecord["principalId"];
+      expect(await repo.findByIds(tenantId, principalId, [])).toEqual([]);
+    });
+
+    it("silently omits ids that do not exist", async () => {
+      const saved = await repo.put(compassRecord());
+      const missing = objectId() as EventRecord["_id"];
+
+      const found = await repo.findByIds(saved.tenantId, saved.principalId, [
+        saved._id,
+        missing,
+      ]);
+
+      expect(found.map((e) => e._id)).toEqual([saved._id]);
+    });
+  });
+
   it("deleteById removes only the owner's event and is idempotent", async () => {
     const saved = await repo.put(compassRecord());
     const other = objectId() as EventRecord["principalId"];

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -112,6 +112,23 @@ export class EventRepository {
     return record ? EventRecordSchema.parse(record) : null;
   }
 
+  // Batch-hydrate full event records by id, owner-scoped. The full-fidelity read
+  // uses this to join a page of occurrence rows back to their owning events (and
+  // then those events' series masters). Not generation-filtered: an event is
+  // unique per identity, and generation on `events` is only a last-touched
+  // watermark, never a read key. An empty id list short-circuits to no query.
+  async findByIds(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    ids: readonly EventId[],
+  ): Promise<EventRecord[]> {
+    if (ids.length === 0) return [];
+    const records = await this.collection
+      .find({ _id: { $in: [...ids] }, tenantId, principalId })
+      .toArray();
+    return records.map((record) => EventRecordSchema.parse(record));
+  }
+
   // Look up one provider-linked event by its provider identity, owner-scoped.
   // Import uses this to resolve a series instance's provider parent to the
   // locally stored master when the master arrived in an earlier page or run.


### PR DESCRIPTION
## What

The **correctness core** of the full-fidelity event read (S39, option a). Two additions, no route yet:

1. **`EventRepository.findByIds`** — batch, owner-scoped hydration of full event records (`$in`, empty-list short-circuit). Used to join a page of occurrence rows back to their owning events + those events' series masters. Not generation-filtered (an event is unique per identity; generation on `events` is only a last-touched watermark).
2. **`assembleEventInstances(occurrences, eventsById)`** — a **pure** function turning a page of materialized occurrence rows (joined to their owning events) into `SyncEventInstance[]`. All I/O stays in the caller, so every recurring-event subtlety is unit-testable without a database.

## The three subtleties a naive join gets wrong (each unit-tested)

- **Overridden instance addressing** — an exception's row is addressed by its **original** start (`exception.recurrenceId`), never the *moved* `occurrence.startAt`, and links to the **master** (`seriesId`), not the exception's own id. Getting this wrong targets the wrong slot on a later edit.
- **Master reachable only via an exception** — the occurrence points at the *exception*, so a "back-fill the seriesMasters in the page" shortcut would silently miss that series' master. The back-fill follows the exception's `seriesId`.
- **Cancelled occurrences omitted** — a cancelled exception still emits an occurrence row; the read drops it (a deleted instance must simply not appear, matching legacy) and doesn't leak an orphan master from it.

## Other correctness notes

- Series master rows are back-filled once per series and appended **out-of-band** (after the instances), never interleaved into the keyset-ordered occurrence stream — a master's own schedule may fall entirely outside the queried range.
- Wire rows are built through `SyncEventInstanceSchema.parse` so the branded `DateTime` fields come from the schema, not raw `toISOString` (the tsgo branded-response CI gotcha).

## Testing

- 7 pure unit tests: single, plain series (2 instances + 1 master), overridden instance (original recurrenceId + master link), master-only-via-exception back-fill, cancelled omitted, orphan skipped, master de-dup across many instances.
- 4 `findByIds` db tests: batch hydrate, cross-principal exclusion, empty-list short-circuit, missing-id omission.
- `bun run type-check`: zero new errors vs `origin/main`. Lint clean via pinned biome.

Next: **B2b** wires the `GET /internal/events/full` route around this core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches calendar read semantics and recurring-series identity (recurrenceId, master back-fill); mistakes would mis-address edits, but logic is isolated, schema-validated, and heavily unit-tested before any route wires it in.
> 
> **Overview**
> Adds the **correctness core** for full-fidelity event reads (no HTTP route yet): owner-scoped **`EventRepository.findByIds`** for batch hydration, and pure **`assembleEventInstances`** to turn occurrence pages plus joined events into `SyncEventInstance[]` matching the legacy browser contract.
> 
> **`assembleEventInstances`** maps singles, series instances, and exceptions into `single` / `occurrence` / `series` rows; drops cancelled occurrences; skips orphans without failing the page; back-fills **one deduped series master per series** after the instance rows (not interleaved with keyset-ordered occurrences). Recurring edge cases are explicit: overridden instances use the exception’s **original** `recurrenceId` and link to the **master** `seriesId` (not moved `startAt` or the exception id); masters are still back-filled when the only in-range row points at an exception.
> 
> Output rows go through **`SyncEventInstanceSchema.parse`**. Coverage: seven unit tests for assembly, four DB tests for `findByIds` (batch, principal scoping, empty list, missing ids).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c471afd9ec1e93d4e0cf48d82c9e196fc501e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->