### PR TITLE
chore(sync): unmount legacy SyncRoutes and drop its startup webhook warning

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,7 +1,6 @@
 import { CONFIG } from "@backend/common/constants/config.constants";
 import mongoService from "@backend/common/services/mongo.service";
 import { initExpressServer } from "@backend/servers/express/express.server";
-import { warnIfWebhookNotPublicHttps } from "@backend/sync/services/watch/google-watch-config";
 import { logger } from "./init"; //must be first import
 import { stopPostHogLogs } from "./logging/posthog-logs";
 import { createServer, type Server } from "node:http";
@@ -15,8 +14,6 @@ function onClose() {
 
 async function start() {
   try {
-    warnIfWebhookNotPublicHttps(logger);
-
     await mongoService.start();
 
     await new Promise((resolve) =>

--- a/packages/backend/src/servers/express/express.server.ts
+++ b/packages/backend/src/servers/express/express.server.ts
@@ -18,7 +18,6 @@ import { ConfigRoutes } from "@backend/config/config.routes.config";
 import { EventRoutes } from "@backend/event/event.routes.config";
 import { EventsRoutes } from "@backend/events/events.routes.config";
 import { HealthRoutes } from "@backend/health/health.routes.config";
-import { SyncRoutes } from "@backend/sync/sync.routes.config";
 import { UserRoutes } from "@backend/user/user.routes.config";
 
 export const initExpressServer = () => {
@@ -44,7 +43,6 @@ export const initExpressServer = () => {
   routes.push(new UserRoutes(app));
   routes.push(new EventRoutes(app));
   routes.push(new EventsRoutes(app));
-  routes.push(new SyncRoutes(app));
   routes.push(new CalendarRoutes(app));
 
   app.use(supertokensErrorHandler()); // Keep this after routes


### PR DESCRIPTION
## Summary

First standalone-safe step toward deleting `packages/backend/src/sync/` wholesale (the legacy in-backend Google-sync engine, now fully superseded by the standalone Sync microservice everywhere).

- `servers/express/express.server.ts` no longer mounts `SyncRoutes` — the legacy engine's own Express routes (Google webhook/import endpoints) were still wired in but unreachable in practice on any Sync-delegated deployment (prod and self-host both are, as of the last two cutovers).
- `app.ts` no longer calls `warnIfWebhookNotPublicHttps` at startup — a sanity check specific to the legacy engine's own webhook config, meaningless once nothing routes to it.

`packages/backend/src/sync/` itself is untouched — still compiles standalone, still has its own test coverage, nothing inside it changed. This just removes the two places outside `sync/` that reference it for routing/startup, clearing the way for later PRs to finish decoupling test infrastructure before the final wholesale deletion.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `./node_modules/.bin/biome check` clean
- [x] `bun run test:backend`: 54 failures, exact zero-delta match against the established pre-existing local-sandbox baseline
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)