### PR TITLE
fix(sync): invalidate browser after provider pull

### DIFF
--- a/packages/backend/src/events/controllers/events.controller.ts
+++ b/packages/backend/src/events/controllers/events.controller.ts
@@ -3,6 +3,7 @@ import { Logger } from "@core/logger/winston.logger";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
 import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
+import * as legacyWatchOwnership from "@backend/sync/services/watch/legacy-watch-ownership";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 
@@ -34,11 +35,17 @@ class EventsController {
       // frequent moment to notice/repair stale Google watches. Cooldown +
       // lease inside the coordinator keep this safe across multiple tabs
       // and repeated reconnects; must never block or fail the stream.
-      void googleWatchRepairService
-        .repairGoogleWatchesForUser(userId)
-        .catch((err) => {
-          logger.error(`Google watch repair failed for user ${userId}:`, err);
-        });
+      // When Sync owns connections/events, Sync maintains its own push
+      // channels — legacy repair would re-register watches at
+      // /api/sync/gcal/notifications and split the write path (legacy
+      // Mongo + SSE) from Sync reads.
+      if (legacyWatchOwnership.isLegacyGoogleWatchOwner()) {
+        void googleWatchRepairService
+          .repairGoogleWatchesForUser(userId)
+          .catch((err) => {
+            logger.error(`Google watch repair failed for user ${userId}:`, err);
+          });
+      }
 
       // Same fire-and-forget shape: lets scheduled watch maintenance (A40)
       // tell an active user apart from an abandoned account without

--- a/packages/backend/src/servers/sse/sync-invalidation.to-server-message.test.ts
+++ b/packages/backend/src/servers/sse/sync-invalidation.to-server-message.test.ts
@@ -23,7 +23,7 @@ describe("syncInvalidationToServerMessages", () => {
     ]);
   });
 
-  it("maps a calendar invalidation to calendarsChanged", () => {
+  it("maps a calendar invalidation to calendarsChanged and eventsChanged", () => {
     const calendarId = objectId();
     expect(
       syncInvalidationToServerMessages({
@@ -31,7 +31,15 @@ describe("syncInvalidationToServerMessages", () => {
         connectionId: objectId() as never,
         calendarId: calendarId as never,
       }),
-    ).toEqual([{ type: "calendarsChanged", calendarIds: [calendarId] }]);
+    ).toEqual([
+      { type: "calendarsChanged", calendarIds: [calendarId] },
+      {
+        type: "eventsChanged",
+        calendarId,
+        eventIds: [],
+        reason: "reconciled",
+      },
+    ]);
   });
 
   it("maps a connection invalidation to a calendarsChanged refetch signal", () => {

--- a/packages/backend/src/servers/sse/sync-invalidation.to-server-message.ts
+++ b/packages/backend/src/servers/sse/sync-invalidation.to-server-message.ts
@@ -17,13 +17,24 @@ export function syncInvalidationToServerMessages(
           reason: "reconciled",
         },
       ];
-    case "calendar":
+    case "calendar": {
+      // Provider pull/repair changed this calendar's events. Emit both so the
+      // SPA refetches the calendar list and the event queries (useEventSSE only
+      // invalidates events on eventsChanged).
+      const calendarId = CalendarIdSchema.parse(invalidation.calendarId);
       return [
         {
           type: "calendarsChanged",
-          calendarIds: [CalendarIdSchema.parse(invalidation.calendarId)],
+          calendarIds: [calendarId],
+        },
+        {
+          type: "eventsChanged",
+          calendarId,
+          eventIds: [],
+          reason: "reconciled",
         },
       ];
+    }
     case "connection":
       // Connection state / calendar membership may have changed; the web
       // invalidates the whole calendar list on this signal.

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -19,6 +19,7 @@ import { publicWatchNotificationIngress } from "@backend/sync/services/public-wa
 import { getSync } from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import { googleWatchMaintenanceService } from "@backend/sync/services/watch/google-watch-maintenance.service";
+import * as legacyWatchOwnership from "@backend/sync/services/watch/legacy-watch-ownership";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 import { ImportGCalRequestSchema } from "../sync.types";
 
@@ -189,6 +190,15 @@ export class SyncController {
     res: Response,
     next: NextFunction,
   ) => {
+    // When Sync owns watches/events, Google push must land on Sync's
+    // `/sync/notifications/google` path. Ack-and-ignore leftover legacy
+    // watches so we do not write legacy Mongo or publish SSE that makes the
+    // SPA refetch Sync before Sync has pulled.
+    if (!legacyWatchOwnership.isLegacyGoogleWatchOwner()) {
+      res.status(Status.OK).send("ignored");
+      return;
+    }
+
     const channelId = req.headers["x-goog-channel-id"] as string;
     const resourceId = req.headers["x-goog-resource-id"] as string;
 

--- a/packages/backend/src/sync/services/watch/legacy-watch-ownership.test.ts
+++ b/packages/backend/src/sync/services/watch/legacy-watch-ownership.test.ts
@@ -1,0 +1,31 @@
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { isLegacyGoogleWatchOwner } from "./legacy-watch-ownership";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("isLegacyGoogleWatchOwner", () => {
+  const originalConnectionRouting = CONFIG.SYNC_CONNECTION_ROUTING;
+  const originalEventRouting = CONFIG.SYNC_EVENT_ROUTING;
+
+  afterEach(() => {
+    CONFIG.SYNC_CONNECTION_ROUTING = originalConnectionRouting;
+    CONFIG.SYNC_EVENT_ROUTING = originalEventRouting;
+  });
+
+  it("is true only when both connection and event routing are legacy", () => {
+    CONFIG.SYNC_CONNECTION_ROUTING = "legacy";
+    CONFIG.SYNC_EVENT_ROUTING = "legacy";
+    expect(isLegacyGoogleWatchOwner()).toBe(true);
+
+    CONFIG.SYNC_CONNECTION_ROUTING = "sync";
+    CONFIG.SYNC_EVENT_ROUTING = "legacy";
+    expect(isLegacyGoogleWatchOwner()).toBe(false);
+
+    CONFIG.SYNC_CONNECTION_ROUTING = "legacy";
+    CONFIG.SYNC_EVENT_ROUTING = "sync";
+    expect(isLegacyGoogleWatchOwner()).toBe(false);
+
+    CONFIG.SYNC_CONNECTION_ROUTING = "sync";
+    CONFIG.SYNC_EVENT_ROUTING = "sync";
+    expect(isLegacyGoogleWatchOwner()).toBe(false);
+  });
+});

--- a/packages/backend/src/sync/services/watch/legacy-watch-ownership.ts
+++ b/packages/backend/src/sync/services/watch/legacy-watch-ownership.ts
@@ -1,0 +1,13 @@
+import { CONFIG } from "@backend/common/constants/config.constants";
+
+/**
+ * Whether the legacy backend should create/repair Google push channels and
+ * process `/api/sync/gcal/notifications`. When Sync owns connection or event
+ * routing, Sync's `/sync/notifications/google` path is authoritative.
+ */
+export function isLegacyGoogleWatchOwner(): boolean {
+  return (
+    CONFIG.SYNC_CONNECTION_ROUTING === "legacy" &&
+    CONFIG.SYNC_EVENT_ROUTING === "legacy"
+  );
+}

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -24,6 +24,7 @@ import { CommandRepository } from "@sync/storage/repositories/command.repository
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
@@ -264,6 +265,7 @@ function buildSchedulers(
       // Where the provider posts change notifications back; the callback route
       // verifies them against the stored subscription.
       callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
+      invalidations: new InvalidationRepository(db),
     },
     owner,
     {

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -243,6 +243,31 @@ describe("dispatchSyncJob", () => {
       updatedAt: now(),
     }) as JobRecord;
 
+  it("invalidates after an empty incremental pull retry once the cursor already advanced", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-1");
+    const reader = new FakeReader([page([], "cursor-1")]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    expect(outcome).toEqual({ result: "done" });
+
+    const feed = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .find({ principalId: calendar.principalId })
+      .toArray();
+    expect(feed).toHaveLength(1);
+    expect(feed[0]?.invalidation).toEqual({
+      kind: "calendar",
+      connectionId: calendar.connectionId,
+      calendarId: calendar._id,
+    });
+  });
+
   it("settles an applied incremental pull as done with no followup", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -22,6 +22,7 @@ import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.c
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -138,6 +139,7 @@ describe("dispatchSyncJob", () => {
   let calendars: ProviderCalendarRepository;
   let commands: CommandRepository;
   let jobs: JobRepository;
+  let invalidations: InvalidationRepository;
   // Dispatch resolves the connection for a calendarListSync job; a test sets what
   // findById returns without seeding a full connection record.
   let stubbedConnection: ProviderConnectionRecord | null;
@@ -149,6 +151,7 @@ describe("dispatchSyncJob", () => {
     calendars = new ProviderCalendarRepository(storage.db());
     commands = new CommandRepository(storage.db());
     jobs = new JobRepository(storage.db());
+    invalidations = new InvalidationRepository(storage.db());
     stubbedConnection = null;
   });
 
@@ -169,6 +172,7 @@ describe("dispatchSyncJob", () => {
     custody: tokenSource,
     notifications,
     callbackUrl: "https://sync.example/sync/notifications/google",
+    invalidations,
   });
 
   const seedCalendar = (): Promise<ProviderCalendarRecord> =>
@@ -250,6 +254,18 @@ describe("dispatchSyncJob", () => {
       now,
     );
     expect(outcome).toEqual({ result: "done" });
+
+    const feed = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.invalidations)
+      .find({ principalId: calendar.principalId })
+      .toArray();
+    expect(feed).toHaveLength(1);
+    expect(feed[0]?.invalidation).toEqual({
+      kind: "calendar",
+      connectionId: calendar.connectionId,
+      calendarId: calendar._id,
+    });
   });
 
   it("hands off an expired-cursor pull to a repair followup", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -17,6 +17,7 @@ import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.c
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
@@ -40,6 +41,10 @@ export interface SyncJobDispatchDeps {
   // url is where the provider posts change notifications back to this service.
   notifications: ProviderNotificationAdapter;
   callbackUrl: string;
+  // Content-free outbox so Compass API can push typed browser SSE after a
+  // provider pull. Without this, incremental pulls update Sync storage but the
+  // open SPA never refetches (S40 gap).
+  invalidations: InvalidationRepository;
 }
 
 // The decision a dispatch makes about a claimed job. The worker loop (a later
@@ -131,6 +136,9 @@ export async function dispatchSyncJob(
     case "incrementalPull": {
       const pull = await pullCalendarChanges(deps, calendar, now);
       if (pull.status === "applied") {
+        if (pull.changed > 0 || pull.deleted > 0) {
+          await appendCalendarInvalidation(deps, calendar, now());
+        }
         return { result: "done" };
       }
       if (pull.status === "notImported") {
@@ -144,13 +152,15 @@ export async function dispatchSyncJob(
       const repair = await repairCalendar(deps, calendar, now);
       // An incomplete repair (the pass yielded no durable cursor) left the old
       // generation intact; retry the whole rebuild later rather than settle.
-      return repair.status === "repaired"
-        ? { result: "done" }
-        : {
-            result: "retry",
-            failureClass: "retryableTransient",
-            reason: "repair did not complete",
-          };
+      if (repair.status === "repaired") {
+        await appendCalendarInvalidation(deps, calendar, now());
+        return { result: "done" };
+      }
+      return {
+        result: "retry",
+        failureClass: "retryableTransient",
+        reason: "repair did not complete",
+      };
     }
     case "subscriptionMaintain": {
       // Open or renew the push channel. Every terminal outcome (watched /
@@ -194,6 +204,23 @@ function importFollowup(
     runAfter: now(),
     coalescingKey: `initialImport:${resource._id}`,
   };
+}
+
+async function appendCalendarInvalidation(
+  deps: Pick<SyncJobDispatchDeps, "invalidations">,
+  calendar: ProviderCalendarRecord,
+  emittedAt: Date,
+): Promise<void> {
+  await deps.invalidations.append({
+    tenantId: calendar.tenantId,
+    principalId: calendar.principalId,
+    invalidation: {
+      kind: "calendar",
+      connectionId: calendar.connectionId,
+      calendarId: calendar._id,
+    },
+    emittedAt,
+  });
 }
 
 function subscriptionFollowup(

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -136,9 +136,7 @@ export async function dispatchSyncJob(
     case "incrementalPull": {
       const pull = await pullCalendarChanges(deps, calendar, now);
       if (pull.status === "applied") {
-        if (pull.changed > 0 || pull.deleted > 0) {
-          await appendCalendarInvalidation(deps, calendar, now());
-        }
+        await appendCalendarInvalidation(deps, calendar, now());
         return { result: "done" };
       }
       if (pull.status === "notImported") {

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -21,8 +21,10 @@ import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.c
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 const objectId = () => faker.database.mongodbObjectId();
@@ -92,6 +94,8 @@ describe("SyncJobWorker", () => {
   let calendars: ProviderCalendarRepository;
   let commands: CommandRepository;
   let jobs: JobRepository;
+  let connections: ProviderConnectionRepository;
+  let invalidations: InvalidationRepository;
 
   beforeEach(() => {
     events = new EventRepository(storage.db());
@@ -100,6 +104,8 @@ describe("SyncJobWorker", () => {
     calendars = new ProviderCalendarRepository(storage.db());
     commands = new CommandRepository(storage.db());
     jobs = new JobRepository(storage.db());
+    connections = new ProviderConnectionRepository(storage.db());
+    invalidations = new InvalidationRepository(storage.db());
   });
 
   const deps = (reader: FakeReader): SyncJobWorkerDeps => ({
@@ -107,10 +113,25 @@ describe("SyncJobWorker", () => {
     occurrences,
     resources,
     calendars,
+    connections,
+    discovery: {
+      provider: "google",
+      discoverCalendars: async () => ({ calendars: [], cursor: null }),
+    },
     commands,
     jobs,
     reader,
     custody: tokenSource,
+    notifications: {
+      provider: "google",
+      watchEvents: async () => {
+        throw new Error("watch not used in worker tests");
+      },
+      stopChannel: async () => {},
+      parseCallback: () => null,
+    },
+    callbackUrl: "https://sync.example/sync/notifications/google",
+    invalidations,
   });
 
   const worker = (reader: FakeReader) =>


### PR DESCRIPTION
## Summary
Staging bug: Google Calendar edits hit **legacy** `/api/sync/gcal/notifications`, which wrote legacy Mongo + published SSE. The SPA refetched `/api/event` (routed to **Sync**), which was still stale — and Sync pulls never emitted change-feed invalidations, so the UI stayed frozen until a full refresh.

### Fixes
1. **Sync:** after an applied incremental pull (or repair) with changes, append a content-free `calendar` invalidation.
2. **Backend SSE bridge:** map `calendar` invalidations to both `calendarsChanged` and `eventsChanged` so `useEventSSE` refetches events.
3. **Legacy ownership:** when `connectionRouting` or `eventRouting` is `sync`, skip legacy watch repair on SSE connect and ack-and-ignore legacy Google notification ingress.

## Test plan
- [x] `bun test:sync` dispatch/worker tests
- [x] `bun test:backend` invalidation mapping + ownership + events controller
- [ ] Staging after Release: edit an event in Google Calendar with SPA open; week view updates without refresh; “Last synced” advances
- [ ] If Sync had no push channels yet, reconnect Google once so Sync registers `/sync/notifications/google` watches


Made with [Cursor](https://cursor.com)