### PR TITLE
feat(web): add event color picker with clear support

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -42,7 +42,7 @@ const UNKNOWN_CALENDAR_ID = CalendarIdSchema.parse("000000000000000000000000");
 export const toSyncContent = (content: {
   title: string;
   description: string;
-  color?: EventColorSlot;
+  color?: EventColorSlot | null;
 }): SyncEventContent => ({
   title: content.title,
   description: content.description,

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -17,7 +17,9 @@ const EditableContentSchema = z.strictObject({
   kind: z.literal("details"),
   title: z.string(),
   description: z.string(),
-  color: EventColorSlotSchema.optional(),
+  // Null clears a previously set color on replace; omit leaves sync color
+  // alone when the client did not touch it.
+  color: EventColorSlotSchema.nullable().optional(),
 });
 
 export const RecurrenceScopeSchema = z.enum([

--- a/packages/core/src/types/event.contracts.ts
+++ b/packages/core/src/types/event.contracts.ts
@@ -14,7 +14,9 @@ export const EventContentSchema = z.discriminatedUnion("kind", [
     kind: z.literal("details"),
     title: z.string(),
     description: z.string(),
-    color: EventColorSlotSchema.optional(),
+    // Null clears a previously set color tag on replace. Reads omit the field
+    // when there is no color.
+    color: EventColorSlotSchema.nullable().optional(),
   }),
   z.strictObject({ kind: z.literal("busy") }),
 ]);

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -104,7 +104,9 @@ export const SyncEventContentSchema = z.strictObject({
   organizer: OrganizerSchema.nullable(),
   attendees: z.array(AttendeeSchema).readonly(),
   conference: ConferenceSchema.nullable(),
-  color: EventColorSlotSchema.optional(),
+  // Null means "clear the color tag" on an update command. Stored/read
+  // records omit the field when there is no color.
+  color: EventColorSlotSchema.nullable().optional(),
 });
 export type SyncEventContent = z.infer<typeof SyncEventContentSchema>;
 

--- a/packages/sync/src/domain/merge-update-content.test.ts
+++ b/packages/sync/src/domain/merge-update-content.test.ts
@@ -79,4 +79,35 @@ describe("mergeUpdateContent", () => {
       description: "New desc",
     });
   });
+
+  it("clears an existing color when the command sends null", () => {
+    const existing = {
+      title: "Old",
+      description: "Old desc",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      color: "blue" as const,
+    };
+
+    expect(
+      mergeUpdateContent(existing, {
+        title: "Old",
+        description: "Old desc",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+        color: null,
+      }),
+    ).toEqual({
+      title: "Old",
+      description: "Old desc",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    });
+  });
 });

--- a/packages/sync/src/domain/merge-update-content.ts
+++ b/packages/sync/src/domain/merge-update-content.ts
@@ -5,16 +5,26 @@ import { type SyncEventContent } from "@core/types/sync/event.contracts";
 // pads the richer fields with null/[] — so applying the wire content verbatim
 // would wipe attendees/location/conference Sync already holds from the
 // provider. Merge: take editable fields from the command, keep the rest from
-// existing. Color is applied only when the command sets one; omitting it
-// preserves whatever Sync already stores.
+// existing. Color: a slot replaces, null clears (field omitted), omit keeps
+// whatever Sync already stores.
 export function mergeUpdateContent(
   existing: SyncEventContent,
   incoming: SyncEventContent,
 ): SyncEventContent {
-  return {
+  const base: SyncEventContent = {
     ...existing,
     title: incoming.title,
     description: incoming.description,
-    ...(incoming.color !== undefined ? { color: incoming.color } : {}),
   };
+
+  if (incoming.color === null) {
+    const { color: _cleared, ...withoutColor } = base;
+    return withoutColor;
+  }
+
+  if (incoming.color !== undefined) {
+    return { ...base, color: incoming.color };
+  }
+
+  return base;
 }

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -635,11 +635,14 @@ function matchesIntendedEdit(
   schedule: EventSchedule,
   recurrence: ProviderWriteRecurrence,
 ): boolean {
+  // Null on the command means "no color"; treat it like an absent color on
+  // the provider read so a clear that already landed counts as a replay.
+  const intendedColor = content.color === null ? undefined : content.color;
   return (
     current.content.title === content.title &&
     current.content.description === content.description &&
     current.content.location === content.location &&
-    current.content.color === content.color &&
+    current.content.color === intendedColor &&
     deepEqual(current.schedule, schedule) &&
     recurrenceMatches(current.recurrence, recurrence)
   );

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -385,6 +385,18 @@ describe("GoogleEventWriter", () => {
     expect(api.calls.patch[0].requestBody).not.toHaveProperty("colorId");
   });
 
+  it("clears Google colorId when content.color is null", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent({
+      ...basePatch,
+      content: content({ color: null }),
+    });
+
+    expect(api.calls.patch[0].requestBody.colorId).toBeNull();
+  });
+
   it("maps each invitation intent straight to sendUpdates", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -216,9 +216,11 @@ function toGoogleBody(
     summary: content.title,
     description: content.description,
     location: content.location,
-    ...(content.color !== undefined
-      ? { colorId: slotToGoogleColorId(content.color) }
-      : {}),
+    ...(content.color === null
+      ? { colorId: null }
+      : content.color !== undefined
+        ? { colorId: slotToGoogleColorId(content.color) }
+        : {}),
     ...scheduleFields(schedule),
     recurrence: recurrence.kind === "series" ? [...recurrence.rules] : null,
   };

--- a/packages/web/src/events/event-draft.parser.test.ts
+++ b/packages/web/src/events/event-draft.parser.test.ts
@@ -46,6 +46,7 @@ const newFormValues = (
   description: "",
   schedule: timedSchedule(),
   calendarId: calendarId(),
+  color: null,
   recurrence: { kind: "single" },
   ...overrides,
 });
@@ -66,6 +67,7 @@ const editFormValues = (
   description: "",
   schedule: timedSchedule(),
   calendarId: calendarId(),
+  color: null,
   recurrence: { kind: "preserve" },
   scope: "this",
   ...overrides,
@@ -99,6 +101,23 @@ describe("parseEventDraft", () => {
       expect(result.input.schedule.start).toContain("-06:00");
       expect(result.input.schedule.end).toContain("-06:00");
       expect(CreateEventInputSchema.parse(result.input)).toBeTruthy();
+    });
+
+    it("includes a selected color and sends null when cleared", () => {
+      const withColor = parseEventDraft(newDraft({ color: "coral" }));
+      expect(withColor.ok).toBe(true);
+      if (!withColor.ok) throw new Error("expected ok");
+      expect(withColor.input.content).toEqual({
+        kind: "details",
+        title: "Standup",
+        description: "",
+        color: "coral",
+      });
+
+      const cleared = parseEventDraft(editDraft({ color: null }));
+      expect(cleared.ok).toBe(true);
+      if (!cleared.ok) throw new Error("expected ok");
+      expect(cleared.input.content.color).toBeNull();
     });
 
     it("normalizes a same-day all-day selection to an exclusive end", () => {

--- a/packages/web/src/events/event-draft.parser.ts
+++ b/packages/web/src/events/event-draft.parser.ts
@@ -200,6 +200,10 @@ export function parseEventDraft(draft: EventDraft): ParseEventDraftResult {
     kind: "details" as const,
     title: draft.values.title,
     description: draft.values.description,
+    // Always include: a slot sets the tag, null clears it on edit (and is a
+    // no-op clear on create). Omitting would preserve an existing sync color
+    // on title-only saves that still carry an explicit draft color of null.
+    color: draft.values.color,
   };
 
   if (draft.mode === "create") {

--- a/packages/web/src/events/event-draft.types.ts
+++ b/packages/web/src/events/event-draft.types.ts
@@ -1,5 +1,6 @@
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
+import { type EventColorSlot } from "@core/types/event-color.contracts";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
 
 // Drafts use required keys with nullable incomplete values. This confines
@@ -29,6 +30,8 @@ type SharedEventFormValues = {
   title: string;
   description: string;
   schedule: EventScheduleDraft;
+  // Null means calendar-default / no event color tag.
+  color: EventColorSlot | null;
 };
 
 // A new draft can only use "single" or "series" and has no irrelevant

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -52,6 +52,7 @@ export function createGridEventDraft(
       description: "",
       schedule,
       calendarId,
+      color: null,
       recurrence: { kind: "single" },
     },
   };
@@ -98,6 +99,8 @@ export function editGridEventDraft(
         event.content.kind === "details" ? event.content.description : "",
       schedule,
       calendarId: event.calendarId,
+      color:
+        event.content.kind === "details" ? (event.content.color ?? null) : null,
       recurrence: { kind: "preserve" },
       scope,
     },
@@ -142,6 +145,8 @@ export function duplicateGridEventDraft(
         event.content.kind === "details" ? event.content.description : "",
       schedule,
       calendarId,
+      color:
+        event.content.kind === "details" ? (event.content.color ?? null) : null,
       recurrence:
         event.recurrence.kind === "series"
           ? { kind: "series", rules: [...event.recurrence.rules] }
@@ -284,10 +289,7 @@ export function gridEventDraftToSchemaEvent(
   color?: EventColorSlot;
 } {
   const { schedule } = draft.values;
-  const color =
-    draft.kind === "edit" && draft.source.content.kind === "details"
-      ? draft.source.content.color
-      : undefined;
+  const color = draft.values.color ?? undefined;
 
   return {
     _id: draft.kind === "edit" ? draft.source.id : draft.clientId,
@@ -390,7 +392,9 @@ export function patchGridDraftScheduleDates(
 
 export function patchGridDraftFields(
   current: GridEventDraft,
-  patch: Partial<Pick<GridEventDraft["values"], "title" | "description">>,
+  patch: Partial<
+    Pick<GridEventDraft["values"], "title" | "description" | "color">
+  >,
 ): GridEventDraft {
   if (current.kind === "create") {
     return {
@@ -401,6 +405,7 @@ export function patchGridDraftFields(
         ...(patch.description !== undefined
           ? { description: patch.description }
           : {}),
+        ...(patch.color !== undefined ? { color: patch.color } : {}),
       },
     };
   }
@@ -413,6 +418,7 @@ export function patchGridDraftFields(
       ...(patch.description !== undefined
         ? { description: patch.description }
         : {}),
+      ...(patch.color !== undefined ? { color: patch.color } : {}),
     },
   };
 }

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -104,7 +104,9 @@ const withCalendarMetadata = (
         calendarId: event.calendarId,
         isBusy: event.content.kind === "busy",
         color:
-          event.content.kind === "details" ? event.content.color : undefined,
+          event.content.kind === "details"
+            ? (event.content.color ?? undefined)
+            : undefined,
       },
     ]),
   );

--- a/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+
+import { EventColorPicker } from "./EventColorPicker";
+
+describe("EventColorPicker", () => {
+  it("selects a color slot and can clear back to calendar default", async () => {
+    const user = userEvent.setup();
+    const onChange = mock();
+
+    const { rerender } = render(
+      <EventColorPicker value={null} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: "blue" }));
+    expect(onChange).toHaveBeenCalledWith("blue");
+
+    rerender(<EventColorPicker value="blue" onChange={onChange} />);
+    await user.click(
+      screen.getByRole("radio", { name: "Calendar default color" }),
+    );
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
@@ -1,0 +1,46 @@
+import {
+  type EventColorSlot,
+  EventColorSlotSchema,
+} from "@core/types/event-color.contracts";
+import { EVENT_COLOR_SLOT_HEX } from "@web/common/styles/theme.util";
+
+const COLOR_SLOTS = EventColorSlotSchema.options;
+
+export interface EventColorPickerProps {
+  value: EventColorSlot | null;
+  onChange: (color: EventColorSlot | null) => void;
+}
+
+const swatchClassName =
+  "h-5 w-5 cursor-pointer appearance-none rounded-sm border border-transparent checked:border-text checked:outline checked:outline-2 checked:outline-offset-1 checked:outline-text focus-visible:ring-2 focus-visible:ring-accent";
+
+export const EventColorPicker = ({
+  value,
+  onChange,
+}: EventColorPickerProps) => (
+  <fieldset className="m-0 min-w-0 border-0 p-0">
+    <legend className="sr-only">Event color</legend>
+    <div className="flex flex-wrap items-center gap-1.5">
+      <input
+        type="radio"
+        name="event-color"
+        checked={value === null}
+        aria-label="Calendar default color"
+        className={`${swatchClassName} border-border bg-bg-primary`}
+        onChange={() => onChange(null)}
+      />
+      {COLOR_SLOTS.map((slot) => (
+        <input
+          key={slot}
+          type="radio"
+          name="event-color"
+          checked={value === slot}
+          aria-label={slot}
+          className={swatchClassName}
+          style={{ backgroundColor: EVENT_COLOR_SLOT_HEX[slot] }}
+          onChange={() => onChange(slot)}
+        />
+      ))}
+    </div>
+  </fieldset>
+);

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -50,6 +50,7 @@ import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSect
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
 import { RecurrenceSection } from "@web/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection";
 import { EventActionMenu } from "@web/views/Forms/EventForm/EventActionMenu";
+import { EventColorPicker } from "@web/views/Forms/EventForm/EventColorPicker/EventColorPicker";
 import { SaveSection } from "@web/views/Forms/EventForm/SaveSection";
 import { TitleActionsRow } from "@web/views/Forms/EventForm/TitleActionsRow";
 import {
@@ -175,8 +176,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         ? seriesBase.recurrence.rules
         : undefined;
 
-    const { title, description } = draft.values;
-    const { base: eventColor } = useEventPalette();
+    const { title, description, color } = draft.values;
+    const { base: eventColor } = useEventPalette(color ?? undefined);
     const category =
       draft.values.schedule.kind === "allDay"
         ? Categories_Event.ALLDAY
@@ -308,7 +309,9 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
     const patchDraftFields = useCallback(
       (
-        patch: Partial<Pick<GridEventDraft["values"], "title" | "description">>,
+        patch: Partial<
+          Pick<GridEventDraft["values"], "title" | "description" | "color">
+        >,
       ) => {
         setLatestDraft((current) => {
           if (!current) return current;
@@ -661,6 +664,10 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                   Calendar: {originalCalendarName}
                 </p>
               )}
+              <EventColorPicker
+                value={color}
+                onChange={(next) => patchDraftFields({ color: next })}
+              />
             </FormCard>
 
             <FormCard>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an event color picker to the form, including clear back to the calendar default.

Users can pick one of the 11 Google-mapped color slots or clear the tag. Clearing is first-class: contracts accept `null`, sync merge drops the stored color, and Google patches get `colorId: null`. Form accents follow the selected slot.

## Changes

- Nullable optional `color` on event/sync/editable content contracts
- Merge clears on `null`; Google writer emits `colorId: null`
- Draft values carry `color: EventColorSlot | null`; parser always includes it
- `EventColorPicker` in the event form (next to calendar)
- Tests for picker, parser, merge clear, and Google clear

## Verification

- `bun run type-check`
- `bun run test:core` / `test:sync` / `test:backend` / `test:web`
- biome on changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

