### PR TITLE
fix(web): allow dragging all-day drafts onto the timed grid

### DIFF
--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -64,7 +64,10 @@ export const GridDraft: FC<Props> = ({
   const handleDrag = (_: GridEventEntity, moveEvent: PartialMouseEvent) => {
     if (!draft) return; // TS Guard
 
-    startDragging(getEventDragOffset(draftAsGridEvent ?? undefined, moveEvent));
+    startDragging(
+      getEventDragOffset(draftAsGridEvent ?? undefined, moveEvent),
+      moveEvent,
+    );
   };
 
   const handleScalerMouseDown = (

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -2,10 +2,7 @@ import { type FC, type MouseEvent } from "react";
 import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
-import {
-  Categories_Event,
-  type GridEvent as GridEventEntity,
-} from "@web/common/types/web.event.types";
+import { type GridEvent as GridEventEntity } from "@web/common/types/web.event.types";
 import {
   getEventDragOffset,
   gridEventDefaultPosition,
@@ -87,7 +84,6 @@ export const GridDraft: FC<Props> = ({
     rendersInAllDayRow && draft?.values.schedule.kind === "timed";
 
   const { onMouseDown } = useGridEventMouseDown(
-    rendersInAllDayRow ? Categories_Event.ALLDAY : Categories_Event.TIMED,
     handleGridDraftClick,
     isMultiDayTimedDraft ? () => {} : handleDrag,
   );

--- a/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
@@ -49,43 +49,25 @@ export const useGridMouseUp = () => {
     }
   }, [isDragging, isResizing, stopDragging, stopResizing]);
 
-  const handleAllDayRowMouseUp = useCallback(() => {
-    if (!draft) return;
+  const commitOnMouseUp = useCallback(
+    (category: Categories_Event) => {
+      if (!draft) return;
 
-    stopMotion();
+      stopMotion();
 
-    const { shouldSubmit, shouldOpenForm } = getNextAction(
-      Categories_Event.ALLDAY,
-    );
+      const { shouldSubmit, shouldOpenForm } = getNextAction(category);
 
-    if (shouldOpenForm) {
-      draftActions.setFormOpen(true);
-      return;
-    }
+      if (shouldOpenForm) {
+        draftActions.setFormOpen(true);
+        return;
+      }
 
-    if (shouldSubmit) {
-      submit(draft);
-    }
-  }, [draft, getNextAction, stopMotion, submit]);
-
-  const handleMainGridMouseUp = useCallback(() => {
-    if (!draft || !isDrafting) return;
-
-    stopMotion();
-
-    const { shouldSubmit, shouldOpenForm } = getNextAction(
-      Categories_Event.TIMED,
-    );
-
-    if (shouldOpenForm) {
-      draftActions.setFormOpen(true);
-      return;
-    }
-
-    if (shouldSubmit) {
-      submit(draft);
-    }
-  }, [draft, isDrafting, getNextAction, stopMotion, submit]);
+      if (shouldSubmit) {
+        submit(draft);
+      }
+    },
+    [draft, getNextAction, stopMotion, submit],
+  );
 
   const onGridMouseUp = useCallback(
     (e: MouseEvent) => {
@@ -94,13 +76,13 @@ export const useGridMouseUp = () => {
 
       // Commit against the live draft schedule so an all-day → timed conversion
       // mid-drag lands in the timed path (store eventType may lag one frame).
-      if (draft.values.schedule.kind === "allDay") {
-        handleAllDayRowMouseUp();
-      } else {
-        handleMainGridMouseUp();
-      }
+      commitOnMouseUp(
+        draft.values.schedule.kind === "allDay"
+          ? Categories_Event.ALLDAY
+          : Categories_Event.TIMED,
+      );
     },
-    [draft, isDrafting, handleAllDayRowMouseUp, handleMainGridMouseUp],
+    [draft, isDrafting, commitOnMouseUp],
   );
 
   useEventListener("mouseup", onGridMouseUp, getElemById("root"));

--- a/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
+++ b/packages/web/src/views/Week/components/Draft/grid/hooks/useGridMouseUp.ts
@@ -12,10 +12,9 @@ import { useDraftContext } from "../../context/useDraftContext";
 export const useGridMouseUp = () => {
   const { actions, state } = useDraftContext();
   const { draft, dragStatus, isDragging, isResizing, resizeStatus } = state;
-  const { discard, stopDragging, stopResizing, submit } = actions;
+  const { stopDragging, stopResizing, submit } = actions;
 
   const draftStatus = useDraftStore(selectDraftStatus);
-  const draftType = draftStatus?.eventType;
   const isDrafting = draftStatus?.isDrafting;
 
   const getNextAction = useCallback(
@@ -72,11 +71,6 @@ export const useGridMouseUp = () => {
   const handleMainGridMouseUp = useCallback(() => {
     if (!draft || !isDrafting) return;
 
-    if (isDrafting && draftType === Categories_Event.ALLDAY) {
-      discard();
-      return;
-    }
-
     stopMotion();
 
     const { shouldSubmit, shouldOpenForm } = getNextAction(
@@ -91,22 +85,16 @@ export const useGridMouseUp = () => {
     if (shouldSubmit) {
       submit(draft);
     }
-  }, [
-    draft,
-    isDrafting,
-    draftType,
-    getNextAction,
-    discard,
-    stopMotion,
-    submit,
-  ]);
+  }, [draft, isDrafting, getNextAction, stopMotion, submit]);
 
   const onGridMouseUp = useCallback(
     (e: MouseEvent) => {
       if (!draft || !isDrafting) return;
       if (e.button !== 0) return;
 
-      if (draft?.values.schedule.kind === "allDay") {
+      // Commit against the live draft schedule so an all-day → timed conversion
+      // mid-drag lands in the timed path (store eventType may lag one frame).
+      if (draft.values.schedule.kind === "allDay") {
         handleAllDayRowMouseUp();
       } else {
         handleMainGridMouseUp();

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.test.ts
@@ -102,7 +102,6 @@ describe("resolveDraftDragSchedule", () => {
       startOfView,
     });
 
-    expect(result.row).toBe("timed");
     expect(result.durationMin).toBe(CROSS_ROW_TIMED_DURATION_MIN);
     expect(result.schedule.kind).toBe("timed");
     expect(dayjs(result.schedule.start).format()).toBe(
@@ -127,7 +126,6 @@ describe("resolveDraftDragSchedule", () => {
       startOfView,
     });
 
-    expect(result.row).toBe("allDay");
     expect(result.schedule.kind).toBe("allDay");
     expect(dayjs(result.schedule.start).format("YYYY-MM-DD")).toBe(
       getDateByXY(440, 0).startOf("day").format("YYYY-MM-DD"),
@@ -149,7 +147,6 @@ describe("resolveDraftDragSchedule", () => {
       startOfView,
     });
 
-    expect(result.row).toBe("allDay");
     expect(result.schedule.kind).toBe("allDay");
     expect(result.durationMin).toBe(24 * 60);
     expect(dayjs(result.schedule.start).format("YYYY-MM-DD")).toBe(
@@ -175,7 +172,6 @@ describe("resolveDraftDragSchedule", () => {
       startOfView,
     });
 
-    expect(result.row).toBe("timed");
     expect(result.durationMin).toBe(90);
     expect(result.schedule.kind).toBe("timed");
     expect(
@@ -202,7 +198,6 @@ describe("resolveDraftDragSchedule", () => {
       startOfView,
     });
 
-    expect(result.row).toBe("timed");
     expect(result.durationMin).toBe(CROSS_ROW_TIMED_DURATION_MIN);
     expect(
       dayjs(result.schedule.end).diff(result.schedule.start, "minutes"),

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.test.ts
@@ -182,4 +182,30 @@ describe("resolveDraftDragSchedule", () => {
       dayjs(result.schedule.end).diff(result.schedule.start, "minutes"),
     ).toBe(90);
   });
+
+  it("ignores a stale all-day dragStatus duration after converting to timed", () => {
+    // Simulates the frame after all-day → timed: schedule is already timed
+    // (60m) but dragStatus still holds the all-day day-length.
+    const result = resolveDraftDragSchedule({
+      clientX: 450,
+      clientY: 200,
+      dragOffset: { x: 0, y: 0 },
+      dragStatus: { durationMin: 24 * 60, hasMoved: true },
+      getDateByXY,
+      getElementById: createGetElementById(),
+      schedule: {
+        kind: "timed",
+        start: new Date("2026-05-13T09:00:00.000"),
+        end: new Date("2026-05-13T10:00:00.000"),
+        timeZone: "UTC",
+      },
+      startOfView,
+    });
+
+    expect(result.row).toBe("timed");
+    expect(result.durationMin).toBe(CROSS_ROW_TIMED_DURATION_MIN);
+    expect(
+      dayjs(result.schedule.end).diff(result.schedule.start, "minutes"),
+    ).toBe(CROSS_ROW_TIMED_DURATION_MIN);
+  });
 });

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.test.ts
@@ -1,0 +1,185 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  ID_GRID_ALLDAY_ROW,
+  ID_GRID_MAIN,
+} from "@web/common/constants/web.constants";
+import { CROSS_ROW_TIMED_DURATION_MIN } from "@web/grid/interaction/math/cross-row.drag";
+import {
+  resolveDraftDragRow,
+  resolveDraftDragSchedule,
+} from "./draft-drag-schedule.util";
+import { describe, expect, it } from "bun:test";
+
+const startOfView = dayjs("2026-05-10T00:00:00.000");
+
+const allDaySchedule = {
+  kind: "allDay" as const,
+  start: new Date("2026-05-13T00:00:00.000"),
+  end: new Date("2026-05-14T00:00:00.000"),
+};
+
+const timedSchedule = {
+  kind: "timed" as const,
+  start: new Date("2026-05-13T09:00:00.000"),
+  end: new Date("2026-05-13T10:00:00.000"),
+  timeZone: "UTC",
+};
+
+const createGetElementById = ({
+  allDayTop = 20,
+  allDayBottom = 60,
+  includeMainGrid = true,
+}: {
+  allDayTop?: number;
+  allDayBottom?: number;
+  includeMainGrid?: boolean;
+} = {}) => {
+  const allDayRow = {
+    getBoundingClientRect: () =>
+      ({
+        top: allDayTop,
+        bottom: allDayBottom,
+        left: 100,
+        right: 800,
+        height: allDayBottom - allDayTop,
+        width: 700,
+        x: 100,
+        y: allDayTop,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  } as HTMLElement;
+
+  const mainGrid = { id: ID_GRID_MAIN } as HTMLElement;
+
+  return (id: string): HTMLElement | null => {
+    if (id === ID_GRID_ALLDAY_ROW) return allDayRow;
+    if (id === ID_GRID_MAIN) return includeMainGrid ? mainGrid : null;
+    return null;
+  };
+};
+
+describe("resolveDraftDragRow", () => {
+  it("returns allDay when the pointer is inside the all-day row", () => {
+    expect(resolveDraftDragRow(40, "allDay", createGetElementById())).toBe(
+      "allDay",
+    );
+  });
+
+  it("returns timed when the pointer is outside the all-day row", () => {
+    expect(resolveDraftDragRow(200, "allDay", createGetElementById())).toBe(
+      "timed",
+    );
+  });
+
+  it("falls back to the source row when either grid row is missing", () => {
+    expect(
+      resolveDraftDragRow(
+        200,
+        "allDay",
+        createGetElementById({ includeMainGrid: false }),
+      ),
+    ).toBe("allDay");
+  });
+});
+
+describe("resolveDraftDragSchedule", () => {
+  const getDateByXY = (x: number, y: number) => {
+    // Simplified grid: day column from x, minutes from y (15-min steps).
+    const dayOffset = Math.max(0, Math.floor((x - 100) / 100));
+    const minutes = Math.max(0, Math.floor(y / 2 / 15) * 15);
+    return startOfView.add(dayOffset, "day").add(minutes, "minutes");
+  };
+
+  it("converts an all-day draft to a timed block over the timed grid", () => {
+    const result = resolveDraftDragSchedule({
+      clientX: 450,
+      clientY: 200,
+      dragOffset: { x: 10, y: 5 },
+      dragStatus: { durationMin: 24 * 60, hasMoved: true },
+      getDateByXY,
+      getElementById: createGetElementById(),
+      schedule: allDaySchedule,
+      startOfView,
+    });
+
+    expect(result.row).toBe("timed");
+    expect(result.durationMin).toBe(CROSS_ROW_TIMED_DURATION_MIN);
+    expect(result.schedule.kind).toBe("timed");
+    expect(dayjs(result.schedule.start).format()).toBe(
+      getDateByXY(450, 200).format(),
+    );
+    expect(dayjs(result.schedule.end).format()).toBe(
+      getDateByXY(450, 200)
+        .add(CROSS_ROW_TIMED_DURATION_MIN, "minutes")
+        .format(),
+    );
+  });
+
+  it("keeps an all-day draft all-day while the pointer stays in the all-day row", () => {
+    const result = resolveDraftDragSchedule({
+      clientX: 450,
+      clientY: 40,
+      dragOffset: { x: 10, y: 5 },
+      dragStatus: { durationMin: 24 * 60 },
+      getDateByXY,
+      getElementById: createGetElementById(),
+      schedule: allDaySchedule,
+      startOfView,
+    });
+
+    expect(result.row).toBe("allDay");
+    expect(result.schedule.kind).toBe("allDay");
+    expect(dayjs(result.schedule.start).format("YYYY-MM-DD")).toBe(
+      getDateByXY(440, 0).startOf("day").format("YYYY-MM-DD"),
+    );
+    expect(dayjs(result.schedule.end).format("YYYY-MM-DD")).toBe(
+      getDateByXY(440, 0).startOf("day").add(1, "day").format("YYYY-MM-DD"),
+    );
+  });
+
+  it("converts a timed draft to a one-day all-day event over the all-day row", () => {
+    const result = resolveDraftDragSchedule({
+      clientX: 450,
+      clientY: 40,
+      dragOffset: { x: 0, y: 20 },
+      dragStatus: { durationMin: 60, hasMoved: true },
+      getDateByXY,
+      getElementById: createGetElementById(),
+      schedule: timedSchedule,
+      startOfView,
+    });
+
+    expect(result.row).toBe("allDay");
+    expect(result.schedule.kind).toBe("allDay");
+    expect(result.durationMin).toBe(24 * 60);
+    expect(dayjs(result.schedule.start).format("YYYY-MM-DD")).toBe(
+      getDateByXY(450, 0).startOf("day").format("YYYY-MM-DD"),
+    );
+    expect(dayjs(result.schedule.end).format("YYYY-MM-DD")).toBe(
+      getDateByXY(450, 0).startOf("day").add(1, "day").format("YYYY-MM-DD"),
+    );
+  });
+
+  it("preserves timed duration when dragging within the timed grid", () => {
+    const result = resolveDraftDragSchedule({
+      clientX: 450,
+      clientY: 200,
+      dragOffset: { x: 0, y: 20 },
+      dragStatus: { durationMin: 90, hasMoved: true },
+      getDateByXY,
+      getElementById: createGetElementById(),
+      schedule: {
+        ...timedSchedule,
+        end: new Date("2026-05-13T10:30:00.000"),
+      },
+      startOfView,
+    });
+
+    expect(result.row).toBe("timed");
+    expect(result.durationMin).toBe(90);
+    expect(result.schedule.kind).toBe("timed");
+    expect(
+      dayjs(result.schedule.end).diff(result.schedule.start, "minutes"),
+    ).toBe(90);
+  });
+});

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.ts
@@ -1,5 +1,5 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
-import { type Dayjs } from "@core/util/date/dayjs";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   ID_GRID_ALLDAY_ROW,
   ID_GRID_MAIN,
@@ -81,10 +81,14 @@ export const resolveDraftDragSchedule = ({
   const row = resolveDraftDragRow(clientY, sourceRow, getElementById);
 
   if (row === "timed") {
+    // Use the live schedule duration for already-timed drafts. After an
+    // all-day → timed conversion, dragStatus may still hold the all-day
+    // day-length (1440m) for a frame; reusing that would invent a multi-day
+    // timed block that snaps back into the all-day row.
     const durationMin =
-      sourceRow === "timed"
-        ? getDragDurationMinutes(schedule, dragStatus)
-        : CROSS_ROW_TIMED_DURATION_MIN;
+      sourceRow === "allDay"
+        ? CROSS_ROW_TIMED_DURATION_MIN
+        : dayjs(schedule.end).diff(schedule.start, "minutes");
     // Same-row timed drag keeps the grab offset; all-day → timed is absolute
     // (pointer marks the start), matching the saved-event cross-row ghost.
     const y = sourceRow === "timed" ? clientY - dragOffset.y : clientY;

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.ts
@@ -1,0 +1,134 @@
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import { type Dayjs } from "@core/util/date/dayjs";
+import {
+  ID_GRID_ALLDAY_ROW,
+  ID_GRID_MAIN,
+} from "@web/common/constants/web.constants";
+import { getElemById } from "@web/common/utils/grid/grid.util";
+import { type GridScheduleDraft } from "@web/events/event-draft.types";
+import {
+  allDayGridSchedule,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { CROSS_ROW_TIMED_DURATION_MIN } from "@web/grid/interaction/math/cross-row.drag";
+import { type Status_Drag } from "@web/views/Week/components/Draft/hooks/state/useDraftState";
+import { getDragDurationMinutes } from "./drag-duration.util";
+
+export type DraftDragRow = "allDay" | "timed";
+
+const ONE_DAY_MINUTES = 24 * 60;
+
+/**
+ * Same divider as the saved-event engine's `resolveDragRow`: the all-day row
+ * rect is the boundary. Inside it the drop is all-day; anywhere else (when both
+ * rows are mounted) it lands in the timed grid. Falls back to the draft's
+ * current kind when either row is missing so same-row dragging still works.
+ */
+export const resolveDraftDragRow = (
+  pointerY: number,
+  sourceRow: DraftDragRow,
+  getElementById: (id: string) => HTMLElement | null = getElemById,
+): DraftDragRow => {
+  const allDayRow = getElementById(ID_GRID_ALLDAY_ROW);
+  const mainGrid = getElementById(ID_GRID_MAIN);
+
+  if (!allDayRow || !mainGrid) {
+    return sourceRow;
+  }
+
+  const rect = allDayRow.getBoundingClientRect();
+  return pointerY >= rect.top && pointerY <= rect.bottom ? "allDay" : "timed";
+};
+
+interface ResolveDraftDragScheduleInput {
+  clientX: number;
+  clientY: number;
+  dragOffset: { x: number; y: number };
+  dragStatus: Status_Drag | null;
+  getDateByXY: (x: number, y: number, firstDayInView: Dayjs) => Dayjs;
+  schedule: GridScheduleDraft;
+  startOfView: Dayjs;
+  /**
+   * Optional DOM lookup override for tests. Defaults to the live grid util.
+   */
+  getElementById?: (id: string) => HTMLElement | null;
+}
+
+export interface ResolvedDraftDragSchedule {
+  durationMin: number;
+  row: DraftDragRow;
+  schedule: GridScheduleDraft;
+}
+
+/**
+ * Maps a draft drag pointer to a schedule, including all-day ↔ timed conversion
+ * when the pointer crosses the all-day / timed divider. Timed placement after a
+ * cross-row conversion hangs a default-length block from the pointer (same
+ * semantics as saved-event cross-row drag).
+ */
+export const resolveDraftDragSchedule = ({
+  clientX,
+  clientY,
+  dragOffset,
+  dragStatus,
+  getDateByXY,
+  getElementById,
+  schedule,
+  startOfView,
+}: ResolveDraftDragScheduleInput): ResolvedDraftDragSchedule => {
+  const sourceRow: DraftDragRow =
+    schedule.kind === "allDay" ? "allDay" : "timed";
+  const row = resolveDraftDragRow(clientY, sourceRow, getElementById);
+
+  if (row === "timed") {
+    const durationMin =
+      sourceRow === "timed"
+        ? getDragDurationMinutes(schedule, dragStatus)
+        : CROSS_ROW_TIMED_DURATION_MIN;
+    // Same-row timed drag keeps the grab offset; all-day → timed is absolute
+    // (pointer marks the start), matching the saved-event cross-row ghost.
+    const y = sourceRow === "timed" ? clientY - dragOffset.y : clientY;
+    let eventStart = getDateByXY(clientX, y, startOfView);
+    let eventEnd = eventStart.add(durationMin, "minutes");
+
+    if (eventEnd.date() !== eventStart.date()) {
+      eventEnd = eventEnd.hour(0).minute(0);
+      eventStart = eventEnd.subtract(durationMin, "minutes");
+    }
+
+    return {
+      durationMin,
+      row,
+      schedule: timedGridSchedule(eventStart.toDate(), eventEnd.toDate()),
+    };
+  }
+
+  if (sourceRow === "allDay") {
+    const durationMin = getDragDurationMinutes(schedule, dragStatus);
+    const x = clientX - dragOffset.x;
+    // Y is irrelevant for all-day day selection (mirrors all-day resize).
+    const eventStart = getDateByXY(x, 0, startOfView).startOf("day");
+    const eventEnd = eventStart.add(durationMin, "minutes");
+
+    return {
+      durationMin,
+      row,
+      schedule: {
+        kind: "allDay",
+        start: eventStart.toDate(),
+        end: eventEnd.toDate(),
+      },
+    };
+  }
+
+  // Timed → all-day: collapse to a one-day all-day event on the drop column.
+  const day = getDateByXY(clientX, 0, startOfView).startOf("day");
+  return {
+    durationMin: ONE_DAY_MINUTES,
+    row,
+    schedule: allDayGridSchedule(
+      day.format(YEAR_MONTH_DAY_FORMAT),
+      day.add(1, "day").format(YEAR_MONTH_DAY_FORMAT),
+    ),
+  };
+};

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/draft-drag-schedule.util.ts
@@ -11,10 +11,9 @@ import {
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
 import { CROSS_ROW_TIMED_DURATION_MIN } from "@web/grid/interaction/math/cross-row.drag";
+import { type DragRow } from "@web/grid/interaction/types/timed-drag.types";
 import { type Status_Drag } from "@web/views/Week/components/Draft/hooks/state/useDraftState";
 import { getDragDurationMinutes } from "./drag-duration.util";
-
-export type DraftDragRow = "allDay" | "timed";
 
 const ONE_DAY_MINUTES = 24 * 60;
 
@@ -23,12 +22,15 @@ const ONE_DAY_MINUTES = 24 * 60;
  * rect is the boundary. Inside it the drop is all-day; anywhere else (when both
  * rows are mounted) it lands in the timed grid. Falls back to the draft's
  * current kind when either row is missing so same-row dragging still works.
+ *
+ * Draft drag still hit-tests live DOM rather than the saved-event layout cache,
+ * so this stays a thin adapter instead of forcing drafts onto that cache shape.
  */
 export const resolveDraftDragRow = (
   pointerY: number,
-  sourceRow: DraftDragRow,
+  sourceRow: DragRow,
   getElementById: (id: string) => HTMLElement | null = getElemById,
-): DraftDragRow => {
+): DragRow => {
   const allDayRow = getElementById(ID_GRID_ALLDAY_ROW);
   const mainGrid = getElementById(ID_GRID_MAIN);
 
@@ -56,7 +58,6 @@ interface ResolveDraftDragScheduleInput {
 
 export interface ResolvedDraftDragSchedule {
   durationMin: number;
-  row: DraftDragRow;
   schedule: GridScheduleDraft;
 }
 
@@ -76,8 +77,7 @@ export const resolveDraftDragSchedule = ({
   schedule,
   startOfView,
 }: ResolveDraftDragScheduleInput): ResolvedDraftDragSchedule => {
-  const sourceRow: DraftDragRow =
-    schedule.kind === "allDay" ? "allDay" : "timed";
+  const sourceRow: DragRow = schedule.kind === "allDay" ? "allDay" : "timed";
   const row = resolveDraftDragRow(clientY, sourceRow, getElementById);
 
   if (row === "timed") {
@@ -102,7 +102,6 @@ export const resolveDraftDragSchedule = ({
 
     return {
       durationMin,
-      row,
       schedule: timedGridSchedule(eventStart.toDate(), eventEnd.toDate()),
     };
   }
@@ -116,12 +115,10 @@ export const resolveDraftDragSchedule = ({
 
     return {
       durationMin,
-      row,
-      schedule: {
-        kind: "allDay",
-        start: eventStart.toDate(),
-        end: eventEnd.toDate(),
-      },
+      schedule: allDayGridSchedule(
+        eventStart.format(YEAR_MONTH_DAY_FORMAT),
+        eventEnd.format(YEAR_MONTH_DAY_FORMAT),
+      ),
     };
   }
 
@@ -129,7 +126,6 @@ export const resolveDraftDragSchedule = ({
   const day = getDateByXY(clientX, 0, startOfView).startOf("day");
   return {
     durationMin: ONE_DAY_MINUTES,
-    row,
     schedule: allDayGridSchedule(
       day.format(YEAR_MONTH_DAY_FORMAT),
       day.add(1, "day").format(YEAR_MONTH_DAY_FORMAT),

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -3,13 +3,21 @@ import { type Event } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createInitialState } from "@web/__tests__/utils/state/store.test.util";
+import {
+  ID_GRID_ALLDAY_ROW,
+  ID_GRID_MAIN,
+} from "@web/common/constants/web.constants";
 import { Categories_Event } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
   editGridEventDraft,
 } from "@web/events/grid-event-draft.adapter";
-import { type Activity_DraftEvent } from "@web/events/stores/draft.store";
+import {
+  type Activity_DraftEvent,
+  draftActions,
+} from "@web/events/stores/draft.store";
+import { CROSS_ROW_TIMED_DURATION_MIN } from "@web/grid/interaction/math/cross-row.drag";
 import {
   type Setters_Draft,
   type State_Draft_Local,
@@ -160,7 +168,15 @@ const createSetters = (
   ...overrides,
 });
 
-const dateCalcs = {} as DateCalcs;
+const dateCalcs = {
+  getDateByXY: (x: number, y: number, startOfView: dayjs.Dayjs) => {
+    const dayOffset = Math.max(0, Math.floor(x / 100));
+    const minutes = Math.max(0, Math.floor(y / 2 / 15) * 15);
+    return startOfView.add(dayOffset, "day").add(minutes, "minutes");
+  },
+  getDateStrByXY: (x: number, y: number, startOfView: dayjs.Dayjs) =>
+    dateCalcs.getDateByXY(x, y, startOfView).format(),
+} as DateCalcs;
 
 const weekProps = {
   component: {
@@ -172,6 +188,27 @@ const weekProps = {
     getLastNavigationSource: () => "manual",
   },
 } as unknown as WeekProps;
+
+const mountDraftDragDom = () => {
+  document.body.innerHTML = "";
+  const allDayRow = document.createElement("div");
+  const mainGrid = document.createElement("div");
+  allDayRow.id = ID_GRID_ALLDAY_ROW;
+  mainGrid.id = ID_GRID_MAIN;
+  allDayRow.getBoundingClientRect = () =>
+    ({
+      top: 20,
+      bottom: 60,
+      left: 0,
+      right: 700,
+      height: 40,
+      width: 700,
+      x: 0,
+      y: 20,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  document.body.append(allDayRow, mainGrid);
+};
 
 const setDraftActivity = (
   activity: Activity_DraftEvent,
@@ -187,18 +224,24 @@ const setDraftActivity = (
   };
 };
 
-const renderDraftActions = (draft: GridEventDraft) => {
+const renderDraftActions = (
+  draft: GridEventDraft,
+  stateOverrides: Partial<State_Draft_Local> = {},
+) => {
   const setDraft = mock();
+  const setDragOffset = mock();
+  const setDragStatus = mock();
   currentState.events!.draft = {
     ...currentState.events!.draft,
     gridDraft: draft,
   };
+  draftActions.setGridDraft(draft);
   const { wrapper } = createStoreWrapper(currentState);
   const { result } = renderHook(
     () =>
       useDraftActions(
-        createState({ draft }),
-        createSetters({ setDraft }),
+        createState({ draft, ...stateOverrides }),
+        createSetters({ setDraft, setDragOffset, setDragStatus }),
         dateCalcs,
         weekProps,
       ),
@@ -206,8 +249,10 @@ const renderDraftActions = (draft: GridEventDraft) => {
   );
 
   setDraft.mockClear();
+  setDragOffset.mockClear();
+  setDragStatus.mockClear();
 
-  return { result, setDraft };
+  return { result, setDraft, setDragOffset, setDragStatus };
 };
 
 const expectDraftRange = (
@@ -369,5 +414,55 @@ describe("useDraftActions", () => {
     result.current.repositionDraftByKeyboard("ArrowDown");
 
     expect(setDraft).not.toHaveBeenCalled();
+  });
+
+  it("converts a new all-day draft to timed while dragging over the timed grid", () => {
+    mountDraftDragDom();
+    setDraftActivity("gridClick", Categories_Event.ALLDAY);
+    const draft = createNewDraft({
+      isAllDay: true,
+      start: "2024-01-16T00:00:00.000Z",
+      end: "2024-01-17T00:00:00.000Z",
+    });
+    const { result, setDraft, setDragOffset, setDragStatus } =
+      renderDraftActions(draft, {
+        isDragging: true,
+        dragOffset: { x: 10, y: 5 },
+        dragStatus: { durationMin: 24 * 60 },
+      });
+
+    result.current.drag({ clientX: 100, clientY: 200 });
+
+    const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
+    expect(nextDraft.values.schedule.kind).toBe("timed");
+    expect(
+      dayjs(nextDraft.values.schedule.end).diff(
+        nextDraft.values.schedule.start,
+        "minutes",
+      ),
+    ).toBe(CROSS_ROW_TIMED_DURATION_MIN);
+    expect(setDragOffset).toHaveBeenCalledWith({ x: 0, y: 0 });
+    expect(setDragStatus).toHaveBeenCalled();
+  });
+
+  it("converts an existing all-day edit draft to timed while dragging over the timed grid", () => {
+    mountDraftDragDom();
+    setDraftActivity("gridClick", Categories_Event.ALLDAY);
+    const draft = createEditDraft({
+      isAllDay: true,
+      start: "2024-01-16T00:00:00.000Z",
+      end: "2024-01-17T00:00:00.000Z",
+    });
+    const { result, setDraft } = renderDraftActions(draft, {
+      isDragging: true,
+      dragOffset: { x: 8, y: 4 },
+      dragStatus: { durationMin: 24 * 60, hasMoved: false },
+    });
+
+    result.current.drag({ clientX: 200, clientY: 180 });
+
+    const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
+    expect(nextDraft.kind).toBe("edit");
+    expect(nextDraft.values.schedule.kind).toBe("timed");
   });
 });

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { type Event } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
@@ -431,7 +431,9 @@ describe("useDraftActions", () => {
         dragStatus: { durationMin: 24 * 60 },
       });
 
-    result.current.drag({ clientX: 100, clientY: 200 });
+    act(() => {
+      result.current.drag({ clientX: 100, clientY: 200 });
+    });
 
     const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
     expect(nextDraft.values.schedule.kind).toBe("timed");
@@ -459,10 +461,43 @@ describe("useDraftActions", () => {
       dragStatus: { durationMin: 24 * 60, hasMoved: false },
     });
 
-    result.current.drag({ clientX: 200, clientY: 180 });
+    act(() => {
+      result.current.drag({ clientX: 200, clientY: 180 });
+    });
 
     const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
     expect(nextDraft.kind).toBe("edit");
     expect(nextDraft.values.schedule.kind).toBe("timed");
+  });
+
+  it("converts on drag start when the pointer is already over the timed grid", () => {
+    mountDraftDragDom();
+    setDraftActivity("gridClick", Categories_Event.ALLDAY);
+    const draft = createNewDraft({
+      isAllDay: true,
+      start: "2024-01-16T00:00:00.000Z",
+      end: "2024-01-17T00:00:00.000Z",
+    });
+    const { result, setDraft } = renderDraftActions(draft, {
+      isDragging: false,
+      dragOffset: { x: 0, y: 0 },
+      dragStatus: { durationMin: 24 * 60 },
+    });
+
+    act(() => {
+      result.current.startDragging(
+        { x: 10, y: 5 },
+        { clientX: 100, clientY: 200 },
+      );
+    });
+
+    const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
+    expect(nextDraft.values.schedule.kind).toBe("timed");
+    expect(
+      dayjs(nextDraft.values.schedule.end).diff(
+        nextDraft.values.schedule.start,
+        "minutes",
+      ),
+    ).toBe(CROSS_ROW_TIMED_DURATION_MIN);
   });
 });

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -34,7 +34,7 @@ import {
 } from "@web/views/Week/components/Draft/hooks/state/useDraftState";
 import { type DateCalcs } from "@web/views/Week/hooks/grid/useDateCalcs";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
-import { getDragDurationMinutes } from "./drag-duration.util";
+import { resolveDraftDragSchedule } from "./draft-drag-schedule.util";
 
 const scopeFromApplyTo = (
   applyTo: RecurringEventUpdateScope,
@@ -256,79 +256,55 @@ export const useDraftActions = (
 
   const drag = useCallback(
     (e: Omit<PartialMouseEvent, "currentTarget">) => {
-      const updateTimesDuringDrag = (
-        e: Omit<PartialMouseEvent, "currentTarget">,
-      ) => {
-        if (!draft) return;
-
-        const isAllDay = draft.values.schedule.kind === "allDay";
-        const rawX = e.clientX;
-        const x = isAllDay ? rawX - dragOffset.x : rawX;
-        const startEndDurationMin = getDragDurationMinutes(
-          draft.values.schedule,
-          dragStatus,
-        );
-
-        const y = e.clientY - dragOffset.y;
-
-        let eventStart = dateCalcs.getDateByXY(
-          x,
-          y,
-          weekProps.component.startOfView,
-        );
-
-        let eventEnd = eventStart.add(startEndDurationMin, "minutes");
-
-        if (!isAllDay) {
-          // Edge case: timed events' end times can overflow past midnight at the bottom of the grid.
-          // Below logic prevents that from occurring.
-          if (eventEnd.date() !== eventStart.date()) {
-            eventEnd = eventEnd.hour(0).minute(0);
-            eventStart = eventEnd.subtract(startEndDurationMin, "minutes");
-          }
-        }
-
-        const schedule: GridScheduleDraft = isAllDay
-          ? {
-              kind: "allDay",
-              start: eventStart.toDate(),
-              end: eventEnd.toDate(),
-            }
-          : {
-              ...draft.values.schedule,
-              start: eventStart.toDate(),
-              end: eventEnd.toDate(),
-            };
-
-        const nextDraft = replaceGridDraftSchedule(draft, schedule);
-
-        setDraft(nextDraft);
-      };
       if (!isDragging) {
         devAlert("not dragging (anymore?)");
         return;
       }
+      if (!draft) return;
 
-      const currTime = dateCalcs.getDateStrByXY(
-        e.clientX,
-        e.clientY,
-        weekProps.component.startOfView,
-      );
-      const draftStartStr = draft
-        ? dayjs(draft.values.schedule.start).format()
-        : undefined;
-      const hasMoved = currTime !== draftStartStr;
+      const { durationMin, schedule } = resolveDraftDragSchedule({
+        clientX: e.clientX,
+        clientY: e.clientY,
+        dragOffset,
+        dragStatus,
+        getDateByXY: dateCalcs.getDateByXY,
+        schedule: draft.values.schedule,
+        startOfView: weekProps.component.startOfView,
+      });
 
-      if (!dragStatus?.hasMoved && hasMoved) {
+      const nextDraft = replaceGridDraftSchedule(draft, schedule);
+      const kindChanged = draft.values.schedule.kind !== schedule.kind;
+      const draftStartStr = dayjs(draft.values.schedule.start).format();
+      const nextStartStr = dayjs(schedule.start).format();
+      const hasMoved =
+        kindChanged ||
+        draftStartStr !== nextStartStr ||
+        dayjs(draft.values.schedule.end).format() !==
+          dayjs(schedule.end).format();
+
+      // Keep the shared store in sync so form hydration and eventType track
+      // cross-row kind flips (local-only updates would be overwritten on
+      // mouseup when the form opens).
+      setDraft(nextDraft);
+      draftActions.setGridDraft(nextDraft);
+
+      // Cross-row conversion switches between grab-offset and absolute pointer
+      // placement; clear the stale offset so the next frame doesn't jump.
+      if (kindChanged) {
+        setDragOffset({ x: 0, y: 0 });
+      }
+
+      if (
+        (!dragStatus?.hasMoved && hasMoved) ||
+        (dragStatus != null && dragStatus.durationMin !== durationMin)
+      ) {
         setDragStatus(
           (_status): Status_Drag => ({
-            ..._status!,
-            hasMoved: true,
+            durationMin,
+            hasMoved: Boolean(_status?.hasMoved || hasMoved),
           }),
         );
       }
-
-      updateTimesDuringDrag(e);
     },
     [
       isDragging,
@@ -338,6 +314,7 @@ export const useDraftActions = (
       dragOffset,
       dragStatus,
       setDraft,
+      setDragOffset,
       setDragStatus,
     ],
   );

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -273,13 +273,12 @@ export const useDraftActions = (
       });
 
       const nextDraft = replaceGridDraftSchedule(draft, schedule);
-      const kindChanged = draft.values.schedule.kind !== schedule.kind;
+      const prev = draft.values.schedule;
+      const kindChanged = prev.kind !== schedule.kind;
       const hasMoved =
         kindChanged ||
-        dayjs(draft.values.schedule.start).format() !==
-          dayjs(schedule.start).format() ||
-        dayjs(draft.values.schedule.end).format() !==
-          dayjs(schedule.end).format();
+        !dayjs(prev.start).isSame(schedule.start) ||
+        !dayjs(prev.end).isSame(schedule.end);
 
       // Keep the shared store in sync so form hydration and eventType track
       // cross-row kind flips (local-only updates would be overwritten on

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -254,19 +254,19 @@ export const useDraftActions = (
     [activity, draft, isInsideVisibleWeek, setDraft],
   );
 
-  const drag = useCallback(
-    (e: Omit<PartialMouseEvent, "currentTarget">) => {
-      if (!isDragging) {
-        devAlert("not dragging (anymore?)");
-        return;
-      }
+  const applyDragPosition = useCallback(
+    (
+      e: Omit<PartialMouseEvent, "currentTarget">,
+      offset: DragOffset,
+      status: Status_Drag | null,
+    ) => {
       if (!draft) return;
 
       const { durationMin, schedule } = resolveDraftDragSchedule({
         clientX: e.clientX,
         clientY: e.clientY,
-        dragOffset,
-        dragStatus,
+        dragOffset: offset,
+        dragStatus: status,
         getDateByXY: dateCalcs.getDateByXY,
         schedule: draft.values.schedule,
         startOfView: weekProps.component.startOfView,
@@ -274,11 +274,10 @@ export const useDraftActions = (
 
       const nextDraft = replaceGridDraftSchedule(draft, schedule);
       const kindChanged = draft.values.schedule.kind !== schedule.kind;
-      const draftStartStr = dayjs(draft.values.schedule.start).format();
-      const nextStartStr = dayjs(schedule.start).format();
       const hasMoved =
         kindChanged ||
-        draftStartStr !== nextStartStr ||
+        dayjs(draft.values.schedule.start).format() !==
+          dayjs(schedule.start).format() ||
         dayjs(draft.values.schedule.end).format() !==
           dayjs(schedule.end).format();
 
@@ -295,8 +294,8 @@ export const useDraftActions = (
       }
 
       if (
-        (!dragStatus?.hasMoved && hasMoved) ||
-        (dragStatus != null && dragStatus.durationMin !== durationMin)
+        (!status?.hasMoved && hasMoved) ||
+        (status != null && status.durationMin !== durationMin)
       ) {
         setDragStatus(
           (_status): Status_Drag => ({
@@ -307,16 +306,25 @@ export const useDraftActions = (
       }
     },
     [
-      isDragging,
-      dateCalcs,
-      weekProps.component.startOfView,
+      dateCalcs.getDateByXY,
       draft,
-      dragOffset,
-      dragStatus,
       setDraft,
       setDragOffset,
       setDragStatus,
+      weekProps.component.startOfView,
     ],
+  );
+
+  const drag = useCallback(
+    (e: Omit<PartialMouseEvent, "currentTarget">) => {
+      if (!isDragging) {
+        devAlert("not dragging (anymore?)");
+        return;
+      }
+
+      applyDragPosition(e, dragOffset, dragStatus);
+    },
+    [applyDragPosition, dragOffset, dragStatus, isDragging],
   );
 
   const isValidMovement = useCallback(
@@ -563,13 +571,24 @@ export const useDraftActions = (
     repositionDraftByKeyboard,
     resize,
     setLocalDraft: setDraft,
-    startDragging: (offset?: DragOffset) => {
+    startDragging: (
+      offset?: DragOffset,
+      initialEvent?: Omit<PartialMouseEvent, "currentTarget">,
+    ) => {
       // Placing `setIsFormOpenBeforeDragging` here rather than inside `startDragging`
       // because `setIsFormOpenBeforeDragging` depends on `isFormOpen` and re-calculates
       // `startDragging` (due to it being a react callback) which causes issues.
       // This is a hacky solution to the issue.
       setIsFormOpenBeforeDragging(isFormOpen);
+      const nextOffset = offset ?? { x: 0, y: 0 };
       startDragging(offset);
+      // Apply the pointer position immediately. Drag often begins only after the
+      // pointer has already left the all-day row; waiting for the next mousemove
+      // (and for isDragging to commit) can miss the cross-row conversion entirely
+      // on a short gesture.
+      if (initialEvent) {
+        applyDragPosition(initialEvent, nextOffset, dragStatus);
+      }
     },
     startResizing,
     stopDragging,

--- a/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
+++ b/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
@@ -1,23 +1,13 @@
 import { type MouseEvent as ReactMouseEvent, useRef } from "react";
-import {
-  ID_GRID_ALLDAY_ROW,
-  ID_GRID_MAIN,
-} from "@web/common/constants/web.constants";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import {
-  Categories_Event,
+  type Categories_Event,
   type GridEvent,
 } from "@web/common/types/web.event.types";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
-import { getElemById } from "@web/common/utils/grid/grid.util";
 
 export const GRID_EVENT_MOUSE_HOLD_DELAY = 750; // ms
 export const GRID_EVENT_MOUSE_HOLD_MOVE_THRESHOLD = 25; // pixels
-
-const elementEventTypeMap = {
-  [Categories_Event.TIMED]: ID_GRID_MAIN,
-  [Categories_Event.ALLDAY]: ID_GRID_ALLDAY_ROW,
-};
 
 type HandleDragHandlers = {
   onMouseMove: (e: MouseEvent) => void;
@@ -29,16 +19,19 @@ type HandleDragHandlers = {
  * - Quick press and release triggers a click
  * - Hold for delay or move beyond threshold triggers drag
  * - When form is open, only allows drag if mouse is still held down
+ *
+ * Listeners attach to `document` so an all-day draft can start dragging when the
+ * pointer leaves the all-day row toward the timed grid (element-scoped
+ * mousemove would stop firing at the row boundary).
  */
 export const useGridEventMouseDown = (
-  eventType: Categories_Event.TIMED | Categories_Event.ALLDAY,
+  _eventType: Categories_Event.TIMED | Categories_Event.ALLDAY,
   onClick: (event: GridEvent) => void,
   onDrag: (event: GridEvent, moveEvent: PartialMouseEvent) => void,
   delay: number = GRID_EVENT_MOUSE_HOLD_DELAY,
 ) => {
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
   const mouseMoved = useRef<boolean>(false);
-  const elementId = elementEventTypeMap[eventType];
   const targetRef = useRef<EventTarget | null>(null);
 
   const hasExceededMoveThreshold = (
@@ -56,20 +49,18 @@ export const useGridEventMouseDown = (
   };
 
   const cleanup = (
-    element: HTMLElement,
     onMouseMove: (e: MouseEvent) => void,
     onMouseUp: () => void,
   ) => {
     if (timeoutId.current) {
       clearTimeout(timeoutId.current);
     }
-    element.removeEventListener("mousemove", onMouseMove);
-    element.removeEventListener("mouseup", onMouseUp);
+    document.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseup", onMouseUp);
   };
 
   const handleDrag = (
     event: GridEvent,
-    element: HTMLElement,
     currentEvent: MouseEvent,
     handlers: HandleDragHandlers,
   ) => {
@@ -77,7 +68,7 @@ export const useGridEventMouseDown = (
     if (isEventFormOpen()) {
       const isMouseDown = document.querySelector(":active") !== null;
       if (!isMouseDown) {
-        cleanup(element, handlers.onMouseMove, handlers.onMouseUp);
+        cleanup(handlers.onMouseMove, handlers.onMouseUp);
         return;
       }
     }
@@ -93,10 +84,6 @@ export const useGridEventMouseDown = (
   const onMouseDown = (e: ReactMouseEvent, event: GridEvent) => {
     e.stopPropagation();
     targetRef.current = e.currentTarget;
-    const element = getElemById(elementId);
-    if (!element) {
-      return;
-    }
     const initialX = e.clientX;
     const initialY = e.clientY;
     mouseMoved.current = false;
@@ -119,7 +106,7 @@ export const useGridEventMouseDown = (
           clientY: moveEvent.clientY,
           currentTarget: targetRef.current as EventTarget & Element,
         });
-        cleanup(element, onMouseMove, onMouseUp);
+        cleanup(onMouseMove, onMouseUp);
       }
     };
 
@@ -128,7 +115,7 @@ export const useGridEventMouseDown = (
         clearTimeout(timeoutId.current);
         onClick(event);
       }
-      cleanup(element, onMouseMove, onMouseUp);
+      cleanup(onMouseMove, onMouseUp);
     };
 
     // Start hold timer
@@ -140,13 +127,12 @@ export const useGridEventMouseDown = (
           clientY: initialY,
         });
 
-        handleDrag(event, element, currentEvent, { onMouseMove, onMouseUp });
+        handleDrag(event, currentEvent, { onMouseMove, onMouseUp });
       }
     }, delay);
 
-    // Set up event listeners
-    element.addEventListener("mousemove", onMouseMove);
-    element.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
   };
 
   return { onMouseDown };

--- a/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
+++ b/packages/web/src/views/Week/hooks/grid/useGridEventMouseDown.ts
@@ -1,9 +1,6 @@
 import { type MouseEvent as ReactMouseEvent, useRef } from "react";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
-import {
-  type Categories_Event,
-  type GridEvent,
-} from "@web/common/types/web.event.types";
+import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEventFormOpen } from "@web/common/utils/form/form.util";
 
 export const GRID_EVENT_MOUSE_HOLD_DELAY = 750; // ms
@@ -25,7 +22,6 @@ type HandleDragHandlers = {
  * mousemove would stop firing at the row boundary).
  */
 export const useGridEventMouseDown = (
-  _eventType: Categories_Event.TIMED | Categories_Event.ALLDAY,
   onClick: (event: GridEvent) => void,
   onDrag: (event: GridEvent, moveEvent: PartialMouseEvent) => void,
   delay: number = GRID_EVENT_MOUSE_HOLD_DELAY,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

All-day draft events (new creates and edits of existing events) could not be dragged into the timed grid — users had to save first, then drag. Draft drag froze `schedule.kind` as `allDay`; saved events already supported cross-row conversion.

This converts draft schedules across the all-day / timed divider during drag, applies the conversion at drag start (when the pointer is often already over the timed grid), listens for drag-start on `document`, and keeps the draft store in sync so form hydration does not overwrite a timed conversion.

## Simplicity

Separate refactor commit removed dead `eventType` plumbing from draft mouse-down, merged duplicate mouse-up handlers, reused shared `DragRow` / `allDayGridSchedule`, and clarified `hasMoved` via `dayjs.isSame`. Kept intentional complexity: immediate apply on drag start, dual local+store updates, offset reset on kind change, and DOM-based row hit-testing (distinct from the layout-cache saved-event path).

## Automated validation

- `bun test:web` focused Draft + cross-row suites — pass
- `bun run lint` — pass (pre-existing unrelated unused-import warning)
- `bun run type-check` — pass (via simplify / independent review)
- Browser at http://localhost:9080/week:
  - New all-day draft dragged into timed grid → timed ~1h block, All day unchecked (2/2)
  - Horizontal move within all-day row, then continue into timed grid → converts on new day
  - Horizontal-only drag still repositions within all-day row

## Independent review

Fresh diff-first review found no high/medium correctness issues. Low findings only: no direct `useGridMouseUp` tests (coverage is via action/schedule tests + manual); residual per-frame store writes during drag are intentional for form hydration correctness. No confirmed defects fixed after review.

## Test plan

- `bun test:web -- ./packages/web/src/views/Week/components/Draft/`
- `bun test:web -- ./packages/web/src/grid/interaction/math/cross-row.drag.test.ts ./packages/web/src/grid/interaction/commit/cross-row.commit.test.ts`
- `bun run lint`
- Browser golden path: all-day draft → timed grid conversion (create + horizontal-then-vertical)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79823f58-43ec-4948-b1d2-d385ab57e3f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79823f58-43ec-4948-b1d2-d385ab57e3f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

