### PR TITLE
feat(scripts): purge-user CLI, and fix account deletion stranding events

### DIFF
--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -242,10 +242,13 @@ class CalendarService {
 
   /**
    * Get every calendar record owned by a user.
+   *
+   * Takes an optional session so a caller deleting inside a transaction reads
+   * the same snapshot it is writing to, rather than the committed state.
    */
-  list = async (userId: ObjectId | string) => {
+  list = async (userId: ObjectId | string, session?: ClientSession) => {
     return mongoService.calendar
-      .find({ userId: zObjectId.parse(userId) })
+      .find({ userId: zObjectId.parse(userId) }, { session })
       .toArray();
   };
 

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -402,9 +402,18 @@ class EventService {
     await notify(userId, deletedBefore, "deleted");
   };
 
+  /**
+   * Wider than `ownedCalendarIds` on purpose: every calendar the user owns,
+   * archived ones included. Archiving (a calendar that vanished from Google's
+   * list, or a Google revoke) leaves the calendar's events in place, and an
+   * event document records only its `calendarId` - never a user. So an
+   * active-only delete would strand those events the moment the calendar row
+   * goes, with nothing left to find them by.
+   */
   deleteAllByUser = async (userId: string, session?: ClientSession) => {
-    const ownedCalendarIds = await this.ownedCalendarIds(userId);
-    return eventRepository.deleteByCalendarIds(ownedCalendarIds, session);
+    const calendars = await calendarService.list(userId, session);
+    const calendarIds = calendars.map((calendar) => calendar._id);
+    return eventRepository.deleteByCalendarIds(calendarIds, session);
   };
 
   /**

--- a/packages/backend/src/user/services/user.service.db.test.ts
+++ b/packages/backend/src/user/services/user.service.db.test.ts
@@ -480,6 +480,53 @@ describe("UserService", () => {
       cleanupSpy.mockRestore();
     });
 
+    it("deletes events owned by an archived calendar", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      const resolveSpy = spyOn(
+        supertokensUserCleanupService,
+        "resolveByExternalUserId",
+      ).mockResolvedValue({ externalUserIds: [], superTokensUserIds: [] });
+      const revokeSpy = spyOn(
+        compassAuthService,
+        "revokeSessionsByUser",
+      ).mockResolvedValue({ sessionsRevoked: 0 });
+      const cleanupSpy = spyOn(
+        supertokensUserCleanupService,
+        "cleanupResolvedTarget",
+      ).mockResolvedValue({
+        superTokensUsers: 0,
+        superTokensMappings: 0,
+        superTokensMetadata: 0,
+      });
+
+      await googleCalendarSyncService.initializeGoogleCalendarSync(userId);
+
+      // Archiving is what a Google revoke, or a calendar disappearing from the
+      // user's Google list, leaves behind: the calendar row stays, its events
+      // stay, and only `isActive` flips.
+      const event = await mongoService.event.findOne({});
+      expect(event).not.toBeNull();
+      await mongoService.calendar.updateOne(
+        { _id: event!.calendarId },
+        { $set: { isActive: false } },
+      );
+      const archived = await mongoService.event.countDocuments({
+        calendarId: event!.calendarId,
+      });
+      expect(archived).toBeGreaterThan(0);
+
+      const summary = await userService.deleteCompassDataForUser(userId, false);
+
+      expect(summary.events).toBeGreaterThanOrEqual(archived);
+      expect(await mongoService.event.countDocuments({})).toBe(0);
+
+      resolveSpy.mockRestore();
+      revokeSpy.mockRestore();
+      cleanupSpy.mockRestore();
+    });
+
     it("includes SuperTokens cleanup results after deleting the Compass user", async () => {
       const userId = mongoService.objectId().toString();
       await userService.upsertUserFromAuth({

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -199,11 +199,14 @@ class UserService {
         logger.warn(`User(${userId}) not found while deleting compass data`);
       }
 
-      const calendars = await calendarService.deleteAllByUser(userId, session);
-      summary.calendars = calendars.deletedCount;
-
+      // Events first: they are reachable only through the calendars that own
+      // them, so deleting the calendars first would leave nothing to find them
+      // by.
       const events = await eventService.deleteAllByUser(userId, session);
       summary.events = events.deletedCount;
+
+      const calendars = await calendarService.deleteAllByUser(userId, session);
+      summary.calendars = calendars.deletedCount;
 
       if (gcalAccess) {
         const watches = await googleWatchService.stopWatches(

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -15,6 +15,7 @@ const mockRunMigratePendingIntent = mock(
   (): Promise<void> => Promise.resolve(),
 );
 const mockRunPreseedSync = mock((): Promise<void> => Promise.resolve());
+const mockRunPurgeUser = mock((): Promise<void> => Promise.resolve());
 
 mock.module("@scripts/cli.validator", () => ({
   CliValidator: mock().mockImplementation(() => ({
@@ -50,6 +51,11 @@ mock.module("@scripts/commands/migrate-pending-intent", () => ({
 mock.module("@scripts/commands/preseed-sync", () => ({
   __esModule: true,
   runPreseedSync: mock(() => mockRunPreseedSync()),
+}));
+
+mock.module("@scripts/commands/purge-user", () => ({
+  __esModule: true,
+  runPurgeUser: mock(() => mockRunPurgeUser()),
 }));
 
 const { default: CompassCLI } = requireActual(
@@ -107,6 +113,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunPreseedSync).toHaveBeenCalled();
+  });
+
+  it("runs purge-user command", async () => {
+    const cli = new CompassCLI(["node", "cli", "purge-user"]);
+
+    await cli.run();
+
+    expect(mockRunPurgeUser).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -5,6 +5,7 @@ import { runMigrateConnections } from "@scripts/commands/migrate-connections";
 import { runMigratePendingIntent } from "@scripts/commands/migrate-pending-intent";
 import { runMigrateProviderState } from "@scripts/commands/migrate-provider-state";
 import { runPreseedSync } from "@scripts/commands/preseed-sync";
+import { runPurgeUser } from "@scripts/commands/purge-user";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
 
@@ -40,6 +41,9 @@ export default class CompassCLI {
       case cmd === "preseed-sync":
         await runPreseedSync();
         break;
+      case cmd === "purge-user":
+        await runPurgeUser();
+        break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }
@@ -52,6 +56,14 @@ export default class CompassCLI {
 
     // Register longer `migrate-*` / preseed names before `migrate` so Commander
     // does not treat them as unknown args to the Umzug migrate command.
+    program
+      .command("purge-user")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "delete every Compass row for one email, across the API db, Sync db, and SuperTokens (--apply to write)",
+      );
+
     program
       .command("preseed-sync")
       .helpOption(false)

--- a/packages/scripts/src/commands/purge-user.db.test.ts
+++ b/packages/scripts/src/commands/purge-user.db.test.ts
@@ -1,0 +1,202 @@
+import { purgeUserByEmail } from "@scripts/commands/purge-user/purge";
+import { type PurgeUserTarget } from "@scripts/commands/purge-user/report.types";
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+const NOW = new Date("2026-07-27T04:00:00.000Z");
+const EMAIL = "lance.essert@example.com";
+const TARGET: PurgeUserTarget = {
+  host: "localhost",
+  database: "test",
+  syncDatabase: "synctest",
+};
+
+describe("purge-user (db)", () => {
+  const syncStorage = setupSyncStorage(import.meta.url);
+
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  const deps = () => ({
+    db: mongoService.db,
+    syncDb: syncStorage.db(),
+    syncClient: syncStorage.client(),
+  });
+
+  /** One user, one active calendar with an event, one job row in Sync. */
+  const seedUser = async (email = EMAIL): Promise<ObjectId> => {
+    const userId = new ObjectId();
+    const calendarId = new ObjectId();
+
+    await mongoService.user.insertOne({
+      _id: userId,
+      email,
+      name: "Lance Essert",
+      firstName: "Lance",
+      lastName: "Essert",
+      locale: "not provided",
+      signedUpAt: NOW,
+    });
+    await mongoService.db
+      .collection(mongoService.calendar.collectionName)
+      .insertOne({ _id: calendarId, userId, isActive: true });
+    await mongoService.db
+      .collection(mongoService.event.collectionName)
+      .insertOne({ _id: new ObjectId(), calendarId, title: "Standup" });
+    await mongoService.db
+      .collection(mongoService.sync.collectionName)
+      .insertOne({ _id: new ObjectId(), user: userId.toString() });
+    await mongoService.db
+      .collection(mongoService.watch.collectionName)
+      .insertOne({ _id: new ObjectId(), user: userId.toString() });
+    await syncStorage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .insertOne({
+        _id: new ObjectId().toString(),
+        tenantId: userId.toString(),
+        principalId: userId.toString(),
+        // The jobs collection carries a unique index on coalescingKey, so a
+        // second seeded row cannot leave it null.
+        coalescingKey: `job-${userId.toString()}`,
+      });
+
+    return userId;
+  };
+
+  it("dry-run reports counts without deleting anything", async () => {
+    await seedUser();
+
+    const report = await purgeUserByEmail(deps(), EMAIL, {
+      dryRun: true,
+      target: TARGET,
+      now: NOW,
+    });
+
+    expect(report.dryRun).toBe(true);
+    expect(report.users).toHaveLength(1);
+    expect(report.users[0]?.counts.events).toBe(1);
+    expect(report.users[0]?.counts.calendars).toBe(1);
+    expect(report.users[0]?.counts.user).toBe(1);
+    expect(report.users[0]?.counts.sync.jobs).toBe(1);
+
+    expect(await mongoService.user.countDocuments({})).toBe(1);
+    expect(
+      await mongoService.db
+        .collection(mongoService.event.collectionName)
+        .countDocuments({}),
+    ).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({}),
+    ).toBe(1);
+  });
+
+  it("purges every duplicate account sharing the email, then reruns clean", async () => {
+    await seedUser();
+    await seedUser();
+    await seedUser("someone.else@example.com");
+
+    const report = await purgeUserByEmail(deps(), EMAIL, {
+      dryRun: false,
+      target: TARGET,
+      now: NOW,
+    });
+
+    expect(report.users).toHaveLength(2);
+    expect(report.users.every(({ counts }) => counts.user === 1)).toBe(true);
+
+    // The unrelated account and everything it owns is untouched.
+    expect(await mongoService.user.countDocuments({})).toBe(1);
+    expect(
+      await mongoService.db
+        .collection(mongoService.event.collectionName)
+        .countDocuments({}),
+    ).toBe(1);
+    expect(
+      await syncStorage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({}),
+    ).toBe(1);
+
+    const rerun = await purgeUserByEmail(deps(), EMAIL, {
+      dryRun: false,
+      target: TARGET,
+      now: NOW,
+    });
+    expect(rerun.users).toHaveLength(0);
+  });
+
+  it("deletes events on archived calendars, which the account-deletion path skips", async () => {
+    const userId = await seedUser();
+    const archivedCalendarId = new ObjectId();
+    await mongoService.db
+      .collection(mongoService.calendar.collectionName)
+      .insertOne({ _id: archivedCalendarId, userId, isActive: false });
+    await mongoService.db
+      .collection(mongoService.event.collectionName)
+      .insertOne({
+        _id: new ObjectId(),
+        calendarId: archivedCalendarId,
+        title: "Revoked Google event",
+      });
+
+    const report = await purgeUserByEmail(deps(), EMAIL, {
+      dryRun: false,
+      target: TARGET,
+      now: NOW,
+    });
+
+    expect(report.users[0]?.counts.events).toBe(2);
+    expect(
+      await mongoService.db
+        .collection(mongoService.event.collectionName)
+        .countDocuments({}),
+    ).toBe(0);
+  });
+
+  it("purges Mongo and records the error when SuperTokens cleanup fails", async () => {
+    await seedUser();
+
+    const report = await purgeUserByEmail(
+      {
+        ...deps(),
+        cleanupAuth: () => Promise.reject(new Error("core unreachable")),
+      },
+      EMAIL,
+      { dryRun: false, target: TARGET, now: NOW },
+    );
+
+    expect(report.auth).toBeNull();
+    expect(report.authError).toBe("core unreachable");
+    expect(await mongoService.user.countDocuments({})).toBe(0);
+  });
+
+  it("normalizes the email before matching", async () => {
+    await seedUser();
+
+    const report = await purgeUserByEmail(deps(), `  ${EMAIL.toUpperCase()} `, {
+      dryRun: true,
+      target: TARGET,
+      now: NOW,
+    });
+
+    expect(report.email).toBe(EMAIL);
+    expect(report.users).toHaveLength(1);
+  });
+});

--- a/packages/scripts/src/commands/purge-user.ts
+++ b/packages/scripts/src/commands/purge-user.ts
@@ -1,0 +1,131 @@
+import { purgeUserByEmail } from "@scripts/commands/purge-user/purge";
+import { type PurgeUserTarget } from "@scripts/commands/purge-user/report.types";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import supertokensUserCleanupService from "@backend/auth/services/supertokens/supertokens.user-cleanup.service";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import mongoService from "@backend/common/services/mongo.service";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const logger = Logger("scripts.commands.purge-user");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before purging a user",
+    );
+  }
+  return uri;
+}
+
+/** Host only - never the credentials that precede it in the URI. */
+function hostOf(uri: string): string {
+  try {
+    return new URL(uri).host || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  email: string;
+  outPath: string | null;
+} {
+  const emailFlag = argv.indexOf("--email");
+  const email = emailFlag >= 0 ? argv[emailFlag + 1]?.trim() : undefined;
+  if (!email) {
+    throw new Error("purge-user requires --email <address>");
+  }
+
+  const outFlag = argv.indexOf("--out");
+  const outPath =
+    outFlag >= 0 && argv[outFlag + 1] ? resolve(argv[outFlag + 1]!) : null;
+
+  return { dryRun: !argv.includes("--apply"), email, outPath };
+}
+
+/**
+ * Deletes every Compass row for one email address - API database, Sync
+ * database, and SuperTokens - so a test account can be reset. Default is
+ * dry-run; pass `--apply` to write. Never calls Google, so the account's
+ * OAuth grant survives and the next sign-in skips the consent screen.
+ *
+ * Restores the operator-side account deletion that went away with the old
+ * `delete` command (#2154); `DELETE /api/user` only ever deletes the caller.
+ *
+ * Usage:
+ *   bun run cli purge-user --email <address> [--apply] [--out report.json]
+ */
+export async function runPurgeUser(): Promise<void> {
+  const syncMongo = new SyncMongoService();
+
+  try {
+    const { dryRun, email, outPath } = parseArgs(process.argv.slice(3));
+    const syncUri = syncMongoUri();
+
+    await mongoService.start();
+    await syncMongo.connect({
+      uri: syncUri,
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const target: PurgeUserTarget = {
+      host: hostOf(CONFIG.MONGO_URI),
+      database: mongoService.db.databaseName,
+      syncDatabase: syncMongo.db.databaseName,
+    };
+
+    logger.info(
+      `purge-user dryRun=${dryRun} email=${email} host=${target.host} db=${target.database} syncDb=${target.syncDatabase}`,
+    );
+
+    const report = await purgeUserByEmail(
+      {
+        db: mongoService.db,
+        syncDb: syncMongo.db,
+        syncClient: syncMongo.client,
+        cleanupAuth: (address) =>
+          supertokensUserCleanupService.cleanupByEmail(address),
+      },
+      email,
+      { dryRun, target },
+    );
+
+    const json = `${JSON.stringify(report, null, 2)}\n`;
+    if (outPath) {
+      writeFileSync(outPath, json, "utf8");
+      logger.info(`Wrote purge report to ${outPath}`);
+    } else {
+      process.stdout.write(json);
+    }
+
+    if (report.authError) {
+      logger.warn(
+        `SuperTokens cleanup failed (${report.authError}); Mongo rows were purged. Rerun --apply once the core is reachable.`,
+      );
+    }
+
+    logger.info(
+      `purge-user dryRun=${report.dryRun} users=${report.users.length} events=${report.users.reduce((sum, user) => sum + user.counts.events, 0)}`,
+    );
+
+    await syncMongo.disconnect();
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/purge-user/purge.ts
+++ b/packages/scripts/src/commands/purge-user/purge.ts
@@ -1,0 +1,277 @@
+import {
+  type PurgeUserAuth,
+  type PurgeUserCounts,
+  type PurgeUserReport,
+  type PurgeUserResult,
+  type PurgeUserTarget,
+} from "@scripts/commands/purge-user/report.types";
+import {
+  type Collection,
+  type Db,
+  type Document,
+  type Filter,
+  type MongoClient,
+  type ObjectId,
+} from "mongodb";
+import {
+  PrincipalIdSchema,
+  TenantIdSchema,
+} from "@core/types/sync/identity.contracts";
+import { Collections } from "@backend/common/constants/collections";
+import { IS_DEV } from "@backend/common/constants/config.constants";
+import { normalizeEmail } from "@backend/common/helpers/email.util";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { purgePrincipal } from "@sync/domain/principal-purge.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+// Collections no code writes anymore but whose rows still key off a user:
+// `calendarlist` predates the 2025 calendar migration and `event_legacy_v1` is
+// the pre-cutover event snapshot. Same IS_DEV naming the live ones use.
+const LEGACY_CALENDAR_LIST = IS_DEV ? "_dev.calendarlist" : "calendarlist";
+const LEGACY_EVENT = IS_DEV ? "_dev.event_legacy_v1" : "event_legacy_v1";
+const WAITLIST = IS_DEV ? "_dev.waitlist" : "waitlist";
+
+export interface PurgeUserDeps {
+  /** The Compass API database (`prod_calendar` outside dev). */
+  db: Db;
+  /** The isolated Sync database (`compass_sync`). */
+  syncDb: Db;
+  syncClient: MongoClient;
+  /**
+   * Clears the SuperTokens user, id-mapping, and metadata for the email.
+   * Optional and fail-open: a SuperTokens core the operator cannot reach must
+   * not block (or half-undo) the Mongo purge.
+   */
+  cleanupAuth?: (email: string) => Promise<PurgeUserAuth>;
+}
+
+export interface PurgeUserOptions {
+  dryRun: boolean;
+  /** Echoed into the report so a dry run shows which deployment it read. */
+  target: PurgeUserTarget;
+  now?: Date;
+}
+
+interface UserDoc {
+  _id: ObjectId;
+  email: string;
+  signedUpAt?: Date;
+  lastLoggedInAt?: Date;
+}
+
+/**
+ * Deletes every row Compass holds for one email address, across the API
+ * database, the Sync database, and SuperTokens.
+ *
+ * Not transactional, by design: the Sync database is a separate deployment, so
+ * no single session could span both. Instead the user document is deleted
+ * last, so a failure part-way leaves the account visible and the command
+ * rerunnable rather than leaving invisible orphans.
+ */
+export async function purgeUserByEmail(
+  deps: PurgeUserDeps,
+  email: string,
+  options: PurgeUserOptions,
+): Promise<PurgeUserReport> {
+  const { dryRun } = options;
+  const normalizedEmail = normalizeEmail(email);
+  const users = await deps.db
+    .collection<UserDoc>(Collections.USER)
+    .find({ email: normalizedEmail })
+    .toArray();
+
+  const results: PurgeUserResult[] = [];
+  for (const user of users) {
+    results.push({
+      userId: user._id.toString(),
+      signedUpAt: user.signedUpAt?.toISOString() ?? null,
+      lastLoggedInAt: user.lastLoggedInAt?.toISOString() ?? null,
+      counts: await purgeOneUser(deps, user._id, dryRun),
+    });
+  }
+
+  const waitlist = await removeMany(dryRun, deps.db.collection(WAITLIST), {
+    email: normalizedEmail,
+  });
+
+  let auth: PurgeUserAuth | null = null;
+  let authError: string | null = null;
+  if (!dryRun && deps.cleanupAuth) {
+    try {
+      auth = await deps.cleanupAuth(normalizedEmail);
+    } catch (error) {
+      authError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  return {
+    generatedAt: (options.now ?? new Date()).toISOString(),
+    dryRun,
+    email: normalizedEmail,
+    target: options.target,
+    users: results,
+    waitlist,
+    auth,
+    authError,
+  };
+}
+
+async function purgeOneUser(
+  deps: PurgeUserDeps,
+  userId: ObjectId,
+  dryRun: boolean,
+): Promise<PurgeUserCounts> {
+  const id = userId.toString();
+
+  // Snapshot first, and take every calendar - not just the active ones the
+  // event service filters to. A calendar archived by a Google revoke still
+  // owns events, and once its row is gone nothing can reach them: post-cutover
+  // event documents carry only `calendarId`, never a user.
+  const calendarIds = await deps.db
+    .collection(Collections.CALENDAR)
+    .find({ userId }, { projection: { _id: 1 } })
+    .map((calendar) => calendar._id)
+    .toArray();
+
+  const events = calendarIds.length
+    ? await removeMany(dryRun, deps.db.collection(Collections.EVENT), {
+        calendarId: { $in: calendarIds },
+      })
+    : 0;
+  const calendars = await removeMany(
+    dryRun,
+    deps.db.collection(Collections.CALENDAR),
+    { userId },
+  );
+  const syncRecords = await removeMany(
+    dryRun,
+    deps.db.collection(Collections.SYNC),
+    { user: id },
+  );
+  const watches = await removeMany(
+    dryRun,
+    deps.db.collection(Collections.WATCH),
+    { user: id },
+  );
+  const legacyCalendarLists = await removeMany(
+    dryRun,
+    deps.db.collection(LEGACY_CALENDAR_LIST),
+    { user: id },
+  );
+  const legacyEvents = await removeMany(
+    dryRun,
+    deps.db.collection(LEGACY_EVENT),
+    { user: id },
+  );
+
+  const sync = await purgeSyncRows(deps, id, dryRun);
+
+  const user = await removeMany(dryRun, deps.db.collection(Collections.USER), {
+    _id: userId,
+  });
+
+  return {
+    events,
+    calendars,
+    syncRecords,
+    watches,
+    legacyCalendarLists,
+    legacyEvents,
+    user,
+    sync,
+  };
+}
+
+/**
+ * Applies the same purge the Sync service runs on account deletion. No
+ * `custody` is passed, so credentials are dropped locally without a provider
+ * revoke - purging staging test data must not disturb the real Google grant.
+ */
+async function purgeSyncRows(
+  deps: PurgeUserDeps,
+  userId: string,
+  dryRun: boolean,
+): Promise<PurgeUserCounts["sync"]> {
+  // toSyncPrincipal owns the user-to-principal mapping; the schemas re-brand
+  // its plain strings for the Sync repositories (and reject a malformed id).
+  const principal = toSyncPrincipal(userId);
+  const tenantId = TenantIdSchema.parse(principal.tenantId);
+  const principalId = PrincipalIdSchema.parse(principal.principalId);
+
+  if (dryRun) return countSyncRows(deps.syncDb, tenantId, principalId);
+
+  return purgePrincipal(
+    {
+      connections: new ProviderConnectionRepository(deps.syncDb),
+      credentials: new CredentialRepository(deps.syncDb),
+      calendars: new ProviderCalendarRepository(deps.syncDb),
+      events: new EventRepository(deps.syncDb),
+      eventOccurrences: new EventOccurrenceRepository(
+        deps.syncDb,
+        deps.syncClient,
+      ),
+      syncResources: new SyncResourceRepository(deps.syncDb),
+      commands: new CommandRepository(deps.syncDb),
+      jobs: new JobRepository(deps.syncDb),
+      deletionMarkers: new DeletionMarkerRepository(deps.syncDb),
+      invalidations: new InvalidationRepository(deps.syncDb),
+    },
+    tenantId,
+    principalId,
+  );
+}
+
+// Every Sync collection is scoped by (tenantId, principalId) except
+// credentials, which hang off a connection id.
+async function countSyncRows(
+  syncDb: Db,
+  tenantId: string,
+  principalId: string,
+): Promise<PurgeUserCounts["sync"]> {
+  const scope = { tenantId, principalId };
+  const count = (name: string) => syncDb.collection(name).countDocuments(scope);
+
+  const connectionIds = await syncDb
+    .collection(SYNC_COLLECTIONS.providerConnections)
+    .find(scope, { projection: { _id: 1 } })
+    .map((connection) => connection._id)
+    .toArray();
+
+  return {
+    connections: connectionIds.length,
+    credentials: connectionIds.length
+      ? await syncDb
+          .collection(SYNC_COLLECTIONS.credentials)
+          .countDocuments({ _id: { $in: connectionIds } })
+      : 0,
+    calendars: await count(SYNC_COLLECTIONS.providerCalendars),
+    events: await count(SYNC_COLLECTIONS.events),
+    eventOccurrences: await count(SYNC_COLLECTIONS.eventOccurrences),
+    syncResources: await count(SYNC_COLLECTIONS.syncResources),
+    commands: await count(SYNC_COLLECTIONS.commands),
+    jobs: await count(SYNC_COLLECTIONS.jobs),
+    deletionMarkers: await count(SYNC_COLLECTIONS.deletionMarkers),
+    invalidations: await count(SYNC_COLLECTIONS.invalidations),
+  };
+}
+
+/** Counts on a dry run, deletes on an apply. Same filter either way. */
+async function removeMany(
+  dryRun: boolean,
+  collection: Collection<Document>,
+  filter: Filter<Document>,
+): Promise<number> {
+  if (dryRun) return collection.countDocuments(filter);
+  const result = await collection.deleteMany(filter);
+  return result.deletedCount;
+}

--- a/packages/scripts/src/commands/purge-user/report.types.ts
+++ b/packages/scripts/src/commands/purge-user/report.types.ts
@@ -1,0 +1,54 @@
+import { z } from "zod/v4";
+import { PrincipalPurgeResponseSchema } from "@core/types/sync/principal.contracts";
+
+export const PurgeUserCountsSchema = z.strictObject({
+  // Deleted by owning-calendar id, snapshotted before the calendars go. Covers
+  // archived calendars too, which the account-deletion path misses.
+  events: z.number().int().nonnegative(),
+  calendars: z.number().int().nonnegative(),
+  syncRecords: z.number().int().nonnegative(),
+  watches: z.number().int().nonnegative(),
+  legacyCalendarLists: z.number().int().nonnegative(),
+  legacyEvents: z.number().int().nonnegative(),
+  user: z.number().int().nonnegative(),
+  sync: PrincipalPurgeResponseSchema,
+});
+export type PurgeUserCounts = z.infer<typeof PurgeUserCountsSchema>;
+
+export const PurgeUserResultSchema = z.strictObject({
+  userId: z.string().min(1),
+  signedUpAt: z.string().nullable(),
+  lastLoggedInAt: z.string().nullable(),
+  counts: PurgeUserCountsSchema,
+});
+export type PurgeUserResult = z.infer<typeof PurgeUserResultSchema>;
+
+export const PurgeUserAuthSchema = z.strictObject({
+  superTokensUsers: z.number().int().nonnegative(),
+  superTokensMappings: z.number().int().nonnegative(),
+  superTokensMetadata: z.number().int().nonnegative(),
+});
+export type PurgeUserAuth = z.infer<typeof PurgeUserAuthSchema>;
+
+// Staging and production share the `prod_calendar` database name, so the host
+// is what tells an operator reviewing a dry run which one they are aimed at.
+export const PurgeUserTargetSchema = z.strictObject({
+  host: z.string().min(1),
+  database: z.string().min(1),
+  syncDatabase: z.string().min(1),
+});
+export type PurgeUserTarget = z.infer<typeof PurgeUserTargetSchema>;
+
+export const PurgeUserReportSchema = z.strictObject({
+  generatedAt: z.string().min(1),
+  dryRun: z.boolean(),
+  email: z.string().min(1),
+  target: PurgeUserTargetSchema,
+  users: z.array(PurgeUserResultSchema),
+  waitlist: z.number().int().nonnegative(),
+  // Null on dry-run, and null when SuperTokens cleanup failed - `authError`
+  // says which. Mongo rows are already gone by then; see purge.ts.
+  auth: PurgeUserAuthSchema.nullable(),
+  authError: z.string().nullable(),
+});
+export type PurgeUserReport = z.infer<typeof PurgeUserReportSchema>;


### PR DESCRIPTION
Duplicate `user` documents for one email had accumulated in staging, making manual testing unreliable. There was no way to clear them: `bun cli delete` was removed in #2154, and `DELETE /api/user` takes its user id from the session, so it can only ever delete the caller.

## `purge-user`

```bash
bun run cli purge-user --email <address> [--apply] [--out report.json]
```

Dry-run by default, counting with the same filters it would delete with. It clears every row for an email across the API database, the Sync database (via the same principal purge the Sync service runs on account deletion), and SuperTokens.

Design points worth reviewing:

- **Never calls Google.** Purging a test account must not disturb its real OAuth grant, so no `custody` is passed to the principal purge and no revoke is attempted. The next sign-in skips the consent screen.
- **Not transactional, deliberately.** The Sync database is a separate deployment, so no single Mongo session could span both. The user document is deleted last instead, so a failure part-way leaves a visible account and a rerunnable command rather than invisible orphans.
- **SuperTokens cleanup is fail-open.** A core the operator cannot reach must not half-undo the Mongo purge; the report carries `authError` and the command is idempotent, so it can be rerun from somewhere that can reach it.
- **The report echoes the resolved host and database names.** Staging and production share the database name `prod_calendar`, so the host is the only thing in a dry run that shows which cluster it read.

It also sweeps three collections nothing writes anymore but which still key off a user: `calendarlist`, `event_legacy_v1`, and `waitlist`.

## The deletion bug

Mapping the data out surfaced a live bug, fixed in the first commit.

`eventService.deleteAllByUser` resolved events through `ownedCalendarIds`, which filters `isActive`. Calendars archived by a Google revoke, or by the calendar-list sweep when a calendar disappears from the user's Google list, keep their events - so account deletion skipped them. An event document records only its `calendarId` and never a user, so once the calendar row was deleted those events became unreachable and stayed in the database permanently.

The fix widens `deleteAllByUser` to every calendar the user owns, archived included, and deletes events before calendars so the ids are still there to delete by. `calendarService.list` gained an optional session, so the lookup reads the transaction snapshot it is writing to rather than the committed state - previously it only found the calendars at all because it read outside the transaction.

The other caller of `deleteAllByUser` is the dev-only `/api/event/delete-all/:userId` route, which wants the wider behaviour too.

## Testing

- New `user.service.db.test.ts` case seeds an event on an archived calendar; confirmed it fails on the old code (`summary.events` short by the archived count) and passes on the new.
- 5 new db tests for `purge-user` against real Mongo, covering both databases: dry-run writes nothing, every duplicate sharing an email is purged while an unrelated account is untouched, a rerun is clean, archived-calendar events are deleted, and a SuperTokens failure still purges Mongo.
- `bun run test:backend` 833 pass / 0 fail, `bun run test:scripts` 81 pass / 0 fail, `bun run type-check` and `biome check` clean.

Not yet run against staging - that needs a staging config and is the destructive step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destructive data-deletion paths and introduces an operator command that wipes multi-database user state; behavior is covered by new DB tests and uses dry-run-by-default safeguards.
> 
> **Overview**
> Fixes **account deletion leaving orphan events** on archived calendars and adds an operator **`purge-user` CLI** to reset test accounts by email.
> 
> **Deletion fix:** `deleteAllByUser` now targets every owned calendar (including `isActive: false`), not only active ones, because events are keyed by `calendarId` only. `deleteCompassDataForUser` deletes **events before calendars** so calendar IDs still exist for the wipe. `calendarService.list` accepts an optional **transaction session** so deletes inside a transaction see a consistent snapshot.
> 
> **`purge-user`:** `bun run cli purge-user --email <address> [--apply] [--out report.json]` — dry-run by default, purges all rows for a normalized email across the API Mongo DB, Sync DB (via `purgePrincipal` without Google revoke), legacy collections (`calendarlist`, `event_legacy_v1`, `waitlist`), and SuperTokens (`authError` fail-open). User documents are deleted last so partial failures stay rerunnable.
> 
> Tests cover archived-calendar event deletion in `deleteCompassDataForUser` and five DB scenarios for `purge-user`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89d0ae3ea7a73652a29ebc3f5d91b3a9ffb0720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->