### PR TITLE
feat(web): resume local event promotion

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
@@ -90,7 +90,7 @@ describe("toCreateSubmitRequest", () => {
     expect(request.input).toMatchObject({
       kind: "create",
       calendarId,
-      clientEventId: null,
+      clientEventId: eventId,
       invitation: "none",
       recurrence: { kind: "single" },
     });
@@ -108,6 +108,10 @@ describe("toCreateSubmitRequest", () => {
 
     expect(request.eventId).toMatch(/^[0-9a-f]{24}$/);
     expect(request.idempotencyKey).toBe(`create:${request.eventId}`);
+    expect(request.input).toMatchObject({
+      kind: "create",
+      clientEventId: null,
+    });
   });
 });
 

--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -17,7 +17,10 @@ import {
   type CommandSubmitRequest,
   CommandSubmitRequestSchema,
 } from "@core/types/sync/command.contracts";
-import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import {
+  ClientEventIdSchema,
+  type SyncEventContent,
+} from "@core/types/sync/event.contracts";
 import { IdempotencyKeySchema } from "@core/types/sync/identity.contracts";
 import { decodeOccurrenceId } from "./occurrence-id";
 import { createHash } from "node:crypto";
@@ -102,6 +105,10 @@ export const toCreateSubmitRequest = (
   input: CreateEventInput,
 ): { request: CommandSubmitRequest; responseEvent: Event } => {
   const eventId = input.id ?? mintEventId();
+  // When the browser supplies an id (optimistic create / IndexedDB promotion),
+  // preserve it as clientEventId so Sync can correlate device origin across
+  // resume. Minted server ids are not client-originated — leave null.
+  const clientEventId = input.id ? ClientEventIdSchema.parse(input.id) : null;
   const request = CommandSubmitRequestSchema.parse({
     idempotencyKey: IdempotencyKeySchema.parse(`create:${eventId}`),
     eventId,
@@ -109,7 +116,7 @@ export const toCreateSubmitRequest = (
     input: {
       kind: "create",
       calendarId: input.calendarId,
-      clientEventId: null,
+      clientEventId,
       invitation: "none",
       content: toSyncContent(input.content),
       schedule: input.schedule,

--- a/packages/web/src/common/utils/sync/local-event-sync.util.test.ts
+++ b/packages/web/src/common/utils/sync/local-event-sync.util.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 const ensureOfflineDataStoreReady = mock();
 const getAllEvents = mock();
 const clearAllEvents = mock();
+const deleteEvent = mock();
 const createEvent = mock();
 const listCalendars = mock();
 
@@ -14,6 +15,7 @@ const syncLocalEventsToCloud = createSyncLocalEventsToCloud({
   ensureOfflineDataStoreReady,
   getOfflineDataStore: () => ({
     clearAllEvents,
+    deleteEvent,
     getAllEvents,
   }),
 });
@@ -25,6 +27,7 @@ describe("syncLocalEventsToCloud", () => {
     ensureOfflineDataStoreReady.mockClear();
     getAllEvents.mockClear();
     clearAllEvents.mockClear();
+    deleteEvent.mockClear();
     createEvent.mockClear();
     listCalendars.mockClear();
     listCalendars.mockResolvedValue([
@@ -65,6 +68,7 @@ describe("syncLocalEventsToCloud", () => {
         calendarId: SERVER_LOCAL_CALENDAR_ID,
       }),
     );
+    expect(deleteEvent).toHaveBeenCalledWith(userRecord.id);
     expect(clearAllEvents).toHaveBeenCalledTimes(1);
   });
 
@@ -74,6 +78,7 @@ describe("syncLocalEventsToCloud", () => {
     await expect(syncLocalEventsToCloud()).resolves.toBe(0);
 
     expect(createEvent).not.toHaveBeenCalled();
+    expect(deleteEvent).not.toHaveBeenCalled();
     expect(listCalendars).not.toHaveBeenCalled();
     expect(clearAllEvents).toHaveBeenCalledTimes(1);
   });
@@ -84,6 +89,7 @@ describe("syncLocalEventsToCloud", () => {
     await expect(syncLocalEventsToCloud()).resolves.toBe(0);
 
     expect(createEvent).not.toHaveBeenCalled();
+    expect(deleteEvent).not.toHaveBeenCalled();
     expect(clearAllEvents).not.toHaveBeenCalled();
   });
 
@@ -97,6 +103,23 @@ describe("syncLocalEventsToCloud", () => {
     // Never POST against a calendar the backend can't resolve (would 404), and
     // never clear the store - the records stay put for a later sync.
     expect(createEvent).not.toHaveBeenCalled();
+    expect(deleteEvent).not.toHaveBeenCalled();
+    expect(clearAllEvents).not.toHaveBeenCalled();
+  });
+
+  it("deletes each promoted event so a mid-batch failure can resume the rest", async () => {
+    const first = createMockLocalEventRecord({}, false);
+    const second = createMockLocalEventRecord({}, false);
+    getAllEvents.mockResolvedValue([first, second]);
+    createEvent
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("network down"));
+
+    await expect(syncLocalEventsToCloud()).rejects.toThrow("network down");
+
+    expect(createEvent).toHaveBeenCalledTimes(2);
+    expect(deleteEvent).toHaveBeenCalledTimes(1);
+    expect(deleteEvent).toHaveBeenCalledWith(first.id);
     expect(clearAllEvents).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/common/utils/sync/local-event-sync.util.ts
+++ b/packages/web/src/common/utils/sync/local-event-sync.util.ts
@@ -11,7 +11,7 @@ import { type LocalEventRecord } from "@web/events/types/local-event.record";
 
 type LocalEventSyncStorage = Pick<
   OfflineDataStore,
-  "clearAllEvents" | "getAllEvents"
+  "clearAllEvents" | "deleteEvent" | "getAllEvents"
 >;
 
 type LocalEventSyncDependencies = {
@@ -75,9 +75,14 @@ export function createSyncLocalEventsToCloud({
 
       for (const record of recordsToSync) {
         await createEvent(toCreateInput(record, serverLocalCalendar.id));
+        // Drop each promoted row immediately so a mid-batch interrupt does not
+        // re-POST already-cloud events on the next resume.
+        await store.deleteEvent(record.id);
       }
     }
 
+    // Demo rows (and any leftover) are never promoted — wipe them once the
+    // user batch finished without throwing.
     await store.clearAllEvents();
 
     return recordsToSync.length;

--- a/packages/web/src/events/types/local-event.record.ts
+++ b/packages/web/src/events/types/local-event.record.ts
@@ -1,8 +1,9 @@
 import { z } from "zod/v4";
 import { EventSchema } from "@core/types/event.contracts";
 
-// There is no syncState field: local sync is push-all-then-clear on
-// connect, so a per-record state machine models a queue that does not exist.
+// There is no syncState field: promotion deletes each row after a successful
+// create, then clears leftovers (demos). A richer per-record state machine
+// is not required for resume safety.
 export const LocalEventRecordSchema = z
   .strictObject({
     version: z.literal(2),


### PR DESCRIPTION
## Summary
- **Web:** After each successful `EventApi.create` during IndexedDB → cloud promotion, delete that local row immediately. `clearAllEvents` still runs only after the full user batch succeeds (demo cleanup). Mid-batch failures no longer re-POST already-promoted events.
- **Backend:** `toCreateSubmitRequest` sets `clientEventId` from the client-supplied `id` (null when the server mints an id).

S42 first slice — no pending-command list API/UI yet.

## Test plan
- [x] `bun test:web packages/web/src/common/utils/sync/local-event-sync.util.test.ts`
- [x] `bun test:backend packages/backend/src/common/services/sync-service/event-command.translation.test.ts`
- [ ] Optional: create local events anonymous → sign up; kill mid-promotion; confirm remaining locals still promote without duplicates


Made with [Cursor](https://cursor.com)