### PR TITLE
fix(web): three new-user engagement fixes from PostHog usage review

### DIFF
--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -4,6 +4,7 @@ export const ROOT_ROUTES = {
   GOOGLE_AUTH_CALLBACK: "/auth/google/callback",
   LIFE: "/life",
   ROOT: "/",
+  WAITLIST: "/waitlist",
   WEEK: "/week",
   WEEK_DATE: "/week/$dateString",
   DAY: "/day",

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -1,3 +1,5 @@
+import { CaretDownIcon } from "@phosphor-icons/react";
+import classNames from "classnames";
 import { useId, useState } from "react";
 import { FAQ_ITEMS } from "./faq";
 
@@ -45,10 +47,18 @@ export function WelcomeGuideBody() {
                 type="button"
                 aria-controls={answerId}
                 aria-expanded={isExpanded}
-                className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
+                className="c-focus-ring flex w-full cursor-pointer select-none items-center justify-between gap-2 text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
                 onClick={() => toggleFaq(item.question)}
               >
-                {item.question}
+                <span>{item.question}</span>
+                <CaretDownIcon
+                  aria-hidden="true"
+                  className={classNames(
+                    "shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none",
+                    isExpanded && "rotate-180",
+                  )}
+                  size={14}
+                />
               </button>
               <div
                 id={answerId}

--- a/packages/web/src/grid/hooks/useTimedDraftCreation.test.ts
+++ b/packages/web/src/grid/hooks/useTimedDraftCreation.test.ts
@@ -1,0 +1,76 @@
+import { act, renderHook } from "@testing-library/react";
+import { type MouseEvent as ReactMouseEvent } from "react";
+import dayjs from "@core/util/date/dayjs";
+import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
+import { useTimedDraftCreation } from "./useTimedDraftCreation";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const START_OF_VIEW = dayjs("2024-01-16T10:00:00.000Z");
+
+const getStartDate = ({ x }: { x: number; y: number }) =>
+  START_OF_VIEW.add(Math.floor(x / 100), "day");
+
+const fakeMouseDown = (clientX: number) =>
+  ({
+    altKey: false,
+    button: 0,
+    clientX,
+    clientY: 0,
+    ctrlKey: false,
+    metaKey: false,
+    preventDefault: mock(),
+    shiftKey: false,
+    stopPropagation: mock(),
+  }) as unknown as ReactMouseEvent<HTMLElement>;
+
+// A plain click: mousedown (via the hook's own API) followed by an immediate
+// mouseup at the same point, dispatched the way the hook's real window
+// listener receives it.
+const releaseMouse = (clientX: number) => {
+  window.dispatchEvent(
+    new MouseEvent("mouseup", { bubbles: true, cancelable: true, clientX }),
+  );
+};
+
+describe("useTimedDraftCreation", () => {
+  beforeEach(() => {
+    draftActions.discard();
+  });
+
+  it("starts a new draft at the new point instead of swallowing the click when one is already open", () => {
+    const onFinish = mock();
+    const { result } = renderHook(() =>
+      useTimedDraftCreation({ getStartDate, onFinish }),
+    );
+
+    act(() => {
+      result.current.startTimedDraftCreation(fakeMouseDown(0));
+      releaseMouse(0);
+    });
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    const firstDraft = onFinish.mock.calls[0]![0];
+
+    // Mirror what real callers do in onFinish: open the draft in the store.
+    act(() => {
+      draftActions.startGridDraft({ activity: "gridClick", draft: firstDraft });
+    });
+    expect(useDraftStore.getState().status?.isDrafting).toBe(true);
+
+    act(() => {
+      result.current.startTimedDraftCreation(fakeMouseDown(300));
+      releaseMouse(300);
+    });
+
+    // The stale draft must be dropped...
+    expect(useDraftStore.getState().gridDraft).toBeNull();
+    // ...and a fresh one created at the new point, not just discarded.
+    expect(onFinish).toHaveBeenCalledTimes(2);
+    const secondDraft = onFinish.mock.calls[1]![0];
+    expect(
+      dayjs(secondDraft.values.schedule.start).isSame(
+        START_OF_VIEW.add(3, "day"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/web/src/grid/hooks/useTimedDraftCreation.ts
+++ b/packages/web/src/grid/hooks/useTimedDraftCreation.ts
@@ -51,9 +51,12 @@ export const useTimedDraftCreation = ({
     event: ReactMouseEvent<HTMLElement>,
     columnCalendarId: CalendarId | null = calendarId,
   ) => {
+    // A plain click elsewhere while a draft is open discards it and starts a
+    // fresh one at the new point, rather than swallowing the click: without
+    // this, a second click anywhere on the grid did nothing but drop the
+    // first draft, which read as a dead click (and lost any typed title).
     if (isDrafting) {
       draftActions.discard();
-      return;
     }
 
     if (

--- a/packages/web/src/routers/index.test.tsx
+++ b/packages/web/src/routers/index.test.tsx
@@ -5,6 +5,7 @@ import {
   lifeRoute,
   rootRoute,
   routeTree,
+  waitlistRoute,
 } from "@web/routers/router.routes";
 import { describe, expect, it } from "bun:test";
 
@@ -23,5 +24,11 @@ describe("routeTree", () => {
   it("gates the authenticated layout behind loadAuthenticated", () => {
     expect(authenticatedLayoutRoute.options.beforeLoad).toBeDefined();
     expect(authenticatedLayoutRoute.parentRoute).toBe(rootRoute);
+  });
+
+  it("redirects the retired /waitlist route to root instead of 404ing", () => {
+    expect(waitlistRoute.fullPath).toBe(ROOT_ROUTES.WAITLIST);
+    expect(waitlistRoute.options.beforeLoad).toBeDefined();
+    expect(waitlistRoute.parentRoute).toBe(rootRoute);
   });
 });

--- a/packages/web/src/routers/loaders.test.ts
+++ b/packages/web/src/routers/loaders.test.ts
@@ -10,6 +10,7 @@ import {
   loadDateParam,
   loadTodayData,
   redirectToDefaultCalendar,
+  redirectToRoot,
   redirectToToday,
   validateWeekDateParam,
 } from "@web/routers/loaders";
@@ -63,12 +64,18 @@ function createTestRouter(initialEntries: string[]) {
     path: "/",
     beforeLoad: redirectToDefaultCalendar,
   });
+  const waitlistRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: ROOT_ROUTES.WAITLIST,
+    beforeLoad: redirectToRoot,
+  });
 
   return createRouter({
     routeTree: rootRoute.addChildren([
       dayRoute.addChildren([dayIndexRoute, dayDateRoute]),
       weekRoute.addChildren([weekIndexRoute, weekDateRoute]),
       rootIndexRoute,
+      waitlistRoute,
     ]),
     history: createMemoryHistory({ initialEntries }),
     defaultPendingMs: 0,
@@ -91,6 +98,14 @@ describe("router redirects", () => {
 
     expect(router.state.location.pathname).toBe(ROOT_ROUTES.WEEK);
     expect(router.state.location.search).toEqual({ auth: "login" });
+  });
+
+  it("redirects /waitlist through / to the bare week route", async () => {
+    const router = createTestRouter(["/waitlist"]);
+
+    await router.load();
+
+    expect(router.state.location.pathname).toBe(ROOT_ROUTES.WEEK);
   });
 
   it("redirects /day to today's dated day route", async () => {

--- a/packages/web/src/routers/loaders.ts
+++ b/packages/web/src/routers/loaders.ts
@@ -55,6 +55,18 @@ export function redirectToDefaultCalendar(): never {
   });
 }
 
+// /waitlist predates self-serve signup and no longer has anything to show;
+// send it through the normal root flow instead of 404ing (external links to
+// it are still out there). That flow already does the right thing per
+// visitor: mobile OSes hit RootView's MobileGate (the real, still-active
+// mobile waitlist), desktop hits the welcome screen.
+export function redirectToRoot(): never {
+  throw redirect({
+    to: ROOT_ROUTES.ROOT,
+    search: (prev: Record<string, unknown>) => prev,
+  });
+}
+
 // Deliberately not params.parse: a throwing parser makes the route not
 // match (-> NotFound), but the existing UX redirects an invalid dateString
 // to the base route instead. Runs in beforeLoad so an invalid param never

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -10,6 +10,7 @@ import {
   loadAuthenticated,
   loadDateParam,
   redirectToDefaultCalendar,
+  redirectToRoot,
   redirectToToday,
   validateDayDateParam,
   validateWeekDateParam,
@@ -115,6 +116,12 @@ export const cleanupRoute = createRoute({
   ),
 });
 
+export const waitlistRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROOT_ROUTES.WAITLIST,
+  beforeLoad: redirectToRoot,
+});
+
 export const googleAuthCallbackRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: ROOT_ROUTES.GOOGLE_AUTH_CALLBACK,
@@ -135,4 +142,5 @@ export const routeTree = rootRoute.addChildren([
   authenticatedRoute,
   ...(IS_DEV ? [cleanupRoute] : []),
   googleAuthCallbackRoute,
+  waitlistRoute,
 ]);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -600,7 +600,7 @@ describe("DayCalendarGrid", () => {
     expect(screen.queryByText("Delete Event")).not.toBeInTheDocument();
   });
 
-  it("dismisses an open form when pressing empty Day timed calendar space", async () => {
+  it("discards an open form and starts a new draft when pressing empty Day timed calendar space", async () => {
     const event = createTimedEvent({
       _id: "open-draft",
       endDate: "2026-05-20T10:00:00.000",
@@ -614,6 +614,7 @@ describe("DayCalendarGrid", () => {
       screen.getByRole("button", { name: /timed event: open draft/i }),
     );
     expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
+    expect(getGridDraft()?.kind).toBe("edit");
 
     const emptySlot = getTimedSlot(3);
     await user.pointer([
@@ -628,14 +629,17 @@ describe("DayCalendarGrid", () => {
         target: emptySlot,
       },
     ]);
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
 
-    expect(screen.queryByRole("dialog", { name: "Event form" })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: /timed event: untitled event/i }),
-    ).not.toBeInTheDocument();
+    // The click both drops the stale "Open draft" edit and starts a fresh
+    // draft at the new point - a plain click elsewhere must never be a
+    // no-op, or it reads as a dead click (see useTimedDraftCreation).
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /timed event: untitled event/i }),
+      ).toBeVisible();
+      expect(screen.getByRole("dialog", { name: "Event form" })).toBeVisible();
+    });
+    expect(getGridDraft()?.kind).toBe("create");
   });
 
   it("keeps the event form open when pressing outside the calendar", async () => {


### PR DESCRIPTION
## Summary

Investigated a week of production PostHog usage (2026-07-20 to 07-28) to find friction hurting new-user engagement, then fixed what was safely fixable without adding new features. Full context in the session, but the headline numbers: 65 people reached the site, 16 clicked "Start Now" into the app, and only 2 ever saved an event — a collapse concentrated in the first minute inside the grid, not the landing pitch.

- **Grid click swallowed on second click**: `useTimedDraftCreation` discarded an open draft and returned early when the grid was clicked elsewhere, creating nothing at the new point. This was the single largest cluster of `$dead_click`/`$rageclick` events on production, and any typed title was lost silently. Now it discards the stale draft and continues into creating a new one at the clicked point. Added a regression test that fails on the old code.
- **`/waitlist` 404s**: the general-access waitlist backend was removed in #1498, but external links to `/waitlist` are still out there — 8% of a measured week's traffic landed on the app's own 404 page. It now redirects through `/`, which already does the right thing per visitor (the real mobile waitlist via `RootView`'s `MobileGate` for mobile OSes, the welcome screen for everyone else).
- **FAQ questions have no expand affordance**: the welcome modal's FAQ items read as static headings (no chevron/icon), yet they were the second-most-clicked element on the landing screen. Added a `CaretDownIcon` that rotates on expand.

Two other findings from the same review didn't need a code change:
- The "anonymous session isn't saved" signal already exists and fires correctly (a toast + sidebar shimmer on first save, shipped 2026-07-23) — verified live rather than duplicating it.
- Production ships a single **2.2MB, uncompressed** JS bundle (`splitting: false`) that plausibly explains the ~2.3s p50 / ~3.7s p75 first paint on `/week`. Enabling splitting cuts the critical path to ~730KB, but hit a genuine Bun 1.3.14 bug (wrong chunk linked as the entry script) that breaks app boot — filed separately rather than shipped half-broken.

## Test plan
- [x] `useTimedDraftCreation.test.ts`: new regression test, verified it fails against the pre-fix code and passes against the fix
- [x] `loaders.test.ts` / `index.test.tsx`: new router-redirect tests for `/waitlist`
- [x] Existing `WelcomeModal.test.tsx` suite still passes unmodified
- [x] `biome check` clean on all touched files
- [x] `tsc --noEmit` clean on both `tsconfig.app.json` and `tsconfig.test.json`
- [x] Manually verified all three fixes live (local dev + staging): second-click draft creation, `/waitlist` → `/week` redirect, FAQ caret rotates and expands
- [ ] Full `bun run test:web` (200+ files) — still running in the background at PR time; will report back if it surfaces anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX and redirect changes with targeted tests; no auth, data, or payment paths touched.
> 
> **Overview**
> Addresses three friction points from production usage: **grid clicks feeling dead**, **stale `/waitlist` links 404ing**, and **FAQ rows lacking an expand affordance**.
> 
> **Timed grid drafting:** `useTimedDraftCreation` no longer returns after discarding an open draft when the user clicks empty grid space elsewhere—it discards and **continues** to start a new draft at the clicked slot (fixing lost titles and `$dead_click`/`$rageclick` clusters). Day calendar integration tests and a dedicated hook regression test cover the behavior.
> 
> **Routing:** Adds `ROOT_ROUTES.WAITLIST`, a public `waitlistRoute` with `redirectToRoot` (preserving search params), which chains through `/` to the default week calendar instead of NotFound.
> 
> **Welcome modal:** FAQ disclosure buttons get a rotating `CaretDownIcon` so expandable items are visually obvious.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4615613e6f5327b707fedfb04f777cb9a399236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->