### PR TITLE
feat(sync): resolve google custom event-label colors on read

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
@@ -107,4 +107,24 @@ describe("syncEventInstanceToBrowser", () => {
 
     expect(event.content).not.toHaveProperty("color");
   });
+
+  it("forwards content.colorHex onto browser details content", () => {
+    const instance = baseInstance({
+      content: { title: "Standup", description: "Daily", colorHex: "#009688" },
+    });
+    const event = syncEventInstanceToBrowser(instance);
+
+    expect(event.content).toEqual({
+      kind: "details",
+      title: "Standup",
+      description: "Daily",
+      colorHex: "#009688",
+    });
+  });
+
+  it("omits content.colorHex on the browser event when sync has none", () => {
+    const event = syncEventInstanceToBrowser(baseInstance());
+
+    expect(event.content).not.toHaveProperty("colorHex");
+  });
 });

--- a/packages/backend/src/common/services/sync-service/event-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.ts
@@ -1,5 +1,5 @@
 import { type Event, EventSchema } from "@core/types/event.contracts";
-import { withColor } from "@core/types/event-color.contracts";
+import { withColor, withColorHex } from "@core/types/event-color.contracts";
 import { type SyncEventInstance } from "@core/types/sync/event.contracts";
 import { composeOccurrenceId } from "./occurrence-id";
 
@@ -8,6 +8,7 @@ const toBrowserDetails = (content: SyncEventInstance["content"]) => ({
   title: content.title,
   description: content.description,
   ...withColor(content.color),
+  ...withColorHex(content.colorHex),
 });
 
 // Translate one sync full-fidelity instance into the browser Event contract.

--- a/packages/core/src/types/event-color.contracts.test.ts
+++ b/packages/core/src/types/event-color.contracts.test.ts
@@ -1,4 +1,4 @@
-import { withColor } from "@core/types/event-color.contracts";
+import { withColor, withColorHex } from "@core/types/event-color.contracts";
 import { describe, expect, it } from "bun:test";
 
 describe("withColor", () => {
@@ -12,5 +12,17 @@ describe("withColor", () => {
       color: null,
     });
     expect({ title: "x", ...withColor(undefined) }).toEqual({ title: "x" });
+  });
+});
+
+describe("withColorHex", () => {
+  it("includes the hex and omits when undefined", () => {
+    expect({ title: "x", ...withColorHex("#009688") }).toEqual({
+      title: "x",
+      colorHex: "#009688",
+    });
+    expect({ title: "x", ...withColorHex(undefined) }).toEqual({
+      title: "x",
+    });
   });
 });

--- a/packages/core/src/types/event-color.contracts.ts
+++ b/packages/core/src/types/event-color.contracts.ts
@@ -1,7 +1,8 @@
 import { z } from "zod/v4";
+import { HexColorSchema } from "@core/types/domain-primitives";
 
-// Compass-owned event color slots. Maps 1:1 onto Google's 11 event colors;
-// providers adapt to/from these names at the boundary.
+// Compass-owned event color slots. Maps 1:1 onto Google's legacy 11 event
+// colors; providers adapt to/from these names at the boundary.
 export const EventColorSlotSchema = z.enum([
   "lavender",
   "mint",
@@ -34,4 +35,18 @@ export function withColor(
   color: EventColorSlot | null | undefined,
 ): { color: EventColorSlot | null } | Record<string, never> {
   return color === undefined ? {} : { color };
+}
+
+// A provider-assigned custom event color (e.g. Google's post-June-2026 event
+// labels) that has no equivalent Compass slot. Read-only: Compass's own color
+// picker still only ever writes `color`, never this. Optional on reads, absent
+// when the provider event carries no custom color.
+export const OptionalHexEventColorSchema = HexColorSchema.optional();
+
+// Spread into an object literal: include `colorHex` only when the caller set
+// it. Mirrors withColor's undefined-omits convention.
+export function withColorHex(
+  colorHex: string | undefined,
+): { colorHex: string } | Record<string, never> {
+  return colorHex === undefined ? {} : { colorHex };
 }

--- a/packages/core/src/types/event.contracts.ts
+++ b/packages/core/src/types/event.contracts.ts
@@ -7,7 +7,10 @@ import {
   RRuleSchema,
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
-import { OptionalNullableEventColorSchema } from "@core/types/event-color.contracts";
+import {
+  OptionalHexEventColorSchema,
+  OptionalNullableEventColorSchema,
+} from "@core/types/event-color.contracts";
 
 export const EventContentSchema = z.discriminatedUnion("kind", [
   z.strictObject({
@@ -17,6 +20,9 @@ export const EventContentSchema = z.discriminatedUnion("kind", [
     // Null clears a previously set color tag on replace. Reads omit the field
     // when there is no color.
     color: OptionalNullableEventColorSchema,
+    // A provider-assigned custom color with no Compass slot equivalent.
+    // Read-only: no write command ever sets this.
+    colorHex: OptionalHexEventColorSchema,
   }),
   z.strictObject({ kind: z.literal("busy") }),
 ]);

--- a/packages/core/src/types/gcal.d.ts
+++ b/packages/core/src/types/gcal.d.ts
@@ -17,7 +17,22 @@ export declare type gSchema$CalendarList = calendar_v3.Schema$CalendarList;
 export declare type gSchema$CalendarListEntry =
   calendar_v3.Schema$CalendarListEntry;
 export declare type gSchema$Channel = calendar_v3.Schema$Channel;
-export declare type gSchema$Event = calendar_v3.Schema$Event;
+
+// Google's July-2026 custom event-label color system. Not yet modeled by the
+// installed @googleapis/calendar client types, so these are hand-declared
+// against the documented shape (id + backgroundColor per calendar-scoped
+// label, referenced from an event by eventLabelId).
+export declare type gSchema$EventLabel = {
+  id?: string | null;
+  backgroundColor?: string | null;
+  name?: string | null;
+};
+export declare type gSchema$Calendar = calendar_v3.Schema$Calendar & {
+  labelProperties?: { eventLabels?: gSchema$EventLabel[] | null } | null;
+};
+export declare type gSchema$Event = calendar_v3.Schema$Event & {
+  eventLabelId?: string | null;
+};
 export declare type gSchema$EventBase = WithGcalId<
   WithRecurrenceRule<gSchema$Event>
 >;

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -8,6 +8,7 @@ import {
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import {
   EventColorSlotSchema,
+  OptionalHexEventColorSchema,
   OptionalNullableEventColorSchema,
 } from "@core/types/event-color.contracts";
 import {
@@ -110,6 +111,9 @@ export const SyncEventContentSchema = z.strictObject({
   // Null means "clear the color tag" on an update command. Stored/read
   // records omit the field when there is no color.
   color: OptionalNullableEventColorSchema,
+  // A provider-assigned custom color with no Compass slot equivalent (e.g. a
+  // Google event label). Read-only: no write command ever sets this.
+  colorHex: OptionalHexEventColorSchema,
 });
 export type SyncEventContent = z.infer<typeof SyncEventContentSchema>;
 
@@ -237,6 +241,7 @@ const SyncInstanceContentSchema = z.strictObject({
   title: z.string(),
   description: z.string(),
   color: EventColorSlotSchema.optional(),
+  colorHex: OptionalHexEventColorSchema,
 });
 export type SyncInstanceContent = z.infer<typeof SyncInstanceContentSchema>;
 

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.ts
@@ -240,6 +240,9 @@ export async function migrateProviderSyncState(
         providerCalendarId: providerCalendarId as ProviderCalendarSourceId,
         displayName: calendar.name.trim() || providerCalendarId,
         color: calendar.backgroundColor,
+        // The legacy store predates Google event labels; a real discovery
+        // pass backfills them the next time calendar-list sync runs.
+        eventLabels: [],
         active: calendar.isActive,
         primary: calendar.isPrimary,
         accessRole: mapAccessRole(calendar.access),
@@ -259,7 +262,7 @@ export async function migrateProviderSyncState(
             ...fields,
             createdAt: now,
             updatedAt: now,
-          } as ProviderCalendarRecord);
+          } as unknown as ProviderCalendarRecord);
         syncCalendarByGcalId.set(providerCalendarId, stub);
         continue;
       }

--- a/packages/scripts/src/commands/migrate-provider-state/migrate.ts
+++ b/packages/scripts/src/commands/migrate-provider-state/migrate.ts
@@ -242,7 +242,7 @@ export async function migrateProviderSyncState(
         color: calendar.backgroundColor,
         // The legacy store predates Google event labels; a real discovery
         // pass backfills them the next time calendar-list sync runs.
-        eventLabels: [],
+        eventLabels: [] as ProviderCalendarRecord["eventLabels"],
         active: calendar.isActive,
         primary: calendar.isPrimary,
         accessRole: mapAccessRole(calendar.access),
@@ -262,7 +262,7 @@ export async function migrateProviderSyncState(
             ...fields,
             createdAt: now,
             updatedAt: now,
-          } as unknown as ProviderCalendarRecord);
+          } as ProviderCalendarRecord);
         syncCalendarByGcalId.set(providerCalendarId, stub);
         continue;
       }

--- a/packages/sync/src/domain/calendar-import.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-import.service.db.test.ts
@@ -138,7 +138,9 @@ describe("importCalendarEvents", () => {
     calendars = new ProviderCalendarRepository(storage.db());
   });
 
-  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+  const seedCalendar = (
+    eventLabels: ProviderCalendarRecord["eventLabels"] = [],
+  ): Promise<ProviderCalendarRecord> =>
     calendars.upsertByProviderCalendar({
       tenantId: objectId() as ProviderCalendarRecord["tenantId"],
       principalId: objectId() as ProviderCalendarRecord["principalId"],
@@ -146,6 +148,7 @@ describe("importCalendarEvents", () => {
       providerCalendarId: "primary@google.com",
       displayName: "Google",
       color: null,
+      eventLabels,
       active: true,
       primary: true,
       accessRole: "owner",
@@ -207,6 +210,20 @@ describe("importCalendarEvents", () => {
 
     expect(reader.calls[0].window).not.toBeNull();
     expect(reader.calls.at(-1)?.window).toBeNull();
+  });
+
+  it("passes the calendar's event-color labels to every reader call", async () => {
+    const calendar = await seedCalendar([{ id: "label-1", hex: "#009688" }]);
+    const reader = new FakeReader({
+      window: [page([single("w")])],
+      full: [page([single("a")], { nextSyncToken: "cursor-1" })],
+    });
+
+    await importCalendarEvents(deps(reader), calendar, now);
+
+    for (const call of reader.calls) {
+      expect(call.colorLabels).toEqual(new Map([["label-1", "#009688"]]));
+    }
   });
 
   it("projects every occurrence of an imported series master", async () => {

--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -145,6 +145,9 @@ class ImportRun {
   // the full pass re-reads, so counting both double-counts.
   #readerSkipped = 0;
   #orphans = 0;
+  // The calendar's custom event-color labels, built once so every page of
+  // both passes resolves colors from the same snapshot.
+  #colorLabels: ReadonlyMap<string, string>;
 
   constructor(
     private readonly deps: CalendarImportDeps,
@@ -152,6 +155,9 @@ class ImportRun {
     private readonly resource: SyncResourceRecord,
     now: () => Date,
   ) {
+    this.#colorLabels = new Map(
+      calendar.eventLabels.map((label) => [label.id, label.hex]),
+    );
     // Import writes the active (live) generation — the one reads serve. Only a
     // repair stages a separate importGeneration; the first import runs with
     // active and import both at 0, so it populates the generation reads serve.
@@ -188,6 +194,7 @@ class ImportRun {
         calendarId: this.calendar.providerCalendarId,
         window: options.window ?? null,
         pageToken,
+        colorLabels: this.#colorLabels,
       });
       if (options.checkpointed) this.#readerSkipped += page.skipped;
       // A first import has no local events to delete, so standalone

--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -1,3 +1,4 @@
+import { toColorLabelMap } from "@sync/domain/color-label-map";
 import { syncHorizon } from "@sync/domain/horizon";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
@@ -145,9 +146,6 @@ class ImportRun {
   // the full pass re-reads, so counting both double-counts.
   #readerSkipped = 0;
   #orphans = 0;
-  // The calendar's custom event-color labels, built once so every page of
-  // both passes resolves colors from the same snapshot.
-  #colorLabels: ReadonlyMap<string, string>;
 
   constructor(
     private readonly deps: CalendarImportDeps,
@@ -155,9 +153,6 @@ class ImportRun {
     private readonly resource: SyncResourceRecord,
     now: () => Date,
   ) {
-    this.#colorLabels = new Map(
-      calendar.eventLabels.map((label) => [label.id, label.hex]),
-    );
     // Import writes the active (live) generation — the one reads serve. Only a
     // repair stages a separate importGeneration; the first import runs with
     // active and import both at 0, so it populates the generation reads serve.
@@ -194,7 +189,7 @@ class ImportRun {
         calendarId: this.calendar.providerCalendarId,
         window: options.window ?? null,
         pageToken,
-        colorLabels: this.#colorLabels,
+        colorLabels: toColorLabelMap(this.calendar.eventLabels),
       });
       if (options.checkpointed) this.#readerSkipped += page.skipped;
       // A first import has no local events to delete, so standalone

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -96,6 +96,7 @@ export async function syncCalendarList(
         calendar.providerCalendarId as ProviderCalendarSourceId,
       displayName: calendar.displayName,
       color: calendar.color,
+      eventLabels: calendar.eventLabels,
       active: calendar.active,
       primary: calendar.primary,
       accessRole: calendar.accessRole,

--- a/packages/sync/src/domain/calendar-pull.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.db.test.ts
@@ -124,7 +124,9 @@ describe("pullCalendarChanges", () => {
     custody: tokenSource,
   });
 
-  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+  const seedCalendar = (
+    eventLabels: ProviderCalendarRecord["eventLabels"] = [],
+  ): Promise<ProviderCalendarRecord> =>
     calendars.upsertByProviderCalendar({
       tenantId: objectId() as ProviderCalendarRecord["tenantId"],
       principalId: objectId() as ProviderCalendarRecord["principalId"],
@@ -132,6 +134,7 @@ describe("pullCalendarChanges", () => {
       providerCalendarId: "primary@google.com",
       displayName: "Google",
       color: null,
+      eventLabels,
       active: true,
       primary: true,
       accessRole: "owner",
@@ -229,6 +232,20 @@ describe("pullCalendarChanges", () => {
     if (result.status !== "applied") throw new Error("expected applied");
     expect(result.resource.syncCursor).toBe("cursor-1");
     expect(result.changed).toBe(1);
+  });
+
+  it("passes the calendar's event-color labels to the reader", async () => {
+    const calendar = await seedCalendar([{ id: "label-1", hex: "#009688" }]);
+    await seedImported(calendar, "cursor-0");
+    const reader = new FakeReader([
+      page([single("new-1")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    await pullCalendarChanges(deps(reader), calendar, now);
+
+    expect(reader.calls[0].colorLabels).toEqual(
+      new Map([["label-1", "#009688"]]),
+    );
   });
 
   it("writes into the active generation when a prior repair left one staged", async () => {

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -102,6 +102,9 @@ export async function pullCalendarChanges(
   let pageToken = resource.pageCursor;
   let cursor = resource.syncCursor;
   let deleted = 0;
+  const colorLabels: ReadonlyMap<string, string> = new Map(
+    calendar.eventLabels.map((label) => [label.id, label.hex]),
+  );
 
   do {
     let page: Awaited<ReturnType<ProviderEventReader["listEventPage"]>>;
@@ -113,6 +116,7 @@ export async function pullCalendarChanges(
         // continues by pageToken alone.
         cursor: pageToken === null ? cursor : null,
         pageToken,
+        colorLabels,
       });
     } catch (error) {
       // An expired cursor cannot be resumed; hand off to repair without

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -1,3 +1,4 @@
+import { toColorLabelMap } from "@sync/domain/color-label-map";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
 import { type ProviderEventCancellation } from "@sync/providers/provider-event.port";
@@ -102,9 +103,7 @@ export async function pullCalendarChanges(
   let pageToken = resource.pageCursor;
   let cursor = resource.syncCursor;
   let deleted = 0;
-  const colorLabels: ReadonlyMap<string, string> = new Map(
-    calendar.eventLabels.map((label) => [label.id, label.hex]),
-  );
+  const colorLabels = toColorLabelMap(calendar.eventLabels);
 
   do {
     let page: Awaited<ReturnType<ProviderEventReader["listEventPage"]>>;

--- a/packages/sync/src/domain/color-label-map.ts
+++ b/packages/sync/src/domain/color-label-map.ts
@@ -1,0 +1,10 @@
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+
+// A calendar's custom event-color labels (Google's post-June-2026 event
+// labels, or any future provider's equivalent), as an id -> hex lookup for
+// resolving one event's providerEventLabelId during normalization.
+export function toColorLabelMap(
+  eventLabels: ProviderCalendarRecord["eventLabels"],
+): ReadonlyMap<string, string> {
+  return new Map(eventLabels.map((label) => [label.id, label.hex]));
+}

--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -122,6 +122,29 @@ describe("assembleEventInstances", () => {
     });
   });
 
+  it("carries event content.colorHex onto assembled instance content", () => {
+    const event = makeEvent({
+      content: {
+        title: "Standup",
+        description: "Daily sync",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+        colorHex: "#009688",
+      },
+    });
+    const occurrence = makeOccurrence({ eventId: event._id });
+
+    const [instance] = assembleEventInstances([occurrence], byId(event));
+
+    expect(instance?.content).toEqual({
+      title: "Standup",
+      description: "Daily sync",
+      colorHex: "#009688",
+    });
+  });
+
   it("omits a persisted null color instead of failing the whole page", () => {
     const event = makeEvent({
       content: {

--- a/packages/sync/src/domain/event-instance-assembly.ts
+++ b/packages/sync/src/domain/event-instance-assembly.ts
@@ -1,4 +1,4 @@
-import { withColor } from "@core/types/event-color.contracts";
+import { withColor, withColorHex } from "@core/types/event-color.contracts";
 import {
   type SyncEventInstance,
   SyncEventInstanceSchema,
@@ -128,4 +128,5 @@ const toInstanceContent = (content: EventRecord["content"]) => ({
   description: content.description,
   // Heal rows that persisted write-command `color: null`.
   ...withColor(content.color ?? undefined),
+  ...withColorHex(content.colorHex),
 });

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -3,19 +3,28 @@ import {
   GoogleCalendarAdapter,
   type GoogleCalendarListApi,
   type GoogleCalendarListPage,
+  type GoogleEventLabel,
 } from "@sync/providers/google/google-calendar.adapter";
 import { ProviderCalendarError } from "@sync/providers/provider-calendar.port";
 
 // A fake calendar-list API that returns scripted pages in order, recording the
 // params it was called with so tests can assert pagination and cursor handling.
+// Event labels default to empty per calendar unless scripted via `labelsById`.
 class FakeCalendarListApi implements GoogleCalendarListApi {
   calls: Array<{ pageToken?: string; syncToken?: string }> = [];
+  labelCalls: string[] = [];
   #pages: GoogleCalendarListPage[];
   #error?: unknown;
+  #labelsById: Record<string, readonly GoogleEventLabel[]>;
 
-  constructor(pages: GoogleCalendarListPage[], error?: unknown) {
+  constructor(
+    pages: GoogleCalendarListPage[],
+    error?: unknown,
+    labelsById: Record<string, readonly GoogleEventLabel[]> = {},
+  ) {
     this.#pages = pages;
     this.#error = error;
+    this.#labelsById = labelsById;
   }
 
   async listPage(params: {
@@ -27,6 +36,13 @@ class FakeCalendarListApi implements GoogleCalendarListApi {
     const page = this.#pages.shift();
     if (!page) throw new Error("FakeCalendarListApi: no page scripted");
     return page;
+  }
+
+  async getEventLabels(
+    calendarId: string,
+  ): Promise<readonly GoogleEventLabel[]> {
+    this.labelCalls.push(calendarId);
+    return this.#labelsById[calendarId] ?? [];
   }
 }
 
@@ -87,6 +103,7 @@ describe("GoogleCalendarAdapter", () => {
         providerCalendarId: "primary-cal",
         displayName: "Primary",
         color: "#112233",
+        eventLabels: [],
         primary: true,
         active: true,
         accessRole: "owner",
@@ -98,6 +115,35 @@ describe("GoogleCalendarAdapter", () => {
         },
       },
     ]);
+  });
+
+  it("resolves each calendar's custom event-color labels via a per-calendar lookup", async () => {
+    const api = new FakeCalendarListApi(
+      [
+        page({
+          items: [entry({ id: "labeled" }), entry({ id: "unlabeled" })],
+          nextSyncToken: "s",
+        }),
+      ],
+      undefined,
+      {
+        labeled: [{ id: "label-1", hex: "#009688" }],
+      },
+    );
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+    const byId = Object.fromEntries(
+      calendars.map((c) => [c.providerCalendarId, c]),
+    );
+
+    expect(byId["labeled"].eventLabels).toEqual([
+      { id: "label-1", hex: "#009688" },
+    ]);
+    expect(byId["unlabeled"].eventLabels).toEqual([]);
+    expect(api.labelCalls).toEqual(["labeled", "unlabeled"]);
   });
 
   it("follows pagination, accumulating items and taking the final sync token", async () => {

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -121,11 +121,13 @@ export class GoogleCalendarAdapter implements ProviderCalendarAdapter {
 
     do {
       const page = await this.#listPage(api, { pageToken, syncToken });
-      for (const item of page.items) {
-        const mapped = mapCalendar(item);
-        if (!mapped) continue;
-        const eventLabels = await api.getEventLabels(mapped.providerCalendarId);
-        calendars.push({ ...mapped, eventLabels });
+      // Label resolution is a per-calendar network call; run a page's calendars
+      // concurrently rather than paying N sequential round-trips.
+      const mapped = await Promise.all(
+        page.items.map((item) => mapCalendar(item, api)),
+      );
+      for (const calendar of mapped) {
+        if (calendar) calendars.push(calendar);
       }
       pageToken = page.nextPageToken ?? undefined;
       // Only the final page carries the token; keep the newest non-null one.
@@ -195,9 +197,10 @@ const CAPABILITIES_BY_ROLE: Record<CalendarAccessRole, CalendarCapabilities> = {
 
 // Map one Google calendar-list entry to provider-neutral facts. An entry
 // without an id is unusable (it cannot be keyed or persisted), so it is dropped.
-function mapCalendar(
+async function mapCalendar(
   item: gSchema$CalendarListEntry,
-): Omit<DiscoveredCalendar, "eventLabels"> | null {
+  api: GoogleCalendarListApi,
+): Promise<DiscoveredCalendar | null> {
   if (!item.id) return null;
 
   const accessRole = mapAccessRole(item.accessRole);
@@ -207,6 +210,7 @@ function mapCalendar(
     // then the id so the required non-empty name always holds.
     displayName: item.summaryOverride || item.summary || item.id,
     color: item.backgroundColor || null,
+    eventLabels: await api.getEventLabels(item.id),
     primary: item.primary === true,
     // deleted appears in incremental results; hidden means the user removed it
     // from their list. Either makes the calendar inactive, not gone.

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -2,6 +2,7 @@ import { calendar } from "@googleapis/calendar";
 import { OAuth2Client } from "google-auth-library";
 import {
   type gCalendar,
+  type gSchema$Calendar,
   type gSchema$CalendarListEntry,
 } from "@core/types/gcal";
 import {
@@ -25,7 +26,14 @@ export interface GoogleCalendarListPage {
   readonly nextSyncToken: string | null;
 }
 
-// The one Google call discovery makes. Depending on this narrow interface (not
+// One calendar's custom event-color labels, narrowed to what color resolution
+// needs. An entry with no id or hex is unusable for lookup and is dropped.
+export interface GoogleEventLabel {
+  readonly id: string;
+  readonly hex: string;
+}
+
+// The Google calls discovery makes. Depending on this narrow interface (not
 // the concrete googleapis client) lets tests supply scripted pages without a
 // network round-trip or module mocking.
 export interface GoogleCalendarListApi {
@@ -33,6 +41,11 @@ export interface GoogleCalendarListApi {
     pageToken?: string;
     syncToken?: string;
   }): Promise<GoogleCalendarListPage>;
+  // Only calendars.get (not calendarList.list) carries labelProperties, so
+  // discovery makes one extra call per calendar to resolve it. Never throws:
+  // a calendar whose label fetch fails is treated as having none, since a
+  // color lookup gap should never fail discovery.
+  getEventLabels(calendarId: string): Promise<readonly GoogleEventLabel[]>;
 }
 
 // Built per-connection from a short-lived access token minted by credential
@@ -61,6 +74,22 @@ const defaultApiFactory: GoogleCalendarListApiFactory = (accessToken) => {
         nextPageToken: data.nextPageToken ?? null,
         nextSyncToken: data.nextSyncToken ?? null,
       };
+    },
+    async getEventLabels(calendarId) {
+      let data: gSchema$Calendar;
+      try {
+        ({ data } = await gcal.calendars.get({ calendarId }));
+      } catch {
+        // A label-fetch failure (permissions, transient error) should never
+        // fail calendar discovery — the calendar just discovers with no
+        // custom colors resolvable this pass.
+        return [];
+      }
+      return (data.labelProperties?.eventLabels ?? [])
+        .filter((label): label is { id: string; backgroundColor: string } =>
+          Boolean(label.id && label.backgroundColor),
+        )
+        .map((label) => ({ id: label.id, hex: label.backgroundColor }));
     },
   };
 };
@@ -94,7 +123,9 @@ export class GoogleCalendarAdapter implements ProviderCalendarAdapter {
       const page = await this.#listPage(api, { pageToken, syncToken });
       for (const item of page.items) {
         const mapped = mapCalendar(item);
-        if (mapped) calendars.push(mapped);
+        if (!mapped) continue;
+        const eventLabels = await api.getEventLabels(mapped.providerCalendarId);
+        calendars.push({ ...mapped, eventLabels });
       }
       pageToken = page.nextPageToken ?? undefined;
       // Only the final page carries the token; keep the newest non-null one.
@@ -166,7 +197,7 @@ const CAPABILITIES_BY_ROLE: Record<CalendarAccessRole, CalendarCapabilities> = {
 // without an id is unusable (it cannot be keyed or persisted), so it is dropped.
 function mapCalendar(
   item: gSchema$CalendarListEntry,
-): DiscoveredCalendar | null {
+): Omit<DiscoveredCalendar, "eventLabels"> | null {
   if (!item.id) return null;
 
   const accessRole = mapAccessRole(item.accessRole);

--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -189,6 +189,23 @@ describe("GoogleEventReaderAdapter", () => {
     expect(result.skipped).toBe(1);
   });
 
+  it("threads colorLabels through to resolve an event's eventLabelId", async () => {
+    const api = new FakeEventListApi([
+      page({ items: [gEvent({ id: "labeled", eventLabelId: "label-1" })] }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+      colorLabels: new Map([["label-1", "#009688"]]),
+    });
+
+    expect(result.events[0]).toMatchObject({
+      content: { colorHex: "#009688" },
+    });
+  });
+
   it("maps an expired sync token (410) to cursorExpired", async () => {
     const api = new FakeEventListApi([], { response: { status: 410 } });
     const { adapter } = adapterWith(api);

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -98,7 +98,7 @@ export class GoogleEventReaderAdapter implements ProviderEventReader {
     let skipped = 0;
     for (const item of page.items) {
       try {
-        events.push(normalizeGoogleEvent(item));
+        events.push(normalizeGoogleEvent(item, input.colorLabels));
       } catch (error) {
         // A structurally unusable event (no id/etag, unmappable schedule) is
         // dropped so one bad row never fails the whole page or the import.

--- a/packages/sync/src/providers/google/google-event.normalizer.test.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.test.ts
@@ -304,4 +304,41 @@ describe("normalizeGoogleEvent", () => {
 
     expect(read.content).not.toHaveProperty("color");
   });
+
+  it("resolves an eventLabelId against the calendar's color labels to colorHex", () => {
+    const colorLabels = new Map([["label-1", "#009688"]]);
+    const read = asProviderEvent(
+      normalizeGoogleEvent(gEvent({ eventLabelId: "label-1" }), colorLabels),
+    );
+
+    expect(read.content.colorHex).toBe("#009688");
+    expect(read.content).not.toHaveProperty("color");
+  });
+
+  it("omits colorHex when the eventLabelId has no matching label (e.g. deleted)", () => {
+    const read = asProviderEvent(
+      normalizeGoogleEvent(
+        gEvent({ eventLabelId: "gone" }),
+        new Map([["other", "#123456"]]),
+      ),
+    );
+
+    expect(read.content).not.toHaveProperty("colorHex");
+  });
+
+  it("omits colorHex when the event has no eventLabelId, even with labels available", () => {
+    const read = asProviderEvent(
+      normalizeGoogleEvent(gEvent({}), new Map([["label-1", "#009688"]])),
+    );
+
+    expect(read.content).not.toHaveProperty("colorHex");
+  });
+
+  it("defaults to no color labels when none are passed", () => {
+    const read = asProviderEvent(
+      normalizeGoogleEvent(gEvent({ eventLabelId: "label-1" })),
+    );
+
+    expect(read.content).not.toHaveProperty("colorHex");
+  });
 });

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -1,6 +1,6 @@
 import { type calendar_v3 } from "@googleapis/calendar";
 import { EventScheduleSchema } from "@core/types/event.contracts";
-import { withColor } from "@core/types/event-color.contracts";
+import { withColor, withColorHex } from "@core/types/event-color.contracts";
 import { type gSchema$Event } from "@core/types/gcal";
 import {
   type Attendee,
@@ -19,11 +19,22 @@ import {
 
 const RFC3339_OFFSET = dayjs.DateFormat.RFC3339_OFFSET;
 
+const NO_COLOR_LABELS: ReadonlyMap<string, string> = new Map();
+
 // Normalize one Google event read into a provider-neutral read. A cancelled
 // event becomes a cancellation (providers strip its content and schedule); an
 // active event becomes a full read. Throws ProviderEventError only when the
 // read is structurally unusable, never for merely sparse events.
-export function normalizeGoogleEvent(item: gSchema$Event): ProviderEventRead {
+//
+// `colorLabels` resolves the owning calendar's custom event-label ids (Google's
+// post-June-2026 color system, id -> hex) to a color when the event carries an
+// `eventLabelId` instead of a legacy `colorId`. Omit for calendars with no
+// custom labels; an id absent from the map (a label deleted after the event
+// was colored) simply leaves the event uncolored, same as no color at all.
+export function normalizeGoogleEvent(
+  item: gSchema$Event,
+  colorLabels: ReadonlyMap<string, string> = NO_COLOR_LABELS,
+): ProviderEventRead {
   const providerEventId = requireId(item);
   const providerVersion = requireVersion(item);
 
@@ -41,7 +52,7 @@ export function normalizeGoogleEvent(item: gSchema$Event): ProviderEventRead {
     providerEventId,
     providerVersion,
     providerUpdatedAt: item.updated ?? null,
-    content: mapContent(item),
+    content: mapContent(item, colorLabels),
     schedule: mapSchedule(item),
     // Absent transparency means "opaque" (busy) in Google's model.
     busy: item.transparency !== "transparent",
@@ -73,13 +84,21 @@ function cancellationSeries(
   };
 }
 
-function mapContent(item: gSchema$Event) {
+function mapContent(
+  item: gSchema$Event,
+  colorLabels: ReadonlyMap<string, string>,
+) {
   // safeParse, not parse: a provider can report a field the neutral contract
   // caps but the provider does not (e.g. an attendee displayName longer than
   // the contract's max). That makes one event unusable, so it must surface as a
   // ProviderEventError the reader can skip — never a raw ZodError that would
   // escape the per-event skip boundary and fail a whole import page.
   const color = googleColorIdToSlot(item.colorId);
+  // A label-colored event carries eventLabelId instead of colorId — the two
+  // are mutually exclusive on the wire, so resolving both is harmless.
+  const colorHex = item.eventLabelId
+    ? colorLabels.get(item.eventLabelId)
+    : undefined;
   const parsed = SyncEventContentSchema.safeParse({
     // Google omits summary/description for untitled/empty events; the neutral
     // contract models those as empty strings, not absence.
@@ -90,6 +109,7 @@ function mapContent(item: gSchema$Event) {
     attendees: mapAttendees(item.attendees),
     conference: mapConference(item),
     ...withColor(color),
+    ...withColorHex(colorHex),
   });
   if (!parsed.success) {
     throw new ProviderEventError(

--- a/packages/sync/src/providers/provider-calendar.port.ts
+++ b/packages/sync/src/providers/provider-calendar.port.ts
@@ -13,6 +13,13 @@ export interface DiscoveredCalendar {
   readonly providerCalendarId: string;
   readonly displayName: string;
   readonly color: string | null;
+  // Custom event-color labels the calendar defines (id -> hex), for providers
+  // that support per-event custom colors beyond a fixed palette (e.g. Google's
+  // post-June-2026 event labels). Empty for a provider or calendar with none.
+  readonly eventLabels: readonly {
+    readonly id: string;
+    readonly hex: string;
+  }[];
   // The provider designates this as the account's default calendar.
   readonly primary: boolean;
   // The calendar is present and visible in the account's list. A deleted or

--- a/packages/sync/src/providers/provider-event-reader.port.ts
+++ b/packages/sync/src/providers/provider-event-reader.port.ts
@@ -33,6 +33,10 @@ export interface ProviderEventReadInput {
   // request of a pass; paging afterward is identified by pageToken alone.
   readonly cursor?: string | null;
   readonly pageToken?: string | null;
+  // The owning calendar's custom event-color labels (id -> hex), for
+  // providers that support them (e.g. Google's post-June-2026 event labels).
+  // A provider with no such concept simply ignores this.
+  readonly colorLabels?: ReadonlyMap<string, string>;
 }
 
 // A provider-neutral event read port. One call reads one page; the caller

--- a/packages/sync/src/storage/contracts/provider-calendar.contracts.ts
+++ b/packages/sync/src/storage/contracts/provider-calendar.contracts.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { HexColorSchema } from "@core/types/domain-primitives";
 import {
   CalendarAccessRoleSchema,
   CalendarCapabilitiesSchema,
@@ -10,6 +11,13 @@ import {
   ProviderCalendarSourceIdSchema,
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
+
+// One custom event-color label the calendar defines (Google's post-June-2026
+// event labels; a provider without the concept reports none).
+const EventLabelSchema = z.strictObject({
+  id: z.string().trim().min(1).max(256),
+  hex: HexColorSchema,
+});
 
 // Persistence record for `provider_calendars`. Provider FACTS
 // only — `active`/`primary`/`accessRole`/`capabilities` reflect what the
@@ -24,6 +32,7 @@ export const ProviderCalendarRecordSchema = z.strictObject({
   providerCalendarId: ProviderCalendarSourceIdSchema,
   displayName: z.string().trim().min(1).max(1024),
   color: z.string().trim().min(1).max(64).nullable(),
+  eventLabels: z.array(EventLabelSchema).readonly().default([]),
   active: z.boolean(),
   primary: z.boolean(),
   accessRole: CalendarAccessRoleSchema,
@@ -42,6 +51,7 @@ export const ProviderCalendarUpsertSchema = z.strictObject({
   providerCalendarId: ProviderCalendarSourceIdSchema,
   displayName: z.string().trim().min(1).max(1024),
   color: z.string().trim().min(1).max(64).nullable(),
+  eventLabels: z.array(EventLabelSchema).readonly().default([]),
   active: z.boolean(),
   primary: z.boolean(),
   accessRole: CalendarAccessRoleSchema,

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.db.test.ts
@@ -120,6 +120,27 @@ describe("ProviderCalendarRepository", () => {
     ).toHaveLength(0);
   });
 
+  it("persists and updates the calendar's custom event-color labels", async () => {
+    const connectionId = objectId();
+    const created = await repo.upsertByProviderCalendar(
+      baseUpsert({
+        connectionId,
+        eventLabels: [{ id: "label-1", hex: "#009688" }],
+      }),
+    );
+    expect(created.eventLabels).toEqual([{ id: "label-1", hex: "#009688" }]);
+
+    const updated = await repo.upsertByProviderCalendar(
+      baseUpsert({ connectionId, eventLabels: [] }),
+    );
+    expect(updated.eventLabels).toEqual([]);
+  });
+
+  it("defaults eventLabels to empty when the caller omits it", async () => {
+    const created = await repo.upsertByProviderCalendar(baseUpsert());
+    expect(created.eventLabels).toEqual([]);
+  });
+
   it("rejects a duplicate (connection, provider-calendar) identity", async () => {
     const shared = {
       tenantId: objectId(),

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -43,6 +43,7 @@ export class ProviderCalendarRepository {
         $set: {
           displayName: fields.displayName,
           color: fields.color,
+          eventLabels: fields.eventLabels,
           active: fields.active,
           primary: fields.primary,
           accessRole: fields.accessRole,

--- a/packages/web/src/common/styles/theme.util.test.ts
+++ b/packages/web/src/common/styles/theme.util.test.ts
@@ -19,4 +19,9 @@ describe("theme.util event color slots", () => {
     );
     expect(getEventPalette().base).not.toBe(EVENT_COLOR_SLOT_HEX.coral);
   });
+
+  it("prefers colorHex over a color slot, and colorHex over the theme default", () => {
+    expect(getEventPalette(undefined, "#009688").base).toBe("#009688");
+    expect(getEventPalette("coral", "#009688").base).toBe("#009688");
+  });
 });

--- a/packages/web/src/common/styles/theme.util.ts
+++ b/packages/web/src/common/styles/theme.util.ts
@@ -85,23 +85,34 @@ const EVENT_PALETTES: Record<ThemeName, EventPalette> = {
   "light-beach": buildEventPalette("light-beach"),
 };
 
-/** The active theme's event palette, or a Google-slot fill when `color` is
- * set. Subscribes so a theme switch re-renders the default (no-slot) case. */
-export const useEventPalette = (color?: EventColorSlot): EventPalette =>
-  resolveEventPalette(useThemeStore(selectTheme), color);
+/** The active theme's event palette, a provider-custom `colorHex` fill, or a
+ * Google-slot fill when `color` is set — in that precedence order. Subscribes
+ * so a theme switch re-renders the default (no-slot) case. */
+export const useEventPalette = (
+  color?: EventColorSlot,
+  colorHex?: string,
+): EventPalette =>
+  resolveEventPalette(useThemeStore(selectTheme), color, colorHex);
 
 /** Non-reactive read for plain functions (e.g. getGradient's identity check).
  * Components should use useEventPalette so they repaint on switch. */
-export const getEventPalette = (color?: EventColorSlot): EventPalette =>
-  resolveEventPalette(useThemeStore.getState().theme, color);
+export const getEventPalette = (
+  color?: EventColorSlot,
+  colorHex?: string,
+): EventPalette =>
+  resolveEventPalette(useThemeStore.getState().theme, color, colorHex);
 
 const resolveEventPalette = (
   themeName: ThemeName,
   color?: EventColorSlot,
-): EventPalette =>
-  color !== undefined
-    ? buildEventPaletteFromBase(EVENT_COLOR_SLOT_HEX[color])
-    : EVENT_PALETTES[themeName];
+  colorHex?: string,
+): EventPalette => {
+  if (colorHex !== undefined) return buildEventPaletteFromBase(colorHex);
+  if (color !== undefined) {
+    return buildEventPaletteFromBase(EVENT_COLOR_SLOT_HEX[color]);
+  }
+  return EVENT_PALETTES[themeName];
+};
 
 // CSS-variable gradients: these land in inline `background` styles, so the
 // browser resolves them against the active [data-theme] — no JS hex needed.

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -1,7 +1,10 @@
 import { z } from "zod/v4";
 import { ValidatedCompassEventSchema } from "@core/types/compass-event.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
-import { EventColorSlotSchema } from "@core/types/event-color.contracts";
+import {
+  EventColorSlotSchema,
+  OptionalHexEventColorSchema,
+} from "@core/types/event-color.contracts";
 
 /** Event category, based on its display type */
 export enum Categories_Event {
@@ -58,5 +61,8 @@ export const GridEventSchema = WebEventSchema.extend({
   // of CompassEvent — so cards can paint a per-event fill without widening
   // the shared core type.
   color: EventColorSlotSchema.optional(),
+  // A provider custom color (e.g. a Google event label) with no Compass slot
+  // equivalent. Takes precedence over `color` when both are somehow present.
+  colorHex: OptionalHexEventColorSchema,
 });
 export type GridEvent = z.infer<typeof GridEventSchema>;

--- a/packages/web/src/events/queries/event.view-model.test.ts
+++ b/packages/web/src/events/queries/event.view-model.test.ts
@@ -83,6 +83,26 @@ describe("Event query view models", () => {
     ).not.toHaveProperty("color");
   });
 
+  test("carries optional content.colorHex onto grid event cards", () => {
+    const labeled = createMockEvent({
+      content: {
+        kind: "details",
+        title: "Eucalyptus meeting",
+        description: "",
+        colorHex: "#009688",
+      },
+    });
+    const plain = createMockEvent();
+    const result = deriveCalendarEventViewModel(normalized(labeled, plain));
+
+    expect(
+      result.timedEvents.find(({ _id }) => _id === labeled.id)?.colorHex,
+    ).toBe("#009688");
+    expect(
+      result.timedEvents.find(({ _id }) => _id === plain.id),
+    ).not.toHaveProperty("colorHex");
+  });
+
   test("returns stable empty shapes", () => {
     const week = deriveCalendarEventViewModel();
     expect(week).toEqual({

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -1,7 +1,7 @@
 import { Origin } from "@core/constants/core.constants";
 import { type EventId } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
-import { withColor } from "@core/types/event-color.contracts";
+import { withColor, withColorHex } from "@core/types/event-color.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
@@ -73,6 +73,7 @@ const eventToGridEvent = (
       ? { isTimedMultiDayDisplay: true }
       : {}),
     ...withColor(details?.color ?? undefined),
+    ...withColorHex(details?.colorHex),
   };
 };
 

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -56,7 +56,10 @@ const AllDayEventCardBase = (
   }: AllDayEventCardProps,
   ref: ForwardedRef<HTMLDivElement>,
 ) => {
-  const { base: baseColor, hover: hoverColor } = useEventPalette(event.color);
+  const { base: baseColor, hover: hoverColor } = useEventPalette(
+    event.color,
+    event.colorHex,
+  );
   const isInPast = dayjs().isAfter(dayjs(event.endDate));
   const isRecurring = isRecurringEvent(event);
   const showRepeatIcon =

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -123,7 +123,10 @@ const TimedEventCardBase = (
     [position.height, showTimeLabel],
   );
 
-  const { base: baseColor, hover: hoverColor } = useEventPalette(event.color);
+  const { base: baseColor, hover: hoverColor } = useEventPalette(
+    event.color,
+    event.colorHex,
+  );
   // Draft fills use the same base as saved cards so the Week overlay matches
   // the form/context-menu swatch (and the eventual save). Draft vs saved is
   // carried by the drop-shadow filter below, not by darkening the color away.


### PR DESCRIPTION
## Summary

Google replaced its fixed 11-color event palette with per-calendar custom
color labels in June/July 2026 (`eventLabelId` on events, `labelProperties`
on calendars). Compass only read the legacy `colorId` field, so
label-colored events silently rendered in the app's default color instead of
their real color.

This adds `colorHex` as a sibling to the existing 11-slot `color` field, at
every hop (sync storage → backend translation → web view-model → grid
cards). It is resolved during calendar discovery by a new `calendars.get`
call (`calendarList.list` doesn't carry `labelProperties`) and threaded into
event normalization via the reader port. **Compass's own color picker is
untouched** — it still only ever writes the 11-slot `color`, never a custom
hex. Writing custom Google labels back is out of scope.

Verified against a live test account (`compasscaltest3@gmail.com`) via the
interactive Google API Explorer before writing any code:
- `events.list`/`events.get` return `eventLabelId` by default — no
  `eventLabelVersion` query param needed on reads.
- `calendarList.list`/`calendarList.get` do **not** carry `labelProperties`
  — only `calendars.get` does, hence the new per-calendar call.
- The existing `calendar.readonly` OAuth scope already covers `calendars.get`
  — no connected user needs to re-consent.

## Simplicity

An independent `/simplify` pass (4 parallel review angles: reuse,
simplification, efficiency, altitude) found and fixed:
- Deduplicated the `eventLabels → Map` construction (was copy-pasted in both
  `calendar-import.service.ts` and `calendar-pull.service.ts`) into a shared
  `toColorLabelMap` helper, and dropped an unnecessary cached field on
  `ImportRun` (the calendar record is immutable for the run's lifetime, so
  there was nothing to cache).
- Folded the per-calendar label fetch into `mapCalendar` and resolved a
  discovery page's calendars concurrently instead of one sequential
  round-trip per calendar.
- Fixed a `migrate.ts` dry-run stub cast that had widened to
  `as unknown as ProviderCalendarRecord` (suppressing structural checking
  entirely) — typing the one literal that broke it restored the original,
  safer single cast.

Everything else — reuse of `HexColorSchema`, the `withColor`/`withColorHex`
split (justified: `color` needs null-clearing semantics for write commands,
`colorHex` is read-only and never needs one), the port-level placement of
`colorLabels`/`eventLabels` (consistent with how `calendarId`/`color` are
already handled generically on the same provider-neutral ports) — was
reviewed and found already at the right altitude.

## Automated validation

- `bun run type-check` — clean across core/sync/backend/web (incl. web test
  tsconfig).
- `bun run lint` — clean; the two pre-existing warnings in
  `render-with-store.tsx` / `ContextMenuItems.tsx` predate this branch and
  are untouched by it.
- Full `bun test:core`, `test:sync`, `test:backend`, `test:scripts` — all
  green (531 / 663 / 836 / 81 passing respectively), including the Mongo-backed
  `.db.test.ts` suites that exercise the new `eventLabels` schema field
  round-tripping through real storage.
- Scoped `bun test` sweep of every web directory touched (`grid`, `events`,
  `common/styles`, `common/types`) — 285 pass, 0 fail.
- The full 800+ file `bun test:web` suite could not be completed locally:
  this dev machine had multiple concurrent Claude Code sessions running full
  web suites in other worktrees at the same time, causing severe resource
  contention (confirmed via `ps`/`vm_stat` — near-zero free memory, processes
  in uninterruptible I/O wait). CI runs this suite on dedicated infra without
  that contention and is the authoritative signal for it.

**No browser-based end-to-end verification was possible in this
environment**: this worktree's `compass.yaml` has no Google OAuth client
configured, and setting one up would require registering a redirect URI in
Google Cloud Console, which isn't something to do unilaterally. The
color-resolution boundary itself is directly unit-tested end-to-end instead
(`theme.util.test.ts` asserts `getEventPalette(color, colorHex).base ===
colorHex` takes precedence; every hop from the Google normalizer through to
the grid card has a dedicated test with concrete hex assertions).

## Independent review

A fresh `code-reviewer` subagent reviewed the complete diff (given only the
worktree, base ref, task intent, and diff — no access to this description or
my own conclusions). Verdict: **ship as-is**, no findings at or above 80
confidence. It specifically verified: `colorHex` precedence over `color`
slot over theme default; the unmapped/deleted-label case degrades safely
(map-miss returns `undefined`, never throws, per-event skip boundary
intact); the new `calendars.get` call fails open (try/catch, returns `[]`)
so a label-fetch error can never fail calendar discovery; the Mongo schema
addition backward-compat parses pre-existing records via its `.default([])`;
and the write path (`google-event-writer.adapter.ts`, `google-color.map.ts`)
has zero references to `colorHex`/`eventLabelId` — this diff is strictly
read-only for colors, as intended. It flagged the N sequential
`calendars.get` calls (now fixed to run concurrently per page, see
Simplicity above) as a real but low-severity cost, since `calendarListSync`
only fires on connect/reconnect, not on a recurring cadence.

## Test plan

```bash
bun run type-check
bun run lint
bun run test:core
bun run test:sync
bun run test:backend
bun run test:scripts
cd packages/web && TZ=Etc/UTC NODE_ENV=test PORT=3000 bun test ./src/grid ./src/events ./src/common/styles ./src/common/types
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync discovery (extra Google API calls), event normalization, and calendar persistence, but changes are read-only for colors with fail-open label fetch and broad test coverage; no auth or write-path changes.
> 
> **Overview**
> Fixes Google **event label** colors (post–June 2026 `eventLabelId`) showing as the app default because only legacy `colorId` was read.
> 
> Introduces read-only **`colorHex`** alongside the existing 11-slot **`color`**, threaded from sync through backend translation to the web grid. Compass’s color picker still writes **`color` only**; custom label writes are out of scope.
> 
> **Discovery** persists per-calendar **`eventLabels`** (id → hex) on provider calendar records via an extra **`calendars.get`** per calendar (concurrent per list page; failures return no labels so discovery never fails). **Import and incremental pull** pass a **`colorLabels`** map into the event reader; the Google normalizer maps **`eventLabelId`** to **`colorHex`**. Missing or deleted labels omit color safely.
> 
> The **UI** prefers **`colorHex`** over slot **`color`** over the theme default in event palettes. Legacy migration seeds empty **`eventLabels`** until the next calendar-list sync backfills them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf46b33b37f3ff960bf34b28109b94e78a02065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->