### PR TITLE
feat(backend): reversible synthetic occurrence-id codec (S39 B4/C prep)

### DIFF
--- a/packages/backend/src/common/services/sync-service/occurrence-id.test.ts
+++ b/packages/backend/src/common/services/sync-service/occurrence-id.test.ts
@@ -1,0 +1,44 @@
+import { faker } from "@faker-js/faker";
+import { composeOccurrenceId, decodeOccurrenceId } from "./occurrence-id";
+import { describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+describe("occurrence id codec", () => {
+  it("round-trips an eventId and recurrenceId", () => {
+    const parts = {
+      eventId: objectId(),
+      recurrenceId: "2026-07-14T15:00:00.000Z",
+    };
+    expect(decodeOccurrenceId(composeOccurrenceId(parts))).toEqual(parts);
+  });
+
+  it("round-trips a recurrenceId carrying a UTC offset (colons in the tail)", () => {
+    // The ISO tail has its own colons; only the FIRST `::` separates the parts.
+    const parts = {
+      eventId: objectId(),
+      recurrenceId: "2026-03-08T01:30:00-07:00",
+    };
+    expect(decodeOccurrenceId(composeOccurrenceId(parts))).toEqual(parts);
+  });
+
+  it("decodes a plain event id (no separator) to null", () => {
+    // A single or series-master row carries a bare event id — not an occurrence.
+    expect(decodeOccurrenceId(objectId())).toBeNull();
+  });
+
+  it("rejects a composite whose eventId is not an ObjectId", () => {
+    expect(
+      decodeOccurrenceId("not-an-id::2026-07-14T15:00:00.000Z"),
+    ).toBeNull();
+  });
+
+  it("rejects a composite whose recurrenceId is not an ISO datetime", () => {
+    expect(decodeOccurrenceId(`${objectId()}::yesterday`)).toBeNull();
+  });
+
+  it("does not mistake a bare ObjectId or empty string for an occurrence", () => {
+    expect(decodeOccurrenceId("")).toBeNull();
+    expect(decodeOccurrenceId(`${objectId()}`)).toBeNull();
+  });
+});

--- a/packages/backend/src/common/services/sync-service/occurrence-id.ts
+++ b/packages/backend/src/common/services/sync-service/occurrence-id.ts
@@ -1,0 +1,49 @@
+// The reversible app-facing id for a projected series occurrence (S39, D1=II).
+//
+// Sync projects series instances rather than materializing them, so a projected
+// occurrence has no id of its own — only its owning series (`eventId`) and its
+// original scheduled start (`recurrenceId`). The browser needs a stable per-row
+// id to key, edit, and delete. B4 (read wiring) composes one from those two
+// parts; C (write wiring) decodes a PUT/DELETE /api/event/:id back into the
+// command's (eventId, recurrenceId, scope). Keeping the codec here, pure and
+// unit-tested, isolates the round-trip from the wiring on both sides.
+//
+// Format: `${eventId}::${recurrenceId}`. The eventId is a 24-char ObjectId hex
+// (no colons) and recurrenceId is an ISO datetime (single colons only, never
+// `::`), so the FIRST `::` is an unambiguous separator. A plain event id (a
+// single or a series master row) has no `::` and decodes to null — the caller
+// treats that as "the whole event", not one occurrence.
+
+const SEPARATOR = "::";
+const OBJECT_ID = /^[0-9a-f]{24}$/;
+// A loose ISO-8601 datetime check: date + T + time, optional fraction, offset
+// (Z or +/-HH:MM). Enough to reject a malformed tail without re-implementing a
+// full parser — the value originated from the sync contract's DateTime.
+const ISO_DATETIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?(Z|[+-]\d{2}:\d{2})$/;
+
+export interface OccurrenceIdParts {
+  eventId: string;
+  recurrenceId: string;
+}
+
+// Compose the app-facing id for one projected occurrence.
+export function composeOccurrenceId(parts: OccurrenceIdParts): string {
+  return `${parts.eventId}${SEPARATOR}${parts.recurrenceId}`;
+}
+
+// Decode an app-facing id back into (eventId, recurrenceId), or null when the id
+// is not a composite occurrence id (a plain event id, or a malformed value). A
+// caller uses null to mean "target the whole event", never to guess.
+export function decodeOccurrenceId(id: string): OccurrenceIdParts | null {
+  const separatorIndex = id.indexOf(SEPARATOR);
+  if (separatorIndex === -1) return null;
+
+  const eventId = id.slice(0, separatorIndex);
+  const recurrenceId = id.slice(separatorIndex + SEPARATOR.length);
+  if (!OBJECT_ID.test(eventId) || !ISO_DATETIME.test(recurrenceId)) {
+    return null;
+  }
+
+  return { eventId, recurrenceId };
+}


### PR DESCRIPTION
## What

A small, pure, well-tested building block for the event read/write wiring (S39, D1=II): the reversible app-facing id for a projected series occurrence. No consumer yet.

Sync **projects** series instances rather than materializing them, so a projected occurrence has no id of its own — only its series (`eventId`) and original start (`recurrenceId`). The browser needs a stable per-row id to key/edit/delete. B4 (read wiring) will `composeOccurrenceId`; C (write wiring) will `decodeOccurrenceId` a `PUT`/`DELETE /api/event/:id` back into a command's `(eventId, recurrenceId, scope)`.

## How

Format `${eventId}::${recurrenceId}`. The `eventId` is a 24-hex ObjectId (no colons) and `recurrenceId` is an ISO datetime (single colons only, never `::`), so the **first** `::` is an unambiguous separator. A plain event id (a single or series-master row) has no `::` and decodes to `null` — the caller reads that as "the whole event", never a guess. Decode validates both parts (ObjectId shape + ISO datetime).

## Testing

6 unit tests: round-trip (incl. a recurrenceId carrying a UTC offset, i.e. colons in the tail), plain-id → null, non-ObjectId eventId → null, non-ISO recurrenceId → null, empty/bare-id → null. `bun run type-check` zero new errors; lint clean via pinned biome.

Part of the option-a program; dormant behind `SYNC_EVENT_ROUTING=legacy`. Next: B4 read-route wiring uses this to translate `SyncEventInstance → Event` (see the internal execution-log B4 spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new utility with tests and no production callers; decode fails closed to null on invalid input.
> 
> **Overview**
> Adds a **pure occurrence-id codec** in `sync-service` for projected recurring events: stable browser-facing ids built as `` `${eventId}::${recurrenceId}` `` without materializing each instance.
> 
> **`composeOccurrenceId`** joins a 24-hex ObjectId and an ISO datetime; **`decodeOccurrenceId`** splits on the first `::`, validates both parts, and returns **`null`** for plain event ids or malformed composites so callers treat those as whole-event targets, not guessed occurrences.
> 
> Includes **six unit tests** (round-trip with Z and offset datetimes, plain id → null, invalid ObjectId/ISO tails, empty string). **No route or API wiring yet**—prep for B4 read and C write paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239cf4794f8282a09e4cfa6260de06bd62e115aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->