### PR TITLE
feat(web): paint Google event colors on grid cards

### DIFF
--- a/packages/web/src/common/styles/theme.util.test.ts
+++ b/packages/web/src/common/styles/theme.util.test.ts
@@ -1,0 +1,22 @@
+import {
+  EVENT_COLOR_SLOT_HEX,
+  getEventPalette,
+} from "@web/common/styles/theme.util";
+import { describe, expect, it } from "bun:test";
+
+describe("theme.util event color slots", () => {
+  it("maps all 11 slots to Google modern palette hexes", () => {
+    expect(Object.keys(EVENT_COLOR_SLOT_HEX)).toHaveLength(11);
+    expect(EVENT_COLOR_SLOT_HEX.lavender).toBe("#7986CB");
+    expect(EVENT_COLOR_SLOT_HEX.blue).toBe("#039BE5");
+    expect(EVENT_COLOR_SLOT_HEX.red).toBe("#D50000");
+  });
+
+  it("builds a palette from a color slot and falls back to the theme default", () => {
+    expect(getEventPalette("coral").base).toBe(EVENT_COLOR_SLOT_HEX.coral);
+    expect(getEventPalette("coral").hover).not.toBe(
+      getEventPalette("coral").base,
+    );
+    expect(getEventPalette().base).not.toBe(EVENT_COLOR_SLOT_HEX.coral);
+  });
+});

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -1,3 +1,4 @@
+import { type EventColorSlot } from "@core/types/event-color.contracts";
 import { type ThemeName } from "@web/settings/theme/theme.constants";
 import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
 import { brighten, darken } from "./color.utils";
@@ -17,6 +18,23 @@ const EVENT_BASE_COLOR: Record<ThemeName, string> = {
   "light-beach": "#454442",
 };
 
+// Google Calendar's modern event color palette (colors.get event backgrounds),
+// keyed by Compass EventColorSlot. Used when an event carries a color tag;
+// otherwise cards fall back to EVENT_BASE_COLOR for the active theme.
+export const EVENT_COLOR_SLOT_HEX: Record<EventColorSlot, string> = {
+  lavender: "#7986CB",
+  mint: "#33B679",
+  plum: "#8E24AA",
+  coral: "#E67C73",
+  gold: "#F6BF26",
+  orange: "#F4511E",
+  blue: "#039BE5",
+  slate: "#616161",
+  indigo: "#3F51B5",
+  green: "#0B8043",
+  red: "#D50000",
+};
+
 export interface EventPalette {
   base: string;
   /** Derived (not a fixed hex) so the hover delta scales with the base the
@@ -29,20 +47,20 @@ export interface EventPalette {
   saveButtonShadow: string;
 }
 
-const buildEventPalette = (theme: ThemeName): EventPalette => {
-  const base = EVENT_BASE_COLOR[theme];
-  return {
-    base,
-    hover: brighten(base),
-    gradient: `linear-gradient(90deg, ${darken(base, 15)}, ${darken(base, 30)})`,
-    // Undarkened: darken(base) sat right at the mid-tone dead zone (see
-    // getContrastText above), leaving Save's text only ~5:1 against its own
-    // fill. The plain base clears 6.5:1+ in both themes; saveButtonShadow
-    // still carries the "elevated" depth cue.
-    saveButtonBg: base,
-    saveButtonShadow: darken(base, 25),
-  };
-};
+const buildEventPaletteFromBase = (base: string): EventPalette => ({
+  base,
+  hover: brighten(base),
+  gradient: `linear-gradient(90deg, ${darken(base, 15)}, ${darken(base, 30)})`,
+  // Undarkened: darken(base) sat right at the mid-tone dead zone (see
+  // getContrastText above), leaving Save's text only ~5:1 against its own
+  // fill. The plain base clears 6.5:1+ in both themes; saveButtonShadow
+  // still carries the "elevated" depth cue.
+  saveButtonBg: base,
+  saveButtonShadow: darken(base, 25),
+});
+
+const buildEventPalette = (theme: ThemeName): EventPalette =>
+  buildEventPaletteFromBase(EVENT_BASE_COLOR[theme]);
 
 // Precomputed for both themes at module load — consumers just index in.
 const EVENT_PALETTES: Record<ThemeName, EventPalette> = {
@@ -50,15 +68,24 @@ const EVENT_PALETTES: Record<ThemeName, EventPalette> = {
   "light-beach": buildEventPalette("light-beach"),
 };
 
-/** The active theme's event palette; subscribes so a theme switch re-renders
- * the caller with the new fills. */
-export const useEventPalette = (): EventPalette =>
-  EVENT_PALETTES[useThemeStore(selectTheme)];
+/** The active theme's event palette, or a Google-slot fill when `color` is
+ * set. Subscribes so a theme switch re-renders the default (no-slot) case. */
+export const useEventPalette = (color?: EventColorSlot): EventPalette => {
+  const themeName = useThemeStore(selectTheme);
+  if (color !== undefined) {
+    return buildEventPaletteFromBase(EVENT_COLOR_SLOT_HEX[color]);
+  }
+  return EVENT_PALETTES[themeName];
+};
 
 /** Non-reactive read for plain functions (e.g. getGradient's identity check).
  * Components should use useEventPalette so they repaint on switch. */
-export const getEventPalette = (): EventPalette =>
-  EVENT_PALETTES[useThemeStore.getState().theme];
+export const getEventPalette = (color?: EventColorSlot): EventPalette => {
+  if (color !== undefined) {
+    return buildEventPaletteFromBase(EVENT_COLOR_SLOT_HEX[color]);
+  }
+  return EVENT_PALETTES[useThemeStore.getState().theme];
+};
 
 // CSS-variable gradients: these land in inline `background` styles, so the
 // browser resolves them against the active [data-theme] — no JS hex needed.

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 import { ValidatedCompassEventSchema } from "@core/types/compass-event.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { EventColorSlotSchema } from "@core/types/event-color.contracts";
 
 /** Event category, based on its display type */
 export enum Categories_Event {
@@ -53,5 +54,9 @@ export const GridEventSchema = WebEventSchema.extend({
   isDemo: z.boolean().optional(),
   /** Timed event shown in the all-day row because it spans midnight. */
   isTimedMultiDayDisplay: z.boolean().optional(),
+  // Optional Google-mapped event color tag. Joined like calendarId — not part
+  // of CompassEvent — so cards can paint a per-event fill without widening
+  // the shared core type.
+  color: EventColorSlotSchema.optional(),
 });
 export type GridEvent = z.infer<typeof GridEventSchema>;

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -3,6 +3,7 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
+import { type EventColorSlot } from "@core/types/event-color.contracts";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -270,15 +271,23 @@ export function gridEventDraftToGridEvent(draft: GridEventDraft): GridEvent {
 }
 
 // Converts a grid draft to the CompassEvent-shaped view used by schema
-// overlays, Day placeholders, and context-menu props. calendarId/isBusy are
-// widened onto the return (rather than adding them to the shared core
-// CompassEvent interface) so colored accents and the busy read-only gate stay
-// correct without a second lookup.
+// overlays, Day placeholders, and context-menu props. calendarId/isBusy/color
+// are widened onto the return (rather than adding them to the shared core
+// CompassEvent interface) so colored accents, the busy read-only gate, and
+// per-event fill stay correct without a second lookup.
 export function gridEventDraftToSchemaEvent(
   draft: GridEventDraft,
   seriesRules?: readonly string[],
-): CompassEvent & { calendarId?: CalendarId; isBusy?: boolean } {
+): CompassEvent & {
+  calendarId?: CalendarId;
+  isBusy?: boolean;
+  color?: EventColorSlot;
+} {
   const { schedule } = draft.values;
+  const color =
+    draft.kind === "edit" && draft.source.content.kind === "details"
+      ? draft.source.content.color
+      : undefined;
 
   return {
     _id: draft.kind === "edit" ? draft.source.id : draft.clientId,
@@ -290,6 +299,7 @@ export function gridEventDraftToSchemaEvent(
         : dayjs(schedule.end).format(),
     isAllDay: schedule.kind === "allDay",
     isBusy: draft.kind === "edit" && draft.source.content.kind === "busy",
+    ...(color !== undefined ? { color } : {}),
     recurrence: legacyRecurrenceFromDraft(draft, seriesRules),
     startDate:
       schedule.kind === "allDay"

--- a/packages/web/src/events/queries/event.view-model.test.ts
+++ b/packages/web/src/events/queries/event.view-model.test.ts
@@ -63,6 +63,26 @@ describe("Event query view models", () => {
     expect(userCard?.isDemo).toBe(false);
   });
 
+  test("carries optional content.color onto grid event cards", () => {
+    const colored = createMockEvent({
+      content: {
+        kind: "details",
+        title: "Blue meeting",
+        description: "",
+        color: "blue",
+      },
+    });
+    const plain = createMockEvent();
+    const result = deriveCalendarEventViewModel(normalized(colored, plain));
+
+    expect(
+      result.timedEvents.find(({ _id }) => _id === colored.id)?.color,
+    ).toBe("blue");
+    expect(
+      result.timedEvents.find(({ _id }) => _id === plain.id),
+    ).not.toHaveProperty("color");
+  });
+
   test("returns stable empty shapes", () => {
     const week = deriveCalendarEventViewModel();
     expect(week).toEqual({

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -2,6 +2,7 @@ import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
+import { type EventColorSlot } from "@core/types/event-color.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -74,14 +75,15 @@ const isValidScheduledEvent = (event: Event): boolean => {
   return isValid;
 };
 
-// Re-attaches calendarId + isBusy onto the GridEvent produced by the
-// Event -> CompassEvent -> GridEvent bridge above. scheduledEventToSchemaEvent
-// returns the hand-written core `CompassEvent` shape (compass-event.contracts.ts),
-// which has neither field, so the bridge itself can't carry them through
-// without widening that shared type (used by 10+ unrelated consumers). Joining
-// back by event id after assembleGridEvent keeps the bridge untouched and scopes
-// the new fields to GridEvent only (packet 08 steps 5 and 8). isBusy
-// backs the read-only gate - see isEventReadOnly in calendars/useCalendarLookup.ts.
+// Re-attaches calendarId + isBusy + optional color onto the GridEvent
+// produced by the Event -> CompassEvent -> GridEvent bridge above.
+// scheduledEventToSchemaEvent returns the hand-written core `CompassEvent`
+// shape (compass-event.contracts.ts), which has none of those fields, so the
+// bridge itself can't carry them through without widening that shared type
+// (used by 10+ unrelated consumers). Joining back by event id after
+// assembleGridEvent keeps the bridge untouched and scopes the new fields to
+// GridEvent only (packet 08 steps 5 and 8). isBusy backs the read-only gate
+// - see isEventReadOnly in calendars/useCalendarLookup.ts.
 const withCalendarMetadata = (
   events: Event[],
   gridEvents: GridEvent[],
@@ -90,11 +92,20 @@ const withCalendarMetadata = (
   const demoEventIdSet = new Set(demoEventIds ?? []);
   const metadataByEventId = new Map<
     string,
-    { calendarId: Event["calendarId"]; isBusy: boolean }
+    {
+      calendarId: Event["calendarId"];
+      isBusy: boolean;
+      color?: EventColorSlot;
+    }
   >(
     events.map((event) => [
       event.id,
-      { calendarId: event.calendarId, isBusy: event.content.kind === "busy" },
+      {
+        calendarId: event.calendarId,
+        isBusy: event.content.kind === "busy",
+        color:
+          event.content.kind === "details" ? event.content.color : undefined,
+      },
     ]),
   );
   return gridEvents.map((gridEvent) => {
@@ -108,6 +119,7 @@ const withCalendarMetadata = (
       isDemo: gridEvent._id
         ? demoEventIdSet.has(gridEvent._id as EventId)
         : false,
+      ...(metadata?.color !== undefined ? { color: metadata.color } : {}),
     };
   });
 };

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -56,7 +56,7 @@ const AllDayEventCardBase = (
   }: AllDayEventCardProps,
   ref: ForwardedRef<HTMLDivElement>,
 ) => {
-  const { base: baseColor, hover: hoverColor } = useEventPalette();
+  const { base: baseColor, hover: hoverColor } = useEventPalette(event.color);
   const isInPast = dayjs().isAfter(dayjs(event.endDate));
   const isRecurring = isRecurringEvent(event);
   const showRepeatIcon =

--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -112,6 +112,28 @@ describe("EventCard", () => {
     );
   });
 
+  it("paints a timed event with its content color slot fill", () => {
+    render(
+      <TimedEventCard
+        displayMode="saved"
+        event={createEvent({
+          color: "blue",
+          startDate: "2099-01-15T09:00:00.000Z",
+          endDate: "2099-01-15T10:00:00.000Z",
+        })}
+        motionMode="idle"
+        position={position}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: "Timed event: Planning block, 9 - 10 AM",
+    });
+    expect(card.style.getPropertyValue("--event-bg")).toBe(
+      getEventPalette("blue").base,
+    );
+  });
+
   it("keeps timed event keyboard activation from reaching parent shortcuts", () => {
     const onEventKeyDown = mock();
     const onParentKeyDown = mock();

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -123,7 +123,7 @@ const TimedEventCardBase = (
     [position.height, showTimeLabel],
   );
 
-  const { base: baseColor, hover: hoverColor } = useEventPalette();
+  const { base: baseColor, hover: hoverColor } = useEventPalette(event.color);
   // Darkened well past the mid-tone "dead zone" (where neither dark nor light
   // text clears 4.5:1) so the draft fill is unambiguously dark and takes the
   // light title color. On the dark theme that separates it from the lighter


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Paint imported Google event colors on calendar grid cards.

Events that carry an optional `content.color` slot now use Google's modern event palette for the card fill. Untagged events keep the theme-flat neutral fill. The calendar accent stripe is unchanged.

## Changes

- Slot-to-hex map and optional-arg `useEventPalette` / `getEventPalette`
- Optional `color` on `GridEvent`; view-model joins it from Event content
- Timed and all-day cards paint from `event.color` when present
- Edit drafts carry source color onto placeholder/draft cards
- Tests for palette, view-model pass-through, and card fill

## Verification

- `bun run type-check`
- `bun run test:web` (1398 pass)
- biome on changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

