### PR TITLE
feat(sync): purge soft-disconnected caches after 30 days

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -2,6 +2,10 @@ import { Logger } from "@core/logger/winston.logger";
 import { createInternalAuthMiddleware } from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import {
+  CONNECTION_CACHE_RETENTION_MS,
+  purgeExpiredDisconnectedConnections,
+} from "@sync/domain/connection-retention.service";
 import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
 import { maintainExpiringSubscriptions } from "@sync/domain/subscription-sweep.service";
 import { SweepScheduler } from "@sync/domain/sweep-scheduler.service";
@@ -22,6 +26,7 @@ import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
@@ -190,13 +195,16 @@ async function start(): Promise<void> {
       enforceLeastPrivilege: config.ENFORCE_LEAST_PRIVILEGE,
     });
 
-    // Storage is up: start draining the job queue and periodically reconciling
-    // stale calendars and renewing expiring push channels. All three register
-    // AFTER the mongo drain so the coordinator's reverse-order teardown stops
-    // them FIRST (the producing sweeps before the drain, so no new jobs are
-    // enqueued while the drain finishes and releases its leases) and closes mongo
-    // last. Only an active, provider-configured deployment does work; a passive
-    // or unconfigured one serves health.
+    // Retention is local-only (no provider calls), so it runs in passive mode
+    // too — soft-disconnected caches must still age out. Register before the
+    // mongo drain so reverse-order teardown stops the sweep first.
+    const retention = buildRetentionSweep(mongo);
+    service.shutdown.register("retention", () => retention.stop());
+    retention.start();
+
+    // Active, provider-configured deployments also drain jobs and renew
+    // channels. Those register AFTER the mongo drain so teardown stops them
+    // first and closes mongo last.
     const schedulers = buildSchedulers(config, mongo);
     if (schedulers) {
       service.shutdown.register("scheduler", () => schedulers.drain.stop());
@@ -208,8 +216,10 @@ async function start(): Promise<void> {
       schedulers.reconcile.start();
       schedulers.subscription.start();
       logger.info(
-        "Sync scheduler draining, reconciling, and renewing channels",
+        "Sync scheduler draining, reconciling, renewing channels, and retaining",
       );
+    } else {
+      logger.info("Sync retention sweep started (passive / unconfigured)");
     }
   } catch (error) {
     logger.error(
@@ -225,6 +235,36 @@ const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
 // maintainSubscription's default renew guard so the sweep and the operation
 // agree on what "near expiry" means.
 const SUBSCRIPTION_RENEW_BEFORE_MS = 24 * 60 * 60_000;
+// How often to look for soft-disconnected connections past the 30-day cache
+// window. Daily is enough for the retention SLA; hourly keeps catch-up snappy.
+const RETENTION_SWEEP_INTERVAL_MS = 60 * 60_000;
+
+// Local-only: purge soft-disconnected connection caches past the retention
+// window. Safe without provider credentials and in passive execution.
+function buildRetentionSweep(mongo: SyncMongoService): SweepScheduler {
+  const db = mongo.db;
+  const deps = {
+    connections: new ProviderConnectionRepository(db),
+    credentials: new CredentialRepository(db),
+    calendars: new ProviderCalendarRepository(db),
+    events: new EventRepository(db),
+    eventOccurrences: new EventOccurrenceRepository(db, mongo.client),
+    syncResources: new SyncResourceRepository(db),
+    jobs: new JobRepository(db),
+    deletionMarkers: new DeletionMarkerRepository(db),
+  };
+  return new SweepScheduler(
+    {
+      sweep: (before) => purgeExpiredDisconnectedConnections(deps, before),
+    },
+    {
+      intervalMs: RETENTION_SWEEP_INTERVAL_MS,
+      windowMs: -CONNECTION_CACHE_RETENTION_MS,
+      onError: (error) =>
+        logger.error("Sync disconnect retention sweep failed", error),
+    },
+  );
+}
 
 // Build the background schedulers for an active, provider-configured deployment:
 // the queue DRAIN (claims and runs jobs), the RECONCILE sweep (the missed-webhook

--- a/packages/sync/src/domain/connection-retention.service.db.test.ts
+++ b/packages/sync/src/domain/connection-retention.service.db.test.ts
@@ -1,0 +1,306 @@
+import { faker } from "@faker-js/faker";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import {
+  CONNECTION_CACHE_RETENTION_MS,
+  purgeExpiredDisconnectedConnections,
+} from "@sync/domain/connection-retention.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type EventOccurrenceRecord,
+  EventOccurrenceRecordSchema,
+} from "@sync/storage/contracts/event-occurrence.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+const NOW = new Date("2026-07-24T12:00:00.000Z");
+const RETENTION_CUTOFF = new Date(
+  NOW.getTime() - CONNECTION_CACHE_RETENTION_MS,
+);
+
+describe("purgeExpiredDisconnectedConnections", () => {
+  const storage = setupSyncStorage(import.meta.url);
+
+  let connections: ProviderConnectionRepository;
+  let credentials: CredentialRepository;
+  let calendars: ProviderCalendarRepository;
+  let events: EventRepository;
+  let eventOccurrences: EventOccurrenceRepository;
+  let syncResources: SyncResourceRepository;
+  let jobs: JobRepository;
+  let deletionMarkers: DeletionMarkerRepository;
+
+  beforeEach(() => {
+    const db = storage.db();
+    connections = new ProviderConnectionRepository(db);
+    credentials = new CredentialRepository(db);
+    calendars = new ProviderCalendarRepository(db);
+    events = new EventRepository(db);
+    eventOccurrences = new EventOccurrenceRepository(db, storage.client());
+    syncResources = new SyncResourceRepository(db);
+    jobs = new JobRepository(db);
+    deletionMarkers = new DeletionMarkerRepository(db);
+  });
+
+  const deps = () => ({
+    connections,
+    credentials,
+    calendars,
+    events,
+    eventOccurrences,
+    syncResources,
+    jobs,
+    deletionMarkers,
+  });
+
+  const seedConnection = async (
+    tenantId: string,
+    principalId: string,
+    disconnectedAt: Date | null,
+  ) => {
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      provider: "google",
+      account: {
+        providerAccountId: objectId(),
+        email: "cache@example.com",
+        displayName: null,
+      },
+      capabilities: ["readEvents"],
+      state: "healthy",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+    if (disconnectedAt) {
+      await connections.markDisconnected(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+        connection._id,
+        disconnectedAt,
+      );
+    }
+    return connection;
+  };
+
+  it("purges cache for connections disconnected before the retention cutoff", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const otherPrincipal = objectId();
+
+    const expired = await seedConnection(
+      tenantId,
+      principalId,
+      new Date(RETENTION_CUTOFF.getTime() - 60_000),
+    );
+    const recent = await seedConnection(
+      tenantId,
+      principalId,
+      new Date(RETENTION_CUTOFF.getTime() + 60_000),
+    );
+    const live = await seedConnection(tenantId, otherPrincipal, null);
+
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: expired._id,
+      providerCalendarId: "primary",
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadBusy: true,
+        canReadEvents: true,
+        canWriteEvents: true,
+        canInviteAttendees: false,
+      },
+    });
+    await events.upsertByProviderIdentity({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      origin: "provider",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId: expired._id,
+      providerEventId: "gcal-1",
+      providerVersion: "etag-1",
+      providerUpdatedAt: NOW,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: {
+        title: "Cached meeting",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T09:00:00-06:00",
+        end: "2026-07-14T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      lifecycleState: "active",
+      generation: 0,
+      confirmedAt: NOW,
+    });
+    const occurrence = EventOccurrenceRecordSchema.parse({
+      _id: objectId(),
+      tenantId,
+      principalId,
+      eventId: objectId(),
+      occurrenceKey: `${objectId()}:${NOW.toISOString()}`,
+      calendarId: calendar._id,
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T09:00:00-06:00",
+        end: "2026-07-14T10:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      startAt: NOW,
+      busy: true,
+      title: "Cached meeting",
+      cancelled: false,
+      generation: 0,
+    });
+    await storage
+      .db()
+      .collection<EventOccurrenceRecord>(SYNC_COLLECTIONS.eventOccurrences)
+      .insertOne(occurrence);
+    await syncResources.ensure({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: expired._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await jobs.enqueue({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: expired._id,
+      resourceId: null,
+      commandId: null,
+      kind: "calendarListSync",
+      priority: 0,
+      runAfter: NOW,
+      coalescingKey: `retention:${expired._id}`,
+    });
+
+    const purged = await purgeExpiredDisconnectedConnections(
+      deps(),
+      RETENTION_CUTOFF,
+    );
+
+    expect(purged).toBe(1);
+    expect(
+      await connections.findById(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+        expired._id,
+      ),
+    ).toBeNull();
+    expect(
+      await calendars.listByConnection(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+        expired._id as ConnectionId,
+      ),
+    ).toHaveLength(0);
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.events)
+        .countDocuments({ connectionId: expired._id }),
+    ).toBe(0);
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.eventOccurrences)
+        .countDocuments({ calendarId: calendar._id }),
+    ).toBe(0);
+    expect(
+      await connections.findById(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+        recent._id,
+      ),
+    ).not.toBeNull();
+    expect(
+      await connections.findById(
+        tenantId as TenantId,
+        otherPrincipal as PrincipalId,
+        live._id,
+      ),
+    ).not.toBeNull();
+  });
+
+  it("is idempotent when nothing is past retention", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedConnection(
+      tenantId,
+      principalId,
+      new Date(RETENTION_CUTOFF.getTime() + 60_000),
+    );
+
+    expect(
+      await purgeExpiredDisconnectedConnections(deps(), RETENTION_CUTOFF),
+    ).toBe(0);
+    expect(
+      await purgeExpiredDisconnectedConnections(deps(), RETENTION_CUTOFF),
+    ).toBe(0);
+  });
+
+  it("bounds the sweep and takes the oldest disconnect first", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const older = await seedConnection(
+      tenantId,
+      principalId,
+      new Date(RETENTION_CUTOFF.getTime() - 3 * 60_000),
+    );
+    await seedConnection(
+      tenantId,
+      principalId,
+      new Date(RETENTION_CUTOFF.getTime() - 60_000),
+    );
+
+    const purged = await purgeExpiredDisconnectedConnections(
+      deps(),
+      RETENTION_CUTOFF,
+      1,
+    );
+
+    expect(purged).toBe(1);
+    expect(
+      await connections.findById(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+        older._id,
+      ),
+    ).toBeNull();
+    expect(
+      await connections.listByPrincipal(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/sync/src/domain/connection-retention.service.db.test.ts
+++ b/packages/sync/src/domain/connection-retention.service.db.test.ts
@@ -268,6 +268,43 @@ describe("purgeExpiredDisconnectedConnections", () => {
     ).toBe(0);
   });
 
+  it("skips purge when the connection reconnects before processing", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const expiredAt = new Date(RETENTION_CUTOFF.getTime() - 60_000);
+    const connection = await seedConnection(tenantId, principalId, expiredAt);
+
+    await connections.upsertByProviderAccount({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      provider: "google",
+      account: {
+        providerAccountId: connection.account.providerAccountId,
+        email: "cache@example.com",
+        displayName: null,
+      },
+      capabilities: ["readEvents"],
+      state: "healthy",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+
+    const purged = await purgeExpiredDisconnectedConnections(
+      deps(),
+      RETENTION_CUTOFF,
+    );
+
+    expect(purged).toBe(0);
+    expect(
+      await connections.findById(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+        connection._id,
+      ),
+    ).not.toBeNull();
+  });
+
   it("bounds the sweep and takes the oldest disconnect first", async () => {
     const tenantId = objectId();
     const principalId = objectId();

--- a/packages/sync/src/domain/connection-retention.service.ts
+++ b/packages/sync/src/domain/connection-retention.service.ts
@@ -31,10 +31,21 @@ export interface ConnectionRetentionDeps {
 export async function purgeDisconnectedConnection(
   deps: ConnectionRetentionDeps,
   connection: ProviderConnectionRecord,
-): Promise<void> {
+  before: Date,
+): Promise<boolean> {
   const tenantId = connection.tenantId;
   const principalId = connection.principalId;
   const connectionId = connection._id;
+
+  const deleted = await deps.connections.deleteIfDisconnectedBefore(
+    tenantId,
+    principalId,
+    connectionId,
+    before,
+  );
+  if (!deleted) {
+    return false;
+  }
 
   const calendars = await deps.calendars.listByConnection(
     tenantId,
@@ -56,7 +67,7 @@ export async function purgeDisconnectedConnection(
     deps.credentials.deleteByConnection(connectionId),
   ]);
   await deps.calendars.deleteByConnection(tenantId, principalId, connectionId);
-  await deps.connections.deleteById(tenantId, principalId, connectionId);
+  return true;
 }
 
 // Purge soft-disconnected connections whose disconnectedAt is before `before`
@@ -68,8 +79,11 @@ export async function purgeExpiredDisconnectedConnections(
   limit = 100,
 ): Promise<number> {
   const expired = await deps.connections.listDisconnectedBefore(before, limit);
+  let purged = 0;
   for (const connection of expired) {
-    await purgeDisconnectedConnection(deps, connection);
+    if (await purgeDisconnectedConnection(deps, connection, before)) {
+      purged += 1;
+    }
   }
-  return expired.length;
+  return purged;
 }

--- a/packages/sync/src/domain/connection-retention.service.ts
+++ b/packages/sync/src/domain/connection-retention.service.ts
@@ -37,16 +37,6 @@ export async function purgeDisconnectedConnection(
   const principalId = connection.principalId;
   const connectionId = connection._id;
 
-  const deleted = await deps.connections.deleteIfDisconnectedBefore(
-    tenantId,
-    principalId,
-    connectionId,
-    before,
-  );
-  if (!deleted) {
-    return false;
-  }
-
   const calendars = await deps.calendars.listByConnection(
     tenantId,
     principalId,
@@ -67,7 +57,13 @@ export async function purgeDisconnectedConnection(
     deps.credentials.deleteByConnection(connectionId),
   ]);
   await deps.calendars.deleteByConnection(tenantId, principalId, connectionId);
-  return true;
+
+  return deps.connections.deleteIfDisconnectedBefore(
+    tenantId,
+    principalId,
+    connectionId,
+    before,
+  );
 }
 
 // Purge soft-disconnected connections whose disconnectedAt is before `before`

--- a/packages/sync/src/domain/connection-retention.service.ts
+++ b/packages/sync/src/domain/connection-retention.service.ts
@@ -1,0 +1,75 @@
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { type DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+// Soft-disconnected connections keep cached provider event content for at most
+// this long (R-CONN-06). Account deletion bypasses the window via purgePrincipal.
+export const CONNECTION_CACHE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface ConnectionRetentionDeps {
+  connections: ProviderConnectionRepository;
+  credentials: CredentialRepository;
+  calendars: ProviderCalendarRepository;
+  events: EventRepository;
+  eventOccurrences: EventOccurrenceRepository;
+  syncResources: SyncResourceRepository;
+  jobs: JobRepository;
+  deletionMarkers: DeletionMarkerRepository;
+}
+
+// Remove one soft-disconnected connection's retained cache and the connection
+// row itself. Credentials were already revoked/deleted at disconnect; this is
+// a belt-and-suspenders delete. Does not touch other connections on the
+// principal, Compass-owned unlinked events, commands, or invalidations
+// (invalidations already TTL out).
+export async function purgeDisconnectedConnection(
+  deps: ConnectionRetentionDeps,
+  connection: ProviderConnectionRecord,
+): Promise<void> {
+  const tenantId = connection.tenantId;
+  const principalId = connection.principalId;
+  const connectionId = connection._id;
+
+  const calendars = await deps.calendars.listByConnection(
+    tenantId,
+    principalId,
+    connectionId,
+  );
+  const calendarIds = calendars.map((calendar) => calendar._id);
+
+  await Promise.all([
+    deps.eventOccurrences.deleteByCalendars(tenantId, principalId, calendarIds),
+    deps.events.deleteByConnection(tenantId, principalId, connectionId),
+    deps.deletionMarkers.deleteByConnection(
+      tenantId,
+      principalId,
+      connectionId,
+    ),
+    deps.syncResources.deleteByConnection(tenantId, principalId, connectionId),
+    deps.jobs.deleteByConnection(tenantId, principalId, connectionId),
+    deps.credentials.deleteByConnection(connectionId),
+  ]);
+  await deps.calendars.deleteByConnection(tenantId, principalId, connectionId);
+  await deps.connections.deleteById(tenantId, principalId, connectionId);
+}
+
+// Purge soft-disconnected connections whose disconnectedAt is before `before`
+// (typically now − 30d). Oldest first, bounded. Returns how many connections
+// were purged. Local-only — safe in passive mode.
+export async function purgeExpiredDisconnectedConnections(
+  deps: ConnectionRetentionDeps,
+  before: Date,
+  limit = 100,
+): Promise<number> {
+  const expired = await deps.connections.listDisconnectedBefore(before, limit);
+  for (const connection of expired) {
+    await purgeDisconnectedConnection(deps, connection);
+  }
+  return expired.length;
+}

--- a/packages/sync/src/storage/index-manifest.db.test.ts
+++ b/packages/sync/src/storage/index-manifest.db.test.ts
@@ -76,6 +76,17 @@ describe("installIndexManifest", () => {
     expect(ttl?.expireAfterSeconds).toBe(0);
   });
 
+  it("installs a partial disconnectedAt index for retention sweeps", async () => {
+    const indexes = await db
+      .collection(SYNC_COLLECTIONS.providerConnections)
+      .indexes();
+    const disconnected = indexes.find((i) => i.name === "disconnected_at");
+    expect(disconnected).toBeDefined();
+    expect(disconnected?.partialFilterExpression).toEqual({
+      disconnectedAt: { $type: "date" },
+    });
+  });
+
   it("installs principal keyset and TTL indexes on invalidations", async () => {
     const indexes = await db
       .collection(SYNC_COLLECTIONS.invalidations)

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -38,6 +38,15 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
     },
     { name: "principal_state", key: { principalId: 1, state: 1 } },
     { name: "health_age", key: { lastHealthyAt: 1 } },
+    {
+      // Retention sweep: soft-disconnected connections past the cache window.
+      // Partial so live connections (disconnectedAt: null) stay out of the index.
+      name: "disconnected_at",
+      key: { disconnectedAt: 1 },
+      options: {
+        partialFilterExpression: { disconnectedAt: { $type: "date" } },
+      },
+    },
   ],
   // Keyed 1:1 by connection id (the automatic _id index); no secondary indexes.
   [SYNC_COLLECTIONS.credentials]: [],

--- a/packages/sync/src/storage/repositories/deletion-marker.repository.ts
+++ b/packages/sync/src/storage/repositories/deletion-marker.repository.ts
@@ -78,6 +78,20 @@ export class DeletionMarkerRepository {
     return count > 0;
   }
 
+  // Hard-delete every deletion marker for one connection (retention).
+  async deleteByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      connectionId,
+    });
+    return result.deletedCount;
+  }
+
   // Hard-delete every deletion marker for a principal (account deletion).
   async deleteByPrincipal(
     tenantId: TenantId,

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -122,6 +122,21 @@ export class EventOccurrenceRepository {
     });
   }
 
+  // Hard-delete occurrences for the given calendars (post-disconnect retention).
+  async deleteByCalendars(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    calendarIds: readonly SyncEventCalendarId[],
+  ): Promise<number> {
+    if (calendarIds.length === 0) return 0;
+    const result = await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      calendarId: { $in: [...calendarIds] },
+    });
+    return result.deletedCount;
+  }
+
   // Hard-delete every occurrence for a principal (account deletion).
   async deleteByPrincipal(
     tenantId: TenantId,

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -287,6 +287,20 @@ export class EventRepository {
     });
   }
 
+  // Hard-delete every provider-linked event for one connection (retention).
+  async deleteByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: NonNullable<EventRecord["connectionId"]>,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      connectionId,
+    });
+    return result.deletedCount;
+  }
+
   // Hard-delete every event for a principal (account deletion).
   async deleteByPrincipal(
     tenantId: TenantId,

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -1,5 +1,6 @@
 import { type Collection, type Db, ObjectId } from "mongodb";
 import {
+  type ConnectionId,
   type PrincipalId,
   type SyncJobId,
   type TenantId,
@@ -200,6 +201,20 @@ export class JobRepository {
       },
     );
     return result.modifiedCount;
+  }
+
+  // Hard-delete every job for one connection (post-disconnect retention).
+  async deleteByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      connectionId,
+    });
+    return result.deletedCount;
   }
 
   // Hard-delete every job for a principal (account deletion).

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -131,6 +131,20 @@ export class ProviderCalendarRepository {
     return records.map((r) => ProviderCalendarRecordSchema.parse(r));
   }
 
+  // Hard-delete every calendar for one connection (post-disconnect retention).
+  async deleteByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      connectionId,
+    });
+    return result.deletedCount;
+  }
+
   // Hard-delete every calendar for a principal (account deletion).
   async deleteByPrincipal(
     tenantId: TenantId,

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -159,6 +159,35 @@ export class ProviderConnectionRepository {
     return ProviderConnectionRecordSchema.parse(result);
   }
 
+  // Soft-disconnected connections whose disconnectedAt is strictly before
+  // `before`, oldest first. Global scan for the retention sweeper (system
+  // liveness, not a user request); each row carries its own owner ids.
+  async listDisconnectedBefore(
+    before: Date,
+    limit: number,
+  ): Promise<ProviderConnectionRecord[]> {
+    const records = await this.collection
+      .find({ disconnectedAt: { $ne: null, $lt: before } })
+      .sort({ disconnectedAt: 1 })
+      .limit(limit)
+      .toArray();
+    return records.map((r) => ProviderConnectionRecordSchema.parse(r));
+  }
+
+  // Hard-delete one connection row after its retained cache has been purged.
+  async deleteById(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: ConnectionId,
+  ): Promise<boolean> {
+    const result = await this.collection.deleteOne({
+      _id: id,
+      tenantId,
+      principalId,
+    });
+    return result.deletedCount === 1;
+  }
+
   // Hard-delete every connection for a principal (account deletion). Soft
   // disconnect uses markDisconnected instead; this removes the rows entirely.
   async deleteByPrincipal(

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -188,6 +188,24 @@ export class ProviderConnectionRepository {
     return result.deletedCount === 1;
   }
 
+  // Hard-delete only when the connection is still soft-disconnected and past
+  // retention. Used by the sweeper so a reconnect during the purge window
+  // does not delete a live connection row.
+  async deleteIfDisconnectedBefore(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: ConnectionId,
+    before: Date,
+  ): Promise<boolean> {
+    const result = await this.collection.deleteOne({
+      _id: id,
+      tenantId,
+      principalId,
+      disconnectedAt: { $ne: null, $lt: before },
+    });
+    return result.deletedCount === 1;
+  }
+
   // Hard-delete every connection for a principal (account deletion). Soft
   // disconnect uses markDisconnected instead; this removes the rows entirely.
   async deleteByPrincipal(

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -331,6 +331,20 @@ export class SyncResourceRepository {
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
 
+  // Hard-delete every sync resource for one connection (post-disconnect retention).
+  async deleteByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<number> {
+    const result = await this.collection.deleteMany({
+      tenantId,
+      principalId,
+      connectionId,
+    });
+    return result.deletedCount;
+  }
+
   // Hard-delete every sync resource for a principal (account deletion).
   async deleteByPrincipal(
     tenantId: TenantId,


### PR DESCRIPTION
## Summary
- Soft-disconnected Sync connections keep cached provider content for at most 30 days (R-CONN-06).
- Hourly retention sweep (local-only, works in passive mode) hard-deletes expired connection caches: occurrences, events, calendars, resources, jobs, markers, credentials (belt-and-suspenders), then the connection row.
- Partial `disconnected_at` index for the sweep. Account deletion still bypasses the window via `#2383`.

## Test plan
- [x] `bun test:sync` (connection-retention + index-manifest)
- [x] `bun type-check`
- [x] `bun lint`
- [ ] Staging: optional — mark a test connection disconnectedAt in the past and confirm next sweep removes its Sync rows


Made with [Cursor](https://cursor.com)