### PR TITLE
refactor(web): make calendar visibility a reactive external store

### DIFF
--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -9,6 +9,7 @@ import {
   initialUserMetadataState,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
+import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
 import { resetEventRepositorySourceForTests } from "@web/events/repositories/event.repository.source.store";
 import {
   initialDraftState,
@@ -40,6 +41,9 @@ const storeResets: StoreReset[] = [
   // poisoning is silent and only surfaces under CI's file ordering).
   resetBackendAvailabilityForTests,
   resetEventRepositorySourceForTests,
+  // Storage itself is cleared by resetBrowserState() (test-lifecycle.ts)
+  // before this runs; this just resyncs the module-singleton store to match.
+  resetCalendarVisibilityStoreForTests,
   // Lives on window.__weekInteractionMotionActive, which survives across
   // test files (the preload reuses one jsdom window). A test that starts a
   // real drag and never completes it would otherwise leave every later

--- a/packages/web/src/auth/compass/state/auth.state.util.ts
+++ b/packages/web/src/auth/compass/state/auth.state.util.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { subscribeToStorageKey } from "@web/common/utils/external-store.util";
 import { clearGoogleRevokedState } from "../../google/state/google.auth.state";
 
 export const AuthStateSchema = z.object({
@@ -146,23 +147,10 @@ export function shouldShowAnonymousCalendarChangeSignUpPrompt(): boolean {
 
 export function subscribeToAuthState(listener: () => void): () => void {
   authStateListeners.add(listener);
-
-  if (typeof window === "undefined") {
-    return () => {
-      authStateListeners.delete(listener);
-    };
-  }
-
-  const handleStorage = (event: StorageEvent) => {
-    if (event.key === STORAGE_KEYS.AUTH) {
-      listener();
-    }
-  };
-
-  window.addEventListener("storage", handleStorage);
+  const unsubscribeStorage = subscribeToStorageKey(STORAGE_KEYS.AUTH, listener);
 
   return () => {
     authStateListeners.delete(listener);
-    window.removeEventListener("storage", handleStorage);
+    unsubscribeStorage();
   };
 }

--- a/packages/web/src/calendars/apply-client-visibility.ts
+++ b/packages/web/src/calendars/apply-client-visibility.ts
@@ -1,11 +1,16 @@
 import { type Calendar } from "@core/types/calendar.contracts";
-import { readHiddenCalendarIds } from "./calendar-visibility.storage";
 
 // Overlay client-owned visibility onto a server calendar list. Server
 // isVisible is ignored: under sync delegation it is always true, and under
-// legacy the Mongo field is no longer written by the web toggle (A2).
-export function applyClientVisibility(calendars: Calendar[]): Calendar[] {
-  const hidden = readHiddenCalendarIds();
+// legacy the Mongo field is no longer written by the web toggle (A2). Takes
+// the hidden id set as a parameter (rather than reading storage itself) so
+// it stays a pure function of the calendars query's `select` - see
+// calendar-visibility.store.ts for where the set comes from and how it stays
+// reactive.
+export function applyClientVisibility(
+  calendars: Calendar[],
+  hidden: ReadonlySet<string>,
+): Calendar[] {
   return calendars.map((calendar) => ({
     ...calendar,
     isVisible: !hidden.has(calendar.id),

--- a/packages/web/src/calendars/calendar-visibility.store.test.ts
+++ b/packages/web/src/calendars/calendar-visibility.store.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { isCalendarHidden } from "./calendar-visibility.storage";
+import {
+  setCalendarVisibility,
+  useHiddenCalendarIds,
+} from "./calendar-visibility.store";
+import { describe, expect, it, spyOn } from "bun:test";
+
+const calendarId = CalendarIdSchema.parse(createObjectIdString());
+
+// Storage clearing + the hidden-ids store resync between tests are both
+// handled by the global test-lifecycle afterEach (resetBrowserState +
+// resetAllStores) - see packages/web/src/__tests__/setup/test-lifecycle.ts.
+
+describe("calendar-visibility.store", () => {
+  it("persists a visibility change and notifies subscribers", () => {
+    const { result } = renderHook(() => useHiddenCalendarIds());
+
+    expect(result.current.has(calendarId)).toBe(false);
+
+    act(() => {
+      expect(setCalendarVisibility(calendarId, false)).toBe(true);
+    });
+
+    expect(result.current.has(calendarId)).toBe(true);
+    expect(isCalendarHidden(calendarId)).toBe(true);
+
+    act(() => {
+      expect(setCalendarVisibility(calendarId, true)).toBe(true);
+    });
+
+    expect(result.current.has(calendarId)).toBe(false);
+  });
+
+  it("leaves the store untouched when the storage write fails", () => {
+    const setSpy = spyOn(persistentBrowserStore, "set").mockReturnValue(false);
+    const { result } = renderHook(() => useHiddenCalendarIds());
+
+    act(() => {
+      expect(setCalendarVisibility(calendarId, false)).toBe(false);
+    });
+
+    expect(result.current.has(calendarId)).toBe(false);
+    setSpy.mockRestore();
+  });
+
+  it("picks up a hide written by another tab via the storage event", () => {
+    const { result } = renderHook(() => useHiddenCalendarIds());
+    expect(result.current.has(calendarId)).toBe(false);
+
+    // A same-tab write never fires "storage" (browsers only dispatch it to
+    // other tabs), so this simulates the cross-tab case directly: write
+    // through the raw persistence layer (bypassing this store's setter,
+    // mirroring another tab's process), then replay the event this window
+    // would receive.
+    persistentBrowserStore.set(
+      STORAGE_KEYS.HIDDEN_CALENDAR_IDS,
+      JSON.stringify([calendarId]),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEYS.HIDDEN_CALENDAR_IDS }),
+      );
+    });
+
+    expect(result.current.has(calendarId)).toBe(true);
+  });
+
+  it("ignores storage events for unrelated keys", () => {
+    const { result } = renderHook(() => useHiddenCalendarIds());
+
+    persistentBrowserStore.set(
+      STORAGE_KEYS.HIDDEN_CALENDAR_IDS,
+      JSON.stringify([calendarId]),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEYS.SIDEBAR_OPEN }),
+      );
+    });
+
+    expect(result.current.has(calendarId)).toBe(false);
+  });
+});

--- a/packages/web/src/calendars/calendar-visibility.store.ts
+++ b/packages/web/src/calendars/calendar-visibility.store.ts
@@ -1,10 +1,13 @@
 import { useSyncExternalStore } from "react";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
-import { createExternalStore } from "@web/common/utils/external-store.util";
+import {
+  createExternalStore,
+  subscribeToStorageKey,
+} from "@web/common/utils/external-store.util";
 import {
   readHiddenCalendarIds,
-  setCalendarHidden,
+  writeHiddenCalendarIds,
 } from "./calendar-visibility.storage";
 
 /**
@@ -28,34 +31,34 @@ function refreshFromStorage(): void {
 /**
  * Persist + broadcast a visibility change. Returns false (and leaves the
  * store untouched) when the storage write fails, so callers can surface a
- * failure toast without the UI silently flipping first.
+ * failure toast without the UI silently flipping first. Builds the next set
+ * from the in-memory store (already the source of truth for this tab) and
+ * writes it directly, rather than writing then re-reading storage to learn
+ * what was just written.
  */
 export function setCalendarVisibility(
   calendarId: CalendarId,
   isVisible: boolean,
 ): boolean {
-  const saved = setCalendarHidden(calendarId, !isVisible);
-  if (saved) refreshFromStorage();
+  const next = new Set(hiddenIdsStore.get());
+  if (isVisible) next.delete(calendarId);
+  else next.add(calendarId);
+
+  const saved = writeHiddenCalendarIds(next);
+  if (saved) hiddenIdsStore.set(next);
   return saved;
 }
 
 function subscribe(onChange: () => void): () => void {
   const unsubscribeStore = hiddenIdsStore.subscribe(onChange);
-
-  if (typeof window === "undefined") return unsubscribeStore;
-
-  // Cross-tab sync: a write in another tab fires "storage" here (never in
-  // the writing tab itself), so pick it up and re-read localStorage.
-  const handleStorage = (event: StorageEvent) => {
-    if (event.key === STORAGE_KEYS.HIDDEN_CALENDAR_IDS) {
-      refreshFromStorage();
-    }
-  };
-  window.addEventListener("storage", handleStorage);
+  const unsubscribeStorage = subscribeToStorageKey(
+    STORAGE_KEYS.HIDDEN_CALENDAR_IDS,
+    refreshFromStorage,
+  );
 
   return () => {
     unsubscribeStore();
-    window.removeEventListener("storage", handleStorage);
+    unsubscribeStorage();
   };
 }
 
@@ -64,9 +67,11 @@ export function useHiddenCalendarIds(): ReadonlySet<string> {
 }
 
 /**
- * Test-only: resyncs the in-memory store from storage. Without this, the
- * module-singleton store keeps a hidden id in memory even after a test
- * clears localStorage directly, leaking into later tests in the same file.
+ * Test-only: resyncs the in-memory store from storage. Registered in
+ * reset-stores.ts for between-test cleanup; also called directly by tests
+ * that seed a hidden id via calendar-visibility.storage.ts's setCalendarHidden
+ * (bypassing this store's own write path) and need the store to observe it
+ * before render.
  */
 export function resetCalendarVisibilityStoreForTests(): void {
   refreshFromStorage();

--- a/packages/web/src/calendars/calendar-visibility.store.ts
+++ b/packages/web/src/calendars/calendar-visibility.store.ts
@@ -1,0 +1,73 @@
+import { useSyncExternalStore } from "react";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { createExternalStore } from "@web/common/utils/external-store.util";
+import {
+  readHiddenCalendarIds,
+  setCalendarHidden,
+} from "./calendar-visibility.storage";
+
+/**
+ * Reactive mirror of the client-owned hidden-calendar-id set (S39 A2
+ * follow-up). Storage (calendar-visibility.storage.ts) stays the source of
+ * truth; this store just makes a change to it observable, so the calendars
+ * query's `select` (calendar.query.ts) can derive isVisible on every read
+ * instead of relying on whichever writer last hand-patched the query cache.
+ * Any future writer of the calendars cache (SSE upsert, rename/color
+ * mutation, test seeding) gets the overlay for free - there's nothing left
+ * to remember to re-run.
+ */
+const hiddenIdsStore = createExternalStore<ReadonlySet<string>>(
+  readHiddenCalendarIds(),
+);
+
+function refreshFromStorage(): void {
+  hiddenIdsStore.set(readHiddenCalendarIds());
+}
+
+/**
+ * Persist + broadcast a visibility change. Returns false (and leaves the
+ * store untouched) when the storage write fails, so callers can surface a
+ * failure toast without the UI silently flipping first.
+ */
+export function setCalendarVisibility(
+  calendarId: CalendarId,
+  isVisible: boolean,
+): boolean {
+  const saved = setCalendarHidden(calendarId, !isVisible);
+  if (saved) refreshFromStorage();
+  return saved;
+}
+
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = hiddenIdsStore.subscribe(onChange);
+
+  if (typeof window === "undefined") return unsubscribeStore;
+
+  // Cross-tab sync: a write in another tab fires "storage" here (never in
+  // the writing tab itself), so pick it up and re-read localStorage.
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEYS.HIDDEN_CALENDAR_IDS) {
+      refreshFromStorage();
+    }
+  };
+  window.addEventListener("storage", handleStorage);
+
+  return () => {
+    unsubscribeStore();
+    window.removeEventListener("storage", handleStorage);
+  };
+}
+
+export function useHiddenCalendarIds(): ReadonlySet<string> {
+  return useSyncExternalStore(subscribe, hiddenIdsStore.get);
+}
+
+/**
+ * Test-only: resyncs the in-memory store from storage. Without this, the
+ * module-singleton store keeps a hidden id in memory even after a test
+ * clears localStorage directly, leaking into later tests in the same file.
+ */
+export function resetCalendarVisibilityStoreForTests(): void {
+  refreshFromStorage();
+}

--- a/packages/web/src/calendars/calendar.query.ts
+++ b/packages/web/src/calendars/calendar.query.ts
@@ -1,4 +1,5 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { CalendarApi } from "@web/api/calendar.api";
 import { useSession } from "@web/auth/compass/session/useSession";
@@ -37,9 +38,13 @@ export function calendarsQueryOptions(authenticated: boolean) {
 export function useCalendarsQuery() {
   const { authenticated } = useSession();
   const hiddenIds = useHiddenCalendarIds();
+  // A fresh arrow function every render would recompute select's full
+  // map+spread over every calendar on every render, not just when hiddenIds
+  // (or the underlying data) actually changes.
+  const select = useCallback(
+    (calendars: Calendar[]) => applyClientVisibility(calendars, hiddenIds),
+    [hiddenIds],
+  );
 
-  return useQuery({
-    ...calendarsQueryOptions(authenticated),
-    select: (calendars) => applyClientVisibility(calendars, hiddenIds),
-  });
+  return useQuery({ ...calendarsQueryOptions(authenticated), select });
 }

--- a/packages/web/src/calendars/calendar.query.ts
+++ b/packages/web/src/calendars/calendar.query.ts
@@ -3,6 +3,7 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { CalendarApi } from "@web/api/calendar.api";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { applyClientVisibility } from "@web/calendars/apply-client-visibility";
+import { useHiddenCalendarIds } from "@web/calendars/calendar-visibility.store";
 import {
   getLocalCalendarSentinelId,
   synthesizeLocalCalendar,
@@ -14,20 +15,20 @@ export const calendarQueryKeys = {
 
 // Anonymous/offline mode never calls the API - it synthesizes the one local
 // calendar from the sentinel id so downstream code (drafts, transitions)
-// always has a calendar list to read from (B12). Authenticated lists overlay
-// client-owned visibility (localStorage) so sync's always-true isVisible and
-// legacy Mongo prefs are not the source of truth (S39 A2).
+// always has a calendar list to read from (B12). The raw server list here
+// never carries client visibility - useCalendarsQuery's `select` overlays it
+// on every read, so any writer of this cache (SSE upsert, mutation, test
+// seeding) gets correct isVisible for free instead of needing to re-run
+// applyClientVisibility itself.
 export function calendarsQueryOptions(authenticated: boolean) {
   return queryOptions({
     queryKey: calendarQueryKeys.all,
     queryFn: async (): Promise<Calendar[]> => {
       if (!authenticated) {
-        return applyClientVisibility([
-          synthesizeLocalCalendar(getLocalCalendarSentinelId()),
-        ]);
+        return [synthesizeLocalCalendar(getLocalCalendarSentinelId())];
       }
 
-      return applyClientVisibility(await CalendarApi.list());
+      return CalendarApi.list();
     },
     staleTime: 60_000,
   });
@@ -35,5 +36,10 @@ export function calendarsQueryOptions(authenticated: boolean) {
 
 export function useCalendarsQuery() {
   const { authenticated } = useSession();
-  return useQuery(calendarsQueryOptions(authenticated));
+  const hiddenIds = useHiddenCalendarIds();
+
+  return useQuery({
+    ...calendarsQueryOptions(authenticated),
+    select: (calendars) => applyClientVisibility(calendars, hiddenIds),
+  });
 }

--- a/packages/web/src/calendars/useCalendarVisibility.ts
+++ b/packages/web/src/calendars/useCalendarVisibility.ts
@@ -1,9 +1,6 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import { calendarQueryKeys } from "@web/calendars/calendar.query";
-import { setCalendarHidden } from "@web/calendars/calendar-visibility.storage";
+import { setCalendarVisibility } from "@web/calendars/calendar-visibility.store";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 
 export const CALENDAR_VISIBILITY_FAILURE_MESSAGE =
@@ -11,33 +8,27 @@ export const CALENDAR_VISIBILITY_FAILURE_MESSAGE =
 
 /**
  * Client-owned calendar visibility toggle (S39 A2).
- * Flips the calendars cache immediately and persists the hidden set in
- * localStorage (default visible). Event queries keep their data; the week/day
- * view models filter by isVisible so hide and show both update the grid
- * without a round trip. No server write — sync list always reports
- * isVisible:true, and the event read already returns every calendar (client
- * filter is the source of truth).
+ * Persists the hidden set in localStorage (default visible) and notifies the
+ * reactive hidden-ids store; the calendars query's `select` re-derives
+ * isVisible from that store on every read (calendar.query.ts), so this hook
+ * only writes storage once - no cache patch to keep in sync. Event queries
+ * keep their data; the week/day view models filter by isVisible so hide and
+ * show both update the grid without a round trip. No server write - sync
+ * list always reports isVisible:true, and the event read already returns
+ * every calendar (client filter is the source of truth).
  */
 export function useCalendarVisibility() {
-  const queryClient = useQueryClient();
   const [failureAnnouncement, setFailureAnnouncement] = useState("");
 
   const toggleCalendarVisibility = (
     calendarId: CalendarId,
     isVisible: boolean,
   ) => {
-    const saved = setCalendarHidden(calendarId, !isVisible);
+    const saved = setCalendarVisibility(calendarId, isVisible);
     if (!saved) {
       showErrorToast(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
       setFailureAnnouncement(CALENDAR_VISIBILITY_FAILURE_MESSAGE);
-      return;
     }
-
-    queryClient.setQueryData<Calendar[]>(calendarQueryKeys.all, (current) =>
-      current?.map((calendar) =>
-        calendar.id === calendarId ? { ...calendar, isVisible } : calendar,
-      ),
-    );
   };
 
   return { toggleCalendarVisibility, failureAnnouncement };

--- a/packages/web/src/common/utils/external-store.util.ts
+++ b/packages/web/src/common/utils/external-store.util.ts
@@ -32,3 +32,24 @@ export function createExternalStore<T>(initial: T): ExternalStore<T> {
     },
   };
 }
+
+/**
+ * Cross-tab sync for a single localStorage key: a write in another tab fires
+ * "storage" here (browsers never fire it in the writing tab itself), so this
+ * calls `onChange` to let the caller re-read its own source of truth. Shared
+ * by every store that mirrors one localStorage key (auth state, calendar
+ * visibility) so the window-listener wiring exists in one place.
+ */
+export function subscribeToStorageKey(
+  key: string,
+  onChange: () => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === key) onChange();
+  };
+  window.addEventListener("storage", handleStorage);
+
+  return () => window.removeEventListener("storage", handleStorage);
+}

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -15,8 +15,6 @@ import { type ApiRequestConfig } from "@web/api/api.types";
 import { BaseApi } from "@web/api/base/base.api";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { isCalendarHidden } from "@web/calendars/calendar-visibility.storage";
-import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
-import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
@@ -134,12 +132,8 @@ describe("CalendarList", () => {
 
   afterEach(() => {
     BaseApi.defaults.adapter = undefined;
-    persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
-    // The hidden-ids store is a module singleton (calendar-visibility.store.ts)
-    // that only resyncs from storage on a write or a cross-tab "storage"
-    // event - neither fires from the plain removal above, so without this it
-    // would keep the last test's hidden id in memory and leak into the next.
-    resetCalendarVisibilityStoreForTests();
+    // Storage clearing + the hidden-ids store resync are both handled by the
+    // global test-lifecycle afterEach (resetBrowserState + resetAllStores).
     mockUseSession.mockReturnValue({
       authenticated: false,
       setAuthenticated: () => {},

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -15,6 +15,7 @@ import { type ApiRequestConfig } from "@web/api/api.types";
 import { BaseApi } from "@web/api/base/base.api";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { isCalendarHidden } from "@web/calendars/calendar-visibility.storage";
+import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
@@ -134,6 +135,11 @@ describe("CalendarList", () => {
   afterEach(() => {
     BaseApi.defaults.adapter = undefined;
     persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
+    // The hidden-ids store is a module singleton (calendar-visibility.store.ts)
+    // that only resyncs from storage on a write or a cross-tab "storage"
+    // event - neither fires from the plain removal above, so without this it
+    // would keep the last test's hidden id in memory and leak into the next.
+    resetCalendarVisibilityStoreForTests();
     mockUseSession.mockReturnValue({
       authenticated: false,
       setAuthenticated: () => {},
@@ -238,14 +244,18 @@ describe("CalendarList", () => {
     const { queryClient } = renderCalendarList([hidden]);
     queryClient.setQueryData<NormalizedEventQueryData>(weekKey, weekData);
 
-    // The button label derives from the cached calendar's isVisible, so
-    // finding the flipped label already proves the calendars cache updated.
-    await user.click(
-      screen.getByRole("button", { name: "Hide Hidden target calendar" }),
-    );
+    const hideButton = screen.getByRole("button", {
+      name: "Hide Hidden target calendar",
+    });
+    await user.click(hideButton);
+
+    // Visibility now lives in the client-owned hidden-ids store (derived by
+    // the calendars query's `select`), not hand-patched onto the raw cache -
+    // event queries are untouched either way.
     expect(queryClient.getQueryData<NormalizedEventQueryData>(weekKey)).toEqual(
       weekData,
     );
+    expect(isCalendarHidden(hidden.id)).toBe(true);
 
     await user.click(
       screen.getByRole("button", { name: "Show Hidden target calendar" }),
@@ -253,6 +263,7 @@ describe("CalendarList", () => {
     expect(queryClient.getQueryData<NormalizedEventQueryData>(weekKey)).toEqual(
       weekData,
     );
+    expect(isCalendarHidden(hidden.id)).toBe(false);
   });
 
   it("announces failure and leaves the button pressed when storage write fails", async () => {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
@@ -17,13 +17,8 @@ import {
   deriveAvailabilityCalendarIds,
 } from "@web/calendars/availability.query";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
-import {
-  readHiddenCalendarIds,
-  setCalendarHidden,
-} from "@web/calendars/calendar-visibility.storage";
-import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
-import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
-import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { readHiddenCalendarIds } from "@web/calendars/calendar-visibility.storage";
+import { setCalendarVisibility } from "@web/calendars/calendar-visibility.store";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { type GridMeasurements } from "@web/grid/types/grid.types";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
@@ -94,11 +89,8 @@ afterEach(() => {
   cleanup();
   seededCalendars = [];
   seededBusyPeriods = [];
-  // The hidden-ids store is a module singleton that only resyncs from
-  // storage on a write or cross-tab event, so a plain removal here would
-  // leave the last test's hidden id in memory - reset both.
-  persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
-  resetCalendarVisibilityStoreForTests();
+  // Storage clearing + the hidden-ids store resync are both handled by the
+  // global test-lifecycle afterEach (resetBrowserState + resetAllStores).
 });
 
 const makeFreeBusyCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
@@ -158,10 +150,7 @@ describe("DayCalendarBusyPeriodsLayer", () => {
     const hiddenCalendar = makeFreeBusyCalendar();
     // isVisible is client-derived from the hidden-ids store now, not a field
     // to seed directly on the fixture - see calendar-visibility.store.ts.
-    // The store is a module singleton that only resyncs from storage on a
-    // write or cross-tab event, so force a resync before render picks it up.
-    setCalendarHidden(hiddenCalendar.id, true);
-    resetCalendarVisibilityStoreForTests();
+    setCalendarVisibility(hiddenCalendar.id, false);
     seededCalendars = [hiddenCalendar];
     seededBusyPeriods = [];
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarBusyPeriods.test.tsx
@@ -11,11 +11,19 @@ import { type AvailabilityResponse } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { cleanup, render, screen } from "@web/__tests__/__mocks__/mock.render";
 import { createCompassQueryClient } from "@web/api/query-client";
+import { applyClientVisibility } from "@web/calendars/apply-client-visibility";
 import {
   availabilityQueryOptions,
   deriveAvailabilityCalendarIds,
 } from "@web/calendars/availability.query";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import {
+  readHiddenCalendarIds,
+  setCalendarHidden,
+} from "@web/calendars/calendar-visibility.storage";
+import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { type GridMeasurements } from "@web/grid/types/grid.types";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
@@ -53,7 +61,14 @@ function Provider({ children }: PropsWithChildren) {
     const client = createCompassQueryClient();
     client.setQueryData(calendarQueryKeys.all, seededCalendars);
 
-    const calendarIds = deriveAvailabilityCalendarIds(seededCalendars);
+    // Mirrors useCalendarsQuery's `select` (calendar.query.ts) so the key
+    // this seeds under matches the key the real hook computes - isVisible on
+    // a raw fixture is no longer authoritative, the hidden-ids store is.
+    const visibleCalendars = applyClientVisibility(
+      seededCalendars,
+      readHiddenCalendarIds(),
+    );
+    const calendarIds = deriveAvailabilityCalendarIds(visibleCalendars);
     // Same range the layer queries, so the seeded entry lands under the key
     // it reads.
     const { startDate, endDate } = dayEventQueryRange(dateInView);
@@ -79,6 +94,11 @@ afterEach(() => {
   cleanup();
   seededCalendars = [];
   seededBusyPeriods = [];
+  // The hidden-ids store is a module singleton that only resyncs from
+  // storage on a write or cross-tab event, so a plain removal here would
+  // leave the last test's hidden id in memory - reset both.
+  persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
+  resetCalendarVisibilityStoreForTests();
 });
 
 const makeFreeBusyCalendar = (overrides: Partial<Calendar> = {}): Calendar => ({
@@ -135,7 +155,13 @@ describe("DayCalendarBusyPeriodsLayer", () => {
     // useAvailabilityQuery's derived calendarIds is empty here - this pins
     // that the render path correctly shows nothing for that disabled query,
     // not just that the id-derivation function does.
-    const hiddenCalendar = makeFreeBusyCalendar({ isVisible: false });
+    const hiddenCalendar = makeFreeBusyCalendar();
+    // isVisible is client-derived from the hidden-ids store now, not a field
+    // to seed directly on the fixture - see calendar-visibility.store.ts.
+    // The store is a module singleton that only resyncs from storage on a
+    // write or cross-tab event, so force a resync before render picks it up.
+    setCalendarHidden(hiddenCalendar.id, true);
+    resetCalendarVisibilityStoreForTests();
     seededCalendars = [hiddenCalendar];
     seededBusyPeriods = [];
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -16,11 +16,15 @@ import {
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { setCalendarHidden } from "@web/calendars/calendar-visibility.storage";
+import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
 import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   DATA_TIMED_GRID_ROW,
   ZIndex,
 } from "@web/common/constants/web.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import {
@@ -310,6 +314,11 @@ afterEach(() => {
     delete (HTMLElement.prototype as { scroll?: unknown }).scroll;
   }
   resetDraft();
+  // The hidden-ids store is a module singleton that only resyncs from
+  // storage on a write or cross-tab event, so a plain removal here would
+  // leave the last test's hidden id in memory - reset both.
+  persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
+  resetCalendarVisibilityStoreForTests();
 });
 
 describe("DayCalendarGrid", () => {
@@ -323,7 +332,13 @@ describe("DayCalendarGrid", () => {
   it("renders enabled calendars as separate event columns", () => {
     const primary = makeCalendar("Primary", { isPrimary: true });
     const projects = makeCalendar("Projects");
-    const hidden = makeCalendar("Hidden", { isVisible: false });
+    const hidden = makeCalendar("Hidden");
+    // isVisible is client-derived from the hidden-ids store now, not a field
+    // to seed directly on the fixture - see calendar-visibility.store.ts.
+    // The store is a module singleton that only resyncs from storage on a
+    // write or cross-tab event, so force a resync before render picks it up.
+    setCalendarHidden(hidden.id, true);
+    resetCalendarVisibilityStoreForTests();
     seededEvents = [
       createMockEvent({
         calendarId: primary.id,
@@ -378,11 +393,11 @@ describe("DayCalendarGrid", () => {
   });
 
   it("falls back to the primary calendar when every calendar is disabled", () => {
-    const primary = makeCalendar("Primary", {
-      isPrimary: true,
-      isVisible: false,
-    });
-    const disabled = makeCalendar("Disabled", { isVisible: false });
+    const primary = makeCalendar("Primary", { isPrimary: true });
+    const disabled = makeCalendar("Disabled");
+    setCalendarHidden(primary.id, true);
+    setCalendarHidden(disabled.id, true);
+    resetCalendarVisibilityStoreForTests();
 
     renderDayCalendarGrid([disabled, primary]);
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -16,15 +16,12 @@ import {
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
-import { setCalendarHidden } from "@web/calendars/calendar-visibility.storage";
-import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
+import { setCalendarVisibility } from "@web/calendars/calendar-visibility.store";
 import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
-import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   DATA_TIMED_GRID_ROW,
   ZIndex,
 } from "@web/common/constants/web.constants";
-import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import {
@@ -314,11 +311,8 @@ afterEach(() => {
     delete (HTMLElement.prototype as { scroll?: unknown }).scroll;
   }
   resetDraft();
-  // The hidden-ids store is a module singleton that only resyncs from
-  // storage on a write or cross-tab event, so a plain removal here would
-  // leave the last test's hidden id in memory - reset both.
-  persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_CALENDAR_IDS);
-  resetCalendarVisibilityStoreForTests();
+  // Storage clearing + the hidden-ids store resync are both handled by the
+  // global test-lifecycle afterEach (resetBrowserState + resetAllStores).
 });
 
 describe("DayCalendarGrid", () => {
@@ -335,10 +329,7 @@ describe("DayCalendarGrid", () => {
     const hidden = makeCalendar("Hidden");
     // isVisible is client-derived from the hidden-ids store now, not a field
     // to seed directly on the fixture - see calendar-visibility.store.ts.
-    // The store is a module singleton that only resyncs from storage on a
-    // write or cross-tab event, so force a resync before render picks it up.
-    setCalendarHidden(hidden.id, true);
-    resetCalendarVisibilityStoreForTests();
+    setCalendarVisibility(hidden.id, false);
     seededEvents = [
       createMockEvent({
         calendarId: primary.id,
@@ -395,9 +386,8 @@ describe("DayCalendarGrid", () => {
   it("falls back to the primary calendar when every calendar is disabled", () => {
     const primary = makeCalendar("Primary", { isPrimary: true });
     const disabled = makeCalendar("Disabled");
-    setCalendarHidden(primary.id, true);
-    setCalendarHidden(disabled.id, true);
-    resetCalendarVisibilityStoreForTests();
+    setCalendarVisibility(primary.id, false);
+    setCalendarVisibility(disabled.id, false);
 
     renderDayCalendarGrid([disabled, primary]);
 


### PR DESCRIPTION
## Summary
- Calendar visibility had two write paths into the calendars query cache: the toggle hand-patched `setQueryData` while `applyClientVisibility` only ran inside the `queryFn` - any future writer of the cache (SSE upsert, mutation, test seeding) had to remember to re-run the overlay itself or hidden calendars would silently reappear.
- Moves the hidden-id set into a `createExternalStore` (same primitive as `event.repository.source.store.ts`) and derives `isVisible` in the calendars query's `select` instead of the `queryFn`. The toggle now writes storage once; `select` re-runs reactively off the store, including across tabs via the `storage` event.
- `useCalendarVisibility` no longer needs `useQueryClient`/`setQueryData` at all - it just persists and notifies the store. Failure-toast/announcement behavior is unchanged.
- Updated `CalendarList.test.tsx`, `DayCalendarGrid.test.tsx`, and `DayCalendarBusyPeriods.test.tsx`, which previously seeded `isVisible: false` directly onto raw calendar fixtures pushed into the query cache (bypassing the overlay entirely under the old code). Under the new model that's no longer authoritative, so they now drive visibility through `setCalendarVisibility`, matching how a real hide/show actually happens.

### Simplification pass (`/simplify`, 4 independent review angles: reuse / simplification / efficiency / altitude)
- Extracted the cross-tab `"storage"` window-listener wiring into a shared `subscribeToStorageKey` helper (`external-store.util.ts`) and reused it from the pre-existing `auth.state.util.ts`, which had copy-pasted the identical pattern.
- Removed a redundant localStorage read-back on every toggle: `setCalendarVisibility` now builds the next hidden-id set from the in-memory store and writes it directly, instead of writing then re-reading storage to learn what it just wrote.
- Memoized `useCalendarsQuery`'s `select` on `hiddenIds` so it only recomputes when visibility actually changes.
- Registered the store's test-reset function in the existing `storeResets` registry (`reset-stores.ts`) instead of three near-duplicate manual `afterEach` blocks - the global test-lifecycle already clears storage and resyncs singleton stores between tests.
- Routed the remaining mid-test seeding calls through `setCalendarVisibility` (the same write path production code uses) instead of a lower-level storage write plus a manual store resync.
- Added `calendar-visibility.store.test.ts` covering the write path, the failure path, and cross-tab storage-event sync directly.

## Test plan
- [x] `./node_modules/.bin/biome check --write` on every changed file - clean
- [x] `bun run type-check` (app + web + web-tests tsconfigs) - clean, both before and after the simplify pass
- [x] Targeted `bun test` across every file touching calendar visibility plus the two files exercising the reused `subscribeToStorageKey` path (`SessionProvider.test.tsx`, `CalendarListHeader.test.tsx`) - 74/74 pass
- [x] Manual browser validation (`bun run dev:web`, anonymous/offline mode): hide instantly empties the week grid and flips the button to "Show", show instantly restores all events, hidden state survives a full page reload (confirms storage→store hydration on init), no console errors
- [x] Independent fresh code-reviewer pass against the complete final diff (no context from implementation) - no confirmed findings; verified every other writer of the calendars cache (SSE invalidation, Google auth, event mutations) never reads `isVisible` off the raw cache, and confirmed the `auth.state.util.ts` extraction preserves identical behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how every consumer of `useCalendarsQuery` derives visibility and removes the old cache-patch path; behavior is well-tested but grid/sidebar filtering depends on the new reactive path staying in sync with storage.
> 
> **Overview**
> **Calendar visibility** is no longer split between `applyClientVisibility` in the calendars `queryFn` and a toggle that hand-patched `setQueryData`. Hidden calendar IDs live in a **`createExternalStore`** mirror of localStorage; **`useCalendarsQuery`** memoizes a `select` that applies **`applyClientVisibility`** on every read, so SSE upserts, mutations, and test seeding get correct **`isVisible`** without re-running the overlay.
> 
> **`useCalendarVisibility`** only calls **`setCalendarVisibility`** (persist + in-tab notify); failure toasts are unchanged. Cross-tab updates use shared **`subscribeToStorageKey`** (also wired into **`subscribeToAuthState`**). Tests reset the store via **`reset-stores.ts`** and drive visibility through **`setCalendarVisibility`** instead of **`isVisible: false`** on raw cache fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1162a704aeb77f366fd046c15371a61203ace046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->