### PR TITLE
fix(deps): bump google-auth-library to v10 for gaxios 7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "exponential-backoff": "^3.1.2",
         "express": "^4.17.1",
         "gaxios": "^7.1.3",
-        "google-auth-library": "^9.15.1",
+        "google-auth-library": "^10.5.0",
         "helmet": "^7.0.0",
         "lodash.mergewith": "^4.6.2",
         "mongodb": "^7.2.0",
@@ -69,7 +69,7 @@
         "@opentelemetry/api-logs": "^0.220.0",
         "bson": "^7.2.0",
         "dayjs": "^1.11.19",
-        "google-auth-library": "^9.15.1",
+        "google-auth-library": "^10.5.0",
         "lodash.mergewith": "^4.6.2",
         "logform": "^2.7.0",
         "rrule": "^2.7.2",
@@ -188,7 +188,7 @@
   "overrides": {
     "gaxios": "^7.1.3",
     "glob": "^13.0.6",
-    "google-auth-library": "^9.15.1",
+    "google-auth-library": "^10.5.0",
     "onetime": "^5.1.2",
     "typescript": "7.0.2",
   },
@@ -981,7 +981,7 @@
 
     "gaxios": ["gaxios@7.3.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
 
-    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
@@ -995,9 +995,9 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+    "google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
 
-    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "googleapis-common": ["googleapis-common@8.0.1", "", { "dependencies": { "extend": "^3.0.2", "gaxios": "^7.0.0-rc.4", "google-auth-library": "^10.1.0", "qs": "^6.7.0", "url-template": "^2.0.8" } }, "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A=="],
 
@@ -1006,8 +1006,6 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphql": ["graphql@16.13.2", "", {}, "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig=="],
-
-    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1835,8 +1833,6 @@
 
     "make-dir/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
-    "mongodb/gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
-
     "mongodb-memory-server-core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "mongodb-memory-server-core/mongodb": ["mongodb@5.9.2", "", { "dependencies": { "bson": "^5.5.0", "mongodb-connection-string-url": "^2.6.0", "socks": "^2.7.1" }, "optionalDependencies": { "@mongodb-js/saslprep": "^1.1.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.0.0", "kerberos": "^1.0.0 || ^2.0.0", "mongodb-client-encryption": ">=2.3.0 <3", "snappy": "^7.2.2" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "kerberos", "mongodb-client-encryption", "snappy"] }, "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ=="],
@@ -1956,8 +1952,6 @@
     "mongodb-memory-server-core/mongodb/bson": ["bson@5.5.1", "", {}, "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g=="],
 
     "mongodb-memory-server-core/mongodb/mongodb-connection-string-url": ["mongodb-connection-string-url@2.6.0", "", { "dependencies": { "@types/whatwg-url": "^8.2.1", "whatwg-url": "^11.0.0" } }, "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ=="],
-
-    "mongodb/gcp-metadata/google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "msw/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/package.json
+++ b/package.json
@@ -71,14 +71,14 @@
   },
   "resolutions": {
     "glob": "^13.0.6",
-    "google-auth-library": "^9.15.1",
+    "google-auth-library": "^10.5.0",
     "gaxios": "^7.1.3",
     "typescript": "7.0.2",
     "onetime": "^5.1.2"
   },
   "overrides": {
     "glob": "^13.0.6",
-    "google-auth-library": "^9.15.1",
+    "google-auth-library": "^10.5.0",
     "gaxios": "^7.1.3",
     "typescript": "7.0.2",
     "onetime": "^5.1.2"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "exponential-backoff": "^3.1.2",
     "express": "^4.17.1",
     "gaxios": "^7.1.3",
-    "google-auth-library": "^9.15.1",
+    "google-auth-library": "^10.5.0",
     "helmet": "^7.0.0",
     "lodash.mergewith": "^4.6.2",
     "mongodb": "^7.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "@opentelemetry/api-logs": "^0.220.0",
     "bson": "^7.2.0",
     "dayjs": "^1.11.19",
-    "google-auth-library": "^9.15.1",
+    "google-auth-library": "^10.5.0",
     "lodash.mergewith": "^4.6.2",
     "logform": "^2.7.0",
     "rrule": "^2.7.2",

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -266,6 +266,9 @@ function buildSchedulers(
       callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
     },
     owner,
+    {
+      onError: (error) => logger.error("Sync job engine failed", error),
+    },
   );
   const drain = new SyncScheduler(
     { worker, jobs },

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -36,6 +36,10 @@ export interface SyncJobWorkerOptions {
   // Math.random.
   random?: () => number;
   now?: () => Date;
+  // Called when a job engine throws (before the worker schedules a retry). The
+  // scheduler's drain onError only sees claim/settle failures; per-job engine
+  // throws were previously swallowed, which left staging imports opaque.
+  onError?: (error: unknown) => void;
 }
 
 const DEFAULT_LEASE_MS = 5 * 60_000;
@@ -90,6 +94,7 @@ export class SyncJobWorker {
   readonly #maxAttempts: number;
   readonly #backoff: (attempt: number, now: Date) => Date;
   readonly #now: () => Date;
+  readonly #onError: (error: unknown) => void;
 
   constructor(
     deps: SyncJobWorkerDeps,
@@ -109,6 +114,7 @@ export class SyncJobWorker {
       options.backoff ??
       ((attempt, now) => jitteredBackoff(attempt, now, random));
     this.#now = options.now ?? (() => new Date());
+    this.#onError = options.onError ?? (() => {});
   }
 
   // Claim and process at most one due job. Returns "idle" when nothing is due.
@@ -162,9 +168,18 @@ export class SyncJobWorker {
     let outcome: Awaited<ReturnType<typeof dispatchSyncJob>>;
     try {
       outcome = await dispatchSyncJob(this.#deps, job, this.#now);
-    } catch {
+    } catch (error) {
       // An engine threw (a transient provider/storage error dispatch does not
       // model as a status). Treat it as retryable; the cap still bounds it.
+      // Log the cause — without this, staging imports fail silently and the
+      // UI stays stuck on "Syncing calendar" with only a retryableTransient
+      // job row to show for it.
+      this.#onError(
+        new Error(
+          `Sync job ${job.kind} (${job._id}) attempt ${job.attempt} failed`,
+          { cause: error instanceof Error ? error : undefined },
+        ),
+      );
       await this.#settleFailure(job, "retryableTransient");
       return;
     }


### PR DESCRIPTION
## Summary

After #2371, sync still failed calendar discovery: curl with the stored access token returned 200, but `@googleapis/calendar` via `OAuth2Client` returned `Login Required`. Reproduced on staging: `google-auth-library@9` + `gaxios@7` builds auth headers that googleapis does not send; `google-auth-library@10` + `gaxios@7` lists calendars successfully.

Also logs sync job engine throws (previously swallowed as silent `retryableTransient`), so the next failure is visible in sync logs.

## Simplicity

Deps + one optional `onError` hook on the existing worker. No React hooks. No simplification opportunities beyond that.

## Manual Testing Steps

- [ ] After staging deploy to ≥ this release, confirm sync job for `compasscaltest3` leaves `importing` and `provider_calendars` populates
- [ ] Confirm command palette leaves "Syncing calendar"
- [ ] If a job fails again, confirm sync logs include `Sync job engine failed` with a cause

## Test plan

- [x] `bun type-check` (after clearing stale `build/node` composite cache)
- [x] `bun test:sync --` worker + google-calendar adapter — 24 pass
- [x] `bun test:backend --` gcal.retry — 37 pass
- [x] Staging repro: auth9+gaxios7 → Login Required; auth10+gaxios7 → ok 3 calendars

Made with [Cursor](https://cursor.com)