### PR TITLE
feat(sync): invalidation outbox + GET /internal/changes

### DIFF
--- a/packages/sync/src/domain/change-feed.service.ts
+++ b/packages/sync/src/domain/change-feed.service.ts
@@ -1,0 +1,79 @@
+import { ObjectId } from "mongodb";
+import {
+  type ChangeFeedCursor,
+  ChangeFeedCursorSchema,
+  type ChangeFeedResponse,
+  type InvalidationEnvelope,
+} from "@core/types/sync/change-feed.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
+  INVALIDATION_RETENTION_MS,
+  type InvalidationRepository,
+} from "@sync/storage/repositories/invalidation.repository";
+
+export const CHANGE_FEED_PAGE_SIZE = 100;
+
+export interface ChangeFeedDeps {
+  invalidations: InvalidationRepository;
+}
+
+// Resume the authenticated principal's content-free invalidation feed.
+//
+// - null cursor: "from now" — empty page + a fresh ObjectId watermark.
+// - valid cursor within retention: keyset page after that id.
+// - malformed or older-than-retention cursor: resyncRequired (caller must
+//   invalidate cached queries rather than trust a partial replay).
+export async function readChangeFeed(
+  deps: ChangeFeedDeps,
+  tenantId: TenantId,
+  principalId: PrincipalId,
+  cursor: string | null,
+  now: () => Date = () => new Date(),
+): Promise<ChangeFeedResponse> {
+  const at = now();
+
+  if (cursor === null) {
+    const highWater = await deps.invalidations.latestId(tenantId, principalId);
+    return {
+      kind: "ok",
+      invalidations: [],
+      // Prefer the principal's current high-water mark. Mint only when the
+      // outbox is empty so the first append after connect is still after the
+      // watermark.
+      nextCursor: asCursor(highWater ?? new ObjectId().toHexString()),
+    };
+  }
+
+  if (!ObjectId.isValid(cursor) || cursor.length !== 24) {
+    return { kind: "resyncRequired" };
+  }
+
+  const cursorTime = ObjectId.createFromHexString(cursor).getTimestamp();
+  if (at.getTime() - cursorTime.getTime() > INVALIDATION_RETENTION_MS) {
+    return { kind: "resyncRequired" };
+  }
+
+  const rows = await deps.invalidations.listAfter(
+    tenantId,
+    principalId,
+    cursor,
+    CHANGE_FEED_PAGE_SIZE,
+  );
+
+  const envelopes: InvalidationEnvelope[] = rows.map((row) => ({
+    invalidation: row.invalidation,
+    emittedAt: row.emittedAt.toISOString() as InvalidationEnvelope["emittedAt"],
+  }));
+
+  const nextCursor =
+    rows.length > 0 ? asCursor(rows[rows.length - 1]._id) : asCursor(cursor);
+
+  return { kind: "ok", invalidations: envelopes, nextCursor };
+}
+
+function asCursor(id: string): ChangeFeedCursor {
+  return ChangeFeedCursorSchema.parse(id);
+}

--- a/packages/sync/src/domain/change-feed.service.ts
+++ b/packages/sync/src/domain/change-feed.service.ts
@@ -68,8 +68,8 @@ export async function readChangeFeed(
     emittedAt: row.emittedAt.toISOString() as InvalidationEnvelope["emittedAt"],
   }));
 
-  const nextCursor =
-    rows.length > 0 ? asCursor(rows[rows.length - 1]._id) : asCursor(cursor);
+  const last = rows.at(-1);
+  const nextCursor = last ? asCursor(last._id) : asCursor(cursor);
 
   return { kind: "ok", invalidations: envelopes, nextCursor };
 }

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -157,7 +157,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const calendar = await seedProviderCalendar(tenantId, principalId);
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -181,7 +181,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const calendar = await seedProviderCalendar(tenantId, principalId);
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -204,7 +204,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const principalId = objectId() as PrincipalId;
     const calendar = await seedProviderCalendar(tenantId, principalId);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -225,7 +225,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const principalId = objectId() as PrincipalId;
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -323,7 +323,7 @@ describe("submitCloudCommand provider dispatch", () => {
       deliveryState: "confirmed",
     });
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       deleteFor(tenantId, principalId, eventId),
       now,
@@ -351,7 +351,7 @@ describe("submitCloudCommand provider dispatch", () => {
     });
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -409,7 +409,7 @@ describe("submitCloudCommand provider dispatch", () => {
     });
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -451,7 +451,7 @@ describe("submitCloudCommand provider dispatch", () => {
     });
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -485,7 +485,7 @@ describe("submitCloudCommand provider dispatch", () => {
     });
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -563,7 +563,7 @@ describe("submitCloudCommand provider dispatch", () => {
     });
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -596,7 +596,7 @@ describe("submitCloudCommand provider dispatch", () => {
     });
     const writer = new FakeWriter();
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       {
         commands,
         events,
@@ -640,7 +640,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const principalId = objectId() as PrincipalId;
     const submit = submitFor(tenantId, principalId, objectId());
 
-    const command = await submitCloudCommand(deps(), submit, now);
+    const { command } = await submitCloudCommand(deps(), submit, now);
 
     expect(command.outcome.state).toBe("confirmed");
     expect(await occurrenceStartsFor(submit.eventId)).toEqual([
@@ -700,7 +700,7 @@ describe("submitCloudCommand provider dispatch", () => {
       expectedVersion: null,
     };
 
-    const command = await submitCloudCommand(deps(), update, now);
+    const { command } = await submitCloudCommand(deps(), update, now);
 
     expect(command.outcome.state).toBe("confirmed");
     expect(await occurrenceStartsFor(eventId)).toEqual([
@@ -715,7 +715,7 @@ describe("submitCloudCommand provider dispatch", () => {
     await submitCloudCommand(deps(), submit, now);
     expect(await occurrenceStartsFor(submit.eventId)).toHaveLength(1);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       deleteFor(tenantId, principalId, submit.eventId),
       now,
@@ -845,7 +845,7 @@ describe("submitCloudCommand provider dispatch", () => {
     expect((await occurrenceStartsFor(masterId)).length).toBeGreaterThan(0);
     expect(await occurrenceStartsFor(exception._id)).toHaveLength(1);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       deleteFor(tenantId, principalId, masterId),
       now,
@@ -875,7 +875,7 @@ describe("submitCloudCommand provider dispatch", () => {
     await reprojectOccurrences(occurrences, master, now, [excepted as never]);
     await reprojectOccurrences(occurrences, exception, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       updateAllFor(tenantId, principalId, masterId, "Renamed"),
       now,
@@ -913,7 +913,7 @@ describe("submitCloudCommand provider dispatch", () => {
     ]);
     await reprojectOccurrences(occurrences, tombstone, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       updateAllFor(tenantId, principalId, masterId, "Renamed"),
       now,
@@ -945,7 +945,7 @@ describe("submitCloudCommand provider dispatch", () => {
     await reprojectOccurrences(occurrences, master, now, [excepted as never]);
     await reprojectOccurrences(occurrences, exception, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       updateAllFor(tenantId, principalId, masterId, "Now single", {
         kind: "single",
@@ -976,7 +976,7 @@ describe("submitCloudCommand provider dispatch", () => {
       deliveryState: "confirmed",
     });
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       deleteFor(tenantId, principalId, masterId),
       now,
@@ -1034,7 +1034,7 @@ describe("submitCloudCommand provider dispatch", () => {
     await reprojectOccurrences(occurrences, master, now);
     expect(await occurrenceStartsFor(masterId)).toHaveLength(3);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       deleteFor(tenantId, principalId, masterId, "this", EXCEPTED),
       now,
@@ -1063,7 +1063,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const master = await seriesMaster(tenantId, principalId, masterId);
     await reprojectOccurrences(occurrences, master, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       updateThisFor(tenantId, principalId, masterId, EXCEPTED, "Moved"),
       now,
@@ -1135,7 +1135,7 @@ describe("submitCloudCommand provider dispatch", () => {
     ]);
     await reprojectOccurrences(occurrences, following, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       deleteFor(tenantId, principalId, masterId, "thisAndFollowing", EXCEPTED),
       now,
@@ -1214,7 +1214,7 @@ describe("submitCloudCommand provider dispatch", () => {
     ]);
     await reprojectOccurrences(occurrences, following, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       splitFor(tenantId, principalId, masterId, EXCEPTED, "Split"),
       now,
@@ -1272,7 +1272,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const master = await seriesMaster(tenantId, principalId, masterId);
     await reprojectOccurrences(occurrences, master, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       splitFor(
         tenantId,
@@ -1298,7 +1298,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const master = await seriesMaster(tenantId, principalId, masterId);
     await reprojectOccurrences(occurrences, master, now);
 
-    const command = await submitCloudCommand(
+    const { command } = await submitCloudCommand(
       deps(),
       // The split point is the series' own first occurrence.
       deleteFor(

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -66,19 +66,28 @@ export async function submitCloudCommand(
   deps: CloudCommandDeps,
   submit: CommandSubmit,
   now: () => Date,
-): Promise<CommandRecord> {
-  const command = await deps.commands.submit(submit);
+): Promise<{ command: CommandRecord; changed: boolean }> {
+  const { record: command, inserted } = await deps.commands.submit(submit);
 
   // Only a freshly-persisted create is applied here. A command already past
   // pending (a confirmed replay, or a kind we don't apply yet) is returned as
   // it stands, so a repeated submit never re-applies or overwrites an outcome.
-  if (command.outcome.state !== "pending") return command;
+  if (command.outcome.state !== "pending") {
+    return { command, changed: false };
+  }
+  const initialOutcomeState = command.outcome.state;
+  const finish = (
+    final: CommandRecord,
+  ): { command: CommandRecord; changed: boolean } => ({
+    command: final,
+    changed: inserted || final.outcome.state !== initialOutcomeState,
+  });
 
   // update/delete apply to an existing event; move is not handled yet.
   if (command.input.kind === "update" || command.input.kind === "delete") {
-    return applyCloudMutation(deps, command, now);
+    return finish(await applyCloudMutation(deps, command, now));
   }
-  if (command.input.kind !== "create") return command;
+  if (command.input.kind !== "create") return finish(command);
 
   // A create whose target calendar is a connected provider calendar must go to
   // the provider, not be confirmed as a local cloud event. Execute it now when
@@ -92,26 +101,28 @@ export async function submitCloudCommand(
   );
   if (providerCalendar) {
     if (deps.execution === "active" && deps.provider) {
-      return executeProviderCreate(
-        {
-          commands: deps.commands,
-          events: deps.events,
-          occurrences: deps.occurrences,
-          writer: deps.provider.writer,
-          custody: deps.provider.custody,
-        },
-        command,
-        providerCalendar,
-        now,
+      return finish(
+        await executeProviderCreate(
+          {
+            commands: deps.commands,
+            events: deps.events,
+            occurrences: deps.occurrences,
+            writer: deps.provider.writer,
+            custody: deps.provider.custody,
+          },
+          command,
+          providerCalendar,
+          now,
+        ),
       );
     }
-    return command;
+    return finish(command);
   }
 
   const record = buildCloudEventRecord(command, now());
   await deps.events.put(record);
   await reprojectOccurrences(deps.occurrences, record, now);
-  return confirmCloud(deps, command);
+  return finish(await confirmCloud(deps, command));
 }
 
 // Apply a cloud-only update or delete to an existing event. Only single,

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -5,6 +5,7 @@ import {
 } from "@sync/domain/connection-state";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { type InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -14,6 +15,9 @@ export interface ConnectionStateRefreshDeps {
   calendars: ProviderCalendarRepository;
   resources: SyncResourceRepository;
   credentials: CredentialRepository;
+  // Optional so unit callers that only assert state can omit the outbox; the
+  // HTTP list path always supplies it so UI clients learn about state changes.
+  invalidations?: InvalidationRepository;
 }
 
 // Re-derive a connection's user-facing state from live evidence and persist it.
@@ -46,7 +50,7 @@ export async function refreshConnectionState(
     return connection;
   }
 
-  return deps.connections.updateDerivedState(
+  const updated = await deps.connections.updateDerivedState(
     connection.tenantId,
     connection.principalId,
     connection._id,
@@ -58,6 +62,20 @@ export async function refreshConnectionState(
     },
     at,
   );
+
+  if (deps.invalidations) {
+    await deps.invalidations.append({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      invalidation: {
+        kind: "connection",
+        connectionId: connection._id,
+      },
+      emittedAt: at,
+    });
+  }
+
+  return updated;
 }
 
 export async function gatherConnectionStateEvidence(

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -132,7 +132,7 @@ describe("executeProviderCreate", () => {
           canInviteAttendees: true,
         },
       });
-    const command = await commands.submit({
+    const { record: command } = await commands.submit({
       tenantId,
       principalId,
       idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
@@ -434,7 +434,7 @@ describe("executeProviderUpdate", () => {
     } as never);
     const event = await events.findById(tenantId, principalId, eventId);
     if (!event) throw new Error("seed failed to read back the event");
-    const command = await commands.submit({
+    const { record: command } = await commands.submit({
       tenantId,
       principalId,
       idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
@@ -730,7 +730,7 @@ describe("executeProviderDelete", () => {
     } as never);
     const event = await events.findById(tenantId, principalId, eventId);
     if (!event) throw new Error("seed failed to read back the event");
-    const command = await commands.submit({
+    const { record: command } = await commands.submit({
       tenantId,
       principalId,
       idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
@@ -1000,22 +1000,24 @@ describe("executeProviderSeriesUpdate", () => {
     master: EventRecord,
     edit: { title: string; recurrence: RecurrenceEdit },
   ) =>
-    commands.submit({
-      tenantId: master.tenantId,
-      principalId: master.principalId,
-      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
-      eventId: master._id,
-      input: {
-        kind: "update",
-        invitation: "all",
-        content: content(edit.title),
-        schedule,
-        recurrence: edit.recurrence,
-        scope: "all",
-        recurrenceId: null,
-      } as unknown as SyncCommandInput,
-      expectedVersion: "etag-1" as never,
-    });
+    (
+      await commands.submit({
+        tenantId: master.tenantId,
+        principalId: master.principalId,
+        idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+        eventId: master._id,
+        input: {
+          kind: "update",
+          invitation: "all",
+          content: content(edit.title),
+          schedule,
+          recurrence: edit.recurrence,
+          scope: "all",
+          recurrenceId: null,
+        } as unknown as SyncCommandInput,
+        expectedVersion: "etag-1" as never,
+      })
+    ).record;
 
   const masterOccurrences = (eventId: EventId) =>
     mongo.db

--- a/packages/sync/src/server/change-feed.routes.db.test.ts
+++ b/packages/sync/src/server/change-feed.routes.db.test.ts
@@ -1,0 +1,214 @@
+import { faker } from "@faker-js/faker";
+import { ObjectId } from "mongodb";
+import { NodeEnv } from "@core/constants/core.constants";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { createSyncService, type SyncService } from "@sync/app";
+import { signInternalRequest } from "@sync/auth/internal-auth";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { CHANGES_PATH } from "@sync/server/change-feed.routes";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { type AddressInfo } from "node:net";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = setupSyncStorage(import.meta.url);
+const objectId = () => faker.database.mongodbObjectId();
+const SECRET = "internal-secret";
+
+const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: uri,
+    INTERNAL_AUTH_TOKEN: SECRET,
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+    ...overrides,
+  }) as SyncConfig;
+
+const signedHeaders = (
+  tenantId: string,
+  principalId: string,
+): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "x-sync-tenant": tenantId,
+    "x-sync-principal": principalId,
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signInternalRequest(SECRET, {
+      timestamp,
+      tenantId,
+      principalId,
+    }),
+  };
+};
+
+describe("GET /internal/changes", () => {
+  let mongo: SyncMongoService;
+  let invalidations: InvalidationRepository;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async (config: SyncConfig = testConfig()) => {
+    service = createSyncService(config, { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  const get = (tenantId: string, principalId: string, query = "") =>
+    fetch(`${base}${CHANGES_PATH}${query}`, {
+      headers: signedHeaders(tenantId, principalId),
+    });
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    invalidations = new InvalidationRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  it("returns an empty page and watermark cursor when resuming from now", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+
+    const res = await get(tenantId, principalId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      kind: string;
+      invalidations: unknown[];
+      nextCursor: string;
+    };
+    expect(body.kind).toBe("ok");
+    expect(body.invalidations).toEqual([]);
+    expect(ObjectId.isValid(body.nextCursor)).toBe(true);
+  });
+
+  it("delivers appended invalidations on resume and advances the cursor", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId() as ConnectionId;
+    await startService();
+
+    // Seed so "from now" watermarks at a real outbox id (avoids same-second
+    // ObjectId races against a freshly minted empty-outbox cursor).
+    await invalidations.append({
+      tenantId,
+      principalId,
+      invalidation: {
+        kind: "command",
+        commandId: objectId() as never,
+      },
+      emittedAt: new Date(),
+    });
+
+    const boot = (await (await get(tenantId, principalId)).json()) as {
+      nextCursor: string;
+    };
+
+    await invalidations.append({
+      tenantId,
+      principalId,
+      invalidation: { kind: "connection", connectionId },
+      emittedAt: new Date(),
+    });
+    await invalidations.append({
+      tenantId,
+      principalId,
+      invalidation: {
+        kind: "event",
+        eventId: objectId() as never,
+      },
+      emittedAt: new Date(),
+    });
+
+    const page = (await (
+      await get(tenantId, principalId, `?cursor=${boot.nextCursor}`)
+    ).json()) as {
+      kind: string;
+      invalidations: Array<{
+        invalidation: { kind: string };
+        emittedAt: string;
+      }>;
+      nextCursor: string;
+    };
+
+    expect(page.kind).toBe("ok");
+    expect(page.invalidations.map((e) => e.invalidation.kind)).toEqual([
+      "connection",
+      "event",
+    ]);
+    expect(typeof page.invalidations[0].emittedAt).toBe("string");
+    // Wire envelopes never carry event content — only the invalidation union.
+    expect(Object.keys(page.invalidations[0]).sort()).toEqual([
+      "emittedAt",
+      "invalidation",
+    ]);
+
+    const idle = (await (
+      await get(tenantId, principalId, `?cursor=${page.nextCursor}`)
+    ).json()) as { invalidations: unknown[] };
+    expect(idle.invalidations).toEqual([]);
+  });
+
+  it("never leaks another principal's invalidations", async () => {
+    const tenantId = objectId();
+    const mine = objectId();
+    const other = objectId();
+    await startService();
+
+    const boot = (await (await get(tenantId, mine)).json()) as {
+      nextCursor: string;
+    };
+    await invalidations.append({
+      tenantId,
+      principalId: other,
+      invalidation: {
+        kind: "connection",
+        connectionId: objectId() as ConnectionId,
+      },
+      emittedAt: new Date(),
+    });
+
+    const page = (await (
+      await get(tenantId, mine, `?cursor=${boot.nextCursor}`)
+    ).json()) as { invalidations: unknown[] };
+    expect(page.invalidations).toEqual([]);
+  });
+
+  it("returns resyncRequired for a malformed or expired cursor", async () => {
+    await startService();
+    const tenantId = objectId();
+    const principalId = objectId();
+
+    const bad = await get(tenantId, principalId, "?cursor=not-an-object-id");
+    expect(await bad.json()).toEqual({ kind: "resyncRequired" });
+
+    // ObjectId from ~8 days ago is outside the 7-day retention window.
+    const stale = ObjectId.createFromTime(
+      Math.floor((Date.now() - 8 * 24 * 60 * 60 * 1000) / 1000),
+    ).toHexString();
+    const expired = await get(tenantId, principalId, `?cursor=${stale}`);
+    expect(await expired.json()).toEqual({ kind: "resyncRequired" });
+  });
+
+  it("serves the feed in passive mode", async () => {
+    await startService(testConfig({ EXECUTION: "passive" }));
+    const res = await get(objectId(), objectId());
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { kind: string }).toMatchObject({
+      kind: "ok",
+    });
+  });
+
+  it("rejects an unsigned request", async () => {
+    await startService();
+    const res = await fetch(`${base}${CHANGES_PATH}`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/sync/src/server/change-feed.routes.ts
+++ b/packages/sync/src/server/change-feed.routes.ts
@@ -1,0 +1,78 @@
+import { type Express, type RequestHandler } from "express";
+import { Status } from "@core/errors/status.codes";
+import {
+  ChangeFeedResponseSchema,
+  ChangeFeedResumeQuerySchema,
+} from "@core/types/sync/change-feed.contracts";
+import { readChangeFeed } from "@sync/domain/change-feed.service";
+import {
+  ensureConnected,
+  internalRateLimit,
+  requireAuth,
+  respondInternalError,
+} from "@sync/server/internal-http";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+export const CHANGES_PATH = "/internal/changes";
+
+export interface ChangeFeedApiDeps {
+  authMiddleware: RequestHandler;
+  mongo: SyncMongoService;
+}
+
+// Internal, authenticated change-feed poll. Serves content-free invalidation
+// envelopes for the signed principal. Read-only against the outbox, so it is
+// available in passive mode. Tenant/principal come from signed auth headers —
+// never from the query.
+export function registerChangeFeedRoutes(
+  app: Express,
+  deps: ChangeFeedApiDeps,
+): void {
+  app.get(
+    CHANGES_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+
+      const rawCursor = req.query["cursor"];
+      // Omit / empty / explicit "null" → resume from now. A repeated query key
+      // arrives as an array from Express and is rejected.
+      let cursor: string | null = null;
+      if (rawCursor !== undefined) {
+        if (Array.isArray(rawCursor)) {
+          res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
+          return;
+        }
+        if (typeof rawCursor !== "string") {
+          res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
+          return;
+        }
+        if (rawCursor !== "" && rawCursor !== "null") {
+          cursor = rawCursor;
+        }
+      }
+
+      const parsed = ChangeFeedResumeQuerySchema.safeParse({ cursor });
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
+        return;
+      }
+
+      try {
+        const response = await readChangeFeed(
+          { invalidations: new InvalidationRepository(deps.mongo.db) },
+          auth.tenantId,
+          auth.principalId,
+          parsed.data.cursor,
+        );
+        res.status(Status.OK).json(ChangeFeedResponseSchema.parse(response));
+      } catch {
+        respondInternalError(res);
+      }
+    },
+  );
+}

--- a/packages/sync/src/server/command.routes.db.test.ts
+++ b/packages/sync/src/server/command.routes.db.test.ts
@@ -157,6 +157,7 @@ describe("POST /internal/commands", () => {
     expect(second.command.outcome.state).toBe("confirmed");
     expect(await mongo.db.collection("commands").countDocuments()).toBe(1);
     expect(await mongo.db.collection("events").countDocuments()).toBe(1);
+    expect(await mongo.db.collection("invalidations").countDocuments()).toBe(2);
   });
 
   it("recovers an interrupted acknowledgement by confirming on retry", async () => {
@@ -168,7 +169,7 @@ describe("POST /internal/commands", () => {
     // Simulate a crash after the command persisted but before it was applied:
     // the command already exists as pending with no event written.
     const commands = new CommandRepository(mongo.db);
-    const pending = await commands.submit({
+    const { record: pending } = await commands.submit({
       tenantId: tenantId as TenantId,
       principalId: principalId as PrincipalId,
       idempotencyKey: request.idempotencyKey as never,

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -23,6 +23,7 @@ import { CredentialRepository } from "@sync/storage/repositories/credential.repo
 import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
@@ -109,6 +110,22 @@ export function registerCommandRoutes(
           },
           () => (deps.now ? new Date(deps.now()) : new Date()),
         );
+
+        // Content-free change-feed notice for Compass API → browser SSE.
+        // Emitted after the durable command write so a crash drops the row
+        // (reconnect refetch covers the gap) rather than inventing a phantom.
+        const invalidations = new InvalidationRepository(deps.mongo.db);
+        const emittedAt = deps.now ? new Date(deps.now()) : new Date();
+        await invalidations.appendMany(
+          auth.tenantId,
+          auth.principalId,
+          [
+            { kind: "command", commandId: command._id },
+            { kind: "event", eventId: command.eventId },
+          ],
+          emittedAt,
+        );
+
         const response: CommandSubmitResponse = {
           command: toSyncCommand(command),
         };

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -87,7 +87,7 @@ export function registerCommandRoutes(
               }
             : undefined;
 
-        const command = await submitCloudCommand(
+        const { command, changed } = await submitCloudCommand(
           {
             commands: new CommandRepository(deps.mongo.db),
             events: new EventRepository(deps.mongo.db),
@@ -112,19 +112,21 @@ export function registerCommandRoutes(
         );
 
         // Content-free change-feed notice for Compass API → browser SSE.
-        // Emitted after the durable command write so a crash drops the row
-        // (reconnect refetch covers the gap) rather than inventing a phantom.
-        const invalidations = new InvalidationRepository(deps.mongo.db);
-        const emittedAt = deps.now ? new Date(deps.now()) : new Date();
-        await invalidations.appendMany(
-          auth.tenantId,
-          auth.principalId,
-          [
-            { kind: "command", commandId: command._id },
-            { kind: "event", eventId: command.eventId },
-          ],
-          emittedAt,
-        );
+        // Emitted only when this request durably changed command/event state,
+        // so an idempotent replay does not duplicate outbox rows.
+        if (changed) {
+          const invalidations = new InvalidationRepository(deps.mongo.db);
+          const emittedAt = deps.now ? new Date(deps.now()) : new Date();
+          await invalidations.appendMany(
+            auth.tenantId,
+            auth.principalId,
+            [
+              { kind: "command", commandId: command._id },
+              { kind: "event", eventId: command.eventId },
+            ],
+            emittedAt,
+          );
+        }
 
         const response: CommandSubmitResponse = {
           command: toSyncCommand(command),

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -57,6 +57,7 @@ import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
@@ -130,6 +131,7 @@ export function registerConnectionRoutes(
           calendars: new ProviderCalendarRepository(deps.mongo.db),
           resources: new SyncResourceRepository(deps.mongo.db),
           credentials: new CredentialRepository(deps.mongo.db),
+          invalidations: new InvalidationRepository(deps.mongo.db),
         };
         const records = await connections.listByPrincipal(
           auth.tenantId,

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -1,5 +1,6 @@
 import express, { type Express } from "express";
 import { type ReadinessRegistry } from "@sync/lifecycle/readiness";
+import { registerChangeFeedRoutes } from "@sync/server/change-feed.routes";
 import { registerCommandRoutes } from "@sync/server/command.routes";
 import {
   type ConnectionApiDeps,
@@ -37,6 +38,11 @@ export function buildSyncApp(deps: {
       writer: deps.connectionApi.writer,
       authAdapter: deps.connectionApi.authAdapter,
       now: deps.connectionApi.now,
+    });
+    // Resumable invalidation outbox for Compass API → browser SSE (S40).
+    registerChangeFeedRoutes(app, {
+      authMiddleware: deps.connectionApi.authMiddleware,
+      mongo: deps.connectionApi.mongo,
     });
     // The public webhook ingress shares the connection API's storage; it needs
     // no auth adapter or secrets, only the db and execution mode.

--- a/packages/sync/src/storage/collections.ts
+++ b/packages/sync/src/storage/collections.ts
@@ -13,6 +13,8 @@ export const SYNC_COLLECTIONS = {
   commands: "commands",
   jobs: "jobs",
   deletionMarkers: "deletion_markers",
+  // Append-only, content-free invalidation outbox for GET /internal/changes.
+  invalidations: "invalidations",
 } as const;
 
 export type SyncCollectionName =

--- a/packages/sync/src/storage/contracts/invalidation.contracts.ts
+++ b/packages/sync/src/storage/contracts/invalidation.contracts.ts
@@ -1,0 +1,29 @@
+import { z } from "zod/v4";
+import { SyncInvalidationSchema } from "@core/types/sync/change-feed.contracts";
+import {
+  PrincipalIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+import { ObjectIdStringSchema } from "@core/types/type.utils";
+
+// Persistence record for `invalidations` — the durable, content-free outbox
+// behind GET /internal/changes. Rows carry IDs (and import progress) only;
+// clients always refetch canonical state. A TTL index removes rows after the
+// retention window; a resume cursor older than that window yields resyncRequired.
+export const InvalidationRecordSchema = z.strictObject({
+  _id: ObjectIdStringSchema,
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  invalidation: SyncInvalidationSchema,
+  emittedAt: z.date(),
+  expiresAt: z.date(),
+});
+export type InvalidationRecord = z.infer<typeof InvalidationRecordSchema>;
+
+export const InvalidationAppendSchema = z.strictObject({
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  invalidation: SyncInvalidationSchema,
+  emittedAt: z.date(),
+});
+export type InvalidationAppend = z.infer<typeof InvalidationAppendSchema>;

--- a/packages/sync/src/storage/index-manifest.db.test.ts
+++ b/packages/sync/src/storage/index-manifest.db.test.ts
@@ -76,6 +76,15 @@ describe("installIndexManifest", () => {
     expect(ttl?.expireAfterSeconds).toBe(0);
   });
 
+  it("installs principal keyset and TTL indexes on invalidations", async () => {
+    const indexes = await db
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .indexes();
+    expect(indexes.some((i) => i.name === "principal_id")).toBe(true);
+    const ttl = indexes.find((i) => i.name === "ttl_expiry");
+    expect(ttl?.expireAfterSeconds).toBe(0);
+  });
+
   it("enforces the unique command idempotency key", async () => {
     const commands = db.collection(SYNC_COLLECTIONS.commands);
     const key = {

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -183,6 +183,19 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       options: { expireAfterSeconds: 0 },
     },
   ],
+  [SYNC_COLLECTIONS.invalidations]: [
+    // Keyset resume for GET /internal/changes: filter by owner, page by _id.
+    {
+      name: "principal_id",
+      key: { tenantId: 1, principalId: 1, _id: 1 },
+    },
+    // TTL: content-free invalidations expire after the retention window.
+    {
+      name: "ttl_expiry",
+      key: { expiresAt: 1 },
+      options: { expireAfterSeconds: 0 },
+    },
+  ],
 };
 
 // Creates every collection and its indexes idempotently. Safe to run on every

--- a/packages/sync/src/storage/repositories/command.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/command.repository.db.test.ts
@@ -49,7 +49,7 @@ describe("CommandRepository", () => {
   });
 
   it("submits a new command as pending with zero attempts", async () => {
-    const command = await repo.submit(submit());
+    const { record: command } = await repo.submit(submit());
     expect(command.outcome).toEqual({ state: "pending" });
     expect(command.attemptCount).toBe(0);
     expect(command._id).toMatch(/^[0-9a-f]{24}$/);
@@ -61,11 +61,12 @@ describe("CommandRepository", () => {
     const first = await repo.submit(
       submit({ tenantId, principalId, idempotencyKey: "dup" }),
     );
+    expect(first.inserted).toBe(true);
     // A retried submit must not create a second command or reset progress.
     await repo.updateOutcome(
       tenantId,
       principalId,
-      first._id,
+      first.record._id,
       { state: "applying" },
       1,
     );
@@ -73,14 +74,15 @@ describe("CommandRepository", () => {
       submit({ tenantId, principalId, idempotencyKey: "dup" }),
     );
 
-    expect(second._id).toBe(first._id);
-    expect(second.outcome).toEqual({ state: "applying" });
-    expect(second.attemptCount).toBe(1);
+    expect(second.inserted).toBe(false);
+    expect(second.record._id).toBe(first.record._id);
+    expect(second.record.outcome).toEqual({ state: "applying" });
+    expect(second.record.attemptCount).toBe(1);
     expect(await db.collection("commands").countDocuments()).toBe(1);
   });
 
   it("transitions outcome through the command lifecycle", async () => {
-    const command = await repo.submit(submit());
+    const { record: command } = await repo.submit(submit());
     const applying = await repo.updateOutcome(
       command.tenantId,
       command.principalId,
@@ -105,7 +107,7 @@ describe("CommandRepository", () => {
   });
 
   it("rejects an outcome update from another principal", async () => {
-    const command = await repo.submit(submit());
+    const { record: command } = await repo.submit(submit());
     const result = await repo.updateOutcome(
       command.tenantId,
       objectId() as CommandSubmit["principalId"],
@@ -119,7 +121,7 @@ describe("CommandRepository", () => {
   it("lists only nonterminal commands, oldest first", async () => {
     const tenantId = objectId();
     const principalId = objectId();
-    const a = await repo.submit(
+    const { record: a } = await repo.submit(
       submit({ tenantId, principalId, idempotencyKey: "a" }),
     );
     await repo.submit(submit({ tenantId, principalId, idempotencyKey: "b" }));
@@ -141,7 +143,7 @@ describe("CommandRepository", () => {
     const tenantId = objectId();
     const principalId = objectId();
     const eventId = objectId();
-    const command = await repo.submit(
+    const { record: command } = await repo.submit(
       submit({ tenantId, principalId, eventId }),
     );
 

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -28,7 +28,9 @@ export class CommandRepository {
   // Insert the command if its idempotency key is new; otherwise return the
   // command already stored for that key unchanged. New commands start pending
   // with a zero attempt count.
-  async submit(input: CommandSubmit): Promise<CommandRecord> {
+  async submit(
+    input: CommandSubmit,
+  ): Promise<{ record: CommandRecord; inserted: boolean }> {
     const fields = CommandSubmitSchema.parse(input);
     const now = new Date();
 
@@ -52,10 +54,15 @@ export class CommandRepository {
           updatedAt: now,
         },
       },
-      { upsert: true, returnDocument: "after" },
+      { upsert: true, returnDocument: "after", includeResultMetadata: true },
     );
-    if (!result) throw new Error("Submit did not return a command record");
-    return CommandRecordSchema.parse(result);
+    if (!result.value) {
+      throw new Error("Submit did not return a command record");
+    }
+    return {
+      record: CommandRecordSchema.parse(result.value),
+      inserted: result.lastErrorObject?.["upserted"] != null,
+    };
   }
 
   async findById(

--- a/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
@@ -1,0 +1,90 @@
+import { faker } from "@faker-js/faker";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  INVALIDATION_RETENTION_MS,
+  InvalidationRepository,
+} from "@sync/storage/repositories/invalidation.repository";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+describe("InvalidationRepository", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let repo: InvalidationRepository;
+
+  beforeEach(() => {
+    repo = new InvalidationRepository(storage.db());
+  });
+
+  it("appends a content-free invalidation with TTL expiry", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId() as ConnectionId;
+    const emittedAt = new Date("2026-07-24T12:00:00.000Z");
+
+    const row = await repo.append({
+      tenantId,
+      principalId,
+      invalidation: { kind: "connection", connectionId },
+      emittedAt,
+    });
+
+    expect(row.invalidation).toEqual({
+      kind: "connection",
+      connectionId,
+    });
+    expect(row.emittedAt).toEqual(emittedAt);
+    expect(row.expiresAt.getTime()).toBe(
+      emittedAt.getTime() + INVALIDATION_RETENTION_MS,
+    );
+    // Never store event content on the outbox row.
+    expect(Object.keys(row.invalidation).sort()).toEqual([
+      "connectionId",
+      "kind",
+    ]);
+  });
+
+  it("keyset-lists only the caller's rows after a cursor", async () => {
+    const tenantId = objectId();
+    const mine = objectId();
+    const other = objectId();
+    const connectionId = objectId() as ConnectionId;
+
+    const first = await repo.append({
+      tenantId,
+      principalId: mine,
+      invalidation: { kind: "connection", connectionId },
+      emittedAt: new Date(),
+    });
+    const second = await repo.append({
+      tenantId,
+      principalId: mine,
+      invalidation: {
+        kind: "event",
+        eventId: objectId() as never,
+      },
+      emittedAt: new Date(),
+    });
+    await repo.append({
+      tenantId,
+      principalId: other,
+      invalidation: { kind: "connection", connectionId },
+      emittedAt: new Date(),
+    });
+
+    const page = await repo.listAfter(tenantId, mine, first._id, 10);
+    expect(page.map((r) => r._id)).toEqual([second._id]);
+  });
+
+  it("has a TTL index that expires rows by expiresAt", async () => {
+    const indexes = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .indexes();
+    const ttl = indexes.find((i) => i.name === "ttl_expiry");
+    expect(ttl?.key).toEqual({ expiresAt: 1 });
+    expect(ttl?.expireAfterSeconds).toBe(0);
+  });
+});

--- a/packages/sync/src/storage/repositories/invalidation.repository.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.ts
@@ -70,7 +70,7 @@ export class InvalidationRepository {
   ): Promise<InvalidationRecord[]> {
     const filter: Record<string, unknown> = { tenantId, principalId };
     if (afterId !== null) {
-      filter._id = { $gt: afterId };
+      filter["_id"] = { $gt: afterId };
     }
     const rows = await this.collection
       .find(filter)

--- a/packages/sync/src/storage/repositories/invalidation.repository.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.ts
@@ -1,0 +1,96 @@
+import { type Collection, type Db, ObjectId } from "mongodb";
+import { type SyncInvalidation } from "@core/types/sync/change-feed.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type InvalidationAppend,
+  InvalidationAppendSchema,
+  type InvalidationRecord,
+  InvalidationRecordSchema,
+} from "@sync/storage/contracts/invalidation.contracts";
+
+// Change-feed rows are retained long enough for a reconnecting API poller to
+// resume; beyond this, GET /internal/changes returns resyncRequired.
+export const INVALIDATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export class InvalidationRepository {
+  private readonly collection: Collection<InvalidationRecord>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<InvalidationRecord>(
+      SYNC_COLLECTIONS.invalidations,
+    );
+  }
+
+  // Append one content-free invalidation. Best-effort relative to the domain
+  // write that triggered it: callers invoke this after a successful commit so
+  // a crash can drop the row (recovery is reconnect + refetch / resync).
+  async append(input: InvalidationAppend): Promise<InvalidationRecord> {
+    const fields = InvalidationAppendSchema.parse(input);
+    const record: InvalidationRecord = InvalidationRecordSchema.parse({
+      _id: new ObjectId().toHexString(),
+      tenantId: fields.tenantId,
+      principalId: fields.principalId,
+      invalidation: fields.invalidation,
+      emittedAt: fields.emittedAt,
+      expiresAt: new Date(
+        fields.emittedAt.getTime() + INVALIDATION_RETENTION_MS,
+      ),
+    });
+    await this.collection.insertOne(record);
+    return record;
+  }
+
+  async appendMany(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    invalidations: readonly SyncInvalidation[],
+    emittedAt: Date = new Date(),
+  ): Promise<InvalidationRecord[]> {
+    const out: InvalidationRecord[] = [];
+    for (const invalidation of invalidations) {
+      out.push(
+        await this.append({ tenantId, principalId, invalidation, emittedAt }),
+      );
+    }
+    return out;
+  }
+
+  // Keyset page strictly after `afterId` for the signed principal. `afterId`
+  // null means "from the beginning of retained history" — the route layer uses
+  // latestId() as the "resume from now" watermark instead.
+  async listAfter(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    afterId: string | null,
+    limit: number,
+  ): Promise<InvalidationRecord[]> {
+    const filter: Record<string, unknown> = { tenantId, principalId };
+    if (afterId !== null) {
+      filter._id = { $gt: afterId };
+    }
+    const rows = await this.collection
+      .find(filter)
+      .sort({ _id: 1 })
+      .limit(limit)
+      .toArray();
+    return rows.map((row) => InvalidationRecordSchema.parse(row));
+  }
+
+  // Highest retained outbox id for the principal, or null when none exist.
+  // Used as the "resume from now" watermark so a later append is always after
+  // the cursor (avoids same-second ObjectId races with a freshly minted id).
+  async latestId(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<string | null> {
+    const row = await this.collection.findOne(
+      { tenantId, principalId },
+      { sort: { _id: -1 }, projection: { _id: 1 } },
+    );
+    return row?._id ?? null;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds append-only `invalidations` outbox (7-day TTL) and `GET /internal/changes` for resumable, content-free Sync invalidations (S40 PR1 / ledger S40 Sync half).
- Null cursor = resume-from-now watermark (principal high-water); keyset pages after cursor; malformed/expired cursor → `resyncRequired`.
- Thin producers: connection state refresh + command submit (`command` + `event` envelopes).
- Backend poll client + browser SSE translation stay for S40 PR2.

## Test plan
- [x] `bun test:sync` focused on change-feed / invalidation / index / connection / command route tests
- [ ] CI green
- [ ] After merge/deploy: hit staging `GET /internal/changes` (signed) → ok watermark; submit a cloud command → envelopes appear on resume


Made with [Cursor](https://cursor.com)