### PR TITLE
fix(sync): fail fast on revoked auth during pull/import/repair/subscription jobs

### DIFF
--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -419,12 +419,13 @@ describe("dispatchSyncJob", () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");
     const reader = new FakeReader([]);
+    const discarded: string[] = [];
     const flakyCustody: SyncJobDispatchDeps["custody"] = {
       getValidAccessToken: async () => {
         throw new ProviderAuthError("refreshFailed", "network blip");
       },
-      discardRevoked: async () => {
-        throw new Error("should not discard on a transient refresh failure");
+      discardRevoked: async (connectionId) => {
+        discarded.push(connectionId);
       },
     };
 
@@ -435,6 +436,7 @@ describe("dispatchSyncJob", () => {
         now,
       ),
     ).rejects.toThrow(ProviderAuthError);
+    expect(discarded).toEqual([]);
   });
 
   it("drops a job whose resource no longer exists", async () => {
@@ -559,5 +561,37 @@ describe("dispatchSyncJob", () => {
       result: "drop",
       reason: "connection no longer exists",
     });
+  });
+
+  it("settles a revoked calendarListSync done, like the resource-based kinds", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId();
+    stubbedConnection = {
+      _id: connectionId,
+      tenantId,
+      principalId,
+    } as ProviderConnectionRecord;
+    const discarded: string[] = [];
+    const revokedCustody: SyncJobDispatchDeps["custody"] = {
+      getValidAccessToken: async () => {
+        throw new ProviderAuthError(
+          "authorizationRevoked",
+          "refresh token revoked",
+        );
+      },
+      discardRevoked: async (id) => {
+        discarded.push(id);
+      },
+    };
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([]), revokedCustody),
+      calendarListJob(connectionId, tenantId, principalId),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    expect(discarded).toEqual([connectionId]);
   });
 });

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -4,6 +4,7 @@ import {
   dispatchSyncJob,
   type SyncJobDispatchDeps,
 } from "@sync/domain/sync-job-dispatch.service";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import {
   type ProviderEvent,
   type ProviderEventRead,
@@ -162,7 +163,10 @@ describe("dispatchSyncJob", () => {
     findById: async () => stubbedConnection,
   } as unknown as SyncJobDispatchDeps["connections"];
 
-  const deps = (reader: FakeReader): SyncJobDispatchDeps => ({
+  const deps = (
+    reader: FakeReader,
+    custody: SyncJobDispatchDeps["custody"] = tokenSource,
+  ): SyncJobDispatchDeps => ({
     events,
     occurrences,
     resources,
@@ -172,7 +176,7 @@ describe("dispatchSyncJob", () => {
     jobs,
     commands,
     reader,
-    custody: tokenSource,
+    custody,
     notifications,
     callbackUrl: "https://sync.example/sync/notifications/google",
     invalidations,
@@ -382,6 +386,55 @@ describe("dispatchSyncJob", () => {
     expect(outcome.followup.coalescingKey).toBe(
       `subscriptionMaintain:${resource._id}`,
     );
+  });
+
+  it("settles a job done and discards the credential when the token is revoked", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reader = new FakeReader([]);
+    const discarded: string[] = [];
+    const revokedCustody: SyncJobDispatchDeps["custody"] = {
+      getValidAccessToken: async () => {
+        throw new ProviderAuthError(
+          "authorizationRevoked",
+          "refresh token revoked",
+        );
+      },
+      discardRevoked: async (connectionId) => {
+        discarded.push(connectionId);
+      },
+    };
+
+    const outcome = await dispatchSyncJob(
+      deps(reader, revokedCustody),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    expect(outcome).toEqual({ result: "done" });
+    expect(discarded).toEqual([calendar.connectionId]);
+  });
+
+  it("leaves a transient refresh failure for the worker to retry", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const reader = new FakeReader([]);
+    const flakyCustody: SyncJobDispatchDeps["custody"] = {
+      getValidAccessToken: async () => {
+        throw new ProviderAuthError("refreshFailed", "network blip");
+      },
+      discardRevoked: async () => {
+        throw new Error("should not discard on a transient refresh failure");
+      },
+    };
+
+    await expect(
+      dispatchSyncJob(
+        deps(reader, flakyCustody),
+        jobFor(resource, "incrementalPull"),
+        now,
+      ),
+    ).rejects.toThrow(ProviderAuthError);
   });
 
   it("drops a job whose resource no longer exists", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -78,6 +78,35 @@ export async function dispatchSyncJob(
   job: JobRecord,
   now: () => Date,
 ): Promise<SyncJobOutcome> {
+  try {
+    return await runSyncJob(deps, job, now);
+  } catch (error) {
+    // Every kind resolves its provider token through getValidAccessToken, so a
+    // dead credential surfaces here whichever engine ran. Settle it done: the
+    // worker's generic catch classes any throw as retryableTransient, which
+    // would burn the whole retry ladder on a grant only a reconnect can fix.
+    // Done rather than a permanent failure because a failed job keeps its
+    // coalescing key and enqueue only $setOnInsert's, so the dead row would
+    // swallow the reconnect's re-enqueue and sync would never restart.
+    // refreshFailed rethrows: that is the transient case, a blip refreshing a
+    // still-good token. Mirrors the write path in provider-command.service.ts.
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason !== "refreshFailed"
+    ) {
+      // Belt and braces: custody already discards on authorizationRevoked.
+      await deps.custody.discardRevoked(job.connectionId);
+      return { result: "done" };
+    }
+    throw error;
+  }
+}
+
+async function runSyncJob(
+  deps: SyncJobDispatchDeps,
+  job: JobRecord,
+  now: () => Date,
+): Promise<SyncJobOutcome> {
   // Calendar-list discovery is keyed on the connection, not a calendar/resource,
   // so it is resolved and handled before the resource-based family below.
   if (job.kind === "calendarListSync") {
@@ -125,72 +154,49 @@ export async function dispatchSyncJob(
     return { result: "drop", reason: "calendar no longer exists" };
   }
 
-  try {
-    switch (job.kind) {
-      case "initialImport": {
-        // Idempotent: a resource that already holds a cursor no-ops inside.
-        await importCalendarEvents(deps, calendar, now);
-        // Bootstrap the push channel once the calendar is imported. The followup
-        // is coalesced and maintainSubscription no-ops on an already-live channel,
-        // so a repeated import (a reclaimed lease, a re-import) never churns it.
-        return {
-          result: "done",
-          followup: subscriptionFollowup(resource, now),
-        };
-      }
-      case "incrementalPull": {
-        const pull = await pullCalendarChanges(deps, calendar, now);
-        if (pull.status === "applied") {
-          await appendCalendarInvalidation(deps, calendar, now());
-          return { result: "done" };
-        }
-        if (pull.status === "notImported") {
-          // A pull before the initial import ever ran: hand off to an import.
-          return { result: "done", followup: importFollowup(resource, now) };
-        }
-        // cursorExpired: the provider cursor is unusable; a repair rebuilds.
-        return { result: "done", followup: repairFollowup(resource, now) };
-      }
-      case "repair": {
-        const repair = await repairCalendar(deps, calendar, now);
-        // An incomplete repair (the pass yielded no durable cursor) left the old
-        // generation intact; retry the whole rebuild later rather than settle.
-        if (repair.status === "repaired") {
-          await appendCalendarInvalidation(deps, calendar, now());
-          return { result: "done" };
-        }
-        return {
-          result: "retry",
-          failureClass: "retryableTransient",
-          reason: "repair did not complete",
-        };
-      }
-      case "subscriptionMaintain": {
-        // Open or renew the push channel. Every terminal outcome (watched /
-        // renewed / current / unsupported / authRevoked) settles the job; a
-        // transient watch failure throws and the worker retries with backoff.
-        await maintainSubscription(deps, calendar, resource, now);
+  switch (job.kind) {
+    case "initialImport": {
+      // Idempotent: a resource that already holds a cursor no-ops inside.
+      await importCalendarEvents(deps, calendar, now);
+      // Bootstrap the push channel once the calendar is imported. The followup
+      // is coalesced and maintainSubscription no-ops on an already-live channel,
+      // so a repeated import (a reclaimed lease, a re-import) never churns it.
+      return { result: "done", followup: subscriptionFollowup(resource, now) };
+    }
+    case "incrementalPull": {
+      const pull = await pullCalendarChanges(deps, calendar, now);
+      if (pull.status === "applied") {
+        await appendCalendarInvalidation(deps, calendar, now());
         return { result: "done" };
       }
+      if (pull.status === "notImported") {
+        // A pull before the initial import ever ran: hand off to an import.
+        return { result: "done", followup: importFollowup(resource, now) };
+      }
+      // cursorExpired: the provider cursor is unusable; a repair rebuilds.
+      return { result: "done", followup: repairFollowup(resource, now) };
     }
-  } catch (error) {
-    // Every kind above resolves its provider token via getValidAccessToken
-    // before doing provider work. A revoked/missing credential is terminal —
-    // retrying cannot help until the user reconnects — so settle the job done
-    // rather than let it fall through to the worker's generic catch, which
-    // treats every throw as retryableTransient and burns the full retry ladder
-    // against a credential already known dead. refreshFailed is left alone: it
-    // is the transient case (a network blip refreshing a still-good token) and
-    // should retry. Mirrors the write path's classification in
-    // provider-command.service.ts.
-    if (
-      error instanceof ProviderAuthError &&
-      error.reason !== "refreshFailed"
-    ) {
-      await deps.custody.discardRevoked(calendar.connectionId);
+    case "repair": {
+      const repair = await repairCalendar(deps, calendar, now);
+      // An incomplete repair (the pass yielded no durable cursor) left the old
+      // generation intact; retry the whole rebuild later rather than settle.
+      if (repair.status === "repaired") {
+        await appendCalendarInvalidation(deps, calendar, now());
+        return { result: "done" };
+      }
+      return {
+        result: "retry",
+        failureClass: "retryableTransient",
+        reason: "repair did not complete",
+      };
+    }
+    case "subscriptionMaintain": {
+      // Open or renew the push channel. Every terminal outcome (watched /
+      // renewed / current / unsupported / authRevoked) settles the job; a
+      // transient watch failure throws and the worker retries with backoff.
+      await maintainSubscription(deps, calendar, resource, now);
       return { result: "done" };
     }
-    throw error;
   }
 }
 

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -4,6 +4,7 @@ import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
 import { repairCalendar } from "@sync/domain/calendar-repair.service";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { type ProviderCalendarAdapter } from "@sync/providers/provider-calendar.port";
 import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
 import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
@@ -124,49 +125,72 @@ export async function dispatchSyncJob(
     return { result: "drop", reason: "calendar no longer exists" };
   }
 
-  switch (job.kind) {
-    case "initialImport": {
-      // Idempotent: a resource that already holds a cursor no-ops inside.
-      await importCalendarEvents(deps, calendar, now);
-      // Bootstrap the push channel once the calendar is imported. The followup
-      // is coalesced and maintainSubscription no-ops on an already-live channel,
-      // so a repeated import (a reclaimed lease, a re-import) never churns it.
-      return { result: "done", followup: subscriptionFollowup(resource, now) };
-    }
-    case "incrementalPull": {
-      const pull = await pullCalendarChanges(deps, calendar, now);
-      if (pull.status === "applied") {
-        await appendCalendarInvalidation(deps, calendar, now());
+  try {
+    switch (job.kind) {
+      case "initialImport": {
+        // Idempotent: a resource that already holds a cursor no-ops inside.
+        await importCalendarEvents(deps, calendar, now);
+        // Bootstrap the push channel once the calendar is imported. The followup
+        // is coalesced and maintainSubscription no-ops on an already-live channel,
+        // so a repeated import (a reclaimed lease, a re-import) never churns it.
+        return {
+          result: "done",
+          followup: subscriptionFollowup(resource, now),
+        };
+      }
+      case "incrementalPull": {
+        const pull = await pullCalendarChanges(deps, calendar, now);
+        if (pull.status === "applied") {
+          await appendCalendarInvalidation(deps, calendar, now());
+          return { result: "done" };
+        }
+        if (pull.status === "notImported") {
+          // A pull before the initial import ever ran: hand off to an import.
+          return { result: "done", followup: importFollowup(resource, now) };
+        }
+        // cursorExpired: the provider cursor is unusable; a repair rebuilds.
+        return { result: "done", followup: repairFollowup(resource, now) };
+      }
+      case "repair": {
+        const repair = await repairCalendar(deps, calendar, now);
+        // An incomplete repair (the pass yielded no durable cursor) left the old
+        // generation intact; retry the whole rebuild later rather than settle.
+        if (repair.status === "repaired") {
+          await appendCalendarInvalidation(deps, calendar, now());
+          return { result: "done" };
+        }
+        return {
+          result: "retry",
+          failureClass: "retryableTransient",
+          reason: "repair did not complete",
+        };
+      }
+      case "subscriptionMaintain": {
+        // Open or renew the push channel. Every terminal outcome (watched /
+        // renewed / current / unsupported / authRevoked) settles the job; a
+        // transient watch failure throws and the worker retries with backoff.
+        await maintainSubscription(deps, calendar, resource, now);
         return { result: "done" };
       }
-      if (pull.status === "notImported") {
-        // A pull before the initial import ever ran: hand off to an import.
-        return { result: "done", followup: importFollowup(resource, now) };
-      }
-      // cursorExpired: the provider cursor is unusable; a repair rebuilds.
-      return { result: "done", followup: repairFollowup(resource, now) };
     }
-    case "repair": {
-      const repair = await repairCalendar(deps, calendar, now);
-      // An incomplete repair (the pass yielded no durable cursor) left the old
-      // generation intact; retry the whole rebuild later rather than settle.
-      if (repair.status === "repaired") {
-        await appendCalendarInvalidation(deps, calendar, now());
-        return { result: "done" };
-      }
-      return {
-        result: "retry",
-        failureClass: "retryableTransient",
-        reason: "repair did not complete",
-      };
-    }
-    case "subscriptionMaintain": {
-      // Open or renew the push channel. Every terminal outcome (watched /
-      // renewed / current / unsupported / authRevoked) settles the job; a
-      // transient watch failure throws and the worker retries with backoff.
-      await maintainSubscription(deps, calendar, resource, now);
+  } catch (error) {
+    // Every kind above resolves its provider token via getValidAccessToken
+    // before doing provider work. A revoked/missing credential is terminal —
+    // retrying cannot help until the user reconnects — so settle the job done
+    // rather than let it fall through to the worker's generic catch, which
+    // treats every throw as retryableTransient and burns the full retry ladder
+    // against a credential already known dead. refreshFailed is left alone: it
+    // is the transient case (a network blip refreshing a still-good token) and
+    // should retry. Mirrors the write path's classification in
+    // provider-command.service.ts.
+    if (
+      error instanceof ProviderAuthError &&
+      error.reason !== "refreshFailed"
+    ) {
+      await deps.custody.discardRevoked(calendar.connectionId);
       return { result: "done" };
     }
+    throw error;
   }
 }
 

--- a/packages/sync/src/domain/sync-scheduler.service.test.ts
+++ b/packages/sync/src/domain/sync-scheduler.service.test.ts
@@ -88,6 +88,48 @@ describe("SyncScheduler", () => {
     expect(worker.calls).toBe(callsAtStop);
   });
 
+  it("does not release owned jobs until an in-flight drain settles", async () => {
+    // job.repository.ts's releaseOwned doc comment calls this out as a real
+    // hazard: racing it against a still-running complete()/scheduleRetry() can
+    // flip a just-finished job back to pending and get it reprocessed. Pin the
+    // ordering stop() relies on to avoid that — release only after the loop's
+    // current drain (and everything it awaited to settle its jobs) has
+    // resolved, not the instant stop() is called.
+    let resolveDrain: (() => void) | null = null;
+    let signalDrainStarted: (() => void) | null = null;
+    const drainStarted = new Promise<void>((resolve) => {
+      signalDrainStarted = resolve;
+    });
+    const worker: JobDrainer = {
+      drain: async () => {
+        signalDrainStarted?.();
+        await new Promise<void>((resolve) => {
+          resolveDrain = resolve;
+        });
+        return 0;
+      },
+    };
+    const jobs = releaser();
+    const scheduler = new SyncScheduler(
+      { worker, jobs },
+      { owner: OWNER, pollMs: 10_000 },
+    );
+
+    scheduler.start();
+    await drainStarted;
+
+    const stopping = scheduler.stop();
+    // Give stop() a tick to run ahead if it were (incorrectly) not waiting on
+    // the in-flight drain before releasing.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(jobs.released).toEqual([]);
+
+    resolveDrain?.();
+    await stopping;
+
+    expect(jobs.released).toEqual([OWNER]);
+  });
+
   it("keeps looping after a drain throws", async () => {
     const errors: unknown[] = [];
     const worker = new FakeWorker([1, 0], 1); // call 1 throws, call 2 idles

--- a/packages/sync/src/domain/sync-scheduler.service.test.ts
+++ b/packages/sync/src/domain/sync-scheduler.service.test.ts
@@ -89,23 +89,22 @@ describe("SyncScheduler", () => {
   });
 
   it("does not release owned jobs until an in-flight drain settles", async () => {
-    // job.repository.ts's releaseOwned doc comment calls this out as a real
-    // hazard: racing it against a still-running complete()/scheduleRetry() can
-    // flip a just-finished job back to pending and get it reprocessed. Pin the
-    // ordering stop() relies on to avoid that — release only after the loop's
-    // current drain (and everything it awaited to settle its jobs) has
-    // resolved, not the instant stop() is called.
-    let resolveDrain: (() => void) | null = null;
-    let signalDrainStarted: (() => void) | null = null;
+    // releaseOwned's precondition (job.repository.ts): racing it against a
+    // still-running complete()/scheduleRetry() can flip a just-finished job
+    // back to pending and reprocess it. FakeWorker cannot hold a drain open,
+    // so this case needs a drainer that blocks until the test releases it.
+    let resolveDrain!: () => void;
+    let signalDrainStarted!: () => void;
     const drainStarted = new Promise<void>((resolve) => {
       signalDrainStarted = resolve;
     });
+    const drainBlocked = new Promise<void>((resolve) => {
+      resolveDrain = resolve;
+    });
     const worker: JobDrainer = {
       drain: async () => {
-        signalDrainStarted?.();
-        await new Promise<void>((resolve) => {
-          resolveDrain = resolve;
-        });
+        signalDrainStarted();
+        await drainBlocked;
         return 0;
       },
     };
@@ -124,7 +123,7 @@ describe("SyncScheduler", () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(jobs.released).toEqual([]);
 
-    resolveDrain?.();
+    resolveDrain();
     await stopping;
 
     expect(jobs.released).toEqual([OWNER]);


### PR DESCRIPTION
## Summary

Chaos QA durability sweep against staging. Surveyed the sync system's existing resilience mechanisms (retry/backoff, webhook idempotency, crash-mid-job recovery, rate limiting — all solid), then live fault-injected staging's public webhook ingress and backend API (malformed bodies, spoofed headers, oversized headers, missing/garbage auth, unknown routes) — all degraded gracefully, no bug found there.

Code-level review turned up one real gap:

- **Auth revocation only fails fast on the write path.** #2427 made the write path (`provider-command.service.ts`) fail a command immediately when `getValidAccessToken` throws a revoked-credential `ProviderAuthError`. The read-side job kinds (`initialImport`, `incrementalPull`, `repair`, `subscriptionMaintain`) call the same `getValidAccessToken` but had no equivalent catch — the error bubbled past `dispatchSyncJob` uncaught and the worker's generic catch-all always classifies a throw as `retryableTransient`. So a job hitting a dead credential during a webhook-triggered pull, or an initial import, burned the full retry ladder (up to `maxAttempts`) against a credential that was already known dead, instead of settling immediately like the write path does.
- **Fix:** wrap the job-kind switch in `dispatchSyncJob` with a single catch that mirrors the write path's classification (`refreshFailed` is transient and retries; everything else, including `authorizationRevoked`, discards the credential and settles the job done).

Also investigated a documented-but-untested hazard: `job.repository.ts`'s `releaseOwned` doc comment warns that racing it against an in-flight `complete()`/`scheduleRetry()` can flip a just-finished job back to pending. Traced the call graph — `app.ts` wires exactly one `SyncJobWorker`/`SyncScheduler` pair per process under a single `randomUUID()` owner, and `SyncScheduler.stop()` already awaits the full drain loop before calling `releaseOwned` — so this isn't reachable today. Added a regression test pinning that ordering instead of speculative code, so a future refactor can't silently reintroduce it.

## Test plan

- [x] `bun run test:sync` — 648 pass, 0 fail (2 new dispatch tests + 1 new scheduler test)
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on changed files — clean
- [x] Live-probed staging's public webhook endpoint and backend API with malformed/spoofed/oversized/unauthenticated requests — all handled gracefully, service stayed healthy throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: cleanup pass

A `/simplify` review pass added one commit on top:

- **Coverage gap:** the catch wrapped only the resource-based switch, but `calendarListSync` is handled in a branch *above* it and resolves a token the same way, so a revoked credential there still burned the full retry ladder. The `try` now wraps the whole dispatch body (`runSyncJob`), covering all five kinds. Test added.
- **Diff shape:** wrapping one call instead of the switch leaves the existing switch un-reindented, so the service-file diff is now purely additive (~30 lines) rather than a 100-line reindent.
- **`job.connectionId`** replaces `calendar.connectionId` for the discard, since it is available before the calendar lookup and every enqueue site sets it from the resource's connection.
- **Comment** now records why the job settles `done` rather than as a `permanent` failure: a failed job keeps its coalescing key and `enqueue` only `$setOnInsert`s, so a terminal row would swallow the reconnect's re-enqueue and sync would never restart. That is the non-obvious constraint behind the choice.
- Minor test tidying (dropped nullability theater in the scheduler test; the transient-refresh test now asserts `discarded` is empty instead of throwing from the stub).

Re-verified: `bun run test:sync` 649 pass / 0 fail, `bun run type-check` clean, biome clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job settlement and credential discard on auth failures for all calendar read/sync job kinds; behavior is aligned with the existing write path but affects webhook-driven pulls and imports when tokens are dead.
> 
> **Overview**
> **Read-path sync jobs** (`initialImport`, `incrementalPull`, `repair`, `subscriptionMaintain`) now handle `ProviderAuthError` inside `dispatchSyncJob`: non-`refreshFailed` errors call `discardRevoked` and return **`done`** instead of bubbling to the worker as **`retryableTransient`**. **`refreshFailed`** still propagates so transient token refresh issues can retry.
> 
> **Tests** add DB coverage for revoked vs flaky refresh on incremental pull, and assert **`SyncScheduler.stop()`** does not call **`releaseOwned`** until an in-flight drain finishes—guarding against re-queuing jobs that just completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903c5b7f6630be777d58d4c5970bdac892ad4532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
