### PR TITLE
feat(core): expose optional event color on app contracts

### DIFF
--- a/docs/architecture/event-domain-model.md
+++ b/docs/architecture/event-domain-model.md
@@ -57,12 +57,6 @@ rediscovering it:
   lets a user change Compass-local visibility, but never creates, deletes, or
   manages sharing/ACLs on a provider calendar (A1, A15). Calendar lifecycle
   stays server-owned and Google-authoritative in v1.
-- **Per-event Google colors.** Compass models calendar identity as an
-  accent/marker plus text label, while an event card's fill stays a single
-  flat neutral color (A9) — there is no per-event color field in
-  `event.contracts.ts` anywhere, so Google's per-event `colorId` overrides are
-  neither imported nor exposed. Surfacing them would need a second color
-  dimension on the card that A9 deliberately avoided.
 
 ## Core Event Schema
 
@@ -74,8 +68,11 @@ Important event fields:
 
 - `id`: Compass event id
 - `calendarId`: required, immutable once created (see Deferred Beyond V1)
-- `content`: discriminated union — `details` (`title` + `description`) or
-  `busy` (free/busy-only calendars)
+- `content`: discriminated union — `details` (`title` + `description` +
+  optional `color` as an `EventColorSlot`) or `busy` (free/busy-only
+  calendars). `color` maps 1:1 onto Google's 11 event `colorId` values; when
+  absent, the card keeps the theme-flat fill and calendar identity stays the
+  accent stripe.
 - `schedule`: discriminated union — `timed` (`start`/`end`/`timeZone`) or
   `allDay` (`DateOnly` `start`/`end`, exclusive end)
 - `recurrence`: discriminated union — `single` (standalone event), `series`

--- a/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
@@ -31,6 +31,26 @@ describe("toSyncContent", () => {
       conference: null,
     });
   });
+
+  it("forwards an optional color onto sync content", () => {
+    expect(
+      toSyncContent({ title: "Standup", description: "Daily", color: "coral" }),
+    ).toEqual({
+      title: "Standup",
+      description: "Daily",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      color: "coral",
+    });
+  });
+
+  it("omits color when the browser did not set one", () => {
+    expect(
+      toSyncContent({ title: "Standup", description: "Daily" }),
+    ).not.toHaveProperty("color");
+  });
 });
 
 describe("resolveCommandTarget", () => {

--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -7,6 +7,7 @@ import {
   EventIdSchema,
 } from "@core/types/domain-primitives";
 import { type Event, EventSchema } from "@core/types/event.contracts";
+import { type EventColorSlot } from "@core/types/event-color.contracts";
 import {
   type CreateEventInput,
   type DeleteEventInput,
@@ -35,10 +36,13 @@ const UNKNOWN_CALENDAR_ID = CalendarIdSchema.parse("000000000000000000000000");
 // so the strict SyncEventContent schema accepts the wire payload. On create
 // those nulls are correct (new event). On update, sync's apply path merges
 // title/description onto the existing record (mergeUpdateContent) so a rename
-// cannot wipe provider-sourced attendees/location/conference.
+// cannot wipe provider-sourced attendees/location/conference. Optional color
+// is forwarded when the browser sets one; omitted color leaves merge to keep
+// whatever Sync already stores.
 export const toSyncContent = (content: {
   title: string;
   description: string;
+  color?: EventColorSlot;
 }): SyncEventContent => ({
   title: content.title,
   description: content.description,
@@ -46,6 +50,7 @@ export const toSyncContent = (content: {
   organizer: null,
   attendees: [],
   conference: null,
+  ...(content.color !== undefined ? { color: content.color } : {}),
 });
 
 export interface CommandTarget {

--- a/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
@@ -87,4 +87,24 @@ describe("syncEventInstanceToBrowser", () => {
     expect(event.createdAt).toBe(instance.createdAt);
     expect(event.updatedAt).toBe(instance.updatedAt);
   });
+
+  it("forwards content.color onto browser details content", () => {
+    const instance = baseInstance({
+      content: { title: "Standup", description: "Daily", color: "blue" },
+    });
+    const event = syncEventInstanceToBrowser(instance);
+
+    expect(event.content).toEqual({
+      kind: "details",
+      title: "Standup",
+      description: "Daily",
+      color: "blue",
+    });
+  });
+
+  it("omits content.color on the browser event when sync has none", () => {
+    const event = syncEventInstanceToBrowser(baseInstance());
+
+    expect(event.content).not.toHaveProperty("color");
+  });
 });

--- a/packages/backend/src/common/services/sync-service/event-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.ts
@@ -2,6 +2,13 @@ import { type Event, EventSchema } from "@core/types/event.contracts";
 import { type SyncEventInstance } from "@core/types/sync/event.contracts";
 import { composeOccurrenceId } from "./occurrence-id";
 
+const toBrowserDetails = (content: SyncEventInstance["content"]) => ({
+  kind: "details" as const,
+  title: content.title,
+  description: content.description,
+  ...(content.color !== undefined ? { color: content.color } : {}),
+});
+
 // Translate one sync full-fidelity instance into the browser Event contract.
 // D1=II: singles and series-master rows keep the real eventId; projected
 // occurrences get a composed id the write path can reverse. content.kind is
@@ -15,11 +22,7 @@ export const syncEventInstanceToBrowser = (
       return EventSchema.parse({
         id: instance.eventId,
         calendarId: instance.calendarId,
-        content: {
-          kind: "details",
-          title: instance.content.title,
-          description: instance.content.description,
-        },
+        content: toBrowserDetails(instance.content),
         schedule: instance.schedule,
         recurrence: { kind: "single" },
         createdAt: instance.createdAt,
@@ -29,11 +32,7 @@ export const syncEventInstanceToBrowser = (
       return EventSchema.parse({
         id: instance.eventId,
         calendarId: instance.calendarId,
-        content: {
-          kind: "details",
-          title: instance.content.title,
-          description: instance.content.description,
-        },
+        content: toBrowserDetails(instance.content),
         schedule: instance.schedule,
         recurrence: { kind: "series", rules: instance.recurrence.rules },
         createdAt: instance.createdAt,
@@ -46,11 +45,7 @@ export const syncEventInstanceToBrowser = (
           recurrenceId: instance.recurrence.recurrenceId,
         }),
         calendarId: instance.calendarId,
-        content: {
-          kind: "details",
-          title: instance.content.title,
-          description: instance.content.description,
-        },
+        content: toBrowserDetails(instance.content),
         schedule: instance.schedule,
         recurrence: { kind: "occurrence", seriesId: instance.eventId },
         createdAt: instance.createdAt,

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -11,11 +11,13 @@ import {
   EventScheduleSchema,
   EventSchema,
 } from "@core/types/event.contracts";
+import { EventColorSlotSchema } from "@core/types/event-color.contracts";
 
 const EditableContentSchema = z.strictObject({
   kind: z.literal("details"),
   title: z.string(),
   description: z.string(),
+  color: EventColorSlotSchema.optional(),
 });
 
 export const RecurrenceScopeSchema = z.enum([

--- a/packages/core/src/types/event.contracts.test.ts
+++ b/packages/core/src/types/event.contracts.test.ts
@@ -47,6 +47,25 @@ describe("Event Contracts", () => {
       expect(result.success).toBe(false);
     });
 
+    it("accepts an optional event color on details content", () => {
+      const result = EventContentSchema.safeParse({
+        kind: "details",
+        title: "x",
+        description: "y",
+        color: "indigo",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({
+          kind: "details",
+          title: "x",
+          description: "y",
+          color: "indigo",
+        });
+      }
+    });
+
     it("rejects unknown keys on busy content", () => {
       const result = EventContentSchema.safeParse({ kind: "busy", extra: 1 });
 

--- a/packages/core/src/types/event.contracts.ts
+++ b/packages/core/src/types/event.contracts.ts
@@ -7,12 +7,14 @@ import {
   RRuleSchema,
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
+import { EventColorSlotSchema } from "@core/types/event-color.contracts";
 
 export const EventContentSchema = z.discriminatedUnion("kind", [
   z.strictObject({
     kind: z.literal("details"),
     title: z.string(),
     description: z.string(),
+    color: EventColorSlotSchema.optional(),
   }),
   z.strictObject({ kind: z.literal("busy") }),
 ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expose optional event color on the browser Event contract and translate it through backend sync adapters.

Imported Google colors already live on sync content. This wires them into app-facing `Event` details (and editable create/replace content) so the client can receive colors on list reads and carry them on writes. Display and Google write-back land in follow-up PRs.

## Changes

- Optional `color: EventColorSlot` on details content in `EventSchema` and editable command content
- `syncEventInstanceToBrowser` forwards color when present
- `toSyncContent` forwards color when the browser sets one
- Contract and translation tests
- Architecture doc: remove A9 carve-out; document optional color on details content

## Verification

- `bun run type-check`
- `bun run test:core`
- `bun run test:backend`
- biome on changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

