### PR TITLE
feat(backend): add sync cutover controls

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -80,6 +80,7 @@ jobs:
           # stay unset until cutover. Staging-cloud sets these to prove S38/S39.
           SYNC_CONNECTION_ROUTING: ${{ vars.SYNC_CONNECTION_ROUTING }}
           SYNC_EVENT_ROUTING: ${{ vars.SYNC_EVENT_ROUTING }}
+          SYNC_CLOUD_MUTATION_MODE: ${{ vars.SYNC_CLOUD_MUTATION_MODE }}
           SYNC_EXECUTION: ${{ vars.SYNC_EXECUTION }}
           WEB_IMAGE: switchbacktech/compass-web:${{ inputs.environment }}-${{ steps.version.outputs.image_version }}
           # Sensitive
@@ -178,6 +179,9 @@ jobs:
               fi
               if [ -n "$SYNC_EVENT_ROUTING" ]; then
                 printf '%s\n' "  eventRouting: \"${SYNC_EVENT_ROUTING}\""
+              fi
+              if [ -n "$SYNC_CLOUD_MUTATION_MODE" ]; then
+                printf '%s\n' "  cloudMutationMode: \"${SYNC_CLOUD_MUTATION_MODE}\""
               fi
               if [ -n "$SYNC_EXECUTION" ]; then
                 printf '%s\n' "  execution: \"${SYNC_EXECUTION}\""

--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -59,7 +59,8 @@ supertokens:
 #   serviceUrl: http://localhost:3010 # base URL the API uses to reach this service; compose uses http://sync:3010
 #   connectionRouting: legacy # legacy (default) | sync; sync delegates provider-connection routes here and requires serviceUrl
 #   eventRouting: legacy # legacy (default) | sync; sync delegates calendar/event reads + commands here and requires serviceUrl
-#   execution: passive # passive | active — active required for OAuth begin + provider import/jobs
+#   cloudMutationMode: enabled # enabled (default) | maintenance — maintenance rejects cloud edits / connect with typed MAINTENANCE
+#   execution: passive # passive | active — active required for OAuth begin + provider import/jobs; refuse active+enabled while any routing is legacy
 # Public OAuth/webhook paths (via Caddy → sync): /sync/google, /sync/notifications/google
 #   maxConcurrency: 4
 #   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -26,6 +26,18 @@ import {
   type Res_Promise,
   type SReqBody,
 } from "@backend/common/types/express.types";
+import { toEventMutationError } from "@backend/event/event.error";
+
+const rejectIfMaintenance = (res: Res_Promise): boolean => {
+  try {
+    assertCloudMutationsAllowed();
+    return false;
+  } catch (err) {
+    const { status, body } = toEventMutationError(err);
+    res.status(status).json(body);
+    return true;
+  }
+};
 
 class AuthController {
   createSession = async (
@@ -63,12 +75,7 @@ class AuthController {
     req: SReqBody<GoogleAuthCodeRequest>,
     res: Res_Promise,
   ): void => {
-    try {
-      assertCloudMutationsAllowed();
-    } catch (err) {
-      res.promise(Promise.reject(err));
-      return;
-    }
+    if (rejectIfMaintenance(res)) return;
 
     if (!isGoogleConfigured(CONFIG)) {
       res.promise(
@@ -95,12 +102,7 @@ class AuthController {
     req: SReqBody<ConnectionBeginRequest>,
     res: Res_Promise,
   ): void => {
-    try {
-      assertCloudMutationsAllowed();
-    } catch (err) {
-      res.promise(Promise.reject(err));
-      return;
-    }
+    if (rejectIfMaintenance(res)) return;
 
     const client =
       getConnectionDelegation() === "sync" ? getSyncServiceClient() : null;

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -16,6 +16,7 @@ import { CONFIG } from "@backend/common/constants/config.constants";
 import { isGoogleConfigured } from "@backend/common/constants/config.util";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
+import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
 import { beginSyncConnection } from "@backend/common/services/sync-service/sync-connection-begin";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
@@ -62,6 +63,13 @@ class AuthController {
     req: SReqBody<GoogleAuthCodeRequest>,
     res: Res_Promise,
   ): void => {
+    try {
+      assertCloudMutationsAllowed();
+    } catch (err) {
+      res.promise(Promise.reject(err));
+      return;
+    }
+
     if (!isGoogleConfigured(CONFIG)) {
       res.promise(
         Promise.reject(error(AuthError.GoogleNotConfigured, "Connect failed")),
@@ -87,6 +95,13 @@ class AuthController {
     req: SReqBody<ConnectionBeginRequest>,
     res: Res_Promise,
   ): void => {
+    try {
+      assertCloudMutationsAllowed();
+    } catch (err) {
+      res.promise(Promise.reject(err));
+      return;
+    }
+
     const client =
       getConnectionDelegation() === "sync" ? getSyncServiceClient() : null;
     if (!client) {

--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -380,4 +380,90 @@ describe("config.constants", () => {
 
     expect(env.SYNC_EVENT_ROUTING).toBe("sync");
   });
+
+  it("defaults cloud mutation mode to enabled and execution to passive", () => {
+    const env = parseConfigFromEnv(validEnv);
+
+    expect(env.SYNC_CLOUD_MUTATION_MODE).toBe("enabled");
+    expect(env.SYNC_EXECUTION).toBe("passive");
+  });
+
+  it("treats blank mutation-mode and execution env vars as defaults", () => {
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      SYNC_CLOUD_MUTATION_MODE: "",
+      SYNC_EXECUTION: "",
+    });
+
+    expect(env.SYNC_CLOUD_MUTATION_MODE).toBe("enabled");
+    expect(env.SYNC_EXECUTION).toBe("passive");
+  });
+
+  it("accepts maintenance + active Sync while routing remains legacy", () => {
+    // Cutover window: Sync can be active for import/jobs while cloud mutations
+    // are paused and browser routes still point at legacy.
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      SYNC_EXECUTION: "active",
+      SYNC_CLOUD_MUTATION_MODE: "maintenance",
+      SYNC_CONNECTION_ROUTING: "legacy",
+      SYNC_EVENT_ROUTING: "legacy",
+      SYNC_SERVICE_URL: "http://localhost:3010",
+      SYNC_INTERNAL_AUTH_TOKEN: "sync-internal-secret",
+    });
+
+    expect(env.SYNC_EXECUTION).toBe("active");
+    expect(env.SYNC_CLOUD_MUTATION_MODE).toBe("maintenance");
+  });
+
+  it("accepts active + enabled only when both routings are sync", () => {
+    const env = parseConfigFromEnv({
+      ...validEnv,
+      SYNC_EXECUTION: "active",
+      SYNC_CLOUD_MUTATION_MODE: "enabled",
+      SYNC_CONNECTION_ROUTING: "sync",
+      SYNC_EVENT_ROUTING: "sync",
+      SYNC_SERVICE_URL: "http://localhost:3010",
+      SYNC_INTERNAL_AUTH_TOKEN: "sync-internal-secret",
+    });
+
+    expect(env.SYNC_EXECUTION).toBe("active");
+    expect(env.SYNC_CLOUD_MUTATION_MODE).toBe("enabled");
+  });
+
+  it.each([
+    ["connection routing legacy", "legacy", "sync"],
+    ["event routing legacy", "sync", "legacy"],
+    ["both routings legacy", "legacy", "legacy"],
+  ] as const)("refuses dual-writer when active + enabled and %s", (_label, connectionRouting, eventRouting) => {
+    expect(() =>
+      parseConfigFromEnv({
+        ...validEnv,
+        SYNC_EXECUTION: "active",
+        SYNC_CLOUD_MUTATION_MODE: "enabled",
+        SYNC_CONNECTION_ROUTING: connectionRouting,
+        SYNC_EVENT_ROUTING: eventRouting,
+        SYNC_SERVICE_URL: "http://localhost:3010",
+        SYNC_INTERNAL_AUTH_TOKEN: "sync-internal-secret",
+      }),
+    ).toThrow("refuse dual-writer");
+  });
+
+  it("refuses dual-writer from the config file path as well", () => {
+    expect(() =>
+      parseRawConfig({
+        ...baseRawConfig,
+        sync: {
+          mongoUri: "mongodb://localhost:27017/compass_sync",
+          internalAuthToken: "sync-internal-secret",
+          callbackBaseUrl: "http://localhost:3010",
+          serviceUrl: "http://localhost:3010",
+          execution: "active",
+          cloudMutationMode: "enabled",
+          connectionRouting: "legacy",
+          eventRouting: "sync",
+        },
+      }),
+    ).toThrow("refuse dual-writer");
+  });
 });

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -47,6 +47,16 @@ const ConfigSchema = z
     // durable write commands. Independent of SYNC_CONNECTION_ROUTING so the
     // riskier event path rolls out separately. Global, not per-request.
     SYNC_EVENT_ROUTING: z.enum(["legacy", "sync"]).default("legacy"),
+    // Whether cloud event writes and provider-connection changes are accepted.
+    // `maintenance` rejects them with a typed MAINTENANCE response (S50).
+    SYNC_CLOUD_MUTATION_MODE: z
+      .enum(["enabled", "maintenance"])
+      .default("enabled"),
+    // Mirror of sync.execution for the backend startup guard + operator
+    // surface. Sync itself enforces passive/active; the API refuses unsafe
+    // dual-writer combinations when this is active and mutations are enabled
+    // while any routing remains legacy.
+    SYNC_EXECUTION: z.enum(["passive", "active"]).default("passive"),
     POSTHOG_KEY: z.string().nonempty().optional(),
     POSTHOG_HOST: z.string().url().optional(),
   })
@@ -126,6 +136,27 @@ const ConfigSchema = z
         path: ["SYNC_SERVICE_URL"],
       });
     }
+
+    // Refuse an active Sync writer while the API still routes any browser
+    // path to legacy AND cloud mutations are enabled — that is a dual-writer
+    // window. Cutover keeps mutations in `maintenance` until both routes are
+    // on Sync (S50 / R-MIG-01).
+    const anyLegacyRouting =
+      env.SYNC_CONNECTION_ROUTING === "legacy" ||
+      env.SYNC_EVENT_ROUTING === "legacy";
+    if (
+      env.SYNC_EXECUTION === "active" &&
+      env.SYNC_CLOUD_MUTATION_MODE === "enabled" &&
+      anyLegacyRouting
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        fatal: true,
+        message:
+          "SYNC_EXECUTION=active with SYNC_CLOUD_MUTATION_MODE=enabled requires both SYNC_CONNECTION_ROUTING and SYNC_EVENT_ROUTING to be sync (refuse dual-writer). Enter maintenance or keep Sync passive while any routing remains legacy",
+        path: ["SYNC_EXECUTION"],
+      });
+    }
   });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -173,6 +204,8 @@ export function parseRawConfig(config: CompassConfig): Config {
       : undefined,
     SYNC_CONNECTION_ROUTING: config.sync?.connectionRouting,
     SYNC_EVENT_ROUTING: config.sync?.eventRouting,
+    SYNC_CLOUD_MUTATION_MODE: config.sync?.cloudMutationMode,
+    SYNC_EXECUTION: config.sync?.execution,
     POSTHOG_KEY: nonEmpty(config.posthog?.key),
     POSTHOG_HOST: nonEmpty(config.posthog?.host) || DEFAULT_POSTHOG_HOST,
   });
@@ -209,6 +242,8 @@ export function parseConfigFromEnv(
     SYNC_INTERNAL_AUTH_TOKEN: nonEmpty(rawEnv["SYNC_INTERNAL_AUTH_TOKEN"]),
     SYNC_CONNECTION_ROUTING: nonEmpty(rawEnv["SYNC_CONNECTION_ROUTING"]),
     SYNC_EVENT_ROUTING: nonEmpty(rawEnv["SYNC_EVENT_ROUTING"]),
+    SYNC_CLOUD_MUTATION_MODE: nonEmpty(rawEnv["SYNC_CLOUD_MUTATION_MODE"]),
+    SYNC_EXECUTION: nonEmpty(rawEnv["SYNC_EXECUTION"]),
     POSTHOG_KEY: rawEnv["POSTHOG_KEY"],
     POSTHOG_HOST: rawEnv["POSTHOG_HOST"] || DEFAULT_POSTHOG_HOST,
   });
@@ -241,3 +276,7 @@ try {
 
 export const CONFIG = parsedConfig;
 export const IS_DEV = isDev(CONFIG.NODE_ENV);
+
+logger.info(
+  `Sync cutover: execution=${CONFIG.SYNC_EXECUTION} connectionRouting=${CONFIG.SYNC_CONNECTION_ROUTING} eventRouting=${CONFIG.SYNC_EVENT_ROUTING} cloudMutationMode=${CONFIG.SYNC_CLOUD_MUTATION_MODE}`,
+);

--- a/packages/backend/src/common/services/sync-service/cloud-mutation-mode.test.ts
+++ b/packages/backend/src/common/services/sync-service/cloud-mutation-mode.test.ts
@@ -1,0 +1,49 @@
+import { Status } from "@core/errors/status.codes";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import {
+  assertCloudMutationsAllowed,
+  getCloudMutationMode,
+  isCloudMutationEnabled,
+} from "@backend/common/services/sync-service/cloud-mutation-mode";
+import {
+  EventMutationException,
+  toEventMutationError,
+} from "@backend/event/event.error";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("cloud-mutation-mode", () => {
+  const originalMode = CONFIG.SYNC_CLOUD_MUTATION_MODE;
+
+  afterEach(() => {
+    CONFIG.SYNC_CLOUD_MUTATION_MODE = originalMode;
+  });
+
+  it("reports enabled by default in the test config", () => {
+    CONFIG.SYNC_CLOUD_MUTATION_MODE = "enabled";
+
+    expect(getCloudMutationMode()).toBe("enabled");
+    expect(isCloudMutationEnabled()).toBe(true);
+    expect(() => assertCloudMutationsAllowed()).not.toThrow();
+  });
+
+  it("throws a typed MAINTENANCE error when paused", () => {
+    CONFIG.SYNC_CLOUD_MUTATION_MODE = "maintenance";
+
+    expect(getCloudMutationMode()).toBe("maintenance");
+    expect(isCloudMutationEnabled()).toBe(false);
+
+    try {
+      assertCloudMutationsAllowed();
+      throw new Error("expected assertCloudMutationsAllowed to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(EventMutationException);
+      const { status, body } = toEventMutationError(error);
+      expect(status).toBe(Status.SERVICE_UNAVAILABLE);
+      expect(body).toEqual({
+        code: "MAINTENANCE",
+        message: "Cloud edits are paused for maintenance",
+        retryable: true,
+      });
+    }
+  });
+});

--- a/packages/backend/src/common/services/sync-service/cloud-mutation-mode.ts
+++ b/packages/backend/src/common/services/sync-service/cloud-mutation-mode.ts
@@ -1,0 +1,29 @@
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { eventMutationError } from "@backend/event/event.error";
+
+export type CloudMutationMode = "enabled" | "maintenance";
+
+/**
+ * Global cloud-mutation posture (S50). When `maintenance`, cloud event writes
+ * and provider-connection changes reject with a typed MAINTENANCE response.
+ * Orthogonal to connection/event routing and Sync execution.
+ */
+export function getCloudMutationMode(): CloudMutationMode {
+  return CONFIG.SYNC_CLOUD_MUTATION_MODE;
+}
+
+export function isCloudMutationEnabled(): boolean {
+  return getCloudMutationMode() === "enabled";
+}
+
+/**
+ * Throw a typed MAINTENANCE EventMutationException when cloud mutations are
+ * paused. Call at the edge of mutating controllers before any write work.
+ */
+export function assertCloudMutationsAllowed(): void {
+  if (isCloudMutationEnabled()) return;
+  throw eventMutationError(
+    "MAINTENANCE",
+    "Cloud edits are paused for maintenance",
+  );
+}

--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -23,6 +23,12 @@ describe("GET /api/config", () => {
           isConfigured: false,
           connectDelegatedToSync: false,
         },
+        sync: {
+          connectionRouting: "legacy",
+          eventRouting: "legacy",
+          cloudMutationMode: "enabled",
+          execution: "passive",
+        },
       });
     } finally {
       CONFIG.GOOGLE_CLIENT_ID = originalClientId;
@@ -47,6 +53,12 @@ describe("GET /api/config", () => {
           isConfigured: false,
           connectDelegatedToSync: false,
         },
+        sync: {
+          connectionRouting: "legacy",
+          eventRouting: "legacy",
+          cloudMutationMode: "enabled",
+          execution: "passive",
+        },
       });
     } finally {
       CONFIG.GOOGLE_CLIENT_ID = originalClientId;
@@ -63,5 +75,19 @@ describe("GET /api/config", () => {
       .expect(Status.OK);
 
     expect(response.body.google.connectDelegatedToSync).toBe(false);
+  });
+
+  it("exposes Sync cutover posture on a legacy deployment", async () => {
+    const response = await baseDriver
+      .getServer()
+      .get("/api/config")
+      .expect(Status.OK);
+
+    expect(response.body.sync).toEqual({
+      connectionRouting: "legacy",
+      eventRouting: "legacy",
+      cloudMutationMode: "enabled",
+      execution: "passive",
+    });
   });
 });

--- a/packages/backend/src/config/controllers/config.controller.test.ts
+++ b/packages/backend/src/config/controllers/config.controller.test.ts
@@ -45,3 +45,33 @@ describe("ConfigController.get connectDelegatedToSync", () => {
     expect(invokeGet().google.connectDelegatedToSync).toBe(true);
   });
 });
+
+describe("ConfigController.get sync cutover posture", () => {
+  const originals = {
+    connectionRouting: CONFIG.SYNC_CONNECTION_ROUTING,
+    eventRouting: CONFIG.SYNC_EVENT_ROUTING,
+    cloudMutationMode: CONFIG.SYNC_CLOUD_MUTATION_MODE,
+    execution: CONFIG.SYNC_EXECUTION,
+  };
+
+  afterEach(() => {
+    CONFIG.SYNC_CONNECTION_ROUTING = originals.connectionRouting;
+    CONFIG.SYNC_EVENT_ROUTING = originals.eventRouting;
+    CONFIG.SYNC_CLOUD_MUTATION_MODE = originals.cloudMutationMode;
+    CONFIG.SYNC_EXECUTION = originals.execution;
+  });
+
+  it("exposes the four global cutover knobs", () => {
+    CONFIG.SYNC_CONNECTION_ROUTING = "legacy";
+    CONFIG.SYNC_EVENT_ROUTING = "legacy";
+    CONFIG.SYNC_CLOUD_MUTATION_MODE = "maintenance";
+    CONFIG.SYNC_EXECUTION = "passive";
+
+    expect(invokeGet().sync).toEqual({
+      connectionRouting: "legacy",
+      eventRouting: "legacy",
+      cloudMutationMode: "maintenance",
+      execution: "passive",
+    });
+  });
+});

--- a/packages/backend/src/config/controllers/config.controller.ts
+++ b/packages/backend/src/config/controllers/config.controller.ts
@@ -2,6 +2,7 @@ import { type Request, type Response } from "express";
 import { type AppConfig, AppConfigSchema } from "@core/types/config.types";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { isGoogleConfigured } from "@backend/common/constants/config.util";
+import { getCloudMutationMode } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
 
 class ConfigController {
@@ -11,6 +12,12 @@ class ConfigController {
         google: {
           isConfigured: isGoogleConfigured(CONFIG),
           connectDelegatedToSync: getConnectionDelegation() === "sync",
+        },
+        sync: {
+          connectionRouting: CONFIG.SYNC_CONNECTION_ROUTING,
+          eventRouting: CONFIG.SYNC_EVENT_ROUTING,
+          cloudMutationMode: getCloudMutationMode(),
+          execution: CONFIG.SYNC_EXECUTION,
         },
       }),
     );

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -23,6 +23,7 @@ import {
 import calendarService from "@backend/calendar/services/calendar.service";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
+import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import {
   toCreateSubmitRequest,
   toDeleteSubmitRequest,
@@ -251,6 +252,7 @@ class EventController {
 
   create = async (req: SessionRequest, res: Response) => {
     try {
+      assertCloudMutationsAllowed();
       const userId = req.session?.getUserId() as string;
       const input = CreateEventInputSchema.parse(req.body);
       const event =
@@ -266,6 +268,7 @@ class EventController {
 
   replace = async (req: SessionRequest, res: Response) => {
     try {
+      assertCloudMutationsAllowed();
       const userId = req.session?.getUserId() as string;
       const eventId = req.params["id"] as string;
       const input = ReplaceEventInputSchema.parse(req.body);
@@ -282,6 +285,7 @@ class EventController {
 
   delete = async (req: SessionRequest, res: Response) => {
     try {
+      assertCloudMutationsAllowed();
       const userId = req.session?.getUserId() as string;
       const eventId = req.params["id"] as string;
       const scopeParam = req.query["scope"];

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -18,6 +18,7 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   DUPLICATE_EVENT_ID: Status.CONFLICT,
   INVALID_SCHEDULE: Status.BAD_REQUEST,
   PROVIDER_FAILURE: 502 as Status,
+  MAINTENANCE: Status.SERVICE_UNAVAILABLE,
 };
 
 const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
@@ -28,6 +29,7 @@ const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
   DUPLICATE_EVENT_ID: false,
   INVALID_SCHEDULE: false,
   PROVIDER_FAILURE: true,
+  MAINTENANCE: true,
 };
 
 export class EventMutationException extends BaseError {

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -11,6 +11,8 @@ import {
   isInvalidGoogleToken,
 } from "@backend/common/services/gcal/gcal.utils";
 import mongoService from "@backend/common/services/mongo.service";
+import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
+import { toEventMutationError } from "@backend/event/event.error";
 import { isMissingGoogleRefreshToken } from "@backend/sync/services/google-sync/google-sync.errors";
 import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
@@ -25,6 +27,17 @@ import { ImportGCalRequestSchema } from "../sync.types";
 
 const logger = Logger("app:sync.controller");
 const REPAIR_STARTED = "REPAIR_STARTED" satisfies NotificationOutcome;
+
+const rejectIfMaintenance = (res: Response): boolean => {
+  try {
+    assertCloudMutationsAllowed();
+    return false;
+  } catch (err) {
+    const { status, body } = toEventMutationError(err);
+    res.status(status).json(body);
+    return true;
+  }
+};
 
 export class SyncController {
   private static handleMissingRefreshToken = async (
@@ -254,6 +267,7 @@ export class SyncController {
   };
 
   static maintain = async (_req: Request, res: Response) => {
+    if (rejectIfMaintenance(res)) return;
     try {
       // To avoid 504 timeouts on this long running endpoint
       // to support the reliance of the google cloud function
@@ -281,6 +295,7 @@ export class SyncController {
   };
 
   static importGCal = (req: Request, res: Response): void => {
+    if (rejectIfMaintenance(res)) return;
     const userId = req.session!.getUserId();
     const { force } = ImportGCalRequestSchema.parse(req.body);
     const isForce = force === true;

--- a/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
+++ b/packages/backend/src/sync/services/event-propagation/compass-to-google/compass-to-google.event-propagation.ts
@@ -4,6 +4,7 @@ import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
+import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import { eventMutationError } from "@backend/event/event.error";
 import { type EventRecord } from "@backend/event/event.record";
 import { eventRepository } from "@backend/event/event.repository";
@@ -77,6 +78,10 @@ export class CompassToGoogleEventPropagation {
     userId: string,
     change: EventChangeSet,
   ): Promise<void> {
+    // Defense-in-depth for cutover maintenance (S50): controllers should
+    // already reject, but never let a late Google write escape.
+    assertCloudMutationsAllowed();
+
     const calendarIds = [
       ...new Set(
         [...change.upserted, ...change.deletedBefore].map((event) =>
@@ -154,6 +159,10 @@ export class CompassToGoogleEventPropagation {
     from: CalendarRecord,
     to: CalendarRecord,
   ): Promise<void> {
+    // Defense-in-depth for cutover maintenance (S50): controllers should
+    // already reject, but never let a late Google write escape.
+    assertCloudMutationsAllowed();
+
     const fromGoogle = from.source.provider === "google" ? from.source : null;
     const toGoogle = to.source.provider === "google" ? to.source : null;
 

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -89,6 +89,11 @@ const CompassConfigSchema = z
         // "sync" delegates to the standalone Sync service and requires
         // serviceUrl (validated backend-side).
         eventRouting: z.enum(["legacy", "sync"]).optional(),
+        // Whether cloud event writes and provider-connection changes are
+        // accepted (`enabled`) or rejected with a typed MAINTENANCE response
+        // (`maintenance`). Independent of routing/execution so cutover can
+        // pause mutations while Sync stays passive or active.
+        cloudMutationMode: z.enum(["enabled", "maintenance"]).optional(),
         callbackBaseUrl: z.string(),
         // Where the OAuth callback redirects the browser after connecting;
         // defaults to callbackBaseUrl when omitted.

--- a/packages/core/src/types/config.types.ts
+++ b/packages/core/src/types/config.types.ts
@@ -12,6 +12,23 @@ export const AppConfigSchema = z.object({
      */
     connectDelegatedToSync: z.boolean().default(false),
   }),
+  /**
+   * Operator-visible Sync cutover posture (S50). Global deployment knobs —
+   * never per-user. Defaults match safe pre-cutover values when omitted.
+   */
+  sync: z
+    .object({
+      connectionRouting: z.enum(["legacy", "sync"]).default("legacy"),
+      eventRouting: z.enum(["legacy", "sync"]).default("legacy"),
+      cloudMutationMode: z.enum(["enabled", "maintenance"]).default("enabled"),
+      execution: z.enum(["passive", "active"]).default("passive"),
+    })
+    .default({
+      connectionRouting: "legacy",
+      eventRouting: "legacy",
+      cloudMutationMode: "enabled",
+      execution: "passive",
+    }),
 });
 
 export type AppConfig = z.infer<typeof AppConfigSchema>;

--- a/packages/core/src/types/event-command.contracts.test.ts
+++ b/packages/core/src/types/event-command.contracts.test.ts
@@ -224,6 +224,7 @@ describe("Event Command Contracts", () => {
         "DUPLICATE_EVENT_ID",
         "INVALID_SCHEDULE",
         "PROVIDER_FAILURE",
+        "MAINTENANCE",
       ] as const;
 
       for (const code of codes) {

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -111,6 +111,8 @@ export const EventMutationErrorCodeSchema = z.enum([
   "DUPLICATE_EVENT_ID",
   "INVALID_SCHEDULE",
   "PROVIDER_FAILURE",
+  // Scoped cutover maintenance: cloud/provider mutations paused (S50).
+  "MAINTENANCE",
 ]);
 
 export const EventMutationErrorSchema = z.strictObject({

--- a/packages/web/src/api/util/backend-unavailable-error.util.test.ts
+++ b/packages/web/src/api/util/backend-unavailable-error.util.test.ts
@@ -75,6 +75,20 @@ describe("isBackendUnavailableError", () => {
     ).toBe(false);
   });
 
+  it("does not treat a maintenance 503 as backend unavailability", () => {
+    // Cutover maintenance answers with 503 + EventMutationError. The API is
+    // up; flipping into local mode would hide the pause and rewrite IndexedDB.
+    expect(
+      isBackendUnavailableError(
+        createApiErrorWithStatus(Status.SERVICE_UNAVAILABLE, {
+          code: "MAINTENANCE",
+          message: "Cloud edits are paused for maintenance",
+          retryable: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("still treats a gateway error with no backend body as unavailability", () => {
     expect(
       isBackendUnavailableError(

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -54,8 +54,9 @@ supertokens:
 #   serviceUrl: http://sync:3010 # base URL the API uses to reach this service; set when delegating to sync
 #   connectionRouting: legacy # legacy (default) | sync; sync delegates provider-connection routes here and requires serviceUrl
 #   eventRouting: legacy # legacy (default) | sync; sync delegates calendar/event reads + commands here and requires serviceUrl
+#   cloudMutationMode: enabled # enabled (default) | maintenance — maintenance rejects cloud edits / connect with typed MAINTENANCE
 # Public OAuth/webhook paths (via Caddy → sync): /sync/google, /sync/notifications/google
-#   execution: passive # passive | active
+#   execution: passive # passive | active — active required for OAuth begin + provider import/jobs; refuse active+enabled while any routing is legacy
 #   maxConcurrency: 4
 #   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)
 #   compassApiDatabase: prod_calendar # API database the least-privilege check must be denied access to


### PR DESCRIPTION
## Summary

S50 cutover controls for Sync migration:

- `sync.cloudMutationMode` / `SYNC_CLOUD_MUTATION_MODE` (`enabled` | `maintenance`, default `enabled`)
- `sync.execution` / `SYNC_EXECUTION` mirrored on the API for startup guard + operator surface
- Typed `MAINTENANCE` (`503`, retryable) on cloud event mutations, Google connect, sync maintain/import, and defense-in-depth Google propagation
- `GET /api/config` exposes `{ connectionRouting, eventRouting, cloudMutationMode, execution }`
- Startup refuses `active` + `enabled` while any routing remains `legacy` (dual-writer)

Does not add per-user routing or long-lived dual-write. Production Sync routing remains founder-gated.

## Simplicity

One global mutation posture helper (`assertCloudMutationsAllowed`) reused at controller edges and propagation. Routing/execution remain independent knobs; only the unsafe combination is refused at parse time.

## Automated validation

- Config parse matrix: defaults, maintenance+active+legacy allowed, active+enabled only when both routings are sync, dual-writer refused (env + yaml)
- `assertCloudMutationsAllowed` → `503` + `{ code: "MAINTENANCE", retryable: true }`
- `GET /api/config` includes sync cutover block
- Web: typed `MAINTENANCE` 503 is not treated as backend-down / IndexedDB flip

## Independent review

Self-reviewed against ledger S50: scoped maintenance, operator-visible mode, validated routing, dual-writer startup guard. No per-user routing.

## Test plan

```bash
bun type-check
bun lint
bun test:backend packages/backend/src/common/constants/config.constants.test.ts packages/backend/src/common/services/sync-service/cloud-mutation-mode.test.ts packages/backend/src/config/controllers/config.controller.test.ts packages/backend/src/config/config.route.test.ts
bun test:core packages/core/src/types/event-command.contracts.test.ts
bun test:web packages/web/src/api/util/backend-unavailable-error.util.test.ts
```

Made with [Cursor](https://cursor.com)