### PR TITLE
fix(web): hide up-next empty-state pressure copy

### DIFF
--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
@@ -84,7 +84,7 @@ describe("UpNextCard", () => {
     expect(screen.getByText("N")).toBeInTheDocument();
   });
 
-  it("shows an empty-state hint when today has no upcoming timed events", () => {
+  it("renders nothing when today has no upcoming timed events", () => {
     render(<UpNextCard />, {
       events: [
         // Already underway, so nothing is "up next".
@@ -101,10 +101,10 @@ describe("UpNextCard", () => {
       ],
     });
 
-    expect(screen.getByRole("region", { name: "Up next" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Up next" })).toBeNull();
     expect(
-      screen.getByText("Nothing scheduled — press C to add an event."),
-    ).toBeInTheDocument();
+      screen.queryByText("Nothing scheduled — press C to add an event."),
+    ).toBeNull();
     expect(screen.queryByText("Past Event")).toBeNull();
     expect(screen.queryByText("All Day Event")).toBeNull();
   });

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
@@ -31,13 +31,7 @@ export const UpNextCard: FC = () => {
   const { now, openEventDetails, upNext } = useUpNextEvent();
 
   if (!upNext) {
-    return (
-      <section aria-label="Up next">
-        <p className="text-text-muted text-xs">
-          Nothing scheduled — press C to add an event.
-        </p>
-      </section>
-    );
+    return null;
   }
 
   const countdown = formatStartsIn(dayjs(upNext.startDate), now);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stops showing “Nothing scheduled — press C to add an event.” in the sidebar when today has no upcoming timed events. `UpNextCard` returns `null` instead, so a free day stays quiet while the Up Next card still appears when there is an upcoming timed event.

## Simplicity

Already minimal: one early-return swap (`section` → `null`) plus matching test assertions. No further simplification commit.

## Automated validation

- Browser at http://localhost:9080 (anonymous): empty sidebar has no pressure copy; MonthPicker and calendar list remain. Creating “Ship Validate Event” shows Up Next with countdown; deleting it restores the quiet empty sidebar. Console only showed expected anonymous PostHog/config connection refusals.
- Focused: `bun test:web -- packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx` — 9 pass
- `bun run verify` selected core → web → type-check → lint → test:a11y: core 528 pass, web 1334 pass, type-check/lint ok; local `test:a11y` failed solely because Playwright Chromium is not installed in this VM (CI e2e passed)
- CI on PR: lint, type-check, unit (core/web/backend/sync/scripts), e2e, CodeQL — all green

## Independent review

Fresh read-only reviewer on `main...HEAD`: no confirmed findings.

## Test plan

- `bun test:web -- packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx`
- `bun run lint`
- Browser empty / with-event / after-delete Up Next sidebar scenarios at http://localhost:9080
- CI Test + CodeQL workflows on the PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9323d43e-2c93-40b2-aa36-73c6001333b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9323d43e-2c93-40b2-aa36-73c6001333b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

