### PR TITLE
fix(web): constrain context menu colors to 6x2 grid

### DIFF
--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -140,9 +140,9 @@ export function ContextMenuItemsView({
         );
       })}
       {!isReadOnly && (
-        <fieldset className="m-0 max-w-68 min-w-0 border-border border-t px-3 py-2">
+        <fieldset className="m-0 min-w-0 border-border border-t px-3 py-2">
           <legend className="sr-only">Event color</legend>
-          <div className="flex flex-wrap items-center gap-1.5">
+          <div className="grid grid-cols-6 gap-1.5">
             {COLOR_OPTIONS.map((slot, colorIndex) => {
               const index = menuActions.length + colorIndex;
               const label = eventColorLabel(slot);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Constrains the event context-menu color swatches to a fixed 6×2 grid so the menu width stays aligned with the Edit/Duplicate/Delete labels instead of stretching from a flex-wrap 9+3 (or 10+2) layout.

## Simplicity

Already minimal: two class changes (`flex flex-wrap` + `max-w-68` → `grid grid-cols-6`). Dropped the soft `max-w-68` cap because fixed columns now define width. No extra abstractions or simplify follow-up commit needed.

## Automated validation

- Browser at http://localhost:9080: created event, right-clicked, confirmed exactly 6 swatches × 2 rows; menu width roughly matches action labels; no related console errors.
- Screenshot: ![Context menu color grid 6x2](https://cursor.com/artifacts/c/art-a508dd2a-9514-4919-8146-da3ca51d43aa)

## Independent review

Fresh diff-first review: no confirmed actionable findings. Layout, a11y/keyboard semantics, read-only gate, and Tailwind usage all look correct.

## Test plan

- `bun test:web packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx packages/web/src/components/ContextMenu/ContextMenuKeyboard.test.tsx` — 15 pass
- `bun run lint` — only pre-existing unused-import warning in unrelated test helper
- Manual browser validation of context-menu color strip layout
- CI on PR + main (Test, Push on main, Release on main) — all green
- Released/deployed as **v1.0.509** to staging-cloud and staging-selfhosted; health checks passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99701e93-583a-41b0-9693-494d2cc671e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99701e93-583a-41b0-9693-494d2cc671e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

