### PR TITLE
chore: clean up dead code left over from PR #2480

### DIFF
--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -319,7 +319,7 @@ Files:
 - `packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx`
 - `packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.ts`
 
-UI state comes from a single server-enriched metadata field (`google.connectionState`) plus two client-only states (`checking`, `repairing`). The sidebar's calendar-list heading (the account email, or "Temporary account" when anonymous) is the lightweight status indicator: it renders with a `c-sync-text-wave` shimmer whenever `getGoogleSyncStatus(state)?.variant === "syncing"` or an event mutation is still pending, and an `sr-only role="status"` live region announces "Syncing…" alongside it. `CalendarListHeader` does not render per-state tooltips or actions itself.
+UI state comes from a single server-enriched metadata field (`google.connectionState`) plus one client-only state (`checking`). The sidebar's calendar-list heading (the account email, or "Temporary account" when anonymous) is the lightweight status indicator: it renders with a `c-sync-text-wave` shimmer whenever `getGoogleSyncStatus(state)?.variant === "syncing"` or an event mutation is still pending, and an `sr-only role="status"` live region announces "Syncing…" alongside it. `CalendarListHeader` does not render per-state tooltips or actions itself.
 
 Detailed sync status and the reconnect/sync actions live in the command palette instead, via `useCalendarSyncCmdItems`/`getGoogleConnectionConfig`:
 
@@ -327,7 +327,7 @@ Detailed sync status and the reconnect/sync actions live in the command palette 
 - `ATTENTION` → **Sync Google Calendar** command action (`onRepairGoogle`); `syncStatus.text` is "Calendar is out of date"
 - `RECONNECT_REQUIRED` → **Reconnect Google Calendar** command action (`onConnectGoogle`); `syncStatus.text` is "Calendar needs reconnecting"
 - `NOT_CONNECTED` → **Connect Google Calendar** command action (`onConnectGoogle`); no `syncStatus`
-- `checking` / `repairing` / `IMPORTING` → no command action; `syncStatus.text` is "Syncing calendar…"
+- `checking` / `IMPORTING` → no command action; `syncStatus.text` is "Syncing calendar…"
 
 User-facing copy avoids the word "repair" — the `ATTENTION` state is framed as needing a sync, not a repair.
 

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -37,7 +37,6 @@ import {
   eventMutationError,
   toEventMutationError,
 } from "@backend/event/event.error";
-import { mapEventRecord } from "@backend/event/event.record.mapper";
 import eventService from "@backend/event/services/event.service";
 
 const send = (res: Response, e: unknown) => {
@@ -248,18 +247,6 @@ class EventController {
       const events = await readAllFromSync(userId, query);
 
       res.status(Status.OK).json({ events });
-    } catch (e) {
-      send(res, e);
-    }
-  };
-
-  readById = async (req: SessionRequest, res: Response) => {
-    try {
-      const userId = req.session?.getUserId() as string;
-      const eventId = req.params["id"] as string;
-      const event = await eventService.readById(userId, eventId);
-
-      res.status(Status.OK).json({ event: mapEventRecord(event) });
     } catch (e) {
       send(res, e);
     }

--- a/packages/backend/src/event/event.routes.config.ts
+++ b/packages/backend/src/event/event.routes.config.ts
@@ -29,7 +29,6 @@ export class EventRoutes extends CommonRoutesConfig {
     this.app
       .route(`/api/event/:id`)
       .all(verifySession())
-      .get(eventController.readById)
       .put(eventController.replace)
       .delete(eventController.delete);
 

--- a/packages/backend/src/event/services/event.service.ts
+++ b/packages/backend/src/event/services/event.service.ts
@@ -1,46 +1,15 @@
-import { type ClientSession, type ObjectId } from "mongodb";
+import { type ClientSession } from "mongodb";
 import calendarService from "@backend/calendar/services/calendar.service";
-import { eventMutationError } from "@backend/event/event.error";
-import { type EventRecord } from "@backend/event/event.record";
 import { eventRepository } from "@backend/event/event.repository";
 
-const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
-
 class EventService {
-  private async ownedCalendarIds(userId: string): Promise<ObjectId[]> {
-    const calendars = await calendarService.list(userId);
-    return calendars.filter((c) => c.isActive).map((c) => c._id);
-  }
-
-  private async requireOwnedEvent(
-    userId: string,
-    eventId: string,
-  ): Promise<EventRecord> {
-    if (!OBJECT_ID_PATTERN.test(eventId)) {
-      throw eventMutationError("EVENT_NOT_FOUND", "Invalid event id");
-    }
-
-    const ownedCalendarIds = await this.ownedCalendarIds(userId);
-    const event = await eventRepository.findById(eventId, ownedCalendarIds);
-
-    if (!event) {
-      throw eventMutationError("EVENT_NOT_FOUND", "Event not found");
-    }
-
-    return event;
-  }
-
-  readById = async (userId: string, eventId: string): Promise<EventRecord> => {
-    return this.requireOwnedEvent(userId, eventId);
-  };
-
   /**
-   * Wider than `ownedCalendarIds` on purpose: every calendar the user owns,
-   * archived ones included. Archiving (a calendar that vanished from Google's
-   * list, or a Google revoke) leaves the calendar's events in place, and an
-   * event document records only its `calendarId` - never a user. So an
-   * active-only delete would strand those events the moment the calendar row
-   * goes, with nothing left to find them by.
+   * Every calendar the user owns, archived ones included. Archiving (a
+   * calendar that vanished from Google's list, or a Google revoke) leaves
+   * the calendar's events in place, and an event document records only its
+   * `calendarId` - never a user. So an active-only delete would strand those
+   * events the moment the calendar row goes, with nothing left to find them
+   * by.
    */
   deleteAllByUser = async (userId: string, session?: ClientSession) => {
     const calendars = await calendarService.list(userId, session);

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
@@ -1,7 +1,7 @@
 import { type Icon } from "@phosphor-icons/react";
 import { type GoogleConnectionState } from "@core/types/user.types";
 
-export type GoogleUiState = "checking" | "repairing" | GoogleConnectionState;
+export type GoogleUiState = "checking" | GoogleConnectionState;
 
 export type CommandActionIcon = Icon;
 

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -45,16 +45,15 @@ describe("getGoogleSyncStatus", () => {
     });
   });
 
-  it.each([
-    "IMPORTING",
-    "repairing",
-    "checking",
-  ] as const)("returns syncing copy for %s", (state) => {
-    expect(getGoogleSyncStatus(state)).toEqual({
-      variant: "syncing",
-      text: "Syncing your calendar…",
-    });
-  });
+  it.each(["IMPORTING", "checking"] as const)(
+    "returns syncing copy for %s",
+    (state) => {
+      expect(getGoogleSyncStatus(state)).toEqual({
+        variant: "syncing",
+        text: "Syncing your calendar…",
+      });
+    },
+  );
 
   it("returns warning copy for ATTENTION, without using the word 'repair'", () => {
     const status = getGoogleSyncStatus("ATTENTION");
@@ -123,17 +122,14 @@ describe("getGoogleConnectionConfig", () => {
     onConnectGoogle.mockClear();
   });
 
-  it.each([
-    "HEALTHY",
-    "checking",
-    "repairing",
-    "IMPORTING",
-    "ATTENTION",
-  ] as const)("returns no command action for %s", (state) => {
-    expect(getGoogleConnectionConfig(state, onConnectGoogle)).toEqual({
-      commandAction: null,
-    });
-  });
+  it.each(["HEALTHY", "checking", "IMPORTING", "ATTENTION"] as const)(
+    "returns no command action for %s",
+    (state) => {
+      expect(getGoogleConnectionConfig(state, onConnectGoogle)).toEqual({
+        commandAction: null,
+      });
+    },
+  );
 
   it("wires NOT_CONNECTED to onConnectGoogle", () => {
     const config = getGoogleConnectionConfig("NOT_CONNECTED", onConnectGoogle);

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.test.ts
@@ -45,15 +45,15 @@ describe("getGoogleSyncStatus", () => {
     });
   });
 
-  it.each(["IMPORTING", "checking"] as const)(
-    "returns syncing copy for %s",
-    (state) => {
-      expect(getGoogleSyncStatus(state)).toEqual({
-        variant: "syncing",
-        text: "Syncing your calendar…",
-      });
-    },
-  );
+  it.each([
+    "IMPORTING",
+    "checking",
+  ] as const)("returns syncing copy for %s", (state) => {
+    expect(getGoogleSyncStatus(state)).toEqual({
+      variant: "syncing",
+      text: "Syncing your calendar…",
+    });
+  });
 
   it("returns warning copy for ATTENTION, without using the word 'repair'", () => {
     const status = getGoogleSyncStatus("ATTENTION");
@@ -122,14 +122,16 @@ describe("getGoogleConnectionConfig", () => {
     onConnectGoogle.mockClear();
   });
 
-  it.each(["HEALTHY", "checking", "IMPORTING", "ATTENTION"] as const)(
-    "returns no command action for %s",
-    (state) => {
-      expect(getGoogleConnectionConfig(state, onConnectGoogle)).toEqual({
-        commandAction: null,
-      });
-    },
-  );
+  it.each([
+    "HEALTHY",
+    "checking",
+    "IMPORTING",
+    "ATTENTION",
+  ] as const)("returns no command action for %s", (state) => {
+    expect(getGoogleConnectionConfig(state, onConnectGoogle)).toEqual({
+      commandAction: null,
+    });
+  });
 
   it("wires NOT_CONNECTED to onConnectGoogle", () => {
     const config = getGoogleConnectionConfig("NOT_CONNECTED", onConnectGoogle);

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -58,7 +58,6 @@ export const getGoogleConnectionConfig = (
 ): GoogleUiConfig => {
   switch (state) {
     case "checking":
-    case "repairing":
     case "IMPORTING":
     case "HEALTHY":
     // ATTENTION means a Sync outage or a permanent conflict; no client
@@ -112,7 +111,6 @@ export const getGoogleSyncStatus = (
     case "HEALTHY":
       return { variant: "healthy", text: "Calendar up-to-date" };
     case "IMPORTING":
-    case "repairing":
     case "checking":
       return { variant: "syncing", text: "Syncing your calendar…" };
     case "ATTENTION":

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.test.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.test.ts
@@ -1,7 +1,6 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import {
   resetGoogleSyncUIStateForTests,
-  setRepairingSyncIndicatorOverride,
   setSyncingSyncIndicatorOverride,
 } from "@web/auth/google/state/google.sync.state";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
@@ -28,15 +27,12 @@ describe("useGoogleUiState", () => {
     expect(result.current).toBe("HEALTHY");
   });
 
-  it("prioritizes transient syncing and repair states", () => {
+  it("prioritizes the transient syncing state", () => {
     userMetadataActions.set({ google: { connectionState: "HEALTHY" } });
     const { result } = renderHook(() => useGoogleUiState());
 
     act(() => setSyncingSyncIndicatorOverride());
     expect(result.current).toBe("IMPORTING");
-
-    act(() => setRepairingSyncIndicatorOverride());
-    expect(result.current).toBe("repairing");
   });
 
   it("reports checking while a returning user's metadata loads", () => {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useGoogleUiState.ts
@@ -26,7 +26,6 @@ export function resolveGoogleUiState({
   syncIndicator: SyncIndicator;
   userMetadataStatus: UserMetadataStatus;
 }): GoogleUiState {
-  if (syncIndicator === "repairing") return "repairing";
   if (syncIndicator === "syncing") return "IMPORTING";
 
   if (hasAuthenticated && userMetadataStatus !== "loaded") {
@@ -36,7 +35,7 @@ export function resolveGoogleUiState({
   return connectionState;
 }
 
-// Merges server metadata with transient repair/import overrides. The external
+// Merges server metadata with transient import overrides. The external
 // store subscription keeps every sync indicator aligned as SSE updates arrive.
 export function useGoogleUiState(): GoogleUiState {
   const connectionState = useUserMetadataStore(selectGoogleConnectionState);

--- a/packages/web/src/auth/google/state/google.sync.state.ts
+++ b/packages/web/src/auth/google/state/google.sync.state.ts
@@ -1,11 +1,11 @@
-// Transient Google sync UI overrides (e.g. repairing, post-connect syncing) live outside
+// Transient Google sync UI overrides (e.g. post-connect syncing) live outside
 // store so auth/sync helpers can update them from async callbacks without dispatch.
 // This module is a minimal external store (mutable snapshot + listener set). Consumers
 // subscribe with useSyncExternalStore(subscribeToGoogleSyncUIState, getGoogleSyncIndicatorOverride, …).
 
 const googleSyncUIListeners = new Set<() => void>();
 
-type SyncIndicator = null | "repairing" | "syncing";
+type SyncIndicator = null | "syncing";
 
 let gSyncIndicator: SyncIndicator = null;
 
@@ -33,10 +33,6 @@ export const clearSyncingSyncIndicatorOverride = () => {
 };
 
 export const getGoogleSyncIndicatorOverride = () => gSyncIndicator;
-
-export const setRepairingSyncIndicatorOverride = () => {
-  setGoogleSyncIndicatorOverride("repairing");
-};
 
 export const setSyncingSyncIndicatorOverride = () => {
   setGoogleSyncIndicatorOverride("syncing");

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -88,7 +88,6 @@ const setMockGoogleConnection = (
   state:
     | "NOT_CONNECTED"
     | "ATTENTION"
-    | "repairing"
     | "IMPORTING"
     | "checking"
     | "HEALTHY" = "NOT_CONNECTED",
@@ -104,7 +103,6 @@ const setMockGoogleConnection = (
       icon: PlusIcon,
       onSelect: mockOnConnectGoogle,
     },
-    repairing: null,
     IMPORTING: null,
     checking: null,
     HEALTHY: null,
@@ -394,7 +392,7 @@ describe("CommandPalette", () => {
   });
 
   it("shows the shimmer class for a syncing status", () => {
-    setMockGoogleConnection("repairing");
+    setMockGoogleConnection("IMPORTING");
     renderPalette();
 
     expect(screen.getByRole("status")).toHaveClass("c-sync-text-wave");

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -326,7 +326,6 @@ describe("CommandPalette", () => {
     });
     const repository: EventRepository = {
       list: async () => [],
-      getById: async () => before,
       create: async () => before,
       replace: async (id, input) => ({
         ...before,

--- a/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
@@ -100,29 +100,29 @@ describe("useCalendarSyncCmdItems", () => {
     expect(result.current.items[0]?.keepOpen).toBeUndefined();
   });
 
-  it.each(["IMPORTING", "checking"] as const)(
-    "returns a disabled syncing row for %s",
-    async (state) => {
-      mockUseConnectGoogle.mockReturnValue({
-        isAvailable: true,
-        isConnecting: false,
-        commandAction: null,
-        state,
-      });
+  it.each([
+    "IMPORTING",
+    "checking",
+  ] as const)("returns a disabled syncing row for %s", async (state) => {
+    mockUseConnectGoogle.mockReturnValue({
+      isAvailable: true,
+      isConnecting: false,
+      commandAction: null,
+      state,
+    });
 
-      const { useCalendarSyncCmdItems } = await importHook();
-      const { result } = renderHook(() => useCalendarSyncCmdItems());
+    const { useCalendarSyncCmdItems } = await importHook();
+    const { result } = renderHook(() => useCalendarSyncCmdItems());
 
-      expect(result.current.items).toEqual([
-        {
-          id: "connect-google-calendar",
-          label: "Syncing your calendar…",
-          icon: CloudArrowUpIcon,
-          iconClassName: "c-sync-icon-wave",
-          disabled: true,
-        },
-      ]);
-      expect(result.current.syncStatus?.variant).toBe("syncing");
-    },
-  );
+    expect(result.current.items).toEqual([
+      {
+        id: "connect-google-calendar",
+        label: "Syncing your calendar…",
+        icon: CloudArrowUpIcon,
+        iconClassName: "c-sync-icon-wave",
+        disabled: true,
+      },
+    ]);
+    expect(result.current.syncStatus?.variant).toBe("syncing");
+  });
 });

--- a/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useCalendarSyncCmdItems.test.ts
@@ -100,30 +100,29 @@ describe("useCalendarSyncCmdItems", () => {
     expect(result.current.items[0]?.keepOpen).toBeUndefined();
   });
 
-  it.each([
-    "repairing",
-    "IMPORTING",
-    "checking",
-  ] as const)("returns a disabled syncing row for %s", async (state) => {
-    mockUseConnectGoogle.mockReturnValue({
-      isAvailable: true,
-      isConnecting: false,
-      commandAction: null,
-      state,
-    });
+  it.each(["IMPORTING", "checking"] as const)(
+    "returns a disabled syncing row for %s",
+    async (state) => {
+      mockUseConnectGoogle.mockReturnValue({
+        isAvailable: true,
+        isConnecting: false,
+        commandAction: null,
+        state,
+      });
 
-    const { useCalendarSyncCmdItems } = await importHook();
-    const { result } = renderHook(() => useCalendarSyncCmdItems());
+      const { useCalendarSyncCmdItems } = await importHook();
+      const { result } = renderHook(() => useCalendarSyncCmdItems());
 
-    expect(result.current.items).toEqual([
-      {
-        id: "connect-google-calendar",
-        label: "Syncing your calendar…",
-        icon: CloudArrowUpIcon,
-        iconClassName: "c-sync-icon-wave",
-        disabled: true,
-      },
-    ]);
-    expect(result.current.syncStatus?.variant).toBe("syncing");
-  });
+      expect(result.current.items).toEqual([
+        {
+          id: "connect-google-calendar",
+          label: "Syncing your calendar…",
+          icon: CloudArrowUpIcon,
+          iconClassName: "c-sync-icon-wave",
+          disabled: true,
+        },
+      ]);
+      expect(result.current.syncStatus?.variant).toBe("syncing");
+    },
+  );
 });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -217,23 +217,23 @@ describe("CalendarListHeader", () => {
     ).toBeNull();
   });
 
-  it.each(["IMPORTING", "checking"] as const)(
-    "shows the wave shimmer and a generic syncing status for %s, with no tooltip",
-    async (state) => {
-      const user = userEvent.setup();
-      mockEmail = "ahab@pequod.com";
-      mockGoogleState = state;
+  it.each([
+    "IMPORTING",
+    "checking",
+  ] as const)("shows the wave shimmer and a generic syncing status for %s, with no tooltip", async (state) => {
+    const user = userEvent.setup();
+    mockEmail = "ahab@pequod.com";
+    mockGoogleState = state;
 
-      renderHeader();
+    renderHeader();
 
-      const email = screen.getByText("ahab@pequod.com");
-      expect(email).toHaveClass("c-sync-text-wave");
-      expect(screen.getByRole("status")).toHaveTextContent("Syncing…");
+    const email = screen.getByText("ahab@pequod.com");
+    expect(email).toHaveClass("c-sync-text-wave");
+    expect(screen.getByRole("status")).toHaveTextContent("Syncing…");
 
-      await user.hover(email);
-      expect(screen.queryByRole("tooltip")).toBeNull();
-    },
-  );
+    await user.hover(email);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
 
   it("shows a sync Google button when the calendar is out of date", async () => {
     const user = userEvent.setup();

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -217,24 +217,23 @@ describe("CalendarListHeader", () => {
     ).toBeNull();
   });
 
-  it.each([
-    "IMPORTING",
-    "repairing",
-    "checking",
-  ] as const)("shows the wave shimmer and a generic syncing status for %s, with no tooltip", async (state) => {
-    const user = userEvent.setup();
-    mockEmail = "ahab@pequod.com";
-    mockGoogleState = state;
+  it.each(["IMPORTING", "checking"] as const)(
+    "shows the wave shimmer and a generic syncing status for %s, with no tooltip",
+    async (state) => {
+      const user = userEvent.setup();
+      mockEmail = "ahab@pequod.com";
+      mockGoogleState = state;
 
-    renderHeader();
+      renderHeader();
 
-    const email = screen.getByText("ahab@pequod.com");
-    expect(email).toHaveClass("c-sync-text-wave");
-    expect(screen.getByRole("status")).toHaveTextContent("Syncing…");
+      const email = screen.getByText("ahab@pequod.com");
+      expect(email).toHaveClass("c-sync-text-wave");
+      expect(screen.getByRole("status")).toHaveTextContent("Syncing…");
 
-    await user.hover(email);
-    expect(screen.queryByRole("tooltip")).toBeNull();
-  });
+      await user.hover(email);
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    },
+  );
 
   it("shows a sync Google button when the calendar is out of date", async () => {
     const user = userEvent.setup();

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
@@ -18,8 +18,7 @@ export const SidebarActions = ({
 }: Props) => {
   const isCmdPaletteOpen = useSettingsStore(selectIsCmdPaletteOpen);
   const googleState = useGoogleUiState();
-  const isCalendarSyncing =
-    googleState === "IMPORTING" || googleState === "repairing";
+  const isCalendarSyncing = googleState === "IMPORTING";
 
   const toggleCmdPalette = () => {
     if (isCmdPaletteOpen) {

--- a/packages/web/src/events/event.api.ts
+++ b/packages/web/src/events/event.api.ts
@@ -30,11 +30,6 @@ const EventApi = {
     return EventListResponseSchema.parse(response.data).events;
   },
 
-  getById: async (id: EventId): Promise<Event> => {
-    const response = await BaseApi.get<unknown>(`/event/${id}`);
-    return EventResponseSchema.parse(response.data).event;
-  },
-
   create: async (input: CreateEventInput): Promise<Event> => {
     const response = await BaseApi.post<unknown>(`/event`, input);
     return EventResponseSchema.parse(response.data).event;

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -97,9 +97,6 @@ const setup = () => {
   const calls: Array<{ method: string; value: unknown }> = [];
   const repository: EventRepository = {
     list: async () => [],
-    getById: async () => {
-      throw new Error("not implemented in test fake");
-    },
     create: async (input: CreateEventInput) => {
       calls.push({ method: "create", value: input });
       await pending.wait();

--- a/packages/web/src/events/mutations/useUndoRedo.test.tsx
+++ b/packages/web/src/events/mutations/useUndoRedo.test.tsx
@@ -45,9 +45,6 @@ const setup = () => {
   const calls: Array<{ method: string; value: unknown }> = [];
   const repository: EventRepository = {
     list: async () => [],
-    getById: async () => {
-      throw new Error("not implemented in test fake");
-    },
     create: async (input: CreateEventInput) => {
       calls.push({ method: "create", value: input });
       return event({ id: (input.id ?? event().id) as EventId });

--- a/packages/web/src/events/repositories/event.repository.types.ts
+++ b/packages/web/src/events/repositories/event.repository.types.ts
@@ -9,7 +9,6 @@ import {
 
 export interface EventRepository {
   list(query: EventListQuery): Promise<Event[]>;
-  getById(id: EventId): Promise<Event>;
   create(input: CreateEventInput): Promise<Event>;
   replace(id: EventId, input: ReplaceEventInput): Promise<Event>;
   delete(id: EventId, scope: RecurrenceScope): Promise<void>;

--- a/packages/web/src/events/repositories/local.event.repository.ts
+++ b/packages/web/src/events/repositories/local.event.repository.ts
@@ -127,14 +127,6 @@ export class LocalEventRepository implements EventRepository {
     return { record: record as SeriesRecord, occurrenceStart: parsed.start };
   }
 
-  async getById(id: EventId): Promise<Event> {
-    const record = await this.findRecordById(id);
-    if (!record) {
-      throw new Error(`Event not found: ${id}`);
-    }
-    return record.event;
-  }
-
   async create(input: CreateEventInput): Promise<Event> {
     const id = input.id ?? (createObjectIdString() as EventId);
     const now = nowDateTime();

--- a/packages/web/src/events/repositories/remote.event.repository.test.ts
+++ b/packages/web/src/events/repositories/remote.event.repository.test.ts
@@ -16,7 +16,6 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 const api = {
   create: mock(),
   list: mock(),
-  getById: mock(),
   replace: mock(),
   delete: mock(),
 } satisfies Record<keyof typeof EventApi, ReturnType<typeof mock>>;
@@ -24,7 +23,6 @@ const api = {
 const localRepository = {
   create: mock(),
   list: mock(),
-  getById: mock(),
   replace: mock(),
   delete: mock(),
 } satisfies Record<keyof EventRepository, ReturnType<typeof mock>>;

--- a/packages/web/src/events/repositories/remote.event.repository.ts
+++ b/packages/web/src/events/repositories/remote.event.repository.ts
@@ -43,13 +43,6 @@ export class RemoteEventRepository implements EventRepository {
     );
   }
 
-  async getById(id: EventId): Promise<Event> {
-    return this.withLocalFallback(
-      () => this.api.getById(id),
-      () => this.localRepository.getById(id),
-    );
-  }
-
   async create(input: CreateEventInput): Promise<Event> {
     return this.withLocalFallback(
       () => this.api.create(input),

--- a/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.interaction.test.tsx
@@ -5,7 +5,7 @@ import { createFakeServerMessageBus } from "@web/__tests__/utils/sse-message-bus
 import {
   getGoogleSyncIndicatorOverride,
   resetGoogleSyncUIStateForTests,
-  setRepairingSyncIndicatorOverride,
+  setSyncingSyncIndicatorOverride,
 } from "@web/auth/google/state/google.sync.state";
 import {
   userMetadataActions,
@@ -139,21 +139,8 @@ describe("useGcalSSE", () => {
     });
   });
 
-  it("keeps the repairing override during an early healthy metadata replay", async () => {
-    setRepairingSyncIndicatorOverride();
-    render(<HookHost />);
-
-    act(() => {
-      fireUserMetadata({ google: { connectionState: "HEALTHY" } });
-    });
-
-    await waitFor(() => {
-      expect(getGoogleSyncIndicatorOverride()).toBe("repairing");
-    });
-  });
-
-  it("refetches metadata and events after importCompleted without clearing repairing", async () => {
-    setRepairingSyncIndicatorOverride();
+  it("refetches metadata and events after importCompleted without clearing syncing", async () => {
+    setSyncingSyncIndicatorOverride();
 
     render(<HookHost />);
 
@@ -167,9 +154,9 @@ describe("useGcalSSE", () => {
     });
 
     await waitFor(() => {
-      // Repairing is a user-initiated override; only its own completion path
-      // clears it. Import SSE refreshes truth from metadata instead.
-      expect(getGoogleSyncIndicatorOverride()).toBe("repairing");
+      // importCompleted alone never clears the override; only metadata that
+      // leaves IMPORTING (or an attention/healthy syncStatusChanged) does.
+      expect(getGoogleSyncIndicatorOverride()).toBe("syncing");
       expect(refreshUserMetadata).toHaveBeenCalled();
       expect(mockInvalidateEventQueries).toHaveBeenCalled();
     });
@@ -202,7 +189,7 @@ describe("useGcalSSE", () => {
   });
 
   it("clears the syncing override and shows the repair toast on WATCH_REPAIR_FAILED", async () => {
-    setRepairingSyncIndicatorOverride();
+    setSyncingSyncIndicatorOverride();
 
     render(<HookHost />);
 
@@ -227,7 +214,7 @@ describe("useGcalSSE", () => {
   });
 
   it("clears the syncing override when Google is revoked", async () => {
-    setRepairingSyncIndicatorOverride();
+    setSyncingSyncIndicatorOverride();
 
     render(<HookHost />);
 

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -122,8 +122,6 @@ const renderEditShortcuts = ({
   );
   const repository: EventRepository = {
     list: async () => [],
-    getById: async (id) =>
-      id === ALL_DAY_EVENT_ID ? allDayEventContract : timedEventContract,
     create: async () => timedEventContract,
     replace: async (id, input) => ({
       ...(id === ALL_DAY_EVENT_ID ? allDayEventContract : timedEventContract),

--- a/packages/web/src/views/Week/hooks/shortcuts/useUndoRedoShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useUndoRedoShortcuts.test.tsx
@@ -54,9 +54,6 @@ const setup = () => {
   });
   const repository: EventRepository = {
     list: async () => [],
-    getById: async () => {
-      throw new Error("not implemented in test fake");
-    },
     create: async (input) => ({ ...before, id: input.id as EventId }),
     replace: async (id: EventId, input): Promise<Event> => ({
       ...before,


### PR DESCRIPTION
## Summary

Two independent dead-code cleanups following #2480 (which removed the legacy Google-connect popup flow now that Sync is mandatory at startup):

1. **`chore(web): remove dead repairing sync-indicator state`** — `setRepairingSyncIndicatorOverride()` lost its only caller (the legacy ATTENTION force-repair action) in #2480. Narrowed `SyncIndicator`/`GoogleUiState` from `null | "repairing" | "syncing"` to `null | "syncing"`, dropped the `"repairing"` branch in `useGoogleUiState`/`useConnectGoogle.util.ts`/`SidebarActions`, and updated every test that referenced `"repairing"`. Tests that used `setRepairingSyncIndicatorOverride()` purely as a generic non-idle trigger now use `setSyncingSyncIndicatorOverride()`; two `SSEProvider` tests that asserted "repairing"-specific persistence (surviving a clear that only targets `"syncing"`) were removed since that scenario no longer exists with just `null | "syncing"`.

2. **`chore: remove orphaned GET /api/event/:id and getById plumbing`** — `GET /api/event/:id` (`event.controller.ts`'s `readById`) still hit the legacy pre-Sync local mongo event store directly, unlike every other event route which now delegates to Sync. Confirmed with a repo-wide grep that nothing above the repository layer on the web side calls `.getById(...)`. Removed end to end: the route, the controller method, `EventApi.getById`, and `EventRepository.getById` from both the remote and local implementations. `event.service.ts`'s `readById`/`requireOwnedEvent`/`ownedCalendarIds` had no other caller either, so those went too — `eventRepository.findById` (the lower-level repository primitive they wrapped) stays, since it's still exercised directly by its own db test.

A third candidate from the same audit — the `intent: z.literal("signIn")` field in `GoogleAuthorizationIntentSchema` — was reviewed and intentionally left as-is: it's already a literal (self-documenting, low risk), and fully collapsing it would ripple into `useStartGoogleAuthorization` and `AuthModal.tsx`'s sign-in call site, which this cleanup effort's guardrail says to leave untouched.

## Simplicity

Both changes are pure deletions (dead state variant, dead route/methods) plus the minimal test/type updates needed to keep everything compiling and passing — no new abstractions introduced.

## Automated validation

Not applicable — no UI-visible behavior change; both changes remove code paths that had zero callers.

## Independent review

No separate reviewer pass was run; verification was via repo-wide greps confirming zero remaining callers/references for each removed symbol, plus the checks below.

## Test plan

- `bunx typescript@7.0.2 --noEmit` (root — core/backend)
- `bunx typescript@7.0.2 -p packages/web/tsconfig.app.json --noEmit`
- `bunx typescript@7.0.2 -p packages/web/tsconfig.test.json --noEmit`
- `bun run test:web` — 1450 pass, 0 fail
- `bun run test:backend:fast` — 367 pass, 14 fail; confirmed by re-running against the pre-change baseline that the same 14 failures (SSE server / `/api/config` tests) pre-exist and are unrelated to this diff (environment-only, no mongo/network in this sandbox)

---
_Generated by [Claude Code](https://claude.ai/code/session_012NHQPbtXL1yQWRuoBqtGiN)_