### PR TITLE
feat(calendar): delegate freebusy availability to Sync

### DIFF
--- a/packages/backend/src/calendar/controllers/calendar.controller.delegation.test.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.delegation.test.ts
@@ -1,9 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type SessionRequest } from "supertokens-node/framework/express";
 import { CONFIG } from "@backend/common/constants/config.constants";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import { type Res_Promise } from "@backend/common/types/express.types";
 import calendarController from "./calendar.controller";
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 const objectId = () => faker.database.mongodbObjectId();
 
@@ -12,6 +13,16 @@ const reqFor = (userId: string) =>
   ({
     session: { getUserId: () => userId },
     query: {},
+  }) as unknown as SessionRequest;
+
+const availabilityReqFor = (userId: string, calendarIds: string[]) =>
+  ({
+    session: { getUserId: () => userId },
+    query: {
+      calendarIds: calendarIds.join(","),
+      start: "2026-07-14T00:00:00.000Z",
+      end: "2026-07-14T23:59:59.000Z",
+    },
   }) as unknown as SessionRequest;
 
 // Capture the promise the controller hands to res.promise so the test can
@@ -52,5 +63,100 @@ describe("CalendarController.list event delegation", () => {
     await calendarController.list(reqFor(objectId()), res);
 
     await expect(settled()).rejects.toThrow();
+  });
+});
+
+describe("CalendarController.availability event delegation", () => {
+  const originalRouting = CONFIG.SYNC_EVENT_ROUTING;
+  const originalServiceUrl = CONFIG.SYNC_SERVICE_URL;
+  const originalToken = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
+
+  afterEach(() => {
+    CONFIG.SYNC_EVENT_ROUTING = originalRouting;
+    CONFIG.SYNC_SERVICE_URL = originalServiceUrl;
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = originalToken;
+    mock.restore();
+  });
+
+  it("delegates availability to sync and fails closed on a sync outage (no legacy fallback)", async () => {
+    CONFIG.SYNC_SERVICE_URL = "http://sync.invalid:4999";
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
+    CONFIG.SYNC_EVENT_ROUTING = "sync";
+
+    const { res, settled } = capturingRes();
+    await calendarController.availability(
+      availabilityReqFor(objectId(), [objectId()]),
+      res,
+    );
+
+    await expect(settled()).rejects.toThrow();
+  });
+
+  it("queries each calendar separately and attributes intervals to their real calendarId", async () => {
+    // The day-grid layout positions a busy block by calendarId and drops
+    // blocks for calendars it doesn't recognize — a merged, single-attributed
+    // response would silently lose busy time for every calendar but one.
+    // This asserts each requested calendar is queried on its own and its
+    // intervals keep their own, correct calendarId in the response.
+    CONFIG.SYNC_SERVICE_URL = "http://sync.invalid:4999";
+    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = "test-sync-secret";
+    CONFIG.SYNC_EVENT_ROUTING = "sync";
+
+    const [first, second] = [objectId(), objectId()];
+    const queryBusyAvailability = mock(
+      (_principal: unknown, request: { calendarIds: readonly string[] }) => {
+        const requested = request.calendarIds[0];
+        const intervals =
+          requested === first
+            ? [
+                {
+                  start: "2026-07-14T09:00:00.000Z",
+                  end: "2026-07-14T10:00:00.000Z",
+                },
+              ]
+            : [
+                {
+                  start: "2026-07-14T14:00:00.000Z",
+                  end: "2026-07-14T15:00:00.000Z",
+                },
+              ];
+        return Promise.resolve({
+          ok: true as const,
+          value: {
+            intervals,
+            computedAt: "2026-07-14T08:00:00.000Z",
+            connections: [],
+            complete: true,
+            issues: [],
+            bookable: true,
+          },
+        });
+      },
+    );
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      queryBusyAvailability,
+    } as never);
+
+    const { res, settled } = capturingRes();
+    await calendarController.availability(
+      availabilityReqFor(objectId(), [first, second]),
+      res,
+    );
+
+    expect(queryBusyAvailability).toHaveBeenCalledTimes(2);
+    await expect(settled()).resolves.toEqual({
+      busyPeriods: [
+        {
+          calendarId: first,
+          start: "2026-07-14T09:00:00.000Z",
+          end: "2026-07-14T10:00:00.000Z",
+        },
+        {
+          calendarId: second,
+          start: "2026-07-14T14:00:00.000Z",
+          end: "2026-07-14T15:00:00.000Z",
+        },
+      ],
+    });
   });
 });

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -3,10 +3,13 @@ import {
   type CalendarListResponse,
   SetCalendarVisibilityInputSchema,
 } from "@core/types/calendar.contracts";
+import { BusyPeriodSchema } from "@core/types/event.contracts";
 import {
   type AvailabilityQuery,
   AvailabilityQuerySchema,
+  type AvailabilityResponse,
 } from "@core/types/event-command.contracts";
+import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
 import { zObjectId } from "@core/types/type.utils";
 import { mapCalendarRecord } from "@backend/calendar/calendar.record.mapper";
 import calendarService from "@backend/calendar/services/calendar.service";
@@ -21,6 +24,13 @@ import {
   type Res_Promise,
   type SReqBody,
 } from "@backend/common/types/express.types";
+
+// Availability is display-only decoration here (inert busy blocks on the
+// grid, not a booking decision), so a generous freshness tolerance avoids
+// flagging normal sync latency as stale. Sync still returns intervals past
+// this age — see busy-query.service.ts — this only affects the `complete`/
+// `bookable` flags, which this display-only caller doesn't act on.
+const AVAILABILITY_DISPLAY_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 // A7 "bounded": AvailabilityQuerySchema (core) only enforces end > start, not
 // a maximum span - an unbounded range would let one request fan a Google
@@ -79,6 +89,55 @@ const listCalendarsFromSync = async (
   return { calendars: result.value.calendars.map(syncCalendarToBrowser) };
 };
 
+// Busy time from the sync service, translated to the browser's per-calendar
+// AvailabilityResponse contract. Sync's busy endpoint reports one MERGED set
+// of intervals across every calendar in a single request — it does not
+// attribute an interval back to its source calendar. The day-grid layout
+// (DayCalendarBusyPeriodsLayer) positions each busy block into a specific
+// per-calendar column and drops any block whose calendarId isn't in that
+// map, so a merged response with a guessed calendarId would silently lose
+// busy time for every calendar but one, not just mislabel it. Query each
+// calendar separately (bounded by AvailabilityQuerySchema's own array size,
+// same fan-out shape the legacy path already does per Google calendar id) so
+// every interval keeps its real, correct calendarId.
+const getAvailabilityFromSync = async (
+  userId: string,
+  query: AvailabilityQuery,
+): Promise<AvailabilityResponse> => {
+  const client = getSyncServiceClient();
+  if (!client) {
+    throw error(GenericError.NotSure, "Sync availability unavailable");
+  }
+  const principal = toSyncPrincipal(userId);
+
+  const perCalendar = await Promise.all(
+    query.calendarIds.map(async (calendarId) => {
+      const result = await client.queryBusyAvailability(principal, {
+        calendarIds: [SyncEventCalendarIdSchema.parse(calendarId)],
+        start: query.start,
+        end: query.end,
+        maxAgeMs: AVAILABILITY_DISPLAY_MAX_AGE_MS,
+        purpose: "display",
+      });
+      if (!result.ok) {
+        throw error(
+          GenericError.NotSure,
+          `Failed to query availability from sync (${result.error.kind})`,
+        );
+      }
+      return result.value.intervals.map((interval) =>
+        BusyPeriodSchema.parse({
+          calendarId,
+          start: interval.start,
+          end: interval.end,
+        }),
+      );
+    }),
+  );
+
+  return { busyPeriods: perCalendar.flat() };
+};
+
 class CalendarController {
   list = async (req: SessionRequest, res: Res_Promise) => {
     try {
@@ -133,7 +192,10 @@ class CalendarController {
       const query = parseAvailabilityQuery(req.query);
       assertBoundedAvailabilityRange(query);
 
-      const response = await calendarService.getAvailability(userId, query);
+      const response =
+        getEventDelegation() === "sync"
+          ? await getAvailabilityFromSync(userId.toString(), query)
+          : await calendarService.getAvailability(userId, query);
 
       res.promise(response);
     } catch (e) {


### PR DESCRIPTION
## Summary

`GET /api/calendar/availability` was the last event surface that never checked `getEventDelegation()` — it always read Google freebusy directly via the legacy `user.google.gRefreshToken`, even when `eventRouting=sync` means Sync owns the connection and that legacy token may be absent or stale. Now branches like every other event route: legacy path unchanged, sync path calls the already-built `SyncServiceClient.queryBusyAvailability`.

Caught a real shape mismatch before shipping, not just a cosmetic one: Sync's busy endpoint returns one **merged** set of intervals across all requested calendars, with no per-calendar attribution. A naive translation (guessing one `calendarId` for every interval) would have been a genuine regression — `DayCalendarBusyPeriodsLayer` positions each busy block into a specific per-calendar column via `calendarId` and **silently drops** any block whose id isn't in that column map. So busy time for every calendar but the guessed one would have visually disappeared in that view, not just carried a wrong a11y label. Fixed by querying each requested calendar separately (`Promise.all`) instead of one merged call, so every interval keeps its real, correct `calendarId`. No Sync-side contract change needed.

## Test plan

- [x] New tests in `calendar.controller.delegation.test.ts`: fails closed on a sync outage (no legacy fallback), and confirms each requested calendar is queried separately with intervals correctly attributed back to their real `calendarId`
- [x] Full `calendar/` test suite — 42/42 pass (legacy path unaffected)
- [x] Full `bun run test:backend` — 56 failures, matching the established pre-existing baseline exactly
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a user-facing read path and adds N sync calls per availability request when multiple calendars are selected; behavior is gated on sync routing and is well tested but affects grid display correctness.
> 
> **Overview**
> **Calendar availability** now follows `getEventDelegation()` like other event surfaces: when routing is `sync`, `GET /api/calendar/availability` uses `SyncServiceClient.queryBusyAvailability` instead of legacy Google freebusy via `calendarService.getAvailability`. Sync failures reject with no legacy fallback.
> 
> Because sync’s busy API returns **merged** intervals without per-calendar attribution, the controller issues **one sync query per requested calendar** and maps each interval to the correct `calendarId` for the day-grid (`DayCalendarBusyPeriodsLayer`). Display-only calls use a 24h `maxAgeMs` and `purpose: "display"`.
> 
> Delegation tests cover sync outage fail-closed behavior and two-calendar fan-out with correct `busyPeriods` attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20e16593ee6008c1aced6e1389af8645bb000d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->