### PR TITLE
fix(sync): stop the legacy repair action from running a third engine

### DIFF
--- a/packages/backend/src/sync/controllers/sync.controller.db.test.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.db.test.ts
@@ -16,6 +16,7 @@ import {
 import { invalidGrant400Error } from "@backend/__tests__/mocks.gcal/errors/error.google.invalidGrant";
 import { invalidSyncTokenError } from "@backend/__tests__/mocks.gcal/errors/error.invalidSyncToken";
 import { missingRefreshTokenError } from "@backend/__tests__/mocks.gcal/errors/error.missingRefreshToken";
+import { CONFIG } from "@backend/common/constants/config.constants";
 import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { sseServer } from "@backend/servers/sse/sse.server";
@@ -33,6 +34,7 @@ import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -695,6 +697,47 @@ describe("SyncController", () => {
 
         getAllEventsSpy.mockRestore();
         getGCalEventsSyncPageTokenSpy.mockRestore();
+      });
+    });
+
+    describe("Sync delegation:", () => {
+      const originalConnectionRouting = CONFIG.SYNC_CONNECTION_ROUTING;
+      const originalEventRouting = CONFIG.SYNC_EVENT_ROUTING;
+
+      afterEach(() => {
+        CONFIG.SYNC_CONNECTION_ROUTING = originalConnectionRouting;
+        CONFIG.SYNC_EVENT_ROUTING = originalEventRouting;
+      });
+
+      it("refuses with 409 and never starts the legacy engine once Sync owns connections/events", async () => {
+        // Assigned in-test (not beforeAll): the shared backend harness's
+        // global beforeEach resets CONFIG to baseline before every test body
+        // runs, so a beforeAll-only override never survives to see it.
+        CONFIG.SYNC_CONNECTION_ROUTING = "sync";
+        CONFIG.SYNC_EVENT_ROUTING = "sync";
+
+        const { user } = await UtilDriver.setupTestUser();
+        const userId = user._id.toString();
+        const repairSpy = spyOn(
+          googleCalendarSyncService,
+          "repairGoogleCalendarSync",
+        );
+        const startSpy = spyOn(
+          googleCalendarSyncService,
+          "startGoogleCalendarSyncIfNeeded",
+        );
+
+        await syncDriver.importGCal(
+          { userId },
+          { force: true },
+          Status.CONFLICT,
+        );
+
+        expect(repairSpy).not.toHaveBeenCalled();
+        expect(startSpy).not.toHaveBeenCalled();
+
+        repairSpy.mockRestore();
+        startSpy.mockRestore();
       });
     });
 

--- a/packages/backend/src/sync/controllers/sync.controller.ts
+++ b/packages/backend/src/sync/controllers/sync.controller.ts
@@ -296,6 +296,16 @@ export class SyncController {
 
   static importGCal = (req: Request, res: Response): void => {
     if (rejectIfMaintenance(res)) return;
+    // Same reasoning as handleGoogleNotification above: once Sync owns
+    // connections/events, the legacy engine has no data of its own left to
+    // repair for this deployment — running it here would just start a
+    // second, wasted import in parallel with Sync (2026-07-29: found while
+    // auditing every place that could kick the legacy engine unconditionally
+    // — see the sign-in fix, PR #2458, for the first instance of this bug).
+    if (!legacyWatchOwnership.isLegacyGoogleWatchOwner()) {
+      res.status(Status.CONFLICT).json({ error: "legacy_sync_unavailable" });
+      return;
+    }
     const userId = req.session!.getUserId();
     const { force } = ImportGCalRequestSchema.parse(req.body);
     const isForce = force === true;

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -145,7 +145,12 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
   }, []);
 
   return {
-    ...getGoogleConnectionConfig(state, onOpenGoogleAuth, onRepairGoogle),
+    ...getGoogleConnectionConfig(
+      state,
+      onOpenGoogleAuth,
+      onRepairGoogle,
+      isConnectDelegatedToSync,
+    ),
     connect: onOpenGoogleAuth,
     isAvailable,
     isConnecting,

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -132,7 +132,7 @@ describe("getGoogleConnectionConfig", () => {
     "IMPORTING",
   ] as const)("returns no command action for %s", (state) => {
     expect(
-      getGoogleConnectionConfig(state, onConnectGoogle, onRepairGoogle),
+      getGoogleConnectionConfig(state, onConnectGoogle, onRepairGoogle, false),
     ).toEqual({ commandAction: null });
   });
 
@@ -141,6 +141,7 @@ describe("getGoogleConnectionConfig", () => {
       "NOT_CONNECTED",
       onConnectGoogle,
       onRepairGoogle,
+      false,
     );
 
     expect(config.commandAction?.label).toBe("Connect Google Calendar");
@@ -153,6 +154,7 @@ describe("getGoogleConnectionConfig", () => {
       "RECONNECT_REQUIRED",
       onConnectGoogle,
       onRepairGoogle,
+      false,
     );
 
     expect(config.commandAction?.label).toBe("Reconnect Google Calendar");
@@ -160,15 +162,30 @@ describe("getGoogleConnectionConfig", () => {
     expect(onConnectGoogle).toHaveBeenCalledTimes(1);
   });
 
-  it("wires ATTENTION to onRepairGoogle", () => {
+  it("wires ATTENTION to onRepairGoogle under legacy routing", () => {
     const config = getGoogleConnectionConfig(
       "ATTENTION",
       onConnectGoogle,
       onRepairGoogle,
+      false,
     );
 
     expect(config.commandAction?.label).toBe("Sync Google Calendar");
     config.commandAction?.onSelect?.();
     expect(onRepairGoogle).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the ATTENTION action under sync delegation (no working remedy exists there)", () => {
+    // onRepairGoogle force-restarts the legacy engine, which the backend now
+    // refuses once Sync owns connections/events — offering the button would
+    // be a dead click, not a real recovery path.
+    const config = getGoogleConnectionConfig(
+      "ATTENTION",
+      onConnectGoogle,
+      onRepairGoogle,
+      true,
+    );
+
+    expect(config).toEqual({ commandAction: null });
   });
 });

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -56,6 +56,15 @@ export const getGoogleConnectionConfig = (
   state: GoogleUiState,
   onConnectGoogle: () => void,
   onRepairGoogle: () => void,
+  // ATTENTION's action force-restarts the LEGACY sync engine
+  // (POST /api/sync/import-gcal) — under sync delegation that has no data of
+  // its own left to repair (the backend now refuses this route once Sync
+  // owns connections/events, see sync.controller.ts), so offering it would
+  // be a dead button. No sync-owned remedy exists for ATTENTION yet either
+  // (it means a Sync outage or a permanent conflict, neither of which a
+  // resync fixes) — hiding it is honest about that gap rather than papering
+  // over it with an action that does nothing.
+  isConnectDelegatedToSync: boolean,
 ): GoogleUiConfig => {
   switch (state) {
     case "checking":
@@ -80,6 +89,9 @@ export const getGoogleConnectionConfig = (
         },
       };
     case "ATTENTION":
+      if (isConnectDelegatedToSync) {
+        return { commandAction: null };
+      }
       return {
         commandAction: {
           label: "Sync Google Calendar",


### PR DESCRIPTION
## Summary

While auditing every place that could kick the legacy sync engine unconditionally (after the sign-in fix, #2458), found a third live instance of the same bug: the "Sync Google Calendar" command-palette action shown for `ATTENTION` state calls `POST /api/sync/import-gcal`, which force-restarts the legacy engine with **no delegation check at all**. Unlike the sign-in path, this one is reachable via a real, currently-clickable button in prod today.

- **Backend**: gated `SyncController.importGCal` with the same `isLegacyGoogleWatchOwner()` check `handleGoogleNotification` already uses in this exact file — refuses with `409` instead of silently running a repair that has no legacy data left to fix once Sync owns connections/events.
- **Frontend**: hid the `ATTENTION` command action entirely under sync delegation (`getGoogleConnectionConfig` now takes `isConnectDelegatedToSync`) rather than leaving a button that would now silently no-op against the backend refusal. No Sync-owned remedy exists for `ATTENTION` yet either — it means a Sync outage or a permanent conflict, neither of which a resync fixes — so hiding the action is honest about that gap rather than offering a dead click. `onRepairGoogle`/`SyncApi.importGCal` stay in place; they're still the correct remedy under legacy routing.

## Test plan

- [x] New backend test confirming `importGCal` refuses with 409 and never calls the legacy engine when sync-delegated
- [x] New frontend tests confirming `getGoogleConnectionConfig` hides the `ATTENTION` action under sync delegation, keeps it under legacy routing
- [x] Full related web sweep — 126/126 pass
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on changed files — clean
- [ ] `sync.controller.db.test.ts`'s real-HTTP-server integration tests fail locally in this sandbox even on a clean baseline (pre-existing "socket hang up", confirmed via git-stash isolation — unrelated to this change). Deferring to CI's `unit (backend)` job, which has been green on every PR this session, as the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync routing and user-visible recovery for Google ATTENTION state, but behavior is narrowly scoped to delegated deployments with tests; legacy paths unchanged.
> 
> **Overview**
> Stops **`POST /api/sync/import-gcal`** from force-starting the legacy Google import when Sync owns connections and events—the same delegation rule already used for Google webhook handling.
> 
> **Backend:** `importGCal` now returns **409** with `legacy_sync_unavailable` via `isLegacyGoogleWatchOwner()` instead of calling `repairGoogleCalendarSync` / `startGoogleCalendarSyncIfNeeded`.
> 
> **Frontend:** The command-palette **“Sync Google Calendar”** action for `ATTENTION` is hidden when connect is sync-delegated, since that action only hits the legacy repair endpoint and there is no sync-owned fix for that state yet. Legacy routing still shows the repair action.
> 
> **Tests:** DB test for 409 + no legacy engine calls under sync routing; unit tests for hiding vs keeping the ATTENTION action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8463638d17cdc7f36bdce7cfc1478b63b5de85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->