### PR TITLE
fix(sync): stamp attempt before token fetch in import and repair too

### DIFF
--- a/packages/sync/src/domain/calendar-import.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-import.service.db.test.ts
@@ -480,6 +480,39 @@ describe("importCalendarEvents", () => {
     expect(resource?.syncCursor).toBeNull();
   });
 
+  it("stamps the attempt even when the token fetch throws", async () => {
+    // The reconcile sweep selects least-recently-attempted resources. A
+    // doomed connection's import must rotate to the back of the sweep after
+    // failing, not tie at lastAttemptAt: null forever and keep winning slots
+    // (2026-07-29: this exact ordering bug kept ~100 credential-less
+    // resources at the sweep's head even after the pull-path half of the fix
+    // had already shipped).
+    const calendar = await seedCalendar();
+    const reader = new FakeReader({ full: [emptyPage()] });
+    const deadCustody: AccessTokenSource = {
+      getValidAccessToken: async () => {
+        throw new Error("token fetch failed");
+      },
+      discardRevoked: async () => {},
+    };
+
+    await expect(
+      importCalendarEvents(
+        { events, occurrences, resources, reader, custody: deadCustody },
+        calendar,
+        now,
+      ),
+    ).rejects.toThrow("token fetch failed");
+
+    const resourceIdValue = (await resourceId(resources, calendar)) as string;
+    const resource = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resourceIdValue,
+    );
+    expect(resource?.lastAttemptAt).toEqual(now());
+  });
+
   it("skips the windowed pass when resuming from a page checkpoint", async () => {
     const calendar = await seedCalendar();
     // Prime the resource with a mid-full-pass checkpoint.

--- a/packages/sync/src/domain/calendar-import.service.ts
+++ b/packages/sync/src/domain/calendar-import.service.ts
@@ -82,14 +82,21 @@ export async function importCalendarEvents(
     return { resource, imported: 0, skipped: 0 };
   }
 
-  const accessToken = await deps.custody.getValidAccessToken(
-    calendar.connectionId,
-  );
+  // Stamp BEFORE the token fetch can throw. Same reasoning as
+  // calendar-pull.service.ts: the reconcile sweep selects least-recently-
+  // attempted resources, so a doomed connection's import must rotate to the
+  // back after failing, not tie at null forever and keep winning sweep slots
+  // (2026-07-29: this exact ordering bug in the import path — not yet caught
+  // by the pull-path fix — kept the same ~100 credential-less resources at
+  // the sweep's head after that fix had already shipped).
   await deps.resources.markAttempt(
     resource.tenantId,
     resource.principalId,
     resource._id,
     now(),
+  );
+  const accessToken = await deps.custody.getValidAccessToken(
+    calendar.connectionId,
   );
 
   const run = new ImportRun(deps, calendar, resource, now);

--- a/packages/sync/src/domain/calendar-repair.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-repair.service.db.test.ts
@@ -332,4 +332,38 @@ describe("repairCalendar", () => {
         .countDocuments({ calendarId: calendar._id }),
     ).toBe(1);
   });
+
+  it("stamps the attempt even when the token fetch throws", async () => {
+    // The reconcile sweep selects least-recently-attempted resources. A
+    // doomed connection's repair must rotate to the back of the sweep after
+    // failing, not tie at lastAttemptAt: null forever and keep winning slots
+    // (2026-07-29 sweep-starvation regression; see the sibling test in
+    // calendar-import.service.db.test.ts).
+    const calendar = await seedCalendar();
+    await seedImported(calendar);
+    const reader = new FakeReader([page([])]);
+    const deadCustody = {
+      getValidAccessToken: async () => {
+        throw new Error("token fetch failed");
+      },
+      discardRevoked: async () => {},
+    };
+
+    await expect(
+      repairCalendar(
+        { events, occurrences, resources, reader, custody: deadCustody },
+        calendar,
+        now,
+      ),
+    ).rejects.toThrow("token fetch failed");
+
+    const resource = await resources.ensure({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      resourceKind: "events",
+      calendarId: calendar._id,
+    });
+    expect(resource.lastAttemptAt).toEqual(now());
+  });
 });

--- a/packages/sync/src/domain/calendar-repair.service.ts
+++ b/packages/sync/src/domain/calendar-repair.service.ts
@@ -62,6 +62,18 @@ export async function repairCalendar(
     calendarId: calendar._id,
   });
 
+  // Stamp BEFORE the token fetch can throw — same reasoning as
+  // calendar-pull.service.ts and calendar-import.service.ts: the reconcile
+  // sweep selects least-recently-attempted resources, so a doomed
+  // connection's repair must rotate to the back after failing, not tie at
+  // null forever and keep winning sweep slots.
+  await deps.resources.markAttempt(
+    resource.tenantId,
+    resource.principalId,
+    resource._id,
+    now(),
+  );
+
   // Reuse an in-flight repair generation (a previous attempt bumped it but never
   // activated) instead of starting yet another; otherwise begin a fresh one.
   const newGeneration =
@@ -75,12 +87,6 @@ export async function repairCalendar(
 
   const accessToken = await deps.custody.getValidAccessToken(
     calendar.connectionId,
-  );
-  await deps.resources.markAttempt(
-    resource.tenantId,
-    resource.principalId,
-    resource._id,
-    now(),
   );
 
   // Rebuild the whole calendar into the new generation. A full unwindowed pass


### PR DESCRIPTION
## Why

PR #2453 fixed a sweep-starvation ordering bug in `calendar-pull.service.ts` (stamp `lastAttemptAt` before the token fetch that can throw), but missed the **identical bug** at the other two `markAttempt` call sites.

Deploying the pull-only fix to production proved it: the next reconcile sweep still selected ~97% credential-less resources (100/103 attempted, only 3 with usable credentials). Reason: most stale resources have **never completed an initial import** (`syncCursor` is `null`), so their incremental pull immediately returns `notImported` and hands off to an `initialImport` job — and `calendar-import.service.ts` had the exact same bug: `getValidAccessToken` before `markAttempt`. A doomed connection's import throws before the stamp, `lastAttemptAt` stays `null` forever, and the resource keeps tying at the front of every sweep. Same issue in `calendar-repair.service.ts`'s `cursorExpired` handoff.

## What changed

Both now stamp `markAttempt` before `getValidAccessToken`, matching the pull-service fix:

- `calendar-import.service.ts`: moved after the (already-first) cursor check, before the token fetch
- `calendar-repair.service.ts`: moved to run right after `resources.ensure`, ahead of both `startNewGeneration` and the token fetch — `startNewGeneration` has no dependency on the stamp, so ordering between them doesn't matter, only that the stamp precedes the throw-capable call

## Tests

Sibling of the pull-service rotation test for both services: the attempt is stamped even when the token fetch throws.

- `bun run test:sync` → 669 pass (2 new)
- lint, type-check clean

## Context

This is the second half of the fix that started as PR #2453. `subscriptionMaintain` was checked and confirmed out of scope — it doesn't call `markAttempt` at all; it's driven by a separate sweep (`listExpiringSubscriptions`) keyed on `subscriptionExpiresAt`, not attempt/success timestamps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering change in sync job paths with targeted regression tests; no auth or data-model changes beyond attempt timestamps.
> 
> **Overview**
> Extends the reconcile **sweep-starvation** fix from `calendar-pull.service.ts` to **initial import** and **repair**: `markAttempt` now runs **before** `getValidAccessToken`, so a failed token fetch still updates `lastAttemptAt` and doomed resources stop tying at the front of least-recently-attempted selection.
> 
> In **`calendar-import.service.ts`**, the stamp sits after the early return when `syncCursor` is already set, then precedes the token fetch. In **`calendar-repair.service.ts`**, it runs right after `resources.ensure`, before generation bump and token fetch.
> 
> DB tests for both paths assert **`lastAttemptAt`** is set when custody throws on token fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e137da652045066cc5fae54e915d627f4d1f36f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->