### PR TITLE
feat(self-host): run Sync by default, mirroring prod architecture

### DIFF
--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -71,12 +71,16 @@ See [Google Calendar](../self-hosting/google-calendar.md) for full setup instruc
 
 ## Sync Service
 
-Optional standalone Sync service (`packages/sync`). Omit the whole `sync:`
-block until you run that service. When present, `mongoUri` and
-`internalAuthToken` are required; Sync uses an **isolated** Mongo database and
-must not share the backend's database user/data.
+Standalone service (`packages/sync`) that owns Google Calendar sync end to
+end. The self-host installer writes a `sync:` block by default (see
+[Self-Hosting](../self-hosting/README.md)) — omit the whole block only for a
+bare install with no Google Calendar sync at all. When present, `mongoUri`
+and `internalAuthToken` are required; Sync uses an **isolated** Mongo
+database and must not share the backend's database user/data.
 
-Cutover and ops: [Sync Service Cutover](../backend/sync-service-cutover.md).
+`connectionRouting` and `eventRouting` below decide whether the backend
+delegates to Sync or still runs its own legacy code — see
+[Sync Service Cutover](../backend/sync-service-cutover.md).
 
 | key | Required | Description |
 |---|---|---|

--- a/docs/backend/sync-service-cutover.md
+++ b/docs/backend/sync-service-cutover.md
@@ -1,0 +1,42 @@
+# Sync Service Cutover
+
+The backend can serve Google Calendar connections and events either from its
+own legacy code, or by delegating to the standalone Sync service
+(`packages/sync`). Two independent config knobs decide which:
+
+| Config key | Env var | Delegates |
+| --- | --- | --- |
+| `sync.connectionRouting` | `SYNC_CONNECTION_ROUTING` | Browser-facing provider-connection routes (connect, list, disconnect) |
+| `sync.eventRouting` | `SYNC_EVENT_ROUTING` | Calendar/event reads and durable write commands |
+
+Both default to `legacy` and independently accept `sync`. They're separate
+switches on purpose: event routing is the riskier surface (it owns writes),
+so it can roll out — and roll back — on its own schedule from connection
+routing.
+
+Selecting `sync` for either key requires `sync.serviceUrl` (the backend's
+address for the Sync service) to be set; the config schema enforces this
+pairing at startup. `sync.execution` must also be `active` on the Sync
+service side for it to actually do provider work (OAuth begin, imports,
+webhook processing) — see [Self-Hosting](../self-hosting/README.md) for
+how the self-host installer wires this up by default, and [Config](../Config/README.md#sync-service)
+for the full key reference.
+
+`sync.cloudMutationMode: maintenance` independently rejects cloud writes and
+new connections with a typed `503 MAINTENANCE` response, regardless of
+routing — useful for a brief freeze during a routing change.
+
+Backend refuses to start with `execution=active` + `cloudMutationMode=enabled`
+while either routing key is still `legacy` (the dual-writer guard) — that
+combination would let both the legacy engine and Sync attempt writes.
+
+## Troubleshooting a Sync-delegation issue
+
+If events or connections aren't behaving as expected under Sync ownership:
+
+1. Confirm `GET /api/config` shows `sync.connectionRouting` / `sync.eventRouting` as `sync`, not `legacy`.
+2. Confirm `sync.serviceUrl` is actually set — the token alone does not enable delegation.
+3. Confirm the Sync service is reachable and healthy on its own port (`GET /health/live` on `sync.port`, default `3010`).
+4. Check the Sync container's own logs, not just the backend's — routing state can be correct while Sync itself is unhealthy or passive. See [Monitoring](../self-hosting/monitoring.md#sync-google-calendar-health).
+
+A backend startup refusal mentioning the dual-writer guard means `execution=active` and `cloudMutationMode=enabled` are set while a routing key is still `legacy` — either flip the remaining routing key to `sync`, or drop back to `passive`/`maintenance` until it is.

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -17,18 +17,26 @@ flowchart TD
     caddy[Caddy<br/>HTTPS]
     web[web container<br/>127.0.0.1:9080]
     backend[backend container<br/>127.0.0.1:3000/api]
-    mongo[(MongoDB<br/>events)]
+    sync[sync container<br/>127.0.0.1:3010]
+    mongo[(MongoDB<br/>prod_calendar + compass_sync)]
     supertokens[SuperTokens Core<br/>signup, login]
     postgres[(Postgres<br/>auth data)]
+    google[Google Calendar]
 
     browser -->|loads Compass| caddy
     caddy -->|web traffic| web
     caddy -->|API traffic| backend
+    caddy -->|/sync/* OAuth + webhooks| sync
     browser -->|caches events locally| indexeddb
     backend -->|Docker volume| mongo
+    backend -->|calendar/event reads + writes| sync
     backend --> supertokens
+    sync -->|Docker volume, own database| mongo
+    sync <-->|OAuth, push notifications| google
     supertokens -->|Docker volume| postgres
 ```
+
+Compass Sync owns Google Calendar sync end to end (OAuth, webhooks, and incremental pulls) in its own isolated database on the same bundled MongoDB — the backend never reads Google credentials directly. Sign-in with Google is the one exception: it stays a direct backend↔Google exchange, separate from calendar sync.
 
 ## Start here
 

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -16,7 +16,7 @@ are manual today. The installer and `./compass update` do not create them for yo
 Keep these things together as one backup set:
 
 1. `~/compass/compass.yaml`
-2. the Mongo data Docker volume, which stores events
+2. the Mongo data Docker volume, which stores events and Google Calendar sync state (the bundled Mongo hosts both the `prod_calendar` and `compass_sync` databases in the same volume — one backup covers both, no separate Sync backup needed)
 3. the Mongo config Docker volume, which stores Mongo replica set metadata
 4. the SuperTokens Postgres Docker volume, which stores user sessions
 

--- a/docs/self-hosting/google-calendar.md
+++ b/docs/self-hosting/google-calendar.md
@@ -5,13 +5,15 @@ You can optionally connect your Google account to enable:
 - Google OAuth (instead of the default email/password auth)
 - Two-way sync between Compass Calendar and Google Calendar
 
+Compass Sync — the same service that runs Google Calendar sync for the hosted `compasscalendar.com` — is part of every self-host install by default (the `sync` container in your `docker compose ps` output). It owns the whole calendar-sync lifecycle: connecting, importing, watching for changes, and pushing your edits back to Google. Signing in with a Google account is a separate, simpler flow that stays in the main backend.
+
 ## The three modes
 
 | Mode | What it does | What you need | Who it's for |
 | --- | --- | --- | --- |
 | **Off (default)** | Google sign-in and connect actions are hidden. Email/password signup works normally. | Nothing. | Everyone who doesn't need Google. |
-| **Local development sign-in & import** | Google sign-in works. One-time Google Calendar import works. No continuous sync. | A Google Cloud OAuth client that allows `http://localhost:9080`, plus `google.clientId` and `google.clientSecret` in `compass.yaml`. | Bun-based local setups that want Google sign-in or a one-time import. |
-| **Public watch notifications** | Google can notify Compass when calendar events change. | A public HTTPS URL Google can reach, real Google OAuth credentials, `google.notificationToken` set, and verified Google watch registration and repair on this install. | Server installs only. See [Server hosting guide](./server-guide.md). |
+| **Local development sign-in & connect** | Google sign-in works. Connecting a calendar works and imports your existing events. Google can't reach `localhost`, so later changes made directly in Google Calendar won't arrive automatically until you set up a public URL. | A Google Cloud OAuth client that allows `http://localhost:9080` (sign-in) and `http://localhost:3010/sync/google` (connect), plus `google.clientId` and `google.clientSecret` in `compass.yaml`. | Bun-based local setups that want Google sign-in or to try connecting a calendar. |
+| **Public, fully-live sync** | Two-way sync: your Compass edits reach Google and Google's changes arrive in Compass, usually within seconds via push notifications (a periodic catch-up covers any it misses). | A public HTTPS URL Google can reach (`sync.callbackBaseUrl`), real Google OAuth credentials, and `google.notificationToken` set. | Server installs. See [Server hosting guide](./server-guide.md). |
 
 Most self-hosters should start with **Off** or a public server setup. Continuous sync needs a public server because Google sends notifications over the public internet.
 
@@ -21,9 +23,9 @@ The installer writes placeholder Google OAuth values to `~/compass/compass.yaml`
 
 Sign up with email and password. Event create, edit, and delete all work without a Google connection. Nothing more to do.
 
-## Local development sign-in & import
+## Local development sign-in & connect
 
-This is an optional add-on for a Bun-based local setup. Browser-driven flows (sign-in, one-time import) work. Watch notifications do not, because Google can't reach `localhost`. After the import, changes made later in Google Calendar will not reliably arrive in Compass unless you also set up public HTTPS watch notifications.
+This is an optional add-on for a Bun-based local setup. Sign-in and connecting a calendar both work over `localhost`; push notifications do not, because Google can't reach `localhost`. Once connected, Compass still catches up on later Google-side changes periodically (every ~10 minutes) even without push — just not immediately.
 
 Add real Google OAuth values to `compass.yaml`:
 
@@ -40,60 +42,47 @@ cd ~/compass
 ./compass rebuild
 ```
 
-In your Google Cloud OAuth client, use **Web application** as the client type and allow the local origin:
+In your Google Cloud OAuth client, use **Web application** as the client type and allow both local origins — one for sign-in, one for connecting a calendar:
 
 ```text
 Authorized JavaScript origins:
   http://localhost:9080
 
 Authorized redirect URIs:
-  http://localhost:9080/auth/google/callback
+  http://localhost:9080/auth/google/callback   # sign-in
+  http://localhost:3010/sync/google            # connect a calendar
 ```
 
-Compass sends the dedicated Google callback page as the OAuth redirect URI.
-That means the redirect URI includes `/auth/google/callback`.
+Sign-in (`/auth/google/callback`) is a popup flow handled by the main backend. Connecting a calendar (`/sync/google`) is a full-page redirect handled by the Sync service — the browser navigates to Google and back, so it needs no JavaScript origin of its own, only the redirect URI above.
 
-This path doesn't make your local backend public. It's for sign-in and one-time import only.
+This path doesn't make your local backend public. It's for sign-in and trying out connect only.
 
-## Public watch notifications
+## Public, fully-live sync
 
 For Google to notify Compass when something changes in Google Calendar, Google must be able to send HTTPS `POST` requests to:
 
 ```text
-/api/sync/gcal/notifications
+/sync/notifications/google
 ```
 
-Local setups do not create a public HTTPS URL, so they can't receive these. You have two paths:
-
-- **Run Compass on a public server.** The recommended path. See [Server hosting guide](./server-guide.md).
-- **Use a public HTTPS tunnel for webhooks only (development).** The backend supports `google.webhookUrl` as a separate public HTTPS base URL for Google webhook callbacks. Browser API traffic and Server-Sent Events keep using localhost:
-
-  ```yaml
-  backend:
-    apiUrl: http://localhost:3000/api
-  google:
-    webhookUrl: https://<public-https-host>/api
-  ```
-
-  This is for Google webhook POSTs only.
+Local setups do not create a public HTTPS URL, so they can't receive these. Run Compass on a public server — see [Server hosting guide](./server-guide.md), which includes the Caddy configuration that proxies `/sync/*` (both the OAuth callback and this webhook path) to the `sync` container.
 
 ### Google Cloud setup
 
 For a public server install, create a Google OAuth client with **Web application** as the client type.
 
-Use your public Compass origin for JavaScript origins and the Compass callback
-page for redirect URIs:
+Use your public Compass origin for sign-in, and the same origin's `/sync/google` path for connect:
 
 ```text
 Authorized JavaScript origins:
   https://cal.example.com
 
 Authorized redirect URIs:
-  https://cal.example.com/auth/google/callback
+  https://cal.example.com/auth/google/callback   # sign-in
+  https://cal.example.com/sync/google            # connect a calendar
 ```
 
-Replace `https://cal.example.com` with your own Compass URL. Do not add `/api`
-to the redirect URI.
+Replace `https://cal.example.com` with your own Compass URL. Do not add `/api` to either redirect URI.
 
 Also check these in Google Cloud:
 
@@ -113,22 +102,29 @@ google:
   clientSecret: <your-google-client-secret>
 ```
 
-Next, check the notification secret Compass uses to verify Google webhook calls.
-Keep `google.notificationToken` set:
+Then point Sync's `callbackBaseUrl` at your public origin (the installer defaults it to `http://localhost:3010`, which only works for local connect, not Google push):
+
+```yaml
+sync:
+  callbackBaseUrl: https://cal.example.com
+```
+
+Next, check the notification secret Compass uses to verify Google webhook calls. Keep `google.notificationToken` set:
 
 - If you installed with the self-host installer, leave the generated value in place.
 - If you are creating `compass.yaml` manually, set it to a long random secret.
 
 This is a Compass webhook secret, not a Google credential.
 
-Then rebuild:
+Then restart so both changes take effect (`callbackBaseUrl` and rebuilding the web image for the OAuth values):
 
 ```bash
 cd ~/compass
 ./compass rebuild
+./compass restart
 ```
 
-After the rebuild, check that the public app sees Google as configured:
+After that, check that the public app sees Google as configured:
 
 ```bash
 curl -fsS https://cal.example.com/api/config
@@ -153,16 +149,13 @@ Google account email does not match the signed-in Compass account
 Before you call continuous Google Calendar sync "working" on any self-host install, verify all of these on that specific install:
 
 - real Google OAuth credentials configured
-- backend reachable by Google over public HTTPS
+- `sync.callbackBaseUrl` reachable by Google over public HTTPS
 - `google.notificationToken` set
-- Google watch registration succeeds
-- watch repair and refresh behavior holds up over time
+- the `sync` container healthy (`docker compose ps`)
 
 To confirm sync is live: create or edit one event directly in Google Calendar and confirm it appears in Compass without reconnecting Google. Then restart Compass and confirm the connection still works after restart.
 
-The repo has the code paths for Google watches and repair. The self-host Docker stack does not schedule watch renewal, so you need to verify and wire up maintenance separately before treating ongoing Google sync as dependable.
-
-Google push delivery to `/api/sync/gcal/notifications` is not guaranteed. Notifications can be delayed or dropped, so Compass does not depend on them alone. Every calendar also converges through incremental catch-up sync (per-calendar sync tokens). The watch repair coordinator keeps channels registered too, combining a defensive repair check on every client SSE (re)connect with scheduled maintenance that re-verifies all watches via `POST /api/sync/maintain-all`. Channels expire after 7 days by default (`google.channelExpirationMin`, in minutes) and renew inside a 3-day buffer before expiry.
+Sync manages its own push-notification channels and their renewal — no separate cron or maintenance step needed, unlike the older backend-only sync engine. Google push delivery is still not guaranteed (notifications can be delayed or dropped), so Compass never depends on push alone: every connected calendar also converges through a periodic reconcile pass (roughly every 10 minutes) that catches up on anything a missed webhook would have delivered.
 
 ## What to read next
 

--- a/docs/self-hosting/monitoring.md
+++ b/docs/self-hosting/monitoring.md
@@ -24,17 +24,24 @@ No authentication required.
 
 The check calls `db.admin().ping()` against MongoDB. Call it on whatever schedule makes sense for your setup — Compass does not impose a polling interval.
 
-## Google sync health
+## Sync (Google Calendar) health
 
-If Google Calendar sync is enabled, watch (channel) health is worth watching separately from the health endpoint above — it degrades quietly (missed notifications, expired channels) rather than returning an error.
+If Google Calendar sync is enabled, the `sync` container's own health is worth watching separately from the backend health endpoint above — it degrades quietly (missed push notifications) rather than returning an error, and the backend health check above never touches it.
 
-What to watch, in backend logs:
+```
+GET /health/live
+```
 
-- **`app:google-watch-repair`** — one line per repair attempt: `REFRESHED`, `REPAIRED`, `FULL_REPAIR_STARTED`, or `PRUNED` (info level), or `SKIPPED` with reason `COOLDOWN`/`LOCKED` (debug level). A `HEALTHY`/`NONE` outcome (nothing to do) is not logged, so silence on this namespace is itself a healthy sign. Repair runs opportunistically on every client SSE (re)connect and via scheduled maintenance.
-- **`app:google-watch-maintenance.service`** — a debug-level summary after each `POST /api/sync/maintain-all` run (counts of ignored/pruned/refreshed/revoked watches across all users).
-- **`GOOGLE_REVOKED` sync-status events** — published over SSE and logged when a user's Google access was revoked or their refresh token went missing. Compass prunes that user's Google-owned data automatically (see [Google Calendar](./google-calendar.md)). They'll need to reconnect.
+on `127.0.0.1:3010` — liveness only (the container is up and serving), not a signal that sync work is actually progressing. `docker compose ps` surfaces this as the container's health status.
 
-`POST /api/sync/maintain-all` re-verifies every user's watches and is how expired/missing channels get caught outside the opportunistic SSE-triggered repair. The self-host Docker stack does not schedule calls to it for you — wire up your own external scheduler (cron, systemd timer, etc.) hitting it with the `x-comp-token` header set to `backend.compassToken`.
+What to watch, in sync container logs (`./compass logs sync`):
+
+- **Startup line** — `compass-sync listening on 3010 (production, execution=active)`. If it instead says `execution=passive`, Sync is up but doing no provider work — check `sync.execution` in `compass.yaml`.
+- **`Sync scheduler draining, reconciling, renewing channels, retaining, and reporting health`** — logged once at startup when active; confirms the job worker, the reconcile sweep, and subscription renewal are all running. If you only see `Sync retention + health snapshot started (passive / unconfigured)` instead, Sync isn't doing calendar work — check `google.clientId`/`google.clientSecret` are set and `sync.execution: active`.
+- **`Sync reconcile sweep enqueued N pull(s)`** — logs roughly every 10 minutes when there's stale work to catch up on. This is the fallback for missed push notifications; every connected calendar converges through it even if Google's webhook never arrives. It's normal for this to log `0` most of the time on a healthy install (nothing missed).
+- **`Sync job {kind} ({id}) dropped: {reason}`** (warn level) — a job settled without completing (e.g. the connection's Google access was revoked). The affected user needs to reconnect; Compass surfaces this in the UI as a "Reconnect Google Calendar" prompt automatically.
+
+Unlike the older backend-only sync engine, Sync manages its own push-notification channel renewal internally — there's no separate cron job or maintenance endpoint to wire up.
 
 ----
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -168,8 +168,9 @@ compass.example.com {  # <- this is the only line you need to change
   reverse_proxy 127.0.0.1:3000
  }
 
- # Sync public surface (OAuth callback + Google push). Only needed when the
- # compose `sync` profile is enabled; safe to omit otherwise.
+ # Sync public surface (OAuth callback + Google push). The `sync` container
+ # runs by default, so this block is required — omitting it breaks Google
+ # Calendar connect.
  handle /sync/* {
   reverse_proxy 127.0.0.1:3010
  }
@@ -254,7 +255,11 @@ backend:
   apiUrl: https://compass.example.com/api
   originsAllowed:
     - https://compass.example.com
+sync:
+  callbackBaseUrl: https://compass.example.com
 ```
+
+`sync.callbackBaseUrl` is what makes Google Calendar connect and push notifications work — it defaults to `http://localhost:3010` (installer default, fine for local-only setups), which Google can never reach. Skip this if you don't plan to connect Google Calendar.
 
 ### Apply config changes
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -21,14 +21,14 @@ import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { settingsActions } from "@web/settings/settings.store";
 import {
   useIsConnectDelegatedToSync,
-  useIsGoogleAvailable,
+  useIsConnectGoogleAvailable,
 } from "../useIsGoogleAvailable/useIsGoogleAvailable";
 import { type UseConnectGoogleResult } from "./useConnectGoogle.types";
 import { getGoogleConnectionConfig } from "./useConnectGoogle.util";
 import { useGoogleUiState } from "./useGoogleUiState";
 
 export const useConnectGoogle = (): UseConnectGoogleResult => {
-  const isAvailable = useIsGoogleAvailable();
+  const isAvailable = useIsConnectGoogleAvailable();
   const isConnectDelegatedToSync = useIsConnectDelegatedToSync();
   const state = useGoogleUiState();
   const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);

--- a/packages/web/src/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable.factory.ts
+++ b/packages/web/src/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable.factory.ts
@@ -52,11 +52,12 @@ export function createGoogleAvailability({
     connectDelegatedToSync;
 
   const loadBackendGoogleAvailability = async (): Promise<void> => {
-    if (!isGoogleAuthConfigured) {
-      setBackendGoogleAvailability("unavailable");
-      return;
-    }
-
+    // Always fetch /config, even without a baked GOOGLE_CLIENT_ID: a
+    // sync-delegated connect flow needs no client-side id at all, so bailing
+    // out here would leave connectDelegatedToSync permanently unknown for
+    // exactly the deployments that need it (e.g. a self-host web image that
+    // hasn't rebuilt with its own client id). Sign-in availability still
+    // requires the baked id — see useIsGoogleAvailable below.
     if (!loadPromise) {
       loadPromise = getConfig()
         .then((config) => {
@@ -88,6 +89,32 @@ export function createGoogleAvailability({
     }, []);
 
     return isGoogleAuthConfigured && isBackendGoogleConfigured;
+  };
+
+  // Connect-calendar availability, distinct from sign-in (useIsGoogleAvailable
+  // above): the sync redirect flow (connectDelegatedToSync) never runs
+  // client-side code exchange, so it needs no baked GOOGLE_CLIENT_ID — only
+  // that the backend has Google configured at all. The legacy popup flow
+  // still needs the baked id, same as sign-in.
+  const useIsConnectGoogleAvailable = (): boolean => {
+    const isBackendGoogleConfigured = useSyncExternalStore(
+      subscribe,
+      getBackendGoogleAvailabilitySnapshot,
+      getBackendGoogleAvailabilitySnapshot,
+    );
+    const delegatedToSync = useSyncExternalStore(
+      subscribe,
+      getConnectDelegatedToSyncSnapshot,
+      getConnectDelegatedToSyncSnapshot,
+    );
+
+    useEffect(() => {
+      void loadBackendGoogleAvailability();
+    }, []);
+
+    return (
+      isBackendGoogleConfigured && (delegatedToSync || isGoogleAuthConfigured)
+    );
   };
 
   const useIsConnectDelegatedToSync = (): boolean => {
@@ -132,6 +159,7 @@ export function createGoogleAvailability({
     setGoogleAvailabilityForTests,
     setConnectDelegatedToSyncForTests,
     useIsGoogleAvailable,
+    useIsConnectGoogleAvailable,
     useIsConnectDelegatedToSync,
   };
 }

--- a/packages/web/src/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable.test.tsx
+++ b/packages/web/src/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable.test.tsx
@@ -76,6 +76,83 @@ describe("useIsGoogleAvailable", () => {
   });
 });
 
+describe("useIsConnectGoogleAvailable", () => {
+  it("is available under sync delegation even with no baked GOOGLE_CLIENT_ID (self-host, unrebuilt web image)", async () => {
+    getConfig.mockClear();
+    getConfig.mockResolvedValue({
+      google: { isConfigured: true, connectDelegatedToSync: true },
+    });
+    const { resetGoogleAvailabilityForTests, useIsConnectGoogleAvailable } =
+      createGoogleAvailability({ getConfig, isGoogleAuthConfigured: false });
+    resetGoogleAvailabilityForTests();
+
+    const { result } = renderHook(() => useIsConnectGoogleAvailable());
+
+    expect(result.current).toBe(false);
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+    // The old behavior bailed out before ever calling getConfig() when no
+    // client id was baked in — this is the regression this test guards.
+    expect(getConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays unavailable on the legacy popup flow with no baked GOOGLE_CLIENT_ID", async () => {
+    getConfig.mockClear();
+    getConfig.mockResolvedValue({
+      google: { isConfigured: true, connectDelegatedToSync: false },
+    });
+    const { resetGoogleAvailabilityForTests, useIsConnectGoogleAvailable } =
+      createGoogleAvailability({ getConfig, isGoogleAuthConfigured: false });
+    resetGoogleAvailabilityForTests();
+
+    const { result } = renderHook(() => useIsConnectGoogleAvailable());
+
+    await waitFor(() => {
+      expect(getConfig).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("stays unavailable when the backend has no Google configured at all, even under sync delegation", async () => {
+    getConfig.mockClear();
+    getConfig.mockResolvedValue({
+      google: { isConfigured: false, connectDelegatedToSync: true },
+    });
+    const { resetGoogleAvailabilityForTests, useIsConnectGoogleAvailable } =
+      createGoogleAvailability({ getConfig, isGoogleAuthConfigured: false });
+    resetGoogleAvailabilityForTests();
+
+    const { result } = renderHook(() => useIsConnectGoogleAvailable());
+
+    await waitFor(() => {
+      expect(getConfig).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBe(false);
+  });
+});
+
+describe("useIsGoogleAvailable (sign-in) stays gated on the baked client id", () => {
+  it("stays unavailable without a baked GOOGLE_CLIENT_ID even when the backend is sync-delegated and configured", async () => {
+    getConfig.mockClear();
+    getConfig.mockResolvedValue({
+      google: { isConfigured: true, connectDelegatedToSync: true },
+    });
+    const { resetGoogleAvailabilityForTests, useIsGoogleAvailable } =
+      createGoogleAvailability({ getConfig, isGoogleAuthConfigured: false });
+    resetGoogleAvailabilityForTests();
+
+    const { result } = renderHook(() => useIsGoogleAvailable());
+
+    await waitFor(() => {
+      expect(getConfig).toHaveBeenCalledTimes(1);
+    });
+    // Sign-in is unaffected by connect delegation — the redirect flow only
+    // relaxes the connect surface, never sign-in.
+    expect(result.current).toBe(false);
+  });
+});
+
 describe("useIsConnectDelegatedToSync", () => {
   it("reflects the backend connect-delegation flag from config", async () => {
     getConfig.mockClear();

--- a/packages/web/src/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable.ts
+++ b/packages/web/src/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable.ts
@@ -12,5 +12,6 @@ export const {
   setGoogleAvailabilityForTests,
   setConnectDelegatedToSyncForTests,
   useIsGoogleAvailable,
+  useIsConnectGoogleAvailable,
   useIsConnectDelegatedToSync,
 } = googleAvailability;

--- a/self-host/compass
+++ b/self-host/compass
@@ -169,6 +169,7 @@ set_compose_env() {
   export COMPASS_WEB_IMAGE="$(strip_quotes "$(read_config_value web.image)")"
   export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"
   export PORT="$(strip_quotes "$(read_config_value backend.port)")"
+  export SYNC_PORT="$(strip_quotes "$(read_config_value sync.port)")"
   export MONGO_INITDB_ROOT_USERNAME="$(strip_quotes "$(read_config_value mongo.username)")"
   export MONGO_INITDB_ROOT_PASSWORD="$(strip_quotes "$(read_config_value mongo.password)")"
   export MONGO_REPLICA_SET_KEY="$(strip_quotes "$(read_config_value mongo.replicaSetKey)")"

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -42,21 +42,22 @@ supertokens:
 #   webhookUrl: REPLACE_WITH_GOOGLE_WEBHOOK_URL # e.g. https://cal.yourdomain.com/api
 #   notificationToken: REPLACE_WITH_NOTIFICATION_TOKEN
 
-# Compass Sync service (optional; omit until you run the standalone service).
-# execution defaults to `passive` (health + read-only verification, no provider
-# calls or job claims). mongoUri MUST point at an isolated database/user that
-# cannot read the backend's database.
-# sync:
-#   port: 3010
-#   mongoUri: mongodb://compass_sync:REPLACE_WITH_SYNC_MONGO_PASSWORD@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
-#   internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
-#   callbackBaseUrl: https://cal.yourdomain.com # public base URL for provider OAuth/webhook callbacks
-#   serviceUrl: http://sync:3010 # base URL the API uses to reach this service; set when delegating to sync
-#   connectionRouting: legacy # legacy (default) | sync; sync delegates provider-connection routes here and requires serviceUrl
-#   eventRouting: legacy # legacy (default) | sync; sync delegates calendar/event reads + commands here and requires serviceUrl
-#   cloudMutationMode: enabled # enabled (default) | maintenance — maintenance rejects cloud edits / connect with typed MAINTENANCE
+# Compass Sync service — self-host runs the same architecture as Compass
+# Cloud: this is required, not optional. It uses the SAME bundled mongo as
+# `mongo:` above, isolated to its own `compass_sync` database — no separate
+# database user exists on the bundled image, so this reuses the root
+# credentials, just against a different database name.
+sync:
+  port: 3010
+  mongoUri: mongodb://compass:REPLACE_WITH_MONGO_PASSWORD@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
+  internalAuthToken: REPLACE_WITH_SYNC_INTERNAL_AUTH_TOKEN # any string; must match the value the API uses
+  callbackBaseUrl: REPLACE_WITH_YOUR_WEB_URL # public base URL for provider OAuth/webhook callbacks; needs a real domain for Google to deliver push notifications, localhost works for OAuth only
+  serviceUrl: http://sync:3010 # base URL the API uses to reach this service
+  connectionRouting: sync
+  eventRouting: sync
+  cloudMutationMode: enabled # enabled (default) | maintenance — maintenance rejects cloud edits / connect with typed MAINTENANCE
+  execution: active
+  maxConcurrency: 4
+  enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)
+  compassApiDatabase: prod_calendar # API database the least-privilege check must be denied access to
 # Public OAuth/webhook paths (via Caddy → sync): /sync/google, /sync/notifications/google
-#   execution: passive # passive | active — active required for OAuth begin + provider import/jobs; refuse active+enabled while any routing is legacy
-#   maxConcurrency: 4
-#   enforceLeastPrivilege: false # true only where a scoped compass_sync database user exists (managed cloud)
-#   compassApiDatabase: prod_calendar # API database the least-privilege check must be denied access to

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -1,6 +1,7 @@
 x-local-bindings:
   web: &web-port "127.0.0.1:${WEB_PORT:-9080}:9080"
   backend: &backend-port "127.0.0.1:${PORT:-3000}:3000"
+  sync: &sync-port "127.0.0.1:${SYNC_PORT:-3010}:3010"
 
 services:
   web:
@@ -70,7 +71,7 @@ services:
     # service tolerates a not-yet-ready store (liveness stays up, readiness 503).
     profiles: [sync]
     ports:
-      - "127.0.0.1:3010:3010"
+      - *sync-port
     environment:
       COMPASS_CONFIG_FILE: /app/compass.yaml
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -121,14 +121,20 @@ describe("self-host docker compose", () => {
     expect(compose).toContain("switchbacktech/compass-sync:");
     // Liveness probe, not readiness: a store-less passive service stays up.
     expect(compose).toContain("http://127.0.0.1:3010/health/live");
+    // "  sync:\n" (colon-then-newline) picks the services.sync: block, not
+    // the earlier "  sync: &sync-port ..." x-local-bindings anchor line.
     const syncBlock = compose
-      .slice(compose.indexOf("  sync:"))
+      .slice(compose.indexOf("  sync:\n"))
       .split(/\n {2}\w/)[0];
     // The `sync` profile lets a deploy start the container only where an
     // isolated sync database is provisioned.
     expect(syncBlock).toContain("profiles: [sync]");
-    // Loopback-only publish so host Caddy can proxy `/sync/*` OAuth/webhooks.
-    expect(syncBlock).toContain('"127.0.0.1:3010:3010"');
+    // Loopback-only publish so host Caddy can proxy `/sync/*` OAuth/webhooks,
+    // port configurable like the web/backend bindings.
+    expect(syncBlock).toContain("*sync-port");
+    expect(compose).toContain(
+      'sync: &sync-port "127.0.0.1:'.concat("$", '{SYNC_PORT:-3010}:3010"'),
+    );
     // The read-only root fs needs a writable mount for the logger's log file,
     // or the container crashes on startup.
     expect(syncBlock).toContain("compass_sync_logs:/app/logs");
@@ -196,6 +202,100 @@ describe("self-host installer", () => {
 
     expect(installer).toContain("self-host/compose.selfhosted.yaml");
     expect(manual).toContain("self-host/compose.selfhosted.yaml");
+  });
+
+  it("writes a sync: block wired for sync-by-default, both installers", () => {
+    const installer = readRepoFile("self-host/install.sh");
+    const manual = readRepoFile("self-host/install-manual.sh");
+
+    for (const script of [installer, manual]) {
+      expect(script).toContain("sync:");
+      expect(script).toContain(
+        "mongo:27017/compass_sync?authSource=admin&replicaSet=rs0",
+      );
+      expect(script).toContain("connectionRouting: sync");
+      expect(script).toContain("eventRouting: sync");
+      expect(script).toContain("execution: active");
+      expect(script).toContain("serviceUrl: http://sync:3010");
+    }
+  });
+
+  it("generates a sync internal auth token as a real secret, not a placeholder", () => {
+    const installer = readRepoFile("self-host/install.sh");
+    const manual = readRepoFile("self-host/install-manual.sh");
+
+    expect(installer).toContain('generate_secret "Sync internal auth token"');
+    expect(installer).toContain("internalAuthToken: $sync_internal_auth_token");
+    expect(manual).toContain("SYNC_INTERNAL_AUTH_TOKEN=$(random_hex)");
+    expect(manual).toContain("internalAuthToken: $SYNC_INTERNAL_AUTH_TOKEN");
+  });
+
+  it("install.sh's own first-boot profile derivation includes sync (not just the downloaded helper's)", async () => {
+    // install.sh hard-codes 'selfhosted}' as its COMPOSE_PROFILES default for
+    // the very first `docker compose up` (start_stack), separately from the
+    // self-host/compass helper it downloads for later use. PR #2450 fixed the
+    // helper's derivation but not this duplicate — meaning a fresh sync:
+    // config would silently never start the sync container on first install.
+    // Exercise install.sh's OWN default_profiles(), the same way the helper's
+    // is exercised above, so this can't regress silently again.
+    const dir = makeTempDir();
+    const configPath = join(dir, "compass.yaml");
+    writeFileSync(
+      configPath,
+      [
+        "mongo:",
+        '  uri: "mongodb://user:pass@mongo:27017/compass"',
+        "sync:",
+        '  mongoUri: "mongodb://user:pass@mongo:27017/compass_sync"',
+      ].join("\n"),
+      { encoding: "utf8" },
+    );
+
+    const installer = readRepoFile("self-host/install.sh");
+    const fns = ["strip_quotes", "read_config_value", "default_profiles"]
+      .map((name) => {
+        const match = installer.match(
+          new RegExp(`^${name}\\(\\)[\\s\\S]*?^}`, "m"),
+        );
+        if (!match)
+          throw new Error(`missing shell function in install.sh: ${name}`);
+        return match[0];
+      })
+      .join("\n\n");
+    const fnsPath = join(dir, "fns.sh");
+    writeFileSync(fnsPath, `${fns}\n`, { encoding: "utf8" });
+
+    const proc = Bun.spawn(
+      [
+        "bash",
+        "-c",
+        `CONFIG_FILE="$1"; . "$2"; default_profiles`,
+        "--",
+        configPath,
+        fnsPath,
+      ],
+      { cwd: repoRoot, stderr: "pipe", stdout: "pipe" },
+    );
+    const [stdout, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("selfhosted,sync");
+    expect(installer).toContain(
+      'export COMPOSE_PROFILES="' +
+        "$" +
+        '{COMPOSE_PROFILES-$(default_profiles)}"',
+    );
+
+    // install-manual.sh has no config-driven derivation (it only ever writes
+    // the bundled mongo URI), so it hardcodes both profiles directly instead.
+    const manual = readRepoFile("self-host/install-manual.sh");
+    expect(manual).toContain(
+      'export COMPOSE_PROFILES="' + "$" + '{COMPOSE_PROFILES-selfhosted,sync}"',
+    );
+    expect(manual).not.toContain("COMPOSE_PROFILES-selfhost}");
   });
 });
 
@@ -304,6 +404,14 @@ describe("self-host helper", () => {
 
     expect(helper).toContain("read_config_value runtime.version");
     expect(helper).not.toContain("read_config_value compose.version");
+  });
+
+  it("exports SYNC_PORT from sync.port, matching the web/backend port pattern", () => {
+    const helper = readRepoFile("self-host/compass");
+
+    expect(helper).toContain(
+      'export SYNC_PORT="$(strip_quotes "$(read_config_value sync.port)")"',
+    );
   });
 
   it("updates in place with compose wait", () => {

--- a/self-host/install-manual.sh
+++ b/self-host/install-manual.sh
@@ -187,8 +187,9 @@ SUPERTOKENS_POSTGRES_PASSWORD=$(random_hex) || exit 1
 SUPERTOKENS_KEY=$(random_hex) || exit 1
 COMPASS_SYNC_TOKEN=$(random_hex) || exit 1
 GCAL_NOTIFICATION_TOKEN=$(random_hex) || exit 1
+SYNC_INTERNAL_AUTH_TOKEN=$(random_hex) || exit 1
 
-echo "  ✓ Generated 6 cryptographic secrets (64 hex chars each)"
+echo "  ✓ Generated 7 cryptographic secrets (64 hex chars each)"
 
 # ── Section 6: Create Config File ─────────────────────────────────────────────
 # The compass.yaml file contains all configuration for your Compass instance.
@@ -244,11 +245,30 @@ supertokens:
 google:
   notificationToken: $GCAL_NOTIFICATION_TOKEN
 
-# To enable Google Calendar sync, uncomment and fill in your OAuth credentials:
+# To enable Google Calendar sign-in and calendar sync, uncomment and fill in
+# your OAuth credentials:
 # google:
 #   clientId: REPLACE_WITH_GOOGLE_CLIENT_ID # e.g. your-id.apps.googleusercontent.com
 #   clientSecret: REPLACE_WITH_GOOGLE_CLIENT_SECRET
 #   channelExpirationMin: 10
+
+# Compass Sync service — self-host runs the same architecture as Compass
+# Cloud. Uses the SAME bundled mongo as `mongo:` above, isolated to its own
+# compass_sync database (no separate database user exists on the bundled
+# image, so this reuses the root credentials against a different database
+# name). callbackBaseUrl defaults to localhost, which works for the OAuth
+# redirect but cannot receive Google push notifications — set it to your
+# public URL once you have a domain.
+sync:
+  port: 3010
+  mongoUri: mongodb://compass:$MONGO_PASSWORD@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
+  internalAuthToken: $SYNC_INTERNAL_AUTH_TOKEN
+  callbackBaseUrl: http://localhost:3010
+  serviceUrl: http://sync:3010
+  connectionRouting: sync
+  eventRouting: sync
+  cloudMutationMode: enabled
+  execution: active
 EOF
 
   chmod 600 "$CONFIG_FILE"
@@ -351,7 +371,7 @@ read_config_value() {
 
 # Export all variables needed by compose.yaml.
 export COMPASS_CONFIG_FILE="$CONFIG_FILE"
-export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhost}"
+export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhosted,sync}"
 export COMPASS_VERSION="$(strip_quotes "$(read_config_value runtime.version)")"
 export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"
 export PORT="$(strip_quotes "$(read_config_value backend.port)")"
@@ -485,7 +505,7 @@ Or use Docker Compose directly:
 
   cd "$COMPASS_HOME"
   export COMPASS_CONFIG_FILE="$CONFIG_FILE"
-  export COMPOSE_PROFILES=selfhost
+  export COMPOSE_PROFILES=selfhosted,sync
   docker compose --project-name "$PROJECT_NAME" -f compose.yaml logs
   docker compose --project-name "$PROJECT_NAME" -f compose.yaml down
   docker compose --project-name "$PROJECT_NAME" -f compose.yaml up -d

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -399,6 +399,7 @@ write_config_if_missing() {
   supertokens_key=$(generate_secret "SuperTokens API key") || exit 1
   compass_sync_token=$(generate_secret "Compass sync token") || exit 1
   gcal_notification_token=$(generate_secret "Google Calendar notification token") || exit 1
+  sync_internal_auth_token=$(generate_secret "Sync internal auth token") || exit 1
 
   umask 077
   TMP_ENV=$COMPASS_HOME/compass.yaml.$$
@@ -443,6 +444,25 @@ google:
 #   clientId: REPLACE_WITH_GOOGLE_CLIENT_ID # e.g. your-id.apps.googleusercontent.com
 #   clientSecret: REPLACE_WITH_GOOGLE_CLIENT_SECRET
 #   channelExpirationMin: 10
+
+# Compass Sync service — self-host runs the same architecture as Compass
+# Cloud. Uses the SAME bundled mongo as \`mongo:\` above, isolated to its own
+# compass_sync database (no separate database user exists on the bundled
+# image, so this reuses the root credentials against a different database
+# name). callbackBaseUrl defaults to localhost, which works for the OAuth
+# redirect but cannot receive Google push notifications — set it to your
+# public URL (and rerun with COMPASS_HOME set, or edit $CONFIG_FILE directly)
+# once you have a domain.
+sync:
+  port: 3010
+  mongoUri: mongodb://compass:$mongo_password@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0
+  internalAuthToken: $sync_internal_auth_token
+  callbackBaseUrl: http://localhost:3010
+  serviceUrl: http://sync:3010
+  connectionRouting: sync
+  eventRouting: sync
+  cloudMutationMode: enabled
+  execution: active
 EOF
 
   chmod 600 "$TMP_ENV" || fail "Could not secure temporary env file."
@@ -485,10 +505,29 @@ EOF
   [ $? -eq 0 ] || fail "Could not write marker file: $MARKER_FILE."
 }
 
+# Mirrors self-host/compass's default_profiles() (PR #2450) — duplicated
+# rather than sourced because the helper script isn't downloaded until after
+# this installer needs it once (start_stack, on first install). Keep the two
+# in sync; self-host/docker-compose.test.ts exercises the canonical copy.
+default_profiles() {
+  profiles=
+
+  mongo_uri=$(strip_quotes "$(read_config_value mongo.uri)")
+  case "$mongo_uri" in
+    "" | *//mongo:* | *@mongo:*) profiles=selfhosted ;;
+  esac
+
+  if [ -n "$(strip_quotes "$(read_config_value sync.mongoUri)")" ]; then
+    profiles="${profiles:+$profiles,}sync"
+  fi
+
+  printf '%s\n' "$profiles"
+}
+
 set_compose_env() {
   [ -f "$CONFIG_FILE" ] || fail "Missing config file: $CONFIG_FILE."
   export COMPASS_CONFIG_FILE="$CONFIG_FILE"
-  export COMPOSE_PROFILES="${COMPOSE_PROFILES-selfhosted}"
+  export COMPOSE_PROFILES="${COMPOSE_PROFILES-$(default_profiles)}"
   export COMPASS_VERSION="$(strip_quotes "$(read_config_value runtime.version)")"
   export WEB_PORT="$(strip_quotes "$(read_config_value web.port)")"
   export PORT="$(strip_quotes "$(read_config_value backend.port)")"


### PR DESCRIPTION
## Summary

Part 1 of retiring the legacy in-backend Google-sync engine, per the "self-host mirrors prod, at least in spirit" direction — two architectures for the same product is unnecessary maintenance burden. This step makes fresh self-host installs run the same Sync-based architecture prod has run since cutover, while the legacy engine stays in the codebase as-is for now (removed in a later change, after cleaning up a few delegation-fork surfaces this work surfaced).

- Both installers write a `sync:` block by default (`connectionRouting`/`eventRouting`/`execution` all `sync`/`sync`/`active`), reusing the bundled mongo's root credentials against an isolated `compass_sync` database — no separate DB user exists on the bundled image.
- **Found and fixed a real, independent bug**: both installers' own first-boot compose-profile logic never actually included the `sync` profile (`install.sh` hardcoded `selfhosted`, `install-manual.sh` hardcoded the wrong string `selfhost`) — a `sync:` config would have silently never started the sync container. `install.sh` now mirrors `self-host/compass`'s `default_profiles()` derivation (added in #2450, but only to the downloaded helper, not the installer's own duplicate); `install-manual.sh` hardcodes both profiles since it only ever writes the bundled mongo URI.
- `compose.yaml`'s sync port is now configurable via `SYNC_PORT`, matching the existing web/backend pattern (was hardcoded to `3010`).
- Split the web app's single Google-availability gate into two: sign-in still requires the build-time `GOOGLE_CLIENT_ID`, but connecting a calendar under sync delegation doesn't need it (the redirect flow runs no client-side code exchange) — so a self-host web image that hasn't been rebuilt with its own client id can still connect Google Calendar. Also fixed the availability loader silently skipping the `/config` fetch entirely when no client id was baked in, which would have left connect-delegation permanently undetectable in exactly the self-host scenario this PR targets.
- Rewrote the self-hosting docs (architecture diagram, Google Calendar setup, server guide, monitoring, Config reference) for the Sync-based redirect flow, and created `docs/backend/sync-service-cutover.md` — 5 places already linked to it and it didn't exist.

## Test plan

- [x] `self-host/compass.example.yaml` and a simulated `install.sh`-generated config both parse against the real `CompassConfigSchema`
- [x] `compose.yaml` resolves correctly via `docker compose config`, including the `SYNC_PORT` override
- [x] `bun test self-host/docker-compose.test.ts` — 41/41 pass
- [x] All web tests referencing the changed hooks — 119/119 pass across 7 files (`useIsGoogleAvailable`, `useConnectGoogle`, `AuthModal`, `CalendarList`, `CommandPalette`)
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default install topology and backend→Sync routing for calendar connect/events on fresh installs; web connect gating is behavior-changing but scoped and tested, with legacy engine still present for non-default configs.
> 
> **Overview**
> Fresh self-host installs now ship with the **standalone Sync service** as the default Google Calendar path—installers emit an active `sync:` block (`connectionRouting`/`eventRouting`/`execution` → sync/sync/active), a generated `internalAuthToken`, and **both** `selfhosted` and `sync` Compose profiles so the sync container actually starts on first boot (including a fix where `install.sh`’s first-boot profile logic never enabled `sync`, and `install-manual.sh` used the wrong profile string).
> 
> **Compose/helper:** sync’s host port is configurable via `sync.port` → `SYNC_PORT`, matching web/backend.
> 
> **Web:** calendar **connect** availability is split from Google **sign-in** (`useIsConnectGoogleAvailable`): sync-delegated connect no longer requires a baked-in `GOOGLE_CLIENT_ID`, and `/config` is always fetched so `connectDelegatedToSync` can be detected on unrebuilt self-host web images.
> 
> **Docs:** self-hosting guides, architecture diagram, Google Calendar (OAuth redirects `/sync/google`, webhooks `/sync/notifications/google`, `sync.callbackBaseUrl`), monitoring, backups, and config reference are updated for Sync-first ops; adds **`docs/backend/sync-service-cutover.md`** for routing/troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f289042079eb3a88f5d962fdd3a5f7d4f135d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->