### PR TITLE
fix(self-host): derive compose profiles from config

### DIFF
--- a/self-host/compass
+++ b/self-host/compass
@@ -130,10 +130,41 @@ load_env_if_present() {
   fi
 }
 
+# The profiles this install actually needs, read off its own config.
+#
+# Defaulting to `selfhosted` regardless of config took a production deployment
+# down (2026-07-29): that deployment uses Atlas and hosted SuperTokens, so a
+# routine `./compass update` started a bundled mongo it had never run, the
+# bundled mongo crash-looped on the host kernel, and the selfhosted overlay's
+# `backend depends_on mongo: service_healthy` then blocked the backend from
+# starting at all.
+#
+#   selfhosted -> bundled mongo + supertokens, only when mongo.uri targets the
+#                 bundled `mongo` service (an external/Atlas URI means those
+#                 containers do not belong to this install).
+#   sync       -> only where an isolated sync database is provisioned.
+#
+# An explicit COMPOSE_PROFILES in the environment still wins, so operators can
+# override this for one-off commands.
+default_profiles() {
+  profiles=
+
+  mongo_uri=$(strip_quotes "$(read_config_value mongo.uri)")
+  case "$mongo_uri" in
+    "" | *//mongo:* | *@mongo:*) profiles=selfhosted ;;
+  esac
+
+  if [ -n "$(strip_quotes "$(read_config_value sync.mongoUri)")" ]; then
+    profiles="${profiles:+$profiles,}sync"
+  fi
+
+  printf '%s\n' "$profiles"
+}
+
 set_compose_env() {
   load_env
   export COMPASS_CONFIG_FILE="$CONFIG_FILE"
-  export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhosted}"
+  export COMPOSE_PROFILES="${COMPOSE_PROFILES-$(default_profiles)}"
   export COMPASS_VERSION="$(strip_quotes "$(read_config_value runtime.version)")"
   export COMPASS_WEB_IMAGE="$(strip_quotes "$(read_config_value web.image)")"
   export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -199,13 +199,104 @@ describe("self-host installer", () => {
   });
 });
 
+// Run the helper's profile derivation against a throwaway config. Sourcing just
+// the pure functions keeps this a behavior test rather than a string match, so
+// it fails if the derivation regresses instead of only if the source is retyped.
+async function runDefaultProfiles(configYaml: string) {
+  const dir = makeTempDir();
+  const configPath = join(dir, "compass.yaml");
+  writeFileSync(configPath, `${configYaml}\n`, { encoding: "utf8" });
+
+  // Lift the pure helpers out of the script so they can be exercised without
+  // running any docker command.
+  const helper = readRepoFile("self-host/compass");
+  const fns = ["strip_quotes", "read_config_value", "default_profiles"]
+    .map((name) => {
+      const match = helper.match(new RegExp(`^${name}\\(\\)[\\s\\S]*?^}`, "m"));
+      if (!match) throw new Error(`missing shell function: ${name}`);
+      return match[0];
+    })
+    .join("\n\n");
+
+  const fnsPath = join(dir, "fns.sh");
+  writeFileSync(fnsPath, `${fns}\n`, { encoding: "utf8" });
+
+  const proc = Bun.spawn(
+    [
+      "bash",
+      "-c",
+      `CONFIG_FILE="$1"; . "$2"; default_profiles`,
+      "--",
+      configPath,
+      fnsPath,
+    ],
+    { cwd: repoRoot, stderr: "pipe", stdout: "pipe" },
+  );
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stderr, stdout: stdout.trim() };
+}
+
 describe("self-host helper", () => {
-  it("defaults Docker Compose to the self-host profile", () => {
+  it("lets an explicit COMPOSE_PROFILES override the derived default", () => {
     const helper = readRepoFile("self-host/compass");
 
     expect(helper).toContain(
-      'COMPOSE_PROFILES="' + "$" + '{COMPOSE_PROFILES-selfhosted}"',
+      'COMPOSE_PROFILES="' + "$" + '{COMPOSE_PROFILES-$(default_profiles)}"',
     );
+  });
+
+  it("omits the selfhosted profile when mongo is external", async () => {
+    // The 2026-07-29 production outage: an Atlas-backed install must not start
+    // the bundled mongo, whose selfhosted overlay gates backend startup.
+    const result = await runDefaultProfiles(
+      [
+        "mongo:",
+        '  uri: "mongodb+srv://u:p@cluster.mongodb.net/prod_calendar"',
+        "sync:",
+        '  mongoUri: "mongodb+srv://u:p@cluster.mongodb.net/compass_sync"',
+      ].join("\n"),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("sync");
+  });
+
+  it("keeps the selfhosted profile when mongo is the bundled service", async () => {
+    const result = await runDefaultProfiles(
+      ["mongo:", '  uri: "mongodb://user:pass@mongo:27017/compass"'].join("\n"),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("selfhosted");
+  });
+
+  it("adds sync alongside selfhosted when a sync database is provisioned", async () => {
+    const result = await runDefaultProfiles(
+      [
+        "mongo:",
+        '  uri: "mongodb://mongo:27017/compass"',
+        "sync:",
+        '  mongoUri: "mongodb://mongo:27017/compass_sync"',
+      ].join("\n"),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("selfhosted,sync");
+  });
+
+  it("defaults to selfhosted before a mongo uri is configured", async () => {
+    const result = await runDefaultProfiles(
+      ["web:", "  port: 9080"].join("\n"),
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("selfhosted");
   });
 
   it("reads the Docker image version from runtime.version", () => {


### PR DESCRIPTION
## Why

`./compass <cmd>` defaulted `COMPOSE_PROFILES` to `selfhosted` regardless of what the install actually runs. For an Atlas-backed deployment that default is wrong in **both** directions:

- it starts bundled services the deployment has never run (`mongo`, `supertokens`, `supertokens-db`), and
- it **omits the `sync` profile**, so the sync container stops being managed.

This took production down on 2026-07-29. A routine `./compass update` started the bundled mongo, which crash-looped on the host kernel, and the selfhosted overlay's `backend depends_on mongo: service_healthy` then blocked the backend from starting at all. The API was down until the stack was restarted with `COMPOSE_PROFILES=` set explicitly.

Note the compose split itself was already correct — the base file has no mongo dependency and the overlay adds it only for selfhosted. The bug was purely the default.

## What changed

Profiles are now derived from the config already on disk:

| profile | when |
|---|---|
| `selfhosted` | `mongo.uri` targets the bundled `mongo` service, or no `mongo.uri` is set yet (preserves fresh-install behavior) |
| `sync` | a sync database is provisioned (`sync.mongoUri`) |

An explicit `COMPOSE_PROFILES` in the environment still wins, so one-off overrides are unchanged.

## Verification

Against the real production config, the derivation returns `sync`, and `docker compose config --services` confirms the practical effect:

| | services started |
|---|---|
| **fixed** | `backend`, `sync`, `web` — matches what that host actually runs |
| **old default** | `backend`, `mongo`, `supertokens`, `supertokens-db`, `web` |

The fixed script is already deployed to the production host.

## Tests

The existing test asserted the literal default string, so it would have passed even if the derivation broke. Replaced it with tests that execute the shell function against throwaway configs and assert the derived profiles — covering external mongo, bundled mongo, bundled + sync, and the not-yet-configured case.

`bun test self-host/docker-compose.test.ts` → 37 pass. Repo lint and type-check clean.

## Risk

Behavior is unchanged for genuine self-hosted installs (bundled mongo still derives `selfhosted`) and for fresh installs before a `mongo.uri` exists. The change only affects installs pointing at an external database — which is exactly the case that was broken.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which containers start on update for external-DB installs (intended fix); bundled self-hosted and fresh installs keep `selfhosted` when the URI targets `mongo` or is unset.
> 
> **Overview**
> **`COMPOSE_PROFILES` is no longer hardcoded to `selfhosted`.** The `compass` helper now calls `default_profiles()`, which reads `compass.yaml` and picks profiles that match the install.
> 
> **`selfhosted`** is set only when `mongo.uri` is empty or points at the bundled `mongo` service (e.g. `@mongo:`). External/Atlas URIs skip it so `./compass update` does not start bundled mongo/supertokens or apply the overlay that blocks the backend on mongo health.
> 
> **`sync`** is appended when `sync.mongoUri` is set. An explicit `COMPOSE_PROFILES` in the environment still overrides the derived default.
> 
> Tests now run `default_profiles` against throwaway configs (external mongo, bundled mongo, sync combinations, unset uri) instead of asserting a fixed string in the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75dd7980a5d679e6105e28525348c03483fcfe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->