### PR TITLE
feat(web): client-owned calendar visibility via localStorage (S39 A2)

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -143,7 +143,8 @@ const DEFAULT_EVENTS: FixtureEvent[] = [
   buildEvent(EVENT_B_ID, CALENDAR_B_ID, EVENT_B_TITLE, 13),
 ];
 
-function buildCalendars(visibility: Record<string, boolean>) {
+function buildCalendars() {
+  // Server isVisible is ignored by the web (S39 A2 overlays localStorage).
   return [
     calendar({
       id: CALENDAR_A_ID,
@@ -153,7 +154,7 @@ function buildCalendars(visibility: Record<string, boolean>) {
       provider: "google",
       access: "owner",
       isPrimary: true,
-      isVisible: visibility[CALENDAR_A_ID],
+      isVisible: true,
     }),
     calendar({
       id: CALENDAR_B_ID,
@@ -163,7 +164,7 @@ function buildCalendars(visibility: Record<string, boolean>) {
       provider: "google",
       access: "reader",
       isPrimary: false,
-      isVisible: visibility[CALENDAR_B_ID],
+      isVisible: true,
     }),
     calendar({
       id: CALENDAR_LOCAL_ID,
@@ -173,18 +174,12 @@ function buildCalendars(visibility: Record<string, boolean>) {
       provider: "local",
       access: "owner",
       isPrimary: false,
-      isVisible: visibility[CALENDAR_LOCAL_ID],
+      isVisible: true,
     }),
   ];
 }
 
-interface VisibilityUpdate {
-  calendarId: string;
-  isVisible: boolean;
-}
-
 interface CalendarExperienceHarness {
-  putCalls: VisibilityUpdate[][];
   mutationRequests: { method: string; pathname: string }[];
 }
 
@@ -199,23 +194,14 @@ type CompassE2EWindow = Window & {
  * "has authenticated before" flag (so the event repository targets the
  * remote API instead of IndexedDB - see event.repository.factory.ts), and
  * handlers for every endpoint the calendar sidebar/CalendarSelect/read-only
- * form/availability query touch. The calendars and event-list handlers
- * share `visibility` state so a `/calendars/select` PUT is reflected by
- * both on the next refetch, emulating server-side visibility filtering
- * (packet 08 step 4). The event-list handler answers the "range" query with
- * the visible fixture events.
+ * form/availability query touch. Visibility is client-owned (S39 A2): the
+ * event list returns every fixture event; the web filters via localStorage.
  */
 async function setupCalendarExperiencePage(
   page: Page,
   events: FixtureEvent[] = DEFAULT_EVENTS,
 ): Promise<CalendarExperienceHarness> {
-  const visibility: Record<string, boolean> = {
-    [CALENDAR_A_ID]: true,
-    [CALENDAR_B_ID]: true,
-    [CALENDAR_LOCAL_ID]: true,
-  };
   const harness: CalendarExperienceHarness = {
-    putCalls: [],
     mutationRequests: [],
   };
 
@@ -265,25 +251,14 @@ async function setupCalendarExperiencePage(
     if (pathname.endsWith("/api/config")) {
       return json({ google: { isConfigured: true } });
     }
-    if (pathname.endsWith("/api/calendars/select") && method === "PUT") {
-      const body = request.postDataJSON() as VisibilityUpdate[];
-      harness.putCalls.push(body);
-      for (const entry of body) {
-        visibility[entry.calendarId] = entry.isVisible;
-      }
-      return route.fulfill({ status: 204 });
-    }
     if (pathname.endsWith("/api/calendars/availability")) {
       return json({ busyPeriods: [] });
     }
     if (pathname.endsWith("/api/calendars") && method === "GET") {
-      return json({ calendars: buildCalendars(visibility) });
+      return json({ calendars: buildCalendars() });
     }
     if (pathname.endsWith("/api/event") && method === "GET") {
-      const matching = events.filter(
-        (event) => visibility[event.calendarId] !== false,
-      );
-      return json({ events: matching });
+      return json({ events });
     }
     if (pathname.startsWith("/api/event") && method !== "GET") {
       harness.mutationRequests.push({ method, pathname });
@@ -320,10 +295,10 @@ async function setupCalendarExperiencePage(
   return harness;
 }
 
-test("sidebar lists calendars, coalesces a visibility toggle, and shows card identity", async ({
+test("sidebar lists calendars, toggles visibility in localStorage, and shows card identity", async ({
   page,
 }) => {
-  const harness = await setupCalendarExperiencePage(page);
+  await setupCalendarExperiencePage(page);
   await ensureSidebarOpen(page);
   const sidebar = page.locator("#sidebar");
   const grid = page.locator("#mainGrid");
@@ -367,19 +342,24 @@ test("sidebar lists calendars, coalesces a visibility toggle, and shows card ide
   );
   await expect(grid.getByRole("button", { name: EVENT_A_TITLE })).toBeVisible();
 
-  await expect.poll(() => harness.putCalls.length).toBe(1);
-  expect(harness.putCalls[0]).toEqual([
-    { calendarId: CALENDAR_B_ID, isVisible: false },
-  ]);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const raw = localStorage.getItem("compass.calendars.hidden-ids");
+        return raw ? (JSON.parse(raw) as string[]) : [];
+      }),
+    )
+    .toEqual([CALENDAR_B_ID]);
 
   await toggleB.click();
   await expect(toggleB).toHaveAttribute("aria-pressed", "true");
   await expect(grid.getByRole("button", { name: EVENT_B_TITLE })).toBeVisible();
 
-  await expect.poll(() => harness.putCalls.length).toBe(2);
-  expect(harness.putCalls[1]).toEqual([
-    { calendarId: CALENDAR_B_ID, isVisible: true },
-  ]);
+  await expect
+    .poll(() =>
+      page.evaluate(() => localStorage.getItem("compass.calendars.hidden-ids")),
+    )
+    .toBeNull();
 });
 
 test("day view separates visible calendars into distinct columns", async ({

--- a/packages/web/src/api/calendar.api.ts
+++ b/packages/web/src/api/calendar.api.ts
@@ -1,17 +1,14 @@
 import {
   type Calendar,
   CalendarListResponseSchema,
-  type SetCalendarVisibilityInput,
 } from "@core/types/calendar.contracts";
 import { BaseApi } from "@web/api/base/base.api";
 
+// Visibility is client-owned (localStorage) as of S39 A2 — no PUT /calendars/select.
 const CalendarApi = {
   list: async (): Promise<Calendar[]> => {
     const response = await BaseApi.get<unknown>("/calendars");
     return CalendarListResponseSchema.parse(response.data).calendars;
-  },
-  setVisibility: (input: SetCalendarVisibilityInput) => {
-    return BaseApi.put<void>("/calendars/select", input);
   },
 };
 

--- a/packages/web/src/calendars/apply-client-visibility.ts
+++ b/packages/web/src/calendars/apply-client-visibility.ts
@@ -1,0 +1,13 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import { readHiddenCalendarIds } from "./calendar-visibility.storage";
+
+// Overlay client-owned visibility onto a server calendar list. Server
+// isVisible is ignored: under sync delegation it is always true, and under
+// legacy the Mongo field is no longer written by the web toggle (A2).
+export function applyClientVisibility(calendars: Calendar[]): Calendar[] {
+  const hidden = readHiddenCalendarIds();
+  return calendars.map((calendar) => ({
+    ...calendar,
+    isVisible: !hidden.has(calendar.id),
+  }));
+}

--- a/packages/web/src/calendars/calendar-visibility.storage.test.ts
+++ b/packages/web/src/calendars/calendar-visibility.storage.test.ts
@@ -1,0 +1,40 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  isCalendarHidden,
+  readHiddenCalendarIds,
+  setCalendarHidden,
+  writeHiddenCalendarIds,
+} from "./calendar-visibility.storage";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
+});
+
+describe("calendar-visibility.storage", () => {
+  it("defaults to no hidden calendars (everything visible)", () => {
+    expect(readHiddenCalendarIds().size).toBe(0);
+    expect(isCalendarHidden("aaaaaaaaaaaaaaaaaaaaaaaa")).toBe(false);
+  });
+
+  it("round-trips a hidden id set", () => {
+    expect(setCalendarHidden("aaaaaaaaaaaaaaaaaaaaaaaa", true)).toBe(true);
+    expect(isCalendarHidden("aaaaaaaaaaaaaaaaaaaaaaaa")).toBe(true);
+    expect(setCalendarHidden("aaaaaaaaaaaaaaaaaaaaaaaa", false)).toBe(true);
+    expect(isCalendarHidden("aaaaaaaaaaaaaaaaaaaaaaaa")).toBe(false);
+  });
+
+  it("clears the storage key when the hidden set becomes empty", () => {
+    writeHiddenCalendarIds(new Set(["aaaaaaaaaaaaaaaaaaaaaaaa"]));
+    writeHiddenCalendarIds(new Set());
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HIDDEN_CALENDAR_IDS),
+    ).toBeNull();
+  });
+
+  it("treats malformed storage as empty (fail open to visible)", () => {
+    persistentBrowserStore.set(STORAGE_KEYS.HIDDEN_CALENDAR_IDS, "{not-json");
+    expect(readHiddenCalendarIds().size).toBe(0);
+  });
+});

--- a/packages/web/src/calendars/calendar-visibility.storage.ts
+++ b/packages/web/src/calendars/calendar-visibility.storage.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+// Hidden calendar ids only — absence means visible (default). A Set of
+// ObjectId-shaped strings; unknown / malformed storage falls back to empty
+// (everything visible) rather than locking the user out of every calendar.
+const HiddenCalendarIdsSchema = z.array(z.string().trim().min(1)).readonly();
+
+export function readHiddenCalendarIds(): ReadonlySet<string> {
+  const raw = persistentBrowserStore.get(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
+  if (!raw) return new Set();
+
+  try {
+    return new Set(HiddenCalendarIdsSchema.parse(JSON.parse(raw)));
+  } catch {
+    return new Set();
+  }
+}
+
+export function writeHiddenCalendarIds(ids: ReadonlySet<string>): boolean {
+  if (ids.size === 0) {
+    return persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
+  }
+  return persistentBrowserStore.set(
+    STORAGE_KEYS.HIDDEN_CALENDAR_IDS,
+    JSON.stringify([...ids]),
+  );
+}
+
+export function setCalendarHidden(
+  calendarId: string,
+  hidden: boolean,
+): boolean {
+  const next = new Set(readHiddenCalendarIds());
+  if (hidden) next.add(calendarId);
+  else next.delete(calendarId);
+  return writeHiddenCalendarIds(next);
+}
+
+export function isCalendarHidden(calendarId: string): boolean {
+  return readHiddenCalendarIds().has(calendarId);
+}

--- a/packages/web/src/calendars/calendar.query.ts
+++ b/packages/web/src/calendars/calendar.query.ts
@@ -2,6 +2,7 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { CalendarApi } from "@web/api/calendar.api";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { applyClientVisibility } from "@web/calendars/apply-client-visibility";
 import {
   getLocalCalendarSentinelId,
   synthesizeLocalCalendar,
@@ -13,16 +14,20 @@ export const calendarQueryKeys = {
 
 // Anonymous/offline mode never calls the API - it synthesizes the one local
 // calendar from the sentinel id so downstream code (drafts, transitions)
-// always has a calendar list to read from (B12).
+// always has a calendar list to read from (B12). Authenticated lists overlay
+// client-owned visibility (localStorage) so sync's always-true isVisible and
+// legacy Mongo prefs are not the source of truth (S39 A2).
 export function calendarsQueryOptions(authenticated: boolean) {
   return queryOptions({
     queryKey: calendarQueryKeys.all,
     queryFn: async (): Promise<Calendar[]> => {
       if (!authenticated) {
-        return [synthesizeLocalCalendar(getLocalCalendarSentinelId())];
+        return applyClientVisibility([
+          synthesizeLocalCalendar(getLocalCalendarSentinelId()),
+        ]);
       }
 
-      return CalendarApi.list();
+      return applyClientVisibility(await CalendarApi.list());
     },
     staleTime: 60_000,
   });

--- a/packages/web/src/calendars/useCalendarVisibility.ts
+++ b/packages/web/src/calendars/useCalendarVisibility.ts
@@ -1,72 +1,36 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import { CalendarApi } from "@web/api/calendar.api";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { setCalendarHidden } from "@web/calendars/calendar-visibility.storage";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { removeEventsByCalendarFromQueries } from "@web/events/queries/event.query.cache";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
-
-const DEFAULT_COALESCE_DELAY_MS = 400;
 
 export const CALENDAR_VISIBILITY_FAILURE_MESSAGE =
   "Couldn't update calendar visibility. The change was undone.";
 
 /**
- * Optimistic + coalesced calendar visibility toggle.
- * Every call flips the calendars cache immediately, and on hide drops that
- * calendar's events from every cached event query so the grid lists
- * react without waiting on the network. Rapid toggles across calendars
- * accumulate in a ref and flush as a single `setVisibility` call after
- * `coalesceDelayMs` of quiet, so dragging through a calendar list doesn't
- * fire one request per row.
+ * Client-owned calendar visibility toggle (S39 A2).
+ * Flips the calendars cache immediately, persists the hidden set in
+ * localStorage (default visible), and on hide drops that calendar's events
+ * from cached event queries so the grid reacts without a round trip. No
+ * server write — sync list always reports isVisible:true, and the event
+ * read already returns every calendar (client filter is the source of truth).
  */
-export function useCalendarVisibility(
-  coalesceDelayMs = DEFAULT_COALESCE_DELAY_MS,
-) {
+export function useCalendarVisibility() {
   const queryClient = useQueryClient();
-  const pendingRef = useRef<Map<CalendarId, boolean>>(new Map());
-  const snapshotRef = useRef<Calendar[] | undefined>(undefined);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
   const [failureAnnouncement, setFailureAnnouncement] = useState("");
-
-  useEffect(() => () => clearTimeout(timerRef.current), []);
-
-  const flush = useCallback(async () => {
-    const pending = pendingRef.current;
-    const snapshot = snapshotRef.current;
-    pendingRef.current = new Map();
-    snapshotRef.current = undefined;
-    if (pending.size === 0) return;
-
-    const input = [...pending.entries()].map(([calendarId, isVisible]) => ({
-      calendarId,
-      isVisible,
-    }));
-
-    try {
-      await CalendarApi.setVisibility(input);
-      void queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all });
-      void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
-    } catch {
-      if (snapshot) {
-        queryClient.setQueryData(calendarQueryKeys.all, snapshot);
-      }
-      void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
-      showErrorToast(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
-      setFailureAnnouncement(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
-    }
-  }, [queryClient]);
 
   const toggleCalendarVisibility = useCallback(
     (calendarId: CalendarId, isVisible: boolean) => {
-      if (pendingRef.current.size === 0) {
-        snapshotRef.current = queryClient.getQueryData<Calendar[]>(
-          calendarQueryKeys.all,
-        );
+      const saved = setCalendarHidden(calendarId, !isVisible);
+      if (!saved) {
+        showErrorToast(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
+        setFailureAnnouncement(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
+        return;
       }
-      pendingRef.current.set(calendarId, isVisible);
 
       queryClient.setQueryData<Calendar[]>(calendarQueryKeys.all, (current) =>
         current?.map((calendar) =>
@@ -76,12 +40,13 @@ export function useCalendarVisibility(
 
       if (!isVisible) {
         removeEventsByCalendarFromQueries(queryClient, new Set([calendarId]));
+        return;
       }
 
-      clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => void flush(), coalesceDelayMs);
+      // Showing again: refetch so events for this calendar reappear.
+      void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
     },
-    [coalesceDelayMs, flush, queryClient],
+    [queryClient],
   );
 
   return { toggleCalendarVisibility, failureAnnouncement };

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -11,6 +11,9 @@ export const StorageKeySchema = z.enum([
   "compass.theme",
   "compass.life.preferences",
   "compass.view.sidebar-open",
+  // S39 A2: client-owned calendar visibility (default visible). Device-local,
+  // matching other compass.* prefs — not synced across browsers.
+  "compass.calendars.hidden-ids",
 ]);
 
 export type StorageKey = z.infer<typeof StorageKeySchema>;
@@ -25,7 +28,8 @@ export const STORAGE_KEYS: Record<
   | "LIFE_PREFERENCES"
   | "SIDEBAR_WIDTH"
   | "SIDEBAR_OPEN"
-  | "THEME",
+  | "THEME"
+  | "HIDDEN_CALENDAR_IDS",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -41,4 +45,5 @@ export const STORAGE_KEYS: Record<
   SIDEBAR_WIDTH: "compass.sidebar.width",
   SIDEBAR_OPEN: "compass.view.sidebar-open",
   THEME: "compass.theme",
+  HIDDEN_CALENDAR_IDS: "compass.calendars.hidden-ids",
 } as const;

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -13,6 +13,9 @@ import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type ApiRequestConfig } from "@web/api/api.types";
 import { BaseApi } from "@web/api/base/base.api";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { isCalendarHidden } from "@web/calendars/calendar-visibility.storage";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
@@ -24,6 +27,7 @@ import {
   expect,
   it,
   mock,
+  spyOn,
 } from "bun:test";
 
 // mock.module is process-wide and not reliably restorable, so the real hook
@@ -101,10 +105,7 @@ const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
 
 const renderCalendarList = (
   calendars: Calendar[],
-  {
-    authenticated = true,
-    coalesceDelayMs,
-  }: { authenticated?: boolean; coalesceDelayMs?: number } = {},
+  { authenticated = true }: { authenticated?: boolean } = {},
 ) => {
   mockUseSession.mockReturnValue({
     authenticated,
@@ -114,12 +115,9 @@ const renderCalendarList = (
   const { queryClient, wrapper } = createStoreWrapper();
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
 
-  const utils = render(
-    <CalendarList coalesceDelayMs={coalesceDelayMs} Header={StubHeader} />,
-    {
-      wrapper,
-    },
-  );
+  const utils = render(<CalendarList Header={StubHeader} />, {
+    wrapper,
+  });
 
   return { queryClient, ...utils };
 };
@@ -134,6 +132,7 @@ describe("CalendarList", () => {
 
   afterEach(() => {
     BaseApi.defaults.adapter = undefined;
+    persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
     mockUseSession.mockReturnValue({
       authenticated: false,
       setAuthenticated: () => {},
@@ -171,9 +170,10 @@ describe("CalendarList", () => {
     expect(screen.queryByText("ahab@pequod.com")).not.toBeInTheDocument();
   });
 
-  it("hides the visibility toggle for anonymous sessions and keeps the local sentinel's own name", () => {
+  it("keeps the local sentinel's own name for anonymous sessions (still toggleable)", () => {
     // The anonymous synthesized local calendar is isPrimary, but must not be
     // relabeled "primary" - the header shows "Temporary account", not its name.
+    // Visibility is client-owned, so the toggle stays available offline.
     const local = makeCalendar({
       name: "Compass",
       provider: "local",
@@ -184,42 +184,17 @@ describe("CalendarList", () => {
 
     expect(screen.getByText("Compass")).toBeInTheDocument();
     expect(screen.queryByText("primary")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide Compass calendar" }),
+    ).toBeInTheDocument();
   });
 
-  it("flips aria-pressed optimistically and coalesces rapid toggles into one final call", async () => {
+  it("flips aria-pressed and persists hidden ids in localStorage", async () => {
     const calendarA = makeCalendar({ name: "Calendar A" });
     const calendarB = makeCalendar({ name: "Calendar B" });
-    // Method-aware: a successful flush invalidates the calendars query, which
-    // (since it's actively observed here) triggers a real GET refetch through
-    // this same adapter. That refetch is an expected side effect of the hook,
-    // not what this test is verifying, so only PUT /calendars/select calls
-    // are counted below.
-    const putCalls: unknown[] = [];
-    BaseApi.defaults.adapter = async <T,>(
-      config: ApiRequestConfig & { body?: unknown },
-    ) => {
-      if (config.method === "PUT") {
-        putCalls.push(config.body);
-        return {
-          config,
-          data: undefined as T,
-          headers: new Headers(),
-          status: 204,
-          statusText: "No Content",
-        };
-      }
-      return {
-        config,
-        data: { calendars: [] } as T,
-        headers: new Headers(),
-        status: 200,
-        statusText: "OK",
-      };
-    };
 
     const user = userEvent.setup({ delay: null });
-    renderCalendarList([calendarA, calendarB], { coalesceDelayMs: 100 });
+    renderCalendarList([calendarA, calendarB]);
 
     const buttonA = screen.getByRole("button", {
       name: "Hide Calendar A calendar",
@@ -232,34 +207,20 @@ describe("CalendarList", () => {
     await waitFor(() => {
       expect(buttonA.getAttribute("aria-pressed")).toBe("false");
     });
+    expect(isCalendarHidden(calendarA.id)).toBe(true);
 
     await user.click(buttonB);
     await waitFor(() => {
       expect(buttonB.getAttribute("aria-pressed")).toBe("false");
     });
+    expect(isCalendarHidden(calendarB.id)).toBe(true);
 
     await user.click(buttonA);
     await waitFor(() => {
       expect(buttonA.getAttribute("aria-pressed")).toBe("true");
     });
-
-    await waitFor(
-      () => {
-        expect(putCalls).toHaveLength(1);
-      },
-      { timeout: 3000 },
-    );
-
-    const body = putCalls[0] as { calendarId: string; isVisible: boolean }[];
-    expect(body).toHaveLength(2);
-    expect(body).toContainEqual({
-      calendarId: calendarA.id,
-      isVisible: true,
-    });
-    expect(body).toContainEqual({
-      calendarId: calendarB.id,
-      isVisible: false,
-    });
+    expect(isCalendarHidden(calendarA.id)).toBe(false);
+    expect(isCalendarHidden(calendarB.id)).toBe(true);
   });
 
   it("removes the hidden calendar's events from a cached week query immediately on toggle-off", async () => {
@@ -274,9 +235,7 @@ describe("CalendarList", () => {
     });
 
     const user = userEvent.setup({ delay: null });
-    const { queryClient } = renderCalendarList([hidden, kept], {
-      coalesceDelayMs: 100,
-    });
+    const { queryClient } = renderCalendarList([hidden, kept]);
     queryClient.setQueryData<NormalizedEventQueryData>(weekKey, {
       ids: [hiddenEvent.id, keptEvent.id],
       entities: { [hiddenEvent.id]: hiddenEvent, [keptEvent.id]: keptEvent },
@@ -292,43 +251,28 @@ describe("CalendarList", () => {
     expect(cached?.entities[keptEvent.id]).toBeDefined();
   });
 
-  it("rolls back the visibility button and announces failure when the flush rejects", async () => {
+  it("announces failure and leaves the button pressed when storage write fails", async () => {
     const calendar = makeCalendar({ name: "Work" });
-    BaseApi.defaults.adapter = mock(async () => {
-      throw new Error("Simulated network failure");
-    });
+    const setSpy = spyOn(persistentBrowserStore, "set").mockReturnValue(false);
 
     const user = userEvent.setup({ delay: null });
-    renderCalendarList([calendar], { coalesceDelayMs: 100 });
+    renderCalendarList([calendar]);
 
     const toggle = screen.getByRole("button", { name: "Hide Work calendar" });
     await user.click(toggle);
-    await waitFor(() => {
-      expect(toggle.getAttribute("aria-pressed")).toBe("false");
-    });
 
-    await waitFor(() => {
-      expect(toggle.getAttribute("aria-pressed")).toBe("true");
-    });
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByRole("status").textContent ?? "").toMatch(
       /couldn.t update calendar visibility/i,
     );
+    setSpy.mockRestore();
   });
 
   it("is reachable by Tab and toggles on Enter and Space", async () => {
     const calendar = makeCalendar({ name: "Work" });
-    BaseApi.defaults.adapter = async <T,>(
-      config: ApiRequestConfig & { body?: unknown },
-    ) => ({
-      config,
-      data: (config.method === "PUT" ? undefined : { calendars: [] }) as T,
-      headers: new Headers(),
-      status: config.method === "PUT" ? 204 : 200,
-      statusText: config.method === "PUT" ? "No Content" : "OK",
-    });
 
     const user = userEvent.setup({ delay: null });
-    renderCalendarList([calendar], { coalesceDelayMs: 100 });
+    renderCalendarList([calendar]);
 
     const toggle = screen.getByRole("button", { name: "Hide Work calendar" });
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -20,21 +20,16 @@ function sortCalendars(calendars: Calendar[]): Calendar[] {
 }
 
 interface Props {
-  /** Test seam only: production callers rely on useCalendarVisibility's default. */
-  coalesceDelayMs?: number;
   /** Test seam only: lets list tests stub the account header's auth/sync hooks. */
   Header?: FC;
 }
 
-export const CalendarList: FC<Props> = ({
-  coalesceDelayMs,
-  Header = CalendarListHeader,
-}) => {
+export const CalendarList: FC<Props> = ({ Header = CalendarListHeader }) => {
   const { authenticated } = useSession();
   const { isAvailable, state } = useConnectGoogle();
   const { data, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
-    useCalendarVisibility(coalesceDelayMs);
+    useCalendarVisibility();
 
   const calendars = sortCalendars(
     (data ?? []).filter((calendar) => calendar.isActive),
@@ -92,23 +87,17 @@ export const CalendarList: FC<Props> = ({
 
             return (
               <li key={calendar.id}>
-                {authenticated ? (
-                  <button
-                    aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${displayName} calendar`}
-                    aria-pressed={calendar.isVisible}
-                    className="c-focus-ring group flex w-full min-w-0 items-center gap-2 rounded px-1 py-0.5 text-left text-text text-xs hover:bg-surface-panel"
-                    onClick={() =>
-                      toggleCalendarVisibility(calendar.id, !calendar.isVisible)
-                    }
-                    type="button"
-                  >
-                    {calendarRow}
-                  </button>
-                ) : (
-                  <div className="flex min-w-0 items-center gap-2 px-1 py-0.5 text-text text-xs">
-                    {calendarRow}
-                  </div>
-                )}
+                <button
+                  aria-label={`${calendar.isVisible ? "Hide" : "Show"} ${displayName} calendar`}
+                  aria-pressed={calendar.isVisible}
+                  className="c-focus-ring group flex w-full min-w-0 items-center gap-2 rounded px-1 py-0.5 text-left text-text text-xs hover:bg-surface-panel"
+                  onClick={() =>
+                    toggleCalendarVisibility(calendar.id, !calendar.isVisible)
+                  }
+                  type="button"
+                >
+                  {calendarRow}
+                </button>
               </li>
             );
           })}

--- a/packages/web/src/events/queries/filter-events-by-visible-calendars.test.ts
+++ b/packages/web/src/events/queries/filter-events-by-visible-calendars.test.ts
@@ -1,0 +1,52 @@
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { filterEventsByVisibleCalendars } from "./filter-events-by-visible-calendars";
+import { describe, expect, it } from "bun:test";
+
+const calendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: CalendarIdSchema.parse(createObjectIdString()),
+  name: "Work",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+describe("filterEventsByVisibleCalendars", () => {
+  it("passes data through when calendars have not loaded", () => {
+    const event = createMockEvent();
+    const data = {
+      ids: [event.id],
+      entities: { [event.id]: event },
+    };
+    expect(filterEventsByVisibleCalendars(data, undefined)).toBe(data);
+  });
+
+  it("drops events on hidden calendars", () => {
+    const visible = calendar({ isVisible: true });
+    const hidden = calendar({ isVisible: false });
+    const kept = createMockEvent({ calendarId: visible.id });
+    const dropped = createMockEvent({ calendarId: hidden.id });
+    const data = {
+      ids: [kept.id, dropped.id],
+      entities: { [kept.id]: kept, [dropped.id]: dropped },
+    };
+
+    const filtered = filterEventsByVisibleCalendars(data, [visible, hidden]);
+    expect(filtered?.ids).toEqual([kept.id]);
+    expect(filtered?.entities[dropped.id]).toBeUndefined();
+    expect(filtered?.entities[kept.id]).toBeDefined();
+  });
+});

--- a/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
+++ b/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
@@ -1,0 +1,34 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type NormalizedEventQueryData } from "./event.query.types";
+
+// Drop events whose calendar is hidden. When calendars have not loaded yet,
+// pass the data through unchanged so the grid does not flash empty.
+export function filterEventsByVisibleCalendars(
+  data: NormalizedEventQueryData | undefined,
+  calendars: Calendar[] | undefined,
+): NormalizedEventQueryData | undefined {
+  if (!data || !calendars) return data;
+
+  const visibleIds = new Set(
+    calendars.filter((calendar) => calendar.isVisible).map((c) => c.id),
+  );
+
+  const ids = data.ids.filter((id) => {
+    const event = data.entities[id];
+    return event !== undefined && visibleIds.has(event.calendarId);
+  });
+
+  if (ids.length === data.ids.length) return data;
+
+  const kept = new Set(ids);
+  const entities = { ...data.entities };
+  for (const id of data.ids) {
+    if (!kept.has(id)) delete entities[id];
+  }
+
+  return {
+    ...data,
+    ids,
+    entities,
+  };
+}

--- a/packages/web/src/events/queries/useDayEventsQuery.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.ts
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { handleError } from "@web/common/utils/event/event.util";
 import { dayEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { deriveCalendarEventViewModel } from "./event.view-model";
+import { filterEventsByVisibleCalendars } from "./filter-events-by-visible-calendars";
 
 type DayEventsQueryArgs = {
   startDate: string;
@@ -29,9 +31,13 @@ export function useDayEventsQuery({ startDate, endDate }: DayEventsQueryArgs) {
 
 export function useDayEventViewModel(args: DayEventsQueryArgs) {
   const query = useDayEventsQuery(args);
+  const { data: calendars } = useCalendarsQuery();
   const viewModel = useMemo(
-    () => deriveCalendarEventViewModel(query.data),
-    [query.data],
+    () =>
+      deriveCalendarEventViewModel(
+        filterEventsByVisibleCalendars(query.data, calendars),
+      ),
+    [query.data, calendars],
   );
   return { ...query, ...viewModel };
 }

--- a/packages/web/src/events/queries/useWeekEventsQuery.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.ts
@@ -1,12 +1,14 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { handleError } from "@web/common/utils/event/event.util";
 import { deriveOverlappingEventQueryData } from "@web/events/queries/event.query.cache";
 import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { deriveCalendarEventViewModel } from "./event.view-model";
+import { filterEventsByVisibleCalendars } from "./filter-events-by-visible-calendars";
 
 type WeekEventsQueryArgs = {
   startOfView: Dayjs;
@@ -53,9 +55,13 @@ export function useWeekEventsQuery(args: WeekEventsQueryArgs) {
 
 export function useWeekEventViewModel(args: WeekEventsQueryArgs) {
   const query = useWeekEventsQuery(args);
+  const { data: calendars } = useCalendarsQuery();
   const viewModel = useMemo(
-    () => deriveCalendarEventViewModel(query.data),
-    [query.data],
+    () =>
+      deriveCalendarEventViewModel(
+        filterEventsByVisibleCalendars(query.data, calendars),
+      ),
+    [query.data, calendars],
   );
   return { ...query, ...viewModel };
 }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -72,9 +72,26 @@ const leftmostEvent = createMockEvent({
 });
 
 // packet 08 step 8: read-only (unwritable calendar) fixtures for the
-// delete/nudge gating tests below.
+// delete/nudge gating tests below. Writable calendar must also be seeded
+// whenever the calendars query is set — week/day view models filter events
+// by visible calendars (S39 A2), so an incomplete list would hide the
+// editable event under test.
 const READ_ONLY_EVENT_ID = EventIdSchema.parse("cccccccccccccccccccccccc");
 const readOnlyCalendarId = CalendarIdSchema.parse(createObjectIdString());
+const writableCalendar: Calendar = {
+  id: editableEvent.calendarId,
+  name: "Primary calendar",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#4285f4",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+};
 const readOnlyCalendar: Calendar = {
   id: readOnlyCalendarId,
   name: "Shared calendar",
@@ -158,7 +175,7 @@ const renderShortcuts = (options?: {
   includeLeftmostEvent?: boolean;
   /** Extra fixtures beyond the three flags above - e.g. a read-only-calendar event. */
   extraEvents?: Event[];
-  /** Seeds the calendars query (packet 08 step 8's read-only gate reads it). Omitted -> unseeded -> every event resolves writable (fails open). */
+  /** Seeds the calendars query (read-only gate + A2 visibility filter). Omitted -> unseeded -> events pass the visibility filter and resolve writable (fails open). */
   calendars?: Calendar[];
 }) => {
   const queryClient = new QueryClient();
@@ -180,9 +197,13 @@ const renderShortcuts = (options?: {
   queryClient.setQueryDefaults(["events"], {
     initialData: toNormalizedEventQueryData(events),
   });
-  if (options?.calendars) {
-    queryClient.setQueryData(calendarQueryKeys.all, options.calendars);
-  }
+  // Always seed calendars so useWeekEventViewModel's visibility filter and
+  // useCalendarsQuery don't race a network fetch (MSW has no /api/calendars
+  // handler in this file). Default = writable calendar for the editable event.
+  queryClient.setQueryData(
+    calendarQueryKeys.all,
+    options?.calendars ?? [writableCalendar],
+  );
   function wrapper({ children }: PropsWithChildren) {
     return (
       <QueryClientProvider client={queryClient}>
@@ -401,7 +422,7 @@ describe("useWeekShortcuts calendar event targeting", () => {
 
     const { queryClient } = renderShortcuts({
       extraEvents: [readOnlyEvent],
-      calendars: [readOnlyCalendar],
+      calendars: [writableCalendar, readOnlyCalendar],
     });
     pressKey("Delete");
 


### PR DESCRIPTION
## Summary

Moves calendar visibility to the browser (S39 A2). Hidden calendar ids live in `localStorage` (`compass.calendars.hidden-ids`); absence means visible. The calendar list overlays that onto `isVisible`, week/day view models drop events on hidden calendars, and the sidebar toggle no longer calls `PUT /calendars/select`. Works for anonymous sessions too now that there is no server write.

Pairs with B4's "load all calendars, filter client-side" choice under `SYNC_EVENT_ROUTING=sync`.

## Simplicity

- One storage module + thin overlay/filter helpers; removed the coalesced server mutation path from `useCalendarVisibility`.
- Dropped dead `CalendarApi.setVisibility` (backend route left intact for now).

## Automated validation

- Unit: hide/show persists ids; malformed storage fails open to visible; hide prunes cached week events; storage write failure announces and leaves pressed state; anonymous local calendar stays named "Compass" and remains toggleable; filter drops hidden-calendar events and passes through when calendars are unloaded.

## Independent review

Self-reviewed working-tree diff before commit. Correctness fix folded in: keep the visibility toggle for anonymous sessions (auth gate was only needed for the old PUT). No remaining correctness issues found.

## Test plan

```bash
bun test:web -- packages/web/src/calendars/calendar-visibility.storage.test.ts packages/web/src/events/queries/filter-events-by-visible-calendars.test.ts packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
./node_modules/.bin/biome check packages/web/src/calendars packages/web/src/api/calendar.api.ts packages/web/src/components/Sidebar/CalendarList packages/web/src/events/queries/filter-events-by-visible-calendars.ts packages/web/src/events/queries/useDayEventsQuery.ts packages/web/src/events/queries/useWeekEventsQuery.ts packages/web/src/common/constants/storage.constants.ts
```

Made with [Cursor](https://cursor.com)