### PR TITLE
fix(auth): stop the legacy sync engine from double-running on sign-in

### DIFF
--- a/packages/backend/src/auth/services/google/google.auth.service.delegation.db.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.delegation.db.test.ts
@@ -1,0 +1,150 @@
+import { faker } from "@faker-js/faker";
+import { type Credentials } from "google-auth-library";
+import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import GoogleOAuthClient from "@backend/auth/services/google/clients/google.oauth.client";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
+import { googleAuthService } from "./google.auth.service";
+import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+// A connection Sync owns must not also run the legacy engine's background
+// sync — otherwise both engines import/watch the same Google account at
+// once (2026-07-29 finding while wiring self-host sync-by-default: this
+// happened on every sign-in under connectionRouting=sync, unnoticed because
+// nothing asserted on it). Dedicated file for its own test process, so the
+// lazy sync-client singleton (sync-service.factory.ts) is built from these
+// CONFIG values rather than a legacy default already cached by another file.
+const enableSyncDelegation = () => {
+  CONFIG.SYNC_SERVICE_URL = "http://sync.invalid:4999";
+  CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
+  CONFIG.SYNC_CONNECTION_ROUTING = "sync";
+};
+
+describe("googleAuthService legacy-engine gating under connection delegation", () => {
+  beforeEach(() => setupTestDb(import.meta.url));
+  beforeEach(cleanupCollections);
+  // The shared backend test harness (mock.setup.ts's mockNodeModules, wired
+  // via the preload) registers its OWN beforeEach that resets the whole
+  // CONFIG object to a pre-captured baseline before every test — running
+  // AFTER a describe-scoped beforeAll but BEFORE each test body. So a
+  // beforeAll-only override here would get silently wiped before test 1 even
+  // runs; enableSyncDelegation must be in beforeEach (this file's own,
+  // registered after the harness's) to survive to the test body. Once the
+  // getSyncServiceClient() singleton is first computed (inside test 1) with
+  // these values, it stays cached for the rest of the file/process — which
+  // is what every test here wants anyway (steady "sync" delegation).
+  beforeEach(enableSyncDelegation);
+  afterAll(cleanupTestDb);
+
+  it("googleSignup does not start the legacy engine", async () => {
+    const startSpy = spyOn(
+      googleCalendarSyncService,
+      "startGoogleCalendarSyncIfNeeded",
+    ).mockResolvedValue();
+    const gUser = UserDriver.generateGoogleUser();
+    const userId = faker.database.mongodbObjectId();
+
+    await googleAuthService.googleSignup(gUser, faker.string.uuid(), userId);
+
+    expect(startSpy).not.toHaveBeenCalled();
+    startSpy.mockRestore();
+  });
+
+  it("repairGoogleConnection persists the reconnect but does not start the legacy engine", async () => {
+    const user = await UserDriver.createUser();
+    const compassUserId = user._id.toString();
+    const gUser = UserDriver.generateGoogleUser({
+      email: user.email,
+      sub: faker.string.uuid(),
+    });
+    const oAuthTokens: Pick<Credentials, "access_token" | "refresh_token"> = {
+      access_token: faker.internet.jwt(),
+      refresh_token: faker.string.uuid(),
+    };
+    const startSpy = spyOn(
+      googleCalendarSyncService,
+      "startGoogleCalendarSyncIfNeeded",
+    ).mockResolvedValue();
+
+    const result = await googleAuthService.repairGoogleConnection(
+      compassUserId,
+      gUser,
+      oAuthTokens,
+    );
+
+    // The reconnect itself (identity/profile persistence) is unaffected —
+    // only the legacy background-sync side effect is gated.
+    expect(result).toEqual({ cUserId: compassUserId });
+    expect(startSpy).not.toHaveBeenCalled();
+    startSpy.mockRestore();
+  });
+
+  it("googleSignin updates the profile but does not run the legacy incremental sync", async () => {
+    const user = await UserDriver.createUser();
+    const compassUserId = user._id.toString();
+    const providerUser = UserDriver.generateGoogleUser({
+      sub: user.google?.googleId,
+    });
+    const importSpy = spyOn(
+      googleCalendarSyncService,
+      "importLatestGoogleCalendarChanges",
+    ).mockResolvedValue(undefined);
+
+    const result = await googleAuthService.googleSignin(providerUser, {
+      access_token: faker.internet.jwt(),
+    });
+
+    expect(result).toEqual({ cUserId: compassUserId });
+    expect(importSpy).not.toHaveBeenCalled();
+    importSpy.mockRestore();
+  });
+
+  it("connectGoogleToCurrentUser (the legacy connect endpoint) also stays silent under sync delegation", async () => {
+    // This endpoint is only reached from the web app when connect is NOT
+    // sync-delegated (the web fork uses the redirect flow instead), but the
+    // backend-side gate is shared with sign-in — assert it holds here too.
+    const user = await UserDriver.createUser({ withGoogle: false });
+    const normalizedEmail = user.email.toLowerCase();
+    const compassUserId = user._id.toString();
+    const gUser = UserDriver.generateGoogleUser({
+      email: normalizedEmail,
+      sub: faker.string.uuid(),
+    });
+    const startSpy = spyOn(
+      googleCalendarSyncService,
+      "startGoogleCalendarSyncIfNeeded",
+    ).mockResolvedValue();
+    const exchangeSpy = spyOn(
+      GoogleOAuthClient.prototype,
+      "exchangeAuthCode",
+    ).mockResolvedValue({
+      gUser,
+      tokens: {
+        access_token: faker.internet.jwt(),
+        refresh_token: faker.string.uuid(),
+      },
+    } as never);
+
+    const result = await googleAuthService.connectGoogleToCurrentUser(
+      compassUserId,
+      {
+        clientType: "web",
+        thirdPartyId: "google",
+        redirectURIInfo: {
+          redirectURIOnProviderDashboard: "http://localhost:9080",
+          redirectURIQueryParams: { code: "auth-code" },
+        },
+      },
+    );
+
+    expect(result).toEqual({ cUserId: compassUserId });
+    expect(startSpy).not.toHaveBeenCalled();
+    exchangeSpy.mockRestore();
+    startSpy.mockRestore();
+  });
+});

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -15,6 +15,7 @@ import { UserError } from "@backend/common/errors/user/user.errors";
 import { normalizeEmail } from "@backend/common/helpers/email.util";
 import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
+import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
 import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 import userService from "@backend/user/services/user.service";
@@ -132,7 +133,14 @@ async function persistStoredGoogleConnection(
   return { cUserId };
 }
 
+// A connection Sync owns is not this engine's to touch — kicking it here
+// too would run both engines against the same Google account at once. Every
+// caller of this function funnels through here (googleSignup,
+// persistGoogleConnection, persistStoredGoogleConnection), so this is the one
+// gate needed for the legacy engine's write-side entirely.
 function startGoogleCalendarSyncIfNeededInBackground(cUserId: string) {
+  if (getConnectionDelegation() === "sync") return;
+
   googleCalendarSyncService
     .startGoogleCalendarSyncIfNeeded(cUserId)
     .catch((err) => {
@@ -288,28 +296,33 @@ async function googleSignin(
     quotaUser: cUserId,
   };
 
-  googleCalendarSyncService
-    .importLatestGoogleCalendarChanges(cUserId, freshContext)
-    .catch(async (err) => {
-      if (
-        err instanceof Error &&
-        err.message === SyncError.NoSyncToken.description
-      ) {
-        getLogger().info(
-          `Resyncing google data due to missing sync for user: ${cUserId}`,
-        );
+  // A connection Sync owns has already imported and stays current on its own
+  // (webhooks + reconcile sweep) — kicking the legacy incremental sync here
+  // too would run both engines against the same Google account at once.
+  if (getConnectionDelegation() !== "sync") {
+    googleCalendarSyncService
+      .importLatestGoogleCalendarChanges(cUserId, freshContext)
+      .catch(async (err) => {
+        if (
+          err instanceof Error &&
+          err.message === SyncError.NoSyncToken.description
+        ) {
+          getLogger().info(
+            `Resyncing google data due to missing sync for user: ${cUserId}`,
+          );
 
-        await userMetadataService.updateUserMetadata({
-          userId: cUserId,
-          data: { sync: { importGCal: "RESTART" } },
-        });
+          await userMetadataService.updateUserMetadata({
+            userId: cUserId,
+            data: { sync: { importGCal: "RESTART" } },
+          });
 
-        startGoogleCalendarSyncIfNeededInBackground(cUserId);
-        return;
-      }
+          startGoogleCalendarSyncIfNeededInBackground(cUserId);
+          return;
+        }
 
-      getLogger().error("Error during incremental sync:", err);
-    });
+        getLogger().error("Error during incremental sync:", err);
+      });
+  }
 
   return { cUserId };
 }


### PR DESCRIPTION
## Summary

Found while wiring self-host sync-by-default (previous PR): every Google sign-in unconditionally kicks off the **legacy in-backend sync engine's** background work (`startGoogleCalendarSyncIfNeeded` / `importLatestGoogleCalendarChanges`), regardless of `connectionRouting`. Prod has run `connectionRouting=sync` since the July cutover — meaning **every sign-in on prod today runs both sync engines against the same Google account in parallel**, unnoticed because nothing asserted on it.

- Gate both call sites behind `getConnectionDelegation() === "sync"`: skip the legacy engine entirely when Sync already owns the connection (it self-drives via webhooks + reconcile, so the legacy engine has nothing useful to do there).
- Legacy-routed deployments (self-hosters who haven't rebuilt, or a rollback scenario) are unaffected — the gate only skips the legacy kick when Sync is confirmed to own the connection.
- `determineGoogleAuthMode` (the SIGNUP/RECONNECT_REPAIR/SIGNIN_INCREMENTAL decision) is untouched — still exercised and correct for legacy-routed sign-ins. An earlier framing of this fix considered simplifying that function directly; that would have broken sign-in for anyone still on legacy routing, so it was dropped in favor of this narrower, additive gate.

Also worth flagging: while building the delegation test for this, I found `event.controller.delegation.test.ts` is itself currently failing (3/6) for what looks like an unrelated, pre-existing reason — filed as a separate follow-up, not fixed here.

## Test plan

- [x] New `google.auth.service.delegation.db.test.ts` (4 tests): `googleSignup`, `repairGoogleConnection`, `googleSignin`, and the legacy `connectGoogleToCurrentUser` endpoint all confirmed to skip the legacy engine under sync delegation, while still correctly persisting the sign-in/reconnect itself
- [x] Full `google.auth.service*` test suite — 51/51 pass (existing legacy-path tests unaffected)
- [x] Full `bun run test:backend` — 56 failures, matching the established pre-existing baseline exactly; none in touched files
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Google OAuth sign-in path and sync kickoff, but the change is a narrow config gate that preserves legacy behavior when Sync does not own connections.
> 
> **Overview**
> Fixes **double sync on Google sign-in** when `connectionRouting=sync`: the backend no longer starts the legacy in-process calendar engine if Sync already owns the connection.
> 
> **`startGoogleCalendarSyncIfNeededInBackground`** now returns immediately when `getConnectionDelegation() === "sync"`, so signup, reconnect, and connect flows still persist credentials/metadata but skip `startGoogleCalendarSyncIfNeeded`. **`googleSignin`** wraps the same rule around `importLatestGoogleCalendarChanges` (and its no-sync-token restart path). Legacy-routed deployments are unchanged.
> 
> Adds **`google.auth.service.delegation.db.test.ts`** with four DB tests that set sync delegation in `beforeEach` and assert those legacy sync entry points are not invoked while auth outcomes still succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5038641f76c9f4326ca715c1fa54611ae479a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->