### PR TITLE
feat(sync): purge principal data on account deletion

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -17,6 +17,7 @@ import {
   EVENTS_FULL_PATH,
   EVENTS_PATH,
 } from "@sync/server/connection.routes";
+import { PRINCIPAL_PATH } from "@sync/server/principal.routes";
 import {
   SyncServiceClient,
   type SyncServiceClientOptions,
@@ -136,6 +137,45 @@ describe("SyncServiceClient", () => {
     const sent = calls[0];
     expect(sent?.url).toBe(`${BASE_URL}${CONNECTIONS_PATH}`);
     expect(sent?.method).toBe("GET");
+    expect(sent?.body).toBeUndefined();
+
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.tenantId).toBe(who.tenantId);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("purges a principal with a signed DELETE the real Sync verifier accepts", async () => {
+    const who = principal();
+    const counts = {
+      connections: 1,
+      credentials: 1,
+      calendars: 0,
+      events: 0,
+      eventOccurrences: 0,
+      syncResources: 0,
+      commands: 0,
+      jobs: 0,
+      deletionMarkers: 0,
+      invalidations: 0,
+    };
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => counts,
+    }));
+
+    const result = await client(fn).purgePrincipal(who);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value).toEqual(counts);
+
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${PRINCIPAL_PATH}`);
+    expect(sent?.method).toBe("DELETE");
     expect(sent?.body).toBeUndefined();
 
     const verdict = verifyInternalRequest({

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -31,6 +31,10 @@ import {
   type EventOccurrenceListResponse,
   EventOccurrenceListResponseSchema,
 } from "@core/types/sync/event.contracts";
+import {
+  type PrincipalPurgeResponse,
+  PrincipalPurgeResponseSchema,
+} from "@core/types/sync/principal.contracts";
 import { createHmac, randomUUID } from "node:crypto";
 
 // The internal endpoints this client calls. Kept in sync with the Sync service's
@@ -43,6 +47,7 @@ const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const EVENTS_PATH = "/internal/events";
 const EVENTS_FULL_PATH = "/internal/events/full";
 const COMMANDS_PATH = "/internal/commands";
+const PRINCIPAL_PATH = "/internal/principal";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -307,8 +312,23 @@ export class SyncServiceClient {
     });
   }
 
+  // Hard-delete every Sync-held row for the signed principal (account deletion).
+  // Served in Sync passive mode too. Idempotent: a retry returns zero counts.
+  purgePrincipal(
+    principal: SyncPrincipal,
+    correlationId?: string,
+  ): Promise<SyncClientResult<PrincipalPurgeResponse>> {
+    return this.#request({
+      method: "DELETE",
+      path: PRINCIPAL_PATH,
+      principal,
+      schema: PrincipalPurgeResponseSchema,
+      correlationId,
+    });
+  }
+
   async #request<T>(input: {
-    method: "GET" | "POST";
+    method: "GET" | "POST" | "DELETE";
     path: string;
     query?: URLSearchParams;
     principal: SyncPrincipal;

--- a/packages/backend/src/user/services/user.service.db.test.ts
+++ b/packages/backend/src/user/services/user.service.db.test.ts
@@ -18,6 +18,7 @@ import { UserError } from "@backend/common/errors/user/user.errors";
 import * as supertokensMiddleware from "@backend/common/middleware/supertokens.middleware";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import mongoService from "@backend/common/services/mongo.service";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
 import userService from "@backend/user/services/user.service";
@@ -31,6 +32,7 @@ import {
   describe,
   expect,
   it,
+  mock,
   spyOn,
 } from "bun:test";
 
@@ -348,6 +350,59 @@ describe("UserService", () => {
         false,
       );
       const user = await UserDriver.createUser();
+
+      await userService.deleteAccount(user._id.toString());
+
+      expect(await mongoService.user.findOne({ _id: user._id })).toBeNull();
+    });
+
+    it("fail-open purges the Sync principal after Compass data is deleted", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+      const purgePrincipal = mock(() =>
+        Promise.resolve({
+          ok: true as const,
+          value: {
+            connections: 0,
+            credentials: 0,
+            calendars: 0,
+            events: 0,
+            eventOccurrences: 0,
+            syncResources: 0,
+            commands: 0,
+            jobs: 0,
+            deletionMarkers: 0,
+            invalidations: 0,
+          },
+          correlationId: "corr-purge",
+        }),
+      );
+      spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+        purgePrincipal,
+      } as never);
+
+      await userService.deleteAccount(userId);
+
+      expect(await mongoService.user.findOne({ _id: user._id })).toBeNull();
+      expect(purgePrincipal).toHaveBeenCalledWith({
+        tenantId: userId,
+        principalId: userId,
+      });
+    });
+
+    it("still deletes the account when Sync principal purge fails", async () => {
+      const user = await UserDriver.createUser();
+      spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+        purgePrincipal: mock(() =>
+          Promise.resolve({
+            ok: false as const,
+            error: {
+              kind: "unavailable" as const,
+              correlationId: "corr-down",
+            },
+          }),
+        ),
+      } as never);
 
       await userService.deleteAccount(user._id.toString());
 

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -18,6 +18,8 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 import { UserError } from "@backend/common/errors/user/user.errors";
 import { normalizeEmail } from "@backend/common/helpers/email.util";
 import mongoService from "@backend/common/services/mongo.service";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import eventService from "@backend/event/services/event.service";
 import syncRecords from "@backend/sync/services/records/sync-records.repository";
 import { googleWatchService } from "@backend/sync/services/watch/google-watch.service";
@@ -252,6 +254,8 @@ class UserService {
    * Order matters: the refresh token has to be read before the delete
    * transaction removes the user doc, and the grant can only be revoked after
    * the delete stops their watches (stopping a watch needs a working grant).
+   * Sync principal purge is fail-open: a Sync outage must not strand an
+   * undeleted Compass account.
    */
   deleteAccount = async (userId: string): Promise<Summary_Delete> => {
     const user = await mongoService.user.findOne({
@@ -268,7 +272,21 @@ class UserService {
       await revokeGoogleGrant(gRefreshToken);
     }
 
+    await this.#purgeSyncPrincipal(userId);
+
     return summary;
+  };
+
+  #purgeSyncPrincipal = async (userId: string): Promise<void> => {
+    const client = getSyncServiceClient();
+    if (!client) return;
+
+    const result = await client.purgePrincipal(toSyncPrincipal(userId));
+    if (!result.ok) {
+      logger.warn(
+        `Sync principal purge failed (${result.error.kind}, correlation=${result.error.correlationId}); continuing anyway`,
+      );
+    }
   };
 
   initUserData = async (

--- a/packages/core/src/types/sync/principal.contracts.test.ts
+++ b/packages/core/src/types/sync/principal.contracts.test.ts
@@ -1,0 +1,56 @@
+import {
+  type PrincipalPurgeResponse,
+  PrincipalPurgeResponseSchema,
+} from "@core/types/sync/principal.contracts";
+import { describe, expect, it } from "bun:test";
+
+const okCounts = (): PrincipalPurgeResponse => ({
+  connections: 1,
+  credentials: 1,
+  calendars: 2,
+  events: 3,
+  eventOccurrences: 4,
+  syncResources: 2,
+  commands: 0,
+  jobs: 1,
+  deletionMarkers: 0,
+  invalidations: 5,
+});
+
+describe("PrincipalPurgeResponseSchema", () => {
+  it("accepts a full non-negative count bag", () => {
+    expect(PrincipalPurgeResponseSchema.safeParse(okCounts()).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts an all-zero idempotent retry", () => {
+    const empty = Object.fromEntries(
+      Object.keys(okCounts()).map((key) => [key, 0]),
+    );
+    expect(PrincipalPurgeResponseSchema.safeParse(empty).success).toBe(true);
+  });
+
+  it("rejects a negative count", () => {
+    expect(
+      PrincipalPurgeResponseSchema.safeParse({
+        ...okCounts(),
+        events: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown field", () => {
+    expect(
+      PrincipalPurgeResponseSchema.safeParse({
+        ...okCounts(),
+        extra: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a missing field", () => {
+    const { connections: _, ...rest } = okCounts();
+    expect(PrincipalPurgeResponseSchema.safeParse(rest).success).toBe(false);
+  });
+});

--- a/packages/core/src/types/sync/principal.contracts.ts
+++ b/packages/core/src/types/sync/principal.contracts.ts
@@ -1,0 +1,20 @@
+import { z } from "zod/v4";
+
+// Response for DELETE /internal/principal — hard-delete every Sync-held row for
+// the signed principal (account deletion). Counts are non-negative and the
+// operation is idempotent: a second call returns zeros.
+export const PrincipalPurgeResponseSchema = z.strictObject({
+  connections: z.number().int().nonnegative(),
+  credentials: z.number().int().nonnegative(),
+  calendars: z.number().int().nonnegative(),
+  events: z.number().int().nonnegative(),
+  eventOccurrences: z.number().int().nonnegative(),
+  syncResources: z.number().int().nonnegative(),
+  commands: z.number().int().nonnegative(),
+  jobs: z.number().int().nonnegative(),
+  deletionMarkers: z.number().int().nonnegative(),
+  invalidations: z.number().int().nonnegative(),
+});
+export type PrincipalPurgeResponse = z.infer<
+  typeof PrincipalPurgeResponseSchema
+>;

--- a/packages/sync/src/domain/principal-purge.service.ts
+++ b/packages/sync/src/domain/principal-purge.service.ts
@@ -1,0 +1,96 @@
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { type PrincipalPurgeResponse } from "@core/types/sync/principal.contracts";
+import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { type DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface PrincipalPurgeDeps {
+  connections: ProviderConnectionRepository;
+  credentials: CredentialRepository;
+  calendars: ProviderCalendarRepository;
+  events: EventRepository;
+  eventOccurrences: EventOccurrenceRepository;
+  syncResources: SyncResourceRepository;
+  commands: CommandRepository;
+  jobs: JobRepository;
+  deletionMarkers: DeletionMarkerRepository;
+  invalidations: InvalidationRepository;
+  // When present, best-effort revoke at the provider before deleting each
+  // credential. Absent (passive / unconfigured) still deletes credentials
+  // locally — account deletion must not leave Sync-held tokens behind.
+  custody?: CredentialCustody;
+}
+
+// Remove every Sync-held row for one principal. Overrides ordinary disconnect
+// retention: connections are hard-deleted, not soft-disconnected. Idempotent —
+// a second call reports zeros. Credentials are keyed only by connectionId, so
+// they are revoked/deleted from the connection list before connections go.
+export async function purgePrincipal(
+  deps: PrincipalPurgeDeps,
+  tenantId: TenantId,
+  principalId: PrincipalId,
+): Promise<PrincipalPurgeResponse> {
+  const connections = await deps.connections.listByPrincipal(
+    tenantId,
+    principalId,
+  );
+
+  let credentials = 0;
+  for (const connection of connections) {
+    if (deps.custody) {
+      const existed = await deps.credentials.findByConnection(connection._id);
+      await deps.custody.disconnect(connection._id);
+      if (existed) credentials += 1;
+    } else if (await deps.credentials.deleteByConnection(connection._id)) {
+      credentials += 1;
+    }
+  }
+
+  // After credentials: drop dependent rows, then the connection records.
+  // Parallel deletes are safe — each collection is independently scoped.
+  const [
+    jobs,
+    syncResources,
+    eventOccurrences,
+    events,
+    deletionMarkers,
+    calendars,
+    commands,
+    invalidations,
+    connectionCount,
+  ] = await Promise.all([
+    deps.jobs.deleteByPrincipal(tenantId, principalId),
+    deps.syncResources.deleteByPrincipal(tenantId, principalId),
+    deps.eventOccurrences.deleteByPrincipal(tenantId, principalId),
+    deps.events.deleteByPrincipal(tenantId, principalId),
+    deps.deletionMarkers.deleteByPrincipal(tenantId, principalId),
+    deps.calendars.deleteByPrincipal(tenantId, principalId),
+    deps.commands.deleteByPrincipal(tenantId, principalId),
+    deps.invalidations.deleteByPrincipal(tenantId, principalId),
+    deps.connections.deleteByPrincipal(tenantId, principalId),
+  ]);
+
+  return {
+    connections: connectionCount,
+    credentials,
+    calendars,
+    events,
+    eventOccurrences,
+    syncResources,
+    commands,
+    jobs,
+    deletionMarkers,
+    invalidations,
+  };
+}

--- a/packages/sync/src/server/principal.routes.db.test.ts
+++ b/packages/sync/src/server/principal.routes.db.test.ts
@@ -1,0 +1,294 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { type PrincipalPurgeResponse } from "@core/types/sync/principal.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { createSyncService, type SyncService } from "@sync/app";
+import { signInternalRequest } from "@sync/auth/internal-auth";
+import { type SyncConfig } from "@sync/config/sync.config";
+import {
+  type ProviderAuthAdapter,
+  type ProviderAuthorization,
+  type RefreshedCredential,
+} from "@sync/providers/provider-auth.port";
+import { PRINCIPAL_PATH } from "@sync/server/principal.routes";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { type AddressInfo } from "node:net";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = setupSyncStorage(import.meta.url);
+const objectId = () => faker.database.mongodbObjectId();
+const SECRET = "internal-secret";
+
+const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: uri,
+    INTERNAL_AUTH_TOKEN: SECRET,
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+    ...overrides,
+  }) as SyncConfig;
+
+class FakeAuthAdapter implements ProviderAuthAdapter {
+  readonly provider = "google" as const;
+  revoked: string[] = [];
+  buildAuthorizationUrl(): string {
+    throw new Error("unused");
+  }
+  exchangeAuthorizationCode(): Promise<ProviderAuthorization> {
+    throw new Error("unused");
+  }
+  refreshAccessToken(): Promise<RefreshedCredential> {
+    throw new Error("unused");
+  }
+  async revoke(input: { token: string }): Promise<void> {
+    this.revoked.push(input.token);
+  }
+}
+
+const signedHeaders = (
+  tenantId: string,
+  principalId: string,
+): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "x-sync-tenant": tenantId,
+    "x-sync-principal": principalId,
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signInternalRequest(SECRET, {
+      timestamp,
+      tenantId,
+      principalId,
+    }),
+  };
+};
+
+const seedConnection = (
+  repo: ProviderConnectionRepository,
+  tenantId: string,
+  principalId: string,
+) =>
+  repo.upsertByProviderAccount({
+    tenantId: tenantId as TenantId,
+    principalId: principalId as PrincipalId,
+    provider: "google",
+    account: {
+      providerAccountId: objectId(),
+      email: "purge@example.com",
+      displayName: null,
+    },
+    capabilities: ["readEvents"],
+    state: "healthy",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+  });
+
+describe("DELETE /internal/principal", () => {
+  let mongo: SyncMongoService;
+  let service: SyncService;
+  let base: string;
+  let adapter: FakeAuthAdapter;
+
+  const startService = async (options?: {
+    config?: SyncConfig;
+    // Omit to use the FakeAuthAdapter; pass null to exercise local-only purge.
+    authAdapter?: ProviderAuthAdapter | null;
+  }) => {
+    const authAdapter =
+      options && "authAdapter" in options ? options.authAdapter : adapter;
+    service = createSyncService(options?.config ?? testConfig(), {
+      mongo,
+      authAdapter: authAdapter ?? undefined,
+    });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    adapter = new FakeAuthAdapter();
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  it("revokes credentials and hard-deletes every principal-scoped row", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const stranger = objectId();
+
+    const connections = new ProviderConnectionRepository(mongo.db);
+    const credentials = new CredentialRepository(mongo.db);
+    const calendars = new ProviderCalendarRepository(mongo.db);
+    const resources = new SyncResourceRepository(mongo.db);
+    const jobs = new JobRepository(mongo.db);
+    const invalidations = new InvalidationRepository(mongo.db);
+
+    const mine = await seedConnection(connections, tenantId, principalId);
+    const theirs = await seedConnection(connections, tenantId, stranger);
+    await credentials.store({
+      connectionId: mine._id,
+      provider: "google",
+      refreshToken: "mine-refresh",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    await credentials.store({
+      connectionId: theirs._id,
+      provider: "google",
+      refreshToken: "theirs-refresh",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    await calendars.upsertByProviderCalendar({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: mine._id,
+      providerCalendarId: "primary",
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadBusy: true,
+        canReadEvents: true,
+        canWriteEvents: true,
+        canInviteAttendees: false,
+      },
+    });
+    await resources.ensure({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: mine._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await jobs.enqueue({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: mine._id,
+      resourceId: null,
+      commandId: null,
+      kind: "calendarListSync",
+      priority: 0,
+      runAfter: new Date(),
+      coalescingKey: `purge-test:${mine._id}`,
+    });
+    await invalidations.append({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      invalidation: { kind: "connection", connectionId: mine._id },
+      emittedAt: new Date(),
+    });
+
+    await startService();
+
+    const res = await fetch(`${base}${PRINCIPAL_PATH}`, {
+      method: "DELETE",
+      headers: signedHeaders(tenantId, principalId),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PrincipalPurgeResponse;
+    expect(body.connections).toBe(1);
+    expect(body.credentials).toBe(1);
+    expect(body.calendars).toBe(1);
+    expect(body.syncResources).toBe(1);
+    expect(body.jobs).toBe(1);
+    expect(body.invalidations).toBe(1);
+
+    expect(adapter.revoked).toEqual(["mine-refresh"]);
+    expect(
+      await connections.listByPrincipal(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+      ),
+    ).toHaveLength(0);
+    expect(await credentials.findByConnection(mine._id)).toBeNull();
+    expect(await credentials.findByConnection(theirs._id)).not.toBeNull();
+    expect(
+      await connections.listByPrincipal(
+        tenantId as TenantId,
+        stranger as PrincipalId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("is idempotent and works in passive mode without an auth adapter", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connections = new ProviderConnectionRepository(mongo.db);
+    const credentials = new CredentialRepository(mongo.db);
+    const connection = await seedConnection(connections, tenantId, principalId);
+    await credentials.store({
+      connectionId: connection._id as ConnectionId,
+      provider: "google",
+      refreshToken: "local-only",
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+
+    await startService({
+      config: testConfig({ EXECUTION: "passive" }),
+      authAdapter: null,
+    });
+
+    const first = await fetch(`${base}${PRINCIPAL_PATH}`, {
+      method: "DELETE",
+      headers: signedHeaders(tenantId, principalId),
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as PrincipalPurgeResponse;
+    expect(firstBody.connections).toBe(1);
+    expect(firstBody.credentials).toBe(1);
+    expect(adapter.revoked).toEqual([]);
+
+    const second = await fetch(`${base}${PRINCIPAL_PATH}`, {
+      method: "DELETE",
+      headers: signedHeaders(tenantId, principalId),
+    });
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as PrincipalPurgeResponse;
+    expect(secondBody).toEqual({
+      connections: 0,
+      credentials: 0,
+      calendars: 0,
+      events: 0,
+      eventOccurrences: 0,
+      syncResources: 0,
+      commands: 0,
+      jobs: 0,
+      deletionMarkers: 0,
+      invalidations: 0,
+    });
+    expect(
+      await mongo.db
+        .collection(SYNC_COLLECTIONS.providerConnections)
+        .countDocuments({
+          tenantId,
+          principalId,
+        }),
+    ).toBe(0);
+  });
+
+  it("rejects an unsigned purge", async () => {
+    await startService();
+    const res = await fetch(`${base}${PRINCIPAL_PATH}`, { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/sync/src/server/principal.routes.ts
+++ b/packages/sync/src/server/principal.routes.ts
@@ -1,0 +1,82 @@
+import { type Express, type RequestHandler } from "express";
+import { Status } from "@core/errors/status.codes";
+import { PrincipalPurgeResponseSchema } from "@core/types/sync/principal.contracts";
+import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { purgePrincipal } from "@sync/domain/principal-purge.service";
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import {
+  ensureConnected,
+  internalRateLimit,
+  requireAuth,
+  respondInternalError,
+} from "@sync/server/internal-http";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+export const PRINCIPAL_PATH = "/internal/principal";
+
+export interface PrincipalApiDeps {
+  authMiddleware: RequestHandler;
+  mongo: SyncMongoService;
+  // Optional: when present, credentials are revoked at the provider before
+  // local delete. Account deletion still proceeds without it (passive /
+  // unconfigured deployments) so Sync-held tokens are never stranded.
+  authAdapter?: ProviderAuthAdapter;
+}
+
+// Hard-delete every Sync-held row for the signed principal. Served in passive
+// mode too — account deletion must wipe Sync data even when provider work is
+// disabled. Soft disconnect retention does NOT apply here.
+export function registerPrincipalRoutes(
+  app: Express,
+  deps: PrincipalApiDeps,
+): void {
+  app.delete(
+    PRINCIPAL_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+
+      try {
+        const credentials = new CredentialRepository(deps.mongo.db);
+        const counts = await purgePrincipal(
+          {
+            connections: new ProviderConnectionRepository(deps.mongo.db),
+            credentials,
+            calendars: new ProviderCalendarRepository(deps.mongo.db),
+            events: new EventRepository(deps.mongo.db),
+            eventOccurrences: new EventOccurrenceRepository(
+              deps.mongo.db,
+              deps.mongo.client,
+            ),
+            syncResources: new SyncResourceRepository(deps.mongo.db),
+            commands: new CommandRepository(deps.mongo.db),
+            jobs: new JobRepository(deps.mongo.db),
+            deletionMarkers: new DeletionMarkerRepository(deps.mongo.db),
+            invalidations: new InvalidationRepository(deps.mongo.db),
+            custody: deps.authAdapter
+              ? new CredentialCustody(credentials, deps.authAdapter)
+              : undefined,
+          },
+          auth.tenantId,
+          auth.principalId,
+        );
+        res.status(Status.OK).json(PrincipalPurgeResponseSchema.parse(counts));
+      } catch {
+        respondInternalError(res);
+      }
+    },
+  );
+}

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -8,6 +8,7 @@ import {
 } from "@sync/server/connection.routes";
 import { registerHealthRoutes } from "@sync/server/health.routes";
 import { registerNotificationRoutes } from "@sync/server/notification.routes";
+import { registerPrincipalRoutes } from "@sync/server/principal.routes";
 import { type StructuredServiceIdentity } from "@sync/service-identity";
 
 // Builds the Sync service's HTTP application. Health probes are always public
@@ -43,6 +44,13 @@ export function buildSyncApp(deps: {
     registerChangeFeedRoutes(app, {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
+    });
+    // Account-deletion hard purge for the signed principal (S43). Served in
+    // passive mode; best-effort provider revoke when an auth adapter exists.
+    registerPrincipalRoutes(app, {
+      authMiddleware: deps.connectionApi.authMiddleware,
+      mongo: deps.connectionApi.mongo,
+      authAdapter: deps.connectionApi.authAdapter,
     });
     // The public webhook ingress shares the connection API's storage; it needs
     // no auth adapter or secrets, only the db and execution mode.

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -135,4 +135,13 @@ export class CommandRepository {
       .toArray();
     return records.map((r) => CommandRecordSchema.parse(r));
   }
+
+  // Hard-delete every command for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
 }

--- a/packages/sync/src/storage/repositories/deletion-marker.repository.ts
+++ b/packages/sync/src/storage/repositories/deletion-marker.repository.ts
@@ -2,7 +2,9 @@ import { type Collection, type Db, ObjectId } from "mongodb";
 import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
+  type PrincipalId,
   type ProviderEventId,
+  type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
@@ -74,5 +76,14 @@ export class DeletionMarkerRepository {
       { limit: 1 },
     );
     return count > 0;
+  }
+
+  // Hard-delete every deletion marker for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
   }
 }

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -122,6 +122,15 @@ export class EventOccurrenceRepository {
     });
   }
 
+  // Hard-delete every occurrence for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
+
   async listByCalendarRange(
     query: OccurrenceRangeQuery,
   ): Promise<EventOccurrenceRecord[]> {

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -287,6 +287,15 @@ export class EventRepository {
     });
   }
 
+  // Hard-delete every event for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
+
   // Bounded, keyset-paginated canonical events for one calendar/generation,
   // ordered by _id so a cursor never skips or repeats a row.
   async listByCalendar(query: EventListQuery): Promise<EventRecord[]> {

--- a/packages/sync/src/storage/repositories/invalidation.repository.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.ts
@@ -93,4 +93,13 @@ export class InvalidationRepository {
     );
     return row?._id ?? null;
   }
+
+  // Hard-delete every invalidation for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
 }

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -201,4 +201,13 @@ export class JobRepository {
     );
     return result.modifiedCount;
   }
+
+  // Hard-delete every job for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
 }

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -130,4 +130,13 @@ export class ProviderCalendarRepository {
     const records = await this.collection.find(query).toArray();
     return records.map((r) => ProviderCalendarRecordSchema.parse(r));
   }
+
+  // Hard-delete every calendar for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
 }

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -158,4 +158,14 @@ export class ProviderConnectionRepository {
     }
     return ProviderConnectionRecordSchema.parse(result);
   }
+
+  // Hard-delete every connection for a principal (account deletion). Soft
+  // disconnect uses markDisconnected instead; this removes the rows entirely.
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
 }

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -330,4 +330,13 @@ export class SyncResourceRepository {
       .toArray();
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
+
+  // Hard-delete every sync resource for a principal (account deletion).
+  async deleteByPrincipal(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({ tenantId, principalId });
+    return result.deletedCount;
+  }
 }


### PR DESCRIPTION
## Summary
- Sync: `DELETE /internal/principal` hard-deletes all principal-scoped Sync data (credentials via connection list + best-effort revoke; then jobs/resources/occurrences/events/markers/calendars/commands/invalidations/connections). Idempotent; served in **passive** mode.
- Backend: after `deleteCompassDataForUser` / Google grant revoke, fail-open `SyncServiceClient.purgePrincipal(toSyncPrincipal(userId))`.
- Shared `PrincipalPurgeResponse` contract in core.

## Test plan
- [x] `bun test:core` (principal.contracts)
- [x] `bun test:sync` (principal.routes.db)
- [x] `bun test:backend` (client + user.service deleteAccount)
- [x] `bun type-check`
- [x] `bun lint`
- [ ] Staging: delete a Sync-connected test account; confirm Sync collections empty for that principal and SPA login is gone


Made with [Cursor](https://cursor.com)