### PR TITLE
fix(web): filter hidden-calendar events at the query-hook layer

### DIFF
--- a/packages/web/src/events/queries/useDayEventsQuery.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.ts
@@ -12,13 +12,20 @@ type DayEventsQueryArgs = {
   endDate: string;
 };
 
-/**
- * Primary day-events read hook. TanStack Query owns the normalized result.
- */
-export function useDayEventsQuery({ startDate, endDate }: DayEventsQueryArgs) {
+function useDayEventsQueryInternal({ startDate, endDate }: DayEventsQueryArgs) {
   const source = useEventRepositorySource();
+  return useQuery(dayEventsQueryOptions({ source, startDate, endDate }));
+}
 
-  const query = useQuery(dayEventsQueryOptions({ source, startDate, endDate }));
+/**
+ * Primary day-events read hook. Data is filtered to visible calendars before
+ * it leaves this module - no caller can see a hidden calendar's events.
+ * TanStack Query owns the normalized (unfiltered) result underneath; this
+ * hook and {@link useDayEventViewModel} are the only ways to read it.
+ */
+export function useDayEventsQuery(args: DayEventsQueryArgs) {
+  const query = useDayEventsQueryInternal(args);
+  const { data: calendars } = useCalendarsQuery();
   const { error } = query;
 
   useEffect(() => {
@@ -26,18 +33,32 @@ export function useDayEventsQuery({ startDate, endDate }: DayEventsQueryArgs) {
     handleError(error as Error);
   }, [error]);
 
-  return query;
+  const data = useMemo(
+    () => filterEventsByVisibleCalendars(query.data, calendars),
+    [query.data, calendars],
+  );
+
+  return { ...query, data };
 }
 
 export function useDayEventViewModel(args: DayEventsQueryArgs) {
   const query = useDayEventsQuery(args);
-  const { data: calendars } = useCalendarsQuery();
   const viewModel = useMemo(
-    () =>
-      deriveCalendarEventViewModel(
-        filterEventsByVisibleCalendars(query.data, calendars),
-      ),
-    [query.data, calendars],
+    () => deriveCalendarEventViewModel(query.data),
+    [query.data],
   );
   return { ...query, ...viewModel };
+}
+
+/**
+ * Read-only day-events loading state. Subscribes to the same cache entry as
+ * {@link useDayEventsQuery} (shared key → no extra fetch), but strips `data`
+ * so a status-only consumer can never read event data - filtered or not.
+ * Callers that only need `isPending`/`isError`/`refetch`-style fields (fetch
+ * triggering, loading UI) should use this instead of discarding the result
+ * of {@link useDayEventsQuery}.
+ */
+export function useDayEventsQueryStatus(args: DayEventsQueryArgs) {
+  const { data: _data, ...status } = useDayEventsQueryInternal(args);
+  return status;
 }

--- a/packages/web/src/events/queries/useWeekEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.test.ts
@@ -1,5 +1,10 @@
+import { type QueryClient } from "@tanstack/react-query";
 import { waitFor } from "@testing-library/react";
-import { type EventId } from "@core/types/domain-primitives";
+import {
+  type Calendar,
+  getCalendarCapabilities,
+} from "@core/types/calendar.contracts";
+import { CalendarIdSchema, type EventId } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
@@ -7,6 +12,25 @@ import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { normalizeEventList } from "@web/events/queries/event.query.normalize";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// useWeekEventsQuery filters to visible calendars, so every test that reads
+// `.data` seeds a matching visible calendar - otherwise the assertion would
+// race the (unseeded) calendars query resolving mid-test.
+const WEEK_CALENDAR_ID = CalendarIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
+const makeVisibleCalendar = (id = WEEK_CALENDAR_ID): Calendar => ({
+  id,
+  name: "Primary calendar",
+  description: "",
+  timeZone: null,
+  foregroundColor: "#000000",
+  backgroundColor: "#4285f4",
+  provider: "google",
+  access: "owner",
+  capabilities: getCalendarCapabilities("owner"),
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+});
 
 const fetchWeekEvents = mock(async () => ({
   ids: ["week-1"],
@@ -16,6 +40,7 @@ const fetchWeekEvents = mock(async () => ({
       title: "Sprint",
       startDate: "2025-11-10T09:00:00",
       endDate: "2025-11-10T10:00:00",
+      calendarId: WEEK_CALENDAR_ID,
     },
   },
 }));
@@ -28,6 +53,8 @@ const { renderHook } =
   require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");
 const { createCompassQueryClient } =
   require("@web/api/query-client") as typeof import("@web/api/query-client");
+const { calendarQueryKeys } =
+  require("@web/calendars/calendar.query") as typeof import("@web/calendars/calendar.query");
 const { useWeekEventsQuery } =
   require("@web/events/queries/useWeekEventsQuery") as typeof import("@web/events/queries/useWeekEventsQuery");
 
@@ -36,6 +63,11 @@ const range = () => {
   return { startOfView: start, endOfView: start.endOf("week") };
 };
 
+const seedVisibleCalendar = (
+  queryClient: QueryClient,
+  calendar: Calendar = makeVisibleCalendar(),
+) => queryClient.setQueryData(calendarQueryKeys.all, [calendar]);
+
 describe("useWeekEventsQuery", () => {
   beforeEach(() => {
     fetchWeekEvents.mockClear();
@@ -43,6 +75,7 @@ describe("useWeekEventsQuery", () => {
 
   it("returns fetched week events without syncing Redux", async () => {
     const queryClient = createCompassQueryClient();
+    seedVisibleCalendar(queryClient);
 
     const result = renderHook(() => useWeekEventsQuery(range()), {
       queryClient,
@@ -57,6 +90,7 @@ describe("useWeekEventsQuery", () => {
 
   it("serves a cached remount from cache without a second fetch", async () => {
     const queryClient = createCompassQueryClient();
+    seedVisibleCalendar(queryClient);
 
     const first = renderHook(() => useWeekEventsQuery(range()), {
       queryClient,
@@ -115,6 +149,7 @@ describe("useWeekEventsQuery", () => {
       }),
       normalizeEventList([event]),
     );
+    seedVisibleCalendar(queryClient, makeVisibleCalendar(event.calendarId));
 
     const shiftedStart = start.add(1, "day");
     const shiftedEnd = shiftedStart.add(6, "day").endOf("day");

--- a/packages/web/src/events/queries/useWeekEventsQuery.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.ts
@@ -37,11 +37,14 @@ function useWeekEventsQueryInternal({
 }
 
 /**
- * Primary week-events read hook. TanStack Query owns the normalized result;
- * consumers derive render data through {@link useWeekEventViewModel}.
+ * Primary week-events read hook. Data is filtered to visible calendars
+ * before it leaves this module - no caller can see a hidden calendar's
+ * events. TanStack Query owns the normalized (unfiltered) result underneath;
+ * this hook and {@link useWeekEventViewModel} are the only ways to read it.
  */
 export function useWeekEventsQuery(args: WeekEventsQueryArgs) {
   const query = useWeekEventsQueryInternal(args);
+  const { data: calendars } = useCalendarsQuery();
   const reportError = args.reportError ?? handleError;
   const { error } = query;
 
@@ -50,26 +53,32 @@ export function useWeekEventsQuery(args: WeekEventsQueryArgs) {
     reportError(error as Error);
   }, [error, reportError]);
 
-  return query;
+  const data = useMemo(
+    () => filterEventsByVisibleCalendars(query.data, calendars),
+    [query.data, calendars],
+  );
+
+  return { ...query, data };
 }
 
 export function useWeekEventViewModel(args: WeekEventsQueryArgs) {
   const query = useWeekEventsQuery(args);
-  const { data: calendars } = useCalendarsQuery();
   const viewModel = useMemo(
-    () =>
-      deriveCalendarEventViewModel(
-        filterEventsByVisibleCalendars(query.data, calendars),
-      ),
-    [query.data, calendars],
+    () => deriveCalendarEventViewModel(query.data),
+    [query.data],
   );
   return { ...query, ...viewModel };
 }
 
 /**
  * Read-only week-events loading state. Subscribes to the same cache entry as
- * {@link useWeekEventsQuery} (shared key → no extra fetch).
+ * {@link useWeekEventsQuery} (shared key → no extra fetch), but strips
+ * `data` so a status-only consumer can never read event data - filtered or
+ * not. Callers that only need `isPending`/`isError`/`refetch`-style fields
+ * (fetch triggering, loading UI) should use this instead of discarding the
+ * result of {@link useWeekEventsQuery}.
  */
 export function useWeekEventsQueryStatus(args: WeekEventsQueryArgs) {
-  return useWeekEventsQueryInternal(args);
+  const { data: _data, ...status } = useWeekEventsQueryInternal(args);
+  return status;
 }

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import type dayjs from "@core/util/date/dayjs";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { dayEventsQueryOptions } from "@web/events/queries/event.query.options";
-import { useDayEventsQuery } from "@web/events/queries/useDayEventsQuery";
+import { useDayEventsQueryStatus } from "@web/events/queries/useDayEventsQuery";
 import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjacentEvents";
 
 /**
@@ -25,7 +25,10 @@ export function useDayEvents(dateInView: dayjs.Dayjs) {
     [dateInView],
   );
 
-  useDayEventsQuery({ startDate, endDate });
+  // Status-only: triggers the fetch and warms the cache entry that
+  // DayCalendarGrid reads via useDayEventViewModel for this same range - it
+  // owns error reporting for this query key.
+  useDayEventsQueryStatus({ startDate, endDate });
 
   // Warm the previous/next day so the next prev/next click resolves from
   // cache. Uses the same start/end-of-day formatting as the read above,

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -32,7 +32,8 @@ export const Grid: FC<Props> = ({
 }) => {
   const { allDayRef, allDayRowRef, mainGridElementRef, mainGridRef } = gridRefs;
   // Subscribes to the same cache entry the event layers read, so this reports
-  // their load without issuing a second fetch.
+  // their load without issuing a second fetch. Status-only - no event data
+  // (filtered or not) is available here.
   const {
     isPending: isLoadingEvents,
     isError: isErrorEvents,

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -5,7 +5,7 @@ import { ROOT_ROUTES, ROUTE_IDS } from "@web/common/constants/routes";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { usePrefetchAdjacentEvents } from "@web/events/queries/usePrefetchAdjacentEvents";
-import { useWeekEventsQuery } from "@web/events/queries/useWeekEventsQuery";
+import { useWeekEventsQueryStatus } from "@web/events/queries/useWeekEventsQuery";
 import { viewActions } from "@web/events/stores/view.store";
 import { WEEK_DAY_COUNT } from "@web/views/Week/util/week-window.util";
 import { type Category_View } from "@web/views/Week/week-view.types";
@@ -68,7 +68,12 @@ export const useWeek = (
     [start, visibleDayCount],
   );
 
-  useWeekEventsQuery({ startOfView: start, endOfView: queryEnd });
+  // Status-only: triggers the fetch and warms the cache entry that the
+  // event-consuming siblings in this tree (Draft, MainGridEvents,
+  // WeekInteractionCoordinator, ...) read via useWeekEventViewModel for the
+  // same range - they own error reporting for this query key, the same way
+  // Grid.tsx's own useWeekEventsQueryStatus call relies on them.
+  useWeekEventsQueryStatus({ startOfView: start, endOfView: queryEnd });
 
   // Warm the previous and next paged windows (J/K) using 7-day read keys.
   const previousStart = useMemo(


### PR DESCRIPTION
## Summary

- `useWeekEventsQuery` / `useDayEventsQuery` (in `packages/web/src/events/queries/`) previously returned unfiltered TanStack Query data — only `useWeekEventViewModel`/`useDayEventViewModel` applied `filterEventsByVisibleCalendars`. Every current consumer of the "primary" hooks happened to discard the result (used only for fetch/status side effects), but the next caller reaching for one to read events directly would silently render hidden-calendar events with no failure signal.
- Filtering now happens inside `useWeekEventsQuery`/`useDayEventsQuery` themselves, so no unfiltered event data leaves `events/queries/`. The view-model hooks derive from the already-filtered data instead of re-filtering.
- `useWeekEventsQueryStatus` and a new `useDayEventsQueryStatus` strip `data` from the return value entirely (via destructure-and-omit, so it's enforced by the type system, not convention), and the three call sites that only needed fetch/status side effects (`useWeek.ts`, `useDayEvents.ts`, `Grid.tsx`) now use these instead of discarding the result of the data-returning hooks.
- Docstrings updated on all four exported hooks to describe the new contract.

Behavior-preserving for current UI: verified the call sites that switched to the status-only hooks each sit alongside a sibling in the same tree (Draft/MainGridEvents/WeekInteractionCoordinator for Week; DayCalendarGrid for Day) that already calls the matching view-model hook with the identical query range, so error reporting for that cache key is still covered — the same assumption Grid.tsx's existing status-only usage already relied on.

## Test plan

- [x] `bun run type-check` — passes clean across all three tsconfig projects
- [x] `./node_modules/.bin/biome check` — no issues on changed files
- [x] `bun test src/views/Week src/events/queries` — 217/217 pass
- [x] `bun test src/views/Day` — 98/98 pass (includes Week shortcuts)
- [x] Updated `useWeekEventsQuery.test.ts` to seed a matching visible calendar via `queryClient.setQueryData(calendarQueryKeys.all, ...)` before render (same pattern as `useWeekShortcuts.test.tsx`), so the new filtering doesn't introduce a timing-dependent race between the mocked event fetch and the calendars fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the contract for primary event read hooks (privacy-sensitive filtering) and which components subscribe for errors vs data; behavior should match current UI if sibling view-model hooks still own error reporting for the same keys.
> 
> **Overview**
> **Day and week event query hooks** now apply `filterEventsByVisibleCalendars` inside `useDayEventsQuery` and `useWeekEventsQuery`, so event data leaving `events/queries/` never includes hidden calendars. `useDayEventViewModel` / `useWeekEventViewModel` derive from that already-filtered data instead of filtering again.
> 
> **Status-only hooks** are tightened: new `useDayEventsQueryStatus` mirrors week, and both status hooks omit `data` via destructure (typed, not convention). `useDayEvents`, `useWeek`, and week `Grid` switch to these hooks when they only need fetch/loading/refetch, instead of calling the data hooks and ignoring results.
> 
> **Tests** seed visible calendars in `useWeekEventsQuery.test.ts` so assertions on `.data` stay stable with the new filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0909cb9b6f275a09f6e6063de2e036124b00fe52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->