### PR TITLE
docs(agents): stop restating AGENTS.md rules in cursor rule files

### DIFF
--- a/.cursor/rules/imports-and-packages.mdc
+++ b/.cursor/rules/imports-and-packages.mdc
@@ -6,13 +6,9 @@ alwaysApply: false
 
 # Imports and package boundaries
 
-- Use `@compass/backend`, `@compass/core`, `@compass/scripts`,
-  `@compass/sync`, `@web/*`, and `@core/*` instead of deep relative imports.
-- Import from concrete source files. Do not create or use `index.ts` or
-  `index.tsx` barrel files.
-- Put shared web/backend contracts in `packages/core` and define them with Zod;
-  infer TypeScript types from the schema.
-- Keep React components in their own files.
+See `AGENTS.md`'s Compass-Specific Rules for import aliases, the barrel-file
+ban, the Zod shared-contracts rule, and the one-component-per-file rule.
+
 - Put code in the package that owns the concept; do not duplicate shared domain
   behavior in web and backend.
 

--- a/.cursor/rules/web-styles.mdc
+++ b/.cursor/rules/web-styles.mdc
@@ -6,12 +6,9 @@ alwaysApply: false
 
 # Web styles
 
-- Use Tailwind semantic colors defined in `packages/web/src/index.css`.
-- Do not add raw palette colors such as `bg-blue-300` or `text-zinc-900`.
-- Prefer canonical Tailwind scale utilities over arbitrary values when an
-  equivalent exists.
-- Treat Tailwind IntelliSense `suggestCanonicalClasses` warnings as required
-  cleanup.
+See `AGENTS.md`'s Compass-Specific Rules for Tailwind semantic colors and
+canonical-scale-utility conventions.
+
 - Preserve the established Compass visual language and responsive behavior.
 - Use native semantic elements and visible focus states for interactive UI.
 

--- a/.cursor/rules/web-testing.mdc
+++ b/.cursor/rules/web-testing.mdc
@@ -6,9 +6,10 @@ alwaysApply: false
 
 # Web testing
 
-- Use React Testing Library and `user-event`.
-- Query by semantic role, accessible name, or visible text.
-- Avoid CSS selectors, `data-*` locators, and implementation-detail assertions.
+See `AGENTS.md`'s Compass-Specific Rules for the RTL/`user-event`/semantic-query
+convention.
+
+- Avoid implementation-detail assertions.
 - Prefer the shared render/store/provider harnesses over broad module mocks.
 - Restore replaced globals, timers, and spies in teardown.
 - Register every new Zustand store in both the reset registry and state seeder.


### PR DESCRIPTION
## Summary
- `#2401` unified skills into `.agents/skills` (referencing `AGENTS.md` instead of restating it) but added `.cursor/rules/*.mdc` files alongside it that still restate `AGENTS.md`'s Compass-Specific Rules almost verbatim
- Cursor's own docs confirm it loads `AGENTS.md` and any glob-matching `.mdc` rule into the *same session* together (complementary, not alternative), so a Cursor session editing a matching file genuinely got each convention loaded twice
- Trims the restated bullets in `imports-and-packages.mdc`, `web-styles.mdc`, and `web-testing.mdc` to a one-line pointer at `AGENTS.md`, keeping only the content with no `AGENTS.md` counterpart (extra rules, code samples, doc pointers)
- `sync-package.mdc` and all 8 `.agents/skills/*.md` files were checked and found to have no overlap — no changes needed there

## Simplicity
Net removal (10 insertions / 16 deletions across 3 files); no logic, no hooks involved — pure doc de-duplication, single source of truth restored for each convention.

## Manual Testing Steps
- [ ] Open `.cursor/rules/imports-and-packages.mdc`, `.cursor/rules/web-styles.mdc`, and `.cursor/rules/web-testing.mdc` in a Markdown viewer and confirm each still reads sensibly standalone (pointer line + kept bullets + code sample)
- [ ] Confirm `AGENTS.md`'s "Compass-Specific Rules" section (aliases, barrel-file ban, Zod contracts, Tailwind colors, RTL/`user-event`) is unchanged and still the canonical source each pointer references

## Test plan
- [x] `rg -n "bg-blue-300|@compass/backend|` + "`user-event`" + `" .cursor/rules AGENTS.md` — confirmed each convention appears once in `AGENTS.md`, with only the pointer text and illustrative code samples remaining in the trimmed files
- [x] `git diff` reviewed for all 3 files — clean, minimal, no accidental removal of non-duplicate content
- Docs/config-only change; no app code affected, no automated test suite applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits to Cursor rule files; no application code, config hooks, or runtime behavior.
> 
> **Overview**
> **Removes duplicate Compass conventions** from three glob-scoped `.cursor/rules/*.mdc` files so they no longer repeat what `AGENTS.md` already loads in the same Cursor session.
> 
> `imports-and-packages.mdc`, `web-styles.mdc`, and `web-testing.mdc` now open with a one-line pointer to **`AGENTS.md`'s Compass-Specific Rules** instead of restating import aliases, barrel bans, Zod contracts, Tailwind semantic colors, canonical utilities, and RTL/`user-event` guidance. **File-specific guidance stays**: extra bullets (e.g. package ownership, visual language, Zustand registry, sequential `test:web`), code samples, and links like `docs/development/testing-playbook.md`. `web-testing.mdc` also keeps an explicit “avoid implementation-detail assertions” bullet after the pointer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe8405c40bc01d47137c9b6c7befc3460d8c936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->