### PR TITLE
refactor: simplify event color plumbing helpers

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -7,7 +7,10 @@ import {
   EventIdSchema,
 } from "@core/types/domain-primitives";
 import { type Event, EventSchema } from "@core/types/event.contracts";
-import { type EventColorSlot } from "@core/types/event-color.contracts";
+import {
+  type EventColorSlot,
+  withColor,
+} from "@core/types/event-color.contracts";
 import {
   type CreateEventInput,
   type DeleteEventInput,
@@ -50,7 +53,7 @@ export const toSyncContent = (content: {
   organizer: null,
   attendees: [],
   conference: null,
-  ...(content.color !== undefined ? { color: content.color } : {}),
+  ...withColor(content.color),
 });
 
 export interface CommandTarget {

--- a/packages/backend/src/common/services/sync-service/event-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.ts
@@ -1,4 +1,5 @@
 import { type Event, EventSchema } from "@core/types/event.contracts";
+import { withColor } from "@core/types/event-color.contracts";
 import { type SyncEventInstance } from "@core/types/sync/event.contracts";
 import { composeOccurrenceId } from "./occurrence-id";
 
@@ -6,7 +7,7 @@ const toBrowserDetails = (content: SyncEventInstance["content"]) => ({
   kind: "details" as const,
   title: content.title,
   description: content.description,
-  ...(content.color !== undefined ? { color: content.color } : {}),
+  ...withColor(content.color),
 });
 
 // Translate one sync full-fidelity instance into the browser Event contract.
@@ -17,39 +18,35 @@ const toBrowserDetails = (content: SyncEventInstance["content"]) => ({
 export const syncEventInstanceToBrowser = (
   instance: SyncEventInstance,
 ): Event => {
+  const shared = {
+    calendarId: instance.calendarId,
+    content: toBrowserDetails(instance.content),
+    schedule: instance.schedule,
+    createdAt: instance.createdAt,
+    updatedAt: instance.updatedAt,
+  };
+
   switch (instance.recurrence.kind) {
     case "single":
       return EventSchema.parse({
+        ...shared,
         id: instance.eventId,
-        calendarId: instance.calendarId,
-        content: toBrowserDetails(instance.content),
-        schedule: instance.schedule,
         recurrence: { kind: "single" },
-        createdAt: instance.createdAt,
-        updatedAt: instance.updatedAt,
       });
     case "series":
       return EventSchema.parse({
+        ...shared,
         id: instance.eventId,
-        calendarId: instance.calendarId,
-        content: toBrowserDetails(instance.content),
-        schedule: instance.schedule,
         recurrence: { kind: "series", rules: instance.recurrence.rules },
-        createdAt: instance.createdAt,
-        updatedAt: instance.updatedAt,
       });
     case "occurrence":
       return EventSchema.parse({
+        ...shared,
         id: composeOccurrenceId({
           eventId: instance.eventId,
           recurrenceId: instance.recurrence.recurrenceId,
         }),
-        calendarId: instance.calendarId,
-        content: toBrowserDetails(instance.content),
-        schedule: instance.schedule,
         recurrence: { kind: "occurrence", seriesId: instance.eventId },
-        createdAt: instance.createdAt,
-        updatedAt: instance.updatedAt,
       });
   }
 };

--- a/packages/core/src/types/event-color.contracts.test.ts
+++ b/packages/core/src/types/event-color.contracts.test.ts
@@ -1,0 +1,16 @@
+import { withColor } from "@core/types/event-color.contracts";
+import { describe, expect, it } from "bun:test";
+
+describe("withColor", () => {
+  it("includes a slot or null and omits when undefined", () => {
+    expect({ title: "x", ...withColor("blue") }).toEqual({
+      title: "x",
+      color: "blue",
+    });
+    expect({ title: "x", ...withColor(null) }).toEqual({
+      title: "x",
+      color: null,
+    });
+    expect({ title: "x", ...withColor(undefined) }).toEqual({ title: "x" });
+  });
+});

--- a/packages/core/src/types/event-color.contracts.ts
+++ b/packages/core/src/types/event-color.contracts.ts
@@ -16,3 +16,22 @@ export const EventColorSlotSchema = z.enum([
   "red",
 ]);
 export type EventColorSlot = z.infer<typeof EventColorSlotSchema>;
+
+// Optional on reads; nullable on write commands so null can clear a tag.
+export const OptionalNullableEventColorSchema =
+  EventColorSlotSchema.nullable().optional();
+
+// Spread into an object literal: include `color` only when the caller set it.
+// Undefined means "leave the field out". Overloads keep slot-only call sites
+// from widening to `null`.
+export function withColor(
+  color: EventColorSlot | undefined,
+): { color: EventColorSlot } | Record<string, never>;
+export function withColor(
+  color: EventColorSlot | null | undefined,
+): { color: EventColorSlot | null } | Record<string, never>;
+export function withColor(
+  color: EventColorSlot | null | undefined,
+): { color: EventColorSlot | null } | Record<string, never> {
+  return color === undefined ? {} : { color };
+}

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -11,7 +11,7 @@ import {
   EventScheduleSchema,
   EventSchema,
 } from "@core/types/event.contracts";
-import { EventColorSlotSchema } from "@core/types/event-color.contracts";
+import { OptionalNullableEventColorSchema } from "@core/types/event-color.contracts";
 
 const EditableContentSchema = z.strictObject({
   kind: z.literal("details"),
@@ -19,7 +19,7 @@ const EditableContentSchema = z.strictObject({
   description: z.string(),
   // Null clears a previously set color on replace; omit leaves sync color
   // alone when the client did not touch it.
-  color: EventColorSlotSchema.nullable().optional(),
+  color: OptionalNullableEventColorSchema,
 });
 
 export const RecurrenceScopeSchema = z.enum([

--- a/packages/core/src/types/event.contracts.ts
+++ b/packages/core/src/types/event.contracts.ts
@@ -7,7 +7,7 @@ import {
   RRuleSchema,
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
-import { EventColorSlotSchema } from "@core/types/event-color.contracts";
+import { OptionalNullableEventColorSchema } from "@core/types/event-color.contracts";
 
 export const EventContentSchema = z.discriminatedUnion("kind", [
   z.strictObject({
@@ -16,7 +16,7 @@ export const EventContentSchema = z.discriminatedUnion("kind", [
     description: z.string(),
     // Null clears a previously set color tag on replace. Reads omit the field
     // when there is no color.
-    color: EventColorSlotSchema.nullable().optional(),
+    color: OptionalNullableEventColorSchema,
   }),
   z.strictObject({ kind: z.literal("busy") }),
 ]);

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -6,7 +6,10 @@ import {
   RRuleSchema,
 } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
-import { EventColorSlotSchema } from "@core/types/event-color.contracts";
+import {
+  EventColorSlotSchema,
+  OptionalNullableEventColorSchema,
+} from "@core/types/event-color.contracts";
 import {
   ConnectionIdSchema,
   ProviderCalendarIdSchema,
@@ -106,7 +109,7 @@ export const SyncEventContentSchema = z.strictObject({
   conference: ConferenceSchema.nullable(),
   // Null means "clear the color tag" on an update command. Stored/read
   // records omit the field when there is no color.
-  color: EventColorSlotSchema.nullable().optional(),
+  color: OptionalNullableEventColorSchema,
 });
 export type SyncEventContent = z.infer<typeof SyncEventContentSchema>;
 

--- a/packages/sync/src/domain/event-instance-assembly.ts
+++ b/packages/sync/src/domain/event-instance-assembly.ts
@@ -1,3 +1,4 @@
+import { withColor } from "@core/types/event-color.contracts";
 import {
   type SyncEventInstance,
   SyncEventInstanceSchema,
@@ -43,13 +44,7 @@ export function assembleEventInstances(
     const event = eventsById.get(occurrence.eventId);
     if (!event) continue;
 
-    const content = {
-      title: event.content.title,
-      description: event.content.description,
-      ...(event.content.color !== undefined
-        ? { color: event.content.color }
-        : {}),
-    };
+    const content = toInstanceContent(event.content);
     const timestamps = {
       createdAt: event.createdAt.toISOString(),
       updatedAt: event.updatedAt.toISOString(),
@@ -116,13 +111,7 @@ export function assembleEventInstances(
       SyncEventInstanceSchema.parse({
         eventId: master._id,
         calendarId: master.calendarId,
-        content: {
-          title: master.content.title,
-          description: master.content.description,
-          ...(master.content.color !== undefined
-            ? { color: master.content.color }
-            : {}),
-        },
+        content: toInstanceContent(master.content),
         schedule: master.schedule,
         recurrence: { kind: "series", rules: master.recurrence.rules },
         createdAt: master.createdAt.toISOString(),
@@ -133,3 +122,9 @@ export function assembleEventInstances(
 
   return instances;
 }
+
+const toInstanceContent = (content: EventRecord["content"]) => ({
+  title: content.title,
+  description: content.description,
+  ...withColor(content.color),
+});

--- a/packages/sync/src/domain/merge-update-content.ts
+++ b/packages/sync/src/domain/merge-update-content.ts
@@ -2,29 +2,25 @@ import { type SyncEventContent } from "@core/types/sync/event.contracts";
 
 // Browser edits only title + description (+ optional color). An update command
 // still carries a full SyncEventContent (strict schema), and the Compass API
-// pads the richer fields with null/[] — so applying the wire content verbatim
-// would wipe attendees/location/conference Sync already holds from the
-// provider. Merge: take editable fields from the command, keep the rest from
-// existing. Color: a slot replaces, null clears (field omitted), omit keeps
-// whatever Sync already stores.
+// pads richer fields with null/[] — applying that verbatim would wipe
+// attendees/location/conference Sync already holds from the provider.
+//
+// Merge editable fields from the command; keep the rest from existing.
+// Color: slot replaces, null clears (omit the field), omit keeps existing.
 export function mergeUpdateContent(
   existing: SyncEventContent,
   incoming: SyncEventContent,
 ): SyncEventContent {
-  const base: SyncEventContent = {
-    ...existing,
+  const { color: existingColor, ...existingWithoutColor } = existing;
+  const merged: SyncEventContent = {
+    ...existingWithoutColor,
     title: incoming.title,
     description: incoming.description,
   };
 
-  if (incoming.color === null) {
-    const { color: _cleared, ...withoutColor } = base;
-    return withoutColor;
-  }
-
-  if (incoming.color !== undefined) {
-    return { ...base, color: incoming.color };
-  }
-
-  return base;
+  if (incoming.color === null) return merged;
+  if (incoming.color !== undefined) return { ...merged, color: incoming.color };
+  return existingColor !== undefined
+    ? { ...merged, color: existingColor }
+    : merged;
 }

--- a/packages/sync/src/providers/google/google-color.map.test.ts
+++ b/packages/sync/src/providers/google/google-color.map.test.ts
@@ -1,5 +1,6 @@
 import {
   GOOGLE_COLOR_ID_TO_SLOT,
+  googleColorIdFields,
   googleColorIdToSlot,
   SLOT_TO_GOOGLE_COLOR_ID,
   slotToGoogleColorId,
@@ -21,5 +22,11 @@ describe("google-color.map", () => {
     expect(googleColorIdToSlot("")).toBeUndefined();
     expect(googleColorIdToSlot(undefined)).toBeUndefined();
     expect(googleColorIdToSlot(null)).toBeUndefined();
+  });
+
+  it("builds Google colorId body fields for set, clear, and omit", () => {
+    expect(googleColorIdFields("blue")).toEqual({ colorId: "7" });
+    expect(googleColorIdFields(null)).toEqual({ colorId: null });
+    expect(googleColorIdFields(undefined)).toEqual({});
   });
 });

--- a/packages/sync/src/providers/google/google-color.map.ts
+++ b/packages/sync/src/providers/google/google-color.map.ts
@@ -32,3 +32,13 @@ export function googleColorIdToSlot(
 export function slotToGoogleColorId(slot: EventColorSlot): string {
   return SLOT_TO_GOOGLE_COLOR_ID[slot];
 }
+
+// Fields for a Google create/patch body: a slot sets colorId, null clears it,
+// undefined leaves Google's existing color untouched (omit the key).
+export function googleColorIdFields(
+  color: EventColorSlot | null | undefined,
+): { colorId: string | null } | Record<string, never> {
+  if (color === undefined) return {};
+  if (color === null) return { colorId: null };
+  return { colorId: slotToGoogleColorId(color) };
+}

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -3,7 +3,7 @@ import { OAuth2Client } from "google-auth-library";
 import { type EventSchedule } from "@core/types/event.contracts";
 import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
-import { slotToGoogleColorId } from "@sync/providers/google/google-color.map";
+import { googleColorIdFields } from "@sync/providers/google/google-color.map";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
 import { type ProviderEventRead } from "@sync/providers/provider-event.port";
 import {
@@ -216,11 +216,7 @@ function toGoogleBody(
     summary: content.title,
     description: content.description,
     location: content.location,
-    ...(content.color === null
-      ? { colorId: null }
-      : content.color !== undefined
-        ? { colorId: slotToGoogleColorId(content.color) }
-        : {}),
+    ...googleColorIdFields(content.color),
     ...scheduleFields(schedule),
     recurrence: recurrence.kind === "series" ? [...recurrence.rules] : null,
   };

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -1,5 +1,6 @@
 import { type calendar_v3 } from "@googleapis/calendar";
 import { EventScheduleSchema } from "@core/types/event.contracts";
+import { withColor } from "@core/types/event-color.contracts";
 import { type gSchema$Event } from "@core/types/gcal";
 import {
   type Attendee,
@@ -88,8 +89,7 @@ function mapContent(item: gSchema$Event) {
     organizer: mapOrganizer(item.organizer),
     attendees: mapAttendees(item.attendees),
     conference: mapConference(item),
-    // Omit entirely when Google reports no color or an unknown id.
-    ...(color !== undefined ? { color } : {}),
+    ...withColor(color),
   });
   if (!parsed.success) {
     throw new ProviderEventError(

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -70,22 +70,21 @@ const EVENT_PALETTES: Record<ThemeName, EventPalette> = {
 
 /** The active theme's event palette, or a Google-slot fill when `color` is
  * set. Subscribes so a theme switch re-renders the default (no-slot) case. */
-export const useEventPalette = (color?: EventColorSlot): EventPalette => {
-  const themeName = useThemeStore(selectTheme);
-  if (color !== undefined) {
-    return buildEventPaletteFromBase(EVENT_COLOR_SLOT_HEX[color]);
-  }
-  return EVENT_PALETTES[themeName];
-};
+export const useEventPalette = (color?: EventColorSlot): EventPalette =>
+  resolveEventPalette(useThemeStore(selectTheme), color);
 
 /** Non-reactive read for plain functions (e.g. getGradient's identity check).
  * Components should use useEventPalette so they repaint on switch. */
-export const getEventPalette = (color?: EventColorSlot): EventPalette => {
-  if (color !== undefined) {
-    return buildEventPaletteFromBase(EVENT_COLOR_SLOT_HEX[color]);
-  }
-  return EVENT_PALETTES[useThemeStore.getState().theme];
-};
+export const getEventPalette = (color?: EventColorSlot): EventPalette =>
+  resolveEventPalette(useThemeStore.getState().theme, color);
+
+const resolveEventPalette = (
+  themeName: ThemeName,
+  color?: EventColorSlot,
+): EventPalette =>
+  color !== undefined
+    ? buildEventPaletteFromBase(EVENT_COLOR_SLOT_HEX[color])
+    : EVENT_PALETTES[themeName];
 
 // CSS-variable gradients: these land in inline `background` styles, so the
 // browser resolves them against the active [data-theme] — no JS hex needed.

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -3,7 +3,10 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
-import { type EventColorSlot } from "@core/types/event-color.contracts";
+import {
+  type EventColorSlot,
+  withColor,
+} from "@core/types/event-color.contracts";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -94,13 +97,9 @@ export function editGridEventDraft(
     kind: "edit",
     source: event,
     values: {
-      title: event.content.kind === "details" ? event.content.title : "",
-      description:
-        event.content.kind === "details" ? event.content.description : "",
+      ...editableDetailsFromEvent(event),
       schedule,
       calendarId: event.calendarId,
-      color:
-        event.content.kind === "details" ? (event.content.color ?? null) : null,
       recurrence: { kind: "preserve" },
       scope,
     },
@@ -140,13 +139,9 @@ export function duplicateGridEventDraft(
     kind: "create",
     source: null,
     values: {
-      title: event.content.kind === "details" ? event.content.title : "",
-      description:
-        event.content.kind === "details" ? event.content.description : "",
+      ...editableDetailsFromEvent(event),
       schedule,
       calendarId,
-      color:
-        event.content.kind === "details" ? (event.content.color ?? null) : null,
       recurrence:
         event.recurrence.kind === "series"
           ? { kind: "series", rules: [...event.recurrence.rules] }
@@ -301,7 +296,7 @@ export function gridEventDraftToSchemaEvent(
         : dayjs(schedule.end).format(),
     isAllDay: schedule.kind === "allDay",
     isBusy: draft.kind === "edit" && draft.source.content.kind === "busy",
-    ...(color !== undefined ? { color } : {}),
+    ...withColor(color),
     recurrence: legacyRecurrenceFromDraft(draft, seriesRules),
     startDate:
       schedule.kind === "allDay"
@@ -396,32 +391,48 @@ export function patchGridDraftFields(
     Pick<GridEventDraft["values"], "title" | "description" | "color">
   >,
 ): GridEventDraft {
+  // Branching on kind keeps create/edit values correlated with the
+  // discriminant (a shared spread widens recurrence across both shapes).
   if (current.kind === "create") {
     return {
       ...current,
-      values: {
-        ...current.values,
-        ...(patch.title !== undefined ? { title: patch.title } : {}),
-        ...(patch.description !== undefined
-          ? { description: patch.description }
-          : {}),
-        ...(patch.color !== undefined ? { color: patch.color } : {}),
-      },
+      values: applyDraftFieldPatch(current.values, patch),
     };
   }
-
   return {
     ...current,
-    values: {
-      ...current.values,
-      ...(patch.title !== undefined ? { title: patch.title } : {}),
-      ...(patch.description !== undefined
-        ? { description: patch.description }
-        : {}),
-      ...(patch.color !== undefined ? { color: patch.color } : {}),
-    },
+    values: applyDraftFieldPatch(current.values, patch),
   };
 }
+
+const applyDraftFieldPatch = <
+  T extends Pick<GridEventDraft["values"], "title" | "description" | "color">,
+>(
+  values: T,
+  patch: Partial<
+    Pick<GridEventDraft["values"], "title" | "description" | "color">
+  >,
+): T => ({
+  ...values,
+  ...(patch.title !== undefined ? { title: patch.title } : {}),
+  ...(patch.description !== undefined
+    ? { description: patch.description }
+    : {}),
+  ...(patch.color !== undefined ? { color: patch.color } : {}),
+});
+
+const editableDetailsFromEvent = (
+  event: Event,
+): { title: string; description: string; color: EventColorSlot | null } => {
+  if (event.content.kind !== "details") {
+    return { title: "", description: "", color: null };
+  }
+  return {
+    title: event.content.title,
+    description: event.content.description,
+    color: event.content.color ?? null,
+  };
+};
 
 // Local, not toISOString: all-day draft Dates are local midnight, so a UTC
 // rendering would shift the day for any non-UTC viewer.

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -2,7 +2,10 @@ import { Origin } from "@core/constants/core.constants";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
-import { type EventColorSlot } from "@core/types/event-color.contracts";
+import {
+  type EventColorSlot,
+  withColor,
+} from "@core/types/event-color.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -121,7 +124,7 @@ const withCalendarMetadata = (
       isDemo: gridEvent._id
         ? demoEventIdSet.has(gridEvent._id as EventId)
         : false,
-      ...(metadata?.color !== undefined ? { color: metadata.color } : {}),
+      ...withColor(metadata?.color),
     };
   });
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the event-color feature PRs (#2420–#2424). No behavior change — same contracts and UI — just clearer, shared helpers so color plumbing is not copy-pasted across packages.

## Changes

- **Core:** `OptionalNullableEventColorSchema` for command/patch schemas; `withColor()` helper for optional slot / clearable (`null`) spreads; unit coverage for both modes.
- **Sync:** `toInstanceContent` for base → instance content (including color inherit); `googleColorIdFields()` for writer payloads; `mergeUpdateContent` uses `withColor` + early return when there is no patch.
- **Backend:** Shared field list in `syncEventInstanceToBrowser`; command translation uses `withColor` instead of inline `...(color !== undefined && { color })`.
- **Web:** `editableDetailsFromEvent` + `applyDraftFieldPatch` for draft adapters; view-model uses `withColor`; single `resolveEventPalette` path for themed vs calendar-default colors.

## Test plan

- [x] `bun run type-check`
- [x] `bun test:core` / `test:sync` / `test:backend` / `test:web`
- [x] biome on touched files
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ccf589e-0fa0-402f-b2fe-1928b8564e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

