### PR TITLE
fix(web): show loading on Google reconnect button immediately

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { AuthApi } from "@web/api/auth.api";
 import { SyncApi } from "@web/api/sync.api";
@@ -33,16 +33,31 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
   const state = useGoogleUiState();
   const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
   const [isConnecting, setIsConnecting] = useState(false);
+  // Sync guard so rapid re-clicks before React re-renders cannot start a
+  // second OAuth attempt; isConnecting alone would still be false in-handler.
   const isConnectingRef = useRef(false);
-  const { startGoogleAuthorization } = useStartGoogleAuthorization({
-    intent: "connectCalendar",
-    prompt: "consent",
-  });
-
   const stopConnecting = useCallback(() => {
     isConnectingRef.current = false;
     setIsConnecting(false);
   }, []);
+  const { startGoogleAuthorization } = useStartGoogleAuthorization({
+    intent: "connectCalendar",
+    prompt: "consent",
+    onError: stopConnecting,
+  });
+
+  // OAuth uses a full navigation. If the user backs out and the page is
+  // restored from bfcache, React state is frozen mid-connecting and would
+  // otherwise leave the sidebar button disabled forever.
+  useEffect(() => {
+    const onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        stopConnecting();
+      }
+    };
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, [stopConnecting]);
 
   const onOpenGoogleAuth = useCallback(() => {
     if (isConnectingRef.current) {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { AuthApi } from "@web/api/auth.api";
 import { SyncApi } from "@web/api/sync.api";
@@ -32,16 +32,33 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
   const isConnectDelegatedToSync = useIsConnectDelegatedToSync();
   const state = useGoogleUiState();
   const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const isConnectingRef = useRef(false);
   const { startGoogleAuthorization } = useStartGoogleAuthorization({
     intent: "connectCalendar",
     prompt: "consent",
   });
 
+  const stopConnecting = useCallback(() => {
+    isConnectingRef.current = false;
+    setIsConnecting(false);
+  }, []);
+
   const onOpenGoogleAuth = useCallback(() => {
+    if (isConnectingRef.current) {
+      return;
+    }
+
+    // Show loading on the sidebar/command action immediately — local-event
+    // flush and beginGoogleConnection both run before the OAuth redirect.
+    isConnectingRef.current = true;
+    setIsConnecting(true);
+
     const start = async () => {
       const didSyncLocalEvents = await syncPendingLocalEvents();
 
       if (!didSyncLocalEvents) {
+        stopConnecting();
         return;
       }
 
@@ -66,6 +83,7 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
           await AuthApi.beginGoogleConnection(beginRequest);
         window.location.assign(authorizationUrl);
       } catch {
+        stopConnecting();
         showErrorToast(
           "We couldn't start connecting your Google Calendar. Please try again.",
           { toastId: GOOGLE_CONNECT_FAILED_TOAST_ID },
@@ -78,6 +96,7 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
     isConnectDelegatedToSync,
     startGoogleAuthorization,
     state,
+    stopConnecting,
     syncConnection?.id,
   ]);
 
@@ -113,6 +132,7 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
   return {
     ...getGoogleConnectionConfig(state, onOpenGoogleAuth, onRepairGoogle),
     isAvailable,
+    isConnecting,
     state,
   };
 };

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
@@ -15,5 +15,7 @@ export type GoogleUiConfig = {
 
 export type UseConnectGoogleResult = GoogleUiConfig & {
   isAvailable: boolean;
+  /** True while connect/reconnect OAuth is starting (before redirect). */
+  isConnecting: boolean;
   state: GoogleUiState;
 };

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -111,6 +111,7 @@ const setMockGoogleConnection = (
 
   mockUseConnectGoogle.mockReturnValue({
     isAvailable: true,
+    isConnecting: false,
     commandAction: commandActionByState[state],
     state,
   });

--- a/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
@@ -39,6 +39,7 @@ describe("useCalendarSyncCmdItems", () => {
   it("returns no items when Google is unavailable", async () => {
     mockUseConnectGoogle.mockReturnValue({
       isAvailable: false,
+      isConnecting: false,
       commandAction: null,
       state: "NOT_CONNECTED",
     });
@@ -53,6 +54,7 @@ describe("useCalendarSyncCmdItems", () => {
     const onSelect = mock();
     mockUseConnectGoogle.mockReturnValue({
       isAvailable: true,
+      isConnecting: false,
       commandAction: {
         label: "Sync Google Calendar",
         icon: CloudArrowUpIcon,
@@ -83,6 +85,7 @@ describe("useCalendarSyncCmdItems", () => {
     const onSelect = mock();
     mockUseConnectGoogle.mockReturnValue({
       isAvailable: true,
+      isConnecting: false,
       commandAction: {
         label: "Connect Google Calendar",
         icon: CloudArrowUpIcon,
@@ -104,6 +107,7 @@ describe("useCalendarSyncCmdItems", () => {
   ] as const)("returns a disabled syncing row for %s", async (state) => {
     mockUseConnectGoogle.mockReturnValue({
       isAvailable: true,
+      isConnecting: false,
       commandAction: null,
       state,
     });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -52,6 +52,7 @@ let isConnectGoogleMocked = true;
 const mockUseConnectGoogle = mock(() => ({
   commandAction: null,
   isAvailable: true,
+  isConnecting: false,
   state: "NOT_CONNECTED" as const,
 }));
 mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -27,7 +27,7 @@ const googleCommandActionFor = (state: GoogleUiState) => {
       return null;
   }
 };
-const mockIsConnecting = false;
+let mockIsConnecting = false;
 const mockUseConnectGoogle = mock(() => ({
   state: mockGoogleState,
   isAvailable: true,

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -27,9 +27,11 @@ const googleCommandActionFor = (state: GoogleUiState) => {
       return null;
   }
 };
+const mockIsConnecting = false;
 const mockUseConnectGoogle = mock(() => ({
   state: mockGoogleState,
   isAvailable: true,
+  isConnecting: mockIsConnecting,
   commandAction: googleCommandActionFor(mockGoogleState),
 }));
 
@@ -106,6 +108,7 @@ describe("CalendarListHeader", () => {
   beforeEach(() => {
     mockEmail = undefined;
     mockGoogleState = "NOT_CONNECTED";
+    mockIsConnecting = false;
     mockIsAnonymousDirty = false;
     mockOpenModal.mockClear();
     mockUseConnectGoogle.mockClear();
@@ -268,8 +271,41 @@ describe("CalendarListHeader", () => {
     const reconnectButton = screen.getByRole("button", {
       name: "Reconnect Google Calendar",
     });
+    expect(reconnectButton).toBeEnabled();
+    expect(reconnectButton).not.toHaveAttribute("aria-busy");
     await user.click(reconnectButton);
     expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an immediate reconnecting state while Google OAuth is starting", () => {
+    mockEmail = "ahab@pequod.com";
+    mockGoogleState = "RECONNECT_REQUIRED";
+    mockIsConnecting = true;
+
+    renderHeader();
+
+    const reconnectButton = screen.getByRole("button", {
+      name: "Reconnecting…",
+    });
+    expect(reconnectButton).toBeDisabled();
+    expect(reconnectButton).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.queryByRole("button", { name: "Reconnect Google Calendar" }),
+    ).toBeNull();
+  });
+
+  it("shows an immediate connecting state while first-time Google OAuth is starting", () => {
+    mockEmail = "ahab@pequod.com";
+    mockGoogleState = "NOT_CONNECTED";
+    mockIsConnecting = true;
+
+    renderHeader();
+
+    const connectButton = screen.getByRole("button", {
+      name: "Connecting…",
+    });
+    expect(connectButton).toBeDisabled();
+    expect(connectButton).toHaveAttribute("aria-busy", "true");
   });
 
   it("shows the shimmer and syncing status while an event mutation is pending", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -105,6 +105,14 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
     hasPendingEventMutations;
   const showGoogleAction = isAvailable && commandAction != null;
   const lastSyncedLabel = formatLastSyncedLabel(syncConnection?.lastSyncedAt);
+  const googleActionLabel =
+    commandAction == null
+      ? null
+      : isConnecting
+        ? state === "RECONNECT_REQUIRED"
+          ? "Reconnecting…"
+          : "Connecting…"
+        : commandAction.label;
 
   return (
     <>
@@ -122,7 +130,9 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
       {lastSyncedLabel ? (
         <p className="mb-2 text-text-muted text-xs">{lastSyncedLabel}</p>
       ) : null}
-      {commandAction != null && showGoogleAction ? (
+      {showGoogleAction &&
+      commandAction != null &&
+      googleActionLabel != null ? (
         <button
           aria-busy={isConnecting || undefined}
           className={CONNECT_GOOGLE_BUTTON_CLASSNAME}
@@ -130,11 +140,7 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
           onClick={commandAction.onSelect}
           type="button"
         >
-          {isConnecting
-            ? state === "RECONNECT_REQUIRED"
-              ? "Reconnecting…"
-              : "Connecting…"
-            : commandAction.label}
+          {googleActionLabel}
         </button>
       ) : null}
       {isSyncing ? (

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -34,7 +34,7 @@ const ANONYMOUS_ACCOUNT_TRIGGER_CLASSNAME =
   "min-w-0 truncate appearance-none border-0 bg-transparent p-0 text-left font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent";
 
 const CONNECT_GOOGLE_BUTTON_CLASSNAME =
-  "c-focus-ring mb-2 w-full rounded-xs bg-accent px-2 py-1.5 text-left font-medium text-on-accent text-xs hover:brightness-110";
+  "c-focus-ring mb-2 w-full rounded-xs bg-accent px-2 py-1.5 text-left font-medium text-on-accent text-xs hover:brightness-110 disabled:pointer-events-none disabled:opacity-60";
 
 /**
  * The calendar list's heading is the account identity (email, or the
@@ -96,7 +96,8 @@ const AnonymousAccountHeader: FC = () => {
 };
 
 const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
-  const { commandAction, isAvailable, state } = useConnectGoogle();
+  const { commandAction, isAvailable, isConnecting, state } =
+    useConnectGoogle();
   const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
   const hasPendingEventMutations = useHasPendingEventMutations();
   const isSyncing =
@@ -121,13 +122,19 @@ const AuthenticatedAccountHeader: FC<{ email: string }> = ({ email }) => {
       {lastSyncedLabel ? (
         <p className="mb-2 text-text-muted text-xs">{lastSyncedLabel}</p>
       ) : null}
-      {showGoogleAction ? (
+      {commandAction != null && showGoogleAction ? (
         <button
+          aria-busy={isConnecting || undefined}
           className={CONNECT_GOOGLE_BUTTON_CLASSNAME}
+          disabled={isConnecting}
           onClick={commandAction.onSelect}
           type="button"
         >
-          {commandAction.label}
+          {isConnecting
+            ? state === "RECONNECT_REQUIRED"
+              ? "Reconnecting…"
+              : "Connecting…"
+            : commandAction.label}
         </button>
       ) : null}
       {isSyncing ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pressing **Reconnect Google Calendar** in the sidebar waited on local-event flush and `beginGoogleConnection` with no visual feedback. `useConnectGoogle` now sets `isConnecting` synchronously on select, and the sidebar button immediately shows a disabled **Reconnecting…** / **Connecting…** state (`aria-busy`) until OAuth redirects or the attempt fails. Loading also clears on legacy OAuth errors and bfcache restore after backing out of Google.

## Simplicity

Kept loading ownership in `useConnectGoogle` (one `useState` + sync `useRef` guard). No new components or shared abstractions. Label derivation stays local to the sidebar header. Retained hooks: `useState` for render, `useRef` for double-submit before re-render, `useEffect` for `pageshow` bfcache cleanup.

## Automated validation

- Browser smoke: `http://localhost:9080` loads week view; sidebar shows "Not saved yet" in anonymous mode; console clean aside from React DevTools tip. Full reconnect click path not exercised (requires SuperTokens + Google OAuth secrets).
- RTL covers reconnect/connect loading presentation (`disabled`, `aria-busy`, label swap).

## Independent review

- First pass (Bugbot): medium — bfcache restore left button stuck disabled. Fixed with `pageshow` + `event.persisted` reset.
- Also wired `onError: stopConnecting` for legacy Google auth failures.
- Final Bugbot pass on complete branch diff: no confirmed findings.

## Test plan

- `bun test:web --` CalendarList, useCalendarSyncCmdItems, useConnectGoogle paths — 54 pass
- `bun run lint` — pass (2 pre-existing unrelated warnings)
- `bun run type-check` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e51de1e-08e8-4303-9f30-6eaf5c5227a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e51de1e-08e8-4303-9f30-6eaf5c5227a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

