### PR TITLE
fix(web): seed day grid fixtures on local calendar

### DIFF
--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -16,6 +16,7 @@ import {
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
 import {
   DATA_TIMED_GRID_ROW,
   ZIndex,
@@ -201,9 +202,16 @@ const withOffset = (dateTime: string) =>
 
 // The query cache (unlike draft.store.ts, still legacy CompassEvent-shaped
 // per its own TODO) requires strict-contract `Event`s.
+//
+// calendarId must match the anonymous local calendar the calendars query
+// synthesizes. Otherwise filterEventsByVisibleCalendars drops every fixture
+// once that query resolves mid-userEvent click (delay:0 yields to macrotasks
+// between hover and pointerdown), and the card unmounts before the
+// interaction engine can open it.
 const toStrictEvent = (event: CompassEvent): Event =>
   createMockEvent({
     id: EventIdSchema.parse(event._id!),
+    calendarId: getLocalCalendarSentinelId(),
     content: {
       kind: "details",
       title: event.title ?? "",


### PR DESCRIPTION
## Summary
- Seed `DayCalendarGrid` test fixtures with `getLocalCalendarSentinelId()` so they match the anonymous local calendar the calendars query synthesizes.
- Without that match, `filterEventsByVisibleCalendars` drops every fixture once calendars resolve mid-`userEvent.click` (`delay: 0` yields between hover and pointerdown), unmounting the card before the interaction engine can open the form.

## Simplicity
No simplification opportunities found. Test-only one-line fixture fix plus a short comment explaining the calendars-query race; no new `useEffect`/`useRef`/`useState`.

## Manual Testing Steps
- [ ] From repo root: `bun test:web packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx`
- [ ] Confirm the previously failing cases pass: overlapping Day event click, Day card pointer open, dismiss form on empty timed/all-day press, keep form open when pressing outside the calendar
- [ ] Confirm full file stays green (expect ~25 pass / 0 fail)

## Test plan
- [x] `bun test:web packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx` — 25 pass, 0 fail
- [x] `bunx tsc -p packages/web --noEmit` — no errors in the changed test file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture and comment updates only; no application logic changes.
> 
> **Overview**
> Fixes flaky/failing **`DayCalendarGrid`** interaction tests by aligning seeded event fixtures with the anonymous local calendar the calendars query synthesizes.
> 
> **`toStrictEvent`** now sets **`calendarId`** to **`getLocalCalendarSentinelId()`** (plus a short comment). Without that match, **`filterEventsByVisibleCalendars`** hides every fixture once calendars resolve mid-**`userEvent.click`** (`delay: 0` yields between hover and pointerdown), so the event card unmounts before the interaction engine can open the form.
> 
> Test-only change; no production behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a6d40fe2d0a8cf67e89f25dc8c605160749f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->