### PR TITLE
fix(sync): rotate failing resources out of the reconcile sweep head

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -381,6 +381,8 @@ function buildSchedulers(
       owner,
       {
         onError: (error) => logger.error("Sync job engine failed", error),
+        onDrop: (job, reason) =>
+          logger.warn(`Sync job ${job.kind} (${job._id}) dropped: ${reason}`),
       },
     );
     return new SyncScheduler(
@@ -396,8 +398,19 @@ function buildSchedulers(
   // synced within the stale window (negative offset from now).
   const reconcile = new SweepScheduler(
     {
-      sweep: (before) =>
-        reconcileStaleCalendars({ resources, jobs }, before, () => new Date()),
+      sweep: async (before) => {
+        const enqueued = await reconcileStaleCalendars(
+          { resources, jobs },
+          before,
+          () => new Date(),
+        );
+        // One line per cycle with work: silence here previously meant either
+        // "all fresh" or "sweep dead", indistinguishably.
+        if (enqueued > 0) {
+          logger.info(`Sync reconcile sweep enqueued ${enqueued} pull(s)`);
+        }
+        return enqueued;
+      },
     },
     {
       windowMs: -RECONCILE_STALE_AFTER_MS,

--- a/packages/sync/src/domain/calendar-pull.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.db.test.ts
@@ -216,6 +216,15 @@ describe("pullCalendarChanges", () => {
 
     expect(result.status).toBe("notImported");
     expect(reader.calls).toHaveLength(0);
+    // Even an early-exit pull stamps the attempt: the reconcile sweep selects
+    // least-recently-attempted resources, so a resource whose pull cannot
+    // proceed must still rotate to the back of the line instead of being
+    // re-selected by every sweep (2026-07-29 head-of-line starvation).
+    const stamped = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ calendarId: calendar._id, resourceKind: "events" });
+    expect(stamped?.lastAttemptAt).toEqual(now());
   });
 
   it("reads from the stored cursor and advances to the new one", async () => {

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -72,18 +72,24 @@ export async function pullCalendarChanges(
     resourceKind: "events",
     calendarId: calendar._id,
   });
+  // Stamp the attempt FIRST — before the cursor check and before the token
+  // fetch can throw. The reconcile sweep selects least-recently-attempted
+  // resources, so a resource whose pull dies early (dead credential, never
+  // imported) must still rotate to the back of the line. When this ran after
+  // getValidAccessToken, ~100 credential-less resources were re-selected by
+  // every sweep and starved the healthy backlog behind them (2026-07-29).
+  await deps.resources.markAttempt(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    now(),
+  );
   if (resource.syncCursor === null) {
     return { status: "notImported", resource };
   }
 
   const accessToken = await deps.custody.getValidAccessToken(
     calendar.connectionId,
-  );
-  await deps.resources.markAttempt(
-    resource.tenantId,
-    resource.principalId,
-    resource._id,
-    now(),
   );
 
   // Write into the active (live) generation, not importGeneration: an

--- a/packages/sync/src/domain/reconcile.service.db.test.ts
+++ b/packages/sync/src/domain/reconcile.service.db.test.ts
@@ -124,4 +124,28 @@ describe("reconcileStaleCalendars", () => {
       new Date("2026-07-02T00:00:00.000Z"),
     );
   });
+
+  it("rotates an attempted-but-never-successful resource behind never-attempted ones", async () => {
+    // The 2026-07-29 regression: ~100 resources whose pulls always die early
+    // (dead credential) have lastSuccessAt null forever. Sorted by success
+    // they monopolize the head of every bounded sweep batch and starve the
+    // healthy stale resources behind them. Sorting by ATTEMPT rotates them:
+    // once tried, they go to the back until everything else has had a turn.
+    const doomed = await seedResource(null); // never succeeds
+    const healthy = await seedResource(new Date("2026-07-05T00:00:00.000Z"));
+    await resources.markAttempt(
+      doomed.tenantId,
+      doomed.principalId,
+      doomed._id,
+      new Date("2026-07-29T16:00:00.000Z"),
+    );
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now, 1);
+
+    expect(enqueued).toBe(1);
+    // The single slot goes to the never-attempted resource, even though the
+    // doomed one is "more stale" by success time (null).
+    expect(await jobByKey(`incrementalPull:${healthy._id}`)).not.toBeNull();
+    expect(await jobByKey(`incrementalPull:${doomed._id}`)).toBeNull();
+  });
 });

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -388,7 +388,7 @@ describe("dispatchSyncJob", () => {
     );
   });
 
-  it("settles a job done and discards the credential when the token is revoked", async () => {
+  it("drops the job with a reason and discards the credential when the token is revoked", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");
     const reader = new FakeReader([]);
@@ -411,7 +411,13 @@ describe("dispatchSyncJob", () => {
       now,
     );
 
-    expect(outcome).toEqual({ result: "done" });
+    // A reasoned drop (settles identically to done, but visible): the silent
+    // done here made a mass credential problem look like a dead sweep.
+    expect(outcome.result).toBe("drop");
+    if (outcome.result === "drop") {
+      expect(outcome.reason).toContain("authorizationRevoked");
+      expect(outcome.reason).toContain(calendar.connectionId);
+    }
     expect(discarded).toEqual([calendar.connectionId]);
   });
 
@@ -563,7 +569,7 @@ describe("dispatchSyncJob", () => {
     });
   });
 
-  it("settles a revoked calendarListSync done, like the resource-based kinds", async () => {
+  it("drops a revoked calendarListSync with a reason, like the resource-based kinds", async () => {
     const tenantId = objectId();
     const principalId = objectId();
     const connectionId = objectId();
@@ -591,7 +597,10 @@ describe("dispatchSyncJob", () => {
       now,
     );
 
-    expect(outcome).toEqual({ result: "done" });
+    expect(outcome.result).toBe("drop");
+    if (outcome.result === "drop") {
+      expect(outcome.reason).toContain("authorizationRevoked");
+    }
     expect(discarded).toEqual([connectionId]);
   });
 });

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -96,7 +96,14 @@ export async function dispatchSyncJob(
     ) {
       // Belt and braces: custody already discards on authorizationRevoked.
       await deps.custody.discardRevoked(job.connectionId);
-      return { result: "done" };
+      // A reasoned drop, not a bare done: settling is identical, but the worker
+      // surfaces drop reasons. This path settled ~100 jobs per sweep invisibly
+      // on 2026-07-29 (credential-less migrated connections), which made the
+      // sweep look broken while it was running fine.
+      return {
+        result: "drop",
+        reason: `credential unusable (${error.reason}) for connection ${job.connectionId}; sync resumes on reconnect`,
+      };
     }
     throw error;
   }

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -40,6 +40,11 @@ export interface SyncJobWorkerOptions {
   // scheduler's drain onError only sees claim/settle failures; per-job engine
   // throws were previously swallowed, which left staging imports opaque.
   onError?: (error: unknown) => void;
+  // Called when dispatch drops a job (settled complete without doing its work:
+  // vanished target, unusable credential). Drops are correct behavior, but an
+  // invisible drop path made a mass credential problem look like a dead sweep
+  // (2026-07-29) — surface them.
+  onDrop?: (job: JobRecord, reason: string) => void;
 }
 
 const DEFAULT_LEASE_MS = 5 * 60_000;
@@ -95,6 +100,7 @@ export class SyncJobWorker {
   readonly #backoff: (attempt: number, now: Date) => Date;
   readonly #now: () => Date;
   readonly #onError: (error: unknown) => void;
+  readonly #onDrop: (job: JobRecord, reason: string) => void;
 
   constructor(
     deps: SyncJobWorkerDeps,
@@ -115,6 +121,7 @@ export class SyncJobWorker {
       ((attempt, now) => jitteredBackoff(attempt, now, random));
     this.#now = options.now ?? (() => new Date());
     this.#onError = options.onError ?? (() => {});
+    this.#onDrop = options.onDrop ?? (() => {});
   }
 
   // Claim and process at most one due job. Returns "idle" when nothing is due.
@@ -194,7 +201,10 @@ export class SyncJobWorker {
         await this.#deps.jobs.complete(job._id, this.#owner);
         return;
       case "drop":
-        // Nothing to do (target vanished); settle so it never retries.
+        // Nothing to do (target vanished, credential unusable); settle so it
+        // never retries — but say so, or a mass drop is indistinguishable from
+        // a stalled queue.
+        this.#onDrop(job, outcome.reason);
         await this.#deps.jobs.complete(job._id, this.#owner);
         return;
       case "retry":

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -150,6 +150,9 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       options: { sparse: true },
     },
     { name: "last_success", key: { lastSuccessAt: 1 } },
+    // Backs the reconcile sweep's round-robin sort (lastAttemptAt asc, nulls
+    // first). The filter still selects on lastSuccessAt via last_success.
+    { name: "last_attempt", key: { lastAttemptAt: 1 } },
   ],
   [SYNC_COLLECTIONS.commands]: [
     {

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -301,7 +301,15 @@ export class SyncResourceRepository {
         resourceKind: "events",
         $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
       })
-      .sort({ lastSuccessAt: 1 })
+      // Round-robin by ATTEMPT, not success: never-attempted first (null sorts
+      // lowest), then least-recently-attempted. Sorting by lastSuccessAt let
+      // resources that fail without ever succeeding (dead credential, dead
+      // calendar) occupy the head of every bounded sweep batch forever,
+      // starving the stale-but-healthy resources behind them (2026-07-29:
+      // 97 credential-less resources monopolized all 100 slots while 886
+      // healthy ones were never selected). The pull stamps lastAttemptAt
+      // before it can fail, so every selected resource rotates to the back.
+      .sort({ lastAttemptAt: 1, lastSuccessAt: 1 })
       .limit(limit)
       .toArray();
     return records.map((r) => SyncResourceRecordSchema.parse(r));


### PR DESCRIPTION
## Why

After the 2026-07-29 cutover, sync convergence flatlined at 42/983 resources with **zero failed jobs and zero errors logged**. The queue drained instantly, the sweep looked dead, and the workers looked idle — all healthy-looking signals.

Root cause: the reconcile sweep selects up to 100 stale resources sorted by `lastSuccessAt` ascending. A resource whose pull fails before ever succeeding — dead or missing credential — keeps `lastSuccessAt: null` forever, and nulls sort first. Production has **97 credential-less migrated connections** (preseed created connection rows for users whose refresh tokens failed verification); their resources monopolized the head of every bounded sweep batch, each pull settled silently within seconds, and the **886 healthy stale resources behind them were never selected**.

Verified against prod: of the sweep's top-100 selection, 97 had no credential, 3 did.

## What changed

**Fairness (the fix):**
- `pullCalendarChanges` stamps `lastAttemptAt` **first** — before the cursor check and before the token fetch can throw — so even an early-exit pull marks the resource as tried
- `listStaleEvents` sorts by `lastAttemptAt` (nulls first), then `lastSuccessAt`: never-attempted resources go first, and every selected resource rotates to the back after its turn. The doomed 97 now cost 97 slots per full rotation instead of 100 of every 100. Matching `last_attempt` index added.

**Observability (why the outage was invisible):**
- dispatch's dead-credential catch settles as a **reasoned drop** instead of a bare `done` — identical settling, but carries the connectionId and reason
- the worker exposes `onDrop`, wired to a warn log — a mass drop is no longer indistinguishable from a stalled queue
- the reconcile sweep logs its enqueued count per cycle — silence previously meant either "all fresh" or "sweep dead", indistinguishably

## Tests

- New: sweep-fairness rotation — an attempted-but-never-successful resource sorts behind a never-attempted one (fails on the old sort)
- New: the `notImported` early-exit stamps `lastAttemptAt`
- Updated: the two revoked-path tests assert the reasoned drop (kind + connectionId in reason) instead of the bare `done`
- `bun run test:sync` → 667 pass; lint, type-check, core, scripts clean

## Deliberately not in this PR

The 97 credential-less connections should eventually surface as needs-reauth to their users and leave the pool entirely — that's a connection-lifecycle change. With this fix they merely rotate harmlessly (~10% of sweep throughput), which is acceptable until that lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reconcile selection and pull ordering for all stale resources; behavior is well-tested but affects production sync throughput and scheduling fairness.
> 
> **Overview**
> Fixes reconcile sweep **head-of-line starvation** where resources that never succeed (e.g. dead credentials with `lastSuccessAt: null`) monopolized every bounded batch and blocked healthy stale calendars from incremental pulls.
> 
> **Fairness:** `pullCalendarChanges` now calls `markAttempt` **before** the no-cursor early exit and token fetch, so failed pulls still advance rotation. `listStaleEvents` sorts by `lastAttemptAt` then `lastSuccessAt` (never-attempted first, then round-robin), with a new `last_attempt` index.
> 
> **Observability:** Unusable credentials return a **reasoned `drop`** from dispatch instead of silent `done`; the worker **`onDrop`** hook logs warnings; the reconcile sweep **logs enqueued pull count** when work is scheduled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c236d95384583a73b2964bf43173224c72b0d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->