### PR TITLE
fix(web): promote full-day timed events to the all-day row

### DIFF
--- a/packages/web/src/common/utils/event/event-nudge.util.test.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.test.ts
@@ -1,9 +1,11 @@
 import dayjs from "@core/util/date/dayjs";
 import {
   getArrowKeyMovement,
+  isTimedEventFullCalendarDay,
   isTimedEventInsideOneDay,
   isTimedEventMultiDay,
   nudgeEventDates,
+  shouldRenderTimedInAllDayRow,
   timedMultiDayToAllDayDates,
 } from "@web/common/utils/event/event-nudge.util";
 import { GRID_TIME_STEP } from "@web/grid/grid.constants";
@@ -150,6 +152,73 @@ describe("isTimedEventMultiDay", () => {
         dayjs("2026-05-21T18:00:00"),
       ),
     ).toBe(true);
+  });
+});
+
+describe("isTimedEventFullCalendarDay", () => {
+  it("is true for midnight to next midnight", () => {
+    expect(
+      isTimedEventFullCalendarDay(
+        dayjs("2026-05-20T00:00:00"),
+        dayjs("2026-05-21T00:00:00"),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for evening events that end at next midnight", () => {
+    expect(
+      isTimedEventFullCalendarDay(
+        dayjs("2026-05-20T22:00:00"),
+        dayjs("2026-05-21T00:00:00"),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for same-day timed and overnight multi-day ranges", () => {
+    expect(
+      isTimedEventFullCalendarDay(
+        dayjs("2026-05-20T10:00:00"),
+        dayjs("2026-05-20T11:00:00"),
+      ),
+    ).toBe(false);
+    expect(
+      isTimedEventFullCalendarDay(
+        dayjs("2026-05-20T22:00:00"),
+        dayjs("2026-05-21T02:00:00"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("shouldRenderTimedInAllDayRow", () => {
+  it("promotes full-calendar-day timed events and multi-day timed events", () => {
+    expect(
+      shouldRenderTimedInAllDayRow(
+        dayjs("2026-05-20T00:00:00"),
+        dayjs("2026-05-21T00:00:00"),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRenderTimedInAllDayRow(
+        dayjs("2026-05-20T22:00:00"),
+        dayjs("2026-05-21T02:00:00"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps evening-to-midnight and same-day timed events in the timed grid", () => {
+    expect(
+      shouldRenderTimedInAllDayRow(
+        dayjs("2026-05-20T22:00:00"),
+        dayjs("2026-05-21T00:00:00"),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRenderTimedInAllDayRow(
+        dayjs("2026-05-20T10:00:00"),
+        dayjs("2026-05-20T11:00:00"),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/web/src/common/utils/event/event-nudge.util.ts
+++ b/packages/web/src/common/utils/event/event-nudge.util.ts
@@ -37,6 +37,19 @@ export const isTimedEventMultiDay = (start: Dayjs, end: Dayjs) =>
   !isTimedEventInsideOneDay(start, end);
 
 /**
+ * Timed events that cover exactly one calendar day as [midnight, next midnight)
+ * — e.g. a Google dateTime full-day block. These stay `kind: "timed"` in storage
+ * but should render in the all-day row instead of a full-height timed column.
+ */
+export const isTimedEventFullCalendarDay = (start: Dayjs, end: Dayjs) =>
+  start.isSame(start.startOf("day")) &&
+  end.isSame(start.add(1, "day").startOf("day"));
+
+/** Timed events that belong in the all-day row for display (not storage). */
+export const shouldRenderTimedInAllDayRow = (start: Dayjs, end: Dayjs) =>
+  isTimedEventMultiDay(start, end) || isTimedEventFullCalendarDay(start, end);
+
+/**
  * Maps a multi-day timed range onto an exclusive all-day date span for the
  * all-day row. Inclusive coverage is every calendar day that contains any
  * part of [start, end); exclusive end is the day after the last of those.

--- a/packages/web/src/events/queries/event.view-model.test.ts
+++ b/packages/web/src/events/queries/event.view-model.test.ts
@@ -139,4 +139,38 @@ describe("Event query view models", () => {
     expect(promoted?.startDate).toBe("2026-07-24");
     expect(promoted?.endDate).toBe("2026-07-26");
   });
+
+  test("promotes midnight-to-midnight timed events into the all-day row", () => {
+    const fullDayTimed = createMockEvent({
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-07-24T00:00:00.000Z",
+        end: "2026-07-25T00:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const eveningToMidnight = createMockEvent({
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-07-24T22:00:00.000Z",
+        end: "2026-07-25T00:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const data = normalized(fullDayTimed, eveningToMidnight);
+
+    const result = deriveCalendarEventViewModel(data);
+
+    expect(result.timedEvents.map(({ _id }) => _id)).toEqual([
+      eveningToMidnight.id,
+    ]);
+    expect(result.allDayEvents.map(({ _id }) => _id)).toEqual([
+      fullDayTimed.id,
+    ]);
+    const promoted = result.allDayEvents[0];
+    expect(promoted?.isAllDay).toBe(true);
+    expect(promoted?.isTimedMultiDayDisplay).toBe(true);
+    expect(promoted?.startDate).toBe("2026-07-24");
+    expect(promoted?.endDate).toBe("2026-07-25");
+  });
 });

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -6,7 +6,7 @@ import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
-  isTimedEventMultiDay,
+  shouldRenderTimedInAllDayRow,
   timedMultiDayToAllDayDates,
 } from "@web/common/utils/event/event-nudge.util";
 import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
@@ -119,7 +119,10 @@ const gridEventsFrom = (
 const timedEventsFrom = (events: Event[], demoEventIds?: readonly EventId[]) =>
   gridEventsFrom(events, "timed", demoEventIds).filter((event) => {
     if (!event.startDate || !event.endDate) return true;
-    return !isTimedEventMultiDay(dayjs(event.startDate), dayjs(event.endDate));
+    return !shouldRenderTimedInAllDayRow(
+      dayjs(event.startDate),
+      dayjs(event.endDate),
+    );
   });
 
 const multiDayTimedAsAllDayFrom = (
@@ -130,7 +133,7 @@ const multiDayTimedAsAllDayFrom = (
     .filter((event) => event.schedule.kind === "timed")
     .filter((event) => {
       const { start, end } = event.schedule;
-      return isTimedEventMultiDay(dayjs(start), dayjs(end));
+      return shouldRenderTimedInAllDayRow(dayjs(start), dayjs(end));
     })
     .map((event) => {
       const { start, end } = event.schedule;

--- a/packages/web/src/grid/layout/all-day-draft.position.test.ts
+++ b/packages/web/src/grid/layout/all-day-draft.position.test.ts
@@ -43,6 +43,48 @@ describe("positionAllDayDraftEvent", () => {
     expect(activeDraftEvent?.row).toBe(3);
   });
 
+  it("places a midnight-to-midnight timed draft in the all-day row", () => {
+    const draft = createGridEventDraft({
+      kind: "timed",
+      start: new Date("2026-05-25T00:00:00"),
+      end: new Date("2026-05-26T00:00:00"),
+      timeZone: "UTC",
+    });
+    draft.values.title = "Full-day timed";
+
+    const { activeDraftEvent, events } = positionAllDayDraftEvent({
+      draft,
+      events: [
+        createAllDayEvent({
+          _id: "first",
+          title: "First",
+        }),
+      ],
+    });
+
+    expect(activeDraftEvent?.isTimedMultiDayDisplay).toBe(true);
+    expect(activeDraftEvent?.isAllDay).toBe(true);
+    expect(activeDraftEvent?.startDate).toBe("2026-05-25");
+    expect(activeDraftEvent?.endDate).toBe("2026-05-26");
+    expect(events.some((event) => event.title === "Full-day timed")).toBe(true);
+  });
+
+  it("does not place an evening-to-midnight timed draft in the all-day row", () => {
+    const draft = createGridEventDraft({
+      kind: "timed",
+      start: new Date("2026-05-25T22:00:00"),
+      end: new Date("2026-05-26T00:00:00"),
+      timeZone: "UTC",
+    });
+
+    const { activeDraftEvent } = positionAllDayDraftEvent({
+      draft,
+      events: [],
+    });
+
+    expect(activeDraftEvent).toBeNull();
+  });
+
   it("replaces an existing all-day event draft before assigning rows", () => {
     const draftId = EventIdSchema.parse("0123456789abcdef01234567");
     const draft = createGridEventDraft(

--- a/packages/web/src/grid/layout/all-day-draft.position.ts
+++ b/packages/web/src/grid/layout/all-day-draft.position.ts
@@ -1,7 +1,7 @@
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
-  isTimedEventMultiDay,
+  shouldRenderTimedInAllDayRow,
   timedMultiDayToAllDayDates,
 } from "@web/common/utils/event/event-nudge.util";
 import { assignEventsToRow } from "@web/common/utils/grid/assign.row";
@@ -17,7 +17,7 @@ export const isDraftRenderedInAllDayRow = (draft: GridEventDraft): boolean => {
   return (
     schedule.kind === "allDay" ||
     (schedule.kind === "timed" &&
-      isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end)))
+      shouldRenderTimedInAllDayRow(dayjs(schedule.start), dayjs(schedule.end)))
   );
 };
 

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.test.ts
@@ -59,4 +59,41 @@ describe("addVisibleDraftEvent", () => {
     expect(result).toHaveLength(2);
     expect(result[0]?.startDate).toContain("2026-05-22T14:00:00");
   });
+
+  it("does not inject a midnight-to-midnight timed draft into the timed layer", () => {
+    const draft = createGridEventDraft({
+      kind: "timed",
+      start: new Date("2026-05-22T00:00:00"),
+      end: new Date("2026-05-23T00:00:00"),
+      timeZone: "UTC",
+    });
+
+    const result = addVisibleDraftEvent({
+      draft,
+      events: [savedTimed],
+      isAllDay: false,
+      visibleDates,
+    });
+
+    expect(result).toEqual([savedTimed]);
+  });
+
+  it("still injects an evening-to-midnight timed draft into the timed layer", () => {
+    const draft = createGridEventDraft({
+      kind: "timed",
+      start: new Date("2026-05-22T22:00:00"),
+      end: new Date("2026-05-23T00:00:00"),
+      timeZone: "UTC",
+    });
+
+    const result = addVisibleDraftEvent({
+      draft,
+      events: [savedTimed],
+      isAllDay: false,
+      visibleDates,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.startDate).toContain("2026-05-22T22:00:00");
+  });
 });

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarDraft.util.ts
@@ -1,7 +1,7 @@
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import {
-  isTimedEventMultiDay,
+  shouldRenderTimedInAllDayRow,
   timedMultiDayToAllDayDates,
 } from "@web/common/utils/event/event-nudge.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
@@ -94,7 +94,9 @@ export const isDraftVisibleOnDate = (
   const { schedule } = draft.values;
 
   if (schedule.kind === "timed") {
-    if (isTimedEventMultiDay(dayjs(schedule.start), dayjs(schedule.end))) {
+    if (
+      shouldRenderTimedInAllDayRow(dayjs(schedule.start), dayjs(schedule.end))
+    ) {
       const dates = timedMultiDayToAllDayDates(
         dayjs(schedule.start),
         dayjs(schedule.end),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Timed events that span exactly local midnight → next midnight were filling the entire timed column. They now render in the all-day row (same display promotion as multi-day timed), without changing stored `schedule.kind`.

## Changes

- Add `isTimedEventFullCalendarDay` and `shouldRenderTimedInAllDayRow`
- Route view-model and draft all-day placement through the new helper
- Keep evening→midnight timed events (`22:00 → 00:00`) in the timed grid
- Do not rewrite Google import or mutate timed → allDay storage

## Test plan

- `bun test:web packages/web/src/common/utils/event/event-nudge.util.test.ts packages/web/src/events/queries/event.view-model.test.ts`
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88549fe0-3cc4-4928-ab7e-8db9216708cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88549fe0-3cc4-4928-ab7e-8db9216708cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

