### PR TITLE
fix(web): refresh Google metadata from Sync SSE signals

### DIFF
--- a/packages/web/src/sse/hooks/useGcalSSE.factory.ts
+++ b/packages/web/src/sse/hooks/useGcalSSE.factory.ts
@@ -31,6 +31,9 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
   return function useGcalSSEWithDependencies() {
     // B10 folds import start/progress/end into syncStatusChanged
     // (syncing/healthy/attention) plus a separate importCompleted summary.
+    // Do not clear the syncing override from a healthy/importCompleted SSE
+    // alone — only metadata that leaves IMPORTING may end the loading UI
+    // (S41: no healthy-from-local-optimism).
     const onSyncStatusChanged = useCallback((message: SyncStatusMessage) => {
       if (message.sync.status === "syncing") {
         if (getGoogleSyncIndicatorOverride() !== null) return;
@@ -39,7 +42,7 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
       }
 
       if (message.sync.status === "healthy") {
-        clearGoogleSyncIndicatorOverride();
+        void dependencies.refreshUserMetadata();
         return;
       }
 
@@ -61,9 +64,14 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
     }, []);
 
     const onImportCompleted = useCallback((_message: ImportResultMessage) => {
-      clearGoogleSyncIndicatorOverride();
       void dependencies.refreshUserMetadata();
       dependencies.invalidateEventQueries();
+    }, []);
+
+    // Sync connection/calendar invalidations arrive as calendarsChanged. Refetch
+    // metadata so IMPORTING → HEALTHY (or RECONNECT/ATTENTION) reaches the UI.
+    const onCalendarsChanged = useCallback(() => {
+      void dependencies.refreshUserMetadata();
     }, []);
 
     const onUserMetadataChanged = useCallback(
@@ -90,6 +98,10 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
         "importCompleted",
         onImportCompleted,
       );
+      const unsubscribeCalendars = dependencies.onServerMessage(
+        "calendarsChanged",
+        onCalendarsChanged,
+      );
       const unsubscribeUserMetadata = dependencies.onServerMessage(
         "userMetadataChanged",
         onUserMetadataChanged,
@@ -98,8 +110,14 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
       return () => {
         unsubscribeSyncStatus();
         unsubscribeImportCompleted();
+        unsubscribeCalendars();
         unsubscribeUserMetadata();
       };
-    }, [onSyncStatusChanged, onImportCompleted, onUserMetadataChanged]);
+    }, [
+      onSyncStatusChanged,
+      onImportCompleted,
+      onCalendarsChanged,
+      onUserMetadataChanged,
+    ]);
   };
 };

--- a/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
@@ -152,7 +152,7 @@ describe("useGcalSSE", () => {
     });
   });
 
-  it("clears the syncing override and triggers refetch after importCompleted", async () => {
+  it("refetches metadata and events after importCompleted without clearing repairing", async () => {
     setRepairingSyncIndicatorOverride();
 
     render(<HookHost />);
@@ -167,8 +167,37 @@ describe("useGcalSSE", () => {
     });
 
     await waitFor(() => {
-      expect(getGoogleSyncIndicatorOverride()).toBe(null);
+      // Repairing is a user-initiated override; only its own completion path
+      // clears it. Import SSE refreshes truth from metadata instead.
+      expect(getGoogleSyncIndicatorOverride()).toBe("repairing");
+      expect(refreshUserMetadata).toHaveBeenCalled();
       expect(mockInvalidateEventQueries).toHaveBeenCalled();
+    });
+  });
+
+  it("refetches metadata on calendarsChanged so Sync connection health can land", async () => {
+    render(<HookHost />);
+
+    act(() => {
+      fireMessage({ type: "calendarsChanged", calendarIds: [] });
+    });
+
+    await waitFor(() => {
+      expect(refreshUserMetadata).toHaveBeenCalled();
+    });
+  });
+
+  it("refetches metadata on healthy syncStatusChanged instead of clearing locally", async () => {
+    render(<HookHost />);
+
+    act(() => {
+      fireMessage({ type: "syncStatusChanged", sync: { status: "syncing" } });
+      fireMessage({ type: "syncStatusChanged", sync: { status: "healthy" } });
+    });
+
+    await waitFor(() => {
+      expect(getGoogleSyncIndicatorOverride()).toBe("syncing");
+      expect(refreshUserMetadata).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- S41 minimal slice: do not clear the syncing override from `syncStatusChanged: healthy` or `importCompleted` alone.
- Refetch `/api/user/metadata` on healthy status, importCompleted, and `calendarsChanged` (Sync connection/calendar invalidations) so IMPORTING → HEALTHY reaches the UI from Sync-backed truth.

## Test plan
- [x] `SSEProvider.interaction.test.tsx`
- [ ] CI green
- [ ] Staging: with Sync healthy, reload or wait for calendarsChanged; command palette should leave “Syncing your calendar…”


Made with [Cursor](https://cursor.com)