### PR TITLE
fix(sync): keep series DTSTART when BYDAY skips start day

### DIFF
--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -162,6 +162,26 @@ describe("projectOccurrences", () => {
       }
     });
 
+    it("keeps DTSTART when BYDAY would otherwise skip the series start day", () => {
+      // Staging repro: Friday start + weekly BYDAY=SU (default week-start
+      // constant). Pure RRULE expansion jumps to Sunday; the create week's
+      // range read must still see Friday so the SPA grid is not empty.
+      const e = event(
+        timed("2026-07-24T12:00:00-06:00", "2026-07-24T13:00:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: ["RRULE:FREQ=WEEKLY;COUNT=12;INTERVAL=1;BYDAY=SU"],
+        },
+      );
+      const occ = projectOccurrences(e, HORIZON);
+      expect(occ[0]?.startAt.toISOString()).toBe("2026-07-24T18:00:00.000Z");
+      expect(occ.map((o) => o.startAt.toISOString()).slice(0, 3)).toEqual([
+        "2026-07-24T18:00:00.000Z",
+        "2026-07-26T18:00:00.000Z",
+        "2026-08-02T18:00:00.000Z",
+      ]);
+    });
+
     it("clamps expansion to the horizon window", () => {
       const e = event(
         timed("2026-01-01T09:00:00-07:00", "2026-01-01T10:00:00-07:00"),

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -59,9 +59,20 @@ function projectSeriesMaster(
     excludedInstants.map((instant) => new Date(instant).getTime()),
   );
   const occurrences: OccurrenceInput[] = [];
+  // DTSTART is always an instance of the series when it falls in the horizon,
+  // even if BYDAY/COUNT would skip it on expansion. Matches CompassEventRRule
+  // (and Google): a Friday event saved with weekly BYDAY=SU still materializes
+  // that Friday so the create week's range read — and the SPA grid — see it.
+  const dtstart = scheduleStartAt(event.schedule);
+  const dtstartMs = dtstart.getTime();
+  if (withinHorizon(dtstart, horizon) && !excluded.has(dtstartMs)) {
+    occurrences.push(toOccurrence(event, event.schedule, dtstart, false));
+  }
 
   for (const originalStart of expandInstants(event.schedule, rules, horizon)) {
     if (excluded.has(originalStart.getTime())) continue;
+    // Already emitted as the DTSTART instance above.
+    if (originalStart.getTime() === dtstartMs) continue;
     const schedule = shiftSchedule(event.schedule, originalStart);
     occurrences.push(toOccurrence(event, schedule, originalStart, false));
   }

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -20,6 +20,7 @@ import {
   type ProviderAuthorization,
   type RefreshedCredential,
 } from "@sync/providers/provider-auth.port";
+import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
   BEGIN_PATH,
   CALENDARS_PATH,
@@ -1481,5 +1482,91 @@ describe("GET /internal/events/full", () => {
     );
 
     expect(res.status).toBe(401);
+  });
+
+  it("create → full-range read returns a new weekly series in the create week", async () => {
+    // Real command path (put + reproject), not a hand-seeded occurrence. Repro
+    // for series roots that vanish from the SPA week query when BYDAY skips
+    // the DTSTART weekday — the create week's narrow range must still see an
+    // occurrence (and therefore the back-filled series master).
+    const tenantId = objectId();
+    const principalId = objectId();
+    const calendarId = objectId();
+    await startService();
+
+    const eventId = objectId();
+    const createRes = await fetch(`${base}${COMMANDS_PATH}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...signedHeaders(tenantId, principalId),
+      },
+      body: JSON.stringify({
+        idempotencyKey: `idem-${objectId()}`,
+        eventId,
+        input: {
+          kind: "create",
+          calendarId,
+          content: {
+            title: "Weekly standup",
+            description: "",
+            location: null,
+            organizer: null,
+            attendees: [],
+            conference: null,
+          },
+          schedule: {
+            kind: "timed",
+            start: "2026-07-24T12:00:00-06:00",
+            end: "2026-07-24T13:00:00-06:00",
+            timeZone: "America/Denver",
+          },
+          // Friday start + Sunday BYDAY — the staging-shaped mismatch.
+          recurrence: {
+            kind: "series",
+            rules: ["RRULE:FREQ=WEEKLY;COUNT=12;INTERVAL=1;BYDAY=SU"],
+          },
+        },
+        expectedVersion: null,
+      }),
+    });
+    expect(createRes.status).toBe(200);
+    const created = (await createRes.json()) as {
+      command: { eventId: string; outcome: { state: string } };
+    };
+    expect(created.command.outcome.state).toBe("confirmed");
+    expect(created.command.eventId).toBe(eventId);
+
+    // SPA week window containing the Friday DTSTART (ends Saturday night).
+    const weekQuery =
+      `calendarIds=${calendarId}` +
+      `&start=${encodeURIComponent("2026-07-19T00:00:00-06:00")}` +
+      `&end=${encodeURIComponent("2026-07-25T23:59:59-06:00")}`;
+    const body = (await (
+      await get(tenantId, principalId, weekQuery)
+    ).json()) as {
+      instances: Array<{
+        eventId: string;
+        recurrence: { kind: string };
+        schedule: { start: string };
+      }>;
+    };
+
+    const kinds = body.instances.map((i) => i.recurrence.kind).sort();
+    expect(kinds).toContain("occurrence");
+    expect(kinds).toContain("series");
+    expect(
+      body.instances.some(
+        (i) =>
+          i.eventId === eventId &&
+          i.recurrence.kind === "occurrence" &&
+          i.schedule.start.startsWith("2026-07-24"),
+      ),
+    ).toBe(true);
+    expect(
+      body.instances.some(
+        (i) => i.eventId === eventId && i.recurrence.kind === "series",
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Newly created weekly recurring series could vanish from Sync range reads for the create week when `RRULE` `BYDAY` skipped the series start weekday (e.g. Friday start + `BYDAY=SU`). Pure rrule expansion jumped past DTSTART, so `event_occurrences` had no in-range row, assembly never back-filled the series master, and the SPA grid stayed empty even though the event existed in storage.

`projectSeriesMaster` now always materializes DTSTART when it falls in the projection horizon and is not excepted, matching `CompassEventRRule` / Google behavior, then expands remaining instants (deduping DTSTART).

## Simplicity

One localized change in occurrence projection — no generation-model bypass, no “always include all series masters” range query.

## Automated validation

- Unit: Friday + `BYDAY=SU` keeps Friday as the first projected occurrence, then Sundays.
- Integration: real `POST /internal/commands` series create → `GET /internal/events/full` for the SPA week window asserts occurrence + series rows for the create day.
- `bun test:sync` — 630 pass, 0 fail.
- `bun type-check` — pass.
- `bun lint` — no new errors (pre-existing unrelated web warning only).

## Independent review

Root cause confirmed as DTSTART omission under BYDAY mismatch (not generation-tag timing). Fix limited to projection; generation isolation unchanged.

## Test plan

```bash
bun test:sync packages/sync/src/domain/occurrence-projection.test.ts packages/sync/src/server/connection.routes.db.test.ts
bun test:sync
bun type-check
bun lint
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0b0e9d6-3b4e-46e6-8877-983697ddf345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b0e9d6-3b4e-46e6-8877-983697ddf345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

