### PR TITLE
feat(sync): centralize redaction and add safety canaries

### DIFF
--- a/packages/sync/src/providers/google/google-auth.adapter.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.ts
@@ -11,6 +11,7 @@ import {
   type ProviderAuthorization,
   type RefreshedCredential,
 } from "@sync/providers/provider-auth.port";
+import { redactedCause } from "@sync/safety/redact-error";
 
 // The subset of google-auth-library's OAuth2Client the adapter uses. Depending
 // on an interface (not the concrete client) lets tests supply a plain fake
@@ -197,16 +198,6 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
     }
     return payload;
   }
-}
-
-// Reduce a provider-SDK error to a bare message before attaching it as a
-// cause. The google-auth-library/gaxios error retains the full token-exchange
-// request config, which includes the app's `client_secret` and the auth code;
-// propagating the raw object would leak that secret the moment any caller logs
-// the cause chain. The message is built from the response, not the request, so
-// it is safe to keep for diagnostics.
-function redactedCause(error: unknown): Error | undefined {
-  return error instanceof Error ? new Error(error.message) : undefined;
 }
 
 // A Google token-endpoint rejection carries the reason in the response body's

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -14,6 +14,7 @@ import {
   type ProviderCalendarAdapter,
   ProviderCalendarError,
 } from "@sync/providers/provider-calendar.port";
+import { redactedCause } from "@sync/safety/redact-error";
 
 // One page of a Google calendar-list read, narrowed to the fields discovery
 // needs. Google returns `nextSyncToken` only on the final page; intermediate
@@ -197,13 +198,4 @@ function isCursorExpired(error: unknown): boolean {
     (error as { response?: { status?: number } })?.response?.status ??
     (error as { code?: number })?.code;
   return status === 410;
-}
-
-// Reduce a provider-SDK error to a bare message before attaching it as a cause.
-// A googleapis/gaxios error retains the full request config, whose headers carry
-// the bearer access token; propagating the raw object would leak that token the
-// moment any caller logs the cause chain. The message is response-derived, so it
-// is safe to keep for diagnostics. (Mirrors the auth adapter's redaction.)
-function redactedCause(error: unknown): Error | undefined {
-  return error instanceof Error ? new Error(error.message) : undefined;
 }

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -10,6 +10,7 @@ import {
   type ProviderEventReader,
   type ProviderEventReadInput,
 } from "@sync/providers/provider-event-reader.port";
+import { redactedCause } from "@sync/safety/redact-error";
 
 // One page of a Google events.list read, narrowed to the fields import needs.
 // Google returns `nextSyncToken` only on the final page of a pass entitled to
@@ -160,13 +161,4 @@ function httpStatus(error: unknown): number | undefined {
     (error as { response?: { status?: number } })?.response?.status ??
     (error as { code?: number })?.code;
   return typeof status === "number" ? status : undefined;
-}
-
-// Reduce a provider-SDK error to a bare message before attaching it as a cause.
-// A googleapis/gaxios error retains the full request config, whose headers carry
-// the bearer access token; propagating the raw object would leak that token the
-// moment any caller logs the cause chain. The message is response-derived, so it
-// is safe to keep for diagnostics. (Mirrors the other Google adapters.)
-function redactedCause(error: unknown): Error | undefined {
-  return error instanceof Error ? new Error(error.message) : undefined;
 }

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -16,6 +16,7 @@ import {
   type ProviderWriteRecurrence,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
+import { redactedCause } from "@sync/safety/redact-error";
 
 // The Google event calls the writer makes. Depending on this narrow interface
 // (not the concrete googleapis client) lets tests script results and errors
@@ -323,14 +324,6 @@ function hasRetryable403Reason(error: unknown): boolean {
   return Boolean(
     errors?.some((e) => e.reason && RETRYABLE_403_REASONS.has(e.reason)),
   );
-}
-
-// Reduce a provider-SDK error to a bare message before attaching it as a cause.
-// A googleapis/gaxios error retains the request config, whose headers carry the
-// bearer access token; propagating the raw object would leak it the moment any
-// caller logged the cause chain. The message is response-derived, so it is safe.
-function redactedCause(error: unknown): Error | undefined {
-  return error instanceof Error ? new Error(error.message) : undefined;
 }
 
 // Google event ids must be base32hex (0-9, a-v), 5-1024 chars. A Compass

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -8,6 +8,7 @@ import {
   type ProviderNotificationAdapter,
   ProviderNotificationError,
 } from "@sync/providers/provider-notifications.port";
+import { redactedCause } from "@sync/safety/redact-error";
 
 // The two Google channel calls the adapter makes. Depending on this narrow
 // interface (not the concrete googleapis client) lets tests script results and
@@ -206,12 +207,4 @@ function googleStatus(error: unknown): number | undefined {
     (error as { response?: { status?: number } })?.response?.status ??
     (error as { code?: number })?.code
   );
-}
-
-// Reduce a provider-SDK error to a bare message before attaching it as a cause.
-// A googleapis/gaxios error retains the request config, whose headers carry the
-// bearer access token; propagating the raw object would leak it the moment any
-// caller logged the cause chain.
-function redactedCause(error: unknown): Error | undefined {
-  return error instanceof Error ? new Error(error.message) : undefined;
 }

--- a/packages/sync/src/safety/redact-error.test.ts
+++ b/packages/sync/src/safety/redact-error.test.ts
@@ -1,0 +1,66 @@
+import { redactedCause } from "./redact-error";
+import { assertNoSafetyCanary, findSafetyCanaryHit } from "./safety-canary";
+import { describe, expect, it } from "bun:test";
+
+describe("redactedCause", () => {
+  it("returns undefined for non-Error values", () => {
+    expect(redactedCause("boom")).toBeUndefined();
+    expect(redactedCause(null)).toBeUndefined();
+    expect(redactedCause({ message: "x" })).toBeUndefined();
+  });
+
+  it("keeps the message but drops request config that holds secrets", () => {
+    const leaky = Object.assign(new Error("invalid_grant"), {
+      config: {
+        data: "client_secret=SUPER_SECRET&refresh_token=rt-xyz",
+        headers: { Authorization: "Bearer ya29.super-secret-token" },
+      },
+      response: { data: { error: "invalid_grant" } },
+    });
+
+    const cause = redactedCause(leaky);
+    expect(cause).toBeInstanceOf(Error);
+    expect(cause?.message).toBe("invalid_grant");
+    expect(cause).not.toBe(leaky);
+    expect((cause as Error & { config?: unknown }).config).toBeUndefined();
+    assertNoSafetyCanary({
+      message: cause?.message,
+      cause,
+      leakyKeys: Object.keys(cause ?? {}),
+    });
+  });
+});
+
+describe("safety canaries", () => {
+  it("detects bearer and oauth secret shapes", () => {
+    expect(
+      findSafetyCanaryHit({ headers: { Authorization: "Bearer abc.def" } }),
+    ).toMatch(/^secret:/);
+    expect(findSafetyCanaryHit("client_secret=SUPER_SECRET&code=auth")).toMatch(
+      /^secret:/,
+    );
+    expect(findSafetyCanaryHit({ refresh_token: "1//rt" })).toMatch(/^secret:/);
+  });
+
+  it("detects event-content shapes that must stay out of feeds/logs", () => {
+    expect(
+      findSafetyCanaryHit({ title: "Team standup", description: "" }),
+    ).toMatch(/^eventContent:/);
+    expect(
+      findSafetyCanaryHit({ attendees: [{ email: "a@example.com" }] }),
+    ).toMatch(/^eventContent:/);
+  });
+
+  it("allows id-only invalidation envelopes", () => {
+    assertNoSafetyCanary({
+      kind: "calendar",
+      connectionId: "6a63dc614f8ab7ae0cc9656a",
+      calendarId: "6a63e568847fa073e9cf6273",
+    });
+    assertNoSafetyCanary({
+      kind: "event",
+      eventId: "6a63e568847fa073e9cf6279",
+      calendarId: "6a63e568847fa073e9cf6273",
+    });
+  });
+});

--- a/packages/sync/src/safety/redact-error.ts
+++ b/packages/sync/src/safety/redact-error.ts
@@ -1,0 +1,11 @@
+/**
+ * Reduce a provider-SDK / gaxios error to a bare message before attaching it
+ * as a cause. googleapis and google-auth-library retain the full request
+ * config on the error object (Authorization bearer, client_secret, auth code,
+ * refresh_token). Propagating the raw object would leak secrets the moment any
+ * caller logs the cause chain. The message is response-derived and safe for
+ * diagnostics.
+ */
+export function redactedCause(error: unknown): Error | undefined {
+  return error instanceof Error ? new Error(error.message) : undefined;
+}

--- a/packages/sync/src/safety/safety-canary.ts
+++ b/packages/sync/src/safety/safety-canary.ts
@@ -1,0 +1,64 @@
+/**
+ * Patterns that must never appear in Sync operational logs, SSE payloads, or
+ * error cause chains (R-SEC / S43). Used by tests as canaries; not a runtime
+ * filter for production traffic.
+ */
+const SECRET_PATTERNS: readonly RegExp[] = [
+  /Bearer\s+[A-Za-z0-9._~+/=-]+/i,
+  /client_secret\s*=\s*\S+/i,
+  /refresh_token\s*=\s*\S+/i,
+  /"access_token"\s*:\s*"[^"]+"/i,
+  /"refresh_token"\s*:\s*"[^"]+"/i,
+];
+
+const EVENT_CONTENT_PATTERNS: readonly RegExp[] = [
+  /"title"\s*:\s*"[^"]+"/i,
+  /"description"\s*:\s*"[^"]+"/i,
+  /"attendees"\s*:\s*\[/i,
+  /"conferenceData"\s*:/i,
+  /"hangoutLink"\s*:/i,
+];
+
+export type SafetyCanaryKind = "secret" | "eventContent";
+
+function serializeForCanary(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Return the first matching canary pattern label, or null if clean. */
+export function findSafetyCanaryHit(
+  value: unknown,
+  kinds: readonly SafetyCanaryKind[] = ["secret", "eventContent"],
+): string | null {
+  const text = serializeForCanary(value);
+  if (kinds.includes("secret")) {
+    for (const pattern of SECRET_PATTERNS) {
+      if (pattern.test(text)) {
+        return `secret:${pattern.source}`;
+      }
+    }
+  }
+  if (kinds.includes("eventContent")) {
+    for (const pattern of EVENT_CONTENT_PATTERNS) {
+      if (pattern.test(text)) {
+        return `eventContent:${pattern.source}`;
+      }
+    }
+  }
+  return null;
+}
+
+/** Assert a value is free of credential / event-content shaped strings. */
+export function assertNoSafetyCanary(
+  value: unknown,
+  kinds?: readonly SafetyCanaryKind[],
+): void {
+  const hit = findSafetyCanaryHit(value, kinds);
+  if (hit) {
+    throw new Error(`Safety canary hit: ${hit}`);
+  }
+}


### PR DESCRIPTION
## Summary
S43 first slice: stop copying `redactedCause` in five Google adapters; move it to `@sync/safety/redact-error` and add token/event-content canaries for Sync safety tests.

Later S43 work (not in this PR): principal purge / account deletion into Sync, cross-tenant isolation matrix, post-disconnect 30-day content sweeper.

## Test plan
- [x] `bun test:sync` on safety + Google adapter tests
- [ ] Follow-up: account-deletion purge into `compass_sync`


Made with [Cursor](https://cursor.com)