### PR TITLE
fix(backend): fix beforeAll/beforeEach CONFIG ordering in event delegation tests

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.delegation.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.delegation.test.ts
@@ -8,7 +8,7 @@ import * as syncServiceFactory from "@backend/common/services/sync-service/sync-
 import eventController from "./event.controller";
 import {
   afterEach,
-  beforeAll,
+  beforeEach,
   describe,
   expect,
   it,
@@ -89,20 +89,15 @@ const enableSyncDelegation = () => {
 };
 
 describe("EventController event delegation", () => {
-  const originalRouting = CONFIG.SYNC_EVENT_ROUTING;
-  const originalServiceUrl = CONFIG.SYNC_SERVICE_URL;
-  const originalToken = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
-
-  beforeAll(() => {
+  // The shared backend harness's global beforeEach (mock.setup.ts) resets
+  // CONFIG to its file-load baseline before every test body runs, which
+  // would wipe a beforeAll-set override. Use beforeEach here so this runs
+  // after that reset, not before it.
+  beforeEach(() => {
     enableSyncDelegation();
   });
 
   afterEach(() => {
-    CONFIG.SYNC_EVENT_ROUTING = originalRouting;
-    CONFIG.SYNC_SERVICE_URL = originalServiceUrl;
-    CONFIG.SYNC_INTERNAL_AUTH_TOKEN = originalToken;
-    // Re-enable for the next test in this file (singleton already primed).
-    enableSyncDelegation();
     mock.restore();
   });
 


### PR DESCRIPTION
## Summary

`event.controller.delegation.test.ts` had 3 of its 6 tests failing when run standalone, expecting specific HTTP status codes (502, 401, 502) but receiving 500. The production code (`event.controller.ts` / `event.error.ts`) was correct — this was a test-harness ordering bug.

The file set `CONFIG.SYNC_EVENT_ROUTING = "sync"` inside `beforeAll`. But the shared backend test harness registers a global `beforeEach` (`mock.setup.ts`) that resets `CONFIG` to its file-load baseline before *every* test body runs. Since `beforeAll` fires once, before even the first test's `beforeEach`, its override was wiped before any test body executed. Every test in the file was silently running in `legacy` routing mode instead of `sync` mode, so the controller hit `eventService` (throwing an unmapped error → generic 500) instead of the sync delegation path that maps failures to specific status codes.

Three of the six tests masked this with loose assertions (`status !== 200`), so they passed anyway; the three tests with exact status assertions failed.

## Simplicity

Fix is a 3-line hook change: move the `CONFIG` override from `beforeAll` to `beforeEach` so it re-asserts sync-mode config after the harness's global reset, right before each test body runs. Also dropped the now-redundant manual save/restore of the original `CONFIG` values, since the harness's own `afterEach` already restores baseline.

Checked the sibling file `calendar.controller.delegation.test.ts` for the same class of bug — it doesn't have it, since it sets `CONFIG` inline inside its single `it()` body (after that test's `beforeEach` has already fired), not in `beforeAll`.

## Automated validation

- Ran the target file standalone 4x in a row (once pre-fix reproducing the failure, 3x post-fix) — all 6 tests pass consistently.
- `bun run type-check` — clean.
- Full backend suite before/after (via `git stash` compare): 56 fail → 53 fail, exactly the 3 tests fixed here, no new regressions. Remaining failures are pre-existing SSE-timeout flakiness unrelated to this file.

## Independent review

N/A — small, isolated test-only fix; not run through a separate review pass.

## Test plan

```
bun run test:backend packages/backend/src/event/controllers/event.controller.delegation.test.ts
bun run test:backend packages/backend/src/calendar/controllers/calendar.controller.delegation.test.ts
bun run type-check
bun run test:backend
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated test harness hook ordering fix with no production code changes.
> 
> **Overview**
> Fixes **event delegation tests** that were asserting sync-routing HTTP statuses (502, 401) but often saw **500** because they never actually ran in `sync` mode.
> 
> The shared harness **`mock.setup.ts`** resets `CONFIG` in a global **`beforeEach`** before each test. **`beforeAll`** ran once and was wiped before every test body, so **`enableSyncDelegation()`** was moved to **`beforeEach`** so sync URL, token, and **`SYNC_EVENT_ROUTING = "sync"`** apply after that reset. Redundant manual CONFIG restore in **`afterEach`** was removed; **`mock.restore()`** remains.
> 
> **Test-only** change; no production behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919ae0a4b404abf46e5072f675d3cebf9d5d49ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->