### PR TITLE
fix(sync): drain the job queue with MAX_CONCURRENCY workers

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -223,12 +223,15 @@ async function start(): Promise<void> {
     // first and closes mongo last.
     const schedulers = buildSchedulers(config, mongo);
     if (schedulers) {
-      service.shutdown.register("scheduler", () => schedulers.drain.stop());
+      service.shutdown.register("scheduler", async () => {
+        // Stop every drain; each releases only its own owner's held jobs.
+        await Promise.all(schedulers.drains.map((drain) => drain.stop()));
+      });
       service.shutdown.register("reconcile", () => schedulers.reconcile.stop());
       service.shutdown.register("subscription", () =>
         schedulers.subscription.stop(),
       );
-      schedulers.drain.start();
+      for (const drain of schedulers.drains) drain.start();
       schedulers.reconcile.start();
       schedulers.subscription.start();
       logger.info(
@@ -320,17 +323,28 @@ function buildRetentionSweep(mongo: SyncMongoService): SweepScheduler {
 }
 
 // Build the background schedulers for an active, provider-configured deployment:
-// the queue DRAIN (claims and runs jobs), the RECONCILE sweep (the missed-webhook
+// the queue DRAINS (claim and run jobs), the RECONCILE sweep (the missed-webhook
 // fallback that enqueues pulls for stale calendars), and the SUBSCRIPTION sweep
 // (that renews push channels before they expire). Returns null when there is
 // nothing to run (passive execution, or no provider credentials to refresh access
-// tokens with). Repositories bind to the now-connected db; a fresh owner id per
-// process scopes the drain worker's leases.
+// tokens with). Repositories bind to the now-connected db.
+//
+// MAX_CONCURRENCY drains run in parallel. A worker's drain loop is sequential —
+// it awaits each job before claiming the next — so a single drain processes the
+// whole queue one job at a time, and one long initialImport stalls every queued
+// pull behind it. That starved change-propagation for hours after the
+// 2026-07-29 production cutover.
+//
+// Each drain gets its OWN owner id, which is load-bearing: leases are per-owner
+// and `releaseOwned(owner)` releases exactly that worker's held jobs on stop, so
+// sharing an id would let one worker's shutdown flip another's in-flight job
+// back to pending mid-run. Racing claims are already safe — claimDueJob is a
+// single atomic findOneAndUpdate, so two workers can never win the same job.
 function buildSchedulers(
   config: SyncConfig,
   mongo: SyncMongoService,
 ): {
-  drain: SyncScheduler;
+  drains: SyncScheduler[];
   reconcile: SweepScheduler;
   subscription: SweepScheduler;
 } | null {
@@ -339,36 +353,45 @@ function buildSchedulers(
   if (!authAdapter) return null;
 
   const db = mongo.db;
-  const owner = randomUUID();
   const resources = new SyncResourceRepository(db);
   const jobs = new JobRepository(db);
-  const worker = new SyncJobWorker(
-    {
-      events: new EventRepository(db),
-      occurrences: new EventOccurrenceRepository(db, mongo.client),
-      resources,
-      calendars: new ProviderCalendarRepository(db),
-      connections: new ProviderConnectionRepository(db),
-      discovery: new GoogleCalendarAdapter(),
-      commands: new CommandRepository(db),
-      jobs,
-      reader: new GoogleEventReaderAdapter(),
-      custody: new CredentialCustody(new CredentialRepository(db), authAdapter),
-      notifications: new GoogleNotificationAdapter(),
-      // Where the provider posts change notifications back; the callback route
-      // verifies them against the stored subscription.
-      callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
-      invalidations: new InvalidationRepository(db),
-    },
-    owner,
-    {
-      onError: (error) => logger.error("Sync job engine failed", error),
-    },
-  );
-  const drain = new SyncScheduler(
-    { worker, jobs },
-    { owner, onError: (error) => logger.error("Sync job drain failed", error) },
-  );
+  const buildDrain = (): SyncScheduler => {
+    const owner = randomUUID();
+    const worker = new SyncJobWorker(
+      {
+        events: new EventRepository(db),
+        occurrences: new EventOccurrenceRepository(db, mongo.client),
+        resources,
+        calendars: new ProviderCalendarRepository(db),
+        connections: new ProviderConnectionRepository(db),
+        discovery: new GoogleCalendarAdapter(),
+        commands: new CommandRepository(db),
+        jobs,
+        reader: new GoogleEventReaderAdapter(),
+        custody: new CredentialCustody(
+          new CredentialRepository(db),
+          authAdapter,
+        ),
+        notifications: new GoogleNotificationAdapter(),
+        // Where the provider posts change notifications back; the callback route
+        // verifies them against the stored subscription.
+        callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
+        invalidations: new InvalidationRepository(db),
+      },
+      owner,
+      {
+        onError: (error) => logger.error("Sync job engine failed", error),
+      },
+    );
+    return new SyncScheduler(
+      { worker, jobs },
+      {
+        owner,
+        onError: (error) => logger.error("Sync job drain failed", error),
+      },
+    );
+  };
+  const drains = Array.from({ length: config.MAX_CONCURRENCY }, buildDrain);
   // The reconcile fallback looks BACK: enqueue a pull for any events resource not
   // synced within the stale window (negative offset from now).
   const reconcile = new SweepScheduler(
@@ -399,7 +422,7 @@ function buildSchedulers(
         logger.error("Sync subscription maintenance sweep failed", error),
     },
   );
-  return { drain, reconcile, subscription };
+  return { drains, reconcile, subscription };
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -204,5 +204,31 @@ describe("JobRepository", () => {
         .countDocuments({ state: "claimed" });
       expect(stillClaimed).toBe(0);
     });
+
+    // Load-bearing for running several drain workers in one process: each has
+    // its own owner id, and one stopping must not yank a job another is still
+    // running. If releaseOwned were not owner-scoped, a rolling shutdown would
+    // flip a peer's in-flight job back to pending and it would be reprocessed.
+    it("releases only the leaving worker's jobs, not a peer's", async () => {
+      await repo.enqueue(enqueue({ coalescingKey: "a", runAfter: past(1000) }));
+      await repo.enqueue(enqueue({ coalescingKey: "b", runAfter: past(1000) }));
+      const leaving = await repo.claimDueJob("leaving-worker", NOW, LEASE_MS);
+      const staying = await repo.claimDueJob("staying-worker", NOW, LEASE_MS);
+      expect(leaving).not.toBeNull();
+      expect(staying).not.toBeNull();
+
+      expect(await repo.releaseOwned("leaving-worker")).toBe(1);
+
+      const peer = await db
+        .collection("jobs")
+        .findOne({ _id: staying!._id as never });
+      expect(peer?.state).toBe("claimed");
+      expect(peer?.leaseOwner).toBe("staying-worker");
+      const released = await db
+        .collection("jobs")
+        .findOne({ _id: leaving!._id as never });
+      expect(released?.state).toBe("pending");
+      expect(released?.leaseOwner).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Why

`MAX_CONCURRENCY` was parsed into `SyncConfig` and then **never read** — grep it and the only hits are the schema and the two mappers. `app.ts` built exactly **one** `SyncJobWorker`, and a worker's `drain()` awaits each job before claiming the next:

```ts
while (processed < max) {
  const outcome = await this.runOnce();   // one job, start to finish
  if (outcome === "idle") break;
  processed += 1;
}
```

So the queue was processed strictly one job at a time regardless of how the knob was set.

## How it showed up

After the 2026-07-29 production cutover, the reconcile sweep enqueued ~100 `incrementalPull` jobs per cycle, but long-running `initialImport` jobs held the single worker. Pulls — the jobs that carry new Google changes into Compass — sat behind them, and the backlog drained at well under one resource per minute against 983 resources.

Confirmed on the live box: two `claimed` jobs, of which one was an expired-lease orphan from a restart, leaving a single live worker. Tuning `maxConcurrency` would have changed nothing.

## What changed

`buildSchedulers` now builds `MAX_CONCURRENCY` drains that run in parallel.

Each drain gets its **own owner id**, which is load-bearing rather than cosmetic: leases are per-owner and `releaseOwned(owner)` releases exactly that worker's held jobs, so one drain stopping cannot flip a peer's in-flight job back to pending mid-run. Shutdown stops all drains together.

Racing claims were already safe — `claimDueJob` is a single atomic `findOneAndUpdate`, and the repository comments already state two workers can never both win a job. This change relies on that existing guarantee rather than introducing new locking.

## Tests

Added the missing invariant test: `releaseOwned` must release **only** the leaving worker's jobs and leave a peer's claim intact. The existing shutdown test only ever used one owner, so nothing covered the case this change depends on — it would have passed even if `releaseOwned` were global.

- `bun run test:sync` → 666 pass
- core 535, scripts 88 pass; lint and type-check clean
- backend: 56 pre-existing local env failures, **identical set to a clean `origin/main` baseline** — no regressions

## Risk

Concurrency is bounded by the existing `MAX_CONCURRENCY` default of 4, so this is 4 workers rather than unbounded fan-out. The claim path is unchanged. Provider API load rises with parallelism, which is the intended effect — the queue is currently the bottleneck, not the provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises parallel Google sync load and changes shutdown semantics for in-flight jobs, but concurrency is capped (default 4) and claims remain atomic.
> 
> **Overview**
> **Sync now runs up to `MAX_CONCURRENCY` parallel job drains** instead of a single sequential worker, so long `initialImport` jobs no longer block the entire queue behind incremental pulls.
> 
> `buildSchedulers` creates one `SyncScheduler` + `SyncJobWorker` per configured slot, each with its **own lease owner id**. Startup starts every drain; shutdown awaits `stop()` on all of them so `releaseOwned` only returns that worker’s claims. Comments document why shared owners would be unsafe during rolling teardown.
> 
> A repository test asserts **`releaseOwned` is owner-scoped**: releasing one worker’s jobs leaves a peer’s claimed job intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0e57981a8809ed344599368a56c07d3fdde573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->