### PR TITLE
fix(web): never let the calendar be silently wrong

### DIFF
--- a/docs/frontend/event-caching.md
+++ b/docs/frontend/event-caching.md
@@ -84,10 +84,12 @@ mutate(payload)
   belong to, so a created or dragged-in event shows immediately — before the
   server responds.
 - **Conditional rollback on failure.** Each mutation snapshots matching cache
-  entries in `onMutate`. On error it restores that snapshot when no other event
-  mutation is still in flight (so a concurrent optimistic write to another
-  event is not clobbered), reports the error (toast), and still settles into a
-  refetch. Invalidation is deferred to a macrotask and gated on
+  entries in `onMutate`. On error it reports a toast and restores that snapshot
+  when it is alone in flight; if other mutations are pending for a *different*
+  write key it restores only this key's entities; if another mutation shares the
+  same key it leaves the newer optimistic write alone. Settle-time invalidation
+  still converges to server truth once no event mutation remains in flight.
+  Invalidation is deferred to a macrotask and gated on
   `queryClient.isMutating(...) === 0` so a refetch never overwrites another
   mutation's live optimistic update (the TanStack Query recipe for concurrent
   optimistic updates, deferred so simultaneous settles cannot all skip).

--- a/docs/frontend/event-caching.md
+++ b/docs/frontend/event-caching.md
@@ -67,11 +67,13 @@ Mutations go through the narrow `EventMutations` interface
 mutate(payload)
    │
    ├─ onMutate:   cancel in-flight reads
+   │              → snapshot matching cache entries
    │              → apply optimistic edit to matching cache entries   (instant UI)
    │
    ├─ mutationFn: persist via repository (captured source)
    │
-   ├─ onError:    report the error (no cache rollback)
+   ├─ onError:    report the error (toast)
+   │              → restore snapshot when no other event mutation is pending
    │
    └─ onSettled:  once NO event mutation remains in flight (checked on a
                   deferred macrotask), invalidate ["events"] → refetch to
@@ -81,11 +83,11 @@ mutate(payload)
 - **Optimistic edits** insert/patch/remove events across exactly the entries they
   belong to, so a created or dragged-in event shows immediately — before the
   server responds.
-- **No per-mutation rollback.** Rapid successive edits are allowed (events stay
-  interactive while pending), so a failed mutation must not restore a snapshot —
-  that would clobber a newer edit's optimistic write. Instead, failures leave the
-  optimistic value in place and the settle-time refetch converges the cache to
-  server truth. Invalidation is deferred to a macrotask and gated on
+- **Conditional rollback on failure.** Each mutation snapshots matching cache
+  entries in `onMutate`. On error it restores that snapshot when no other event
+  mutation is still in flight (so a concurrent optimistic write to another
+  event is not clobbered), reports the error (toast), and still settles into a
+  refetch. Invalidation is deferred to a macrotask and gated on
   `queryClient.isMutating(...) === 0` so a refetch never overwrites another
   mutation's live optimistic update (the TanStack Query recipe for concurrent
   optimistic updates, deferred so simultaneous settles cannot all skip).
@@ -112,7 +114,9 @@ sides call the **same** predicate:
 
 - **Mutations** — invalidate `["events"]` on settle (see above).
 - **SSE** — background `EVENT_CHANGED` invalidates the
-  relevant scope so it refetches. See [SSE Runtime](./frontend-runtime-flow.md#sse-runtime).
+  relevant scope so it refetches. Native EventSource reconnect (`open`) and
+  window focus also invalidate/refetch so a laptop-sleep gap is not silent.
+  See [SSE Runtime](./frontend-runtime-flow.md#sse-runtime).
 - **Auth / source transitions** — refresh the repository source store and drop
   stale entries (e.g. Google revoked → fall back to `local`).
 

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -299,6 +299,8 @@ Responsibilities:
 
 - open/close `EventSource` to `GET /api/events/stream` based on auth state
 - refetch events when background event changes arrive (`EVENT_CHANGED`)
+- refetch events/calendars when the native EventSource fires `open` again
+  (reconnect after sleep) via `onStreamReopen`
 - react to Google import progress and Google revocation events
 - apply `USER_METADATA` pushed on stream connect and when the backend refreshes metadata
 

--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.tsx
@@ -38,7 +38,11 @@ export function SidebarEventDetails({
   const draft = useDraftStore(selectGridDraft);
   const isFormOpen = useDraftStore(selectIsEventFormOpen);
   const _id = draft?.kind === "edit" ? draft.source.id : undefined;
-  const onSave = useSaveEventForm();
+  const {
+    saveEventForm: onSave,
+    fieldErrors,
+    clearFieldErrors,
+  } = useSaveEventForm();
   const onDelete = useDeleteEvent(_id as string);
   const onDuplicate = useDuplicateEvent(_id as string);
   const onClose = useCloseEventForm();
@@ -119,12 +123,16 @@ export function SidebarEventDetails({
         </>
       }
       draft={draft}
+      fieldErrors={fieldErrors}
       isDraft={!existing}
       isExistingEvent={existing}
       isFormOpen={isFormOpen}
       onClose={onClose}
       onDuplicate={onDuplicate}
-      syncDraft={draftActions.setGridDraft}
+      syncDraft={(next) => {
+        clearFieldErrors();
+        draftActions.setGridDraft(next);
+      }}
     />
   );
 }

--- a/packages/web/src/events/mutations/event.mutation.runtime.ts
+++ b/packages/web/src/events/mutations/event.mutation.runtime.ts
@@ -156,3 +156,27 @@ export function isSupersededByLaterEditWrite(
       variablesEventId(mutation) === eventId,
   );
 }
+
+/**
+ * True when another pending event mutation shares this write key. Used to skip
+ * per-key snapshot restore on failure so a newer optimistic write for the same
+ * event is not clobbered.
+ */
+export function hasOtherPendingWriteForKey(
+  queryClient: QueryClient,
+  eventId: string,
+  ownVariables: unknown,
+): boolean {
+  const mutations = queryClient.getMutationCache().getAll() as AnyMutation[];
+  const self = mutations.find(
+    (mutation) => mutation.state.variables === ownVariables,
+  );
+  if (!self) return false;
+  return mutations.some(
+    (mutation) =>
+      mutation !== self &&
+      mutation.state.status === "pending" &&
+      operationOf(mutation) !== undefined &&
+      variablesEventId(mutation) === eventId,
+  );
+}

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -338,7 +338,7 @@ describe("useEventMutations", () => {
     });
   });
 
-  test("reports the error and invalidates instead of rolling back when a replace fails", async () => {
+  test("reports the error, rolls back the optimistic write, and invalidates when a replace fails", async () => {
     const context = setup();
     const original = event();
     context.queryClient.setQueryData(calendarKey, normalized(original));
@@ -361,16 +361,14 @@ describe("useEventMutations", () => {
 
     await waitFor(() => {
       expect(context.errors[0]?.message).toBe("write failed");
-      // No in-memory rollback: the settle-time invalidation refetches server
-      // truth instead of restoring a snapshot.
+      expect(
+        context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[original.id].content,
+      ).toMatchObject({ title: "Original" });
       expect(
         context.queryClient.getQueryState(calendarKey)?.isInvalidated,
       ).toBe(true);
     });
-    expect(
-      context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
-        ?.entities[original.id].content,
-    ).toMatchObject({ title: "Changed" });
   });
 
   test("keeps a newer edit's optimistic value when an older edit for the same event fails", async () => {

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -559,6 +559,10 @@ describe("useEventMutations", () => {
 
     await waitFor(() => {
       expect(context.errors[0]?.message).toBe("doomed edit failed");
+      expect(
+        context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[doomed.id].content,
+      ).toMatchObject({ title: "Original" });
     });
     expect(
       context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -228,7 +228,7 @@ export function useEventMutations(
     },
     onError: (
       error: Error,
-      variables: Variables,
+      _variables: Variables,
       context: EventMutationContext | undefined,
     ) => {
       reportError(error);

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -1,4 +1,8 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryKey,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
@@ -53,6 +57,10 @@ import {
   recordEventDeleteHistory,
   recordEventEditHistory,
 } from "./event.mutation-history";
+
+type EventMutationContext = {
+  previousQueries: Array<[QueryKey, unknown]>;
+};
 
 const nowDateTime = () => DateTimeSchema.parse(new Date().toISOString());
 
@@ -187,11 +195,11 @@ export function useEventMutations(
     [queryClient],
   );
 
-  // No per-mutation rollback: failed mutations leave their optimistic write
-  // in place and rely on the settle-time refetch to restore server truth.
-  // Invalidation only runs once NO event mutation remains in flight, so a
-  // refetch never overwrites another mutation's live optimistic update.
-  // The check is deferred to a macrotask because a settling mutation still
+  // Snapshot + conditional rollback: a failed mutation restores its pre-image
+  // when it is the only in-flight event mutation. Concurrent writes (same key
+  // or another event) skip snapshot restore so a newer optimistic update is
+  // not clobbered; settle-time invalidation still converges to server truth.
+  // Invalidation is deferred to a macrotask because a settling mutation still
   // counts as pending during its own onSettled — deferring lets simultaneous
   // settles reliably observe count 0 instead of each seeing the other and skipping.
   const settle = () => {
@@ -203,18 +211,40 @@ export function useEventMutations(
       }
     }, 0);
   };
-  const buildMutation = <Variables>(
+  const buildMutation = <Variables extends { writeKey: EventId }>(
     operation: EventMutationOperation,
     mutationFn: (variables: Variables) => Promise<unknown>,
     optimistic: (variables: Variables) => void,
   ) => ({
     mutationKey: eventMutationKeys.operation(operation),
     mutationFn,
-    onMutate: async (variables: Variables) => {
+    onMutate: async (variables: Variables): Promise<EventMutationContext> => {
       await queryClient.cancelQueries({ queryKey: eventQueryKeys.all });
+      const previousQueries = queryClient.getQueriesData<unknown>({
+        queryKey: eventQueryKeys.all,
+      });
       optimistic(variables);
+      return { previousQueries };
     },
-    onError: (error: Error) => reportError(error),
+    onError: (
+      error: Error,
+      variables: Variables,
+      context: EventMutationContext | undefined,
+    ) => {
+      reportError(error);
+      // Full-query snapshots would clobber a concurrent optimistic write to a
+      // different event. TanStack still counts *this* mutation as pending while
+      // onError runs (it dispatches status "error" only afterwards), so
+      // isMutating === 1 means we are alone and safe to restore.
+      const pendingEventMutations = queryClient.isMutating({
+        mutationKey: eventMutationKeys.all,
+      });
+      if (context && pendingEventMutations <= 1) {
+        for (const [queryKey, data] of context.previousQueries) {
+          queryClient.setQueryData(queryKey, data);
+        }
+      }
+    },
     onSettled: settle,
   });
   // Shared by every mutationFn below: wait for earlier writes to the same

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -65,22 +65,6 @@ type EventMutationContext = {
   previousQueries: Array<[QueryKey, unknown]>;
 };
 
-function eventMatchesWriteKey(event: Event, writeKey: EventId): boolean {
-  if (event.id === writeKey) return true;
-  if (
-    event.recurrence.kind === "occurrence" &&
-    event.recurrence.seriesId === writeKey
-  ) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * When other event mutations are still pending, restore only entities owned by
- * `writeKey` from the pre-mutation snapshot so a concurrent optimistic write
- * to a different event is preserved.
- */
 function restoreWriteKeyFromSnapshot(
   queryClient: ReturnType<typeof useQueryClient>,
   writeKey: EventId,
@@ -101,36 +85,21 @@ function restoreWriteKeyFromSnapshot(
   })) {
     if (!current || !isEventQueryKey(queryKey)) continue;
     const snap = snapByKey.get(JSON.stringify(queryKey));
-    const affectedIds = new Set<EventId>();
-
-    const collect = (data: NormalizedEventQueryData | undefined) => {
-      if (!data) return;
-      for (const id of data.ids) {
-        const event = data.entities[id];
-        if (event && eventMatchesWriteKey(event, writeKey)) {
-          affectedIds.add(id);
-        }
-      }
-      if (data.entities[writeKey]) affectedIds.add(writeKey);
-    };
-    collect(current);
-    collect(snap);
-
-    if (affectedIds.size === 0) continue;
+    const snapEvent = snap?.entities[writeKey];
+    const currentEvent = current.entities[writeKey];
+    if (!snapEvent && !currentEvent) continue;
 
     const entities = { ...current.entities };
     let ids = [...current.ids];
-    for (const id of affectedIds) {
-      const snapEvent = snap?.entities[id];
-      if (snapEvent) {
-        entities[id] = snapEvent;
-        if (!ids.includes(id)) ids = [...ids, id];
-      } else {
-        delete entities[id];
-        ids = ids.filter((candidate) => candidate !== id);
-      }
+    if (snapEvent) {
+      entities[writeKey] = snapEvent;
+      if (!ids.includes(writeKey)) ids = [...ids, writeKey];
+    } else {
+      delete entities[writeKey];
+      ids = ids.filter((candidate) => candidate !== writeKey);
     }
-    queryClient.setQueryData(queryKey, { ids, entities });
+    // Preserve optional fields like demoEventIds on the query payload.
+    queryClient.setQueryData(queryKey, { ...current, ids, entities });
   }
 }
 
@@ -319,9 +288,11 @@ export function useEventMutations(
         return;
       }
       // Another mutation shares this write key (newer optimistic edit) — leave
-      // the cache alone so we do not clobber it. Different-key concurrency can
-      // surgically restore only this writeKey's entities.
+      // the cache alone so we do not clobber it. Deletes wait for settle when
+      // concurrent (recurring deletes touch more than writeKey). Different-key
+      // create/replace concurrency restores only entities[writeKey].
       if (
+        operation === "delete" ||
         hasOtherPendingWriteForKey(queryClient, variables.writeKey, variables)
       ) {
         return;

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -25,10 +25,12 @@ import {
   findEventInCache,
   findSeriesEventsInCache,
   insertEventIntoQueries,
+  isEventQueryKey,
   removeEventFromQueries,
   upsertEventAcrossQueries,
 } from "@web/events/queries/event.query.cache";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
 import {
   projectRecurringDelete,
   projectRecurringEdit,
@@ -43,6 +45,7 @@ import {
   eventMutationKeys,
 } from "./event.mutation.keys";
 import {
+  hasOtherPendingWriteForKey,
   isSupersededByLaterEditWrite,
   markAnonymousEventWrite,
   type PrecedingEventWrites,
@@ -61,6 +64,75 @@ import {
 type EventMutationContext = {
   previousQueries: Array<[QueryKey, unknown]>;
 };
+
+function eventMatchesWriteKey(event: Event, writeKey: EventId): boolean {
+  if (event.id === writeKey) return true;
+  if (
+    event.recurrence.kind === "occurrence" &&
+    event.recurrence.seriesId === writeKey
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * When other event mutations are still pending, restore only entities owned by
+ * `writeKey` from the pre-mutation snapshot so a concurrent optimistic write
+ * to a different event is preserved.
+ */
+function restoreWriteKeyFromSnapshot(
+  queryClient: ReturnType<typeof useQueryClient>,
+  writeKey: EventId,
+  previousQueries: Array<[QueryKey, unknown]>,
+) {
+  const snapByKey = new Map(
+    previousQueries.map(([queryKey, data]) => [
+      JSON.stringify(queryKey),
+      data as NormalizedEventQueryData | undefined,
+    ]),
+  );
+
+  for (const [
+    queryKey,
+    current,
+  ] of queryClient.getQueriesData<NormalizedEventQueryData>({
+    queryKey: eventQueryKeys.all,
+  })) {
+    if (!current || !isEventQueryKey(queryKey)) continue;
+    const snap = snapByKey.get(JSON.stringify(queryKey));
+    const affectedIds = new Set<EventId>();
+
+    const collect = (data: NormalizedEventQueryData | undefined) => {
+      if (!data) return;
+      for (const id of data.ids) {
+        const event = data.entities[id];
+        if (event && eventMatchesWriteKey(event, writeKey)) {
+          affectedIds.add(id);
+        }
+      }
+      if (data.entities[writeKey]) affectedIds.add(writeKey);
+    };
+    collect(current);
+    collect(snap);
+
+    if (affectedIds.size === 0) continue;
+
+    const entities = { ...current.entities };
+    let ids = [...current.ids];
+    for (const id of affectedIds) {
+      const snapEvent = snap?.entities[id];
+      if (snapEvent) {
+        entities[id] = snapEvent;
+        if (!ids.includes(id)) ids = [...ids, id];
+      } else {
+        delete entities[id];
+        ids = ids.filter((candidate) => candidate !== id);
+      }
+    }
+    queryClient.setQueryData(queryKey, { ids, entities });
+  }
+}
 
 const nowDateTime = () => DateTimeSchema.parse(new Date().toISOString());
 
@@ -195,13 +267,14 @@ export function useEventMutations(
     [queryClient],
   );
 
-  // Snapshot + conditional rollback: a failed mutation restores its pre-image
-  // when it is the only in-flight event mutation. Concurrent writes (same key
-  // or another event) skip snapshot restore so a newer optimistic update is
-  // not clobbered; settle-time invalidation still converges to server truth.
-  // Invalidation is deferred to a macrotask because a settling mutation still
-  // counts as pending during its own onSettled — deferring lets simultaneous
-  // settles reliably observe count 0 instead of each seeing the other and skipping.
+  // Snapshot + conditional rollback: a failed mutation restores its pre-image.
+  // Alone in flight → full query restore. Concurrent writes → restore only
+  // entities owned by this writeKey so another event's optimistic update is
+  // preserved. Settle-time invalidation still converges to server truth once
+  // no event mutation remains in flight. Invalidation is deferred to a
+  // macrotask because a settling mutation still counts as pending during its
+  // own onSettled — deferring lets simultaneous settles reliably observe
+  // count 0 instead of each seeing the other and skipping.
   const settle = () => {
     setTimeout(() => {
       if (
@@ -228,22 +301,36 @@ export function useEventMutations(
     },
     onError: (
       error: Error,
-      _variables: Variables,
+      variables: Variables,
       context: EventMutationContext | undefined,
     ) => {
       reportError(error);
-      // Full-query snapshots would clobber a concurrent optimistic write to a
-      // different event. TanStack still counts *this* mutation as pending while
-      // onError runs (it dispatches status "error" only afterwards), so
-      // isMutating === 1 means we are alone and safe to restore.
+      if (!context) return;
+      // TanStack still counts *this* mutation as pending while onError runs
+      // (it dispatches status "error" only afterwards), so isMutating === 1
+      // means we are alone and a full snapshot restore is safe.
       const pendingEventMutations = queryClient.isMutating({
         mutationKey: eventMutationKeys.all,
       });
-      if (context && pendingEventMutations <= 1) {
+      if (pendingEventMutations <= 1) {
         for (const [queryKey, data] of context.previousQueries) {
           queryClient.setQueryData(queryKey, data);
         }
+        return;
       }
+      // Another mutation shares this write key (newer optimistic edit) — leave
+      // the cache alone so we do not clobber it. Different-key concurrency can
+      // surgically restore only this writeKey's entities.
+      if (
+        hasOtherPendingWriteForKey(queryClient, variables.writeKey, variables)
+      ) {
+        return;
+      }
+      restoreWriteKeyFromSnapshot(
+        queryClient,
+        variables.writeKey,
+        context.previousQueries,
+      );
     },
     onSettled: settle,
   });

--- a/packages/web/src/events/queries/event.query.options.ts
+++ b/packages/web/src/events/queries/event.query.options.ts
@@ -14,8 +14,10 @@ import { fetchWeekEvents } from "./week.event.query";
 const EVENT_QUERY_CACHE_OPTIONS = {
   staleTime: 2 * 60 * 1000, // 2 minutes
   gcTime: 10 * 60 * 1000, // 10 minutes
-  refetchOnWindowFocus: true,
-} as const;
+  // "always": staleTime would otherwise skip focus refetch for 2 minutes and
+  // leave a missed SSE/sleep gap on screen.
+  refetchOnWindowFocus: "always" as const,
+};
 
 export type EventsQueryArgs = {
   source: EventRepositorySource;

--- a/packages/web/src/events/queries/event.query.options.ts
+++ b/packages/web/src/events/queries/event.query.options.ts
@@ -7,14 +7,14 @@ import { fetchWeekEvents } from "./week.event.query";
 
 /**
  * Shared cache policy for event reads. `staleTime` lets back-navigation to a
- * recently viewed range render instantly from cache; all data-change paths
- * (mutations, SSE, auth transitions) invalidate explicitly, so fetch triggers
- * stay identical to the pre-migration behavior (mount, key change, invalidation).
+ * recently viewed range render instantly from cache; mutations and SSE still
+ * invalidate explicitly. Window-focus refetch covers gaps a laptop sleep /
+ * native SSE reconnect may miss while `retry: false` left a failed fetch idle.
  */
 const EVENT_QUERY_CACHE_OPTIONS = {
   staleTime: 2 * 60 * 1000, // 2 minutes
   gcTime: 10 * 60 * 1000, // 10 minutes
-  refetchOnWindowFocus: false,
+  refetchOnWindowFocus: true,
 } as const;
 
 export type EventsQueryArgs = {

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -123,4 +123,32 @@ describe("EventGrid", () => {
         .height,
     ).toContain("6 *");
   });
+
+  it("shows a couldn't-load state with retry when event fetch failed", async () => {
+    const onRetryEvents = mock();
+    const user = userEvent.setup();
+
+    render(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isErrorEvents
+        onAllDayMouseDown={mock()}
+        onRetryEvents={onRetryEvents}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Couldn't load events.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetryEvents).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -19,6 +19,9 @@ export interface EventGridProps {
   gridRefs: GridRefs;
   /** First load only. Background refetches keep the grid interactive. */
   isLoadingEvents?: boolean;
+  /** Failed fetch with nothing reliable to show — mirrors CalendarList. */
+  isErrorEvents?: boolean;
+  onRetryEvents?: () => void;
   onAllDayMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
   onTimedMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
   timedEventsLayer: ReactNode;
@@ -32,6 +35,8 @@ export const EventGrid: FC<EventGridProps> = ({
   allDayRowsCount = 0,
   gridRefs,
   isLoadingEvents = false,
+  isErrorEvents = false,
+  onRetryEvents,
   onAllDayMouseDown,
   onTimedMouseDown,
   timedEventsLayer,
@@ -71,6 +76,22 @@ export const EventGrid: FC<EventGridProps> = ({
         className="pointer-events-none [&>div]:my-0"
         role="status"
       />
+    )}
+    {isErrorEvents && !isLoadingEvents && (
+      <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/80 px-4">
+        <div className="flex items-center gap-3 text-sm">
+          <p className="text-error">Couldn't load events.</p>
+          {onRetryEvents ? (
+            <button
+              className="c-focus-ring rounded-xs px-1.5 py-0.5 text-accent hover:brightness-110"
+              onClick={onRetryEvents}
+              type="button"
+            >
+              Retry
+            </button>
+          ) : null}
+        </div>
+      </div>
     )}
   </div>
 );

--- a/packages/web/src/sse/client/sse.client.ts
+++ b/packages/web/src/sse/client/sse.client.ts
@@ -25,8 +25,11 @@ function getListeners(
   return listeners;
 }
 
+const reopenListeners = new Set<() => void>();
+
 let es: EventSource | null = null;
 let forwardingHandler: ((e: MessageEvent) => void) | null = null;
+let openHandler: (() => void) | null = null;
 
 export const openStream = (): EventSource => {
   if (es) return es;
@@ -54,7 +57,15 @@ export const openStream = (): EventSource => {
       listener(parsed.data);
     }
   };
+  // Native EventSource reconnects after laptop sleep without going through
+  // openStream() again; the open event is the seam that refetches the gap.
+  openHandler = () => {
+    for (const listener of reopenListeners) {
+      listener();
+    }
+  };
   es.addEventListener(SSE_MESSAGE_EVENT, forwardingHandler);
+  es.addEventListener("open", openHandler);
   return es;
 };
 
@@ -62,9 +73,13 @@ export const closeStream = (): void => {
   if (es && forwardingHandler) {
     es.removeEventListener(SSE_MESSAGE_EVENT, forwardingHandler);
   }
+  if (es && openHandler) {
+    es.removeEventListener("open", openHandler);
+  }
   es?.close();
   es = null;
   forwardingHandler = null;
+  openHandler = null;
 };
 
 export const getStream = (): EventSource | null => es;
@@ -79,6 +94,13 @@ export function onServerMessage<T extends ServerMessage["type"]>(
   const listeners = getListeners(type);
   listeners.add(listener);
   return () => listeners.delete(listener);
+}
+
+export function onStreamReopen(handler: () => void): () => void {
+  reopenListeners.add(handler);
+  return () => {
+    reopenListeners.delete(handler);
+  };
 }
 
 export type OnServerMessage = typeof onServerMessage;

--- a/packages/web/src/sse/hooks/useSSEConnection.test.tsx
+++ b/packages/web/src/sse/hooks/useSSEConnection.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { createCompassQueryClient } from "@web/api/query-client";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockUseSession = mock();
+const mockUseUser = mock();
+const openStream = mock();
+const closeStream = mock();
+let reopenHandler: (() => void) | null = null;
+const onStreamReopen = mock((handler: () => void) => {
+  reopenHandler = handler;
+  return () => {
+    if (reopenHandler === handler) reopenHandler = null;
+  };
+});
+
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+mock.module("@web/auth/compass/user/hooks/useUser", () => ({
+  useUser: mockUseUser,
+}));
+mock.module("../client/sse.client", () => ({
+  openStream,
+  closeStream,
+  onStreamReopen,
+}));
+
+const { useSSEConnection } =
+  require("./useSSEConnection") as typeof import("./useSSEConnection");
+
+const Host = () => {
+  useSSEConnection();
+  return null;
+};
+
+describe("useSSEConnection", () => {
+  beforeEach(() => {
+    reopenHandler = null;
+    openStream.mockClear();
+    closeStream.mockClear();
+    onStreamReopen.mockClear();
+    mockUseSession.mockReturnValue({
+      authenticated: true,
+      setAuthenticated: mock(),
+    });
+    mockUseUser.mockReturnValue({ userId: "test-user-id" });
+  });
+
+  it("invalidates event and calendar queries when the stream reopens", async () => {
+    const queryClient = createCompassQueryClient();
+    const invalidateSpy = mock(queryClient.invalidateQueries.bind(queryClient));
+    queryClient.invalidateQueries = invalidateSpy;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Host />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(openStream).toHaveBeenCalled();
+      expect(onStreamReopen).toHaveBeenCalled();
+    });
+
+    invalidateSpy.mockClear();
+    reopenHandler?.();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: eventQueryKeys.all,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: calendarQueryKeys.all,
+    });
+  });
+});

--- a/packages/web/src/sse/hooks/useSSEConnection.ts
+++ b/packages/web/src/sse/hooks/useSSEConnection.ts
@@ -4,7 +4,14 @@ import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
-import { closeStream, openStream } from "../client/sse.client";
+import { closeStream, onStreamReopen, openStream } from "../client/sse.client";
+
+const invalidateScheduleQueries = (
+  queryClient: ReturnType<typeof useQueryClient>,
+) => {
+  void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+  void queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all });
+};
 
 export const useSSEConnection = () => {
   const { authenticated } = useSession();
@@ -16,10 +23,19 @@ export const useSSEConnection = () => {
       openStream();
       // A (re)opened stream may have missed changes while disconnected;
       // reconcile once rather than trusting the gap is empty (B10).
-      void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
-      void queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all });
+      invalidateScheduleQueries(queryClient);
     } else {
       closeStream();
     }
+  }, [authenticated, userId, queryClient]);
+
+  useEffect(() => {
+    if (!(authenticated || userId)) return;
+
+    // Native reconnect after sleep fires EventSource "open" without remounting
+    // this effect — refetch what was missed while the stream was down.
+    return onStreamReopen(() => {
+      invalidateScheduleQueries(queryClient);
+    });
   }, [authenticated, userId, queryClient]);
 };

--- a/packages/web/src/sse/hooks/useSSEConnection.ts
+++ b/packages/web/src/sse/hooks/useSSEConnection.ts
@@ -19,21 +19,14 @@ export const useSSEConnection = () => {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (authenticated || userId) {
-      openStream();
-      // A (re)opened stream may have missed changes while disconnected;
-      // reconcile once rather than trusting the gap is empty (B10).
-      invalidateScheduleQueries(queryClient);
-    } else {
+    if (!(authenticated || userId)) {
       closeStream();
+      return;
     }
-  }, [authenticated, userId, queryClient]);
 
-  useEffect(() => {
-    if (!(authenticated || userId)) return;
-
-    // Native reconnect after sleep fires EventSource "open" without remounting
-    // this effect — refetch what was missed while the stream was down.
+    openStream();
+    // Open and native reconnect can both follow a disconnect gap.
+    invalidateScheduleQueries(queryClient);
     return onStreamReopen(() => {
       invalidateScheduleQueries(queryClient);
     });

--- a/packages/web/src/sse/provider/SSEProvider.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.test.tsx
@@ -24,6 +24,7 @@ mock.module("../client/sse.client", () => ({
   closeStream,
   getStream,
   onServerMessage: createFakeServerMessageBus().onServerMessage,
+  onStreamReopen: () => () => undefined,
 }));
 
 const { default: SSEProvider } =

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -60,7 +60,9 @@ export function DayCalendarGrid() {
   const {
     allDayEvents,
     events: dayEvents,
+    isError: isErrorEvents,
     isPending: isLoadingEvents,
+    refetch,
     rowCount: allDayRowsCount,
     timedEvents,
   } = useDayEventViewModel(dayEventQueryRange(dateInView));
@@ -313,8 +315,10 @@ export function DayCalendarGrid() {
           allDayEventsLayer={allDayEventsLayer}
           allDayRowsCount={allDayRowsCount}
           gridRefs={gridRefs}
+          isErrorEvents={isErrorEvents}
           isLoadingEvents={isLoadingEvents}
           onAllDayMouseDown={handleAllDayMouseDown}
+          onRetryEvents={() => void refetch()}
           onTimedMouseDown={handleTimedMouseDown}
           timedEventsLayer={timedEventsLayer}
           today={today}

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -152,6 +152,7 @@ const scheduleDateStrings = (draft: GridEventDraft) => {
 export const EventForm: React.FC<GridEventFormProps> = memo(
   ({
     draft,
+    fieldErrors,
     onClose: _onClose,
     onDelete,
     onSubmit,
@@ -681,7 +682,21 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           )}
         </div>
 
-        {!isReadOnly && <SaveSection onSubmit={onSubmitForm} />}
+        {!isReadOnly && (
+          <>
+            {fieldErrors && Object.keys(fieldErrors).length > 0 ? (
+              <ul
+                className="flex list-none flex-col gap-1 border-border border-t px-4 pt-3 text-error text-xs"
+                role="alert"
+              >
+                {Object.entries(fieldErrors).map(([field, message]) => (
+                  <li key={field}>{message}</li>
+                ))}
+              </ul>
+            ) : null}
+            <SaveSection onSubmit={onSubmitForm} />
+          </>
+        )}
       </EventFormShell>
     );
   },

--- a/packages/web/src/views/Forms/EventForm/types.ts
+++ b/packages/web/src/views/Forms/EventForm/types.ts
@@ -5,6 +5,7 @@ import { type GridEventDraft } from "@web/events/event-draft.types";
 // canonical GridEventDraft.
 export interface GridEventFormProps {
   draft: GridEventDraft;
+  fieldErrors?: Record<string, string>;
   isDraft: boolean;
   isExistingEvent: boolean;
   onClose: () => void;

--- a/packages/web/src/views/Forms/EventFormPanel/EventFormPanel.tsx
+++ b/packages/web/src/views/Forms/EventFormPanel/EventFormPanel.tsx
@@ -16,6 +16,7 @@ export type EventFormPanelProps = {
   confirmation: EventFormPanelConfirmation;
   confirmationUi?: ReactNode;
   draft: GridEventDraft | null;
+  fieldErrors?: Record<string, string>;
   isDraft: boolean;
   isExistingEvent: boolean;
   isFormOpen: boolean;
@@ -33,6 +34,7 @@ export function EventFormPanel({
   confirmation,
   confirmationUi,
   draft,
+  fieldErrors,
   isDraft,
   isExistingEvent,
   isFormOpen,
@@ -54,6 +56,7 @@ export function EventFormPanel({
     <>
       <EventForm
         draft={draft}
+        fieldErrors={fieldErrors}
         isDraft={isDraft}
         isExistingEvent={isExistingEvent}
         onClose={onClose}

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.test.tsx
@@ -1,0 +1,87 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { type PropsWithChildren } from "react";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import {
+  draftActions,
+  initialDraftState,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
+import { useSaveEventForm } from "./useSaveEventForm";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const calendarId = CalendarIdSchema.parse("cccccccccccccccccccccccc");
+
+const makeCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
+  id: calendarId,
+  name: "Personal",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#3b82f6",
+  provider: "local",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+  ...overrides,
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  queryClient.setQueryData(calendarQueryKeys.all, [makeCalendar()]);
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  return { queryClient, Wrapper };
+}
+
+describe("useSaveEventForm", () => {
+  beforeEach(() => {
+    draftActions.discard();
+  });
+
+  it("keeps the form open and surfaces field errors when the draft is invalid", () => {
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T10:00:00.000Z"),
+        new Date("2026-05-20T09:00:00.000Z"),
+      ),
+    );
+    draftActions.startGridDraft({ activity: "gridClick", draft });
+    draftActions.setFormOpen(true);
+
+    const { queryClient, Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSaveEventForm(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.saveEventForm({
+        ...draft,
+        values: { ...draft.values, calendarId },
+      });
+    });
+
+    expect(result.current.fieldErrors.end).toBeDefined();
+    expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+    expect(useDraftStore.getState().status?.isFormOpen).toBe(true);
+    expect(useDraftStore.getState()).not.toEqual(initialDraftState);
+  });
+});

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.test.tsx
@@ -63,6 +63,8 @@ describe("useSaveEventForm", () => {
         new Date("2026-05-20T10:00:00.000Z"),
         new Date("2026-05-20T09:00:00.000Z"),
       ),
+      undefined,
+      calendarId,
     );
     draftActions.startGridDraft({ activity: "gridClick", draft });
     draftActions.setFormOpen(true);
@@ -73,10 +75,7 @@ describe("useSaveEventForm", () => {
     });
 
     act(() => {
-      result.current.saveEventForm({
-        ...draft,
-        values: { ...draft.values, calendarId },
-      });
+      result.current.saveEventForm(draft);
     });
 
     expect(result.current.fieldErrors.end).toBeDefined();

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
@@ -12,13 +12,21 @@ export function useSaveEventForm() {
   const closeEventForm = useCloseEventForm();
   const { create, replace } = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const clearFieldErrors = useCallback(() => {
+    setFieldErrors({});
+  }, []);
 
   const saveEventForm = useCallback(
     (
       draft: GridEventDraft | null,
       applyTo: RecurringEventUpdateScope = RecurringEventUpdateScope.THIS_EVENT,
     ) => {
-      if (!draft) return closeEventForm();
+      if (!draft) {
+        clearFieldErrors();
+        return closeEventForm();
+      }
 
       if (draft.kind === "create") {
         // Respects a calendar the user explicitly chose via CalendarSelect;
@@ -27,32 +35,48 @@ export function useSaveEventForm() {
         const calendarId =
           draft.values.calendarId ??
           getDefaultTargetCalendar(calendars ?? [])?.id;
-        if (!calendarId) return closeEventForm();
+        if (!calendarId) {
+          setFieldErrors({ calendarId: "Calendar is required" });
+          return;
+        }
 
         const parsed = parseGridEventDraft({
           ...draft,
           values: { ...draft.values, calendarId },
         });
 
-        if (parsed.ok && parsed.mode === "create") {
-          create(parsed.input);
+        if (!parsed.ok) {
+          setFieldErrors(parsed.fieldErrors);
+          return;
         }
-      } else {
-        const scope = toRecurrenceScope(applyTo);
-        const parsed = parseGridEventDraft({
-          ...draft,
-          values: { ...draft.values, scope },
-        });
 
-        if (parsed.ok && parsed.mode === "edit") {
-          replace({ id: parsed.eventId, input: parsed.input });
+        if (parsed.mode === "create") {
+          clearFieldErrors();
+          create(parsed.input);
+          closeEventForm();
         }
+        return;
       }
 
-      closeEventForm();
+      const scope = toRecurrenceScope(applyTo);
+      const parsed = parseGridEventDraft({
+        ...draft,
+        values: { ...draft.values, scope },
+      });
+
+      if (!parsed.ok) {
+        setFieldErrors(parsed.fieldErrors);
+        return;
+      }
+
+      if (parsed.mode === "edit") {
+        clearFieldErrors();
+        replace({ id: parsed.eventId, input: parsed.input });
+        closeEventForm();
+      }
     },
-    [calendars, closeEventForm, create, replace],
+    [calendars, clearFieldErrors, closeEventForm, create, replace],
   );
 
-  return saveEventForm;
+  return { saveEventForm, fieldErrors, clearFieldErrors };
 }

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -33,7 +33,11 @@ export const Grid: FC<Props> = ({
   const { allDayRef, allDayRowRef, mainGridElementRef, mainGridRef } = gridRefs;
   // Subscribes to the same cache entry the event layers read, so this reports
   // their load without issuing a second fetch.
-  const { isPending: isLoadingEvents } = useWeekEventsQueryStatus({
+  const {
+    isPending: isLoadingEvents,
+    isError: isErrorEvents,
+    refetch,
+  } = useWeekEventsQueryStatus({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
@@ -79,8 +83,10 @@ export const Grid: FC<Props> = ({
                 allDayGridOffsetTopPx={GRID_Y_START}
                 allDayRowsCount={allDayRowsCount}
                 gridRefs={gridRefs}
+                isErrorEvents={isErrorEvents}
                 isLoadingEvents={isLoadingEvents}
                 onAllDayMouseDown={onAllDayMouseDown}
+                onRetryEvents={() => void refetch()}
                 onTimedMouseDown={onTimedMouseDown}
                 timedEventsLayer={timedEventsLayer}
                 today={today}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three failure paths were silent; this wires existing query/mutation/SSE states into UI the app already knows how to show.

- **Invalid save:** `useSaveEventForm` keeps the form open and returns `fieldErrors`; the event form renders them instead of discarding the draft.
- **Failed mutation:** optimistic writes snapshot on mutate, restore when the failing mutation is alone in flight (toast via existing `reportError`), and still invalidate on settle. Concurrent writes are left alone so a newer optimistic edit is not clobbered.
- **Failed fetch:** Day/Week grids surface a CalendarList-style “Couldn't load events / Retry” overlay from `isError` + `refetch`.
- **Stale after sleep:** SSE `open` reconnect notifies `onStreamReopen` → invalidate events/calendars; event queries also `refetchOnWindowFocus: true`.

## Test plan

- [x] `bun test:web --` focused suites for save form, mutations, EventGrid, SSE connection/provider, SidebarEventDetails
- [ ] Manual: submit an invalid timed range and confirm the form stays open with the end-time error
- [ ] Manual: force a write failure (offline) and confirm toast + rollback of a lone edit
- [ ] Manual: fail the events query and confirm grid Retry refetches
- [ ] Manual: sleep/wake or drop SSE and confirm events refetch on reconnect / window focus

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31b2f1f9-4e53-434f-b7ae-76f143b68f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31b2f1f9-4e53-434f-b7ae-76f143b68f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

