### PR TITLE
feat(backend): delegate GET /api/event to sync (S39 B4)

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
@@ -1,0 +1,90 @@
+import { faker } from "@faker-js/faker";
+import { EventSchema } from "@core/types/event.contracts";
+import {
+  type SyncEventInstance,
+  SyncEventInstanceSchema,
+} from "@core/types/sync/event.contracts";
+import { syncEventInstanceToBrowser } from "./event-list.translation";
+import { composeOccurrenceId } from "./occurrence-id";
+import { describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const baseInstance = (
+  overrides: Partial<SyncEventInstance> = {},
+): SyncEventInstance =>
+  SyncEventInstanceSchema.parse({
+    eventId: objectId(),
+    calendarId: objectId(),
+    content: { title: "Standup", description: "Daily" },
+    schedule: {
+      kind: "timed",
+      start: "2026-07-14T09:00:00.000Z",
+      end: "2026-07-14T09:30:00.000Z",
+      timeZone: "UTC",
+    },
+    recurrence: { kind: "single" },
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-02T00:00:00.000Z",
+    ...overrides,
+  });
+
+describe("syncEventInstanceToBrowser", () => {
+  it("maps a single to Event with recurrence.kind=single and the real eventId", () => {
+    const instance = baseInstance();
+    const event = syncEventInstanceToBrowser(instance);
+
+    expect(() => EventSchema.parse(event)).not.toThrow();
+    expect(event.id).toBe(instance.eventId);
+    expect(event.recurrence).toEqual({ kind: "single" });
+    expect(event.content).toEqual({
+      kind: "details",
+      title: "Standup",
+      description: "Daily",
+    });
+    expect(event.calendarId).toBe(instance.calendarId);
+  });
+
+  it("maps a series master row keeping the real eventId and rules", () => {
+    const instance = baseInstance({
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+    });
+    const event = syncEventInstanceToBrowser(instance);
+
+    expect(event.id).toBe(instance.eventId);
+    expect(event.recurrence).toEqual({
+      kind: "series",
+      rules: ["RRULE:FREQ=WEEKLY"],
+    });
+  });
+
+  it("composes an occurrence id and sets seriesId to the owning eventId", () => {
+    const eventId = objectId();
+    const recurrenceId = "2026-07-14T09:00:00.000Z";
+    const instance = baseInstance({
+      eventId,
+      recurrence: { kind: "occurrence", recurrenceId },
+    });
+    const event = syncEventInstanceToBrowser(instance);
+
+    expect(event.id).toBe(composeOccurrenceId({ eventId, recurrenceId }));
+    expect(event.recurrence).toEqual({ kind: "occurrence", seriesId: eventId });
+  });
+
+  it("passes schedule and timestamps through", () => {
+    const instance = baseInstance({
+      schedule: {
+        kind: "allDay",
+        start: "2026-07-14",
+        end: "2026-07-15",
+      },
+      createdAt: "2026-06-01T12:00:00.000Z",
+      updatedAt: "2026-06-02T12:00:00.000Z",
+    });
+    const event = syncEventInstanceToBrowser(instance);
+
+    expect(event.schedule).toEqual(instance.schedule);
+    expect(event.createdAt).toBe(instance.createdAt);
+    expect(event.updatedAt).toBe(instance.updatedAt);
+  });
+});

--- a/packages/backend/src/common/services/sync-service/event-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.ts
@@ -1,0 +1,60 @@
+import { type Event, EventSchema } from "@core/types/event.contracts";
+import { type SyncEventInstance } from "@core/types/sync/event.contracts";
+import { composeOccurrenceId } from "./occurrence-id";
+
+// Translate one sync full-fidelity instance into the browser Event contract.
+// D1=II: singles and series-master rows keep the real eventId; projected
+// occurrences get a composed id the write path can reverse. content.kind is
+// always "details" (sync always carries title+description). calendarId passes
+// through as the sync calendar id (S39 option 2 — no legacy bridge).
+export const syncEventInstanceToBrowser = (
+  instance: SyncEventInstance,
+): Event => {
+  switch (instance.recurrence.kind) {
+    case "single":
+      return EventSchema.parse({
+        id: instance.eventId,
+        calendarId: instance.calendarId,
+        content: {
+          kind: "details",
+          title: instance.content.title,
+          description: instance.content.description,
+        },
+        schedule: instance.schedule,
+        recurrence: { kind: "single" },
+        createdAt: instance.createdAt,
+        updatedAt: instance.updatedAt,
+      });
+    case "series":
+      return EventSchema.parse({
+        id: instance.eventId,
+        calendarId: instance.calendarId,
+        content: {
+          kind: "details",
+          title: instance.content.title,
+          description: instance.content.description,
+        },
+        schedule: instance.schedule,
+        recurrence: { kind: "series", rules: instance.recurrence.rules },
+        createdAt: instance.createdAt,
+        updatedAt: instance.updatedAt,
+      });
+    case "occurrence":
+      return EventSchema.parse({
+        id: composeOccurrenceId({
+          eventId: instance.eventId,
+          recurrenceId: instance.recurrence.recurrenceId,
+        }),
+        calendarId: instance.calendarId,
+        content: {
+          kind: "details",
+          title: instance.content.title,
+          description: instance.content.description,
+        },
+        schedule: instance.schedule,
+        recurrence: { kind: "occurrence", seriesId: instance.eventId },
+        createdAt: instance.createdAt,
+        updatedAt: instance.updatedAt,
+      });
+  }
+};

--- a/packages/backend/src/event/controllers/event.controller.delegation.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.delegation.test.ts
@@ -1,0 +1,56 @@
+import { faker } from "@faker-js/faker";
+import { type Response } from "express";
+import { type SessionRequest } from "supertokens-node/framework/express";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import eventController from "./event.controller";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+// A session request stub carrying only what readAll reads.
+const reqFor = (userId: string) =>
+  ({
+    session: { getUserId: () => userId },
+    query: {
+      start: "2026-07-14T00:00:00.000Z",
+      end: "2026-07-21T00:00:00.000Z",
+    },
+  }) as unknown as SessionRequest;
+
+describe("EventController.readAll event delegation", () => {
+  const originalRouting = CONFIG.SYNC_EVENT_ROUTING;
+  const originalServiceUrl = CONFIG.SYNC_SERVICE_URL;
+  const originalToken = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
+
+  afterEach(() => {
+    CONFIG.SYNC_EVENT_ROUTING = originalRouting;
+    CONFIG.SYNC_SERVICE_URL = originalServiceUrl;
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = originalToken;
+  });
+
+  it("delegates the event list to sync when event routing is sync", async () => {
+    // Point at an unreachable sync service so the delegated read fails at the
+    // fetch. The error response proves the SYNC branch ran (the legacy branch
+    // reads the event store instead) AND that it fails closed rather than
+    // silently falling back. This dedicated file gets its own test process, so
+    // the lazy sync client singleton is built from the values set here rather
+    // than the legacy default from another test.
+    CONFIG.SYNC_SERVICE_URL = "http://sync.invalid:4999";
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
+    CONFIG.SYNC_EVENT_ROUTING = "sync";
+
+    const json = mock();
+    const res = {
+      status: mock().mockReturnThis(),
+      json,
+    } as unknown as Response;
+
+    await eventController.readAll(reqFor(objectId()), res);
+
+    // Fail-closed: sync unreachable -> error envelope, not a legacy empty list.
+    expect(res.status).toHaveBeenCalled();
+    const status = (res.status as ReturnType<typeof mock>).mock.calls[0]?.[0];
+    expect(status).not.toBe(200);
+    expect(json).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -8,6 +8,19 @@ import {
   EventListQuerySchema,
   ReplaceEventInputSchema,
 } from "@core/types/event-command.contracts";
+import {
+  type EventInstanceListQuery,
+  type SyncEventCalendarId,
+  SyncEventCalendarIdSchema,
+} from "@core/types/sync/event.contracts";
+import calendarService from "@backend/calendar/services/calendar.service";
+import { GenericError } from "@backend/common/errors/generic/generic.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { syncEventInstanceToBrowser } from "@backend/common/services/sync-service/event-list.translation";
+import { getEventDelegation } from "@backend/common/services/sync-service/event-routing";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import { toEventMutationError } from "@backend/event/event.error";
 import { mapEventRecord } from "@backend/event/event.record.mapper";
 import eventService from "@backend/event/services/event.service";
@@ -25,14 +38,102 @@ const parseListQuery = (query: Request["query"]): EventListQuery => {
   });
 };
 
+// Resolve every calendar the principal owns under sync delegation: provider
+// calendars from sync, plus the Compass-native local calendar (local-first
+// events are keyed by its legacy CalendarId). V1 queries ALL of them — the
+// web filters by localStorage visibility client-side (A2). Empty means the
+// user has nothing to read yet; return [] rather than calling sync with an
+// invalid empty calendarIds.
+const resolveSyncCalendarIds = async (
+  client: SyncServiceClient,
+  userId: string,
+): Promise<SyncEventCalendarId[]> => {
+  const principal = toSyncPrincipal(userId);
+  const [calendarsResult, localCalendar] = await Promise.all([
+    client.listCalendars(principal),
+    calendarService.getLocalCalendar(userId),
+  ]);
+
+  if (!calendarsResult.ok) {
+    throw error(
+      GenericError.NotSure,
+      `Failed to list calendars from sync (${calendarsResult.error.kind})`,
+    );
+  }
+
+  const ids: SyncEventCalendarId[] = [
+    ...calendarsResult.value.calendars.map((c) => c.id),
+  ];
+  if (localCalendar) {
+    ids.push(SyncEventCalendarIdSchema.parse(localCalendar._id.toHexString()));
+  }
+  return ids;
+};
+
+// Drain every page of full-fidelity instances for the range. Sync pages at
+// most 500; legacy readAll was unbounded within the view window, so we follow
+// nextCursor until exhausted. Horizon note: sync clamps 12mo past / 18mo
+// future — the browser only views inside that window.
+const listAllFullEvents = async (
+  client: SyncServiceClient,
+  userId: string,
+  query: EventListQuery,
+  calendarIds: readonly SyncEventCalendarId[],
+) => {
+  const principal = toSyncPrincipal(userId);
+  const instances = [];
+  let cursor: string | undefined;
+
+  for (;;) {
+    const pageQuery: EventInstanceListQuery = {
+      calendarIds,
+      start: query.start,
+      end: query.end,
+      ...(cursor !== undefined ? { cursor } : {}),
+    };
+    const result = await client.listFullEvents(principal, pageQuery);
+    if (!result.ok) {
+      throw error(
+        GenericError.NotSure,
+        `Failed to list events from sync (${result.error.kind})`,
+      );
+    }
+    instances.push(...result.value.instances);
+    if (result.value.nextCursor === null) break;
+    cursor = result.value.nextCursor;
+  }
+
+  return instances;
+};
+
+// GET /api/event under SYNC_EVENT_ROUTING=sync: fetch full-fidelity instances
+// from sync and translate to the browser Event contract. Fail-closed — a sync
+// outage surfaces as an error rather than silently falling back to legacy
+// (which would show a different, stale store).
+const readAllFromSync = async (userId: string, query: EventListQuery) => {
+  const client = getSyncServiceClient();
+  if (!client) {
+    throw error(GenericError.NotSure, "Sync event listing unavailable");
+  }
+
+  const calendarIds = await resolveSyncCalendarIds(client, userId);
+  if (calendarIds.length === 0) return [];
+
+  const instances = await listAllFullEvents(client, userId, query, calendarIds);
+  return instances.map(syncEventInstanceToBrowser);
+};
+
 class EventController {
   readAll = async (req: SessionRequest, res: Response) => {
     try {
       const userId = req.session?.getUserId() as string;
       const query = parseListQuery(req.query);
-      const events = await eventService.readAll(userId, query);
+      const events =
+        getEventDelegation() === "sync"
+          ? await readAllFromSync(userId, query)
+          : (await eventService.readAll(userId, query)).map(mapEventRecord);
 
-      res.status(Status.OK).json({ events: events.map(mapEventRecord) });
+      res.status(Status.OK).json({ events });
     } catch (e) {
       send(res, e);
     }

--- a/packages/core/src/types/domain-primitives.test.ts
+++ b/packages/core/src/types/domain-primitives.test.ts
@@ -16,12 +16,18 @@ describe("Domain Primitives", () => {
       ).toBe(true);
     });
 
-    it("rejects a short id", () => {
-      expect(EventIdSchema.safeParse("abc123").success).toBe(false);
+    it("accepts a composed occurrence id", () => {
+      // S39 D1=II: projected instances use `${eventId}::${recurrenceId}`.
+      const composed = `${faker.database.mongodbObjectId()}::2026-07-14T15:00:00.000Z`;
+      expect(EventIdSchema.safeParse(composed).success).toBe(true);
     });
 
-    it("rejects a non-hex id", () => {
-      expect(EventIdSchema.safeParse("g".repeat(24)).success).toBe(false);
+    it("rejects an empty id", () => {
+      expect(EventIdSchema.safeParse("").success).toBe(false);
+    });
+
+    it("rejects a whitespace-only id", () => {
+      expect(EventIdSchema.safeParse("   ").success).toBe(false);
     });
   });
 

--- a/packages/core/src/types/domain-primitives.ts
+++ b/packages/core/src/types/domain-primitives.ts
@@ -6,7 +6,16 @@ import {
   zYearMonthDayString,
 } from "@core/types/type.utils";
 
-export const EventIdSchema = ObjectIdStringSchema.brand<"EventId">();
+// Opaque on purpose: under sync event delegation (S39 D1=II) a projected
+// series occurrence carries a composed id (`${eventId}::${recurrenceId}`),
+// not a Mongo ObjectId. The web treats Event.id as opaque (React key +
+// PUT/DELETE target); only the backend decode step cares about the shape.
+export const EventIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .brand<"EventId">();
 export type EventId = z.infer<typeof EventIdSchema>;
 
 export const CalendarIdSchema = ObjectIdStringSchema.brand<"CalendarId">();

--- a/packages/core/src/types/event.contracts.test.ts
+++ b/packages/core/src/types/event.contracts.test.ts
@@ -148,8 +148,10 @@ describe("Event Contracts", () => {
       expect(EventRecurrenceSchema.safeParse(recurrence).success).toBe(false);
     });
 
-    it("rejects an occurrence with an invalid seriesId", () => {
-      const recurrence = { kind: "occurrence", seriesId: "not-an-id" };
+    it("rejects an occurrence with an empty seriesId", () => {
+      // EventId is an opaque non-empty string (S39 D1=II); emptiness is the
+      // only shape check left at this layer.
+      const recurrence = { kind: "occurrence", seriesId: "" };
 
       expect(EventRecurrenceSchema.safeParse(recurrence).success).toBe(false);
     });


### PR DESCRIPTION
## Summary

Wires `GET /api/event` to the sync full-fidelity read when `SYNC_EVENT_ROUTING=sync` (S39 B4, option a).

- Gate on `getEventDelegation() === "sync"` in `event.controller.readAll`; legacy path untouched.
- Resolve the principal's calendars (sync provider calendars + Compass-native local) and query all of them — v1 lets the web filter visibility client-side (A2).
- Translate each `SyncEventInstance` → browser `Event` via `syncEventInstanceToBrowser` (parse through `EventSchema`):
  - single / series → real `eventId`
  - occurrence → `composeOccurrenceId({ eventId, recurrenceId })` with `recurrence.seriesId = eventId`
- Relax `EventIdSchema` to an opaque non-empty string so composite occurrence ids validate.
- Fail-closed on sync outage; response shape stays `{ events: Event[] }`.

Dormant behind `SYNC_EVENT_ROUTING=legacy` (default). Builds on occurrence-id codec (#2365).

## Simplicity

Pure translation helper + thin controller branch. No new request-shape change for calendarIds (backend resolves). Reuses existing `listFullEvents` / `listCalendars` / `composeOccurrenceId`.

## Automated validation

- Focused unit tests for translation (single / series / occurrence / schedule pass-through).
- Fail-closed delegation test (unreachable sync → non-200; dedicated process for lazy client singleton).
- Legacy `readAll` response-shape test still green.

## Independent review

Pending CI + reviewer.

## Test plan

```bash
bun test:core -- packages/core/src/types/domain-primitives.test.ts packages/core/src/types/event.contracts.test.ts
bun test:backend -- packages/backend/src/common/services/sync-service/event-list.translation.test.ts packages/backend/src/event/controllers/event.controller.test.ts packages/backend/src/event/controllers/event.controller.delegation.test.ts
./node_modules/.bin/biome check <changed files>
bun run type-check  # 25 pre-existing Res_Promise errors; zero new
```

Made with [Cursor](https://cursor.com)