### PR TITLE
fix(web): convert recurring events to all-day on "All" edits

### DIFF
--- a/packages/backend/src/event/services/event.service.db.test.ts
+++ b/packages/backend/src/event/services/event.service.db.test.ts
@@ -119,6 +119,69 @@ describe("EventService (local calendar)", () => {
     expect(instances).toHaveLength(3);
   });
 
+  it("replace scope 'all' converts a timed series to all-day and rematerializes instances", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const calendar = await seedLocalCalendar(user._id);
+
+    const created = await eventService.create(user._id.toString(), {
+      calendarId: calendar._id.toHexString() as never,
+      content: { kind: "details", title: "Weekly sync", description: "" },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-14T15:00:00-06:00",
+        end: "2026-07-14T16:00:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY;COUNT=3"] },
+    });
+
+    const timedInstances = await mongoService.event
+      .find({ "recurrence.seriesId": created._id })
+      .toArray();
+    expect(timedInstances).toHaveLength(3);
+    expect(timedInstances.every((i) => i.schedule.kind === "timed")).toBe(true);
+
+    await eventService.replace(user._id.toString(), created._id.toHexString(), {
+      content: { kind: "details", title: "Weekly sync", description: "" },
+      schedule: {
+        kind: "allDay",
+        start: "2026-07-14",
+        end: "2026-07-15",
+      },
+      recurrence: { kind: "preserve" },
+      scope: "all",
+    });
+
+    const base = await eventService.readById(
+      user._id.toString(),
+      created._id.toHexString(),
+    );
+    expect(base.schedule).toEqual({
+      kind: "allDay",
+      start: "2026-07-14",
+      end: "2026-07-15",
+    });
+
+    const instances = await mongoService.event
+      .find({ "recurrence.seriesId": created._id })
+      .sort({ "schedule.start": 1 })
+      .toArray();
+
+    expect(instances).toHaveLength(3);
+    expect(instances.map((i) => i.schedule)).toEqual([
+      { kind: "allDay", start: "2026-07-14", end: "2026-07-15" },
+      { kind: "allDay", start: "2026-07-21", end: "2026-07-22" },
+      { kind: "allDay", start: "2026-07-28", end: "2026-07-29" },
+    ]);
+    // Old timed instance ids are replaced by rematerialization.
+    expect(
+      instances.every(
+        (instance) =>
+          !timedInstances.some((prior) => prior._id.equals(instance._id)),
+      ),
+    ).toBe(true);
+  });
+
   it("deletes a standalone event", async () => {
     const { user } = await UtilDriver.setupTestUser();
     const calendar = await seedLocalCalendar(user._id);

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -206,6 +206,57 @@ describe("useEventMutations", () => {
     context.pending.resolve();
   });
 
+  test("optimistically converts a series from timed to all-day for all-events edits", async () => {
+    const context = setup();
+    const seriesId = event().id;
+    const first = occurrence(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-02T16:00:00.000Z",
+        "2026-07-02T17:00:00.000Z",
+      ),
+    });
+    const second = occurrence(seriesId, {
+      schedule: timedSchedule(
+        "2026-07-03T16:00:00.000Z",
+        "2026-07-03T17:00:00.000Z",
+      ),
+    });
+    context.queryClient.setQueryData(calendarKey, normalized(first, second));
+    context.queryClient.setQueryData(dayKey, normalized(first));
+
+    act(() =>
+      context.hook.result.current.mutations.replace(
+        replacePayload(first.id, {
+          schedule: {
+            kind: "allDay",
+            start: "2026-07-02",
+            end: "2026-07-03",
+          },
+          scope: "all",
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      const week =
+        context.queryClient.getQueryData<NormalizedEventQueryData>(
+          calendarKey,
+        )!;
+      expect(week.entities[first.id].schedule).toEqual({
+        kind: "allDay",
+        start: "2026-07-02",
+        end: "2026-07-03",
+      });
+      expect(week.entities[second.id].schedule).toEqual({
+        kind: "allDay",
+        start: "2026-07-03",
+        end: "2026-07-04",
+      });
+    });
+
+    context.pending.resolve();
+  });
+
   test("optimistically moves only this-and-following instances", async () => {
     const context = setup();
     const seriesId = event().id;

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { act, type PropsWithChildren } from "react";
-import { type EventId } from "@core/types/domain-primitives";
+import { DateOnlySchema, type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import {
   type CreateEventInput,
@@ -229,8 +229,8 @@ describe("useEventMutations", () => {
         replacePayload(first.id, {
           schedule: {
             kind: "allDay",
-            start: "2026-07-02",
-            end: "2026-07-03",
+            start: DateOnlySchema.parse("2026-07-02"),
+            end: DateOnlySchema.parse("2026-07-03"),
           },
           scope: "all",
         }),

--- a/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
@@ -21,6 +21,17 @@ const occurrence = (day: number) =>
     recurrence: { kind: "occurrence", seriesId: SERIES_ID },
   });
 
+const allDayOccurrence = (day: number) =>
+  createMockEvent({
+    content: { kind: "details", title: "Original", description: "" },
+    schedule: {
+      kind: "allDay",
+      start: `2026-07-${String(day).padStart(2, "0")}`,
+      end: `2026-07-${String(day + 1).padStart(2, "0")}`,
+    } as never,
+    recurrence: { kind: "occurrence", seriesId: SERIES_ID },
+  });
+
 const seriesBase = () =>
   createMockEvent({
     id: SERIES_ID,
@@ -267,17 +278,11 @@ describe("projectRecurringEdit", () => {
   });
 
   test("converts every occurrence to timed for an all-events all-day to timed flip", () => {
-    const events = [1, 2, 3].map((day) =>
-      createMockEvent({
-        content: { kind: "details", title: "Original", description: "" },
-        schedule: {
-          kind: "allDay",
-          start: `2026-07-${String(day).padStart(2, "0")}`,
-          end: `2026-07-${String(day + 1).padStart(2, "0")}`,
-        } as never,
-        recurrence: { kind: "occurrence", seriesId: SERIES_ID },
-      }),
-    );
+    const events = [
+      allDayOccurrence(1),
+      allDayOccurrence(2),
+      allDayOccurrence(3),
+    ];
     const original = events[1];
     const edited = {
       ...original,
@@ -301,8 +306,8 @@ describe("projectRecurringEdit", () => {
         id: event.id,
         ...(event.schedule.kind === "timed"
           ? {
-              start: event.schedule.start as string,
-              end: event.schedule.end as string,
+              start: dayjs(event.schedule.start).toISOString(),
+              end: dayjs(event.schedule.end).toISOString(),
               timeZone: event.schedule.timeZone,
             }
           : {}),
@@ -310,23 +315,73 @@ describe("projectRecurringEdit", () => {
     ).toEqual([
       {
         id: events[0].id,
-        start: "2026-07-01T16:00:00+00:00",
-        end: "2026-07-01T17:00:00+00:00",
+        start: "2026-07-01T16:00:00.000Z",
+        end: "2026-07-01T17:00:00.000Z",
         timeZone: "UTC",
       },
       {
         id: events[1].id,
-        start: "2026-07-02T16:00:00+00:00",
-        end: "2026-07-02T17:00:00+00:00",
+        start: "2026-07-02T16:00:00.000Z",
+        end: "2026-07-02T17:00:00.000Z",
         timeZone: "UTC",
       },
       {
         id: events[2].id,
-        start: "2026-07-03T16:00:00+00:00",
-        end: "2026-07-03T17:00:00+00:00",
+        start: "2026-07-03T16:00:00.000Z",
+        end: "2026-07-03T17:00:00.000Z",
         timeZone: "UTC",
       },
     ]);
+  });
+
+  test("preserves wall-clock time when all-day to timed crosses a DST spring-forward", () => {
+    // 2026-03-08 is the America/Denver spring-forward (02:00 → 03:00).
+    const events = [
+      createMockEvent({
+        content: { kind: "details", title: "Original", description: "" },
+        schedule: {
+          kind: "allDay",
+          start: "2026-03-07",
+          end: "2026-03-08",
+        } as never,
+        recurrence: { kind: "occurrence", seriesId: SERIES_ID },
+      }),
+      createMockEvent({
+        content: { kind: "details", title: "Original", description: "" },
+        schedule: {
+          kind: "allDay",
+          start: "2026-03-08",
+          end: "2026-03-09",
+        } as never,
+        recurrence: { kind: "occurrence", seriesId: SERIES_ID },
+      }),
+    ];
+    const original = events[0];
+    const edited = {
+      ...original,
+      schedule: {
+        kind: "timed" as const,
+        start: "2026-03-07T15:00:00-07:00",
+        end: "2026-03-07T16:00:00-07:00",
+        timeZone: "America/Denver",
+      } as never,
+    };
+
+    const result = projectRecurringEdit({
+      scope: "all",
+      edited,
+      original,
+      seriesEvents: events,
+    });
+
+    const starts = result.upserts.map((event) =>
+      event.schedule.kind === "timed"
+        ? dayjs(event.schedule.start)
+            .tz("America/Denver")
+            .format("YYYY-MM-DD HH:mm")
+        : null,
+    );
+    expect(starts).toEqual(["2026-03-07 15:00", "2026-03-08 15:00"]);
   });
 });
 

--- a/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
@@ -189,6 +189,145 @@ describe("projectRecurringEdit", () => {
     expect([...result.removeIds]).toEqual([events[0].id]);
     expect(result.upserts).toEqual([edited]);
   });
+
+  test("converts every occurrence to all-day for an all-events kind flip", () => {
+    const events = [occurrence(1), occurrence(2), occurrence(3)];
+    const original = events[1];
+    const edited = {
+      ...original,
+      schedule: {
+        kind: "allDay" as const,
+        start: "2026-07-02",
+        end: "2026-07-03",
+      } as never,
+    };
+
+    const result = projectRecurringEdit({
+      scope: "all",
+      edited,
+      original,
+      seriesEvents: events,
+    });
+
+    expect(
+      result.upserts.map((event) => ({
+        id: event.id,
+        schedule: event.schedule,
+      })),
+    ).toEqual([
+      {
+        id: events[0].id,
+        schedule: { kind: "allDay", start: "2026-07-01", end: "2026-07-02" },
+      },
+      {
+        id: events[1].id,
+        schedule: { kind: "allDay", start: "2026-07-02", end: "2026-07-03" },
+      },
+      {
+        id: events[2].id,
+        schedule: { kind: "allDay", start: "2026-07-03", end: "2026-07-04" },
+      },
+    ]);
+  });
+
+  test("converts only the cutoff and future occurrences to all-day", () => {
+    const events = [occurrence(1), occurrence(2), occurrence(3)];
+    const original = events[1];
+    const edited = {
+      ...original,
+      schedule: {
+        kind: "allDay" as const,
+        start: "2026-07-02",
+        end: "2026-07-03",
+      } as never,
+    };
+
+    const result = projectRecurringEdit({
+      scope: "thisAndFollowing",
+      edited,
+      original,
+      seriesEvents: events,
+    });
+
+    expect(
+      result.upserts.map((event) => ({
+        id: event.id,
+        schedule: event.schedule,
+      })),
+    ).toEqual([
+      {
+        id: events[1].id,
+        schedule: { kind: "allDay", start: "2026-07-02", end: "2026-07-03" },
+      },
+      {
+        id: events[2].id,
+        schedule: { kind: "allDay", start: "2026-07-03", end: "2026-07-04" },
+      },
+    ]);
+  });
+
+  test("converts every occurrence to timed for an all-events all-day to timed flip", () => {
+    const events = [1, 2, 3].map((day) =>
+      createMockEvent({
+        content: { kind: "details", title: "Original", description: "" },
+        schedule: {
+          kind: "allDay",
+          start: `2026-07-${String(day).padStart(2, "0")}`,
+          end: `2026-07-${String(day + 1).padStart(2, "0")}`,
+        } as never,
+        recurrence: { kind: "occurrence", seriesId: SERIES_ID },
+      }),
+    );
+    const original = events[1];
+    const edited = {
+      ...original,
+      schedule: {
+        kind: "timed" as const,
+        start: "2026-07-02T16:00:00.000Z",
+        end: "2026-07-02T17:00:00.000Z",
+        timeZone: "UTC",
+      } as never,
+    };
+
+    const result = projectRecurringEdit({
+      scope: "all",
+      edited,
+      original,
+      seriesEvents: events,
+    });
+
+    expect(
+      result.upserts.map((event) => ({
+        id: event.id,
+        ...(event.schedule.kind === "timed"
+          ? {
+              start: event.schedule.start as string,
+              end: event.schedule.end as string,
+              timeZone: event.schedule.timeZone,
+            }
+          : {}),
+      })),
+    ).toEqual([
+      {
+        id: events[0].id,
+        start: "2026-07-01T16:00:00+00:00",
+        end: "2026-07-01T17:00:00+00:00",
+        timeZone: "UTC",
+      },
+      {
+        id: events[1].id,
+        start: "2026-07-02T16:00:00+00:00",
+        end: "2026-07-02T17:00:00+00:00",
+        timeZone: "UTC",
+      },
+      {
+        id: events[2].id,
+        start: "2026-07-03T16:00:00+00:00",
+        end: "2026-07-03T17:00:00+00:00",
+        timeZone: "UTC",
+      },
+    ]);
+  });
 });
 
 describe("projectRecurringDelete", () => {

--- a/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.test.ts
@@ -1,4 +1,8 @@
-import { type EventId } from "@core/types/domain-primitives";
+import {
+  DateOnlySchema,
+  type EventId,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import {
@@ -228,15 +232,27 @@ describe("projectRecurringEdit", () => {
     ).toEqual([
       {
         id: events[0].id,
-        schedule: { kind: "allDay", start: "2026-07-01", end: "2026-07-02" },
+        schedule: {
+          kind: "allDay",
+          start: DateOnlySchema.parse("2026-07-01"),
+          end: DateOnlySchema.parse("2026-07-02"),
+        },
       },
       {
         id: events[1].id,
-        schedule: { kind: "allDay", start: "2026-07-02", end: "2026-07-03" },
+        schedule: {
+          kind: "allDay",
+          start: DateOnlySchema.parse("2026-07-02"),
+          end: DateOnlySchema.parse("2026-07-03"),
+        },
       },
       {
         id: events[2].id,
-        schedule: { kind: "allDay", start: "2026-07-03", end: "2026-07-04" },
+        schedule: {
+          kind: "allDay",
+          start: DateOnlySchema.parse("2026-07-03"),
+          end: DateOnlySchema.parse("2026-07-04"),
+        },
       },
     ]);
   });
@@ -268,11 +284,19 @@ describe("projectRecurringEdit", () => {
     ).toEqual([
       {
         id: events[1].id,
-        schedule: { kind: "allDay", start: "2026-07-02", end: "2026-07-03" },
+        schedule: {
+          kind: "allDay",
+          start: DateOnlySchema.parse("2026-07-02"),
+          end: DateOnlySchema.parse("2026-07-03"),
+        },
       },
       {
         id: events[2].id,
-        schedule: { kind: "allDay", start: "2026-07-03", end: "2026-07-04" },
+        schedule: {
+          kind: "allDay",
+          start: DateOnlySchema.parse("2026-07-03"),
+          end: DateOnlySchema.parse("2026-07-04"),
+        },
       },
     ]);
   });
@@ -317,19 +341,19 @@ describe("projectRecurringEdit", () => {
         id: events[0].id,
         start: "2026-07-01T16:00:00.000Z",
         end: "2026-07-01T17:00:00.000Z",
-        timeZone: "UTC",
+        timeZone: TimeZoneSchema.parse("UTC"),
       },
       {
         id: events[1].id,
         start: "2026-07-02T16:00:00.000Z",
         end: "2026-07-02T17:00:00.000Z",
-        timeZone: "UTC",
+        timeZone: TimeZoneSchema.parse("UTC"),
       },
       {
         id: events[2].id,
         start: "2026-07-03T16:00:00.000Z",
         end: "2026-07-03T17:00:00.000Z",
-        timeZone: "UTC",
+        timeZone: TimeZoneSchema.parse("UTC"),
       },
     ]);
   });

--- a/packages/web/src/events/recurrence/projectRecurringEdit.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.ts
@@ -1,3 +1,4 @@
+import { DateOnlySchema, DateTimeSchema } from "@core/types/domain-primitives";
 import { type Event, type EventSchedule } from "@core/types/event.contracts";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
@@ -54,8 +55,10 @@ const convertScheduleKind = (
     const start = targetDay.toYearMonthDayString();
     return {
       kind: "allDay",
-      start,
-      end: dayjs(start).add(durationDays, "day").toYearMonthDayString(),
+      start: DateOnlySchema.parse(start),
+      end: DateOnlySchema.parse(
+        dayjs(start).add(durationDays, "day").toYearMonthDayString(),
+      ),
     };
   }
 
@@ -65,8 +68,8 @@ const convertScheduleKind = (
   const start = targetDay.add(timeOfDayMs, "millisecond");
   return {
     kind: "timed",
-    start: start.format(),
-    end: start.add(durationMs, "millisecond").format(),
+    start: DateTimeSchema.parse(start.format()),
+    end: DateTimeSchema.parse(start.add(durationMs, "millisecond").format()),
     timeZone: edited.schedule.timeZone,
   };
 };

--- a/packages/web/src/events/recurrence/projectRecurringEdit.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.ts
@@ -29,48 +29,53 @@ const seriesPatch = (event: Event, edited: Event): Event => ({
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-const calendarDay = (value: string) => dayjs(value).startOf("day");
-
 // When the edit flips timed ↔ allDay, millisecond deltas across kinds produce
-// full-day timed ghosts (or invalid allDay strings). Rebuild each instance
-// from the edited schedule shape, shifted by that instance's day offset from
-// the edited occurrence so the edited card lands on `edited.schedule` and
-// siblings keep their relative days.
+// full-day timed ghosts (or invalid allDay strings). Copy the edited schedule
+// onto each instance, shifted by that instance's day offset from the original
+// occurrence so the edited card keeps `edited.schedule` and siblings keep
+// their relative days.
 const convertScheduleKind = (
   event: Event,
   original: Event,
   edited: Event,
 ): EventSchedule => {
-  const dayDeltaDays = calendarDay(edited.schedule.start).diff(
-    calendarDay(original.schedule.start),
-    "day",
-  );
-  const targetDay = calendarDay(event.schedule.start).add(dayDeltaDays, "day");
+  const dayOffset = dayjs(event.schedule.start)
+    .startOf("day")
+    .diff(dayjs(original.schedule.start).startOf("day"), "day");
 
-  if (edited.schedule.kind === "allDay") {
-    const durationDays = dayjs(edited.schedule.end).diff(
-      dayjs(edited.schedule.start),
-      "day",
-    );
-    const start = targetDay.toYearMonthDayString();
+  const { schedule } = edited;
+  if (schedule.kind === "allDay") {
     return {
       kind: "allDay",
-      start: DateOnlySchema.parse(start),
+      start: DateOnlySchema.parse(
+        dayjs(schedule.start).add(dayOffset, "day").toYearMonthDayString(),
+      ),
       end: DateOnlySchema.parse(
-        dayjs(start).add(durationDays, "day").toYearMonthDayString(),
+        dayjs(schedule.end).add(dayOffset, "day").toYearMonthDayString(),
       ),
     };
   }
 
-  const editedStart = dayjs(edited.schedule.start);
-  const durationMs = dayjs(edited.schedule.end).diff(editedStart);
-  const timeOfDayMs = editedStart.diff(editedStart.startOf("day"));
-  const start = targetDay.add(timeOfDayMs, "millisecond");
+  // Shift by calendar day in the event's zone so DST transitions keep the
+  // same wall-clock time (plain `.add(n, "day")` on an offset string is a
+  // fixed 24h step and drifts across spring-forward / fall-back).
+  const shiftTimed = (value: string) => {
+    const local = dayjs(value).tz(schedule.timeZone);
+    return DateTimeSchema.parse(
+      dayjs
+        .tz(
+          `${local.add(dayOffset, "day").format("YYYY-MM-DD")}T${local.format("HH:mm:ss")}`,
+          schedule.timeZone,
+        )
+        .format(),
+    );
+  };
+
   return {
     kind: "timed",
-    start: DateTimeSchema.parse(start.format()),
-    end: DateTimeSchema.parse(start.add(durationMs, "millisecond").format()),
-    timeZone: edited.schedule.timeZone,
+    start: shiftTimed(schedule.start),
+    end: shiftTimed(schedule.end),
+    timeZone: schedule.timeZone,
   };
 };
 

--- a/packages/web/src/events/recurrence/projectRecurringEdit.ts
+++ b/packages/web/src/events/recurrence/projectRecurringEdit.ts
@@ -1,4 +1,4 @@
-import { type Event } from "@core/types/event.contracts";
+import { type Event, type EventSchedule } from "@core/types/event.contracts";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 
@@ -28,6 +28,49 @@ const seriesPatch = (event: Event, edited: Event): Event => ({
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+const calendarDay = (value: string) => dayjs(value).startOf("day");
+
+// When the edit flips timed ↔ allDay, millisecond deltas across kinds produce
+// full-day timed ghosts (or invalid allDay strings). Rebuild each instance
+// from the edited schedule shape, shifted by that instance's day offset from
+// the edited occurrence so the edited card lands on `edited.schedule` and
+// siblings keep their relative days.
+const convertScheduleKind = (
+  event: Event,
+  original: Event,
+  edited: Event,
+): EventSchedule => {
+  const dayDeltaDays = calendarDay(edited.schedule.start).diff(
+    calendarDay(original.schedule.start),
+    "day",
+  );
+  const targetDay = calendarDay(event.schedule.start).add(dayDeltaDays, "day");
+
+  if (edited.schedule.kind === "allDay") {
+    const durationDays = dayjs(edited.schedule.end).diff(
+      dayjs(edited.schedule.start),
+      "day",
+    );
+    const start = targetDay.toYearMonthDayString();
+    return {
+      kind: "allDay",
+      start,
+      end: dayjs(start).add(durationDays, "day").toYearMonthDayString(),
+    };
+  }
+
+  const editedStart = dayjs(edited.schedule.start);
+  const durationMs = dayjs(edited.schedule.end).diff(editedStart);
+  const timeOfDayMs = editedStart.diff(editedStart.startOf("day"));
+  const start = targetDay.add(timeOfDayMs, "millisecond");
+  return {
+    kind: "timed",
+    start: start.format(),
+    end: start.add(durationMs, "millisecond").format(),
+    timeZone: edited.schedule.timeZone,
+  };
+};
+
 // Shift every affected instance by the drag's delta so the change renders
 // optimistically. Both series-wide scopes shift by the same delta; they
 // differ only in which instances are affected (computed by the caller). Each
@@ -35,6 +78,13 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 // at its old time in the cache here — lands on the edited time because
 // (old + (edited - original)) === edited.
 const shiftEvent = (event: Event, original: Event, edited: Event): Event => {
+  if (edited.schedule.kind !== original.schedule.kind) {
+    return {
+      ...event,
+      schedule: convertScheduleKind(event, original, edited),
+    };
+  }
+
   const startDelta = dayjs(edited.schedule.start).diff(original.schedule.start);
   const endDelta = dayjs(edited.schedule.end).diff(original.schedule.end);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Converting a repeating timed event to all-day and choosing **All Events** left occurrences in the timed grid as full-column cards (visually burying other events). Optimistic `projectRecurringEdit` only shifted start/end deltas and never flipped `schedule.kind`.

This change rebuilds each affected occurrence's schedule from the edited kind, shifted by calendar-day offset in the event timezone (DST-safe), so occurrences move to the all-day row immediately. Backend rematerialization for timed→allDay scope `all` is covered by a DB regression test.

## Simplicity

Simplified `convertScheduleKind` to copy `edited.schedule` and shift by day offset instead of reconstructing duration/time-of-day onto a target day. Timed shifts go through the event timezone so spring-forward/fall-back keep wall-clock time.

## Automated validation

- CLI: `projectRecurringEdit` timed→allDay scope `all` yields `kind: "allDay"` for every occurrence
- Focused web tests (projector + `useEventMutations` optimistic cache) — 36 pass
- Backend `event.service.db.test.ts` rematerialize guard — 34 pass
- Full `bun run type-check` and `bun run lint`
- Browser UI golden path not exercised end-to-end: anonymous/local mode does not rematerialize series occurrences, and login/Google are not provisioned in this environment. Regression covered at the optimistic mutation and rematerialize layers that implement the bug path.

## Independent review

Fresh read-only review initially **request-changes** for a DST wall-clock skew on the all-day→timed path. Fixed by timezone calendar-day shifting; added a spring-forward regression test. Residual risks noted: optimistic IDs vs rematerialized IDs until invalidate (pre-existing pattern); off-range instances correct on refetch.

## Test plan

- `bun test:web` on `projectRecurringEdit.test.ts` + `useEventMutations.test.tsx`
- `bun test:backend` on `event.service.db.test.ts`
- `bun run type-check`
- `bun run lint`
- CLI projection scenario for timed→allDay scope `all`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c99e30b3-0530-4ac6-bdf6-bc5583244da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c99e30b3-0530-4ac6-bdf6-bc5583244da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

