### PR TITLE
feat(sync): emit sanitized health snapshots

### DIFF
--- a/packages/core/src/types/sync/health.contracts.test.ts
+++ b/packages/core/src/types/sync/health.contracts.test.ts
@@ -1,0 +1,71 @@
+import {
+  SYNC_HEALTH_SNAPSHOT_EVENT,
+  type SyncHealthSnapshot,
+  SyncHealthSnapshotSchema,
+} from "@core/types/sync/health.contracts";
+import { describe, expect, it } from "bun:test";
+
+const sample = (): SyncHealthSnapshot => ({
+  environment: "test",
+  execution: "passive",
+  provider: "google",
+  service: "compass-sync",
+  connections: {
+    connecting: 0,
+    importing: 1,
+    catchingUp: 0,
+    healthy: 10,
+    delayed: 2,
+    actionRequired: 1,
+    disconnected: 3,
+  },
+  jobs: {
+    pending: 4,
+    claimed: 1,
+    failed: 0,
+    oldestDueAgeMs: 12_000,
+  },
+  subscriptions: {
+    healthy: 8,
+    renewSoon: 1,
+    expired: 0,
+    missing: 2,
+  },
+  freshness: {
+    sampleSize: 9,
+    p50Ms: 5_000,
+    p95Ms: 20_000,
+    p99Ms: 40_000,
+    percentOver30s: 11.1,
+  },
+  computedAt: "2026-07-25T02:00:00.000Z",
+  computeMs: 42,
+});
+
+describe("SyncHealthSnapshotSchema", () => {
+  it("accepts a bounded aggregate snapshot", () => {
+    expect(SyncHealthSnapshotSchema.safeParse(sample()).success).toBe(true);
+  });
+
+  it("rejects unknown fields (cardinality / leakage guard)", () => {
+    expect(
+      SyncHealthSnapshotSchema.safeParse({
+        ...sample(),
+        tenantId: "should-not-appear",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a negative count", () => {
+    expect(
+      SyncHealthSnapshotSchema.safeParse({
+        ...sample(),
+        jobs: { ...sample().jobs, pending: -1 },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("exports the stable event name for capture + alerts", () => {
+    expect(SYNC_HEALTH_SNAPSHOT_EVENT).toBe("sync_health_snapshot");
+  });
+});

--- a/packages/core/src/types/sync/health.contracts.ts
+++ b/packages/core/src/types/sync/health.contracts.ts
@@ -1,0 +1,63 @@
+import { z } from "zod/v4";
+import { DateTimeSchema } from "@core/types/domain-primitives";
+
+// Sanitized, bounded-cardinality sync health snapshot (R-OPS / S44).
+// Emitted as `sync_health_snapshot` every five minutes. Counts and ages only —
+// never tokens, event content, tenant/principal ids, or raw provider errors.
+export const SyncHealthConnectionCountsSchema = z.strictObject({
+  connecting: z.number().int().nonnegative(),
+  importing: z.number().int().nonnegative(),
+  catchingUp: z.number().int().nonnegative(),
+  healthy: z.number().int().nonnegative(),
+  delayed: z.number().int().nonnegative(),
+  actionRequired: z.number().int().nonnegative(),
+  disconnected: z.number().int().nonnegative(),
+});
+export type SyncHealthConnectionCounts = z.infer<
+  typeof SyncHealthConnectionCountsSchema
+>;
+
+export const SyncHealthJobBacklogSchema = z.strictObject({
+  pending: z.number().int().nonnegative(),
+  claimed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  // Age of the oldest due pending/claimed-expired job, or null when none due.
+  oldestDueAgeMs: z.number().int().nonnegative().nullable(),
+});
+export type SyncHealthJobBacklog = z.infer<typeof SyncHealthJobBacklogSchema>;
+
+export const SyncHealthSubscriptionCountsSchema = z.strictObject({
+  healthy: z.number().int().nonnegative(),
+  renewSoon: z.number().int().nonnegative(),
+  expired: z.number().int().nonnegative(),
+  missing: z.number().int().nonnegative(),
+});
+export type SyncHealthSubscriptionCounts = z.infer<
+  typeof SyncHealthSubscriptionCountsSchema
+>;
+
+export const SyncHealthFreshnessSchema = z.strictObject({
+  sampleSize: z.number().int().nonnegative(),
+  p50Ms: z.number().int().nonnegative().nullable(),
+  p95Ms: z.number().int().nonnegative().nullable(),
+  p99Ms: z.number().int().nonnegative().nullable(),
+  // Share of sampled events resources whose last success is older than 30s.
+  percentOver30s: z.number().min(0).max(100).nullable(),
+});
+export type SyncHealthFreshness = z.infer<typeof SyncHealthFreshnessSchema>;
+
+export const SyncHealthSnapshotSchema = z.strictObject({
+  environment: z.string().min(1),
+  execution: z.enum(["passive", "active"]),
+  provider: z.literal("google"),
+  service: z.literal("compass-sync"),
+  connections: SyncHealthConnectionCountsSchema,
+  jobs: SyncHealthJobBacklogSchema,
+  subscriptions: SyncHealthSubscriptionCountsSchema,
+  freshness: SyncHealthFreshnessSchema,
+  computedAt: DateTimeSchema,
+  computeMs: z.number().int().nonnegative(),
+});
+export type SyncHealthSnapshot = z.infer<typeof SyncHealthSnapshotSchema>;
+
+export const SYNC_HEALTH_SNAPSHOT_EVENT = "sync_health_snapshot" as const;

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -35,6 +35,12 @@ import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { emitHealthSnapshot } from "@sync/telemetry/health-snapshot.service";
+import {
+  createPostHogCaptureClient,
+  DEFAULT_POSTHOG_HOST,
+  type PostHogCaptureClient,
+} from "@sync/telemetry/posthog-capture";
 import { randomUUID } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
@@ -202,6 +208,16 @@ async function start(): Promise<void> {
     service.shutdown.register("retention", () => retention.stop());
     retention.start();
 
+    // Sanitized sync_health_snapshot every five minutes (S44). Runs in passive
+    // mode too so the heartbeat stays alive before provider work is enabled.
+    const posthog = buildPostHogClient(config);
+    if (posthog) {
+      service.shutdown.register("posthog", () => posthog.shutdown());
+    }
+    const health = buildHealthSnapshotSweep(service.identity, mongo, posthog);
+    service.shutdown.register("health", () => health.stop());
+    health.start();
+
     // Active, provider-configured deployments also drain jobs and renew
     // channels. Those register AFTER the mongo drain so teardown stops them
     // first and closes mongo last.
@@ -216,10 +232,12 @@ async function start(): Promise<void> {
       schedulers.reconcile.start();
       schedulers.subscription.start();
       logger.info(
-        "Sync scheduler draining, reconciling, renewing channels, and retaining",
+        "Sync scheduler draining, reconciling, renewing channels, retaining, and reporting health",
       );
     } else {
-      logger.info("Sync retention sweep started (passive / unconfigured)");
+      logger.info(
+        "Sync retention + health snapshot started (passive / unconfigured)",
+      );
     }
   } catch (error) {
     logger.error(
@@ -238,6 +256,41 @@ const SUBSCRIPTION_RENEW_BEFORE_MS = 24 * 60 * 60_000;
 // How often to look for soft-disconnected connections past the 30-day cache
 // window. Daily is enough for the retention SLA; hourly keeps catch-up snappy.
 const RETENTION_SWEEP_INTERVAL_MS = 60 * 60_000;
+// Architecture: one sync_health_snapshot every five minutes.
+const HEALTH_SNAPSHOT_INTERVAL_MS = 5 * 60_000;
+
+function buildPostHogClient(config: SyncConfig): PostHogCaptureClient | null {
+  if (!config.POSTHOG_KEY) return null;
+  return createPostHogCaptureClient({
+    apiKey: config.POSTHOG_KEY,
+    host: config.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST,
+  });
+}
+
+function buildHealthSnapshotSweep(
+  identity: ReturnType<typeof buildServiceIdentity>,
+  mongo: SyncMongoService,
+  client: PostHogCaptureClient | null,
+): SweepScheduler {
+  return new SweepScheduler(
+    {
+      // SweepScheduler always passes `before`; health ignore it and use now.
+      sweep: async () => {
+        await emitHealthSnapshot({
+          deps: { mongo, identity },
+          client,
+        });
+        return 1;
+      },
+    },
+    {
+      intervalMs: HEALTH_SNAPSHOT_INTERVAL_MS,
+      jitterRatio: 0.05,
+      onError: (error) =>
+        logger.error("Sync health snapshot emit failed", error),
+    },
+  );
+}
 
 // Local-only: purge soft-disconnected connection caches past the retention
 // window. Safe without provider credentials and in passive execution.

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -52,6 +52,10 @@ export const SyncConfigSchema = z.strictObject({
   // the Google adapter refuses to construct when either is absent.
   GOOGLE_CLIENT_ID: z.string().trim().min(1).optional(),
   GOOGLE_CLIENT_SECRET: z.string().trim().min(1).optional(),
+  // Optional PostHog credentials for sanitized sync_health_snapshot events.
+  // When absent, the health emitter no-ops (local/dev without analytics).
+  POSTHOG_KEY: z.string().trim().min(1).optional(),
+  POSTHOG_HOST: z.url().optional(),
 });
 export type SyncConfig = z.infer<typeof SyncConfigSchema>;
 
@@ -76,6 +80,8 @@ export function parseSyncConfig(config: CompassConfig): SyncConfig {
     // Empty-string (unfilled deploy placeholder) or null coerces to absent.
     GOOGLE_CLIENT_ID: config.google?.clientId || undefined,
     GOOGLE_CLIENT_SECRET: config.google?.clientSecret || undefined,
+    POSTHOG_KEY: config.posthog?.key || undefined,
+    POSTHOG_HOST: config.posthog?.host || undefined,
   });
 }
 
@@ -96,6 +102,8 @@ export function parseSyncConfigFromEnv(
     COMPASS_API_DATABASE: rawEnv["SYNC_COMPASS_API_DATABASE"],
     GOOGLE_CLIENT_ID: rawEnv["GOOGLE_CLIENT_ID"] || undefined,
     GOOGLE_CLIENT_SECRET: rawEnv["GOOGLE_CLIENT_SECRET"] || undefined,
+    POSTHOG_KEY: rawEnv["POSTHOG_KEY"] || undefined,
+    POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || undefined,
   });
 }
 

--- a/packages/sync/src/telemetry/health-heartbeat.test.ts
+++ b/packages/sync/src/telemetry/health-heartbeat.test.ts
@@ -1,0 +1,25 @@
+import {
+  HEALTH_SNAPSHOT_STALE_AFTER_MS,
+  isHealthHeartbeatMissing,
+} from "@sync/telemetry/health-heartbeat";
+import { describe, expect, it } from "bun:test";
+
+describe("isHealthHeartbeatMissing", () => {
+  const now = new Date("2026-07-25T02:20:00.000Z");
+
+  it("is missing when no snapshot has ever been emitted", () => {
+    expect(isHealthHeartbeatMissing(null, now)).toBe(true);
+  });
+
+  it("is healthy within the 10-minute alert window", () => {
+    const last = new Date(
+      now.getTime() - HEALTH_SNAPSHOT_STALE_AFTER_MS + 1_000,
+    );
+    expect(isHealthHeartbeatMissing(last, now)).toBe(false);
+  });
+
+  it("is missing once the snapshot is older than 10 minutes", () => {
+    const last = new Date(now.getTime() - HEALTH_SNAPSHOT_STALE_AFTER_MS - 1);
+    expect(isHealthHeartbeatMissing(last, now)).toBe(true);
+  });
+});

--- a/packages/sync/src/telemetry/health-heartbeat.ts
+++ b/packages/sync/src/telemetry/health-heartbeat.ts
@@ -1,0 +1,13 @@
+// Alert threshold from 04-security: no sync_health_snapshot for > 10 minutes.
+export const HEALTH_SNAPSHOT_STALE_AFTER_MS = 10 * 60_000;
+
+// Pure predicate for the missing-heartbeat alert simulation (S44 evidence).
+export function isHealthHeartbeatMissing(
+  lastEmittedAt: Date | null,
+  now: Date,
+): boolean {
+  if (lastEmittedAt === null) return true;
+  return (
+    now.getTime() - lastEmittedAt.getTime() > HEALTH_SNAPSHOT_STALE_AFTER_MS
+  );
+}

--- a/packages/sync/src/telemetry/health-snapshot.queries.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.queries.test.ts
@@ -1,0 +1,22 @@
+import { SYNC_HEALTH_SNAPSHOT_EVENT } from "@core/types/sync/health.contracts";
+import {
+  SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL,
+  SYNC_HEALTH_FRESHNESS_HOGQL,
+  SYNC_HEALTH_HEARTBEAT_HOGQL,
+} from "@sync/telemetry/health-snapshot.queries";
+import { describe, expect, it } from "bun:test";
+
+describe("sync health HogQL fixtures", () => {
+  it("scopes every fixture to the sanitized snapshot event", () => {
+    for (const query of [
+      SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL,
+      SYNC_HEALTH_FRESHNESS_HOGQL,
+      SYNC_HEALTH_HEARTBEAT_HOGQL,
+    ]) {
+      expect(query).toContain(SYNC_HEALTH_SNAPSHOT_EVENT);
+      expect(query).not.toContain("title");
+      expect(query).not.toContain("refresh_token");
+      expect(query).not.toContain("principalId");
+    }
+  });
+});

--- a/packages/sync/src/telemetry/health-snapshot.queries.ts
+++ b/packages/sync/src/telemetry/health-snapshot.queries.ts
@@ -1,0 +1,38 @@
+import { SYNC_HEALTH_SNAPSHOT_EVENT } from "@core/types/sync/health.contracts";
+
+// HogQL fixtures for the Sync health dashboard / alerts (S44 evidence).
+// Wired into PostHog insights in S45; kept here so the event shape and
+// alert predicates stay next to the emitter.
+export const SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL = `
+SELECT
+  properties.environment,
+  properties.connections.healthy,
+  properties.connections.delayed,
+  properties.connections.actionRequired,
+  properties.connections.disconnected
+FROM events
+WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
+  AND timestamp > now() - INTERVAL 1 DAY
+ORDER BY timestamp DESC
+LIMIT 288
+`.trim();
+
+export const SYNC_HEALTH_FRESHNESS_HOGQL = `
+SELECT
+  timestamp,
+  properties.freshness.p50Ms,
+  properties.freshness.p95Ms,
+  properties.freshness.p99Ms,
+  properties.freshness.percentOver30s
+FROM events
+WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
+  AND timestamp > now() - INTERVAL 1 DAY
+ORDER BY timestamp DESC
+`.trim();
+
+export const SYNC_HEALTH_HEARTBEAT_HOGQL = `
+SELECT count() AS snapshots
+FROM events
+WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
+  AND timestamp > now() - INTERVAL 10 MINUTE
+`.trim();

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -1,0 +1,171 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { assertNoSafetyCanary } from "@sync/safety/safety-canary";
+import { buildServiceIdentity } from "@sync/service-identity";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import {
+  computeHealthSnapshot,
+  emitHealthSnapshot,
+  HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS,
+} from "@sync/telemetry/health-snapshot.service";
+import { type PostHogCaptureClient } from "@sync/telemetry/posthog-capture";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+const NOW = new Date("2026-07-25T02:00:00.000Z");
+
+describe("computeHealthSnapshot", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+  let resources: SyncResourceRepository;
+  let jobs: JobRepository;
+
+  beforeEach(() => {
+    connections = new ProviderConnectionRepository(storage.db());
+    resources = new SyncResourceRepository(storage.db());
+    jobs = new JobRepository(storage.db());
+  });
+
+  const identity = buildServiceIdentity({
+    environment: NodeEnv.Test,
+    execution: "passive",
+  });
+
+  const deps = () => ({
+    mongo: storage.mongo(),
+    identity,
+    now: () => NOW,
+  });
+
+  const seedConnection = (
+    state: "healthy" | "delayed" | "actionRequired" | "disconnected",
+  ) =>
+    connections.upsertByProviderAccount({
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
+      provider: "google",
+      account: {
+        providerAccountId: objectId(),
+        email: "h@example.com",
+        displayName: null,
+      },
+      capabilities: ["readEvents"],
+      state,
+      stateReason: state === "actionRequired" ? "authorizationRevoked" : null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+
+  it("aggregates connection states, jobs, subscriptions, and freshness", async () => {
+    await seedConnection("healthy");
+    await seedConnection("healthy");
+    await seedConnection("delayed");
+    await seedConnection("disconnected");
+
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const healthySub = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "events",
+      calendarId: objectId() as never,
+    });
+    await resources.updateSubscription(tenantId, principalId, healthySub._id, {
+      subscriptionId: "ch-healthy",
+      subscriptionResourceId: "res-1",
+      subscriptionToken: "tok-1",
+      subscriptionExpiresAt: new Date(
+        NOW.getTime() + HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS + 60_000,
+      ),
+    });
+    await resources.advanceCursor(
+      tenantId,
+      principalId,
+      healthySub._id,
+      "cursor",
+      new Date(NOW.getTime() - 5_000),
+    );
+
+    const missing = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "events",
+      calendarId: objectId() as never,
+    });
+    await resources.advanceCursor(
+      tenantId,
+      principalId,
+      missing._id,
+      "cursor",
+      new Date(NOW.getTime() - 60_000),
+    );
+
+    await jobs.enqueue({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceId: null,
+      commandId: null,
+      kind: "incrementalPull",
+      priority: 0,
+      runAfter: new Date(NOW.getTime() - 15_000),
+      coalescingKey: `pull:${objectId()}`,
+    });
+
+    const snapshot = await computeHealthSnapshot(deps());
+
+    expect(snapshot.service).toBe("compass-sync");
+    expect(snapshot.provider).toBe("google");
+    expect(snapshot.connections.healthy).toBe(2);
+    expect(snapshot.connections.delayed).toBe(1);
+    expect(snapshot.connections.disconnected).toBe(1);
+    expect(snapshot.jobs.pending).toBe(1);
+    expect(snapshot.jobs.oldestDueAgeMs).toBe(15_000);
+    expect(snapshot.subscriptions.healthy).toBe(1);
+    expect(snapshot.subscriptions.missing).toBe(1);
+    expect(snapshot.freshness.sampleSize).toBe(2);
+    expect(snapshot.freshness.p50Ms).toBeGreaterThan(0);
+    expect(snapshot.freshness.percentOver30s).toBeGreaterThan(0);
+    expect(snapshot.computedAt).toBe(NOW.toISOString());
+
+    // R-SEC-04 / S44: aggregates must never carry content or credential shapes.
+    assertNoSafetyCanary(snapshot);
+  });
+
+  it("emits through PostHog when a client is configured", async () => {
+    const captured: Array<{
+      event: string;
+      properties: Record<string, unknown>;
+    }> = [];
+    const client: PostHogCaptureClient = {
+      capture: async ({ event, properties }) => {
+        captured.push({ event, properties });
+      },
+      shutdown: async () => {},
+    };
+
+    const snapshot = await emitHealthSnapshot({ deps: deps(), client });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.event).toBe("sync_health_snapshot");
+    expect(captured[0]?.properties["service"]).toBe("compass-sync");
+    expect(snapshot.connections.healthy).toBe(0);
+    assertNoSafetyCanary(captured[0]?.properties);
+  });
+
+  it("still computes when PostHog is not configured", async () => {
+    const snapshot = await emitHealthSnapshot({ deps: deps(), client: null });
+    expect(snapshot.service).toBe("compass-sync");
+  });
+});

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -166,14 +166,11 @@ async function summarizeFreshness(
 ): Promise<SyncHealthSnapshot["freshness"]> {
   const rows = await db
     .collection(SYNC_COLLECTIONS.syncResources)
-    .find(
-      { resourceKind: "events", lastSuccessAt: { $ne: null } },
-      {
-        projection: { lastSuccessAt: 1 },
-        limit: FRESHNESS_SAMPLE_LIMIT,
-        sort: { lastSuccessAt: 1 },
-      },
-    )
+    .aggregate<{ lastSuccessAt: Date | null }>([
+      { $match: { resourceKind: "events", lastSuccessAt: { $ne: null } } },
+      { $project: { lastSuccessAt: 1 } },
+      { $sample: { size: FRESHNESS_SAMPLE_LIMIT } },
+    ])
     .toArray();
 
   if (rows.length === 0) {

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -1,0 +1,225 @@
+import { type Db } from "mongodb";
+import { ConnectionStateSchema } from "@core/types/sync/connection.contracts";
+import {
+  SYNC_HEALTH_SNAPSHOT_EVENT,
+  type SyncHealthSnapshot,
+  SyncHealthSnapshotSchema,
+} from "@core/types/sync/health.contracts";
+import { type StructuredServiceIdentity } from "@sync/service-identity";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+import {
+  captureSafely,
+  type PostHogCaptureClient,
+} from "@sync/telemetry/posthog-capture";
+
+// Channels expiring within this window count as renewSoon (aligns with the
+// subscription maintenance sweep).
+export const HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS = 24 * 60 * 60_000;
+const FRESHNESS_SLO_MS = 30_000;
+// Cap the in-process freshness sample so a huge deployment stays bounded.
+const FRESHNESS_SAMPLE_LIMIT = 5_000;
+
+export interface HealthSnapshotDeps {
+  mongo: SyncMongoService;
+  identity: StructuredServiceIdentity;
+  now?: () => Date;
+}
+
+// Build one sanitized aggregate snapshot from Sync storage. Pure relative to
+// PostHog — callers decide whether to emit.
+export async function computeHealthSnapshot(
+  deps: HealthSnapshotDeps,
+): Promise<SyncHealthSnapshot> {
+  const started = Date.now();
+  const now = deps.now?.() ?? new Date();
+  const db = deps.mongo.db;
+
+  const [connections, jobs, subscriptions, freshness] = await Promise.all([
+    countConnectionsByState(db),
+    summarizeJobs(db, now),
+    summarizeSubscriptions(db, now),
+    summarizeFreshness(db, now),
+  ]);
+
+  return SyncHealthSnapshotSchema.parse({
+    environment: deps.identity.environment,
+    execution: deps.identity.execution,
+    provider: "google",
+    service: "compass-sync",
+    connections,
+    jobs,
+    subscriptions,
+    freshness,
+    computedAt: now.toISOString(),
+    computeMs: Date.now() - started,
+  });
+}
+
+export async function emitHealthSnapshot(input: {
+  deps: HealthSnapshotDeps;
+  client: PostHogCaptureClient | null;
+}): Promise<SyncHealthSnapshot> {
+  const snapshot = await computeHealthSnapshot(input.deps);
+  await captureSafely(input.client, {
+    event: SYNC_HEALTH_SNAPSHOT_EVENT,
+    // One service-level distinct id — never a user id (R-SEC-04).
+    distinctId: "compass-sync",
+    properties: snapshot as unknown as Record<string, unknown>,
+  });
+  return snapshot;
+}
+
+async function countConnectionsByState(
+  db: Db,
+): Promise<SyncHealthSnapshot["connections"]> {
+  const rows = await db
+    .collection(SYNC_COLLECTIONS.providerConnections)
+    .aggregate<{ _id: string; count: number }>([
+      { $group: { _id: "$state", count: { $sum: 1 } } },
+    ])
+    .toArray();
+
+  const counts: SyncHealthSnapshot["connections"] = {
+    connecting: 0,
+    importing: 0,
+    catchingUp: 0,
+    healthy: 0,
+    delayed: 0,
+    actionRequired: 0,
+    disconnected: 0,
+  };
+  for (const row of rows) {
+    const state = ConnectionStateSchema.safeParse(row._id);
+    if (!state.success) continue;
+    counts[state.data] = row.count;
+  }
+  return counts;
+}
+
+async function summarizeJobs(
+  db: Db,
+  now: Date,
+): Promise<SyncHealthSnapshot["jobs"]> {
+  const collection = db.collection(SYNC_COLLECTIONS.jobs);
+  const [pending, claimed, failed, oldestDue] = await Promise.all([
+    collection.countDocuments({ state: "pending" }),
+    collection.countDocuments({ state: "claimed" }),
+    collection.countDocuments({ state: "failed" }),
+    collection.findOne(
+      {
+        $or: [
+          { state: "pending", runAfter: { $lte: now } },
+          { state: "claimed", leaseExpiresAt: { $lt: now } },
+        ],
+      },
+      { sort: { runAfter: 1 }, projection: { runAfter: 1 } },
+    ),
+  ]);
+
+  const oldestDueAgeMs =
+    oldestDue?.["runAfter"] instanceof Date
+      ? Math.max(0, now.getTime() - oldestDue["runAfter"].getTime())
+      : null;
+
+  return { pending, claimed, failed, oldestDueAgeMs };
+}
+
+async function summarizeSubscriptions(
+  db: Db,
+  now: Date,
+): Promise<SyncHealthSnapshot["subscriptions"]> {
+  const renewBefore = new Date(
+    now.getTime() + HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS,
+  );
+  const collection = db.collection(SYNC_COLLECTIONS.syncResources);
+  const eventsFilter = { resourceKind: "events" as const };
+
+  const [healthy, renewSoon, expired, missing] = await Promise.all([
+    collection.countDocuments({
+      ...eventsFilter,
+      subscriptionId: { $ne: null },
+      subscriptionExpiresAt: { $gte: renewBefore },
+    }),
+    collection.countDocuments({
+      ...eventsFilter,
+      subscriptionId: { $ne: null },
+      subscriptionExpiresAt: { $gte: now, $lt: renewBefore },
+    }),
+    collection.countDocuments({
+      ...eventsFilter,
+      subscriptionId: { $ne: null },
+      subscriptionExpiresAt: { $lt: now },
+    }),
+    collection.countDocuments({
+      ...eventsFilter,
+      subscriptionId: null,
+    }),
+  ]);
+
+  return { healthy, renewSoon, expired, missing };
+}
+
+async function summarizeFreshness(
+  db: Db,
+  now: Date,
+): Promise<SyncHealthSnapshot["freshness"]> {
+  const rows = await db
+    .collection(SYNC_COLLECTIONS.syncResources)
+    .find(
+      { resourceKind: "events", lastSuccessAt: { $ne: null } },
+      {
+        projection: { lastSuccessAt: 1 },
+        limit: FRESHNESS_SAMPLE_LIMIT,
+        sort: { lastSuccessAt: 1 },
+      },
+    )
+    .toArray();
+
+  if (rows.length === 0) {
+    return {
+      sampleSize: 0,
+      p50Ms: null,
+      p95Ms: null,
+      p99Ms: null,
+      percentOver30s: null,
+    };
+  }
+
+  const ages = rows
+    .map((row) => {
+      const at = row["lastSuccessAt"];
+      return at instanceof Date ? now.getTime() - at.getTime() : null;
+    })
+    .filter((age): age is number => age !== null)
+    .map((age) => Math.max(0, age))
+    .sort((a, b) => a - b);
+
+  if (ages.length === 0) {
+    return {
+      sampleSize: 0,
+      p50Ms: null,
+      p95Ms: null,
+      p99Ms: null,
+      percentOver30s: null,
+    };
+  }
+
+  const over30 = ages.filter((age) => age > FRESHNESS_SLO_MS).length;
+  return {
+    sampleSize: ages.length,
+    p50Ms: percentile(ages, 0.5),
+    p95Ms: percentile(ages, 0.95),
+    p99Ms: percentile(ages, 0.99),
+    percentOver30s: Math.round((over30 / ages.length) * 1000) / 10,
+  };
+}
+
+function percentile(sorted: readonly number[], p: number): number {
+  if (sorted.length === 1) return sorted[0]!;
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(p * sorted.length) - 1),
+  );
+  return sorted[index]!;
+}

--- a/packages/sync/src/telemetry/posthog-capture.test.ts
+++ b/packages/sync/src/telemetry/posthog-capture.test.ts
@@ -1,0 +1,69 @@
+import {
+  captureSafely,
+  createPostHogCaptureClient,
+} from "@sync/telemetry/posthog-capture";
+import { describe, expect, it } from "bun:test";
+
+describe("createPostHogCaptureClient", () => {
+  it("posts a capture payload to /i/v0/e/", async () => {
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const client = createPostHogCaptureClient({
+      apiKey: "phc_test",
+      host: "https://us.i.posthog.com",
+      fetch: (async (input, init) => {
+        calls.push({
+          url: String(input),
+          body: JSON.parse(String(init?.body)),
+        });
+        return { ok: true, status: 200 } as Response;
+      }) as typeof fetch,
+    });
+
+    await client.capture({
+      event: "sync_health_snapshot",
+      distinctId: "compass-sync",
+      properties: { service: "compass-sync", healthy: 1 },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("https://us.i.posthog.com/i/v0/e/");
+    expect(calls[0]?.body).toMatchObject({
+      api_key: "phc_test",
+      distinct_id: "compass-sync",
+      event: "sync_health_snapshot",
+      properties: {
+        service: "compass-sync",
+        healthy: 1,
+        $lib: "compass-sync",
+      },
+    });
+  });
+
+  it("captureSafely returns false without throwing when client is null", async () => {
+    await expect(
+      captureSafely(null, {
+        event: "sync_health_snapshot",
+        distinctId: "compass-sync",
+        properties: {},
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("captureSafely swallows delivery failures", async () => {
+    const client = createPostHogCaptureClient({
+      apiKey: "phc_test",
+      host: "https://us.i.posthog.com",
+      fetch: (async () => {
+        throw new Error("network down");
+      }) as typeof fetch,
+    });
+
+    await expect(
+      captureSafely(client, {
+        event: "sync_health_snapshot",
+        distinctId: "compass-sync",
+        properties: {},
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/sync/src/telemetry/posthog-capture.ts
+++ b/packages/sync/src/telemetry/posthog-capture.ts
@@ -1,0 +1,81 @@
+import { Logger } from "@core/logger/winston.logger";
+
+const logger = Logger("sync:posthog");
+
+export interface PostHogCaptureClient {
+  capture: (input: {
+    event: string;
+    distinctId: string;
+    properties: Record<string, unknown>;
+  }) => Promise<void>;
+  shutdown: () => Promise<void>;
+}
+
+export interface PostHogCaptureOptions {
+  apiKey: string;
+  host: string;
+  fetch?: typeof fetch;
+}
+
+const DEFAULT_HOST = "https://us.i.posthog.com";
+
+// Thin HTTP capture client for Sync aggregate events. No-ops are handled by
+// the caller when apiKey is absent — this client always attempts delivery.
+export function createPostHogCaptureClient(
+  options: PostHogCaptureOptions,
+): PostHogCaptureClient {
+  const host = options.host.replace(/\/+$/, "") || DEFAULT_HOST;
+  const send = options.fetch ?? globalThis.fetch;
+
+  return {
+    async capture({ event, distinctId, properties }) {
+      const response = await send(new URL("/i/v0/e/", host), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: options.apiKey,
+          distinct_id: distinctId,
+          event,
+          properties: {
+            ...properties,
+            $lib: "compass-sync",
+          },
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `PostHog capture rejected with status ${response.status}`,
+        );
+      }
+    },
+    async shutdown() {
+      // Stateless HTTP client — nothing to flush.
+    },
+  };
+}
+
+// Best-effort capture: log and continue on failure so telemetry never takes
+// down the Sync process.
+export async function captureSafely(
+  client: PostHogCaptureClient | null,
+  input: {
+    event: string;
+    distinctId: string;
+    properties: Record<string, unknown>;
+  },
+): Promise<boolean> {
+  if (!client) return false;
+  try {
+    await client.capture(input);
+    return true;
+  } catch (error) {
+    logger.warn(
+      `PostHog capture failed for ${input.event}: ${
+        error instanceof Error ? error.message : "unknown"
+      }`,
+    );
+    return false;
+  }
+}
+
+export { DEFAULT_HOST as DEFAULT_POSTHOG_HOST };


### PR DESCRIPTION
## Summary
- S44: emit `sync_health_snapshot` every 5 minutes from Sync (passive-safe).
- Aggregates connection-state counts, job backlog/oldest due age, subscription health, and freshness p50/p95/p99.
- Optional PostHog via shared `compass.yaml` `posthog` / `POSTHOG_KEY` (no-op when unset).
- Evidence: schema + canary scan, aggregation db tests, missing-heartbeat predicate, HogQL fixtures for S45 alerts.

## Test plan
- [x] `bun test:core` (health.contracts)
- [x] `bun test:sync` (telemetry + sync.config)
- [x] `bun type-check` / `bun lint`
- [ ] Staging: set PostHog key on Sync, confirm `sync_health_snapshot` appears in PostHog


Made with [Cursor](https://cursor.com)