### PR TITLE
feat(web): show reconnect action in calendar list header

### DIFF
--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -11,13 +11,25 @@ let mockEmail: string | undefined;
 let mockGoogleState: GoogleUiState = "NOT_CONNECTED";
 let mockIsAnonymousDirty = false;
 const mockConnectGoogle = mock();
+const googleCommandActionFor = (state: GoogleUiState) => {
+  switch (state) {
+    case "NOT_CONNECTED":
+      return { label: "Connect Google Calendar", onSelect: mockConnectGoogle };
+    case "RECONNECT_REQUIRED":
+      return {
+        label: "Reconnect Google Calendar",
+        onSelect: mockConnectGoogle,
+      };
+    case "ATTENTION":
+      return { label: "Sync Google Calendar", onSelect: mockConnectGoogle };
+    default:
+      return null;
+  }
+};
 const mockUseConnectGoogle = mock(() => ({
   state: mockGoogleState,
   isAvailable: true,
-  commandAction:
-    mockGoogleState === "NOT_CONNECTED"
-      ? { label: "Connect Google Calendar", onSelect: mockConnectGoogle }
-      : null,
+  commandAction: googleCommandActionFor(mockGoogleState),
 }));
 
 mock.module("@web/auth/compass/state/auth.state.util", () => ({
@@ -193,7 +205,7 @@ describe("CalendarListHeader", () => {
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
-  it("shows no warning color or tooltip/action when out of date, and clicking does nothing", async () => {
+  it("shows a sync Google button when the calendar is out of date", async () => {
     const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "ATTENTION";
@@ -206,14 +218,14 @@ describe("CalendarListHeader", () => {
     expect(email).not.toHaveClass("text-warning");
     expect(screen.queryByRole("status")).toBeNull();
 
-    await user.hover(email);
-    expect(screen.queryByRole("tooltip")).toBeNull();
-
-    await user.click(email);
-    expect(screen.queryByRole("button")).toBeNull();
+    const syncButton = screen.getByRole("button", {
+      name: "Sync Google Calendar",
+    });
+    await user.click(syncButton);
+    expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
   });
 
-  it("shows no error color or tooltip/action when reconnect is required", async () => {
+  it("shows a reconnect Google button when reconnect is required", async () => {
     const user = userEvent.setup();
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "RECONNECT_REQUIRED";
@@ -225,8 +237,11 @@ describe("CalendarListHeader", () => {
     expect(email).not.toHaveClass("text-error");
     expect(screen.queryByRole("status")).toBeNull();
 
-    await user.hover(email);
-    expect(screen.queryByRole("tooltip")).toBeNull();
+    const reconnectButton = screen.getByRole("button", {
+      name: "Reconnect Google Calendar",
+    });
+    await user.click(reconnectButton);
+    expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
   });
 
   it("shows the shimmer and syncing status while an event mutation is pending", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -37,7 +37,8 @@ const CONNECT_GOOGLE_BUTTON_CLASSNAME =
  * The calendar list's heading is the account identity (email, or the
  * not-saved-yet label when anonymous) rather than a generic "Calendars"
  * title, and carries the syncing wave shimmer plus the sign-up-to-save CTA
- * for anonymous users. Google connect is surfaced inline when not linked.
+ * for anonymous users. Google connect / reconnect / repair actions mirror
+ * the command palette when Sync (or legacy) exposes a commandAction.
  */
 export const CalendarListHeader: FC = () => {
   const { email } = useUser();
@@ -98,8 +99,7 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
   const isSyncing =
     getGoogleSyncStatus(state, syncConnection)?.variant === "syncing" ||
     hasPendingEventMutations;
-  const showConnectGoogle =
-    state === "NOT_CONNECTED" && isAvailable && commandAction != null;
+  const showGoogleAction = isAvailable && commandAction != null;
 
   return (
     <>
@@ -114,13 +114,13 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
           {email}
         </span>
       </h2>
-      {showConnectGoogle ? (
+      {showGoogleAction ? (
         <button
           className={CONNECT_GOOGLE_BUTTON_CLASSNAME}
           onClick={commandAction.onSelect}
           type="button"
         >
-          Connect Google Calendar
+          {commandAction.label}
         </button>
       ) : null}
       {isSyncing ? (


### PR DESCRIPTION
## Summary
- Sidebar calendar list header now shows **Reconnect Google Calendar** / **Sync Google Calendar** when `useConnectGoogle` exposes those actions (same labels as the command palette).
- Continues S41 after #2377: reconnect was palette-only; users stuck needing reconnect now get an in-sidebar CTA that still passes `connectionId` through the existing connect flow.

## Test plan
- [x] `bun test:web packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx`
- [ ] On staging after Release: force `RECONNECT_REQUIRED` (or revoke) as compasscaltest3 and confirm sidebar Reconnect navigates to Sync OAuth with connection binding


Made with [Cursor](https://cursor.com)