### PR TITLE
feat(scripts): preseed sync service safely

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -21,6 +21,7 @@ Primary file:
 | `bun run cli migrate-connections [--apply] [--out report.json] [--user-id id]...` | `packages/scripts/src/commands/migrate-connections.ts` | S47: idempotently upsert Sync connections + credentials from legacy users. Default dry-run; `--apply` writes. Never clears source tokens or enqueues Sync jobs. |
 | `bun run cli migrate-provider-state [--apply] [--out report.json] [--user-id id]...` | `packages/scripts/src/commands/migrate-provider-state.ts` | S48: idempotently upsert Sync calendars, linked events, occurrences, and sync cursors from legacy data. Default dry-run; `--apply` writes. Requires S47 connections. Defers unlinked events to S49; skips legacy watches for Sync rewatch. |
 | `bun run cli migrate-pending-intent [--apply] [--out report.json] [--user-id id]... [--target-calendar-id id] [--target-gcal-id id]` | `packages/scripts/src/commands/migrate-pending-intent.ts` | S49: preserve unlinked Compass events in Sync and submit resumable backfill create commands. Default dry-run; `--apply` writes. Never infers target by email; never mirrors already-linked events. |
+| `bun run cli preseed-sync [--apply] [--out dir] [--mode live\|frozen] [--phase inventory\|connections\|state\|pending\|all] [--user-id id]...` | `packages/scripts/src/commands/preseed-sync.ts` | S51: compose S46–S49 into a resumable Sync pre-seed with blocking parity + immutable execution record under `--out`. Exit 1 when parity blockers remain. Never enables workers/callbacks or deletes source. |
 
 ## Migration Internals
 

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -14,6 +14,7 @@ const mockRunMigrateProviderState = mock(
 const mockRunMigratePendingIntent = mock(
   (): Promise<void> => Promise.resolve(),
 );
+const mockRunPreseedSync = mock((): Promise<void> => Promise.resolve());
 
 mock.module("@scripts/cli.validator", () => ({
   CliValidator: mock().mockImplementation(() => ({
@@ -44,6 +45,11 @@ mock.module("@scripts/commands/migrate-provider-state", () => ({
 mock.module("@scripts/commands/migrate-pending-intent", () => ({
   __esModule: true,
   runMigratePendingIntent: mock(() => mockRunMigratePendingIntent()),
+}));
+
+mock.module("@scripts/commands/preseed-sync", () => ({
+  __esModule: true,
+  runPreseedSync: mock(() => mockRunPreseedSync()),
 }));
 
 const { default: CompassCLI } = requireActual(
@@ -93,6 +99,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunMigratePendingIntent).toHaveBeenCalled();
+  });
+
+  it("runs preseed-sync command", async () => {
+    const cli = new CompassCLI(["node", "cli", "preseed-sync"]);
+
+    await cli.run();
+
+    expect(mockRunPreseedSync).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -4,6 +4,7 @@ import { runMigrator } from "@scripts/commands/migrate";
 import { runMigrateConnections } from "@scripts/commands/migrate-connections";
 import { runMigratePendingIntent } from "@scripts/commands/migrate-pending-intent";
 import { runMigrateProviderState } from "@scripts/commands/migrate-provider-state";
+import { runPreseedSync } from "@scripts/commands/preseed-sync";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
 
@@ -36,6 +37,9 @@ export default class CompassCLI {
       case cmd === "migrate-pending-intent":
         await runMigratePendingIntent();
         break;
+      case cmd === "preseed-sync":
+        await runPreseedSync();
+        break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }
@@ -46,8 +50,16 @@ export default class CompassCLI {
 
     program.enablePositionalOptions(true).passThroughOptions(true);
 
-    // Register longer `migrate-*` names before `migrate` so Commander does not
-    // treat them as unknown args to the Umzug migrate command.
+    // Register longer `migrate-*` / preseed names before `migrate` so Commander
+    // does not treat them as unknown args to the Umzug migrate command.
+    program
+      .command("preseed-sync")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "compose S46–S49 Sync pre-seed with blocking parity (S51; --apply to write)",
+      );
+
     program
       .command("migrate-pending-intent")
       .helpOption(false)

--- a/packages/scripts/src/commands/preseed-sync.db.test.ts
+++ b/packages/scripts/src/commands/preseed-sync.db.test.ts
@@ -1,0 +1,249 @@
+import { runPreseedSyncComposition } from "@scripts/commands/preseed-sync/preseed";
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+const NOW = new Date("2026-07-25T04:00:00.000Z");
+
+describe("preseed-sync (db)", () => {
+  const syncStorage = setupSyncStorage(import.meta.url);
+
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+    await mongoService.calendar.deleteMany({});
+    await mongoService.event.deleteMany({});
+    await mongoService.sync.deleteMany({});
+    await mongoService.watch.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  async function seedGoogleUser() {
+    const userId = new ObjectId();
+    const calendarId = new ObjectId();
+    const eventId = new ObjectId();
+
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "preseed@example.com",
+      firstName: "Pre",
+      lastName: "Seed",
+      name: "Pre Seed",
+      locale: "en",
+      google: {
+        googleId: "google-subject-preseed",
+        picture: "",
+        gRefreshToken: "preseed-refresh",
+      },
+    });
+    await mongoService.calendar.insertOne({
+      _id: calendarId,
+      userId,
+      name: "Primary",
+      description: "",
+      timeZone: "America/Denver",
+      foregroundColor: "#000000",
+      backgroundColor: "#4285f4",
+      access: "owner",
+      isPrimary: true,
+      isVisible: true,
+      isActive: true,
+      source: {
+        provider: "google",
+        calendarId: "primary",
+        etag: "etag-preseed",
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+    await mongoService.event.insertOne({
+      _id: eventId,
+      calendarId,
+      content: { kind: "details", title: "linked", description: "" },
+      schedule: {
+        kind: "timed",
+        start: NOW,
+        end: new Date(NOW.getTime() + 3600_000),
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "single" },
+      externalReference: {
+        provider: "google",
+        eventId: "gcal-event-1",
+        recurringEventId: null,
+      },
+      createdAt: NOW,
+      updatedAt: null,
+    });
+
+    return { userId };
+  }
+
+  async function loadCollections() {
+    const [users, calendars, events, syncDocs, watches] = await Promise.all([
+      mongoService.user.find({}).toArray(),
+      mongoService.calendar.find({}).toArray(),
+      mongoService.event.find({}).toArray(),
+      mongoService.sync.find({}).toArray(),
+      mongoService.watch.find({}).toArray(),
+    ]);
+    return { users, calendars, events, syncDocs, watches };
+  }
+
+  it("dry-run writes nothing; apply then frozen rerun converges", async () => {
+    const { userId } = await seedGoogleUser();
+
+    const dry = await runPreseedSyncComposition(
+      {
+        loadCollections,
+        syncDb: syncStorage.db(),
+        syncClient: syncStorage.client(),
+      },
+      {
+        dryRun: true,
+        mode: "live",
+        phase: "all",
+        now: NOW,
+      },
+    );
+
+    expect(dry.report.phases.connections?.counts.wouldCreate).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerConnections)
+        .countDocuments(),
+    ).toBe(0);
+
+    const sourceBefore = await mongoService.user.findOne({ _id: userId });
+    expect(sourceBefore?.google?.gRefreshToken).toBe("preseed-refresh");
+
+    const applied = await runPreseedSyncComposition(
+      {
+        loadCollections,
+        syncDb: syncStorage.db(),
+        syncClient: syncStorage.client(),
+      },
+      {
+        dryRun: false,
+        mode: "live",
+        phase: "all",
+        now: NOW,
+      },
+    );
+    expect(applied.exitCode).toBe(0);
+    expect(applied.report.phases.connections?.counts.created).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerConnections)
+        .countDocuments(),
+    ).toBe(1);
+
+    const sourceAfter = await mongoService.user.findOne({ _id: userId });
+    expect(sourceAfter?.google?.gRefreshToken).toBe("preseed-refresh");
+
+    const frozen = await runPreseedSyncComposition(
+      {
+        loadCollections,
+        syncDb: syncStorage.db(),
+        syncClient: syncStorage.client(),
+      },
+      {
+        dryRun: false,
+        mode: "frozen",
+        phase: "all",
+        now: NOW,
+      },
+    );
+    expect(frozen.exitCode).toBe(0);
+    expect(frozen.report.parity.ok).toBe(true);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.providerConnections)
+        .countDocuments(),
+    ).toBe(1);
+  });
+
+  it("blocks when inventory finds duplicate google calendars", async () => {
+    const userId = new ObjectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "dup@example.com",
+      firstName: "Dup",
+      lastName: "User",
+      name: "Dup User",
+      locale: "en",
+      google: {
+        googleId: "google-subject-dup",
+        picture: "",
+        gRefreshToken: "dup-refresh",
+      },
+    });
+    await mongoService.calendar.insertMany([
+      {
+        _id: new ObjectId(),
+        userId,
+        name: "Primary A",
+        description: "",
+        timeZone: "UTC",
+        foregroundColor: "#000",
+        backgroundColor: "#fff",
+        access: "owner",
+        isPrimary: true,
+        isVisible: true,
+        isActive: true,
+        source: { provider: "google", calendarId: "primary", etag: "a" },
+        createdAt: NOW,
+        updatedAt: null,
+      },
+      {
+        _id: new ObjectId(),
+        userId,
+        name: "Primary B",
+        description: "",
+        timeZone: "UTC",
+        foregroundColor: "#000",
+        backgroundColor: "#fff",
+        access: "owner",
+        isPrimary: false,
+        isVisible: true,
+        isActive: true,
+        source: { provider: "google", calendarId: "primary", etag: "b" },
+        createdAt: NOW,
+        updatedAt: null,
+      },
+    ]);
+
+    const result = await runPreseedSyncComposition(
+      {
+        loadCollections,
+        syncDb: syncStorage.db(),
+        syncClient: syncStorage.client(),
+      },
+      {
+        dryRun: true,
+        mode: "live",
+        phase: "inventory",
+        now: NOW,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report.parity.ok).toBe(false);
+    expect(
+      result.report.parity.blockers.some(
+        (b) => b.code === "inventory_duplicate",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/scripts/src/commands/preseed-sync.ts
+++ b/packages/scripts/src/commands/preseed-sync.ts
@@ -1,0 +1,159 @@
+import { loadInventoryCollections } from "@scripts/commands/inventory-legacy-sync/inventory";
+import { runPreseedSyncComposition } from "@scripts/commands/preseed-sync/preseed";
+import {
+  type PreseedMode,
+  PreseedModeSchema,
+  type PreseedPhase,
+  PreseedPhaseSchema,
+} from "@scripts/commands/preseed-sync/report.types";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { resolve } from "node:path";
+
+const logger = Logger("scripts.commands.preseed-sync");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before preseed-sync",
+    );
+  }
+  return uri;
+}
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  outDir: string | null;
+  userIds: Set<string> | undefined;
+  mode: PreseedMode;
+  phase: PreseedPhase;
+  targetCalendarId: string | undefined;
+  targetGcalId: string | undefined;
+} {
+  const apply = argv.includes("--apply");
+  const dryRun = !apply;
+  const outFlag = argv.indexOf("--out");
+  const outDir =
+    outFlag >= 0 && argv[outFlag + 1] ? resolve(argv[outFlag + 1]!) : null;
+
+  const userIds = new Set<string>();
+  let mode: PreseedMode = "live";
+  let phase: PreseedPhase = "all";
+  let targetCalendarId: string | undefined;
+  let targetGcalId: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--user-id" && argv[i + 1]) {
+      userIds.add(argv[i + 1]!);
+      i += 1;
+    } else if (argv[i] === "--mode" && argv[i + 1]) {
+      mode = PreseedModeSchema.parse(argv[i + 1]);
+      i += 1;
+    } else if (argv[i] === "--phase" && argv[i + 1]) {
+      phase = PreseedPhaseSchema.parse(argv[i + 1]);
+      i += 1;
+    } else if (argv[i] === "--target-calendar-id" && argv[i + 1]) {
+      targetCalendarId = argv[i + 1]!;
+      i += 1;
+    } else if (argv[i] === "--target-gcal-id" && argv[i + 1]) {
+      targetGcalId = argv[i + 1]!;
+      i += 1;
+    }
+  }
+
+  return {
+    dryRun,
+    outDir,
+    userIds: userIds.size > 0 ? userIds : undefined,
+    mode,
+    phase,
+    targetCalendarId,
+    targetGcalId,
+  };
+}
+
+/**
+ * S51: compose S46–S49 into a resumable Sync pre-seed with blocking parity and
+ * an immutable execution record. Default dry-run; `--apply` writes Sync only.
+ * Never enables workers/callbacks, never deletes source, never calls Google.
+ *
+ * Usage:
+ *   bun run cli preseed-sync [--apply] [--out <dir>] [--mode live|frozen]
+ *     [--phase inventory|connections|state|pending|all]
+ *     [--user-id <id>]... [--target-calendar-id id] [--target-gcal-id id]
+ */
+export async function runPreseedSync(): Promise<void> {
+  const argv = process.argv.slice(3);
+  const {
+    dryRun,
+    outDir,
+    userIds,
+    mode,
+    phase,
+    targetCalendarId,
+    targetGcalId,
+  } = parseArgs(argv);
+  const syncMongo = new SyncMongoService();
+
+  try {
+    await mongoService.start();
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const result = await runPreseedSyncComposition(
+      {
+        loadCollections: () => loadInventoryCollections(mongoService),
+        syncDb: syncMongo.db,
+        syncClient: syncMongo.client,
+      },
+      {
+        dryRun,
+        mode,
+        phase,
+        userIds,
+        targetCalendarId,
+        targetGcalId,
+        outDir,
+        argv,
+        gitSha: process.env["GITHUB_SHA"] ?? process.env["GIT_SHA"] ?? null,
+        compassApiMongoDbName: mongoService.db?.databaseName ?? null,
+        syncMongoDbName: syncMongo.db.databaseName,
+      },
+    );
+
+    if (!outDir) {
+      process.stdout.write(`${JSON.stringify(result.report, null, 2)}\n`);
+    } else {
+      logger.info(`Wrote preseed artifacts to ${outDir}`);
+    }
+
+    logger.info(
+      `preseed-sync dryRun=${result.report.dryRun} mode=${result.report.mode} phase=${result.report.phase} parity.ok=${result.report.parity.ok} blockers=${result.report.parity.blockers.length} warnings=${result.report.parity.warnings.length} exit=${result.exitCode}`,
+    );
+
+    await syncMongo.disconnect();
+    await mongoService.stop();
+    process.exit(result.exitCode);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    try {
+      await mongoService.stop();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/preseed-sync/execution-record.test.ts
+++ b/packages/scripts/src/commands/preseed-sync/execution-record.test.ts
@@ -1,0 +1,95 @@
+import {
+  buildExecutionRecord,
+  writePreseedArtifacts,
+} from "@scripts/commands/preseed-sync/execution-record";
+import { type PreseedParityReport } from "@scripts/commands/preseed-sync/report.types";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const parityReport = {
+  generatedAt: "2026-07-25T00:00:00.000Z",
+  dryRun: true,
+  mode: "live",
+  phase: "all",
+  userIdFilter: null,
+  phases: {},
+  parity: {
+    ok: true,
+    blockers: [],
+    warnings: [],
+    counts: {
+      unexplainedSkips: 0,
+      duplicateIdentities: 0,
+      orphans: 0,
+      missingAuthority: 0,
+      credentialVerifyFailures: 0,
+      deltaCreates: 0,
+      deltaUpdates: 0,
+    },
+  },
+} satisfies PreseedParityReport;
+
+describe("execution-record", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("builds a schema-valid record with cutover safety flags false", () => {
+    const startedAt = new Date("2026-07-25T00:00:00.000Z");
+    const finishedAt = new Date("2026-07-25T00:00:01.000Z");
+    const record = buildExecutionRecord({
+      startedAt,
+      finishedAt,
+      argv: ["--mode", "live"],
+      dryRun: true,
+      mode: "live",
+      phase: "all",
+      userIdFilter: null,
+      outDir: "/tmp/preseed",
+      gitSha: "abc",
+      compassApiMongoDbName: "dev_calendar",
+      syncMongoDbName: "compass_sync",
+      phasesExecuted: [],
+      parityReport,
+      exitCode: 0,
+    });
+
+    expect(record.kind).toBe("sync-preseed-execution");
+    expect(record.durationMs).toBe(1000);
+    expect(record.environment.workersEnabledByThisTool).toBe(false);
+    expect(record.environment.callbacksEnabledByThisTool).toBe(false);
+    expect(record.environment.sourceRecordsDeletedByThisTool).toBe(false);
+  });
+
+  it("refuses to overwrite an existing execution record", () => {
+    const dir = mkdtempSync(join(tmpdir(), "preseed-"));
+    dirs.push(dir);
+    const record = buildExecutionRecord({
+      startedAt: new Date(),
+      finishedAt: new Date(),
+      argv: [],
+      dryRun: true,
+      mode: "live",
+      phase: "inventory",
+      userIdFilter: null,
+      outDir: dir,
+      gitSha: null,
+      compassApiMongoDbName: null,
+      syncMongoDbName: null,
+      phasesExecuted: [],
+      parityReport,
+      exitCode: 0,
+    });
+
+    writePreseedArtifacts(dir, parityReport, record, []);
+    expect(() => writePreseedArtifacts(dir, parityReport, record, [])).toThrow(
+      /Refusing to overwrite immutable execution record/,
+    );
+  });
+});

--- a/packages/scripts/src/commands/preseed-sync/execution-record.ts
+++ b/packages/scripts/src/commands/preseed-sync/execution-record.ts
@@ -1,0 +1,115 @@
+import {
+  type PreseedExecutionRecord,
+  PreseedExecutionRecordSchema,
+  type PreseedMode,
+  type PreseedParityReport,
+  type PreseedPhase,
+} from "@scripts/commands/preseed-sync/report.types";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type PhaseExecutionSummary = {
+  name: "inventory" | "connections" | "state" | "pending";
+  startedAt: string;
+  finishedAt: string;
+  dryRun: boolean;
+  summaryCounts: Record<string, number>;
+  artifactPath: string;
+};
+
+export function buildExecutionRecord(args: {
+  startedAt: Date;
+  finishedAt: Date;
+  argv: string[];
+  dryRun: boolean;
+  mode: PreseedMode;
+  phase: PreseedPhase;
+  userIdFilter: string[] | null;
+  outDir: string | null;
+  gitSha: string | null;
+  compassApiMongoDbName: string | null;
+  syncMongoDbName: string | null;
+  phasesExecuted: PhaseExecutionSummary[];
+  parityReport: PreseedParityReport;
+  exitCode: 0 | 1;
+}): PreseedExecutionRecord {
+  return PreseedExecutionRecordSchema.parse({
+    schemaVersion: 1,
+    kind: "sync-preseed-execution",
+    runId: randomUUID(),
+    startedAt: args.startedAt.toISOString(),
+    finishedAt: args.finishedAt.toISOString(),
+    durationMs: Math.max(
+      0,
+      args.finishedAt.getTime() - args.startedAt.getTime(),
+    ),
+    command: {
+      argv: args.argv,
+      dryRun: args.dryRun,
+      apply: !args.dryRun,
+      mode: args.mode,
+      phase: args.phase,
+      userIdFilter: args.userIdFilter,
+      outDir: args.outDir,
+    },
+    environment: {
+      gitSha: args.gitSha,
+      nodeBun: process.versions.bun ?? process.version,
+      compassApiMongoDbName: args.compassApiMongoDbName,
+      syncMongoDbName: args.syncMongoDbName,
+      workersEnabledByThisTool: false,
+      callbacksEnabledByThisTool: false,
+      sourceRecordsDeletedByThisTool: false,
+    },
+    phasesExecuted: args.phasesExecuted,
+    parity: {
+      ok: args.parityReport.parity.ok,
+      blockerCount: args.parityReport.parity.blockers.length,
+      warningCount: args.parityReport.parity.warnings.length,
+      reportPath: "parity-report.json",
+    },
+    exitCode: args.exitCode,
+  });
+}
+
+/**
+ * Write immutable preseed artifacts. Refuses to overwrite an existing
+ * execution-record.json in the destination directory.
+ */
+export function writePreseedArtifacts(
+  outDir: string,
+  parityReport: PreseedParityReport,
+  executionRecord: PreseedExecutionRecord,
+  phaseArtifacts: Array<{ relativePath: string; json: unknown }>,
+): void {
+  mkdirSync(outDir, { recursive: true });
+  mkdirSync(join(outDir, "phases"), { recursive: true });
+
+  const executionPath = join(outDir, "execution-record.json");
+  if (existsSync(executionPath)) {
+    throw new Error(
+      `Refusing to overwrite immutable execution record at ${executionPath}; pass a fresh --out directory`,
+    );
+  }
+
+  writeFileSync(
+    join(outDir, "parity-report.json"),
+    `${JSON.stringify(parityReport, null, 2)}\n`,
+    "utf8",
+  );
+
+  for (const artifact of phaseArtifacts) {
+    writeFileSync(
+      join(outDir, artifact.relativePath),
+      `${JSON.stringify(artifact.json, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
+  writeFileSync(
+    executionPath,
+    `${JSON.stringify(executionRecord, null, 2)}\n`,
+    "utf8",
+  );
+}

--- a/packages/scripts/src/commands/preseed-sync/parity.test.ts
+++ b/packages/scripts/src/commands/preseed-sync/parity.test.ts
@@ -1,0 +1,165 @@
+import { evaluatePreseedParity } from "@scripts/commands/preseed-sync/parity";
+import { describe, expect, it } from "bun:test";
+
+describe("evaluatePreseedParity", () => {
+  it("treats explained skips as warnings", () => {
+    const parity = evaluatePreseedParity(
+      {
+        connections: {
+          generatedAt: "2026-07-25T00:00:00.000Z",
+          dryRun: true,
+          counts: {
+            scanned: 1,
+            wouldCreate: 0,
+            wouldUpdate: 0,
+            created: 0,
+            updated: 0,
+            skipped: 1,
+          },
+          results: [
+            {
+              userId: "u1",
+              tenantId: "u1",
+              principalId: "u1",
+              providerAccountId: null,
+              accountEmail: "p@example.com",
+              action: "skipped",
+              connectionId: null,
+              credentialVerified: false,
+              skipCategory: "no_google_identity",
+              detail: "password-only",
+            },
+          ],
+        },
+        providerState: {
+          generatedAt: "2026-07-25T00:00:00.000Z",
+          dryRun: true,
+          counts: {
+            usersScanned: 0,
+            usersMigrated: 0,
+            usersWouldMigrate: 0,
+            usersSkipped: 0,
+            calendarsCreated: 0,
+            calendarsUpdated: 0,
+            calendarsWouldCreate: 0,
+            calendarsWouldUpdate: 0,
+            calendarsSkipped: 0,
+            eventsCreated: 0,
+            eventsUpdated: 0,
+            eventsWouldCreate: 0,
+            eventsWouldUpdate: 0,
+            eventsSkipped: 1,
+            syncResourcesCreated: 0,
+            syncResourcesUpdated: 0,
+            syncResourcesWouldCreate: 0,
+            syncResourcesWouldUpdate: 0,
+            syncResourcesSkipped: 0,
+            watchesSkippedRewatch: 0,
+            unlinkedDeferred: 1,
+          },
+          users: [],
+          skips: [
+            {
+              category: "unlinked_deferred",
+              id: "e1",
+              detail: "deferred to S49",
+            },
+          ],
+          samples: [],
+        },
+      },
+      { mode: "live", dryRun: true },
+    );
+
+    expect(parity.ok).toBe(true);
+    expect(parity.blockers).toHaveLength(0);
+    expect(parity.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("blocks inventory duplicates and orphans", () => {
+    const parity = evaluatePreseedParity(
+      {
+        inventory: {
+          generatedAt: "2026-07-25T00:00:00.000Z",
+          dryRun: true,
+          source: {
+            users: {
+              total: 1,
+              withGoogle: 1,
+              withRefreshToken: 1,
+              missingToken: 0,
+            },
+            calendars: { total: 2, google: 2, local: 0 },
+            events: { total: 0, linkedGoogle: 0, unlinked: 0 },
+            syncDocs: {
+              total: 0,
+              eventCursorRows: 0,
+              calendarListCursorRows: 0,
+            },
+            watches: {
+              total: 0,
+              eventWatches: 0,
+              calendarListWatches: 0,
+              expired: 0,
+            },
+          },
+          targets: [],
+          duplicates: [
+            {
+              kind: "google_calendar_identity",
+              key: "u1:primary",
+              count: 2,
+              ids: ["c1", "c2"],
+            },
+          ],
+          orphans: [{ kind: "event", id: "e1", reason: "calendar missing" }],
+          missingAuthority: [],
+          skips: [],
+          counts: { scanned: 1, reportable: 1, skipped: 0 },
+        },
+      },
+      { mode: "live", dryRun: true },
+    );
+
+    expect(parity.ok).toBe(false);
+    expect(parity.blockers.some((b) => b.code === "inventory_duplicate")).toBe(
+      true,
+    );
+    expect(parity.blockers.some((b) => b.code === "inventory_orphan")).toBe(
+      true,
+    );
+  });
+
+  it("allows live creates but blocks frozen residual wouldCreate after apply", () => {
+    const phases = {
+      connections: {
+        generatedAt: "2026-07-25T00:00:00.000Z",
+        dryRun: false,
+        counts: {
+          scanned: 1,
+          wouldCreate: 1,
+          wouldUpdate: 0,
+          created: 0,
+          updated: 0,
+          skipped: 0,
+        },
+        results: [],
+      },
+    };
+
+    const live = evaluatePreseedParity(phases, {
+      mode: "live",
+      dryRun: false,
+    });
+    expect(live.ok).toBe(true);
+
+    const frozen = evaluatePreseedParity(phases, {
+      mode: "frozen",
+      dryRun: false,
+    });
+    expect(frozen.ok).toBe(false);
+    expect(
+      frozen.blockers.some((b) => b.code === "frozen_residual_creates"),
+    ).toBe(true);
+  });
+});

--- a/packages/scripts/src/commands/preseed-sync/parity.ts
+++ b/packages/scripts/src/commands/preseed-sync/parity.ts
@@ -85,6 +85,7 @@ export function evaluatePreseedParity(
 ): PreseedParity {
   const blockers: PreseedFinding[] = [];
   const warnings: PreseedFinding[] = [];
+  let unexplainedSkips = 0;
 
   const inventory = phases.inventory;
   if (inventory) {
@@ -137,6 +138,7 @@ export function evaluatePreseedParity(
           detail: `${skip.category}: ${skip.detail}`,
         });
       } else {
+        unexplainedSkips += 1;
         blockers.push({
           code: "inventory_blocking_skip",
           phase: "inventory",
@@ -185,6 +187,7 @@ export function evaluatePreseedParity(
           detail: result.detail,
         });
       } else {
+        unexplainedSkips += 1;
         blockers.push({
           code: result.skipCategory,
           phase: "connections",
@@ -213,6 +216,7 @@ export function evaluatePreseedParity(
           detail: `${skip.category}: ${skip.detail}`,
         });
       } else {
+        unexplainedSkips += 1;
         blockers.push({
           code: "state_blocking_skip",
           phase: "state",
@@ -241,6 +245,7 @@ export function evaluatePreseedParity(
           detail: `${skip.category}: ${skip.detail}`,
         });
       } else {
+        unexplainedSkips += 1;
         blockers.push({
           code: "pending_blocking_skip",
           phase: "pending",
@@ -302,7 +307,7 @@ export function evaluatePreseedParity(
     blockers,
     warnings,
     counts: {
-      unexplainedSkips: blockers.length,
+      unexplainedSkips,
       duplicateIdentities: inventory?.duplicates.length ?? 0,
       orphans: inventory?.orphans.length ?? 0,
       missingAuthority:

--- a/packages/scripts/src/commands/preseed-sync/parity.ts
+++ b/packages/scripts/src/commands/preseed-sync/parity.ts
@@ -1,0 +1,323 @@
+import { type LegacySyncInventoryReport } from "@scripts/commands/inventory-legacy-sync/report.types";
+import { type MigrateConnectionsReport } from "@scripts/commands/migrate-connections/report.types";
+import { type MigratePendingIntentReport } from "@scripts/commands/migrate-pending-intent/report.types";
+import { type MigrateProviderStateReport } from "@scripts/commands/migrate-provider-state/report.types";
+import {
+  type PreseedFinding,
+  type PreseedMode,
+  type PreseedParity,
+} from "@scripts/commands/preseed-sync/report.types";
+
+const INVENTORY_BLOCKING_SKIPS = new Set([
+  "missing_refresh_token",
+  "orphan_calendar",
+  "orphan_event",
+  "orphan_sync",
+  "orphan_watch",
+  "orphan_cursor_calendar",
+  "orphan_watch_calendar",
+  "duplicate_google_calendar",
+  "duplicate_sync_user",
+  "duplicate_watch",
+  "legacy_nested_watch",
+]);
+
+const INVENTORY_EXPLAINED_SKIPS = new Set(["no_google_identity"]);
+
+const CONNECTION_BLOCKING = new Set([
+  "missing_refresh_token",
+  "empty_google_id",
+  "disconnected_in_sync",
+]);
+
+const CONNECTION_EXPLAINED = new Set(["no_google_identity"]);
+
+const STATE_BLOCKING = new Set([
+  "missing_connection",
+  "disconnected_in_sync",
+  "orphan_calendar",
+  "orphan_event",
+  "orphan_cursor",
+  "duplicate_google_calendar",
+  "missing_provider_event_id",
+  "missing_series_master",
+  "unmappable_event",
+]);
+
+const STATE_EXPLAINED = new Set([
+  "no_google_identity",
+  "local_calendar",
+  "unlinked_deferred",
+  "subscription_requires_rewatch",
+]);
+
+const PENDING_BLOCKING = new Set([
+  "missing_selected_target",
+  "missing_connection",
+  "orphan_event",
+  "unmappable_event",
+  "read_only_target",
+  "target_not_owned",
+]);
+
+const PENDING_EXPLAINED = new Set([
+  "already_provider_linked",
+  "occurrence_not_backfillable",
+  "busy_not_eligible",
+  "outside_sync_horizon",
+  "no_google_identity",
+]);
+
+export type PreseedPhaseReports = {
+  inventory?: LegacySyncInventoryReport;
+  connections?: MigrateConnectionsReport;
+  providerState?: MigrateProviderStateReport;
+  pendingIntent?: MigratePendingIntentReport;
+};
+
+/**
+ * Derive blocking vs explained findings from S46–S49 reports (R-MIG-05).
+ * `frozen` additionally fails when an apply still leaves residual creates.
+ */
+export function evaluatePreseedParity(
+  phases: PreseedPhaseReports,
+  options: { mode: PreseedMode; dryRun: boolean },
+): PreseedParity {
+  const blockers: PreseedFinding[] = [];
+  const warnings: PreseedFinding[] = [];
+
+  const inventory = phases.inventory;
+  if (inventory) {
+    for (const dup of inventory.duplicates) {
+      blockers.push({
+        code: "inventory_duplicate",
+        phase: "inventory",
+        id: dup.key,
+        detail: `${dup.kind} count=${dup.count}`,
+      });
+    }
+    for (const orphan of inventory.orphans) {
+      blockers.push({
+        code: "inventory_orphan",
+        phase: "inventory",
+        id: orphan.id,
+        detail: `${orphan.kind}: ${orphan.reason}`,
+      });
+    }
+    for (const missing of inventory.missingAuthority) {
+      if (missing.reason === "no_google") {
+        warnings.push({
+          code: "inventory_missing_authority",
+          phase: "inventory",
+          id: missing.userId,
+          detail: missing.reason,
+        });
+        continue;
+      }
+      blockers.push({
+        code: "inventory_missing_authority",
+        phase: "inventory",
+        id: missing.userId,
+        detail: missing.reason,
+      });
+    }
+    for (const skip of inventory.skips) {
+      if (INVENTORY_EXPLAINED_SKIPS.has(skip.category)) {
+        warnings.push({
+          code: skip.category,
+          phase: "inventory",
+          id: skip.id,
+          detail: skip.detail,
+        });
+      } else if (INVENTORY_BLOCKING_SKIPS.has(skip.category)) {
+        blockers.push({
+          code: "inventory_blocking_skip",
+          phase: "inventory",
+          id: skip.id,
+          detail: `${skip.category}: ${skip.detail}`,
+        });
+      } else {
+        blockers.push({
+          code: "inventory_blocking_skip",
+          phase: "inventory",
+          id: skip.id,
+          detail: `unexplained skip ${skip.category}: ${skip.detail}`,
+        });
+      }
+    }
+  }
+
+  const connections = phases.connections;
+  if (connections) {
+    for (const result of connections.results) {
+      if (result.action !== "skipped" || !result.skipCategory) {
+        if (
+          !options.dryRun &&
+          (result.action === "created" || result.action === "updated") &&
+          !result.credentialVerified
+        ) {
+          blockers.push({
+            code: "connection_credential_unverified",
+            phase: "connections",
+            id: result.userId,
+            detail: result.detail,
+          });
+        }
+        continue;
+      }
+      if (CONNECTION_EXPLAINED.has(result.skipCategory)) {
+        warnings.push({
+          code: result.skipCategory,
+          phase: "connections",
+          id: result.userId,
+          detail: result.detail,
+        });
+      } else if (CONNECTION_BLOCKING.has(result.skipCategory)) {
+        blockers.push({
+          code:
+            result.skipCategory === "missing_refresh_token"
+              ? "connection_missing_refresh_token"
+              : result.skipCategory === "empty_google_id"
+                ? "connection_empty_google_id"
+                : "connection_disconnected_in_sync",
+          phase: "connections",
+          id: result.userId,
+          detail: result.detail,
+        });
+      } else {
+        blockers.push({
+          code: result.skipCategory,
+          phase: "connections",
+          id: result.userId,
+          detail: `unexplained skip: ${result.detail}`,
+        });
+      }
+    }
+  }
+
+  const providerState = phases.providerState;
+  if (providerState) {
+    for (const skip of providerState.skips) {
+      if (STATE_EXPLAINED.has(skip.category)) {
+        warnings.push({
+          code: skip.category,
+          phase: "state",
+          id: skip.id,
+          detail: skip.detail,
+        });
+      } else if (STATE_BLOCKING.has(skip.category)) {
+        blockers.push({
+          code: "state_blocking_skip",
+          phase: "state",
+          id: skip.id,
+          detail: `${skip.category}: ${skip.detail}`,
+        });
+      } else {
+        blockers.push({
+          code: "state_blocking_skip",
+          phase: "state",
+          id: skip.id,
+          detail: `unexplained skip ${skip.category}: ${skip.detail}`,
+        });
+      }
+    }
+  }
+
+  const pendingIntent = phases.pendingIntent;
+  if (pendingIntent) {
+    for (const skip of pendingIntent.skips) {
+      if (PENDING_EXPLAINED.has(skip.category)) {
+        warnings.push({
+          code: skip.category,
+          phase: "pending",
+          id: skip.id,
+          detail: skip.detail,
+        });
+      } else if (PENDING_BLOCKING.has(skip.category)) {
+        blockers.push({
+          code: "pending_blocking_skip",
+          phase: "pending",
+          id: skip.id,
+          detail: `${skip.category}: ${skip.detail}`,
+        });
+      } else {
+        blockers.push({
+          code: "pending_blocking_skip",
+          phase: "pending",
+          id: skip.id,
+          detail: `unexplained skip ${skip.category}: ${skip.detail}`,
+        });
+      }
+    }
+  }
+
+  const deltaCreates =
+    (connections?.counts.created ?? 0) +
+    (connections?.counts.wouldCreate ?? 0) +
+    (providerState?.counts.calendarsCreated ?? 0) +
+    (providerState?.counts.calendarsWouldCreate ?? 0) +
+    (providerState?.counts.eventsCreated ?? 0) +
+    (providerState?.counts.eventsWouldCreate ?? 0) +
+    (providerState?.counts.syncResourcesCreated ?? 0) +
+    (providerState?.counts.syncResourcesWouldCreate ?? 0) +
+    (pendingIntent?.counts.eventsCreated ?? 0) +
+    (pendingIntent?.counts.eventsWouldCreate ?? 0) +
+    (pendingIntent?.counts.commandsCreated ?? 0) +
+    (pendingIntent?.counts.commandsWouldCreate ?? 0);
+
+  const deltaUpdates =
+    (connections?.counts.updated ?? 0) +
+    (connections?.counts.wouldUpdate ?? 0) +
+    (providerState?.counts.calendarsUpdated ?? 0) +
+    (providerState?.counts.calendarsWouldUpdate ?? 0) +
+    (providerState?.counts.eventsUpdated ?? 0) +
+    (providerState?.counts.eventsWouldUpdate ?? 0) +
+    (providerState?.counts.syncResourcesUpdated ?? 0) +
+    (providerState?.counts.syncResourcesWouldUpdate ?? 0) +
+    (pendingIntent?.counts.eventsUpdated ?? 0) +
+    (pendingIntent?.counts.eventsWouldUpdate ?? 0);
+
+  // Frozen cutover: after apply, residual would_create means the source still
+  // has unmigrated rows (or the plan did not converge). Live allows creates.
+  if (options.mode === "frozen" && !options.dryRun) {
+    const residualWouldCreate =
+      (connections?.counts.wouldCreate ?? 0) +
+      (providerState?.counts.calendarsWouldCreate ?? 0) +
+      (providerState?.counts.eventsWouldCreate ?? 0) +
+      (providerState?.counts.syncResourcesWouldCreate ?? 0) +
+      (pendingIntent?.counts.eventsWouldCreate ?? 0) +
+      (pendingIntent?.counts.commandsWouldCreate ?? 0);
+    if (residualWouldCreate > 0) {
+      blockers.push({
+        code: "frozen_residual_creates",
+        phase: "aggregate",
+        id: "frozen",
+        detail: `frozen apply left wouldCreate=${residualWouldCreate}`,
+      });
+    }
+  }
+
+  return {
+    ok: blockers.length === 0,
+    blockers,
+    warnings,
+    counts: {
+      unexplainedSkips: blockers.length,
+      duplicateIdentities: inventory?.duplicates.length ?? 0,
+      orphans: inventory?.orphans.length ?? 0,
+      missingAuthority:
+        inventory?.missingAuthority.filter((m) => m.reason !== "no_google")
+          .length ?? 0,
+      credentialVerifyFailures: connections
+        ? connections.results.filter(
+            (r) =>
+              !options.dryRun &&
+              (r.action === "created" || r.action === "updated") &&
+              !r.credentialVerified,
+          ).length
+        : 0,
+      deltaCreates,
+      deltaUpdates,
+    },
+  };
+}

--- a/packages/scripts/src/commands/preseed-sync/preseed.ts
+++ b/packages/scripts/src/commands/preseed-sync/preseed.ts
@@ -1,0 +1,339 @@
+import {
+  type InventoryCollections,
+  inventoryLegacySyncData,
+} from "@scripts/commands/inventory-legacy-sync/inventory";
+import { migrateProviderConnections } from "@scripts/commands/migrate-connections/migrate";
+import { migratePendingCompassIntent } from "@scripts/commands/migrate-pending-intent/migrate";
+import { migrateProviderSyncState } from "@scripts/commands/migrate-provider-state/migrate";
+import {
+  buildExecutionRecord,
+  type PhaseExecutionSummary,
+  writePreseedArtifacts,
+} from "@scripts/commands/preseed-sync/execution-record";
+import {
+  evaluatePreseedParity,
+  type PreseedPhaseReports,
+} from "@scripts/commands/preseed-sync/parity";
+import {
+  type PreseedMode,
+  type PreseedParityReport,
+  PreseedParityReportSchema,
+  type PreseedPhase,
+} from "@scripts/commands/preseed-sync/report.types";
+import { type Db, type MongoClient } from "mongodb";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export type PreseedOptions = {
+  dryRun: boolean;
+  mode: PreseedMode;
+  phase: PreseedPhase;
+  userIds?: Set<string>;
+  targetCalendarId?: string;
+  targetGcalId?: string;
+  now?: Date;
+  outDir?: string | null;
+  argv?: string[];
+  gitSha?: string | null;
+  compassApiMongoDbName?: string | null;
+  syncMongoDbName?: string | null;
+};
+
+export type PreseedResult = {
+  exitCode: 0 | 1;
+  report: PreseedParityReport;
+};
+
+const PHASE_ORDER = ["inventory", "connections", "state", "pending"] as const;
+
+function phasesToRun(phase: PreseedPhase): Array<(typeof PHASE_ORDER)[number]> {
+  if (phase === "all") return [...PHASE_ORDER];
+  return [phase];
+}
+
+function filterCollections(
+  collections: InventoryCollections,
+  userIds: Set<string> | undefined,
+): InventoryCollections {
+  if (!userIds || userIds.size === 0) return collections;
+  const users = collections.users.filter((u) =>
+    userIds.has(u._id.toHexString()),
+  );
+  const userIdSet = new Set(users.map((u) => u._id.toHexString()));
+  const calendars = collections.calendars.filter((c) =>
+    userIdSet.has(c.userId.toHexString()),
+  );
+  const calendarIds = new Set(calendars.map((c) => c._id.toHexString()));
+  return {
+    users,
+    calendars,
+    events: collections.events.filter((e) =>
+      calendarIds.has(e.calendarId.toHexString()),
+    ),
+    syncDocs: collections.syncDocs.filter((s) => userIdSet.has(s.user)),
+    watches: collections.watches.filter((w) => userIdSet.has(w.user)),
+  };
+}
+
+/**
+ * Compose S46–S49 into a resumable pre-seed with blocking parity (S51).
+ * Never enables workers/callbacks, never deletes source records, never calls
+ * Google. Returns an exitCode for the CLI to propagate.
+ */
+export async function runPreseedSyncComposition(
+  deps: {
+    loadCollections: () => Promise<InventoryCollections>;
+    syncDb: Db;
+    syncClient: MongoClient;
+  },
+  options: PreseedOptions,
+): Promise<PreseedResult> {
+  const startedAt = options.now ?? new Date();
+  const dryRun = options.dryRun;
+  const selected = phasesToRun(options.phase);
+  const phases: PreseedPhaseReports = {};
+  const phasesExecuted: PhaseExecutionSummary[] = [];
+  const phaseArtifacts: Array<{ relativePath: string; json: unknown }> = [];
+
+  const connections = new ProviderConnectionRepository(deps.syncDb);
+  const credentials = new CredentialRepository(deps.syncDb);
+  const calendars = new ProviderCalendarRepository(deps.syncDb);
+  const events = new EventRepository(deps.syncDb);
+  const occurrences = new EventOccurrenceRepository(
+    deps.syncDb,
+    deps.syncClient,
+  );
+  const resources = new SyncResourceRepository(deps.syncDb);
+  const commands = new CommandRepository(deps.syncDb);
+
+  let collections: InventoryCollections | null = null;
+  const ensureCollections = async () => {
+    if (!collections) {
+      collections = filterCollections(
+        await deps.loadCollections(),
+        options.userIds,
+      );
+    }
+    return collections;
+  };
+
+  for (const name of selected) {
+    const phaseStarted = new Date();
+    if (name === "inventory") {
+      const source = await ensureCollections();
+      const report = inventoryLegacySyncData(source, { now: startedAt });
+      phases.inventory = report;
+      phasesExecuted.push({
+        name,
+        startedAt: phaseStarted.toISOString(),
+        finishedAt: new Date().toISOString(),
+        dryRun: true,
+        summaryCounts: {
+          users: report.source.users.total,
+          withGoogle: report.source.users.withGoogle,
+          duplicates: report.duplicates.length,
+          orphans: report.orphans.length,
+        },
+        artifactPath: "phases/inventory.json",
+      });
+      phaseArtifacts.push({
+        relativePath: "phases/inventory.json",
+        json: report,
+      });
+      continue;
+    }
+
+    if (name === "connections") {
+      const source = await ensureCollections();
+      const report = await migrateProviderConnections(
+        { connections, credentials },
+        source.users,
+        { dryRun, userIds: options.userIds, now: startedAt },
+      );
+      phases.connections = report;
+      phasesExecuted.push({
+        name,
+        startedAt: phaseStarted.toISOString(),
+        finishedAt: new Date().toISOString(),
+        dryRun,
+        summaryCounts: { ...report.counts },
+        artifactPath: "phases/connections.json",
+      });
+      phaseArtifacts.push({
+        relativePath: "phases/connections.json",
+        json: report,
+      });
+      continue;
+    }
+
+    if (name === "state") {
+      const source = await ensureCollections();
+      const report = await migrateProviderSyncState(
+        {
+          connections,
+          calendars,
+          events,
+          occurrences,
+          resources,
+        },
+        source,
+        { dryRun, userIds: options.userIds, now: startedAt },
+      );
+      phases.providerState = report;
+      phasesExecuted.push({
+        name,
+        startedAt: phaseStarted.toISOString(),
+        finishedAt: new Date().toISOString(),
+        dryRun,
+        summaryCounts: { ...report.counts },
+        artifactPath: "phases/provider-state.json",
+      });
+      phaseArtifacts.push({
+        relativePath: "phases/provider-state.json",
+        json: report,
+      });
+      continue;
+    }
+
+    const source = await ensureCollections();
+    const report = await migratePendingCompassIntent(
+      {
+        connections,
+        calendars,
+        events,
+        occurrences,
+        commands,
+      },
+      source,
+      {
+        dryRun,
+        userIds: options.userIds,
+        now: startedAt,
+        targetCalendarId: options.targetCalendarId,
+        targetGcalId: options.targetGcalId,
+      },
+    );
+    phases.pendingIntent = report;
+    phasesExecuted.push({
+      name,
+      startedAt: phaseStarted.toISOString(),
+      finishedAt: new Date().toISOString(),
+      dryRun,
+      summaryCounts: { ...report.counts },
+      artifactPath: "phases/pending-intent.json",
+    });
+    phaseArtifacts.push({
+      relativePath: "phases/pending-intent.json",
+      json: report,
+    });
+  }
+
+  // Frozen apply: re-plan dry-run on the same source to detect residual creates.
+  if (options.mode === "frozen" && !dryRun && options.phase === "all") {
+    const source = await ensureCollections();
+    const residualConnections = await migrateProviderConnections(
+      { connections, credentials },
+      source.users,
+      { dryRun: true, userIds: options.userIds, now: startedAt },
+    );
+    const residualState = await migrateProviderSyncState(
+      { connections, calendars, events, occurrences, resources },
+      source,
+      { dryRun: true, userIds: options.userIds, now: startedAt },
+    );
+    const residualPending = await migratePendingCompassIntent(
+      { connections, calendars, events, occurrences, commands },
+      source,
+      {
+        dryRun: true,
+        userIds: options.userIds,
+        now: startedAt,
+        targetCalendarId: options.targetCalendarId,
+        targetGcalId: options.targetGcalId,
+      },
+    );
+    // Overlay would_* from the convergence pass onto the apply reports so
+    // evaluatePreseedParity can see residual creates after apply.
+    if (phases.connections) {
+      phases.connections = {
+        ...phases.connections,
+        counts: {
+          ...phases.connections.counts,
+          wouldCreate: residualConnections.counts.wouldCreate,
+          wouldUpdate: residualConnections.counts.wouldUpdate,
+        },
+      };
+    }
+    if (phases.providerState) {
+      phases.providerState = {
+        ...phases.providerState,
+        counts: {
+          ...phases.providerState.counts,
+          calendarsWouldCreate: residualState.counts.calendarsWouldCreate,
+          eventsWouldCreate: residualState.counts.eventsWouldCreate,
+          syncResourcesWouldCreate:
+            residualState.counts.syncResourcesWouldCreate,
+        },
+      };
+    }
+    if (phases.pendingIntent) {
+      phases.pendingIntent = {
+        ...phases.pendingIntent,
+        counts: {
+          ...phases.pendingIntent.counts,
+          eventsWouldCreate: residualPending.counts.eventsWouldCreate,
+          commandsWouldCreate: residualPending.counts.commandsWouldCreate,
+        },
+      };
+    }
+  }
+
+  const parity = evaluatePreseedParity(phases, {
+    mode: options.mode,
+    dryRun,
+  });
+  const finishedAt = new Date();
+  const report = PreseedParityReportSchema.parse({
+    generatedAt: finishedAt.toISOString(),
+    dryRun,
+    mode: options.mode,
+    phase: options.phase,
+    userIdFilter: options.userIds ? [...options.userIds].sort() : null,
+    phases,
+    parity,
+  });
+
+  const exitCode: 0 | 1 = parity.ok ? 0 : 1;
+  const executionRecord = buildExecutionRecord({
+    startedAt,
+    finishedAt,
+    argv: options.argv ?? [],
+    dryRun,
+    mode: options.mode,
+    phase: options.phase,
+    userIdFilter: report.userIdFilter,
+    outDir: options.outDir ?? null,
+    gitSha: options.gitSha ?? null,
+    compassApiMongoDbName: options.compassApiMongoDbName ?? null,
+    syncMongoDbName: options.syncMongoDbName ?? null,
+    phasesExecuted,
+    parityReport: report,
+    exitCode,
+  });
+
+  if (options.outDir) {
+    writePreseedArtifacts(
+      options.outDir,
+      report,
+      executionRecord,
+      phaseArtifacts,
+    );
+  }
+
+  return { exitCode, report };
+}

--- a/packages/scripts/src/commands/preseed-sync/preseed.ts
+++ b/packages/scripts/src/commands/preseed-sync/preseed.ts
@@ -145,6 +145,13 @@ export async function runPreseedSyncComposition(
         relativePath: "phases/inventory.json",
         json: report,
       });
+      const inventoryParity = evaluatePreseedParity(
+        { inventory: report },
+        { mode: options.mode, dryRun },
+      );
+      if (!dryRun && inventoryParity.blockers.length > 0) {
+        break;
+      }
       continue;
     }
 
@@ -234,32 +241,16 @@ export async function runPreseedSyncComposition(
   }
 
   // Frozen apply: re-plan dry-run on the same source to detect residual creates.
-  if (options.mode === "frozen" && !dryRun && options.phase === "all") {
+  if (options.mode === "frozen" && !dryRun) {
     const source = await ensureCollections();
-    const residualConnections = await migrateProviderConnections(
-      { connections, credentials },
-      source.users,
-      { dryRun: true, userIds: options.userIds, now: startedAt },
-    );
-    const residualState = await migrateProviderSyncState(
-      { connections, calendars, events, occurrences, resources },
-      source,
-      { dryRun: true, userIds: options.userIds, now: startedAt },
-    );
-    const residualPending = await migratePendingCompassIntent(
-      { connections, calendars, events, occurrences, commands },
-      source,
-      {
-        dryRun: true,
-        userIds: options.userIds,
-        now: startedAt,
-        targetCalendarId: options.targetCalendarId,
-        targetGcalId: options.targetGcalId,
-      },
-    );
-    // Overlay would_* from the convergence pass onto the apply reports so
-    // evaluatePreseedParity can see residual creates after apply.
-    if (phases.connections) {
+    if (selected.includes("connections") && phases.connections) {
+      const residualConnections = await migrateProviderConnections(
+        { connections, credentials },
+        source.users,
+        { dryRun: true, userIds: options.userIds, now: startedAt },
+      );
+      // Overlay would_* from the convergence pass onto the apply reports so
+      // evaluatePreseedParity can see residual creates after apply.
       phases.connections = {
         ...phases.connections,
         counts: {
@@ -269,7 +260,12 @@ export async function runPreseedSyncComposition(
         },
       };
     }
-    if (phases.providerState) {
+    if (selected.includes("state") && phases.providerState) {
+      const residualState = await migrateProviderSyncState(
+        { connections, calendars, events, occurrences, resources },
+        source,
+        { dryRun: true, userIds: options.userIds, now: startedAt },
+      );
       phases.providerState = {
         ...phases.providerState,
         counts: {
@@ -281,7 +277,18 @@ export async function runPreseedSyncComposition(
         },
       };
     }
-    if (phases.pendingIntent) {
+    if (selected.includes("pending") && phases.pendingIntent) {
+      const residualPending = await migratePendingCompassIntent(
+        { connections, calendars, events, occurrences, commands },
+        source,
+        {
+          dryRun: true,
+          userIds: options.userIds,
+          now: startedAt,
+          targetCalendarId: options.targetCalendarId,
+          targetGcalId: options.targetGcalId,
+        },
+      );
       phases.pendingIntent = {
         ...phases.pendingIntent,
         counts: {

--- a/packages/scripts/src/commands/preseed-sync/report.types.ts
+++ b/packages/scripts/src/commands/preseed-sync/report.types.ts
@@ -1,0 +1,119 @@
+import { LegacySyncInventoryReportSchema } from "@scripts/commands/inventory-legacy-sync/report.types";
+import { MigrateConnectionsReportSchema } from "@scripts/commands/migrate-connections/report.types";
+import { MigratePendingIntentReportSchema } from "@scripts/commands/migrate-pending-intent/report.types";
+import { MigrateProviderStateReportSchema } from "@scripts/commands/migrate-provider-state/report.types";
+import { z } from "zod/v4";
+
+export const PreseedPhaseSchema = z.enum([
+  "inventory",
+  "connections",
+  "state",
+  "pending",
+  "all",
+]);
+export type PreseedPhase = z.infer<typeof PreseedPhaseSchema>;
+
+export const PreseedModeSchema = z.enum(["live", "frozen"]);
+export type PreseedMode = z.infer<typeof PreseedModeSchema>;
+
+export const PreseedBlockerCodeSchema = z.enum([
+  "inventory_duplicate",
+  "inventory_orphan",
+  "inventory_missing_authority",
+  "inventory_blocking_skip",
+  "connection_missing_refresh_token",
+  "connection_empty_google_id",
+  "connection_disconnected_in_sync",
+  "connection_credential_unverified",
+  "state_blocking_skip",
+  "pending_blocking_skip",
+  "frozen_residual_creates",
+]);
+export type PreseedBlockerCode = z.infer<typeof PreseedBlockerCodeSchema>;
+
+export const PreseedFindingSchema = z.strictObject({
+  code: PreseedBlockerCodeSchema.or(z.string().min(1)),
+  phase: z.enum(["inventory", "connections", "state", "pending", "aggregate"]),
+  id: z.string().min(1),
+  detail: z.string().min(1),
+});
+export type PreseedFinding = z.infer<typeof PreseedFindingSchema>;
+
+export const PreseedParitySchema = z.strictObject({
+  ok: z.boolean(),
+  blockers: z.array(PreseedFindingSchema),
+  warnings: z.array(PreseedFindingSchema),
+  counts: z.strictObject({
+    unexplainedSkips: z.number().int().nonnegative(),
+    duplicateIdentities: z.number().int().nonnegative(),
+    orphans: z.number().int().nonnegative(),
+    missingAuthority: z.number().int().nonnegative(),
+    credentialVerifyFailures: z.number().int().nonnegative(),
+    deltaCreates: z.number().int().nonnegative(),
+    deltaUpdates: z.number().int().nonnegative(),
+  }),
+});
+export type PreseedParity = z.infer<typeof PreseedParitySchema>;
+
+export const PreseedParityReportSchema = z.strictObject({
+  generatedAt: z.string().min(1),
+  dryRun: z.boolean(),
+  mode: PreseedModeSchema,
+  phase: PreseedPhaseSchema,
+  userIdFilter: z.array(z.string().min(1)).nullable(),
+  phases: z.strictObject({
+    inventory: LegacySyncInventoryReportSchema.optional(),
+    connections: MigrateConnectionsReportSchema.optional(),
+    providerState: MigrateProviderStateReportSchema.optional(),
+    pendingIntent: MigratePendingIntentReportSchema.optional(),
+  }),
+  parity: PreseedParitySchema,
+});
+export type PreseedParityReport = z.infer<typeof PreseedParityReportSchema>;
+
+export const PreseedExecutionRecordSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  kind: z.literal("sync-preseed-execution"),
+  runId: z.string().min(1),
+  startedAt: z.string().min(1),
+  finishedAt: z.string().min(1),
+  durationMs: z.number().int().nonnegative(),
+  command: z.strictObject({
+    argv: z.array(z.string()),
+    dryRun: z.boolean(),
+    apply: z.boolean(),
+    mode: PreseedModeSchema,
+    phase: PreseedPhaseSchema,
+    userIdFilter: z.array(z.string().min(1)).nullable(),
+    outDir: z.string().nullable(),
+  }),
+  environment: z.strictObject({
+    gitSha: z.string().nullable(),
+    nodeBun: z.string().min(1),
+    compassApiMongoDbName: z.string().nullable(),
+    syncMongoDbName: z.string().nullable(),
+    workersEnabledByThisTool: z.literal(false),
+    callbacksEnabledByThisTool: z.literal(false),
+    sourceRecordsDeletedByThisTool: z.literal(false),
+  }),
+  phasesExecuted: z.array(
+    z.strictObject({
+      name: z.enum(["inventory", "connections", "state", "pending"]),
+      startedAt: z.string().min(1),
+      finishedAt: z.string().min(1),
+      dryRun: z.boolean(),
+      summaryCounts: z.record(z.string(), z.number()),
+      artifactPath: z.string().min(1),
+    }),
+  ),
+  parity: z.strictObject({
+    ok: z.boolean(),
+    blockerCount: z.number().int().nonnegative(),
+    warningCount: z.number().int().nonnegative(),
+    reportPath: z.string().min(1),
+  }),
+  exitCode: z.union([z.literal(0), z.literal(1)]),
+});
+export type PreseedExecutionRecord = z.infer<
+  typeof PreseedExecutionRecordSchema
+>;


### PR DESCRIPTION
## Summary

S51 Sync pre-seed composer:

- `bun run cli preseed-sync [--apply] [--out dir] [--mode live|frozen] [--phase …] [--user-id …]`
- Orchestrates inventory → connections → provider-state → pending-intent
- Blocking parity report (exit 1 on unexplained skips/duplicates/orphans/credential failures)
- Frozen mode re-plans after apply to require residual `wouldCreate === 0`
- Immutable `execution-record.json` + per-phase artifacts under `--out` (refuses overwrite)

Does not enable workers/callbacks, delete source records, or call Google.

## Simplicity

Calls existing S46–S49 library functions; adds only orchestration, parity taxonomy, and execution-record I/O.

## Automated validation

- Parity: explained skips warn; duplicates/orphans block; frozen residual creates fail
- Execution record: cutover safety flags false; overwrite refused
- DB: dry-run writes nothing; apply + frozen rerun converges; duplicate calendars exit 1
- CLI dispatches `preseed-sync`

## Test plan

```bash
bun type-check
bun lint
bun test:scripts packages/scripts/src/commands/preseed-sync packages/scripts/src/commands/preseed-sync.db.test.ts packages/scripts/src/cli.test.ts
```

Made with [Cursor](https://cursor.com)