### PR TITLE
fix(web): dedupe catchall errors when backend fails

### DIFF
--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -4,6 +4,7 @@ import { type ThemeName } from "@web/settings/theme/theme.constants";
 import { useThemeStore } from "@web/settings/theme/theme.store";
 
 export const EVENT_DELETED_TOAST_ID: Id = "event-deleted";
+export const GENERIC_ERROR_TOAST_ID: Id = "generic-error";
 export const GOOGLE_REVOKED_TOAST_ID: Id = "google-revoked-api";
 export const GOOGLE_REPAIR_FAILED_TOAST_ID: Id = "google-repair-failed";
 export const GOOGLE_CONNECT_FAILED_TOAST_ID: Id = "google-connect-failed";

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -16,6 +16,13 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const { handleError } = await import("@web/common/utils/event/event.util");
 
+function createServerError(status = Status.INTERNAL_SERVER): ApiError {
+  const error = new Error(`Request failed with status ${status}`) as ApiError;
+  error.name = "ApiError";
+  error.response = { status } as ApiResponse<unknown>;
+  return error;
+}
+
 describe("handleError", () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
   const { port, mocks } = createTestToastPort();
@@ -44,9 +51,7 @@ describe("handleError", () => {
   it("logs once and does not reload on a server error", () => {
     // Carries a `response` like a real 500 from `createApiError`: backend
     // availability is judged on the response status, not the message text.
-    const error = new Error("Request failed with status 500") as ApiError;
-    error.name = "ApiError";
-    error.response = { status: Status.INTERNAL_SERVER } as ApiResponse<unknown>;
+    const error = createServerError();
 
     handleError(error);
 
@@ -63,10 +68,7 @@ describe("handleError", () => {
 
   it("does not stack a second catchall toast while one is already visible", () => {
     mocks.isActive.mockReturnValue(true);
-
-    const error = new Error("Request failed with status 500") as ApiError;
-    error.name = "ApiError";
-    error.response = { status: Status.INTERNAL_SERVER } as ApiResponse<unknown>;
+    const error = createServerError();
 
     handleError(error);
     handleError(error);
@@ -79,8 +81,7 @@ describe("handleError", () => {
     // "unavailable"), and it's retryable, so the user just needs a nudge. It
     // must not console.error - otherwise every transient provider hiccup
     // becomes a fresh error-tracking issue via capture_console_errors.
-    const error = new Error("Request failed with status 502") as ApiError;
-    error.name = "ApiError";
+    const error = createServerError(502);
     error.response = {
       status: 502,
       data: {

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -1,7 +1,9 @@
 import { ObjectId } from "bson";
 import { Status } from "@core/errors/status.codes";
 import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { type ApiError, type ApiResponse } from "@web/api/api.types";
+import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
@@ -9,28 +11,25 @@ import {
   isEventInRange,
   refocusEventElement,
 } from "@web/common/utils/event/event.util";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const { handleError } = await import("@web/common/utils/event/event.util");
 
 describe("handleError", () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
+  const { port, mocks } = createTestToastPort();
 
   beforeEach(() => {
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+    mocks.error.mockClear();
+    mocks.isActive.mockReturnValue(false);
+    registerToastPort(port);
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
   });
-
-  // handleError now surfaces a toast (showErrorToast) instead of a native
-  // alert(). We assert on console.error rather than the toast: showErrorToast
-  // is import-bound to react-toastify, which several sibling suites replace
-  // process-wide via `mock.module`, so spying on the toast singleton is
-  // order-fragile. console.error is a call-time global — a stable seam that
-  // cleanly distinguishes "handled/notified" from "silently ignored", since
-  // handleError logs immediately before it notifies.
 
   it("does not log backend-unavailable errors", () => {
     const error = new Error("Request failed");
@@ -39,6 +38,7 @@ describe("handleError", () => {
     handleError(error);
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(mocks.error).not.toHaveBeenCalled();
   });
 
   it("logs once and does not reload on a server error", () => {
@@ -55,6 +55,23 @@ describe("handleError", () => {
     // proves handleError reached the notify path (rather than early-returning).
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
+      toastId: GENERIC_ERROR_TOAST_ID,
+    });
+  });
+
+  it("does not stack a second catchall toast while one is already visible", () => {
+    mocks.isActive.mockReturnValue(true);
+
+    const error = new Error("Request failed with status 500") as ApiError;
+    error.name = "ApiError";
+    error.response = { status: Status.INTERNAL_SERVER } as ApiResponse<unknown>;
+
+    handleError(error);
+    handleError(error);
+
+    expect(mocks.error).not.toHaveBeenCalled();
   });
 
   it("does not log a retryable, backend-authored mutation failure", () => {
@@ -76,6 +93,10 @@ describe("handleError", () => {
     handleError(error);
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
+      toastId: GENERIC_ERROR_TOAST_ID,
+    });
   });
 });
 

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -192,6 +192,12 @@ const isRetryableMutationError = (error: Error): boolean => {
   return parsed.success && parsed.data.retryable;
 };
 
+const CATCHALL_TOAST_MESSAGE =
+  "Something went wrong behind the scenes. Please try again later.";
+
+const showCatchallToast = (message: string) =>
+  showErrorToast(message, { toastId: GENERIC_ERROR_TOAST_ID });
+
 export const handleError = (error: Error) => {
   if (isBackendUnavailableError(error)) {
     return;
@@ -206,24 +212,18 @@ export const handleError = (error: Error) => {
 
   if (isRetryableMutationError(error)) {
     // Expected transient failure: nudge the user to retry without logging it.
-    showErrorToast(
-      "Something went wrong behind the scenes. Please try again later.",
-      { toastId: GENERIC_ERROR_TOAST_ID },
-    );
+    showCatchallToast(CATCHALL_TOAST_MESSAGE);
     return;
   }
 
   console.error(error);
 
   if (code === Status.INTERNAL_SERVER) {
-    showErrorToast(
-      "Something went wrong behind the scenes. Please try again later.",
-      { toastId: GENERIC_ERROR_TOAST_ID },
-    );
+    showCatchallToast(CATCHALL_TOAST_MESSAGE);
     return;
   }
 
-  showErrorToast(error.message, { toastId: GENERIC_ERROR_TOAST_ID });
+  showCatchallToast(error.message);
 };
 
 export const isEventInRange = (

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -11,6 +11,7 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type ApiError } from "@web/api/api.types";
 import { isBackendUnavailableError } from "@web/api/util/backend-unavailable-error.util";
 import { getUserId } from "@web/auth/compass/session/session.util";
+import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
 import {
   DATA_EVENT_ELEMENT_ID,
   ID_GRID_ALLDAY_ROW,
@@ -207,6 +208,7 @@ export const handleError = (error: Error) => {
     // Expected transient failure: nudge the user to retry without logging it.
     showErrorToast(
       "Something went wrong behind the scenes. Please try again later.",
+      { toastId: GENERIC_ERROR_TOAST_ID },
     );
     return;
   }
@@ -216,11 +218,12 @@ export const handleError = (error: Error) => {
   if (code === Status.INTERNAL_SERVER) {
     showErrorToast(
       "Something went wrong behind the scenes. Please try again later.",
+      { toastId: GENERIC_ERROR_TOAST_ID },
     );
     return;
   }
 
-  showErrorToast(error.message);
+  showErrorToast(error.message, { toastId: GENERIC_ERROR_TOAST_ID });
 };
 
 export const isEventInRange = (

--- a/packages/web/src/events/queries/useDayEventsQuery.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { handleError } from "@web/common/utils/event/event.util";
 import { dayEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
 import { deriveCalendarEventViewModel } from "./event.view-model";
@@ -14,19 +13,12 @@ type DayEventsQueryArgs = {
 
 /**
  * Primary day-events read hook. TanStack Query owns the normalized result.
+ * Load failures are shown contextually (e.g. EventGrid) — no global toast.
  */
 export function useDayEventsQuery({ startDate, endDate }: DayEventsQueryArgs) {
   const source = useEventRepositorySource();
 
-  const query = useQuery(dayEventsQueryOptions({ source, startDate, endDate }));
-  const { error } = query;
-
-  useEffect(() => {
-    if (!error) return;
-    handleError(error as Error);
-  }, [error]);
-
-  return query;
+  return useQuery(dayEventsQueryOptions({ source, startDate, endDate }));
 }
 
 export function useDayEventViewModel(args: DayEventsQueryArgs) {

--- a/packages/web/src/events/queries/useWeekEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.test.ts
@@ -85,10 +85,9 @@ describe("useWeekEventsQuery", () => {
     });
     const queryClient = createCompassQueryClient();
 
-    const result = renderHook(
-      () => useWeekEventsQuery({ ...range(), reportError: () => {} }),
-      { queryClient },
-    );
+    const result = renderHook(() => useWeekEventsQuery(range()), {
+      queryClient,
+    });
 
     await waitFor(() => {
       expect(result.result.current.error?.message).toBe("boom");

--- a/packages/web/src/events/queries/useWeekEventsQuery.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.ts
@@ -14,7 +14,12 @@ type WeekEventsQueryArgs = {
   endOfView: Dayjs;
 };
 
-function useWeekEventsQueryInternal({
+/**
+ * Primary week-events read hook. TanStack Query owns the normalized result;
+ * consumers derive render data through {@link useWeekEventViewModel}.
+ * Load failures are shown contextually (e.g. EventGrid) — no global toast.
+ */
+export function useWeekEventsQuery({
   startOfView,
   endOfView,
 }: WeekEventsQueryArgs) {
@@ -32,15 +37,6 @@ function useWeekEventsQueryInternal({
         endDate,
       }),
   });
-}
-
-/**
- * Primary week-events read hook. TanStack Query owns the normalized result;
- * consumers derive render data through {@link useWeekEventViewModel}.
- * Load failures are shown contextually (e.g. EventGrid) — no global toast.
- */
-export function useWeekEventsQuery(args: WeekEventsQueryArgs) {
-  return useWeekEventsQueryInternal(args);
 }
 
 export function useWeekEventViewModel(args: WeekEventsQueryArgs) {
@@ -61,5 +57,5 @@ export function useWeekEventViewModel(args: WeekEventsQueryArgs) {
  * {@link useWeekEventsQuery} (shared key → no extra fetch).
  */
 export function useWeekEventsQueryStatus(args: WeekEventsQueryArgs) {
-  return useWeekEventsQueryInternal(args);
+  return useWeekEventsQuery(args);
 }

--- a/packages/web/src/events/queries/useWeekEventsQuery.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.ts
@@ -1,9 +1,8 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
-import { handleError } from "@web/common/utils/event/event.util";
 import { deriveOverlappingEventQueryData } from "@web/events/queries/event.query.cache";
 import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
 import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
@@ -13,7 +12,6 @@ import { filterEventsByVisibleCalendars } from "./filter-events-by-visible-calen
 type WeekEventsQueryArgs = {
   startOfView: Dayjs;
   endOfView: Dayjs;
-  reportError?: (error: Error) => void;
 };
 
 function useWeekEventsQueryInternal({
@@ -39,18 +37,10 @@ function useWeekEventsQueryInternal({
 /**
  * Primary week-events read hook. TanStack Query owns the normalized result;
  * consumers derive render data through {@link useWeekEventViewModel}.
+ * Load failures are shown contextually (e.g. EventGrid) — no global toast.
  */
 export function useWeekEventsQuery(args: WeekEventsQueryArgs) {
-  const query = useWeekEventsQueryInternal(args);
-  const reportError = args.reportError ?? handleError;
-  const { error } = query;
-
-  useEffect(() => {
-    if (!error) return;
-    reportError(error as Error);
-  }, [error, reportError]);
-
-  return query;
+  return useWeekEventsQueryInternal(args);
 }
 
 export function useWeekEventViewModel(args: WeekEventsQueryArgs) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the backend returns 500s, event list failures were double-reported: the EventGrid inline “Couldn't load events. Retry” overlay and a global “Something went wrong behind the scenes…” toast. Multiple week/day query observers each called `handleError`, and without a stable `toastId` those toasts queued under `limit={1}`, so the same message reappeared after auto-dismiss.

- Stop toasting from `useWeekEventsQuery` / `useDayEventsQuery` — load failures stay contextual (same pattern as CalendarList)
- Give catchall `handleError` toasts a stable `GENERIC_ERROR_TOAST_ID` so concurrent failures collapse to one visible toast

## Simplicity

- Collapsed `useWeekEventsQueryInternal` into `useWeekEventsQuery` now that the toast `useEffect` is gone; `useWeekEventsQueryStatus` shares the same hook
- Routed catchall notifications through one `showCatchallToast` helper
- Deduplicated server-error fixture construction in `handleError` tests
- No added React state/effects (removed two error-reporting effects)

## Automated validation

- Focused web tests: `event.util`, `useWeekEventsQuery`, `EventGrid` — 19 pass
- `bun run lint` — pass (2 pre-existing unrelated warnings)
- CI: monitored on this PR after push

## Independent review

Fresh diff-first review confirmed the dual EventGrid+toast fix and toastId dedupe are sound.

Accepted finding (explicitly out of scope for this change): Up Next consumes `useDayEventsQuery` without inline error UI, so an isolated day-query failure can look empty instead of toasting. Restoring day-query toasts would reintroduce dual reporting on week view when both queries fail. Proper fix is Up Next contextual error UI in a follow-up.

Minor notes not fixed: thin toast-absence coverage on list hooks; dedupe test covers `isActive` short-circuit rather than same-tick racing.

## Test plan

- `bun run test:web -- packages/web/src/common/utils/event/event.util.test.ts packages/web/src/events/queries/useWeekEventsQuery.test.ts packages/web/src/grid/components/EventGrid.test.tsx`
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c839b5c-3c58-48ee-8c5f-b3783d8867d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c839b5c-3c58-48ee-8c5f-b3783d8867d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

