### PR TITLE
fix(auth): collapse Google auth mode to a 2-way SIGNUP/SIGNIN split

### DIFF
--- a/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
@@ -74,9 +74,6 @@ describe("googleAuthService", () => {
       spyOn(googleAuthService, "repairGoogleConnection").mockResolvedValue({
         cUserId: "repair-id",
       });
-      spyOn(googleAuthService, "googleSignin").mockResolvedValue({
-        cUserId: "signin-id",
-      });
     });
 
     afterEach(() => {
@@ -85,7 +82,6 @@ describe("googleAuthService", () => {
       // describe block below and cause unrelated assertions to fail.
       (googleAuthService.googleSignup as Mock).mockRestore();
       (googleAuthService.repairGoogleConnection as Mock).mockRestore();
-      (googleAuthService.googleSignin as Mock).mockRestore();
     });
 
     it("routes SIGNUP to googleSignup", async () => {
@@ -104,8 +100,6 @@ describe("googleAuthService", () => {
       const decision: AuthDecision = {
         authMode: "SIGNUP",
         compassUserId: null,
-        hasStoredRefreshToken: false,
-        hasHealthySync: false,
         createdNewRecipeUser: true,
       };
 
@@ -136,8 +130,6 @@ describe("googleAuthService", () => {
       const decision: AuthDecision = {
         authMode: "SIGNUP",
         compassUserId: null,
-        hasStoredRefreshToken: false,
-        hasHealthySync: false,
         createdNewRecipeUser: true,
       };
 
@@ -148,7 +140,7 @@ describe("googleAuthService", () => {
       );
     });
 
-    it("routes RECONNECT_REPAIR to repairGoogleConnection", async () => {
+    it("routes SIGNIN to repairGoogleConnection", async () => {
       const providerUser = makeProviderUser();
       const recipeUserId = faker.database.mongodbObjectId();
 
@@ -162,10 +154,8 @@ describe("googleAuthService", () => {
       };
 
       const decision: AuthDecision = {
-        authMode: "RECONNECT_REPAIR",
+        authMode: "SIGNIN",
         compassUserId: faker.string.uuid(),
-        hasStoredRefreshToken: false,
-        hasHealthySync: true,
         createdNewRecipeUser: false,
       };
 
@@ -175,37 +165,6 @@ describe("googleAuthService", () => {
 
       expect(googleAuthService.repairGoogleConnection).toHaveBeenCalledWith(
         decision.compassUserId!,
-        providerUser,
-        oAuthTokens,
-      );
-    });
-
-    it("routes SIGNIN_INCREMENTAL to googleSignin", async () => {
-      const providerUser = makeProviderUser();
-      const recipeUserId = faker.database.mongodbObjectId();
-      const oAuthTokens = makeOAuthTokens();
-
-      const success: GoogleSignInSuccess = {
-        providerUser,
-        oAuthTokens,
-        createdNewRecipeUser: false,
-        recipeUserId,
-        loginMethodsLength: 1,
-      };
-
-      const decision: AuthDecision = {
-        authMode: "SIGNIN_INCREMENTAL",
-        compassUserId: faker.string.uuid(),
-        hasStoredRefreshToken: true,
-        hasHealthySync: true,
-        createdNewRecipeUser: false,
-      };
-
-      mockDetermineGoogleAuthMode().mockResolvedValue(decision);
-
-      await googleAuthService.handleGoogleAuth(success);
-
-      expect(googleAuthService.googleSignin).toHaveBeenCalledWith(
         providerUser,
         oAuthTokens,
       );
@@ -229,10 +188,8 @@ describe("googleAuthService", () => {
       };
 
       const decision: AuthDecision = {
-        authMode: "SIGNIN_INCREMENTAL",
+        authMode: "SIGNIN",
         compassUserId,
-        hasStoredRefreshToken: true,
-        hasHealthySync: true,
         createdNewRecipeUser: false,
       };
 
@@ -248,15 +205,13 @@ describe("googleAuthService", () => {
       expect(decisionCall![0]).toBe("google_auth_decision");
       expect(decisionCall![1]).toEqual(
         expect.objectContaining({
-          authMode: "SIGNIN_INCREMENTAL",
+          authMode: "SIGNIN",
           compassUserTraceId: expect.any(String),
           createdNewRecipeUser: false,
           googleUserTraceId: expect.any(String),
           hasCompassUserId: true,
           hasGoogleUserId: true,
-          hasHealthySync: true,
           hasProviderEmail: true,
-          hasStoredRefreshToken: true,
           loginMethodsLength: 2,
           providerEmailTraceId: expect.any(String),
         }),
@@ -328,10 +283,8 @@ describe("googleAuthService", () => {
       });
 
       mockDetermineGoogleAuthMode().mockResolvedValue({
-        authMode: "RECONNECT_REPAIR",
+        authMode: "SIGNIN",
         compassUserId,
-        hasStoredRefreshToken: true,
-        hasHealthySync: false,
         createdNewRecipeUser: false,
       });
 
@@ -355,29 +308,6 @@ describe("googleAuthService", () => {
       expect(updatedUser?.google?.picture).toBe(providerUser.picture);
       expect(metadata.sync?.importGCal).toBe("RESTART");
       expect(metadata.sync?.incrementalGCalSync).toBe("RESTART");
-    });
-  });
-
-  describe("googleSignin", () => {
-    it("preserves the stored refresh token when Google does not return a new one", async () => {
-      const user = await UserDriver.createUser();
-      const compassUserId = user._id.toString();
-      const storedRefreshToken = user.google?.gRefreshToken;
-      const providerUser = UserDriver.generateGoogleUser({
-        sub: user.google?.googleId,
-        picture: faker.image.url(),
-      });
-
-      await expect(
-        googleAuthService.googleSignin(providerUser, {
-          access_token: faker.internet.jwt(),
-        }),
-      ).resolves.toEqual({ cUserId: compassUserId });
-
-      const updatedUser = await mongoService.user.findOne({ _id: user._id });
-
-      expect(updatedUser?.google?.gRefreshToken).toBe(storedRefreshToken);
-      expect(updatedUser?.google?.picture).toBe(providerUser.picture);
     });
   });
 

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -64,9 +64,7 @@ function getGoogleAuthDecisionTrace({
     createdNewRecipeUser,
     hasCompassUserId: Boolean(decision.compassUserId),
     hasGoogleUserId: Boolean(googleUserId),
-    hasHealthySync: decision.hasHealthySync,
     hasProviderEmail: Boolean(providerEmail),
-    hasStoredRefreshToken: decision.hasStoredRefreshToken,
     loginMethodsLength,
     ...(compassUserTraceId ? { compassUserTraceId } : {}),
     ...(googleUserTraceId ? { googleUserTraceId } : {}),
@@ -225,40 +223,6 @@ async function connectGoogleToCurrentUser(
   return persistGoogleConnection(cUserId, validatedGUser, refreshToken);
 }
 
-async function googleSignin(
-  gUser: TokenPayload,
-  oAuthTokens: Pick<Credentials, "refresh_token" | "access_token">,
-) {
-  const gUserId = StringV4Schema.parse(gUser.sub, {
-    error: () => "Invalid Google user ID",
-  });
-  const refreshToken = oAuthTokens.refresh_token
-    ? StringV4Schema.parse(oAuthTokens.refresh_token, {
-        error: () => "Invalid or missing Google refresh token",
-      })
-    : undefined;
-  const update: Record<string, unknown> = {
-    "google.picture": gUser.picture || "not provided",
-    lastLoggedInAt: new Date(),
-  };
-
-  if (refreshToken) {
-    update["google.gRefreshToken"] = refreshToken;
-  }
-
-  const user = await mongoService.user.findOneAndUpdate(
-    { "google.googleId": gUserId },
-    { $set: update },
-    { returnDocument: "after" },
-  );
-
-  const cUserId = zObjectId
-    .parse(user?._id, { error: () => "Invalid credentials" })
-    .toString();
-
-  return { cUserId };
-}
-
 async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
   const {
     providerUser,
@@ -318,11 +282,14 @@ async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
       return;
     }
 
-    case "RECONNECT_REPAIR": {
-      // User exists but needs repair (missing refresh token or unhealthy sync)
+    case "SIGNIN": {
+      // Returning user - repairGoogleConnection covers both the healthy
+      // refresh case and the missing/stale-token case (it falls back to
+      // persistStoredGoogleConnection when Google doesn't return a new
+      // refresh token).
       const compassUserId = decision.compassUserId;
       if (!compassUserId) {
-        throw new Error("Compass user ID expected for Google repair");
+        throw new Error("Compass user ID expected for Google sign-in");
       }
 
       await googleAuthService.repairGoogleConnection(
@@ -330,12 +297,6 @@ async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
         providerUser,
         oAuthTokens,
       );
-      return;
-    }
-
-    case "SIGNIN_INCREMENTAL": {
-      // Healthy returning user - attempt incremental sync
-      await googleAuthService.googleSignin(providerUser, oAuthTokens);
       return;
     }
   }
@@ -346,6 +307,5 @@ export const googleAuthService = {
   repairGoogleConnection,
   getConnectedCompassUserId,
   connectGoogleToCurrentUser,
-  googleSignin,
   handleGoogleAuth,
 };

--- a/packages/backend/src/auth/services/google/google.auth.success.service.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.success.service.test.ts
@@ -43,8 +43,6 @@ function makeDecision(overrides: Partial<AuthDecision>): AuthDecision {
   return {
     authMode: "SIGNUP",
     compassUserId: null,
-    hasStoredRefreshToken: false,
-    hasHealthySync: false,
     createdNewRecipeUser: true,
     ...overrides,
   };
@@ -69,16 +67,12 @@ describe("handleGoogleAuth", () => {
     spyOn(googleAuthService, "googleSignup").mockResolvedValue({
       cUserId: "signup-id",
     });
-    spyOn(googleAuthService, "googleSignin").mockResolvedValue({
-      cUserId: "signin-id",
-    });
   });
 
   beforeEach(() => {
     mockDetermineGoogleAuthMode.mockReset();
     (googleAuthService.repairGoogleConnection as Mock).mockClear();
     (googleAuthService.googleSignup as Mock).mockClear();
-    (googleAuthService.googleSignin as Mock).mockClear();
   });
 
   afterAll(() => {
@@ -112,7 +106,6 @@ describe("handleGoogleAuth", () => {
         recipeUserId,
       );
       expect(googleAuthService.repairGoogleConnection).not.toHaveBeenCalled();
-      expect(googleAuthService.googleSignin).not.toHaveBeenCalled();
     });
 
     it("throws when refresh_token is missing for new user", async () => {
@@ -136,18 +129,16 @@ describe("handleGoogleAuth", () => {
     });
   });
 
-  describe("RECONNECT_REPAIR path", () => {
-    it("calls repairGoogleConnection when user exists but refresh token is missing", async () => {
+  describe("SIGNIN path", () => {
+    it("calls repairGoogleConnection for a returning user", async () => {
       const compassUserId = faker.database.mongodbObjectId();
       const providerUser = makeProviderUser();
       const oAuthTokens = makeOAuthTokens();
 
       mockDetermineGoogleAuthMode.mockResolvedValue(
         makeDecision({
-          authMode: "RECONNECT_REPAIR",
+          authMode: "SIGNIN",
           compassUserId,
-          hasStoredRefreshToken: false,
-          hasHealthySync: true,
           createdNewRecipeUser: false,
         }),
       );
@@ -168,138 +159,6 @@ describe("handleGoogleAuth", () => {
         providerUser,
         oAuthTokens,
       );
-      expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
-      expect(googleAuthService.googleSignin).not.toHaveBeenCalled();
-    });
-
-    it("calls repairGoogleConnection when user exists but sync is unhealthy", async () => {
-      const compassUserId = faker.database.mongodbObjectId();
-      const providerUser = makeProviderUser();
-      const oAuthTokens = makeOAuthTokens();
-
-      mockDetermineGoogleAuthMode.mockResolvedValue(
-        makeDecision({
-          authMode: "RECONNECT_REPAIR",
-          compassUserId,
-          hasStoredRefreshToken: true,
-          hasHealthySync: false,
-          createdNewRecipeUser: false,
-        }),
-      );
-
-      const success: GoogleSignInSuccess = {
-        providerUser,
-        oAuthTokens,
-        createdNewRecipeUser: false,
-        recipeUserId: compassUserId,
-        loginMethodsLength: 1,
-      };
-
-      await googleAuthService.handleGoogleAuth(success);
-
-      expect(googleAuthService.repairGoogleConnection).toHaveBeenCalledTimes(1);
-      expect(googleAuthService.repairGoogleConnection).toHaveBeenCalledWith(
-        compassUserId,
-        providerUser,
-        oAuthTokens,
-      );
-      expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
-      expect(googleAuthService.googleSignin).not.toHaveBeenCalled();
-    });
-
-    it("calls repairGoogleConnection when both refresh token is missing and sync is unhealthy", async () => {
-      const compassUserId = faker.database.mongodbObjectId();
-      const providerUser = makeProviderUser();
-      const oAuthTokens = makeOAuthTokens();
-
-      mockDetermineGoogleAuthMode.mockResolvedValue(
-        makeDecision({
-          authMode: "RECONNECT_REPAIR",
-          compassUserId,
-          hasStoredRefreshToken: false,
-          hasHealthySync: false,
-          createdNewRecipeUser: false,
-        }),
-      );
-
-      const success: GoogleSignInSuccess = {
-        providerUser,
-        oAuthTokens,
-        createdNewRecipeUser: false,
-        recipeUserId: compassUserId,
-        loginMethodsLength: 1,
-      };
-
-      await googleAuthService.handleGoogleAuth(success);
-
-      expect(googleAuthService.repairGoogleConnection).toHaveBeenCalledTimes(1);
-      expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
-      expect(googleAuthService.googleSignin).not.toHaveBeenCalled();
-    });
-
-    it("calls repairGoogleConnection when no sync record exists", async () => {
-      const compassUserId = faker.database.mongodbObjectId();
-      const providerUser = makeProviderUser();
-      const oAuthTokens = makeOAuthTokens();
-
-      mockDetermineGoogleAuthMode.mockResolvedValue(
-        makeDecision({
-          authMode: "RECONNECT_REPAIR",
-          compassUserId,
-          hasStoredRefreshToken: true,
-          hasHealthySync: false,
-          createdNewRecipeUser: false,
-        }),
-      );
-
-      const success: GoogleSignInSuccess = {
-        providerUser,
-        oAuthTokens,
-        createdNewRecipeUser: false,
-        recipeUserId: compassUserId,
-        loginMethodsLength: 1,
-      };
-
-      await googleAuthService.handleGoogleAuth(success);
-
-      expect(googleAuthService.repairGoogleConnection).toHaveBeenCalledTimes(1);
-      expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
-      expect(googleAuthService.googleSignin).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("SIGNIN_INCREMENTAL path", () => {
-    it("calls googleSignin when user exists with valid refresh token and healthy sync", async () => {
-      const compassUserId = faker.database.mongodbObjectId();
-      const providerUser = makeProviderUser();
-      const oAuthTokens = makeOAuthTokens();
-
-      mockDetermineGoogleAuthMode.mockResolvedValue(
-        makeDecision({
-          authMode: "SIGNIN_INCREMENTAL",
-          compassUserId,
-          hasStoredRefreshToken: true,
-          hasHealthySync: true,
-          createdNewRecipeUser: false,
-        }),
-      );
-
-      const success: GoogleSignInSuccess = {
-        providerUser,
-        oAuthTokens,
-        createdNewRecipeUser: false,
-        recipeUserId: compassUserId,
-        loginMethodsLength: 1,
-      };
-
-      await googleAuthService.handleGoogleAuth(success);
-
-      expect(googleAuthService.googleSignin).toHaveBeenCalledTimes(1);
-      expect(googleAuthService.googleSignin).toHaveBeenCalledWith(
-        providerUser,
-        oAuthTokens,
-      );
-      expect(googleAuthService.repairGoogleConnection).not.toHaveBeenCalled();
       expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
     });
   });
@@ -318,32 +177,11 @@ describe("handleGoogleAuth", () => {
       });
       expect(googleAuthService.googleSignup).toHaveBeenCalled();
 
-      const reconnectUserId = faker.database.mongodbObjectId();
-      mockDetermineGoogleAuthMode.mockResolvedValueOnce(
-        makeDecision({
-          authMode: "RECONNECT_REPAIR",
-          compassUserId: reconnectUserId,
-          hasStoredRefreshToken: false,
-          hasHealthySync: true,
-          createdNewRecipeUser: false,
-        }),
-      );
-      await googleAuthService.handleGoogleAuth({
-        providerUser: makeProviderUser(),
-        oAuthTokens: makeOAuthTokens(),
-        createdNewRecipeUser: false,
-        recipeUserId: reconnectUserId,
-        loginMethodsLength: 1,
-      });
-      expect(googleAuthService.repairGoogleConnection).toHaveBeenCalled();
-
       const signinUserId = faker.database.mongodbObjectId();
       mockDetermineGoogleAuthMode.mockResolvedValueOnce(
         makeDecision({
-          authMode: "SIGNIN_INCREMENTAL",
+          authMode: "SIGNIN",
           compassUserId: signinUserId,
-          hasStoredRefreshToken: true,
-          hasHealthySync: true,
           createdNewRecipeUser: false,
         }),
       );
@@ -354,7 +192,7 @@ describe("handleGoogleAuth", () => {
         recipeUserId: signinUserId,
         loginMethodsLength: 1,
       });
-      expect(googleAuthService.googleSignin).toHaveBeenCalled();
+      expect(googleAuthService.repairGoogleConnection).toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/auth/services/google/google.auth.success.utils.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.success.utils.test.ts
@@ -1,23 +1,8 @@
 import { faker } from "@faker-js/faker";
 import { ObjectId } from "mongodb";
-import * as syncRecords from "@backend/sync/services/records/sync-records.repository";
 import * as userQueries from "@backend/user/queries/user.queries";
 import { determineGoogleAuthMode } from "./util/google.auth.util";
 import { describe, expect, it, spyOn } from "bun:test";
-
-function makeCompassUser(overrides?: {
-  googleId?: string;
-  hasRefreshToken?: boolean;
-}) {
-  return {
-    _id: new ObjectId(),
-    google: {
-      googleId: overrides?.googleId ?? faker.string.uuid(),
-      gRefreshToken:
-        overrides?.hasRefreshToken === false ? null : faker.string.uuid(),
-    },
-  };
-}
 
 describe("determineGoogleAuthMode", () => {
   it("returns SIGNUP when there is no linked Compass user", async () => {
@@ -29,8 +14,6 @@ describe("determineGoogleAuthMode", () => {
     ).resolves.toEqual({
       authMode: "SIGNUP",
       compassUserId: null,
-      hasStoredRefreshToken: false,
-      hasHealthySync: false,
       createdNewRecipeUser: true,
     });
 
@@ -40,57 +23,15 @@ describe("determineGoogleAuthMode", () => {
     });
   });
 
-  it("returns RECONNECT_REPAIR when the user is missing a stored refresh token", async () => {
-    const user = makeCompassUser({ hasRefreshToken: false });
+  it("returns SIGNIN when a Compass user is already linked", async () => {
+    const user = { _id: new ObjectId() };
     spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValue(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue({
-      google: { events: [{ nextSyncToken: "x" }] },
-    });
-    spyOn(syncRecords, "canDoIncrementalSync").mockReturnValue(true);
 
     await expect(
-      determineGoogleAuthMode(user.google.googleId, null, false),
+      determineGoogleAuthMode(faker.string.uuid(), null, false),
     ).resolves.toEqual({
-      authMode: "RECONNECT_REPAIR",
+      authMode: "SIGNIN",
       compassUserId: user._id.toString(),
-      hasStoredRefreshToken: false,
-      hasHealthySync: true,
-      createdNewRecipeUser: false,
-    });
-  });
-
-  it("returns RECONNECT_REPAIR when sync is not healthy", async () => {
-    const user = makeCompassUser();
-    spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValue(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue({ google: { events: [] } });
-    spyOn(syncRecords, "canDoIncrementalSync").mockReturnValue(false);
-
-    await expect(
-      determineGoogleAuthMode(user.google.googleId, null, false),
-    ).resolves.toEqual({
-      authMode: "RECONNECT_REPAIR",
-      compassUserId: user._id.toString(),
-      hasStoredRefreshToken: true,
-      hasHealthySync: false,
-      createdNewRecipeUser: false,
-    });
-  });
-
-  it("returns SIGNIN_INCREMENTAL when the user has a refresh token and healthy sync", async () => {
-    const user = makeCompassUser();
-    spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValue(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue({
-      google: { events: [{ nextSyncToken: "token" }] },
-    });
-    spyOn(syncRecords, "canDoIncrementalSync").mockReturnValue(true);
-
-    await expect(
-      determineGoogleAuthMode(user.google.googleId, null, false),
-    ).resolves.toEqual({
-      authMode: "SIGNIN_INCREMENTAL",
-      compassUserId: user._id.toString(),
-      hasStoredRefreshToken: true,
-      hasHealthySync: true,
       createdNewRecipeUser: false,
     });
   });
@@ -99,15 +40,12 @@ describe("determineGoogleAuthMode", () => {
     const user = { _id: new ObjectId() };
     const googleUserId = faker.string.uuid();
     spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValueOnce(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue(null);
 
     await expect(
       determineGoogleAuthMode(googleUserId, " Existing@Example.com ", false),
     ).resolves.toEqual({
-      authMode: "RECONNECT_REPAIR",
+      authMode: "SIGNIN",
       compassUserId: user._id.toString(),
-      hasStoredRefreshToken: false,
-      hasHealthySync: false,
       createdNewRecipeUser: false,
     });
 

--- a/packages/backend/src/auth/services/google/google.auth.types.ts
+++ b/packages/backend/src/auth/services/google/google.auth.types.ts
@@ -1,12 +1,10 @@
 import { type Credentials, type TokenPayload } from "google-auth-library";
 
-export type AuthMode = "SIGNUP" | "SIGNIN_INCREMENTAL" | "RECONNECT_REPAIR";
+export type AuthMode = "SIGNUP" | "SIGNIN";
 
 export type AuthDecision = {
   authMode: AuthMode;
   compassUserId: string | null;
-  hasStoredRefreshToken: boolean;
-  hasHealthySync: boolean;
   createdNewRecipeUser: boolean;
 };
 

--- a/packages/backend/src/auth/services/google/util/google.auth.util.test.ts
+++ b/packages/backend/src/auth/services/google/util/google.auth.util.test.ts
@@ -1,27 +1,12 @@
 import { faker } from "@faker-js/faker";
 import { type Credentials, type TokenPayload } from "google-auth-library";
 import { ObjectId } from "mongodb";
-import * as syncRecords from "@backend/sync/services/records/sync-records.repository";
 import * as userQueries from "@backend/user/queries/user.queries";
 import {
   determineGoogleAuthMode,
   parseReconnectGoogleParams,
 } from "./google.auth.util";
 import { describe, expect, it, spyOn } from "bun:test";
-
-function makeCompassUser(overrides?: {
-  googleId?: string;
-  hasRefreshToken?: boolean;
-}) {
-  return {
-    _id: new ObjectId(),
-    google: {
-      googleId: overrides?.googleId ?? faker.string.uuid(),
-      gRefreshToken:
-        overrides?.hasRefreshToken === false ? null : faker.string.uuid(),
-    },
-  };
-}
 
 describe("determineGoogleAuthMode", () => {
   it("returns SIGNUP when there is no linked Compass user", async () => {
@@ -33,8 +18,6 @@ describe("determineGoogleAuthMode", () => {
     ).resolves.toEqual({
       authMode: "SIGNUP",
       compassUserId: null,
-      hasStoredRefreshToken: false,
-      hasHealthySync: false,
       createdNewRecipeUser: true,
     });
 
@@ -44,57 +27,15 @@ describe("determineGoogleAuthMode", () => {
     });
   });
 
-  it("returns RECONNECT_REPAIR when the user is missing a stored refresh token", async () => {
-    const user = makeCompassUser({ hasRefreshToken: false });
+  it("returns SIGNIN when a Compass user is already linked", async () => {
+    const user = { _id: new ObjectId() };
     spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValue(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue({
-      google: { events: [{ nextSyncToken: "x" }] },
-    });
-    spyOn(syncRecords, "canDoIncrementalSync").mockReturnValue(true);
 
     await expect(
-      determineGoogleAuthMode(user.google.googleId, null, false),
+      determineGoogleAuthMode(faker.string.uuid(), null, false),
     ).resolves.toEqual({
-      authMode: "RECONNECT_REPAIR",
+      authMode: "SIGNIN",
       compassUserId: user._id.toString(),
-      hasStoredRefreshToken: false,
-      hasHealthySync: true,
-      createdNewRecipeUser: false,
-    });
-  });
-
-  it("returns RECONNECT_REPAIR when sync is not healthy", async () => {
-    const user = makeCompassUser();
-    spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValue(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue({ google: { events: [] } });
-    spyOn(syncRecords, "canDoIncrementalSync").mockReturnValue(false);
-
-    await expect(
-      determineGoogleAuthMode(user.google.googleId, null, false),
-    ).resolves.toEqual({
-      authMode: "RECONNECT_REPAIR",
-      compassUserId: user._id.toString(),
-      hasStoredRefreshToken: true,
-      hasHealthySync: false,
-      createdNewRecipeUser: false,
-    });
-  });
-
-  it("returns SIGNIN_INCREMENTAL when the user has a refresh token and healthy sync", async () => {
-    const user = makeCompassUser();
-    spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValue(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue({
-      google: { events: [{ nextSyncToken: "token" }] },
-    });
-    spyOn(syncRecords, "canDoIncrementalSync").mockReturnValue(true);
-
-    await expect(
-      determineGoogleAuthMode(user.google.googleId, null, false),
-    ).resolves.toEqual({
-      authMode: "SIGNIN_INCREMENTAL",
-      compassUserId: user._id.toString(),
-      hasStoredRefreshToken: true,
-      hasHealthySync: true,
       createdNewRecipeUser: false,
     });
   });
@@ -103,15 +44,12 @@ describe("determineGoogleAuthMode", () => {
     const user = { _id: new ObjectId() };
     const googleUserId = faker.string.uuid();
     spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValueOnce(user);
-    spyOn(syncRecords, "getSync").mockResolvedValue(null);
 
     await expect(
       determineGoogleAuthMode(googleUserId, " Existing@Example.com ", false),
     ).resolves.toEqual({
-      authMode: "RECONNECT_REPAIR",
+      authMode: "SIGNIN",
       compassUserId: user._id.toString(),
-      hasStoredRefreshToken: false,
-      hasHealthySync: false,
       createdNewRecipeUser: false,
     });
 

--- a/packages/backend/src/auth/services/google/util/google.auth.util.ts
+++ b/packages/backend/src/auth/services/google/util/google.auth.util.ts
@@ -1,9 +1,5 @@
 import { type Credentials, type TokenPayload } from "google-auth-library";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
-import {
-  canDoIncrementalSync,
-  getSync,
-} from "@backend/sync/services/records/sync-records.repository";
 import { findCanonicalCompassUser } from "@backend/user/queries/user.queries";
 import {
   type AuthDecision,
@@ -21,32 +17,13 @@ export async function determineGoogleAuthMode(
     return {
       authMode: "SIGNUP",
       compassUserId: null,
-      hasStoredRefreshToken: false,
-      hasHealthySync: false,
-      createdNewRecipeUser,
-    };
-  }
-
-  const compassUserId = user._id.toString();
-  const hasStoredRefreshToken = !!user.google?.gRefreshToken;
-  const sync = await getSync({ userId: compassUserId });
-  const hasHealthySync = sync ? !!canDoIncrementalSync(sync) : false;
-
-  if (!hasStoredRefreshToken || !hasHealthySync) {
-    return {
-      authMode: "RECONNECT_REPAIR",
-      compassUserId,
-      hasStoredRefreshToken,
-      hasHealthySync,
       createdNewRecipeUser,
     };
   }
 
   return {
-    authMode: "SIGNIN_INCREMENTAL",
-    compassUserId,
-    hasStoredRefreshToken,
-    hasHealthySync,
+    authMode: "SIGNIN",
+    compassUserId: user._id.toString(),
     createdNewRecipeUser,
   };
 }


### PR DESCRIPTION
## Summary

`determineGoogleAuthMode`'s 3-way `SIGNUP`/`RECONNECT_REPAIR`/`SIGNIN_INCREMENTAL` split derived `hasHealthySync` from the legacy `sync` Mongo collection. That collection is never populated once a deployment is delegated to the standalone Sync service (every prod/self-host deployment today), so the check is structurally always-false — every returning Google user has been routed through `RECONNECT_REPAIR` instead of ever reaching `SIGNIN_INCREMENTAL` since prod's cutover.

`repairGoogleConnection` (via `user.service.ts`'s `updateGoogleConnection`) is already a strict superset of `googleSignin`'s behavior — it sets `lastLoggedInAt`, preserves the stored refresh token when Google doesn't return a new one, and additionally handles a not-yet-linked `googleId`. So rather than redesigning the health check to query Sync for real connection status, this collapses the routing to a 2-way `SIGNUP`/`SIGNIN` split: `SIGNIN` always calls `repairGoogleConnection`, and `googleSignin` is deleted as fully subsumed.

This also removes `google.auth.util.ts`'s `sync/` import (`getSync`/`canDoIncrementalSync`) entirely — one of the remaining call sites blocking the final wholesale deletion of `packages/backend/src/sync/` (task 4.8 in the legacy-sync-removal plan).

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `./node_modules/.bin/biome check` clean on touched files
- [x] `bun run test:backend`: 54 failures, matching the pre-existing local-sandbox baseline exactly (SSE/socket-hang-up flakes unrelated to this change); zero failures in any `google.auth.*` file
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the login path for every returning Google user in authentication code, but intentionally unifies on `repairGoogleConnection` after removing a sync check that could mis-route users; regression risk is mainly around token persistence and sync restart side effects.
> 
> **Overview**
> **Collapses Google auth routing** from three modes (`SIGNUP`, `RECONNECT_REPAIR`, `SIGNIN_INCREMENTAL`) to **two** (`SIGNUP` | `SIGNIN`). `determineGoogleAuthMode` no longer reads legacy sync health or stored refresh tokens—it only checks whether a canonical Compass user exists (by Google id or email).
> 
> **Returning users (`SIGNIN`)** always call **`repairGoogleConnection`** instead of sometimes using the lighter **`googleSignin`** path. **`googleSignin` is deleted** from `google.auth.service` and exports; behavior for missing refresh tokens is expected to be covered by `repairGoogleConnection` / `persistStoredGoogleConnection`.
> 
> **`AuthDecision` and decision logs** drop `hasStoredRefreshToken` and `hasHealthySync`. **`google.auth.util`** drops the `sync/` repository dependency (`getSync`, `canDoIncrementalSync`).
> 
> Tests are aligned with the two-mode model and consolidated SIGNIN/repair scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23938034d52319e62a20a896c355e88b3831bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->