### PR TITLE
docs(agents): add cursor cloud setup and run notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,37 @@ Validation defaults:
 - Branches: `type/action[-issue-number]`, for example `feature/add-form`.
 - Commits: conventional, lower-case, present tense, for example
   `fix(web): handle disconnected google state`.
+
+## Cursor Cloud specific instructions
+
+Bun (`bun@1.3.14`) is the runtime and package manager; the startup update
+script runs `bun install`. The VM's system `node` may be older than the
+`engines` field asks for, but everything runs through Bun, so that mismatch is
+not a blocker.
+
+- `compass.yaml` at the repo root is required for `dev:web`, `dev:backend`, and
+  `cli` — even frontend-only `dev:web` aborts if the config still contains
+  placeholders. Bootstrap with `cp compass.example.yaml compass.yaml`, then
+  replace every value: the validator (`packages/core/src/config/compass.config.ts`)
+  rejects any string containing `REPLACE_WITH_`. For frontend/anonymous work,
+  dummy local values (any non-placeholder strings) are fine. This file is
+  gitignored and holds secrets — never commit it.
+- Web: `bun run dev:web` serves http://localhost:9080 and works fully in the
+  anonymous / IndexedDB mode with no backend (create/edit events, shortcuts,
+  etc.), which is the quickest way to exercise core functionality.
+- Tests need no external services — the DB-backed suites (`test:backend`,
+  `test:sync`, `test:scripts`) spin up an in-memory MongoDB automatically, and
+  SuperTokens/Google are mocked. Run the focused suite per AGENTS.md
+  (`bun test:core|web|backend|sync|scripts`).
+- Backend: `bun run dev:backend` serves http://localhost:3000/api and needs a
+  reachable MongoDB. Because the backend uses transactions, Mongo must be a
+  replica set and `mongo.uri` must include `replicaSet=...` — a standalone
+  `mongod` will not work. Locally: install `mongodb-org`, run
+  `mongod --dbpath /data/db --replSet rs0`, then `mongosh --eval
+  'rs.initiate()'` once. `GET /api/health` returning `200 {"status":"ok"}`
+  confirms the backend is up and Mongo is reachable.
+- Auth/login and real Google Calendar sync are gated on external services not
+  provisioned by default: a SuperTokens instance (`supertokens.uri`/`key`) and
+  Google OAuth (`google.clientId`/`clientSecret`). Without them the backend
+  still runs and serves anonymous/health traffic, but do not attempt login
+  flows (see the AGENTS.md rule) until those are configured.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for Compass and documents the non-obvious startup caveats for future agents. The only tracked change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`; no application code was modified. The startup update script is `bun install`.

## Simplicity

Change is docs-only. Environment setup relies on the repo's existing Bun scripts (`dev:web`, `dev:backend`, `test:*`, `build:web`) rather than adding new tooling.

## Automated validation

Verified the environment end-to-end:

- Web dev server (`bun run dev:web`, http://localhost:9080) — created a calendar event "Hello World from Cursor" in anonymous/IndexedDB mode and confirmed it renders on the week grid.
- Backend API (`bun run dev:backend`, http://localhost:3000/api) against a local single-node MongoDB replica set — `GET /api/health` returns `200 {"status":"ok"}` (confirms Mongo connectivity).
- Production web build (`bun run build:web`) completes successfully.

[compass_web_create_event.mp4](https://cursor.com/agents/bc-9cd7f797-3939-4c58-982b-89bedc3eb1f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompass_web_create_event.mp4)

[Hello World event created on the calendar](https://cursor.com/agents/bc-9cd7f797-3939-4c58-982b-89bedc3eb1f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompass_event_created.webp)

## Independent review

N/A — docs-only change; reviewed the added AGENTS.md section for accuracy against observed behavior.

## Test plan

```
bun install
bun run lint          # exit 0 (1 pre-existing, unmodified warning)
bun run type-check    # exit 0
bun run test:core     # 528 pass
bun run test:web      # 1327 pass
bun run test:backend  # 823 pass, 5 skip
bun run test:sync     # 632 pass
bun run test:scripts  # 75 pass
bun run build:web     # build complete
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cd7f797-3939-4c58-982b-89bedc3eb1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cd7f797-3939-4c58-982b-89bedc3eb1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

