### PR TITLE
fix(web): default all-day->timed conversion to a visible time, not fixed 9am

### DIFF
--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -3,8 +3,9 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   ID_GRID_EVENTS_ALLDAY,
   ID_GRID_EVENTS_TIMED,
+  ID_GRID_MAIN,
 } from "@web/common/constants/web.constants";
-import { getElemById } from "@web/common/utils/grid/grid.util";
+import { getElemById, getMinuteHeight } from "@web/common/utils/grid/grid.util";
 import { roundToNext } from "@web/common/utils/round/round.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
@@ -14,6 +15,10 @@ import {
 import { draftActions } from "@web/events/stores/draft.store";
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
 import { isDraftRenderedInAllDayRow } from "@web/grid/layout/all-day-draft.position";
+
+// Keeps a newly-timed event off the very top edge of the scrolled-in
+// viewport rather than glued flush against it.
+const VISIBLE_START_MARGIN_MIN = 30;
 
 export const createTimedDraft = (
   isCurrentWeek: boolean,
@@ -68,6 +73,25 @@ export const getDraftTimes = (isCurrentWeek: boolean, startOfWeek: Dayjs) => {
   const endDate = _end.format();
 
   return { startDate, endDate };
+};
+
+// Timed grid only ever shows a fraction of the 24hr day at once, so a
+// draft that needs a visible default time (e.g. converting all-day->timed)
+// should land inside whatever's currently scrolled into view, not at a
+// fixed hour that may be scrolled off-screen. Returns minutes-from-midnight,
+// or null when the grid isn't mounted/measurable yet.
+export const getVisibleGridStartMinute = (): number | null => {
+  const grid = getElemById(ID_GRID_MAIN);
+  if (!grid || grid.clientHeight === 0) return null;
+
+  const minuteHeight = getMinuteHeight(grid.clientHeight);
+  const visibleStartMinute = grid.scrollTop / minuteHeight;
+  const snapped = roundToNext(
+    visibleStartMinute + VISIBLE_START_MARGIN_MIN,
+    GRID_TIME_STEP,
+  );
+
+  return Math.min(Math.max(snapped, 0), 23 * 60);
 };
 
 export const getDraftContainer = (draft: GridEventDraft) =>

--- a/packages/web/src/common/utils/grid/grid.util.ts
+++ b/packages/web/src/common/utils/grid/grid.util.ts
@@ -1,4 +1,5 @@
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 import {
   AFTER_TMRW_MULTIPLE,
   DIVIDER_GRID,
@@ -57,6 +58,12 @@ export const getBeforeTodayPercent = () => {
 export const getCurrentMinute = () => {
   return dayjs().get("hours") * 60 + dayjs().get("minutes");
 };
+
+// Timed grid always renders exactly TIMED_VISIBLE_HOURS worth of rows in
+// whatever height it's given, so this ratio is the single source of truth
+// for converting between the grid's pixel geometry and clock minutes.
+export const getMinuteHeight = (clientHeight: number) =>
+  clientHeight / TIMED_VISIBLE_HOURS / 60;
 
 export const getCurrentPercentOfDay = () => {
   return (getCurrentMinute() / 1440) * 100;

--- a/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
+++ b/packages/web/src/views/Day/components/Calendar/useDayCalendarScrollToNow.ts
@@ -1,7 +1,9 @@
 import { type RefObject, useCallback, useEffect } from "react";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
-import { getCurrentMinute } from "@web/common/utils/grid/grid.util";
-import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
+import {
+  getCurrentMinute,
+  getMinuteHeight,
+} from "@web/common/utils/grid/grid.util";
 
 export const useDayCalendarScrollToNow = (
   mainGridRef: RefObject<HTMLElement | null>,
@@ -10,7 +12,7 @@ export const useDayCalendarScrollToNow = (
     const timedGrid = mainGridRef.current;
     if (!timedGrid) return;
 
-    const minuteHeight = timedGrid.clientHeight / TIMED_VISIBLE_HOURS / 60;
+    const minuteHeight = getMinuteHeight(timedGrid.clientHeight);
     timedGrid.scroll({
       behavior: "smooth",
       top: getCurrentMinute() * minuteHeight - 150,

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@web/__tests__/render-with-store";
 import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
 import { Categories_Event } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
@@ -22,7 +23,7 @@ import {
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { type Props as DateTimeSectionProps } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 type CapturedDateTimeSectionProps = Pick<
   DateTimeSectionProps,
@@ -604,12 +605,10 @@ describe("EventForm", () => {
     // means the grid is scrolled to 1pm (780 minutes from midnight) -
     // well past the 9am default this test exists to disprove.
     const fakeGrid = document.createElement("section");
+    fakeGrid.id = ID_GRID_MAIN;
     Object.defineProperty(fakeGrid, "clientHeight", { value: 780 });
     fakeGrid.scrollTop = 780;
-    const getElementByIdSpy = spyOn(
-      document,
-      "getElementById",
-    ).mockImplementation((id: string) => (id === "mainGrid" ? fakeGrid : null));
+    document.body.appendChild(fakeGrid);
 
     function Harness() {
       const [draft, setDraft] = useState<GridEventDraft | null>(
@@ -637,8 +636,6 @@ describe("EventForm", () => {
     act(() => capturedDateControlsSectionProps?.onToggleAllDay(false));
 
     await user.click(screen.getByRole("button", { name: "Save" }));
-
-    getElementByIdSpy.mockRestore();
 
     const savedDraft = onSubmit.mock.calls[0]?.[0] as GridEventDraft;
     expect(savedDraft.values.schedule).toMatchObject({ kind: "timed" });

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -22,7 +22,7 @@ import {
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { type Props as DateTimeSectionProps } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 type CapturedDateTimeSectionProps = Pick<
   DateTimeSectionProps,
@@ -590,6 +590,67 @@ describe("EventForm", () => {
     if (savedDraft.values.schedule.kind !== "timed") {
       throw new Error("expected a timed schedule");
     }
+    expect(
+      savedDraft.values.schedule.end.getTime() -
+        savedDraft.values.schedule.start.getTime(),
+    ).toBe(60 * 60 * 1000);
+  });
+
+  it("converts an all-day draft to a timed event inside the grid's current scroll position, not a fixed 9am", async () => {
+    const user = userEvent.setup();
+    const onSubmit = mock();
+
+    // clientHeight/13hrs/60min = 1 minute per pixel, so scrollTop=780
+    // means the grid is scrolled to 1pm (780 minutes from midnight) -
+    // well past the 9am default this test exists to disprove.
+    const fakeGrid = document.createElement("section");
+    Object.defineProperty(fakeGrid, "clientHeight", { value: 780 });
+    fakeGrid.scrollTop = 780;
+    const getElementByIdSpy = spyOn(
+      document,
+      "getElementById",
+    ).mockImplementation((id: string) => (id === "mainGrid" ? fakeGrid : null));
+
+    function Harness() {
+      const [draft, setDraft] = useState<GridEventDraft | null>(
+        createAllDayDraft(),
+      );
+
+      if (!draft) return null;
+
+      return (
+        <EventForm
+          draft={draft}
+          isDraft
+          isExistingEvent={false}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={onSubmit}
+          setDraft={setDraft}
+        />
+      );
+    }
+
+    renderWithStore(<Harness />);
+
+    act(() => capturedDateControlsSectionProps?.onToggleAllDay(false));
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    getElementByIdSpy.mockRestore();
+
+    const savedDraft = onSubmit.mock.calls[0]?.[0] as GridEventDraft;
+    expect(savedDraft.values.schedule).toMatchObject({ kind: "timed" });
+    if (savedDraft.values.schedule.kind !== "timed") {
+      throw new Error("expected a timed schedule");
+    }
+
+    // visibleStartMinute (780) + 30min margin, rounded up to next 15 = 810
+    // minutes from midnight = 13:30.
+    expect(dayjs(savedDraft.values.schedule.start).format("HH:mm")).toBe(
+      "13:30",
+    );
     expect(
       savedDraft.values.schedule.end.getTime() -
         savedDraft.values.schedule.start.getTime(),

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -18,10 +18,7 @@ import {
   isEventReadOnly,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
-import {
-  ID_EVENT_FORM,
-  ID_GRID_MAIN,
-} from "@web/common/constants/web.constants";
+import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
 import { useEventPalette } from "@web/common/styles/theme.util";
 import { type SelectOption } from "@web/common/types/component.types";
 import { Categories_Event } from "@web/common/types/web.event.types";
@@ -29,12 +26,11 @@ import {
   getTimeOptionByValue,
   mapToBackend,
 } from "@web/common/utils/datetime/web.date.util";
+import { getVisibleGridStartMinute } from "@web/common/utils/draft/draft.util";
 import {
   isComboboxInteraction,
   isDeleteTextEditingTarget,
 } from "@web/common/utils/form/form.util";
-import { getElemById } from "@web/common/utils/grid/grid.util";
-import { roundToNext } from "@web/common/utils/round/round.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import {
   Focusable,
@@ -49,7 +45,6 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { BUSY_EVENT_TITLE } from "@web/events/queries/event.view-model";
 import { useEventById } from "@web/events/queries/useEventById";
-import { GRID_TIME_STEP, TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection";
@@ -141,24 +136,6 @@ const handleEventFormDelete = ({
 };
 
 const DEFAULT_TIMED_START_HOUR = 9; // fallback when the grid can't be measured
-const VISIBLE_START_MARGIN_MIN = 30; // keep the draft off the very top edge of the viewport
-
-// Timed grid only ever shows TIMED_VISIBLE_HOURS of the 24hr day at once, so
-// an all-day->timed conversion needs to land inside whatever's scrolled into
-// view right now, not at a fixed hour that may be scrolled off-screen.
-const getVisibleGridStartMinute = (): number | null => {
-  const grid = getElemById(ID_GRID_MAIN);
-  if (!grid || grid.clientHeight === 0) return null;
-
-  const minuteHeight = grid.clientHeight / TIMED_VISIBLE_HOURS / 60;
-  const visibleStartMinute = grid.scrollTop / minuteHeight;
-  const snapped = roundToNext(
-    visibleStartMinute + VISIBLE_START_MARGIN_MIN,
-    GRID_TIME_STEP,
-  );
-
-  return Math.min(Math.max(snapped, 0), 23 * 60);
-};
 
 const scheduleDateStrings = (draft: GridEventDraft) => {
   const { schedule } = draft.values;
@@ -496,13 +473,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         return;
       }
 
-      const visibleStartMinute = getVisibleGridStartMinute();
-      const timedStart =
-        visibleStartMinute === null
-          ? dayjs(selectedStartDate).hour(DEFAULT_TIMED_START_HOUR).minute(0)
-          : dayjs(selectedStartDate)
-              .startOf("day")
-              .add(visibleStartMinute, "minute");
+      const startMinute =
+        getVisibleGridStartMinute() ?? DEFAULT_TIMED_START_HOUR * 60;
+      const timedStart = dayjs(selectedStartDate)
+        .startOf("day")
+        .add(startMinute, "minute");
       const timedEnd = timedStart.add(1, "hour");
       const nextStartTime = getTimeOptionByValue(timedStart);
       const nextEndTime = getTimeOptionByValue(timedEnd);

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -18,7 +18,10 @@ import {
   isEventReadOnly,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
-import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
+import {
+  ID_EVENT_FORM,
+  ID_GRID_MAIN,
+} from "@web/common/constants/web.constants";
 import { useEventPalette } from "@web/common/styles/theme.util";
 import { type SelectOption } from "@web/common/types/component.types";
 import { Categories_Event } from "@web/common/types/web.event.types";
@@ -30,6 +33,8 @@ import {
   isComboboxInteraction,
   isDeleteTextEditingTarget,
 } from "@web/common/utils/form/form.util";
+import { getElemById } from "@web/common/utils/grid/grid.util";
+import { roundToNext } from "@web/common/utils/round/round.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import {
   Focusable,
@@ -44,6 +49,7 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { BUSY_EVENT_TITLE } from "@web/events/queries/event.view-model";
 import { useEventById } from "@web/events/queries/useEventById";
+import { GRID_TIME_STEP, TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection";
@@ -132,6 +138,26 @@ const handleEventFormDelete = ({
   }
 
   onDelete();
+};
+
+const DEFAULT_TIMED_START_HOUR = 9; // fallback when the grid can't be measured
+const VISIBLE_START_MARGIN_MIN = 30; // keep the draft off the very top edge of the viewport
+
+// Timed grid only ever shows TIMED_VISIBLE_HOURS of the 24hr day at once, so
+// an all-day->timed conversion needs to land inside whatever's scrolled into
+// view right now, not at a fixed hour that may be scrolled off-screen.
+const getVisibleGridStartMinute = (): number | null => {
+  const grid = getElemById(ID_GRID_MAIN);
+  if (!grid || grid.clientHeight === 0) return null;
+
+  const minuteHeight = grid.clientHeight / TIMED_VISIBLE_HOURS / 60;
+  const visibleStartMinute = grid.scrollTop / minuteHeight;
+  const snapped = roundToNext(
+    visibleStartMinute + VISIBLE_START_MARGIN_MIN,
+    GRID_TIME_STEP,
+  );
+
+  return Math.min(Math.max(snapped, 0), 23 * 60);
 };
 
 const scheduleDateStrings = (draft: GridEventDraft) => {
@@ -470,7 +496,13 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         return;
       }
 
-      const timedStart = dayjs(selectedStartDate).hour(9).minute(0);
+      const visibleStartMinute = getVisibleGridStartMinute();
+      const timedStart =
+        visibleStartMinute === null
+          ? dayjs(selectedStartDate).hour(DEFAULT_TIMED_START_HOUR).minute(0)
+          : dayjs(selectedStartDate)
+              .startOf("day")
+              .add(visibleStartMinute, "minute");
       const timedEnd = timedStart.add(1, "hour");
       const nextStartTime = getTimeOptionByValue(timedStart);
       const nextEndTime = getTimeOptionByValue(timedEnd);

--- a/packages/web/src/views/Week/hooks/grid/useScroll.ts
+++ b/packages/web/src/views/Week/hooks/grid/useScroll.ts
@@ -1,15 +1,17 @@
 import { type MutableRefObject, useCallback, useEffect } from "react";
-import { getCurrentMinute } from "@web/common/utils/grid/grid.util";
-import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
+import {
+  getCurrentMinute,
+  getMinuteHeight,
+} from "@web/common/utils/grid/grid.util";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 export const useScroll = (
   timedGridRef: MutableRefObject<HTMLElement | null>,
 ) => {
   const scrollToNow = useCallback(() => {
-    const gridRowHeight =
-      (timedGridRef.current?.clientHeight || 0) / TIMED_VISIBLE_HOURS;
-    const minuteHeight = gridRowHeight / 60;
+    const minuteHeight = getMinuteHeight(
+      timedGridRef.current?.clientHeight || 0,
+    );
 
     const buffer = 150;
     const top = getCurrentMinute() * minuteHeight - buffer;


### PR DESCRIPTION
## Summary
- Fixes a UX bug: scrolling the timed grid down, creating an all-day draft, then unchecking "All day?" always converted it to a fixed 9:00-10:00am timed event — invisible if the current scroll position didn't include 9am.
- The default start time is now derived from the timed grid's actual visible scroll window (same minute-height math as the existing "scroll to now" logic), snapped to the next 15-minute mark with a 30-minute margin off the top edge, so the converted event always lands somewhere already on screen.
- Falls back to the previous 9am behavior only when the grid can't be measured (e.g. not mounted).
- Intentionally scoped to visibility only — does not attempt to dodge overlaps with other events that day (would require wiring day-event data into `EventForm`, which has none today).

## Simplification performed
A 4-angle cleanup pass (reuse / simplification / efficiency / altitude) on the initial fix surfaced two real issues, both fixed in a follow-up commit:
- The `clientHeight / TIMED_VISIBLE_HOURS / 60` minute-height formula was inlined a third time (already duplicated between the Week and Day "scroll to now" hooks). Extracted into a single `getMinuteHeight` helper in `grid.util.ts`; all three call sites now share it.
- The new `getVisibleGridStartMinute` helper was a pure DOM+math function living inline in `EventForm.tsx` with no dependency on component state. Relocated to `draft.util.ts` next to its sibling `getDraftTimes` (both compute a default start time for a newly-created timed event).
- Also collapsed a null-check ternary into a single `??` expression in `onToggleAllDay`, and simplified the new test to use a real DOM element with the real grid id instead of spying on `document.getElementById` (the suite's global `afterEach` already resets `document.body`).
- Considered but skipped: reusing the interaction engine's `buildTimedGridLayoutCache` pixel-per-minute formula instead of the simpler shared helper — that cache requires day-column/smart-scroll/edge-threshold config unrelated to this fix and would be disproportionate machinery for a form toggle handler.

## Test plan
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean (2 pre-existing unrelated warnings)
- [x] Focused tests: `EventForm.test.tsx` (21/21, incl. new test), `draft.util.test.ts` + `grid.util.test.ts` (22/22), `WeekView.render.test.tsx` (1/1) — all passing
- [x] Manual verification in browser: scrolled grid to hide 9am, created an all-day draft, unchecked "All day?" — event landed at 11:30am (top of visible window + margin, rounded), fully visible without scrolling. Repeated with grid scrolled to the very top — landed at 12:30am, still correctly the top of that visible window.

## Independent review
A fresh reviewer (no prior context) reviewed the full branch diff against `AGENTS.md` conventions, refactor fidelity, boundary conditions, and accessibility/security/data-loss risk. No confirmed findings — reported as a small, well-scoped, behavior-preserving fix with adequate regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)