### PR TITLE
feat(web): show Sync connection summary on metadata

### DIFF
--- a/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
@@ -3,7 +3,11 @@ import {
   type ConnectionStateReason,
   type ProviderConnection,
 } from "@core/types/sync/connection.contracts";
-import { toGoogleConnectionState } from "./connection-state.translation";
+import {
+  selectPrimaryGoogleConnection,
+  toGoogleConnectionState,
+  toGoogleSyncConnectionSummary,
+} from "./connection-state.translation";
 import { describe, expect, it } from "bun:test";
 
 // A ProviderConnection is a rich record, but the translation reads only state +
@@ -113,6 +117,45 @@ describe("toGoogleConnectionState", () => {
       expect(
         toGoogleConnectionState([connection("healthy"), connection("healthy")]),
       ).toBe("HEALTHY");
+    });
+  });
+});
+
+describe("selectPrimaryGoogleConnection", () => {
+  it("returns null when there are no connections", () => {
+    expect(selectPrimaryGoogleConnection([])).toBeNull();
+  });
+
+  it("selects the precedence-winning connection for reconnect", () => {
+    const healthy = { ...connection("healthy"), id: "healthy" };
+    const broken = {
+      ...connection("actionRequired", "authorizationRevoked"),
+      id: "broken",
+    };
+    expect(selectPrimaryGoogleConnection([healthy, broken])?.id).toBe("broken");
+  });
+});
+
+describe("toGoogleSyncConnectionSummary", () => {
+  it("maps id, state, timestamps, and account email only", () => {
+    const record = {
+      ...connection("delayed", "workOverdue"),
+      id: "c-summary",
+      account: {
+        providerAccountId: "a1",
+        email: "user@example.com",
+        displayName: "User",
+      },
+      lastSyncedAt: "2026-07-24T10:00:00.000Z",
+      lastHealthyAt: "2026-07-23T10:00:00.000Z",
+    };
+    expect(toGoogleSyncConnectionSummary(record)).toEqual({
+      id: "c-summary",
+      state: "delayed",
+      stateReason: "workOverdue",
+      lastSyncedAt: "2026-07-24T10:00:00.000Z",
+      lastHealthyAt: "2026-07-23T10:00:00.000Z",
+      accountEmail: "user@example.com",
     });
   });
 });

--- a/packages/backend/src/common/services/sync-service/connection-state.translation.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.ts
@@ -3,7 +3,10 @@ import {
   type ConnectionStateReason,
   type ProviderConnection,
 } from "@core/types/sync/connection.contracts";
-import { type GoogleConnectionState } from "@core/types/user.types";
+import {
+  type GoogleConnectionState,
+  type GoogleSyncConnectionSummary,
+} from "@core/types/user.types";
 
 /**
  * Translate the sync service's multi-connection health model into the single
@@ -91,4 +94,31 @@ export function toGoogleConnectionState(
   // Unreachable: translateConnection never returns NOT_CONNECTED, so a non-empty
   // list always matches a precedence value. Defensive only.
   return "NOT_CONNECTED";
+}
+
+// The connection whose translated enum matches the product precedence winner.
+// Used so reconnect can target the broken account, not a healthy sibling.
+export function selectPrimaryGoogleConnection(
+  connections: readonly ProviderConnection[],
+): ProviderConnection | null {
+  if (connections.length === 0) return null;
+  const target = toGoogleConnectionState(connections);
+  const primary = connections.find(
+    (connection) =>
+      translateConnection(connection.state, connection.stateReason) === target,
+  );
+  return primary ?? connections[0] ?? null;
+}
+
+export function toGoogleSyncConnectionSummary(
+  connection: ProviderConnection,
+): GoogleSyncConnectionSummary {
+  return {
+    id: connection.id,
+    state: connection.state,
+    stateReason: connection.stateReason,
+    lastSyncedAt: connection.lastSyncedAt,
+    lastHealthyAt: connection.lastHealthyAt,
+    accountEmail: connection.account.email,
+  };
 }

--- a/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
+++ b/packages/backend/src/common/services/sync-service/google-connection-status.test.ts
@@ -1,5 +1,8 @@
 import { type ConnectionListResponse } from "@core/types/sync/connection.contracts";
-import { resolveGoogleConnectionStateFromSync } from "./google-connection-status";
+import {
+  resolveGoogleConnectionFromSync,
+  resolveGoogleConnectionStateFromSync,
+} from "./google-connection-status";
 import {
   type SyncClientResult,
   type SyncPrincipal,
@@ -88,5 +91,59 @@ describe("resolveGoogleConnectionStateFromSync", () => {
         await resolveGoogleConnectionStateFromSync(client, principal),
       ).toBe("ATTENTION");
     }
+  });
+});
+
+describe("resolveGoogleConnectionFromSync", () => {
+  it("includes the primary connection summary for the browser", async () => {
+    const client = clientReturning({
+      ok: true,
+      value: {
+        connections: [
+          {
+            ...connection("healthy"),
+            id: "healthy-1",
+            account: {
+              providerAccountId: "a1",
+              email: "ok@example.com",
+              displayName: null,
+            },
+            lastSyncedAt: "2026-07-24T12:00:00.000Z",
+            lastHealthyAt: "2026-07-24T12:00:00.000Z",
+          },
+          {
+            ...connection("actionRequired", "authorizationRevoked"),
+            id: "broken-1",
+            account: {
+              providerAccountId: "a2",
+              email: "bad@example.com",
+              displayName: null,
+            },
+          },
+        ],
+      },
+      correlationId: "corr-1",
+    });
+
+    const resolved = await resolveGoogleConnectionFromSync(client, principal);
+    expect(resolved.connectionState).toBe("RECONNECT_REQUIRED");
+    expect(resolved.connection).toMatchObject({
+      id: "broken-1",
+      state: "actionRequired",
+      stateReason: "authorizationRevoked",
+      accountEmail: "bad@example.com",
+    });
+  });
+
+  it("returns a null summary when Sync is unavailable", async () => {
+    const client = clientReturning({
+      ok: false,
+      error: { kind: "unavailable", correlationId: "corr-1" },
+    });
+
+    expect(await resolveGoogleConnectionFromSync(client, principal)).toEqual({
+      connectionState: "ATTENTION",
+      connection: null,
+    });
   });
 });

--- a/packages/backend/src/common/services/sync-service/google-connection-status.ts
+++ b/packages/backend/src/common/services/sync-service/google-connection-status.ts
@@ -1,12 +1,25 @@
 import { Logger } from "@core/logger/winston.logger";
-import { type GoogleConnectionState } from "@core/types/user.types";
-import { toGoogleConnectionState } from "./connection-state.translation";
+import {
+  type GoogleConnectionState,
+  type GoogleSyncConnectionSummary,
+} from "@core/types/user.types";
+import {
+  selectPrimaryGoogleConnection,
+  toGoogleConnectionState,
+  toGoogleSyncConnectionSummary,
+} from "./connection-state.translation";
 import {
   type SyncPrincipal,
   type SyncServiceClient,
 } from "./sync-service.client";
 
 const logger = Logger("app:google-connection-status");
+
+export interface GoogleConnectionFromSync {
+  connectionState: GoogleConnectionState;
+  // Primary Sync connection summary for the browser (null when none / outage).
+  connection: GoogleSyncConnectionSummary | null;
+}
 
 /**
  * Resolve the browser-facing Google connection state from the sync service.
@@ -18,18 +31,35 @@ const logger = Logger("app:google-connection-status");
  * status delegation, and a deployment that routes connections to sync is
  * expected to monitor sync availability.
  */
-export async function resolveGoogleConnectionStateFromSync(
+export async function resolveGoogleConnectionFromSync(
   client: Pick<SyncServiceClient, "listConnections">,
   principal: SyncPrincipal,
-): Promise<GoogleConnectionState> {
+): Promise<GoogleConnectionFromSync> {
   const result = await client.listConnections(principal);
   if (result.ok) {
-    return toGoogleConnectionState(result.value.connections);
+    const { connections } = result.value;
+    const primary = selectPrimaryGoogleConnection(connections);
+    return {
+      connectionState: toGoogleConnectionState(connections),
+      connection: primary ? toGoogleSyncConnectionSummary(primary) : null,
+    };
   }
 
   logger.warn(
     `Sync connection status unavailable (${result.error.kind}); reporting ATTENTION ` +
       `[correlationId=${result.error.correlationId}]`,
   );
-  return "ATTENTION";
+  return { connectionState: "ATTENTION", connection: null };
+}
+
+/** @deprecated Prefer resolveGoogleConnectionFromSync (keeps summary). */
+export async function resolveGoogleConnectionStateFromSync(
+  client: Pick<SyncServiceClient, "listConnections">,
+  principal: SyncPrincipal,
+): Promise<GoogleConnectionState> {
+  const { connectionState } = await resolveGoogleConnectionFromSync(
+    client,
+    principal,
+  );
+  return connectionState;
 }

--- a/packages/backend/src/user/services/user-metadata.service.ts
+++ b/packages/backend/src/user/services/user-metadata.service.ts
@@ -1,11 +1,12 @@
 import mergeWith from "lodash.mergewith";
 import {
   type GoogleConnectionState,
+  type GoogleSyncConnectionSummary,
   type UserMetadata,
 } from "@core/types/user.types";
 import { getUserMetadataStore } from "@backend/auth/ports/supertokens.registry";
 import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
-import { resolveGoogleConnectionStateFromSync } from "@backend/common/services/sync-service/google-connection-status";
+import { resolveGoogleConnectionFromSync } from "@backend/common/services/sync-service/google-connection-status";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import { isGoogleSyncActive } from "@backend/sync/services/google-sync/google-sync.activity";
@@ -15,6 +16,7 @@ import { type GetUserMetadataResponse } from "@backend/user/types/user.types";
 
 type GoogleMetadataAssessment = {
   connectionState: GoogleConnectionState;
+  connection?: GoogleSyncConnectionSummary | null;
 };
 
 const legacyEmailUpdatesKey = "subscribeToUpdates";
@@ -61,11 +63,7 @@ class UserMetadataService {
     if (getConnectionDelegation() === "sync") {
       const client = getSyncServiceClient();
       if (client) {
-        const connectionState = await resolveGoogleConnectionStateFromSync(
-          client,
-          toSyncPrincipal(userId),
-        );
-        return { connectionState };
+        return resolveGoogleConnectionFromSync(client, toSyncPrincipal(userId));
       }
     }
 
@@ -168,15 +166,20 @@ class UserMetadataService {
       };
     }
 
-    const { connectionState } = await this.assessGoogleMetadata(
+    const { connectionState, connection } = await this.assessGoogleMetadata(
       userId,
       metadata,
     );
 
+    // Cast: SuperTokens JSONObject's index signature doesn't accept our nested
+    // google.connection summary type even though every field is JSON-safe.
     return {
       ...metadata,
-      google: { connectionState },
-    };
+      google: {
+        connectionState,
+        ...(connection !== undefined ? { connection } : {}),
+      },
+    } as UserMetadata;
   };
 }
 

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -33,7 +33,23 @@ export type GoogleConnectionState =
   | "HEALTHY"
   | "ATTENTION";
 
-export interface UserMetadata extends SupertokensUserMetadata.JSONObject {
+// Sync-backed primary connection summary for the browser (S41). Present only
+// when connection routing is delegated to Sync. IDs/timestamps/state only —
+// never credentials or event content. Plain strings so the payload stays a
+// SuperTokens JSONObject (no Zod brands on the metadata wire).
+export interface GoogleSyncConnectionSummary {
+  id: string;
+  state: string;
+  stateReason: string | null;
+  lastSyncedAt: string | null;
+  lastHealthyAt: string | null;
+  accountEmail: string | null;
+}
+
+// Intersection (not extends): SuperTokens JSONObject's string index signature
+// rejects a nested `google.connection` object on an interface extends clause,
+// even though every field is JSON-safe.
+export type UserMetadata = SupertokensUserMetadata.JSONObject & {
   skipOnboarding?: boolean;
   sync?: {
     importGCal?: SyncStatus;
@@ -41,8 +57,9 @@ export interface UserMetadata extends SupertokensUserMetadata.JSONObject {
   };
   google?: {
     connectionState?: GoogleConnectionState;
+    connection?: GoogleSyncConnectionSummary | null;
   };
-}
+};
 
 export interface UserProfile
   extends Pick<

--- a/packages/web/src/api/auth.api.ts
+++ b/packages/web/src/api/auth.api.ts
@@ -4,6 +4,7 @@ import {
   type Result_Auth_Compass,
 } from "@core/types/auth.types";
 import {
+  type ConnectionBeginRequest,
   type ConnectionBeginResponse,
   ConnectionBeginResponseSchema,
 } from "@core/types/sync/connection.contracts";
@@ -39,11 +40,14 @@ const AuthApi = {
   // Sync-delegated connect: ask the backend for the provider consent URL the
   // browser should navigate to (the redirect flow). Only meaningful where the
   // deployment delegates connections to the sync service; the legacy flow uses
-  // connectGoogle above. `connectionId` is omitted for a fresh connection.
-  async beginGoogleConnection(): Promise<ConnectionBeginResponse> {
+  // connectGoogle above. Pass `connectionId` to reconnect an existing
+  // connection; omit it for a fresh one.
+  async beginGoogleConnection(
+    request: ConnectionBeginRequest = {},
+  ): Promise<ConnectionBeginResponse> {
     const response = await BaseApi.post<ConnectionBeginResponse>(
       `/auth/google/connect/begin`,
-      {},
+      request,
     );
 
     return ConnectionBeginResponseSchema.parse(response.data);

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { AuthApi } from "@web/api/auth.api";
 import { SyncApi } from "@web/api/sync.api";
 import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
@@ -8,6 +9,10 @@ import {
   setRepairingSyncIndicatorOverride,
 } from "@web/auth/google/state/google.sync.state";
 import { syncPendingLocalEvents } from "@web/auth/google/util/google.auth.util";
+import {
+  selectGoogleSyncConnection,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import {
   GOOGLE_CONNECT_FAILED_TOAST_ID,
   GOOGLE_REPAIR_FAILED_TOAST_ID,
@@ -26,6 +31,7 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
   const isAvailable = useIsGoogleAvailable();
   const isConnectDelegatedToSync = useIsConnectDelegatedToSync();
   const state = useGoogleUiState();
+  const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
   const { startGoogleAuthorization } = useStartGoogleAuthorization({
     intent: "connectCalendar",
     prompt: "consent",
@@ -49,9 +55,15 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
       // Sync-delegated connect: the sync service owns the OAuth round-trip, so
       // the browser just navigates to the consent URL it mints. No client-side
       // code exchange happens here; the connection is linked when Google calls
-      // back to the sync service.
+      // back to the sync service. Reconnect binds the flow to the primary
+      // connection id from metadata so the wrong account cannot spawn a second.
       try {
-        const { authorizationUrl } = await AuthApi.beginGoogleConnection();
+        const beginRequest =
+          state === "RECONNECT_REQUIRED" && syncConnection?.id
+            ? { connectionId: syncConnection.id as ConnectionId }
+            : {};
+        const { authorizationUrl } =
+          await AuthApi.beginGoogleConnection(beginRequest);
         window.location.assign(authorizationUrl);
       } catch {
         showErrorToast(
@@ -62,7 +74,12 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
     };
 
     void start();
-  }, [isConnectDelegatedToSync, startGoogleAuthorization]);
+  }, [
+    isConnectDelegatedToSync,
+    startGoogleAuthorization,
+    state,
+    syncConnection?.id,
+  ]);
 
   const onRepairGoogle = useCallback(() => {
     const startRepair = async () => {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -37,6 +37,54 @@ describe("getGoogleSyncStatus", () => {
   it("returns error copy for RECONNECT_REQUIRED", () => {
     expect(getGoogleSyncStatus("RECONNECT_REQUIRED")?.variant).toBe("error");
   });
+
+  it("uses Sync catchingUp copy when a connection summary is present", () => {
+    expect(
+      getGoogleSyncStatus("IMPORTING", {
+        id: "c1",
+        state: "catchingUp",
+        stateReason: null,
+        lastSyncedAt: null,
+        lastHealthyAt: null,
+        accountEmail: "a@example.com",
+      }),
+    ).toEqual({
+      variant: "syncing",
+      text: "Catching up your calendar…",
+    });
+  });
+
+  it("uses Sync delayed copy when a connection summary is present", () => {
+    expect(
+      getGoogleSyncStatus("ATTENTION", {
+        id: "c1",
+        state: "delayed",
+        stateReason: "workOverdue",
+        lastSyncedAt: "2026-07-24T12:00:00.000Z",
+        lastHealthyAt: null,
+        accountEmail: null,
+      }),
+    ).toEqual({
+      variant: "warning",
+      text: "Calendar sync is delayed",
+    });
+  });
+
+  it("uses Sync healthy copy from the connection summary", () => {
+    expect(
+      getGoogleSyncStatus("HEALTHY", {
+        id: "c1",
+        state: "healthy",
+        stateReason: null,
+        lastSyncedAt: "2026-07-24T12:00:00.000Z",
+        lastHealthyAt: "2026-07-24T12:00:00.000Z",
+        accountEmail: "a@example.com",
+      }),
+    ).toEqual({
+      variant: "healthy",
+      text: "Calendar up-to-date",
+    });
+  });
 });
 
 describe("getGoogleConnectionConfig", () => {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -1,4 +1,5 @@
 import { CloudArrowUpIcon } from "@phosphor-icons/react";
+import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { type SyncStatus } from "@web/calendars/sync-status.types";
 import {
   type CommandActionIcon,
@@ -46,7 +47,30 @@ export const getGoogleConnectionConfig = (
   }
 };
 
-export const getGoogleSyncStatus = (state: GoogleUiState): SyncStatus => {
+// Prefer Sync vocabulary when a connection summary is present; fall back to the
+// collapsed product enum for legacy deployments.
+export const getGoogleSyncStatus = (
+  state: GoogleUiState,
+  connection?: GoogleSyncConnectionSummary | null,
+): SyncStatus => {
+  if (connection) {
+    switch (connection.state) {
+      case "healthy":
+        return { variant: "healthy", text: "Calendar up-to-date" };
+      case "connecting":
+      case "importing":
+        return { variant: "syncing", text: "Syncing your calendar…" };
+      case "catchingUp":
+        return { variant: "syncing", text: "Catching up your calendar…" };
+      case "delayed":
+        return { variant: "warning", text: "Calendar sync is delayed" };
+      case "actionRequired":
+      case "disconnected":
+        // Product enum already distinguishes reconnect vs soft attention.
+        break;
+    }
+  }
+
   switch (state) {
     case "HEALTHY":
       return { variant: "healthy", text: "Calendar up-to-date" };

--- a/packages/web/src/auth/state/user-metadata.store.ts
+++ b/packages/web/src/auth/state/user-metadata.store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import {
   type GoogleConnectionState,
+  type GoogleSyncConnectionSummary,
   type UserMetadata,
 } from "@core/types/user.types";
 import { IS_DEV } from "@web/common/constants/env.constants";
@@ -75,3 +76,9 @@ export const selectGoogleConnectionState = (
   state: UserMetadataState,
 ): GoogleConnectionState =>
   state.current?.google?.connectionState ?? "NOT_CONNECTED";
+
+/** Sync-backed primary connection summary, or null when absent / legacy. */
+export const selectGoogleSyncConnection = (
+  state: UserMetadataState,
+): GoogleSyncConnectionSummary | null =>
+  state.current?.google?.connection ?? null;

--- a/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.ts
@@ -1,37 +1,37 @@
 import { CloudArrowUpIcon } from "@phosphor-icons/react";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
 import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import {
+  selectGoogleSyncConnection,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { type SyncStatus } from "@web/calendars/sync-status.types";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
-
-const SYNCING_CALENDAR_LABEL = "Syncing your calendar…";
-
-const isCalendarSyncing = (state: GoogleUiState) =>
-  state === "repairing" || state === "IMPORTING" || state === "checking";
 
 export const useCalendarSyncCmdItems = (): {
   items: CommandItem[];
   syncStatus: SyncStatus;
 } => {
   const { commandAction, isAvailable, state } = useConnectGoogle();
+  const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
+  const syncStatus = getGoogleSyncStatus(state, syncConnection);
 
   if (!isAvailable) {
     return { items: [], syncStatus: null };
   }
 
-  if (isCalendarSyncing(state)) {
+  if (syncStatus?.variant === "syncing") {
     return {
       items: [
         {
           id: "connect-google-calendar",
-          label: SYNCING_CALENDAR_LABEL,
+          label: syncStatus.text,
           icon: CloudArrowUpIcon,
           iconClassName: "c-sync-icon-wave",
           disabled: true,
         },
       ],
-      syncStatus: getGoogleSyncStatus(state),
+      syncStatus,
     };
   }
 
@@ -47,6 +47,6 @@ export const useCalendarSyncCmdItems = (): {
           },
         ]
       : [],
-    syncStatus: getGoogleSyncStatus(state),
+    syncStatus,
   };
 };

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -7,6 +7,10 @@ import {
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import {
+  selectGoogleSyncConnection,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import {
   Tooltip,
@@ -89,9 +93,10 @@ const AnonymousAccountHeader: FC = () => {
 
 const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
   const { commandAction, isAvailable, state } = useConnectGoogle();
+  const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
   const hasPendingEventMutations = useHasPendingEventMutations();
   const isSyncing =
-    getGoogleSyncStatus(state)?.variant === "syncing" ||
+    getGoogleSyncStatus(state, syncConnection)?.variant === "syncing" ||
     hasPendingEventMutations;
   const showConnectGoogle =
     state === "NOT_CONNECTED" && isAvailable && commandAction != null;

--- a/packages/web/src/sse/hooks/useGcalSSE.factory.ts
+++ b/packages/web/src/sse/hooks/useGcalSSE.factory.ts
@@ -82,7 +82,15 @@ export const createUseGcalSSE = (dependencies: GcalSSEDependencies) => {
         const metadata = message.metadata as UserMetadata;
         dependencies.setUserMetadata(metadata);
 
-        if (metadata.google?.connectionState !== "IMPORTING") {
+        // Prefer Sync's in-progress states when present; otherwise the collapsed
+        // product enum. Never clear syncing from local optimism alone (S41).
+        const syncState = metadata.google?.connection?.state;
+        const syncInProgress =
+          syncState === "connecting" ||
+          syncState === "importing" ||
+          syncState === "catchingUp";
+        const enumImporting = metadata.google?.connectionState === "IMPORTING";
+        if (!syncInProgress && !enumImporting) {
           clearSyncingSyncIndicatorOverride();
         }
       },


### PR DESCRIPTION
## Summary
- S41 slice: Sync-backed `google.connection` summary on `/api/user/metadata` (id, state, stateReason, timestamps, accountEmail).
- Command palette / sidebar status copy uses Sync vocabulary (`catchingUp`, `delayed`, …) when the summary is present.
- Reconnect passes `connectionId` so OAuth rebinds the broken connection.
- Legacy deployments unchanged (no summary → enum fallback).

## Test plan
- [x] Backend translation / status / metadata tests
- [x] Web util / palette / SSE / CalendarListHeader tests
- [x] `bun type-check`
- [ ] CI green
- [ ] Staging: metadata includes `google.connection.state: "healthy"` for compasscaltest3; reconnect (if forced) posts connectionId


Made with [Cursor](https://cursor.com)