### PR TITLE
fix(web): hide non-actionable email-update palette rows

### DIFF
--- a/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.test.ts
@@ -101,35 +101,62 @@ describe("useSubscribeCmdItems", () => {
   });
 
   it("hides the command when email updates are unavailable", async () => {
-    mockGetEmailUpdates.mockResolvedValue({ status: "unavailable" });
+    let resolveStatus!: (value: { status: "unavailable" }) => void;
+    mockGetEmailUpdates.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
     const { useSubscribeCmdItems } = await importHook();
 
     const { result } = renderHook(() => useSubscribeCmdItems(true));
 
-    await waitFor(() => expect(result.current).toEqual([]));
+    expect(result.current).toEqual([]);
+    expect(mockGetEmailUpdates).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveStatus({ status: "unavailable" }));
+
+    expect(result.current).toEqual([]);
+    expect(mockSubscribeToEmailUpdates).not.toHaveBeenCalled();
   });
 
   it("hides the command for an existing subscriber", async () => {
-    mockGetEmailUpdates.mockResolvedValue({ status: "subscribed" });
+    let resolveStatus!: (value: { status: "subscribed" }) => void;
+    mockGetEmailUpdates.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
     const { useSubscribeCmdItems } = await importHook();
 
     const { result } = renderHook(() => useSubscribeCmdItems(true));
 
-    await waitFor(() => {
-      expect(result.current).toEqual([]);
-    });
+    expect(result.current).toEqual([]);
+    expect(mockGetEmailUpdates).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveStatus({ status: "subscribed" }));
+
+    expect(result.current).toEqual([]);
     expect(mockSubscribeToEmailUpdates).not.toHaveBeenCalled();
   });
 
   it("does not offer an opt-in to a previously unsubscribed user", async () => {
-    mockGetEmailUpdates.mockResolvedValue({ status: "unsubscribed" });
+    let resolveStatus!: (value: { status: "unsubscribed" }) => void;
+    mockGetEmailUpdates.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
     const { useSubscribeCmdItems } = await importHook();
 
     const { result } = renderHook(() => useSubscribeCmdItems(true));
 
-    await waitFor(() => {
-      expect(result.current).toEqual([]);
-    });
+    expect(result.current).toEqual([]);
+    expect(mockGetEmailUpdates).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveStatus({ status: "unsubscribed" }));
+
+    expect(result.current).toEqual([]);
     expect(mockSubscribeToEmailUpdates).not.toHaveBeenCalled();
   });
 
@@ -154,8 +181,13 @@ describe("useSubscribeCmdItems", () => {
   });
 
   it("hides the check failure and retries after reopening the palette", async () => {
+    let rejectStatus!: (error: Error) => void;
     mockGetEmailUpdates
-      .mockRejectedValueOnce(new Error("network error"))
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectStatus = reject;
+        }),
+      )
       .mockResolvedValueOnce({ status: "not_subscribed" });
     const { useSubscribeCmdItems } = await importHook();
 
@@ -164,10 +196,12 @@ describe("useSubscribeCmdItems", () => {
       { initialProps: { open: true } },
     );
 
-    await waitFor(() => {
-      expect(result.current).toEqual([]);
-      expect(mockGetEmailUpdates).toHaveBeenCalledTimes(1);
-    });
+    expect(mockGetEmailUpdates).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual([]);
+
+    await act(async () => rejectStatus(new Error("network error")));
+
+    expect(result.current).toEqual([]);
     rerender({ open: false });
     rerender({ open: true });
 

--- a/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.test.ts
@@ -73,7 +73,7 @@ describe("useSubscribeCmdItems", () => {
     expect(mockGetEmailUpdates).not.toHaveBeenCalled();
   });
 
-  it("waits to fetch until the palette opens and shows a loading item", async () => {
+  it("waits to fetch until the palette opens and shows nothing while checking", async () => {
     let resolveStatus!: (value: { status: "not_subscribed" }) => void;
     mockGetEmailUpdates.mockReturnValue(
       new Promise((resolve) => {
@@ -90,15 +90,14 @@ describe("useSubscribeCmdItems", () => {
     expect(result.current).toEqual([]);
     rerender({ open: true });
 
-    expect(result.current).toEqual([
-      expect.objectContaining({
-        disabled: true,
-        label: "Checking email update status…",
-      }),
-    ]);
+    expect(result.current).toEqual([]);
     expect(mockGetEmailUpdates).toHaveBeenCalledTimes(1);
 
     await act(async () => resolveStatus({ status: "not_subscribed" }));
+
+    await waitFor(() => {
+      expect(result.current[0]?.label).toBe("Opt in to email updates");
+    });
   });
 
   it("hides the command when email updates are unavailable", async () => {
@@ -110,20 +109,16 @@ describe("useSubscribeCmdItems", () => {
     await waitFor(() => expect(result.current).toEqual([]));
   });
 
-  it("shows a disabled subscribed item for an existing subscriber", async () => {
+  it("hides the command for an existing subscriber", async () => {
     mockGetEmailUpdates.mockResolvedValue({ status: "subscribed" });
     const { useSubscribeCmdItems } = await importHook();
 
     const { result } = renderHook(() => useSubscribeCmdItems(true));
 
     await waitFor(() => {
-      expect(result.current).toEqual([
-        expect.objectContaining({
-          disabled: true,
-          label: "You’re subscribed to updates",
-        }),
-      ]);
+      expect(result.current).toEqual([]);
     });
+    expect(mockSubscribeToEmailUpdates).not.toHaveBeenCalled();
   });
 
   it("does not offer an opt-in to a previously unsubscribed user", async () => {
@@ -133,12 +128,7 @@ describe("useSubscribeCmdItems", () => {
     const { result } = renderHook(() => useSubscribeCmdItems(true));
 
     await waitFor(() => {
-      expect(result.current).toEqual([
-        expect.objectContaining({
-          disabled: true,
-          label: "You’re unsubscribed from updates",
-        }),
-      ]);
+      expect(result.current).toEqual([]);
     });
     expect(mockSubscribeToEmailUpdates).not.toHaveBeenCalled();
   });
@@ -158,12 +148,12 @@ describe("useSubscribeCmdItems", () => {
     });
 
     await waitFor(() => {
-      expect(result.current[0]?.label).toBe("You’re subscribed to updates");
+      expect(result.current).toEqual([]);
     });
     expect(mockSubscribeToEmailUpdates).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the check failure and retries after reopening the palette", async () => {
+  it("hides the check failure and retries after reopening the palette", async () => {
     mockGetEmailUpdates
       .mockRejectedValueOnce(new Error("network error"))
       .mockResolvedValueOnce({ status: "not_subscribed" });
@@ -175,9 +165,8 @@ describe("useSubscribeCmdItems", () => {
     );
 
     await waitFor(() => {
-      expect(result.current[0]?.label).toBe(
-        "Couldn’t check email update status",
-      );
+      expect(result.current).toEqual([]);
+      expect(mockGetEmailUpdates).toHaveBeenCalledTimes(1);
     });
     rerender({ open: false });
     rerender({ open: true });

--- a/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
@@ -1,5 +1,6 @@
 import { BellIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
+import { type EmailUpdatesStatus } from "@core/types/email/email.types";
 import { UserApi } from "@web/api/user.api";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { SUBSCRIBE_TO_UPDATES_TOAST_ID } from "@web/common/constants/toast.constants";
@@ -8,22 +9,13 @@ import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 
 /**
- * Returns the actionable email-updates opt-in command when the user is
- * eligible. Kit remains the source of truth; this hook caches one lookup per
- * mount and retries a failed lookup when the palette next opens. Non-actionable
- * statuses (subscribed, unsubscribed, checking, error) yield no items.
+ * Returns the email-updates opt-in command when Kit reports the user as
+ * eligible. Caches one lookup per mount; retries a failed lookup the next
+ * time the palette opens.
  */
 export const useSubscribeCmdItems = (open: boolean): CommandItem[] => {
   const { authenticated } = useSession();
-  const [status, setStatus] = useState<
-    | "idle"
-    | "checking"
-    | "unavailable"
-    | "not_subscribed"
-    | "subscribed"
-    | "unsubscribed"
-    | "error"
-  >("idle");
+  const [status, setStatus] = useState<"idle" | EmailUpdatesStatus>("idle");
   const hasChecked = useRef(false);
 
   useEffect(() => {
@@ -36,19 +28,10 @@ export const useSubscribeCmdItems = (open: boolean): CommandItem[] => {
     if (!open || hasChecked.current) return;
 
     hasChecked.current = true;
-    setStatus("checking");
-    const getEmailUpdates = UserApi.getEmailUpdates;
-
-    if (!getEmailUpdates) {
-      setStatus("unavailable");
-      return;
-    }
-
-    void getEmailUpdates()
+    void UserApi.getEmailUpdates()
       .then((response) => setStatus(response.status))
       .catch(() => {
         hasChecked.current = false;
-        setStatus("error");
       });
   }, [authenticated, open]);
 

--- a/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.ts
@@ -1,8 +1,4 @@
-import {
-  BellIcon,
-  CircleNotchIcon,
-  WarningCircleIcon,
-} from "@phosphor-icons/react";
+import { BellIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { UserApi } from "@web/api/user.api";
 import { useSession } from "@web/auth/compass/session/useSession";
@@ -12,9 +8,10 @@ import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 
 /**
- * Returns the email-updates command only when that integration is available.
- * Kit remains the source of truth; this hook caches one lookup per mount and
- * retries a failed lookup when the palette next opens.
+ * Returns the actionable email-updates opt-in command when the user is
+ * eligible. Kit remains the source of truth; this hook caches one lookup per
+ * mount and retries a failed lookup when the palette next opens. Non-actionable
+ * statuses (subscribed, unsubscribed, checking, error) yield no items.
  */
 export const useSubscribeCmdItems = (open: boolean): CommandItem[] => {
   const { authenticated } = useSession();
@@ -55,53 +52,7 @@ export const useSubscribeCmdItems = (open: boolean): CommandItem[] => {
       });
   }, [authenticated, open]);
 
-  if (!authenticated || status === "idle" || status === "unavailable")
-    return [];
-
-  if (status === "checking") {
-    return [
-      {
-        id: "subscribe-to-updates",
-        label: "Checking email update status…",
-        icon: CircleNotchIcon,
-        iconClassName: "animate-spin",
-        disabled: true,
-      },
-    ];
-  }
-
-  if (status === "subscribed") {
-    return [
-      {
-        id: "subscribe-to-updates",
-        label: "You’re subscribed to updates",
-        icon: BellIcon,
-        disabled: true,
-      },
-    ];
-  }
-
-  if (status === "unsubscribed") {
-    return [
-      {
-        id: "subscribe-to-updates",
-        label: "You’re unsubscribed from updates",
-        icon: BellIcon,
-        disabled: true,
-      },
-    ];
-  }
-
-  if (status === "error") {
-    return [
-      {
-        id: "subscribe-to-updates",
-        label: "Couldn’t check email update status",
-        icon: WarningCircleIcon,
-        disabled: true,
-      },
-    ];
-  }
+  if (!authenticated || status !== "not_subscribed") return [];
 
   return [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Command palette no longer shows status-only email-update rows (`You're subscribed…`, unsubscribed, checking, check-failed).
- Eligible users still get the actionable **Opt in to email updates** item; after a successful subscribe the item disappears and the success toast remains.
- Status lookup (`GET /user/email-updates`) is unchanged so we can decide eligibility; unsubscribe stays via the Kit email footer / ReleaseNotesPrompt flows.

## Test plan
- [x] `bun test packages/web/src/components/CommandPalette/hooks/useSubscribeCmdItems.test.ts`
- [ ] Open command palette as a subscribed user — Settings has no email-updates row
- [ ] As a not-subscribed user — **Opt in to email updates** still appears and works
- [ ] As a previously unsubscribed user — no opt-in row

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-579ba4f6-c638-4f61-8ef4-48b1d824b0c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579ba4f6-c638-4f61-8ef4-48b1d824b0c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

