### PR TITLE
chore(user): strip the legacy sync-health fallback from assessGoogleMetadata

### DIFF
--- a/packages/backend/src/user/services/user-metadata.service.db.test.ts
+++ b/packages/backend/src/user/services/user-metadata.service.db.test.ts
@@ -1,8 +1,6 @@
 import { type UserMetadata } from "@core/types/user.types";
-import { GoogleWatchDriver } from "@backend/__tests__/drivers/google-watch.driver";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { UserMetadataServiceDriver } from "@backend/__tests__/drivers/user-metadata.service.driver";
-import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
   cleanupCollections,
   cleanupTestDb,
@@ -11,21 +9,12 @@ import {
 import { getUserMetadataStore } from "@backend/auth/ports/supertokens.registry";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import {
-  endGoogleSync,
-  resetGoogleSyncActivityForTests,
-  tryBeginGoogleSync,
-} from "@backend/sync/services/google-sync/google-sync.activity";
-import { googleCalendarSyncService } from "@backend/sync/services/google-sync/google-sync.service";
-import * as googleWatchConfig from "@backend/sync/services/watch/google-watch-config";
-import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,
   expect,
   it,
-  spyOn,
 } from "bun:test";
 
 describe("UserMetadataService", () => {
@@ -34,7 +23,6 @@ describe("UserMetadataService", () => {
   beforeAll(initSupertokens);
   beforeAll(() => setupTestDb(import.meta.url));
   beforeEach(cleanupCollections);
-  afterEach(resetGoogleSyncActivityForTests);
   afterAll(cleanupTestDb);
 
   describe("updateUserMetadata", () => {
@@ -134,119 +122,13 @@ describe("UserMetadataService", () => {
       expect(metadata.google?.connectionState).toBe("RECONNECT_REQUIRED");
     });
 
-    it("returns HEALTHY when the account is connected and sync state is healthy", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const userId = user._id.toString();
-
-      const metadata = await driver.fetchUserMetadata(userId);
-
-      expect(metadata.google?.connectionState).toBe("HEALTHY");
-    });
-
-    it("returns HEALTHY without active watches when running without an HTTPS Google webhook URL", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const userId = user._id.toString();
-      const isUsingGcalWebhookHttpsSpy = spyOn(
-        googleWatchConfig,
-        "isUsingGcalWebhookHttps",
-      ).mockReturnValue(false);
-
-      await GoogleWatchDriver.removeActiveGoogleWatchesForUser(userId);
-
-      const metadata = await driver.fetchUserMetadata(userId);
-
-      expect(metadata.google?.connectionState).toBe("HEALTHY");
-
-      isUsingGcalWebhookHttpsSpy.mockRestore();
-    });
-
-    it("returns ATTENTION without active watches when using an HTTPS Google webhook URL", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const userId = user._id.toString();
-      const isUsingGcalWebhookHttpsSpy = spyOn(
-        googleWatchConfig,
-        "isUsingGcalWebhookHttps",
-      ).mockReturnValue(true);
-
-      await GoogleWatchDriver.removeActiveGoogleWatchesForUser(userId);
-
-      const metadata = await driver.fetchUserMetadata(userId);
-
-      expect(metadata.google?.connectionState).toBe("ATTENTION");
-
-      isUsingGcalWebhookHttpsSpy.mockRestore();
-    });
-
-    it("returns ATTENTION without scheduling repair when connected sync state is broken", async () => {
+    it("returns ATTENTION when connected but no Sync client is configured", async () => {
+      // The test env sets no SYNC_SERVICE_URL, so assessGoogleMetadata falls
+      // back to this deployment-without-Sync case — there's no sync engine
+      // left to check health against, so a connected user reports ATTENTION
+      // rather than a fabricated HEALTHY/IMPORTING.
       const user = await UserDriver.createUser();
       const userId = user._id.toString();
-      const restartSpy = spyOn(
-        googleCalendarSyncService,
-        "startGoogleCalendarSyncIfNeeded",
-      ).mockResolvedValue();
-
-      const metadata = await driver.fetchUserMetadata(userId);
-
-      expect(metadata.google?.connectionState).toBe("ATTENTION");
-      expect(restartSpy).not.toHaveBeenCalled();
-
-      restartSpy.mockRestore();
-    });
-
-    it("returns ATTENTION after a repair failed", async () => {
-      const user = await UserDriver.createUser();
-      const userId = user._id.toString();
-
-      await driver.updateUserMetadata({
-        userId,
-        data: { sync: { importGCal: "ERRORED" } },
-      });
-
-      const metadata = await driver.fetchUserMetadata(userId);
-
-      expect(metadata.google?.connectionState).toBe("ATTENTION");
-    });
-
-    it("returns ATTENTION when stored importing metadata has no active sync", async () => {
-      const user = await UserDriver.createUser();
-      const userId = user._id.toString();
-      const restartSpy = spyOn(
-        googleCalendarSyncService,
-        "startGoogleCalendarSyncIfNeeded",
-      ).mockResolvedValue();
-
-      await driver.updateUserMetadata({
-        userId,
-        data: { sync: { importGCal: "IMPORTING" } },
-      });
-
-      const metadata = await driver.fetchUserMetadata(userId);
-
-      expect(metadata.google?.connectionState).toBe("ATTENTION");
-      expect(restartSpy).not.toHaveBeenCalled();
-
-      restartSpy.mockRestore();
-    });
-
-    it("returns IMPORTING while Google sync work is active", async () => {
-      const user = await UserDriver.createUser();
-      const userId = user._id.toString();
-
-      expect(tryBeginGoogleSync(userId)).toBe(true);
-      const metadata = await driver.fetchUserMetadata(userId);
-      endGoogleSync(userId);
-
-      expect(metadata.google?.connectionState).toBe("IMPORTING");
-    });
-
-    it("returns ATTENTION when a restart is pending", async () => {
-      const user = await UserDriver.createUser();
-      const userId = user._id.toString();
-
-      await driver.updateUserMetadata({
-        userId,
-        data: { sync: { importGCal: "RESTART" } },
-      });
 
       const metadata = await driver.fetchUserMetadata(userId);
 

--- a/packages/backend/src/user/services/user-metadata.service.ts
+++ b/packages/backend/src/user/services/user-metadata.service.ts
@@ -5,12 +5,9 @@ import {
   type UserMetadata,
 } from "@core/types/user.types";
 import { getUserMetadataStore } from "@backend/auth/ports/supertokens.registry";
-import { getConnectionDelegation } from "@backend/common/services/sync-service/connection-routing";
 import { resolveGoogleConnectionFromSync } from "@backend/common/services/sync-service/google-connection-status";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
-import { isGoogleSyncActive } from "@backend/sync/services/google-sync/google-sync.activity";
-import { isGoogleCalendarSyncHealthy } from "@backend/sync/services/google-sync/google-sync.health";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 import { type GetUserMetadataResponse } from "@backend/user/types/user.types";
 
@@ -53,22 +50,17 @@ class UserMetadataService {
 
   assessGoogleMetadata = async (
     userId: string,
-    metadata?: UserMetadata,
   ): Promise<GoogleMetadataAssessment> => {
-    // When this deployment routes provider connections to the sync service, the
-    // connection state is owned there, not by the legacy google sub-doc, so
-    // derive it from sync. getConnectionDelegation() only returns "sync" once a
-    // client is configured (it fails safe to "legacy" otherwise), so a client is
-    // present here; the guard keeps this defensive.
-    if (getConnectionDelegation() === "sync") {
-      const client = getSyncServiceClient();
-      if (client) {
-        return resolveGoogleConnectionFromSync(client, toSyncPrincipal(userId));
-      }
+    const client = getSyncServiceClient();
+    if (client) {
+      return resolveGoogleConnectionFromSync(client, toSyncPrincipal(userId));
     }
 
-    const storedMetadata =
-      metadata ?? (await this.getStoredUserMetadata(userId));
+    // No Sync client configured — every real deployment has one (self-host
+    // and prod both require it); this only happens in a dev/test environment
+    // that hasn't provisioned Sync. Without it there's no sync engine left to
+    // check health against, so report ATTENTION rather than fabricate
+    // HEALTHY/IMPORTING from data that no longer means anything.
     const user = await findCompassUserBy("_id", userId);
     const googleId = user?.google?.googleId;
     const hasRefreshToken = Boolean(user?.google?.gRefreshToken);
@@ -79,20 +71,6 @@ class UserMetadataService {
 
     if (!hasRefreshToken) {
       return { connectionState: "RECONNECT_REQUIRED" };
-    }
-
-    if (isGoogleSyncActive(userId)) {
-      return { connectionState: "IMPORTING" };
-    }
-
-    const importStatus = storedMetadata.sync?.importGCal;
-    if (importStatus === "IMPORTING" || importStatus === "RESTART") {
-      return { connectionState: "ATTENTION" };
-    }
-
-    const isHealthy = await isGoogleCalendarSyncHealthy(userId);
-    if (isHealthy) {
-      return { connectionState: "HEALTHY" };
     }
 
     return { connectionState: "ATTENTION" };
@@ -166,10 +144,8 @@ class UserMetadataService {
       };
     }
 
-    const { connectionState, connection } = await this.assessGoogleMetadata(
-      userId,
-      metadata,
-    );
+    const { connectionState, connection } =
+      await this.assessGoogleMetadata(userId);
 
     // Cast: SuperTokens JSONObject's index signature doesn't accept our nested
     // google.connection summary type even though every field is JSON-safe.


### PR DESCRIPTION
## Summary
- `getConnectionDelegation()` always resolves `"sync"` in every real deployment now (self-host and prod both require Sync) — `assessGoogleMetadata`'s `isGoogleSyncActive`/`isGoogleCalendarSyncHealthy` legacy fallback was only reachable in a dev/test environment that never provisioned Sync.
- Collapsed the fallback: ask Sync if a client is configured; otherwise report `NOT_CONNECTED`/`RECONNECT_REQUIRED` from core user fields (not legacy-engine specific) or `ATTENTION` for a connected-but-unverifiable user — matching the same "fail closed to ATTENTION" pattern `resolveGoogleConnectionFromSync` already uses for a Sync outage, rather than fabricating `HEALTHY`/`IMPORTING` from a legacy engine that will no longer exist.
- Rewrote `user-metadata.service.db.test.ts`'s 8 tests that exercised the deep legacy fallback (distinguishing `HEALTHY`/`IMPORTING`/`ATTENTION` by watch state, sync activity, and stored import status) down to one test proving the new collapsed behavior — those distinctions no longer exist once the legacy engine isn't there to produce them.

Part of the ongoing self-host/legacy-sync-removal effort (task 4.2).

## Test plan
- [x] `bunx typescript@7.0.2 --noEmit` — clean
- [x] full repo `biome check` — clean
- [x] `bun run test:backend` — fail list identical to the established pre-existing baseline (zero diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `google.connectionState` is computed for metadata consumers; production should still use Sync, but dev/test without Sync will no longer show HEALTHY/IMPORTING from legacy signals.
> 
> **Overview**
> **`assessGoogleMetadata`** no longer uses **`getConnectionDelegation`**, in-process Google sync activity, calendar health checks, or stored **`importGCal`** metadata to infer **`HEALTHY`** / **`IMPORTING`**. When a Sync service client exists, connection state comes only from **`resolveGoogleConnectionFromSync`**; otherwise connected users without Sync get **`ATTENTION`** instead of legacy-derived states.
> 
> **`fetchUserMetadata`** calls **`assessGoogleMetadata(userId)`** without passing stored metadata. DB tests drop the eight legacy health/watch/import scenarios and keep one case for the no-Sync-client test environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee84c3c14abf03dfcde710f38946e7b0b5ef6dcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->