### PR TITLE
fix(web): make calendar visibility toggle instant both ways

### DIFF
--- a/packages/web/src/calendars/useCalendarVisibility.ts
+++ b/packages/web/src/calendars/useCalendarVisibility.ts
@@ -5,19 +5,18 @@ import { type CalendarId } from "@core/types/domain-primitives";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { setCalendarHidden } from "@web/calendars/calendar-visibility.storage";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
-import { removeEventsByCalendarFromQueries } from "@web/events/queries/event.query.cache";
-import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 
 export const CALENDAR_VISIBILITY_FAILURE_MESSAGE =
   "Couldn't update calendar visibility. The change was undone.";
 
 /**
  * Client-owned calendar visibility toggle (S39 A2).
- * Flips the calendars cache immediately, persists the hidden set in
- * localStorage (default visible), and on hide drops that calendar's events
- * from cached event queries so the grid reacts without a round trip. No
- * server write — sync list always reports isVisible:true, and the event
- * read already returns every calendar (client filter is the source of truth).
+ * Flips the calendars cache immediately and persists the hidden set in
+ * localStorage (default visible). Event queries keep their data; the week/day
+ * view models filter by isVisible so hide and show both update the grid
+ * without a round trip. No server write — sync list always reports
+ * isVisible:true, and the event read already returns every calendar (client
+ * filter is the source of truth).
  */
 export function useCalendarVisibility() {
   const queryClient = useQueryClient();
@@ -37,14 +36,6 @@ export function useCalendarVisibility() {
           calendar.id === calendarId ? { ...calendar, isVisible } : calendar,
         ),
       );
-
-      if (!isVisible) {
-        removeEventsByCalendarFromQueries(queryClient, new Set([calendarId]));
-        return;
-      }
-
-      // Showing again: refetch so events for this calendar reappear.
-      void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
     },
     [queryClient],
   );

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -223,7 +223,7 @@ describe("CalendarList", () => {
     expect(isCalendarHidden(calendarB.id)).toBe(true);
   });
 
-  it("removes the hidden calendar's events from a cached week query immediately on toggle-off", async () => {
+  it("keeps cached events on hide/show and only flips calendar isVisible", async () => {
     const hidden = makeCalendar({ name: "Hidden target" });
     const kept = makeCalendar({ name: "Kept" });
     const hiddenEvent = createMockEvent({ calendarId: hidden.id });
@@ -233,22 +233,41 @@ describe("CalendarList", () => {
       start: "2026-07-13T00:00:00.000Z",
       end: "2026-07-20T00:00:00.000Z",
     });
+    const weekData: NormalizedEventQueryData = {
+      ids: [hiddenEvent.id, keptEvent.id],
+      entities: { [hiddenEvent.id]: hiddenEvent, [keptEvent.id]: keptEvent },
+    };
 
     const user = userEvent.setup({ delay: null });
     const { queryClient } = renderCalendarList([hidden, kept]);
-    queryClient.setQueryData<NormalizedEventQueryData>(weekKey, {
-      ids: [hiddenEvent.id, keptEvent.id],
-      entities: { [hiddenEvent.id]: hiddenEvent, [keptEvent.id]: keptEvent },
+    queryClient.setQueryData<NormalizedEventQueryData>(weekKey, weekData);
+
+    const hideButton = screen.getByRole("button", {
+      name: "Hide Hidden target calendar",
     });
+    await user.click(hideButton);
+
+    expect(queryClient.getQueryData<NormalizedEventQueryData>(weekKey)).toEqual(
+      weekData,
+    );
+    expect(
+      queryClient
+        .getQueryData<Calendar[]>(calendarQueryKeys.all)
+        ?.find((calendar) => calendar.id === hidden.id)?.isVisible,
+    ).toBe(false);
 
     await user.click(
-      screen.getByRole("button", { name: "Hide Hidden target calendar" }),
+      screen.getByRole("button", { name: "Show Hidden target calendar" }),
     );
 
-    const cached = queryClient.getQueryData<NormalizedEventQueryData>(weekKey);
-    expect(cached?.ids).toEqual([keptEvent.id]);
-    expect(cached?.entities[hiddenEvent.id]).toBeUndefined();
-    expect(cached?.entities[keptEvent.id]).toBeDefined();
+    expect(queryClient.getQueryData<NormalizedEventQueryData>(weekKey)).toEqual(
+      weekData,
+    );
+    expect(
+      queryClient
+        .getQueryData<Calendar[]>(calendarQueryKeys.all)
+        ?.find((calendar) => calendar.id === hidden.id)?.isVisible,
+    ).toBe(true);
   });
 
   it("announces failure and leaves the button pressed when storage write fails", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hide was instant because we pruned that calendar’s events from the React Query cache; show was slow because we then had to invalidate and refetch. This change keeps events in cache and relies on the existing `filterEventsByVisibleCalendars` path, so both directions only flip `isVisible` (+ localStorage) and update the grid on the next render.

![Calendar hidden](https://cursor.com/artifacts/c/art-ec12473c-20bb-432e-8dc7-bb67a60ca77e)
![Calendar shown again instantly](https://cursor.com/artifacts/c/art-06f3b5c4-3e93-49fa-ac88-65bb720051bf)

## Simplicity

Removed the asymmetric prune/invalidate branches from `useCalendarVisibility`. No snapshot/restore; the client filter already did the right job. Simplify pass found no further cleanup.

## Automated validation

- `bun test:web -- packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx packages/web/src/events/queries/filter-events-by-visible-calendars.test.ts` — 12 pass
- Browser at http://localhost:9080: created two events, hide/show twice — both directions instant; console clean
- CI on PR: lint, type-check, unit (all packages), e2e, CodeQL — success

## Independent review

Fresh read-only review of `main...HEAD`: no confirmed defects. Acceptable residual risk: hidden-calendar events remain in RQ memory until GC (by design).

## Test plan

- `bun test:web -- packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx packages/web/src/events/queries/filter-events-by-visible-calendars.test.ts`
- Browser: hide calendar with events → events gone immediately; show → events back immediately (http://localhost:9080)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d12c0462-839b-42b5-8247-057290493984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d12c0462-839b-42b5-8247-057290493984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

