### PR TITLE
feat(backend): add listFullEvents to SyncServiceClient

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1,7 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type BusyAvailabilityRequest } from "@core/types/sync/availability.contracts";
 import { type CommandSubmitRequest } from "@core/types/sync/command.contracts";
-import { type EventOccurrenceListQuery } from "@core/types/sync/event.contracts";
+import {
+  type EventInstanceListQuery,
+  type EventOccurrenceListQuery,
+} from "@core/types/sync/event.contracts";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { verifyInternalRequest } from "@sync/auth/internal-auth";
 import { COMMANDS_PATH } from "@sync/server/command.routes";
@@ -9,6 +12,7 @@ import {
   AVAILABILITY_BUSY_PATH,
   BEGIN_PATH,
   CONNECTIONS_PATH,
+  EVENTS_FULL_PATH,
   EVENTS_PATH,
 } from "@sync/server/connection.routes";
 import {
@@ -227,6 +231,64 @@ describe("SyncServiceClient", () => {
       calendarIds: [objectId()] as EventOccurrenceListQuery["calendarIds"],
       start: "2026-07-14T09:00:00.000Z" as EventOccurrenceListQuery["start"],
       end: "2026-07-14T17:00:00.000Z" as EventOccurrenceListQuery["end"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
+  });
+
+  it("lists full events with a signed GET the real Sync verifier accepts", async () => {
+    const who = principal();
+    const calendarA = objectId();
+    const calendarB = objectId();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ instances: [], nextCursor: null }),
+    }));
+
+    const result = await client(fn).listFullEvents(who, {
+      calendarIds: [
+        calendarA,
+        calendarB,
+      ] as EventInstanceListQuery["calendarIds"],
+      start: "2026-07-14T09:00:00.000Z" as EventInstanceListQuery["start"],
+      end: "2026-07-14T17:00:00.000Z" as EventInstanceListQuery["end"],
+      limit: 100,
+    });
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.instances).toEqual([]);
+
+    const sent = calls[0];
+    expect(sent?.method).toBe("GET");
+    expect(sent?.body).toBeUndefined();
+    // Path parity with the Sync full-event route + repeated calendarIds params.
+    expect(sent?.url.startsWith(`${BASE_URL}${EVENTS_FULL_PATH}?`)).toBe(true);
+    const query = new URL(sent?.url ?? "").searchParams;
+    expect(query.getAll("calendarIds")).toEqual([calendarA, calendarB]);
+    expect(query.get("limit")).toBe("100");
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("rejects a full-event body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ instances: [{ bogus: true }], nextCursor: null }),
+    }));
+
+    const result = await client(fn).listFullEvents(principal(), {
+      calendarIds: [objectId()] as EventInstanceListQuery["calendarIds"],
+      start: "2026-07-14T09:00:00.000Z" as EventInstanceListQuery["start"],
+      end: "2026-07-14T17:00:00.000Z" as EventInstanceListQuery["end"],
     });
 
     expect(result.ok).toBe(false);

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -17,6 +17,9 @@ import {
   ConnectionListResponseSchema,
 } from "@core/types/sync/connection.contracts";
 import {
+  type EventInstanceListQuery,
+  type EventInstanceListResponse,
+  EventInstanceListResponseSchema,
   type EventOccurrenceListQuery,
   type EventOccurrenceListResponse,
   EventOccurrenceListResponseSchema,
@@ -29,6 +32,7 @@ const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const EVENTS_PATH = "/internal/events";
+const EVENTS_FULL_PATH = "/internal/events/full";
 const COMMANDS_PATH = "/internal/commands";
 
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -186,6 +190,36 @@ export class SyncServiceClient {
       query: params,
       principal,
       schema: EventOccurrenceListResponseSchema,
+      correlationId,
+    });
+  }
+
+  // A page of full-fidelity event rows (content + schedule + series linkage) for
+  // the given calendars and range, scoped to the signed principal. Backs the
+  // browser calendar read; unlike listEventOccurrences (busy/availability), each
+  // row carries what the app needs to render AND edit. Same query serialization:
+  // `calendarIds` as repeated params, and `query.cursor` from a prior response's
+  // `nextCursor` to page.
+  listFullEvents(
+    principal: SyncPrincipal,
+    query: EventInstanceListQuery,
+    correlationId?: string,
+  ): Promise<SyncClientResult<EventInstanceListResponse>> {
+    const params = new URLSearchParams();
+    for (const calendarId of query.calendarIds) {
+      params.append("calendarIds", calendarId);
+    }
+    params.set("start", query.start);
+    params.set("end", query.end);
+    if (query.cursor !== undefined) params.set("cursor", query.cursor);
+    if (query.limit !== undefined) params.set("limit", String(query.limit));
+
+    return this.#request({
+      method: "GET",
+      path: EVENTS_FULL_PATH,
+      query: params,
+      principal,
+      schema: EventInstanceListResponseSchema,
       correlationId,
     });
   }


### PR DESCRIPTION
## What

Backend building block for the browser event-read delegation (S39 B3). Adds `SyncServiceClient.listFullEvents(principal, query, correlationId?)` — a signed, principal-scoped `GET /internal/events/full` returning a page of full-fidelity `SyncEventInstance` rows.

Mirrors `listEventOccurrences` exactly (same query serialization — `calendarIds` as repeated params, `start`/`end`/`cursor`/`limit`) but hits the full-event route and parses `EventInstanceListResponse`. No route/consumer wired yet (byte-identical).

## Testing

Contract tests import the real `@sync` `EVENTS_FULL_PATH` + `verifyInternalRequest` for path parity + cross-service signature acceptance, plus `invalidResponse` on a bad body. 21 pass in the client test file. `bun run type-check` zero new errors; lint clean via pinned biome.

Next: **A1** calendar-list delegation, then the read-route wiring that translates these instances into the browser `Event` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive internal client API following the same auth and request patterns as existing Sync client methods, with no production wiring in this PR.
> 
> **Overview**
> Adds **`SyncServiceClient.listFullEvents`**, a principal-scoped signed **GET** to **`/internal/events/full`** that returns paginated **`SyncEventInstance`** rows (full calendar read data), using the same query shape as occurrence listing (`calendarIds`, `start`/`end`, optional `cursor`/`limit`) and **`EventInstanceListResponseSchema`** validation.
> 
> Contract tests assert path parity with the Sync **`EVENTS_FULL_PATH`**, cross-service signature acceptance via **`verifyInternalRequest`**, and **`invalidResponse`** when the body does not match the contract. **No HTTP routes or callers are wired yet**—this is the backend client building block for browser event-read delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd111787f05cf5827199b81b7b4811a45ee18270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->