### PR TITLE
chore(events): strip the now-dead legacy watch-repair gate from streamEvents

### DIFF
--- a/packages/backend/src/events/controllers/events.controller.db.test.ts
+++ b/packages/backend/src/events/controllers/events.controller.db.test.ts
@@ -6,11 +6,6 @@ import {
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import eventsController from "@backend/events/controllers/events.controller";
-import {
-  type GoogleWatchRepairResult,
-  googleWatchRepairService,
-} from "@backend/sync/services/watch/google-watch-repair.service";
-import { GoogleWatchStateStatus } from "@backend/sync/services/watch/google-watch-state";
 import userService from "@backend/user/services/user.service";
 import {
   afterAll,
@@ -29,99 +24,8 @@ describe("EventsController", () => {
   beforeEach(cleanupCollections);
   afterAll(cleanupTestDb);
 
-  it("11: fire-and-forgets the watch repair coordinator after subscribing and replaying metadata", async () => {
-    const userId = "507f1f77bcf86cd799439011";
-    const noneResult: GoogleWatchRepairResult = {
-      action: "NONE",
-      inspection: {
-        status: GoogleWatchStateStatus.NOT_APPLICABLE,
-        reason: "GOOGLE_NOT_CONNECTED",
-        expectedWatchCalendarIds: [],
-        activeWatches: [],
-        duplicateWatches: [],
-        expiredWatches: [],
-        missingWatchCalendarIds: [],
-        staleWatches: [],
-        watchesToRefresh: [],
-        incompleteCalendarIds: [],
-      },
-    };
-    const repairSpy = spyOn(
-      googleWatchRepairService,
-      "repairGoogleWatchesForUser",
-    ).mockResolvedValue(noneResult);
-
-    const req = {
-      session: { getUserId: () => userId },
-      on: mock(),
-    } as unknown as Request;
-    const res = {
-      setHeader: mock(),
-      flushHeaders: mock(),
-      write: mock(),
-      status: mock().mockReturnThis(),
-      end: mock(),
-      headersSent: false,
-    } as unknown as Response;
-
-    await eventsController.streamEvents(req, res);
-
-    expect(repairSpy).toHaveBeenCalledWith(userId);
-  });
-
-  it("does not let a repair failure affect the SSE response", async () => {
-    const userId = "507f1f77bcf86cd799439012";
-    spyOn(
-      googleWatchRepairService,
-      "repairGoogleWatchesForUser",
-    ).mockImplementation(() =>
-      Promise.reject(new Error("simulated repair failure")),
-    );
-
-    const req = {
-      session: { getUserId: () => userId },
-      on: mock(),
-    } as unknown as Request;
-    const res = {
-      setHeader: mock(),
-      flushHeaders: mock(),
-      write: mock(),
-      status: mock().mockReturnThis(),
-      end: mock(),
-      headersSent: false,
-    } as unknown as Response;
-
-    await expect(
-      eventsController.streamEvents(req, res),
-    ).resolves.toBeUndefined();
-    expect(res.status).not.toHaveBeenCalled();
-
-    // Let the fire-and-forget rejection's .catch handler settle so it
-    // doesn't surface as an unhandled rejection in a later test.
-    await new Promise((resolve) => setImmediate(resolve));
-  });
-
-  it("fire-and-forgets a lastSeenAt touch alongside the repair coordinator (A40)", async () => {
+  it("fire-and-forgets a lastSeenAt touch after subscribing and replaying metadata (A40)", async () => {
     const userId = "507f1f77bcf86cd799439013";
-    const noneResult: GoogleWatchRepairResult = {
-      action: "NONE",
-      inspection: {
-        status: GoogleWatchStateStatus.NOT_APPLICABLE,
-        reason: "GOOGLE_NOT_CONNECTED",
-        expectedWatchCalendarIds: [],
-        activeWatches: [],
-        duplicateWatches: [],
-        expiredWatches: [],
-        missingWatchCalendarIds: [],
-        staleWatches: [],
-        watchesToRefresh: [],
-        incompleteCalendarIds: [],
-      },
-    };
-    spyOn(
-      googleWatchRepairService,
-      "repairGoogleWatchesForUser",
-    ).mockResolvedValue(noneResult);
     const touchSpy = spyOn(userService, "touchLastSeenAt");
 
     const req = {
@@ -144,24 +48,6 @@ describe("EventsController", () => {
 
   it("does not let a lastSeenAt touch failure affect the SSE response", async () => {
     const userId = "507f1f77bcf86cd799439014";
-    spyOn(
-      googleWatchRepairService,
-      "repairGoogleWatchesForUser",
-    ).mockResolvedValue({
-      action: "NONE",
-      inspection: {
-        status: GoogleWatchStateStatus.NOT_APPLICABLE,
-        reason: "GOOGLE_NOT_CONNECTED",
-        expectedWatchCalendarIds: [],
-        activeWatches: [],
-        duplicateWatches: [],
-        expiredWatches: [],
-        missingWatchCalendarIds: [],
-        staleWatches: [],
-        watchesToRefresh: [],
-        incompleteCalendarIds: [],
-      },
-    });
     spyOn(userService, "touchLastSeenAt").mockImplementation(() =>
       Promise.reject(new Error("simulated touch failure")),
     );

--- a/packages/backend/src/events/controllers/events.controller.ts
+++ b/packages/backend/src/events/controllers/events.controller.ts
@@ -2,8 +2,6 @@ import { type Request, type Response } from "express";
 import { Logger } from "@core/logger/winston.logger";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
-import { googleWatchRepairService } from "@backend/sync/services/watch/google-watch-repair.service";
-import * as legacyWatchOwnership from "@backend/sync/services/watch/legacy-watch-ownership";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 
@@ -31,23 +29,7 @@ class EventsController {
         metadata: metadata as Record<string, unknown>,
       });
 
-      // Defensive, fire-and-forget: a client reconnecting is a cheap,
-      // frequent moment to notice/repair stale Google watches. Cooldown +
-      // lease inside the coordinator keep this safe across multiple tabs
-      // and repeated reconnects; must never block or fail the stream.
-      // When Sync owns connections/events, Sync maintains its own push
-      // channels — legacy repair would re-register watches at
-      // /api/sync/gcal/notifications and split the write path (legacy
-      // Mongo + SSE) from Sync reads.
-      if (legacyWatchOwnership.isLegacyGoogleWatchOwner()) {
-        void googleWatchRepairService
-          .repairGoogleWatchesForUser(userId)
-          .catch((err) => {
-            logger.error(`Google watch repair failed for user ${userId}:`, err);
-          });
-      }
-
-      // Same fire-and-forget shape: lets scheduled watch maintenance (A40)
+      // Fire-and-forget: lets scheduled watch maintenance (A40)
       // tell an active user apart from an abandoned account without
       // blocking or failing the stream.
       void userService.touchLastSeenAt(userId).catch((err) => {


### PR DESCRIPTION
## Summary
- `isLegacyGoogleWatchOwner()` always resolves `false` in every real deployment now (it's `true` only when neither connection nor event routing has a Sync client configured, which no real deployment lacks) — `streamEvents`'s fire-and-forget `googleWatchRepairService.repairGoogleWatchesForUser` call never ran. Deleted the gate and its body together, not just the condition — the legacy repair coordinator itself stays untouched (`packages/backend/src/sync/` is a later deletion target), only this one now-dead call site is removed.
- Checked both `isLegacyGoogleWatchOwner` and `repairGoogleWatchesForUser` for callers across production **and test** files before touching anything (the prior task in this series found a caller-grep that skipped test files missed a real dependency) — `isLegacyGoogleWatchOwner`'s only other caller is `sync.controller.ts` (already correctly gated, untouched), and `repairGoogleWatchesForUser`'s other callers are all internal to `packages/backend/src/sync/` itself, unrelated to this controller.
- Rewrote `events.controller.db.test.ts`: deleted the two tests specifically about the watch-repair fire-and-forget (their subject no longer runs); kept the two `touchLastSeenAt` (A40) tests, dropping their now-vestigial `repairGoogleWatchesForUser` spy setup since nothing calls it anymore.

Part of the ongoing self-host/legacy-sync-removal effort (task 4.5).

## Test plan
- [x] `bunx typescript@7.0.2 --noEmit` — clean
- [x] full repo `biome check` — clean
- [x] `bun run test:backend` — fail list identical to the established pre-existing baseline (zero diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow removal of dead code on the events SSE path; no auth, data, or active repair behavior in production.
> 
> **Overview**
> Removes the **fire-and-forget** `googleWatchRepairService.repairGoogleWatchesForUser` path from `streamEvents`, along with the `isLegacyGoogleWatchOwner()` gate that always evaluated false in real deployments—so that repair never actually ran on SSE reconnect.
> 
> **`touchLastSeenAt`** on subscribe stays unchanged: still fire-and-forget with errors logged, not surfaced on the SSE response.
> 
> Tests drop the two watch-repair cases and simplify the A40 `lastSeenAt` tests by removing vestigial repair mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51565b6bfc83db3ebf8909cb5aa5e73c65ff73cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->