### PR TITLE
fix(sync): trust one proxy hop behind Caddy for rate limits

### DIFF
--- a/packages/sync/src/server/sync.server.test.ts
+++ b/packages/sync/src/server/sync.server.test.ts
@@ -1,6 +1,9 @@
 import { NodeEnv } from "@core/constants/core.constants";
 import { createSyncService, type SyncService } from "@sync/app";
 import { type SyncConfig } from "@sync/config/sync.config";
+import { ReadinessRegistry } from "@sync/lifecycle/readiness";
+import { buildSyncApp } from "@sync/server/sync.server";
+import { afterEach, describe, expect, it } from "bun:test";
 import { type AddressInfo } from "node:net";
 
 const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
@@ -20,6 +23,20 @@ async function listen(service: SyncService): Promise<string> {
   const { port } = service.httpServer.address() as AddressInfo;
   return `http://127.0.0.1:${port}`;
 }
+
+describe("buildSyncApp", () => {
+  it("trusts one proxy hop so Caddy X-Forwarded-For does not trip rate-limit", () => {
+    const app = buildSyncApp({
+      identity: {
+        name: "compass-sync",
+        environment: NodeEnv.Test,
+        execution: "passive",
+      },
+      readiness: new ReadinessRegistry(),
+    });
+    expect(app.get("trust proxy")).toBe(1);
+  });
+});
 
 describe("Sync HTTP server health endpoints", () => {
   let service: SyncService;

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -19,6 +19,9 @@ export function buildSyncApp(deps: {
   connectionApi?: ConnectionApiDeps;
 }): Express {
   const app = express();
+  // Caddy terminates TLS and proxies `/sync/*` with X-Forwarded-For. One hop
+  // of trust keeps express-rate-limit from rejecting those public routes.
+  app.set("trust proxy", 1);
   app.use(express.json());
 
   registerHealthRoutes(app, deps);


### PR DESCRIPTION
## Summary

When Caddy proxies `/sync/*` it sets `X-Forwarded-For`. Without `trust proxy`, `express-rate-limit` throws `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` on the public OAuth/notification routes. Trust one hop (loopback Caddy → sync).

## Simplicity

Single `app.set("trust proxy", 1)` at app construction; matches the one-hop compose layout.

## Automated validation

Unit test asserts `trust proxy === 1` on `buildSyncApp`.

## Independent review

Self-reviewed. Observed on staging when hitting `/sync/google` through Caddy before rollback.

## Test plan

```bash
bun test:sync -- packages/sync/src/server/sync.server.test.ts
```

Made with [Cursor](https://cursor.com)