### PR TITLE
fix(sync): settle durable provider read failures instead of wedging jobs

### DIFF
--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -170,6 +170,121 @@ describe("refreshConnectionState", () => {
     expect(after.state).toBe("importing");
   });
 
+  it("reports delayed/providerErrors when an active calendar's reads durably fail", async () => {
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    const eventsResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+    // Imported successfully, THEN the provider started durably rejecting reads —
+    // the case that used to leave every health signal green.
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "events-cursor",
+      new Date(),
+    );
+    await resources.markReadFailure(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      new Date(),
+      "Not Found (HTTP 404, reason notFound)",
+    );
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("delayed");
+    expect(after.stateReason).toBe("providerErrors");
+  });
+
+  it("ignores a read-failure marker on a calendar that is no longer active", async () => {
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "retired@example.com" as ProviderCalendarSourceId,
+      displayName: "Retired",
+      color: null,
+      active: false,
+      primary: false,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    const eventsResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+    await resources.markReadFailure(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      new Date(),
+      "Not Found (HTTP 404, reason notFound)",
+    );
+
+    // No active calendar is broken, so the connection is healthy.
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("healthy");
+  });
+
   it("derives actionRequired/authorizationRevoked when the credential is missing", async () => {
     const connection = await seedImportingConnection();
     await credentials.deleteByConnection(connection._id);

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -118,6 +118,11 @@ export async function gatherConnectionStateEvidence(
     disconnectedAt: connection.disconnectedAt,
     credential: credentialState(credential),
     permanentConflict: false,
+    // Only ACTIVE calendars count: a deactivated calendar's stale marker is not
+    // a problem the user can act on, and its jobs are dropped anyway.
+    durableReadFailure: activeCalendars.some(
+      (c) => eventsByCalendar.get(c._id)?.lastReadFailureAt != null,
+    ),
     accountIdentified: Boolean(connection.account.providerAccountId),
     // Discovery must have finished, and every currently-active calendar must
     // hold a durable events cursor (the initialImport settle condition).

--- a/packages/sync/src/domain/connection-state.test.ts
+++ b/packages/sync/src/domain/connection-state.test.ts
@@ -14,6 +14,7 @@ const healthy = (
   disconnectedAt: null,
   credential: "valid",
   permanentConflict: false,
+  durableReadFailure: false,
   accountIdentified: true,
   initialImportComplete: true,
   catchingUp: false,
@@ -49,6 +50,13 @@ describe("deriveConnectionState", () => {
     expect(derive({ permanentConflict: true })).toEqual({
       state: "actionRequired",
       reason: "permanentConflict",
+    });
+  });
+
+  it("is delayed with providerErrors when a calendar's reads are durably rejected", () => {
+    expect(derive({ durableReadFailure: true })).toEqual({
+      state: "delayed",
+      reason: "providerErrors",
     });
   });
 
@@ -128,6 +136,22 @@ describe("deriveConnectionState", () => {
       expect(
         derive({ credential: "expired", permanentConflict: true }).reason,
       ).toBe("authorizationExpired");
+    });
+
+    it("a durable read failure dominates importing", () => {
+      // The calendar the provider refuses to read can never earn a cursor, so
+      // without this precedence the connection would sit on "importing" forever
+      // rather than reporting the provider problem.
+      expect(
+        derive({ durableReadFailure: true, initialImportComplete: false })
+          .state,
+      ).toBe("delayed");
+    });
+
+    it("a bad credential dominates a durable read failure", () => {
+      expect(
+        derive({ credential: "revoked", durableReadFailure: true }).state,
+      ).toBe("actionRequired");
     });
 
     it("connecting dominates importing and overdue work", () => {

--- a/packages/sync/src/domain/connection-state.ts
+++ b/packages/sync/src/domain/connection-state.ts
@@ -23,6 +23,12 @@ export interface ConnectionStateEvidence {
   readonly credential: CredentialState;
   // A permanent conflict the user must resolve (e.g. an unsafe version clash).
   readonly permanentConflict: boolean;
+  // At least one ACTIVE calendar's reads are durably rejected by the provider
+  // (see the readFailed settlement in sync-job-dispatch). Its job was settled
+  // rather than left retrying, so no overdue-work signal remains to notice —
+  // without this, a connection whose primary calendar had been dead for days
+  // still reported healthy, every other signal green (2026-07-30).
+  readonly durableReadFailure: boolean;
   // The provider account identity has been resolved.
   readonly accountIdentified: boolean;
   // The first complete in-horizon import has finished.
@@ -71,6 +77,15 @@ export function deriveConnectionState(
 
   if (evidence.permanentConflict) {
     return { state: "actionRequired", reason: "permanentConflict" };
+  }
+
+  // Ranked above connecting/importing deliberately: a calendar the provider
+  // durably refuses to read never earns a cursor, so the import-complete test
+  // below can never pass and the connection would otherwise sit on "importing"
+  // forever. Delayed/providerErrors says the true thing in both cases — the
+  // never-imported one and the imported-then-broken one.
+  if (evidence.durableReadFailure) {
+    return { state: "delayed", reason: "providerErrors" };
   }
 
   if (!evidence.accountIdentified) {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -6,7 +6,10 @@ import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { type ProviderCalendarAdapter } from "@sync/providers/provider-calendar.port";
-import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
+import {
+  ProviderEventReadError,
+  type ProviderEventReader,
+} from "@sync/providers/provider-event-reader.port";
 import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
 import {
   type JobEnqueue,
@@ -105,6 +108,42 @@ export async function dispatchSyncJob(
         reason: `credential unusable (${error.reason}) for connection ${job.connectionId}; sync resumes on reconnect`,
       };
     }
+
+    // A DURABLE read rejection: Google answered with a 4xx that is not 410
+    // (cursor expired) or 429 (rate limited) — a calendar deleted out from under
+    // us, access revoked for it, or a permanently rejected id. Retrying cannot
+    // fix it, and treating it as retryableTransient burned all 20 attempts and
+    // wedged the job in state:"failed" (2026-07-30: 3 such jobs in prod).
+    //
+    // Settle it as a DROP, not failureClass:"permanent", for the same reason the
+    // credential path above does: a failed job keeps its coalescing key and
+    // enqueue only $setOnInsert's, so a permanent row would swallow the
+    // re-enqueue after the calendar is reconnected or re-shared and sync would
+    // never restart. Dropping frees the key.
+    //
+    // Dropping also erases the only evidence the job row carried, so stamp the
+    // resource first — that marker is what connection health reads, so a dead
+    // primary calendar stops reporting healthy.
+    if (
+      error instanceof ProviderEventReadError &&
+      error.reason === "readFailed"
+    ) {
+      const detail =
+        error.cause instanceof Error ? error.cause.message : error.message;
+      if (job.resourceId) {
+        await deps.resources.markReadFailure(
+          job.tenantId,
+          job.principalId,
+          job.resourceId,
+          now(),
+          detail,
+        );
+      }
+      return {
+        result: "drop",
+        reason: `provider durably rejected reads for resource ${job.resourceId} (${detail}); sync resumes once the calendar is readable again`,
+      };
+    }
     throw error;
   }
 }
@@ -159,6 +198,17 @@ async function runSyncJob(
   );
   if (!calendar) {
     return { result: "drop", reason: "calendar no longer exists" };
+  }
+  // The provider no longer lists this calendar (discovery marked it inactive),
+  // or the user turned it off. Nothing here is worth a provider call. Dropping
+  // settles the job instead of leaving it to retry: a pending/failed
+  // initialImport for a deactivated calendar kept its coalescing key and burned
+  // Google quota on every sweep until an operator noticed (2026-07-30).
+  if (!calendar.active) {
+    return {
+      result: "drop",
+      reason: `calendar ${calendar._id} is inactive; sync resumes if it is reactivated`,
+    };
   }
 
   switch (job.kind) {

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -140,12 +140,25 @@ describe("SyncJobWorker", () => {
   const worker = (reader: FakeReader) =>
     new SyncJobWorker(deps(reader), OWNER, { now });
 
+  // A worker that records every drop reason, so a test can assert the drop path
+  // was taken (and why) rather than only that the job row vanished.
+  const workerRecordingDrops = (reader: FakeReader) => {
+    const drops: string[] = [];
+    const w = new SyncJobWorker(deps(reader), OWNER, {
+      now,
+      onDrop: (_job, reason) => drops.push(reason),
+    });
+    return { worker: w, drops };
+  };
+
   const workerWith = (
     reader: FakeReader,
     options: { maxAttempts?: number; random?: () => number },
   ) => new SyncJobWorker(deps(reader), OWNER, { now, ...options });
 
-  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+  const seedCalendar = (
+    overrides: Partial<{ active: boolean }> = {},
+  ): Promise<ProviderCalendarRecord> =>
     calendars.upsertByProviderCalendar({
       tenantId: objectId() as ProviderCalendarRecord["tenantId"],
       principalId: objectId() as ProviderCalendarRecord["principalId"],
@@ -153,7 +166,7 @@ describe("SyncJobWorker", () => {
       providerCalendarId: "primary@google.com",
       displayName: "Google",
       color: null,
-      active: true,
+      active: overrides.active ?? true,
       primary: true,
       accessRole: "owner",
       capabilities: {
@@ -447,6 +460,143 @@ describe("SyncJobWorker", () => {
     expect(
       await jobs.findById(resource.tenantId, resource.principalId, job._id),
     ).toBeNull();
+  });
+
+  it("settles a job whose calendar went inactive instead of retrying it", async () => {
+    const calendar = await seedCalendar({ active: false });
+    const resource = await seedResource(calendar, null);
+    const job = await enqueue(resource, "initialImport");
+
+    // A reader with no scripted pages: reaching it at all would throw, so the
+    // job must be settled before any provider call is made.
+    const { worker: w, drops } = workerRecordingDrops(new FakeReader([]));
+    await w.runOnce();
+
+    expect(
+      await jobs.findById(resource.tenantId, resource.principalId, job._id),
+    ).toBeNull();
+    expect(drops).toHaveLength(1);
+    expect(drops[0]).toContain("inactive");
+  });
+
+  it("frees the coalescing key when an inactive calendar's job is settled", async () => {
+    const calendar = await seedCalendar({ active: false });
+    const resource = await seedResource(calendar, null);
+    await enqueue(resource, "initialImport");
+
+    await worker(new FakeReader([])).runOnce();
+
+    // Reactivating the calendar and re-triggering must produce a fresh pending
+    // job — the settled one left no row to swallow the re-enqueue.
+    await calendars.upsertByProviderCalendar({
+      tenantId: calendar.tenantId,
+      principalId: calendar.principalId,
+      connectionId: calendar.connectionId,
+      providerCalendarId: calendar.providerCalendarId,
+      displayName: calendar.displayName,
+      color: calendar.color,
+      active: true,
+      primary: calendar.primary,
+      accessRole: calendar.accessRole,
+      capabilities: calendar.capabilities,
+    });
+    const requeued = await enqueue(resource, "initialImport");
+    expect(requeued.state).toBe("pending");
+  });
+
+  it("settles a durably-rejected read instead of burning the retry ladder", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    const job = await enqueue(resource, "incrementalPull");
+
+    const { worker: w, drops } = workerRecordingDrops(
+      new FakeReader(
+        [],
+        new ProviderEventReadError("readFailed", "Google rejected the read", {
+          cause: new Error("Not Found (HTTP 404, reason notFound)"),
+        }),
+      ),
+    );
+    await w.runOnce();
+
+    // Settled and removed — NOT left pending for 20 more attempts, and not
+    // parked in state:"failed" where it would need an operator to clear it.
+    expect(
+      await jobs.findById(resource.tenantId, resource.principalId, job._id),
+    ).toBeNull();
+    expect(drops).toHaveLength(1);
+    expect(drops[0]).toContain("HTTP 404");
+  });
+
+  it("keeps the coalescing key reusable after a durable read failure", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await enqueue(resource, "incrementalPull");
+
+    await worker(
+      new FakeReader([], new ProviderEventReadError("readFailed", "rejected")),
+    ).runOnce();
+
+    // The whole reason this settles as a drop rather than failureClass
+    // "permanent": a failed row keeps its key and enqueue only $setOnInsert's,
+    // so a re-share/reconnect could never restart sync for this resource.
+    const requeued = await enqueue(resource, "incrementalPull");
+    expect(requeued.state).toBe("pending");
+    expect(
+      await storage
+        .db()
+        .collection(SYNC_COLLECTIONS.jobs)
+        .countDocuments({ coalescingKey: `incrementalPull:${resource._id}` }),
+    ).toBe(1);
+  });
+
+  it("records a durable read failure on the resource so health can see it", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await enqueue(resource, "incrementalPull");
+
+    await worker(
+      new FakeReader(
+        [],
+        new ProviderEventReadError("readFailed", "Google rejected the read", {
+          cause: new Error("Not Found (HTTP 404, reason notFound)"),
+        }),
+      ),
+    ).runOnce();
+
+    // Dropping the job erases its evidence, so the resource marker is the only
+    // durable trace left for connection health and triage.
+    const after = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(after?.lastReadFailureAt).toEqual(now());
+    expect(after?.lastReadFailureDetail).toContain("HTTP 404");
+    expect(after?.lastReadFailureDetail).toContain("notFound");
+  });
+
+  it("clears the read-failure marker once the calendar reads again", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    await enqueue(resource, "incrementalPull");
+    await worker(
+      new FakeReader([], new ProviderEventReadError("readFailed", "rejected")),
+    ).runOnce();
+
+    // The calendar becomes readable again and a fresh pull succeeds.
+    await enqueue(resource, "incrementalPull");
+    await worker(
+      new FakeReader([pageOf([single("ok")], "cursor-1")]),
+    ).runOnce();
+
+    const after = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(after?.lastReadFailureAt).toBeNull();
+    expect(after?.lastReadFailureDetail).toBeNull();
   });
 
   it("drains every due job and then reports how many it processed", async () => {

--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -256,6 +256,37 @@ describe("GoogleEventReaderAdapter", () => {
     ).rejects.toMatchObject({ reason: "readFailed" });
   });
 
+  it("keeps the HTTP status and Google's reason on the cause for triage", async () => {
+    const rejected = Object.assign(new Error("Not Found"), {
+      response: {
+        status: 404,
+        data: { error: { errors: [{ reason: "notFound" }] } },
+      },
+    });
+    const api = new FakeEventListApi([], rejected);
+    const { adapter } = adapterWith(api);
+
+    const error = await adapter
+      .listEventPage({ accessToken: "tok", calendarId: "primary@google.com" })
+      .catch((e) => e as ProviderEventReadError);
+
+    // Without these, a durable readFailed row is guesswork to diagnose: the
+    // message alone does not say which rejection Google gave.
+    expect((error.cause as Error)?.message).toContain("HTTP 404");
+    expect((error.cause as Error)?.message).toContain("notFound");
+  });
+
+  it("still reports the status when the error carries no Google reason", async () => {
+    const api = new FakeEventListApi([], { response: { status: 403 } });
+    const { adapter } = adapterWith(api);
+
+    const error = await adapter
+      .listEventPage({ accessToken: "tok", calendarId: "primary@google.com" })
+      .catch((e) => e as ProviderEventReadError);
+
+    expect((error.cause as Error)?.message).toContain("HTTP 403");
+  });
+
   it("never leaks the access token onto a thrown error's cause", async () => {
     const leaky = new Error("boom") as Error & { config?: unknown };
     leaky.config = { headers: { Authorization: "Bearer super-secret-token" } };

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -133,7 +133,7 @@ export class GoogleEventReaderAdapter implements ProviderEventReader {
       throw new ProviderEventReadError(
         classifyReadError(error),
         "Google rejected the events list read",
-        { cause: redactedCause(error) },
+        { cause: readFailureCause(error) },
       );
     }
   }
@@ -151,6 +151,42 @@ function classifyReadError(
     return "transient";
   }
   return "readFailed";
+}
+
+// The cause attached to a read error. Like redactedCause it drops everything
+// request-derived (the gaxios config carries the bearer token), but keeps the
+// two response facts triage needs: the numeric HTTP status and Google's
+// machine-readable error reason. Without them a durable readFailed row is
+// guesswork to diagnose from logs (2026-07-30 prod triage).
+function readFailureCause(error: unknown): Error | undefined {
+  const status = httpStatus(error);
+  const reason = googleErrorReason(error);
+  const facts = [
+    ...(status === undefined ? [] : [`HTTP ${status}`]),
+    ...(reason === undefined ? [] : [`reason ${reason}`]),
+  ];
+  // Nothing response-derived to add (a bare network failure): fall back to the
+  // plain redacted message.
+  if (facts.length === 0) return redactedCause(error);
+  const message = error instanceof Error ? error.message : null;
+  return new Error(
+    message ? `${message} (${facts.join(", ")})` : facts.join(", "),
+  );
+}
+
+// Google's machine-readable reason for a failed call (e.g. "notFound",
+// "rateLimitExceeded"), from the standard error body; googleapis also copies
+// the errors array onto the error object itself. Response-derived only.
+function googleErrorReason(error: unknown): string | undefined {
+  const fromBody = (
+    error as {
+      response?: { data?: { error?: { errors?: { reason?: unknown }[] } } };
+    }
+  )?.response?.data?.error?.errors?.[0]?.reason;
+  const fromError = (error as { errors?: { reason?: unknown }[] })?.errors?.[0]
+    ?.reason;
+  const reason = fromBody ?? fromError;
+  return typeof reason === "string" ? reason : undefined;
 }
 
 // The HTTP status of a googleapis/gaxios error, from the response or the error

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -739,6 +739,7 @@ async function linkConnection(
       disconnectedAt: null,
       credential: "valid",
       permanentConflict: false,
+      durableReadFailure: false,
       accountIdentified: true,
       initialImportComplete: false,
       catchingUp: false,

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -45,6 +45,14 @@ export const SyncResourceRecordSchema = z.strictObject({
   activeGeneration: z.number().int().min(0).default(0),
   lastAttemptAt: z.date().nullable(),
   lastSuccessAt: z.date().nullable(),
+  // Set when the provider durably rejects reads for this resource (a
+  // non-transient 4xx retries cannot fix — see the readFailed settlement in
+  // sync-job-dispatch). Cleared by the next successful pass (advanceCursor).
+  // Connection health surfaces a non-null marker on an active calendar as
+  // delayed/providerErrors. Defaults tolerate rows written before the field.
+  lastReadFailureAt: z.date().nullable().default(null),
+  // The redacted failure detail (HTTP status + provider reason) for triage.
+  lastReadFailureDetail: z.string().min(1).nullable().default(null),
   // Push subscription: the provider channel id, its opaque resource id, the
   // per-channel secret the provider echoes back on callbacks, and when it
   // expires. All null when no subscription is active.

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -193,6 +193,61 @@ describe("SyncResourceRepository", () => {
     expect(done?.lastSuccessAt).toEqual(succeededAt);
   });
 
+  it("keeps the first read failure's timestamp while refreshing its detail", async () => {
+    const resource = await repo.ensure(upsert());
+    const first = new Date("2026-07-20T12:00:00.000Z");
+    const later = new Date("2026-07-23T12:00:00.000Z");
+    await repo.markReadFailure(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      first,
+      "Not Found (HTTP 404, reason notFound)",
+    );
+    await repo.markReadFailure(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      later,
+      "Forbidden (HTTP 403, reason forbidden)",
+    );
+
+    const after = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    // The FIRST timestamp is what says how long the calendar has been dead.
+    expect(after?.lastReadFailureAt).toEqual(first);
+    expect(after?.lastReadFailureDetail).toContain("HTTP 403");
+  });
+
+  it("clears the read-failure marker when the cursor next advances", async () => {
+    const resource = await repo.ensure(upsert());
+    await repo.markReadFailure(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      new Date("2026-07-20T12:00:00.000Z"),
+      "Not Found (HTTP 404, reason notFound)",
+    );
+    await repo.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "sync-token",
+      new Date("2026-07-24T12:00:00.000Z"),
+    );
+
+    const after = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(after?.lastReadFailureAt).toBeNull();
+    expect(after?.lastReadFailureDetail).toBeNull();
+  });
+
   it("updates and clears the push subscription", async () => {
     const resource = await repo.ensure(upsert());
     await repo.updateSubscription(

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -55,6 +55,8 @@ export class SyncResourceRepository {
           activeGeneration: 0,
           lastAttemptAt: null,
           lastSuccessAt: null,
+          lastReadFailureAt: null,
+          lastReadFailureDetail: null,
           subscriptionId: null,
           subscriptionResourceId: null,
           subscriptionToken: null,
@@ -95,7 +97,10 @@ export class SyncResourceRepository {
   }
 
   // Advance the incremental cursor after a batch fully commits, clearing the
-  // mid-batch checkpoint and recording success.
+  // mid-batch checkpoint and recording success. A successful pass also clears
+  // any durable read-failure marker: the provider is answering again, so the
+  // connection must stop reporting delayed/providerErrors without an operator
+  // having to clear anything by hand.
   async advanceCursor(
     tenantId: TenantId,
     principalId: PrincipalId,
@@ -110,10 +115,38 @@ export class SyncResourceRepository {
           syncCursor,
           pageCursor: null,
           lastSuccessAt: succeededAt,
+          lastReadFailureAt: null,
+          lastReadFailureDetail: null,
           updatedAt: new Date(),
         },
       },
     );
+  }
+
+  // Record that the provider DURABLY rejected reads for this resource (a 4xx
+  // retrying cannot fix). The job that hit it is settled and removed rather than
+  // left to burn its retry ladder, so this marker is the only evidence left —
+  // connection health reads it, and a later successful pass clears it. Keeps the
+  // first failure's timestamp on repeat failures so health can show how long the
+  // calendar has been dead, but always refreshes the detail.
+  async markReadFailure(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    at: Date,
+    detail: string,
+  ): Promise<void> {
+    await this.collection.updateOne({ _id: id, tenantId, principalId }, [
+      {
+        $set: {
+          // $ifNull keeps the FIRST failure's timestamp across repeats (a row
+          // written before this field existed reads as null and takes `at`).
+          lastReadFailureAt: { $ifNull: ["$lastReadFailureAt", at] },
+          lastReadFailureDetail: detail,
+          updatedAt: new Date(),
+        },
+      },
+    ]);
   }
 
   async updateSubscription(


### PR DESCRIPTION
## Summary

Closes three related gaps around durable provider read failures found while triaging prod on 2026-07-30 (3 real wedged jobs).

**1. Jobs are not cancelled when their calendar deactivates.** A `provider_calendars` row went `active: false` but its pending `initialImport` job kept its coalescing key and retried on every sweep, burning Google API calls. `runSyncJob` now drops a job whose resolved calendar is inactive, before any provider call.

**2. `readFailed` burned the whole retry ladder.** A durable Google 4xx (anything `classifyReadError` maps to `readFailed` — not 410 cursor-expired, not 429 rate-limited) propagated out of dispatch and hit the worker's generic catch, which classes any throw as `retryableTransient`. That spent all 20 attempts and left the job in `state: "failed"`. `dispatchSyncJob` now settles it explicitly.

It settles as a **drop, not `failureClass: "permanent"`** — deliberately, and for the same reason the credential-unusable path above it does: a failed job keeps its coalescing key and `enqueue` only `$setOnInsert`s, so a permanent row would swallow the re-enqueue after the calendar is reconnected or re-shared, and sync for that resource could never restart. Dropping frees the key. A regression test pins this.

**3. A dead primary calendar still reported `healthy`.** `deriveConnectionState` never saw per-calendar read failures, and dropping the job (point 2) erases the only evidence the job row carried. So the drop now stamps `lastReadFailureAt` / `lastReadFailureDetail` on the sync resource first, and `gatherConnectionStateEvidence` derives a new `durableReadFailure` signal from active calendars' markers. It is ranked above `connecting`/`importing` in the derivation because a calendar the provider refuses to read never earns a cursor, so the import-complete test can never pass — without the precedence the connection would swap "healthy forever" for "importing forever". The marker clears on the next successful pass (`advanceCursor`), so recovery needs no operator action.

**Also:** `redactedCause` stripped the HTTP status from the logged error, making triage guesswork. The read path now keeps the numeric status and Google's machine-readable error reason on the cause (`Not Found (HTTP 404, reason notFound)`). Both are response-derived; the request config — which carries the bearer token — is still dropped, and the existing no-token-leak test still passes.

## Simplicity

No new abstraction layers. Both settlements are inline branches in `dispatchSyncJob` next to the existing `ProviderAuthError` branch they mirror; the health signal is one boolean on the existing pure `ConnectionStateEvidence` input plus a three-line `some()` in the evidence gatherer. No new service, no new job state, no new `ConnectionStateReason` (the existing `providerErrors` fits). The two new resource fields default to `null`, so no migration is needed for existing rows.

## Automated validation

Not applicable — no browser, CLI, or API scenario was exercised. The behavior is queue-internal and is covered by the storage-backed tests below, which run against a real mongod.

## Independent review

Not run as a separate reviewer pass. Worth a close look from a fresh reviewer on two judgment calls:

- **Drop vs. permanent for `readFailed`.** Dropping means a durably-broken calendar's job disappears rather than parking visibly in `state: "failed"`. That is intentional (coalescing-key reuse, per the constraint above), and the visibility it would have cost is what point 3 restores via the resource marker and connection state — but it is the load-bearing tradeoff in this diff.
- **Ranking `durableReadFailure` above `importing`.** This changes what a connection reports during a first import where one active calendar is unreadable: `delayed`/`providerErrors` instead of `importing`.

## Test plan

```
bun test:sync      # 687 pass, 0 fail
bun test:core      # 535 pass, 0 fail
bun test:scripts   #  91 pass, 0 fail
bun type-check     # clean
bun lint           # clean
```

New tests: 6 in `sync-job-worker.service.db.test.ts` (inactive-calendar settle, key freed after it, durable-read-failure settle, key reusable after it, resource marker written, marker cleared on recovery), 3 in `connection-state.test.ts` (delayed/providerErrors, dominates importing, credential dominates it), 2 in `connection-state-refresh.service.db.test.ts` (active calendar marker → delayed, inactive calendar marker ignored), 2 in `sync-resource.repository.db.test.ts` (first-failure timestamp kept while detail refreshes, marker cleared by `advanceCursor`), 2 in `google-event-reader.adapter.test.ts` (status + reason on the cause, status alone when no reason).

Note: the storage-backed suites cannot bind `::` in the sandbox this ran in, so `mongodb-memory-server`'s port probe fails there; they were run against a local IPv4-forced listener shim, which was removed before committing and is not part of this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZVBgWuNrzEDdTfL3f54X1)_