### PR TITLE
chore(cloud): make cloud agent env deterministic + one-command backend setup

### DIFF
--- a/.cursor/bootstrap-backend.sh
+++ b/.cursor/bootstrap-backend.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# One-command local backend bootstrap for Compass (Linux dev VMs / Cursor Cloud).
+#
+# Idempotent and safe to re-run. It:
+#   1. Writes a working compass.yaml (if missing) with non-placeholder values so
+#      config validation passes. Real auth/Google values are read from the
+#      environment when present (SUPERTOKENS_URI, SUPERTOKENS_KEY,
+#      GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET); otherwise safe local dummies are
+#      used and Google stays disabled.
+#   2. Installs MongoDB (mongodb-org) if it is not already present.
+#   3. Starts MongoDB as a single-node replica set (the backend uses
+#      transactions, so a replica set with `replicaSet=` in the URI is required).
+#
+# After this, run `bun run dev:backend` and check `curl -s localhost:3000/api/health`.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MONGO_URI="${MONGO_URI:-mongodb://localhost:27017/dev_calendar?replicaSet=rs0}"
+
+# 1. compass.yaml -----------------------------------------------------------
+if [ ! -f compass.yaml ]; then
+  echo "[bootstrap] creating compass.yaml from compass.example.yaml"
+  cp compass.example.yaml compass.yaml
+  sed -i \
+    -e "s#REPLACE_WITH_COMPASS_TOKEN#${COMPASS_TOKEN:-local-dev-compass-token}#" \
+    -e "s#REPLACE_WITH_SUPERTOKENS_URI#${SUPERTOKENS_URI:-http://localhost:3567}#" \
+    -e "s#REPLACE_WITH_SUPERTOKENS_KEY#${SUPERTOKENS_KEY:-local-dev-supertokens-key}#" \
+    compass.yaml
+  # Replace the whole mongo.uri line (the example ships an Atlas placeholder).
+  sed -i "s#^  uri: mongodb.*#  uri: ${MONGO_URI//#/\\#}#" compass.yaml
+
+  if [ -n "${GOOGLE_CLIENT_ID:-}" ] && [ -n "${GOOGLE_CLIENT_SECRET:-}" ]; then
+    echo "[bootstrap] enabling Google integration from environment"
+    {
+      echo ""
+      echo "google:"
+      echo "  clientId: ${GOOGLE_CLIENT_ID}"
+      echo "  clientSecret: ${GOOGLE_CLIENT_SECRET}"
+    } >> compass.yaml
+  fi
+else
+  echo "[bootstrap] compass.yaml already exists — leaving it untouched"
+fi
+
+# 2. MongoDB ----------------------------------------------------------------
+if ! command -v mongod >/dev/null 2>&1; then
+  if ! command -v apt-get >/dev/null 2>&1; then
+    echo "[bootstrap] mongod not found and apt-get unavailable; install MongoDB 8.0 manually." >&2
+    exit 1
+  fi
+  echo "[bootstrap] installing mongodb-org"
+  . /etc/os-release
+  curl -fsSL https://pgp.mongodb.com/server-8.0.asc \
+    | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor --yes
+  echo "deb [ arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu ${VERSION_CODENAME}/mongodb-org/8.0 multiverse" \
+    | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq mongodb-org
+fi
+
+# 3. Start + initiate replica set ------------------------------------------
+if ! pgrep -x mongod >/dev/null 2>&1; then
+  echo "[bootstrap] starting mongod (single-node replica set rs0)"
+  sudo mkdir -p /data/db
+  sudo chown -R "$(whoami)" /data/db
+  mongod --dbpath /data/db --replSet rs0 --bind_ip 127.0.0.1 --port 27017 \
+    --fork --logpath /tmp/mongod.log
+fi
+
+if ! mongosh --quiet --eval 'rs.status().ok' >/dev/null 2>&1; then
+  echo "[bootstrap] initiating replica set rs0"
+  mongosh --quiet --eval \
+    'rs.initiate({_id:"rs0",members:[{_id:0,host:"127.0.0.1:27017"}]})'
+fi
+
+echo "[bootstrap] done. Start the API with: bun run dev:backend"
+echo "[bootstrap] health check:            curl -s localhost:3000/api/health"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://www.cursor.com/schemas/environment.schema.json",
+  "install": "curl -fsSL https://bun.sh/install | bash -s bun-v1.3.14\n\"$HOME/.bun/bin/bun\" install"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,11 @@ everything runs through Bun, so that mismatch is not a blocker.
   `test:sync`, `test:scripts`) spin up an in-memory MongoDB automatically, and
   SuperTokens/Google are mocked. Run the focused suite per AGENTS.md
   (`bun test:core|web|backend|sync|scripts`).
+- Playwright e2e/a11y (`bun test:e2e`, `bun test:a11y`) are self-contained —
+  they boot their own web server on port 9150 with `e2e/compass.playwright.yaml`
+  (no real backend), but require the browser first: `bunx playwright install
+  chromium`. Axe "incomplete" results are logged, not failures (see
+  `docs/development/testing-playbook.md`).
 - Backend: run `bash .cursor/bootstrap-backend.sh` once to write a working
   `compass.yaml` and install/start a single-node MongoDB replica set, then
   `bun run dev:backend` (serves http://localhost:3000/api). The script is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,34 +100,39 @@ of truth:
 
 ## Cursor Cloud specific instructions
 
-Bun (`bun@1.3.14`) is the runtime and package manager; the startup update
-script runs `bun install`. The VM's system `node` may be older than the
-`engines` field asks for, but everything runs through Bun, so that mismatch is
-not a blocker.
+Bun (`bun@1.3.14`) is the runtime and package manager. The environment is
+defined in `.cursor/environment.json`: its `install` step installs Bun (fresh
+VMs do not ship it) and runs `bun install`, so Bun is guaranteed on boot. The
+VM's system `node` may be older than the `engines` field asks for, but
+everything runs through Bun, so that mismatch is not a blocker.
 
 - `compass.yaml` at the repo root is required for `dev:web`, `dev:backend`, and
   `cli` — even frontend-only `dev:web` aborts if the config still contains
-  placeholders. Bootstrap with `cp compass.example.yaml compass.yaml`, then
-  replace every value: the validator (`packages/core/src/config/compass.config.ts`)
-  rejects any string containing `REPLACE_WITH_`. For frontend/anonymous work,
-  dummy local values (any non-placeholder strings) are fine. This file is
-  gitignored and holds secrets — never commit it.
+  placeholders. The validator (`packages/core/src/config/compass.config.ts`)
+  rejects any string containing `REPLACE_WITH_` (comments are ignored). This
+  file is gitignored and holds secrets — never commit it.
 - Web: `bun run dev:web` serves http://localhost:9080 and works fully in the
   anonymous / IndexedDB mode with no backend (create/edit events, shortcuts,
-  etc.), which is the quickest way to exercise core functionality.
+  etc.), which is the quickest way to exercise core functionality. For
+  frontend-only work, `cp compass.example.yaml compass.yaml` and replace the
+  placeholders with any dummy non-placeholder strings.
 - Tests need no external services — the DB-backed suites (`test:backend`,
   `test:sync`, `test:scripts`) spin up an in-memory MongoDB automatically, and
   SuperTokens/Google are mocked. Run the focused suite per AGENTS.md
   (`bun test:core|web|backend|sync|scripts`).
-- Backend: `bun run dev:backend` serves http://localhost:3000/api and needs a
-  reachable MongoDB. Because the backend uses transactions, Mongo must be a
-  replica set and `mongo.uri` must include `replicaSet=...` — a standalone
-  `mongod` will not work. Locally: install `mongodb-org`, run
-  `mongod --dbpath /data/db --replSet rs0`, then `mongosh --eval
-  'rs.initiate()'` once. `GET /api/health` returning `200 {"status":"ok"}`
-  confirms the backend is up and Mongo is reachable.
+- Backend: run `bash .cursor/bootstrap-backend.sh` once to write a working
+  `compass.yaml` and install/start a single-node MongoDB replica set, then
+  `bun run dev:backend` (serves http://localhost:3000/api). The script is
+  idempotent and reads `SUPERTOKENS_URI`, `SUPERTOKENS_KEY`, `GOOGLE_CLIENT_ID`,
+  and `GOOGLE_CLIENT_SECRET` from the environment when set (otherwise dummy
+  local auth values, Google disabled). Non-obvious: the backend uses
+  transactions, so Mongo must be a replica set and `mongo.uri` must include
+  `replicaSet=...` — a standalone `mongod` will not work. `GET /api/health`
+  returning `200 {"status":"ok"}` confirms the backend is up and Mongo is
+  reachable.
 - Auth/login and real Google Calendar sync are gated on external services not
-  provisioned by default: a SuperTokens instance (`supertokens.uri`/`key`) and
-  Google OAuth (`google.clientId`/`clientSecret`). Without them the backend
-  still runs and serves anonymous/health traffic, but do not attempt login
-  flows (see the AGENTS.md rule) until those are configured.
+  provisioned by default: a SuperTokens instance and Google OAuth. Provide them
+  as environment secrets so `bootstrap-backend.sh` wires them into
+  `compass.yaml`. Without them the backend still runs and serves
+  anonymous/health traffic, but do not attempt login flows (see the AGENTS.md
+  rule) until those are configured.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Optimizations for Cloud Agent sessions in this repo, based on friction hit during first-time setup:

- **`.cursor/environment.json`** — pins the startup `install` step to install Bun `1.3.14` (fresh VMs don't ship Bun, so a bare `bun install` update script would fail) and then run `bun install`. Repo config takes precedence over UI/snapshot env config, so boots are now deterministic.
- **`.cursor/bootstrap-backend.sh`** — one idempotent command to stand up the backend locally: writes a valid `compass.yaml`, installs `mongodb-org`, and starts a single-node MongoDB replica set (required because the backend uses transactions). Reads `SUPERTOKENS_URI`, `SUPERTOKENS_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` from the environment when present, otherwise uses safe local dummies (Google disabled).
- **AGENTS.md** — updates the `## Cursor Cloud specific instructions` section to reference the above and drop the now-redundant manual MongoDB steps.

No application code changed.

## Simplicity

Reuses existing repo scripts and the config validator; adds only a small config file and a self-contained, idempotent shell script. AGENTS.md got shorter where manual steps were replaced by the script.

## Automated validation

- Executed the exact `.cursor/environment.json` `install` command — installs Bun `1.3.14` and runs `bun install` cleanly (idempotent).
- Ran `bash .cursor/bootstrap-backend.sh` — idempotent path is a no-op when Mongo/`compass.yaml` already exist; `GET /api/health` → `200 {"status":"ok"}`.
- Validated the script's `compass.yaml` generation (including the `GOOGLE_*` branch) through the real parser `packages/core/src/config/compass.config.ts` — parses without placeholder errors.
- `bun run lint` → exit 0 (biome validates the new `environment.json`; only a pre-existing, unmodified warning remains).

## Independent review

N/A — infra/docs only; reviewed the generated `compass.yaml` against the config validator and confirmed the `install` command runs end-to-end.

## Test plan

```
# environment.json install step
curl -fsSL https://bun.sh/install | bash -s bun-v1.3.14 && "$HOME/.bun/bin/bun" install

# backend bootstrap
bash .cursor/bootstrap-backend.sh
bun run dev:backend
curl -s localhost:3000/api/health   # {"status":"ok",...}

bun run lint                        # exit 0
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cd7f797-3939-4c58-982b-89bedc3eb1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cd7f797-3939-4c58-982b-89bedc3eb1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

