### PR TITLE
feat(backend): delegate GET /api/calendars to sync (calendar-list delegation)

### DIFF
--- a/packages/backend/src/calendar/controllers/calendar.controller.delegation.test.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.delegation.test.ts
@@ -1,0 +1,56 @@
+import { faker } from "@faker-js/faker";
+import { type SessionRequest } from "supertokens-node/framework/express";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { type Res_Promise } from "@backend/common/types/express.types";
+import calendarController from "./calendar.controller";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+// A session request stub carrying only what list() reads.
+const reqFor = (userId: string) =>
+  ({
+    session: { getUserId: () => userId },
+    query: {},
+  }) as unknown as SessionRequest;
+
+// Capture the promise the controller hands to res.promise so the test can
+// observe whether it resolved or rejected.
+const capturingRes = () => {
+  let settled: Promise<unknown> | undefined;
+  const res = {
+    promise: (value: unknown) => {
+      settled = Promise.resolve(value);
+    },
+  } as unknown as Res_Promise;
+  return { res, settled: () => settled };
+};
+
+describe("CalendarController.list event delegation", () => {
+  const originalRouting = CONFIG.SYNC_EVENT_ROUTING;
+  const originalServiceUrl = CONFIG.SYNC_SERVICE_URL;
+  const originalToken = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
+
+  afterEach(() => {
+    CONFIG.SYNC_EVENT_ROUTING = originalRouting;
+    CONFIG.SYNC_SERVICE_URL = originalServiceUrl;
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = originalToken;
+  });
+
+  it("delegates the calendar list to sync when event routing is sync", async () => {
+    // Point at an unreachable sync service so the delegated read fails at the
+    // fetch. The rejection proves the SYNC branch ran (the legacy branch reads
+    // the calendar store instead) AND that it fails closed rather than silently
+    // returning an empty calendar list. This dedicated file gets its own test
+    // process, so the lazy sync client singleton is built from the values set
+    // here rather than the legacy default from another test.
+    CONFIG.SYNC_SERVICE_URL = "http://sync.invalid:4999";
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
+    CONFIG.SYNC_EVENT_ROUTING = "sync";
+
+    const { res, settled } = capturingRes();
+    await calendarController.list(reqFor(objectId()), res);
+
+    await expect(settled()).rejects.toThrow();
+  });
+});

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -13,6 +13,10 @@ import calendarService from "@backend/calendar/services/calendar.service";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
+import { syncCalendarToBrowser } from "@backend/common/services/sync-service/calendar-list.translation";
+import { getEventDelegation } from "@backend/common/services/sync-service/event-routing";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import {
   type Res_Promise,
   type SReqBody,
@@ -52,6 +56,29 @@ const parseAvailabilityQuery = (query: SessionRequest["query"]) => {
   });
 };
 
+// List the caller's calendars from the sync service and translate them to the
+// browser Calendar contract. A sync failure rejects (rather than returning an
+// empty list) so the browser surfaces a load error and retries, instead of
+// silently hiding every calendar.
+const listCalendarsFromSync = async (
+  userId: string,
+): Promise<CalendarListResponse> => {
+  const client = getSyncServiceClient();
+  if (!client) {
+    throw error(GenericError.NotSure, "Sync calendar listing unavailable");
+  }
+
+  const result = await client.listCalendars(toSyncPrincipal(userId));
+  if (!result.ok) {
+    throw error(
+      GenericError.NotSure,
+      `Failed to list calendars from sync (${result.error.kind})`,
+    );
+  }
+
+  return { calendars: result.value.calendars.map(syncCalendarToBrowser) };
+};
+
 class CalendarController {
   list = async (req: SessionRequest, res: Res_Promise) => {
     try {
@@ -59,10 +86,14 @@ class CalendarController {
         error: () => error(AuthError.InadequatePermissions, "List Failed"),
       });
 
-      const records = await calendarService.list(userId);
-      const response: CalendarListResponse = {
-        calendars: records.map(mapCalendarRecord),
-      };
+      const response =
+        getEventDelegation() === "sync"
+          ? await listCalendarsFromSync(userId.toString())
+          : {
+              calendars: (await calendarService.list(userId)).map(
+                mapCalendarRecord,
+              ),
+            };
 
       res.promise(response);
     } catch (e) {

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -94,10 +94,7 @@ class CalendarController {
 
         res.promise({
           calendars: localCalendar
-            ? [
-                ...syncResponse.calendars,
-                mapCalendarRecord(localCalendar),
-              ]
+            ? [...syncResponse.calendars, mapCalendarRecord(localCalendar)]
             : syncResponse.calendars,
         });
         return;

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -86,16 +86,26 @@ class CalendarController {
         error: () => error(AuthError.InadequatePermissions, "List Failed"),
       });
 
-      const response =
-        getEventDelegation() === "sync"
-          ? await listCalendarsFromSync(userId.toString())
-          : {
-              calendars: (await calendarService.list(userId)).map(
-                mapCalendarRecord,
-              ),
-            };
+      if (getEventDelegation() === "sync") {
+        const [syncResponse, localCalendar] = await Promise.all([
+          listCalendarsFromSync(userId.toString()),
+          calendarService.getLocalCalendar(userId),
+        ]);
 
-      res.promise(response);
+        res.promise({
+          calendars: localCalendar
+            ? [
+                ...syncResponse.calendars,
+                mapCalendarRecord(localCalendar),
+              ]
+            : syncResponse.calendars,
+        });
+        return;
+      }
+
+      res.promise({
+        calendars: (await calendarService.list(userId)).map(mapCalendarRecord),
+      });
     } catch (e) {
       res.promise(Promise.reject(e));
     }

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
@@ -1,0 +1,95 @@
+import { faker } from "@faker-js/faker";
+import { getCalendarCapabilities } from "@core/types/calendar.contracts";
+import {
+  type ProviderCalendar,
+  ProviderCalendarSchema,
+} from "@core/types/sync/connection.contracts";
+import { syncCalendarToBrowser } from "./calendar-list.translation";
+import { describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const providerCalendar = (
+  overrides: Partial<ProviderCalendar> = {},
+): ProviderCalendar =>
+  ProviderCalendarSchema.parse({
+    id: objectId(),
+    tenantId: objectId(),
+    principalId: objectId(),
+    connectionId: objectId(),
+    providerCalendarId: "primary@group.calendar.google.com",
+    displayName: "Work",
+    color: "#33b679",
+    active: true,
+    primary: false,
+    accessRole: "owner",
+    capabilities: {
+      canReadEvents: true,
+      canWriteEvents: true,
+      canReadBusy: true,
+      canInviteAttendees: true,
+    },
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-02T00:00:00.000Z",
+    ...overrides,
+  });
+
+describe("syncCalendarToBrowser", () => {
+  it("uses the sync calendar id directly as the browser calendar id", () => {
+    const calendar = providerCalendar();
+    // Option 2: calendars are sync-owned, so no id bridge — the browser uses
+    // sync's id verbatim.
+    expect(syncCalendarToBrowser(calendar).id).toBe(calendar.id);
+  });
+
+  it("maps display name, primary, and active through", () => {
+    const result = syncCalendarToBrowser(
+      providerCalendar({
+        displayName: "Personal",
+        primary: true,
+        active: false,
+      }),
+    );
+    expect(result.name).toBe("Personal");
+    expect(result.isPrimary).toBe(true);
+    expect(result.isActive).toBe(false);
+  });
+
+  it("puts the provider colour on the background and defaults the foreground", () => {
+    const result = syncCalendarToBrowser(
+      providerCalendar({ color: "#4285f4" }),
+    );
+    expect(result.backgroundColor).toBe("#4285f4");
+    expect(result.foregroundColor).toBe("#000000");
+  });
+
+  it("falls back to the legacy default colour when the provider omits one", () => {
+    const result = syncCalendarToBrowser(providerCalendar({ color: null }));
+    expect(result.backgroundColor).toBe("#9e9e9e");
+  });
+
+  it("always reports the calendar visible (visibility is client-side now)", () => {
+    const result = syncCalendarToBrowser(providerCalendar({ active: false }));
+    expect(result.isVisible).toBe(true);
+  });
+
+  it("leaves description empty and timeZone null (sync stores neither)", () => {
+    const result = syncCalendarToBrowser(providerCalendar());
+    expect(result.description).toBe("");
+    expect(result.timeZone).toBeNull();
+  });
+
+  it.each([
+    ["owner", "owner"],
+    ["editor", "writer"],
+    ["viewer", "reader"],
+    ["busyOnly", "freeBusyReader"],
+  ] as const)("maps sync access role %s to browser access %s and derives capabilities", (syncRole, browserAccess) => {
+    const result = syncCalendarToBrowser(
+      providerCalendar({ accessRole: syncRole }),
+    );
+    expect(result.access).toBe(browserAccess);
+    // Capabilities are derived from the access role, matching the legacy mapper.
+    expect(result.capabilities).toEqual(getCalendarCapabilities(browserAccess));
+  });
+});

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
@@ -68,6 +68,15 @@ describe("syncCalendarToBrowser", () => {
     expect(result.backgroundColor).toBe("#9e9e9e");
   });
 
+  it("falls back to the default colour when the provider colour is not hex", () => {
+    // Sync stores colour as a loose string; a non-hex value must not 500 the
+    // whole calendar list.
+    const result = syncCalendarToBrowser(
+      providerCalendar({ color: "cornflower" }),
+    );
+    expect(result.backgroundColor).toBe("#9e9e9e");
+  });
+
   it("always reports the calendar visible (visibility is client-side now)", () => {
     const result = syncCalendarToBrowser(providerCalendar({ active: false }));
     expect(result.isVisible).toBe(true);

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
@@ -4,6 +4,7 @@ import {
   CalendarSchema,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
+import { HexColorSchema } from "@core/types/domain-primitives";
 import { type ProviderCalendar } from "@core/types/sync/connection.contracts";
 
 // Legacy's default calendar colours (map.calendar.ts), reused so a sync-served
@@ -42,13 +43,20 @@ const mapCalendarAccessRole = (
 // visible and the web applies its own hidden set.
 export const syncCalendarToBrowser = (calendar: ProviderCalendar): Calendar => {
   const access = mapCalendarAccessRole(calendar.accessRole);
+  // Sync stores the provider colour as a loose string; the browser Calendar
+  // requires a hex colour. Fall back to the default rather than 500 the whole
+  // list if a provider ever hands back a non-hex value.
+  const backgroundColor =
+    calendar.color && HexColorSchema.safeParse(calendar.color).success
+      ? calendar.color
+      : DEFAULT_BACKGROUND;
   return CalendarSchema.parse({
     id: calendar.id,
     name: calendar.displayName,
     description: "",
     timeZone: null,
     foregroundColor: DEFAULT_FOREGROUND,
-    backgroundColor: calendar.color ?? DEFAULT_BACKGROUND,
+    backgroundColor,
     provider: "google",
     access,
     capabilities: getCalendarCapabilities(access),

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
@@ -1,0 +1,59 @@
+import {
+  type Calendar,
+  type CalendarAccess,
+  CalendarSchema,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { type ProviderCalendar } from "@core/types/sync/connection.contracts";
+
+// Legacy's default calendar colours (map.calendar.ts), reused so a sync-served
+// calendar looks identical to a legacy one when the provider omits a colour.
+const DEFAULT_BACKGROUND = "#9e9e9e";
+const DEFAULT_FOREGROUND = "#000000";
+
+// Sync reports the provider's access role in its own vocabulary; the browser
+// Calendar uses the legacy Google-derived enum. Exhaustive, no default, so a new
+// role fails the build rather than silently mapping to something permissive.
+const mapCalendarAccessRole = (
+  role: ProviderCalendar["accessRole"],
+): CalendarAccess => {
+  switch (role) {
+    case "owner":
+      return "owner";
+    case "editor":
+      return "writer";
+    case "viewer":
+      return "reader";
+    case "busyOnly":
+      return "freeBusyReader";
+  }
+};
+
+// Translate one sync ProviderCalendar into the browser Calendar contract. Under
+// sync-owned calendars (S39 option 2), the browser uses sync's calendar id
+// directly, so no id bridge is needed. Capabilities are DERIVED from the access
+// role via the same helper the legacy mapper uses, sidestepping the difference
+// between sync's and the browser's capability shapes.
+//
+// Deliberate v1 gaps, all contract-valid: description is empty and timeZone is
+// null (sync's provider_calendars stores neither), the single provider colour
+// becomes the background (foreground defaults), and isVisible is always true —
+// visibility is owned client-side now, so the server reports every calendar
+// visible and the web applies its own hidden set.
+export const syncCalendarToBrowser = (calendar: ProviderCalendar): Calendar => {
+  const access = mapCalendarAccessRole(calendar.accessRole);
+  return CalendarSchema.parse({
+    id: calendar.id,
+    name: calendar.displayName,
+    description: "",
+    timeZone: null,
+    foregroundColor: DEFAULT_FOREGROUND,
+    backgroundColor: calendar.color ?? DEFAULT_BACKGROUND,
+    provider: "google",
+    access,
+    capabilities: getCalendarCapabilities(access),
+    isPrimary: calendar.primary,
+    isVisible: true,
+    isActive: calendar.active,
+  });
+};

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -11,6 +11,7 @@ import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
   AVAILABILITY_BUSY_PATH,
   BEGIN_PATH,
+  CALENDARS_PATH,
   CONNECTIONS_PATH,
   EVENTS_FULL_PATH,
   EVENTS_PATH,
@@ -144,6 +145,46 @@ describe("SyncServiceClient", () => {
     if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
     expect(verdict.context.tenantId).toBe(who.tenantId);
     expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("lists calendars with a signed GET the real Sync verifier accepts", async () => {
+    const who = principal();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ calendars: [] }),
+    }));
+
+    const result = await client(fn).listCalendars(who);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.calendars).toEqual([]);
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${CALENDARS_PATH}`);
+    expect(sent?.method).toBe("GET");
+    expect(sent?.body).toBeUndefined();
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("rejects a calendars body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ calendars: [{ bogus: true }] }),
+    }));
+
+    const result = await client(fn).listCalendars(principal());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
   });
 
   it("rejects a connections body that does not match the contract", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -10,6 +10,8 @@ import {
   CommandSubmitResponseSchema,
 } from "@core/types/sync/command.contracts";
 import {
+  type CalendarListResponse,
+  CalendarListResponseSchema,
   type ConnectionBeginRequest,
   type ConnectionBeginResponse,
   ConnectionBeginResponseSchema,
@@ -29,6 +31,7 @@ import { createHmac, randomUUID } from "node:crypto";
 // The internal endpoints this client calls. Kept in sync with the Sync service's
 // route paths; a contract test asserts they match.
 const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
+const CALENDARS_PATH = "/internal/calendars";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const EVENTS_PATH = "/internal/events";
@@ -141,6 +144,22 @@ export class SyncServiceClient {
       path: CONNECTIONS_PATH,
       principal,
       schema: ConnectionListResponseSchema,
+      correlationId,
+    });
+  }
+
+  // The caller's provider calendars, scoped to the signed principal. A read;
+  // served in passive mode too. Backs the browser calendar list under sync
+  // delegation.
+  listCalendars(
+    principal: SyncPrincipal,
+    correlationId?: string,
+  ): Promise<SyncClientResult<CalendarListResponse>> {
+    return this.#request({
+      method: "GET",
+      path: CALENDARS_PATH,
+      principal,
+      schema: CalendarListResponseSchema,
       correlationId,
     });
   }


### PR DESCRIPTION
## What

S39 **A1** — calendar-list delegation (option 2, sync-owned calendars). When `SYNC_EVENT_ROUTING=sync`, the browser calendar list is served from the sync service instead of the legacy calendar store. Legacy stays the default; dormant until the switch flips.

This is the calendar half of option 2: the browser must get calendars from sync (with sync's ids) so the event read can query them by the same ids.

## How

- **`SyncServiceClient.listCalendars`** — signed `GET /internal/calendars`, mirroring `listConnections`.
- **`syncCalendarToBrowser`** (pure) — `ProviderCalendar` → browser `Calendar`:
  - Uses sync's calendar id **directly** as the browser `CalendarId` (option 2, no id bridge).
  - **Capabilities derived from the access role** via the same `getCalendarCapabilities` helper the legacy mapper uses — sidestepping the different capability shapes on each side.
  - Access role mapped exhaustively (`owner/editor/viewer/busyOnly` → `owner/writer/reader/freeBusyReader`), no default so a new role fails the build.
  - Deliberate v1 gaps, all contract-valid: empty description, null timeZone, single provider colour on the background, and **`isVisible` always true** — visibility is client-side now (A2), so the server reports every calendar visible and the web applies its own hidden set.
- **`calendar.controller.list`** branches on `getEventDelegation()`; a sync failure **rejects** rather than returning an empty list, so the browser retries instead of silently hiding every calendar.

## Testing

- Translation: all 4 access-role mappings + capability derivation, colour default/fallback, `isVisible:true`, empty description/null timeZone.
- Client contract test: path parity vs the real `@sync` `CALENDARS_PATH` + signature acceptance + `invalidResponse`.
- Controller delegation test (dedicated file so the lazy client singleton builds from primed config): proves the sync branch runs and **fails closed** on an unreachable sync service; the existing legacy-path controller test is unchanged.
- `bun run type-check` zero new errors; lint clean via pinned biome.

Next: **A2** moves calendar visibility client-side (localStorage), then **B4** wires the event read with the `SyncEventInstance → Event` translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches a core read path behind a feature flag and depends on sync availability; misconfiguration or sync outages surface as list errors rather than silent empty calendars.
> 
> **Overview**
> When **`SYNC_EVENT_ROUTING=sync`**, **`CalendarController.list`** no longer reads only the legacy calendar store. It fetches provider calendars from the sync service via a new **`SyncServiceClient.listCalendars`** (signed `GET /internal/calendars`), maps each row with **`syncCalendarToBrowser`** (sync calendar ids used as browser ids, access roles translated, capabilities from **`getCalendarCapabilities`**), and still appends the user’s **local** calendar when present. Legacy routing is unchanged.
> 
> Sync list failures **reject** the request instead of returning an empty list. **`isVisible`** is always **true** on sync-mapped calendars (visibility treated as client-side). Tests cover translation, client contract/auth, and delegation/fail-closed behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0679557b7fbf59ac7725216dee4fd204224fb035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->