### PR TITLE
fix(sync): cascade series exceptions on provider delete

### DIFF
--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -816,6 +816,266 @@ describe("executeProviderDelete", () => {
     expect(writer.deleteCalls).toHaveLength(0);
   });
 
+  it("cascades local series exceptions when deleting a provider series", async () => {
+    // Staging repro: Google-side instance override stays in Sync after the
+    // master is deleted with scope=all, and keeps resurfacing in range reads.
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar: ProviderCalendarRecord = {
+      _id: objectId() as never,
+      tenantId,
+      principalId,
+      connectionId,
+      providerCalendarId: "primary@google.com" as never,
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: [],
+      createdAt: now(),
+      updatedAt: now(),
+    } as never;
+    const masterId = objectId() as EventId;
+    await events.put({
+      _id: masterId,
+      tenantId,
+      principalId,
+      origin: "provider",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-series-1" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: {
+        title: "Weekly",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule,
+      recurrence: {
+        kind: "seriesMaster",
+        rules: ["RRULE:FREQ=WEEKLY;COUNT=4"],
+      },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const master = await events.findById(tenantId, principalId, masterId);
+    if (!master) throw new Error("seed failed to read back the master");
+    const exceptionId = objectId() as EventId;
+    await events.put({
+      _id: exceptionId,
+      tenantId,
+      principalId,
+      origin: "provider",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-inst-override" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: {
+        title: "Moved instance",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-21T11:00:00-06:00",
+        end: "2026-07-21T12:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: {
+        kind: "exception",
+        seriesId: masterId,
+        recurrenceId: "2026-07-21T09:00:00-06:00" as never,
+        cancelled: false,
+      },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const exception = await events.findById(
+      tenantId,
+      principalId,
+      exceptionId,
+    );
+    if (!exception) throw new Error("seed failed to read back the exception");
+    await reprojectOccurrences(occurrences, master, now);
+    await reprojectOccurrences(occurrences, exception, now);
+    const { record: command } = await commands.submit({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId: masterId,
+      input: { kind: "delete", invitation: "none", scope: "all" } as never,
+      expectedVersion: null,
+    });
+
+    const result = await executeProviderDelete(
+      {
+        commands,
+        events,
+        occurrences,
+        writer: new FakeDeleteWriter(),
+        custody: tokenSource(),
+        markers,
+      },
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(await events.findById(tenantId, principalId, masterId)).toBeNull();
+    expect(
+      await events.findById(tenantId, principalId, exceptionId),
+    ).toBeNull();
+    expect(await events.findSeriesExceptions(tenantId, principalId, masterId))
+      .toEqual([]);
+    expect(
+      await mongo.db
+        .collection(SYNC_COLLECTIONS.eventOccurrences)
+        .countDocuments({ eventId: { $in: [masterId, exceptionId] } }),
+    ).toBe(0);
+  });
+
+  it("clears leftover series exceptions on an already-gone master replay", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar: ProviderCalendarRecord = {
+      _id: objectId() as never,
+      tenantId,
+      principalId,
+      connectionId,
+      providerCalendarId: "primary@google.com" as never,
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: [],
+      createdAt: now(),
+      updatedAt: now(),
+    } as never;
+    const masterId = objectId() as EventId;
+    const exceptionId = objectId() as EventId;
+    // Master already removed (prior attempt); orphan exception remains.
+    await events.put({
+      _id: exceptionId,
+      tenantId,
+      principalId,
+      origin: "provider",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-inst-orphan" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: {
+        title: "Orphan",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule,
+      recurrence: {
+        kind: "exception",
+        seriesId: masterId,
+        recurrenceId: "2026-07-21T09:00:00-06:00" as never,
+        cancelled: false,
+      },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const ghostMaster = {
+      _id: masterId,
+      tenantId,
+      principalId,
+      origin: "provider",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-series-1" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: {
+        title: "Weekly",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule,
+      recurrence: {
+        kind: "seriesMaster",
+        rules: ["RRULE:FREQ=WEEKLY;COUNT=4"],
+      },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as EventRecord;
+    const { record: command } = await commands.submit({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId: masterId,
+      input: { kind: "delete", invitation: "none", scope: "all" } as never,
+      expectedVersion: null,
+    });
+
+    const result = await executeProviderDelete(
+      {
+        commands,
+        events,
+        occurrences,
+        writer: new FakeDeleteWriter(),
+        custody: tokenSource(),
+        markers,
+      },
+      command,
+      ghostMaster,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(
+      await events.findById(tenantId, principalId, exceptionId),
+    ).toBeNull();
+  });
+
   it("keeps the event deletionPending and stays pending on a transient failure", async () => {
     const { tenantId, principalId, calendar, event, command } = await seed();
     const writer = new FakeDeleteWriter();

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -912,11 +912,7 @@ describe("executeProviderDelete", () => {
       updatedAt: now(),
       confirmedAt: now(),
     } as never);
-    const exception = await events.findById(
-      tenantId,
-      principalId,
-      exceptionId,
-    );
+    const exception = await events.findById(tenantId, principalId, exceptionId);
     if (!exception) throw new Error("seed failed to read back the exception");
     await reprojectOccurrences(occurrences, master, now);
     await reprojectOccurrences(occurrences, exception, now);
@@ -949,8 +945,9 @@ describe("executeProviderDelete", () => {
     expect(
       await events.findById(tenantId, principalId, exceptionId),
     ).toBeNull();
-    expect(await events.findSeriesExceptions(tenantId, principalId, masterId))
-      .toEqual([]);
+    expect(
+      await events.findSeriesExceptions(tenantId, principalId, masterId),
+    ).toEqual([]);
     expect(
       await mongo.db
         .collection(SYNC_COLLECTIONS.eventOccurrences)

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -1,4 +1,4 @@
-import { type DateTime } from "@core/types/domain-primitives";
+import { type DateTime, type EventId } from "@core/types/domain-primitives";
 import {
   type EditableRecurrence,
   type EventSchedule,
@@ -522,12 +522,10 @@ async function commitProviderSeriesUpdate(
   //
   // Deferred gap: for a provider-linked series this removes only the LOCAL copy
   // of the override, not the override event at the provider — patching a Google
-  // master does not delete its instance overrides. That is harmless today
-  // because provider-linked exceptions are only ever created by import, which
-  // does not exist yet, so `discarded` is always empty here. Once import lands,
-  // an edit-all must also cancel the discarded overrides at the provider (the
-  // same gap already noted for the provider delete path), or a later pull would
-  // resurrect them.
+  // master does not delete its instance overrides. An edit-all must also cancel
+  // the discarded overrides at the provider, or a later pull could resurrect
+  // them. (Provider series delete cascades local exceptions in
+  // executeProviderDelete; edit-all still needs the provider cancel.)
   for (const exception of discarded) {
     await deps.occurrences.replaceForEvent(
       exception._id,
@@ -739,12 +737,18 @@ export async function executeProviderDelete(
 
   // Mark the event as being deleted. If it is already gone locally, a prior
   // attempt removed it (the marker was written first) — the delete converged.
+  // Still cascade any leftover series exceptions: older builds removed the
+  // master without clearing overrides, and a crash between exception cleanup
+  // and confirm can leave the same residue.
   const marked = await deps.events.replaceExisting({
     ...event,
     lifecycleState: "deletionPending",
     updatedAt: now(),
   });
-  if (!marked) return confirmDeletion(deps, command);
+  if (!marked) {
+    await clearSeriesExceptions(deps, command, command.eventId);
+    return confirmDeletion(deps, command);
+  }
 
   let accessToken: string;
   try {
@@ -782,10 +786,11 @@ export async function executeProviderDelete(
 
   // The provider confirmed the deletion. Write the content-free tombstone first
   // (so no window exists where the event is gone with no marker), clear the
-  // occurrences, then remove the local record, then confirm. Clearing before the
-  // delete matters: a crash after deleteById would otherwise strand the
-  // occurrence rows, since the retry's already-gone (`!marked`) branch confirms
-  // without clearing them. All steps are idempotent.
+  // master's occurrences, cascade local series exceptions (Google-side instance
+  // overrides), then remove the master LAST — same crash-safety as the cloud
+  // series delete / pull cascade. Clearing before deleteById matters: a crash
+  // after deleteById would otherwise strand occurrence rows, since the retry's
+  // already-gone (`!marked`) branch confirms without ever clearing them.
   await deps.markers.record({
     tenantId: event.tenantId,
     principalId: event.principalId,
@@ -797,8 +802,37 @@ export async function executeProviderDelete(
     deletedAt: now(),
   });
   await deps.occurrences.replaceForEvent(event._id, event.generation, []);
+  await clearSeriesExceptions(deps, command, event._id);
   await deps.events.deleteById(event.tenantId, event.principalId, event._id);
   return confirmDeletion(deps, command);
+}
+
+// Remove every local exception of a series (occurrences first). Idempotent:
+// findSeriesExceptions is empty when the target was a single event or when a
+// prior attempt already cleared overrides. Does not call the provider — Google
+// series delete already discarded the instances with the master.
+async function clearSeriesExceptions(
+  deps: ProviderDeleteDeps,
+  command: CommandRecord,
+  seriesId: EventId,
+): Promise<void> {
+  const exceptions = await deps.events.findSeriesExceptions(
+    command.tenantId,
+    command.principalId,
+    seriesId,
+  );
+  for (const exception of exceptions) {
+    await deps.occurrences.replaceForEvent(
+      exception._id,
+      exception.generation,
+      [],
+    );
+    await deps.events.deleteById(
+      command.tenantId,
+      command.principalId,
+      exception._id,
+    );
+  }
 }
 
 // Confirm a completed deletion: the event has no live provider target anymore,


### PR DESCRIPTION
## Summary
- After Google confirms a provider series delete (`scope=all`), Sync now cascades `findSeriesExceptions`: clear occurrence rows, delete exception events, then delete the master (same order as cloud series delete).
- Already-gone replay path also clears leftover exceptions so older staging orphans and crash mid-cascade residue heal on retry.
- DB coverage: series master + exception → both gone; orphan exception with missing master → cleared on replay.

## Why
Staging cutover found Google instance overrides left active after Compass deleted the series. Pull cannot heal once the master is gone. Browser DELETE 503 with backend 204 remains reporting noise; this is the real blocking Sync gap.

## Test plan
- [x] `bun test:sync -- packages/sync/src/domain/provider-command.service.db.test.ts`
- [x] `bun test:sync` (full suite)
- [ ] Staging re-gate after deploy: create weekly → Google edit one instance → delete scope=all → range has neither master nor exception; orphan scan clean; CRUD smoke


Made with [Cursor](https://cursor.com)