### PR TITLE
fix(web): make grid load-error overlay visible and retryable

### DIFF
--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -130,7 +130,7 @@ describe("EventGrid", () => {
 
     render(
       <EventGrid
-        allDayEventsLayer={<div />}
+        allDayEventsLayer={<div data-testid="timed-underlay" />}
         gridRefs={createGridRefs()}
         isErrorEvents
         onAllDayMouseDown={mock()}
@@ -147,8 +147,40 @@ describe("EventGrid", () => {
       />,
     );
 
-    expect(screen.getByText("Couldn't load events.")).toBeInTheDocument();
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Couldn't load events.");
+    expect(alert).toHaveClass("bg-background");
+    expect(within(alert).getByRole("button", { name: "Retry" })).toHaveClass(
+      "bg-accent",
+    );
+
     await user.click(screen.getByRole("button", { name: "Retry" }));
     expect(onRetryEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the error overlay while events are loading", () => {
+    render(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isErrorEvents
+        isLoadingEvents
+        onAllDayMouseDown={mock()}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Loading events" }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -149,10 +149,10 @@ describe("EventGrid", () => {
 
     const alert = screen.getByRole("alert");
     expect(alert).toHaveTextContent("Couldn't load events.");
-    expect(alert).toHaveClass("bg-background");
-    expect(within(alert).getByRole("button", { name: "Retry" })).toHaveClass(
-      "bg-accent",
-    );
+    expect(alert.closest(".bg-background")).toBeTruthy();
+    expect(
+      within(alert.parentElement!).getByRole("button", { name: "Retry" }),
+    ).toHaveClass("bg-accent");
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
     expect(onRetryEvents).toHaveBeenCalledTimes(1);
@@ -179,9 +179,34 @@ describe("EventGrid", () => {
     );
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("status", { name: "Loading events" }),
-    ).toBeInTheDocument();
+    const loader = screen.getByRole("status", { name: "Loading events" });
+    expect(loader).toBeInTheDocument();
+    // Retry loading must block the grid (opaque overlay is not click-through).
+    expect(loader).not.toHaveClass("pointer-events-none");
+  });
+
+  it("keeps first-load loader click-through for drag-create", () => {
+    render(
+      <EventGrid
+        allDayEventsLayer={<div />}
+        gridRefs={createGridRefs()}
+        isLoadingEvents
+        onAllDayMouseDown={mock()}
+        onTimedMouseDown={mock()}
+        timedEventsLayer={<div />}
+        today={dayjs("2026-05-20T00:00:00.000")}
+        visibleDates={[
+          {
+            date: dayjs("2026-05-20T00:00:00.000"),
+            key: "date-0",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("status", { name: "Loading events" })).toHaveClass(
+      "pointer-events-none",
+    );
   });
 
   it("shows the loader for first load and for retry after error", () => {

--- a/packages/web/src/grid/components/EventGrid.test.tsx
+++ b/packages/web/src/grid/components/EventGrid.test.tsx
@@ -4,7 +4,7 @@ import { type RefCallback } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
-import { EventGrid } from "./EventGrid";
+import { EventGrid, isEventGridLoading } from "./EventGrid";
 
 const createGridRefs = () => ({
   allDayColumnsRef: { current: null },
@@ -130,7 +130,7 @@ describe("EventGrid", () => {
 
     render(
       <EventGrid
-        allDayEventsLayer={<div data-testid="timed-underlay" />}
+        allDayEventsLayer={<div />}
         gridRefs={createGridRefs()}
         isErrorEvents
         onAllDayMouseDown={mock()}
@@ -182,5 +182,12 @@ describe("EventGrid", () => {
     expect(
       screen.getByRole("status", { name: "Loading events" }),
     ).toBeInTheDocument();
+  });
+
+  it("shows the loader for first load and for retry after error", () => {
+    expect(isEventGridLoading(true, false, false)).toBe(true);
+    expect(isEventGridLoading(false, true, true)).toBe(true);
+    expect(isEventGridLoading(false, true, false)).toBe(false);
+    expect(isEventGridLoading(false, false, true)).toBe(false);
   });
 });

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -76,10 +76,9 @@ export const EventGrid: FC<EventGridProps> = ({
         className="pointer-events-none bg-background [&>div]:my-0"
         role="status"
       />
-    )}{" "}
+    )}
     {isErrorEvents && !isLoadingEvents && (
       <div
-        aria-live="assertive"
         className="absolute inset-0 z-20 flex items-center justify-center bg-background px-4"
         role="alert"
       >
@@ -99,3 +98,12 @@ export const EventGrid: FC<EventGridProps> = ({
     )}
   </div>
 );
+
+/** First load, or a Retry refetch after failure — both should show the loader. */
+export function isEventGridLoading(
+  isPending: boolean,
+  isError: boolean,
+  isFetching: boolean,
+): boolean {
+  return isPending || (isError && isFetching);
+}

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -17,9 +17,9 @@ export interface EventGridProps {
   allDayGridOffsetTopPx?: number;
   allDayRowsCount?: number;
   gridRefs: GridRefs;
-  /** First load only. Background refetches keep the grid interactive. */
+  /** First load, or refetch after a failed load (Retry). */
   isLoadingEvents?: boolean;
-  /** Failed fetch with nothing reliable to show — mirrors CalendarList. */
+  /** Failed fetch with nothing reliable to show. */
   isErrorEvents?: boolean;
   onRetryEvents?: () => void;
   onAllDayMouseDown: (event: ReactMouseEvent<HTMLElement>) => void;
@@ -73,17 +73,21 @@ export const EventGrid: FC<EventGridProps> = ({
       // drag-creates an event for as long as the first fetch runs.
       <AbsoluteOverflowLoader
         aria-label="Loading events"
-        className="pointer-events-none [&>div]:my-0"
+        className="pointer-events-none bg-background [&>div]:my-0"
         role="status"
       />
-    )}
+    )}{" "}
     {isErrorEvents && !isLoadingEvents && (
-      <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/80 px-4">
-        <div className="flex items-center gap-3 text-sm">
-          <p className="text-error">Couldn't load events.</p>
+      <div
+        aria-live="assertive"
+        className="absolute inset-0 z-20 flex items-center justify-center bg-background px-4"
+        role="alert"
+      >
+        <div className="flex max-w-sm flex-col items-center gap-3 rounded-md border border-border-strong bg-surface-raised px-5 py-4 text-center shadow-[0_8px_24px_var(--color-shadow-default)]">
+          <p className="text-sm text-text">Couldn't load events.</p>
           {onRetryEvents ? (
             <button
-              className="c-focus-ring rounded-xs px-1.5 py-0.5 text-accent hover:brightness-110"
+              className="c-focus-ring rounded-sm bg-accent px-3 py-1.5 text-on-accent text-sm hover:bg-accent-hover"
               onClick={onRetryEvents}
               type="button"
             >

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -68,22 +68,25 @@ export const EventGrid: FC<EventGridProps> = ({
       data-testid="grid-focus-indicator"
     />
     {isLoadingEvents && (
-      // pointer-events-none: the loader is informational and covers the whole
-      // grid, so without it the overlay swallows the mousedown that
-      // drag-creates an event for as long as the first fetch runs.
+      // First load keeps pointer-events-none so drag-create still works under
+      // the spinner. Retry after error must block the grid — the overlay is
+      // opaque and should not click through.
       <AbsoluteOverflowLoader
         aria-label="Loading events"
-        className="pointer-events-none bg-background [&>div]:my-0"
+        className={
+          isErrorEvents
+            ? "z-20 bg-background [&>div]:my-0"
+            : "pointer-events-none bg-background [&>div]:my-0"
+        }
         role="status"
       />
     )}
     {isErrorEvents && !isLoadingEvents && (
-      <div
-        className="absolute inset-0 z-20 flex items-center justify-center bg-background px-4"
-        role="alert"
-      >
+      <div className="absolute inset-0 z-20 flex items-center justify-center bg-background px-4">
         <div className="flex max-w-sm flex-col items-center gap-3 rounded-md border border-border-strong bg-surface-raised px-5 py-4 text-center shadow-[0_8px_24px_var(--color-shadow-default)]">
-          <p className="text-sm text-text">Couldn't load events.</p>
+          <p className="text-sm text-text" role="alert">
+            Couldn't load events.
+          </p>
           {onRetryEvents ? (
             <button
               className="c-focus-ring rounded-sm bg-accent px-3 py-1.5 text-on-accent text-sm hover:bg-accent-hover"

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -70,11 +70,15 @@ export function DayCalendarGrid() {
     allDayEvents,
     events: dayEvents,
     isError: isErrorEvents,
-    isPending: isLoadingEvents,
+    isFetching,
+    isPending,
     refetch,
     rowCount: allDayRowsCount,
     timedEvents,
   } = useDayEventViewModel(dayEventQueryRange(dateInView));
+  // First load uses isPending; Retry uses isFetching so the overlay gives
+  // feedback instead of looking like a no-op when the refetch also fails.
+  const isLoadingEvents = isPending || (isErrorEvents && isFetching);
   const {
     calendarColumnIndexById,
     displayedAllDayEvents,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -25,7 +25,7 @@ import {
   selectGridDraft,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { EventGrid } from "@web/grid/components/EventGrid";
+import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
 import { useAllDayDraftCreation } from "@web/grid/hooks/useAllDayDraftCreation";
 import { useGridCoordinates } from "@web/grid/hooks/useGridCoordinates";
 import { useGridMeasurements } from "@web/grid/hooks/useGridMeasurements";
@@ -76,9 +76,11 @@ export function DayCalendarGrid() {
     rowCount: allDayRowsCount,
     timedEvents,
   } = useDayEventViewModel(dayEventQueryRange(dateInView));
-  // First load uses isPending; Retry uses isFetching so the overlay gives
-  // feedback instead of looking like a no-op when the refetch also fails.
-  const isLoadingEvents = isPending || (isErrorEvents && isFetching);
+  const isLoadingEvents = isEventGridLoading(
+    isPending,
+    isErrorEvents,
+    isFetching,
+  );
   const {
     calendarColumnIndexById,
     displayedAllDayEvents,

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -2,7 +2,7 @@ import { type FC } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useWeekEventsQueryStatus } from "@web/events/queries/useWeekEventsQuery";
-import { EventGrid } from "@web/grid/components/EventGrid";
+import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
 import { AllDayRow } from "@web/views/Week/components/Grid/AllDayRow/AllDayRow";
 import { EdgeNavigationIndicators } from "@web/views/Week/components/Grid/MainGrid/EdgeNavigationIndicators/EdgeNavigationIndicators";
 import { MainGrid } from "@web/views/Week/components/Grid/MainGrid/MainGrid";
@@ -42,9 +42,11 @@ export const Grid: FC<Props> = ({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
-  // First load uses isPending; Retry uses isFetching so the overlay gives
-  // feedback instead of looking like a no-op when the refetch also fails.
-  const isLoadingEvents = isPending || (isErrorEvents && isFetching);
+  const isLoadingEvents = isEventGridLoading(
+    isPending,
+    isErrorEvents,
+    isFetching,
+  );
 
   useDragEdgeNavigation(mainGridRef, weekProps);
 

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -34,13 +34,17 @@ export const Grid: FC<Props> = ({
   // Subscribes to the same cache entry the event layers read, so this reports
   // their load without issuing a second fetch.
   const {
-    isPending: isLoadingEvents,
+    isPending,
+    isFetching,
     isError: isErrorEvents,
     refetch,
   } = useWeekEventsQueryStatus({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
+  // First load uses isPending; Retry uses isFetching so the overlay gives
+  // feedback instead of looking like a no-op when the refetch also fails.
+  const isLoadingEvents = isPending || (isErrorEvents && isFetching);
 
   useDragEdgeNavigation(mainGridRef, weekProps);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The grid “Couldn't load events. Retry” state was hard to see over events (`bg-background/80` let the grid show through) and Retry looked broken because refetch used `isPending` only — background refetches never showed loading, so a still-failing 502 left the UI unchanged.

- Opaque full-grid overlay + raised panel with a filled accent Retry button
- Treat `isError && isFetching` as loading via shared `isEventGridLoading`
- Retry spinner blocks the grid; first-load spinner stays click-through for drag-create

## Simplicity

- Shared `isEventGridLoading` for Day/Week call sites
- Removed stray whitespace node and redundant `aria-live` on the alert wrapper
- Alert role scoped to the message text (Retry stays a normal control)

## Automated validation

- `bun run test:web -- packages/web/src/grid/components/EventGrid.test.tsx` — 9 pass
- `bun run lint` — pass (pre-existing unrelated warnings)

## Independent review

Confirmed findings fixed:
- Retry loader was click-through under an opaque overlay — now blocks when `isErrorEvents`
- Alert wrapping the Retry button — alert moved onto the message

Accepted: no Day/Week integration test for call-site wiring; helper unit tests cover the loading predicate.

## Test plan

- `bun run test:web -- packages/web/src/grid/components/EventGrid.test.tsx`
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c839b5c-3c58-48ee-8c5f-b3783d8867d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c839b5c-3c58-48ee-8c5f-b3783d8867d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

