### PR TITLE
feat(backend): bridge sync change feed to browser SSE

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@core/types/sync/event.contracts";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { verifyInternalRequest } from "@sync/auth/internal-auth";
+import { CHANGES_PATH } from "@sync/server/change-feed.routes";
 import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
   AVAILABILITY_BUSY_PATH,
@@ -172,6 +173,42 @@ describe("SyncServiceClient", () => {
     if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
     expect(verdict.context.tenantId).toBe(who.tenantId);
     expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("polls the change feed from now and with a resume cursor", async () => {
+    const who = principal();
+    const cursor = objectId();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({
+        kind: "ok",
+        invalidations: [],
+        nextCursor: cursor,
+      }),
+    }));
+
+    const fromNow = await client(fn).getChanges(who, null);
+    if (!fromNow.ok) throw new Error(`expected ok, got ${fromNow.error.kind}`);
+    expect(fromNow.value).toEqual({
+      kind: "ok",
+      invalidations: [],
+      nextCursor: cursor,
+    });
+    expect(calls[0]?.url).toBe(`${BASE_URL}${CHANGES_PATH}`);
+    expect(calls[0]?.method).toBe("GET");
+
+    const resumed = await client(fn).getChanges(who, cursor as never);
+    if (!resumed.ok) throw new Error(`expected ok, got ${resumed.error.kind}`);
+    expect(calls[1]?.url).toBe(
+      `${BASE_URL}${CHANGES_PATH}?cursor=${encodeURIComponent(cursor)}`,
+    );
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: calls[0]?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
   });
 
   it("rejects a calendars body that does not match the contract", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -5,6 +5,11 @@ import {
   BusyAvailabilityResponseSchema,
 } from "@core/types/sync/availability.contracts";
 import {
+  type ChangeFeedCursor,
+  type ChangeFeedResponse,
+  ChangeFeedResponseSchema,
+} from "@core/types/sync/change-feed.contracts";
+import {
   type CommandSubmitRequest,
   type CommandSubmitResponse,
   CommandSubmitResponseSchema,
@@ -32,6 +37,7 @@ import { createHmac, randomUUID } from "node:crypto";
 // route paths; a contract test asserts they match.
 const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 const CALENDARS_PATH = "/internal/calendars";
+const CHANGES_PATH = "/internal/changes";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const EVENTS_PATH = "/internal/events";
@@ -277,6 +283,26 @@ export class SyncServiceClient {
       principal,
       body: request,
       schema: BusyAvailabilityResponseSchema,
+      correlationId,
+    });
+  }
+
+  // Resumable content-free invalidation page for the signed principal. Pass
+  // `null` to resume from now (empty page + watermark). A stale/unknown cursor
+  // returns `{ kind: "resyncRequired" }` rather than a partial replay.
+  getChanges(
+    principal: SyncPrincipal,
+    cursor: ChangeFeedCursor | null,
+    correlationId?: string,
+  ): Promise<SyncClientResult<ChangeFeedResponse>> {
+    const params = new URLSearchParams();
+    if (cursor !== null) params.set("cursor", cursor);
+    return this.#request({
+      method: "GET",
+      path: CHANGES_PATH,
+      query: params,
+      principal,
+      schema: ChangeFeedResponseSchema,
       correlationId,
     });
   }

--- a/packages/backend/src/events/controllers/events.controller.ts
+++ b/packages/backend/src/events/controllers/events.controller.ts
@@ -1,6 +1,7 @@
 import { type Request, type Response } from "express";
 import { Logger } from "@core/logger/winston.logger";
 import { sseServer } from "@backend/servers/sse/sse.server";
+import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
 import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
@@ -14,7 +15,13 @@ class EventsController {
     try {
       // Subscribe immediately so no events are missed during the metadata fetch.
       const unsubscribe = sseServer.subscribe(userId, res);
-      req.on("close", unsubscribe);
+      // When Sync is configured, poll its invalidation outbox for this user and
+      // publish typed browser SSE. No-op when Sync is not wired (legacy-only).
+      syncChangeFeedBridge.onSubscribe(userId);
+      req.on("close", () => {
+        unsubscribe();
+        syncChangeFeedBridge.onUnsubscribe(userId);
+      });
 
       // Replay current state after subscribing — client is never stuck on reconnect.
       const metadata = await userMetadataService.fetchUserMetadata(userId);

--- a/packages/backend/src/servers/sse/sse.server.ts
+++ b/packages/backend/src/servers/sse/sse.server.ts
@@ -54,6 +54,12 @@ class SSEServer {
     };
   }
 
+  // Active SSE connections for a user. The Sync change-feed bridge uses this
+  // to stop polling when the last tab closes.
+  subscriberCount(userId: string): number {
+    return this.connections.get(userId)?.size ?? 0;
+  }
+
   publish(userId: string, message: ServerMessage): void {
     const conns = this.connections.get(userId);
     if (!conns?.size) return;

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
@@ -1,0 +1,101 @@
+import { Logger } from "@core/logger/winston.logger";
+import { type ChangeFeedCursor } from "@core/types/sync/change-feed.contracts";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
+import { sseServer } from "@backend/servers/sse/sse.server";
+import { syncInvalidationToServerMessages } from "@backend/servers/sse/sync-invalidation.to-server-message";
+
+const logger = Logger("app:sse.sync-change-feed");
+
+const POLL_INTERVAL_MS = 2000;
+const ERROR_BACKOFF_MS = 5000;
+
+interface Poller {
+  stop: () => void;
+}
+
+// While a user has at least one SSE connection and Sync is configured, poll
+// GET /internal/changes and publish typed browser SSE. Cursor is in-memory per
+// user for the life of the connection set; reconnect starts from now.
+class SyncChangeFeedBridge {
+  readonly #pollers = new Map<string, Poller>();
+
+  onSubscribe(userId: string): void {
+    if (!getSyncServiceClient()) return;
+    if (this.#pollers.has(userId)) return;
+    this.#pollers.set(userId, this.#start(userId));
+  }
+
+  onUnsubscribe(userId: string): void {
+    if (sseServer.subscriberCount(userId) > 0) return;
+    const poller = this.#pollers.get(userId);
+    if (!poller) return;
+    poller.stop();
+    this.#pollers.delete(userId);
+  }
+
+  #start(userId: string): Poller {
+    let stopped = false;
+    let cursor: ChangeFeedCursor | null = null;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const schedule = (delayMs: number) => {
+      if (stopped) return;
+      timer = setTimeout(() => {
+        void tick();
+      }, delayMs);
+      timer.unref?.();
+    };
+
+    const tick = async () => {
+      if (stopped) return;
+      const client = getSyncServiceClient();
+      if (!client) {
+        schedule(ERROR_BACKOFF_MS);
+        return;
+      }
+
+      const result = await client.getChanges(toSyncPrincipal(userId), cursor);
+      if (stopped) return;
+
+      if (!result.ok) {
+        logger.warn(
+          `Sync change-feed poll failed for user ${userId}: ${result.error.kind}`,
+        );
+        schedule(ERROR_BACKOFF_MS);
+        return;
+      }
+
+      const page = result.value;
+      if (page.kind === "resyncRequired") {
+        // Broad invalidate; client refetches canonical state. Resume from now.
+        sseServer.publishCalendarsChanged(userId, []);
+        cursor = null;
+        schedule(POLL_INTERVAL_MS);
+        return;
+      }
+
+      for (const envelope of page.invalidations) {
+        for (const message of syncInvalidationToServerMessages(
+          envelope.invalidation,
+        )) {
+          sseServer.publish(userId, message);
+        }
+      }
+      cursor = page.nextCursor;
+      schedule(POLL_INTERVAL_MS);
+    };
+
+    // Prime with a from-now watermark, then poll.
+    schedule(0);
+
+    return {
+      stop: () => {
+        stopped = true;
+        if (timer !== undefined) clearTimeout(timer);
+      },
+    };
+  }
+}
+
+export const syncChangeFeedBridge = new SyncChangeFeedBridge();

--- a/packages/backend/src/servers/sse/sync-invalidation.to-server-message.test.ts
+++ b/packages/backend/src/servers/sse/sync-invalidation.to-server-message.test.ts
@@ -1,0 +1,90 @@
+import { faker } from "@faker-js/faker";
+import { syncInvalidationToServerMessages } from "@backend/servers/sse/sync-invalidation.to-server-message";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+describe("syncInvalidationToServerMessages", () => {
+  it("maps an event invalidation to eventsChanged", () => {
+    const eventId = objectId();
+    const calendarId = objectId();
+    expect(
+      syncInvalidationToServerMessages({
+        kind: "event",
+        eventId: eventId as never,
+        calendarId: calendarId as never,
+      }),
+    ).toEqual([
+      {
+        type: "eventsChanged",
+        calendarId,
+        eventIds: [eventId],
+        reason: "reconciled",
+      },
+    ]);
+  });
+
+  it("maps a calendar invalidation to calendarsChanged", () => {
+    const calendarId = objectId();
+    expect(
+      syncInvalidationToServerMessages({
+        kind: "calendar",
+        connectionId: objectId() as never,
+        calendarId: calendarId as never,
+      }),
+    ).toEqual([{ type: "calendarsChanged", calendarIds: [calendarId] }]);
+  });
+
+  it("maps a connection invalidation to a calendarsChanged refetch signal", () => {
+    expect(
+      syncInvalidationToServerMessages({
+        kind: "connection",
+        connectionId: objectId() as never,
+      }),
+    ).toEqual([{ type: "calendarsChanged", calendarIds: [] }]);
+  });
+
+  it("maps incomplete import progress to syncing", () => {
+    expect(
+      syncInvalidationToServerMessages({
+        kind: "importProgress",
+        connectionId: objectId() as never,
+        progress: {
+          calendarsTotal: 2,
+          calendarsCompleted: 1,
+          complete: false,
+        },
+      }),
+    ).toEqual([{ type: "syncStatusChanged", sync: { status: "syncing" } }]);
+  });
+
+  it("maps complete import progress to healthy + importCompleted", () => {
+    expect(
+      syncInvalidationToServerMessages({
+        kind: "importProgress",
+        connectionId: objectId() as never,
+        progress: {
+          calendarsTotal: 2,
+          calendarsCompleted: 2,
+          complete: true,
+        },
+      }),
+    ).toEqual([
+      { type: "syncStatusChanged", sync: { status: "healthy" } },
+      {
+        type: "importCompleted",
+        operation: "full",
+        eventsCount: 0,
+        calendarsCount: 2,
+      },
+    ]);
+  });
+
+  it("skips command invalidations (paired with event on the write path)", () => {
+    expect(
+      syncInvalidationToServerMessages({
+        kind: "command",
+        commandId: objectId() as never,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/backend/src/servers/sse/sync-invalidation.to-server-message.ts
+++ b/packages/backend/src/servers/sse/sync-invalidation.to-server-message.ts
@@ -1,0 +1,49 @@
+import { CalendarIdSchema, EventIdSchema } from "@core/types/domain-primitives";
+import { type ServerMessage } from "@core/types/server-message.contracts";
+import { type SyncInvalidation } from "@core/types/sync/change-feed.contracts";
+
+// Translate a content-free Sync invalidation into zero or more browser SSE
+// messages. The browser treats these as refetch signals; payloads stay id-only.
+export function syncInvalidationToServerMessages(
+  invalidation: SyncInvalidation,
+): ServerMessage[] {
+  switch (invalidation.kind) {
+    case "event":
+      return [
+        {
+          type: "eventsChanged",
+          calendarId: CalendarIdSchema.parse(invalidation.calendarId),
+          eventIds: [EventIdSchema.parse(invalidation.eventId)],
+          reason: "reconciled",
+        },
+      ];
+    case "calendar":
+      return [
+        {
+          type: "calendarsChanged",
+          calendarIds: [CalendarIdSchema.parse(invalidation.calendarId)],
+        },
+      ];
+    case "connection":
+      // Connection state / calendar membership may have changed; the web
+      // invalidates the whole calendar list on this signal.
+      return [{ type: "calendarsChanged", calendarIds: [] }];
+    case "importProgress":
+      if (invalidation.progress.complete) {
+        return [
+          { type: "syncStatusChanged", sync: { status: "healthy" } },
+          {
+            type: "importCompleted",
+            operation: "full",
+            eventsCount: 0,
+            calendarsCount: invalidation.progress.calendarsCompleted,
+          },
+        ];
+      }
+      return [{ type: "syncStatusChanged", sync: { status: "syncing" } }];
+    case "command":
+      // Paired with an `event` invalidation on the write path; nothing extra
+      // for the browser.
+      return [];
+  }
+}

--- a/packages/core/src/types/sync/change-feed.contracts.test.ts
+++ b/packages/core/src/types/sync/change-feed.contracts.test.ts
@@ -81,8 +81,12 @@ describe("Sync change-feed contracts", () => {
       expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(true);
     });
 
-    it("accepts an event invalidation carrying only an id", () => {
-      const invalidation = { kind: "event", eventId: objectId() };
+    it("accepts an event invalidation carrying event and calendar ids", () => {
+      const invalidation = {
+        kind: "event",
+        eventId: objectId(),
+        calendarId: objectId(),
+      };
       expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(true);
     });
 
@@ -90,6 +94,7 @@ describe("Sync change-feed contracts", () => {
       const invalidation = {
         kind: "event",
         eventId: objectId(),
+        calendarId: objectId(),
         title: "Therapy",
       };
       expect(SyncInvalidationSchema.safeParse(invalidation).success).toBe(
@@ -125,7 +130,11 @@ describe("Sync change-feed contracts", () => {
   describe("InvalidationEnvelopeSchema", () => {
     it("accepts an envelope with no tenant/principal identifiers", () => {
       const envelope = {
-        invalidation: { kind: "event", eventId: objectId() },
+        invalidation: {
+          kind: "event",
+          eventId: objectId(),
+          calendarId: objectId(),
+        },
         emittedAt: "2026-07-20T12:00:00.000Z",
       };
       expect(InvalidationEnvelopeSchema.safeParse(envelope).success).toBe(true);
@@ -133,7 +142,11 @@ describe("Sync change-feed contracts", () => {
 
     it("rejects a leaked tenantId field", () => {
       const envelope = {
-        invalidation: { kind: "event", eventId: objectId() },
+        invalidation: {
+          kind: "event",
+          eventId: objectId(),
+          calendarId: objectId(),
+        },
         emittedAt: "2026-07-20T12:00:00.000Z",
         tenantId: objectId(),
       };
@@ -172,7 +185,11 @@ describe("Sync change-feed contracts", () => {
         kind: "ok",
         invalidations: [
           {
-            invalidation: { kind: "event", eventId: objectId() },
+            invalidation: {
+              kind: "event",
+              eventId: objectId(),
+              calendarId: objectId(),
+            },
             emittedAt: "2026-07-20T12:00:00.000Z",
           },
         ],

--- a/packages/core/src/types/sync/change-feed.contracts.ts
+++ b/packages/core/src/types/sync/change-feed.contracts.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { DateTimeSchema, EventIdSchema } from "@core/types/domain-primitives";
+import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
 import {
   ConnectionIdSchema,
   ProviderCalendarIdSchema,
@@ -54,6 +55,9 @@ const CalendarInvalidationSchema = z.strictObject({
 const EventInvalidationSchema = z.strictObject({
   kind: z.literal("event"),
   eventId: EventIdSchema,
+  // Needed so Compass API can emit typed browser `eventsChanged` without a
+  // second Sync round-trip. Still content-free (ids only).
+  calendarId: SyncEventCalendarIdSchema,
 });
 
 const CommandInvalidationSchema = z.strictObject({

--- a/packages/sync/src/server/change-feed.routes.db.test.ts
+++ b/packages/sync/src/server/change-feed.routes.db.test.ts
@@ -123,6 +123,7 @@ describe("GET /internal/changes", () => {
       invalidation: {
         kind: "event",
         eventId: objectId() as never,
+        calendarId: objectId() as never,
       },
       emittedAt: new Date(),
     });

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -115,15 +115,33 @@ export function registerCommandRoutes(
         // Emitted only when this request durably changed command/event state,
         // so an idempotent replay does not duplicate outbox rows.
         if (changed) {
+          const events = new EventRepository(deps.mongo.db);
+          const event = await events.findById(
+            auth.tenantId,
+            auth.principalId,
+            command.eventId,
+          );
           const invalidations = new InvalidationRepository(deps.mongo.db);
           const emittedAt = deps.now ? new Date(deps.now()) : new Date();
+          const notices = [
+            {
+              kind: "command" as const,
+              commandId: command._id,
+            },
+            ...(event
+              ? [
+                  {
+                    kind: "event" as const,
+                    eventId: command.eventId,
+                    calendarId: event.calendarId,
+                  },
+                ]
+              : []),
+          ];
           await invalidations.appendMany(
             auth.tenantId,
             auth.principalId,
-            [
-              { kind: "command", commandId: command._id },
-              { kind: "event", eventId: command.eventId },
-            ],
+            notices,
             emittedAt,
           );
         }

--- a/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
@@ -64,6 +64,7 @@ describe("InvalidationRepository", () => {
       invalidation: {
         kind: "event",
         eventId: objectId() as never,
+        calendarId: objectId() as never,
       },
       emittedAt: new Date(),
     });


### PR DESCRIPTION
## Summary
- S40 PR2: while a user has an open SSE connection and Sync is configured, poll `GET /internal/changes` and publish typed browser `ServerMessage`s.
- `SyncServiceClient.getChanges` + path contract coverage.
- Event invalidations now include `calendarId` (still content-free) so `eventsChanged` can be emitted without a follow-up Sync read.
- No-op when Sync client is null (legacy-only deploys unchanged).

## Test plan
- [x] Focused core / backend / sync tests
- [ ] CI green
- [ ] Staging: open calendar as compasscaltest3 with Sync routing; mutate an event via Sync path; confirm SSE-driven refetch (or calendarsChanged after connection invalidate)


Made with [Cursor](https://cursor.com)