### PR TITLE
fix(sync): self-heal failed jobs and surface wedged work in connection state

### DIFF
--- a/packages/scripts/src/commands/refresh-connection-states/refresh.ts
+++ b/packages/scripts/src/commands/refresh-connection-states/refresh.ts
@@ -8,6 +8,7 @@ import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { ProviderConnectionRecordSchema } from "@sync/storage/contracts/provider-connection.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -46,6 +47,7 @@ export async function refreshConnectionStates(
     calendars: new ProviderCalendarRepository(db),
     resources: new SyncResourceRepository(db),
     credentials: new CredentialRepository(db),
+    jobs: new JobRepository(db),
     invalidations: new InvalidationRepository(db),
   };
 
@@ -126,7 +128,8 @@ async function gatherEvidenceOnly(
   deps: Parameters<typeof refreshConnectionState>[0],
   record: Parameters<typeof refreshConnectionState>[1],
 ): Promise<{ state: string; reason: string | null }> {
-  const evidence = await gatherConnectionStateEvidence(deps, record);
-  const derived = deriveConnectionState(evidence, new Date());
+  const now = new Date();
+  const evidence = await gatherConnectionStateEvidence(deps, record, now);
+  const derived = deriveConnectionState(evidence, now);
   return { state: derived.state, reason: derived.reason };
 }

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -6,6 +6,7 @@ import {
   CONNECTION_CACHE_RETENTION_MS,
   purgeExpiredDisconnectedConnections,
 } from "@sync/domain/connection-retention.service";
+import { requeueFailedJobs } from "@sync/domain/failed-job-requeue.service";
 import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
 import { maintainExpiringSubscriptions } from "@sync/domain/subscription-sweep.service";
 import { SweepScheduler } from "@sync/domain/sweep-scheduler.service";
@@ -222,9 +223,13 @@ async function start(): Promise<void> {
       service.shutdown.register("subscription", () =>
         schedulers.subscription.stop(),
       );
+      service.shutdown.register("failedJobRequeue", () =>
+        schedulers.failedJobRequeue.stop(),
+      );
       for (const drain of schedulers.drains) drain.start();
       schedulers.reconcile.start();
       schedulers.subscription.start();
+      schedulers.failedJobRequeue.start();
       logger.info(
         "Sync scheduler draining, reconciling, renewing channels, retaining, and reporting health",
       );
@@ -241,6 +246,13 @@ async function start(): Promise<void> {
   }
 }
 
+// A failed job is eligible for the self-heal sweep once it has sat failed for
+// at least this long — long enough that a real provider outage has had a
+// chance to clear before we burn another retry ladder on it.
+const FAILED_JOB_REQUEUE_COOLDOWN_MS = 30 * 60_000;
+// How many times the self-heal sweep will requeue the same job before
+// leaving it failed for an operator instead.
+const FAILED_JOB_MAX_REQUEUES = 3;
 // A resource not synced within this window is swept for a reconcile pull.
 const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
 // A push channel expiring within this window is swept for renewal. Matches
@@ -328,6 +340,7 @@ function buildSchedulers(
   drains: SyncScheduler[];
   reconcile: SweepScheduler;
   subscription: SweepScheduler;
+  failedJobRequeue: SweepScheduler;
 } | null {
   if (config.EXECUTION !== "active") return null;
   const authAdapter = buildAuthAdapter(config);
@@ -413,7 +426,38 @@ function buildSchedulers(
         logger.error("Sync subscription maintenance sweep failed", error),
     },
   );
-  return { drains, reconcile, subscription };
+  // Self-heal sweep: give jobs stuck in state:"failed" a fresh retry ladder
+  // once they have cooled down, and loudly log any that keep re-failing past
+  // the requeue cap. Looks BACK, like reconcile — a job is eligible once it
+  // has been failed since before the cooldown window.
+  const failedJobRequeue = new SweepScheduler(
+    {
+      sweep: async (before) => {
+        const result = await requeueFailedJobs(
+          { jobs },
+          before,
+          () => new Date(),
+          FAILED_JOB_MAX_REQUEUES,
+        );
+        if (result.requeued > 0) {
+          logger.info(
+            `Sync self-heal sweep requeued ${result.requeued} failed job(s)`,
+          );
+        }
+        if (result.exhausted > 0) {
+          logger.error(
+            `Sync self-heal sweep: ${result.exhausted} failed job(s) exhausted their requeue budget and need operator attention`,
+          );
+        }
+        return result.requeued;
+      },
+    },
+    {
+      windowMs: -FAILED_JOB_REQUEUE_COOLDOWN_MS,
+      onError: (error) => logger.error("Sync self-heal sweep failed", error),
+    },
+  );
+  return { drains, reconcile, subscription, failedJobRequeue };
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -5,7 +5,9 @@ import {
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
+import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -19,15 +21,17 @@ describe("refreshConnectionState", () => {
   let calendars: ProviderCalendarRepository;
   let resources: SyncResourceRepository;
   let credentials: CredentialRepository;
+  let jobs: JobRepository;
 
   beforeEach(() => {
     connections = new ProviderConnectionRepository(storage.db());
     calendars = new ProviderCalendarRepository(storage.db());
     resources = new SyncResourceRepository(storage.db());
     credentials = new CredentialRepository(storage.db());
+    jobs = new JobRepository(storage.db());
   });
 
-  const deps = () => ({ connections, calendars, resources, credentials });
+  const deps = () => ({ connections, calendars, resources, credentials, jobs });
 
   async function seedImportingConnection() {
     const connection = await connections.upsertByProviderAccount({
@@ -123,6 +127,84 @@ describe("refreshConnectionState", () => {
     expect(after.stateReason).toBeNull();
     expect(after.lastHealthyAt).toBeInstanceOf(Date);
     expect(after.lastSyncedAt).toBeInstanceOf(Date);
+  });
+
+  it("reports delayed/providerErrors when a job for the connection is wedged in state:failed", async () => {
+    // The 2026-07-30 gap: oldestDueWorkAt was hardcoded to null here, so a job
+    // that exhausted its retry ladder and terminalized as state:"failed" was
+    // invisible to the connection's own health state — every signal green
+    // while a calendar sat unsynced for ~25h. A failed job is unconditionally
+    // overdue (see findOldestOverdueByConnection), so this must flip the
+    // connection to delayed the moment one exists, independent of any
+    // otherwise-healthy import evidence.
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: "#fff",
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    const eventsResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "events-cursor",
+      new Date(),
+    );
+
+    await jobs.enqueue({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceId: eventsResource._id,
+      commandId: null,
+      kind: "incrementalPull",
+      priority: 0,
+      runAfter: new Date("2026-01-01T00:00:00.000Z"),
+      coalescingKey: `incrementalPull:${eventsResource._id}`,
+    } as JobEnqueue);
+    const claimed = await jobs.claimDueJob(
+      "worker",
+      new Date("2026-01-01T00:00:00.000Z"),
+      60_000,
+    );
+    await jobs.fail(claimed!._id, "worker", "retryableTransient");
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("delayed");
+    expect(after.stateReason).toBe("providerErrors");
   });
 
   it("keeps importing when an active calendar still lacks a cursor", async () => {

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -6,6 +6,7 @@ import {
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { type InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -15,6 +16,7 @@ export interface ConnectionStateRefreshDeps {
   calendars: ProviderCalendarRepository;
   resources: SyncResourceRepository;
   credentials: CredentialRepository;
+  jobs: JobRepository;
   // Optional so unit callers that only assert state can omit the outbox; the
   // HTTP list path always supplies it so UI clients learn about state changes.
   invalidations?: InvalidationRepository;
@@ -29,7 +31,7 @@ export async function refreshConnectionState(
   now: () => Date = () => new Date(),
 ): Promise<ProviderConnectionRecord> {
   const at = now();
-  const evidence = await gatherConnectionStateEvidence(deps, connection);
+  const evidence = await gatherConnectionStateEvidence(deps, connection, at);
   const derived = deriveConnectionState(evidence, at);
 
   const lastSyncedAt = maxDate(
@@ -81,8 +83,9 @@ export async function refreshConnectionState(
 export async function gatherConnectionStateEvidence(
   deps: ConnectionStateRefreshDeps,
   connection: ProviderConnectionRecord,
+  now: Date,
 ): Promise<ConnectionStateEvidence & { resourceSuccessAts: Date[] }> {
-  const [credential, calendars, resources] = await Promise.all([
+  const [credential, calendars, resources, oldestOverdue] = await Promise.all([
     deps.credentials.findByConnection(connection._id),
     deps.calendars.listByConnection(
       connection.tenantId,
@@ -93,6 +96,12 @@ export async function gatherConnectionStateEvidence(
       connection.tenantId,
       connection.principalId,
       connection._id,
+    ),
+    deps.jobs.findOldestOverdueByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+      now,
     ),
   ]);
 
@@ -128,8 +137,10 @@ export async function gatherConnectionStateEvidence(
     // hold a durable events cursor (the initialImport settle condition).
     initialImportComplete: discoveryDone && allActiveImported,
     catchingUp: false,
-    oldestDueWorkAt: null,
-    recentProviderErrors: false,
+    oldestDueWorkAt: oldestOverdue?.runAfter ?? null,
+    // A job that used up its retry ladder on retryableTransient failures is
+    // itself provider-error evidence, distinct from a plain backlog.
+    recentProviderErrors: oldestOverdue?.failureClass === "retryableTransient",
     resourceSuccessAts,
   };
 }

--- a/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
+++ b/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
@@ -1,0 +1,96 @@
+import { faker } from "@faker-js/faker";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { requeueFailedJobs } from "@sync/domain/failed-job-requeue.service";
+import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+
+const objectId = () => faker.database.mongodbObjectId();
+const NOW = new Date("2026-07-20T12:00:00.000Z");
+const now = () => NOW;
+// Jobs last due before this instant have cooled down enough to requeue.
+const cooldownBefore = new Date("2026-07-20T11:30:00.000Z");
+
+describe("requeueFailedJobs", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let jobs: JobRepository;
+
+  beforeEach(() => {
+    jobs = new JobRepository(storage.db());
+  });
+
+  const deps = () => ({ jobs });
+
+  // Enqueue, claim, and fail a job so a test starts directly from
+  // state:"failed" without driving a real worker's retry ladder.
+  const seedFailed = async (
+    overrides: Partial<JobEnqueue> = {},
+  ): Promise<string> => {
+    const job = await jobs.enqueue({
+      tenantId: objectId(),
+      principalId: objectId(),
+      connectionId: objectId(),
+      resourceId: null,
+      commandId: null,
+      kind: "incrementalPull",
+      priority: 0,
+      runAfter: new Date("2026-07-20T10:00:00.000Z"),
+      coalescingKey: `pull:${objectId()}`,
+      ...overrides,
+    } as JobEnqueue);
+    const claimed = await jobs.claimDueJob("worker", NOW, 60_000);
+    await jobs.fail(claimed!._id, "worker", "retryableTransient");
+    return job._id;
+  };
+
+  it("requeues a cooled-down failed job with a fresh attempt budget", async () => {
+    const id = await seedFailed({
+      runAfter: new Date("2026-07-20T10:00:00.000Z"),
+    });
+
+    const result = await requeueFailedJobs(deps(), cooldownBefore, now, 3);
+
+    expect(result).toEqual({ requeued: 1, exhausted: 0 });
+    const raw = await storage
+      .db()
+      .collection("jobs")
+      .findOne({ _id: id as never });
+    expect(raw?.state).toBe("pending");
+    expect(raw?.runAfter).toEqual(NOW);
+    expect(raw?.requeuedCount).toBe(1);
+  });
+
+  it("leaves a job that has not cooled down yet failed", async () => {
+    await seedFailed({ runAfter: new Date("2026-07-20T11:45:00.000Z") });
+
+    const result = await requeueFailedJobs(deps(), cooldownBefore, now, 3);
+
+    expect(result).toEqual({ requeued: 0, exhausted: 0 });
+  });
+
+  it("stops requeuing once a job hits the cap and reports it as exhausted", async () => {
+    const id = await seedFailed({
+      runAfter: new Date("2026-07-20T10:00:00.000Z"),
+    });
+    // Burn the requeue budget: requeue, then fail again, `maxRequeues` times.
+    for (let cycle = 0; cycle < 2; cycle += 1) {
+      await jobs.requeue(id as never, new Date("2026-07-20T10:00:00.000Z"));
+      const reclaimed = await jobs.claimDueJob(
+        "worker",
+        new Date("2026-07-20T10:00:00.000Z"),
+        60_000,
+      );
+      await jobs.fail(reclaimed!._id, "worker", "retryableTransient");
+    }
+
+    const result = await requeueFailedJobs(deps(), cooldownBefore, now, 2);
+
+    expect(result).toEqual({ requeued: 0, exhausted: 1 });
+  });
+
+  it("does nothing when there are no failed jobs", async () => {
+    expect(await requeueFailedJobs(deps(), cooldownBefore, now, 3)).toEqual({
+      requeued: 0,
+      exhausted: 0,
+    });
+  });
+});

--- a/packages/sync/src/domain/failed-job-requeue.service.ts
+++ b/packages/sync/src/domain/failed-job-requeue.service.ts
@@ -1,0 +1,50 @@
+import { type JobRepository } from "@sync/storage/repositories/job.repository";
+
+export interface FailedJobRequeueDeps {
+  jobs: JobRepository;
+}
+
+export interface FailedJobRequeueResult {
+  // How many failed jobs this sweep gave a fresh retry ladder.
+  requeued: number;
+  // How many failed jobs have hit the requeue cap and re-failed anyway — the
+  // sweep will not touch them again; they need an operator.
+  exhausted: number;
+}
+
+// The self-heal sweep for jobs terminalized as state:"failed". A worker marks
+// a job failed once it exhausts its per-attempt retry ladder (see
+// sync-job-worker.service.ts); nothing else ever requeues it. When the
+// underlying condition was transient (a provider blip, a network partition
+// that outlasted the ladder), that job is stuck forever with no further
+// signal — a staging calendar sat wedged ~25h this way with every other
+// health signal green (2026-07-30).
+//
+// Requeuing resets the job to pending with a fresh attempt count (so it gets
+// the FULL retry ladder again, not one more attempt), but requeuedCount
+// itself is never reset — that is the bound on how many times this sweep will
+// keep giving a persistently-broken resource another chance before it counts
+// as needing operator attention instead.
+//
+// A GLOBAL scan across owners (this is system liveness, not a user request);
+// each requeued job keeps its own owner ids and coalescing key. The periodic
+// trigger that drives this on an interval is the same SweepScheduler every
+// other sweep uses.
+export async function requeueFailedJobs(
+  deps: FailedJobRequeueDeps,
+  before: Date,
+  now: () => Date,
+  maxRequeues: number,
+  limit = 100,
+): Promise<FailedJobRequeueResult> {
+  const candidates = await deps.jobs.listFailedForRequeue(
+    before,
+    maxRequeues,
+    limit,
+  );
+  for (const job of candidates) {
+    await deps.jobs.requeue(job._id, now());
+  }
+  const exhausted = await deps.jobs.countExhaustedFailed(maxRequeues);
+  return { requeued: candidates.length, exhausted };
+}

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -123,6 +123,7 @@ export function registerConnectionRoutes(
           calendars: repos.calendars,
           resources: repos.syncResources,
           credentials: repos.credentials,
+          jobs: repos.jobs,
           invalidations: repos.invalidations,
         };
         const records = await connections.listByPrincipal(

--- a/packages/sync/src/storage/contracts/job.contracts.ts
+++ b/packages/sync/src/storage/contracts/job.contracts.ts
@@ -50,6 +50,11 @@ export const JobRecordSchema = z.strictObject({
   leaseOwner: z.string().trim().min(1).nullable(),
   leaseExpiresAt: z.date().nullable(),
   failureClass: JobFailureClassSchema.nullable(),
+  // How many times the self-heal sweep has requeued this job after it reached
+  // state:"failed". Distinct from `attempt` (which a requeue resets to give
+  // the job a fresh retry ladder) so a resource that keeps failing cannot be
+  // requeued forever — the sweep stops once this hits its cap.
+  requeuedCount: z.number().int().min(0),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -62,6 +67,7 @@ export const JobEnqueueSchema = JobRecordSchema.omit({
   leaseOwner: true,
   leaseExpiresAt: true,
   failureClass: true,
+  requeuedCount: true,
   createdAt: true,
   updatedAt: true,
 });

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import { type SyncJobId } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
@@ -229,6 +230,151 @@ describe("JobRepository", () => {
         .findOne({ _id: leaving!._id as never });
       expect(released?.state).toBe("pending");
       expect(released?.leaseOwner).toBeNull();
+    });
+  });
+
+  describe("self-heal requeue", () => {
+    const NOW = new Date("2026-07-20T12:00:00.000Z");
+    const past = (ms: number) => new Date(NOW.getTime() - ms);
+
+    // Enqueue, claim, and fail a job in one step so a test can start directly
+    // from state:"failed" without driving a real worker's retry ladder.
+    const seedFailed = async (
+      overrides: Partial<JobEnqueue> = {},
+    ): Promise<SyncJobId> => {
+      const job = await repo.enqueue(
+        enqueue({ runAfter: past(1000), ...overrides }),
+      );
+      const claimed = await repo.claimDueJob("worker", NOW, 60_000);
+      await repo.fail(claimed!._id, "worker", "retryableTransient");
+      return job._id;
+    };
+
+    it("lists a failed job whose runAfter is before the cooldown cutoff", async () => {
+      const id = await seedFailed({ runAfter: past(60 * 60_000) });
+      const candidates = await repo.listFailedForRequeue(
+        past(30 * 60_000),
+        3,
+        100,
+      );
+      expect(candidates.map((j) => j._id)).toEqual([id]);
+    });
+
+    it("excludes a failed job that has not cooled down yet", async () => {
+      await seedFailed({ runAfter: past(5 * 60_000) });
+      const candidates = await repo.listFailedForRequeue(
+        past(30 * 60_000),
+        3,
+        100,
+      );
+      expect(candidates).toHaveLength(0);
+    });
+
+    it("excludes a failed job at or over the requeue cap", async () => {
+      const id = await seedFailed({ runAfter: past(60 * 60_000) });
+      // Simulate two prior requeue-then-fail-again cycles.
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        await repo.requeue(id, past(50 * 60_000));
+        const reclaimed = await repo.claimDueJob("worker", NOW, 60_000);
+        await repo.fail(reclaimed!._id, "worker", "retryableTransient");
+      }
+
+      const underCap = await repo.listFailedForRequeue(
+        past(30 * 60_000),
+        2,
+        100,
+      );
+      expect(underCap).toHaveLength(0);
+      expect(await repo.countExhaustedFailed(2)).toBe(1);
+    });
+
+    it("excludes a permanently classed failure from requeue and exhaustion", async () => {
+      await repo.enqueue(enqueue({ runAfter: past(60 * 60_000) }));
+      const claimed = await repo.claimDueJob("worker", NOW, 60_000);
+      await repo.fail(claimed!._id, "worker", "permanent");
+
+      expect(
+        await repo.listFailedForRequeue(past(30 * 60_000), 3, 100),
+      ).toHaveLength(0);
+      expect(await repo.countExhaustedFailed(0)).toBe(0);
+    });
+
+    it("requeue resets a failed job to pending with a fresh attempt budget", async () => {
+      const id = await seedFailed({ runAfter: past(60 * 60_000) });
+      expect(await repo.requeue(id, NOW)).toBe(true);
+
+      const after = await db.collection("jobs").findOne({ _id: id as never });
+      expect(after?.state).toBe("pending");
+      expect(after?.attempt).toBe(0);
+      expect(after?.leaseOwner).toBeNull();
+      expect(after?.failureClass).toBeNull();
+      expect(after?.runAfter).toEqual(NOW);
+      expect(after?.requeuedCount).toBe(1);
+    });
+
+    it("does not requeue a job that is not currently failed", async () => {
+      const job = await repo.enqueue(enqueue({ runAfter: past(1000) }));
+      expect(await repo.requeue(job._id, NOW)).toBe(false);
+    });
+
+    it("finds the oldest overdue job for a connection, including a failed one", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      const failed = await repo.enqueue(
+        enqueue({
+          tenantId,
+          principalId,
+          connectionId,
+          runAfter: past(60 * 60_000),
+          coalescingKey: "pull:failed-resource",
+        }),
+      );
+      const claimed = await repo.claimDueJob("worker", NOW, 60_000);
+      await repo.fail(claimed!._id, "worker", "retryableTransient");
+      // A pending job on the same connection, due more recently — the failed
+      // job is still older and should win.
+      await repo.enqueue(
+        enqueue({
+          tenantId,
+          principalId,
+          connectionId,
+          runAfter: past(5 * 60_000),
+          coalescingKey: "pull:pending-resource",
+        }),
+      );
+
+      const oldest = await repo.findOldestOverdueByConnection(
+        tenantId,
+        principalId,
+        connectionId,
+        NOW,
+      );
+      expect(oldest?.runAfter).toEqual(failed.runAfter);
+      expect(oldest?.failureClass).toBe("retryableTransient");
+    });
+
+    it("reports no overdue work for a connection with only healthy pending jobs", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      await repo.enqueue(
+        enqueue({
+          tenantId,
+          principalId,
+          connectionId,
+          runAfter: new Date(NOW.getTime() + 60_000), // not due yet
+        }),
+      );
+
+      expect(
+        await repo.findOldestOverdueByConnection(
+          tenantId,
+          principalId,
+          connectionId,
+          NOW,
+        ),
+      ).toBeNull();
     });
   });
 });

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -50,6 +50,7 @@ export class JobRepository {
           leaseOwner: null,
           leaseExpiresAt: null,
           failureClass: null,
+          requeuedCount: 0,
           createdAt: now,
           updatedAt: now,
         },
@@ -201,6 +202,110 @@ export class JobRepository {
       },
     );
     return result.modifiedCount;
+  }
+
+  // Failed jobs the self-heal sweep should give a fresh retry ladder: still
+  // failed (a concurrent operator/reconnect action may have moved it on),
+  // last due before the sweep's cooldown cutoff (`before`), not a permanently
+  // classed failure (retrying that can never help), and under the requeue
+  // cap. Gated on `runAfter` rather than `updatedAt` — the latter is set via
+  // $currentDate (real wall-clock, not the injected `now` used everywhere
+  // else) and is pure audit metadata, never a field business logic reads.
+  // Oldest-due-first so a long-wedged job is healed before a recently-failed
+  // one.
+  async listFailedForRequeue(
+    before: Date,
+    maxRequeues: number,
+    limit: number,
+  ): Promise<JobRecord[]> {
+    const rows = await this.collection
+      .find({
+        state: "failed",
+        failureClass: { $ne: "permanent" },
+        requeuedCount: { $lt: maxRequeues },
+        runAfter: { $lte: before },
+      })
+      .sort({ runAfter: 1 })
+      .limit(limit)
+      .toArray();
+    return rows.map((row) => JobRecordSchema.parse(row));
+  }
+
+  // Give a failed job a fresh attempt budget and return it to the pending
+  // pool, bumping requeuedCount (NOT reset by this — that is the sweep's
+  // budget, distinct from the per-worker attempt count this clears). Scoped
+  // to state:"failed" so a job an operator or reconnect already moved on is
+  // left alone. Reusing the same _id/coalescingKey in place, rather than
+  // remove+enqueue, means the sweep never has to race the coalescing key's
+  // $setOnInsert uniqueness against a fresh notification for the same
+  // resource.
+  async requeue(id: SyncJobId, now: Date): Promise<boolean> {
+    const result = await this.collection.updateOne(
+      { _id: id, state: "failed" },
+      {
+        $set: {
+          state: "pending",
+          runAfter: now,
+          attempt: 0,
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          failureClass: null,
+        },
+        $inc: { requeuedCount: 1 },
+        $currentDate: { updatedAt: true },
+      },
+    );
+    return result.modifiedCount === 1;
+  }
+
+  // Failed jobs that exhausted the self-heal requeue budget and re-failed —
+  // the sweep will not touch them again; an operator must. Used to drive a
+  // loud, recurring alert rather than a silent terminal state.
+  async countExhaustedFailed(maxRequeues: number): Promise<number> {
+    return this.collection.countDocuments({
+      state: "failed",
+      failureClass: { $ne: "permanent" },
+      requeuedCount: { $gte: maxRequeues },
+    });
+  }
+
+  // The oldest piece of overdue work for one connection, if any: a pending
+  // job past its runAfter, a claimed job whose lease lapsed, or ANY failed
+  // job (a terminal failure is always overdue — nothing will run it again
+  // without the self-heal sweep or an operator). Feeds
+  // ConnectionStateEvidence.oldestDueWorkAt, which was previously wired to a
+  // hardcoded null — a wedged failed job was invisible to the connection's
+  // own health state (2026-07-30: every signal green with jobs stuck ~25h).
+  async findOldestOverdueByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+    now: Date,
+  ): Promise<{
+    runAfter: Date;
+    failureClass: JobRecord["failureClass"];
+  } | null> {
+    const result = await this.collection.findOne(
+      {
+        tenantId,
+        principalId,
+        connectionId,
+        $or: [
+          { state: "pending", runAfter: { $lte: now } },
+          { state: "claimed", leaseExpiresAt: { $lt: now } },
+          { state: "failed" },
+        ],
+      },
+      {
+        sort: { runAfter: 1 },
+        projection: { runAfter: 1, failureClass: 1 },
+      },
+    );
+    if (!result || !(result["runAfter"] instanceof Date)) return null;
+    return {
+      runAfter: result["runAfter"],
+      failureClass: result["failureClass"] ?? null,
+    };
   }
 
   // Outstanding work for one connection (support diagnostics / S45).


### PR DESCRIPTION
## Summary
- A sync job that exhausts its retry ladder terminalizes as `state:"failed"` and nothing ever requeues it — a wedged calendar could sit unsynced indefinitely with no automatic recovery. Adds a periodic self-heal sweep (`failed-job-requeue.service.ts`, wired into `app.ts` alongside the existing reconcile/subscription sweeps) that gives a cooled-down failed job a fresh retry ladder, bounded by a requeue cap; jobs that keep re-failing past the cap are loudly logged instead of silently retried forever.
- Separately, `ConnectionStateEvidence.oldestDueWorkAt` and `recentProviderErrors` were hardcoded to `null`/`false` in `gatherConnectionStateEvidence` — so the `delayed`/`workOverdue` and `delayed`/`providerErrors` derivation paths were dead code in practice. A job stuck in `state:"failed"` was invisible to the connection's own health state: every signal could read green while a calendar sat unsynced for hours. Wires both from a new `JobRepository.findOldestOverdueByConnection` query (any due pending/claimed job, or unconditionally any failed job) so the existing connection state machine actually reflects wedged work.

## Test plan
- [x] `bun run type-check`
- [x] `TZ=Etc/UTC bun run test:sync` (698 passing, including new coverage for the requeue sweep, the repository's cooldown/cap/permanent-failure filtering, and the connection-state evidence wiring)
- [x] `TZ=Etc/UTC bun run test:scripts` (56 passing — covers the `refresh-connection-states` CLI wiring)
- [x] `./node_modules/.bin/biome check .`
- [x] `bun run knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)