### PR TITLE
fix(sync): fail move commands instead of stranding them silently pending

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -253,6 +253,44 @@ describe("submitCloudCommand provider dispatch", () => {
     expect(writer.calls).toHaveLength(0);
   });
 
+  // A "move" command has no executor anywhere yet - accepting it and leaving
+  // it pending would strand the write forever while the caller sees success
+  // (submitCommandOrThrow only rejects failed/cancelled outcomes). It must
+  // fail explicitly instead.
+  it("fails a move command as unsupportedCapability rather than leaving it pending", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const submit: CommandSubmit = {
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId: objectId() as EventId,
+      input: {
+        kind: "move",
+        calendarId: objectId(),
+      } as unknown as SyncCommandInput,
+      expectedVersion: null,
+    };
+
+    const { command } = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+      },
+      submit,
+      now,
+    );
+
+    expect(command.outcome).toEqual({
+      state: "failed",
+      failureReason: "unsupportedCapability",
+    });
+  });
+
   it("omits null color when persisting a cloud create", async () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -105,6 +105,16 @@ export async function submitCloudCommand(
   if (command.input.kind === "update" || command.input.kind === "delete") {
     return finish(await applyCloudMutation(deps, command, now));
   }
+  // A "move" command has no executor anywhere (no local apply, no provider
+  // dispatch, no worker picks up a pending one) - leaving it pending would
+  // strand the write forever while the caller sees success (submitCommandOrThrow
+  // only rejects failed/cancelled). Fail it explicitly instead, the same way an
+  // unsupported provider capability fails, so the caller gets a real error
+  // rather than a silent no-op. Remove this branch once move has a real
+  // executor.
+  if (command.input.kind === "move") {
+    return finish(await failCloud(deps, command, "unsupportedCapability"));
+  }
   if (command.input.kind !== "create") return finish(command);
 
   // A create whose target calendar is a connected provider calendar must go to
@@ -694,6 +704,21 @@ async function confirmCloud(
     command.attemptCount,
   );
   return confirmed ?? command;
+}
+
+async function failCloud(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  failureReason: "unsupportedCapability",
+): Promise<CommandRecord> {
+  const failed = await deps.commands.updateOutcome(
+    command.tenantId,
+    command.principalId,
+    command._id,
+    { state: "failed", failureReason },
+    command.attemptCount,
+  );
+  return failed ?? command;
 }
 
 // Apply an update command's content/schedule/recurrence to an existing cloud

--- a/packages/sync/src/server/command.routes.db.test.ts
+++ b/packages/sync/src/server/command.routes.db.test.ts
@@ -261,10 +261,12 @@ describe("POST /internal/commands", () => {
     expect(await mongo.db.collection("events").countDocuments()).toBe(0);
   });
 
-  it("persists an unhandled command kind as durable pending intent", async () => {
+  it("fails a move command as unsupportedCapability rather than stranding it pending", async () => {
     const tenantId = objectId();
     const principalId = objectId();
-    // move is not applied locally yet, so it is recorded pending.
+    // move has no executor anywhere yet - leaving it pending would strand the
+    // write forever while the caller sees success (nothing rejects a merely
+    // "pending" outcome), so it fails explicitly instead.
     const request = createRequest({
       input: { kind: "move", calendarId: objectId() },
     });
@@ -273,9 +275,12 @@ describe("POST /internal/commands", () => {
     const res = await submit(tenantId, principalId, request);
 
     const body = (await res.json()) as {
-      command: { outcome: { state: string } };
+      command: { outcome: { state: string; failureReason?: string } };
     };
-    expect(body.command.outcome.state).toBe("pending");
+    expect(body.command.outcome).toEqual({
+      state: "failed",
+      failureReason: "unsupportedCapability",
+    });
     // No event is written for a command that was only recorded, not applied.
     expect(await mongo.db.collection("events").countDocuments()).toBe(0);
     expect(await mongo.db.collection("commands").countDocuments()).toBe(1);


### PR DESCRIPTION
## Summary

Found while investigating whether it's safe to delete legacy `event.service.ts` code: dragging an event to a different calendar silently no-ops in production while the API reports success.

`submitCloudCommand`'s dispatch (`packages/sync/src/domain/cloud-command.service.ts`) only handles `update`/`delete`/`create` commands — a `"move"` command falls through unchanged and stays `pending` forever. No worker ever picks up a pending command (confirmed via `sync-job-worker.service.ts`'s own comment: *"commandApply/reconcile arrive later ... No producer enqueues these kinds yet"*). Since `event.controller.ts`'s `submitCommandOrThrow` only rejects `failed`/`cancelled` outcomes, a permanently-pending move is treated as success and the API returns 200 — but the event's `calendarId` never actually changes anywhere (no Mongo write, no Google `events.move` call).

This is a deliberately staged rollout, not an oversight — the code already has `// move is not handled yet ... lands in a later slice` comments throughout. Full move execution (real Google API call, series/exception handling, cloud vs. provider-linked paths) is comparable in scope to the existing update/delete executors (~700 lines of careful edge-case handling) and stays a tracked follow-up.

This PR is the narrower, immediate fix: explicitly fail a `move` command as `unsupportedCapability` — the same failure class an unsupported provider capability already uses — instead of leaving it silently pending. The backend already maps this to a `PROVIDER_FAILURE` error via the existing `mapSyncFailure` switch, and the web client already has a generic handling path for `PROVIDER_FAILURE` (confirmed via `event.util.ts`'s own comment), so no client-side change is needed.

## Test plan
- [x] `bunx tsc --noEmit` clean (both `packages/sync` and `packages/backend`)
- [x] `./node_modules/.bin/biome check` clean
- [x] New test: `cloud-command.service.db.test.ts` — a submitted move command resolves to `{state: "failed", failureReason: "unsupportedCapability"}`
- [x] Updated test: `command.routes.db.test.ts`'s existing test asserted the old (buggy) "stays pending" behavior — rewritten to assert the fix
- [x] `bun run test:sync`: 672/672 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)