### PR TITLE
feat(scripts): migrate pending compass intent

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -20,6 +20,7 @@ Primary file:
 | `bun run cli inventory-legacy-sync [--out path.json]` | `packages/scripts/src/commands/inventory-legacy-sync.ts` | Read-only S46 inventory of legacy Google sync data (users/credentials/calendars/events/cursors/watches). Never writes or calls providers. |
 | `bun run cli migrate-connections [--apply] [--out report.json] [--user-id id]...` | `packages/scripts/src/commands/migrate-connections.ts` | S47: idempotently upsert Sync connections + credentials from legacy users. Default dry-run; `--apply` writes. Never clears source tokens or enqueues Sync jobs. |
 | `bun run cli migrate-provider-state [--apply] [--out report.json] [--user-id id]...` | `packages/scripts/src/commands/migrate-provider-state.ts` | S48: idempotently upsert Sync calendars, linked events, occurrences, and sync cursors from legacy data. Default dry-run; `--apply` writes. Requires S47 connections. Defers unlinked events to S49; skips legacy watches for Sync rewatch. |
+| `bun run cli migrate-pending-intent [--apply] [--out report.json] [--user-id id]... [--target-calendar-id id] [--target-gcal-id id]` | `packages/scripts/src/commands/migrate-pending-intent.ts` | S49: preserve unlinked Compass events in Sync and submit resumable backfill create commands. Default dry-run; `--apply` writes. Never infers target by email; never mirrors already-linked events. |
 
 ## Migration Internals
 

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -11,6 +11,9 @@ const mockRunMigrateConnections = mock((): Promise<void> => Promise.resolve());
 const mockRunMigrateProviderState = mock(
   (): Promise<void> => Promise.resolve(),
 );
+const mockRunMigratePendingIntent = mock(
+  (): Promise<void> => Promise.resolve(),
+);
 
 mock.module("@scripts/cli.validator", () => ({
   CliValidator: mock().mockImplementation(() => ({
@@ -36,6 +39,11 @@ mock.module("@scripts/commands/migrate-connections", () => ({
 mock.module("@scripts/commands/migrate-provider-state", () => ({
   __esModule: true,
   runMigrateProviderState: mock(() => mockRunMigrateProviderState()),
+}));
+
+mock.module("@scripts/commands/migrate-pending-intent", () => ({
+  __esModule: true,
+  runMigratePendingIntent: mock(() => mockRunMigratePendingIntent()),
 }));
 
 const { default: CompassCLI } = requireActual(
@@ -77,6 +85,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunMigrateProviderState).toHaveBeenCalled();
+  });
+
+  it("runs migrate-pending-intent command", async () => {
+    const cli = new CompassCLI(["node", "cli", "migrate-pending-intent"]);
+
+    await cli.run();
+
+    expect(mockRunMigratePendingIntent).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -2,6 +2,7 @@ import { CliValidator } from "@scripts/cli.validator";
 import { runInventoryLegacySync } from "@scripts/commands/inventory-legacy-sync";
 import { runMigrator } from "@scripts/commands/migrate";
 import { runMigrateConnections } from "@scripts/commands/migrate-connections";
+import { runMigratePendingIntent } from "@scripts/commands/migrate-pending-intent";
 import { runMigrateProviderState } from "@scripts/commands/migrate-provider-state";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
@@ -32,6 +33,9 @@ export default class CompassCLI {
       case cmd === "migrate-provider-state":
         await runMigrateProviderState();
         break;
+      case cmd === "migrate-pending-intent":
+        await runMigratePendingIntent();
+        break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }
@@ -44,6 +48,14 @@ export default class CompassCLI {
 
     // Register longer `migrate-*` names before `migrate` so Commander does not
     // treat them as unknown args to the Umzug migrate command.
+    program
+      .command("migrate-pending-intent")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "preserve unlinked Compass events and submit Sync backfill commands (S49; --apply to write)",
+      );
+
     program
       .command("migrate-provider-state")
       .helpOption(false)

--- a/packages/scripts/src/commands/migrate-pending-intent.db.test.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent.db.test.ts
@@ -1,0 +1,292 @@
+import { migrateProviderConnections } from "@scripts/commands/migrate-connections/migrate";
+import { migratePendingCompassIntent } from "@scripts/commands/migrate-pending-intent/migrate";
+import { migrateProviderSyncState } from "@scripts/commands/migrate-provider-state/migrate";
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+const NOW = new Date("2026-07-25T04:00:00.000Z");
+
+describe("migrate-pending-intent (db)", () => {
+  const syncStorage = setupSyncStorage(import.meta.url);
+
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+    await mongoService.calendar.deleteMany({});
+    await mongoService.event.deleteMany({});
+    await mongoService.sync.deleteMany({});
+    await mongoService.watch.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  function deps() {
+    const db = syncStorage.db();
+    return {
+      connections: new ProviderConnectionRepository(db),
+      calendars: new ProviderCalendarRepository(db),
+      events: new EventRepository(db),
+      occurrences: new EventOccurrenceRepository(db, syncStorage.client()),
+      commands: new CommandRepository(db),
+      resources: new SyncResourceRepository(db),
+      credentials: new CredentialRepository(db),
+    };
+  }
+
+  async function seedPasswordUserWithLocalDraft() {
+    const userId = new ObjectId();
+    const localCalendarId = new ObjectId();
+    const googleCalendarId = new ObjectId();
+    const draftId = new ObjectId();
+
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "password@example.com",
+      firstName: "Pass",
+      lastName: "Word",
+      name: "Pass Word",
+      locale: "en",
+      google: {
+        googleId: "google-subject-1556",
+        picture: "",
+        gRefreshToken: "refresh-1556",
+      },
+    });
+    await mongoService.calendar.insertMany([
+      {
+        _id: localCalendarId,
+        userId,
+        name: "Compass",
+        description: "",
+        timeZone: "America/Denver",
+        foregroundColor: "#000000",
+        backgroundColor: "#ffffff",
+        access: "owner",
+        isPrimary: true,
+        isVisible: true,
+        isActive: true,
+        source: { provider: "local" },
+        createdAt: NOW,
+        updatedAt: null,
+      },
+      {
+        _id: googleCalendarId,
+        userId,
+        name: "Primary",
+        description: "",
+        timeZone: "America/Denver",
+        foregroundColor: "#000000",
+        backgroundColor: "#4285f4",
+        access: "owner",
+        isPrimary: true,
+        isVisible: true,
+        isActive: true,
+        source: {
+          provider: "google",
+          calendarId: "primary",
+          etag: "etag-1",
+        },
+        createdAt: NOW,
+        updatedAt: null,
+      },
+    ]);
+    await mongoService.event.insertOne({
+      _id: draftId,
+      calendarId: localCalendarId,
+      content: { kind: "details", title: "pre-google draft", description: "" },
+      schedule: {
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 1800_000),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      externalReference: null,
+      createdAt: NOW,
+      updatedAt: null,
+    });
+
+    return { userId, draftId, googleCalendarId };
+  }
+
+  async function loadSource() {
+    const [users, calendars, events, syncDocs, watches] = await Promise.all([
+      mongoService.user.find({}).toArray(),
+      mongoService.calendar.find({}).toArray(),
+      mongoService.event.find({}).toArray(),
+      mongoService.sync.find({}).toArray(),
+      mongoService.watch.find({}).toArray(),
+    ]);
+    return { users, calendars, events, syncDocs, watches };
+  }
+
+  it("#1556: put unlinked draft + pending create; rerun is idempotent", async () => {
+    const { userId, draftId } = await seedPasswordUserWithLocalDraft();
+    const repositories = deps();
+    const source = await loadSource();
+
+    await migrateProviderConnections(
+      {
+        connections: repositories.connections,
+        credentials: repositories.credentials,
+      },
+      source.users,
+      { dryRun: false, now: NOW },
+    );
+    await migrateProviderSyncState(
+      {
+        connections: repositories.connections,
+        calendars: repositories.calendars,
+        events: repositories.events,
+        occurrences: repositories.occurrences,
+        resources: repositories.resources,
+      },
+      source,
+      { dryRun: false, now: NOW },
+    );
+
+    const first = await migratePendingCompassIntent(
+      {
+        connections: repositories.connections,
+        calendars: repositories.calendars,
+        events: repositories.events,
+        occurrences: repositories.occurrences,
+        commands: repositories.commands,
+      },
+      source,
+      { dryRun: false, now: NOW },
+    );
+
+    expect(first.counts.eventsCreated).toBe(1);
+    expect(first.counts.commandsCreated).toBe(1);
+    expect(first.users[0]?.targetCalendarId).toMatch(/^[0-9a-f]{24}$/);
+
+    const stored = await repositories.events.findById(
+      userId.toHexString() as never,
+      userId.toHexString() as never,
+      draftId.toHexString() as never,
+    );
+    expect(stored?.origin).toBe("compass");
+    expect(stored?.providerEventId).toBeNull();
+    expect(stored?.content.title).toBe("pre-google draft");
+
+    const commands = await syncStorage
+      .db()
+      .collection(SYNC_COLLECTIONS.commands)
+      .find({})
+      .toArray();
+    expect(commands).toHaveLength(1);
+    expect(commands[0]?.idempotencyKey).toBe(`create:${draftId.toHexString()}`);
+    expect(commands[0]?.outcome.state).toBe("pending");
+    expect(commands[0]?.input.calendarId).toBe(
+      first.users[0]?.targetCalendarId,
+    );
+
+    const second = await migratePendingCompassIntent(
+      {
+        connections: repositories.connections,
+        calendars: repositories.calendars,
+        events: repositories.events,
+        occurrences: repositories.occurrences,
+        commands: repositories.commands,
+      },
+      source,
+      { dryRun: false, now: NOW },
+    );
+    expect(second.counts.eventsUpdated).toBe(1);
+    expect(second.counts.eventsCreated).toBe(0);
+    expect(second.counts.commandsAlreadyPresent).toBe(1);
+    expect(second.counts.commandsCreated).toBe(0);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.commands)
+        .countDocuments(),
+    ).toBe(1);
+    expect(await mongoService.event.countDocuments()).toBe(1);
+  });
+
+  it("does not mirror already provider-linked legacy events", async () => {
+    const { userId, googleCalendarId } = await seedPasswordUserWithLocalDraft();
+    await mongoService.event.insertOne({
+      _id: new ObjectId(),
+      calendarId: googleCalendarId,
+      content: { kind: "details", title: "already linked", description: "" },
+      schedule: {
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 1800_000),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      externalReference: {
+        provider: "google",
+        eventId: "gcal-linked",
+        recurringEventId: null,
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+
+    const repositories = deps();
+    const source = await loadSource();
+    await migrateProviderConnections(
+      {
+        connections: repositories.connections,
+        credentials: repositories.credentials,
+      },
+      source.users,
+      { dryRun: false, now: NOW },
+    );
+    await migrateProviderSyncState(
+      {
+        connections: repositories.connections,
+        calendars: repositories.calendars,
+        events: repositories.events,
+        occurrences: repositories.occurrences,
+        resources: repositories.resources,
+      },
+      source,
+      { dryRun: false, now: NOW },
+    );
+
+    const report = await migratePendingCompassIntent(
+      {
+        connections: repositories.connections,
+        calendars: repositories.calendars,
+        events: repositories.events,
+        occurrences: repositories.occurrences,
+        commands: repositories.commands,
+      },
+      source,
+      { dryRun: false, now: NOW },
+    );
+
+    expect(
+      report.skips.some((s) => s.category === "already_provider_linked"),
+    ).toBe(true);
+    expect(
+      await syncStorage.db().collection(SYNC_COLLECTIONS.events).findOne({
+        tenantId: userId.toHexString(),
+        "content.title": "already linked",
+        origin: "compass",
+        providerEventId: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/scripts/src/commands/migrate-pending-intent.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent.ts
@@ -1,0 +1,143 @@
+import { loadInventoryCollections } from "@scripts/commands/inventory-legacy-sync/inventory";
+import { migratePendingCompassIntent } from "@scripts/commands/migrate-pending-intent/migrate";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const logger = Logger("scripts.commands.migrate-pending-intent");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before migrating pending intent",
+    );
+  }
+  return uri;
+}
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  outPath: string | null;
+  userIds: Set<string> | undefined;
+  targetCalendarId: string | undefined;
+  targetGcalId: string | undefined;
+} {
+  const apply = argv.includes("--apply");
+  const dryRun = !apply;
+  const outFlag = argv.indexOf("--out");
+  const outPath =
+    outFlag >= 0 && argv[outFlag + 1] ? resolve(argv[outFlag + 1]!) : null;
+
+  const userIds = new Set<string>();
+  let targetCalendarId: string | undefined;
+  let targetGcalId: string | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--user-id" && argv[i + 1]) {
+      userIds.add(argv[i + 1]!);
+      i += 1;
+    } else if (argv[i] === "--target-calendar-id" && argv[i + 1]) {
+      targetCalendarId = argv[i + 1]!;
+      i += 1;
+    } else if (argv[i] === "--target-gcal-id" && argv[i + 1]) {
+      targetGcalId = argv[i + 1]!;
+      i += 1;
+    }
+  }
+
+  return {
+    dryRun,
+    outPath,
+    userIds: userIds.size > 0 ? userIds : undefined,
+    targetCalendarId,
+    targetGcalId,
+  };
+}
+
+/**
+ * S49: preserve unlinked Compass events in Sync and submit resumable backfill
+ * create commands for eligible events. Default dry-run; `--apply` writes.
+ * Never mirrors already-linked events, never infers target by email, never
+ * calls Google, never enqueues Sync jobs.
+ *
+ * Usage:
+ *   bun run cli migrate-pending-intent [--apply] [--out report.json]
+ *     [--user-id <id>]... [--target-calendar-id <syncId>]
+ *     [--target-gcal-id <providerCalendarId>]
+ */
+export async function runMigratePendingIntent(): Promise<void> {
+  const { dryRun, outPath, userIds, targetCalendarId, targetGcalId } =
+    parseArgs(process.argv.slice(3));
+  const syncMongo = new SyncMongoService();
+
+  try {
+    await mongoService.start();
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const collections = await loadInventoryCollections(mongoService);
+    const report = await migratePendingCompassIntent(
+      {
+        connections: new ProviderConnectionRepository(syncMongo.db),
+        calendars: new ProviderCalendarRepository(syncMongo.db),
+        events: new EventRepository(syncMongo.db),
+        occurrences: new EventOccurrenceRepository(
+          syncMongo.db,
+          syncMongo.client,
+        ),
+        commands: new CommandRepository(syncMongo.db),
+      },
+      {
+        users: collections.users,
+        calendars: collections.calendars,
+        events: collections.events,
+      },
+      { dryRun, userIds, targetCalendarId, targetGcalId },
+    );
+
+    try {
+      const json = `${JSON.stringify(report, null, 2)}\n`;
+      if (outPath) {
+        writeFileSync(outPath, json, "utf8");
+        logger.info(`Wrote pending-intent migration report to ${outPath}`);
+      } else {
+        process.stdout.write(json);
+      }
+    } catch (outputError) {
+      logger.error(outputError);
+      if (dryRun) throw outputError;
+      logger.error(
+        "migrate-pending-intent apply completed but report output failed; database changes were persisted",
+      );
+    }
+
+    logger.info(
+      `migrate-pending-intent dryRun=${report.dryRun} users=${report.counts.usersScanned} events=${report.counts.eventsCreated + report.counts.eventsUpdated + report.counts.eventsWouldCreate + report.counts.eventsWouldUpdate} commands=${report.counts.commandsCreated + report.counts.commandsWouldCreate}`,
+    );
+
+    await syncMongo.disconnect();
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/migrate-pending-intent/map.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent/map.ts
@@ -1,0 +1,164 @@
+import {
+  toSyncContent,
+  toSyncSchedule,
+} from "@scripts/commands/migrate-provider-state/map";
+import { type ObjectId } from "mongodb";
+import { type EventId, EventIdSchema } from "@core/types/domain-primitives";
+import { type EditableRecurrence } from "@core/types/event.contracts";
+import {
+  type SyncEventContent,
+  type SyncEventRecurrence,
+} from "@core/types/sync/event.contracts";
+import {
+  IdempotencyKeySchema,
+  type PrincipalId,
+  type ProviderCalendarId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { type EventRecord as LegacyEventRecord } from "@backend/event/event.record";
+import { syncHorizon } from "@sync/domain/horizon";
+import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
+import { type EventRecord as SyncEventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+
+export { toSyncContent, toSyncSchedule };
+
+export function byHexId(a: { _id: ObjectId }, b: { _id: ObjectId }): number {
+  return a._id.toHexString().localeCompare(b._id.toHexString());
+}
+
+export function backfillIdempotencyKey(eventId: string) {
+  return IdempotencyKeySchema.parse(`create:${eventId}`);
+}
+
+export function toSyncRecurrence(
+  recurrence: LegacyEventRecord["recurrence"],
+): SyncEventRecurrence | null {
+  if (recurrence.kind === "single") return { kind: "single" };
+  if (recurrence.kind === "series") {
+    return { kind: "seriesMaster", rules: recurrence.rules };
+  }
+  return null;
+}
+
+export function toEditableRecurrence(
+  recurrence: SyncEventRecurrence,
+): EditableRecurrence | null {
+  if (recurrence.kind === "single") return { kind: "single" };
+  if (recurrence.kind === "seriesMaster") {
+    return { kind: "series", rules: recurrence.rules };
+  }
+  return null;
+}
+
+export function isWithinSyncHorizon(
+  schedule: ReturnType<typeof toSyncSchedule>,
+  now: Date,
+): boolean {
+  const horizon = syncHorizon(now);
+  const startMs =
+    schedule.kind === "timed"
+      ? Date.parse(schedule.start)
+      : Date.parse(`${schedule.start}T00:00:00.000Z`);
+  if (!Number.isFinite(startMs)) return false;
+  return startMs >= horizon.start.getTime() && startMs < horizon.end.getTime();
+}
+
+export function buildUnlinkedEventRecord(args: {
+  event: LegacyEventRecord;
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  content: SyncEventContent;
+  schedule: ReturnType<typeof toSyncSchedule>;
+  recurrence: SyncEventRecurrence;
+  now: Date;
+  existing: SyncEventRecord | null;
+}): SyncEventRecord {
+  const eventId = EventIdSchema.parse(args.event._id.toHexString());
+  return {
+    _id: eventId,
+    tenantId: args.tenantId,
+    principalId: args.principalId,
+    origin: "compass",
+    calendarId: args.event.calendarId.toHexString() as never,
+    clientEventId: null,
+    connectionId: null,
+    providerEventId: null,
+    providerVersion: null,
+    providerUpdatedAt: null,
+    deliveryState: null,
+    providerMetadata: null,
+    content: args.content,
+    schedule: args.schedule,
+    recurrence: args.recurrence,
+    lifecycleState: "active",
+    generation: args.existing?.generation ?? 0,
+    createdAt: args.existing?.createdAt ?? args.event.createdAt,
+    updatedAt: args.now,
+    confirmedAt: args.now,
+  };
+}
+
+export function buildBackfillCommandSubmit(args: {
+  tenantId: TenantId;
+  principalId: PrincipalId;
+  eventId: EventId;
+  targetCalendarId: ProviderCalendarId;
+  content: SyncEventContent;
+  schedule: ReturnType<typeof toSyncSchedule>;
+  editableRecurrence: EditableRecurrence;
+}): CommandSubmit {
+  return {
+    tenantId: args.tenantId,
+    principalId: args.principalId,
+    idempotencyKey: backfillIdempotencyKey(args.eventId),
+    eventId: args.eventId,
+    expectedVersion: null,
+    input: {
+      kind: "create",
+      calendarId: args.targetCalendarId,
+      clientEventId: null,
+      invitation: "none",
+      content: args.content,
+      schedule: args.schedule,
+      recurrence: args.editableRecurrence,
+    },
+  };
+}
+
+/** Prefer primary writable; never use email. Deterministic by `_id`. */
+export function selectBackfillTarget(
+  calendars: readonly ProviderCalendarRecord[],
+  options: {
+    targetCalendarId?: string;
+    targetGcalId?: string;
+  },
+):
+  | { ok: true; calendar: ProviderCalendarRecord }
+  | { ok: false; reason: "missing" | "not_owned" | "read_only" } {
+  const writable = [...calendars]
+    .filter((c) => c.active && c.capabilities.canWriteEvents)
+    .sort((a, b) => a._id.localeCompare(b._id));
+
+  if (options.targetCalendarId) {
+    const match = calendars.find((c) => c._id === options.targetCalendarId);
+    if (!match) return { ok: false, reason: "not_owned" };
+    if (!match.active || !match.capabilities.canWriteEvents) {
+      return { ok: false, reason: "read_only" };
+    }
+    return { ok: true, calendar: match };
+  }
+
+  if (options.targetGcalId) {
+    const match = writable.find(
+      (c) => c.providerCalendarId === options.targetGcalId,
+    );
+    if (!match) return { ok: false, reason: "missing" };
+    return { ok: true, calendar: match };
+  }
+
+  const primary = writable.find((c) => c.primary);
+  if (primary) return { ok: true, calendar: primary };
+  if (writable[0]) return { ok: true, calendar: writable[0] };
+  return { ok: false, reason: "missing" };
+}

--- a/packages/scripts/src/commands/migrate-pending-intent/map.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent/map.ts
@@ -17,6 +17,7 @@ import {
 } from "@core/types/sync/identity.contracts";
 import { type EventRecord as LegacyEventRecord } from "@backend/event/event.record";
 import { syncHorizon } from "@sync/domain/horizon";
+import { projectOccurrences } from "@sync/domain/occurrence-projection";
 import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
 import { type EventRecord as SyncEventRecord } from "@sync/storage/contracts/event.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
@@ -54,8 +55,21 @@ export function toEditableRecurrence(
 export function isWithinSyncHorizon(
   schedule: ReturnType<typeof toSyncSchedule>,
   now: Date,
+  recurrence?: SyncEventRecurrence | null,
 ): boolean {
   const horizon = syncHorizon(now);
+  if (recurrence?.kind === "seriesMaster") {
+    return (
+      projectOccurrences(
+        {
+          schedule,
+          recurrence,
+          content: { title: "" },
+        } as SyncEventRecord,
+        horizon,
+      ).length > 0
+    );
+  }
   const startMs =
     schedule.kind === "timed"
       ? Date.parse(schedule.start)

--- a/packages/scripts/src/commands/migrate-pending-intent/migrate.test.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent/migrate.test.ts
@@ -1,0 +1,184 @@
+import {
+  backfillIdempotencyKey,
+  selectBackfillTarget,
+} from "@scripts/commands/migrate-pending-intent/map";
+import { migratePendingCompassIntent } from "@scripts/commands/migrate-pending-intent/migrate";
+import { ObjectId } from "mongodb";
+import { describe, expect, it, mock } from "bun:test";
+
+const NOW = new Date("2026-07-25T04:00:00.000Z");
+const USER_ID = new ObjectId("507f1f77bcf86cd799439011");
+const LOCAL_CAL_ID = new ObjectId("507f1f77bcf86cd799439021");
+const TARGET_CAL_ID = "507f1f77bcf86cd799439099";
+
+describe("migrate-pending-intent helpers", () => {
+  it("builds create:eventId idempotency keys", () => {
+    expect(backfillIdempotencyKey("abc")).toBe("create:abc");
+  });
+
+  it("selects primary writable target without using email", () => {
+    const selected = selectBackfillTarget(
+      [
+        {
+          _id: "cal-secondary",
+          primary: false,
+          active: true,
+          providerCalendarId: "secondary",
+          capabilities: { canWriteEvents: true },
+        },
+        {
+          _id: "cal-primary",
+          primary: true,
+          active: true,
+          providerCalendarId: "primary",
+          capabilities: { canWriteEvents: true },
+        },
+      ] as never,
+      {},
+    );
+    expect(selected.ok && selected.calendar._id).toBe("cal-primary");
+  });
+
+  it("rejects a foreign target calendar id", () => {
+    const selected = selectBackfillTarget(
+      [
+        {
+          _id: "cal-primary",
+          primary: true,
+          active: true,
+          providerCalendarId: "primary",
+          capabilities: { canWriteEvents: true },
+        },
+      ] as never,
+      { targetCalendarId: "someone-elses-calendar" },
+    );
+    expect(selected.ok).toBe(false);
+    if (!selected.ok) expect(selected.reason).toBe("not_owned");
+  });
+});
+
+describe("migratePendingCompassIntent", () => {
+  it("dry-run preserves counts and does not write", async () => {
+    const put = mock(() => {
+      throw new Error("should not put in dry-run");
+    });
+    const submit = mock(() => {
+      throw new Error("should not submit in dry-run");
+    });
+
+    const report = await migratePendingCompassIntent(
+      {
+        connections: {
+          listByPrincipal: async () => [
+            {
+              _id: "conn-1",
+              provider: "google",
+              disconnectedAt: null,
+            },
+          ],
+        } as never,
+        calendars: {
+          listByPrincipal: async () => [
+            {
+              _id: TARGET_CAL_ID,
+              connectionId: "conn-1",
+              primary: true,
+              active: true,
+              providerCalendarId: "primary",
+              capabilities: { canWriteEvents: true },
+            },
+          ],
+        } as never,
+        events: {
+          findById: async () => null,
+          put,
+        } as never,
+        occurrences: {
+          replaceForEvent: async () => {
+            throw new Error("unused");
+          },
+        } as never,
+        commands: { submit } as never,
+      },
+      {
+        users: [
+          {
+            _id: USER_ID,
+            email: "alice@example.com",
+            firstName: "A",
+            lastName: "Lice",
+            name: "A Lice",
+            locale: "en",
+            google: {
+              googleId: "google-1",
+              picture: "",
+              gRefreshToken: "refresh",
+            },
+          },
+        ],
+        calendars: [
+          {
+            _id: LOCAL_CAL_ID,
+            userId: USER_ID,
+            name: "Local",
+            description: "",
+            timeZone: "America/Denver",
+            foregroundColor: "#000000",
+            backgroundColor: "#ffffff",
+            access: "owner",
+            isPrimary: true,
+            isVisible: true,
+            isActive: true,
+            source: { provider: "local" },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+        ],
+        events: [
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439031"),
+            calendarId: LOCAL_CAL_ID,
+            content: { kind: "details", title: "draft", description: "" },
+            schedule: {
+              kind: "timed",
+              start: NOW,
+              end: new Date(NOW.getTime() + 1800_000),
+              timeZone: "America/Denver",
+            },
+            recurrence: { kind: "single" },
+            externalReference: null,
+            createdAt: NOW,
+            updatedAt: null,
+          },
+          {
+            _id: new ObjectId("507f1f77bcf86cd799439032"),
+            calendarId: LOCAL_CAL_ID,
+            content: { kind: "details", title: "linked", description: "" },
+            schedule: {
+              kind: "timed",
+              start: NOW,
+              end: new Date(NOW.getTime() + 1800_000),
+              timeZone: "America/Denver",
+            },
+            recurrence: { kind: "single" },
+            externalReference: {
+              provider: "google",
+              eventId: "g-1",
+              recurringEventId: null,
+            },
+            createdAt: NOW,
+            updatedAt: null,
+          },
+        ],
+      },
+      { dryRun: true, now: NOW },
+    );
+
+    expect(report.counts.eventsWouldCreate).toBe(1);
+    expect(report.counts.commandsWouldCreate).toBe(1);
+    expect(report.counts.eventsSkipped).toBe(1);
+    expect(report.users[0]?.targetCalendarId).toBe(TARGET_CAL_ID);
+    expect(put).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/scripts/src/commands/migrate-pending-intent/migrate.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent/migrate.ts
@@ -307,7 +307,7 @@ export async function migratePendingCompassIntent(
         continue;
       }
 
-      if (!isWithinSyncHorizon(schedule, now)) {
+      if (!isWithinSyncHorizon(schedule, now, syncRecurrence)) {
         counts.commandsSkipped += 1;
         skips.push({
           category: "outside_sync_horizon",

--- a/packages/scripts/src/commands/migrate-pending-intent/migrate.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent/migrate.ts
@@ -1,0 +1,399 @@
+import {
+  buildBackfillCommandSubmit,
+  buildUnlinkedEventRecord,
+  byHexId,
+  isWithinSyncHorizon,
+  selectBackfillTarget,
+  toEditableRecurrence,
+  toSyncContent,
+  toSyncRecurrence,
+  toSyncSchedule,
+} from "@scripts/commands/migrate-pending-intent/map";
+import {
+  type MigratePendingIntentReport,
+  MigratePendingIntentReportSchema,
+  type MigratePendingIntentSkip,
+  type MigratePendingIntentUserResult,
+} from "@scripts/commands/migrate-pending-intent/report.types";
+import { type ObjectId } from "mongodb";
+import { EventIdSchema } from "@core/types/domain-primitives";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { type Schema_User } from "@core/types/user.types";
+import { type CalendarRecord } from "@backend/calendar/calendar.record";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { type EventRecord as LegacyEventRecord } from "@backend/event/event.record";
+import { reprojectOccurrences } from "@sync/domain/reproject";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+
+export interface MigratePendingIntentSource {
+  users: Array<{ _id: ObjectId } & Schema_User>;
+  calendars: CalendarRecord[];
+  events: LegacyEventRecord[];
+}
+
+export interface MigratePendingIntentDeps {
+  connections: ProviderConnectionRepository;
+  calendars: ProviderCalendarRepository;
+  events: EventRepository;
+  occurrences: EventOccurrenceRepository;
+  commands: CommandRepository;
+}
+
+export interface MigratePendingIntentOptions {
+  dryRun: boolean;
+  now?: Date;
+  userIds?: ReadonlySet<string>;
+  /** Sync provider_calendars._id override (never email). */
+  targetCalendarId?: string;
+  /** Provider source calendar id override (e.g. "primary"). */
+  targetGcalId?: string;
+}
+
+interface AggregateCounts {
+  eventsCreated: number;
+  eventsUpdated: number;
+  eventsWouldCreate: number;
+  eventsWouldUpdate: number;
+  eventsSkipped: number;
+  commandsCreated: number;
+  commandsAlreadyPresent: number;
+  commandsWouldCreate: number;
+  commandsSkipped: number;
+}
+
+const emptyCounts = (): AggregateCounts => ({
+  eventsCreated: 0,
+  eventsUpdated: 0,
+  eventsWouldCreate: 0,
+  eventsWouldUpdate: 0,
+  eventsSkipped: 0,
+  commandsCreated: 0,
+  commandsAlreadyPresent: 0,
+  commandsWouldCreate: 0,
+  commandsSkipped: 0,
+});
+
+/**
+ * S49: preserve unlinked Compass events in Sync and submit resumable backfill
+ * create commands for eligible events targeting an explicit Sync calendar.
+ * Never mirrors already-linked events, never infers target by email, never
+ * calls Google, never enqueues jobs.
+ */
+export async function migratePendingCompassIntent(
+  deps: MigratePendingIntentDeps,
+  source: MigratePendingIntentSource,
+  options: MigratePendingIntentOptions,
+): Promise<MigratePendingIntentReport> {
+  const now = options.now ?? new Date();
+  const nowFn = () => now;
+  const skips: MigratePendingIntentSkip[] = [];
+  const usersOut: MigratePendingIntentUserResult[] = [];
+  const counts = emptyCounts();
+
+  const users = [...source.users]
+    .filter((user) =>
+      options.userIds ? options.userIds.has(user._id.toHexString()) : true,
+    )
+    .sort(byHexId);
+
+  const calendarsByUser = new Map<string, CalendarRecord[]>();
+  for (const calendar of source.calendars) {
+    const userId = calendar.userId.toHexString();
+    const list = calendarsByUser.get(userId) ?? [];
+    list.push(calendar);
+    calendarsByUser.set(userId, list);
+  }
+
+  const eventsByCalendar = new Map<string, LegacyEventRecord[]>();
+  for (const event of source.events) {
+    const calendarId = event.calendarId.toHexString();
+    const list = eventsByCalendar.get(calendarId) ?? [];
+    list.push(event);
+    eventsByCalendar.set(calendarId, list);
+  }
+
+  for (const user of users) {
+    const userId = user._id.toHexString();
+    const principal = toSyncPrincipal(userId);
+    const tenantId = principal.tenantId as TenantId;
+    const principalId = principal.principalId as PrincipalId;
+    const userCounts = {
+      eventsUpserted: 0,
+      commandsSubmitted: 0,
+      commandsAlreadyPresent: 0,
+    };
+
+    const userCalendars = calendarsByUser.get(userId) ?? [];
+    const calendarById = new Map(
+      userCalendars.map((c) => [c._id.toHexString(), c]),
+    );
+
+    const connections = await deps.connections.listByPrincipal(
+      tenantId,
+      principalId,
+    );
+    const liveGoogle = connections.find(
+      (c) => c.provider === "google" && c.disconnectedAt == null,
+    );
+
+    const syncCalendars = await deps.calendars.listByPrincipal(
+      tenantId,
+      principalId,
+      { activeOnly: false },
+    );
+
+    let targetCalendarId: string | null = null;
+    let connectionId: ConnectionId | null = liveGoogle?._id ?? null;
+    let targetOk = false;
+
+    if (liveGoogle) {
+      const selected = selectBackfillTarget(syncCalendars, {
+        targetCalendarId: options.targetCalendarId,
+        targetGcalId: options.targetGcalId,
+      });
+      if (selected.ok) {
+        targetOk = true;
+        targetCalendarId = selected.calendar._id;
+        connectionId = selected.calendar.connectionId;
+      } else if (options.targetCalendarId && selected.reason === "not_owned") {
+        skips.push({
+          category: "target_not_owned",
+          id: options.targetCalendarId,
+          detail: "target calendar is not owned by this principal",
+        });
+      } else if (selected.reason === "read_only") {
+        skips.push({
+          category: "read_only_target",
+          id: options.targetCalendarId ?? options.targetGcalId ?? "default",
+          detail: "selected target calendar is not writable",
+        });
+      }
+    }
+
+    const pendingEvents: LegacyEventRecord[] = [];
+    for (const calendar of userCalendars) {
+      for (const event of eventsByCalendar.get(calendar._id.toHexString()) ??
+        []) {
+        if (event.externalReference != null) {
+          counts.eventsSkipped += 1;
+          skips.push({
+            category: "already_provider_linked",
+            id: event._id.toHexString(),
+            detail: "legacy event already has an external reference",
+          });
+          continue;
+        }
+        pendingEvents.push(event);
+      }
+    }
+    pendingEvents.sort(byHexId);
+
+    if (pendingEvents.length === 0 && !liveGoogle) {
+      usersOut.push({
+        userId,
+        tenantId,
+        principalId,
+        connectionId: null,
+        targetCalendarId: null,
+        action: "skipped",
+        skipCategory: "no_google_identity",
+        detail: "no unlinked events and no live Sync google connection",
+        counts: userCounts,
+      });
+      continue;
+    }
+
+    for (const event of pendingEvents) {
+      const calendar = calendarById.get(event.calendarId.toHexString());
+      if (!calendar) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "orphan_event",
+          id: event._id.toHexString(),
+          detail: "event calendar is not owned by this user",
+        });
+        continue;
+      }
+
+      if (event.content.kind === "busy") {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "busy_not_eligible",
+          id: event._id.toHexString(),
+          detail: "busy events are not eligible for provider backfill",
+        });
+        continue;
+      }
+
+      const syncRecurrence = toSyncRecurrence(event.recurrence);
+      if (!syncRecurrence) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "occurrence_not_backfillable",
+          id: event._id.toHexString(),
+          detail: "occurrence rows are not independently backfilled",
+        });
+        continue;
+      }
+
+      let content: ReturnType<typeof toSyncContent>;
+      let schedule: ReturnType<typeof toSyncSchedule>;
+      try {
+        content = toSyncContent(event.content);
+        schedule = toSyncSchedule(event.schedule);
+      } catch (error) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "unmappable_event",
+          id: event._id.toHexString(),
+          detail:
+            error instanceof Error
+              ? error.message
+              : "failed to map event content/schedule",
+        });
+        continue;
+      }
+
+      const eventId = EventIdSchema.parse(event._id.toHexString());
+      const existing = await deps.events.findById(
+        tenantId,
+        principalId,
+        eventId,
+      );
+
+      if (existing?.providerEventId != null) {
+        counts.eventsSkipped += 1;
+        skips.push({
+          category: "already_provider_linked",
+          id: event._id.toHexString(),
+          detail: "Sync event already has provider identity",
+        });
+        continue;
+      }
+
+      if (options.dryRun) {
+        if (existing) counts.eventsWouldUpdate += 1;
+        else counts.eventsWouldCreate += 1;
+        userCounts.eventsUpserted += 1;
+      } else {
+        const record = buildUnlinkedEventRecord({
+          event,
+          tenantId,
+          principalId,
+          content,
+          schedule,
+          recurrence: syncRecurrence,
+          now,
+          existing,
+        });
+        await deps.events.put(record);
+        await reprojectOccurrences(deps.occurrences, record, nowFn);
+        if (existing) counts.eventsUpdated += 1;
+        else counts.eventsCreated += 1;
+        userCounts.eventsUpserted += 1;
+      }
+
+      const editable = toEditableRecurrence(syncRecurrence);
+      if (!editable) {
+        counts.commandsSkipped += 1;
+        continue;
+      }
+
+      if (!isWithinSyncHorizon(schedule, now)) {
+        counts.commandsSkipped += 1;
+        skips.push({
+          category: "outside_sync_horizon",
+          id: event._id.toHexString(),
+          detail: "event preserved unlinked; outside sync horizon for backfill",
+        });
+        continue;
+      }
+
+      if (!liveGoogle) {
+        counts.commandsSkipped += 1;
+        skips.push({
+          category: "missing_connection",
+          id: event._id.toHexString(),
+          detail: "no live Sync google connection for backfill command",
+        });
+        continue;
+      }
+
+      if (!targetOk || !targetCalendarId) {
+        counts.commandsSkipped += 1;
+        skips.push({
+          category: "missing_selected_target",
+          id: event._id.toHexString(),
+          detail:
+            "event preserved unlinked; no writable Sync calendar selected for backfill",
+        });
+        continue;
+      }
+
+      if (options.dryRun) {
+        counts.commandsWouldCreate += 1;
+        userCounts.commandsSubmitted += 1;
+        continue;
+      }
+
+      const { inserted } = await deps.commands.submit(
+        buildBackfillCommandSubmit({
+          tenantId,
+          principalId,
+          eventId,
+          targetCalendarId: targetCalendarId as never,
+          content,
+          schedule,
+          editableRecurrence: editable,
+        }),
+      );
+      if (inserted) {
+        counts.commandsCreated += 1;
+        userCounts.commandsSubmitted += 1;
+      } else {
+        counts.commandsAlreadyPresent += 1;
+        userCounts.commandsAlreadyPresent += 1;
+      }
+    }
+
+    usersOut.push({
+      userId,
+      tenantId,
+      principalId,
+      connectionId,
+      targetCalendarId,
+      action: options.dryRun ? "would_migrate" : "migrated",
+      skipCategory: null,
+      detail: options.dryRun
+        ? "would preserve unlinked events and submit backfill commands"
+        : "preserved unlinked events and submitted backfill commands",
+      counts: userCounts,
+    });
+  }
+
+  return MigratePendingIntentReportSchema.parse({
+    generatedAt: now.toISOString(),
+    dryRun: options.dryRun,
+    counts: {
+      usersScanned: users.length,
+      usersMigrated: usersOut.filter((u) => u.action === "migrated").length,
+      usersWouldMigrate: usersOut.filter((u) => u.action === "would_migrate")
+        .length,
+      usersSkipped: usersOut.filter((u) => u.action === "skipped").length,
+      ...counts,
+    },
+    users: usersOut,
+    skips: skips.sort(
+      (a, b) =>
+        a.category.localeCompare(b.category) || a.id.localeCompare(b.id),
+    ),
+  });
+}

--- a/packages/scripts/src/commands/migrate-pending-intent/report.types.ts
+++ b/packages/scripts/src/commands/migrate-pending-intent/report.types.ts
@@ -1,0 +1,77 @@
+import { z } from "zod/v4";
+
+export const MigratePendingIntentSkipCategorySchema = z.enum([
+  "already_provider_linked",
+  "occurrence_not_backfillable",
+  "busy_not_eligible",
+  "outside_sync_horizon",
+  "missing_selected_target",
+  "missing_connection",
+  "orphan_event",
+  "unmappable_event",
+  "read_only_target",
+  "target_not_owned",
+  "no_google_identity",
+]);
+export type MigratePendingIntentSkipCategory = z.infer<
+  typeof MigratePendingIntentSkipCategorySchema
+>;
+
+export const MigratePendingIntentSkipSchema = z.strictObject({
+  category: MigratePendingIntentSkipCategorySchema,
+  id: z.string().min(1),
+  detail: z.string().min(1),
+});
+export type MigratePendingIntentSkip = z.infer<
+  typeof MigratePendingIntentSkipSchema
+>;
+
+export const MigratePendingIntentUserActionSchema = z.enum([
+  "would_migrate",
+  "migrated",
+  "skipped",
+]);
+
+export const MigratePendingIntentUserResultSchema = z.strictObject({
+  userId: z.string().min(1),
+  tenantId: z.string().min(1),
+  principalId: z.string().min(1),
+  connectionId: z.string().nullable(),
+  targetCalendarId: z.string().nullable(),
+  action: MigratePendingIntentUserActionSchema,
+  skipCategory: MigratePendingIntentSkipCategorySchema.nullable(),
+  detail: z.string().min(1),
+  counts: z.strictObject({
+    eventsUpserted: z.number().int().nonnegative(),
+    commandsSubmitted: z.number().int().nonnegative(),
+    commandsAlreadyPresent: z.number().int().nonnegative(),
+  }),
+});
+export type MigratePendingIntentUserResult = z.infer<
+  typeof MigratePendingIntentUserResultSchema
+>;
+
+export const MigratePendingIntentReportSchema = z.strictObject({
+  generatedAt: z.string().min(1),
+  dryRun: z.boolean(),
+  counts: z.strictObject({
+    usersScanned: z.number().int().nonnegative(),
+    usersMigrated: z.number().int().nonnegative(),
+    usersWouldMigrate: z.number().int().nonnegative(),
+    usersSkipped: z.number().int().nonnegative(),
+    eventsCreated: z.number().int().nonnegative(),
+    eventsUpdated: z.number().int().nonnegative(),
+    eventsWouldCreate: z.number().int().nonnegative(),
+    eventsWouldUpdate: z.number().int().nonnegative(),
+    eventsSkipped: z.number().int().nonnegative(),
+    commandsCreated: z.number().int().nonnegative(),
+    commandsAlreadyPresent: z.number().int().nonnegative(),
+    commandsWouldCreate: z.number().int().nonnegative(),
+    commandsSkipped: z.number().int().nonnegative(),
+  }),
+  users: z.array(MigratePendingIntentUserResultSchema),
+  skips: z.array(MigratePendingIntentSkipSchema),
+});
+export type MigratePendingIntentReport = z.infer<
+  typeof MigratePendingIntentReportSchema
+>;


### PR DESCRIPTION
## Summary
- Adds `bun run cli migrate-pending-intent` (S49 / #1556): preserves unlinked Compass events in Sync via `EventRepository.put` + occurrence reprojection, and submits resumable pending `create` commands via `CommandRepository.submit`.
- Target selection: Sync primary writable calendar, or `--target-calendar-id` / `--target-gcal-id`. Never infers by email.
- Skips already-linked events, occurrences, busy events, and outside-horizon backfill (event still preserved). Default dry-run; `--apply` writes. No Google calls, no job enqueue.

## Test plan
- [x] Focused unit + db tests (`#1556` put+command, idempotent rerun, no mirror of linked events)
- [x] CLI wiring test
- [x] `bun type-check` / `bun lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `--apply` mutates Sync events and command queues for real users during migration; mitigations include default dry-run, idempotent keys, and explicit skip categories, but operator error or wrong targets could still enqueue unwanted creates.
> 
> **Overview**
> Adds **`bun run cli migrate-pending-intent`** (S49), completing the legacy→Sync migration path after S47/S48 by handling **unlinked Compass events** that S48 intentionally skipped.
> 
> For eligible legacy events (no `externalReference`, mappable content, etc.), the command **upserts Sync events** with `origin: "compass"` and no provider identity, **reprojects occurrences**, and **submits idempotent pending `create` commands** (`create:<eventId>`) via `CommandRepository.submit` toward a writable Google calendar. Target selection uses the primary writable Sync calendar or explicit `--target-calendar-id` / `--target-gcal-id`—**never email**. Default is **dry-run**; `--apply` persists writes. Already-linked events are not mirrored; events outside the sync horizon may still be preserved without a backfill command.
> 
> CLI wiring, docs table entry, Zod migration reports, and unit/DB tests (including idempotent rerun and linked-event skip) are included. The runner does not call Google or enqueue Sync jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ec3956832adeb6d6a77acda3c56db031156a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->