### PR TITLE
fix(sync): exclude credential-less connections from the reconcile sweep

### DIFF
--- a/packages/sync/src/domain/reconcile.service.db.test.ts
+++ b/packages/sync/src/domain/reconcile.service.db.test.ts
@@ -3,6 +3,7 @@ import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -15,29 +16,44 @@ describe("reconcileStaleCalendars", () => {
   const storage = setupSyncStorage(import.meta.url);
   let resources: SyncResourceRepository;
   let jobs: JobRepository;
+  let credentials: CredentialRepository;
 
   beforeEach(() => {
     resources = new SyncResourceRepository(storage.db());
     jobs = new JobRepository(storage.db());
+    credentials = new CredentialRepository(storage.db());
   });
 
   const deps = () => ({ resources, jobs });
 
   // Ensure an events resource and set its last success to `lastSuccessAt`
   // (omit for a never-synced resource). Each gets a distinct calendar so the
-  // unique (connection, kind, calendar) identity never collides.
+  // unique (connection, kind, calendar) identity never collides. The sweep
+  // only selects resources whose connection can still authenticate, so a
+  // credential is stored by default; pass withCredential: false to simulate a
+  // dead/disconnected connection.
   const seedResource = async (
     lastSuccessAt: Date | null,
+    options: { withCredential?: boolean } = {},
   ): Promise<SyncResourceRecord> => {
     const tenantId = objectId() as SyncResourceRecord["tenantId"];
     const principalId = objectId() as SyncResourceRecord["principalId"];
+    const connectionId = objectId() as SyncResourceRecord["connectionId"];
     const resource = await resources.ensure({
       tenantId,
       principalId,
-      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      connectionId,
       resourceKind: "events",
       calendarId: objectId() as SyncResourceRecord["calendarId"],
     });
+    if (options.withCredential ?? true) {
+      await credentials.store({
+        connectionId,
+        provider: "google",
+        refreshToken: "refresh-token",
+        scopes: [],
+      });
+    }
     if (lastSuccessAt) {
       await resources.advanceCursor(
         tenantId,
@@ -147,5 +163,24 @@ describe("reconcileStaleCalendars", () => {
     // doomed one is "more stale" by success time (null).
     expect(await jobByKey(`incrementalPull:${healthy._id}`)).not.toBeNull();
     expect(await jobByKey(`incrementalPull:${doomed._id}`)).toBeNull();
+  });
+
+  it("excludes a resource whose connection has no stored credential, however stale", async () => {
+    // The rotation fix above only helps AFTER a first attempt: it does nothing
+    // for the population still tied at lastAttemptAt: null, where dead-
+    // credential resources and genuinely healthy never-attempted ones sit
+    // side by side. Mongo's tie-break there is not random — in prod it
+    // reproducibly favored the dead-credential cohort (2026-07-29: a clean
+    // post-rotation-fix sweep batch still selected 100 resources with only 1
+    // holding a credential). The sweep must exclude credential-less
+    // connections outright; they resume via reconnect, not reconcile.
+    const deadCredential = await seedResource(null, { withCredential: false });
+    const healthy = await seedResource(new Date("2026-07-05T00:00:00.000Z"));
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now, 1);
+
+    expect(enqueued).toBe(1);
+    expect(await jobByKey(`incrementalPull:${healthy._id}`)).not.toBeNull();
+    expect(await jobByKey(`incrementalPull:${deadCredential._id}`)).toBeNull();
   });
 });

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -287,30 +287,52 @@ export class SyncResourceRepository {
 
   // Events resources whose last successful sync is older than `before` (or which
   // never succeeded), oldest first, bounded. This is the reconcile sweep's input
-  // — a missed-webhook fallback — so it is a GLOBAL scan across owners, not
-  // owner-scoped: each returned resource carries its own (tenantId, principalId)
-  // for the job the caller enqueues. A never-synced resource (lastSuccessAt
-  // null) sorts first so bootstrapping a new calendar is not starved by the
-  // stale ones. Uses the last_success index.
+  // — a missed-webhook fallback for connections that CAN still authenticate — so
+  // it is a GLOBAL scan across owners, not owner-scoped: each returned resource
+  // carries its own (tenantId, principalId) for the job the caller enqueues. A
+  // never-synced resource (lastSuccessAt null) sorts first so bootstrapping a
+  // new calendar is not starved by the stale ones. Uses the last_success index.
   async listStaleEvents(
     before: Date,
     limit: number,
   ): Promise<SyncResourceRecord[]> {
     const records = await this.collection
-      .find({
-        resourceKind: "events",
-        $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
-      })
-      // Round-robin by ATTEMPT, not success: never-attempted first (null sorts
-      // lowest), then least-recently-attempted. Sorting by lastSuccessAt let
-      // resources that fail without ever succeeding (dead credential, dead
-      // calendar) occupy the head of every bounded sweep batch forever,
-      // starving the stale-but-healthy resources behind them (2026-07-29:
-      // 97 credential-less resources monopolized all 100 slots while 886
-      // healthy ones were never selected). The pull stamps lastAttemptAt
-      // before it can fail, so every selected resource rotates to the back.
-      .sort({ lastAttemptAt: 1, lastSuccessAt: 1 })
-      .limit(limit)
+      .aggregate<SyncResourceRecord>([
+        {
+          $match: {
+            resourceKind: "events",
+            $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
+          },
+        },
+        // A resource whose connection has no stored credential can never
+        // succeed here no matter how many sweeps retry it — reconnect is what
+        // resumes it (registerConnection's own calendarListSync enqueue), not
+        // reconcile. Excluding it at the query level, rather than relying on
+        // the lastAttemptAt rotation below, matters because the rotation only
+        // helps AFTER a resource's first attempt: the whole never-attempted
+        // population (dead-credential resources alongside genuinely healthy
+        // new ones) ties at lastAttemptAt: null, and Mongo's tie-break across
+        // that tie is not random — it reproducibly favored the dead-credential
+        // cohort (2026-07-29: an isolated post-rotation-fix sweep batch still
+        // selected 100 resources with only 1 holding a credential).
+        {
+          $lookup: {
+            from: SYNC_COLLECTIONS.credentials,
+            localField: "connectionId",
+            foreignField: "_id",
+            as: "_credential",
+          },
+        },
+        { $match: { "_credential.0": { $exists: true } } },
+        { $project: { _credential: 0 } },
+        // Round-robin by ATTEMPT, not success: never-attempted first (null
+        // sorts lowest), then least-recently-attempted, so a resource that
+        // fails without succeeding still rotates to the back after each try
+        // rather than re-winning every sweep. The pull stamps lastAttemptAt
+        // before it can fail, so this holds even on failure.
+        { $sort: { lastAttemptAt: 1, lastSuccessAt: 1 } },
+        { $limit: limit },
+      ])
       .toArray();
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }


### PR DESCRIPTION
## Summary

- The `lastAttemptAt` rotation fix (#2453 / #2454) only reorders resources *after* their first attempt. Every never-attempted resource still ties at `lastAttemptAt: null`, and that tied population mixes dead-credential resources in with genuinely healthy new ones.
- Mongo's tie-break across equal sort keys is not random. In prod it reproducibly favored the dead-credential cohort: an isolated, timestamp-scoped post-rotation-fix sweep batch selected 100 resources, only 1 of which held a credential — versus an expected ~50% if selection were actually fair.
- Fix: exclude credential-less connections at the query level (`$lookup` against `credentials` in `listStaleEvents`) instead of relying on rotation to eventually deprioritize them. Reconcile is a missed-webhook catch-up for connections that can still authenticate — a credential-less connection can never succeed here no matter how many times it's retried, and its sync resumes independently on reconnect (`calendarListSync` enqueue in `connection.routes.ts`).

## Test plan

- [x] `bun run test:sync` — 670/670 pass, including a new test asserting a credential-less resource is never selected however stale, alongside the existing rotation/coverage tests (updated to seed a credential by default, matching the new query's requirement)
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global reconcile selection logic used by the periodic sweep, but the behavior is narrow (credential gate + existing sort) and covered by new and updated DB tests.
> 
> **Overview**
> The stale-calendar reconcile sweep was still wasting bounded batch slots on connections with **no stored credential**. `lastAttemptAt` rotation only helps after a first pull attempt; never-attempted resources all tie at `null`, and Mongo’s tie-break was favoring that dead-credential cohort in production.
> 
> **`listStaleEvents`** now uses an aggregation that **`$lookup`s `credentials`** and drops resources whose `connectionId` has no row, while keeping the existing attempt-based round-robin sort. Reconcile is documented as catch-up only for connections that can still authenticate; disconnected flows are expected to resume via reconnect, not this sweep.
> 
> DB tests seed a credential by default in **`seedResource`** and add a case that a credential-less resource is never enqueued however stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0631526412760d0c4794c2e11f6298b4ffaf5517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->