### PR TITLE
chore(scripts): add refresh-connection-states CLI backfill

### DIFF
--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -7,6 +7,7 @@ import { runMigrateProviderState } from "@scripts/commands/migrate-provider-stat
 import { runPreseedSync } from "@scripts/commands/preseed-sync";
 import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
 import { runPurgeUser } from "@scripts/commands/purge-user";
+import { runRefreshConnectionStates } from "@scripts/commands/refresh-connection-states";
 import { MigratorType } from "@scripts/common/cli.types";
 import { Command } from "commander";
 
@@ -45,6 +46,9 @@ export default class CompassCLI {
       case cmd === "purge-corrupt-sync-events":
         await runPurgeCorruptSyncEvents();
         break;
+      case cmd === "refresh-connection-states":
+        await runRefreshConnectionStates();
+        break;
       case cmd === "purge-user":
         await runPurgeUser();
         break;
@@ -82,6 +86,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Delete Sync events that fail EventRecordSchema (poison from aborted migrate)",
+      );
+
+    program
+      .command("refresh-connection-states")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Re-derive every provider connection's stored state from live evidence (--apply to write)",
       );
 
     program

--- a/packages/scripts/src/commands/refresh-connection-states.ts
+++ b/packages/scripts/src/commands/refresh-connection-states.ts
@@ -1,0 +1,54 @@
+import { refreshConnectionStates } from "@scripts/commands/refresh-connection-states/refresh";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.refresh-connection-states");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before refresh-connection-states",
+    );
+  }
+  return uri;
+}
+
+/**
+ * Re-derive every provider connection's stored state from live evidence, the
+ * same derivation `GET /internal/connections` runs on each fetch. Default
+ * dry-run; `--apply` persists. Safe to rerun.
+ *
+ *   bun run cli refresh-connection-states [--apply]
+ */
+export async function runRefreshConnectionStates(): Promise<void> {
+  const apply = process.argv.slice(3).includes("--apply");
+  const syncMongo = new SyncMongoService();
+  try {
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+    const report = await refreshConnectionStates(syncMongo.db, {
+      dryRun: !apply,
+    });
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `refresh-connection-states dryRun=${report.dryRun} scanned=${report.scanned} changed=${report.changed}`,
+    );
+    await syncMongo.disconnect();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/refresh-connection-states/refresh.db.test.ts
+++ b/packages/scripts/src/commands/refresh-connection-states/refresh.db.test.ts
@@ -1,0 +1,106 @@
+import { refreshConnectionStates } from "@scripts/commands/refresh-connection-states/refresh";
+import { ObjectId } from "mongodb";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const objectId = () => new ObjectId().toHexString();
+
+describe("refreshConnectionStates", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+  let credentials: CredentialRepository;
+
+  beforeEach(() => {
+    connections = new ProviderConnectionRepository(storage.db());
+    credentials = new CredentialRepository(storage.db());
+  });
+
+  async function seedConnection(withCredential: boolean) {
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: {
+        providerAccountId: objectId(),
+        email: "user@example.com",
+        displayName: "User",
+      },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "importing",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+    if (withCredential) {
+      await credentials.store({
+        connectionId: connection._id,
+        provider: "google",
+        refreshToken: "refresh",
+        scopes: ["https://www.googleapis.com/auth/calendar.events"],
+      });
+    }
+    return connection;
+  }
+
+  it("dry-run reports the transition a credential-less connection needs, without writing it", async () => {
+    const doomed = await seedConnection(false);
+
+    const report = await refreshConnectionStates(storage.db(), {
+      dryRun: true,
+    });
+
+    expect(report.changed).toBe(1);
+    expect(report.transitions["importing->actionRequired"]).toBe(1);
+    const stillStored = await connections.findById(
+      doomed.tenantId,
+      doomed.principalId,
+      doomed._id,
+    );
+    expect(stillStored?.state).toBe("importing");
+  });
+
+  it("apply persists the derived state and is idempotent on rerun", async () => {
+    const doomed = await seedConnection(false);
+
+    const first = await refreshConnectionStates(storage.db(), {
+      dryRun: false,
+    });
+    expect(first.changed).toBe(1);
+
+    const updated = await connections.findById(
+      doomed.tenantId,
+      doomed.principalId,
+      doomed._id,
+    );
+    expect(updated?.state).toBe("actionRequired");
+    expect(updated?.stateReason).toBe("authorizationRevoked");
+
+    const second = await refreshConnectionStates(storage.db(), {
+      dryRun: false,
+    });
+    expect(second.changed).toBe(0);
+  });
+
+  it("only flags the connection that actually needs a transition, in a mixed batch", async () => {
+    const doomed = await seedConnection(false);
+    const credentialed = await seedConnection(true);
+
+    const report = await refreshConnectionStates(storage.db(), {
+      dryRun: false,
+    });
+
+    expect(report.scanned).toBe(2);
+    expect(report.changed).toBe(1);
+    expect(report.samples.map((s) => s.id)).toEqual([doomed._id]);
+    const untouched = await connections.findById(
+      credentialed.tenantId,
+      credentialed.principalId,
+      credentialed._id,
+    );
+    // Unimported but credentialed stays on its own natural derived state
+    // (connecting/importing), never forced anywhere by this pass.
+    expect(untouched?.state).not.toBe("actionRequired");
+  });
+});

--- a/packages/scripts/src/commands/refresh-connection-states/refresh.ts
+++ b/packages/scripts/src/commands/refresh-connection-states/refresh.ts
@@ -1,0 +1,132 @@
+import { type Db } from "mongodb";
+import { deriveConnectionState } from "@sync/domain/connection-state";
+import {
+  gatherConnectionStateEvidence,
+  refreshConnectionState,
+} from "@sync/domain/connection-state-refresh.service";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { ProviderConnectionRecordSchema } from "@sync/storage/contracts/provider-connection.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+export type RefreshConnectionStatesReport = {
+  generatedAt: string;
+  dryRun: boolean;
+  scanned: number;
+  changed: number;
+  transitions: Record<string, number>;
+  samples: Array<{
+    id: string;
+    from: string;
+    to: string;
+    reason: string | null;
+  }>;
+};
+
+/**
+ * Re-derive every provider connection's stored state from live evidence (the
+ * same derivation `GET /internal/connections` already runs on each fetch — see
+ * connection-state-refresh.service.ts). Connections normally self-heal the
+ * first time their owner loads the app; this exists to catch up connections
+ * stuck on a stale stored state (e.g. "importing" from a preseed migration)
+ * ahead of that, for accurate dashboards/ops queries. Safe to rerun — a
+ * connection already showing its derived state is left untouched.
+ */
+export async function refreshConnectionStates(
+  db: Db,
+  options: { dryRun: boolean; limit?: number } = { dryRun: true },
+): Promise<RefreshConnectionStatesReport> {
+  const limit = options.limit ?? Infinity;
+  const connections = new ProviderConnectionRepository(db);
+  const refreshDeps = {
+    connections,
+    calendars: new ProviderCalendarRepository(db),
+    resources: new SyncResourceRepository(db),
+    credentials: new CredentialRepository(db),
+    invalidations: new InvalidationRepository(db),
+  };
+
+  const transitions: Record<string, number> = {};
+  const samples: Array<{
+    id: string;
+    from: string;
+    to: string;
+    reason: string | null;
+  }> = [];
+  let scanned = 0;
+  let changed = 0;
+
+  const cursor = db.collection(SYNC_COLLECTIONS.providerConnections).find({});
+  for await (const doc of cursor) {
+    scanned += 1;
+    const record = ProviderConnectionRecordSchema.parse(doc);
+
+    if (options.dryRun) {
+      const evidence = await gatherEvidenceOnly(refreshDeps, record);
+      if (evidence.state === record.state) continue;
+      changed += 1;
+      recordTransition(
+        transitions,
+        samples,
+        record,
+        evidence.state,
+        evidence.reason,
+      );
+    } else {
+      const updated = await refreshConnectionState(refreshDeps, record);
+      if (updated.state === record.state) continue;
+      changed += 1;
+      recordTransition(
+        transitions,
+        samples,
+        record,
+        updated.state,
+        updated.stateReason,
+      );
+    }
+    if (changed >= limit) break;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    dryRun: options.dryRun,
+    scanned,
+    changed,
+    transitions,
+    samples,
+  };
+}
+
+function recordTransition(
+  transitions: Record<string, number>,
+  samples: Array<{
+    id: string;
+    from: string;
+    to: string;
+    reason: string | null;
+  }>,
+  record: { _id: string; state: string },
+  to: string,
+  reason: string | null,
+): void {
+  const key = `${record.state}->${to}`;
+  transitions[key] = (transitions[key] ?? 0) + 1;
+  if (samples.length < 20) {
+    samples.push({ id: record._id, from: record.state, to, reason });
+  }
+}
+
+// Dry-run needs the derived state WITHOUT persisting — refreshConnectionState
+// always writes on a mismatch, so dry-run re-derives the same evidence
+// in-memory instead of calling it.
+async function gatherEvidenceOnly(
+  deps: Parameters<typeof refreshConnectionState>[0],
+  record: Parameters<typeof refreshConnectionState>[1],
+): Promise<{ state: string; reason: string | null }> {
+  const evidence = await gatherConnectionStateEvidence(deps, record);
+  const derived = deriveConnectionState(evidence, new Date());
+  return { state: derived.state, reason: derived.reason };
+}

--- a/packages/sync/src/domain/reconcile.service.db.test.ts
+++ b/packages/sync/src/domain/reconcile.service.db.test.ts
@@ -3,6 +3,7 @@ import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -15,29 +16,44 @@ describe("reconcileStaleCalendars", () => {
   const storage = setupSyncStorage(import.meta.url);
   let resources: SyncResourceRepository;
   let jobs: JobRepository;
+  let credentials: CredentialRepository;
 
   beforeEach(() => {
     resources = new SyncResourceRepository(storage.db());
     jobs = new JobRepository(storage.db());
+    credentials = new CredentialRepository(storage.db());
   });
 
   const deps = () => ({ resources, jobs });
 
   // Ensure an events resource and set its last success to `lastSuccessAt`
   // (omit for a never-synced resource). Each gets a distinct calendar so the
-  // unique (connection, kind, calendar) identity never collides.
+  // unique (connection, kind, calendar) identity never collides. The sweep
+  // only selects resources whose connection can still authenticate, so a
+  // credential is stored by default; pass withCredential: false to simulate a
+  // dead/disconnected connection.
   const seedResource = async (
     lastSuccessAt: Date | null,
+    options: { withCredential?: boolean } = {},
   ): Promise<SyncResourceRecord> => {
     const tenantId = objectId() as SyncResourceRecord["tenantId"];
     const principalId = objectId() as SyncResourceRecord["principalId"];
+    const connectionId = objectId() as SyncResourceRecord["connectionId"];
     const resource = await resources.ensure({
       tenantId,
       principalId,
-      connectionId: objectId() as SyncResourceRecord["connectionId"],
+      connectionId,
       resourceKind: "events",
       calendarId: objectId() as SyncResourceRecord["calendarId"],
     });
+    if (options.withCredential ?? true) {
+      await credentials.store({
+        connectionId,
+        provider: "google",
+        refreshToken: "refresh-token",
+        scopes: [],
+      });
+    }
     if (lastSuccessAt) {
       await resources.advanceCursor(
         tenantId,
@@ -147,5 +163,24 @@ describe("reconcileStaleCalendars", () => {
     // doomed one is "more stale" by success time (null).
     expect(await jobByKey(`incrementalPull:${healthy._id}`)).not.toBeNull();
     expect(await jobByKey(`incrementalPull:${doomed._id}`)).toBeNull();
+  });
+
+  it("excludes a resource whose connection has no stored credential, however stale", async () => {
+    // The rotation fix above only helps AFTER a first attempt: it does nothing
+    // for the population still tied at lastAttemptAt: null, where dead-
+    // credential resources and genuinely healthy never-attempted ones sit
+    // side by side. Mongo's tie-break there is not random — in prod it
+    // reproducibly favored the dead-credential cohort (2026-07-29: a clean
+    // post-rotation-fix sweep batch still selected 100 resources with only 1
+    // holding a credential). The sweep must exclude credential-less
+    // connections outright; they resume via reconnect, not reconcile.
+    const deadCredential = await seedResource(null, { withCredential: false });
+    const healthy = await seedResource(new Date("2026-07-05T00:00:00.000Z"));
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now, 1);
+
+    expect(enqueued).toBe(1);
+    expect(await jobByKey(`incrementalPull:${healthy._id}`)).not.toBeNull();
+    expect(await jobByKey(`incrementalPull:${deadCredential._id}`)).toBeNull();
   });
 });

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -287,30 +287,52 @@ export class SyncResourceRepository {
 
   // Events resources whose last successful sync is older than `before` (or which
   // never succeeded), oldest first, bounded. This is the reconcile sweep's input
-  // — a missed-webhook fallback — so it is a GLOBAL scan across owners, not
-  // owner-scoped: each returned resource carries its own (tenantId, principalId)
-  // for the job the caller enqueues. A never-synced resource (lastSuccessAt
-  // null) sorts first so bootstrapping a new calendar is not starved by the
-  // stale ones. Uses the last_success index.
+  // — a missed-webhook fallback for connections that CAN still authenticate — so
+  // it is a GLOBAL scan across owners, not owner-scoped: each returned resource
+  // carries its own (tenantId, principalId) for the job the caller enqueues. A
+  // never-synced resource (lastSuccessAt null) sorts first so bootstrapping a
+  // new calendar is not starved by the stale ones. Uses the last_success index.
   async listStaleEvents(
     before: Date,
     limit: number,
   ): Promise<SyncResourceRecord[]> {
     const records = await this.collection
-      .find({
-        resourceKind: "events",
-        $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
-      })
-      // Round-robin by ATTEMPT, not success: never-attempted first (null sorts
-      // lowest), then least-recently-attempted. Sorting by lastSuccessAt let
-      // resources that fail without ever succeeding (dead credential, dead
-      // calendar) occupy the head of every bounded sweep batch forever,
-      // starving the stale-but-healthy resources behind them (2026-07-29:
-      // 97 credential-less resources monopolized all 100 slots while 886
-      // healthy ones were never selected). The pull stamps lastAttemptAt
-      // before it can fail, so every selected resource rotates to the back.
-      .sort({ lastAttemptAt: 1, lastSuccessAt: 1 })
-      .limit(limit)
+      .aggregate<SyncResourceRecord>([
+        {
+          $match: {
+            resourceKind: "events",
+            $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
+          },
+        },
+        // A resource whose connection has no stored credential can never
+        // succeed here no matter how many sweeps retry it — reconnect is what
+        // resumes it (registerConnection's own calendarListSync enqueue), not
+        // reconcile. Excluding it at the query level, rather than relying on
+        // the lastAttemptAt rotation below, matters because the rotation only
+        // helps AFTER a resource's first attempt: the whole never-attempted
+        // population (dead-credential resources alongside genuinely healthy
+        // new ones) ties at lastAttemptAt: null, and Mongo's tie-break across
+        // that tie is not random — it reproducibly favored the dead-credential
+        // cohort (2026-07-29: an isolated post-rotation-fix sweep batch still
+        // selected 100 resources with only 1 holding a credential).
+        {
+          $lookup: {
+            from: SYNC_COLLECTIONS.credentials,
+            localField: "connectionId",
+            foreignField: "_id",
+            as: "_credential",
+          },
+        },
+        { $match: { "_credential.0": { $exists: true } } },
+        { $project: { _credential: 0 } },
+        // Round-robin by ATTEMPT, not success: never-attempted first (null
+        // sorts lowest), then least-recently-attempted, so a resource that
+        // fails without succeeding still rotates to the back after each try
+        // rather than re-winning every sweep. The pull stamps lastAttemptAt
+        // before it can fail, so this holds even on failure.
+        { $sort: { lastAttemptAt: 1, lastSuccessAt: 1 } },
+        { $limit: limit },
+      ])
       .toArray();
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }


### PR DESCRIPTION
## Summary

- ~706 prod `provider_connections` are stranded showing `state: "importing"` because a preseed-migration bug (unguarded `credentials.store()` in the connections-migration loop, no per-user isolation) left them with no credential row behind them.
- These self-heal automatically the moment their owner next loads Compass (`GET /internal/connections` already calls `refreshConnectionState` on every fetch, deriving `actionRequired`/`authorizationRevoked` → the existing "Reconnect Google Calendar" UI). But until then, ops/dashboards querying `provider_connections.state` see a misleading "still importing" instead of the true "needs reconnect" state.
- Adds `bun run cli refresh-connection-states [--apply]`: batches the same `refreshConnectionState` derivation (no new state-transition logic) over every connection. Default dry-run; idempotent — a connection already at its derived state is left untouched.

## Test plan

- [x] `bun run test:scripts` — 91/91 pass, including 3 new tests: dry-run reports without writing, apply persists + is idempotent on rerun, a mixed batch only flags the connection that actually needs it
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production Mongo queries for global reconcile sweeps and adds a write-capable ops CLI; logic reuses existing derivation but `--apply` mutates all connections when run.
> 
> **Overview**
> Adds **`refresh-connection-states`** CLI to backfill stale `provider_connections.state` (e.g. stuck on `importing` after preseed) by re-running the same derivation as `GET /internal/connections`. Default is dry-run; **`--apply`** persists. Idempotent batch with JSON report (transitions, samples).
> 
> **Reconcile sweep fix:** `listStaleEvents` now **excludes event resources whose connection has no credential** (`$lookup` on credentials), so bounded stale-calendar sweeps stop wasting slots on connections that can only recover via reconnect—not incremental pull. Reconcile tests seed credentials by default and add coverage for credential-less exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8dea396be6f94b2ab86f6e5ce9d6faf0aa4694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->