### PR TITLE
fix(sync): make partial-index type guards provable to the query planner

### DIFF
--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -79,6 +79,14 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       // such events on (null,null,null) — allowing only one unlinked event.
       // Filtering on a real string providerEventId is robust whether the
       // repository stores unlinked provider fields as null or absent.
+      //
+      // PLANNER TRAP for every $type partial filter in this manifest: Mongo
+      // only uses a partial index when the query provably implies its filter,
+      // and a plain equality does NOT prove a $type predicate. Queries meant
+      // to hit these indexes must assert the type themselves, e.g.
+      // { providerEventId: { $eq: id, $type: "string" } } — semantically a
+      // no-op, but without it the planner silently falls back to a COLLSCAN
+      // (which is exactly what melted prod on this index).
       options: {
         unique: true,
         partialFilterExpression: { providerEventId: { $type: "string" } },

--- a/packages/sync/src/storage/repositories/deletion-marker.repository.ts
+++ b/packages/sync/src/storage/repositories/deletion-marker.repository.ts
@@ -42,7 +42,8 @@ export class DeletionMarkerRepository {
       {
         connectionId: fields.connectionId,
         calendarId: fields.calendarId,
-        providerEventId: fields.providerEventId,
+        // $type: see the PLANNER TRAP note in index-manifest.ts.
+        providerEventId: { $eq: fields.providerEventId, $type: "string" },
       },
       {
         $set: {
@@ -72,7 +73,12 @@ export class DeletionMarkerRepository {
     providerEventId: ProviderEventId,
   ): Promise<boolean> {
     const count = await this.collection.countDocuments(
-      { connectionId, calendarId, providerEventId },
+      {
+        connectionId,
+        calendarId,
+        // $type: see the PLANNER TRAP note in index-manifest.ts.
+        providerEventId: { $eq: providerEventId, $type: "string" },
+      },
       { limit: 1 },
     );
     return count > 0;

--- a/packages/sync/src/storage/repositories/event.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.db.test.ts
@@ -101,6 +101,32 @@ describe("EventRepository", () => {
     expect(await db.collection("events").countDocuments()).toBe(1);
   });
 
+  // The $type in the upsert filter looks redundant (the input is always a
+  // string) but is what lets the planner use the provider_event_identity
+  // PARTIAL index — without it every upsert COLLSCANs, which took prod down.
+  // This pins the plan so a cleanup can't silently strip the operator.
+  // See the PLANNER TRAP note in index-manifest.ts.
+  it("provider-identity filter is served by the partial index, not a scan", async () => {
+    const identity = {
+      connectionId: objectId(),
+      calendarId: objectId(),
+      providerEventId: "evt-plan",
+    };
+    await repo.upsertByProviderIdentity(linkedUpsert(identity));
+
+    const plan = await db
+      .collection("events")
+      .find({
+        connectionId: identity.connectionId,
+        calendarId: identity.calendarId,
+        providerEventId: { $eq: identity.providerEventId, $type: "string" },
+      })
+      .explain("queryPlanner");
+    const winning = JSON.stringify(plan);
+    expect(winning).toContain("provider_event_identity");
+    expect(winning).not.toContain("COLLSCAN");
+  });
+
   it("stores many unlinked Compass events (no provider identity collision)", async () => {
     const principalId = objectId();
     await repo.put(compassRecord({ principalId }));

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -62,12 +62,9 @@ export class EventRepository {
       {
         connectionId: input.connectionId,
         calendarId: input.calendarId,
-        // $type is redundant with $eq here (providerEventId is always a string
-        // by this method's input type) but load-bearing for the planner: it's
-        // what lets Mongo prove the provider_event_identity partial index
-        // (partialFilterExpression providerEventId:{$type:"string"}) covers
-        // this query. Without it, equality alone doesn't imply the partial
-        // filter and every upsert falls back to a full collection scan.
+        // $type is a semantic no-op but makes the provider_event_identity
+        // partial index provable to the planner — without it, COLLSCAN.
+        // See the PLANNER TRAP note in index-manifest.ts.
         providerEventId: { $eq: input.providerEventId, $type: "string" },
       },
       {
@@ -152,7 +149,8 @@ export class EventRepository {
       principalId,
       connectionId: identity.connectionId,
       calendarId: identity.calendarId,
-      providerEventId: identity.providerEventId,
+      // $type: see the PLANNER TRAP note in index-manifest.ts.
+      providerEventId: { $eq: identity.providerEventId, $type: "string" },
     });
     return record ? EventRecordSchema.parse(record) : null;
   }
@@ -175,7 +173,8 @@ export class EventRepository {
       principalId,
       connectionId: identity.connectionId,
       calendarId: identity.calendarId,
-      providerEventId: identity.providerEventId,
+      // $type: see the PLANNER TRAP note in index-manifest.ts.
+      providerEventId: { $eq: identity.providerEventId, $type: "string" },
     });
     if (!record) return { record: null, corruptDeletedId: null };
     const parsed = EventRecordSchema.safeParse(record);

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -62,7 +62,13 @@ export class EventRepository {
       {
         connectionId: input.connectionId,
         calendarId: input.calendarId,
-        providerEventId: input.providerEventId,
+        // $type is redundant with $eq here (providerEventId is always a string
+        // by this method's input type) but load-bearing for the planner: it's
+        // what lets Mongo prove the provider_event_identity partial index
+        // (partialFilterExpression providerEventId:{$type:"string"}) covers
+        // this query. Without it, equality alone doesn't imply the partial
+        // filter and every upsert falls back to a full collection scan.
+        providerEventId: { $eq: input.providerEventId, $type: "string" },
       },
       {
         // input already omits _id/createdAt/updatedAt (see ProviderEventUpsert).

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -85,7 +85,11 @@ export class ProviderConnectionRepository {
   async findByDiagnosticKey(
     diagnosticKey: string,
   ): Promise<ProviderConnectionRecord | null> {
-    const record = await this.collection.findOne({ diagnosticKey });
+    // $type makes the diagnostic_key partial index provable to the planner
+    // (see upsertByProviderIdentity for why plain $eq isn't enough).
+    const record = await this.collection.findOne({
+      diagnosticKey: { $eq: diagnosticKey, $type: "string" },
+    });
     if (record) return this.parseRecord(record);
 
     // Pre-S45 rows omit diagnosticKey until first read; match derived keys.
@@ -219,8 +223,10 @@ export class ProviderConnectionRepository {
     before: Date,
     limit: number,
   ): Promise<ProviderConnectionRecord[]> {
+    // $type makes the disconnected_at partial index provable to the planner
+    // (see upsertByProviderIdentity for why plain $ne/$lt isn't enough).
     const records = await this.collection
-      .find({ disconnectedAt: { $ne: null, $lt: before } })
+      .find({ disconnectedAt: { $type: "date", $lt: before } })
       .sort({ disconnectedAt: 1 })
       .limit(limit)
       .toArray();

--- a/packages/sync/src/storage/repositories/provider-connection.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.ts
@@ -85,8 +85,8 @@ export class ProviderConnectionRepository {
   async findByDiagnosticKey(
     diagnosticKey: string,
   ): Promise<ProviderConnectionRecord | null> {
-    // $type makes the diagnostic_key partial index provable to the planner
-    // (see upsertByProviderIdentity for why plain $eq isn't enough).
+    // $type makes the diagnostic_key partial index provable to the planner.
+    // See the PLANNER TRAP note in index-manifest.ts.
     const record = await this.collection.findOne({
       diagnosticKey: { $eq: diagnosticKey, $type: "string" },
     });
@@ -223,8 +223,8 @@ export class ProviderConnectionRepository {
     before: Date,
     limit: number,
   ): Promise<ProviderConnectionRecord[]> {
-    // $type makes the disconnected_at partial index provable to the planner
-    // (see upsertByProviderIdentity for why plain $ne/$lt isn't enough).
+    // $type makes the disconnected_at partial index provable to the planner.
+    // See the PLANNER TRAP note in index-manifest.ts.
     const records = await this.collection
       .find({ disconnectedAt: { $type: "date", $lt: before } })
       .sort({ disconnectedAt: 1 })


### PR DESCRIPTION
## Summary

- Root-caused a live Atlas "Query Targeting: Scanned Objects / Returned > 1000" alert on the `Production1` cluster (avg ratio ~44,829) to `upsertByProviderIdentity` in `event.repository.ts`: its `findOneAndUpdate` filters `compass_sync.events` on `{connectionId, calendarId, providerEventId}` equality only, but the matching unique index (`provider_event_identity`) is a **partial** index guarded by `partialFilterExpression: { providerEventId: { $type: "string" } }`. Mongo's planner cannot infer that an `$eq` to a string literal satisfies a `$type` partial filter, so it never considers the index at all — confirmed via `$indexStats` (0 ops since last restart) — and falls back to a full `COLLSCAN` of all ~515K docs on **every** sync write (~1.5-2.6s each, matching the slow-query log exactly).
- Fix: add the `$type` predicate alongside `$eq` on the same field. This is a no-op on the result set (BSON type bracketing means `$eq` to a string already only matches strings) but makes the partial filter provable, so the planner picks the index. Verified live against prod via `explain`: `COLLSCAN` (515K docs, ~2s) → `IXSCAN` (1 key, 1 doc, 1ms).
- Applied the same fix to every other query aimed at a `$type` partial index: `findByProviderIdentity`/`findByProviderIdentitySafe` (events), `record`/`exists` (deletion markers, whose only secondary index is the same shape — collection is empty today thanks to the 30-day TTL, which is the only reason it isn't alerting), and `findByDiagnosticKey`/`listDisconnectedBefore` (provider connections).

## Simplicity

Surgical: one extra query operator per site, no behavior change to what's matched or returned — only which plan the server picks. The canonical explanation lives once in `index-manifest.ts` (a "PLANNER TRAP" note next to the `$type` partial filters it concerns) with one-line pointers at call sites. Considered and rejected: fixing at the index level (a provable partial filter would require drop-and-recreating a unique index on a live 515K-doc collection, and the manifest's idempotent `createIndex` errors on a same-name/different-spec conflict — the query-side fix is deploy-only), and a shared query helper (six inline uses don't justify an abstraction).

## Automated validation

Verified live against the production `compass_sync` cluster (read-only): `explain` on the exact upsert filter shape shows `COLLSCAN`/`totalDocsExamined: 514991`/~2-3s without the `$type` predicate, and `IXSCAN` via `provider_event_identity`/`totalDocsExamined: 1`/~0-1ms with it. Same before/after confirmed for the `provider_connections` partial indexes.

## Independent review

Fresh-eyes senior review of the first commit confirmed the approach and found: (1) the same defect at four more call sites — deletion-marker `record`/`exists` (latent COLLSCAN, masked only by the TTL keeping the collection empty) and event `findByProviderIdentity`/`findByProviderIdentitySafe` (silently degrading to a per-calendar scan via `principal_calendar` instead of a unique-index seek, which is why they never hit the slow-query log); (2) comments alone can't protect a deliberately-redundant operator from a future cleanup — so the plan is now pinned by an explain-based db test that fails CI if `provider_event_identity` stops serving the identity filter; (3) a confusing cross-file comment reference, replaced by the single manifest note. All three fixed in the second commit. Deliberately left alone: `deleteStaleProviderEventsBelowGeneration`'s `$ne: null` (served by `principal_calendar`; `$type` would change semantics for the 4 legacy non-string prod rows).

## Test plan

- `TZ=UTC bun run test:sync -- <event|provider-connection|deletion-marker repository db tests + index-manifest db test>` — 41 pass, including the new plan-pinning test
- `bunx typescript@7.0.2 --noEmit -p packages/sync/tsconfig.json` — clean
- `bunx typescript@7.0.2 --noEmit` (root) — clean
