### PR TITLE
fix(sync): refuse provider writes when the writer is unavailable

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -8,7 +8,10 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
-import { submitCloudCommand } from "@sync/domain/cloud-command.service";
+import {
+  ProviderWriteUnavailableError,
+  submitCloudCommand,
+} from "@sync/domain/cloud-command.service";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
@@ -178,13 +181,16 @@ describe("submitCloudCommand provider dispatch", () => {
     expect(writer.calls).toHaveLength(1);
   });
 
-  it("leaves a provider-targeted create pending when passive", async () => {
+  // Accepting these would strand the write: nothing re-dispatches a pending
+  // command, so the caller would see success for an event that never reaches
+  // the provider. Production hit exactly that on 2026-07-29.
+  it("refuses a provider-targeted create when passive", async () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
     const calendar = await seedProviderCalendar(tenantId, principalId);
     const writer = new FakeWriter();
 
-    const { command } = await submitCloudCommand(
+    const submit = submitCloudCommand(
       {
         commands,
         events,
@@ -198,16 +204,16 @@ describe("submitCloudCommand provider dispatch", () => {
       now,
     );
 
-    expect(command.outcome.state).toBe("pending");
+    await expect(submit).rejects.toThrow(ProviderWriteUnavailableError);
     expect(writer.calls).toHaveLength(0);
   });
 
-  it("leaves a provider-targeted create pending when no provider is configured", async () => {
+  it("refuses a provider-targeted create when no provider is configured", async () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
     const calendar = await seedProviderCalendar(tenantId, principalId);
 
-    const { command } = await submitCloudCommand(
+    const submit = submitCloudCommand(
       {
         commands,
         events,
@@ -220,7 +226,7 @@ describe("submitCloudCommand provider dispatch", () => {
       now,
     );
 
-    expect(command.outcome.state).toBe("pending");
+    await expect(submit).rejects.toThrow(ProviderWriteUnavailableError);
   });
 
   it("still confirms a cloud (non-provider) create locally when active", async () => {

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -34,6 +34,21 @@ import { type EventOccurrenceRepository } from "@sync/storage/repositories/event
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { createHash } from "node:crypto";
 
+// A provider-targeted write arrived while provider work is unavailable
+// (execution is passive, or no provider is configured). Nothing re-dispatches a
+// pending command, so accepting it would strand the write permanently while the
+// caller believes it succeeded. Callers surface this as a retryable 503.
+//
+// Production hit exactly that on 2026-07-29: routing was flipped to Sync while
+// the sync process was still passive, and creates returned 200 with the event
+// silently never reaching Google.
+export class ProviderWriteUnavailableError extends Error {
+  constructor() {
+    super("Provider writes are unavailable; command not accepted");
+    this.name = "ProviderWriteUnavailableError";
+  }
+}
+
 export interface CloudCommandDeps {
   commands: CommandRepository;
   events: EventRepository;
@@ -45,8 +60,8 @@ export interface CloudCommandDeps {
   markers: DeletionMarkerRepository;
   execution: SyncExecutionMode;
   // Provider write capability, present only when a provider is configured and
-  // provider work is enabled. Absent means provider-targeted commands stay
-  // pending instead of executing.
+  // provider work is enabled. Absent means a provider-targeted command is
+  // refused (see ProviderWriteUnavailableError) rather than left pending.
   provider?: {
     writer: ProviderEventWriter;
     custody: CredentialCustody;
@@ -119,7 +134,11 @@ export async function submitCloudCommand(
         ),
       );
     }
-    return finish(command);
+    // Nothing else ever picks this command up: no scheduled work re-dispatches
+    // a pending command, so returning it here would strand the write forever
+    // while the caller sees success. Refuse instead, so the caller can retry
+    // once provider work is enabled.
+    throw new ProviderWriteUnavailableError();
   }
 
   const record = buildCloudEventRecord(command, now());

--- a/packages/sync/src/server/command.routes.db.test.ts
+++ b/packages/sync/src/server/command.routes.db.test.ts
@@ -221,7 +221,7 @@ describe("POST /internal/commands", () => {
     });
   });
 
-  it("leaves a create targeting a provider calendar pending for the provider path", async () => {
+  it("refuses a create targeting a provider calendar when the writer is unavailable", async () => {
     const tenantId = objectId();
     const principalId = objectId();
     await startService();
@@ -252,10 +252,11 @@ describe("POST /internal/commands", () => {
     });
     const res = await submit(tenantId, principalId, request);
 
-    const body = (await res.json()) as {
-      command: { outcome: { state: string } };
-    };
-    expect(body.command.outcome.state).toBe("pending");
+    // 503, not a pending 200: nothing re-dispatches a pending command, so
+    // answering OK would tell the caller a write landed that would never reach
+    // the provider (the 2026-07-29 production failure).
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "provider_write_unavailable" });
     // No local cloud event is written for a provider-targeted create.
     expect(await mongo.db.collection("events").countDocuments()).toBe(0);
   });

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -8,7 +8,10 @@ import {
 } from "@core/types/sync/command.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
-import { submitCloudCommand } from "@sync/domain/cloud-command.service";
+import {
+  ProviderWriteUnavailableError,
+  submitCloudCommand,
+} from "@sync/domain/cloud-command.service";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import {
@@ -160,7 +163,16 @@ export function registerCommandRoutes(
           command: toSyncCommand(command),
         };
         res.status(Status.OK).json(response);
-      } catch {
+      } catch (error) {
+        // Provider writes being unavailable is a retryable service state, not a
+        // bug: answer 503 so the caller retries instead of believing a write
+        // landed that nothing will ever apply.
+        if (error instanceof ProviderWriteUnavailableError) {
+          res
+            .status(Status.SERVICE_UNAVAILABLE)
+            .json({ error: "provider_write_unavailable" });
+          return;
+        }
         respondInternalError(res);
       }
     },


### PR DESCRIPTION
## Why

A create targeting a **provider calendar** was recorded as `pending` and returned **HTTP 200** whenever provider work was unavailable — `execution: passive`, or no provider configured.

Nothing ever re-dispatches a pending command:

- `commandApply` exists in the job-kind enum but has **zero enqueue sites**
- `submitCloudCommand` receives no jobs repository, so it cannot enqueue one
- no sweep scans pending commands

So the write was stranded **permanently**, while the caller saw success.

## How it showed up

Production hit this on 2026-07-29. Routing was flipped to Sync while the sync process was still running `passive` (its container had not been restarted). Event creates returned 200 and silently never reached Google. The user's event simply vanished; the only trace was a `commands` row stuck at `outcome.state: pending, attemptCount: 0` with no job.

## What changed

`submitCloudCommand` now throws `ProviderWriteUnavailableError` in that branch, and the command route maps it to **503 `provider_write_unavailable`** — a retryable service state, so the caller retries instead of believing a write landed.

Cloud-only (non-provider) creates are unaffected: they still confirm locally in passive mode, which is the documented reason that path is served while passive.

This is the "fail loudly" half of the gap. Durable dispatch — enqueueing a real `commandApply` job so a command survives a passive window — remains a separate, larger slice.

## Tests

Three tests asserted the stranding as intended behavior, so they would have passed forever while the bug persisted. Updated to assert the refusal, including the route's 503 status and body.

- `bun run test:sync` → 665 pass
- lint, type-check clean
- backend: 56 pre-existing local env failures (SuperTokens init), **identical set on a clean `origin/main` baseline** — no regressions

## Risk

Behavior only changes on a path that was already broken. The trade-off is deliberate: a visible 503 the caller can retry is strictly better than a silent 200 for a write that will never happen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command-submit behavior for provider-calendar creates during passive or misconfigured sync; mitigated by replacing a silent failure mode with an explicit retryable 503 on a path that previously never completed writes.
> 
> **Overview**
> **Provider-calendar creates** that cannot run immediately (sync `execution` is **passive**, or no provider writer is configured) no longer return **HTTP 200** with `outcome.state: pending`. `submitCloudCommand` now throws **`ProviderWriteUnavailableError`** because nothing re-dispatches pending commands, so a success response would strand writes that never reach Google.
> 
> The internal command route maps that error to **503** with body `{ error: "provider_write_unavailable" }` so callers can retry once provider work is available. **Cloud-only** creates on non-provider calendars are unchanged and still confirm locally in passive mode.
> 
> Tests were updated from expecting pending success to expecting the refusal (domain throws + route **503**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993c1b2c3ff81f515a8972c824950a8936cf3aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->