### PR TITLE
fix(backend): give sync commands a 30s deadline for provider deletes

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -686,6 +686,58 @@ describe("SyncServiceClient", () => {
     expect(result.error.kind).toBe("timeout");
   });
 
+  it("keeps submitCommand open longer than the default read deadline", async () => {
+    // Default client timeout is 20ms; a 50ms response must still succeed for
+    // commands (provider deletes run inline and routinely exceed the read
+    // deadline).
+    const who = principal();
+    const eventId = objectId();
+    const commandBody = {
+      id: objectId(),
+      tenantId: who.tenantId,
+      principalId: who.principalId,
+      idempotencyKey: "slow-delete-key",
+      eventId,
+      input: {
+        kind: "delete",
+        invitation: "none",
+        scope: "all",
+        recurrenceId: null,
+      },
+      expectedVersion: null,
+      outcome: {
+        state: "confirmed",
+        providerEventId: null,
+        providerVersion: null,
+      },
+      attemptCount: 1,
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:01.000Z",
+    };
+    const fn: SyncServiceClientOptions["fetch"] = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return {
+        status: 200,
+        json: async () => ({ command: commandBody }),
+      };
+    };
+
+    const result = await client(fn).submitCommand(who, {
+      idempotencyKey: "slow-delete-key",
+      eventId,
+      input: {
+        kind: "delete",
+        invitation: "none",
+        scope: "all",
+        recurrenceId: null,
+      },
+      expectedVersion: null,
+    } as CommandSubmitRequest);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value.command.outcome.state).toBe("confirmed");
+  });
+
   it("rejects a 200 body that does not match the contract", async () => {
     const { fn } = fakeFetch(async () => ({
       status: 200,

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -54,7 +54,12 @@ const COMMANDS_PATH = "/internal/commands";
 const PRINCIPAL_PATH = "/internal/principal";
 const DIAGNOSTIC_CONNECTION_PATH_PREFIX = "/internal/diagnostics/connections/";
 
-const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 5_000;
+// Provider create/update/delete run inline inside POST /internal/commands.
+// The default read deadline is too short for a Google round-trip; aborting
+// mid-delete leaves Sync applying the mutation while Compass API returns an
+// error (staging: DELETE appeared to fail with 5xx while the event was gone).
+export const COMMAND_TIMEOUT_MS = 30_000;
 
 // The identity a request acts on behalf of. Signed into the request so the Sync
 // service derives ownership from the signature, never the body.
@@ -277,6 +282,7 @@ export class SyncServiceClient {
       body: request,
       schema: CommandSubmitResponseSchema,
       correlationId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
     });
   }
 
@@ -356,6 +362,7 @@ export class SyncServiceClient {
     body?: unknown;
     schema: z.ZodType<T>;
     correlationId?: string;
+    timeoutMs?: number;
   }): Promise<SyncClientResult<T>> {
     const correlationId = input.correlationId ?? this.#newCorrelationId();
     const timestamp = this.#now();
@@ -375,7 +382,8 @@ export class SyncServiceClient {
         : `${this.#baseUrl}${input.path}`;
 
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
+    const deadlineMs = input.timeoutMs ?? this.#timeoutMs;
+    const timer = setTimeout(() => controller.abort(), deadlineMs);
     let response: { status: number; json: () => Promise<unknown> };
     try {
       response = await this.#fetch(url, {

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -176,6 +176,18 @@ const submitCommandOrThrow = async (
 ) => {
   const result = await client.submitCommand(toSyncPrincipal(userId), request);
   if (!result.ok) {
+    // Timeout/unavailable can mean Sync already accepted (or finished) the
+    // mutation — especially provider deletes, which run inline. Do not fall
+    // back to legacy; surface a retryable provider failure instead.
+    if (
+      result.error.kind === "timeout" ||
+      result.error.kind === "unavailable"
+    ) {
+      throw eventMutationError(
+        "PROVIDER_FAILURE",
+        `Sync command ${result.error.kind}; the mutation may already be applied`,
+      );
+    }
     throw error(
       GenericError.NotSure,
       `Failed to submit command to sync (${result.error.kind})`,

--- a/packages/sync/src/server/command.routes.db.test.ts
+++ b/packages/sync/src/server/command.routes.db.test.ts
@@ -364,6 +364,12 @@ describe("POST /internal/commands", () => {
     const created = createRequest();
     await startService();
     await submit(tenantId, principalId, created);
+    const eventNoticesBefore = await mongo.db
+      .collection("invalidations")
+      .countDocuments({
+        "invalidation.kind": "event",
+        "invalidation.eventId": created.eventId,
+      });
 
     const del = {
       idempotencyKey: `idem-${objectId()}`,
@@ -378,6 +384,22 @@ describe("POST /internal/commands", () => {
     };
     expect(body.command.outcome.state).toBe("confirmed");
     expect(await mongo.db.collection("events").countDocuments()).toBe(0);
+    // Event row is gone, but the outbox still carries eventsChanged so the
+    // SPA can drop the tombstone without waiting on a full refetch.
+    const eventNoticesAfter = await mongo.db
+      .collection("invalidations")
+      .find({
+        "invalidation.kind": "event",
+        "invalidation.eventId": created.eventId,
+      })
+      .toArray();
+    expect(eventNoticesAfter.length).toBe(eventNoticesBefore + 1);
+    expect(
+      eventNoticesAfter.some(
+        (row) =>
+          row["invalidation"]?.["calendarId"] === created.input.calendarId,
+      ),
+    ).toBe(true);
   });
 
   it("confirms an idempotent delete of an already-absent event", async () => {

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -87,10 +87,20 @@ export function registerCommandRoutes(
               }
             : undefined;
 
+        const events = new EventRepository(deps.mongo.db);
+        // Snapshot calendarId before apply: a confirmed delete removes the
+        // event row, and the change-feed still needs an eventsChanged notice
+        // so the SPA (and other tabs) drop it without a manual reload.
+        const before = await events.findById(
+          auth.tenantId,
+          auth.principalId,
+          request.eventId,
+        );
+
         const { command, changed } = await submitCloudCommand(
           {
             commands: new CommandRepository(deps.mongo.db),
-            events: new EventRepository(deps.mongo.db),
+            events,
             calendars: new ProviderCalendarRepository(deps.mongo.db),
             occurrences: new EventOccurrenceRepository(
               deps.mongo.db,
@@ -115,12 +125,12 @@ export function registerCommandRoutes(
         // Emitted only when this request durably changed command/event state,
         // so an idempotent replay does not duplicate outbox rows.
         if (changed) {
-          const events = new EventRepository(deps.mongo.db);
-          const event = await events.findById(
+          const after = await events.findById(
             auth.tenantId,
             auth.principalId,
             command.eventId,
           );
+          const calendarId = after?.calendarId ?? before?.calendarId;
           const invalidations = new InvalidationRepository(deps.mongo.db);
           const emittedAt = deps.now ? new Date(deps.now()) : new Date();
           const notices = [
@@ -128,12 +138,12 @@ export function registerCommandRoutes(
               kind: "command" as const,
               commandId: command._id,
             },
-            ...(event
+            ...(calendarId
               ? [
                   {
                     kind: "event" as const,
                     eventId: command.eventId,
-                    calendarId: event.calendarId,
+                    calendarId,
                   },
                 ]
               : []),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Staging saw `DELETE /api/event` return 5xx while the event was actually removed (Compass + Google). Root cause: provider deletes run **inline** in Sync `POST /internal/commands`, but the backend Sync client used a **5s** deadline meant for reads. The client aborted mid-flight; Sync finished the Google delete anyway.

## Changes

- `submitCommand` uses a **30s** deadline (`COMMAND_TIMEOUT_MS`); reads stay at 5s
- Map Sync `timeout` / `unavailable` on command submit to retryable `PROVIDER_FAILURE` (mutation may already be applied; still no legacy fallback)
- After delete, emit `eventsChanged` using the **pre-delete** `calendarId` so SSE clients learn about removals

## Automated validation

- Unit: `submitCommand` succeeds when response arrives after the short read deadline
- Integration: cloud delete confirms and appends an event invalidation with calendarId
- `bun test:backend` (client + delegation) and `bun test:sync` (command routes) — pass

## Test plan

```bash
bun test:backend packages/backend/src/common/services/sync-service/sync-service.client.test.ts
bun test:sync packages/sync/src/server/command.routes.db.test.ts
```

Staging re-check after deploy: delete a provider-linked event and a weekly series; expect **204** (not 5xx) and event gone after reload.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0b0e9d6-3b4e-46e6-8877-983697ddf345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b0e9d6-3b4e-46e6-8877-983697ddf345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

