### PR TITLE
feat(web): show sync connection last-synced timestamps

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -1,8 +1,37 @@
 import {
+  formatLastSyncedLabel,
   getGoogleConnectionConfig,
   getGoogleSyncStatus,
 } from "./useConnectGoogle.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+describe("formatLastSyncedLabel", () => {
+  const nowMs = Date.parse("2026-07-24T12:00:00.000Z");
+
+  it("returns null when lastSyncedAt is missing or invalid", () => {
+    expect(formatLastSyncedLabel(null, nowMs)).toBeNull();
+    expect(formatLastSyncedLabel(undefined, nowMs)).toBeNull();
+    expect(formatLastSyncedLabel("not-a-date", nowMs)).toBeNull();
+  });
+
+  it("formats recent relative ages", () => {
+    expect(formatLastSyncedLabel("2026-07-24T11:59:30.000Z", nowMs)).toBe(
+      "Last synced just now",
+    );
+    expect(formatLastSyncedLabel("2026-07-24T11:59:00.000Z", nowMs)).toBe(
+      "Last synced 1 minute ago",
+    );
+    expect(formatLastSyncedLabel("2026-07-24T11:45:00.000Z", nowMs)).toBe(
+      "Last synced 15 minutes ago",
+    );
+    expect(formatLastSyncedLabel("2026-07-24T10:00:00.000Z", nowMs)).toBe(
+      "Last synced 2 hours ago",
+    );
+    expect(formatLastSyncedLabel("2026-07-22T12:00:00.000Z", nowMs)).toBe(
+      "Last synced 2 days ago",
+    );
+  });
+});
 
 describe("getGoogleSyncStatus", () => {
   it("returns no sync status when Google is not connected", () => {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -9,6 +9,49 @@ import {
 
 const COMMAND_ICON: CommandActionIcon = CloudArrowUpIcon;
 
+/** Short relative label for Sync connection `lastSyncedAt` (ISO). */
+export const formatLastSyncedLabel = (
+  lastSyncedAt: string | null | undefined,
+  nowMs: number = Date.now(),
+): string | null => {
+  if (!lastSyncedAt) {
+    return null;
+  }
+
+  const syncedMs = Date.parse(lastSyncedAt);
+  if (Number.isNaN(syncedMs)) {
+    return null;
+  }
+
+  const deltaSec = Math.max(0, Math.floor((nowMs - syncedMs) / 1000));
+  if (deltaSec < 60) {
+    return "Last synced just now";
+  }
+
+  const deltaMin = Math.floor(deltaSec / 60);
+  if (deltaMin < 60) {
+    return deltaMin === 1
+      ? "Last synced 1 minute ago"
+      : `Last synced ${deltaMin} minutes ago`;
+  }
+
+  const deltaHr = Math.floor(deltaMin / 60);
+  if (deltaHr < 24) {
+    return deltaHr === 1
+      ? "Last synced 1 hour ago"
+      : `Last synced ${deltaHr} hours ago`;
+  }
+
+  const deltaDay = Math.floor(deltaHr / 24);
+  if (deltaDay < 7) {
+    return deltaDay === 1
+      ? "Last synced 1 day ago"
+      : `Last synced ${deltaDay} days ago`;
+  }
+
+  return `Last synced ${new Date(syncedMs).toLocaleDateString()}`;
+};
+
 export const getGoogleConnectionConfig = (
   state: GoogleUiState,
   onConnectGoogle: () => void,

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockOpenModal = mock();
@@ -109,6 +110,7 @@ describe("CalendarListHeader", () => {
     mockOpenModal.mockClear();
     mockUseConnectGoogle.mockClear();
     mockConnectGoogle.mockClear();
+    userMetadataActions.clear();
   });
 
   it("shows a default-colored not-saved-yet heading with a sign-up tooltip before any changes are made", async () => {
@@ -181,9 +183,35 @@ describe("CalendarListHeader", () => {
     expect(email).toHaveClass("text-text");
     expect(email).not.toHaveClass("c-sync-text-wave");
     expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByText(/Last synced/)).toBeNull();
 
     await user.hover(email);
     expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("shows last-synced timing when Sync connection metadata includes lastSyncedAt", () => {
+    mockEmail = "ahab@pequod.com";
+    mockGoogleState = "HEALTHY";
+    userMetadataActions.set({
+      google: {
+        connectionState: "HEALTHY",
+        connection: {
+          id: "conn-1",
+          state: "healthy",
+          stateReason: null,
+          lastSyncedAt: new Date().toISOString(),
+          lastHealthyAt: new Date().toISOString(),
+          accountEmail: "compasscaltest3@gmail.com",
+        },
+      },
+    });
+
+    renderHeader();
+
+    expect(screen.getByText("Last synced just now")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Google Calendar/ }),
+    ).toBeNull();
   });
 
   it.each([

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -6,7 +6,10 @@ import {
 } from "@web/auth/compass/state/auth.state.util";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import { getGoogleSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import {
+  formatLastSyncedLabel,
+  getGoogleSyncStatus,
+} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import {
   selectGoogleSyncConnection,
   useUserMetadataStore,
@@ -100,6 +103,7 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
     getGoogleSyncStatus(state, syncConnection)?.variant === "syncing" ||
     hasPendingEventMutations;
   const showGoogleAction = isAvailable && commandAction != null;
+  const lastSyncedLabel = formatLastSyncedLabel(syncConnection?.lastSyncedAt);
 
   return (
     <>
@@ -114,6 +118,9 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
           {email}
         </span>
       </h2>
+      {lastSyncedLabel ? (
+        <p className="mb-2 text-text-muted text-xs">{lastSyncedLabel}</p>
+      ) : null}
       {showGoogleAction ? (
         <button
           className={CONNECT_GOOGLE_BUTTON_CLASSNAME}


### PR DESCRIPTION
## Summary
- Adds `formatLastSyncedLabel` for Sync `lastSyncedAt` (relative ages).
- Calendar list header shows muted “Last synced …” under the account email when metadata includes a Sync connection summary.

Continues S41 after #2377 / #2378. Multi-connection list / disconnect proxy still deferred.

## Test plan
- [x] `bun test:web` on util + CalendarListHeader tests
- [ ] Staging after Release: healthy Sync user sees last-synced under email in sidebar


Made with [Cursor](https://cursor.com)