### PR TITLE
chore(calendar): strip the now-dead legacy branch from calendar.controller.ts

### DIFF
--- a/packages/backend/src/calendar/controllers/calendar.controller.test.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.test.ts
@@ -1,28 +1,21 @@
-import { ObjectId } from "mongodb";
 import { type SessionRequest } from "supertokens-node/framework/express";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { CalendarListResponseSchema } from "@core/types/calendar.contracts";
-import {
-  type AvailabilityResponse,
-  AvailabilityResponseSchema,
-} from "@core/types/event-command.contracts";
 import { restoreFileMocks } from "@backend/__tests__/helpers/mock.setup";
-import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import calendarController from "@backend/calendar/controllers/calendar.controller";
 import calendarService from "@backend/calendar/services/calendar.service";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import { type Res_Promise } from "@backend/common/types/express.types";
 import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 // These exercise calendarController.availability directly against fake
 // req/res objects (no supertest), mirroring events.controller.test.ts - the
-// route itself is a one-line wire-up (calendar.routes.config.ts) and the
-// business logic under test (query parsing, the A7 62-day bound,
-// ownership/visibility) belongs to the controller and calendarService
-// respectively. calendarService.getAvailability's own owned/visible/
-// freeBusyReader/google-error behavior is covered in calendar.service.test.ts;
-// this file only pins the controller's request-shape parsing and its
-// backend-only range bound.
+// route itself is a one-line wire-up (calendar.routes.config.ts). The A7
+// 62-day bound is enforced in the controller before any sync call, so it's
+// pinned here independent of which service backs the request; happy-path
+// sync-delegated behavior (per-calendar attribution, outage handling) is
+// covered by calendar.controller.delegation.test.ts.
 
 describe("CalendarController availability", () => {
   const userId = "507f1f77bcf86cd799439011";
@@ -42,40 +35,8 @@ describe("CalendarController availability", () => {
     return { promise } as unknown as Res_Promise;
   };
 
-  it("parses comma-separated calendarIds and forwards start/end to calendarService.getAvailability", async () => {
-    const availabilityResponse: AvailabilityResponse = { busyPeriods: [] };
-    const getAvailabilitySpy = spyOn(
-      calendarService,
-      "getAvailability",
-    ).mockResolvedValue(availabilityResponse);
-
-    const req = buildReq({
-      calendarIds: "507f1f77bcf86cd799439012,507f1f77bcf86cd799439013",
-      start: "2024-01-15T00:00:00.000Z",
-      end: "2024-01-16T00:00:00.000Z",
-    });
-    const res = buildRes();
-
-    await calendarController.availability(req, res);
-
-    expect(getAvailabilitySpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        calendarIds: ["507f1f77bcf86cd799439012", "507f1f77bcf86cd799439013"],
-        start: "2024-01-15T00:00:00.000Z",
-        end: "2024-01-16T00:00:00.000Z",
-      }),
-    );
-    expect(String(getAvailabilitySpy.mock.calls[0]?.[0])).toBe(userId);
-    expect(res.promise).toHaveBeenCalledWith(availabilityResponse);
-    // Packet 09 step 2: pin the response-boundary shape of GET
-    // /api/calendars/availability against the shared core schema.
-    const sentBody = (res.promise as Mock).mock.calls[0]?.[0];
-    expect(() => AvailabilityResponseSchema.parse(sentBody)).not.toThrow();
-  });
-
-  it("rejects a range longer than 62 days with a 400, without calling calendarService.getAvailability (A7 bounded)", async () => {
-    const getAvailabilitySpy = spyOn(calendarService, "getAvailability");
+  it("rejects a range longer than 62 days with a 400, without querying sync (A7 bounded)", async () => {
+    const clientSpy = spyOn(syncServiceFactory, "getSyncServiceClient");
 
     const req = buildReq({
       calendarIds: "507f1f77bcf86cd799439012",
@@ -86,7 +47,7 @@ describe("CalendarController availability", () => {
 
     await calendarController.availability(req, res);
 
-    expect(getAvailabilitySpy).not.toHaveBeenCalled();
+    expect(clientSpy).not.toHaveBeenCalled();
     expect(res.promise).toHaveBeenCalledTimes(1);
 
     const rejection = (res.promise as Mock).mock
@@ -98,6 +59,8 @@ describe("CalendarController availability", () => {
       // arg's `.description` does) - see error.handler.ts.
       expect((e as BaseError).result).toMatch(/62 days/i);
     });
+
+    clientSpy.mockRestore();
   });
 });
 
@@ -113,23 +76,45 @@ describe("CalendarController list", () => {
   });
 
   it("returns a CalendarListResponse-shaped body for the session user's calendars", async () => {
-    const record = CalendarRecordSchema.parse({
-      _id: new ObjectId(),
-      userId: new ObjectId(userId),
-      name: "Work",
-      description: "",
-      timeZone: "America/Denver",
-      foregroundColor: "#000000",
-      backgroundColor: "#ffffff",
-      access: "owner",
-      isPrimary: true,
-      isVisible: true,
-      isActive: true,
-      source: { provider: "google", calendarId: "gcal-1", etag: "etag-1" },
-      createdAt: new Date(),
-      updatedAt: null,
-    });
-    const listSpy = spyOn(calendarService, "list").mockResolvedValue([record]);
+    const listCalendars = mock(() =>
+      Promise.resolve({
+        ok: true as const,
+        value: {
+          calendars: [
+            {
+              id: "507f1f77bcf86cd799439099",
+              tenantId: userId,
+              principalId: userId,
+              connectionId: "507f1f77bcf86cd799439098",
+              providerCalendarId: "gcal-1",
+              displayName: "Work",
+              color: "#000000",
+              active: true,
+              primary: true,
+              accessRole: "owner" as const,
+              capabilities: {
+                canWriteEvents: true,
+                canReadBusy: true,
+                canInviteAttendees: true,
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ],
+        },
+      }),
+    );
+    const clientSpy = spyOn(
+      syncServiceFactory,
+      "getSyncServiceClient",
+    ).mockReturnValue({ listCalendars } as never);
+    // Not a .db.test.ts file, so there's no real Mongo connection here —
+    // getLocalCalendar's own findOne would throw ("did you forget to call
+    // `start`?") without this.
+    const localCalendarSpy = spyOn(
+      calendarService,
+      "getLocalCalendar",
+    ).mockResolvedValue(null);
 
     const req = {
       query: {},
@@ -140,11 +125,13 @@ describe("CalendarController list", () => {
 
     await calendarController.list(req, res);
 
-    expect(listSpy).toHaveBeenCalledWith(expect.anything());
-    expect(String(listSpy.mock.calls[0]?.[0])).toBe(userId);
+    expect(listCalendars).toHaveBeenCalledTimes(1);
     expect(promise).toHaveBeenCalledTimes(1);
 
     const sentBody = promise.mock.calls[0]?.[0];
     expect(() => CalendarListResponseSchema.parse(sentBody)).not.toThrow();
+
+    clientSpy.mockRestore();
+    localCalendarSpy.mockRestore();
   });
 });

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -17,7 +17,6 @@ import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { syncCalendarToBrowser } from "@backend/common/services/sync-service/calendar-list.translation";
-import { getEventDelegation } from "@backend/common/services/sync-service/event-routing";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import {
@@ -145,22 +144,15 @@ class CalendarController {
         error: () => error(AuthError.InadequatePermissions, "List Failed"),
       });
 
-      if (getEventDelegation() === "sync") {
-        const [syncResponse, localCalendar] = await Promise.all([
-          listCalendarsFromSync(userId.toString()),
-          calendarService.getLocalCalendar(userId),
-        ]);
-
-        res.promise({
-          calendars: localCalendar
-            ? [...syncResponse.calendars, mapCalendarRecord(localCalendar)]
-            : syncResponse.calendars,
-        });
-        return;
-      }
+      const [syncResponse, localCalendar] = await Promise.all([
+        listCalendarsFromSync(userId.toString()),
+        calendarService.getLocalCalendar(userId),
+      ]);
 
       res.promise({
-        calendars: (await calendarService.list(userId)).map(mapCalendarRecord),
+        calendars: localCalendar
+          ? [...syncResponse.calendars, mapCalendarRecord(localCalendar)]
+          : syncResponse.calendars,
       });
     } catch (e) {
       res.promise(Promise.reject(e));
@@ -192,10 +184,7 @@ class CalendarController {
       const query = parseAvailabilityQuery(req.query);
       assertBoundedAvailabilityRange(query);
 
-      const response =
-        getEventDelegation() === "sync"
-          ? await getAvailabilityFromSync(userId.toString(), query)
-          : await calendarService.getAvailability(userId, query);
+      const response = await getAvailabilityFromSync(userId.toString(), query);
 
       res.promise(response);
     } catch (e) {

--- a/packages/backend/src/calendar/services/calendar.service.db.test.ts
+++ b/packages/backend/src/calendar/services/calendar.service.db.test.ts
@@ -1,6 +1,4 @@
 import { ObjectId } from "mongodb";
-import { type CalendarAccess } from "@core/types/calendar.contracts";
-import { AvailabilityQuerySchema } from "@core/types/event-command.contracts";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
   cleanupCollections,
@@ -10,9 +8,8 @@ import {
 import { CalendarRecordSchema } from "@backend/calendar/calendar.record";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { createGoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
-import gcalService from "@backend/common/services/gcal/gcal.service";
 import mongoService from "@backend/common/services/mongo.service";
-import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 
 describe("CalendarService", () => {
   beforeEach(() => setupTestDb(import.meta.url));
@@ -33,45 +30,6 @@ describe("CalendarService", () => {
       isVisible: true,
       isActive: true,
       source: { provider: "local" },
-      createdAt: new Date(),
-      updatedAt: null,
-    });
-    await mongoService.calendar.insertOne(record);
-    return record;
-  };
-
-  const seedGoogleCalendar = async (
-    userId: ObjectId,
-    overrides: {
-      access?: CalendarAccess;
-      googleCalendarId?: string;
-      isActive?: boolean;
-      isVisible?: boolean;
-    } = {},
-  ) => {
-    const {
-      access = "freeBusyReader",
-      googleCalendarId = `google-cal-${new ObjectId().toHexString()}`,
-      isActive = true,
-      isVisible = true,
-    } = overrides;
-    const record = CalendarRecordSchema.parse({
-      _id: new ObjectId(),
-      userId,
-      name: "Shared calendar",
-      description: "",
-      timeZone: null,
-      foregroundColor: "#000000",
-      backgroundColor: "#ffffff",
-      access,
-      isPrimary: false,
-      isVisible,
-      isActive,
-      source: {
-        provider: "google",
-        calendarId: googleCalendarId,
-        etag: "etag-1",
-      },
       createdAt: new Date(),
       updatedAt: null,
     });
@@ -223,193 +181,6 @@ describe("CalendarService", () => {
       expect(result.deletedCount).toBeGreaterThan(0);
       const remaining = await calendarService.list(user._id.toString());
       expect(remaining).toHaveLength(0);
-    });
-  });
-
-  describe("getAvailability", () => {
-    it("merges busy periods from multiple freeBusyReader calendars, mapped back to compass ids", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const calendarA = await seedGoogleCalendar(user._id, {
-        googleCalendarId: "google-a",
-      });
-      const calendarB = await seedGoogleCalendar(user._id, {
-        googleCalendarId: "google-b",
-      });
-      spyOn(gcalService, "queryFreeBusy").mockResolvedValue({
-        calendars: {
-          "google-a": {
-            busy: [
-              {
-                start: "2024-01-15T09:00:00.000Z",
-                end: "2024-01-15T10:00:00.000Z",
-              },
-            ],
-          },
-          "google-b": {
-            busy: [
-              {
-                start: "2024-01-15T11:00:00.000Z",
-                end: "2024-01-15T12:00:00.000Z",
-              },
-            ],
-          },
-        },
-      });
-
-      const query = AvailabilityQuerySchema.parse({
-        calendarIds: [calendarA._id.toHexString(), calendarB._id.toHexString()],
-        start: "2024-01-15T00:00:00.000Z",
-        end: "2024-01-16T00:00:00.000Z",
-      });
-
-      const response = await calendarService.getAvailability(
-        user._id.toString(),
-        query,
-      );
-
-      expect(response.busyPeriods).toHaveLength(2);
-      expect(response.busyPeriods).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            calendarId: calendarA._id.toHexString(),
-            start: "2024-01-15T09:00:00.000Z",
-            end: "2024-01-15T10:00:00.000Z",
-          }),
-          expect.objectContaining({
-            calendarId: calendarB._id.toHexString(),
-            start: "2024-01-15T11:00:00.000Z",
-            end: "2024-01-15T12:00:00.000Z",
-          }),
-        ]),
-      );
-    });
-
-    it("rejects a writer calendar's id (busy time must come from its synced events, not freebusy)", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const writerCalendar = await seedGoogleCalendar(user._id, {
-        access: "writer",
-      });
-      const queryFreeBusySpy = spyOn(gcalService, "queryFreeBusy");
-
-      const query = AvailabilityQuerySchema.parse({
-        calendarIds: [writerCalendar._id.toHexString()],
-        start: "2024-01-15T00:00:00.000Z",
-        end: "2024-01-16T00:00:00.000Z",
-      });
-
-      await expect(
-        calendarService.getAvailability(user._id.toString(), query),
-      ).rejects.toThrow();
-      expect(queryFreeBusySpy).not.toHaveBeenCalled();
-    });
-
-    it("rejects an id for a calendar the user does not own", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const { user: otherUser } = await UtilDriver.setupTestUser();
-      const othersCalendar = await seedGoogleCalendar(otherUser._id);
-
-      const query = AvailabilityQuerySchema.parse({
-        calendarIds: [othersCalendar._id.toHexString()],
-        start: "2024-01-15T00:00:00.000Z",
-        end: "2024-01-16T00:00:00.000Z",
-      });
-
-      await expect(
-        calendarService.getAvailability(user._id.toString(), query),
-      ).rejects.toThrow();
-    });
-
-    it("filters a hidden freeBusyReader calendar out of the request instead of rejecting it", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const visibleCalendar = await seedGoogleCalendar(user._id, {
-        googleCalendarId: "google-visible",
-      });
-      const hiddenCalendar = await seedGoogleCalendar(user._id, {
-        googleCalendarId: "google-hidden",
-        isVisible: false,
-      });
-      const queryFreeBusySpy = spyOn(
-        gcalService,
-        "queryFreeBusy",
-      ).mockResolvedValue({
-        calendars: {
-          "google-visible": {
-            busy: [
-              {
-                start: "2024-01-15T09:00:00.000Z",
-                end: "2024-01-15T10:00:00.000Z",
-              },
-            ],
-          },
-        },
-      });
-
-      const query = AvailabilityQuerySchema.parse({
-        calendarIds: [
-          visibleCalendar._id.toHexString(),
-          hiddenCalendar._id.toHexString(),
-        ],
-        start: "2024-01-15T00:00:00.000Z",
-        end: "2024-01-16T00:00:00.000Z",
-      });
-
-      const response = await calendarService.getAvailability(
-        user._id.toString(),
-        query,
-      );
-
-      expect(response.busyPeriods).toEqual([
-        expect.objectContaining({
-          calendarId: visibleCalendar._id.toHexString(),
-        }),
-      ]);
-      expect(queryFreeBusySpy).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ gCalendarIds: ["google-visible"] }),
-      );
-    });
-
-    it("treats a per-calendar Google freebusy error as an empty busy list for that calendar", async () => {
-      const { user } = await UtilDriver.setupTestUser();
-      const okCalendar = await seedGoogleCalendar(user._id, {
-        googleCalendarId: "google-ok",
-      });
-      const erroringCalendar = await seedGoogleCalendar(user._id, {
-        googleCalendarId: "google-erroring",
-      });
-      spyOn(gcalService, "queryFreeBusy").mockResolvedValue({
-        calendars: {
-          "google-ok": {
-            busy: [
-              {
-                start: "2024-01-15T09:00:00.000Z",
-                end: "2024-01-15T10:00:00.000Z",
-              },
-            ],
-          },
-          "google-erroring": {
-            errors: [{ domain: "calendar", reason: "notFound" }],
-          },
-        },
-      });
-
-      const query = AvailabilityQuerySchema.parse({
-        calendarIds: [
-          okCalendar._id.toHexString(),
-          erroringCalendar._id.toHexString(),
-        ],
-        start: "2024-01-15T00:00:00.000Z",
-        end: "2024-01-16T00:00:00.000Z",
-      });
-
-      const response = await calendarService.getAvailability(
-        user._id.toString(),
-        query,
-      );
-
-      expect(response.busyPeriods).toEqual([
-        expect.objectContaining({ calendarId: okCalendar._id.toHexString() }),
-      ]);
     });
   });
 });

--- a/packages/backend/src/calendar/services/calendar.service.ts
+++ b/packages/backend/src/calendar/services/calendar.service.ts
@@ -5,14 +5,6 @@ import {
   type ClientSession,
   ObjectId,
 } from "mongodb";
-import { Logger } from "@core/logger/winston.logger";
-import { type CalendarId } from "@core/types/domain-primitives";
-import { type BusyPeriod, BusyPeriodSchema } from "@core/types/event.contracts";
-import {
-  type AvailabilityQuery,
-  type AvailabilityResponse,
-  AvailabilityResponseSchema,
-} from "@core/types/event-command.contracts";
 import { Resource_Sync } from "@core/types/sync.types";
 import { zObjectId } from "@core/types/type.utils";
 import {
@@ -20,18 +12,10 @@ import {
   CalendarRecordSchema,
 } from "@backend/calendar/calendar.record";
 import { mapGoogleCalendar } from "@backend/calendar/calendar.record.mapper";
-import { GenericError } from "@backend/common/errors/generic/generic.errors";
-import { error } from "@backend/common/errors/handlers/error.handler";
-import {
-  createGoogleRequestContext,
-  type GoogleRequestContext,
-} from "@backend/common/services/gcal/gcal.context";
-import gcalService from "@backend/common/services/gcal/gcal.service";
+import { type GoogleRequestContext } from "@backend/common/services/gcal/gcal.context";
 import mongoService from "@backend/common/services/mongo.service";
 import { getCalendarsToSync } from "@backend/sync/services/init/google-sync-init";
 import { updateSync } from "@backend/sync/services/records/sync-records.repository";
-
-const logger = Logger("app:calendar.service");
 
 class CalendarService {
   /**
@@ -371,101 +355,6 @@ class CalendarService {
       userId: zObjectId.parse(userId),
       isActive: true,
     });
-  };
-
-  /**
-   * Resolves compass calendar ids -> BusyPeriod[] via Google's freebusy API
-   * (packet 08 phase 4; A7). Strict-parse ethos: every requested id must
-   * resolve to a calendar this user owns that's active, google-sourced, and
-   * freeBusyReader specifically - an owner/writer/reader calendar's busy
-   * time is already derivable from its synced events, so re-querying
-   * freebusy for it here would just double it up and cost an extra Google
-   * round trip. A hidden calendar is filtered out silently rather than
-   * rejected (mirrors packet 08 step 4's read filtering) - the server must
-   * never leak a hidden calendar's busy time even if the client still asks
-   * for it mid visibility-toggle.
-   */
-  getAvailability = async (
-    userId: ObjectId | string,
-    query: AvailabilityQuery,
-  ): Promise<AvailabilityResponse> => {
-    const userObjectId = zObjectId.parse(userId);
-    const requestedIds = query.calendarIds.map((id) => zObjectId.parse(id));
-
-    const records = await mongoService.calendar
-      .find({ _id: { $in: requestedIds }, userId: userObjectId })
-      .toArray();
-    const recordById = new Map(
-      records.map((record) => [record._id.toHexString(), record]),
-    );
-
-    const resolved = requestedIds.map((id) => {
-      const record = recordById.get(id.toHexString());
-      const isOwnedFreeBusyReaderCalendar =
-        !!record &&
-        record.isActive &&
-        record.source.provider === "google" &&
-        record.access === "freeBusyReader";
-
-      if (!isOwnedFreeBusyReaderCalendar) {
-        throw error(
-          GenericError.BadRequest,
-          "Availability can only be queried for the user's own active freeBusyReader Google calendars",
-        );
-      }
-
-      return record;
-    });
-
-    const visible = resolved.filter((record) => record.isVisible);
-    if (visible.length === 0) {
-      return { busyPeriods: [] };
-    }
-
-    const googleIdToCompassId = new Map<string, CalendarId>();
-    for (const record of visible) {
-      if (record.source.provider === "google") {
-        googleIdToCompassId.set(
-          record.source.calendarId,
-          record._id.toHexString() as CalendarId,
-        );
-      }
-    }
-
-    const context = await createGoogleRequestContext(userObjectId.toString());
-    const response = await gcalService.queryFreeBusy(context, {
-      timeMin: query.start,
-      timeMax: query.end,
-      gCalendarIds: [...googleIdToCompassId.keys()],
-    });
-
-    const busyPeriods: BusyPeriod[] = [];
-    for (const [googleId, compassId] of googleIdToCompassId) {
-      const calendarResult = response.calendars?.[googleId];
-      if (!calendarResult) continue;
-
-      if (calendarResult.errors && calendarResult.errors.length > 0) {
-        // Never log the google calendar id - compassId is the safe handle.
-        logger.warn(
-          `getAvailability: Google returned a freebusy error for calendar ${compassId}`,
-        );
-        continue;
-      }
-
-      for (const busy of calendarResult.busy ?? []) {
-        if (!busy.start || !busy.end) continue;
-
-        busyPeriods.push(
-          BusyPeriodSchema.parse({
-            calendarId: compassId,
-            start: busy.start,
-            end: busy.end,
-          }),
-        );
-      }
-    }
-
-    return AvailabilityResponseSchema.parse({ busyPeriods });
   };
 
   /**


### PR DESCRIPTION
## Summary
- `getEventDelegation()` always resolves `"sync"` in every real deployment now — `calendar.controller.ts`'s `list()`/`availability()` legacy branches (`calendarService.list`/`getAvailability`) never ran. Collapsed both handlers to their sync-only path.
- Only deleted `calendarService.getAvailability` itself — its one caller was the branch just removed. The other methods a first pass assumed were "legacy, delete now" (`initializeGoogleCalendars`, `upsertGoogleCalendarEntries`, `archiveGoogleCalendar`, `list`, `getPrimaryGoogleCalendar`, `getActiveGoogleCalendars`, `getOwnedActiveCalendar`) turned out to still have live callers inside `packages/backend/src/sync/` and `event.service.ts` — neither is touched by this change, so `calendar.service.ts` keeps them until those callers are themselves removed in a later phase.
- **Found and deliberately left alone**: `calendarController.setVisibility` is genuinely unconditional (not delegation-gated) but writes to the local `calendar` Mongo collection, which sync-delegated Google calendars never populate (`calendar-list.translation.ts` hardcodes `isVisible: true` and nothing calls back into Sync to persist a toggle) — visibility toggling silently no-ops for those calendars today. This is a pre-existing product gap, unrelated to this cleanup pass, not fixed here.
- Rewrote `calendar.controller.test.ts`'s list/availability tests off the deleted legacy service calls (the A7 62-day-bound test now asserts no sync client is queried, since the bound check happens before any service call regardless of which one backs it; the list happy-path test now mocks the sync client instead of `calendarService.list`). Removed `calendar.service.db.test.ts`'s `getAvailability` describe block (5 tests) and its now-unused `seedGoogleCalendar` helper.

Part of the ongoing self-host/legacy-sync-removal effort (task 4.3).

## Test plan
- [x] `bunx typescript@7.0.2 --noEmit` — clean
- [x] full repo `biome check` — clean
- [x] `bun run test:backend` — fail list identical to the established pre-existing baseline (zero diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Availability behavior now depends entirely on sync instead of the removed Google freebusy path; deployments without a sync client will fail list/availability where the old legacy branch might have applied.
> 
> **Overview**
> **Calendar list and availability always go through the sync service** now that `getEventDelegation()` is effectively always `"sync"`. `calendar.controller.ts` drops the `getEventDelegation()` branches: `list()` always calls `listCalendarsFromSync` plus optional local calendar merge, and `availability()` always uses `getAvailabilityFromSync` instead of `calendarService.getAvailability`.
> 
> **The Mongo/Google freebusy implementation is removed** from `calendar.service.ts` (`getAvailability` and related imports). Other `calendarService` methods used by sync and events are unchanged.
> 
> **Tests are aligned with the sync-only paths**: controller tests mock `getSyncServiceClient` instead of `calendarService.list`/`getAvailability`; the A7 62-day bound test asserts the sync client is never called; the five `getAvailability` DB tests and `seedGoogleCalendar` helper are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 823103911fad00554bb8644efbaa85fe1ab21572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->