### PR TITLE
feat(scripts): inventory legacy sync data

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -17,6 +17,7 @@ Primary file:
 | `bun run cli migrate <umzug-subcommand>` | `packages/scripts/src/commands/migrate.ts` | Runs wrapped Umzug subcommands: `pending`, `executed`, `up`, `down`, and `create`. Inspect `bun run cli migrate --help` before bounded execution. |
 | `bun run cli migrate pending` | `packages/scripts/src/commands/migrate.ts` | Lists pending migrations. |
 | `bun run cli migrate executed` | `packages/scripts/src/commands/migrate.ts` | Lists executed migrations. |
+| `bun run cli inventory-legacy-sync [--out path.json]` | `packages/scripts/src/commands/inventory-legacy-sync.ts` | Read-only S46 inventory of legacy Google sync data (users/credentials/calendars/events/cursors/watches). Never writes or calls providers. |
 
 ## Migration Internals
 

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -6,6 +6,7 @@ const requireActual = createRequire(import.meta.url);
 
 const mockExitHelpfully = mock();
 const mockRunMigrator = mock((): Promise<void> => Promise.resolve());
+const mockRunInventory = mock((): Promise<void> => Promise.resolve());
 
 mock.module("@scripts/cli.validator", () => ({
   CliValidator: mock().mockImplementation(() => ({
@@ -16,6 +17,11 @@ mock.module("@scripts/cli.validator", () => ({
 mock.module("@scripts/commands/migrate", () => ({
   __esModule: true,
   runMigrator: mock((type: MigratorType) => mockRunMigrator(type)),
+}));
+
+mock.module("@scripts/commands/inventory-legacy-sync", () => ({
+  __esModule: true,
+  runInventoryLegacySync: mock(() => mockRunInventory()),
 }));
 
 const { default: CompassCLI } = requireActual(
@@ -33,6 +39,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunMigrator).toHaveBeenCalledWith(MigratorType.MIGRATION);
+  });
+
+  it("runs inventory-legacy-sync command", async () => {
+    const cli = new CompassCLI(["node", "cli", "inventory-legacy-sync"]);
+
+    await cli.run();
+
+    expect(mockRunInventory).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,4 +1,5 @@
 import { CliValidator } from "@scripts/cli.validator";
+import { runInventoryLegacySync } from "@scripts/commands/inventory-legacy-sync";
 import { runMigrator } from "@scripts/commands/migrate";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
@@ -20,6 +21,9 @@ export default class CompassCLI {
       case cmd === "migrate":
         await runMigrator(MigratorType.MIGRATION);
         break;
+      case cmd === "inventory-legacy-sync":
+        await runInventoryLegacySync();
+        break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }
@@ -35,6 +39,14 @@ export default class CompassCLI {
       .helpOption(false)
       .allowUnknownOption(true)
       .description("run database schema migrations");
+
+    program
+      .command("inventory-legacy-sync")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "read-only inventory of legacy Google sync data (S46; no writes)",
+      );
 
     return program;
   }

--- a/packages/scripts/src/commands/inventory-legacy-sync.db.test.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync.db.test.ts
@@ -1,0 +1,167 @@
+import {
+  inventoryLegacySyncData,
+  loadInventoryCollections,
+} from "@scripts/commands/inventory-legacy-sync/inventory";
+import { ObjectId } from "mongodb";
+import { Resource_Sync } from "@core/types/sync.types";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+const NOW = new Date("2026-07-25T03:00:00.000Z");
+
+describe("inventory-legacy-sync (db)", () => {
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+    await mongoService.sync.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  it("loads a production-shaped fixture and does not write", async () => {
+    const userId = new ObjectId();
+    const calendarId = new ObjectId();
+    const watchId = new ObjectId();
+
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "fixture@example.com",
+      firstName: "Fix",
+      lastName: "Ture",
+      name: "Fix Ture",
+      locale: "en",
+      google: {
+        googleId: "subject-fixture",
+        picture: "",
+        gRefreshToken: "token-fixture",
+      },
+    });
+    await mongoService.calendar.insertOne({
+      _id: calendarId,
+      userId,
+      name: "Primary",
+      description: "",
+      timeZone: "America/Denver",
+      foregroundColor: "#000000",
+      backgroundColor: "#ffffff",
+      access: "owner",
+      isPrimary: true,
+      isVisible: true,
+      isActive: true,
+      source: {
+        provider: "google",
+        calendarId: "primary",
+        etag: "etag-fixture",
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+    await mongoService.event.insertOne({
+      _id: new ObjectId(),
+      calendarId,
+      content: { kind: "details", title: "standup", description: "" },
+      schedule: {
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 1800_000),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      externalReference: {
+        provider: "google",
+        eventId: "gcal-evt-1",
+        recurringEventId: null,
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+    await mongoService.sync.insertOne({
+      user: userId.toHexString(),
+      google: {
+        calendarlist: [
+          {
+            gCalendarId: Resource_Sync.CALENDAR,
+            nextSyncToken: "cal-sync",
+          },
+        ],
+        events: [{ gCalendarId: "primary", nextSyncToken: "evt-sync" }],
+      },
+    });
+    await mongoService.watch.insertOne({
+      _id: watchId,
+      user: userId.toHexString(),
+      resourceId: "resource-1",
+      expiration: String(NOW.getTime() + 86_400_000),
+      gCalendarId: "primary",
+      createdAt: NOW,
+    });
+
+    const beforeUsers = await mongoService.user.countDocuments();
+    const beforeEvents = await mongoService.event.countDocuments();
+    const beforeWatches = await mongoService.watch.countDocuments();
+
+    const collections = await loadInventoryCollections(mongoService);
+    const report = inventoryLegacySyncData(collections, { now: NOW });
+    const again = inventoryLegacySyncData(collections, { now: NOW });
+
+    expect(report).toEqual(again);
+    expect(report.dryRun).toBe(true);
+    expect(report.source.users.total).toBe(1);
+    expect(report.source.calendars.google).toBe(1);
+    expect(report.source.events.linkedGoogle).toBe(1);
+    expect(report.source.watches.eventWatches).toBe(1);
+    expect(report.targets[0]?.tenantId).toBe(userId.toHexString());
+    expect(report.targets[0]?.principalId).toBe(userId.toHexString());
+    expect(report.targets[0]?.providerAccountId).toBe("subject-fixture");
+
+    expect(await mongoService.user.countDocuments()).toBe(beforeUsers);
+    expect(await mongoService.event.countDocuments()).toBe(beforeEvents);
+    expect(await mongoService.watch.countDocuments()).toBe(beforeWatches);
+  });
+
+  it("flags residual nested watch fields on sync documents", async () => {
+    const userId = new ObjectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "legacy@example.com",
+      firstName: "L",
+      lastName: "G",
+      name: "L G",
+      locale: "en",
+      google: {
+        googleId: "subject-legacy",
+        picture: "",
+        gRefreshToken: "token",
+      },
+    });
+    await mongoService.sync.insertOne({
+      user: userId.toHexString(),
+      google: {
+        calendarlist: [],
+        events: [
+          {
+            gCalendarId: "primary",
+            nextSyncToken: "tok",
+            channelId: "507f1f77bcf86cd799439099",
+            resourceId: "legacy-resource",
+            expiration: String(NOW.getTime() + 1000),
+          } as never,
+        ],
+      },
+    });
+
+    const report = inventoryLegacySyncData(
+      await loadInventoryCollections(mongoService),
+      { now: NOW },
+    );
+
+    expect(report.skips.some((s) => s.category === "legacy_nested_watch")).toBe(
+      true,
+    );
+  });
+});

--- a/packages/scripts/src/commands/inventory-legacy-sync.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync.ts
@@ -1,0 +1,49 @@
+import {
+  inventoryLegacySyncData,
+  loadInventoryCollections,
+} from "@scripts/commands/inventory-legacy-sync/inventory";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const logger = Logger("scripts.commands.inventory-legacy-sync");
+
+/**
+ * S46: read-only inventory of legacy Google sync data in the Compass API DB.
+ * Does not write, repair, refresh tokens, or call providers.
+ *
+ * Usage:
+ *   bun run cli inventory-legacy-sync [--out path.json]
+ */
+export async function runInventoryLegacySync(): Promise<void> {
+  const outFlag = process.argv.indexOf("--out");
+  const outPath =
+    outFlag >= 0 && process.argv[outFlag + 1]
+      ? resolve(process.argv[outFlag + 1]!)
+      : null;
+
+  try {
+    await mongoService.start();
+    const collections = await loadInventoryCollections(mongoService);
+    const report = inventoryLegacySyncData(collections);
+    const json = `${JSON.stringify(report, null, 2)}\n`;
+
+    if (outPath) {
+      writeFileSync(outPath, json, "utf8");
+      logger.info(`Wrote legacy sync inventory to ${outPath}`);
+    } else {
+      process.stdout.write(json);
+    }
+
+    logger.info(
+      `Inventory: scanned=${report.counts.scanned} reportable=${report.counts.reportable} skipped=${report.counts.skipped}`,
+    );
+
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/inventory-legacy-sync/inventory.test.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync/inventory.test.ts
@@ -1,0 +1,281 @@
+import { inventoryLegacySyncData } from "@scripts/commands/inventory-legacy-sync/inventory";
+import { ObjectId } from "mongodb";
+import { Resource_Sync } from "@core/types/sync.types";
+import { describe, expect, it } from "bun:test";
+
+const NOW = new Date("2026-07-25T03:00:00.000Z");
+
+describe("inventoryLegacySyncData", () => {
+  it("reports deterministic Sync targets and is stable across repeats", () => {
+    const userId = new ObjectId("507f1f77bcf86cd799439011");
+    const calendarId = new ObjectId("507f1f77bcf86cd799439012");
+    const eventLinked = new ObjectId("507f1f77bcf86cd799439013");
+    const eventLocal = new ObjectId("507f1f77bcf86cd799439014");
+
+    const input = {
+      users: [
+        {
+          _id: userId,
+          email: "alice@example.com",
+          firstName: "A",
+          lastName: "L",
+          name: "A L",
+          locale: "en",
+          google: {
+            googleId: "google-subject-1",
+            picture: "",
+            gRefreshToken: "refresh-1",
+          },
+        },
+      ],
+      calendars: [
+        {
+          _id: calendarId,
+          userId,
+          name: "Primary",
+          description: "",
+          timeZone: "UTC" as const,
+          foregroundColor: "#000000" as const,
+          backgroundColor: "#ffffff" as const,
+          access: "owner" as const,
+          isPrimary: true,
+          isVisible: true,
+          isActive: true,
+          source: {
+            provider: "google" as const,
+            calendarId: "primary",
+            etag: "etag-1",
+          },
+          createdAt: NOW,
+          updatedAt: null,
+        },
+      ],
+      events: [
+        {
+          _id: eventLinked,
+          calendarId,
+          content: { kind: "details" as const, title: "Meet", description: "" },
+          schedule: {
+            kind: "timed" as const,
+            start: NOW,
+            end: new Date(NOW.getTime() + 3600_000),
+            timeZone: "UTC" as const,
+          },
+          recurrence: { kind: "single" as const },
+          externalReference: {
+            provider: "google" as const,
+            eventId: "g-1",
+            recurringEventId: null,
+          },
+          createdAt: NOW,
+          updatedAt: null,
+        },
+        {
+          _id: eventLocal,
+          calendarId,
+          content: {
+            kind: "details" as const,
+            title: "Local",
+            description: "",
+          },
+          schedule: {
+            kind: "timed" as const,
+            start: NOW,
+            end: new Date(NOW.getTime() + 3600_000),
+            timeZone: "UTC" as const,
+          },
+          recurrence: { kind: "single" as const },
+          externalReference: null,
+          createdAt: NOW,
+          updatedAt: null,
+        },
+      ],
+      syncDocs: [
+        {
+          _id: new ObjectId("507f1f77bcf86cd799439015"),
+          user: userId.toHexString(),
+          google: {
+            calendarlist: [
+              {
+                gCalendarId: Resource_Sync.CALENDAR,
+                nextSyncToken: "cal-token",
+              },
+            ],
+            events: [{ gCalendarId: "primary", nextSyncToken: "evt-token" }],
+          },
+        },
+      ],
+      watches: [
+        {
+          _id: new ObjectId("507f1f77bcf86cd799439016"),
+          user: userId.toHexString(),
+          resourceId: "res-cal",
+          expiration: String(NOW.getTime() + 86_400_000),
+          gCalendarId: Resource_Sync.CALENDAR,
+          createdAt: NOW,
+        },
+        {
+          _id: new ObjectId("507f1f77bcf86cd799439017"),
+          user: userId.toHexString(),
+          resourceId: "res-evt",
+          expiration: String(NOW.getTime() + 86_400_000),
+          gCalendarId: "primary",
+          createdAt: NOW,
+        },
+      ],
+    };
+
+    const first = inventoryLegacySyncData(input, { now: NOW });
+    const second = inventoryLegacySyncData(input, { now: NOW });
+
+    expect(first).toEqual(second);
+    expect(first.dryRun).toBe(true);
+    expect(first.targets).toHaveLength(1);
+    expect(first.targets[0]).toMatchObject({
+      userId: userId.toHexString(),
+      tenantId: userId.toHexString(),
+      principalId: userId.toHexString(),
+      providerAccountId: "google-subject-1",
+      hasRefreshToken: true,
+      eventTargets: { linkedGoogle: 1, unlinkedPendingIntent: 1 },
+    });
+    expect(first.targets[0]?.calendarTargets).toEqual([
+      {
+        compassCalendarId: calendarId.toHexString(),
+        providerCalendarId: "primary",
+      },
+    ]);
+    expect(first.source.users.withRefreshToken).toBe(1);
+    expect(first.skips).toEqual([]);
+    expect(first.counts.skipped).toBe(0);
+  });
+
+  it("categorizes missing authority, orphans, and duplicates", () => {
+    const orphanUserId = new ObjectId("507f1f77bcf86cd799439021");
+    const userId = new ObjectId("507f1f77bcf86cd799439022");
+    const calendarA = new ObjectId("507f1f77bcf86cd799439023");
+    const calendarB = new ObjectId("507f1f77bcf86cd799439024");
+    const orphanEvent = new ObjectId("507f1f77bcf86cd799439025");
+
+    const report = inventoryLegacySyncData(
+      {
+        users: [
+          {
+            _id: userId,
+            email: "bob@example.com",
+            firstName: "B",
+            lastName: "O",
+            name: "B O",
+            locale: "en",
+            google: {
+              googleId: "google-subject-2",
+              picture: "",
+              gRefreshToken: "",
+            },
+          },
+        ],
+        calendars: [
+          {
+            _id: calendarA,
+            userId,
+            name: "A",
+            description: "",
+            timeZone: "UTC" as const,
+            foregroundColor: "#000000" as const,
+            backgroundColor: "#ffffff" as const,
+            access: "owner" as const,
+            isPrimary: true,
+            isVisible: true,
+            isActive: true,
+            source: {
+              provider: "google" as const,
+              calendarId: "dup",
+              etag: "e1",
+            },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+          {
+            _id: calendarB,
+            userId,
+            name: "B",
+            description: "",
+            timeZone: "UTC" as const,
+            foregroundColor: "#000000" as const,
+            backgroundColor: "#ffffff" as const,
+            access: "owner" as const,
+            isPrimary: false,
+            isVisible: true,
+            isActive: true,
+            source: {
+              provider: "google" as const,
+              calendarId: "dup",
+              etag: "e2",
+            },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439026"),
+            userId: orphanUserId,
+            name: "Orphan cal",
+            description: "",
+            timeZone: "UTC" as const,
+            foregroundColor: "#000000" as const,
+            backgroundColor: "#ffffff" as const,
+            access: "owner" as const,
+            isPrimary: true,
+            isVisible: true,
+            isActive: true,
+            source: { provider: "local" as const },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+        ],
+        events: [
+          {
+            _id: orphanEvent,
+            calendarId: new ObjectId("507f1f77bcf86cd799439027"),
+            content: {
+              kind: "details" as const,
+              title: "orphan",
+              description: "",
+            },
+            schedule: {
+              kind: "timed" as const,
+              start: NOW,
+              end: new Date(NOW.getTime() + 3600_000),
+              timeZone: "UTC" as const,
+            },
+            recurrence: { kind: "single" as const },
+            externalReference: null,
+            createdAt: NOW,
+            updatedAt: null,
+          },
+        ],
+        syncDocs: [
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439028"),
+            user: orphanUserId.toHexString(),
+            google: { calendarlist: [], events: [] },
+          },
+        ],
+        watches: [],
+      },
+      { now: NOW },
+    );
+
+    expect(
+      report.skips.some((s) => s.category === "missing_refresh_token"),
+    ).toBe(true);
+    expect(
+      report.skips.some((s) => s.category === "duplicate_google_calendar"),
+    ).toBe(true);
+    expect(report.skips.some((s) => s.category === "orphan_calendar")).toBe(
+      true,
+    );
+    expect(report.skips.some((s) => s.category === "orphan_event")).toBe(true);
+    expect(report.skips.some((s) => s.category === "orphan_sync")).toBe(true);
+    expect(report.skips.every((s) => s.category.length > 0)).toBe(true);
+  });
+});

--- a/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
@@ -257,12 +257,15 @@ export function inventoryLegacySyncData(
     });
   }
 
+  const seenOrphanCursorIds = new Set<string>();
   for (const doc of syncDocs) {
     const eventRows = doc.google?.events ?? [];
     for (const row of eventRows) {
       const known = googleCalByUser.get(doc.user);
       if (known?.has(row.gCalendarId)) continue;
       const id = `${doc.user}:${row.gCalendarId}`;
+      if (seenOrphanCursorIds.has(id)) continue;
+      seenOrphanCursorIds.add(id);
       orphans.push({
         kind: "cursor_calendar",
         id,

--- a/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
@@ -1,0 +1,554 @@
+import {
+  type InventoryDuplicate,
+  type InventoryMissingAuthority,
+  type InventoryOrphan,
+  type InventorySkip,
+  type InventoryUserTarget,
+  type LegacySyncInventoryReport,
+  LegacySyncInventoryReportSchema,
+} from "@scripts/commands/inventory-legacy-sync/report.types";
+import { type ObjectId } from "mongodb";
+import { Resource_Sync, type Schema_Sync } from "@core/types/sync.types";
+import { type Schema_User } from "@core/types/user.types";
+import { type Schema_Watch } from "@core/types/watch.types";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { type EventRecord } from "@backend/event/event.record";
+
+export interface InventoryCollections {
+  users: Array<{ _id: ObjectId } & Schema_User>;
+  calendars: CalendarRecord[];
+  events: EventRecord[];
+  syncDocs: Array<Partial<Schema_Sync> & { _id?: ObjectId; user: string }>;
+  watches: Schema_Watch[];
+}
+
+export interface InventoryOptions {
+  /** Injected for stable repeated reports in tests. */
+  now?: Date;
+}
+
+const byId = (a: string, b: string) => a.localeCompare(b);
+
+function hasRefreshToken(user: Schema_User): boolean {
+  const token = user.google?.gRefreshToken?.trim();
+  return typeof token === "string" && token.length > 0;
+}
+
+function hasGoogleIdentity(user: Schema_User): boolean {
+  return typeof user.google?.googleId?.trim() === "string"
+    ? user.google.googleId.trim().length > 0
+    : false;
+}
+
+function isExpiredWatch(watch: Schema_Watch, now: Date): boolean {
+  const expiration = Number(watch.expiration);
+  if (!Number.isFinite(expiration)) return false;
+  return expiration <= now.getTime();
+}
+
+function nestedHasLegacyChannel(details: unknown): boolean {
+  if (!details || typeof details !== "object") return false;
+  const row = details as Record<string, unknown>;
+  return (
+    typeof row["channelId"] === "string" ||
+    typeof row["resourceId"] === "string" ||
+    typeof row["expiration"] === "string"
+  );
+}
+
+/**
+ * Read-only inventory of legacy Compass Google sync data (S46).
+ * Never writes, deletes, refreshes tokens, or calls providers.
+ */
+export function inventoryLegacySyncData(
+  input: InventoryCollections,
+  options: InventoryOptions = {},
+): LegacySyncInventoryReport {
+  const now = options.now ?? new Date();
+  const skips: InventorySkip[] = [];
+  const duplicates: InventoryDuplicate[] = [];
+  const orphans: InventoryOrphan[] = [];
+  const missingAuthority: InventoryMissingAuthority[] = [];
+
+  const users = [...input.users].sort((a, b) =>
+    a._id.toHexString().localeCompare(b._id.toHexString()),
+  );
+  const userIds = new Set(users.map((u) => u._id.toHexString()));
+
+  const calendars = [...input.calendars];
+  const events = [...input.events];
+  const syncDocs = [...input.syncDocs];
+  const watches = [...input.watches];
+
+  // --- duplicates: google calendars ---
+  const googleCalKeyCounts = new Map<string, string[]>();
+  for (const calendar of calendars) {
+    if (calendar.source.provider !== "google") continue;
+    const key = `${calendar.userId.toHexString()}:${calendar.source.calendarId}`;
+    const ids = googleCalKeyCounts.get(key) ?? [];
+    ids.push(calendar._id.toHexString());
+    googleCalKeyCounts.set(key, ids);
+  }
+  for (const [key, ids] of [...googleCalKeyCounts.entries()].sort(([a], [b]) =>
+    byId(a, b),
+  )) {
+    if (ids.length < 2) continue;
+    duplicates.push({
+      kind: "google_calendar_identity",
+      key,
+      count: ids.length,
+      ids: [...ids].sort(byId),
+    });
+    for (const id of ids) {
+      skips.push({
+        category: "duplicate_google_calendar",
+        id,
+        detail: `duplicate (userId, source.calendarId)=${key}`,
+      });
+    }
+  }
+
+  // --- duplicates: sync docs per user ---
+  const syncByUser = new Map<string, string[]>();
+  for (const doc of syncDocs) {
+    const id = doc._id?.toHexString() ?? `user:${doc.user}`;
+    const ids = syncByUser.get(doc.user) ?? [];
+    ids.push(id);
+    syncByUser.set(doc.user, ids);
+  }
+  for (const [userId, ids] of [...syncByUser.entries()].sort(([a], [b]) =>
+    byId(a, b),
+  )) {
+    if (ids.length < 2) continue;
+    duplicates.push({
+      kind: "sync_user",
+      key: userId,
+      count: ids.length,
+      ids: [...ids].sort(byId),
+    });
+    for (const id of ids) {
+      skips.push({
+        category: "duplicate_sync_user",
+        id,
+        detail: `multiple sync documents for user=${userId}`,
+      });
+    }
+  }
+
+  // --- duplicates: watches ---
+  const watchKeyCounts = new Map<string, string[]>();
+  for (const watch of watches) {
+    const key = `${watch.user}:${watch.gCalendarId}`;
+    const id = String(watch._id);
+    const ids = watchKeyCounts.get(key) ?? [];
+    ids.push(id);
+    watchKeyCounts.set(key, ids);
+  }
+  for (const [key, ids] of [...watchKeyCounts.entries()].sort(([a], [b]) =>
+    byId(a, b),
+  )) {
+    if (ids.length < 2) continue;
+    duplicates.push({
+      kind: "watch_identity",
+      key,
+      count: ids.length,
+      ids: [...ids].sort(byId),
+    });
+    for (const id of ids) {
+      skips.push({
+        category: "duplicate_watch",
+        id,
+        detail: `duplicate (user, gCalendarId)=${key}`,
+      });
+    }
+  }
+
+  // --- orphans ---
+  const calendarIds = new Set(calendars.map((c) => c._id.toHexString()));
+  const googleCalByUser = new Map<string, Set<string>>();
+  for (const calendar of calendars) {
+    if (calendar.source.provider !== "google") continue;
+    const userId = calendar.userId.toHexString();
+    const set = googleCalByUser.get(userId) ?? new Set();
+    set.add(calendar.source.calendarId);
+    googleCalByUser.set(userId, set);
+  }
+
+  for (const calendar of calendars) {
+    const userId = calendar.userId.toHexString();
+    if (userIds.has(userId)) continue;
+    orphans.push({
+      kind: "calendar",
+      id: calendar._id.toHexString(),
+      reason: `calendar.userId=${userId} has no user`,
+    });
+    skips.push({
+      category: "orphan_calendar",
+      id: calendar._id.toHexString(),
+      detail: `calendar.userId=${userId} has no user`,
+    });
+  }
+
+  for (const event of events) {
+    const calendarId = event.calendarId.toHexString();
+    if (calendarIds.has(calendarId)) continue;
+    orphans.push({
+      kind: "event",
+      id: event._id.toHexString(),
+      reason: `event.calendarId=${calendarId} has no calendar`,
+    });
+    skips.push({
+      category: "orphan_event",
+      id: event._id.toHexString(),
+      detail: `event.calendarId=${calendarId} has no calendar`,
+    });
+  }
+
+  for (const doc of syncDocs) {
+    if (userIds.has(doc.user)) continue;
+    const id = doc._id?.toHexString() ?? `user:${doc.user}`;
+    orphans.push({
+      kind: "sync",
+      id,
+      reason: `sync.user=${doc.user} has no user`,
+    });
+    skips.push({
+      category: "orphan_sync",
+      id,
+      detail: `sync.user=${doc.user} has no user`,
+    });
+  }
+
+  for (const watch of watches) {
+    if (!userIds.has(watch.user)) {
+      const id = String(watch._id);
+      orphans.push({
+        kind: "watch",
+        id,
+        reason: `watch.user=${watch.user} has no user`,
+      });
+      skips.push({
+        category: "orphan_watch",
+        id,
+        detail: `watch.user=${watch.user} has no user`,
+      });
+      continue;
+    }
+    if (watch.gCalendarId === Resource_Sync.CALENDAR) continue;
+    const known = googleCalByUser.get(watch.user);
+    if (known?.has(watch.gCalendarId)) continue;
+    const id = String(watch._id);
+    orphans.push({
+      kind: "watch_calendar",
+      id,
+      reason: `watch gCalendarId=${watch.gCalendarId} has no google calendar for user`,
+    });
+    skips.push({
+      category: "orphan_watch_calendar",
+      id,
+      detail: `watch gCalendarId=${watch.gCalendarId} has no google calendar for user=${watch.user}`,
+    });
+  }
+
+  for (const doc of syncDocs) {
+    const eventRows = doc.google?.events ?? [];
+    for (const row of eventRows) {
+      const known = googleCalByUser.get(doc.user);
+      if (known?.has(row.gCalendarId)) continue;
+      const id = `${doc.user}:${row.gCalendarId}`;
+      orphans.push({
+        kind: "cursor_calendar",
+        id,
+        reason: `events cursor gCalendarId=${row.gCalendarId} has no google calendar`,
+      });
+      skips.push({
+        category: "orphan_cursor_calendar",
+        id,
+        detail: `events cursor gCalendarId=${row.gCalendarId} has no google calendar for user=${doc.user}`,
+      });
+    }
+  }
+
+  // --- legacy nested watch fields on sync docs ---
+  for (const doc of syncDocs) {
+    const id = doc._id?.toHexString() ?? `user:${doc.user}`;
+    const rows = [
+      ...(doc.google?.events ?? []),
+      ...(doc.google?.calendarlist ?? []),
+    ];
+    if (!rows.some(nestedHasLegacyChannel)) continue;
+    skips.push({
+      category: "legacy_nested_watch",
+      id,
+      detail:
+        "sync.google.* still carries channelId/resourceId/expiration (pre-watch-collection)",
+    });
+  }
+
+  // --- per-user authority + targets ---
+  const calendarsByUser = new Map<string, CalendarRecord[]>();
+  for (const calendar of calendars) {
+    const userId = calendar.userId.toHexString();
+    const list = calendarsByUser.get(userId) ?? [];
+    list.push(calendar);
+    calendarsByUser.set(userId, list);
+  }
+
+  const calendarOwner = new Map<string, string>();
+  for (const calendar of calendars) {
+    calendarOwner.set(
+      calendar._id.toHexString(),
+      calendar.userId.toHexString(),
+    );
+  }
+
+  const eventsByUser = new Map<
+    string,
+    { linkedGoogle: number; unlinked: number }
+  >();
+  for (const event of events) {
+    const owner = calendarOwner.get(event.calendarId.toHexString());
+    if (!owner) continue;
+    const bucket = eventsByUser.get(owner) ?? {
+      linkedGoogle: 0,
+      unlinked: 0,
+    };
+    if (event.externalReference?.provider === "google") {
+      bucket.linkedGoogle += 1;
+    } else {
+      bucket.unlinked += 1;
+    }
+    eventsByUser.set(owner, bucket);
+  }
+
+  const syncDocByUser = new Map<string, (typeof syncDocs)[number]>();
+  for (const doc of syncDocs) {
+    if (!syncDocByUser.has(doc.user)) syncDocByUser.set(doc.user, doc);
+  }
+
+  const watchesByUser = new Map<string, Schema_Watch[]>();
+  for (const watch of watches) {
+    const list = watchesByUser.get(watch.user) ?? [];
+    list.push(watch);
+    watchesByUser.set(watch.user, list);
+  }
+
+  const targets: InventoryUserTarget[] = [];
+  let withGoogle = 0;
+  let withRefreshToken = 0;
+  let missingToken = 0;
+
+  for (const user of users) {
+    const userId = user._id.toHexString();
+    const principal = toSyncPrincipal(userId);
+    const googleOk = hasGoogleIdentity(user);
+    const tokenOk = hasRefreshToken(user);
+
+    if (googleOk) withGoogle += 1;
+    if (tokenOk) withRefreshToken += 1;
+
+    if (!googleOk) {
+      const reason =
+        user.google === undefined ? "no_google" : "empty_google_id";
+      missingAuthority.push({ userId, reason });
+      skips.push({
+        category: "no_google_identity",
+        id: userId,
+        detail:
+          reason === "no_google"
+            ? "user has no google identity"
+            : "user google.googleId is empty",
+      });
+    }
+
+    if (googleOk && !tokenOk) {
+      missingToken += 1;
+      missingAuthority.push({ userId, reason: "empty_refresh_token" });
+      skips.push({
+        category: "missing_refresh_token",
+        id: userId,
+        detail: "user has google identity but empty gRefreshToken",
+      });
+    }
+
+    const userCalendars = (calendarsByUser.get(userId) ?? []).sort((a, b) =>
+      a._id.toHexString().localeCompare(b._id.toHexString()),
+    );
+    const calendarTargets = userCalendars
+      .flatMap((c) =>
+        c.source.provider === "google"
+          ? [
+              {
+                compassCalendarId: c._id.toHexString(),
+                providerCalendarId: c.source.calendarId,
+              },
+            ]
+          : [],
+      )
+      .sort((a, b) => byId(a.providerCalendarId, b.providerCalendarId));
+
+    const eventCounts = eventsByUser.get(userId) ?? {
+      linkedGoogle: 0,
+      unlinked: 0,
+    };
+
+    const syncDoc = syncDocByUser.get(userId);
+    const userWatches = watchesByUser.get(userId) ?? [];
+    const watchKeys = new Set(
+      userWatches.map((w) => `${w.user}:${w.gCalendarId}`),
+    );
+
+    const syncResourceTargets: InventoryUserTarget["syncResourceTargets"] = [];
+    const calendarListRows = syncDoc?.google?.calendarlist ?? [];
+    if (
+      calendarListRows.length > 0 ||
+      watchKeys.has(`${userId}:${Resource_Sync.CALENDAR}`)
+    ) {
+      syncResourceTargets.push({
+        resourceKind: "calendarList",
+        gCalendarId: null,
+        hasCursor: calendarListRows.some((r) => Boolean(r.nextSyncToken)),
+        hasWatch: watchKeys.has(`${userId}:${Resource_Sync.CALENDAR}`),
+      });
+    }
+    const eventCursorIds = new Set(
+      (syncDoc?.google?.events ?? []).map((r) => r.gCalendarId),
+    );
+    for (const watch of userWatches) {
+      if (watch.gCalendarId !== Resource_Sync.CALENDAR) {
+        eventCursorIds.add(watch.gCalendarId);
+      }
+    }
+    for (const gCalendarId of [...eventCursorIds].sort(byId)) {
+      syncResourceTargets.push({
+        resourceKind: "events",
+        gCalendarId,
+        hasCursor: (syncDoc?.google?.events ?? []).some(
+          (r) => r.gCalendarId === gCalendarId && Boolean(r.nextSyncToken),
+        ),
+        hasWatch: watchKeys.has(`${userId}:${gCalendarId}`),
+      });
+    }
+
+    targets.push({
+      userId,
+      tenantId: principal.tenantId,
+      principalId: principal.principalId,
+      providerAccountId: user.google?.googleId?.trim() || null,
+      accountEmail: user.email ?? null,
+      hasRefreshToken: tokenOk,
+      calendarTargets,
+      eventTargets: {
+        linkedGoogle: eventCounts.linkedGoogle,
+        unlinkedPendingIntent: eventCounts.unlinked,
+      },
+      syncResourceTargets,
+    });
+  }
+
+  let eventCursorRows = 0;
+  let calendarListCursorRows = 0;
+  for (const doc of syncDocs) {
+    eventCursorRows += doc.google?.events?.length ?? 0;
+    calendarListCursorRows += doc.google?.calendarlist?.length ?? 0;
+  }
+
+  let eventWatches = 0;
+  let calendarListWatches = 0;
+  let expired = 0;
+  for (const watch of watches) {
+    if (watch.gCalendarId === Resource_Sync.CALENDAR) calendarListWatches += 1;
+    else eventWatches += 1;
+    if (isExpiredWatch(watch, now)) expired += 1;
+  }
+
+  const googleCalendars = calendars.filter(
+    (c) => c.source.provider === "google",
+  ).length;
+  const linkedEvents = events.filter(
+    (e) => e.externalReference?.provider === "google",
+  ).length;
+
+  const scanned =
+    users.length +
+    calendars.length +
+    events.length +
+    syncDocs.length +
+    watches.length;
+
+  const report: LegacySyncInventoryReport = {
+    generatedAt: now.toISOString(),
+    dryRun: true,
+    source: {
+      users: {
+        total: users.length,
+        withGoogle,
+        withRefreshToken,
+        missingToken,
+      },
+      calendars: {
+        total: calendars.length,
+        google: googleCalendars,
+        local: calendars.length - googleCalendars,
+      },
+      events: {
+        total: events.length,
+        linkedGoogle: linkedEvents,
+        unlinked: events.length - linkedEvents,
+      },
+      syncDocs: {
+        total: syncDocs.length,
+        eventCursorRows,
+        calendarListCursorRows,
+      },
+      watches: {
+        total: watches.length,
+        eventWatches,
+        calendarListWatches,
+        expired,
+      },
+    },
+    targets,
+    duplicates: duplicates.sort((a, b) => byId(a.key, b.key)),
+    orphans: orphans.sort((a, b) => byId(a.id, b.id)),
+    missingAuthority: missingAuthority.sort((a, b) => byId(a.userId, b.userId)),
+    skips: skips.sort(
+      (a, b) => byId(a.category, b.category) || byId(a.id, b.id),
+    ),
+    counts: {
+      scanned,
+      reportable: targets.length,
+      skipped: skips.length,
+    },
+  };
+
+  return LegacySyncInventoryReportSchema.parse(report);
+}
+
+export async function loadInventoryCollections(deps: {
+  user: {
+    find: (q: object) => {
+      toArray: () => Promise<InventoryCollections["users"]>;
+    };
+  };
+  calendar: {
+    find: (q: object) => { toArray: () => Promise<CalendarRecord[]> };
+  };
+  event: { find: (q: object) => { toArray: () => Promise<EventRecord[]> } };
+  sync: {
+    find: (q: object) => {
+      toArray: () => Promise<InventoryCollections["syncDocs"]>;
+    };
+  };
+  watch: { find: (q: object) => { toArray: () => Promise<Schema_Watch[]> } };
+}): Promise<InventoryCollections> {
+  const [users, calendars, events, syncDocs, watches] = await Promise.all([
+    deps.user.find({}).toArray(),
+    deps.calendar.find({}).toArray(),
+    deps.event.find({}).toArray(),
+    deps.sync.find({}).toArray(),
+    deps.watch.find({}).toArray(),
+  ]);
+  return { users, calendars, events, syncDocs, watches };
+}

--- a/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
@@ -324,7 +324,14 @@ export function inventoryLegacySyncData(
 
   const syncDocByUser = new Map<string, (typeof syncDocs)[number]>();
   for (const doc of syncDocs) {
-    if (!syncDocByUser.has(doc.user)) syncDocByUser.set(doc.user, doc);
+    const existing = syncDocByUser.get(doc.user);
+    const docId = doc._id?.toHexString() ?? `user:${doc.user}`;
+    if (
+      !existing ||
+      byId(docId, existing._id?.toHexString() ?? `user:${existing.user}`) < 0
+    ) {
+      syncDocByUser.set(doc.user, doc);
+    }
   }
 
   const watchesByUser = new Map<string, Schema_Watch[]>();

--- a/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync/inventory.ts
@@ -165,7 +165,9 @@ export function inventoryLegacySyncData(
   }
 
   // --- orphans ---
-  const calendarIds = new Set(calendars.map((c) => c._id.toHexString()));
+  const calendarById = new Map(
+    calendars.map((calendar) => [calendar._id.toHexString(), calendar]),
+  );
   const googleCalByUser = new Map<string, Set<string>>();
   for (const calendar of calendars) {
     if (calendar.source.provider !== "google") continue;
@@ -192,16 +194,20 @@ export function inventoryLegacySyncData(
 
   for (const event of events) {
     const calendarId = event.calendarId.toHexString();
-    if (calendarIds.has(calendarId)) continue;
+    const calendar = calendarById.get(calendarId);
+    if (calendar && userIds.has(calendar.userId.toHexString())) continue;
+    const reason = calendar
+      ? `event.calendarId=${calendarId} calendar.userId=${calendar.userId.toHexString()} has no user`
+      : `event.calendarId=${calendarId} has no calendar`;
     orphans.push({
       kind: "event",
       id: event._id.toHexString(),
-      reason: `event.calendarId=${calendarId} has no calendar`,
+      reason,
     });
     skips.push({
       category: "orphan_event",
       id: event._id.toHexString(),
-      detail: `event.calendarId=${calendarId} has no calendar`,
+      detail: reason,
     });
   }
 

--- a/packages/scripts/src/commands/inventory-legacy-sync/report.types.ts
+++ b/packages/scripts/src/commands/inventory-legacy-sync/report.types.ts
@@ -1,0 +1,131 @@
+import { z } from "zod/v4";
+
+// Categorized skips for the S46 inventory. Every skip must use one of these;
+// unexplained skips block cutover later (05-migration-and-rollout.md).
+export const InventorySkipCategorySchema = z.enum([
+  "no_google_identity",
+  "missing_refresh_token",
+  "orphan_calendar",
+  "orphan_event",
+  "orphan_sync",
+  "orphan_watch",
+  "orphan_cursor_calendar",
+  "orphan_watch_calendar",
+  "duplicate_google_calendar",
+  "duplicate_sync_user",
+  "duplicate_watch",
+  "legacy_nested_watch",
+]);
+export type InventorySkipCategory = z.infer<typeof InventorySkipCategorySchema>;
+
+export const InventorySkipSchema = z.strictObject({
+  category: InventorySkipCategorySchema,
+  id: z.string().min(1),
+  detail: z.string().min(1),
+});
+export type InventorySkip = z.infer<typeof InventorySkipSchema>;
+
+export const InventoryDuplicateSchema = z.strictObject({
+  kind: z.enum(["google_calendar_identity", "sync_user", "watch_identity"]),
+  key: z.string().min(1),
+  count: z.number().int().positive(),
+  ids: z.array(z.string().min(1)),
+});
+export type InventoryDuplicate = z.infer<typeof InventoryDuplicateSchema>;
+
+export const InventoryOrphanSchema = z.strictObject({
+  kind: z.enum([
+    "calendar",
+    "event",
+    "sync",
+    "watch",
+    "cursor_calendar",
+    "watch_calendar",
+  ]),
+  id: z.string().min(1),
+  reason: z.string().min(1),
+});
+export type InventoryOrphan = z.infer<typeof InventoryOrphanSchema>;
+
+export const InventoryMissingAuthoritySchema = z.strictObject({
+  userId: z.string().min(1),
+  reason: z.enum(["no_google", "empty_refresh_token", "empty_google_id"]),
+});
+export type InventoryMissingAuthority = z.infer<
+  typeof InventoryMissingAuthoritySchema
+>;
+
+export const InventorySyncResourceTargetSchema = z.strictObject({
+  resourceKind: z.enum(["calendarList", "events"]),
+  gCalendarId: z.string().nullable(),
+  hasCursor: z.boolean(),
+  hasWatch: z.boolean(),
+});
+
+export const InventoryUserTargetSchema = z.strictObject({
+  userId: z.string().min(1),
+  tenantId: z.string().min(1),
+  principalId: z.string().min(1),
+  providerAccountId: z.string().nullable(),
+  accountEmail: z.string().nullable(),
+  hasRefreshToken: z.boolean(),
+  calendarTargets: z.array(
+    z.strictObject({
+      compassCalendarId: z.string().min(1),
+      providerCalendarId: z.string().min(1),
+    }),
+  ),
+  eventTargets: z.strictObject({
+    linkedGoogle: z.number().int().nonnegative(),
+    unlinkedPendingIntent: z.number().int().nonnegative(),
+  }),
+  syncResourceTargets: z.array(InventorySyncResourceTargetSchema),
+});
+export type InventoryUserTarget = z.infer<typeof InventoryUserTargetSchema>;
+
+export const LegacySyncInventoryReportSchema = z.strictObject({
+  generatedAt: z.string().min(1),
+  dryRun: z.literal(true),
+  source: z.strictObject({
+    users: z.strictObject({
+      total: z.number().int().nonnegative(),
+      withGoogle: z.number().int().nonnegative(),
+      withRefreshToken: z.number().int().nonnegative(),
+      missingToken: z.number().int().nonnegative(),
+    }),
+    calendars: z.strictObject({
+      total: z.number().int().nonnegative(),
+      google: z.number().int().nonnegative(),
+      local: z.number().int().nonnegative(),
+    }),
+    events: z.strictObject({
+      total: z.number().int().nonnegative(),
+      linkedGoogle: z.number().int().nonnegative(),
+      unlinked: z.number().int().nonnegative(),
+    }),
+    syncDocs: z.strictObject({
+      total: z.number().int().nonnegative(),
+      eventCursorRows: z.number().int().nonnegative(),
+      calendarListCursorRows: z.number().int().nonnegative(),
+    }),
+    watches: z.strictObject({
+      total: z.number().int().nonnegative(),
+      eventWatches: z.number().int().nonnegative(),
+      calendarListWatches: z.number().int().nonnegative(),
+      expired: z.number().int().nonnegative(),
+    }),
+  }),
+  targets: z.array(InventoryUserTargetSchema),
+  duplicates: z.array(InventoryDuplicateSchema),
+  orphans: z.array(InventoryOrphanSchema),
+  missingAuthority: z.array(InventoryMissingAuthoritySchema),
+  skips: z.array(InventorySkipSchema),
+  counts: z.strictObject({
+    scanned: z.number().int().nonnegative(),
+    reportable: z.number().int().nonnegative(),
+    skipped: z.number().int().nonnegative(),
+  }),
+});
+export type LegacySyncInventoryReport = z.infer<
+  typeof LegacySyncInventoryReportSchema
+>;


### PR DESCRIPTION
## Summary
- S46 CLI: `bun run cli inventory-legacy-sync [--out path.json]`
- Read-only scan of legacy Compass API Mongo (users/credentials/calendars/events/sync/watches)
- Stable report with deterministic Sync targets (`tenantId`/`principalId` = user id), duplicates, orphans, missing authority, categorized skips
- Unit + production-shaped DB fixture tests; no writes/provider calls

## Test plan
- [x] `bun test packages/scripts/src/commands/inventory-legacy-sync/inventory.test.ts`
- [x] `bun test:scripts -- './packages/scripts/src/commands/inventory-legacy-sync.db.test.ts'`
- [x] CLI wiring test for `inventory-legacy-sync`
- [ ] Optional: run against staging snapshot and archive report before S47


Made with [Cursor](https://cursor.com)