### PR TITLE
fix(web): show multi-day timed events in the all-day row

### DIFF
--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -58,6 +58,17 @@ export function resolveCalendarCardIdentity(
 }
 
 /**
+ * Grid-only content flags that force read-only treatment regardless of
+ * calendar write capability (passed as the `isBusy` argument to
+ * {@link isEventReadOnly}).
+ */
+export const isGridEventContentReadOnly = (event: {
+  isBusy?: boolean;
+  isTimedMultiDayDisplay?: boolean;
+}): boolean =>
+  (event.isBusy ?? false) || (event.isTimedMultiDayDisplay ?? false);
+
+/**
  * An event is read-only (inspectable but never mutable) when either:
  * - it's a busy event (content.kind === "busy") - a private event on a
  *   reader calendar whose real fields the server never sends, so there is

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -51,5 +51,7 @@ export const GridEventSchema = WebEventSchema.extend({
   calendarId: CalendarIdSchema.optional(),
   isBusy: z.boolean().optional(),
   isDemo: z.boolean().optional(),
+  /** Timed event shown in the all-day row because it spans midnight. */
+  isTimedMultiDayDisplay: z.boolean().optional(),
 });
 export type GridEvent = z.infer<typeof GridEventSchema>;

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -12,6 +12,7 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
+import { isDraftRenderedInAllDayRow } from "@web/grid/layout/all-day-draft.position";
 
 export const createTimedDraft = (
   isCurrentWeek: boolean,
@@ -61,6 +62,6 @@ export const getDraftTimes = (isCurrentWeek: boolean, startOfWeek: Dayjs) => {
 };
 
 export const getDraftContainer = (draft: GridEventDraft) =>
-  draft.values.schedule.kind === "allDay"
+  isDraftRenderedInAllDayRow(draft)
     ? getElemById(ID_GRID_EVENTS_ALLDAY)
     : getElemById(ID_GRID_EVENTS_TIMED);

--- a/packages/web/src/common/utils/event/event-nudge.util.test.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.test.ts
@@ -162,4 +162,13 @@ describe("timedMultiDayToAllDayDates", () => {
       ),
     ).toEqual({ startDate: "2026-05-22", endDate: "2026-05-24" });
   });
+
+  it("does not include the day after a midnight-exclusive end", () => {
+    expect(
+      timedMultiDayToAllDayDates(
+        dayjs("2026-05-22T08:00:00"),
+        dayjs("2026-05-25T00:00:00"),
+      ),
+    ).toEqual({ startDate: "2026-05-22", endDate: "2026-05-25" });
+  });
 });

--- a/packages/web/src/common/utils/event/event-nudge.util.test.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.test.ts
@@ -1,6 +1,10 @@
+import dayjs from "@core/util/date/dayjs";
 import {
   getArrowKeyMovement,
+  isTimedEventInsideOneDay,
+  isTimedEventMultiDay,
   nudgeEventDates,
+  timedMultiDayToAllDayDates,
 } from "@web/common/utils/event/event-nudge.util";
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
 import { describe, expect, it } from "bun:test";
@@ -108,5 +112,54 @@ describe("nudgeEventDates", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe("isTimedEventMultiDay", () => {
+  it("is false for same-day timed events and exact next-midnight ends", () => {
+    expect(
+      isTimedEventMultiDay(
+        dayjs("2026-05-20T10:00:00"),
+        dayjs("2026-05-20T11:00:00"),
+      ),
+    ).toBe(false);
+    expect(
+      isTimedEventInsideOneDay(
+        dayjs("2026-05-20T22:00:00"),
+        dayjs("2026-05-21T00:00:00"),
+      ),
+    ).toBe(true);
+    expect(
+      isTimedEventMultiDay(
+        dayjs("2026-05-20T22:00:00"),
+        dayjs("2026-05-21T00:00:00"),
+      ),
+    ).toBe(false);
+  });
+
+  it("is true for overnight and multi-day timed ranges", () => {
+    expect(
+      isTimedEventMultiDay(
+        dayjs("2026-05-20T22:00:00"),
+        dayjs("2026-05-21T02:00:00"),
+      ),
+    ).toBe(true);
+    expect(
+      isTimedEventMultiDay(
+        dayjs("2026-05-20T08:00:00"),
+        dayjs("2026-05-21T18:00:00"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("timedMultiDayToAllDayDates", () => {
+  it("maps a Fri–Sat timed range to an exclusive Fri–Sun all-day span", () => {
+    expect(
+      timedMultiDayToAllDayDates(
+        dayjs("2026-05-22T08:00:00"),
+        dayjs("2026-05-23T18:00:00"),
+      ),
+    ).toEqual({ startDate: "2026-05-22", endDate: "2026-05-24" });
   });
 });

--- a/packages/web/src/common/utils/event/event-nudge.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.ts
@@ -44,10 +44,17 @@ export const isTimedEventMultiDay = (start: Dayjs, end: Dayjs) =>
 export const timedMultiDayToAllDayDates = (
   start: Dayjs,
   end: Dayjs,
-): { startDate: string; endDate: string } => ({
-  startDate: start.startOf("day").format(YEAR_MONTH_DAY_FORMAT),
-  endDate: end.startOf("day").add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
-});
+): { startDate: string; endDate: string } => {
+  const endDayStart = end.startOf("day");
+  const exclusiveEnd = end.isSame(endDayStart)
+    ? endDayStart
+    : endDayStart.add(1, "day");
+
+  return {
+    startDate: start.startOf("day").format(YEAR_MONTH_DAY_FORMAT),
+    endDate: exclusiveEnd.format(YEAR_MONTH_DAY_FORMAT),
+  };
+};
 
 export const nudgeEventDates = (
   event: Pick<CompassEvent, "startDate" | "endDate" | "isAllDay">,

--- a/packages/web/src/common/utils/event/event-nudge.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.ts
@@ -32,6 +32,23 @@ export const isTimedEventInsideOneDay = (start: Dayjs, end: Dayjs) => {
   return end.isSame(start, "day") || end.isSame(midnightAfterStart);
 };
 
+/** Timed events that cross midnight render in the all-day row (Google-style). */
+export const isTimedEventMultiDay = (start: Dayjs, end: Dayjs) =>
+  !isTimedEventInsideOneDay(start, end);
+
+/**
+ * Maps a multi-day timed range onto an exclusive all-day date span for the
+ * all-day row. Inclusive coverage is every calendar day that contains any
+ * part of [start, end); exclusive end is the day after the last of those.
+ */
+export const timedMultiDayToAllDayDates = (
+  start: Dayjs,
+  end: Dayjs,
+): { startDate: string; endDate: string } => ({
+  startDate: start.startOf("day").format(YEAR_MONTH_DAY_FORMAT),
+  endDate: end.startOf("day").add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
+});
+
 export const nudgeEventDates = (
   event: Pick<CompassEvent, "startDate" | "endDate" | "isAllDay">,
   movement: EventNudgeMovement,

--- a/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
+++ b/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
@@ -20,8 +20,18 @@ function useMinuteTick(): Dayjs {
 export function useUpNextEvent() {
   const now = useMinuteTick();
   const { startDate, endDate } = dayEventQueryRange(now);
-  const { events, timedEvents } = useDayEventViewModel({ startDate, endDate });
-  const upNext = timedEvents
+  const { events, timedEvents, allDayEvents } = useDayEventViewModel({
+    startDate,
+    endDate,
+  });
+  const multiDayTimed = allDayEvents
+    .filter((event) => event.isTimedMultiDayDisplay)
+    .flatMap((gridEvent) => {
+      const source = events.find((event) => event.id === gridEvent._id);
+      if (!source || source.schedule.kind !== "timed") return [];
+      return [{ ...gridEvent, startDate: source.schedule.start }];
+    });
+  const upNext = [...timedEvents, ...multiDayTimed]
     .filter((event) => dayjs(event.startDate).isAfter(now))
     .sort(
       (a, b) => dayjs(a.startDate).valueOf() - dayjs(b.startDate).valueOf(),

--- a/packages/web/src/events/queries/event.view-model.test.ts
+++ b/packages/web/src/events/queries/event.view-model.test.ts
@@ -74,4 +74,29 @@ describe("Event query view models", () => {
       demoEventIds: undefined,
     });
   });
+
+  test("promotes multi-day timed events into the all-day row", () => {
+    const multiDayTimed = createMockEvent({
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-07-24T08:00:00.000Z",
+        end: "2026-07-25T18:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const sameDayTimed = createMockEvent();
+    const data = normalized(multiDayTimed, sameDayTimed);
+
+    const result = deriveCalendarEventViewModel(data);
+
+    expect(result.timedEvents.map(({ _id }) => _id)).toEqual([sameDayTimed.id]);
+    expect(result.allDayEvents.map(({ _id }) => _id)).toEqual([
+      multiDayTimed.id,
+    ]);
+    const promoted = result.allDayEvents[0];
+    expect(promoted?.isAllDay).toBe(true);
+    expect(promoted?.isTimedMultiDayDisplay).toBe(true);
+    expect(promoted?.startDate).toBe("2026-07-24");
+    expect(promoted?.endDate).toBe("2026-07-26");
+  });
 });

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -2,12 +2,17 @@ import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
   assembleGridEvent,
   type EventWithDates,
   hasEventDates,
 } from "@web/common/utils/event/event.util";
+import {
+  isTimedEventMultiDay,
+  timedMultiDayToAllDayDates,
+} from "@web/common/utils/event/event-nudge.util";
 import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
@@ -129,11 +134,55 @@ const gridEventsFrom = (
 };
 
 const timedEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
-  gridEventsFrom(events, "timed", demoEventIds);
+  gridEventsFrom(events, "timed", demoEventIds).filter((event) => {
+    if (!event.startDate || !event.endDate) return true;
+    return !isTimedEventMultiDay(dayjs(event.startDate), dayjs(event.endDate));
+  });
+
+const multiDayTimedAsAllDayFrom = (
+  events: Event[],
+  demoEventIds?: readonly EventId[],
+): GridEvent[] => {
+  const scheduled = events
+    .filter(isValidScheduledEvent)
+    .filter((event) => event.recurrence.kind !== "series")
+    .flatMap((event) => {
+      if (event.schedule.kind !== "timed") return [];
+      const start = dayjs(event.schedule.start);
+      const end = dayjs(event.schedule.end);
+      if (!isTimedEventMultiDay(start, end)) return [];
+      return [event];
+    });
+
+  const assembled = scheduled.flatMap((event) => {
+    const schedule = event.schedule;
+    if (schedule.kind !== "timed") return [];
+    const dates = timedMultiDayToAllDayDates(
+      dayjs(schedule.start),
+      dayjs(schedule.end),
+    );
+    const schemaEvent: EventWithDates = {
+      ...scheduledEventToSchemaEvent(event),
+      isAllDay: true,
+      startDate: dates.startDate,
+      endDate: dates.endDate,
+    };
+    return [
+      {
+        ...assembleGridEvent(schemaEvent),
+        isTimedMultiDayDisplay: true,
+      },
+    ];
+  });
+
+  return withCalendarMetadata(scheduled, assembled, demoEventIds);
+};
 
 const allDayEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
-  assignEventsToRow(gridEventsFrom(events, "allDay", demoEventIds))
-    .allDayEvents;
+  assignEventsToRow([
+    ...gridEventsFrom(events, "allDay", demoEventIds),
+    ...multiDayTimedAsAllDayFrom(events, demoEventIds),
+  ]).allDayEvents;
 
 const rowCountFrom = (events: GridEvent[]) => {
   const rows = events

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -146,33 +146,25 @@ const multiDayTimedAsAllDayFrom = (
   const scheduled = events
     .filter(isValidScheduledEvent)
     .filter((event) => event.recurrence.kind !== "series")
-    .flatMap((event) => {
-      if (event.schedule.kind !== "timed") return [];
-      const start = dayjs(event.schedule.start);
-      const end = dayjs(event.schedule.end);
-      if (!isTimedEventMultiDay(start, end)) return [];
-      return [event];
+    .filter((event) => event.schedule.kind === "timed")
+    .filter((event) => {
+      const { start, end } = event.schedule;
+      return isTimedEventMultiDay(dayjs(start), dayjs(end));
     });
 
-  const assembled = scheduled.flatMap((event) => {
-    const schedule = event.schedule;
-    if (schedule.kind !== "timed") return [];
-    const dates = timedMultiDayToAllDayDates(
-      dayjs(schedule.start),
-      dayjs(schedule.end),
-    );
+  const assembled = scheduled.map((event) => {
+    const { start, end } = event.schedule;
+    const dates = timedMultiDayToAllDayDates(dayjs(start), dayjs(end));
     const schemaEvent: EventWithDates = {
       ...scheduledEventToSchemaEvent(event),
       isAllDay: true,
       startDate: dates.startDate,
       endDate: dates.endDate,
     };
-    return [
-      {
-        ...assembleGridEvent(schemaEvent),
-        isTimedMultiDayDisplay: true,
-      },
-    ];
+    return {
+      ...assembleGridEvent(schemaEvent),
+      isTimedMultiDayDisplay: true,
+    };
   });
 
   return withCalendarMetadata(scheduled, assembled, demoEventIds);

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -139,12 +139,10 @@ const AllDayEventCardBase = (
         onEventKeyDown?.(event);
       }}
       onMouseDown={(e: MouseEvent) => {
-        if (!onEventMouseDown) {
-          e.stopPropagation();
-          return;
-        }
-
-        onEventMouseDown(e, event);
+        // Stop bubble so the all-day row create handler cannot overwrite a
+        // card click (including read-only open for busy / multi-day timed).
+        e.stopPropagation();
+        onEventMouseDown?.(e, event);
       }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/packages/web/src/grid/layout/all-day-draft.position.ts
+++ b/packages/web/src/grid/layout/all-day-draft.position.ts
@@ -1,10 +1,46 @@
+import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import {
+  isTimedEventMultiDay,
+  timedMultiDayToAllDayDates,
+} from "@web/common/utils/event/event-nudge.util";
 import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   getGridDraftId,
   gridEventDraftToGridEvent,
 } from "@web/events/grid-event-draft.adapter";
+
+export const isDraftRenderedInAllDayRow = (draft: GridEventDraft): boolean => {
+  const { schedule } = draft.values;
+
+  return (
+    schedule.kind === "allDay" ||
+    (schedule.kind === "timed" &&
+      isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end)))
+  );
+};
+
+export const draftToAllDayRowGridEvent = (draft: GridEventDraft): GridEvent => {
+  const { schedule } = draft.values;
+
+  if (schedule.kind === "allDay") {
+    return gridEventDraftToGridEvent(draft);
+  }
+
+  const dates = timedMultiDayToAllDayDates(
+    dayjs(schedule.start),
+    dayjs(schedule.end),
+  );
+
+  return {
+    ...gridEventDraftToGridEvent(draft),
+    endDate: dates.endDate,
+    isAllDay: true,
+    isTimedMultiDayDisplay: true,
+    startDate: dates.startDate,
+  };
+};
 
 export const positionAllDayDraftEvent = ({
   draft,
@@ -16,11 +52,11 @@ export const positionAllDayDraftEvent = ({
   activeDraftEvent: GridEvent | null;
   events: GridEvent[];
 } => {
-  if (!draft || draft.values.schedule.kind !== "allDay") {
+  if (!draft || !isDraftRenderedInAllDayRow(draft)) {
     return { activeDraftEvent: null, events };
   }
 
-  const draftEvent = gridEventDraftToGridEvent(draft);
+  const draftEvent = draftToAllDayRowGridEvent(draft);
   const draftId = getGridDraftId(draft);
   const existingIndex = draftId
     ? events.findIndex((event) => event._id === draftId)

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -84,7 +84,7 @@ export const DayCalendarAllDayEventsLayer = ({
           isReadOnly={isEventReadOnly(
             calendarLookup,
             event.calendarId,
-            event.isBusy ?? false,
+            (event.isBusy ?? false) || (event.isTimedMultiDayDisplay ?? false),
           )}
           key={event._id ?? "all-day-draft"}
           measurements={measurements}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import {
   isEventReadOnly,
+  isGridEventContentReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
@@ -84,7 +85,7 @@ export const DayCalendarAllDayEventsLayer = ({
           isReadOnly={isEventReadOnly(
             calendarLookup,
             event.calendarId,
-            (event.isBusy ?? false) || (event.isTimedMultiDayDisplay ?? false),
+            isGridEventContentReadOnly(event),
           )}
           key={event._id ?? "all-day-draft"}
           measurements={measurements}

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
@@ -1,3 +1,4 @@
+import { Origin } from "@core/constants/core.constants";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
@@ -10,14 +11,16 @@ const visibleDates: GridVisibleDate[] = [
   { key: "2026-05-22", date: dayjs("2026-05-22T00:00:00") },
 ];
 
-const savedTimed: GridEvent = {
+const savedTimed = {
   _id: "saved-timed",
   title: "Saved",
   isAllDay: false,
   startDate: "2026-05-22T10:00:00",
   endDate: "2026-05-22T11:00:00",
+  origin: Origin.COMPASS,
+  user: "user",
   position: gridEventDefaultPosition,
-};
+} as GridEvent;
 
 describe("addVisibleDraftEvent", () => {
   it("does not inject a multi-day timed draft into the timed layer", () => {

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
@@ -1,0 +1,59 @@
+import dayjs from "@core/util/date/dayjs";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import { addVisibleDraftEvent } from "./dayCalendarDraft.util";
+import { describe, expect, it } from "bun:test";
+
+const visibleDates: GridVisibleDate[] = [
+  { key: "2026-05-22", date: dayjs("2026-05-22T00:00:00") },
+];
+
+const savedTimed: GridEvent = {
+  _id: "saved-timed",
+  title: "Saved",
+  isAllDay: false,
+  startDate: "2026-05-22T10:00:00",
+  endDate: "2026-05-22T11:00:00",
+  position: gridEventDefaultPosition,
+};
+
+describe("addVisibleDraftEvent", () => {
+  it("does not inject a multi-day timed draft into the timed layer", () => {
+    const draft = createGridEventDraft({
+      kind: "timed",
+      start: new Date("2026-05-22T08:00:00"),
+      end: new Date("2026-05-23T18:00:00"),
+      timeZone: "UTC",
+    });
+
+    const result = addVisibleDraftEvent({
+      draft,
+      events: [savedTimed],
+      isAllDay: false,
+      visibleDates,
+    });
+
+    expect(result).toEqual([savedTimed]);
+  });
+
+  it("still injects a same-day timed draft into the timed layer", () => {
+    const draft = createGridEventDraft({
+      kind: "timed",
+      start: new Date("2026-05-22T14:00:00"),
+      end: new Date("2026-05-22T15:00:00"),
+      timeZone: "UTC",
+    });
+
+    const result = addVisibleDraftEvent({
+      draft,
+      events: [savedTimed],
+      isAllDay: false,
+      visibleDates,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.startDate).toContain("2026-05-22T14:00:00");
+  });
+});

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
@@ -1,5 +1,6 @@
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { isTimedEventMultiDay } from "@web/common/utils/event/event-nudge.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   getGridDraftId,
@@ -29,6 +30,16 @@ export const addVisibleDraftEvent = ({
 
   if (isAllDay) {
     return positionAllDayDraftEvent({ draft, events }).events;
+  }
+
+  const schedule = draft.values.schedule;
+  // Multi-day timed drafts stay represented by the promoted all-day bar;
+  // injecting a timed card here overflows the day column.
+  if (
+    schedule.kind === "timed" &&
+    isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end))
+  ) {
+    return events;
   }
 
   const draftEvent = gridEventDraftToGridEvent(draft);

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
@@ -1,12 +1,18 @@
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { isTimedEventMultiDay } from "@web/common/utils/event/event-nudge.util";
+import {
+  isTimedEventMultiDay,
+  timedMultiDayToAllDayDates,
+} from "@web/common/utils/event/event-nudge.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   getGridDraftId,
   gridEventDraftToGridEvent,
 } from "@web/events/grid-event-draft.adapter";
-import { positionAllDayDraftEvent } from "@web/grid/layout/all-day-draft.position";
+import {
+  isDraftRenderedInAllDayRow,
+  positionAllDayDraftEvent,
+} from "@web/grid/layout/all-day-draft.position";
 import { type GridVisibleDate } from "@web/grid/types/grid.types";
 
 export const addVisibleDraftEvent = ({
@@ -22,7 +28,7 @@ export const addVisibleDraftEvent = ({
 }) => {
   if (
     !draft ||
-    (draft.values.schedule.kind === "allDay") !== isAllDay ||
+    isDraftRenderedInAllDayRow(draft) !== isAllDay ||
     !isDraftVisibleOnDate(draft, visibleDates)
   ) {
     return events;
@@ -30,16 +36,6 @@ export const addVisibleDraftEvent = ({
 
   if (isAllDay) {
     return positionAllDayDraftEvent({ draft, events }).events;
-  }
-
-  const schedule = draft.values.schedule;
-  // Multi-day timed drafts stay represented by the promoted all-day bar;
-  // injecting a timed card here overflows the day column.
-  if (
-    schedule.kind === "timed" &&
-    isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end))
-  ) {
-    return events;
   }
 
   const draftEvent = gridEventDraftToGridEvent(draft);
@@ -98,6 +94,23 @@ export const isDraftVisibleOnDate = (
   const { schedule } = draft.values;
 
   if (schedule.kind === "timed") {
+    if (isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end))) {
+      const dates = timedMultiDayToAllDayDates(
+        dayjs(schedule.start),
+        dayjs(schedule.end),
+      );
+      const visibleDay = visibleDate.startOf("day");
+      const start = dayjs(dates.startDate).startOf("day");
+      const end = dayjs(dates.endDate).startOf("day");
+      const inclusiveEnd = end.isAfter(start) ? end.subtract(1, "day") : start;
+
+      return (
+        visibleDay.isSame(start) ||
+        visibleDay.isSame(inclusiveEnd) ||
+        (visibleDay.isAfter(start) && visibleDay.isBefore(inclusiveEnd))
+      );
+    }
+
     return dayjs(schedule.start).isSame(visibleDate, "day");
   }
 

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -1,7 +1,6 @@
 import { type FC, type MouseEvent } from "react";
 import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
-import dayjs from "@core/util/date/dayjs";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import {
   Categories_Event,
@@ -11,9 +10,12 @@ import {
   getEventDragOffset,
   gridEventDefaultPosition,
 } from "@web/common/utils/event/event.util";
-import { isTimedEventMultiDay } from "@web/common/utils/event/event-nudge.util";
 import { focusEventFormTitle } from "@web/common/utils/form/form.util";
 import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
+import {
+  draftToAllDayRowGridEvent,
+  isDraftRenderedInAllDayRow,
+} from "@web/grid/layout/all-day-draft.position";
 import { type TimedDeckLayout } from "@web/grid/layout/timed-deck.layout";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 import { GridEvent } from "@web/views/Week/components/Event/Grid/GridEvent/GridEvent";
@@ -77,27 +79,18 @@ export const GridDraft: FC<Props> = ({
 
   const motionMode = isResizing ? "resizing" : isDragging ? "dragging" : "idle";
 
+  const rendersInAllDayRow = draft ? isDraftRenderedInAllDayRow(draft) : false;
+
   const { onMouseDown } = useGridEventMouseDown(
-    draft?.values.schedule.kind === "allDay"
-      ? Categories_Event.ALLDAY
-      : Categories_Event.TIMED,
+    rendersInAllDayRow ? Categories_Event.ALLDAY : Categories_Event.TIMED,
     handleGridDraftClick,
     handleDrag,
   );
 
   if (!draft || !draftAsGridEvent) return null;
 
-  const isAllDay = draft.values.schedule.kind === "allDay";
-  const schedule = draft.values.schedule;
-  const isMultiDayTimedDraft =
-    schedule.kind === "timed" &&
-    isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end));
-  // Multi-day timed events render as all-day bars; keep the form draft in
-  // the store but do not mount an overflowing timed grid card.
-  if (isMultiDayTimedDraft) return null;
-
-  const allDayDraftEvent = isAllDay
-    ? (activeAllDayDraftEvent ?? draftAsGridEvent)
+  const allDayDraftEvent = rendersInAllDayRow
+    ? (activeAllDayDraftEvent ?? draftToAllDayRowGridEvent(draft))
     : draftAsGridEvent;
 
   return (
@@ -115,7 +108,7 @@ export const GridDraft: FC<Props> = ({
         />
       ))}
 
-      {isAllDay ? (
+      {rendersInAllDayRow ? (
         <AllDayEventMemo
           event={allDayDraftEvent}
           isPlaceholder={false}

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -80,11 +80,13 @@ export const GridDraft: FC<Props> = ({
   const motionMode = isResizing ? "resizing" : isDragging ? "dragging" : "idle";
 
   const rendersInAllDayRow = draft ? isDraftRenderedInAllDayRow(draft) : false;
+  const isMultiDayTimedDraft =
+    rendersInAllDayRow && draft?.values.schedule.kind === "timed";
 
   const { onMouseDown } = useGridEventMouseDown(
     rendersInAllDayRow ? Categories_Event.ALLDAY : Categories_Event.TIMED,
     handleGridDraftClick,
-    handleDrag,
+    isMultiDayTimedDraft ? () => {} : handleDrag,
   );
 
   if (!draft || !draftAsGridEvent) return null;
@@ -115,11 +117,17 @@ export const GridDraft: FC<Props> = ({
           key={`draft-${draftAsGridEvent._id}`}
           measurements={measurements}
           onKeyDown={focusEventFormTitle}
-          onMouseDown={(e: MouseEvent, event: GridEventEntity) => {
-            e.preventDefault();
-            onMouseDown(e, event);
-          }}
-          onScalerMouseDown={handleScalerMouseDown}
+          onMouseDown={
+            isMultiDayTimedDraft
+              ? undefined
+              : (e: MouseEvent, event: GridEventEntity) => {
+                  e.preventDefault();
+                  onMouseDown(e, event);
+                }
+          }
+          onScalerMouseDown={
+            isMultiDayTimedDraft ? undefined : handleScalerMouseDown
+          }
           weekDays={weekProps.component.weekDays}
         />
       ) : (

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -1,6 +1,7 @@
 import { type FC, type MouseEvent } from "react";
 import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import {
   Categories_Event,
@@ -10,6 +11,7 @@ import {
   getEventDragOffset,
   gridEventDefaultPosition,
 } from "@web/common/utils/event/event.util";
+import { isTimedEventMultiDay } from "@web/common/utils/event/event-nudge.util";
 import { focusEventFormTitle } from "@web/common/utils/form/form.util";
 import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { type TimedDeckLayout } from "@web/grid/layout/timed-deck.layout";
@@ -86,6 +88,14 @@ export const GridDraft: FC<Props> = ({
   if (!draft || !draftAsGridEvent) return null;
 
   const isAllDay = draft.values.schedule.kind === "allDay";
+  const schedule = draft.values.schedule;
+  const isMultiDayTimedDraft =
+    schedule.kind === "timed" &&
+    isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end));
+  // Multi-day timed events render as all-day bars; keep the form draft in
+  // the store but do not mount an overflowing timed grid card.
+  if (isMultiDayTimedDraft) return null;
+
   const allDayDraftEvent = isAllDay
     ? (activeAllDayDraftEvent ?? draftAsGridEvent)
     : draftAsGridEvent;

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -55,10 +55,10 @@ const AllDayEventBase = (
 
   const shouldTrackCalendarHover = !isPlaceholder && Boolean(event._id);
   const handleEventMouseDown = (e: MouseEvent, selectedEvent: GridEvent) => {
-    if (!onMouseDown) {
-      e.stopPropagation();
-      return;
-    }
+    // Always stop bubble so the all-day row's create-draft handler cannot
+    // overwrite a card click (including read-only open).
+    e.stopPropagation();
+    if (!onMouseDown) return;
 
     onMouseDown(e, selectedEvent);
   };

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -54,11 +54,14 @@ export const AllDayEvents = ({
   // registry.
   const visibleAllDayEvents = useMemo(
     () =>
-      allDayEvents.filter(
-        (event: GridEvent) =>
-          isAllDayEventInVisibleDays(event, weekDays) &&
-          !(event._id === draftId && !draftOverlay?.isAllDay),
-      ),
+      allDayEvents.filter((event: GridEvent) => {
+        if (!isAllDayEventInVisibleDays(event, weekDays)) return false;
+        // Timed drafts normally replace the saved all-day card with GridDraft.
+        // Multi-day timed display bars stay put: the form edits the timed
+        // source, but the grid must not remount an overflowing timed card.
+        if (event.isTimedMultiDayDisplay) return true;
+        return !(event._id === draftId && !draftOverlay?.isAllDay);
+      }),
     [allDayEvents, draftOverlay?.isAllDay, draftId, weekDays],
   );
   // Resolved once per event here (not inside each card) and kept referentially
@@ -97,10 +100,11 @@ export const AllDayEvents = ({
         visibleAllDayEventsWithIdentity.map(
           ({ event, calendarIdentity, isReadOnly }) => {
             const isPlaceholder = event._id === draftId;
-            const eventForDisplay = mergeGridEventWithDraftOverlay(
-              event,
-              draftOverlay,
-            );
+            // Never overlay timed draft dates onto a multi-day timed display
+            // bar — that would replace YYYY-MM-DD span dates with datetimes.
+            const eventForDisplay = event.isTimedMultiDayDisplay
+              ? event
+              : mergeGridEventWithDraftOverlay(event, draftOverlay);
             // The placeholder can carry a live (dragging/resizing) calendarId
             // from the draft store; everything else reuses the stable,
             // list-level resolved identity above.

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -2,6 +2,7 @@ import { type MouseEvent, useMemo } from "react";
 import {
   type CalendarCardIdentity,
   isEventReadOnly,
+  isGridEventContentReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
@@ -78,7 +79,7 @@ export const AllDayEvents = ({
         isReadOnly: isEventReadOnly(
           calendarLookup,
           event.calendarId,
-          (event.isBusy ?? false) || (event.isTimedMultiDayDisplay ?? false),
+          isGridEventContentReadOnly(event),
         ),
       })),
     [visibleAllDayEvents, calendarLookup],

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -78,7 +78,7 @@ export const AllDayEvents = ({
         isReadOnly: isEventReadOnly(
           calendarLookup,
           event.calendarId,
-          event.isBusy ?? false,
+          (event.isBusy ?? false) || (event.isTimedMultiDayDisplay ?? false),
         ),
       })),
     [visibleAllDayEvents, calendarLookup],

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -56,10 +56,10 @@ export const AllDayEvents = ({
     () =>
       allDayEvents.filter((event: GridEvent) => {
         if (!isAllDayEventInVisibleDays(event, weekDays)) return false;
-        // Timed drafts normally replace the saved all-day card with GridDraft.
-        // Multi-day timed display bars stay put: the form edits the timed
-        // source, but the grid must not remount an overflowing timed card.
-        if (event.isTimedMultiDayDisplay) return true;
+        // Multi-day timed display bars stay in the all-day row, but while
+        // editing GridDraft owns the live bar — hide the saved view-model
+        // card to avoid a stale duplicate underneath the portal draft.
+        if (event.isTimedMultiDayDisplay) return event._id !== draftId;
         return !(event._id === draftId && !draftOverlay?.isAllDay);
       }),
     [allDayEvents, draftOverlay?.isAllDay, draftId, weekDays],


### PR DESCRIPTION
## Summary

Timed events that cross midnight overflowed the timed grid and only appeared on the start day. They now render as all-day spanning bars (Google-style), reusing existing all-day layout/visibility.

## Changes

- Promote multi-day timed events into the all-day row via the view-model (`isTimedMultiDayDisplay`)
- Correct exclusive end when the timed end is exactly midnight
- Keep Up Next sourced from the real timed schedule
- Keep the all-day bar when opening the form (no overflowing timed draft card)
- Read-only drag/resize for display bars

## Simplicity

Rewrote away from per-day segment clones + interaction merge (~900 lines) to a small view-model routing change.

## Automated validation

- Focused web tests for nudge dates, view-model promotion, and draft injection — pass
- `bun run type-check` — pass
- `bun run lint` — pass (pre-existing unused-import warning unrelated)

## Independent review

Confirmed midnight exclusive-end and form-open overflow findings; both fixed on the branch.

## Test plan

- `bun test:web packages/web/src/common/utils/event/event-nudge.util.test.ts packages/web/src/events/queries/event.view-model.test.ts packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts`
- `bun run type-check`
- `bun run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core calendar view-model routing, draft placement, and interaction/read-only gates across day and week grids; regressions could affect event display, editing, or sidebar Up Next ordering.
> 
> **Overview**
> **Multi-day timed events** (anything that crosses midnight, with ends exactly at midnight still treated as same-day) no longer render in the timed grid. The view-model **promotes** them into the all-day row as spanning bars with `isTimedMultiDayDisplay`, using shared helpers `isTimedEventMultiDay` and `timedMultiDayToAllDayDates` for exclusive end-date math.
> 
> **Drafts and layers** follow the same rule: `isDraftRenderedInAllDayRow` / `draftToAllDayRowGridEvent` route multi-day timed drafts to the all-day row; day/week timed layers skip injecting those drafts. While editing, saved multi-day display bars are hidden so `GridDraft` does not duplicate the bar; multi-day timed drafts disable drag/resize on the all-day bar.
> 
> **Read-only and UX:** `isGridEventContentReadOnly` treats display bars like busy events (inspectable, not grid-mutable). All-day card mousedown always stops propagation so row “create draft” does not swallow clicks. **Up Next** still ranks by real timed `schedule.start` for promoted events.
> 
> Tests cover nudge/date mapping, view-model promotion, and draft injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1748e455935801a0bafa34c71750ad597d2f1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->