### PR TITLE
feat(sync): add GET /internal/events/full route

### DIFF
--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -24,10 +24,15 @@ import {
   BEGIN_PATH,
   CALENDARS_PATH,
   CONNECTIONS_PATH,
+  EVENTS_FULL_PATH,
   EVENTS_PATH,
   OAUTH_CALLBACK_PATH,
 } from "@sync/server/connection.routes";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type EventRecord,
+  EventRecordSchema,
+} from "@sync/storage/contracts/event.contracts";
 import {
   type EventOccurrenceRecord,
   EventOccurrenceRecordSchema,
@@ -1188,6 +1193,200 @@ describe("GET /internal/events", () => {
     await startService();
 
     const res = await fetch(`${base}${EVENTS_PATH}?calendarIds=${objectId()}`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /internal/events/full", () => {
+  let mongo: SyncMongoService;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async (config: SyncConfig = testConfig()) => {
+    service = createSyncService(config, { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  const timed = {
+    kind: "timed" as const,
+    start: "2026-07-14T09:00:00-06:00",
+    end: "2026-07-14T10:00:00-06:00",
+    timeZone: "America/Denver",
+  };
+
+  // Seed a full event record, validated through its schema.
+  const seedEvent = (
+    tenantId: string,
+    principalId: string,
+    overrides: Partial<EventRecord> = {},
+  ) => {
+    const record = EventRecordSchema.parse({
+      _id: objectId(),
+      tenantId,
+      principalId,
+      origin: "compass",
+      calendarId: objectId(),
+      clientEventId: null,
+      connectionId: null,
+      providerEventId: null,
+      providerVersion: null,
+      providerUpdatedAt: null,
+      deliveryState: null,
+      providerMetadata: null,
+      content: {
+        title: "Standup",
+        description: "Daily sync",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: timed,
+      recurrence: { kind: "single" },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-02T00:00:00.000Z"),
+      confirmedAt: null,
+      ...overrides,
+    });
+    return mongo.db
+      .collection<EventRecord>("events")
+      .insertOne(record)
+      .then(() => record);
+  };
+
+  const seedOccurrence = (
+    tenantId: string,
+    principalId: string,
+    overrides: Partial<EventOccurrenceRecord> = {},
+  ) => {
+    const start = overrides.startAt ?? new Date();
+    const record = EventOccurrenceRecordSchema.parse({
+      _id: objectId(),
+      tenantId,
+      principalId,
+      eventId: objectId(),
+      occurrenceKey: `${objectId()}:${start.toISOString()}`,
+      calendarId: objectId(),
+      schedule: timed,
+      startAt: start,
+      busy: true,
+      title: "Standup",
+      cancelled: false,
+      generation: 0,
+      ...overrides,
+    });
+    return mongo.db
+      .collection<EventOccurrenceRecord>("event_occurrences")
+      .insertOne(record);
+  };
+
+  const wideRange = () =>
+    `start=${dayjs().subtract(1, "day").toISOString()}&end=${dayjs()
+      .add(1, "day")
+      .toISOString()}`;
+
+  const get = (tenantId: string, principalId: string, query: string) =>
+    fetch(`${base}${EVENTS_FULL_PATH}?${query}`, {
+      headers: signedHeaders(tenantId, principalId),
+    });
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  it("joins an occurrence to its single event and returns full content", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const calendarId = objectId() as EventRecord["calendarId"];
+    const event = await seedEvent(tenantId, principalId, {
+      calendarId,
+      recurrence: { kind: "single" },
+    });
+    await seedOccurrence(tenantId, principalId, {
+      eventId: event._id,
+      calendarId: calendarId as EventOccurrenceRecord["calendarId"],
+    });
+    await startService();
+
+    const body = (await (
+      await get(
+        tenantId,
+        principalId,
+        `calendarIds=${calendarId}&${wideRange()}`,
+      )
+    ).json()) as { instances: unknown[]; nextCursor: string | null };
+
+    expect(body.instances).toHaveLength(1);
+    expect(body.instances[0]).toMatchObject({
+      eventId: event._id,
+      recurrence: { kind: "single" },
+      content: { title: "Standup", description: "Daily sync" },
+    });
+  });
+
+  it("returns instance rows plus one back-filled series master row", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const calendarId = objectId() as EventRecord["calendarId"];
+    const master = await seedEvent(tenantId, principalId, {
+      calendarId,
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+    });
+    await seedOccurrence(tenantId, principalId, {
+      eventId: master._id,
+      calendarId: calendarId as EventOccurrenceRecord["calendarId"],
+      startAt: new Date(),
+    });
+    await startService();
+
+    const body = (await (
+      await get(
+        tenantId,
+        principalId,
+        `calendarIds=${calendarId}&${wideRange()}`,
+      )
+    ).json()) as {
+      instances: Array<{ recurrence: { kind: string } }>;
+    };
+
+    const kinds = body.instances.map((i) => i.recurrence.kind).sort();
+    expect(kinds).toEqual(["occurrence", "series"]);
+  });
+
+  it("scopes the read to the signed principal", async () => {
+    const tenantId = objectId();
+    const owner = objectId();
+    const stranger = objectId();
+    const calendarId = objectId() as EventRecord["calendarId"];
+    const event = await seedEvent(tenantId, owner, { calendarId });
+    await seedOccurrence(tenantId, owner, {
+      eventId: event._id,
+      calendarId: calendarId as EventOccurrenceRecord["calendarId"],
+    });
+    await startService();
+
+    const body = (await (
+      await get(tenantId, stranger, `calendarIds=${calendarId}&${wideRange()}`)
+    ).json()) as { instances: unknown[] };
+
+    expect(body.instances).toEqual([]);
+  });
+
+  it("rejects an unsigned request", async () => {
+    await startService();
+
+    const res = await fetch(
+      `${base}${EVENTS_FULL_PATH}?calendarIds=${objectId()}`,
+    );
 
     expect(res.status).toBe(401);
   });

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -1362,6 +1362,61 @@ describe("GET /internal/events/full", () => {
     expect(kinds).toEqual(["occurrence", "series"]);
   });
 
+  it("second-hops to back-fill a master reachable only via an exception", async () => {
+    // The only in-range row is an OVERRIDDEN instance whose occurrence points at
+    // the exception event, not the master. The master is fetched only by the
+    // route's second findByIds hop (via the exception's seriesId), so this proves
+    // that hop actually runs and merges.
+    const tenantId = objectId();
+    const principalId = objectId();
+    const calendarId = objectId() as EventRecord["calendarId"];
+    const master = await seedEvent(tenantId, principalId, {
+      calendarId,
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+    });
+    const exception = await seedEvent(tenantId, principalId, {
+      calendarId,
+      recurrence: {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId: "2026-07-14T15:00:00.000Z" as never,
+        cancelled: false,
+      },
+    });
+    // Occurrence for the exception only — no occurrence for the master in range.
+    await seedOccurrence(tenantId, principalId, {
+      eventId: exception._id,
+      calendarId: calendarId as EventOccurrenceRecord["calendarId"],
+      startAt: new Date(),
+    });
+    await startService();
+
+    const body = (await (
+      await get(
+        tenantId,
+        principalId,
+        `calendarIds=${calendarId}&${wideRange()}`,
+      )
+    ).json()) as {
+      instances: Array<{
+        eventId: string;
+        recurrence: { kind: string; recurrenceId?: string };
+      }>;
+    };
+
+    const occurrence = body.instances.find(
+      (i) => i.recurrence.kind === "occurrence",
+    );
+    const series = body.instances.find((i) => i.recurrence.kind === "series");
+    // The overridden instance links to the master and is addressed by its
+    // ORIGINAL start, and the master row was back-filled via the second hop.
+    expect(occurrence?.eventId).toBe(master._id);
+    expect(occurrence?.recurrence.recurrenceId).toBe(
+      "2026-07-14T15:00:00.000Z",
+    );
+    expect(series?.eventId).toBe(master._id);
+  });
+
   it("scopes the read to the signed principal", async () => {
     const tenantId = objectId();
     const owner = objectId();

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -14,6 +14,8 @@ import {
   ProviderConnectionSchema,
 } from "@core/types/sync/connection.contracts";
 import {
+  EventInstanceListQuerySchema,
+  type EventInstanceListResponse,
   EventOccurrenceListQuerySchema,
   type EventOccurrenceListResponse,
   type SyncEventOccurrence,
@@ -33,6 +35,7 @@ import {
   computeBusyAvailability,
 } from "@sync/domain/busy-query.service";
 import { deriveConnectionState } from "@sync/domain/connection-state";
+import { assembleEventInstances } from "@sync/domain/event-instance-assembly";
 import {
   HORIZON_FUTURE_MONTHS,
   HORIZON_PAST_MONTHS,
@@ -51,6 +54,7 @@ import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurr
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
@@ -61,6 +65,7 @@ import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 export const CONNECTIONS_PATH = "/internal/connections";
 export const CALENDARS_PATH = "/internal/calendars";
 export const EVENTS_PATH = "/internal/events";
+export const EVENTS_FULL_PATH = "/internal/events/full";
 export const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 export const BEGIN_PATH = "/internal/connections/begin";
 // Where the provider redirects the browser after consent; `begin` builds the
@@ -267,6 +272,135 @@ export function registerConnectionRoutes(
         const last = records.at(-1);
         const response: EventOccurrenceListResponse = {
           occurrences: records.map(toSyncEventOccurrence),
+          nextCursor:
+            records.length === limit && last
+              ? encodeOccurrenceCursor(last)
+              : null,
+        };
+        res.status(Status.OK).json(response);
+      } catch {
+        respondInternalError(res);
+      }
+    },
+  );
+
+  // The full-fidelity event read backing the browser calendar. Same range/paging
+  // shape as the occurrence feed, but each row carries the content, timestamps,
+  // and series linkage needed to render AND edit — the occurrence page is joined
+  // back to its owning events (and their series masters) and assembled into the
+  // legacy-equivalent row-set. Scoped to the signed principal; a read, served in
+  // passive mode too.
+  app.get(
+    EVENTS_FULL_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+
+      const parsed = EventInstanceListQuerySchema.safeParse({
+        calendarIds: toQueryArray(req.query["calendarIds"]),
+        start: req.query["start"],
+        end: req.query["end"],
+        cursor: req.query["cursor"],
+        limit:
+          req.query["limit"] === undefined
+            ? undefined
+            : Number(req.query["limit"]),
+      });
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_query" });
+        return;
+      }
+      const query = parsed.data;
+
+      const after = decodeOccurrenceCursor(query.cursor);
+      if (query.cursor !== undefined && !after) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
+        return;
+      }
+
+      const now = deps.now ? deps.now() : Date.now();
+      const start = maxDate(
+        new Date(query.start),
+        dayjs(now).subtract(HORIZON_PAST_MONTHS, "month").toDate(),
+      );
+      const end = minDate(
+        new Date(query.end),
+        dayjs(now).add(HORIZON_FUTURE_MONTHS, "month").toDate(),
+      );
+      if (start >= end) {
+        const empty: EventInstanceListResponse = {
+          instances: [],
+          nextCursor: null,
+        };
+        res.status(Status.OK).json(empty);
+        return;
+      }
+
+      const limit = query.limit ?? DEFAULT_EVENT_PAGE_LIMIT;
+      try {
+        const occurrenceRepo = new EventOccurrenceRepository(
+          deps.mongo.db,
+          deps.mongo.client,
+        );
+        const eventRepo = new EventRepository(deps.mongo.db);
+        const resources = new SyncResourceRepository(deps.mongo.db);
+        const activeByCalendar = await resources.activeGenerationByCalendar(
+          auth.tenantId,
+          auth.principalId,
+          [...query.calendarIds],
+        );
+        const calendars = [...query.calendarIds].map((calendarId) => ({
+          calendarId,
+          generation: activeByCalendar.get(calendarId) ?? 0,
+        }));
+        const records = await occurrenceRepo.listByCalendarRange({
+          tenantId: auth.tenantId,
+          principalId: auth.principalId,
+          calendars,
+          start,
+          end,
+          limit,
+          after,
+        });
+
+        // Hydrate the owning event of every occurrence in the page, then a
+        // second hop for any series master referenced only by an exception (an
+        // exception's occurrence points at the exception, whose seriesId names a
+        // master that may not otherwise be in the page).
+        const eventIds = [...new Set(records.map((record) => record.eventId))];
+        const events = await eventRepo.findByIds(
+          auth.tenantId,
+          auth.principalId,
+          eventIds,
+        );
+        const eventsById = new Map(events.map((event) => [event._id, event]));
+        const missingMasterIds = [
+          ...new Set(
+            events.flatMap((event) =>
+              event.recurrence.kind === "exception" &&
+              !eventsById.has(event.recurrence.seriesId)
+                ? [event.recurrence.seriesId]
+                : [],
+            ),
+          ),
+        ];
+        if (missingMasterIds.length > 0) {
+          const masters = await eventRepo.findByIds(
+            auth.tenantId,
+            auth.principalId,
+            missingMasterIds,
+          );
+          for (const master of masters) eventsById.set(master._id, master);
+        }
+
+        // The cursor tracks only the occurrence page (back-filled master rows are
+        // appended out-of-band by the assembler, so they never affect paging).
+        const last = records.at(-1);
+        const response: EventInstanceListResponse = {
+          instances: assembleEventInstances(records, eventsById),
           nextCursor:
             records.length === limit && last
               ? encodeOccurrenceCursor(last)


### PR DESCRIPTION
## What

Wires the full-fidelity event read (S39 B2b) — the `GET /internal/events/full` endpoint that produces the `SyncEventInstance` rows the browser calendar will consume.

It mirrors the existing `GET /internal/events` (occurrence) route for all the shared concerns — auth, `ensureConnected`, query parse, cursor decode/validate, horizon clamp, active-generation resolution, limit default, error handling — then adds the join + assembly:

1. `listByCalendarRange` → the in-range occurrence page.
2. Batch `findByIds` the distinct occurrence `eventId`s.
3. **Second hop:** for any exception event whose `seriesId` master isn't already loaded, `findByIds` those masters and merge (an exception's occurrence points at the exception, whose series master may not otherwise be in the page).
4. `assembleEventInstances(records, eventsById)` → the legacy-equivalent row-set.

The cursor tracks **only** the occurrence page; back-filled master rows are appended out-of-band by the assembler and never affect paging. Scoped to the signed principal; served in passive mode too.

The pure `assembleEventInstances` + `findByIds` this calls were reviewed/merged in the prior PR; this PR is the route wiring.

## Testing

4 db integration tests: single-event join returns full content; a recurring series returns an occurrence row **plus** one back-filled master row; principal scoping (a stranger sees `[]`); unsigned request → 401. Full sync route db suite: 46 pass. `bun run type-check` zero new errors; lint clean via pinned biome.

Next: **B3** adds the backend `listFullEvents` client method; then the calendar-list delegation and read-route wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated read path over calendar/event data with multi-step hydration; behavior is covered by integration tests and mirrors the existing occurrence route’s scoping and paging guarantees.
> 
> **Overview**
> **Adds `GET /internal/events/full`** (`EVENTS_FULL_PATH`) as the full-fidelity calendar read: same auth, horizon clamp, active-generation filtering, and occurrence keyset paging as `GET /internal/events`, but the response is `{ instances, nextCursor }` built from joined event data.
> 
> After `listByCalendarRange`, the handler batch-loads owning events with `EventRepository.findByIds`, **second-hops** missing series masters when the page only has exception occurrences, then calls **`assembleEventInstances`**. Paging cursors still track the occurrence page only; back-filled series rows do not affect `nextCursor`.
> 
> **DB integration tests** cover single-event content join, recurring series + back-filled master, exception-only-in-range second hop, principal scoping, and unsigned → 401.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63924a465596778e13da2e68f3b912ca66678d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->