### PR TITLE
feat(sync): expose public /sync oauth paths and staging routing knobs

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -76,6 +76,11 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
           SSH_HOST: ${{ vars.SSH_HOST }}
           SSH_USER: ${{ vars.SSH_USER }}
+          # Sync routing (optional; omit → legacy/passive defaults). Prod must
+          # stay unset until cutover. Staging-cloud sets these to prove S38/S39.
+          SYNC_CONNECTION_ROUTING: ${{ vars.SYNC_CONNECTION_ROUTING }}
+          SYNC_EVENT_ROUTING: ${{ vars.SYNC_EVENT_ROUTING }}
+          SYNC_EXECUTION: ${{ vars.SYNC_EXECUTION }}
           WEB_IMAGE: switchbacktech/compass-web:${{ inputs.environment }}-${{ steps.version.outputs.image_version }}
           # Sensitive
           COMPASS_SYNC_TOKEN: ${{ secrets.COMPASS_SYNC_TOKEN }}
@@ -164,7 +169,19 @@ jobs:
                 "  mongoUri: \"${SYNC_MONGO_URI}\"" \
                 "  internalAuthToken: \"${SYNC_INTERNAL_AUTH_TOKEN}\"" \
                 "  callbackBaseUrl: \"${FRONTEND_URL}\"" \
+                '  serviceUrl: "http://sync:3010"' \
                 '  enforceLeastPrivilege: true'
+              # Optional per-environment routing/execution (GitHub Environment
+              # vars). Empty → schema defaults (legacy / passive).
+              if [ -n "$SYNC_CONNECTION_ROUTING" ]; then
+                printf '%s\n' "  connectionRouting: \"${SYNC_CONNECTION_ROUTING}\""
+              fi
+              if [ -n "$SYNC_EVENT_ROUTING" ]; then
+                printf '%s\n' "  eventRouting: \"${SYNC_EVENT_ROUTING}\""
+              fi
+              if [ -n "$SYNC_EXECUTION" ]; then
+                printf '%s\n' "  execution: \"${SYNC_EXECUTION}\""
+              fi
             fi
           } | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"

--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -56,10 +56,11 @@ supertokens:
 #   mongoUri: mongodb+srv://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@cluster/compass_sync?retryWrites=true&w=majority
 #   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
 #   callbackBaseUrl: http://localhost:3010 # public base URL for provider OAuth/webhook callbacks
-#   serviceUrl: http://localhost:3010 # base URL the API uses to reach this service; set only when delegating to sync
+#   serviceUrl: http://localhost:3010 # base URL the API uses to reach this service; compose uses http://sync:3010
 #   connectionRouting: legacy # legacy (default) | sync; sync delegates provider-connection routes here and requires serviceUrl
 #   eventRouting: legacy # legacy (default) | sync; sync delegates calendar/event reads + commands here and requires serviceUrl
-#   execution: passive # passive | active
+#   execution: passive # passive | active — active required for OAuth begin + provider import/jobs
+# Public OAuth/webhook paths (via Caddy → sync): /sync/google, /sync/notifications/google
 #   maxConcurrency: 4
 #   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)
 #   compassApiDatabase: prod_calendar # API database the least-privilege check must be denied access to

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -168,6 +168,12 @@ compass.example.com {  # <- this is the only line you need to change
   reverse_proxy 127.0.0.1:3000
  }
 
+ # Sync public surface (OAuth callback + Google push). Only needed when the
+ # compose `sync` profile is enabled; safe to omit otherwise.
+ handle /sync/* {
+  reverse_proxy 127.0.0.1:3010
+ }
+
  handle {
   reverse_proxy 127.0.0.1:9080
  }
@@ -175,8 +181,9 @@ compass.example.com {  # <- this is the only line you need to change
 ```
 
 This tells Caddy to serve your public domain over HTTPS, send `/api/*` requests
-to the Compass backend on `127.0.0.1:3000`, and send everything else to the web
-app on `127.0.0.1:9080`.
+to the Compass backend on `127.0.0.1:3000`, send `/sync/*` to the Sync service
+on `127.0.0.1:3010` (Google OAuth redirect `/sync/google` and push notifications),
+and send everything else to the web app on `127.0.0.1:9080`.
 
 Save the file and validate your changes:
 

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -168,7 +168,7 @@ describe("dispatchSyncJob", () => {
     reader,
     custody: tokenSource,
     notifications,
-    callbackUrl: "https://sync.example/oauth/google/notifications",
+    callbackUrl: "https://sync.example/sync/notifications/google",
   });
 
   const seedCalendar = (): Promise<ProviderCalendarRecord> =>

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -521,7 +521,7 @@ describe("POST /internal/connections/begin", () => {
   });
 });
 
-describe("GET /oauth/google/callback", () => {
+describe("GET /sync/google", () => {
   let mongo: SyncMongoService;
   let connections: ProviderConnectionRepository;
   let credentials: CredentialRepository;

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -70,7 +70,9 @@ export const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 export const BEGIN_PATH = "/internal/connections/begin";
 // Where the provider redirects the browser after consent; `begin` builds the
 // redirect_uri from it and the public callback route below mounts on it.
-export const OAUTH_CALLBACK_PATH = "/oauth/google/callback";
+// Public reverse-proxy path (Caddy `/sync/*` → sync). Must match the Google
+// OAuth client authorized redirect URI (`/sync/google`).
+export const OAUTH_CALLBACK_PATH = "/sync/google";
 
 // The rolling window Sync materializes occurrences for (shared with the
 // projection layer via @sync/domain/horizon). A query's range is clamped to it

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -44,7 +44,7 @@ const googHeaders = (
   ...overrides,
 });
 
-describe("POST /oauth/google/notifications", () => {
+describe("POST /sync/notifications/google", () => {
   let mongo: SyncMongoService;
   let resources: SyncResourceRepository;
   let service: SyncService;

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -10,7 +10,9 @@ import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
-export const NOTIFICATIONS_PATH = "/oauth/google/notifications";
+// Public reverse-proxy path under the same `/sync/*` prefix as the OAuth
+// callback (no Google Console registration required for webhooks).
+export const NOTIFICATIONS_PATH = "/sync/notifications/google";
 
 // Public callbacks arrive fast and in bursts (Google fans out per change); this
 // backstop bounds a flood or a spoof storm without shaping normal delivery.

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -51,9 +51,10 @@ supertokens:
 #   mongoUri: mongodb://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
 #   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
 #   callbackBaseUrl: https://cal.yourdomain.com # public base URL for provider OAuth/webhook callbacks
-#   serviceUrl: http://sync:3010 # base URL the API uses to reach this service; set only when delegating to sync
+#   serviceUrl: http://sync:3010 # base URL the API uses to reach this service; set when delegating to sync
 #   connectionRouting: legacy # legacy (default) | sync; sync delegates provider-connection routes here and requires serviceUrl
 #   eventRouting: legacy # legacy (default) | sync; sync delegates calendar/event reads + commands here and requires serviceUrl
+# Public OAuth/webhook paths (via Caddy → sync): /sync/google, /sync/notifications/google
 #   execution: passive # passive | active
 #   maxConcurrency: 4
 #   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -64,11 +64,13 @@ services:
     # isolated sync database is provisioned, so environments without one never
     # start a crash-looping container. Where enabled, Sync stays passive
     # (serves health, does no provider work) until explicitly activated.
-    # No published host port and no Caddy route: reachable only on the internal
-    # compose network. No depends_on mongo: Atlas environments have no mongo
-    # container, and the service tolerates a not-yet-ready store (liveness stays
-    # up, readiness 503).
+    # Bound to loopback only so the host Caddy can reverse-proxy the public
+    # `/sync/*` OAuth + webhook paths; not exposed on a public interface.
+    # No depends_on mongo: Atlas environments have no mongo container, and the
+    # service tolerates a not-yet-ready store (liveness stays up, readiness 503).
     profiles: [sync]
+    ports:
+      - "127.0.0.1:3010:3010"
     environment:
       COMPASS_CONFIG_FILE: /app/compass.yaml
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -127,6 +127,8 @@ describe("self-host docker compose", () => {
     // The `sync` profile lets a deploy start the container only where an
     // isolated sync database is provisioned.
     expect(syncBlock).toContain("profiles: [sync]");
+    // Loopback-only publish so host Caddy can proxy `/sync/*` OAuth/webhooks.
+    expect(syncBlock).toContain('"127.0.0.1:3010:3010"');
     // The read-only root fs needs a writable mount for the logger's log file,
     // or the container crashes on startup.
     expect(syncBlock).toContain("compass_sync_logs:/app/logs");
@@ -322,6 +324,18 @@ describe("staging deploy workflow", () => {
     expect(workflow).toContain("'sync:'");
     expect(workflow).toContain('mongoUri: \\"$'.concat('{SYNC_MONGO_URI}\\"'));
     expect(workflow).toContain("enforceLeastPrivilege: true");
+    // Backend reaches sync on the compose network; routing stays opt-in via
+    // GitHub Environment vars (prod must leave them unset = legacy).
+    expect(workflow).toContain('serviceUrl: "http://sync:3010"');
+    expect(workflow).toContain(
+      "SYNC_CONNECTION_ROUTING: $".concat("{{ vars.SYNC_CONNECTION_ROUTING }}"),
+    );
+    expect(workflow).toContain(
+      "SYNC_EVENT_ROUTING: $".concat("{{ vars.SYNC_EVENT_ROUTING }}"),
+    );
+    expect(workflow).toContain(
+      "SYNC_EXECUTION: $".concat("{{ vars.SYNC_EXECUTION }}"),
+    );
     expect(workflow).toContain(
       'DEPLOY_PROFILES="$'.concat(
         "{DEPLOY_PROFILES:+$",


### PR DESCRIPTION
## Summary

Unblocks proving S38/S39 on staging-cloud:

- Sync public paths match the founder-registered OAuth URI: `GET /sync/google`, `POST /sync/notifications/google`
- Compose publishes `127.0.0.1:3010:3010` so host Caddy can proxy `/sync/*`
- Deploy always writes `sync.serviceUrl: http://sync:3010` when sync is enabled
- Optional GitHub Environment vars `SYNC_CONNECTION_ROUTING`, `SYNC_EVENT_ROUTING`, `SYNC_EXECUTION` (unset = legacy/passive; production must stay unset)

## Simplicity

One public prefix (`/sync/*`) for every browser/provider-facing sync surface; routing remains opt-in via env vars rather than hardcoding staging into the workflow.

## Automated validation

- Sync route DB tests updated for new paths (connection + notification + dispatch fixture)
- Compose/deploy workflow contract tests assert loopback publish + serviceUrl + routing var wiring

## Independent review

Self-reviewed. Production stays legacy because routing vars are omitted there. Staging Caddy `/sync/*` handle applied at flip time (not in this PR's file set — host config).

## Test plan

```bash
bun test:sync -- packages/sync/src/server/connection.routes.db.test.ts packages/sync/src/server/notification.routes.db.test.ts packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
bun test:scripts -- self-host/docker-compose.test.ts
```

Made with [Cursor](https://cursor.com)