### PR TITLE
chore(sync): add operating and recovery controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "verify": "bun packages/scripts/src/testing/verify.ts",
     "build:backend": "bun packages/scripts/src/commands/build.backend.ts",
     "build:sync": "bun packages/scripts/src/commands/build.sync.ts",
-    "build:web": "cd packages/web && bun run build.ts"
+    "build:web": "cd packages/web && bun run build.ts",
+    "sync:backup": "bun packages/scripts/src/commands/sync-backup.ts",
+    "sync:restore": "bun packages/scripts/src/commands/sync-restore.ts"
   },
   "dependencies": {
     "@compass/backend": "*",

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -17,6 +17,7 @@ import {
   EVENTS_FULL_PATH,
   EVENTS_PATH,
 } from "@sync/server/connection.routes";
+import { DIAGNOSTIC_CONNECTION_PATH } from "@sync/server/diagnostic.routes";
 import { PRINCIPAL_PATH } from "@sync/server/principal.routes";
 import {
   SyncServiceClient,
@@ -186,6 +187,43 @@ describe("SyncServiceClient", () => {
     if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
     expect(verdict.context.tenantId).toBe(who.tenantId);
     expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("resolves a diagnostic connection with a signed GET", async () => {
+    const who = principal();
+    const key = "a".repeat(32);
+    const payload = {
+      diagnosticKey: key,
+      connectionId: "507f1f77bcf86cd799439011",
+      tenantId: who.tenantId,
+      principalId: who.principalId,
+      provider: "google",
+      state: "healthy",
+      stateReason: null,
+      accountEmail: "ops@example.com",
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+      disconnectedAt: null,
+      calendarCount: 1,
+      pendingJobCount: 0,
+      pendingCommandCount: 0,
+    };
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => payload,
+    }));
+
+    const result = await client(fn).resolveDiagnosticConnection(who, key);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.diagnosticKey).toBe(key);
+
+    const expectedPath = DIAGNOSTIC_CONNECTION_PATH.replace(
+      ":diagnosticKey",
+      key,
+    );
+    expect(calls[0]?.url).toBe(`${BASE_URL}${expectedPath}`);
+    expect(calls[0]?.method).toBe("GET");
   });
 
   it("lists calendars with a signed GET the real Sync verifier accepts", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -24,6 +24,10 @@ import {
   ConnectionListResponseSchema,
 } from "@core/types/sync/connection.contracts";
 import {
+  type DiagnosticConnectionResponse,
+  DiagnosticConnectionResponseSchema,
+} from "@core/types/sync/diagnostic.contracts";
+import {
   type EventInstanceListQuery,
   type EventInstanceListResponse,
   EventInstanceListResponseSchema,
@@ -48,6 +52,7 @@ const EVENTS_PATH = "/internal/events";
 const EVENTS_FULL_PATH = "/internal/events/full";
 const COMMANDS_PATH = "/internal/commands";
 const PRINCIPAL_PATH = "/internal/principal";
+const DIAGNOSTIC_CONNECTION_PATH_PREFIX = "/internal/diagnostics/connections/";
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
@@ -323,6 +328,22 @@ export class SyncServiceClient {
       path: PRINCIPAL_PATH,
       principal,
       schema: PrincipalPurgeResponseSchema,
+      correlationId,
+    });
+  }
+
+  // Private support lookup by non-user-facing diagnostic connection key (S45).
+  // The signed principal proves INTERNAL_AUTH_TOKEN possession; lookup is global.
+  resolveDiagnosticConnection(
+    principal: SyncPrincipal,
+    diagnosticKey: string,
+    correlationId?: string,
+  ): Promise<SyncClientResult<DiagnosticConnectionResponse>> {
+    return this.#request({
+      method: "GET",
+      path: `${DIAGNOSTIC_CONNECTION_PATH_PREFIX}${diagnosticKey}`,
+      principal,
+      schema: DiagnosticConnectionResponseSchema,
       correlationId,
     });
   }

--- a/packages/core/src/types/sync/diagnostic.contracts.test.ts
+++ b/packages/core/src/types/sync/diagnostic.contracts.test.ts
@@ -1,0 +1,54 @@
+import {
+  type DiagnosticConnectionResponse,
+  DiagnosticConnectionResponseSchema,
+} from "@core/types/sync/diagnostic.contracts";
+import { describe, expect, it } from "bun:test";
+
+const sample = (): DiagnosticConnectionResponse => ({
+  diagnosticKey: "a".repeat(32),
+  connectionId: "507f1f77bcf86cd799439011",
+  tenantId: "507f1f77bcf86cd799439012",
+  principalId: "507f1f77bcf86cd799439013",
+  provider: "google",
+  state: "delayed",
+  stateReason: null,
+  accountEmail: "user@example.com",
+  lastSyncedAt: "2026-07-24T12:00:00.000Z",
+  lastHealthyAt: "2026-07-24T11:00:00.000Z",
+  disconnectedAt: null,
+  calendarCount: 2,
+  pendingJobCount: 1,
+  pendingCommandCount: 0,
+});
+
+describe("DiagnosticConnectionResponseSchema", () => {
+  it("accepts a metadata-only support payload", () => {
+    expect(DiagnosticConnectionResponseSchema.safeParse(sample()).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects event content / credential fields", () => {
+    expect(
+      DiagnosticConnectionResponseSchema.safeParse({
+        ...sample(),
+        title: "Secret meeting",
+      }).success,
+    ).toBe(false);
+    expect(
+      DiagnosticConnectionResponseSchema.safeParse({
+        ...sample(),
+        refreshToken: "tok",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a short diagnostic key", () => {
+    expect(
+      DiagnosticConnectionResponseSchema.safeParse({
+        ...sample(),
+        diagnosticKey: "abc",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/types/sync/diagnostic.contracts.ts
+++ b/packages/core/src/types/sync/diagnostic.contracts.ts
@@ -1,0 +1,39 @@
+import { z } from "zod/v4";
+import { DateTimeSchema } from "@core/types/domain-primitives";
+import {
+  ConnectionStateReasonSchema,
+  ConnectionStateSchema,
+} from "@core/types/sync/connection.contracts";
+import {
+  ConnectionIdSchema,
+  PrincipalIdSchema,
+  ProviderKindSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+
+// Private support lookup for a non-user-facing diagnostic connection key
+// (R-OPS-05 / S45). Metadata and counts only — never tokens or event content.
+export const DiagnosticConnectionResponseSchema = z.strictObject({
+  diagnosticKey: z
+    .string()
+    .length(32)
+    .regex(/^[0-9a-f]+$/),
+  connectionId: ConnectionIdSchema,
+  tenantId: TenantIdSchema,
+  principalId: PrincipalIdSchema,
+  provider: ProviderKindSchema,
+  state: ConnectionStateSchema,
+  stateReason: ConnectionStateReasonSchema.nullable(),
+  // Account email helps authorized support confirm the right connection; it is
+  // never emitted on the public health snapshot / PostHog aggregates.
+  accountEmail: z.string().nullable(),
+  lastSyncedAt: DateTimeSchema.nullable(),
+  lastHealthyAt: DateTimeSchema.nullable(),
+  disconnectedAt: DateTimeSchema.nullable(),
+  calendarCount: z.number().int().nonnegative(),
+  pendingJobCount: z.number().int().nonnegative(),
+  pendingCommandCount: z.number().int().nonnegative(),
+});
+export type DiagnosticConnectionResponse = z.infer<
+  typeof DiagnosticConnectionResponseSchema
+>;

--- a/packages/scripts/src/commands/sync-backup.ts
+++ b/packages/scripts/src/commands/sync-backup.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+/**
+ * Dump the isolated Sync Mongo database (`compass_sync`) for restore drills.
+ *
+ * Usage:
+ *   bun packages/scripts/src/commands/sync-backup.ts [--out DIR]
+ *
+ * Requires mongodump on PATH and SYNC_MONGO_URI (or compass.yaml `sync.mongoUri`).
+ * Does not dump the Compass API database.
+ */
+import { loadCompassConfig } from "@core/config/compass.config";
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+function mongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const config = loadCompassConfig();
+  const uri = config.sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before backing up",
+    );
+  }
+  return uri;
+}
+
+function outDir(argv: string[]): string {
+  const flag = argv.indexOf("--out");
+  if (flag >= 0 && argv[flag + 1]) return argv[flag + 1]!;
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return join(process.cwd(), "tmp", "sync-backups", stamp);
+}
+
+function main(): void {
+  const uri = mongoUri();
+  const dest = outDir(process.argv.slice(2));
+  mkdirSync(dest, { recursive: true });
+
+  const result = spawnSync("mongodump", ["--uri", uri, "--out", dest], {
+    stdio: "inherit",
+  });
+  if (result.error) {
+    console.error(
+      "mongodump failed to start. Install MongoDB Database Tools and retry.",
+    );
+    console.error(result.error.message);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+  console.log(`Sync database dump written to ${dest}`);
+  console.log(
+    "Restore with: bun packages/scripts/src/commands/sync-restore.ts --from <dump-dir>",
+  );
+}
+
+main();

--- a/packages/scripts/src/commands/sync-restore.ts
+++ b/packages/scripts/src/commands/sync-restore.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+/**
+ * Restore a Sync Mongo dump produced by sync-backup.ts.
+ *
+ * Usage:
+ *   bun packages/scripts/src/commands/sync-restore.ts --from DIR [--drop]
+ *
+ * `--drop` drops each collection before restore (typical for a drill onto an
+ * empty/throwaway Sync database). Never point this at production without an
+ * explicit maintenance window.
+ */
+import { loadCompassConfig } from "@core/config/compass.config";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+function mongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const config = loadCompassConfig();
+  const uri = config.sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before restoring",
+    );
+  }
+  return uri;
+}
+
+function fromDir(argv: string[]): string {
+  const flag = argv.indexOf("--from");
+  if (flag < 0 || !argv[flag + 1]) {
+    throw new Error("Required: --from <mongodump-output-dir>");
+  }
+  return argv[flag + 1]!;
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const uri = mongoUri();
+  const source = fromDir(argv);
+  if (!existsSync(source)) {
+    throw new Error(`Dump directory not found: ${source}`);
+  }
+  const drop = argv.includes("--drop");
+
+  const args = ["--uri", uri, `--dir=${source}`];
+  if (drop) args.push("--drop");
+
+  const result = spawnSync("mongorestore", args, { stdio: "inherit" });
+  if (result.error) {
+    console.error(
+      "mongorestore failed to start. Install MongoDB Database Tools and retry.",
+    );
+    console.error(result.error.message);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+  console.log(`Sync database restored from ${source}`);
+}
+
+main();

--- a/packages/sync/src/domain/connection-diagnostic.service.ts
+++ b/packages/sync/src/domain/connection-diagnostic.service.ts
@@ -20,21 +20,22 @@ export async function resolveDiagnosticConnection(
   const connection = await deps.connections.findByDiagnosticKey(diagnosticKey);
   if (!connection) return null;
 
-  const [calendars, pendingJobCount, pendingCommands] = await Promise.all([
-    deps.calendars.listByConnection(
-      connection.tenantId,
-      connection.principalId,
-      connection._id,
-    ),
+  const calendars = await deps.calendars.listByConnection(
+    connection.tenantId,
+    connection.principalId,
+    connection._id,
+  );
+  const [pendingJobCount, pendingCommandCount] = await Promise.all([
     deps.jobs.countOutstandingByConnection(
       connection.tenantId,
       connection.principalId,
       connection._id,
     ),
-    deps.commands.listNonterminal(
+    deps.commands.countNonterminalByConnection(
       connection.tenantId,
       connection.principalId,
-      100,
+      connection._id,
+      calendars.map((calendar) => calendar._id),
     ),
   ]);
 
@@ -52,6 +53,6 @@ export async function resolveDiagnosticConnection(
     disconnectedAt: connection.disconnectedAt?.toISOString() ?? null,
     calendarCount: calendars.length,
     pendingJobCount,
-    pendingCommandCount: pendingCommands.length,
+    pendingCommandCount,
   };
 }

--- a/packages/sync/src/domain/connection-diagnostic.service.ts
+++ b/packages/sync/src/domain/connection-diagnostic.service.ts
@@ -1,0 +1,57 @@
+import { type DiagnosticConnectionResponse } from "@core/types/sync/diagnostic.contracts";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+
+export interface ConnectionDiagnosticDeps {
+  connections: ProviderConnectionRepository;
+  calendars: ProviderCalendarRepository;
+  jobs: JobRepository;
+  commands: CommandRepository;
+}
+
+// Resolve a non-user-facing diagnostic key to connection metadata for
+// authorized support tooling (R-OPS-05). Returns null when unknown.
+export async function resolveDiagnosticConnection(
+  deps: ConnectionDiagnosticDeps,
+  diagnosticKey: string,
+): Promise<DiagnosticConnectionResponse | null> {
+  const connection = await deps.connections.findByDiagnosticKey(diagnosticKey);
+  if (!connection) return null;
+
+  const [calendars, pendingJobCount, pendingCommands] = await Promise.all([
+    deps.calendars.listByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    ),
+    deps.jobs.countOutstandingByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    ),
+    deps.commands.listNonterminal(
+      connection.tenantId,
+      connection.principalId,
+      100,
+    ),
+  ]);
+
+  return {
+    diagnosticKey: connection.diagnosticKey,
+    connectionId: connection._id,
+    tenantId: connection.tenantId,
+    principalId: connection.principalId,
+    provider: connection.provider,
+    state: connection.state,
+    stateReason: connection.stateReason,
+    accountEmail: connection.account.email,
+    lastSyncedAt: connection.lastSyncedAt?.toISOString() ?? null,
+    lastHealthyAt: connection.lastHealthyAt?.toISOString() ?? null,
+    disconnectedAt: connection.disconnectedAt?.toISOString() ?? null,
+    calendarCount: calendars.length,
+    pendingJobCount,
+    pendingCommandCount: pendingCommands.length,
+  };
+}

--- a/packages/sync/src/domain/connection-diagnostic.service.ts
+++ b/packages/sync/src/domain/connection-diagnostic.service.ts
@@ -1,4 +1,7 @@
-import { type DiagnosticConnectionResponse } from "@core/types/sync/diagnostic.contracts";
+import {
+  type DiagnosticConnectionResponse,
+  DiagnosticConnectionResponseSchema,
+} from "@core/types/sync/diagnostic.contracts";
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
@@ -39,7 +42,7 @@ export async function resolveDiagnosticConnection(
     ),
   ]);
 
-  return {
+  return DiagnosticConnectionResponseSchema.parse({
     diagnosticKey: connection.diagnosticKey,
     connectionId: connection._id,
     tenantId: connection.tenantId,
@@ -54,5 +57,5 @@ export async function resolveDiagnosticConnection(
     calendarCount: calendars.length,
     pendingJobCount,
     pendingCommandCount,
-  };
+  });
 }

--- a/packages/sync/src/safety/diagnostic-key.test.ts
+++ b/packages/sync/src/safety/diagnostic-key.test.ts
@@ -1,0 +1,22 @@
+import { deriveDiagnosticKey } from "@sync/safety/diagnostic-key";
+import { describe, expect, it } from "bun:test";
+
+describe("deriveDiagnosticKey", () => {
+  it("is stable for the same connection id", () => {
+    const id = "507f1f77bcf86cd799439011";
+    expect(deriveDiagnosticKey(id)).toBe(deriveDiagnosticKey(id));
+  });
+
+  it("differs across connection ids and is 32 hex chars", () => {
+    const a = deriveDiagnosticKey("507f1f77bcf86cd799439011");
+    const b = deriveDiagnosticKey("507f1f77bcf86cd799439012");
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("is not the raw connection id", () => {
+    const id = "507f1f77bcf86cd799439011";
+    expect(deriveDiagnosticKey(id)).not.toBe(id);
+    expect(deriveDiagnosticKey(id)).not.toContain(id);
+  });
+});

--- a/packages/sync/src/safety/diagnostic-key.ts
+++ b/packages/sync/src/safety/diagnostic-key.ts
@@ -1,0 +1,14 @@
+import { createHash } from "node:crypto";
+
+// Non-user-facing connection key for logs and support lookup (R-OPS-05).
+// Derived from the connection id so upserts can stamp it at insert without a
+// second round-trip. Not a secret: knowing the connection id already implies
+// privileged access. Do not put the raw connection id in PostHog properties.
+export const DIAGNOSTIC_KEY_LENGTH = 32;
+
+export function deriveDiagnosticKey(connectionId: string): string {
+  return createHash("sha256")
+    .update(`sync-connection:${connectionId}`)
+    .digest("hex")
+    .slice(0, DIAGNOSTIC_KEY_LENGTH);
+}

--- a/packages/sync/src/server/diagnostic.routes.db.test.ts
+++ b/packages/sync/src/server/diagnostic.routes.db.test.ts
@@ -1,0 +1,140 @@
+import { faker } from "@faker-js/faker";
+import { NodeEnv } from "@core/constants/core.constants";
+import { type DiagnosticConnectionResponse } from "@core/types/sync/diagnostic.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { createSyncService, type SyncService } from "@sync/app";
+import { signInternalRequest } from "@sync/auth/internal-auth";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { deriveDiagnosticKey } from "@sync/safety/diagnostic-key";
+import { DIAGNOSTIC_CONNECTION_PATH } from "@sync/server/diagnostic.routes";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { type AddressInfo } from "node:net";
+
+const uri = process.env["SYNC_MONGO_URI"] as string;
+const storage = setupSyncStorage(import.meta.url);
+const objectId = () => faker.database.mongodbObjectId();
+const SECRET = "internal-secret";
+
+const testConfig = (): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 0,
+    MONGO_URI: uri,
+    INTERNAL_AUTH_TOKEN: SECRET,
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+  }) as SyncConfig;
+
+const signedHeaders = (
+  tenantId: string,
+  principalId: string,
+): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "x-sync-tenant": tenantId,
+    "x-sync-principal": principalId,
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signInternalRequest(SECRET, {
+      timestamp,
+      tenantId,
+      principalId,
+    }),
+  };
+};
+
+describe("GET /internal/diagnostics/connections/:diagnosticKey", () => {
+  let mongo: SyncMongoService;
+  let service: SyncService;
+  let base: string;
+
+  beforeEach(async () => {
+    mongo = storage.mongo();
+    service = createSyncService(testConfig(), { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  it("resolves a diagnostic key to metadata without event content", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connections = new ProviderConnectionRepository(mongo.db);
+    const calendars = new ProviderCalendarRepository(mongo.db);
+
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      provider: "google",
+      account: {
+        providerAccountId: objectId(),
+        email: "support-lookup@example.com",
+        displayName: null,
+      },
+      capabilities: ["readEvents"],
+      state: "delayed",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+    await calendars.upsertByProviderCalendar({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary",
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadBusy: true,
+        canReadEvents: true,
+        canWriteEvents: true,
+        canInviteAttendees: false,
+      },
+    });
+
+    expect(connection.diagnosticKey).toBe(deriveDiagnosticKey(connection._id));
+
+    const path = DIAGNOSTIC_CONNECTION_PATH.replace(
+      ":diagnosticKey",
+      connection.diagnosticKey,
+    );
+    const response = await fetch(`${base}${path}`, {
+      headers: signedHeaders(objectId(), objectId()),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as DiagnosticConnectionResponse;
+    expect(body.connectionId).toBe(connection._id);
+    expect(body.tenantId).toBe(tenantId);
+    expect(body.principalId).toBe(principalId);
+    expect(body.accountEmail).toBe("support-lookup@example.com");
+    expect(body.state).toBe("delayed");
+    expect(body.calendarCount).toBe(1);
+    expect(body).not.toHaveProperty("refreshToken");
+    expect(body).not.toHaveProperty("title");
+  });
+
+  it("returns 404 for an unknown diagnostic key", async () => {
+    const path = DIAGNOSTIC_CONNECTION_PATH.replace(
+      ":diagnosticKey",
+      "a".repeat(32),
+    );
+    const response = await fetch(`${base}${path}`, {
+      headers: signedHeaders(objectId(), objectId()),
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/sync/src/server/diagnostic.routes.ts
+++ b/packages/sync/src/server/diagnostic.routes.ts
@@ -1,0 +1,71 @@
+import { type Express, type RequestHandler } from "express";
+import { Status } from "@core/errors/status.codes";
+import { DiagnosticConnectionResponseSchema } from "@core/types/sync/diagnostic.contracts";
+import { resolveDiagnosticConnection } from "@sync/domain/connection-diagnostic.service";
+import {
+  ensureConnected,
+  internalRateLimit,
+  requireAuth,
+  respondInternalError,
+} from "@sync/server/internal-http";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+export const DIAGNOSTIC_CONNECTION_PATH =
+  "/internal/diagnostics/connections/:diagnosticKey";
+
+export interface DiagnosticApiDeps {
+  authMiddleware: RequestHandler;
+  mongo: SyncMongoService;
+}
+
+// Private support lookup. Auth proves the caller holds INTERNAL_AUTH_TOKEN
+// (same as every internal route); the diagnostic key is resolved globally
+// because operators do not know the tenant/principal from logs alone.
+export function registerDiagnosticRoutes(
+  app: Express,
+  deps: DiagnosticApiDeps,
+): void {
+  app.get(
+    DIAGNOSTIC_CONNECTION_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+
+      const diagnosticKey = String(req.params["diagnosticKey"] ?? "");
+      if (!/^[0-9a-f]{32}$/.test(diagnosticKey)) {
+        res
+          .status(Status.BAD_REQUEST)
+          .json({ error: "invalid_diagnostic_key" });
+        return;
+      }
+
+      try {
+        const result = await resolveDiagnosticConnection(
+          {
+            connections: new ProviderConnectionRepository(deps.mongo.db),
+            calendars: new ProviderCalendarRepository(deps.mongo.db),
+            jobs: new JobRepository(deps.mongo.db),
+            commands: new CommandRepository(deps.mongo.db),
+          },
+          diagnosticKey,
+        );
+        if (!result) {
+          res.status(Status.NOT_FOUND).json({ error: "not_found" });
+          return;
+        }
+        res
+          .status(Status.OK)
+          .json(DiagnosticConnectionResponseSchema.parse(result));
+      } catch {
+        respondInternalError(res);
+      }
+    },
+  );
+}

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -6,6 +6,7 @@ import {
   type ConnectionApiDeps,
   registerConnectionRoutes,
 } from "@sync/server/connection.routes";
+import { registerDiagnosticRoutes } from "@sync/server/diagnostic.routes";
 import { registerHealthRoutes } from "@sync/server/health.routes";
 import { registerNotificationRoutes } from "@sync/server/notification.routes";
 import { registerPrincipalRoutes } from "@sync/server/principal.routes";
@@ -51,6 +52,11 @@ export function buildSyncApp(deps: {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
       authAdapter: deps.connectionApi.authAdapter,
+    });
+    // Private support diagnostic lookup by non-user-facing connection key (S45).
+    registerDiagnosticRoutes(app, {
+      authMiddleware: deps.connectionApi.authMiddleware,
+      mongo: deps.connectionApi.mongo,
     });
     // The public webhook ingress shares the connection API's storage; it needs
     // no auth adapter or secrets, only the db and execution mode.

--- a/packages/sync/src/storage/contracts/provider-connection.contracts.ts
+++ b/packages/sync/src/storage/contracts/provider-connection.contracts.ts
@@ -41,6 +41,12 @@ export const ProviderConnectionRecordSchema = z
     capabilities: ProviderCapabilitySetSchema,
     state: ConnectionStateSchema,
     stateReason: ConnectionStateReasonSchema.nullable(),
+    // Non-user-facing key for logs / private support lookup (R-OPS-05). Derived
+    // from `_id` at insert; never returned on the public connection wire.
+    diagnosticKey: z
+      .string()
+      .length(32)
+      .regex(/^[0-9a-f]+$/),
     // When the user disconnected this connection, or null while connected. This
     // is durable evidence, not a derived flag: connection-state derivation
     // treats a non-null value as the top-priority "disconnected" state, so a

--- a/packages/sync/src/storage/index-manifest.db.test.ts
+++ b/packages/sync/src/storage/index-manifest.db.test.ts
@@ -87,6 +87,17 @@ describe("installIndexManifest", () => {
     });
   });
 
+  it("installs a unique diagnostic_key index for support lookup", async () => {
+    const indexes = await db
+      .collection(SYNC_COLLECTIONS.providerConnections)
+      .indexes();
+    const diagnostic = indexes.find((i) => i.name === "diagnostic_key");
+    expect(diagnostic?.unique).toBe(true);
+    expect(diagnostic?.partialFilterExpression).toEqual({
+      diagnosticKey: { $type: "string" },
+    });
+  });
+
   it("installs principal keyset and TTL indexes on invalidations", async () => {
     const indexes = await db
       .collection(SYNC_COLLECTIONS.invalidations)

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -47,6 +47,17 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
         partialFilterExpression: { disconnectedAt: { $type: "date" } },
       },
     },
+    {
+      // Private support lookup by non-user-facing diagnostic key (S45).
+      // Partial so pre-S45 rows without the field do not collide on null
+      // while reads lazily stamp keys.
+      name: "diagnostic_key",
+      key: { diagnosticKey: 1 },
+      options: {
+        unique: true,
+        partialFilterExpression: { diagnosticKey: { $type: "string" } },
+      },
+    },
   ],
   // Keyed 1:1 by connection id (the automatic _id index); no secondary indexes.
   [SYNC_COLLECTIONS.credentials]: [],

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -2,7 +2,9 @@ import { type Collection, type Db, ObjectId } from "mongodb";
 import { type EventId } from "@core/types/domain-primitives";
 import { type SyncCommandOutcome } from "@core/types/sync/command.contracts";
 import {
+  type ConnectionId,
   type PrincipalId,
+  type ProviderCalendarId,
   type SyncCommandId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
@@ -134,6 +136,51 @@ export class CommandRepository {
       .limit(limit)
       .toArray();
     return records.map((r) => CommandRecordSchema.parse(r));
+  }
+
+  // Outstanding commands for one connection (support diagnostics / S45).
+  // Provider work is keyed by linked event connectionId or by create/move
+  // calendar targets on that connection.
+  async countNonterminalByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+    calendarIds: readonly ProviderCalendarId[],
+  ): Promise<number> {
+    const matchOr: Record<string, unknown>[] = [
+      { "event.connectionId": connectionId },
+    ];
+    if (calendarIds.length > 0) {
+      matchOr.push({
+        "input.kind": { $in: ["create", "move"] },
+        "input.calendarId": { $in: calendarIds },
+      });
+    }
+
+    const [result] = await this.collection
+      .aggregate<{ count: number }>([
+        {
+          $match: {
+            tenantId,
+            principalId,
+            "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+          },
+        },
+        {
+          $lookup: {
+            from: SYNC_COLLECTIONS.events,
+            localField: "eventId",
+            foreignField: "_id",
+            as: "event",
+          },
+        },
+        { $unwind: { path: "$event", preserveNullAndEmptyArrays: true } },
+        { $match: { $or: matchOr } },
+        { $count: "count" },
+      ])
+      .toArray();
+
+    return result?.count ?? 0;
   }
 
   // Hard-delete every command for a principal (account deletion).

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -203,6 +203,20 @@ export class JobRepository {
     return result.modifiedCount;
   }
 
+  // Outstanding work for one connection (support diagnostics / S45).
+  async countOutstandingByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<number> {
+    return this.collection.countDocuments({
+      tenantId,
+      principalId,
+      connectionId,
+      state: { $in: ["pending", "claimed"] },
+    });
+  }
+
   // Hard-delete every job for one connection (post-disconnect retention).
   async deleteByConnection(
     tenantId: TenantId,

--- a/packages/sync/src/storage/repositories/provider-connection.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.db.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { deriveDiagnosticKey } from "@sync/safety/diagnostic-key";
 import { type ProviderConnectionUpsert } from "@sync/storage/contracts/provider-connection.contracts";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 
@@ -43,6 +44,14 @@ describe("ProviderConnectionRepository", () => {
     expect(created.state).toBe("importing");
     // A fresh connection carries no disconnect evidence.
     expect(created.disconnectedAt).toBeNull();
+    expect(created.diagnosticKey).toBe(deriveDiagnosticKey(created._id));
+  });
+
+  it("finds a connection by diagnostic key", async () => {
+    const created = await repo.upsertByProviderAccount(baseUpsert());
+    const found = await repo.findByDiagnosticKey(created.diagnosticKey);
+    expect(found?._id).toBe(created._id);
+    expect(await repo.findByDiagnosticKey("b".repeat(32))).toBeNull();
   });
 
   it("clears disconnect evidence when the account reconnects via upsert", async () => {

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -86,7 +86,19 @@ export class ProviderConnectionRepository {
     diagnosticKey: string,
   ): Promise<ProviderConnectionRecord | null> {
     const record = await this.collection.findOne({ diagnosticKey });
-    return record ? this.parseRecord(record) : null;
+    if (record) return this.parseRecord(record);
+
+    // Pre-S45 rows omit diagnosticKey until first read; match derived keys.
+    const legacyRows = await this.collection
+      .find({ diagnosticKey: { $not: { $type: "string" } } })
+      .toArray();
+    for (const legacy of legacyRows) {
+      const id = String(legacy._id) as ConnectionId;
+      if (deriveDiagnosticKey(id) === diagnosticKey) {
+        return this.parseRecord(legacy);
+      }
+    }
+    return null;
   }
 
   async findById(

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -89,6 +89,12 @@ export class ProviderConnectionRepository {
     if (record) return this.parseRecord(record);
 
     // Pre-S45 rows omit diagnosticKey until first read; match derived keys.
+    const hasLegacyRows = await this.collection.findOne(
+      { diagnosticKey: { $not: { $type: "string" } } },
+      { projection: { _id: 1 } },
+    );
+    if (!hasLegacyRows) return null;
+
     const legacyRows = await this.collection
       .find({ diagnosticKey: { $not: { $type: "string" } } })
       .toArray();

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -8,6 +8,7 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { deriveDiagnosticKey } from "@sync/safety/diagnostic-key";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
   type ProviderConnectionRecord,
@@ -37,6 +38,7 @@ export class ProviderConnectionRepository {
   ): Promise<ProviderConnectionRecord> {
     const fields = ProviderConnectionUpsertSchema.parse(input);
     const now = new Date();
+    const connectionId = new ObjectId().toHexString() as ConnectionId;
 
     const result = await this.collection.findOneAndUpdate(
       {
@@ -61,7 +63,8 @@ export class ProviderConnectionRepository {
           updatedAt: now,
         },
         $setOnInsert: {
-          _id: new ObjectId().toHexString() as ConnectionId,
+          _id: connectionId,
+          diagnosticKey: deriveDiagnosticKey(connectionId),
           tenantId: fields.tenantId,
           principalId: fields.principalId,
           provider: fields.provider,
@@ -74,7 +77,16 @@ export class ProviderConnectionRepository {
     if (!result) {
       throw new Error("Upsert did not return a connection record");
     }
-    return ProviderConnectionRecordSchema.parse(result);
+    return this.parseRecord(result);
+  }
+
+  // Global support lookup by non-user-facing diagnostic key. Callers must
+  // already hold internal auth — this is not principal-scoped.
+  async findByDiagnosticKey(
+    diagnosticKey: string,
+  ): Promise<ProviderConnectionRecord | null> {
+    const record = await this.collection.findOne({ diagnosticKey });
+    return record ? this.parseRecord(record) : null;
   }
 
   async findById(
@@ -87,7 +99,7 @@ export class ProviderConnectionRepository {
       tenantId,
       principalId,
     });
-    return record ? ProviderConnectionRecordSchema.parse(record) : null;
+    return record ? this.parseRecord(record) : null;
   }
 
   async listByPrincipal(
@@ -97,7 +109,7 @@ export class ProviderConnectionRepository {
     const records = await this.collection
       .find({ tenantId, principalId })
       .toArray();
-    return records.map((r) => ProviderConnectionRecordSchema.parse(r));
+    return Promise.all(records.map((r) => this.parseRecord(r)));
   }
 
   // Record that the user disconnected this connection. Sets the durable
@@ -156,7 +168,30 @@ export class ProviderConnectionRepository {
     if (!result) {
       throw new Error("Connection not found while updating derived state");
     }
-    return ProviderConnectionRecordSchema.parse(result);
+    return this.parseRecord(result);
+  }
+
+  // Stamp diagnosticKey on pre-S45 rows, then validate. Read paths share this
+  // so support lookup and API reads never fail parse on legacy documents.
+  private async parseRecord(
+    record: ProviderConnectionRecord | Record<string, unknown>,
+  ): Promise<ProviderConnectionRecord> {
+    const id = String((record as { _id: ConnectionId })._id) as ConnectionId;
+    if (
+      typeof (record as { diagnosticKey?: unknown }).diagnosticKey !== "string"
+    ) {
+      const diagnosticKey = deriveDiagnosticKey(id);
+      const stamped = await this.collection.findOneAndUpdate(
+        { _id: id },
+        { $set: { diagnosticKey } },
+        { returnDocument: "after" },
+      );
+      if (!stamped) {
+        throw new Error("Connection not found while stamping diagnostic key");
+      }
+      return ProviderConnectionRecordSchema.parse(stamped);
+    }
+    return ProviderConnectionRecordSchema.parse(record);
   }
 
   // Soft-disconnected connections whose disconnectedAt is strictly before
@@ -171,7 +206,7 @@ export class ProviderConnectionRepository {
       .sort({ disconnectedAt: 1 })
       .limit(limit)
       .toArray();
-    return records.map((r) => ProviderConnectionRecordSchema.parse(r));
+    return Promise.all(records.map((r) => this.parseRecord(r)));
   }
 
   // Hard-delete one connection row after its retained cache has been purged.

--- a/packages/sync/src/telemetry/health-alert.test.ts
+++ b/packages/sync/src/telemetry/health-alert.test.ts
@@ -1,0 +1,38 @@
+import {
+  isUnhealthyConnectionAlert,
+  unhealthyConnectionPercent,
+} from "@sync/telemetry/health-alert";
+import { describe, expect, it } from "bun:test";
+
+const counts = (overrides: {
+  healthy?: number;
+  delayed?: number;
+  actionRequired?: number;
+  disconnected?: number;
+}) => ({
+  connecting: 0,
+  importing: 0,
+  catchingUp: 0,
+  healthy: overrides.healthy ?? 100,
+  delayed: overrides.delayed ?? 0,
+  actionRequired: overrides.actionRequired ?? 0,
+  disconnected: overrides.disconnected ?? 0,
+});
+
+describe("unhealthy connection alert", () => {
+  it("computes percent from delayed + actionRequired", () => {
+    expect(
+      unhealthyConnectionPercent(counts({ healthy: 98, delayed: 2 })),
+    ).toBeCloseTo(2);
+    expect(unhealthyConnectionPercent(counts({}))).toBe(0);
+  });
+
+  it("fires only after two consecutive windows above 1%", () => {
+    const ok = counts({ delayed: 0 });
+    const bad = counts({ healthy: 98, delayed: 2 });
+    expect(isUnhealthyConnectionAlert([bad])).toBe(false);
+    expect(isUnhealthyConnectionAlert([ok, bad])).toBe(false);
+    expect(isUnhealthyConnectionAlert([bad, bad])).toBe(true);
+    expect(isUnhealthyConnectionAlert([bad, ok, bad])).toBe(false);
+  });
+});

--- a/packages/sync/src/telemetry/health-alert.ts
+++ b/packages/sync/src/telemetry/health-alert.ts
@@ -1,0 +1,33 @@
+import { type SyncHealthConnectionCounts } from "@core/types/sync/health.contracts";
+
+// R-OPS-03: more than 1% unhealthy for two consecutive reporting windows.
+export const UNHEALTHY_CONNECTION_ALERT_PERCENT = 1;
+
+// Unhealthy = delayed + actionRequired (user-visible problems). Disconnected
+// is intentional and excluded from the ratio denominator's "problem" side.
+export function unhealthyConnectionPercent(
+  connections: SyncHealthConnectionCounts,
+): number {
+  const total =
+    connections.connecting +
+    connections.importing +
+    connections.catchingUp +
+    connections.healthy +
+    connections.delayed +
+    connections.actionRequired +
+    connections.disconnected;
+  if (total === 0) return 0;
+  const unhealthy = connections.delayed + connections.actionRequired;
+  return (unhealthy * 100) / total;
+}
+
+export function isUnhealthyConnectionAlert(
+  windows: readonly SyncHealthConnectionCounts[],
+): boolean {
+  if (windows.length < 2) return false;
+  const lastTwo = windows.slice(-2);
+  return lastTwo.every(
+    (window) =>
+      unhealthyConnectionPercent(window) > UNHEALTHY_CONNECTION_ALERT_PERCENT,
+  );
+}

--- a/packages/sync/src/telemetry/health-dashboard.test.ts
+++ b/packages/sync/src/telemetry/health-dashboard.test.ts
@@ -1,0 +1,16 @@
+import { SYNC_HEALTH_SNAPSHOT_EVENT } from "@core/types/sync/health.contracts";
+import { SYNC_HEALTH_DASHBOARD } from "@sync/telemetry/health-dashboard";
+import { describe, expect, it } from "bun:test";
+
+describe("SYNC_HEALTH_DASHBOARD", () => {
+  it("defines one primary dashboard with required panels and alerts", () => {
+    expect(SYNC_HEALTH_DASHBOARD.name).toBe("Sync health");
+    expect(SYNC_HEALTH_DASHBOARD.panels.length).toBeGreaterThanOrEqual(5);
+    expect(SYNC_HEALTH_DASHBOARD.alerts).toHaveLength(2);
+    for (const panel of SYNC_HEALTH_DASHBOARD.panels) {
+      expect(panel.query).toContain(SYNC_HEALTH_SNAPSHOT_EVENT);
+      expect(panel.query).not.toContain("refresh_token");
+      expect(panel.query).not.toContain("principalId");
+    }
+  });
+});

--- a/packages/sync/src/telemetry/health-dashboard.ts
+++ b/packages/sync/src/telemetry/health-dashboard.ts
@@ -1,0 +1,61 @@
+import {
+  SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL,
+  SYNC_HEALTH_FRESHNESS_HOGQL,
+  SYNC_HEALTH_HEARTBEAT_HOGQL,
+  SYNC_HEALTH_JOB_BACKLOG_HOGQL,
+  SYNC_HEALTH_SUBSCRIPTION_HOGQL,
+  SYNC_HEALTH_UNHEALTHY_RATIO_HOGQL,
+} from "@sync/telemetry/health-snapshot.queries";
+
+// As-code definition of the single Sync health dashboard (R-OPS-01 / S45).
+// Wire these HogQL fixtures into PostHog insights + alerts in the Compass
+// PostHog project; this module is the source of truth for panel names/queries.
+export const SYNC_HEALTH_DASHBOARD = {
+  name: "Sync health",
+  description:
+    "Primary Sync operating view: connection state, freshness, backlog, subscriptions, and snapshot heartbeat.",
+  panels: [
+    {
+      name: "Connection state distribution",
+      query: SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL,
+      decision: "Is the system broadly healthy?",
+    },
+    {
+      name: "Unhealthy connection ratio",
+      query: SYNC_HEALTH_UNHEALTHY_RATIO_HOGQL,
+      decision: "Alert when >1% for two consecutive windows",
+    },
+    {
+      name: "Freshness percentiles",
+      query: SYNC_HEALTH_FRESHNESS_HOGQL,
+      decision: "Are users seeing current data?",
+    },
+    {
+      name: "Job backlog",
+      query: SYNC_HEALTH_JOB_BACKLOG_HOGQL,
+      decision: "Is capacity or throttling the limit?",
+    },
+    {
+      name: "Subscription health",
+      query: SYNC_HEALTH_SUBSCRIPTION_HOGQL,
+      decision: "Will push delivery remain alive?",
+    },
+    {
+      name: "Snapshot heartbeat",
+      query: SYNC_HEALTH_HEARTBEAT_HOGQL,
+      decision: "Is telemetry itself alive?",
+    },
+  ],
+  alerts: [
+    {
+      name: "Sync unhealthy connections >1%",
+      query: SYNC_HEALTH_UNHEALTHY_RATIO_HOGQL,
+      condition: "ratio > 1 for two consecutive 5-minute windows",
+    },
+    {
+      name: "Sync health snapshot missing",
+      query: SYNC_HEALTH_HEARTBEAT_HOGQL,
+      condition: "snapshots == 0 over 10 minutes",
+    },
+  ],
+} as const;

--- a/packages/sync/src/telemetry/health-snapshot.queries.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.queries.test.ts
@@ -3,6 +3,9 @@ import {
   SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL,
   SYNC_HEALTH_FRESHNESS_HOGQL,
   SYNC_HEALTH_HEARTBEAT_HOGQL,
+  SYNC_HEALTH_JOB_BACKLOG_HOGQL,
+  SYNC_HEALTH_SUBSCRIPTION_HOGQL,
+  SYNC_HEALTH_UNHEALTHY_RATIO_HOGQL,
 } from "@sync/telemetry/health-snapshot.queries";
 import { describe, expect, it } from "bun:test";
 
@@ -10,7 +13,10 @@ describe("sync health HogQL fixtures", () => {
   it("scopes every fixture to the sanitized snapshot event", () => {
     for (const query of [
       SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL,
+      SYNC_HEALTH_UNHEALTHY_RATIO_HOGQL,
       SYNC_HEALTH_FRESHNESS_HOGQL,
+      SYNC_HEALTH_JOB_BACKLOG_HOGQL,
+      SYNC_HEALTH_SUBSCRIPTION_HOGQL,
       SYNC_HEALTH_HEARTBEAT_HOGQL,
     ]) {
       expect(query).toContain(SYNC_HEALTH_SNAPSHOT_EVENT);

--- a/packages/sync/src/telemetry/health-snapshot.queries.ts
+++ b/packages/sync/src/telemetry/health-snapshot.queries.ts
@@ -1,8 +1,8 @@
 import { SYNC_HEALTH_SNAPSHOT_EVENT } from "@core/types/sync/health.contracts";
 
-// HogQL fixtures for the Sync health dashboard / alerts (S44 evidence).
-// Wired into PostHog insights in S45; kept here so the event shape and
-// alert predicates stay next to the emitter.
+// HogQL fixtures for the Sync health dashboard / alerts (S44/S45).
+// Wired into PostHog insights from SYNC_HEALTH_DASHBOARD; kept here so the
+// event shape and alert predicates stay next to the emitter.
 export const SYNC_HEALTH_CONNECTION_DISTRIBUTION_HOGQL = `
 SELECT
   properties.environment,
@@ -10,6 +10,40 @@ SELECT
   properties.connections.delayed,
   properties.connections.actionRequired,
   properties.connections.disconnected
+FROM events
+WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
+  AND timestamp > now() - INTERVAL 1 DAY
+ORDER BY timestamp DESC
+LIMIT 288
+`.trim();
+
+export const SYNC_HEALTH_UNHEALTHY_RATIO_HOGQL = `
+SELECT
+  timestamp,
+  properties.environment,
+  if(
+    (
+      properties.connections.connecting +
+      properties.connections.importing +
+      properties.connections.catchingUp +
+      properties.connections.healthy +
+      properties.connections.delayed +
+      properties.connections.actionRequired +
+      properties.connections.disconnected
+    ) = 0,
+    0,
+    (
+      (properties.connections.delayed + properties.connections.actionRequired) * 100.0
+    ) / (
+      properties.connections.connecting +
+      properties.connections.importing +
+      properties.connections.catchingUp +
+      properties.connections.healthy +
+      properties.connections.delayed +
+      properties.connections.actionRequired +
+      properties.connections.disconnected
+    )
+  ) AS unhealthyPercent
 FROM events
 WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
   AND timestamp > now() - INTERVAL 1 DAY
@@ -28,6 +62,36 @@ FROM events
 WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
   AND timestamp > now() - INTERVAL 1 DAY
 ORDER BY timestamp DESC
+`.trim();
+
+export const SYNC_HEALTH_JOB_BACKLOG_HOGQL = `
+SELECT
+  timestamp,
+  properties.environment,
+  properties.jobs.pending,
+  properties.jobs.claimed,
+  properties.jobs.failed,
+  properties.jobs.oldestDueAgeMs
+FROM events
+WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
+  AND timestamp > now() - INTERVAL 1 DAY
+ORDER BY timestamp DESC
+LIMIT 288
+`.trim();
+
+export const SYNC_HEALTH_SUBSCRIPTION_HOGQL = `
+SELECT
+  timestamp,
+  properties.environment,
+  properties.subscriptions.healthy,
+  properties.subscriptions.renewSoon,
+  properties.subscriptions.expired,
+  properties.subscriptions.missing
+FROM events
+WHERE event = '${SYNC_HEALTH_SNAPSHOT_EVENT}'
+  AND timestamp > now() - INTERVAL 1 DAY
+ORDER BY timestamp DESC
+LIMIT 288
 `.trim();
 
 export const SYNC_HEALTH_HEARTBEAT_HOGQL = `


### PR DESCRIPTION
## Summary
- S45 operating controls: non-user-facing `diagnosticKey` on connections, private `GET /internal/diagnostics/connections/:key`, and `SyncServiceClient.resolveDiagnosticConnection`.
- As-code Sync health dashboard + HogQL alert fixtures (unhealthy >1%, missing heartbeat) with pure alert predicates.
- Sync DB `bun sync:backup` / `bun sync:restore` helpers for restore drills (isolated `compass_sync` only).

Private runbook: `compass-calendar-internal/projects/sync-service/10-operating-runbook.md` (not in this PR).

## Test plan
- [x] `bun test:sync:fast`
- [x] focused sync DB tests (diagnostic routes, connection repo, index manifest)
- [x] `SyncServiceClient` diagnostic path test
- [ ] Wire HogQL panels/alerts in Compass PostHog project (ops follow-up; MCP was on Switchback)
- [ ] Staging restore drill evidence before cutover


Made with [Cursor](https://cursor.com)