### PR TITLE
fix(sync): re-derive connection state after import completes

### DIFF
--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
+import {
+  type ProviderCalendarId,
+  type ProviderCalendarSourceId,
+} from "@core/types/sync/identity.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+describe("refreshConnectionState", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+  let calendars: ProviderCalendarRepository;
+  let resources: SyncResourceRepository;
+  let credentials: CredentialRepository;
+
+  beforeEach(() => {
+    connections = new ProviderConnectionRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+    resources = new SyncResourceRepository(storage.db());
+    credentials = new CredentialRepository(storage.db());
+  });
+
+  const deps = () => ({ connections, calendars, resources, credentials });
+
+  async function seedImportingConnection() {
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: {
+        providerAccountId: "acct-1",
+        email: "user@example.com",
+        displayName: "User",
+      },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "importing",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+    await credentials.store({
+      connectionId: connection._id,
+      provider: "google",
+      refreshToken: "refresh",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    return connection;
+  }
+
+  it("stays importing until discovery finishes", async () => {
+    const connection = await seedImportingConnection();
+    await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("importing");
+  });
+
+  it("becomes healthy once discovery and active calendar imports finish", async () => {
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: "#fff",
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+
+    const eventsResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "events-cursor",
+      new Date(),
+    );
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("healthy");
+    expect(after.stateReason).toBeNull();
+    expect(after.lastHealthyAt).toBeInstanceOf(Date);
+    expect(after.lastSyncedAt).toBeInstanceOf(Date);
+  });
+
+  it("keeps importing when an active calendar still lacks a cursor", async () => {
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("importing");
+  });
+});

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -1,15 +1,15 @@
-import { beforeEach, describe, expect, it } from "bun:test";
 import { faker } from "@faker-js/faker";
-import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
-import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
 import {
   type ProviderCalendarId,
   type ProviderCalendarSourceId,
 } from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { beforeEach, describe, expect, it } from "bun:test";
 
 const objectId = () => faker.database.mongodbObjectId();
 

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -1,7 +1,7 @@
 import {
-  deriveConnectionState,
   type ConnectionStateEvidence,
   type CredentialState,
+  deriveConnectionState,
 } from "@sync/domain/connection-state";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
@@ -33,7 +33,9 @@ export async function refreshConnectionState(
     ...evidence.resourceSuccessAts,
   );
   const lastHealthyAt =
-    derived.state === "healthy" ? (connection.lastHealthyAt ?? at) : connection.lastHealthyAt;
+    derived.state === "healthy"
+      ? (connection.lastHealthyAt ?? at)
+      : connection.lastHealthyAt;
 
   if (
     connection.state === derived.state &&
@@ -86,7 +88,9 @@ export async function gatherConnectionStateEvidence(
   const discoveryDone = calendarList?.lastSuccessAt != null;
   const allActiveImported =
     activeCalendars.length === 0 ||
-    activeCalendars.every((c) => eventsByCalendar.get(c._id)?.syncCursor != null);
+    activeCalendars.every(
+      (c) => eventsByCalendar.get(c._id)?.syncCursor != null,
+    );
 
   const resourceSuccessAts = resources
     .map((r) => r.lastSuccessAt)

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -1,0 +1,130 @@
+import {
+  deriveConnectionState,
+  type ConnectionStateEvidence,
+  type CredentialState,
+} from "@sync/domain/connection-state";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface ConnectionStateRefreshDeps {
+  connections: ProviderConnectionRepository;
+  calendars: ProviderCalendarRepository;
+  resources: SyncResourceRepository;
+  credentials: CredentialRepository;
+}
+
+// Re-derive a connection's user-facing state from live evidence and persist it.
+// Stored state at OAuth link time is always "importing"; without this refresh
+// the UI stays on "Syncing calendar" forever after the import chain finishes.
+export async function refreshConnectionState(
+  deps: ConnectionStateRefreshDeps,
+  connection: ProviderConnectionRecord,
+  now: () => Date = () => new Date(),
+): Promise<ProviderConnectionRecord> {
+  const at = now();
+  const evidence = await gatherConnectionStateEvidence(deps, connection);
+  const derived = deriveConnectionState(evidence, at);
+
+  const lastSyncedAt = maxDate(
+    connection.lastSyncedAt,
+    ...evidence.resourceSuccessAts,
+  );
+  const lastHealthyAt =
+    derived.state === "healthy" ? (connection.lastHealthyAt ?? at) : connection.lastHealthyAt;
+
+  if (
+    connection.state === derived.state &&
+    connection.stateReason === derived.reason &&
+    sameDate(connection.lastSyncedAt, lastSyncedAt) &&
+    sameDate(connection.lastHealthyAt, lastHealthyAt)
+  ) {
+    return connection;
+  }
+
+  return deps.connections.updateDerivedState(
+    connection.tenantId,
+    connection.principalId,
+    connection._id,
+    {
+      state: derived.state,
+      stateReason: derived.reason,
+      lastSyncedAt,
+      lastHealthyAt,
+    },
+    at,
+  );
+}
+
+export async function gatherConnectionStateEvidence(
+  deps: ConnectionStateRefreshDeps,
+  connection: ProviderConnectionRecord,
+): Promise<ConnectionStateEvidence & { resourceSuccessAts: Date[] }> {
+  const [credential, calendars, resources] = await Promise.all([
+    deps.credentials.findByConnection(connection._id),
+    deps.calendars.listByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    ),
+    deps.resources.listByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    ),
+  ]);
+
+  const activeCalendars = calendars.filter((c) => c.active);
+  const eventsByCalendar = new Map(
+    resources
+      .filter((r) => r.resourceKind === "events" && r.calendarId)
+      .map((r) => [r.calendarId as string, r]),
+  );
+  const calendarList = resources.find((r) => r.resourceKind === "calendarList");
+  const discoveryDone = calendarList?.lastSuccessAt != null;
+  const allActiveImported =
+    activeCalendars.length === 0 ||
+    activeCalendars.every((c) => eventsByCalendar.get(c._id)?.syncCursor != null);
+
+  const resourceSuccessAts = resources
+    .map((r) => r.lastSuccessAt)
+    .filter((d): d is Date => d instanceof Date);
+
+  return {
+    disconnectedAt: connection.disconnectedAt,
+    credential: credentialState(credential),
+    permanentConflict: false,
+    accountIdentified: Boolean(connection.account.providerAccountId),
+    // Discovery must have finished, and every currently-active calendar must
+    // hold a durable events cursor (the initialImport settle condition).
+    initialImportComplete: discoveryDone && allActiveImported,
+    catchingUp: false,
+    oldestDueWorkAt: null,
+    recentProviderErrors: false,
+    resourceSuccessAts,
+  };
+}
+
+function credentialState(
+  credential: Awaited<ReturnType<CredentialRepository["findByConnection"]>>,
+): CredentialState {
+  if (!credential?.refreshToken) return "revoked";
+  return "valid";
+}
+
+function maxDate(...dates: Array<Date | null | undefined>): Date | null {
+  let max: Date | null = null;
+  for (const d of dates) {
+    if (!(d instanceof Date)) continue;
+    if (!max || d.getTime() > max.getTime()) max = d;
+  }
+  return max;
+}
+
+function sameDate(a: Date | null, b: Date | null): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  return a.getTime() === b.getTime();
+}

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -40,6 +40,7 @@ import {
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
 
@@ -146,6 +147,8 @@ const signedHeaders = (
 describe("GET /internal/connections", () => {
   let mongo: SyncMongoService;
   let repo: ProviderConnectionRepository;
+  let credentials: CredentialRepository;
+  let resources: SyncResourceRepository;
   let service: SyncService;
   let base: string;
 
@@ -159,9 +162,43 @@ describe("GET /internal/connections", () => {
     base = `http://127.0.0.1:${port}`;
   };
 
+  // List refreshes stored state from live evidence. Healthy requires a valid
+  // credential and a finished calendar-list discovery (no active calendars is
+  // enough for the import settle check).
+  const seedHealthyConnection = async (
+    tenantId: string,
+    principalId: string,
+    email: string,
+  ) => {
+    const connection = await seedConnection(repo, tenantId, principalId, email);
+    await credentials.store({
+      connectionId: connection._id,
+      provider: "google",
+      refreshToken: "stored-refresh-token",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    return connection;
+  };
+
   beforeEach(() => {
     mongo = storage.mongo();
     repo = new ProviderConnectionRepository(mongo.db);
+    credentials = new CredentialRepository(mongo.db);
+    resources = new SyncResourceRepository(mongo.db);
   });
 
   afterEach(async () => {
@@ -171,7 +208,7 @@ describe("GET /internal/connections", () => {
   it("returns the caller's connections mapped to the wire contract", async () => {
     const tenantId = objectId();
     const principalId = objectId();
-    await seedConnection(repo, tenantId, principalId, "me@example.com");
+    await seedHealthyConnection(tenantId, principalId, "me@example.com");
     await startService();
 
     const res = await fetch(`${base}${CONNECTIONS_PATH}`, {

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -35,6 +35,7 @@ import {
   computeBusyAvailability,
 } from "@sync/domain/busy-query.service";
 import { deriveConnectionState } from "@sync/domain/connection-state";
+import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
 import { assembleEventInstances } from "@sync/domain/event-instance-assembly";
 import {
   HORIZON_FUTURE_MONTHS,
@@ -107,8 +108,8 @@ export interface ConnectionApiDeps {
 // Internal, authenticated connection endpoints. The tenant/principal comes from
 // the signed auth context, never the request, so every query is scoped to the
 // caller's own principal. Reads are allowed in passive mode — they touch no
-// provider. The record's stored state is authoritative (it was derived from
-// evidence at write time), so this layer only reshapes it to the wire contract.
+// provider. Stored state can lag (OAuth link writes "importing"); list refreshes
+// each row from live evidence before shaping the wire contract.
 export function registerConnectionRoutes(
   app: Express,
   deps: ConnectionApiDeps,
@@ -123,13 +124,22 @@ export function registerConnectionRoutes(
       if (!ensureConnected(deps.mongo, res)) return;
 
       try {
-        const repo = new ProviderConnectionRepository(deps.mongo.db);
-        const records = await repo.listByPrincipal(
+        const connections = new ProviderConnectionRepository(deps.mongo.db);
+        const refreshDeps = {
+          connections,
+          calendars: new ProviderCalendarRepository(deps.mongo.db),
+          resources: new SyncResourceRepository(deps.mongo.db),
+          credentials: new CredentialRepository(deps.mongo.db),
+        };
+        const records = await connections.listByPrincipal(
           auth.tenantId,
           auth.principalId,
         );
+        const refreshed = await Promise.all(
+          records.map((record) => refreshConnectionState(refreshDeps, record)),
+        );
         const response: ConnectionListResponse = {
-          connections: records.map(toProviderConnection),
+          connections: refreshed.map(toProviderConnection),
         };
         res.status(Status.OK).json(response);
       } catch {

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -1,5 +1,9 @@
 import { type Collection, type Db, ObjectId } from "mongodb";
 import {
+  type ConnectionState,
+  type ConnectionStateReason,
+} from "@core/types/sync/connection.contracts";
+import {
   type ConnectionId,
   type PrincipalId,
   type TenantId,
@@ -119,5 +123,39 @@ export class ProviderConnectionRepository {
       },
     );
     return result.matchedCount === 1;
+  }
+
+  // Persist a freshly derived user-facing state (and sync health timestamps).
+  // Callers must pass a state already produced by deriveConnectionState — this
+  // does not re-derive. Owner-scoped; returns the updated row.
+  async updateDerivedState(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: ConnectionId,
+    fields: {
+      state: ConnectionState;
+      stateReason: ConnectionStateReason | null;
+      lastSyncedAt: Date | null;
+      lastHealthyAt: Date | null;
+    },
+    now: Date = new Date(),
+  ): Promise<ProviderConnectionRecord> {
+    const result = await this.collection.findOneAndUpdate(
+      { _id: id, tenantId, principalId },
+      {
+        $set: {
+          state: fields.state,
+          stateReason: fields.stateReason,
+          lastSyncedAt: fields.lastSyncedAt,
+          lastHealthyAt: fields.lastHealthyAt,
+          updatedAt: now,
+        },
+      },
+      { returnDocument: "after" },
+    );
+    if (!result) {
+      throw new Error("Connection not found while updating derived state");
+    }
+    return ProviderConnectionRecordSchema.parse(result);
   }
 }


### PR DESCRIPTION
## Summary

Staging import finished (3 calendars, 600+ events, empty job queue) but `/internal/connections` still reported `state: importing`, so the command palette never left "Syncing calendar".

OAuth link correctly derives `importing` once, then nothing re-derived after discovery/import. List now refreshes each connection from live evidence (discovery cursor + per-calendar events cursors + credential) before returning the wire shape.

## Simplicity

One small refresh service + repository write. No React hooks. No simplification opportunities beyond that.

## Manual Testing Steps

- [ ] On staging after deploy, reload as `compasscaltest3@gmail.com`
- [ ] Confirm command palette is no longer stuck on "Syncing calendar"
- [ ] Confirm calendars appear in the sidebar

## Test plan

- [x] `bun test:sync -- packages/sync/src/domain/connection-state-refresh.service.db.test.ts` — 3 pass
- [x] `bun type-check`

Made with [Cursor](https://cursor.com)