### PR TITLE
refactor(web): collapse dual sources of truth in create/edit

### DIFF
--- a/packages/web/src/calendars/isEventReadOnly.test.ts
+++ b/packages/web/src/calendars/isEventReadOnly.test.ts
@@ -6,6 +6,7 @@ import { CalendarIdSchema } from "@core/types/domain-primitives";
 import {
   buildCalendarLookup,
   isEventReadOnly,
+  isGridEventInteractionReadOnly,
 } from "@web/calendars/useCalendarLookup";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { describe, expect, it } from "bun:test";
@@ -96,5 +97,41 @@ describe("isEventReadOnly", () => {
     const someId = CalendarIdSchema.parse(createObjectIdString());
 
     expect(isEventReadOnly(lookup, someId, false)).toBe(false);
+  });
+});
+
+describe("isGridEventInteractionReadOnly", () => {
+  it("treats busy and timed multi-day display content as read-only", () => {
+    const calendar = makeCalendar({ access: "owner" });
+    const lookup = buildCalendarLookup([calendar]);
+
+    expect(
+      isGridEventInteractionReadOnly(lookup, {
+        calendarId: calendar.id,
+        isBusy: true,
+      }),
+    ).toBe(true);
+    expect(
+      isGridEventInteractionReadOnly(lookup, {
+        calendarId: calendar.id,
+        isTimedMultiDayDisplay: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still respects calendar write capability for ordinary events", () => {
+    const reader = makeCalendar({
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+    const owner = makeCalendar({ access: "owner" });
+    const lookup = buildCalendarLookup([reader, owner]);
+
+    expect(
+      isGridEventInteractionReadOnly(lookup, { calendarId: reader.id }),
+    ).toBe(true);
+    expect(
+      isGridEventInteractionReadOnly(lookup, { calendarId: owner.id }),
+    ).toBe(false);
   });
 });

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -96,3 +96,24 @@ export function isEventReadOnly(
 
   return !calendar.capabilities.canWrite;
 }
+
+/**
+ * Single read-only predicate for grid card registration and edit shortcuts
+ * (delete / nudge). Uses {@link isGridEventContentReadOnly} so busy content
+ * and timed multi-day display bars cannot diverge between pointer and
+ * keyboard gates.
+ */
+export function isGridEventInteractionReadOnly(
+  lookup: ReadonlyMap<CalendarId, Calendar>,
+  event: {
+    calendarId?: CalendarId | null;
+    isBusy?: boolean;
+    isTimedMultiDayDisplay?: boolean;
+  },
+): boolean {
+  return isEventReadOnly(
+    lookup,
+    event.calendarId,
+    isGridEventContentReadOnly(event),
+  );
+}

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -1,18 +1,10 @@
 import { Origin } from "@core/constants/core.constants";
-import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
-import {
-  type EventColorSlot,
-  withColor,
-} from "@core/types/event-color.contracts";
+import { withColor } from "@core/types/event-color.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import {
-  assembleGridEvent,
-  type EventWithDates,
-  hasEventDates,
-} from "@web/common/utils/event/event.util";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
   isTimedEventMultiDay,
   timedMultiDayToAllDayDates,
@@ -30,11 +22,35 @@ import { type NormalizedEventQueryData } from "./event.query.types";
 // there's nothing real to duplicate/resubmit.
 export const BUSY_EVENT_TITLE = "Busy";
 
-// The grid renderer (assembleGridEvent) still consumes the CompassEvent
-// shape rather than the core Event contract directly, scoped to scheduled
-// (timed/allDay) events.
-const scheduledEventToSchemaEvent = (event: Event): CompassEvent => {
+type EventToGridEventOptions = {
+  demoEventIds?: readonly EventId[];
+  /** Override schedule dates / all-day for multi-day timed display promotion. */
+  scheduleOverride?: {
+    isAllDay: boolean;
+    startDate: string;
+    endDate: string;
+    isTimedMultiDayDisplay?: boolean;
+  };
+};
+
+/**
+ * Direct Event → GridEvent assembly for the calendar view-model hot path.
+ * Avoids the Event → CompassEvent → GridEvent bridge and joins calendar
+ * metadata (calendarId / isBusy / color / isDemo) inline.
+ */
+const eventToGridEvent = (
+  event: Event,
+  { demoEventIds, scheduleOverride }: EventToGridEventOptions = {},
+): GridEvent => {
   const { schedule } = event;
+  const isAllDay = scheduleOverride?.isAllDay ?? schedule.kind === "allDay";
+  const startDate = scheduleOverride?.startDate ?? schedule.start;
+  const endDate = scheduleOverride?.endDate ?? schedule.end;
+  const color =
+    event.content.kind === "details"
+      ? (event.content.color ?? undefined)
+      : undefined;
+
   return {
     _id: event.id,
     title:
@@ -42,9 +58,10 @@ const scheduledEventToSchemaEvent = (event: Event): CompassEvent => {
     description:
       event.content.kind === "details" ? event.content.description : "",
     origin: Origin.COMPASS,
-    isAllDay: schedule.kind === "allDay",
-    startDate: schedule.start,
-    endDate: schedule.end,
+    user: "",
+    isAllDay,
+    startDate,
+    endDate,
     recurrence:
       event.recurrence.kind === "series"
         ? { rule: [...event.recurrence.rules], eventId: event.id }
@@ -52,6 +69,14 @@ const scheduledEventToSchemaEvent = (event: Event): CompassEvent => {
           ? { eventId: event.recurrence.seriesId }
           : undefined,
     updatedAt: event.updatedAt ?? undefined,
+    position: gridEventDefaultPosition,
+    calendarId: event.calendarId,
+    isBusy: event.content.kind === "busy",
+    isDemo: Boolean(demoEventIds?.includes(event.id)),
+    ...(scheduleOverride?.isTimedMultiDayDisplay
+      ? { isTimedMultiDayDisplay: true }
+      : {}),
+    ...withColor(color),
   };
 };
 
@@ -59,13 +84,11 @@ const eventsFrom = (data?: NormalizedEventQueryData): Event[] =>
   data?.ids.flatMap((id) => (data.entities[id] ? [data.entities[id]] : [])) ??
   [];
 
-// assembleGridEvent/hasEventDates still operate on the CompassEvent
-// shape; bridged via scheduledEventToSchemaEvent above. A cache entry with a
-// missing/malformed `schedule` is a bug upstream (normalizeEventList/query
-// seeding), not a case to silently swallow — but it must not crash this
-// shared derivation, since every grid
-// consumer recomputes from it on every render (a throw here becomes a
-// render-crash loop). Log loudly and drop the offending event instead.
+// A cache entry with a missing/malformed `schedule` is a bug upstream
+// (normalizeEventList/query seeding), not a case to silently swallow — but
+// it must not crash this shared derivation, since every grid consumer
+// recomputes from it on every render (a throw here becomes a render-crash
+// loop). Log loudly and drop the offending event instead.
 const isValidScheduledEvent = (event: Event): boolean => {
   const isValid =
     event.schedule != null && typeof event.schedule.kind === "string";
@@ -78,57 +101,6 @@ const isValidScheduledEvent = (event: Event): boolean => {
   return isValid;
 };
 
-// Re-attaches calendarId + isBusy + optional color onto the GridEvent
-// produced by the Event -> CompassEvent -> GridEvent bridge above.
-// scheduledEventToSchemaEvent returns the hand-written core `CompassEvent`
-// shape (compass-event.contracts.ts), which has none of those fields, so the
-// bridge itself can't carry them through without widening that shared type
-// (used by 10+ unrelated consumers). Joining back by event id after
-// assembleGridEvent keeps the bridge untouched and scopes the new fields to
-// GridEvent only (packet 08 steps 5 and 8). isBusy backs the read-only gate
-// - see isEventReadOnly in calendars/useCalendarLookup.ts.
-const withCalendarMetadata = (
-  events: Event[],
-  gridEvents: GridEvent[],
-  demoEventIds?: readonly EventId[],
-): GridEvent[] => {
-  const demoEventIdSet = new Set(demoEventIds ?? []);
-  const metadataByEventId = new Map<
-    string,
-    {
-      calendarId: Event["calendarId"];
-      isBusy: boolean;
-      color?: EventColorSlot;
-    }
-  >(
-    events.map((event) => [
-      event.id,
-      {
-        calendarId: event.calendarId,
-        isBusy: event.content.kind === "busy",
-        color:
-          event.content.kind === "details"
-            ? (event.content.color ?? undefined)
-            : undefined,
-      },
-    ]),
-  );
-  return gridEvents.map((gridEvent) => {
-    const metadata = gridEvent._id
-      ? metadataByEventId.get(gridEvent._id)
-      : undefined;
-    return {
-      ...gridEvent,
-      calendarId: metadata?.calendarId,
-      isBusy: metadata?.isBusy ?? false,
-      isDemo: gridEvent._id
-        ? demoEventIdSet.has(gridEvent._id as EventId)
-        : false,
-      ...withColor(metadata?.color),
-    };
-  });
-};
-
 // A series base is metadata-only: its schedule is the first occurrence's
 // datetime (kept so the RRULE and series id are reachable for editing), but
 // the first occurrence itself is a separately materialized doc that renders
@@ -137,18 +109,12 @@ const gridEventsFrom = (
   events: Event[],
   kind: "timed" | "allDay",
   demoEventIds?: readonly EventId[],
-) => {
-  const scheduled = events
+) =>
+  events
     .filter(isValidScheduledEvent)
     .filter((event) => event.schedule.kind === kind)
-    .filter((event) => event.recurrence.kind !== "series");
-  const assembled = scheduled
-    .map(scheduledEventToSchemaEvent)
-    .filter((event): event is EventWithDates => hasEventDates(event))
-    .map(assembleGridEvent);
-
-  return withCalendarMetadata(scheduled, assembled, demoEventIds);
-};
+    .filter((event) => event.recurrence.kind !== "series")
+    .map((event) => eventToGridEvent(event, { demoEventIds }));
 
 const timedEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
   gridEventsFrom(events, "timed", demoEventIds).filter((event) => {
@@ -159,33 +125,28 @@ const timedEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
 const multiDayTimedAsAllDayFrom = (
   events: Event[],
   demoEventIds?: readonly EventId[],
-): GridEvent[] => {
-  const scheduled = events
+): GridEvent[] =>
+  events
     .filter(isValidScheduledEvent)
     .filter((event) => event.recurrence.kind !== "series")
     .filter((event) => event.schedule.kind === "timed")
     .filter((event) => {
       const { start, end } = event.schedule;
       return isTimedEventMultiDay(dayjs(start), dayjs(end));
+    })
+    .map((event) => {
+      const { start, end } = event.schedule;
+      const dates = timedMultiDayToAllDayDates(dayjs(start), dayjs(end));
+      return eventToGridEvent(event, {
+        demoEventIds,
+        scheduleOverride: {
+          isAllDay: true,
+          startDate: dates.startDate,
+          endDate: dates.endDate,
+          isTimedMultiDayDisplay: true,
+        },
+      });
     });
-
-  const assembled = scheduled.map((event) => {
-    const { start, end } = event.schedule;
-    const dates = timedMultiDayToAllDayDates(dayjs(start), dayjs(end));
-    const schemaEvent: EventWithDates = {
-      ...scheduledEventToSchemaEvent(event),
-      isAllDay: true,
-      startDate: dates.startDate,
-      endDate: dates.endDate,
-    };
-    return {
-      ...assembleGridEvent(schemaEvent),
-      isTimedMultiDayDisplay: true,
-    };
-  });
-
-  return withCalendarMetadata(scheduled, assembled, demoEventIds);
-};
 
 const allDayEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
   assignEventsToRow([

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -105,15 +105,18 @@ const isValidScheduledEvent = (event: Event): boolean => {
 // datetime (kept so the RRULE and series id are reachable for editing), but
 // the first occurrence itself is a separately materialized doc that renders
 // the actual card. Rendering the base too would double the first day.
+const scheduledNonSeries = (events: Event[]) =>
+  events
+    .filter(isValidScheduledEvent)
+    .filter((event) => event.recurrence.kind !== "series");
+
 const gridEventsFrom = (
   events: Event[],
   kind: "timed" | "allDay",
   demoEventIds?: readonly EventId[],
 ) =>
-  events
-    .filter(isValidScheduledEvent)
+  scheduledNonSeries(events)
     .filter((event) => event.schedule.kind === kind)
-    .filter((event) => event.recurrence.kind !== "series")
     .map((event) => eventToGridEvent(event, { demoEventIds }));
 
 const timedEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
@@ -126,9 +129,7 @@ const multiDayTimedAsAllDayFrom = (
   events: Event[],
   demoEventIds?: readonly EventId[],
 ): GridEvent[] =>
-  events
-    .filter(isValidScheduledEvent)
-    .filter((event) => event.recurrence.kind !== "series")
+  scheduledNonSeries(events)
     .filter((event) => event.schedule.kind === "timed")
     .filter((event) => {
       const { start, end } = event.schedule;

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -46,17 +46,13 @@ const eventToGridEvent = (
   const isAllDay = scheduleOverride?.isAllDay ?? schedule.kind === "allDay";
   const startDate = scheduleOverride?.startDate ?? schedule.start;
   const endDate = scheduleOverride?.endDate ?? schedule.end;
-  const color =
-    event.content.kind === "details"
-      ? (event.content.color ?? undefined)
-      : undefined;
+  const isBusy = event.content.kind === "busy";
+  const details = event.content.kind === "details" ? event.content : undefined;
 
   return {
     _id: event.id,
-    title:
-      event.content.kind === "details" ? event.content.title : BUSY_EVENT_TITLE,
-    description:
-      event.content.kind === "details" ? event.content.description : "",
+    title: details?.title ?? BUSY_EVENT_TITLE,
+    description: details?.description ?? "",
     origin: Origin.COMPASS,
     user: "",
     isAllDay,
@@ -71,12 +67,12 @@ const eventToGridEvent = (
     updatedAt: event.updatedAt ?? undefined,
     position: gridEventDefaultPosition,
     calendarId: event.calendarId,
-    isBusy: event.content.kind === "busy",
+    isBusy,
     isDemo: Boolean(demoEventIds?.includes(event.id)),
     ...(scheduleOverride?.isTimedMultiDayDisplay
       ? { isTimedMultiDayDisplay: true }
       : {}),
-    ...withColor(color),
+    ...withColor(details?.color ?? undefined),
   };
 };
 

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -1,0 +1,208 @@
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import {
+  isGridEventInteractionReadOnly,
+  useCalendarLookup,
+} from "@web/calendars/useCalendarLookup";
+import { ID_SIDEBAR } from "@web/common/constants/web.constants";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { getArrowKeyMovement } from "@web/common/utils/event/event-nudge.util";
+import { nudgeEventFromKeyboard } from "@web/common/utils/event/event-nudge-shortcut.util";
+import {
+  isDeleteTextEditingTarget,
+  isEditableKeyboardTarget,
+  isEventFormKeyboardTarget,
+  isEventFormOpen,
+} from "@web/common/utils/form/form.util";
+import {
+  type EventMutationDependencies,
+  useEventMutations,
+} from "@web/events/mutations/useEventMutations";
+import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
+import { draftActions } from "@web/events/stores/draft.store";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
+
+const DRAFT_MOVEMENT_HOTKEY_OPTIONS = {
+  ignoreInputs: false,
+  preventDefault: false,
+  stopPropagation: false,
+} as const;
+
+export type GridEventShortcutTarget = {
+  eventId: string;
+  eventType: "all-day" | "timed";
+};
+
+export type GridEventEditDayBoundary =
+  | {
+      kind: "follow";
+      /** Day view: navigate so a day-crossing nudge stays on screen. */
+      onCrossed: (date: Dayjs) => void;
+    }
+  | {
+      kind: "clamp";
+      /** Week view: refuse nudges that leave the visible week window. */
+      weekDays: Dayjs[];
+    };
+
+/**
+ * Shared Delete / Shift+arrow nudge / draft Arrow reposition shortcuts for
+ * Day and Week. Targeting, day-boundary policy, and draft reposition stay
+ * view-specific (Day follows across midnight; Week clamps to weekDays).
+ *
+ * Handlers close over latest render values; TanStack Hotkeys syncs the
+ * callback each render, so event-list refs are unnecessary.
+ */
+export function useGridEventEditShortcuts({
+  allDayEvents = [],
+  dayBoundary,
+  dependencies = {},
+  repositionDraftByKey,
+  targeting,
+  timedEvents,
+}: {
+  allDayEvents?: GridEvent[];
+  dayBoundary: GridEventEditDayBoundary;
+  dependencies?: EventMutationDependencies;
+  /**
+   * View-owned draft move. Return true when the draft moved so the shared
+   * hook can preventDefault. Day may also navigate here on day-cross.
+   */
+  repositionDraftByKey: (key: string) => boolean;
+  targeting: {
+    getFocused: () => GridEventShortcutTarget | null;
+    getHovered: () => GridEventShortcutTarget | null;
+    getFirstVisible: () => GridEventShortcutTarget | null;
+  };
+  timedEvents: GridEvent[];
+}) {
+  const calendarLookup = useCalendarLookup();
+  const { delete: deleteEvent } = useEventMutations(dependencies);
+  const updateEvent = useUpdateEvent(dependencies);
+
+  const findCalendarEventForTarget = (target: GridEventShortcutTarget) => {
+    const events = target.eventType === "all-day" ? allDayEvents : timedEvents;
+    return events.find((candidate) => candidate._id === target.eventId) ?? null;
+  };
+
+  const deleteTargetedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
+    if (
+      isDeleteTextEditingTarget(keyboardEvent) ||
+      isEventFormKeyboardTarget(keyboardEvent)
+    ) {
+      return;
+    }
+
+    if (document.activeElement?.closest(`#${ID_SIDEBAR}`)) {
+      return;
+    }
+
+    const target =
+      targeting.getFocused() ??
+      targeting.getHovered() ??
+      targeting.getFirstVisible();
+    if (!target) return;
+
+    const event = findCalendarEventForTarget(target);
+    if (!event) return;
+
+    if (isGridEventInteractionReadOnly(calendarLookup, event)) {
+      return;
+    }
+
+    keyboardEvent.preventDefault();
+    keyboardEvent.stopPropagation();
+    deleteEventAndDiscardDraft(deleteEvent, event);
+  };
+
+  const moveFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
+    if (isEventFormOpen()) return;
+
+    // Focused only (no hover/first-visible fallback): moving an event the
+    // user isn't focused on would be surprising.
+    const target = targeting.getFocused();
+    if (!target) return;
+
+    const event = findCalendarEventForTarget(target);
+    if (!event?._id) return;
+
+    if (isGridEventInteractionReadOnly(calendarLookup, event)) {
+      return;
+    }
+
+    const movement = getArrowKeyMovement(
+      keyboardEvent.key,
+      Boolean(event.isAllDay),
+    );
+    if (!movement) return;
+
+    if (dayBoundary.kind === "clamp") {
+      const start = dayjs(event.startDate);
+      const { weekDays } = dayBoundary;
+      if (movement.days === -1 && !start.isAfter(weekDays[0], "day")) {
+        return;
+      }
+      if (
+        movement.days === 1 &&
+        !start.isBefore(weekDays[weekDays.length - 1], "day")
+      ) {
+        return;
+      }
+    }
+
+    const previousStart = dayjs(event.startDate).startOf("day");
+
+    nudgeEventFromKeyboard({
+      event,
+      keyboardEvent,
+      onNudge: (nudgedEvent) => {
+        updateEvent({ event: nudgedEvent }, true);
+        if (dayBoundary.kind === "follow") {
+          const nextStart = dayjs(nudgedEvent.startDate).startOf("day");
+          if (!nextStart.isSame(previousStart, "day")) {
+            dayBoundary.onCrossed(nextStart);
+          }
+        }
+      },
+      afterNudge: () => draftActions.discard(),
+    });
+  };
+
+  const moveShortcutCreatedDraft = (keyboardEvent: KeyboardEvent) => {
+    if (isEditableKeyboardTarget(keyboardEvent)) return;
+
+    const didMove = repositionDraftByKey(keyboardEvent.key);
+    if (!didMove) return;
+
+    keyboardEvent.preventDefault();
+    keyboardEvent.stopPropagation();
+  };
+
+  useAppShortcut("Delete", deleteTargetedCalendarEvent, {
+    ignoreInputs: false,
+  });
+  useAppShortcut(
+    "ArrowUp",
+    moveShortcutCreatedDraft,
+    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "ArrowDown",
+    moveShortcutCreatedDraft,
+    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "ArrowLeft",
+    moveShortcutCreatedDraft,
+    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut(
+    "ArrowRight",
+    moveShortcutCreatedDraft,
+    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
+  );
+  useAppShortcut("Shift+ArrowUp", moveFocusedCalendarEvent);
+  useAppShortcut("Shift+ArrowDown", moveFocusedCalendarEvent);
+  useAppShortcut("Shift+ArrowLeft", moveFocusedCalendarEvent);
+  useAppShortcut("Shift+ArrowRight", moveFocusedCalendarEvent);
+}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import {
-  isEventReadOnly,
-  isGridEventContentReadOnly,
+  isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
@@ -82,11 +81,7 @@ export const DayCalendarAllDayEventsLayer = ({
           event={event}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
-          isReadOnly={isEventReadOnly(
-            calendarLookup,
-            event.calendarId,
-            isGridEventContentReadOnly(event),
-          )}
+          isReadOnly={isGridEventInteractionReadOnly(calendarLookup, event)}
           key={event._id ?? "all-day-draft"}
           measurements={measurements}
           onOpenEvent={onOpenEvent}
@@ -145,11 +140,7 @@ export const DayCalendarTimedEventsLayer = ({
           event={event}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
-          isReadOnly={isEventReadOnly(
-            calendarLookup,
-            event.calendarId,
-            event.isBusy ?? false,
-          )}
+          isReadOnly={isGridEventInteractionReadOnly(calendarLookup, event)}
           key={event._id ?? "timed-draft"}
           measurements={measurements}
           onOpenEvent={onOpenEvent}

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -1,46 +1,19 @@
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
-import {
-  isEventReadOnly,
-  useCalendarLookup,
-} from "@web/calendars/useCalendarLookup";
-import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { repositionDraftByKeyboard } from "@web/common/utils/draft/reposition-draft-by-keyboard.util";
-import { nudgeEventFromKeyboard } from "@web/common/utils/event/event-nudge-shortcut.util";
-import {
-  isDeleteTextEditingTarget,
-  isEditableKeyboardTarget,
-  isEventFormKeyboardTarget,
-  isEventFormOpen,
-} from "@web/common/utils/form/form.util";
-import {
-  type EventMutationDependencies,
-  useEventMutations,
-} from "@web/events/mutations/useEventMutations";
-import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
+import { type EventMutationDependencies } from "@web/events/mutations/useEventMutations";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
-import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import {
-  type DayGridEventTarget,
   getFirstVisibleDayGridEventTarget,
   getFocusedDayGridEventTarget,
   getHoveredDayGridEventTarget,
 } from "@web/views/Day/interaction/targeting/day-event.targeting";
-import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
-
-const DRAFT_MOVEMENT_HOTKEY_OPTIONS = {
-  ignoreInputs: false,
-  preventDefault: false,
-  stopPropagation: false,
-} as const;
 
 /**
- * Day-view edit shortcuts shared with Week: Delete, Shift+arrows (nudge /
- * day-move), and Arrow keys to reposition an open draft. Shift+ArrowLeft/Right
- * move a focused event by one day and follow that day in the Day view.
- *
- * Handlers close over latest render values; TanStack Hotkeys syncs the
- * callback each render, so event-list refs are unnecessary.
+ * Day-view edit shortcuts: Delete, Shift+arrows (nudge / day-move), and
+ * Arrow keys to reposition an open draft. Shift+ArrowLeft/Right move a
+ * focused event by one day and follow that day in the Day view.
  */
 export function useDayEventNudgeShortcuts({
   allDayEvents = [],
@@ -54,130 +27,39 @@ export function useDayEventNudgeShortcuts({
   navigateToDate?: (date: Dayjs) => void;
   timedEvents: GridEvent[];
 }) {
-  const calendarLookup = useCalendarLookup();
-  const { delete: deleteEvent } = useEventMutations(dependencies);
-  const updateEvent = useUpdateEvent(dependencies);
+  useGridEventEditShortcuts({
+    allDayEvents,
+    dependencies,
+    timedEvents,
+    dayBoundary: {
+      kind: "follow",
+      onCrossed: (date) => navigateToDate?.(date),
+    },
+    targeting: {
+      getFocused: getFocusedDayGridEventTarget,
+      getHovered: getHoveredDayGridEventTarget,
+      getFirstVisible: getFirstVisibleDayGridEventTarget,
+    },
+    repositionDraftByKey: (key) => {
+      const { gridDraft, status } = useDraftStore.getState();
+      const previousStart = gridDraft
+        ? dayjs(gridDraft.values.schedule.start).startOf("day")
+        : null;
 
-  const findCalendarEventForTarget = (target: DayGridEventTarget) => {
-    const events = target.eventType === "all-day" ? allDayEvents : timedEvents;
-    return events.find((candidate) => candidate._id === target.eventId) ?? null;
-  };
+      const nextDraft = repositionDraftByKeyboard({
+        activity: status?.activity,
+        draft: gridDraft,
+        key,
+      });
+      if (!nextDraft) return false;
 
-  const deleteTargetedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
-    if (
-      isDeleteTextEditingTarget(keyboardEvent) ||
-      isEventFormKeyboardTarget(keyboardEvent)
-    ) {
-      return;
-    }
+      draftActions.setGridDraft(nextDraft);
 
-    if (document.activeElement?.closest(`#${ID_SIDEBAR}`)) {
-      return;
-    }
-
-    const target =
-      getFocusedDayGridEventTarget() ??
-      getHoveredDayGridEventTarget() ??
-      getFirstVisibleDayGridEventTarget();
-    if (!target) return;
-
-    const event = findCalendarEventForTarget(target);
-    if (!event) return;
-
-    if (
-      isEventReadOnly(calendarLookup, event.calendarId, event.isBusy ?? false)
-    ) {
-      return;
-    }
-
-    keyboardEvent.preventDefault();
-    keyboardEvent.stopPropagation();
-    deleteEventAndDiscardDraft(deleteEvent, event);
-  };
-
-  const moveFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
-    if (isEventFormOpen()) return;
-
-    // Focused only (no hover/first-visible fallback): moving an event the
-    // user isn't focused on would be surprising.
-    const target = getFocusedDayGridEventTarget();
-    if (!target) return;
-
-    const event = findCalendarEventForTarget(target);
-    if (!event?._id) return;
-
-    if (
-      isEventReadOnly(calendarLookup, event.calendarId, event.isBusy ?? false)
-    ) {
-      return;
-    }
-
-    const previousStart = dayjs(event.startDate).startOf("day");
-
-    nudgeEventFromKeyboard({
-      event,
-      keyboardEvent,
-      onNudge: (nudgedEvent) => {
-        updateEvent({ event: nudgedEvent }, true);
-        const nextStart = dayjs(nudgedEvent.startDate).startOf("day");
-        if (!nextStart.isSame(previousStart, "day")) {
-          navigateToDate?.(nextStart);
-        }
-      },
-      afterNudge: () => draftActions.discard(),
-    });
-  };
-
-  const moveShortcutCreatedDraft = (keyboardEvent: KeyboardEvent) => {
-    if (isEditableKeyboardTarget(keyboardEvent)) return;
-
-    const { gridDraft, status } = useDraftStore.getState();
-    const previousStart = gridDraft
-      ? dayjs(gridDraft.values.schedule.start).startOf("day")
-      : null;
-
-    const nextDraft = repositionDraftByKeyboard({
-      activity: status?.activity,
-      draft: gridDraft,
-      key: keyboardEvent.key,
-    });
-    if (!nextDraft) return;
-
-    keyboardEvent.preventDefault();
-    keyboardEvent.stopPropagation();
-    draftActions.setGridDraft(nextDraft);
-
-    const nextStart = dayjs(nextDraft.values.schedule.start).startOf("day");
-    if (previousStart && !nextStart.isSame(previousStart, "day")) {
-      navigateToDate?.(nextStart);
-    }
-  };
-
-  useAppShortcut("Delete", deleteTargetedCalendarEvent, {
-    ignoreInputs: false,
+      const nextStart = dayjs(nextDraft.values.schedule.start).startOf("day");
+      if (previousStart && !nextStart.isSame(previousStart, "day")) {
+        navigateToDate?.(nextStart);
+      }
+      return true;
+    },
   });
-  useAppShortcut(
-    "ArrowUp",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "ArrowDown",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "ArrowLeft",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "ArrowRight",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut("Shift+ArrowUp", moveFocusedCalendarEvent);
-  useAppShortcut("Shift+ArrowDown", moveFocusedCalendarEvent);
-  useAppShortcut("Shift+ArrowLeft", moveFocusedCalendarEvent);
-  useAppShortcut("Shift+ArrowRight", moveFocusedCalendarEvent);
 }

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo } from "react";
+import { type FC, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { Origin } from "@core/constants/core.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -6,11 +6,6 @@ import { getDraftContainer } from "@web/common/utils/draft/draft.util";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
-import {
-  selectDraftActivity,
-  selectGridDraft,
-  useDraftStore,
-} from "@web/events/stores/draft.store";
 import { positionAllDayDraftEvent } from "@web/grid/layout/all-day-draft.position";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -34,37 +29,8 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
-  const { actions, state } = useDraftContext();
-  const { draft, isDragging, isFormOpen, isResizing } = state;
-  const { setLocalDraft } = actions;
-  const gridDraftFromStore = useDraftStore(selectGridDraft);
-  const activity = useDraftStore(selectDraftActivity);
-
-  // Context-menu Edit only flips store isFormOpen (handleChange skips
-  // eventRightClick), so hydrate local draft during render — otherwise the
-  // portal would lag a frame behind the sidebar form. Allow a non-null
-  // overwrite only for eventRightClick: an earlier create/nudge can leave
-  // stale local state, but keyboard repositioning (other activities) updates
-  // local only and must not be undone here.
-  if (
-    !isDragging &&
-    !isResizing &&
-    isFormOpen &&
-    gridDraftFromStore &&
-    (draft === null || activity === "eventRightClick")
-  ) {
-    setLocalDraft(gridDraftFromStore);
-  }
-
-  // Sidebar edits write the shared draft store. Mirror into Week local draft
-  // when the store draft changes while the form is idle.
-  useEffect(() => {
-    if (isDragging || isResizing || !isFormOpen || !gridDraftFromStore) {
-      return;
-    }
-
-    setLocalDraft(gridDraftFromStore);
-  }, [gridDraftFromStore, isDragging, isFormOpen, isResizing, setLocalDraft]);
+  const { state } = useDraftContext();
+  const { draft } = state;
 
   // GridEvent-shaped projection of the canonical GridEventDraft, for
   // the still-unconverted grid-layout helpers below (deck layout, all-day

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   type Activity_DraftEvent,
   draftActions,
+  useDraftStore,
 } from "@web/events/stores/draft.store";
 import { CROSS_ROW_TIMED_DURATION_MIN } from "@web/grid/interaction/math/cross-row.drag";
 import {
@@ -145,6 +146,7 @@ const createState = (
   draft: createEditDraft(),
   dragOffset: { x: 0, y: 0 },
   dragStatus: null,
+  gestureOriginDraft: null,
   isDragging: false,
   isFormOpen: true,
   isFormOpenBeforeDragging: null,
@@ -157,9 +159,9 @@ const createSetters = (
   overrides: Partial<Setters_Draft> = {},
 ): Setters_Draft => ({
   setDateBeingChanged: mock(),
-  setDraft: mock(),
   setDragOffset: mock(),
   setDragStatus: mock(),
+  setGestureOriginDraft: mock(),
   setIsDragging: mock(),
   setIsFormOpen: mock(),
   setIsFormOpenBeforeDragging: mock(),
@@ -221,13 +223,25 @@ const setDraftActivity = (
     isDrafting: true,
     isFormOpen: false,
   };
+  const existing = useDraftStore.getState();
+  useDraftStore.setState({
+    gridDraft: existing.gridDraft,
+    status: {
+      activity,
+      dateToResize: null,
+      eventType,
+      isDrafting: true,
+      isFormOpen: false,
+    },
+  });
 };
+
+const readStoreDraft = () => useDraftStore.getState().gridDraft;
 
 const renderDraftActions = (
   draft: GridEventDraft,
   stateOverrides: Partial<State_Draft_Local> = {},
 ) => {
-  const setDraft = mock();
   const setDragOffset = mock();
   const setDragStatus = mock();
   currentState.events!.draft = {
@@ -240,29 +254,24 @@ const renderDraftActions = (
     () =>
       useDraftActions(
         createState({ draft, ...stateOverrides }),
-        createSetters({ setDraft, setDragOffset, setDragStatus }),
+        createSetters({ setDragOffset, setDragStatus }),
         dateCalcs,
         weekProps,
       ),
     { wrapper },
   );
 
-  setDraft.mockClear();
   setDragOffset.mockClear();
   setDragStatus.mockClear();
 
-  return { result, setDraft, setDragOffset, setDragStatus };
+  return { result, setDragOffset, setDragStatus };
 };
 
-const expectDraftRange = (
-  setDraft: ReturnType<typeof mock>,
-  startDate: string,
-  endDate: string,
-) => {
-  const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
-
-  expect(dayjs(nextDraft.values.schedule.start).isSame(startDate)).toBe(true);
-  expect(dayjs(nextDraft.values.schedule.end).isSame(endDate)).toBe(true);
+const expectDraftRange = (startDate: string, endDate: string) => {
+  const nextDraft = readStoreDraft();
+  expect(nextDraft).not.toBeNull();
+  expect(dayjs(nextDraft!.values.schedule.start).isSame(startDate)).toBe(true);
+  expect(dayjs(nextDraft!.values.schedule.end).isSame(endDate)).toBe(true);
 };
 
 describe("useDraftActions", () => {
@@ -278,29 +287,29 @@ describe("useDraftActions", () => {
         isFormOpen: false,
       },
     };
+    draftActions.discard();
+    draftActions.setGridDraft(draft);
   });
 
   it("moves a shortcut-created timed draft by keyboard while preserving duration", () => {
     setDraftActivity("createShortcut");
-    const { result, setDraft } = renderDraftActions(
+    const { result } = renderDraftActions(
       createNewDraft({
         start: "2024-01-16T10:00:00.000Z",
         end: "2024-01-16T11:00:00.000Z",
       }),
     );
 
+    const before = readStoreDraft();
     result.current.repositionDraftByKeyboard("ArrowDown");
 
-    expectDraftRange(
-      setDraft,
-      "2024-01-16T10:15:00.000Z",
-      "2024-01-16T11:15:00.000Z",
-    );
+    expectDraftRange("2024-01-16T10:15:00.000Z", "2024-01-16T11:15:00.000Z");
+    expect(readStoreDraft()).not.toBe(before);
   });
 
   it("moves a mouse-created timed draft by keyboard while preserving duration", () => {
     setDraftActivity("gridClick");
-    const { result, setDraft } = renderDraftActions(
+    const { result } = renderDraftActions(
       createNewDraft({
         start: "2024-01-16T10:00:00.000Z",
         end: "2024-01-16T11:00:00.000Z",
@@ -309,16 +318,12 @@ describe("useDraftActions", () => {
 
     result.current.repositionDraftByKeyboard("ArrowDown");
 
-    expectDraftRange(
-      setDraft,
-      "2024-01-16T10:15:00.000Z",
-      "2024-01-16T11:15:00.000Z",
-    );
+    expectDraftRange("2024-01-16T10:15:00.000Z", "2024-01-16T11:15:00.000Z");
   });
 
   it("moves a clicked existing timed event draft by keyboard", () => {
     setDraftActivity("gridClick");
-    const { result, setDraft } = renderDraftActions(
+    const { result } = renderDraftActions(
       createEditDraft({
         start: "2024-01-16T10:00:00.000Z",
         end: "2024-01-16T11:00:00.000Z",
@@ -327,16 +332,12 @@ describe("useDraftActions", () => {
 
     result.current.repositionDraftByKeyboard("ArrowLeft");
 
-    expectDraftRange(
-      setDraft,
-      "2024-01-15T10:00:00.000Z",
-      "2024-01-15T11:00:00.000Z",
-    );
+    expectDraftRange("2024-01-15T10:00:00.000Z", "2024-01-15T11:00:00.000Z");
   });
 
   it("moves a keyboard-opened existing timed event draft by keyboard", () => {
     setDraftActivity("keyboardEdit");
-    const { result, setDraft } = renderDraftActions(
+    const { result } = renderDraftActions(
       createEditDraft({
         start: "2024-01-16T10:00:00.000Z",
         end: "2024-01-16T11:00:00.000Z",
@@ -345,30 +346,30 @@ describe("useDraftActions", () => {
 
     result.current.repositionDraftByKeyboard("ArrowRight");
 
-    expectDraftRange(
-      setDraft,
-      "2024-01-17T10:00:00.000Z",
-      "2024-01-17T11:00:00.000Z",
-    );
+    expectDraftRange("2024-01-17T10:00:00.000Z", "2024-01-17T11:00:00.000Z");
   });
 
   it("does not move a timed draft past midnight", () => {
     setDraftActivity("createShortcut");
-    const { result, setDraft } = renderDraftActions(
-      createNewDraft({
-        start: "2024-01-16T23:00:00.000Z",
-        end: "2024-01-17T00:00:00.000Z",
-      }),
-    );
+    const draft = createNewDraft({
+      start: "2024-01-16T23:00:00.000Z",
+      end: "2024-01-17T00:00:00.000Z",
+    });
+    const { result } = renderDraftActions(draft);
 
     result.current.repositionDraftByKeyboard("ArrowDown");
 
-    expect(setDraft).not.toHaveBeenCalled();
+    expect(readStoreDraft()).toBe(useDraftStore.getState().gridDraft);
+    expect(
+      dayjs(readStoreDraft()!.values.schedule.start).isSame(
+        draft.values.schedule.start,
+      ),
+    ).toBe(true);
   });
 
   it("moves a clicked existing all-day event draft horizontally and ignores vertical arrows", () => {
     setDraftActivity("gridClick", Categories_Event.ALLDAY);
-    const { result, setDraft } = renderDraftActions(
+    const { result } = renderDraftActions(
       createEditDraft({
         isAllDay: true,
         start: "2024-01-16T00:00:00.000Z",
@@ -378,21 +379,17 @@ describe("useDraftActions", () => {
 
     result.current.repositionDraftByKeyboard("ArrowRight");
 
-    expectDraftRange(
-      setDraft,
-      "2024-01-17T00:00:00.000Z",
-      "2024-01-18T00:00:00.000Z",
-    );
+    expectDraftRange("2024-01-17T00:00:00.000Z", "2024-01-18T00:00:00.000Z");
 
-    setDraft.mockClear();
+    const afterHorizontal = readStoreDraft();
     result.current.repositionDraftByKeyboard("ArrowDown");
 
-    expect(setDraft).not.toHaveBeenCalled();
+    expect(readStoreDraft()).toBe(afterHorizontal);
   });
 
   it("moves a shortcut-created all-day draft horizontally and ignores vertical arrows", () => {
     setDraftActivity("createShortcut", Categories_Event.ALLDAY);
-    const { result, setDraft } = renderDraftActions(
+    const { result } = renderDraftActions(
       createNewDraft({
         isAllDay: true,
         start: "2024-01-16T00:00:00.000Z",
@@ -402,16 +399,12 @@ describe("useDraftActions", () => {
 
     result.current.repositionDraftByKeyboard("ArrowRight");
 
-    expectDraftRange(
-      setDraft,
-      "2024-01-17T00:00:00.000Z",
-      "2024-01-18T00:00:00.000Z",
-    );
+    expectDraftRange("2024-01-17T00:00:00.000Z", "2024-01-18T00:00:00.000Z");
 
-    setDraft.mockClear();
+    const afterHorizontal = readStoreDraft();
     result.current.repositionDraftByKeyboard("ArrowDown");
 
-    expect(setDraft).not.toHaveBeenCalled();
+    expect(readStoreDraft()).toBe(afterHorizontal);
   });
 
   // A live drag-create must not turn into a local resize: `resize()` freezes
@@ -457,22 +450,21 @@ describe("useDraftActions", () => {
       start: "2024-01-16T00:00:00.000Z",
       end: "2024-01-17T00:00:00.000Z",
     });
-    const { result, setDraft, setDragOffset, setDragStatus } =
-      renderDraftActions(draft, {
-        isDragging: true,
-        dragOffset: { x: 10, y: 5 },
-        dragStatus: { durationMin: 24 * 60 },
-      });
+    const { result, setDragOffset, setDragStatus } = renderDraftActions(draft, {
+      isDragging: true,
+      dragOffset: { x: 10, y: 5 },
+      dragStatus: { durationMin: 24 * 60 },
+    });
 
     act(() => {
       result.current.drag({ clientX: 100, clientY: 200 });
     });
 
-    const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
-    expect(nextDraft.values.schedule.kind).toBe("timed");
+    const nextDraft = readStoreDraft();
+    expect(nextDraft!.values.schedule.kind).toBe("timed");
     expect(
-      dayjs(nextDraft.values.schedule.end).diff(
-        nextDraft.values.schedule.start,
+      dayjs(nextDraft!.values.schedule.end).diff(
+        nextDraft!.values.schedule.start,
         "minutes",
       ),
     ).toBe(CROSS_ROW_TIMED_DURATION_MIN);
@@ -488,7 +480,7 @@ describe("useDraftActions", () => {
       start: "2024-01-16T00:00:00.000Z",
       end: "2024-01-17T00:00:00.000Z",
     });
-    const { result, setDraft } = renderDraftActions(draft, {
+    const { result } = renderDraftActions(draft, {
       isDragging: true,
       dragOffset: { x: 8, y: 4 },
       dragStatus: { durationMin: 24 * 60, hasMoved: false },
@@ -498,9 +490,9 @@ describe("useDraftActions", () => {
       result.current.drag({ clientX: 200, clientY: 180 });
     });
 
-    const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
-    expect(nextDraft.kind).toBe("edit");
-    expect(nextDraft.values.schedule.kind).toBe("timed");
+    const nextDraft = readStoreDraft();
+    expect(nextDraft!.kind).toBe("edit");
+    expect(nextDraft!.values.schedule.kind).toBe("timed");
   });
 
   it("converts on drag start when the pointer is already over the timed grid", () => {
@@ -511,7 +503,7 @@ describe("useDraftActions", () => {
       start: "2024-01-16T00:00:00.000Z",
       end: "2024-01-17T00:00:00.000Z",
     });
-    const { result, setDraft } = renderDraftActions(draft, {
+    const { result } = renderDraftActions(draft, {
       isDragging: false,
       dragOffset: { x: 0, y: 0 },
       dragStatus: { durationMin: 24 * 60 },
@@ -524,11 +516,11 @@ describe("useDraftActions", () => {
       );
     });
 
-    const nextDraft = setDraft.mock.calls[0]?.[0] as GridEventDraft;
-    expect(nextDraft.values.schedule.kind).toBe("timed");
+    const nextDraft = readStoreDraft();
+    expect(nextDraft!.values.schedule.kind).toBe("timed");
     expect(
-      dayjs(nextDraft.values.schedule.end).diff(
-        nextDraft.values.schedule.start,
+      dayjs(nextDraft!.values.schedule.end).diff(
+        nextDraft!.values.schedule.start,
         "minutes",
       ),
     ).toBe(CROSS_ROW_TIMED_DURATION_MIN);

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -216,23 +216,20 @@ const setDraftActivity = (
   activity: Activity_DraftEvent,
   eventType = Categories_Event.TIMED,
 ) => {
-  currentState.events!.draft = currentState.events!.draft ?? {};
-  currentState.events!.draft.status = {
+  // createStoreWrapper reseeds Zustand from currentState, so keep both in sync.
+  const status = {
     activity,
     eventType,
     isDrafting: true,
     isFormOpen: false,
   };
-  const existing = useDraftStore.getState();
+  currentState.events!.draft = {
+    ...(currentState.events!.draft ?? {}),
+    status,
+  };
   useDraftStore.setState({
-    gridDraft: existing.gridDraft,
-    status: {
-      activity,
-      dateToResize: null,
-      eventType,
-      isDrafting: true,
-      isFormOpen: false,
-    },
+    gridDraft: useDraftStore.getState().gridDraft,
+    status,
   });
 };
 
@@ -407,39 +404,38 @@ describe("useDraftActions", () => {
     expect(readStoreDraft()).toBe(afterHorizontal);
   });
 
-  // A live drag-create must not turn into a local resize: `resize()` freezes
-  // the store draft as its origin, and during creation that draft moves with
-  // the pointer, which would collapse its math.
-  it("mirrors a live drag-create into local state without starting a resize", () => {
+  // Drag-create uses the store-owned preview (`creating`). handleChange must
+  // not start a local resize — that freezes against a moving store draft.
+  it("does not start a local resize while a drag-create preview is live", () => {
     setDraftActivity("creating");
     const draft = createNewDraft({
       start: "2024-01-16T10:00:00.000Z",
       end: "2024-01-16T11:00:00.000Z",
     });
-    const setDraft = mock();
     const setIsResizing = mock();
+    const setGestureOriginDraft = mock();
 
     currentState.events!.draft = {
       ...currentState.events!.draft,
       gridDraft: draft,
     };
+    draftActions.setGridDraft(draft);
     const { wrapper } = createStoreWrapper(currentState);
 
     renderHook(
       () =>
         useDraftActions(
-          createState({ draft: null }),
-          createSetters({ setDraft, setIsResizing }),
+          createState({ draft }),
+          createSetters({ setIsResizing, setGestureOriginDraft }),
           dateCalcs,
           weekProps,
         ),
       { wrapper },
     );
 
-    expect(setDraft).toHaveBeenCalledWith(draft);
-    // The mount effect calls setIsResizing(false) to clear stale state; what
-    // must never happen is a resize being switched *on*.
     expect(setIsResizing).not.toHaveBeenCalledWith(true);
+    expect(setGestureOriginDraft).not.toHaveBeenCalled();
+    expect(useDraftStore.getState().gridDraft).toEqual(draft);
   });
 
   it("converts a new all-day draft to timed while dragging over the timed grid", () => {

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -21,11 +21,13 @@ import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import {
   draftActions,
   selectDraftStatus,
-  selectGridDraft,
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
-import { useDraftEffects } from "@web/views/Week/components/Draft/hooks/effects/useDraftEffects";
+import {
+  clearGestureEphemera,
+  useDraftEffects,
+} from "@web/views/Week/components/Draft/hooks/effects/useDraftEffects";
 import {
   type DragOffset,
   type Setters_Draft,
@@ -56,10 +58,6 @@ export const useDraftActions = (
 ) => {
   const mutations = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
-  // Prefer the store selector so high-frequency gesture writes stay in sync
-  // with React renders; gesture handlers also re-read via getState().
-  const draft = useDraftStore(selectGridDraft);
-
   const { activity, isDrafting } = useDraftStore(selectDraftStatus)!;
 
   const {
@@ -127,23 +125,9 @@ export const useDraftActions = (
   ]);
 
   const discard = useCallback(() => {
-    setIsDragging(false);
-    setIsFormOpen(false);
-    setIsResizing(false);
-    setDragStatus(null);
-    setResizeStatus(null);
-    setDateBeingChanged(null);
-    setGestureOriginDraft(null);
+    clearGestureEphemera(setters);
     draftActions.discard();
-  }, [
-    setDateBeingChanged,
-    setDragStatus,
-    setGestureOriginDraft,
-    setIsDragging,
-    setIsFormOpen,
-    setIsResizing,
-    setResizeStatus,
-  ]);
+  }, [setters]);
 
   const determineSubmitAction = useCallback(
     (draft: GridEventDraft) => {
@@ -532,38 +516,16 @@ export const useDraftActions = (
     if (activity === "eventRightClick") {
       return; // Prevents form and context menu from opening at same time
     }
-    if (activity === "keyboardEdit") {
+    if (
+      activity === "keyboardEdit" ||
+      activity === "createShortcut" ||
+      activity === "gridClick"
+    ) {
       setIsFormOpen(true);
-      return;
     }
-    if (activity === "createShortcut" || activity === "gridClick") {
-      setIsFormOpen(true);
-      return;
-    }
-<<<<<<< HEAD
-    if (activity === "creating") {
-      // Mirror the running drag-create preview. Deliberately does not start a
-      // local resize: `resize()` freezes the store draft as its origin, so
-      // letting it run against a store draft that moves with the pointer would
-      // collapse its math.
-      if (gridDraftFromStore) setDraft(gridDraftFromStore);
-    }
-  }, [
-    isDrafting,
-    activity,
-    create,
-    setDraft,
-    gridDraftFromStore,
-    setIsFormOpen,
-  ]);
-=======
-    if (activity === "resizing") {
-      if (dateToResize === "startDate" || dateToResize === "endDate") {
-        startResizing(dateToResize);
-      }
-    }
-  }, [isDrafting, activity, dateToResize, setIsFormOpen, startResizing]);
->>>>>>> d408b41c (refactor(web): make zustand the sole draft values owner)
+    // "creating": store already owns the live drag-create preview — no
+    // local mirror or resize start needed.
+  }, [isDrafting, activity, setIsFormOpen]);
 
   const actions = {
     submit,
@@ -594,13 +556,7 @@ export const useDraftActions = (
     stopResizing,
   };
 
-  useDraftEffects(
-    { ...draftState, draft },
-    setters,
-    weekProps,
-    isDrafting,
-    handleChange,
-  );
+  useDraftEffects(draftState, setters, weekProps, isDrafting, handleChange);
 
   return actions;
 };

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -45,6 +45,9 @@ const scopeFromApplyTo = (
       ? "thisAndFollowing"
       : "this";
 
+const readLiveDraft = (): GridEventDraft | null =>
+  useDraftStore.getState().gridDraft;
+
 export const useDraftActions = (
   draftState: State_Draft_Local,
   setters: Setters_Draft,
@@ -53,15 +56,17 @@ export const useDraftActions = (
 ) => {
   const mutations = useEventMutations();
   const { data: calendars } = useCalendarsQuery();
-  const gridDraftFromStore = useDraftStore(selectGridDraft);
+  // Prefer the store selector so high-frequency gesture writes stay in sync
+  // with React renders; gesture handlers also re-read via getState().
+  const draft = useDraftStore(selectGridDraft);
 
   const { activity, isDrafting } = useDraftStore(selectDraftStatus)!;
 
   const {
     dateBeingChanged,
-    draft,
     dragOffset,
     dragStatus,
+    gestureOriginDraft,
     isDragging,
     isResizing,
     resizeStatus,
@@ -74,9 +79,9 @@ export const useDraftActions = (
     setIsResizing,
     setDragOffset,
     setDragStatus,
+    setGestureOriginDraft,
     setResizeStatus,
     setDateBeingChanged,
-    setDraft,
     setIsFormOpen,
     setIsFormOpenBeforeDragging,
   } = setters;
@@ -93,10 +98,14 @@ export const useDraftActions = (
 
   const startResizing = useCallback(
     (dateBeingChanged: "startDate" | "endDate") => {
+      const liveDraft = readLiveDraft();
+      if (liveDraft) {
+        setGestureOriginDraft(liveDraft);
+      }
       setIsResizing(true);
       setDateBeingChanged(dateBeingChanged);
     },
-    [setIsResizing, setDateBeingChanged],
+    [setDateBeingChanged, setGestureOriginDraft, setIsResizing],
   );
 
   const stopDragging = useCallback(() => {
@@ -109,26 +118,27 @@ export const useDraftActions = (
     setIsResizing(false);
     setResizeStatus(null);
     setDateBeingChanged("endDate");
-  }, [setIsResizing, setResizeStatus, setDateBeingChanged]);
+    setGestureOriginDraft(null);
+  }, [
+    setDateBeingChanged,
+    setGestureOriginDraft,
+    setIsResizing,
+    setResizeStatus,
+  ]);
 
   const discard = useCallback(() => {
-    setDraft(null);
     setIsDragging(false);
     setIsFormOpen(false);
     setIsResizing(false);
     setDragStatus(null);
     setResizeStatus(null);
     setDateBeingChanged(null);
-
-    if (gridDraftFromStore || isDrafting) {
-      draftActions.discard();
-    }
+    setGestureOriginDraft(null);
+    draftActions.discard();
   }, [
-    gridDraftFromStore,
-    isDrafting,
     setDateBeingChanged,
-    setDraft,
     setDragStatus,
+    setGestureOriginDraft,
     setIsDragging,
     setIsFormOpen,
     setIsResizing,
@@ -239,18 +249,19 @@ export const useDraftActions = (
 
   const repositionDraftByKeyboard = useCallback(
     (key: string) => {
+      const liveDraft = readLiveDraft();
       const nextDraft = applyDraftKeyboardReposition({
         activity,
-        draft,
+        draft: liveDraft,
         key,
         isStartAllowed: (nextStart) => isInsideVisibleWeek(dayjs(nextStart)),
       });
       if (!nextDraft) return false;
 
-      setDraft(nextDraft);
+      draftActions.setGridDraft(nextDraft);
       return true;
     },
-    [activity, draft, isInsideVisibleWeek, setDraft],
+    [activity, isInsideVisibleWeek],
   );
 
   const applyDragPosition = useCallback(
@@ -259,7 +270,8 @@ export const useDraftActions = (
       offset: DragOffset,
       status: Status_Drag | null,
     ) => {
-      if (!draft) return;
+      const liveDraft = readLiveDraft();
+      if (!liveDraft) return;
 
       const { durationMin, schedule } = resolveDraftDragSchedule({
         clientX: e.clientX,
@@ -267,22 +279,18 @@ export const useDraftActions = (
         dragOffset: offset,
         dragStatus: status,
         getDateByXY: dateCalcs.getDateByXY,
-        schedule: draft.values.schedule,
+        schedule: liveDraft.values.schedule,
         startOfView: weekProps.component.startOfView,
       });
 
-      const nextDraft = replaceGridDraftSchedule(draft, schedule);
-      const prev = draft.values.schedule;
+      const nextDraft = replaceGridDraftSchedule(liveDraft, schedule);
+      const prev = liveDraft.values.schedule;
       const kindChanged = prev.kind !== schedule.kind;
       const hasMoved =
         kindChanged ||
         !dayjs(prev.start).isSame(schedule.start) ||
         !dayjs(prev.end).isSame(schedule.end);
 
-      // Keep the shared store in sync so form hydration and eventType track
-      // cross-row kind flips (local-only updates would be overwritten on
-      // mouseup when the form opens).
-      setDraft(nextDraft);
       draftActions.setGridDraft(nextDraft);
 
       // Cross-row conversion switches between grab-offset and absolute pointer
@@ -305,8 +313,6 @@ export const useDraftActions = (
     },
     [
       dateCalcs.getDateByXY,
-      draft,
-      setDraft,
       setDragOffset,
       setDragStatus,
       weekProps.component.startOfView,
@@ -326,43 +332,44 @@ export const useDraftActions = (
   );
 
   const isValidMovement = useCallback(
-    (currTime: dayjs.Dayjs) => {
-      if (!draft || !dateBeingChanged) return false;
+    (currTime: dayjs.Dayjs, liveDraft: GridEventDraft) => {
+      if (!dateBeingChanged) return false;
 
-      const isAllDay = draft.values.schedule.kind === "allDay";
+      const isAllDay = liveDraft.values.schedule.kind === "allDay";
       if (isAllDay) {
         return true;
       }
 
       const draftDate =
         dateBeingChanged === "startDate"
-          ? draft.values.schedule.start
-          : draft.values.schedule.end;
+          ? liveDraft.values.schedule.start
+          : liveDraft.values.schedule.end;
       const _currTime = currTime.format();
       const noChange = dayjs(draftDate).format() === _currTime;
 
       if (noChange) return false;
 
       const diffDay =
-        currTime.day() !== dayjs(draft.values.schedule.start).day();
+        currTime.day() !== dayjs(liveDraft.values.schedule.start).day();
       if (diffDay) return false;
 
       const sameStart =
-        _currTime === dayjs(draft.values.schedule.start).format();
+        _currTime === dayjs(liveDraft.values.schedule.start).format();
       if (sameStart) return false;
 
       return true;
     },
-    [dateBeingChanged, draft],
+    [dateBeingChanged],
   );
 
   const resize = useCallback(
     (e: MouseEvent) => {
-      // Freeze the origin against the store draft: local `setDraft` updates
+      const liveDraft = readLiveDraft();
+      // Freeze the origin against the gesture snapshot so live store updates
       // mid-gesture must not shift the resize baseline.
-      if (!draft || !gridDraftFromStore) return;
+      if (!liveDraft || !gestureOriginDraft) return;
 
-      const isAllDay = draft.values.schedule.kind === "allDay";
+      const isAllDay = liveDraft.values.schedule.kind === "allDay";
       const _dateBeingChanged = dateBeingChanged as "startDate" | "endDate";
       const oppositeKey =
         _dateBeingChanged === "startDate" ? "endDate" : "startDate";
@@ -378,34 +385,39 @@ export const useDraftActions = (
           ? dayjs(date).format(YEAR_MONTH_DAY_FORMAT)
           : dayjs(date).format();
       const draftDates: Record<"startDate" | "endDate", string> = {
-        startDate: formatDraftDate(draft.values.schedule.start),
-        endDate: formatDraftDate(draft.values.schedule.end),
+        startDate: formatDraftDate(liveDraft.values.schedule.start),
+        endDate: formatDraftDate(liveDraft.values.schedule.end),
       };
       const originDates: Record<"startDate" | "endDate", string> = {
-        startDate: formatDraftDate(gridDraftFromStore.values.schedule.start),
-        endDate: formatDraftDate(gridDraftFromStore.values.schedule.end),
+        startDate: formatDraftDate(gestureOriginDraft.values.schedule.start),
+        endDate: formatDraftDate(gestureOriginDraft.values.schedule.end),
       };
+
+      let workingDraft = liveDraft;
+      let workingDateBeingChanged = dateBeingChanged;
 
       const flipIfNeeded = (currTime: Dayjs) => {
         let startDate = draftDates.startDate;
         let endDate = draftDates.endDate;
 
         let justFlipped = false;
-        let dateKey = dateBeingChanged;
+        let dateKey = workingDateBeingChanged;
         const opposite = dayjs(draftDates[oppositeKey]);
         const comparisonKeyword =
-          dateBeingChanged === "startDate" ? "after" : "before";
+          workingDateBeingChanged === "startDate" ? "after" : "before";
 
         if (comparisonKeyword === "after") {
           if (currTime.isAfter(opposite)) {
             dateKey = oppositeKey;
             startDate = draftDates.endDate;
+            workingDateBeingChanged = dateKey;
             setDateBeingChanged(dateKey);
 
             justFlipped = true;
           }
         } else if (comparisonKeyword === "before") {
           if (currTime.isBefore(opposite)) {
+            workingDateBeingChanged = oppositeKey;
             setDateBeingChanged(oppositeKey);
             if (isAllDay) {
               // For all-day events, move by day
@@ -438,17 +450,12 @@ export const useDraftActions = (
               end: dayjs(endDate).toDate(),
             }
           : {
-              ...draft.values.schedule,
+              ...workingDraft.values.schedule,
               start: dayjs(startDate).toDate(),
               end: dayjs(endDate).toDate(),
             };
 
-        setDraft((_draft) => {
-          if (!_draft) return _draft;
-
-          return replaceGridDraftSchedule(_draft, schedule);
-        });
-
+        workingDraft = replaceGridDraftSchedule(workingDraft, schedule);
         return justFlipped;
       };
 
@@ -465,7 +472,7 @@ export const useDraftActions = (
         weekProps.component.startOfView,
       );
 
-      if (!isValidMovement(currTime)) {
+      if (!isValidMovement(currTime, workingDraft)) {
         return;
       }
 
@@ -495,41 +502,30 @@ export const useDraftActions = (
         setResizeStatus({ hasMoved: true });
       }
 
-      setDraft((_draft) => {
-        if (!_draft) return _draft;
+      const nextSchedule: GridScheduleDraft = {
+        ...workingDraft.values.schedule,
+        ...(dateChanged === "startDate"
+          ? { start: dayjs(updatedTime).toDate() }
+          : { end: dayjs(updatedTime).toDate() }),
+      } as GridScheduleDraft;
 
-        const nextSchedule: GridScheduleDraft = {
-          ..._draft.values.schedule,
-          ...(dateChanged === "startDate"
-            ? { start: dayjs(updatedTime).toDate() }
-            : { end: dayjs(updatedTime).toDate() }),
-        } as GridScheduleDraft;
-
-        return replaceGridDraftSchedule(_draft, nextSchedule);
-      });
+      draftActions.setGridDraft(
+        replaceGridDraftSchedule(workingDraft, nextSchedule),
+      );
     },
     [
       dateBeingChanged,
       dateCalcs,
-      draft,
-      gridDraftFromStore,
+      gestureOriginDraft,
       isResizing,
       isValidMovement,
       resizeStatus?.hasMoved,
       setDateBeingChanged,
-      setDraft,
       setIsFormOpen,
       setResizeStatus,
       weekProps.component.startOfView,
     ],
   );
-
-  const create = useCallback(async () => {
-    if (!gridDraftFromStore) return;
-
-    setDraft(gridDraftFromStore);
-    setIsFormOpen(true);
-  }, [gridDraftFromStore, setDraft, setIsFormOpen]);
 
   const handleChange = useCallback(async () => {
     if (!isDrafting) return;
@@ -537,14 +533,14 @@ export const useDraftActions = (
       return; // Prevents form and context menu from opening at same time
     }
     if (activity === "keyboardEdit") {
-      if (gridDraftFromStore) setDraft(gridDraftFromStore);
       setIsFormOpen(true);
       return;
     }
     if (activity === "createShortcut" || activity === "gridClick") {
-      await create();
+      setIsFormOpen(true);
       return;
     }
+<<<<<<< HEAD
     if (activity === "creating") {
       // Mirror the running drag-create preview. Deliberately does not start a
       // local resize: `resize()` freezes the store draft as its origin, so
@@ -560,6 +556,14 @@ export const useDraftActions = (
     gridDraftFromStore,
     setIsFormOpen,
   ]);
+=======
+    if (activity === "resizing") {
+      if (dateToResize === "startDate" || dateToResize === "endDate") {
+        startResizing(dateToResize);
+      }
+    }
+  }, [isDrafting, activity, dateToResize, setIsFormOpen, startResizing]);
+>>>>>>> d408b41c (refactor(web): make zustand the sole draft values owner)
 
   const actions = {
     submit,
@@ -567,15 +571,13 @@ export const useDraftActions = (
     drag,
     repositionDraftByKeyboard,
     resize,
-    setLocalDraft: setDraft,
     startDragging: (
       offset?: DragOffset,
       initialEvent?: Omit<PartialMouseEvent, "currentTarget">,
     ) => {
-      // Placing `setIsFormOpenBeforeDragging` here rather than inside `startDragging`
-      // because `setIsFormOpenBeforeDragging` depends on `isFormOpen` and re-calculates
-      // `startDragging` (due to it being a react callback) which causes issues.
-      // This is a hacky solution to the issue.
+      // Capture form-open before startDragging so the callback identity of
+      // startDragging does not depend on isFormOpen (which would recreate it
+      // and disrupt gesture start). Gesture policy only — not draft ownership.
       setIsFormOpenBeforeDragging(isFormOpen);
       const nextOffset = offset ?? { x: 0, y: 0 };
       startDragging(offset);
@@ -592,7 +594,13 @@ export const useDraftActions = (
     stopResizing,
   };
 
-  useDraftEffects(draftState, setters, weekProps, isDrafting, handleChange);
+  useDraftEffects(
+    { ...draftState, draft },
+    setters,
+    weekProps,
+    isDrafting,
+    handleChange,
+  );
 
   return actions;
 };

--- a/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.test.ts
@@ -39,6 +39,7 @@ const createState = (
   draft: createDraft(),
   dragOffset: { x: 0, y: 0 },
   dragStatus: { durationMin: 60, hasMoved: true },
+  gestureOriginDraft: null,
   isDragging: true,
   isFormOpen: false,
   isFormOpenBeforeDragging: null,
@@ -51,9 +52,9 @@ const createSetters = (
   overrides: Partial<Setters_Draft> = {},
 ): Setters_Draft => ({
   setDateBeingChanged: mock(),
-  setDraft: mock(),
   setDragOffset: mock(),
   setDragStatus: mock(),
+  setGestureOriginDraft: mock(),
   setIsDragging: mock(),
   setIsFormOpen: mock(),
   setIsFormOpenBeforeDragging: mock(),

--- a/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.test.ts
@@ -65,9 +65,6 @@ const createSetters = (
 
 const weekProps = {
   component: { week: "2024-01-15" },
-  util: {
-    getLastNavigationSource: () => "manual",
-  },
 } as unknown as WeekProps;
 
 describe("useDraftEffects", () => {

--- a/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
@@ -7,7 +7,8 @@ import {
   type State_Draft_Local,
 } from "../state/useDraftState";
 
-const clearGestureEphemera = (setters: Setters_Draft) => {
+/** Clears Week-local gesture flags; does not touch the store draft. */
+export const clearGestureEphemera = (setters: Setters_Draft) => {
   setters.setIsDragging(false);
   setters.setIsResizing(false);
   setters.setDragStatus(null);
@@ -23,16 +24,8 @@ export const useDraftEffects = (
   isDrafting: boolean,
   handleChange: () => Promise<void>,
 ) => {
-  const { draft, isDragging, isResizing, dateBeingChanged } = state;
-  const {
-    setIsDragging,
-    setIsFormOpen,
-    setIsResizing,
-    setResizeStatus,
-    setDragStatus,
-    setDateBeingChanged,
-    setGestureOriginDraft,
-  } = setters;
+  const { draft, isDragging, isResizing } = state;
+  const { setIsFormOpen, setDragStatus } = setters;
   const isFirstWeekEffectRef = useRef(true);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: draft state should clear only when the visible week changes.
@@ -44,54 +37,27 @@ export const useDraftEffects = (
       return;
     }
 
+    // Drag-to-edge week changes happen while isDragging/isResizing is true,
+    // so this early return also preserves the in-flight draft.
     if (isDragging || isResizing) {
       return;
     }
 
-    // Only skip clearing if we're currently dragging AND the week change was due to drag-to-edge navigation
-    const lastNavigationSource = weekProps.util.getLastNavigationSource();
-    const isDragToEdgeNavigation = lastNavigationSource === "drag-to-edge";
-    const shouldPreserveDuringDrag =
-      (isDragging || isResizing) && isDragToEdgeNavigation;
-
-    if (shouldPreserveDuringDrag) {
-      return;
-    }
-
     clearGestureEphemera(setters);
-    // With store-owned draft values, week navigation must discard the
-    // canonical draft (previously only the local portal copy was cleared).
     draftActions.discard();
   }, [weekProps.component.week]);
 
   useEffect(() => {
     if (isResizing) {
-      setDateBeingChanged(dateBeingChanged);
       setIsFormOpen(false);
     }
-  }, [dateBeingChanged, isResizing, setDateBeingChanged, setIsFormOpen]);
+  }, [isResizing, setIsFormOpen]);
 
   useEffect(() => {
-    const isStaleDraft = !isDrafting;
-    if (isStaleDraft) {
-      setIsDragging(false);
-      setIsFormOpen(false);
-      setIsResizing(false);
-      setDragStatus(null);
-      setResizeStatus(null);
-      setDateBeingChanged(null);
-      setGestureOriginDraft(null);
-    }
-  }, [
-    isDrafting,
-    setDateBeingChanged,
-    setDragStatus,
-    setGestureOriginDraft,
-    setIsDragging,
-    setIsFormOpen,
-    setIsResizing,
-    setResizeStatus,
-  ]);
+    if (isDrafting) return;
+    clearGestureEphemera(setters);
+    setIsFormOpen(false);
+  }, [isDrafting, setIsFormOpen, setters]);
 
   useEffect(() => {
     handleChange();

--- a/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
@@ -55,9 +55,9 @@ export const useDraftEffects = (
 
   useEffect(() => {
     if (isDrafting) return;
+    // Store discard already clears isFormOpen; only gesture ephemera remains.
     clearGestureEphemera(setters);
-    setIsFormOpen(false);
-  }, [isDrafting, setIsFormOpen, setters]);
+  }, [isDrafting, setters]);
 
   useEffect(() => {
     handleChange();

--- a/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/effects/useDraftEffects.ts
@@ -1,10 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import dayjs from "@core/util/date/dayjs";
+import { draftActions } from "@web/events/stores/draft.store";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import {
   type Setters_Draft,
   type State_Draft_Local,
 } from "../state/useDraftState";
+
+const clearGestureEphemera = (setters: Setters_Draft) => {
+  setters.setIsDragging(false);
+  setters.setIsResizing(false);
+  setters.setDragStatus(null);
+  setters.setResizeStatus(null);
+  setters.setDateBeingChanged(null);
+  setters.setGestureOriginDraft(null);
+};
 
 export const useDraftEffects = (
   state: State_Draft_Local,
@@ -15,17 +25,25 @@ export const useDraftEffects = (
 ) => {
   const { draft, isDragging, isResizing, dateBeingChanged } = state;
   const {
-    setDraft,
     setIsDragging,
     setIsFormOpen,
     setIsResizing,
     setResizeStatus,
     setDragStatus,
     setDateBeingChanged,
+    setGestureOriginDraft,
   } = setters;
+  const isFirstWeekEffectRef = useRef(true);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: draft state should clear only when the visible week changes.
   useEffect(() => {
+    // Skip mount: discarding here would wipe a draft that was just seeded
+    // into the store before the provider mounted.
+    if (isFirstWeekEffectRef.current) {
+      isFirstWeekEffectRef.current = false;
+      return;
+    }
+
     if (isDragging || isResizing) {
       return;
     }
@@ -40,13 +58,10 @@ export const useDraftEffects = (
       return;
     }
 
-    setDraft(null);
-    setIsDragging(false);
-    setIsFormOpen(false);
-    setIsResizing(false);
-    setDragStatus(null);
-    setResizeStatus(null);
-    setDateBeingChanged(null);
+    clearGestureEphemera(setters);
+    // With store-owned draft values, week navigation must discard the
+    // canonical draft (previously only the local portal copy was cleared).
+    draftActions.discard();
   }, [weekProps.component.week]);
 
   useEffect(() => {
@@ -59,19 +74,19 @@ export const useDraftEffects = (
   useEffect(() => {
     const isStaleDraft = !isDrafting;
     if (isStaleDraft) {
-      setDraft(null);
       setIsDragging(false);
       setIsFormOpen(false);
       setIsResizing(false);
       setDragStatus(null);
       setResizeStatus(null);
       setDateBeingChanged(null);
+      setGestureOriginDraft(null);
     }
   }, [
     isDrafting,
     setDateBeingChanged,
-    setDraft,
     setDragStatus,
+    setGestureOriginDraft,
     setIsDragging,
     setIsFormOpen,
     setIsResizing,

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
@@ -1,6 +1,10 @@
 import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { type GridEventDraft } from "@web/events/event-draft.types";
-import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
+import {
+  draftActions,
+  selectGridDraft,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { lockGlobalCursor } from "@web/interaction/dom/cursor.lock";
 
 export interface Status_Drag {
@@ -19,12 +23,22 @@ export interface DragOffset {
 
 export interface State_Draft_Local {
   dateBeingChanged: "startDate" | "endDate" | null;
+  /** Canonical draft values from Zustand — sole owner for portal and form. */
   draft: GridEventDraft | null;
   dragOffset: DragOffset;
   dragStatus: Status_Drag | null;
+  /**
+   * Snapshot of the draft at resize-gesture start. Resize math freezes against
+   * this so live store updates mid-gesture do not shift the baseline.
+   */
+  gestureOriginDraft: GridEventDraft | null;
   isDragging: boolean;
   isResizing: boolean;
   isFormOpen: boolean;
+  /**
+   * Gesture policy: whether the form was open when drag began. Used by submit
+   * to reopen the form instead of persisting; not a second draft copy.
+   */
   isFormOpenBeforeDragging: boolean | null;
   resizeStatus: Status_Resize | null;
 }
@@ -32,9 +46,9 @@ export interface State_Draft_Local {
 export interface Setters_Draft {
   setIsDragging: (value: boolean) => void;
   setIsResizing: (value: boolean) => void;
-  setDraft: Dispatch<SetStateAction<GridEventDraft | null>>;
   setDragOffset: Dispatch<SetStateAction<DragOffset>>;
   setDragStatus: Dispatch<SetStateAction<Status_Drag | null>>;
+  setGestureOriginDraft: Dispatch<SetStateAction<GridEventDraft | null>>;
   setResizeStatus: (value: Status_Resize | null) => void;
   setDateBeingChanged: (value: "startDate" | "endDate" | null) => void;
   setIsFormOpen: (value: boolean) => void;
@@ -57,15 +71,17 @@ export const useDraftState = () => {
 
     return lockGlobalCursor("move");
   }, [isDragging]);
-  const [draft, setDraft] = useState<GridEventDraft | null>(null);
+
   // Mid-drag cursor-offset (pixels between the pointer and the dragged
-  // event's origin), populated only while a mouse-drag is active. Kept as a
-  // sibling to `draft` rather than folded into it: `GridEventDraft` is the
-  // persisted-shape contract (dates + form fields) and has no grid-layout
+  // event's origin), populated only while a mouse-drag is active. Kept as
+  // gesture ephemera rather than folded into the draft: `GridEventDraft` is
+  // the persisted-shape contract (dates + form fields) and has no grid-layout
   // concept of a cursor offset.
   const [dragOffset, setDragOffset] = useState<DragOffset>(ZERO_DRAG_OFFSET);
   const [dragStatus, setDragStatus] = useState<Status_Drag | null>(null);
   const [resizeStatus, setResizeStatus] = useState<Status_Resize | null>(null);
+  const [gestureOriginDraft, setGestureOriginDraft] =
+    useState<GridEventDraft | null>(null);
   const [dateBeingChanged, setDateBeingChanged] = useState<
     "startDate" | "endDate" | null
   >("endDate");
@@ -81,10 +97,13 @@ export const useDraftState = () => {
     boolean | null
   >(null);
 
+  const draft = useDraftStore(selectGridDraft);
+
   const state: State_Draft_Local = {
     draft,
     dragOffset,
     dragStatus,
+    gestureOriginDraft,
     isDragging,
     isFormOpen,
     isResizing,
@@ -96,9 +115,9 @@ export const useDraftState = () => {
   const setters: Setters_Draft = {
     setIsDragging,
     setIsResizing,
-    setDraft,
     setDragOffset,
     setDragStatus,
+    setGestureOriginDraft,
     setResizeStatus,
     setDateBeingChanged,
     setIsFormOpen,

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
@@ -119,7 +119,8 @@ export const useDraftState = () => {
   };
 
   // Stable identity so discard/effects can depend on `setters` without
-  // re-running every render.
+  // re-running every render. useState setters are stable; setIsFormOpen is
+  // the store action (also stable).
   const setters: Setters_Draft = useMemo(
     () => ({
       setIsDragging,
@@ -132,17 +133,8 @@ export const useDraftState = () => {
       setIsFormOpen,
       setIsFormOpenBeforeDragging,
     }),
-    [
-      setDateBeingChanged,
-      setDragOffset,
-      setDragStatus,
-      setGestureOriginDraft,
-      setIsDragging,
-      setIsFormOpen,
-      setIsFormOpenBeforeDragging,
-      setIsResizing,
-      setResizeStatus,
-    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stable setter identities
+    [],
   );
 
   return { state, setters };

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
@@ -1,4 +1,10 @@
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   draftActions,
@@ -112,17 +118,32 @@ export const useDraftState = () => {
     isFormOpenBeforeDragging,
   };
 
-  const setters: Setters_Draft = {
-    setIsDragging,
-    setIsResizing,
-    setDragOffset,
-    setDragStatus,
-    setGestureOriginDraft,
-    setResizeStatus,
-    setDateBeingChanged,
-    setIsFormOpen,
-    setIsFormOpenBeforeDragging,
-  };
+  // Stable identity so discard/effects can depend on `setters` without
+  // re-running every render.
+  const setters: Setters_Draft = useMemo(
+    () => ({
+      setIsDragging,
+      setIsResizing,
+      setDragOffset,
+      setDragStatus,
+      setGestureOriginDraft,
+      setResizeStatus,
+      setDateBeingChanged,
+      setIsFormOpen,
+      setIsFormOpenBeforeDragging,
+    }),
+    [
+      setDateBeingChanged,
+      setDragOffset,
+      setDragStatus,
+      setGestureOriginDraft,
+      setIsDragging,
+      setIsFormOpen,
+      setIsFormOpenBeforeDragging,
+      setIsResizing,
+      setResizeStatus,
+    ],
+  );
 
   return { state, setters };
 };

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,8 +1,7 @@
 import { type MouseEvent, useMemo } from "react";
 import {
   type CalendarCardIdentity,
-  isEventReadOnly,
-  isGridEventContentReadOnly,
+  isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
@@ -79,11 +78,7 @@ export const AllDayEvents = ({
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
         // optimistic state change (packet 08 step 8).
-        isReadOnly: isEventReadOnly(
-          calendarLookup,
-          event.calendarId,
-          isGridEventContentReadOnly(event),
-        ),
+        isReadOnly: isGridEventInteractionReadOnly(calendarLookup, event),
       })),
     [visibleAllDayEvents, calendarLookup],
   );

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import {
   type CalendarCardIdentity,
-  isEventReadOnly,
+  isGridEventInteractionReadOnly,
   resolveCalendarCardIdentity,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
@@ -76,11 +76,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
         // optimistic state change (packet 08 step 8).
-        isReadOnly: isEventReadOnly(
-          calendarLookup,
-          item.event.calendarId,
-          item.event.isBusy ?? false,
-        ),
+        isReadOnly: isGridEventInteractionReadOnly(calendarLookup, item.event),
       })),
     [timedEventItems, calendarLookup],
   );

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -1,28 +1,14 @@
-import { useCallback, useEffect, useRef } from "react";
-import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { useCallback, useEffect } from "react";
+import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
-import {
-  isEventReadOnly,
-  useCalendarLookup,
-} from "@web/calendars/useCalendarLookup";
-import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
   createAlldayDraft,
   createTimedDraft,
 } from "@web/common/utils/draft/draft.util";
-import { getArrowKeyMovement } from "@web/common/utils/event/event-nudge.util";
-import { nudgeEventFromKeyboard } from "@web/common/utils/event/event-nudge-shortcut.util";
-import {
-  isDeleteTextEditingTarget,
-  isEditableKeyboardTarget,
-  isEventFormKeyboardTarget,
-  isEventFormOpen,
-} from "@web/common/utils/form/form.util";
+import { isEventFormOpen } from "@web/common/utils/form/form.util";
 import { focusFirstSidebarItem } from "@web/components/Sidebar/util/sidebarFocus.util";
-import { useEventMutations } from "@web/events/mutations/useEventMutations";
-import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import { draftActions } from "@web/events/stores/draft.store";
 import {
@@ -30,11 +16,8 @@ import {
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
-import {
-  useAppShortcut,
-  useAppShortcutUp,
-} from "@web/shortcuts/useAppShortcut";
-import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
+import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
+import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 import { useDraftContext } from "@web/views/Week/components/Draft/context/useDraftContext";
 import { type Util_Scroll } from "@web/views/Week/hooks/grid/useScroll";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -43,7 +26,6 @@ import {
   getFirstVisibleWeekGridEventTarget,
   getFocusedWeekGridEventTarget,
   getHoveredWeekGridEventTarget,
-  type WeekGridEventTarget,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 
 export interface ShortcutProps {
@@ -57,12 +39,6 @@ export interface ShortcutProps {
   scrollUtil: Util_Scroll;
 }
 
-const DRAFT_MOVEMENT_HOTKEY_OPTIONS = {
-  ignoreInputs: false,
-  preventDefault: false,
-  stopPropagation: false,
-} as const;
-
 export const useWeekShortcuts = ({
   isCurrentWeek,
   queryEndOfView,
@@ -73,13 +49,6 @@ export const useWeekShortcuts = ({
   util,
   scrollUtil,
 }: ShortcutProps) => {
-  const mutations = useEventMutations();
-  const { delete: deleteEvent } = mutations;
-  const updateEvent = useUpdateEvent();
-  // Read-only (unwritable calendar or busy content) events can be inspected
-  // but never mutated - delete and nudge/move below gate on this before
-  // touching the store (packet 08 step 8).
-  const calendarLookup = useCalendarLookup();
   const { data: calendars = [], isPending: isCalendarsPending } =
     useCalendarsQuery();
   const defaultTargetCalendarId =
@@ -93,15 +62,8 @@ export const useWeekShortcuts = ({
     startOfView: queryStartOfView,
     endOfView: queryEndOfView,
   });
-  const allDayEventsRef = useRef(allDayEvents);
-  const timedEventsRef = useRef(timedEvents);
   const { decrementWeek, incrementWeek, goToToday, shiftViewByDay } = util;
   const { scrollToNow } = scrollUtil;
-
-  useEffect(() => {
-    allDayEventsRef.current = allDayEvents;
-    timedEventsRef.current = timedEvents;
-  }, [allDayEvents, timedEvents]);
 
   const _discardDraft = useCallback(() => {
     if (isEventFormOpen()) {
@@ -201,133 +163,17 @@ export const useWeekShortcuts = ({
     focusWeekGridEventTarget(target);
   }, []);
 
-  const findCalendarEventForTarget = useCallback(
-    (target: WeekGridEventTarget) => {
-      const events =
-        target.eventType === "all-day"
-          ? allDayEventsRef.current
-          : timedEventsRef.current;
-
-      return (
-        events.find((candidate) => candidate._id === target.eventId) ?? null
-      );
+  useGridEventEditShortcuts({
+    allDayEvents,
+    timedEvents,
+    dayBoundary: { kind: "clamp", weekDays },
+    targeting: {
+      getFocused: getFocusedWeekGridEventTarget,
+      getHovered: getHoveredWeekGridEventTarget,
+      getFirstVisible: getFirstVisibleWeekGridEventTarget,
     },
-    [],
-  );
-
-  const getTargetedCalendarEvent = useCallback(() => {
-    const target =
-      getFocusedWeekGridEventTarget() ??
-      getHoveredWeekGridEventTarget() ??
-      getFirstVisibleWeekGridEventTarget();
-
-    if (!target) return null;
-
-    const event = findCalendarEventForTarget(target);
-    if (!event) return null;
-
-    return { event, target };
-  }, [findCalendarEventForTarget]);
-
-  const deleteTargetedCalendarEvent = useCallback(
-    (keyboardEvent: KeyboardEvent) => {
-      if (
-        isDeleteTextEditingTarget(keyboardEvent) ||
-        isEventFormKeyboardTarget(keyboardEvent)
-      ) {
-        return;
-      }
-
-      // Focus inside the sidebar (e.g. via the "u" shortcut) means the user
-      // is acting on the sidebar, not grid events
-      if (document.activeElement?.closest(`#${ID_SIDEBAR}`)) {
-        return;
-      }
-
-      const resolvedTarget = getTargetedCalendarEvent();
-      if (!resolvedTarget) {
-        return;
-      }
-
-      if (
-        isEventReadOnly(
-          calendarLookup,
-          resolvedTarget.event.calendarId,
-          resolvedTarget.event.isBusy ?? false,
-        )
-      ) {
-        return;
-      }
-
-      keyboardEvent.preventDefault();
-      keyboardEvent.stopPropagation();
-
-      deleteEventAndDiscardDraft(deleteEvent, resolvedTarget.event);
-    },
-    [calendarLookup, deleteEvent, getTargetedCalendarEvent],
-  );
-
-  const moveFocusedCalendarEvent = useCallback(
-    (keyboardEvent: KeyboardEvent) => {
-      if (isEventFormOpen()) return;
-
-      // Focused only (no hover/first-visible fallback): moving an event the
-      // user isn't focused on would be surprising
-      const target = getFocusedWeekGridEventTarget();
-      if (!target) return;
-
-      const event = findCalendarEventForTarget(target);
-      if (!event?._id) return;
-
-      if (
-        isEventReadOnly(calendarLookup, event.calendarId, event.isBusy ?? false)
-      ) {
-        return;
-      }
-
-      const movement = getArrowKeyMovement(
-        keyboardEvent.key,
-        Boolean(event.isAllDay),
-      );
-      if (!movement) return;
-
-      const start = dayjs(event.startDate);
-
-      if (movement.days === -1 && !start.isAfter(weekDays[0], "day")) {
-        return;
-      }
-
-      if (
-        movement.days === 1 &&
-        !start.isBefore(weekDays[weekDays.length - 1], "day")
-      ) {
-        return;
-      }
-
-      nudgeEventFromKeyboard({
-        event,
-        keyboardEvent,
-        onNudge: (nudgedEvent) => {
-          updateEvent({ event: nudgedEvent }, true);
-        },
-        afterNudge: () => draftActions.discard(),
-      });
-    },
-    [calendarLookup, findCalendarEventForTarget, updateEvent, weekDays],
-  );
-
-  const moveShortcutCreatedDraft = useCallback(
-    (event: KeyboardEvent) => {
-      if (isEditableKeyboardTarget(event)) return;
-
-      const didMove = repositionDraftByKeyboard(event.key);
-      if (!didMove) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-    },
-    [repositionDraftByKeyboard],
-  );
+    repositionDraftByKey: repositionDraftByKeyboard,
+  });
 
   useAppShortcutUp("J", goToPreviousWeek);
   useAppShortcutUp("K", goToNextWeek);
@@ -338,31 +184,4 @@ export const useWeekShortcuts = ({
   useAppShortcutUp("C", createTimedDraftEvent);
   useAppShortcutUp("I", focusSidebar);
   useAppShortcutUp("U", focusFirstCalendarEvent);
-  useAppShortcut("Delete", deleteTargetedCalendarEvent, {
-    ignoreInputs: false,
-  });
-  useAppShortcut(
-    "ArrowUp",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "ArrowDown",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "ArrowLeft",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut(
-    "ArrowRight",
-    moveShortcutCreatedDraft,
-    DRAFT_MOVEMENT_HOTKEY_OPTIONS,
-  );
-  useAppShortcut("Shift+ArrowUp", moveFocusedCalendarEvent);
-  useAppShortcut("Shift+ArrowDown", moveFocusedCalendarEvent);
-  useAppShortcut("Shift+ArrowLeft", moveFocusedCalendarEvent);
-  useAppShortcut("Shift+ArrowRight", moveFocusedCalendarEvent);
 };

--- a/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
+++ b/packages/web/src/views/Week/interaction/WeekInteractionCoordinator.tsx
@@ -40,7 +40,7 @@ export const WeekInteractionCoordinator: FC<Props> = ({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
-  const { actions, state } = useDraftContext();
+  const { state } = useDraftContext();
   const updateEvent = useUpdateEvent();
   const activeInteractionEventRef = useRef<Event | null>(null);
   const layoutSourcesRef = useRef(getLayoutSources);
@@ -144,7 +144,6 @@ export const WeekInteractionCoordinator: FC<Props> = ({
     if (result.hadFormOpenBeforeInteraction) {
       const draft = gridEventDraftFromSavedResult(result.event);
       if (draft) {
-        actions.setLocalDraft(draft);
         draftActions.setGridDraft(draft);
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes Zustand the sole owner of create/edit draft values, drops the Event → CompassEvent → GridEvent hot-path conversion tax, and (in progress) shares Day/Week edit shortcuts plus a unified read-only gate.

### Phase 1 — One draft owner
- Week portal/form/keyboard/drag/resize all read and write `gridDraft` in the draft store
- Local Week state keeps only gesture ephemera (`isDragging`, offsets, statuses, `gestureOriginDraft` for resize baseline, `isFormOpenBeforeDragging` policy)
- Removes render-time store→local hydration and the idle-form mirror in `Draft.tsx`
- Week navigation discards the canonical store draft (after mount), matching the old “portal cleared” behavior

### Phase 2 — Direct Event → GridEvent assembly
- `event.view-model.ts` builds `GridEvent` straight from `Event` with inline `calendarId` / `isBusy` / `color` / `isDemo`
- Deletes `scheduledEventToSchemaEvent` + `withCalendarMetadata` from the hot path
- Leaves `GridEvent` as the grid UI type and draft CompassEvent projections for still-unconverted render helpers

### Phase 3 — Shared edit shortcuts / RO (next)
- Extract `useGridEventEditShortcuts` and unify the RO content flag used by registration and keyboard gates

## Simplicity

Removed a second draft copy and the sync machinery that existed only to keep it aligned. View-model assembly no longer builds a throwaway CompassEvent just to rejoin metadata.

## Automated validation

- `bun test:web` on Week Draft hooks/effects and Week interaction suites (100 pass)
- `bun test:web packages/web/src/events/queries/event.view-model.test.ts` (6 pass)

## Independent review

Pending completion of Phase 3.

## Test plan

- `bun test:web packages/web/src/views/Week/components/Draft packages/web/src/views/Week/interaction`
- `bun test:web packages/web/src/events/queries/event.view-model.test.ts`
- Day/Week shortcut + RO suites after Phase 3 lands

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-443c6f77-0972-4374-bc9d-5fb9b51a9d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-443c6f77-0972-4374-bc9d-5fb9b51a9d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

