### PR TITLE
feat(backend): delegate event writes to sync submitCommand (S39 C)

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
@@ -1,0 +1,183 @@
+import { faker } from "@faker-js/faker";
+import { EventSchema } from "@core/types/event.contracts";
+import { CommandSubmitRequestSchema } from "@core/types/sync/command.contracts";
+import {
+  resolveCommandTarget,
+  toCreateSubmitRequest,
+  toDeleteSubmitRequest,
+  toReplaceSubmitRequests,
+  toSyncContent,
+} from "./event-command.translation";
+import { composeOccurrenceId } from "./occurrence-id";
+import { describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const timedSchedule = {
+  kind: "timed" as const,
+  start: "2026-07-14T09:00:00.000Z",
+  end: "2026-07-14T10:00:00.000Z",
+  timeZone: "UTC",
+};
+
+describe("toSyncContent", () => {
+  it("pads browser details into the full sync content shape", () => {
+    expect(toSyncContent({ title: "Standup", description: "Daily" })).toEqual({
+      title: "Standup",
+      description: "Daily",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    });
+  });
+});
+
+describe("resolveCommandTarget", () => {
+  it("decodes a composed occurrence id into eventId + recurrenceId", () => {
+    const eventId = objectId();
+    const recurrenceId = "2026-07-14T09:00:00.000Z";
+    const id = composeOccurrenceId({ eventId, recurrenceId });
+
+    expect(resolveCommandTarget(id, "this")).toEqual({
+      eventId,
+      scope: "this",
+      recurrenceId,
+    });
+  });
+
+  it("drops recurrenceId when scope is all on a composed id", () => {
+    const eventId = objectId();
+    const id = composeOccurrenceId({
+      eventId,
+      recurrenceId: "2026-07-14T09:00:00.000Z",
+    });
+
+    expect(resolveCommandTarget(id, "all")).toEqual({
+      eventId,
+      scope: "all",
+      recurrenceId: null,
+    });
+  });
+
+  it("coerces a plain id with scope this to all + null recurrenceId", () => {
+    // Web sends scope "this" for singles; sync requires scope all ⇔ no recurrenceId.
+    const eventId = objectId();
+    expect(resolveCommandTarget(eventId, "this")).toEqual({
+      eventId,
+      scope: "all",
+      recurrenceId: null,
+    });
+  });
+});
+
+describe("toCreateSubmitRequest", () => {
+  it("builds a create command and a parseable response Event", () => {
+    const calendarId = objectId();
+    const eventId = objectId();
+    const { request, responseEvent } = toCreateSubmitRequest({
+      id: eventId,
+      calendarId,
+      content: { kind: "details", title: "Lunch", description: "" },
+      schedule: timedSchedule,
+      recurrence: { kind: "single" },
+    });
+
+    expect(() => CommandSubmitRequestSchema.parse(request)).not.toThrow();
+    expect(request.eventId).toBe(eventId);
+    expect(request.idempotencyKey).toBe(`create:${eventId}`);
+    expect(request.expectedVersion).toBeNull();
+    expect(request.input).toMatchObject({
+      kind: "create",
+      calendarId,
+      clientEventId: null,
+      invitation: "none",
+      recurrence: { kind: "single" },
+    });
+    expect(() => EventSchema.parse(responseEvent)).not.toThrow();
+    expect(responseEvent.id).toBe(eventId);
+  });
+
+  it("mints an eventId when the client omits one", () => {
+    const { request } = toCreateSubmitRequest({
+      calendarId: objectId(),
+      content: { kind: "details", title: "X", description: "" },
+      schedule: timedSchedule,
+      recurrence: { kind: "single" },
+    });
+
+    expect(request.eventId).toMatch(/^[0-9a-f]{24}$/);
+    expect(request.idempotencyKey).toBe(`create:${request.eventId}`);
+  });
+});
+
+describe("toReplaceSubmitRequests", () => {
+  it("emits a single update for a plain-id replace without a calendar move", () => {
+    const eventId = objectId();
+    const { requests, responseEvent } = toReplaceSubmitRequests(eventId, {
+      content: { kind: "details", title: "Renamed", description: "" },
+      schedule: timedSchedule,
+      recurrence: { kind: "preserve" },
+      scope: "this",
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.input.kind).toBe("update");
+    if (requests[0]?.input.kind !== "update") return;
+    // Plain id + scope this → coerced to all.
+    expect(requests[0].input.scope).toBe("all");
+    expect(requests[0].input.recurrenceId).toBeNull();
+    expect(() => EventSchema.parse(responseEvent)).not.toThrow();
+  });
+
+  it("addresses an occurrence update with the decoded recurrenceId", () => {
+    const eventId = objectId();
+    const recurrenceId = "2026-07-14T09:00:00.000Z";
+    const id = composeOccurrenceId({ eventId, recurrenceId });
+    const { requests } = toReplaceSubmitRequests(id, {
+      content: { kind: "details", title: "Moved", description: "" },
+      schedule: timedSchedule,
+      recurrence: { kind: "preserve" },
+      scope: "this",
+    });
+
+    expect(requests).toHaveLength(1);
+    const update = requests[0];
+    expect(update?.eventId).toBe(eventId);
+    if (update?.input.kind !== "update") return;
+    expect(update.input.scope).toBe("this");
+    expect(update.input.recurrenceId).toBe(recurrenceId);
+  });
+
+  it("appends a move command when calendarId is present", () => {
+    const eventId = objectId();
+    const calendarId = objectId();
+    const { requests } = toReplaceSubmitRequests(eventId, {
+      calendarId,
+      content: { kind: "details", title: "X", description: "" },
+      schedule: timedSchedule,
+      recurrence: { kind: "single" },
+      scope: "this",
+    });
+
+    expect(requests.map((r) => r.input.kind)).toEqual(["update", "move"]);
+    expect(requests[1]?.input).toEqual({ kind: "move", calendarId });
+    // Distinct idempotency keys so the two stay independently retryable.
+    expect(requests[0]?.idempotencyKey).not.toBe(requests[1]?.idempotencyKey);
+  });
+});
+
+describe("toDeleteSubmitRequest", () => {
+  it("builds a delete command from a composed occurrence id", () => {
+    const eventId = objectId();
+    const recurrenceId = "2026-07-14T09:00:00.000Z";
+    const id = composeOccurrenceId({ eventId, recurrenceId });
+    const request = toDeleteSubmitRequest(id, { scope: "this" });
+
+    expect(() => CommandSubmitRequestSchema.parse(request)).not.toThrow();
+    expect(request.eventId).toBe(eventId);
+    if (request.input.kind !== "delete") return;
+    expect(request.input.scope).toBe("this");
+    expect(request.input.recurrenceId).toBe(recurrenceId);
+  });
+});

--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -1,0 +1,243 @@
+import { ObjectId } from "mongodb";
+import {
+  CalendarIdSchema,
+  type DateTime,
+  DateTimeSchema,
+  type EventId,
+  EventIdSchema,
+} from "@core/types/domain-primitives";
+import { type Event, EventSchema } from "@core/types/event.contracts";
+import {
+  type CreateEventInput,
+  type DeleteEventInput,
+  type RecurrenceScope,
+  type ReplaceEventInput,
+} from "@core/types/event-command.contracts";
+import {
+  type CommandSubmitRequest,
+  CommandSubmitRequestSchema,
+} from "@core/types/sync/command.contracts";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import { IdempotencyKeySchema } from "@core/types/sync/identity.contracts";
+import { decodeOccurrenceId } from "./occurrence-id";
+import { createHash } from "node:crypto";
+
+// Acknowledgment filler when replace omits calendarId (no move). The web is
+// optimistic and discards the response body after EventResponseSchema.parse;
+// we still need a contract-valid calendarId to round-trip the parse.
+const UNKNOWN_CALENDAR_ID = CalendarIdSchema.parse("000000000000000000000000");
+
+// Expand browser details-content into sync's fuller content shape. Browser
+// edits never touch location/organizer/attendees/conference — pad with nulls
+// so a strict sync write can't fail validation or wipe fields Sync stores.
+export const toSyncContent = (content: {
+  title: string;
+  description: string;
+}): SyncEventContent => ({
+  title: content.title,
+  description: content.description,
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+});
+
+export interface CommandTarget {
+  eventId: EventId;
+  scope: RecurrenceScope;
+  recurrenceId: DateTime | null;
+}
+
+// Address a browser event id for a sync command. A composed occurrence id
+// (`eventId::recurrenceId`) reverses into the series + original start; scope
+// "all" drops the recurrenceId so the whole series is targeted. A plain id
+// (single or series master) has no occurrence to address — coerce to scope
+// "all" + null recurrenceId so sync's coherence refine accepts the request
+// (the web often sends scope "this" for singles).
+export const resolveCommandTarget = (
+  id: string,
+  scope: RecurrenceScope,
+): CommandTarget => {
+  const parts = decodeOccurrenceId(id);
+  if (parts) {
+    if (scope === "all") {
+      return {
+        eventId: EventIdSchema.parse(parts.eventId),
+        scope: "all",
+        recurrenceId: null,
+      };
+    }
+    return {
+      eventId: EventIdSchema.parse(parts.eventId),
+      scope,
+      recurrenceId: DateTimeSchema.parse(parts.recurrenceId),
+    };
+  }
+
+  return {
+    eventId: EventIdSchema.parse(id),
+    scope: "all",
+    recurrenceId: null,
+  };
+};
+
+const hashedIdempotencyKey = (prefix: string, payload: unknown): string => {
+  const digest = createHash("sha256")
+    .update(JSON.stringify(payload))
+    .digest("hex")
+    .slice(0, 40);
+  return IdempotencyKeySchema.parse(`${prefix}:${digest}`);
+};
+
+const mintEventId = (): EventId =>
+  EventIdSchema.parse(new ObjectId().toHexString());
+
+// Create → one submit request. Prefer the client-supplied id (optimistic
+// create / undo-of-delete); mint an ObjectId when absent. Idempotency key is
+// stable on eventId so a retried POST maps to the same command.
+export const toCreateSubmitRequest = (
+  input: CreateEventInput,
+): { request: CommandSubmitRequest; responseEvent: Event } => {
+  const eventId = input.id ?? mintEventId();
+  const request = CommandSubmitRequestSchema.parse({
+    idempotencyKey: IdempotencyKeySchema.parse(`create:${eventId}`),
+    eventId,
+    expectedVersion: null,
+    input: {
+      kind: "create",
+      calendarId: input.calendarId,
+      clientEventId: null,
+      invitation: "none",
+      content: toSyncContent(input.content),
+      schedule: input.schedule,
+      recurrence: input.recurrence,
+    },
+  });
+
+  const now = new Date().toISOString();
+  const responseEvent = EventSchema.parse({
+    id: eventId,
+    calendarId: input.calendarId,
+    content: input.content,
+    schedule: input.schedule,
+    recurrence: input.recurrence,
+    createdAt: now,
+    updatedAt: null,
+  });
+
+  return { request, responseEvent };
+};
+
+// Replace → one update command, plus a move when calendarId is present.
+// Separate idempotency keys so the two stay independently retryable. The
+// response Event is synthesized from the request (web is optimistic and only
+// needs EventResponseSchema to parse).
+export const toReplaceSubmitRequests = (
+  id: string,
+  input: ReplaceEventInput,
+): { requests: CommandSubmitRequest[]; responseEvent: Event } => {
+  const target = resolveCommandTarget(id, input.scope);
+
+  const updateRequest = CommandSubmitRequestSchema.parse({
+    idempotencyKey: hashedIdempotencyKey("update", {
+      eventId: target.eventId,
+      scope: target.scope,
+      recurrenceId: target.recurrenceId,
+      content: input.content,
+      schedule: input.schedule,
+      recurrence: input.recurrence,
+    }),
+    eventId: target.eventId,
+    expectedVersion: null,
+    input: {
+      kind: "update",
+      invitation: "none",
+      content: toSyncContent(input.content),
+      schedule: input.schedule,
+      recurrence: input.recurrence,
+      scope: target.scope,
+      recurrenceId: target.recurrenceId,
+    },
+  });
+
+  const requests: CommandSubmitRequest[] = [updateRequest];
+
+  if (input.calendarId !== undefined) {
+    requests.push(
+      CommandSubmitRequestSchema.parse({
+        idempotencyKey: hashedIdempotencyKey("move", {
+          eventId: target.eventId,
+          calendarId: input.calendarId,
+        }),
+        eventId: target.eventId,
+        expectedVersion: null,
+        input: {
+          kind: "move",
+          calendarId: input.calendarId,
+        },
+      }),
+    );
+  }
+
+  const responseEvent = synthesizeReplaceEvent(id, input, target);
+  return { requests, responseEvent };
+};
+
+export const toDeleteSubmitRequest = (
+  id: string,
+  input: DeleteEventInput,
+): CommandSubmitRequest => {
+  const target = resolveCommandTarget(id, input.scope);
+  return CommandSubmitRequestSchema.parse({
+    idempotencyKey: hashedIdempotencyKey("delete", {
+      eventId: target.eventId,
+      scope: target.scope,
+      recurrenceId: target.recurrenceId,
+    }),
+    eventId: target.eventId,
+    expectedVersion: null,
+    input: {
+      kind: "delete",
+      invitation: "none",
+      scope: target.scope,
+      recurrenceId: target.recurrenceId,
+    },
+  });
+};
+
+// Best-effort Event for the browser response. Cache updates are optimistic;
+// this only needs to satisfy EventResponseSchema.parse on the web.
+const synthesizeReplaceEvent = (
+  requestId: string,
+  input: ReplaceEventInput,
+  target: CommandTarget,
+): Event => {
+  const recurrence = (() => {
+    if (input.recurrence.kind === "series") {
+      return { kind: "series" as const, rules: input.recurrence.rules };
+    }
+    if (input.recurrence.kind === "single") {
+      return { kind: "single" as const };
+    }
+    // preserve: keep occurrence linkage when the request addressed one;
+    // otherwise a plain single is the safe acknowledgment shape.
+    if (target.recurrenceId !== null) {
+      return { kind: "occurrence" as const, seriesId: target.eventId };
+    }
+    return { kind: "single" as const };
+  })();
+
+  const parts = decodeOccurrenceId(requestId);
+  const responseId =
+    parts && target.recurrenceId !== null ? requestId : target.eventId;
+
+  return EventSchema.parse({
+    id: responseId,
+    calendarId: input.calendarId ?? UNKNOWN_CALENDAR_ID,
+    content: input.content,
+    schedule: input.schedule,
+    recurrence,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+};

--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -29,7 +29,10 @@ const UNKNOWN_CALENDAR_ID = CalendarIdSchema.parse("000000000000000000000000");
 
 // Expand browser details-content into sync's fuller content shape. Browser
 // edits never touch location/organizer/attendees/conference — pad with nulls
-// so a strict sync write can't fail validation or wipe fields Sync stores.
+// so the strict SyncEventContent schema accepts the wire payload. On create
+// those nulls are correct (new event). On update, sync's apply path merges
+// title/description onto the existing record (mergeUpdateContent) so a rename
+// cannot wipe provider-sourced attendees/location/conference.
 export const toSyncContent = (content: {
   title: string;
   description: string;

--- a/packages/backend/src/event/controllers/event.controller.delegation.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.delegation.test.ts
@@ -3,53 +3,136 @@ import { type Response } from "express";
 import { type SessionRequest } from "supertokens-node/framework/express";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import eventController from "./event.controller";
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
 
 const objectId = () => faker.database.mongodbObjectId();
 
-// A session request stub carrying only what readAll reads.
-const reqFor = (userId: string) =>
+const sessionReq = (userId: string, extras: Partial<SessionRequest> = {}) =>
   ({
     session: { getUserId: () => userId },
-    query: {
-      start: "2026-07-14T00:00:00.000Z",
-      end: "2026-07-21T00:00:00.000Z",
-    },
+    query: {},
+    params: {},
+    body: {},
+    ...extras,
   }) as unknown as SessionRequest;
 
-describe("EventController.readAll event delegation", () => {
+const jsonRes = () => {
+  const json = mock();
+  const res = {
+    status: mock().mockReturnThis(),
+    json,
+    send: mock().mockReturnThis(),
+  } as unknown as Response;
+  return { res, json };
+};
+
+const enableSyncDelegation = () => {
+  // Point at an unreachable sync service so delegated calls fail at fetch.
+  // Proves the SYNC branch ran (legacy would hit the event store) AND that
+  // it fails closed — never falls back. This dedicated file gets its own
+  // test process, so the lazy sync client singleton is built from these
+  // values rather than a legacy default from another file.
+  CONFIG.SYNC_SERVICE_URL = "http://sync.invalid:4999";
+  CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
+  CONFIG.SYNC_EVENT_ROUTING = "sync";
+};
+
+describe("EventController event delegation", () => {
   const originalRouting = CONFIG.SYNC_EVENT_ROUTING;
   const originalServiceUrl = CONFIG.SYNC_SERVICE_URL;
   const originalToken = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
+
+  beforeAll(() => {
+    enableSyncDelegation();
+  });
 
   afterEach(() => {
     CONFIG.SYNC_EVENT_ROUTING = originalRouting;
     CONFIG.SYNC_SERVICE_URL = originalServiceUrl;
     CONFIG.SYNC_INTERNAL_AUTH_TOKEN = originalToken;
+    // Re-enable for the next test in this file (singleton already primed).
+    enableSyncDelegation();
   });
 
   it("delegates the event list to sync when event routing is sync", async () => {
-    // Point at an unreachable sync service so the delegated read fails at the
-    // fetch. The error response proves the SYNC branch ran (the legacy branch
-    // reads the event store instead) AND that it fails closed rather than
-    // silently falling back. This dedicated file gets its own test process, so
-    // the lazy sync client singleton is built from the values set here rather
-    // than the legacy default from another test.
-    CONFIG.SYNC_SERVICE_URL = "http://sync.invalid:4999";
-    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
-    CONFIG.SYNC_EVENT_ROUTING = "sync";
+    const { res, json } = jsonRes();
+    await eventController.readAll(
+      sessionReq(objectId(), {
+        query: {
+          start: "2026-07-14T00:00:00.000Z",
+          end: "2026-07-21T00:00:00.000Z",
+        },
+      }),
+      res,
+    );
 
-    const json = mock();
-    const res = {
-      status: mock().mockReturnThis(),
-      json,
-    } as unknown as Response;
-
-    await eventController.readAll(reqFor(objectId()), res);
-
-    // Fail-closed: sync unreachable -> error envelope, not a legacy empty list.
-    expect(res.status).toHaveBeenCalled();
     const status = (res.status as ReturnType<typeof mock>).mock.calls[0]?.[0];
+    expect(status).not.toBe(200);
+    expect(json).toHaveBeenCalled();
+  });
+
+  it("delegates create to sync and fails closed (no legacy fallback)", async () => {
+    const { res, json } = jsonRes();
+    await eventController.create(
+      sessionReq(objectId(), {
+        body: {
+          id: objectId(),
+          calendarId: objectId(),
+          content: { kind: "details", title: "Lunch", description: "" },
+          schedule: {
+            kind: "timed",
+            start: "2026-07-14T12:00:00.000Z",
+            end: "2026-07-14T13:00:00.000Z",
+            timeZone: "UTC",
+          },
+          recurrence: { kind: "single" },
+        },
+      }),
+      res,
+    );
+
+    const status = (res.status as ReturnType<typeof mock>).mock.calls[0]?.[0];
+    expect(status).not.toBe(200);
+    expect(json).toHaveBeenCalled();
+  });
+
+  it("delegates replace to sync and fails closed (no legacy fallback)", async () => {
+    const { res, json } = jsonRes();
+    await eventController.replace(
+      sessionReq(objectId(), {
+        params: { id: objectId() },
+        body: {
+          content: { kind: "details", title: "Renamed", description: "" },
+          schedule: {
+            kind: "timed",
+            start: "2026-07-14T12:00:00.000Z",
+            end: "2026-07-14T13:00:00.000Z",
+            timeZone: "UTC",
+          },
+          recurrence: { kind: "preserve" },
+          scope: "this",
+        },
+      }),
+      res,
+    );
+
+    const status = (res.status as ReturnType<typeof mock>).mock.calls[0]?.[0];
+    expect(status).not.toBe(200);
+    expect(json).toHaveBeenCalled();
+  });
+
+  it("delegates delete to sync and fails closed (no legacy fallback)", async () => {
+    const { res, json } = jsonRes();
+    await eventController.delete(
+      sessionReq(objectId(), {
+        params: { id: objectId() },
+        query: { scope: "this" },
+      }),
+      res,
+    );
+
+    const status = (res.status as ReturnType<typeof mock>).mock.calls[0]?.[0];
+    expect(status).not.toBe(204);
     expect(status).not.toBe(200);
     expect(json).toHaveBeenCalled();
   });

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -2,12 +2,19 @@ import { type Request, type Response } from "express";
 import { type SessionRequest } from "supertokens-node/framework/express";
 import { Status } from "@core/errors/status.codes";
 import {
+  type CreateEventInput,
   CreateEventInputSchema,
+  type DeleteEventInput,
   DeleteEventInputSchema,
   type EventListQuery,
   EventListQuerySchema,
+  type ReplaceEventInput,
   ReplaceEventInputSchema,
 } from "@core/types/event-command.contracts";
+import {
+  type CommandSubmitRequest,
+  type SyncCommandFailureReason,
+} from "@core/types/sync/command.contracts";
 import {
   type EventInstanceListQuery,
   type SyncEventCalendarId,
@@ -16,12 +23,20 @@ import {
 import calendarService from "@backend/calendar/services/calendar.service";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
+import {
+  toCreateSubmitRequest,
+  toDeleteSubmitRequest,
+  toReplaceSubmitRequests,
+} from "@backend/common/services/sync-service/event-command.translation";
 import { syncEventInstanceToBrowser } from "@backend/common/services/sync-service/event-list.translation";
 import { getEventDelegation } from "@backend/common/services/sync-service/event-routing";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
-import { toEventMutationError } from "@backend/event/event.error";
+import {
+  eventMutationError,
+  toEventMutationError,
+} from "@backend/event/event.error";
 import { mapEventRecord } from "@backend/event/event.record.mapper";
 import eventService from "@backend/event/services/event.service";
 
@@ -123,6 +138,89 @@ const readAllFromSync = async (userId: string, query: EventListQuery) => {
   return instances.map(syncEventInstanceToBrowser);
 };
 
+const requireSyncClient = (): SyncServiceClient => {
+  const client = getSyncServiceClient();
+  if (!client) {
+    throw error(GenericError.NotSure, "Sync event commands unavailable");
+  }
+  return client;
+};
+
+const mapSyncFailure = (reason: SyncCommandFailureReason) => {
+  switch (reason) {
+    case "readOnlyCalendar":
+      return eventMutationError("CALENDAR_READ_ONLY", "Calendar is read-only");
+    case "versionConflict":
+      return eventMutationError(
+        "RECURRENCE_CONFLICT",
+        "Event was modified elsewhere",
+      );
+    case "unsupportedCapability":
+    case "permanentProviderError":
+    case "authorizationRevoked":
+      return eventMutationError(
+        "PROVIDER_FAILURE",
+        `Sync command failed (${reason})`,
+      );
+  }
+};
+
+// Submit one command. Never falls back to the legacy store — a timeout or
+// unavailable response may already have been accepted by sync, so retrying
+// via eventService would duplicate the write.
+const submitCommandOrThrow = async (
+  client: SyncServiceClient,
+  userId: string,
+  request: CommandSubmitRequest,
+) => {
+  const result = await client.submitCommand(toSyncPrincipal(userId), request);
+  if (!result.ok) {
+    throw error(
+      GenericError.NotSure,
+      `Failed to submit command to sync (${result.error.kind})`,
+    );
+  }
+
+  const { outcome } = result.value.command;
+  if (outcome.state === "failed") {
+    throw mapSyncFailure(outcome.failureReason);
+  }
+  if (outcome.state === "cancelled") {
+    throw eventMutationError("PROVIDER_FAILURE", "Sync command was cancelled");
+  }
+  return result.value.command;
+};
+
+const createFromSync = async (userId: string, input: CreateEventInput) => {
+  const client = requireSyncClient();
+  const { request, responseEvent } = toCreateSubmitRequest(input);
+  await submitCommandOrThrow(client, userId, request);
+  return responseEvent;
+};
+
+const replaceFromSync = async (
+  userId: string,
+  eventId: string,
+  input: ReplaceEventInput,
+) => {
+  const client = requireSyncClient();
+  const { requests, responseEvent } = toReplaceSubmitRequests(eventId, input);
+  for (const request of requests) {
+    await submitCommandOrThrow(client, userId, request);
+  }
+  return responseEvent;
+};
+
+const deleteFromSync = async (
+  userId: string,
+  eventId: string,
+  input: DeleteEventInput,
+) => {
+  const client = requireSyncClient();
+  const request = toDeleteSubmitRequest(eventId, input);
+  await submitCommandOrThrow(client, userId, request);
+};
+
 class EventController {
   readAll = async (req: SessionRequest, res: Response) => {
     try {
@@ -155,9 +253,12 @@ class EventController {
     try {
       const userId = req.session?.getUserId() as string;
       const input = CreateEventInputSchema.parse(req.body);
-      const event = await eventService.create(userId, input);
+      const event =
+        getEventDelegation() === "sync"
+          ? await createFromSync(userId, input)
+          : mapEventRecord(await eventService.create(userId, input));
 
-      res.status(Status.OK).json({ event: mapEventRecord(event) });
+      res.status(Status.OK).json({ event });
     } catch (e) {
       send(res, e);
     }
@@ -168,9 +269,12 @@ class EventController {
       const userId = req.session?.getUserId() as string;
       const eventId = req.params["id"] as string;
       const input = ReplaceEventInputSchema.parse(req.body);
-      const event = await eventService.replace(userId, eventId, input);
+      const event =
+        getEventDelegation() === "sync"
+          ? await replaceFromSync(userId, eventId, input)
+          : mapEventRecord(await eventService.replace(userId, eventId, input));
 
-      res.status(Status.OK).json({ event: mapEventRecord(event) });
+      res.status(Status.OK).json({ event });
     } catch (e) {
       send(res, e);
     }
@@ -185,7 +289,11 @@ class EventController {
         scope: typeof scopeParam === "string" ? scopeParam : "this",
       });
 
-      await eventService.delete(userId, eventId, input);
+      if (getEventDelegation() === "sync") {
+        await deleteFromSync(userId, eventId, input);
+      } else {
+        await eventService.delete(userId, eventId, input);
+      }
 
       res.status(Status.NO_CONTENT).send();
     } catch (e) {

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -4,6 +4,7 @@ import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { mergeUpdateContent } from "@sync/domain/merge-update-content";
 import {
   occurrenceScheduleAt,
   scheduleStartAt,
@@ -463,7 +464,7 @@ async function updateCloudOccurrence(
     master,
     command.input.recurrenceId,
     {
-      content: command.input.content,
+      content: mergeUpdateContent(master.content, command.input.content),
       schedule: command.input.schedule,
       cancelled: false,
     },
@@ -625,7 +626,7 @@ function buildRemainderMaster(
     ...master,
     _id: remainderMasterId(master._id, command.input.recurrenceId as DateTime),
     clientEventId: null,
-    content: input.content,
+    content: mergeUpdateContent(master.content, input.content),
     schedule: input.schedule,
     recurrence,
     createdAt: now,
@@ -664,7 +665,8 @@ async function confirmCloud(
 
 // Apply an update command's content/schedule/recurrence to an existing cloud
 // event, preserving its identity and provider fields. "preserve" keeps the
-// current recurrence; "single"/"series" set it.
+// current recurrence; "single"/"series" set it. Content merges so a
+// title/description edit cannot wipe provider-sourced attendees/etc.
 function applyCloudUpdate(
   existing: EventRecord,
   command: CommandRecord,
@@ -676,7 +678,7 @@ function applyCloudUpdate(
   const { input } = command;
   return {
     ...existing,
-    content: input.content,
+    content: mergeUpdateContent(existing.content, input.content),
     schedule: input.schedule,
     recurrence:
       input.recurrence.kind === "preserve"

--- a/packages/sync/src/domain/merge-update-content.test.ts
+++ b/packages/sync/src/domain/merge-update-content.test.ts
@@ -1,0 +1,38 @@
+import { mergeUpdateContent } from "./merge-update-content";
+import { describe, expect, it } from "bun:test";
+
+describe("mergeUpdateContent", () => {
+  it("updates title and description without wiping richer fields", () => {
+    const existing = {
+      title: "Old",
+      description: "Old desc",
+      location: "Room A",
+      organizer: { email: "a@example.com", displayName: "A" },
+      attendees: [
+        {
+          email: "b@example.com",
+          displayName: "B",
+          responseStatus: "accepted" as const,
+        },
+      ],
+      conference: { url: "https://meet.example/x", label: "Meet" },
+    };
+    const incoming = {
+      title: "New",
+      description: "New desc",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    };
+
+    expect(mergeUpdateContent(existing, incoming)).toEqual({
+      title: "New",
+      description: "New desc",
+      location: "Room A",
+      organizer: existing.organizer,
+      attendees: existing.attendees,
+      conference: existing.conference,
+    });
+  });
+});

--- a/packages/sync/src/domain/merge-update-content.ts
+++ b/packages/sync/src/domain/merge-update-content.ts
@@ -1,0 +1,17 @@
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+
+// Browser edits only title + description. An update command still carries a
+// full SyncEventContent (strict schema), and the Compass API pads the richer
+// fields with null/[] — so applying the wire content verbatim would wipe
+// attendees/location/conference Sync already holds from the provider.
+// Merge: take editable fields from the command, keep the rest from existing.
+export function mergeUpdateContent(
+  existing: SyncEventContent,
+  incoming: SyncEventContent,
+): SyncEventContent {
+  return {
+    ...existing,
+    title: incoming.title,
+    description: incoming.description,
+  };
+}

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -14,6 +14,7 @@ import {
   type ConnectionId,
   type ProviderEventId,
 } from "@core/types/sync/identity.contracts";
+import { mergeUpdateContent } from "@sync/domain/merge-update-content";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
@@ -273,11 +274,14 @@ export async function executeProviderUpdate(
   }
   if (!current) return failCommand(deps, command, "permanentProviderError");
 
+  // Merge so a title/description edit cannot wipe provider-sourced attendees.
+  const content = mergeUpdateContent(event.content, input.content);
+
   // Replay: the provider already holds this edit, so confirm at its version
   // rather than writing again. A single-event update always writes recurrence
   // "single", so that is the intended recurrence to compare against.
   if (
-    matchesIntendedEdit(current, input.content, input.schedule, {
+    matchesIntendedEdit(current, content, input.schedule, {
       kind: "single",
     })
   ) {
@@ -285,6 +289,7 @@ export async function executeProviderUpdate(
       deps,
       command,
       event,
+      content,
       current.providerVersion,
       now,
     );
@@ -295,7 +300,7 @@ export async function executeProviderUpdate(
     result = await deps.writer.patchEvent({
       ...location,
       expectedVersion: command.expectedVersion,
-      content: input.content,
+      content,
       schedule: input.schedule,
       recurrence: { kind: "single" },
       invitation: input.invitation,
@@ -312,6 +317,7 @@ export async function executeProviderUpdate(
     deps,
     command,
     event,
+    content,
     result.providerVersion,
     now,
   );
@@ -325,6 +331,7 @@ async function commitProviderUpdate(
   deps: ProviderMutationDeps,
   command: CommandRecord,
   event: EventRecord,
+  content: SyncEventContent,
   providerVersion: string,
   now: () => Date,
 ): Promise<CommandRecord> {
@@ -334,7 +341,7 @@ async function commitProviderUpdate(
   const { input } = command;
   const updated: EventRecord = {
     ...event,
-    content: input.content,
+    content,
     schedule: input.schedule,
     providerVersion: providerVersion as ProviderEventVersion,
     providerUpdatedAt: null,
@@ -427,20 +434,18 @@ export async function executeProviderSeriesUpdate(
   }
   if (!current) return failCommand(deps, command, "permanentProviderError");
 
+  const content = mergeUpdateContent(master.content, input.content);
+
   // Replay: the provider already holds this series edit (rules included), so
   // confirm at its version rather than writing again.
   if (
-    matchesIntendedEdit(
-      current,
-      input.content,
-      input.schedule,
-      intendedRecurrence,
-    )
+    matchesIntendedEdit(current, content, input.schedule, intendedRecurrence)
   ) {
     return commitProviderSeriesUpdate(
       deps,
       command,
       master,
+      content,
       current.providerVersion,
       now,
     );
@@ -451,7 +456,7 @@ export async function executeProviderSeriesUpdate(
     result = await deps.writer.patchEvent({
       ...location,
       expectedVersion: command.expectedVersion,
-      content: input.content,
+      content,
       schedule: input.schedule,
       recurrence: intendedRecurrence,
       invitation: input.invitation,
@@ -468,6 +473,7 @@ export async function executeProviderSeriesUpdate(
     deps,
     command,
     master,
+    content,
     result.providerVersion,
     now,
   );
@@ -491,6 +497,7 @@ async function commitProviderSeriesUpdate(
   deps: ProviderMutationDeps,
   command: CommandRecord,
   master: EventRecord,
+  content: SyncEventContent,
   providerVersion: string,
   now: () => Date,
 ): Promise<CommandRecord> {
@@ -536,7 +543,7 @@ async function commitProviderSeriesUpdate(
 
   const updated: EventRecord = {
     ...master,
-    content: input.content,
+    content,
     schedule: input.schedule,
     recurrence: storedSeriesRecurrence(input.recurrence, master),
     providerVersion: providerVersion as ProviderEventVersion,


### PR DESCRIPTION
## Summary

Wires `POST`/`PUT`/`DELETE` `/api/event` to sync `submitCommand` when `SYNC_EVENT_ROUTING=sync` (S39 C).

- Pure `event-command.translation`: browser inputs → `CommandSubmitRequest` (create / update[+move] / delete)
- `decodeOccurrenceId` addresses occurrence rows; plain ids coerce to `scope: "all"` + `recurrenceId: null` (web often sends `scope: "this"` for singles)
- Replace with `calendarId` submits **update then move** under distinct hashed idempotency keys
- Fail-closed: never falls back to `eventService` after a sync attempt (timeout may already have been accepted)
- Response `{ event }` is synthesized for `EventResponseSchema` parse (web mutations are optimistic)
- `readById` stays legacy (out of scope)

Dormant behind `SYNC_EVENT_ROUTING=legacy` (default). Builds on occurrence-id codec (#2365) and B4 read wiring (#2366).

## Simplicity

Translation stays pure and unit-tested; controller only gates + submits. No web/contract request-shape change.

## Automated validation

- Translation unit tests: content pad, target resolve, create/replace/delete request shapes, move append
- Fail-closed delegation tests for create/replace/delete (unreachable sync → non-2xx; dedicated process)

## Independent review

Pending CI + reviewer.

## Test plan

```bash
bun test:backend -- packages/backend/src/common/services/sync-service/event-command.translation.test.ts packages/backend/src/event/controllers/event.controller.delegation.test.ts
./node_modules/.bin/biome check <changed files>
bun run type-check  # 25 pre-existing; zero new
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core event mutation paths and provider/cloud update application; mis-translation or merge bugs could duplicate writes or strip calendar data, though routing stays off by default and fail-closed behavior reduces double-write risk.
> 
> **Overview**
> When `SYNC_EVENT_ROUTING=sync`, **create**, **replace**, and **delete** on `/api/event` go through sync `submitCommand` instead of the legacy `eventService`, matching the existing list delegation. A new **event-command.translation** layer maps browser inputs to `CommandSubmitRequest` (create; update with optional separate **move** when `calendarId` is set; delete), resolves composed occurrence ids, coerces plain ids to `scope: "all"`, pads title/description into full sync content, and returns synthesized `{ event }` responses for optimistic clients. The controller **never falls back** to legacy after a sync attempt and maps sync command failures to existing mutation error codes.
> 
> Sync gains **`mergeUpdateContent`** so update commands that carry null-padded content only change **title/description** and do not wipe provider-held attendees, location, or conference on cloud and provider apply paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42379793bed7b3c07c71fabda5f32aeb7e0bccd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->