### PR TITLE
fix(web): show sample banner only when demos are visible

### DIFF
--- a/packages/web/src/components/DemoEventsBanner/DemoEventsBannerGate.tsx
+++ b/packages/web/src/components/DemoEventsBanner/DemoEventsBannerGate.tsx
@@ -4,10 +4,18 @@ import {
   dismissDemoEventsBanner,
   hasDismissedDemoEventsBanner,
 } from "@web/components/DemoEventsBanner/DemoEventsBanner";
+import { type DemoEventsRange } from "@web/events/demo-events.util";
 import { useDemoEventsPresent } from "@web/events/hooks/useDemoEventsPresent";
 
-export const DemoEventsBannerGate: FC = () => {
-  const hasDemoEvents = useDemoEventsPresent();
+interface DemoEventsBannerGateProps {
+  /** Visible calendar range; banner only shows when sample events overlap it. */
+  range: DemoEventsRange;
+}
+
+export const DemoEventsBannerGate: FC<DemoEventsBannerGateProps> = ({
+  range,
+}) => {
+  const hasDemoEvents = useDemoEventsPresent(range);
   const [dismissed, setDismissed] = useState(hasDismissedDemoEventsBanner);
 
   const handleDismiss = useCallback(() => {

--- a/packages/web/src/events/demo-events.util.test.ts
+++ b/packages/web/src/events/demo-events.util.test.ts
@@ -1,6 +1,11 @@
 import { EventScheduleSchema } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { createMockLocalEventRecord } from "@web/__tests__/utils/factories/event.factory";
-import { clearDemoEvents, hasDemoEvents } from "@web/events/demo-events.util";
+import {
+  clearDemoEvents,
+  hasDemoEvents,
+  toDemoEventsRange,
+} from "@web/events/demo-events.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const getAllEvents = mock(
@@ -8,16 +13,19 @@ const getAllEvents = mock(
 );
 const deleteEvent = mock(async () => undefined);
 const invalidateQueries = mock(async () => undefined);
+const getStore = () => ({ getAllEvents, deleteEvent });
 
-mock.module(
-  "@web/common/storage/offline-data/offline-data.store.registry",
-  () => ({
-    getOfflineDataStore: () => ({
-      getAllEvents,
-      deleteEvent,
-    }),
-  }),
-);
+describe("toDemoEventsRange", () => {
+  it("builds an exclusive-end range from inclusive calendar days", () => {
+    const start = dayjs("2026-07-26");
+    const end = dayjs("2026-08-01");
+
+    expect(toDemoEventsRange(start.hour(15), end.endOf("day"))).toEqual({
+      start: start.startOf("day").format(),
+      end: end.startOf("day").add(1, "day").format(),
+    });
+  });
+});
 
 describe("hasDemoEvents", () => {
   beforeEach(() => {
@@ -32,13 +40,13 @@ describe("hasDemoEvents", () => {
       createMockLocalEventRecord({}, false),
     ]);
 
-    await expect(hasDemoEvents()).resolves.toBe(true);
+    await expect(hasDemoEvents(undefined, getStore)).resolves.toBe(true);
   });
 
   it("returns false when no demo events exist", async () => {
     getAllEvents.mockResolvedValueOnce([createMockLocalEventRecord({}, false)]);
 
-    await expect(hasDemoEvents()).resolves.toBe(false);
+    await expect(hasDemoEvents(undefined, getStore)).resolves.toBe(false);
   });
 
   it("returns true only when a demo event overlaps the given range", async () => {
@@ -67,24 +75,33 @@ describe("hasDemoEvents", () => {
     getAllEvents.mockResolvedValue([inRange, outOfRange]);
 
     await expect(
-      hasDemoEvents({
-        start: "2026-07-26T00:00:00.000-05:00",
-        end: "2026-08-02T00:00:00.000-05:00",
-      }),
+      hasDemoEvents(
+        {
+          start: "2026-07-26T00:00:00.000-05:00",
+          end: "2026-08-02T00:00:00.000-05:00",
+        },
+        getStore,
+      ),
     ).resolves.toBe(true);
 
     await expect(
-      hasDemoEvents({
-        start: "2026-08-02T00:00:00.000-05:00",
-        end: "2026-08-09T00:00:00.000-05:00",
-      }),
+      hasDemoEvents(
+        {
+          start: "2026-08-02T00:00:00.000-05:00",
+          end: "2026-08-09T00:00:00.000-05:00",
+        },
+        getStore,
+      ),
     ).resolves.toBe(true);
 
     await expect(
-      hasDemoEvents({
-        start: "2026-08-09T00:00:00.000-05:00",
-        end: "2026-08-16T00:00:00.000-05:00",
-      }),
+      hasDemoEvents(
+        {
+          start: "2026-08-09T00:00:00.000-05:00",
+          end: "2026-08-16T00:00:00.000-05:00",
+        },
+        getStore,
+      ),
     ).resolves.toBe(false);
   });
 
@@ -104,10 +121,13 @@ describe("hasDemoEvents", () => {
     ]);
 
     await expect(
-      hasDemoEvents({
-        start: "2026-07-26T00:00:00.000-05:00",
-        end: "2026-08-02T00:00:00.000-05:00",
-      }),
+      hasDemoEvents(
+        {
+          start: "2026-07-26T00:00:00.000-05:00",
+          end: "2026-08-02T00:00:00.000-05:00",
+        },
+        getStore,
+      ),
     ).resolves.toBe(false);
   });
 
@@ -126,10 +146,13 @@ describe("hasDemoEvents", () => {
     ]);
 
     await expect(
-      hasDemoEvents({
-        start: "2026-07-26T00:00:00.000-05:00",
-        end: "2026-08-02T00:00:00.000-05:00",
-      }),
+      hasDemoEvents(
+        {
+          start: "2026-07-26T00:00:00.000-05:00",
+          end: "2026-08-02T00:00:00.000-05:00",
+        },
+        getStore,
+      ),
     ).resolves.toBe(true);
   });
 });
@@ -146,9 +169,10 @@ describe("clearDemoEvents", () => {
     const user = createMockLocalEventRecord({}, false);
     getAllEvents.mockResolvedValueOnce([demo, user]);
 
-    const removed = await clearDemoEvents({
-      invalidateQueries,
-    } as never);
+    const removed = await clearDemoEvents(
+      { invalidateQueries } as never,
+      getStore,
+    );
 
     expect(removed).toBe(1);
     expect(deleteEvent).toHaveBeenCalledTimes(1);

--- a/packages/web/src/events/demo-events.util.test.ts
+++ b/packages/web/src/events/demo-events.util.test.ts
@@ -1,0 +1,158 @@
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import { createMockLocalEventRecord } from "@web/__tests__/utils/factories/event.factory";
+import { clearDemoEvents, hasDemoEvents } from "@web/events/demo-events.util";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const getAllEvents = mock(
+  async () => [] as ReturnType<typeof createMockLocalEventRecord>[],
+);
+const deleteEvent = mock(async () => undefined);
+const invalidateQueries = mock(async () => undefined);
+
+mock.module(
+  "@web/common/storage/offline-data/offline-data.store.registry",
+  () => ({
+    getOfflineDataStore: () => ({
+      getAllEvents,
+      deleteEvent,
+    }),
+  }),
+);
+
+describe("hasDemoEvents", () => {
+  beforeEach(() => {
+    getAllEvents.mockClear();
+    deleteEvent.mockClear();
+    invalidateQueries.mockClear();
+  });
+
+  it("returns true when any demo event exists", async () => {
+    getAllEvents.mockResolvedValueOnce([
+      createMockLocalEventRecord({}, true),
+      createMockLocalEventRecord({}, false),
+    ]);
+
+    await expect(hasDemoEvents()).resolves.toBe(true);
+  });
+
+  it("returns false when no demo events exist", async () => {
+    getAllEvents.mockResolvedValueOnce([createMockLocalEventRecord({}, false)]);
+
+    await expect(hasDemoEvents()).resolves.toBe(false);
+  });
+
+  it("returns true only when a demo event overlaps the given range", async () => {
+    const inRange = createMockLocalEventRecord(
+      {
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2026-07-27T10:00:00.000-05:00",
+          end: "2026-07-27T11:00:00.000-05:00",
+          timeZone: "America/Chicago",
+        }),
+      },
+      true,
+    );
+    const outOfRange = createMockLocalEventRecord(
+      {
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2026-08-03T10:00:00.000-05:00",
+          end: "2026-08-03T11:00:00.000-05:00",
+          timeZone: "America/Chicago",
+        }),
+      },
+      true,
+    );
+    getAllEvents.mockResolvedValue([inRange, outOfRange]);
+
+    await expect(
+      hasDemoEvents({
+        start: "2026-07-26T00:00:00.000-05:00",
+        end: "2026-08-02T00:00:00.000-05:00",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      hasDemoEvents({
+        start: "2026-08-02T00:00:00.000-05:00",
+        end: "2026-08-09T00:00:00.000-05:00",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      hasDemoEvents({
+        start: "2026-08-09T00:00:00.000-05:00",
+        end: "2026-08-16T00:00:00.000-05:00",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("ignores non-demo events inside the range", async () => {
+    getAllEvents.mockResolvedValueOnce([
+      createMockLocalEventRecord(
+        {
+          schedule: EventScheduleSchema.parse({
+            kind: "timed",
+            start: "2026-07-27T10:00:00.000-05:00",
+            end: "2026-07-27T11:00:00.000-05:00",
+            timeZone: "America/Chicago",
+          }),
+        },
+        false,
+      ),
+    ]);
+
+    await expect(
+      hasDemoEvents({
+        start: "2026-07-26T00:00:00.000-05:00",
+        end: "2026-08-02T00:00:00.000-05:00",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("matches all-day demo events with exclusive range end", async () => {
+    getAllEvents.mockResolvedValueOnce([
+      createMockLocalEventRecord(
+        {
+          schedule: EventScheduleSchema.parse({
+            kind: "allDay",
+            start: "2026-07-27",
+            end: "2026-07-28",
+          }),
+        },
+        true,
+      ),
+    ]);
+
+    await expect(
+      hasDemoEvents({
+        start: "2026-07-26T00:00:00.000-05:00",
+        end: "2026-08-02T00:00:00.000-05:00",
+      }),
+    ).resolves.toBe(true);
+  });
+});
+
+describe("clearDemoEvents", () => {
+  beforeEach(() => {
+    getAllEvents.mockClear();
+    deleteEvent.mockClear();
+    invalidateQueries.mockClear();
+  });
+
+  it("deletes only demo events and invalidates the events query", async () => {
+    const demo = createMockLocalEventRecord({}, true);
+    const user = createMockLocalEventRecord({}, false);
+    getAllEvents.mockResolvedValueOnce([demo, user]);
+
+    const removed = await clearDemoEvents({
+      invalidateQueries,
+    } as never);
+
+    expect(removed).toBe(1);
+    expect(deleteEvent).toHaveBeenCalledTimes(1);
+    expect(deleteEvent).toHaveBeenCalledWith(demo.id);
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/events/demo-events.util.ts
+++ b/packages/web/src/events/demo-events.util.ts
@@ -1,5 +1,8 @@
 import { type QueryClient } from "@tanstack/react-query";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { type OfflineDataStore } from "@web/common/storage/offline-data/offline-data.store";
 import { getOfflineDataStore } from "@web/common/storage/offline-data/offline-data.store.registry";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { eventMatchesRange } from "@web/events/queries/event.query.normalize";
 
@@ -8,8 +11,28 @@ export type DemoEventsRange = {
   end: string;
 };
 
-export async function hasDemoEvents(range?: DemoEventsRange): Promise<boolean> {
-  const records = await getOfflineDataStore().getAllEvents();
+type DemoEventsReadStore = Pick<OfflineDataStore, "getAllEvents">;
+type DemoEventsWriteStore = Pick<
+  OfflineDataStore,
+  "getAllEvents" | "deleteEvent"
+>;
+
+/** Inclusive calendar days → exclusive-end instant range for demo overlap checks. */
+export function toDemoEventsRange(
+  startOfView: Dayjs,
+  endOfView: Dayjs,
+): DemoEventsRange {
+  return {
+    start: toUTCOffset(startOfView.startOf("day")),
+    end: toUTCOffset(endOfView.startOf("day").add(1, "day")),
+  };
+}
+
+export async function hasDemoEvents(
+  range?: DemoEventsRange,
+  getStore: () => DemoEventsReadStore = getOfflineDataStore,
+): Promise<boolean> {
+  const records = await getStore().getAllEvents();
   if (!range) {
     return records.some((record) => record.isDemo);
   }
@@ -22,8 +45,9 @@ export async function hasDemoEvents(range?: DemoEventsRange): Promise<boolean> {
 
 export async function clearDemoEvents(
   queryClient: QueryClient,
+  getStore: () => DemoEventsWriteStore = getOfflineDataStore,
 ): Promise<number> {
-  const store = getOfflineDataStore();
+  const store = getStore();
   const records = await store.getAllEvents();
   const demoRecords = records.filter((record) => record.isDemo);
 

--- a/packages/web/src/events/demo-events.util.ts
+++ b/packages/web/src/events/demo-events.util.ts
@@ -1,10 +1,23 @@
 import { type QueryClient } from "@tanstack/react-query";
 import { getOfflineDataStore } from "@web/common/storage/offline-data/offline-data.store.registry";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import { eventMatchesRange } from "@web/events/queries/event.query.normalize";
 
-export async function hasDemoEvents(): Promise<boolean> {
+export type DemoEventsRange = {
+  start: string;
+  end: string;
+};
+
+export async function hasDemoEvents(range?: DemoEventsRange): Promise<boolean> {
   const records = await getOfflineDataStore().getAllEvents();
-  return records.some((record) => record.isDemo);
+  if (!range) {
+    return records.some((record) => record.isDemo);
+  }
+
+  return records.some(
+    (record) =>
+      record.isDemo && eventMatchesRange(record.event, range.start, range.end),
+  );
 }
 
 export async function clearDemoEvents(

--- a/packages/web/src/events/hooks/useDemoEventsPresent.ts
+++ b/packages/web/src/events/hooks/useDemoEventsPresent.ts
@@ -1,14 +1,19 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { hasDemoEvents } from "@web/events/demo-events.util";
+import {
+  type DemoEventsRange,
+  hasDemoEvents,
+} from "@web/events/demo-events.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 
-export function useDemoEventsPresent(): boolean {
+export function useDemoEventsPresent(range?: DemoEventsRange): boolean {
   const queryClient = useQueryClient();
   const source = useEventRepositorySource();
   const [present, setPresent] = useState(false);
   const refreshGenerationRef = useRef(0);
+  const rangeStart = range?.start;
+  const rangeEnd = range?.end;
 
   const refresh = useCallback(() => {
     if (source !== "local") {
@@ -19,12 +24,16 @@ export function useDemoEventsPresent(): boolean {
 
     refreshGenerationRef.current += 1;
     const generation = refreshGenerationRef.current;
-    void hasDemoEvents().then((result) => {
+    const rangeArg =
+      rangeStart !== undefined && rangeEnd !== undefined
+        ? { start: rangeStart, end: rangeEnd }
+        : undefined;
+    void hasDemoEvents(rangeArg).then((result) => {
       if (generation === refreshGenerationRef.current) {
         setPresent(result);
       }
     });
-  }, [source]);
+  }, [rangeEnd, rangeStart, source]);
 
   useEffect(() => {
     refresh();

--- a/packages/web/src/events/hooks/useDemoEventsPresent.ts
+++ b/packages/web/src/events/hooks/useDemoEventsPresent.ts
@@ -7,18 +7,30 @@ import {
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 
+function rangeKey(range?: DemoEventsRange): string {
+  return range ? `${range.start}|${range.end}` : "";
+}
+
 export function useDemoEventsPresent(range?: DemoEventsRange): boolean {
   const queryClient = useQueryClient();
   const source = useEventRepositorySource();
-  const [present, setPresent] = useState(false);
+  const [state, setState] = useState<{
+    present: boolean;
+    key: string;
+  }>({ present: false, key: "" });
   const refreshGenerationRef = useRef(0);
   const rangeStart = range?.start;
   const rangeEnd = range?.end;
+  const currentKey = rangeKey(
+    rangeStart !== undefined && rangeEnd !== undefined
+      ? { start: rangeStart, end: rangeEnd }
+      : undefined,
+  );
 
   const refresh = useCallback(() => {
     if (source !== "local") {
       refreshGenerationRef.current += 1;
-      setPresent(false);
+      setState({ present: false, key: currentKey });
       return;
     }
 
@@ -30,10 +42,10 @@ export function useDemoEventsPresent(range?: DemoEventsRange): boolean {
         : undefined;
     void hasDemoEvents(rangeArg).then((result) => {
       if (generation === refreshGenerationRef.current) {
-        setPresent(result);
+        setState({ present: result, key: rangeKey(rangeArg) });
       }
     });
-  }, [rangeEnd, rangeStart, source]);
+  }, [currentKey, rangeEnd, rangeStart, source]);
 
   useEffect(() => {
     refresh();
@@ -49,5 +61,6 @@ export function useDemoEventsPresent(range?: DemoEventsRange): boolean {
     });
   }, [queryClient, refresh]);
 
-  return present;
+  // Drop stale "present" from a previous range while the next check is in flight.
+  return state.key === currentKey && state.present;
 }

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -25,7 +25,10 @@ import {
 import { getShortcutMenuSections } from "@web/shortcuts/data/shortcuts.data";
 import { DayCalendarGrid } from "@web/views/Day/components/Calendar/DayCalendarGrid";
 import { Header } from "@web/views/Day/components/Header/Header";
-import { useDayEvents } from "@web/views/Day/hooks/events/useDayEvents";
+import {
+  dayEventQueryRange,
+  useDayEvents,
+} from "@web/views/Day/hooks/events/useDayEvents";
 import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
 import { useDayViewShortcuts } from "@web/views/Day/hooks/shortcuts/useDayViewShortcuts";
@@ -122,6 +125,11 @@ export const DayViewContent = memo(() => {
     welcomeGuideActions.open();
   }, []);
 
+  const demoEventsRange = useMemo(() => {
+    const { startDate, endDate } = dayEventQueryRange(dateInView);
+    return { start: startDate, end: endDate };
+  }, [dateInView]);
+
   return (
     <div id="day" className="flex h-screen w-screen overflow-hidden">
       <CommandPalette
@@ -139,7 +147,7 @@ export const DayViewContent = memo(() => {
         className="flex h-screen flex-1 flex-col overflow-hidden bg-background pt-5 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
       >
         <Header />
-        <DemoEventsBannerGate />
+        <DemoEventsBannerGate range={demoEventsRange} />
 
         <div className="flex w-full flex-1 overflow-hidden">
           <DayCalendarGrid />

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -13,6 +13,7 @@ import { useUpNextEventShortcut } from "@web/components/Sidebar/UpNextCard/useUp
 import { useSidebarShortcuts } from "@web/components/Sidebar/useSidebarShortcuts";
 import { focusFirstSidebarItem } from "@web/components/Sidebar/util/sidebarFocus.util";
 import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
+import { toDemoEventsRange } from "@web/events/demo-events.util";
 import {
   selectIsEventFormOpen,
   useDraftStore,
@@ -25,10 +26,7 @@ import {
 import { getShortcutMenuSections } from "@web/shortcuts/data/shortcuts.data";
 import { DayCalendarGrid } from "@web/views/Day/components/Calendar/DayCalendarGrid";
 import { Header } from "@web/views/Day/components/Header/Header";
-import {
-  dayEventQueryRange,
-  useDayEvents,
-} from "@web/views/Day/hooks/events/useDayEvents";
+import { useDayEvents } from "@web/views/Day/hooks/events/useDayEvents";
 import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
 import { useDayViewShortcuts } from "@web/views/Day/hooks/shortcuts/useDayViewShortcuts";
@@ -125,10 +123,10 @@ export const DayViewContent = memo(() => {
     welcomeGuideActions.open();
   }, []);
 
-  const demoEventsRange = useMemo(() => {
-    const { startDate, endDate } = dayEventQueryRange(dateInView);
-    return { start: startDate, end: endDate };
-  }, [dateInView]);
+  const demoEventsRange = useMemo(
+    () => toDemoEventsRange(dateInView, dateInView),
+    [dateInView],
+  );
 
   return (
     <div id="day" className="flex h-screen w-screen overflow-hidden">

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
-import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { getCommandPalettePlaceholder } from "@web/components/CommandPalette/more.cmd.constants";
@@ -13,6 +12,7 @@ import { Sidebar } from "@web/components/Sidebar/Sidebar";
 import { useUpNextEventShortcut } from "@web/components/Sidebar/UpNextCard/useUpNextEvent";
 import { useSidebarShortcuts } from "@web/components/Sidebar/useSidebarShortcuts";
 import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
+import { toDemoEventsRange } from "@web/events/demo-events.util";
 import {
   draftActions,
   selectIsEventFormOpen,
@@ -142,14 +142,12 @@ export const WeekView = () => {
     welcomeGuideActions.open();
   }, []);
 
-  // Exclusive end so all-day sample events on the last visible day still match.
   const demoEventsRange = useMemo(
-    () => ({
-      start: toUTCOffset(weekProps.component.startOfView.startOf("day")),
-      end: toUTCOffset(
-        weekProps.component.endOfView.startOf("day").add(1, "day"),
+    () =>
+      toDemoEventsRange(
+        weekProps.component.startOfView,
+        weekProps.component.endOfView,
       ),
-    }),
     [weekProps.component.endOfView, weekProps.component.startOfView],
   );
 

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { CommandPalette } from "@web/components/CommandPalette/CommandPalette";
 import { getCommandPalettePlaceholder } from "@web/components/CommandPalette/more.cmd.constants";
@@ -141,6 +142,17 @@ export const WeekView = () => {
     welcomeGuideActions.open();
   }, []);
 
+  // Exclusive end so all-day sample events on the last visible day still match.
+  const demoEventsRange = useMemo(
+    () => ({
+      start: toUTCOffset(weekProps.component.startOfView.startOf("day")),
+      end: toUTCOffset(
+        weekProps.component.endOfView.startOf("day").add(1, "day"),
+      ),
+    }),
+    [weekProps.component.endOfView, weekProps.component.startOfView],
+  );
+
   return (
     <div id="cal" className="flex h-screen w-screen overflow-hidden">
       <CommandPalette
@@ -160,7 +172,7 @@ export const WeekView = () => {
             className="flex h-screen flex-1 flex-col overflow-hidden bg-background pt-5 pr-0 pb-0 pl-8 transition-[width] duration-200 ease-out motion-reduce:transition-none"
           >
             <Header scrollUtil={scrollUtil} weekProps={weekProps} />
-            <DemoEventsBannerGate />
+            <DemoEventsBannerGate range={demoEventsRange} />
 
             <WeekGridScrollArea>
               <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The sample-events banner previously appeared whenever any demo events existed in local storage, including on weeks/days with none visible.

## Change

- Gate the banner on the visible day/week range via `toDemoEventsRange` + range-aware `hasDemoEvents`
- Ignore stale “present” results while a new range check is in flight
- Keep command-palette “Clear sample events” unscoped so demos can still be cleared from any week
- Avoid sticky `mock.module` in util tests (inject a store seam instead)

## Simplification

- Shared `toDemoEventsRange` for Day and Week instead of duplicating exclusive-end math
- Retained `useEffect` / `useRef` / `useState` in `useDemoEventsPresent` to sync with IndexedDB + the events query cache (non-React systems)

## Validation

- Browser: banner on sample week → hidden on empty week → reappears on return
- `bun test packages/web/src/events/demo-events.util.test.ts`
- `bun run test:web` (1359 pass)
- `bun run type-check`
- `bun run lint` (pre-existing unused-import warning elsewhere)
- Independent review: fixed stale-true banner across range changes

![Sample week with banner](https://cursor.com/artifacts/c/art-dd295279-a476-4f3b-9a79-104f55a61704)
![Empty week without banner](https://cursor.com/artifacts/c/art-f7bd7d43-3d16-4bf9-9974-4848a3dd9946)
![Banner reappears on sample week](https://cursor.com/artifacts/c/art-13946d2b-faf1-4bff-b96e-2a580ad53fff)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a462f7b2-846e-4296-8455-c56b7d19b187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a462f7b2-846e-4296-8455-c56b7d19b187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

