### PR TITLE
feat(sync): write event colors back to Google

### DIFF
--- a/packages/sync/src/domain/merge-update-content.test.ts
+++ b/packages/sync/src/domain/merge-update-content.test.ts
@@ -35,4 +35,48 @@ describe("mergeUpdateContent", () => {
       conference: existing.conference,
     });
   });
+
+  it("applies an incoming color and preserves existing color when omitted", () => {
+    const existing = {
+      title: "Old",
+      description: "Old desc",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      color: "blue" as const,
+    };
+
+    expect(
+      mergeUpdateContent(existing, {
+        title: "New",
+        description: "New desc",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+        color: "coral",
+      }),
+    ).toEqual({
+      ...existing,
+      title: "New",
+      description: "New desc",
+      color: "coral",
+    });
+
+    expect(
+      mergeUpdateContent(existing, {
+        title: "New",
+        description: "New desc",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      }),
+    ).toEqual({
+      ...existing,
+      title: "New",
+      description: "New desc",
+    });
+  });
 });

--- a/packages/sync/src/domain/merge-update-content.ts
+++ b/packages/sync/src/domain/merge-update-content.ts
@@ -1,10 +1,12 @@
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 
-// Browser edits only title + description. An update command still carries a
-// full SyncEventContent (strict schema), and the Compass API pads the richer
-// fields with null/[] — so applying the wire content verbatim would wipe
-// attendees/location/conference Sync already holds from the provider.
-// Merge: take editable fields from the command, keep the rest from existing.
+// Browser edits only title + description (+ optional color). An update command
+// still carries a full SyncEventContent (strict schema), and the Compass API
+// pads the richer fields with null/[] — so applying the wire content verbatim
+// would wipe attendees/location/conference Sync already holds from the
+// provider. Merge: take editable fields from the command, keep the rest from
+// existing. Color is applied only when the command sets one; omitting it
+// preserves whatever Sync already stores.
 export function mergeUpdateContent(
   existing: SyncEventContent,
   incoming: SyncEventContent,
@@ -13,5 +15,6 @@ export function mergeUpdateContent(
     ...existing,
     title: incoming.title,
     description: incoming.description,
+    ...(incoming.color !== undefined ? { color: incoming.color } : {}),
   };
 }

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -619,7 +619,7 @@ function exceptionInstant(event: EventRecord): DateTime {
 // Whether the provider's current event already carries this command's intended
 // edit — the signal that a prior attempt landed and this is a safe replay.
 // Compares ONLY the fields a patch actually writes (title, description,
-// location, schedule, recurrence). organizer/attendees/conference are
+// location, color, schedule, recurrence). organizer/attendees/conference are
 // read-reflected, not written by the provider adapter, so they drift
 // independently (e.g. an attendee RSVPs) — comparing them would turn a landed
 // edit into a false miss, then a stale-version patch, then a spurious
@@ -639,6 +639,7 @@ function matchesIntendedEdit(
     current.content.title === content.title &&
     current.content.description === content.description &&
     current.content.location === content.location &&
+    current.content.color === content.color &&
     deepEqual(current.schedule, schedule) &&
     recurrenceMatches(current.recurrence, recurrence)
   );

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -371,6 +371,20 @@ describe("GoogleEventWriter", () => {
     });
   });
 
+  it("maps content.color onto Google colorId and omits colorId when unset", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({
+      ...baseCreate,
+      content: content({ color: "blue" }),
+    });
+    await writer.patchEvent({ ...basePatch, content: content() });
+
+    expect(api.calls.insert[0].requestBody.colorId).toBe("7");
+    expect(api.calls.patch[0].requestBody).not.toHaveProperty("colorId");
+  });
+
   it("maps each invitation intent straight to sendUpdates", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -3,6 +3,7 @@ import { OAuth2Client } from "google-auth-library";
 import { type EventSchedule } from "@core/types/event.contracts";
 import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import { slotToGoogleColorId } from "@sync/providers/google/google-color.map";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
 import { type ProviderEventRead } from "@sync/providers/provider-event.port";
 import {
@@ -215,6 +216,9 @@ function toGoogleBody(
     summary: content.title,
     description: content.description,
     location: content.location,
+    ...(content.color !== undefined
+      ? { colorId: slotToGoogleColorId(content.color) }
+      : {}),
     ...scheduleFields(schedule),
     recurrence: recurrence.kind === "series" ? [...recurrence.rules] : null,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Write Compass event colors back to Google Calendar and keep them stable across updates.

Sync already stores optional `content.color` from ingest. This completes the provider write path: update merges apply color when set (and preserve it when omitted), Google create/patch bodies include `colorId`, and replay detection compares color so a color-only edit is not treated as already landed.

## Changes

- `mergeUpdateContent` applies incoming color when present; omits keep existing
- `toGoogleBody` maps `content.color` to Google `colorId` via `slotToGoogleColorId`
- `matchesIntendedEdit` compares `color`
- Unit tests for merge and writer mapping

## Verification

- `bun run type-check`
- `bun run test:sync` (639 pass)
- biome on changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

