### PR TITLE
feat(scripts): migrate provider sync state

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -19,6 +19,7 @@ Primary file:
 | `bun run cli migrate executed` | `packages/scripts/src/commands/migrate.ts` | Lists executed migrations. |
 | `bun run cli inventory-legacy-sync [--out path.json]` | `packages/scripts/src/commands/inventory-legacy-sync.ts` | Read-only S46 inventory of legacy Google sync data (users/credentials/calendars/events/cursors/watches). Never writes or calls providers. |
 | `bun run cli migrate-connections [--apply] [--out report.json] [--user-id id]...` | `packages/scripts/src/commands/migrate-connections.ts` | S47: idempotently upsert Sync connections + credentials from legacy users. Default dry-run; `--apply` writes. Never clears source tokens or enqueues Sync jobs. |
+| `bun run cli migrate-provider-state [--apply] [--out report.json] [--user-id id]...` | `packages/scripts/src/commands/migrate-provider-state.ts` | S48: idempotently upsert Sync calendars, linked events, occurrences, and sync cursors from legacy data. Default dry-run; `--apply` writes. Requires S47 connections. Defers unlinked events to S49; skips legacy watches for Sync rewatch. |
 
 ## Migration Internals
 

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -8,6 +8,9 @@ const mockExitHelpfully = mock();
 const mockRunMigrator = mock((): Promise<void> => Promise.resolve());
 const mockRunInventory = mock((): Promise<void> => Promise.resolve());
 const mockRunMigrateConnections = mock((): Promise<void> => Promise.resolve());
+const mockRunMigrateProviderState = mock(
+  (): Promise<void> => Promise.resolve(),
+);
 
 mock.module("@scripts/cli.validator", () => ({
   CliValidator: mock().mockImplementation(() => ({
@@ -28,6 +31,11 @@ mock.module("@scripts/commands/inventory-legacy-sync", () => ({
 mock.module("@scripts/commands/migrate-connections", () => ({
   __esModule: true,
   runMigrateConnections: mock(() => mockRunMigrateConnections()),
+}));
+
+mock.module("@scripts/commands/migrate-provider-state", () => ({
+  __esModule: true,
+  runMigrateProviderState: mock(() => mockRunMigrateProviderState()),
 }));
 
 const { default: CompassCLI } = requireActual(
@@ -61,6 +69,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunMigrateConnections).toHaveBeenCalled();
+  });
+
+  it("runs migrate-provider-state command", async () => {
+    const cli = new CompassCLI(["node", "cli", "migrate-provider-state"]);
+
+    await cli.run();
+
+    expect(mockRunMigrateProviderState).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -2,6 +2,7 @@ import { CliValidator } from "@scripts/cli.validator";
 import { runInventoryLegacySync } from "@scripts/commands/inventory-legacy-sync";
 import { runMigrator } from "@scripts/commands/migrate";
 import { runMigrateConnections } from "@scripts/commands/migrate-connections";
+import { runMigrateProviderState } from "@scripts/commands/migrate-provider-state";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
 
@@ -28,6 +29,9 @@ export default class CompassCLI {
       case cmd === "migrate-connections":
         await runMigrateConnections();
         break;
+      case cmd === "migrate-provider-state":
+        await runMigrateProviderState();
+        break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }
@@ -40,6 +44,14 @@ export default class CompassCLI {
 
     // Register longer `migrate-*` names before `migrate` so Commander does not
     // treat them as unknown args to the Umzug migrate command.
+    program
+      .command("migrate-provider-state")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "idempotently copy legacy Google calendars/events/cursors into Sync (S48; --apply to write)",
+      );
+
     program
       .command("migrate-connections")
       .helpOption(false)

--- a/packages/scripts/src/commands/migrate-provider-state.db.test.ts
+++ b/packages/scripts/src/commands/migrate-provider-state.db.test.ts
@@ -320,10 +320,11 @@ describe("migrate-provider-state (db)", () => {
     ).toBe(3);
   });
 
-  it("keeps one calendar when duplicates exist and skips the rest", async () => {
+  it("keeps one calendar when duplicates exist and still migrates dup events", async () => {
     const { userId } = await seedLegacyFixture();
+    const dupCalendarId = new ObjectId();
     await mongoService.calendar.insertOne({
-      _id: new ObjectId(),
+      _id: dupCalendarId,
       userId,
       name: "Primary Dup",
       description: "",
@@ -338,6 +339,25 @@ describe("migrate-provider-state (db)", () => {
         provider: "google",
         calendarId: "primary",
         etag: "etag-dup",
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+    await mongoService.event.insertOne({
+      _id: new ObjectId(),
+      calendarId: dupCalendarId,
+      content: { kind: "details", title: "on-dup", description: "" },
+      schedule: {
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 1800_000),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      externalReference: {
+        provider: "google",
+        eventId: "gcal-on-dup",
+        recurringEventId: null,
       },
       createdAt: NOW,
       updatedAt: null,
@@ -370,5 +390,55 @@ describe("migrate-provider-state (db)", () => {
         .collection(SYNC_COLLECTIONS.providerCalendars)
         .countDocuments(),
     ).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.events)
+        .findOne({ providerEventId: "gcal-on-dup" }),
+    ).not.toBeNull();
+  });
+
+  it("preserves existing event generation on re-apply", async () => {
+    const { userId } = await seedLegacyFixture();
+    const repositories = deps();
+    await migrateProviderConnections(
+      {
+        connections: repositories.connections,
+        credentials: new CredentialRepository(syncStorage.db()),
+      },
+      await mongoService.user.find({}).toArray(),
+      { dryRun: false, now: NOW },
+    );
+
+    await migrateProviderSyncState(repositories, await loadSource(), {
+      dryRun: false,
+      now: NOW,
+    });
+
+    await syncStorage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .updateMany({}, { $set: { generation: 3 } });
+    await syncStorage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .updateMany(
+        { resourceKind: "events" },
+        { $set: { activeGeneration: 3, importGeneration: 3 } },
+      );
+
+    await migrateProviderSyncState(repositories, await loadSource(), {
+      dryRun: false,
+      now: NOW,
+    });
+
+    const generations = await syncStorage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .find({ tenantId: userId.toHexString() })
+      .project({ generation: 1 })
+      .toArray();
+    expect(generations.length).toBeGreaterThan(0);
+    expect(generations.every((row) => row.generation === 3)).toBe(true);
   });
 });

--- a/packages/scripts/src/commands/migrate-provider-state.db.test.ts
+++ b/packages/scripts/src/commands/migrate-provider-state.db.test.ts
@@ -1,0 +1,374 @@
+import { migrateProviderConnections } from "@scripts/commands/migrate-connections/migrate";
+import { migrateProviderSyncState } from "@scripts/commands/migrate-provider-state/migrate";
+import { ObjectId } from "mongodb";
+import { Resource_Sync } from "@core/types/sync.types";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+const NOW = new Date("2026-07-25T04:00:00.000Z");
+
+describe("migrate-provider-state (db)", () => {
+  const syncStorage = setupSyncStorage(import.meta.url);
+
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+    await mongoService.calendar.deleteMany({});
+    await mongoService.event.deleteMany({});
+    await mongoService.sync.deleteMany({});
+    await mongoService.watch.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  function deps() {
+    const db = syncStorage.db();
+    return {
+      connections: new ProviderConnectionRepository(db),
+      calendars: new ProviderCalendarRepository(db),
+      events: new EventRepository(db),
+      occurrences: new EventOccurrenceRepository(db, syncStorage.client()),
+      resources: new SyncResourceRepository(db),
+    };
+  }
+
+  async function seedLegacyFixture() {
+    const userId = new ObjectId();
+    const calendarId = new ObjectId();
+    const masterId = new ObjectId();
+    const exceptionId = new ObjectId();
+    const unlinkedId = new ObjectId();
+    const watchId = new ObjectId();
+
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "state@example.com",
+      firstName: "State",
+      lastName: "Migrate",
+      name: "State Migrate",
+      locale: "en",
+      google: {
+        googleId: "google-subject-state",
+        picture: "",
+        gRefreshToken: "legacy-refresh-token",
+      },
+    });
+    await mongoService.calendar.insertOne({
+      _id: calendarId,
+      userId,
+      name: "Primary",
+      description: "",
+      timeZone: "America/Denver",
+      foregroundColor: "#000000",
+      backgroundColor: "#4285f4",
+      access: "owner",
+      isPrimary: true,
+      isVisible: true,
+      isActive: true,
+      source: {
+        provider: "google",
+        calendarId: "primary",
+        etag: "etag-cal",
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+    await mongoService.event.insertMany([
+      {
+        _id: masterId,
+        calendarId,
+        content: { kind: "details", title: "weekly", description: "" },
+        schedule: {
+          kind: "timed",
+          start: NOW,
+          end: new Date(NOW.getTime() + 3600_000),
+          timeZone: "America/Denver",
+        },
+        recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+        externalReference: {
+          provider: "google",
+          eventId: "gcal-master-1",
+          recurringEventId: null,
+        },
+        createdAt: NOW,
+        updatedAt: null,
+      },
+      {
+        _id: exceptionId,
+        calendarId,
+        content: { kind: "details", title: "weekly (moved)", description: "" },
+        schedule: {
+          kind: "timed",
+          start: new Date(NOW.getTime() + 86_400_000),
+          end: new Date(NOW.getTime() + 86_400_000 + 3600_000),
+          timeZone: "America/Denver",
+        },
+        recurrence: { kind: "occurrence", seriesId: masterId },
+        externalReference: {
+          provider: "google",
+          eventId: "gcal-exception-1",
+          recurringEventId: "gcal-master-1",
+        },
+        createdAt: NOW,
+        updatedAt: null,
+      },
+      {
+        _id: new ObjectId(),
+        calendarId,
+        content: { kind: "details", title: "standup", description: "" },
+        schedule: {
+          kind: "timed",
+          start: NOW,
+          end: new Date(NOW.getTime() + 1800_000),
+          timeZone: "America/Denver",
+        },
+        recurrence: { kind: "single" },
+        externalReference: {
+          provider: "google",
+          eventId: "gcal-single-1",
+          recurringEventId: null,
+        },
+        createdAt: NOW,
+        updatedAt: null,
+      },
+      {
+        _id: unlinkedId,
+        calendarId,
+        content: { kind: "details", title: "draft", description: "" },
+        schedule: {
+          kind: "timed",
+          start: NOW,
+          end: new Date(NOW.getTime() + 1800_000),
+          timeZone: "America/Denver",
+        },
+        recurrence: { kind: "single" },
+        externalReference: null,
+        createdAt: NOW,
+        updatedAt: null,
+      },
+    ]);
+    await mongoService.sync.insertOne({
+      user: userId.toHexString(),
+      google: {
+        calendarlist: [
+          {
+            gCalendarId: Resource_Sync.CALENDAR,
+            nextSyncToken: "cal-sync-token",
+          },
+        ],
+        events: [{ gCalendarId: "primary", nextSyncToken: "evt-sync-token" }],
+      },
+    });
+    await mongoService.watch.insertOne({
+      _id: watchId,
+      user: userId.toHexString(),
+      resourceId: "resource-1",
+      expiration: String(NOW.getTime() + 86_400_000),
+      gCalendarId: "primary",
+      createdAt: NOW,
+    });
+
+    return { userId, calendarId, masterId, exceptionId, unlinkedId, watchId };
+  }
+
+  async function loadSource() {
+    const [users, calendars, events, syncDocs, watches] = await Promise.all([
+      mongoService.user.find({}).toArray(),
+      mongoService.calendar.find({}).toArray(),
+      mongoService.event.find({}).toArray(),
+      mongoService.sync.find({}).toArray(),
+      mongoService.watch.find({}).toArray(),
+    ]);
+    return { users, calendars, events, syncDocs, watches };
+  }
+
+  it("dry-run does not write; apply then rerun is idempotent", async () => {
+    const { userId, unlinkedId } = await seedLegacyFixture();
+    const repositories = deps();
+
+    await migrateProviderConnections(
+      {
+        connections: repositories.connections,
+        credentials: new CredentialRepository(syncStorage.db()),
+      },
+      await mongoService.user.find({}).toArray(),
+      { dryRun: false, now: NOW },
+    );
+
+    const source = await loadSource();
+    const dry = await migrateProviderSyncState(repositories, source, {
+      dryRun: true,
+      now: NOW,
+    });
+    expect(dry.counts.usersWouldMigrate).toBe(1);
+    expect(dry.counts.calendarsWouldCreate).toBe(1);
+    expect(dry.counts.eventsWouldCreate).toBe(3);
+    expect(dry.counts.unlinkedDeferred).toBe(1);
+    expect(dry.counts.watchesSkippedRewatch).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerCalendars)
+        .countDocuments(),
+    ).toBe(0);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.events)
+        .countDocuments(),
+    ).toBe(0);
+
+    const first = await migrateProviderSyncState(repositories, source, {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(first.counts.usersMigrated).toBe(1);
+    expect(first.counts.calendarsCreated).toBe(1);
+    expect(first.counts.eventsCreated).toBe(3);
+    expect(first.counts.unlinkedDeferred).toBe(1);
+    expect(
+      first.skips.some(
+        (s) =>
+          s.category === "unlinked_deferred" &&
+          s.id === unlinkedId.toHexString(),
+      ),
+    ).toBe(true);
+    expect(
+      first.skips.every((s) => s.category !== "missing_series_master"),
+    ).toBe(true);
+
+    const calendars = await repositories.calendars.listByPrincipal(
+      userId.toHexString() as never,
+      userId.toHexString() as never,
+    );
+    expect(calendars).toHaveLength(1);
+    expect(calendars[0]?.providerCalendarId).toBe("primary");
+    expect(calendars[0]?.accessRole).toBe("owner");
+    expect(calendars[0]?.color).toBe("#4285f4");
+
+    const syncEvents = await syncStorage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .find({})
+      .toArray();
+    expect(syncEvents).toHaveLength(3);
+    expect(
+      syncEvents.filter((e) => e.providerEventId === "gcal-master-1"),
+    ).toHaveLength(1);
+    expect(
+      syncEvents.filter((e) => e.providerEventId === "gcal-exception-1"),
+    ).toHaveLength(1);
+    expect(
+      syncEvents.filter((e) => e.recurrence?.kind === "exception"),
+    ).toHaveLength(1);
+
+    const resources = await repositories.resources.listByConnection(
+      userId.toHexString() as never,
+      userId.toHexString() as never,
+      calendars[0]!.connectionId,
+    );
+    const calendarList = resources.find(
+      (r) => r.resourceKind === "calendarList",
+    );
+    const eventsResource = resources.find((r) => r.resourceKind === "events");
+    expect(calendarList?.syncCursor).toBe("cal-sync-token");
+    expect(eventsResource?.syncCursor).toBe("evt-sync-token");
+    expect(eventsResource?.subscriptionId).toBeNull();
+
+    const occurrences = await syncStorage
+      .db()
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .countDocuments();
+    expect(occurrences).toBeGreaterThan(0);
+
+    // Source rows remain.
+    expect(await mongoService.event.countDocuments()).toBe(4);
+    expect(await mongoService.watch.countDocuments()).toBe(1);
+
+    const second = await migrateProviderSyncState(repositories, source, {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(second.counts.calendarsUpdated).toBe(1);
+    expect(second.counts.eventsUpdated).toBe(3);
+    expect(second.counts.calendarsCreated).toBe(0);
+    expect(second.counts.eventsCreated).toBe(0);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerCalendars)
+        .countDocuments(),
+    ).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.events)
+        .countDocuments(),
+    ).toBe(3);
+  });
+
+  it("keeps one calendar when duplicates exist and skips the rest", async () => {
+    const { userId } = await seedLegacyFixture();
+    await mongoService.calendar.insertOne({
+      _id: new ObjectId(),
+      userId,
+      name: "Primary Dup",
+      description: "",
+      timeZone: "America/Denver",
+      foregroundColor: "#000000",
+      backgroundColor: "#ffffff",
+      access: "owner",
+      isPrimary: true,
+      isVisible: true,
+      isActive: true,
+      source: {
+        provider: "google",
+        calendarId: "primary",
+        etag: "etag-dup",
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+
+    const repositories = deps();
+    await migrateProviderConnections(
+      {
+        connections: repositories.connections,
+        credentials: new CredentialRepository(syncStorage.db()),
+      },
+      await mongoService.user.find({}).toArray(),
+      { dryRun: false, now: NOW },
+    );
+
+    const report = await migrateProviderSyncState(
+      repositories,
+      await loadSource(),
+      { dryRun: false, now: NOW },
+    );
+
+    expect(report.counts.calendarsCreated).toBe(1);
+    expect(report.counts.calendarsSkipped).toBe(1);
+    expect(
+      report.skips.some((s) => s.category === "duplicate_google_calendar"),
+    ).toBe(true);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerCalendars)
+        .countDocuments(),
+    ).toBe(1);
+  });
+});

--- a/packages/scripts/src/commands/migrate-provider-state.ts
+++ b/packages/scripts/src/commands/migrate-provider-state.ts
@@ -1,0 +1,127 @@
+import { loadInventoryCollections } from "@scripts/commands/inventory-legacy-sync/inventory";
+import { migrateProviderSyncState } from "@scripts/commands/migrate-provider-state/migrate";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const logger = Logger("scripts.commands.migrate-provider-state");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before migrating provider state",
+    );
+  }
+  return uri;
+}
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  outPath: string | null;
+  userIds: Set<string> | undefined;
+} {
+  const apply = argv.includes("--apply");
+  const dryRun = !apply;
+  const outFlag = argv.indexOf("--out");
+  const outPath =
+    outFlag >= 0 && argv[outFlag + 1] ? resolve(argv[outFlag + 1]!) : null;
+
+  const userIds = new Set<string>();
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--user-id" && argv[i + 1]) {
+      userIds.add(argv[i + 1]!);
+      i += 1;
+    }
+  }
+
+  return {
+    dryRun,
+    outPath,
+    userIds: userIds.size > 0 ? userIds : undefined,
+  };
+}
+
+/**
+ * S48: idempotently copy legacy Google calendars, linked events, sync cursors,
+ * and watch associations into Sync. Default is dry-run; pass `--apply` to write.
+ * Never deletes source rows, never calls Google, never enqueues Sync jobs.
+ * Unlinked events are deferred to S49; legacy watches require a Sync rewatch.
+ *
+ * Usage:
+ *   bun run cli migrate-provider-state [--dry-run|--apply] [--out report.json]
+ *     [--user-id <id>]...
+ */
+export async function runMigrateProviderState(): Promise<void> {
+  const { dryRun, outPath, userIds } = parseArgs(process.argv.slice(3));
+  const syncMongo = new SyncMongoService();
+
+  try {
+    await mongoService.start();
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const collections = await loadInventoryCollections(mongoService);
+    const report = await migrateProviderSyncState(
+      {
+        connections: new ProviderConnectionRepository(syncMongo.db),
+        calendars: new ProviderCalendarRepository(syncMongo.db),
+        events: new EventRepository(syncMongo.db),
+        occurrences: new EventOccurrenceRepository(
+          syncMongo.db,
+          syncMongo.client,
+        ),
+        resources: new SyncResourceRepository(syncMongo.db),
+      },
+      collections,
+      { dryRun, userIds },
+    );
+
+    try {
+      const json = `${JSON.stringify(report, null, 2)}\n`;
+      if (outPath) {
+        writeFileSync(outPath, json, "utf8");
+        logger.info(`Wrote provider-state migration report to ${outPath}`);
+      } else {
+        process.stdout.write(json);
+      }
+    } catch (outputError) {
+      logger.error(outputError);
+      if (dryRun) {
+        throw outputError;
+      }
+      logger.error(
+        "migrate-provider-state apply completed but report output failed; database changes were persisted",
+      );
+    }
+
+    logger.info(
+      `migrate-provider-state dryRun=${report.dryRun} users=${report.counts.usersScanned} calendars=${report.counts.calendarsCreated + report.counts.calendarsUpdated + report.counts.calendarsWouldCreate + report.counts.calendarsWouldUpdate} events=${report.counts.eventsCreated + report.counts.eventsUpdated + report.counts.eventsWouldCreate + report.counts.eventsWouldUpdate} unlinkedDeferred=${report.counts.unlinkedDeferred} watchesRewatch=${report.counts.watchesSkippedRewatch}`,
+    );
+
+    await syncMongo.disconnect();
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/migrate-provider-state/map.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/map.ts
@@ -1,0 +1,178 @@
+import { type ObjectId } from "mongodb";
+import { type CalendarAccess } from "@core/types/calendar.contracts";
+import {
+  type DateOnly,
+  type DateTime,
+  DateTimeSchema,
+  EventIdSchema,
+} from "@core/types/domain-primitives";
+import { type EventSchedule } from "@core/types/event.contracts";
+import {
+  type CalendarAccessRole,
+  type CalendarCapabilities,
+} from "@core/types/sync/connection.contracts";
+import {
+  type ProviderEventVersion,
+  ProviderEventVersionSchema,
+  type SyncEventContent,
+  type SyncEventRecurrence,
+} from "@core/types/sync/event.contracts";
+import {
+  type EventScheduleRecord,
+  type EventRecord as LegacyEventRecord,
+} from "@backend/event/event.record";
+
+/** Same role collapse as `google-calendar.adapter` ACCESS_ROLE_BY_GOOGLE. */
+const ACCESS_ROLE_BY_LEGACY: Record<CalendarAccess, CalendarAccessRole> = {
+  owner: "owner",
+  writer: "editor",
+  reader: "viewer",
+  freeBusyReader: "busyOnly",
+};
+
+/** Same capability matrix as `google-calendar.adapter` CAPABILITIES_BY_ROLE. */
+const CAPABILITIES_BY_ROLE: Record<CalendarAccessRole, CalendarCapabilities> = {
+  owner: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+  editor: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+  viewer: {
+    canReadEvents: true,
+    canWriteEvents: false,
+    canReadBusy: true,
+    canInviteAttendees: false,
+  },
+  busyOnly: {
+    canReadEvents: false,
+    canWriteEvents: false,
+    canReadBusy: true,
+    canInviteAttendees: false,
+  },
+};
+
+export const MIGRATED_PROVIDER_VERSION: ProviderEventVersion =
+  ProviderEventVersionSchema.parse("migrated-from-legacy");
+
+const PLACEHOLDER_SERIES_ID = EventIdSchema.parse("000000000000000000000000");
+
+export function mapAccessRole(access: CalendarAccess): CalendarAccessRole {
+  return ACCESS_ROLE_BY_LEGACY[access] ?? "busyOnly";
+}
+
+export function capabilitiesForAccess(
+  access: CalendarAccess,
+): CalendarCapabilities {
+  return CAPABILITIES_BY_ROLE[mapAccessRole(access)];
+}
+
+export function toSyncContent(
+  content: LegacyEventRecord["content"],
+): SyncEventContent {
+  if (content.kind === "busy") {
+    return {
+      title: "",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    };
+  }
+  return {
+    title: content.title,
+    description: content.description,
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  };
+}
+
+export function toSyncSchedule(schedule: EventScheduleRecord): EventSchedule {
+  if (schedule.kind === "timed") {
+    return {
+      kind: "timed",
+      start: DateTimeSchema.parse(schedule.start.toISOString()),
+      end: DateTimeSchema.parse(schedule.end.toISOString()),
+      timeZone: schedule.timeZone,
+    };
+  }
+  return {
+    kind: "allDay",
+    start: schedule.start as DateOnly,
+    end: schedule.end as DateOnly,
+  };
+}
+
+export function recurrenceIdFromOccurrence(
+  schedule: EventScheduleRecord,
+): DateTime {
+  if (schedule.kind === "timed") {
+    return DateTimeSchema.parse(schedule.start.toISOString());
+  }
+  return DateTimeSchema.parse(`${schedule.start}T00:00:00.000Z`);
+}
+
+export type SyncRecurrencePlan =
+  | { ok: true; recurrence: SyncEventRecurrence; needsMaster: false }
+  | {
+      ok: true;
+      recurrence: Extract<SyncEventRecurrence, { kind: "exception" }>;
+      needsMaster: true;
+      seriesProviderId: string;
+      legacySeriesId: string;
+    }
+  | { ok: false; detail: string };
+
+/**
+ * Map a legacy Compass recurrence onto Sync. Occurrences become exceptions once
+ * the Sync series master id is known; callers resolve `seriesId` after masters
+ * are upserted.
+ */
+export function planSyncRecurrence(
+  event: LegacyEventRecord,
+): SyncRecurrencePlan {
+  const recurrence = event.recurrence;
+  if (recurrence.kind === "single") {
+    return { ok: true, recurrence: { kind: "single" }, needsMaster: false };
+  }
+  if (recurrence.kind === "series") {
+    return {
+      ok: true,
+      recurrence: { kind: "seriesMaster", rules: recurrence.rules },
+      needsMaster: false,
+    };
+  }
+  const seriesProviderId =
+    event.externalReference?.recurringEventId?.trim() || null;
+  if (!seriesProviderId) {
+    return {
+      ok: false,
+      detail: "occurrence missing externalReference.recurringEventId",
+    };
+  }
+  return {
+    ok: true,
+    recurrence: {
+      kind: "exception",
+      seriesId: PLACEHOLDER_SERIES_ID,
+      recurrenceId: recurrenceIdFromOccurrence(event.schedule),
+      cancelled: false,
+    },
+    needsMaster: true,
+    seriesProviderId,
+    legacySeriesId: recurrence.seriesId.toHexString(),
+  };
+}
+
+export function byHexId(a: { _id: ObjectId }, b: { _id: ObjectId }): number {
+  return a._id.toHexString().localeCompare(b._id.toHexString());
+}

--- a/packages/scripts/src/commands/migrate-provider-state/map.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/map.ts
@@ -17,8 +17,10 @@ import {
   type SyncEventContent,
   type SyncEventRecurrence,
 } from "@core/types/sync/event.contracts";
+import { convertRfc5545ToIso } from "@core/util/date/date.util";
 import {
   type EventScheduleRecord,
+  type ExternalEventReference,
   type EventRecord as LegacyEventRecord,
 } from "@backend/event/event.record";
 
@@ -112,9 +114,34 @@ export function toSyncSchedule(schedule: EventScheduleRecord): EventSchedule {
   };
 }
 
+function recurrenceIdFromGoogleInstanceId(
+  externalReference: ExternalEventReference,
+): DateTime | null {
+  const { eventId, recurringEventId } = externalReference;
+  if (!recurringEventId) return null;
+  const prefix = `${recurringEventId}_`;
+  if (!eventId.startsWith(prefix)) return null;
+  const suffix = eventId.slice(prefix.length);
+  const iso =
+    convertRfc5545ToIso(suffix) ??
+    (/^\d{8}$/.test(suffix)
+      ? `${suffix.slice(0, 4)}-${suffix.slice(4, 6)}-${suffix.slice(6, 8)}T00:00:00.000Z`
+      : null);
+  if (!iso) return null;
+  return DateTimeSchema.parse(iso);
+}
+
+/** Sync recurrenceId is the instance's original slot, not its current schedule. */
 export function recurrenceIdFromOccurrence(
   schedule: EventScheduleRecord,
+  externalReference: ExternalEventReference | null,
 ): DateTime {
+  const fromProviderId =
+    externalReference?.provider === "google"
+      ? recurrenceIdFromGoogleInstanceId(externalReference)
+      : null;
+  if (fromProviderId) return fromProviderId;
+
   if (schedule.kind === "timed") {
     return DateTimeSchema.parse(schedule.start.toISOString());
   }
@@ -164,7 +191,10 @@ export function planSyncRecurrence(
     recurrence: {
       kind: "exception",
       seriesId: PLACEHOLDER_SERIES_ID,
-      recurrenceId: recurrenceIdFromOccurrence(event.schedule),
+      recurrenceId: recurrenceIdFromOccurrence(
+        event.schedule,
+        event.externalReference,
+      ),
       cancelled: false,
     },
     needsMaster: true,

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.test.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.test.ts
@@ -270,6 +270,51 @@ describe("migrateProviderSyncState", () => {
             updatedAt: null,
           },
           {
+            _id: new ObjectId("507f1f77bcf86cd799439033"),
+            calendarId: CALENDAR_ID,
+            content: { kind: "details", title: "weekly", description: "" },
+            schedule: {
+              kind: "timed",
+              start: NOW,
+              end: new Date(NOW.getTime() + 3600_000),
+              timeZone: "America/Denver",
+            },
+            recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+            externalReference: {
+              provider: "google",
+              eventId: "gcal-master-1",
+              recurringEventId: null,
+            },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439034"),
+            calendarId: CALENDAR_ID,
+            content: {
+              kind: "details",
+              title: "weekly (moved)",
+              description: "",
+            },
+            schedule: {
+              kind: "timed",
+              start: new Date(NOW.getTime() + 86_400_000),
+              end: new Date(NOW.getTime() + 86_400_000 + 3600_000),
+              timeZone: "America/Denver",
+            },
+            recurrence: {
+              kind: "occurrence",
+              seriesId: new ObjectId("507f1f77bcf86cd799439033"),
+            },
+            externalReference: {
+              provider: "google",
+              eventId: "gcal-exception-1",
+              recurringEventId: "gcal-master-1",
+            },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+          {
             _id: new ObjectId("507f1f77bcf86cd799439032"),
             calendarId: CALENDAR_ID,
             content: { kind: "details", title: "local only", description: "" },
@@ -313,7 +358,7 @@ describe("migrateProviderSyncState", () => {
     expect(report.dryRun).toBe(true);
     expect(report.counts.usersWouldMigrate).toBe(1);
     expect(report.counts.calendarsWouldCreate).toBe(1);
-    expect(report.counts.eventsWouldCreate).toBe(1);
+    expect(report.counts.eventsWouldCreate).toBe(3);
     expect(report.counts.unlinkedDeferred).toBe(1);
     expect(report.counts.watchesSkippedRewatch).toBe(1);
     expect(
@@ -322,5 +367,8 @@ describe("migrateProviderSyncState", () => {
     expect(report.skips.some((s) => s.category === "unlinked_deferred")).toBe(
       true,
     );
+    expect(
+      report.skips.some((s) => s.category === "missing_series_master"),
+    ).toBe(false);
   });
 });

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.test.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.test.ts
@@ -1,0 +1,326 @@
+import {
+  capabilitiesForAccess,
+  mapAccessRole,
+  planSyncRecurrence,
+  toSyncContent,
+  toSyncSchedule,
+} from "@scripts/commands/migrate-provider-state/map";
+import { migrateProviderSyncState } from "@scripts/commands/migrate-provider-state/migrate";
+import { ObjectId } from "mongodb";
+import { describe, expect, it, mock } from "bun:test";
+
+const NOW = new Date("2026-07-25T04:00:00.000Z");
+const USER_ID = new ObjectId("507f1f77bcf86cd799439011");
+const CONNECTION_ID = "507f1f77bcf86cd799439099";
+const CALENDAR_ID = new ObjectId("507f1f77bcf86cd799439021");
+
+describe("migrate-provider-state map helpers", () => {
+  it("maps legacy access roles like the Google calendar adapter", () => {
+    expect(mapAccessRole("owner")).toBe("owner");
+    expect(mapAccessRole("writer")).toBe("editor");
+    expect(mapAccessRole("reader")).toBe("viewer");
+    expect(mapAccessRole("freeBusyReader")).toBe("busyOnly");
+    expect(capabilitiesForAccess("writer").canWriteEvents).toBe(true);
+    expect(capabilitiesForAccess("reader").canWriteEvents).toBe(false);
+  });
+
+  it("maps content and timed schedules", () => {
+    expect(
+      toSyncContent({
+        kind: "details",
+        title: "standup",
+        description: "notes",
+      }),
+    ).toEqual({
+      title: "standup",
+      description: "notes",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    });
+    expect(toSyncContent({ kind: "busy" }).title).toBe("");
+    expect(
+      toSyncSchedule({
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 1800_000),
+        timeZone: "America/Denver",
+      }),
+    ).toEqual({
+      kind: "timed",
+      start: "2026-07-25T04:00:00.000Z",
+      end: "2026-07-25T04:30:00.000Z",
+      timeZone: "America/Denver",
+    });
+  });
+
+  it("plans series masters and occurrences", () => {
+    const masterPlan = planSyncRecurrence({
+      _id: new ObjectId(),
+      calendarId: CALENDAR_ID,
+      content: { kind: "details", title: "series", description: "" },
+      schedule: {
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 1800_000),
+        timeZone: "UTC",
+      },
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      externalReference: {
+        provider: "google",
+        eventId: "master-1",
+        recurringEventId: null,
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+    expect(masterPlan.ok && !masterPlan.needsMaster).toBe(true);
+    if (masterPlan.ok && !masterPlan.needsMaster) {
+      expect(masterPlan.recurrence).toEqual({
+        kind: "seriesMaster",
+        rules: ["RRULE:FREQ=WEEKLY"],
+      });
+    }
+
+    const occurrencePlan = planSyncRecurrence({
+      _id: new ObjectId(),
+      calendarId: CALENDAR_ID,
+      content: { kind: "details", title: "exception", description: "" },
+      schedule: {
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 1800_000),
+        timeZone: "UTC",
+      },
+      recurrence: { kind: "occurrence", seriesId: new ObjectId() },
+      externalReference: {
+        provider: "google",
+        eventId: "instance-1",
+        recurringEventId: "master-1",
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+    expect(occurrencePlan.ok && occurrencePlan.needsMaster).toBe(true);
+  });
+});
+
+describe("migrateProviderSyncState", () => {
+  it("dry-run skips users without a Sync connection and does not write", async () => {
+    const upsertCalendar = mock(() => {
+      throw new Error("should not upsert calendar in dry-run");
+    });
+    const upsertEvent = mock(() => {
+      throw new Error("should not upsert event in dry-run");
+    });
+    const ensure = mock(() => {
+      throw new Error("should not ensure resource in dry-run");
+    });
+
+    const report = await migrateProviderSyncState(
+      {
+        connections: {
+          listByPrincipal: async () => [],
+        } as never,
+        calendars: {
+          listByConnection: async () => [],
+          upsertByProviderCalendar: upsertCalendar,
+        } as never,
+        events: {
+          findByProviderIdentity: async () => null,
+          upsertByProviderIdentity: upsertEvent,
+        } as never,
+        occurrences: {
+          replaceForEvent: async () => {
+            throw new Error("unused");
+          },
+        } as never,
+        resources: {
+          listByConnection: async () => [],
+          ensure,
+          advanceCursor: async () => {
+            throw new Error("unused");
+          },
+        } as never,
+      },
+      {
+        users: [
+          {
+            _id: USER_ID,
+            email: "alice@example.com",
+            firstName: "A",
+            lastName: "Lice",
+            name: "A Lice",
+            locale: "en",
+            google: {
+              googleId: "google-1",
+              picture: "",
+              gRefreshToken: "refresh",
+            },
+          },
+        ],
+        calendars: [],
+        events: [],
+        syncDocs: [],
+        watches: [],
+      },
+      { dryRun: true, now: NOW },
+    );
+
+    expect(report.counts.usersSkipped).toBe(1);
+    expect(report.users[0]?.skipCategory).toBe("missing_connection");
+    expect(upsertCalendar).not.toHaveBeenCalled();
+    expect(upsertEvent).not.toHaveBeenCalled();
+    expect(ensure).not.toHaveBeenCalled();
+  });
+
+  it("dry-run reports would_migrate when a connection exists", async () => {
+    const report = await migrateProviderSyncState(
+      {
+        connections: {
+          listByPrincipal: async () => [
+            {
+              _id: CONNECTION_ID,
+              provider: "google",
+              account: { providerAccountId: "google-1" },
+              disconnectedAt: null,
+            },
+          ],
+        } as never,
+        calendars: {
+          listByConnection: async () => [],
+          upsertByProviderCalendar: async () => {
+            throw new Error("dry-run");
+          },
+        } as never,
+        events: {
+          findByProviderIdentity: async () => null,
+          upsertByProviderIdentity: async () => {
+            throw new Error("dry-run");
+          },
+        } as never,
+        occurrences: { replaceForEvent: async () => undefined } as never,
+        resources: {
+          listByConnection: async () => [],
+          ensure: async () => {
+            throw new Error("dry-run");
+          },
+          advanceCursor: async () => {
+            throw new Error("dry-run");
+          },
+        } as never,
+      },
+      {
+        users: [
+          {
+            _id: USER_ID,
+            email: "alice@example.com",
+            firstName: "A",
+            lastName: "Lice",
+            name: "A Lice",
+            locale: "en",
+            google: {
+              googleId: "google-1",
+              picture: "",
+              gRefreshToken: "refresh",
+            },
+          },
+        ],
+        calendars: [
+          {
+            _id: CALENDAR_ID,
+            userId: USER_ID,
+            name: "Primary",
+            description: "",
+            timeZone: "America/Denver",
+            foregroundColor: "#000000",
+            backgroundColor: "#ffffff",
+            access: "owner",
+            isPrimary: true,
+            isVisible: true,
+            isActive: true,
+            source: {
+              provider: "google",
+              calendarId: "primary",
+              etag: "etag-1",
+            },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+        ],
+        events: [
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439031"),
+            calendarId: CALENDAR_ID,
+            content: { kind: "details", title: "standup", description: "" },
+            schedule: {
+              kind: "timed",
+              start: NOW,
+              end: new Date(NOW.getTime() + 1800_000),
+              timeZone: "America/Denver",
+            },
+            recurrence: { kind: "single" },
+            externalReference: {
+              provider: "google",
+              eventId: "gcal-evt-1",
+              recurringEventId: null,
+            },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439032"),
+            calendarId: CALENDAR_ID,
+            content: { kind: "details", title: "local only", description: "" },
+            schedule: {
+              kind: "timed",
+              start: NOW,
+              end: new Date(NOW.getTime() + 1800_000),
+              timeZone: "America/Denver",
+            },
+            recurrence: { kind: "single" },
+            externalReference: null,
+            createdAt: NOW,
+            updatedAt: null,
+          },
+        ],
+        syncDocs: [
+          {
+            user: USER_ID.toHexString(),
+            google: {
+              calendarlist: [
+                { gCalendarId: "calendarlist", nextSyncToken: "cal-sync" },
+              ],
+              events: [{ gCalendarId: "primary", nextSyncToken: "evt-sync" }],
+            },
+          },
+        ],
+        watches: [
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439041"),
+            user: USER_ID.toHexString(),
+            resourceId: "resource-1",
+            expiration: String(NOW.getTime() + 86_400_000),
+            gCalendarId: "primary",
+            createdAt: NOW,
+          },
+        ],
+      },
+      { dryRun: true, now: NOW },
+    );
+
+    expect(report.dryRun).toBe(true);
+    expect(report.counts.usersWouldMigrate).toBe(1);
+    expect(report.counts.calendarsWouldCreate).toBe(1);
+    expect(report.counts.eventsWouldCreate).toBe(1);
+    expect(report.counts.unlinkedDeferred).toBe(1);
+    expect(report.counts.watchesSkippedRewatch).toBe(1);
+    expect(
+      report.skips.some((s) => s.category === "subscription_requires_rewatch"),
+    ).toBe(true);
+    expect(report.skips.some((s) => s.category === "unlinked_deferred")).toBe(
+      true,
+    );
+  });
+});

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.ts
@@ -728,7 +728,7 @@ async function migrateCalendarListResource(args: {
     resourceKind: "calendarList",
     calendarId: null,
   });
-  if (cursor) {
+  if (cursor && resource.syncCursor === null) {
     await args.deps.resources.advanceCursor(
       args.tenantId,
       args.principalId,
@@ -777,7 +777,7 @@ async function migrateEventsResource(args: {
     resourceKind: "events",
     calendarId: args.calendarId,
   });
-  if (args.cursor) {
+  if (args.cursor && resource.syncCursor === null) {
     await args.deps.resources.advanceCursor(
       args.tenantId,
       args.principalId,

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.ts
@@ -689,8 +689,9 @@ async function migrateCalendarListResource(args: {
   userCounts: MigrateProviderStateUserResult["counts"];
 }): Promise<void> {
   const cursor =
-    args.syncDoc?.google?.calendarlist?.find((r) => Boolean(r.nextSyncToken))
-      ?.nextSyncToken ?? null;
+    args.syncDoc?.google?.calendarlist?.find(
+      (r) => r.gCalendarId === Resource_Sync.CALENDAR,
+    )?.nextSyncToken ?? null;
   const existing = args.existingResources.find(
     (row) => row.resourceKind === "calendarList" && row.calendarId === null,
   );

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.ts
@@ -250,10 +250,17 @@ export async function migrateProviderSyncState(
         if (existed) counts.calendarsWouldUpdate += 1;
         else counts.calendarsWouldCreate += 1;
         userCounts.calendarsUpserted += 1;
-        const stub = existingByProviderId.get(
-          providerCalendarId as ProviderCalendarSourceId,
-        );
-        if (stub) syncCalendarByGcalId.set(providerCalendarId, stub);
+        const stub =
+          existingByProviderId.get(
+            providerCalendarId as ProviderCalendarSourceId,
+          ) ??
+          ({
+            _id: calendar._id.toHexString(),
+            ...fields,
+            createdAt: now,
+            updatedAt: now,
+          } as ProviderCalendarRecord);
+        syncCalendarByGcalId.set(providerCalendarId, stub);
         continue;
       }
 
@@ -363,9 +370,23 @@ export async function migrateProviderSyncState(
       });
     }
 
+    const keptByGcalId = new Map(
+      googleCalendars.map((calendar) => [calendar.source.calendarId, calendar]),
+    );
+    const legacyGoogleCalendarById = new Map<string, GoogleCalendarRecord>();
+    for (const calendar of calendarsByUser.get(userId) ?? []) {
+      if (calendar.source.provider !== "google") continue;
+      const kept = keptByGcalId.get(calendar.source.calendarId);
+      if (!kept) continue;
+      legacyGoogleCalendarById.set(
+        calendar._id.toHexString(),
+        calendar as GoogleCalendarRecord,
+      );
+    }
+
     const userEvents: LegacyEventRecord[] = [];
-    for (const calendar of googleCalendars) {
-      const list = eventsByCalendar.get(calendar._id.toHexString()) ?? [];
+    for (const calendarId of legacyGoogleCalendarById.keys()) {
+      const list = eventsByCalendar.get(calendarId) ?? [];
       userEvents.push(...list);
     }
     userEvents.sort(byHexId);
@@ -414,10 +435,10 @@ export async function migrateProviderSyncState(
     const upsertedSyncEvents: SyncEventRecord[] = [];
 
     for (const event of [...mastersAndSingles, ...exceptions]) {
-      const calendar = googleCalendars.find((row) =>
-        row._id.equals(event.calendarId),
+      const calendar = legacyGoogleCalendarById.get(
+        event.calendarId.toHexString(),
       );
-      if (!calendar || calendar.source.provider !== "google") {
+      if (!calendar) {
         counts.eventsSkipped += 1;
         skips.push({
           category: "orphan_event",
@@ -429,12 +450,6 @@ export async function migrateProviderSyncState(
 
       const syncCalendar = syncCalendarByGcalId.get(calendar.source.calendarId);
       if (!syncCalendar) {
-        if (options.dryRun) {
-          counts.eventsWouldCreate += 1;
-          userCounts.eventsUpserted += 1;
-          maybeSample(samples, event);
-          continue;
-        }
         counts.eventsSkipped += 1;
         skips.push({
           category: "orphan_event",
@@ -498,6 +513,19 @@ export async function migrateProviderSyncState(
         else counts.eventsWouldCreate += 1;
         userCounts.eventsUpserted += 1;
         maybeSample(samples, event);
+        if (recurrence.kind === "seriesMaster") {
+          syncMasterByProviderId.set(
+            providerEventId,
+            existing?.recurrence.kind === "seriesMaster"
+              ? existing
+              : ({
+                  _id: (existing?._id ??
+                    event._id.toHexString()) as SyncEventRecord["_id"],
+                  recurrence,
+                  providerEventId,
+                } as SyncEventRecord),
+          );
+        }
         continue;
       }
 
@@ -519,6 +547,13 @@ export async function migrateProviderSyncState(
         continue;
       }
 
+      const eventsResource = existingResources.find(
+        (row) =>
+          row.resourceKind === "events" && row.calendarId === syncCalendar._id,
+      );
+      const generation =
+        existing?.generation ?? eventsResource?.activeGeneration ?? 0;
+
       const record = await deps.events.upsertByProviderIdentity({
         tenantId,
         principalId,
@@ -535,7 +570,7 @@ export async function migrateProviderSyncState(
         schedule,
         recurrence,
         lifecycleState: "active",
-        generation: 0,
+        generation,
         confirmedAt: now,
       });
 

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.ts
@@ -1,0 +1,845 @@
+import {
+  byHexId,
+  capabilitiesForAccess,
+  MIGRATED_PROVIDER_VERSION,
+  mapAccessRole,
+  planSyncRecurrence,
+  toSyncContent,
+  toSyncSchedule,
+} from "@scripts/commands/migrate-provider-state/map";
+import {
+  type MigrateProviderStateReport,
+  MigrateProviderStateReportSchema,
+  type MigrateProviderStateSample,
+  type MigrateProviderStateSkip,
+  type MigrateProviderStateUserResult,
+} from "@scripts/commands/migrate-provider-state/report.types";
+import { type ObjectId } from "mongodb";
+import { type DateTime, type EventId } from "@core/types/domain-primitives";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type ProviderCalendarSourceId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { Resource_Sync, type Schema_Sync } from "@core/types/sync.types";
+import { type Schema_User } from "@core/types/user.types";
+import { type Schema_Watch } from "@core/types/watch.types";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { type EventRecord as LegacyEventRecord } from "@backend/event/event.record";
+import { reprojectOccurrences } from "@sync/domain/reproject";
+import { type EventRecord as SyncEventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export interface MigrateProviderStateSource {
+  users: Array<{ _id: ObjectId } & Schema_User>;
+  calendars: CalendarRecord[];
+  events: LegacyEventRecord[];
+  syncDocs: Array<Partial<Schema_Sync> & { _id?: ObjectId; user: string }>;
+  watches: Schema_Watch[];
+}
+
+export interface MigrateProviderStateDeps {
+  connections: ProviderConnectionRepository;
+  calendars: ProviderCalendarRepository;
+  events: EventRepository;
+  occurrences: EventOccurrenceRepository;
+  resources: SyncResourceRepository;
+}
+
+export interface MigrateProviderStateOptions {
+  dryRun: boolean;
+  now?: Date;
+  /** When set, only these Compass user ids are considered. */
+  userIds?: ReadonlySet<string>;
+}
+
+interface AggregateCounts {
+  calendarsCreated: number;
+  calendarsUpdated: number;
+  calendarsWouldCreate: number;
+  calendarsWouldUpdate: number;
+  calendarsSkipped: number;
+  eventsCreated: number;
+  eventsUpdated: number;
+  eventsWouldCreate: number;
+  eventsWouldUpdate: number;
+  eventsSkipped: number;
+  syncResourcesCreated: number;
+  syncResourcesUpdated: number;
+  syncResourcesWouldCreate: number;
+  syncResourcesWouldUpdate: number;
+  syncResourcesSkipped: number;
+  watchesSkippedRewatch: number;
+  unlinkedDeferred: number;
+}
+
+const emptyCounts = (): AggregateCounts => ({
+  calendarsCreated: 0,
+  calendarsUpdated: 0,
+  calendarsWouldCreate: 0,
+  calendarsWouldUpdate: 0,
+  calendarsSkipped: 0,
+  eventsCreated: 0,
+  eventsUpdated: 0,
+  eventsWouldCreate: 0,
+  eventsWouldUpdate: 0,
+  eventsSkipped: 0,
+  syncResourcesCreated: 0,
+  syncResourcesUpdated: 0,
+  syncResourcesWouldCreate: 0,
+  syncResourcesWouldUpdate: 0,
+  syncResourcesSkipped: 0,
+  watchesSkippedRewatch: 0,
+  unlinkedDeferred: 0,
+});
+
+/**
+ * Idempotently migrate legacy Google calendars, linked events, sync cursors,
+ * and watch associations into Sync (S48). Never deletes source rows, never
+ * calls Google, never enqueues jobs, never treats cache absence as deletion.
+ * Unlinked events are deferred to S49. Legacy watches are skipped so Sync can
+ * open fresh subscriptions (`subscription_requires_rewatch`).
+ */
+export async function migrateProviderSyncState(
+  deps: MigrateProviderStateDeps,
+  source: MigrateProviderStateSource,
+  options: MigrateProviderStateOptions,
+): Promise<MigrateProviderStateReport> {
+  const now = options.now ?? new Date();
+  const nowFn = () => now;
+  const skips: MigrateProviderStateSkip[] = [];
+  const usersOut: MigrateProviderStateUserResult[] = [];
+  const samples: MigrateProviderStateSample[] = [];
+  const counts = emptyCounts();
+
+  const users = [...source.users]
+    .filter((user) =>
+      options.userIds ? options.userIds.has(user._id.toHexString()) : true,
+    )
+    .sort(byHexId);
+
+  const calendarsByUser = groupCalendars(source.calendars);
+  const eventsByCalendar = groupEvents(source.events);
+  const syncByUser = groupSyncDocs(source.syncDocs);
+  const watchesByUser = groupWatches(source.watches);
+
+  for (const user of users) {
+    const userId = user._id.toHexString();
+    const principal = toSyncPrincipal(userId);
+    const tenantId = principal.tenantId as TenantId;
+    const principalId = principal.principalId as PrincipalId;
+
+    const userCounts = {
+      calendarsUpserted: 0,
+      eventsUpserted: 0,
+      syncResourcesUpserted: 0,
+      unlinkedDeferred: 0,
+      watchesSkippedRewatch: 0,
+    };
+
+    if (!user.google?.googleId?.trim()) {
+      skips.push({
+        category: "no_google_identity",
+        id: userId,
+        detail: "user has no google identity",
+      });
+      usersOut.push({
+        userId,
+        tenantId,
+        principalId,
+        connectionId: null,
+        action: "skipped",
+        skipCategory: "no_google_identity",
+        detail: "user has no google identity",
+        counts: userCounts,
+      });
+      continue;
+    }
+
+    const providerAccountId = user.google.googleId.trim();
+    const connection = (
+      await deps.connections.listByPrincipal(tenantId, principalId)
+    ).find(
+      (row) =>
+        row.provider === "google" &&
+        row.account.providerAccountId === providerAccountId,
+    );
+
+    if (!connection) {
+      skips.push({
+        category: "missing_connection",
+        id: userId,
+        detail: "run migrate-connections (S47) before migrate-provider-state",
+      });
+      usersOut.push({
+        userId,
+        tenantId,
+        principalId,
+        connectionId: null,
+        action: "skipped",
+        skipCategory: "missing_connection",
+        detail: "no Sync google connection for this principal",
+        counts: userCounts,
+      });
+      continue;
+    }
+
+    if (connection.disconnectedAt != null) {
+      skips.push({
+        category: "disconnected_in_sync",
+        id: userId,
+        detail: "Sync connection is disconnected; not migrating provider state",
+      });
+      usersOut.push({
+        userId,
+        tenantId,
+        principalId,
+        connectionId: connection._id,
+        action: "skipped",
+        skipCategory: "disconnected_in_sync",
+        detail: "Sync connection is disconnected",
+        counts: userCounts,
+      });
+      continue;
+    }
+
+    const connectionId = connection._id as ConnectionId;
+    const existingCalendars = await deps.calendars.listByConnection(
+      tenantId,
+      principalId,
+      connectionId,
+    );
+    const existingByProviderId = new Map(
+      existingCalendars.map((row) => [row.providerCalendarId, row]),
+    );
+
+    const googleCalendars = selectGoogleCalendars(
+      calendarsByUser.get(userId) ?? [],
+      skips,
+      counts,
+    );
+
+    const syncCalendarByGcalId = new Map<string, ProviderCalendarRecord>();
+
+    for (const calendar of googleCalendars) {
+      const providerCalendarId = calendar.source.calendarId;
+      const existed = existingByProviderId.has(
+        providerCalendarId as ProviderCalendarSourceId,
+      );
+      const fields = {
+        tenantId,
+        principalId,
+        connectionId,
+        providerCalendarId: providerCalendarId as ProviderCalendarSourceId,
+        displayName: calendar.name.trim() || providerCalendarId,
+        color: calendar.backgroundColor,
+        active: calendar.isActive,
+        primary: calendar.isPrimary,
+        accessRole: mapAccessRole(calendar.access),
+        capabilities: capabilitiesForAccess(calendar.access),
+      };
+
+      if (options.dryRun) {
+        if (existed) counts.calendarsWouldUpdate += 1;
+        else counts.calendarsWouldCreate += 1;
+        userCounts.calendarsUpserted += 1;
+        const stub = existingByProviderId.get(
+          providerCalendarId as ProviderCalendarSourceId,
+        );
+        if (stub) syncCalendarByGcalId.set(providerCalendarId, stub);
+        continue;
+      }
+
+      const record = await deps.calendars.upsertByProviderCalendar(fields);
+      syncCalendarByGcalId.set(providerCalendarId, record);
+      if (existed) counts.calendarsUpdated += 1;
+      else counts.calendarsCreated += 1;
+      userCounts.calendarsUpserted += 1;
+    }
+
+    // Dry-run without prior Sync calendars: resources/events still report
+    // would_* using provider calendar ids, but cannot bind Sync calendar ids.
+    const existingResources = await deps.resources.listByConnection(
+      tenantId,
+      principalId,
+      connectionId,
+    );
+
+    const syncDoc = syncByUser.get(userId);
+    const userWatches = watchesByUser.get(userId) ?? [];
+
+    await migrateCalendarListResource({
+      deps,
+      tenantId,
+      principalId,
+      connectionId,
+      dryRun: options.dryRun,
+      existingResources,
+      syncDoc,
+      now,
+      counts,
+      userCounts,
+    });
+
+    const eventCursorIds = new Set<string>();
+    for (const row of syncDoc?.google?.events ?? []) {
+      if (row.gCalendarId) eventCursorIds.add(row.gCalendarId);
+    }
+    for (const watch of userWatches) {
+      if (watch.gCalendarId !== Resource_Sync.CALENDAR) {
+        eventCursorIds.add(watch.gCalendarId);
+      }
+    }
+    for (const gCalendarId of syncCalendarByGcalId.keys()) {
+      eventCursorIds.add(gCalendarId);
+    }
+
+    for (const gCalendarId of [...eventCursorIds].sort()) {
+      const syncCalendar = syncCalendarByGcalId.get(gCalendarId);
+      if (!syncCalendar) {
+        if (
+          !options.dryRun ||
+          !googleCalendars.some(
+            (c) =>
+              c.source.provider === "google" &&
+              c.source.calendarId === gCalendarId,
+          )
+        ) {
+          counts.syncResourcesSkipped += 1;
+          skips.push({
+            category: "orphan_cursor",
+            id: `${userId}:${gCalendarId}`,
+            detail: `events cursor/watch for gCalendarId=${gCalendarId} has no migrated provider calendar`,
+          });
+          continue;
+        }
+      }
+
+      const calendarId = syncCalendar?._id ?? null;
+      const cursor =
+        syncDoc?.google?.events?.find((r) => r.gCalendarId === gCalendarId)
+          ?.nextSyncToken ?? null;
+
+      if (options.dryRun && !calendarId) {
+        if (cursor) {
+          counts.syncResourcesWouldCreate += 1;
+          userCounts.syncResourcesUpserted += 1;
+        }
+        continue;
+      }
+
+      if (!calendarId) continue;
+
+      await migrateEventsResource({
+        deps,
+        tenantId,
+        principalId,
+        connectionId,
+        calendarId,
+        gCalendarId,
+        cursor,
+        dryRun: options.dryRun,
+        existingResources,
+        now,
+        counts,
+        userCounts,
+      });
+    }
+
+    for (const watch of userWatches) {
+      counts.watchesSkippedRewatch += 1;
+      userCounts.watchesSkippedRewatch += 1;
+      skips.push({
+        category: "subscription_requires_rewatch",
+        id: String(watch._id),
+        detail: `legacy watch for gCalendarId=${watch.gCalendarId}; Sync will open a fresh subscription`,
+      });
+    }
+
+    const userEvents: LegacyEventRecord[] = [];
+    for (const calendar of googleCalendars) {
+      const list = eventsByCalendar.get(calendar._id.toHexString()) ?? [];
+      userEvents.push(...list);
+    }
+    userEvents.sort(byHexId);
+
+    const linked: LegacyEventRecord[] = [];
+    for (const event of userEvents) {
+      if (event.externalReference == null) {
+        counts.unlinkedDeferred += 1;
+        userCounts.unlinkedDeferred += 1;
+        skips.push({
+          category: "unlinked_deferred",
+          id: event._id.toHexString(),
+          detail: "unlinked Compass event deferred to S49",
+        });
+        continue;
+      }
+      if (event.externalReference.provider !== "google") {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "unmappable_event",
+          id: event._id.toHexString(),
+          detail: `unsupported external provider=${event.externalReference.provider}`,
+        });
+        continue;
+      }
+      if (!event.externalReference.eventId.trim()) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "missing_provider_event_id",
+          id: event._id.toHexString(),
+          detail: "linked event has empty provider event id",
+        });
+        continue;
+      }
+      linked.push(event);
+    }
+
+    const mastersAndSingles = linked.filter(
+      (event) => event.recurrence.kind !== "occurrence",
+    );
+    const exceptions = linked.filter(
+      (event) => event.recurrence.kind === "occurrence",
+    );
+
+    const syncMasterByProviderId = new Map<string, SyncEventRecord>();
+    const upsertedSyncEvents: SyncEventRecord[] = [];
+
+    for (const event of [...mastersAndSingles, ...exceptions]) {
+      const calendar = googleCalendars.find((row) =>
+        row._id.equals(event.calendarId),
+      );
+      if (!calendar || calendar.source.provider !== "google") {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "orphan_event",
+          id: event._id.toHexString(),
+          detail: "event calendar is not a migrated google calendar",
+        });
+        continue;
+      }
+
+      const syncCalendar = syncCalendarByGcalId.get(calendar.source.calendarId);
+      if (!syncCalendar) {
+        if (options.dryRun) {
+          counts.eventsWouldCreate += 1;
+          userCounts.eventsUpserted += 1;
+          maybeSample(samples, event);
+          continue;
+        }
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "orphan_event",
+          id: event._id.toHexString(),
+          detail: "no Sync provider calendar for event",
+        });
+        continue;
+      }
+
+      const plan = planSyncRecurrence(event);
+      if (!plan.ok) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "unmappable_event",
+          id: event._id.toHexString(),
+          detail: plan.detail,
+        });
+        continue;
+      }
+
+      let recurrence = plan.recurrence;
+      if (plan.needsMaster) {
+        const master =
+          syncMasterByProviderId.get(plan.seriesProviderId) ??
+          (await deps.events.findByProviderIdentity(tenantId, principalId, {
+            connectionId,
+            calendarId: syncCalendar._id,
+            providerEventId: plan.seriesProviderId as never,
+          }));
+        if (!master || master.recurrence.kind !== "seriesMaster") {
+          counts.eventsSkipped += 1;
+          skips.push({
+            category: "missing_series_master",
+            id: event._id.toHexString(),
+            detail: `no Sync series master for providerEventId=${plan.seriesProviderId} (legacy seriesId=${plan.legacySeriesId})`,
+          });
+          continue;
+        }
+        syncMasterByProviderId.set(plan.seriesProviderId, master);
+        recurrence = {
+          kind: "exception",
+          seriesId: master._id as EventId,
+          recurrenceId: plan.recurrence.recurrenceId,
+          cancelled: false,
+        };
+      }
+
+      const providerEventId = event.externalReference!.eventId.trim();
+      const existing = await deps.events.findByProviderIdentity(
+        tenantId,
+        principalId,
+        {
+          connectionId,
+          calendarId: syncCalendar._id,
+          providerEventId: providerEventId as never,
+        },
+      );
+
+      if (options.dryRun) {
+        if (existing) counts.eventsWouldUpdate += 1;
+        else counts.eventsWouldCreate += 1;
+        userCounts.eventsUpserted += 1;
+        maybeSample(samples, event);
+        continue;
+      }
+
+      let content: ReturnType<typeof toSyncContent>;
+      let schedule: ReturnType<typeof toSyncSchedule>;
+      try {
+        content = toSyncContent(event.content);
+        schedule = toSyncSchedule(event.schedule);
+      } catch (error) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "unmappable_event",
+          id: event._id.toHexString(),
+          detail:
+            error instanceof Error
+              ? error.message
+              : "failed to map event content/schedule",
+        });
+        continue;
+      }
+
+      const record = await deps.events.upsertByProviderIdentity({
+        tenantId,
+        principalId,
+        origin: "provider",
+        calendarId: syncCalendar._id,
+        clientEventId: null,
+        connectionId,
+        providerEventId: providerEventId as never,
+        providerVersion: MIGRATED_PROVIDER_VERSION,
+        providerUpdatedAt: event.updatedAt,
+        deliveryState: null,
+        providerMetadata: null,
+        content,
+        schedule,
+        recurrence,
+        lifecycleState: "active",
+        generation: 0,
+        confirmedAt: now,
+      });
+
+      if (existing) counts.eventsUpdated += 1;
+      else counts.eventsCreated += 1;
+      userCounts.eventsUpserted += 1;
+      upsertedSyncEvents.push(record);
+      maybeSample(samples, event);
+
+      if (record.recurrence.kind === "seriesMaster" && record.providerEventId) {
+        syncMasterByProviderId.set(record.providerEventId, record);
+      }
+    }
+
+    if (!options.dryRun) {
+      await reprojectMigratedEvents(
+        deps.occurrences,
+        upsertedSyncEvents,
+        nowFn,
+      );
+    }
+
+    usersOut.push({
+      userId,
+      tenantId,
+      principalId,
+      connectionId,
+      action: options.dryRun ? "would_migrate" : "migrated",
+      skipCategory: null,
+      detail: options.dryRun
+        ? "would upsert calendars, linked events, and sync resources"
+        : "upserted calendars, linked events, and sync resources",
+      counts: userCounts,
+    });
+  }
+
+  return MigrateProviderStateReportSchema.parse({
+    generatedAt: now.toISOString(),
+    dryRun: options.dryRun,
+    counts: {
+      usersScanned: users.length,
+      usersMigrated: usersOut.filter((u) => u.action === "migrated").length,
+      usersWouldMigrate: usersOut.filter((u) => u.action === "would_migrate")
+        .length,
+      usersSkipped: usersOut.filter((u) => u.action === "skipped").length,
+      ...counts,
+    },
+    users: usersOut,
+    skips: skips.sort(
+      (a, b) =>
+        a.category.localeCompare(b.category) || a.id.localeCompare(b.id),
+    ),
+    samples,
+  });
+}
+
+function maybeSample(
+  samples: MigrateProviderStateSample[],
+  event: LegacyEventRecord,
+): void {
+  if (samples.length >= 5) return;
+  if (event.externalReference?.provider !== "google") return;
+  samples.push({
+    sourceEventId: event._id.toHexString(),
+    providerEventId: event.externalReference.eventId,
+    title: event.content.kind === "details" ? event.content.title : "",
+    recurrenceKind: event.recurrence.kind,
+    scheduleKind: event.schedule.kind,
+  });
+}
+
+async function reprojectMigratedEvents(
+  occurrences: EventOccurrenceRepository,
+  events: readonly SyncEventRecord[],
+  now: () => Date,
+): Promise<void> {
+  const masters = events.filter((e) => e.recurrence.kind === "seriesMaster");
+  const exceptions = events.filter((e) => e.recurrence.kind === "exception");
+  const singles = events.filter((e) => e.recurrence.kind === "single");
+
+  for (const master of masters) {
+    const seriesExceptions = exceptions.filter(
+      (row) =>
+        row.recurrence.kind === "exception" &&
+        row.recurrence.seriesId === master._id,
+    );
+    const instants = seriesExceptions.map((row) => {
+      if (row.recurrence.kind !== "exception") {
+        throw new Error("expected exception");
+      }
+      return row.recurrence.recurrenceId as DateTime;
+    });
+    await reprojectOccurrences(occurrences, master, now, instants);
+  }
+
+  for (const exception of exceptions) {
+    await reprojectOccurrences(occurrences, exception, now);
+  }
+  for (const single of singles) {
+    await reprojectOccurrences(occurrences, single, now);
+  }
+}
+
+async function migrateCalendarListResource(args: {
+  deps: MigrateProviderStateDeps;
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  connectionId: ConnectionId;
+  dryRun: boolean;
+  existingResources: Awaited<
+    ReturnType<SyncResourceRepository["listByConnection"]>
+  >;
+  syncDoc: (Partial<Schema_Sync> & { user: string }) | undefined;
+  now: Date;
+  counts: AggregateCounts;
+  userCounts: MigrateProviderStateUserResult["counts"];
+}): Promise<void> {
+  const cursor =
+    args.syncDoc?.google?.calendarlist?.find((r) => Boolean(r.nextSyncToken))
+      ?.nextSyncToken ?? null;
+  const existing = args.existingResources.find(
+    (row) => row.resourceKind === "calendarList" && row.calendarId === null,
+  );
+
+  if (!cursor && !existing) {
+    // Still ensure a calendarList resource on apply so discovery has a home.
+    if (args.dryRun) {
+      args.counts.syncResourcesWouldCreate += 1;
+      args.userCounts.syncResourcesUpserted += 1;
+      return;
+    }
+    await args.deps.resources.ensure({
+      tenantId: args.tenantId,
+      principalId: args.principalId,
+      connectionId: args.connectionId,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    args.counts.syncResourcesCreated += 1;
+    args.userCounts.syncResourcesUpserted += 1;
+    return;
+  }
+
+  if (args.dryRun) {
+    if (existing) args.counts.syncResourcesWouldUpdate += 1;
+    else args.counts.syncResourcesWouldCreate += 1;
+    args.userCounts.syncResourcesUpserted += 1;
+    return;
+  }
+
+  const resource = await args.deps.resources.ensure({
+    tenantId: args.tenantId,
+    principalId: args.principalId,
+    connectionId: args.connectionId,
+    resourceKind: "calendarList",
+    calendarId: null,
+  });
+  if (cursor) {
+    await args.deps.resources.advanceCursor(
+      args.tenantId,
+      args.principalId,
+      resource._id,
+      cursor,
+      args.now,
+    );
+  }
+  if (existing) args.counts.syncResourcesUpdated += 1;
+  else args.counts.syncResourcesCreated += 1;
+  args.userCounts.syncResourcesUpserted += 1;
+}
+
+async function migrateEventsResource(args: {
+  deps: MigrateProviderStateDeps;
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  connectionId: ConnectionId;
+  calendarId: ProviderCalendarRecord["_id"];
+  gCalendarId: string;
+  cursor: string | null;
+  dryRun: boolean;
+  existingResources: Awaited<
+    ReturnType<SyncResourceRepository["listByConnection"]>
+  >;
+  now: Date;
+  counts: AggregateCounts;
+  userCounts: MigrateProviderStateUserResult["counts"];
+}): Promise<void> {
+  const existing = args.existingResources.find(
+    (row) =>
+      row.resourceKind === "events" && row.calendarId === args.calendarId,
+  );
+
+  if (args.dryRun) {
+    if (existing) args.counts.syncResourcesWouldUpdate += 1;
+    else args.counts.syncResourcesWouldCreate += 1;
+    args.userCounts.syncResourcesUpserted += 1;
+    return;
+  }
+
+  const resource = await args.deps.resources.ensure({
+    tenantId: args.tenantId,
+    principalId: args.principalId,
+    connectionId: args.connectionId,
+    resourceKind: "events",
+    calendarId: args.calendarId,
+  });
+  if (args.cursor) {
+    await args.deps.resources.advanceCursor(
+      args.tenantId,
+      args.principalId,
+      resource._id,
+      args.cursor,
+      args.now,
+    );
+  }
+  if (existing) args.counts.syncResourcesUpdated += 1;
+  else args.counts.syncResourcesCreated += 1;
+  args.userCounts.syncResourcesUpserted += 1;
+}
+
+type GoogleCalendarRecord = CalendarRecord & {
+  source: Extract<CalendarRecord["source"], { provider: "google" }>;
+};
+
+function selectGoogleCalendars(
+  calendars: CalendarRecord[],
+  skips: MigrateProviderStateSkip[],
+  counts: AggregateCounts,
+): GoogleCalendarRecord[] {
+  const selected: GoogleCalendarRecord[] = [];
+  const seen = new Map<string, GoogleCalendarRecord>();
+
+  for (const calendar of [...calendars].sort(byHexId)) {
+    if (calendar.source.provider !== "google") {
+      counts.calendarsSkipped += 1;
+      skips.push({
+        category: "local_calendar",
+        id: calendar._id.toHexString(),
+        detail: "local calendars are not provider sync state",
+      });
+      continue;
+    }
+    const googleCalendar = calendar as GoogleCalendarRecord;
+    const key = googleCalendar.source.calendarId;
+    const prior = seen.get(key);
+    if (prior) {
+      counts.calendarsSkipped += 1;
+      skips.push({
+        category: "duplicate_google_calendar",
+        id: calendar._id.toHexString(),
+        detail: `duplicate (userId, source.calendarId); keeping ${prior._id.toHexString()}`,
+      });
+      continue;
+    }
+    seen.set(key, googleCalendar);
+    selected.push(googleCalendar);
+  }
+  return selected;
+}
+
+function groupCalendars(
+  calendars: CalendarRecord[],
+): Map<string, CalendarRecord[]> {
+  const map = new Map<string, CalendarRecord[]>();
+  for (const calendar of calendars) {
+    const userId = calendar.userId.toHexString();
+    const list = map.get(userId) ?? [];
+    list.push(calendar);
+    map.set(userId, list);
+  }
+  return map;
+}
+
+function groupEvents(
+  events: LegacyEventRecord[],
+): Map<string, LegacyEventRecord[]> {
+  const map = new Map<string, LegacyEventRecord[]>();
+  for (const event of events) {
+    const calendarId = event.calendarId.toHexString();
+    const list = map.get(calendarId) ?? [];
+    list.push(event);
+    map.set(calendarId, list);
+  }
+  return map;
+}
+
+function groupSyncDocs(
+  syncDocs: MigrateProviderStateSource["syncDocs"],
+): Map<string, MigrateProviderStateSource["syncDocs"][number]> {
+  const map = new Map<string, MigrateProviderStateSource["syncDocs"][number]>();
+  for (const doc of [...syncDocs].sort((a, b) =>
+    a.user.localeCompare(b.user),
+  )) {
+    if (!map.has(doc.user)) map.set(doc.user, doc);
+  }
+  return map;
+}
+
+function groupWatches(watches: Schema_Watch[]): Map<string, Schema_Watch[]> {
+  const map = new Map<string, Schema_Watch[]>();
+  for (const watch of watches) {
+    const list = map.get(watch.user) ?? [];
+    list.push(watch);
+    map.set(watch.user, list);
+  }
+  return map;
+}

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.ts
@@ -508,6 +508,24 @@ export async function migrateProviderSyncState(
         },
       );
 
+      let content: ReturnType<typeof toSyncContent>;
+      let schedule: ReturnType<typeof toSyncSchedule>;
+      try {
+        content = toSyncContent(event.content);
+        schedule = toSyncSchedule(event.schedule);
+      } catch (error) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "unmappable_event",
+          id: event._id.toHexString(),
+          detail:
+            error instanceof Error
+              ? error.message
+              : "failed to map event content/schedule",
+        });
+        continue;
+      }
+
       if (options.dryRun) {
         if (existing) counts.eventsWouldUpdate += 1;
         else counts.eventsWouldCreate += 1;
@@ -526,24 +544,6 @@ export async function migrateProviderSyncState(
                 } as SyncEventRecord),
           );
         }
-        continue;
-      }
-
-      let content: ReturnType<typeof toSyncContent>;
-      let schedule: ReturnType<typeof toSyncSchedule>;
-      try {
-        content = toSyncContent(event.content);
-        schedule = toSyncSchedule(event.schedule);
-      } catch (error) {
-        counts.eventsSkipped += 1;
-        skips.push({
-          category: "unmappable_event",
-          id: event._id.toHexString(),
-          detail:
-            error instanceof Error
-              ? error.message
-              : "failed to map event content/schedule",
-        });
         continue;
       }
 

--- a/packages/scripts/src/commands/migrate-provider-state/report.types.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/report.types.ts
@@ -1,0 +1,100 @@
+import { z } from "zod/v4";
+
+export const MigrateProviderStateSkipCategorySchema = z.enum([
+  "no_google_identity",
+  "missing_connection",
+  "disconnected_in_sync",
+  "orphan_calendar",
+  "orphan_event",
+  "orphan_cursor",
+  "duplicate_google_calendar",
+  "local_calendar",
+  "unlinked_deferred",
+  "subscription_requires_rewatch",
+  "missing_provider_event_id",
+  "missing_series_master",
+  "unmappable_event",
+]);
+export type MigrateProviderStateSkipCategory = z.infer<
+  typeof MigrateProviderStateSkipCategorySchema
+>;
+
+export const MigrateProviderStateSkipSchema = z.strictObject({
+  category: MigrateProviderStateSkipCategorySchema,
+  id: z.string().min(1),
+  detail: z.string().min(1),
+});
+export type MigrateProviderStateSkip = z.infer<
+  typeof MigrateProviderStateSkipSchema
+>;
+
+export const MigrateProviderStateUserActionSchema = z.enum([
+  "would_migrate",
+  "migrated",
+  "skipped",
+]);
+
+export const MigrateProviderStateUserResultSchema = z.strictObject({
+  userId: z.string().min(1),
+  tenantId: z.string().min(1),
+  principalId: z.string().min(1),
+  connectionId: z.string().nullable(),
+  action: MigrateProviderStateUserActionSchema,
+  skipCategory: MigrateProviderStateSkipCategorySchema.nullable(),
+  detail: z.string().min(1),
+  counts: z.strictObject({
+    calendarsUpserted: z.number().int().nonnegative(),
+    eventsUpserted: z.number().int().nonnegative(),
+    syncResourcesUpserted: z.number().int().nonnegative(),
+    unlinkedDeferred: z.number().int().nonnegative(),
+    watchesSkippedRewatch: z.number().int().nonnegative(),
+  }),
+});
+export type MigrateProviderStateUserResult = z.infer<
+  typeof MigrateProviderStateUserResultSchema
+>;
+
+export const MigrateProviderStateSampleSchema = z.strictObject({
+  sourceEventId: z.string().min(1),
+  providerEventId: z.string().min(1),
+  title: z.string(),
+  recurrenceKind: z.string().min(1),
+  scheduleKind: z.string().min(1),
+});
+export type MigrateProviderStateSample = z.infer<
+  typeof MigrateProviderStateSampleSchema
+>;
+
+export const MigrateProviderStateReportSchema = z.strictObject({
+  generatedAt: z.string().min(1),
+  dryRun: z.boolean(),
+  counts: z.strictObject({
+    usersScanned: z.number().int().nonnegative(),
+    usersMigrated: z.number().int().nonnegative(),
+    usersWouldMigrate: z.number().int().nonnegative(),
+    usersSkipped: z.number().int().nonnegative(),
+    calendarsCreated: z.number().int().nonnegative(),
+    calendarsUpdated: z.number().int().nonnegative(),
+    calendarsWouldCreate: z.number().int().nonnegative(),
+    calendarsWouldUpdate: z.number().int().nonnegative(),
+    calendarsSkipped: z.number().int().nonnegative(),
+    eventsCreated: z.number().int().nonnegative(),
+    eventsUpdated: z.number().int().nonnegative(),
+    eventsWouldCreate: z.number().int().nonnegative(),
+    eventsWouldUpdate: z.number().int().nonnegative(),
+    eventsSkipped: z.number().int().nonnegative(),
+    syncResourcesCreated: z.number().int().nonnegative(),
+    syncResourcesUpdated: z.number().int().nonnegative(),
+    syncResourcesWouldCreate: z.number().int().nonnegative(),
+    syncResourcesWouldUpdate: z.number().int().nonnegative(),
+    syncResourcesSkipped: z.number().int().nonnegative(),
+    watchesSkippedRewatch: z.number().int().nonnegative(),
+    unlinkedDeferred: z.number().int().nonnegative(),
+  }),
+  users: z.array(MigrateProviderStateUserResultSchema),
+  skips: z.array(MigrateProviderStateSkipSchema),
+  samples: z.array(MigrateProviderStateSampleSchema),
+});
+export type MigrateProviderStateReport = z.infer<
+  typeof MigrateProviderStateReportSchema
+>;


### PR DESCRIPTION
## Summary
- Adds `bun run cli migrate-provider-state` (S48): idempotently upserts Sync provider calendars, linked events + occurrence reprojection, and sync resources/cursors from legacy Compass Google data.
- Requires S47 Sync connections. Default dry-run; `--apply` writes. Never deletes source rows, never calls Google, never enqueues jobs.
- Unlinked events are categorized `unlinked_deferred` (S49). Legacy watches are skipped as `subscription_requires_rewatch` so Sync can open fresh subscriptions.
- Duplicate Google calendars keep the lowest `_id`; access/capabilities match the Google calendar adapter mapping.

## Test plan
- [x] Focused scripts tests for migrate-provider-state (+ cli wiring)
- [x] `bun type-check`
- [x] `bun lint`
- Manual (requires `compass.yaml` + Sync Mongo):
  1. `bun run cli migrate-connections --apply --user-id <id>`
  2. `bun run cli migrate-provider-state --out /tmp/s48-dry.json`
  3. `bun run cli migrate-provider-state --apply --out /tmp/s48-apply.json`
  4. Re-run apply; expect updates only, no duplicate Sync calendars/events.

Made with [Cursor](https://cursor.com)