### PR TITLE
fix(web): seed shortcut drafts with default calendar

### DIFF
--- a/packages/web/src/common/utils/draft/draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/draft.util.test.ts
@@ -1,9 +1,11 @@
+import { CalendarIdSchema } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import {
   ID_GRID_EVENTS_ALLDAY,
   ID_GRID_EVENTS_TIMED,
 } from "@web/common/constants/web.constants";
 import { Categories_Event } from "@web/common/types/web.event.types";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { createGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useDraftStore } from "@web/events/stores/draft.store";
 import { assembleDefaultEvent } from "../event/event.util";
@@ -94,6 +96,38 @@ describe("shortcut draft creation", () => {
       "2026-06-01T10:15:00.000Z",
     );
     expectSameTime(gridDraft?.values.schedule.end, "2026-06-01T11:15:00.000Z");
+  });
+
+  it("stores a provided calendarId on timed shortcut drafts", async () => {
+    setSystemTime(new Date("2026-05-20T10:07:00.000Z"));
+    const calendarId = CalendarIdSchema.parse(createObjectIdString());
+
+    await createTimedDraft(
+      true,
+      dayjs("2026-05-20T00:00:00.000Z"),
+      "createShortcut",
+      calendarId,
+    );
+
+    expect(useDraftStore.getState().gridDraft?.values.calendarId).toBe(
+      calendarId,
+    );
+  });
+
+  it("stores a provided calendarId on all-day shortcut drafts", async () => {
+    setSystemTime(new Date("2026-05-20T10:07:00.000Z"));
+    const calendarId = CalendarIdSchema.parse(createObjectIdString());
+
+    await createAlldayDraft(
+      dayjs("2026-05-18T00:00:00.000Z"),
+      dayjs("2026-05-24T23:59:59.999Z"),
+      "createShortcut",
+      calendarId,
+    );
+
+    expect(useDraftStore.getState().gridDraft?.values.calendarId).toBe(
+      calendarId,
+    );
   });
 });
 

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -1,3 +1,4 @@
+import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   ID_GRID_EVENTS_ALLDAY,
@@ -18,10 +19,13 @@ export const createTimedDraft = (
   isCurrentWeek: boolean,
   startOfView: Dayjs,
   activity: "createShortcut",
+  calendarId: CalendarId | null = null,
 ) => {
   const { startDate, endDate } = getDraftTimes(isCurrentWeek, startOfView);
   const draft = createGridEventDraft(
     timedGridSchedule(new Date(startDate), new Date(endDate)),
+    undefined,
+    calendarId,
   );
 
   draftActions.startGridDraft({ activity, draft });
@@ -31,6 +35,7 @@ export const createAlldayDraft = (
   startOfView: Dayjs,
   endOfView: Dayjs,
   activity: "createShortcut",
+  calendarId: CalendarId | null = null,
 ) => {
   const today = dayjs();
   const start = today.isBetween(startOfView, endOfView, "day", "[]")
@@ -38,11 +43,15 @@ export const createAlldayDraft = (
     : startOfView.startOf("day");
   const startDate = start.format();
   const endDate = start.add(1, "day").format();
-  const draft = createGridEventDraft({
-    kind: "allDay",
-    start: new Date(startDate),
-    end: new Date(endDate),
-  });
+  const draft = createGridEventDraft(
+    {
+      kind: "allDay",
+      start: new Date(startDate),
+      end: new Date(endDate),
+    },
+    undefined,
+    calendarId,
+  );
 
   draftActions.startGridDraft({ activity, draft });
 };

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -806,6 +806,37 @@ describe("DayCalendarGrid", () => {
     expect(parseFloat(draftCard.style.left)).toBeGreaterThanOrEqual(180);
   });
 
+  it("seeds CREATE_ALLDAY_DRAFT with the default target calendar, not column 0", async () => {
+    const holidays = makeCalendar("Holidays in United States", {
+      access: "reader",
+      capabilities: {
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: true,
+      },
+    });
+    const primary = makeCalendar("compasscaltest3@gmail.com", {
+      isPrimary: true,
+    });
+    renderDayCalendarGrid([holidays, primary]);
+
+    act(() => {
+      emitViewCommand("CREATE_ALLDAY_DRAFT");
+    });
+
+    await waitFor(() => {
+      expect(getGridDraft()?.values.calendarId).toBe(primary.id);
+      expect(getIsFormOpen()).toBe(true);
+    });
+
+    const draftCard = screen.getByRole("button", {
+      name: /all-day event: untitled event/i,
+    });
+    expect(parseFloat(draftCard.style.left)).toBeGreaterThanOrEqual(180);
+  });
+
   it("rejects timed draft creation on a read-only calendar", async () => {
     const primary = makeCalendar("Primary", { isPrimary: true });
     const holidays = makeCalendar("Holidays", {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -771,6 +771,41 @@ describe("DayCalendarGrid", () => {
     });
   });
 
+  it("seeds CREATE_TIMED_DRAFT with the default target calendar, not column 0", async () => {
+    // Holidays is first in column order (read-only, visible) but is not the
+    // default create target — primary writable Google is. Shortcut drafts
+    // must land on primary so the grid column matches the form.
+    const holidays = makeCalendar("Holidays in United States", {
+      access: "reader",
+      capabilities: {
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: false,
+        canManage: false,
+        canWatchEvents: true,
+      },
+    });
+    const primary = makeCalendar("compasscaltest3@gmail.com", {
+      isPrimary: true,
+    });
+    renderDayCalendarGrid([holidays, primary]);
+
+    act(() => {
+      emitViewCommand("CREATE_TIMED_DRAFT");
+    });
+
+    await waitFor(() => {
+      expect(getGridDraft()?.values.calendarId).toBe(primary.id);
+      expect(getIsFormOpen()).toBe(true);
+    });
+
+    const draftCard = screen.getByRole("button", {
+      name: /timed event: untitled event/i,
+    });
+    // Column widths are 180; primary is the second column (index 1).
+    expect(parseFloat(draftCard.style.left)).toBeGreaterThanOrEqual(180);
+  });
+
   it("rejects timed draft creation on a read-only calendar", async () => {
     const primary = makeCalendar("Primary", { isPrimary: true });
     const holidays = makeCalendar("Holidays", {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -8,6 +8,8 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
@@ -59,6 +61,11 @@ export function DayCalendarGrid() {
   const dateInView = useDateInView();
   const { navigateToDate } = useDateNavigation();
   const today = useMemo(() => dayjs(), []);
+  const { data: calendars = [] } = useCalendarsQuery();
+  const defaultTargetCalendarId = useMemo(
+    () => getDefaultTargetCalendar(calendars)?.id ?? null,
+    [calendars],
+  );
   const {
     allDayEvents,
     events: dayEvents,
@@ -175,9 +182,14 @@ export function DayCalendarGrid() {
   const createAllDayDraftFromShortcut = useCallback(
     () =>
       openShortcutDraft(() =>
-        createAlldayDraft(dateInView, dateInView, "createShortcut"),
+        createAlldayDraft(
+          dateInView,
+          dateInView,
+          "createShortcut",
+          defaultTargetCalendarId,
+        ),
       ),
-    [dateInView, openShortcutDraft],
+    [dateInView, defaultTargetCalendarId, openShortcutDraft],
   );
 
   const createTimedDraftFromShortcut = useCallback(
@@ -187,9 +199,10 @@ export function DayCalendarGrid() {
           dateInView.isSame(dayjs(), "day"),
           dateInView,
           "createShortcut",
+          defaultTargetCalendarId,
         ),
       ),
-    [dateInView, openShortcutDraft],
+    [dateInView, defaultTargetCalendarId, openShortcutDraft],
   );
 
   // onViewCommand returns its own unsubscribe and emitViewCommand reads the

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -61,11 +61,11 @@ export function DayCalendarGrid() {
   const dateInView = useDateInView();
   const { navigateToDate } = useDateNavigation();
   const today = useMemo(() => dayjs(), []);
-  const { data: calendars = [] } = useCalendarsQuery();
-  const defaultTargetCalendarId = useMemo(
-    () => getDefaultTargetCalendar(calendars)?.id ?? null,
-    [calendars],
-  );
+  const { data: calendars = [], isPending: isCalendarsPending } =
+    useCalendarsQuery();
+  // Seed shortcuts with the form's default create target, not day-column order.
+  const defaultTargetCalendarId =
+    getDefaultTargetCalendar(calendars)?.id ?? null;
   const {
     allDayEvents,
     events: dayEvents,
@@ -172,11 +172,16 @@ export function DayCalendarGrid() {
       if (gridDraft) {
         return;
       }
+      // Avoid locking in calendarId: null while the calendars query is still
+      // loading; the form would show the default once data arrives.
+      if (isCalendarsPending && !defaultTargetCalendarId) {
+        return;
+      }
 
       createDraft();
       draftActions.setFormOpen(true);
     },
-    [gridDraft],
+    [defaultTargetCalendarId, gridDraft, isCalendarsPending],
   );
 
   const createAllDayDraftFromShortcut = useCallback(

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -660,7 +660,9 @@ describe("useWeekShortcuts view command bus", () => {
     });
 
     await waitFor(() => {
-      expect(useDraftStore.getState().status?.activity).toBe("createShortcut");
+      const { gridDraft, status } = useDraftStore.getState();
+      expect(status?.activity).toBe("createShortcut");
+      expect(gridDraft?.values.calendarId).toBe(writableCalendar.id);
     });
   });
 
@@ -672,7 +674,9 @@ describe("useWeekShortcuts view command bus", () => {
     });
 
     await waitFor(() => {
-      expect(useDraftStore.getState().status?.activity).toBe("createShortcut");
+      const { gridDraft, status } = useDraftStore.getState();
+      expect(status?.activity).toBe("createShortcut");
+      expect(gridDraft?.values.calendarId).toBe(writableCalendar.id);
     });
   });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 import {
   isEventReadOnly,
   useCalendarLookup,
@@ -78,6 +80,11 @@ export const useWeekShortcuts = ({
   // but never mutated - delete and nudge/move below gate on this before
   // touching the store (packet 08 step 8).
   const calendarLookup = useCalendarLookup();
+  const { data: calendars = [] } = useCalendarsQuery();
+  const defaultTargetCalendarId = useMemo(
+    () => getDefaultTargetCalendar(calendars)?.id ?? null,
+    [calendars],
+  );
   const {
     actions: { repositionDraftByKeyboard },
   } = useDraftContext();
@@ -130,17 +137,27 @@ export const useWeekShortcuts = ({
   }, [_discardDraft, shiftViewByDay]);
 
   const createAllDayDraftEvent = useCallback(() => {
-    void createAlldayDraft(startOfView, endOfView, "createShortcut");
-  }, [startOfView, endOfView]);
+    void createAlldayDraft(
+      startOfView,
+      endOfView,
+      "createShortcut",
+      defaultTargetCalendarId,
+    );
+  }, [defaultTargetCalendarId, startOfView, endOfView]);
 
   const createTimedDraftEvent = useCallback(() => {
-    void createTimedDraft(isCurrentWeek, startOfView, "createShortcut");
-  }, [isCurrentWeek, startOfView]);
+    void createTimedDraft(
+      isCurrentWeek,
+      startOfView,
+      "createShortcut",
+      defaultTargetCalendarId,
+    );
+  }, [defaultTargetCalendarId, isCurrentWeek, startOfView]);
 
   // The command palette's create-event rows emit these same commands
   // (event.cmd.constants.ts) so the "C"/"A" keys and the palette rows run
-  // identical code. Resubscribes only when the week in view changes (these
-  // callbacks are memoized on startOfView/endOfView/isCurrentWeek).
+  // identical code. Resubscribes when the create handlers change (week in
+  // view or default target calendar).
   useEffect(() => {
     const unsubscribeCreateAllDayDraft = onViewCommand(
       "CREATE_ALLDAY_DRAFT",

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
@@ -80,11 +80,10 @@ export const useWeekShortcuts = ({
   // but never mutated - delete and nudge/move below gate on this before
   // touching the store (packet 08 step 8).
   const calendarLookup = useCalendarLookup();
-  const { data: calendars = [] } = useCalendarsQuery();
-  const defaultTargetCalendarId = useMemo(
-    () => getDefaultTargetCalendar(calendars)?.id ?? null,
-    [calendars],
-  );
+  const { data: calendars = [], isPending: isCalendarsPending } =
+    useCalendarsQuery();
+  const defaultTargetCalendarId =
+    getDefaultTargetCalendar(calendars)?.id ?? null;
   const {
     actions: { repositionDraftByKeyboard },
   } = useDraftContext();
@@ -137,22 +136,32 @@ export const useWeekShortcuts = ({
   }, [_discardDraft, shiftViewByDay]);
 
   const createAllDayDraftEvent = useCallback(() => {
+    // Same guard as DayCalendarGrid.openShortcutDraft: do not seed a sticky
+    // null calendarId while calendars are still loading.
+    if (isCalendarsPending && !defaultTargetCalendarId) {
+      return;
+    }
+
     void createAlldayDraft(
       startOfView,
       endOfView,
       "createShortcut",
       defaultTargetCalendarId,
     );
-  }, [defaultTargetCalendarId, startOfView, endOfView]);
+  }, [defaultTargetCalendarId, endOfView, isCalendarsPending, startOfView]);
 
   const createTimedDraftEvent = useCallback(() => {
+    if (isCalendarsPending && !defaultTargetCalendarId) {
+      return;
+    }
+
     void createTimedDraft(
       isCurrentWeek,
       startOfView,
       "createShortcut",
       defaultTargetCalendarId,
     );
-  }, [defaultTargetCalendarId, isCurrentWeek, startOfView]);
+  }, [defaultTargetCalendarId, isCalendarsPending, isCurrentWeek, startOfView]);
 
   // The command palette's create-event rows emit these same commands
   // (event.cmd.constants.ts) so the "C"/"A" keys and the palette rows run


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pressing `c` on day view created a draft with `calendarId: null`, so the grid always placed it in column 0 (e.g. Holidays) while the event form displayed the default target calendar (primary writable Google / local).

Shortcut draft creation now seeds `calendarId` from `getDefaultTargetCalendar`, matching the form display and save fallback. Week view shortcuts get the same treatment for consistency.

## Test plan

- [x] `draft.util` asserts provided `calendarId` is stored on timed and all-day shortcut drafts
- [x] Day grid regression: `CREATE_TIMED_DRAFT` with Holidays first + primary second seeds primary and places the draft in column 1
- [ ] Manually: day view with multiple calendars, press `c`, confirm draft appears under the primary account column matching the form
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09739303-8f91-4dbb-9a71-a8e9a7db21fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09739303-8f91-4dbb-9a71-a8e9a7db21fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

