### PR TITLE
feat(sync): import Google event colors into sync storage

### DIFF
--- a/packages/core/src/types/event-color.contracts.ts
+++ b/packages/core/src/types/event-color.contracts.ts
@@ -1,0 +1,18 @@
+import { z } from "zod/v4";
+
+// Compass-owned event color slots. Maps 1:1 onto Google's 11 event colors;
+// providers adapt to/from these names at the boundary.
+export const EventColorSlotSchema = z.enum([
+  "lavender",
+  "mint",
+  "plum",
+  "coral",
+  "gold",
+  "orange",
+  "blue",
+  "slate",
+  "indigo",
+  "green",
+  "red",
+]);
+export type EventColorSlot = z.infer<typeof EventColorSlotSchema>;

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -6,6 +6,7 @@ import {
   RRuleSchema,
 } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
+import { EventColorSlotSchema } from "@core/types/event-color.contracts";
 import {
   ConnectionIdSchema,
   ProviderCalendarIdSchema,
@@ -103,6 +104,7 @@ export const SyncEventContentSchema = z.strictObject({
   organizer: OrganizerSchema.nullable(),
   attendees: z.array(AttendeeSchema).readonly(),
   conference: ConferenceSchema.nullable(),
+  color: EventColorSlotSchema.optional(),
 });
 export type SyncEventContent = z.infer<typeof SyncEventContentSchema>;
 
@@ -229,6 +231,7 @@ export type EventOccurrenceListResponse = z.infer<
 const SyncInstanceContentSchema = z.strictObject({
   title: z.string(),
   description: z.string(),
+  color: EventColorSlotSchema.optional(),
 });
 export type SyncInstanceContent = z.infer<typeof SyncInstanceContentSchema>;
 

--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -99,6 +99,29 @@ describe("assembleEventInstances", () => {
     expect(instance?.updatedAt).toBe("2026-07-02T00:00:00.000Z");
   });
 
+  it("carries event content.color onto assembled instance content", () => {
+    const event = makeEvent({
+      content: {
+        title: "Standup",
+        description: "Daily sync",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+        color: "coral",
+      },
+    });
+    const occurrence = makeOccurrence({ eventId: event._id });
+
+    const [instance] = assembleEventInstances([occurrence], byId(event));
+
+    expect(instance?.content).toEqual({
+      title: "Standup",
+      description: "Daily sync",
+      color: "coral",
+    });
+  });
+
   it("maps plain series instances to occurrence rows plus one master row", () => {
     const master = makeEvent({
       recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },

--- a/packages/sync/src/domain/event-instance-assembly.ts
+++ b/packages/sync/src/domain/event-instance-assembly.ts
@@ -46,6 +46,9 @@ export function assembleEventInstances(
     const content = {
       title: event.content.title,
       description: event.content.description,
+      ...(event.content.color !== undefined
+        ? { color: event.content.color }
+        : {}),
     };
     const timestamps = {
       createdAt: event.createdAt.toISOString(),
@@ -116,6 +119,9 @@ export function assembleEventInstances(
         content: {
           title: master.content.title,
           description: master.content.description,
+          ...(master.content.color !== undefined
+            ? { color: master.content.color }
+            : {}),
         },
         schedule: master.schedule,
         recurrence: { kind: "series", rules: master.recurrence.rules },

--- a/packages/sync/src/providers/google/google-color.map.test.ts
+++ b/packages/sync/src/providers/google/google-color.map.test.ts
@@ -1,0 +1,25 @@
+import {
+  GOOGLE_COLOR_ID_TO_SLOT,
+  googleColorIdToSlot,
+  SLOT_TO_GOOGLE_COLOR_ID,
+  slotToGoogleColorId,
+} from "@sync/providers/google/google-color.map";
+import { describe, expect, it } from "bun:test";
+
+describe("google-color.map", () => {
+  it("round-trips all 11 Google color ids both directions", () => {
+    for (const [id, slot] of Object.entries(GOOGLE_COLOR_ID_TO_SLOT)) {
+      expect(googleColorIdToSlot(id)).toBe(slot);
+      expect(slotToGoogleColorId(slot)).toBe(id);
+      expect(SLOT_TO_GOOGLE_COLOR_ID[slot]).toBe(id);
+    }
+    expect(Object.keys(GOOGLE_COLOR_ID_TO_SLOT)).toHaveLength(11);
+  });
+
+  it("returns undefined for unknown, empty, or missing color ids", () => {
+    expect(googleColorIdToSlot("42")).toBeUndefined();
+    expect(googleColorIdToSlot("")).toBeUndefined();
+    expect(googleColorIdToSlot(undefined)).toBeUndefined();
+    expect(googleColorIdToSlot(null)).toBeUndefined();
+  });
+});

--- a/packages/sync/src/providers/google/google-color.map.ts
+++ b/packages/sync/src/providers/google/google-color.map.ts
@@ -1,0 +1,34 @@
+import { type EventColorSlot } from "@core/types/event-color.contracts";
+
+// Google Calendar event colorId values (1-11) mapped to Compass color slots.
+// See https://developers.google.com/workspace/calendar/api/v3/reference/colors
+export const GOOGLE_COLOR_ID_TO_SLOT = {
+  "1": "lavender",
+  "2": "mint",
+  "3": "plum",
+  "4": "coral",
+  "5": "gold",
+  "6": "orange",
+  "7": "blue",
+  "8": "slate",
+  "9": "indigo",
+  "10": "green",
+  "11": "red",
+} as const satisfies Record<string, EventColorSlot>;
+
+export const SLOT_TO_GOOGLE_COLOR_ID = Object.fromEntries(
+  Object.entries(GOOGLE_COLOR_ID_TO_SLOT).map(([id, slot]) => [slot, id]),
+) as { readonly [K in EventColorSlot]: string };
+
+export function googleColorIdToSlot(
+  colorId: string | null | undefined,
+): EventColorSlot | undefined {
+  if (colorId == null) return undefined;
+  return GOOGLE_COLOR_ID_TO_SLOT[
+    colorId as keyof typeof GOOGLE_COLOR_ID_TO_SLOT
+  ];
+}
+
+export function slotToGoogleColorId(slot: EventColorSlot): string {
+  return SLOT_TO_GOOGLE_COLOR_ID[slot];
+}

--- a/packages/sync/src/providers/google/google-event.normalizer.test.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.test.ts
@@ -290,4 +290,18 @@ describe("normalizeGoogleEvent", () => {
     expect(error).toBeInstanceOf(ProviderEventError);
     expect(error.reason).toBe("unmappableContent");
   });
+
+  it("maps Google colorId 7 to content.color blue", () => {
+    const read = asProviderEvent(
+      normalizeGoogleEvent(gEvent({ colorId: "7" })),
+    );
+
+    expect(read.content.color).toBe("blue");
+  });
+
+  it("omits content.color when Google reports no colorId", () => {
+    const read = asProviderEvent(normalizeGoogleEvent(gEvent({})));
+
+    expect(read.content).not.toHaveProperty("color");
+  });
 });

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -9,6 +9,7 @@ import {
   SyncEventContentSchema,
 } from "@core/types/sync/event.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { googleColorIdToSlot } from "@sync/providers/google/google-color.map";
 import {
   ProviderEventError,
   type ProviderEventRead,
@@ -77,6 +78,7 @@ function mapContent(item: gSchema$Event) {
   // the contract's max). That makes one event unusable, so it must surface as a
   // ProviderEventError the reader can skip — never a raw ZodError that would
   // escape the per-event skip boundary and fail a whole import page.
+  const color = googleColorIdToSlot(item.colorId);
   const parsed = SyncEventContentSchema.safeParse({
     // Google omits summary/description for untitled/empty events; the neutral
     // contract models those as empty strings, not absence.
@@ -86,6 +88,8 @@ function mapContent(item: gSchema$Event) {
     organizer: mapOrganizer(item.organizer),
     attendees: mapAttendees(item.attendees),
     conference: mapConference(item),
+    // Omit entirely when Google reports no color or an unknown id.
+    ...(color !== undefined ? { color } : {}),
   });
   if (!parsed.success) {
     throw new ProviderEventError(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Import Google Calendar event colors into Compass sync storage during ingest.

Google's `colorId` values (1-11) map onto a Compass-owned enum of 11 color slots. Imported and pulled events store the optional `color` on sync event content; full-fidelity instance assembly inherits it from the owning event. Nothing displays or writes colors back yet.

## Changes

- Add `EventColorSlotSchema` / `EventColorSlot` in core
- Add optional `color` on `SyncEventContentSchema` and `SyncInstanceContentSchema`
- Add Google colorId to slot map helpers
- Map `colorId` in the Google event normalizer (omit when absent or unknown)
- Carry `color` through event instance assembly
- Unit tests for the map, normalizer, and assembly inheritance

## Verification

- `bun run type-check` passed
- `bun run test:sync` - 637 pass, 0 fail
- `bun run test:backend` - 828 pass, 0 fail (core contracts touched)
- `./node_modules/.bin/biome check` on changed files - clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

