### PR TITLE
refactor(web): share the visibility-filtered events across grid consumers

### DIFF
--- a/packages/web/src/calendars/useCalendarVisibility.ts
+++ b/packages/web/src/calendars/useCalendarVisibility.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
@@ -22,23 +22,23 @@ export function useCalendarVisibility() {
   const queryClient = useQueryClient();
   const [failureAnnouncement, setFailureAnnouncement] = useState("");
 
-  const toggleCalendarVisibility = useCallback(
-    (calendarId: CalendarId, isVisible: boolean) => {
-      const saved = setCalendarHidden(calendarId, !isVisible);
-      if (!saved) {
-        showErrorToast(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
-        setFailureAnnouncement(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
-        return;
-      }
+  const toggleCalendarVisibility = (
+    calendarId: CalendarId,
+    isVisible: boolean,
+  ) => {
+    const saved = setCalendarHidden(calendarId, !isVisible);
+    if (!saved) {
+      showErrorToast(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
+      setFailureAnnouncement(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
+      return;
+    }
 
-      queryClient.setQueryData<Calendar[]>(calendarQueryKeys.all, (current) =>
-        current?.map((calendar) =>
-          calendar.id === calendarId ? { ...calendar, isVisible } : calendar,
-        ),
-      );
-    },
-    [queryClient],
-  );
+    queryClient.setQueryData<Calendar[]>(calendarQueryKeys.all, (current) =>
+      current?.map((calendar) =>
+        calendar.id === calendarId ? { ...calendar, isVisible } : calendar,
+      ),
+    );
+  };
 
   return { toggleCalendarVisibility, failureAnnouncement };
 }

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -9,6 +9,7 @@ import {
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type ApiRequestConfig } from "@web/api/api.types";
 import { BaseApi } from "@web/api/base/base.api";
@@ -225,49 +226,33 @@ describe("CalendarList", () => {
 
   it("keeps cached events on hide/show and only flips calendar isVisible", async () => {
     const hidden = makeCalendar({ name: "Hidden target" });
-    const kept = makeCalendar({ name: "Kept" });
     const hiddenEvent = createMockEvent({ calendarId: hidden.id });
-    const keptEvent = createMockEvent({ calendarId: kept.id });
     const weekKey = eventQueryKeys.week({
       source: "remote",
       start: "2026-07-13T00:00:00.000Z",
       end: "2026-07-20T00:00:00.000Z",
     });
-    const weekData: NormalizedEventQueryData = {
-      ids: [hiddenEvent.id, keptEvent.id],
-      entities: { [hiddenEvent.id]: hiddenEvent, [keptEvent.id]: keptEvent },
-    };
+    const weekData = toNormalizedEventQueryData([hiddenEvent]);
 
     const user = userEvent.setup({ delay: null });
-    const { queryClient } = renderCalendarList([hidden, kept]);
+    const { queryClient } = renderCalendarList([hidden]);
     queryClient.setQueryData<NormalizedEventQueryData>(weekKey, weekData);
 
-    const hideButton = screen.getByRole("button", {
-      name: "Hide Hidden target calendar",
-    });
-    await user.click(hideButton);
-
+    // The button label derives from the cached calendar's isVisible, so
+    // finding the flipped label already proves the calendars cache updated.
+    await user.click(
+      screen.getByRole("button", { name: "Hide Hidden target calendar" }),
+    );
     expect(queryClient.getQueryData<NormalizedEventQueryData>(weekKey)).toEqual(
       weekData,
     );
-    expect(
-      queryClient
-        .getQueryData<Calendar[]>(calendarQueryKeys.all)
-        ?.find((calendar) => calendar.id === hidden.id)?.isVisible,
-    ).toBe(false);
 
     await user.click(
       screen.getByRole("button", { name: "Show Hidden target calendar" }),
     );
-
     expect(queryClient.getQueryData<NormalizedEventQueryData>(weekKey)).toEqual(
       weekData,
     );
-    expect(
-      queryClient
-        .getQueryData<Calendar[]>(calendarQueryKeys.all)
-        ?.find((calendar) => calendar.id === hidden.id)?.isVisible,
-    ).toBe(true);
   });
 
   it("announces failure and leaves the button pressed when storage write fails", async () => {

--- a/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
+++ b/packages/web/src/events/queries/filter-events-by-visible-calendars.ts
@@ -1,6 +1,16 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type NormalizedEventQueryData } from "./event.query.types";
 
+// Module-level memo keyed on the (data, calendars) cache references — both
+// are stable between cache writes. Without it, each consumer's useMemo builds
+// a distinct filtered object whenever a calendar is hidden, which defeats
+// deriveCalendarEventViewModel's WeakMap and re-runs the grid assembly once
+// per consumer instead of once total.
+const filteredCache = new WeakMap<
+  NormalizedEventQueryData,
+  WeakMap<Calendar[], NormalizedEventQueryData>
+>();
+
 // Drop events whose calendar is hidden. When calendars have not loaded yet,
 // pass the data through unchanged so the grid does not flash empty.
 export function filterEventsByVisibleCalendars(
@@ -9,6 +19,23 @@ export function filterEventsByVisibleCalendars(
 ): NormalizedEventQueryData | undefined {
   if (!data || !calendars) return data;
 
+  let byCalendars = filteredCache.get(data);
+  if (!byCalendars) {
+    byCalendars = new WeakMap();
+    filteredCache.set(data, byCalendars);
+  }
+  const cached = byCalendars.get(calendars);
+  if (cached) return cached;
+
+  const result = computeFilteredData(data, calendars);
+  byCalendars.set(calendars, result);
+  return result;
+}
+
+function computeFilteredData(
+  data: NormalizedEventQueryData,
+  calendars: Calendar[],
+): NormalizedEventQueryData {
   const visibleIds = new Set(
     calendars.filter((calendar) => calendar.isVisible).map((c) => c.id),
   );


### PR DESCRIPTION
## Summary

Cleanup pass over #2430 (instant calendar visibility toggle). Since hidden calendars' events now stay in the query cache, the per-consumer `useMemo` around `filterEventsByVisibleCalendars` built a distinct filtered object in each of the week view's 6 consumers whenever any calendar was hidden. That defeated the module-level WeakMap in `deriveCalendarEventViewModel`, so every cache update ran 6 full grid assemblies instead of 1 (roughly 4,800 dayjs parses vs 800 for a 200-event week), silently and only in the hidden-calendar state.

## Changes

- Memoize `filterEventsByVisibleCalendars` at module level, keyed on the `(data, calendars)` cache references (both stable between cache writes), so the filtered result is referentially stable and the shared view-model derivation keeps hitting. Same WeakMap idiom the view model already uses, and entries are garbage-collected with their cache entries.
- CalendarList test: seed the week cache via the existing `toNormalizedEventQueryData` helper instead of a hand-rolled `{ ids, entities }` literal that could drift from the real normalizer.
- CalendarList test: drop the `getQueryData(...).isVisible` assertions (the Hide/Show button label derives from the cached calendar, so finding the flipped label already proves the cache updated) and the vestigial second calendar/event fixture left over from the deleted selective-removal behavior.
- Remove a `useCallback` in `useCalendarVisibility` whose identity no consumer observes.

No behavior change intended.

## Testing

- `biome check` (repo-pinned) clean on the three files
- `bun run type-check` clean
- 12/12 tests in the two edited suites, 22/22 across `packages/web/src/events/queries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted caching and test refactors in the calendar visibility path; no auth, API, or persistence logic changes.
> 
> **Overview**
> **Performance fix** for calendar hide/show: `filterEventsByVisibleCalendars` now memoizes results in a module-level `WeakMap` keyed on the stable React Query `(data, calendars)` references, so every week-view consumer gets the **same** filtered object instead of each `useMemo` building its own copy. That restores hits on `deriveCalendarEventViewModel`'s WeakMap and avoids repeating full grid assembly (~6× work when any calendar is hidden).
> 
> **Cleanup:** `useCalendarVisibility` drops an unused `useCallback` wrapper. **CalendarList** tests use `toNormalizedEventQueryData`, lean on Hide/Show button labels instead of direct `isVisible` cache reads, and remove an extra calendar/event fixture from the old behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0caa4abedc908cf563db55bece0cf271f442b262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->