### PR TITLE
fix(backend): preserve maintenance envelope in express errors

### DIFF
--- a/packages/backend/src/auth/controllers/auth.controller.test.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.test.ts
@@ -1,10 +1,40 @@
+import { Status } from "@core/errors/status.codes";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import authController from "./auth.controller";
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 
 describe("auth.controller", () => {
   describe("connectGoogle", () => {
+    const originalMutationMode = CONFIG.SYNC_CLOUD_MUTATION_MODE;
+
+    afterEach(() => {
+      CONFIG.SYNC_CLOUD_MUTATION_MODE = originalMutationMode;
+    });
+
+    it("rejects Google connect with typed MAINTENANCE during cutover", () => {
+      CONFIG.SYNC_CLOUD_MUTATION_MODE = "maintenance";
+      const status = mock().mockReturnThis();
+      const json = mock();
+      const promise = mock();
+
+      authController.connectGoogle(
+        {
+          body: {},
+          session: { getUserId: () => "507f1f77bcf86cd799439011" },
+        } as never,
+        { status, json, promise } as never,
+      );
+
+      expect(promise).not.toHaveBeenCalled();
+      expect(status).toHaveBeenCalledWith(Status.SERVICE_UNAVAILABLE);
+      expect(json).toHaveBeenCalledWith({
+        code: "MAINTENANCE",
+        message: "Cloud edits are paused for maintenance",
+        retryable: true,
+      });
+    });
+
     it("rejects Google connect when Google is not configured", async () => {
       const originalClientId = CONFIG.GOOGLE_CLIENT_ID;
       const originalClientSecret = CONFIG.GOOGLE_CLIENT_SECRET;
@@ -56,6 +86,37 @@ describe("auth.controller", () => {
       await expect(promise.mock.calls[0][0]).rejects.toMatchObject({
         code: AuthError.GoogleNotConfigured.code,
         description: AuthError.GoogleNotConfigured.description,
+      });
+    });
+  });
+
+  describe("beginGoogleConnection", () => {
+    const originalMutationMode = CONFIG.SYNC_CLOUD_MUTATION_MODE;
+
+    afterEach(() => {
+      CONFIG.SYNC_CLOUD_MUTATION_MODE = originalMutationMode;
+    });
+
+    it("rejects connect begin with typed MAINTENANCE during cutover", () => {
+      CONFIG.SYNC_CLOUD_MUTATION_MODE = "maintenance";
+      const status = mock().mockReturnThis();
+      const json = mock();
+      const promise = mock();
+
+      authController.beginGoogleConnection(
+        {
+          body: {},
+          session: { getUserId: () => "507f1f77bcf86cd799439011" },
+        } as never,
+        { status, json, promise } as never,
+      );
+
+      expect(promise).not.toHaveBeenCalled();
+      expect(status).toHaveBeenCalledWith(Status.SERVICE_UNAVAILABLE);
+      expect(json).toHaveBeenCalledWith({
+        code: "MAINTENANCE",
+        message: "Cloud edits are paused for maintenance",
+        retryable: true,
       });
     });
   });

--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -22,6 +22,10 @@ import {
   type Info_Error,
 } from "@backend/common/types/error.types";
 import { type SessionResponse } from "@backend/common/types/express.types";
+import {
+  EventMutationException,
+  toEventMutationError,
+} from "@backend/event/event.error";
 import { pruneGoogleDataAndNotifyRevoked } from "@backend/sync/services/google-sync/google-sync.revoked";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { getSyncByToken } from "@backend/sync/services/records/sync-records.repository";
@@ -82,7 +86,12 @@ export const handleExpressError = async (
   res.header("Content-Type", "application/json");
 
   errorHandler.log(e);
-  if (e instanceof BaseError) {
+  // Typed mutation/cutover errors must keep the EventMutationError envelope
+  // (`code`/`message`/`retryable`), not the generic `{ result, message }` shape.
+  if (e instanceof EventMutationException) {
+    const { status, body } = toEventMutationError(e);
+    res.status(status).json(body);
+  } else if (e instanceof BaseError) {
     res.status(e.statusCode).json(toClientErrorPayload(e));
   } else {
     const userId = await parseUserId(res, e);

--- a/packages/backend/src/common/errors/handlers/error.handler.test.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.test.ts
@@ -8,6 +8,7 @@ import {
   toClientErrorPayload,
 } from "@backend/common/errors/handlers/error.handler";
 import { UserError } from "@backend/common/errors/user/user.errors";
+import { eventMutationError } from "@backend/event/event.error";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import userService from "@backend/user/services/user.service";
 import { describe, expect, it, mock, spyOn } from "bun:test";
@@ -62,6 +63,32 @@ describe("error.handler", () => {
   });
 
   describe("handleExpressError", () => {
+    it("returns the EventMutationError envelope for MAINTENANCE", async () => {
+      const json = mock();
+      const res = {
+        header: mock().mockReturnThis(),
+        status: mock().mockReturnThis(),
+        json,
+      } as unknown as Parameters<typeof handleExpressError>[1];
+      const req = {} as Parameters<typeof handleExpressError>[0];
+
+      await handleExpressError(
+        req,
+        res,
+        eventMutationError(
+          "MAINTENANCE",
+          "Cloud edits are paused for maintenance",
+        ),
+      );
+
+      expect(res.status).toHaveBeenCalledWith(Status.SERVICE_UNAVAILABLE);
+      expect(json).toHaveBeenCalledWith({
+        code: "MAINTENANCE",
+        message: "Cloud edits are paused for maintenance",
+        retryable: true,
+      });
+    });
+
     it("returns 401 with GOOGLE_REVOKED payload when Google token is invalid", async () => {
       const userId = "507f1f77bcf86cd799439011";
       spyOn(userService, "pruneGoogleData").mockResolvedValue();


### PR DESCRIPTION
## Summary

Follow-up to S50 (#2392): keep typed `MAINTENANCE` responses as `{ code, message, retryable }` when `EventMutationException` flows through `handleExpressError` / promise middleware. Auth connect already responds via `toEventMutationError` on the PR tip; this hardens the shared path and adds regression tests.

## Simplicity

One instanceof branch in the shared express handler; auth controller tests pin the cutover response shape.

## Automated validation

- `handleExpressError(MAINTENANCE)` → 503 + EventMutationError envelope
- `connectGoogle` / `beginGoogleConnection` under `cloudMutationMode=maintenance` return the same envelope without `res.promise`

## Test plan

```bash
bun test:backend packages/backend/src/common/errors/handlers/error.handler.test.ts packages/backend/src/auth/controllers/auth.controller.test.ts
```

Made with [Cursor](https://cursor.com)