### PR TITLE
fix(web): clear command palette search on close

### DIFF
--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { PlusIcon } from "@phosphor-icons/react";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
@@ -12,6 +12,7 @@ import {
 } from "@web/events/stores/undo.store";
 import {
   selectIsCmdPaletteOpen,
+  settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -272,6 +273,26 @@ describe("CommandPalette", () => {
     renderPalette();
     fireEvent.keyDown(getInput(), { key: "Escape" });
     expect(isOpen()).toBe(false);
+  });
+
+  it("clears the search query when reopened after close", () => {
+    renderPalette();
+    const input = getInput();
+
+    fireEvent.change(input, { target: { value: "ligh" } });
+    expect(input).toHaveValue("ligh");
+    expect(screen.getByText("Switch to light theme")).toBeInTheDocument();
+    expect(screen.queryByText("Go to Today")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(isOpen()).toBe(false);
+
+    act(() => {
+      settingsActions.openCmdPalette();
+    });
+    expect(isOpen()).toBe(true);
+    expect(getInput()).toHaveValue("");
+    expect(screen.getByText("Go to Today")).toBeInTheDocument();
   });
 
   it("closes on outside press", () => {

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -9,7 +9,7 @@ import {
 } from "@floating-ui/react";
 import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type SyncStatusVariant } from "@web/calendars/sync-status.types";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { eventCommandPaletteItems } from "@web/components/CommandPalette/event.cmd.constants";
@@ -89,6 +89,15 @@ const CommandPaletteContent = ({
   const [search, setSearch] = useState("");
   const [activeIndex, setActiveIndex] = useState<number | null>(0);
   const listRef = useRef<Array<HTMLElement | null>>([]);
+
+  // Clear leftover query when closed via any path (Escape, select, Mod+K
+  // toggle, sidebar) so the next open starts fresh.
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      setActiveIndex(0);
+    }
+  }, [open]);
 
   // Focus the search input the moment it mounts (commit phase, like the
   // autoFocus attribute — but without tripping the a11y lint). Stable identity

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -9,7 +9,7 @@ import {
 } from "@floating-ui/react";
 import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { type SyncStatusVariant } from "@web/calendars/sync-status.types";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { eventCommandPaletteItems } from "@web/components/CommandPalette/event.cmd.constants";
@@ -79,25 +79,16 @@ export function filterSections(
     .filter((section) => section.items.length > 0);
 }
 
+/** Mounted only while open so search/activeIndex reset on every reopen. */
 const CommandPaletteContent = ({
   placeholder,
   sections,
 }: CommandPaletteContentProps) => {
   const { syncStatus } = useCalendarSyncCmdItems();
-  const open = useSettingsStore(selectIsCmdPaletteOpen);
 
   const [search, setSearch] = useState("");
   const [activeIndex, setActiveIndex] = useState<number | null>(0);
   const listRef = useRef<Array<HTMLElement | null>>([]);
-
-  // Clear leftover query when closed via any path (Escape, select, Mod+K
-  // toggle, sidebar) so the next open starts fresh.
-  useEffect(() => {
-    if (!open) {
-      setSearch("");
-      setActiveIndex(0);
-    }
-  }, [open]);
 
   // Focus the search input the moment it mounts (commit phase, like the
   // autoFocus attribute — but without tripping the a11y lint). Stable identity
@@ -137,8 +128,6 @@ const CommandPaletteContent = ({
     role,
     listNav,
   ]);
-
-  if (!open) return null;
 
   let itemIndex = -1;
 
@@ -325,6 +314,8 @@ export const CommandPalette = ({
     ...getMoreCommandPaletteSections(currentView),
   ];
 
+  if (!open) return null;
+
   return (
     <CommandPaletteContent placeholder={placeholder} sections={sections} />
   );
@@ -335,8 +326,11 @@ export const LifeCommandPalette = ({
 }: {
   placeholder: string;
 }) => {
+  const open = useSettingsStore(selectIsCmdPaletteOpen);
   const navigate = useNavigate();
   const themeCmdItems = useThemeCmdItems();
+
+  if (!open) return null;
 
   return (
     <CommandPaletteContent


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Command palette search used to stick around after close because `CommandPaletteContent` stayed mounted with local `useState`. Reopening showed the previous query (e.g. `ligh`) instead of a fresh input.

Fix: mount `CommandPaletteContent` only while the palette is open so React remount resets search and selection on every reopen path (Escape, select, Mod+K, sidebar). `keepOpen` sync actions still keep the query while the palette stays open.

## Simplicity

Dropped an initial close-`useEffect` reset in favor of open-gated remount — fewer lifecycle sync hooks, same behavior.

## Automated validation

Browser at `http://localhost:9080` (frontend-only):
1. Ctrl+K → type `ligh` → filtered to Life / light theme
2. Escape → close
3. Ctrl+K → input empty, full default list restored (PASS)

![Filtered palette with ligh](https://cursor.com/artifacts/c/art-c527115b-4b87-43bf-aa76-5b966e692a37)
![Reopened palette empty search](https://cursor.com/artifacts/c/art-add4615f-f685-4092-a1ef-903f2aca5c34)

## Independent review

Fresh diff-first review after remount refactor: no confirmed findings. Residual: clear-on-reopen covered by Escape + store open test; Mod+K/sidebar share the same flag.

## Test plan

- `bun test:web packages/web/src/components/CommandPalette/CommandPalette.test.tsx` — 21 pass
- `bun run lint` — pass (2 pre-existing unrelated warnings)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb1f42f2-1e0f-4550-a2a9-508ed599ed80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb1f42f2-1e0f-4550-a2a9-508ed599ed80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

