### PR TITLE
feat(scripts): migrate provider connections

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -18,6 +18,7 @@ Primary file:
 | `bun run cli migrate pending` | `packages/scripts/src/commands/migrate.ts` | Lists pending migrations. |
 | `bun run cli migrate executed` | `packages/scripts/src/commands/migrate.ts` | Lists executed migrations. |
 | `bun run cli inventory-legacy-sync [--out path.json]` | `packages/scripts/src/commands/inventory-legacy-sync.ts` | Read-only S46 inventory of legacy Google sync data (users/credentials/calendars/events/cursors/watches). Never writes or calls providers. |
+| `bun run cli migrate-connections [--apply] [--out report.json] [--user-id id]...` | `packages/scripts/src/commands/migrate-connections.ts` | S47: idempotently upsert Sync connections + credentials from legacy users. Default dry-run; `--apply` writes. Never clears source tokens or enqueues Sync jobs. |
 
 ## Migration Internals
 

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -7,6 +7,7 @@ const requireActual = createRequire(import.meta.url);
 const mockExitHelpfully = mock();
 const mockRunMigrator = mock((): Promise<void> => Promise.resolve());
 const mockRunInventory = mock((): Promise<void> => Promise.resolve());
+const mockRunMigrateConnections = mock((): Promise<void> => Promise.resolve());
 
 mock.module("@scripts/cli.validator", () => ({
   CliValidator: mock().mockImplementation(() => ({
@@ -22,6 +23,11 @@ mock.module("@scripts/commands/migrate", () => ({
 mock.module("@scripts/commands/inventory-legacy-sync", () => ({
   __esModule: true,
   runInventoryLegacySync: mock(() => mockRunInventory()),
+}));
+
+mock.module("@scripts/commands/migrate-connections", () => ({
+  __esModule: true,
+  runMigrateConnections: mock(() => mockRunMigrateConnections()),
 }));
 
 const { default: CompassCLI } = requireActual(
@@ -47,6 +53,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunInventory).toHaveBeenCalled();
+  });
+
+  it("runs migrate-connections command", async () => {
+    const cli = new CompassCLI(["node", "cli", "migrate-connections"]);
+
+    await cli.run();
+
+    expect(mockRunMigrateConnections).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,6 +1,7 @@
 import { CliValidator } from "@scripts/cli.validator";
 import { runInventoryLegacySync } from "@scripts/commands/inventory-legacy-sync";
 import { runMigrator } from "@scripts/commands/migrate";
+import { runMigrateConnections } from "@scripts/commands/migrate-connections";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
 
@@ -24,6 +25,9 @@ export default class CompassCLI {
       case cmd === "inventory-legacy-sync":
         await runInventoryLegacySync();
         break;
+      case cmd === "migrate-connections":
+        await runMigrateConnections();
+        break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }
@@ -32,13 +36,17 @@ export default class CompassCLI {
   private _createProgram(): Command {
     const program = new Command();
 
+    program.enablePositionalOptions(true).passThroughOptions(true);
+
+    // Register longer `migrate-*` names before `migrate` so Commander does not
+    // treat them as unknown args to the Umzug migrate command.
     program
-      .enablePositionalOptions(true)
-      .passThroughOptions(true)
-      .command("migrate")
+      .command("migrate-connections")
       .helpOption(false)
       .allowUnknownOption(true)
-      .description("run database schema migrations");
+      .description(
+        "idempotently copy legacy Google connections into Sync (S47; --apply to write)",
+      );
 
     program
       .command("inventory-legacy-sync")
@@ -47,6 +55,12 @@ export default class CompassCLI {
       .description(
         "read-only inventory of legacy Google sync data (S46; no writes)",
       );
+
+    program
+      .command("migrate")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description("run database schema migrations");
 
     return program;
   }

--- a/packages/scripts/src/commands/migrate-connections.db.test.ts
+++ b/packages/scripts/src/commands/migrate-connections.db.test.ts
@@ -1,0 +1,155 @@
+import { migrateProviderConnections } from "@scripts/commands/migrate-connections/migrate";
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { GOOGLE_SCOPES } from "@sync/providers/google/google.scopes";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+const NOW = new Date("2026-07-25T04:00:00.000Z");
+
+describe("migrate-connections (db)", () => {
+  const syncStorage = setupSyncStorage(import.meta.url);
+
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  it("dry-run does not write Sync rows; apply then rerun is idempotent", async () => {
+    const userId = new ObjectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "migrate@example.com",
+      firstName: "Mig",
+      lastName: "Rate",
+      name: "Mig Rate",
+      locale: "en",
+      google: {
+        googleId: "google-subject-migrate",
+        picture: "",
+        gRefreshToken: "legacy-refresh-token",
+      },
+    });
+
+    const connections = new ProviderConnectionRepository(syncStorage.db());
+    const credentials = new CredentialRepository(syncStorage.db());
+    const users = await mongoService.user.find({}).toArray();
+
+    const dry = await migrateProviderConnections(
+      { connections, credentials },
+      users,
+      { dryRun: true, now: NOW },
+    );
+    expect(dry.counts.wouldCreate).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerConnections)
+        .countDocuments(),
+    ).toBe(0);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.credentials)
+        .countDocuments(),
+    ).toBe(0);
+
+    // Source credential must remain untouched.
+    const sourceBefore = await mongoService.user.findOne({ _id: userId });
+    expect(sourceBefore?.google?.gRefreshToken).toBe("legacy-refresh-token");
+
+    const first = await migrateProviderConnections(
+      { connections, credentials },
+      users,
+      { dryRun: false, now: NOW },
+    );
+    expect(first.counts.created).toBe(1);
+    expect(first.results[0]?.credentialVerified).toBe(true);
+    const connectionId = first.results[0]?.connectionId;
+    expect(connectionId).toMatch(/^[0-9a-f]{24}$/);
+
+    const stored = await credentials.findByConnection(connectionId as never);
+    expect(stored?.refreshToken).toBe("legacy-refresh-token");
+    expect(stored?.scopes).toEqual([...GOOGLE_SCOPES]);
+    expect(stored?.accessToken).toBeNull();
+
+    const listed = await connections.listByPrincipal(
+      userId.toHexString() as never,
+      userId.toHexString() as never,
+    );
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.state).toBe("importing");
+    expect(listed[0]?.account.providerAccountId).toBe("google-subject-migrate");
+
+    const second = await migrateProviderConnections(
+      { connections, credentials },
+      users,
+      { dryRun: false, now: NOW },
+    );
+    expect(second.counts.updated).toBe(1);
+    expect(second.results[0]?.connectionId).toBe(connectionId);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerConnections)
+        .countDocuments(),
+    ).toBe(1);
+
+    const sourceAfter = await mongoService.user.findOne({ _id: userId });
+    expect(sourceAfter?.google?.gRefreshToken).toBe("legacy-refresh-token");
+  });
+
+  it("migrates an OAuth user and skips a password-only user", async () => {
+    const oauthId = new ObjectId();
+    const passwordId = new ObjectId();
+    await mongoService.user.insertMany([
+      {
+        _id: oauthId,
+        email: "oauth@example.com",
+        firstName: "O",
+        lastName: "Auth",
+        name: "O Auth",
+        locale: "en",
+        google: {
+          googleId: "google-oauth",
+          picture: "",
+          gRefreshToken: "oauth-refresh",
+        },
+      },
+      {
+        _id: passwordId,
+        email: "password@example.com",
+        firstName: "P",
+        lastName: "Word",
+        name: "P Word",
+        locale: "en",
+      },
+    ]);
+
+    const report = await migrateProviderConnections(
+      {
+        connections: new ProviderConnectionRepository(syncStorage.db()),
+        credentials: new CredentialRepository(syncStorage.db()),
+      },
+      await mongoService.user.find({}).toArray(),
+      { dryRun: false, now: NOW },
+    );
+
+    expect(report.counts.created).toBe(1);
+    expect(report.counts.skipped).toBe(1);
+    expect(
+      report.results.find((r) => r.userId === passwordId.toHexString())
+        ?.skipCategory,
+    ).toBe("no_google_identity");
+  });
+});

--- a/packages/scripts/src/commands/migrate-connections.ts
+++ b/packages/scripts/src/commands/migrate-connections.ts
@@ -1,0 +1,106 @@
+import { migrateProviderConnections } from "@scripts/commands/migrate-connections/migrate";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const logger = Logger("scripts.commands.migrate-connections");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before migrating connections",
+    );
+  }
+  return uri;
+}
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  outPath: string | null;
+  userIds: Set<string> | undefined;
+} {
+  const apply = argv.includes("--apply");
+  const dryRun = !apply;
+  const outFlag = argv.indexOf("--out");
+  const outPath =
+    outFlag >= 0 && argv[outFlag + 1] ? resolve(argv[outFlag + 1]!) : null;
+
+  const userIds = new Set<string>();
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--user-id" && argv[i + 1]) {
+      userIds.add(argv[i + 1]!);
+      i += 1;
+    }
+  }
+
+  return {
+    dryRun,
+    outPath,
+    userIds: userIds.size > 0 ? userIds : undefined,
+  };
+}
+
+/**
+ * S47: idempotently copy legacy Google connections + refresh tokens into Sync
+ * custody. Default is dry-run; pass `--apply` to write. Never clears source
+ * credentials, never enqueues Sync jobs, never calls Google.
+ *
+ * Usage:
+ *   bun run cli migrate-connections [--dry-run|--apply] [--out report.json]
+ *     [--user-id <id>]...
+ */
+export async function runMigrateConnections(): Promise<void> {
+  const { dryRun, outPath, userIds } = parseArgs(process.argv.slice(3));
+  const syncMongo = new SyncMongoService();
+
+  try {
+    await mongoService.start();
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const users = await mongoService.user.find({}).toArray();
+    const report = await migrateProviderConnections(
+      {
+        connections: new ProviderConnectionRepository(syncMongo.db),
+        credentials: new CredentialRepository(syncMongo.db),
+      },
+      users,
+      { dryRun, userIds },
+    );
+
+    const json = `${JSON.stringify(report, null, 2)}\n`;
+    if (outPath) {
+      writeFileSync(outPath, json, "utf8");
+      logger.info(`Wrote connection migration report to ${outPath}`);
+    } else {
+      process.stdout.write(json);
+    }
+
+    logger.info(
+      `migrate-connections dryRun=${report.dryRun} scanned=${report.counts.scanned} created=${report.counts.created} updated=${report.counts.updated} skipped=${report.counts.skipped}`,
+    );
+
+    await syncMongo.disconnect();
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/migrate-connections.ts
+++ b/packages/scripts/src/commands/migrate-connections.ts
@@ -79,12 +79,22 @@ export async function runMigrateConnections(): Promise<void> {
       { dryRun, userIds },
     );
 
-    const json = `${JSON.stringify(report, null, 2)}\n`;
-    if (outPath) {
-      writeFileSync(outPath, json, "utf8");
-      logger.info(`Wrote connection migration report to ${outPath}`);
-    } else {
-      process.stdout.write(json);
+    try {
+      const json = `${JSON.stringify(report, null, 2)}\n`;
+      if (outPath) {
+        writeFileSync(outPath, json, "utf8");
+        logger.info(`Wrote connection migration report to ${outPath}`);
+      } else {
+        process.stdout.write(json);
+      }
+    } catch (outputError) {
+      logger.error(outputError);
+      if (dryRun) {
+        throw outputError;
+      }
+      logger.error(
+        "migrate-connections apply completed but report output failed; database changes were persisted",
+      );
     }
 
     logger.info(

--- a/packages/scripts/src/commands/migrate-connections/migrate.test.ts
+++ b/packages/scripts/src/commands/migrate-connections/migrate.test.ts
@@ -1,0 +1,163 @@
+import { migrateProviderConnections } from "@scripts/commands/migrate-connections/migrate";
+import { ObjectId } from "mongodb";
+import { describe, expect, it, mock } from "bun:test";
+
+const NOW = new Date("2026-07-25T04:00:00.000Z");
+const USER_ID = new ObjectId("507f1f77bcf86cd799439011");
+const CONNECTION_ID = "507f1f77bcf86cd799439099";
+
+describe("migrateProviderConnections", () => {
+  it("dry-run reports would_create without writing", async () => {
+    const upsert = mock(() => {
+      throw new Error("should not upsert in dry-run");
+    });
+    const store = mock(() => {
+      throw new Error("should not store in dry-run");
+    });
+
+    const report = await migrateProviderConnections(
+      {
+        connections: {
+          listByPrincipal: async () => [],
+          upsertByProviderAccount: upsert,
+        } as never,
+        credentials: { store, findByConnection: async () => null } as never,
+      },
+      [
+        {
+          _id: USER_ID,
+          email: "alice@example.com",
+          google: {
+            googleId: "google-1",
+            picture: "",
+            gRefreshToken: "refresh-1",
+          },
+        },
+      ],
+      { dryRun: true, now: NOW },
+    );
+
+    expect(report.dryRun).toBe(true);
+    expect(report.counts.wouldCreate).toBe(1);
+    expect(report.results[0]?.action).toBe("would_create");
+    expect(upsert).not.toHaveBeenCalled();
+    expect(store).not.toHaveBeenCalled();
+  });
+
+  it("skips users without google or refresh token", async () => {
+    const report = await migrateProviderConnections(
+      {
+        connections: {
+          listByPrincipal: async () => [],
+          upsertByProviderAccount: async () => {
+            throw new Error("unused");
+          },
+        } as never,
+        credentials: {
+          store: async () => {
+            throw new Error("unused");
+          },
+          findByConnection: async () => null,
+        } as never,
+      },
+      [
+        {
+          _id: new ObjectId("507f1f77bcf86cd799439012"),
+          email: "password@example.com",
+        },
+        {
+          _id: new ObjectId("507f1f77bcf86cd799439013"),
+          email: "oauth@example.com",
+          google: {
+            googleId: "google-2",
+            picture: "",
+            gRefreshToken: "",
+          },
+        },
+      ],
+      { dryRun: true, now: NOW },
+    );
+
+    expect(report.counts.skipped).toBe(2);
+    expect(report.results.map((r) => r.skipCategory)).toEqual([
+      "no_google_identity",
+      "missing_refresh_token",
+    ]);
+  });
+
+  it("apply creates then rerun updates the same connection id", async () => {
+    let existing: {
+      _id: string;
+      provider: "google";
+      account: { providerAccountId: string };
+    } | null = null;
+    const upsert = mock(
+      async (input: { account: { providerAccountId: string } }) => {
+        existing = {
+          _id: CONNECTION_ID,
+          provider: "google",
+          account: { providerAccountId: input.account.providerAccountId },
+        };
+        return existing;
+      },
+    );
+    const storedToken = { value: "" };
+    const store = mock(async (input: { refreshToken: string }) => {
+      storedToken.value = input.refreshToken;
+      return {
+        _id: CONNECTION_ID,
+        refreshToken: input.refreshToken,
+        scopes: [
+          "https://www.googleapis.com/auth/userinfo.email",
+          "https://www.googleapis.com/auth/calendar.readonly",
+          "https://www.googleapis.com/auth/calendar.events",
+        ],
+      };
+    });
+    const findByConnection = mock(async () => ({
+      _id: CONNECTION_ID,
+      refreshToken: storedToken.value,
+      scopes: [
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/calendar.readonly",
+        "https://www.googleapis.com/auth/calendar.events",
+      ],
+    }));
+
+    const deps = {
+      connections: {
+        listByPrincipal: async () => (existing ? [existing] : []),
+        upsertByProviderAccount: upsert,
+      } as never,
+      credentials: { store, findByConnection } as never,
+    };
+    const users = [
+      {
+        _id: USER_ID,
+        email: "alice@example.com",
+        google: {
+          googleId: "google-1",
+          picture: "",
+          gRefreshToken: "refresh-1",
+        },
+      },
+    ];
+
+    const first = await migrateProviderConnections(deps, users, {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(first.counts.created).toBe(1);
+    expect(first.results[0]?.connectionId).toBe(CONNECTION_ID);
+    expect(first.results[0]?.credentialVerified).toBe(true);
+
+    const second = await migrateProviderConnections(deps, users, {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(second.counts.updated).toBe(1);
+    expect(second.results[0]?.connectionId).toBe(CONNECTION_ID);
+    expect(upsert).toHaveBeenCalledTimes(2);
+    expect(store).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/scripts/src/commands/migrate-connections/migrate.ts
+++ b/packages/scripts/src/commands/migrate-connections/migrate.ts
@@ -7,6 +7,7 @@ import { type ObjectId } from "mongodb";
 import {
   type ConnectionId,
   type PrincipalId,
+  ProviderAccountIdSchema,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { type Schema_User } from "@core/types/user.types";
@@ -147,7 +148,7 @@ export async function migrateProviderConnections(
       principalId,
       provider: "google",
       account: {
-        providerAccountId,
+        providerAccountId: ProviderAccountIdSchema.parse(providerAccountId),
         email: accountEmail,
         displayName: null,
       },

--- a/packages/scripts/src/commands/migrate-connections/migrate.ts
+++ b/packages/scripts/src/commands/migrate-connections/migrate.ts
@@ -1,0 +1,206 @@
+import {
+  type MigrateConnectionResult,
+  type MigrateConnectionsReport,
+  MigrateConnectionsReportSchema,
+} from "@scripts/commands/migrate-connections/report.types";
+import { type ObjectId } from "mongodb";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { type Schema_User } from "@core/types/user.types";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { GOOGLE_SCOPES } from "@sync/providers/google/google.scopes";
+import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
+import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+
+export interface MigrateConnectionSourceUser {
+  _id: ObjectId;
+  email: string;
+  google?: Schema_User["google"];
+}
+
+export interface MigrateConnectionsDeps {
+  connections: ProviderConnectionRepository;
+  credentials: CredentialRepository;
+}
+
+export interface MigrateConnectionsOptions {
+  dryRun: boolean;
+  now?: Date;
+  /** When set, only these Compass user ids are considered. */
+  userIds?: ReadonlySet<string>;
+}
+
+function hasRefreshToken(user: MigrateConnectionSourceUser): boolean {
+  return Boolean(user.google?.gRefreshToken?.trim());
+}
+
+/**
+ * Idempotently upsert Sync provider connections + credentials from legacy
+ * Compass users (S47). Never clears source tokens, never enqueues Sync jobs,
+ * never calls Google.
+ */
+export async function migrateProviderConnections(
+  deps: MigrateConnectionsDeps,
+  users: readonly MigrateConnectionSourceUser[],
+  options: MigrateConnectionsOptions,
+): Promise<MigrateConnectionsReport> {
+  const now = options.now ?? new Date();
+  const scopes = [...GOOGLE_SCOPES];
+  const capabilities = googleCapabilitiesFromScopes(scopes);
+  const results: MigrateConnectionResult[] = [];
+
+  const selected = [...users]
+    .filter((user) =>
+      options.userIds ? options.userIds.has(user._id.toHexString()) : true,
+    )
+    .sort((a, b) => a._id.toHexString().localeCompare(b._id.toHexString()));
+
+  for (const user of selected) {
+    const userId = user._id.toHexString();
+    const principal = toSyncPrincipal(userId);
+    const tenantId = principal.tenantId as TenantId;
+    const principalId = principal.principalId as PrincipalId;
+    const accountEmail = user.email?.trim() || null;
+
+    if (!user.google) {
+      results.push({
+        userId,
+        tenantId,
+        principalId,
+        providerAccountId: null,
+        accountEmail,
+        action: "skipped",
+        connectionId: null,
+        credentialVerified: false,
+        skipCategory: "no_google_identity",
+        detail: "user has no google identity",
+      });
+      continue;
+    }
+
+    const providerAccountId = user.google.googleId?.trim() || null;
+    if (!providerAccountId) {
+      results.push({
+        userId,
+        tenantId,
+        principalId,
+        providerAccountId: null,
+        accountEmail,
+        action: "skipped",
+        connectionId: null,
+        credentialVerified: false,
+        skipCategory: "empty_google_id",
+        detail: "user google.googleId is empty",
+      });
+      continue;
+    }
+
+    if (!hasRefreshToken(user)) {
+      results.push({
+        userId,
+        tenantId,
+        principalId,
+        providerAccountId,
+        accountEmail,
+        action: "skipped",
+        connectionId: null,
+        credentialVerified: false,
+        skipCategory: "missing_refresh_token",
+        detail: "user has google identity but empty gRefreshToken",
+      });
+      continue;
+    }
+
+    const existing = (
+      await deps.connections.listByPrincipal(tenantId, principalId)
+    ).find(
+      (connection) =>
+        connection.provider === "google" &&
+        connection.account.providerAccountId === providerAccountId,
+    );
+    const existed = existing !== undefined;
+
+    if (options.dryRun) {
+      results.push({
+        userId,
+        tenantId,
+        principalId,
+        providerAccountId,
+        accountEmail,
+        action: existed ? "would_update" : "would_create",
+        connectionId: existing?._id ?? null,
+        credentialVerified: false,
+        skipCategory: null,
+        detail: existed
+          ? "would upsert connection and refresh credential in Sync custody"
+          : "would create connection and store credential in Sync custody",
+      });
+      continue;
+    }
+
+    const connection = await deps.connections.upsertByProviderAccount({
+      tenantId,
+      principalId,
+      provider: "google",
+      account: {
+        providerAccountId,
+        email: accountEmail,
+        displayName: null,
+      },
+      capabilities,
+      // Same derived posture as a freshly linked account before first import.
+      state: "importing",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+
+    await deps.credentials.store({
+      connectionId: connection._id as ConnectionId,
+      provider: "google",
+      refreshToken: user.google.gRefreshToken.trim(),
+      scopes,
+    });
+
+    const stored = await deps.credentials.findByConnection(connection._id);
+    const credentialVerified =
+      stored !== null &&
+      stored.refreshToken === user.google.gRefreshToken.trim() &&
+      scopes.every((scope) => stored.scopes.includes(scope));
+
+    results.push({
+      userId,
+      tenantId,
+      principalId,
+      providerAccountId,
+      accountEmail,
+      action: existed ? "updated" : "created",
+      connectionId: connection._id,
+      credentialVerified,
+      skipCategory: null,
+      detail: existed
+        ? "upserted connection and refreshed credential in Sync custody"
+        : "created connection and stored credential in Sync custody",
+    });
+  }
+
+  const counts = {
+    scanned: selected.length,
+    wouldCreate: results.filter((r) => r.action === "would_create").length,
+    wouldUpdate: results.filter((r) => r.action === "would_update").length,
+    created: results.filter((r) => r.action === "created").length,
+    updated: results.filter((r) => r.action === "updated").length,
+    skipped: results.filter((r) => r.action === "skipped").length,
+  };
+
+  return MigrateConnectionsReportSchema.parse({
+    generatedAt: now.toISOString(),
+    dryRun: options.dryRun,
+    counts,
+    results,
+  });
+}

--- a/packages/scripts/src/commands/migrate-connections/migrate.ts
+++ b/packages/scripts/src/commands/migrate-connections/migrate.ts
@@ -125,6 +125,23 @@ export async function migrateProviderConnections(
     );
     const existed = existing !== undefined;
 
+    if (existing !== undefined && existing.disconnectedAt != null) {
+      results.push({
+        userId,
+        tenantId,
+        principalId,
+        providerAccountId,
+        accountEmail,
+        action: "skipped",
+        connectionId: existing._id,
+        credentialVerified: false,
+        skipCategory: "disconnected_in_sync",
+        detail:
+          "Sync connection is disconnected; not reviving from legacy token",
+      });
+      continue;
+    }
+
     if (options.dryRun) {
       results.push({
         userId,

--- a/packages/scripts/src/commands/migrate-connections/report.types.ts
+++ b/packages/scripts/src/commands/migrate-connections/report.types.ts
@@ -4,6 +4,7 @@ export const MigrateConnectionSkipCategorySchema = z.enum([
   "no_google_identity",
   "missing_refresh_token",
   "empty_google_id",
+  "disconnected_in_sync",
 ]);
 export type MigrateConnectionSkipCategory = z.infer<
   typeof MigrateConnectionSkipCategorySchema

--- a/packages/scripts/src/commands/migrate-connections/report.types.ts
+++ b/packages/scripts/src/commands/migrate-connections/report.types.ts
@@ -1,0 +1,52 @@
+import { z } from "zod/v4";
+
+export const MigrateConnectionSkipCategorySchema = z.enum([
+  "no_google_identity",
+  "missing_refresh_token",
+  "empty_google_id",
+]);
+export type MigrateConnectionSkipCategory = z.infer<
+  typeof MigrateConnectionSkipCategorySchema
+>;
+
+export const MigrateConnectionActionSchema = z.enum([
+  "would_create",
+  "would_update",
+  "created",
+  "updated",
+  "skipped",
+]);
+
+export const MigrateConnectionResultSchema = z.strictObject({
+  userId: z.string().min(1),
+  tenantId: z.string().min(1),
+  principalId: z.string().min(1),
+  providerAccountId: z.string().nullable(),
+  accountEmail: z.string().nullable(),
+  action: MigrateConnectionActionSchema,
+  connectionId: z.string().nullable(),
+  // Read-back after apply: credential present with expected scopes (no provider call).
+  credentialVerified: z.boolean(),
+  skipCategory: MigrateConnectionSkipCategorySchema.nullable(),
+  detail: z.string().min(1),
+});
+export type MigrateConnectionResult = z.infer<
+  typeof MigrateConnectionResultSchema
+>;
+
+export const MigrateConnectionsReportSchema = z.strictObject({
+  generatedAt: z.string().min(1),
+  dryRun: z.boolean(),
+  counts: z.strictObject({
+    scanned: z.number().int().nonnegative(),
+    wouldCreate: z.number().int().nonnegative(),
+    wouldUpdate: z.number().int().nonnegative(),
+    created: z.number().int().nonnegative(),
+    updated: z.number().int().nonnegative(),
+    skipped: z.number().int().nonnegative(),
+  }),
+  results: z.array(MigrateConnectionResultSchema),
+});
+export type MigrateConnectionsReport = z.infer<
+  typeof MigrateConnectionsReportSchema
+>;


### PR DESCRIPTION
## Summary
- S47 CLI: `bun run cli migrate-connections [--apply] [--out report.json] [--user-id id]...`
- Copies legacy `user.google` → Sync `provider_connections` + `credentials` (idempotent upsert by provider account identity)
- Default dry-run; `--apply` writes. Credential read-back verification in report. Never clears source tokens or enqueues Sync jobs.

## Test plan
- [x] Unit: dry-run / skips / create+rerun
- [x] DB: dry-run no writes, apply+rerun idempotent, password vs OAuth
- [x] CLI wiring


Made with [Cursor](https://cursor.com)