### PR TITLE
perf(sync,backend): multiplex the SSE change-feed poll into one global feed

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,6 +1,7 @@
 import { CONFIG } from "@backend/common/constants/config.constants";
 import mongoService from "@backend/common/services/mongo.service";
 import { initExpressServer } from "@backend/servers/express/express.server";
+import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
 import { logger } from "./init"; //must be first import
 import { stopPostHogLogs } from "./logging/posthog-logs";
 import { createServer, type Server } from "node:http";
@@ -22,6 +23,12 @@ async function start() {
         resolve(undefined);
       }),
     );
+
+    // One multiplexed poll of Sync's global change feed for the life of this
+    // process, fanning invalidations out to whichever SSE subscribers are
+    // locally connected. Started here (not at module import) so a test
+    // importing the bridge for its types never triggers a live network poll.
+    syncChangeFeedBridge.start();
   } catch (error) {
     logger.error("Problems encountered during startup", error);
 
@@ -39,6 +46,7 @@ async function closeHttpServer(): Promise<void> {
 
 async function gracefulShutdown(): Promise<void> {
   try {
+    syncChangeFeedBridge.stop();
     await closeHttpServer();
     await mongoService.stop();
     await stopPostHogLogs();

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -3,8 +3,14 @@ import { type BusyAvailabilityRequest } from "@core/types/sync/availability.cont
 import { type CommandSubmitRequest } from "@core/types/sync/command.contracts";
 import { type EventInstanceListQuery } from "@core/types/sync/event.contracts";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
-import { verifyInternalRequest } from "@sync/auth/internal-auth";
-import { CHANGES_PATH } from "@sync/server/change-feed.routes";
+import {
+  verifyInternalRequest,
+  verifyServiceRequest,
+} from "@sync/auth/internal-auth";
+import {
+  CHANGES_ALL_PATH,
+  CHANGES_PATH,
+} from "@sync/server/change-feed.routes";
 import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
   AVAILABILITY_BUSY_PATH,
@@ -245,6 +251,69 @@ describe("SyncServiceClient", () => {
       now: NOW,
     });
     if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+  });
+
+  it("polls the GLOBAL change feed with no principal, signed as the service", async () => {
+    const cursor = objectId();
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({
+        kind: "ok",
+        invalidations: [
+          {
+            invalidation: { kind: "connection", connectionId: objectId() },
+            emittedAt: "2026-07-30T00:00:00.000Z",
+            tenantId: objectId(),
+            principalId: objectId(),
+          },
+        ],
+        nextCursor: cursor,
+      }),
+    }));
+
+    const fromNow = await client(fn).getGlobalChanges(null);
+    if (!fromNow.ok) throw new Error(`expected ok, got ${fromNow.error.kind}`);
+    expect(fromNow.value.kind).toBe("ok");
+    expect(calls[0]?.url).toBe(`${BASE_URL}${CHANGES_ALL_PATH}`);
+    expect(calls[0]?.method).toBe("GET");
+
+    await client(fn).getGlobalChanges(cursor as never);
+    expect(calls[1]?.url).toBe(
+      `${BASE_URL}${CHANGES_ALL_PATH}?cursor=${encodeURIComponent(cursor)}`,
+    );
+
+    // No tenant/principal headers at all — the real Sync service-auth
+    // verifier accepts it on that basis alone.
+    expect(calls[0]?.headers).not.toHaveProperty("x-sync-tenant");
+    expect(calls[0]?.headers).not.toHaveProperty("x-sync-principal");
+    const verdict = verifyServiceRequest({
+      secret: SECRET,
+      headers: calls[0]?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+
+    // And the per-principal verifier must NOT accept it (missing identity).
+    expect(
+      verifyInternalRequest({
+        secret: SECRET,
+        headers: calls[0]?.headers ?? {},
+        now: NOW,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects a global-changes body that does not match the contract", async () => {
+    const { fn } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({ kind: "ok", invalidations: [{ bogus: true }] }),
+    }));
+
+    const result = await client(fn).getGlobalChanges(null);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("invalidResponse");
   });
 
   it("rejects a calendars body that does not match the contract", async () => {

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -8,6 +8,8 @@ import {
   type ChangeFeedCursor,
   type ChangeFeedResponse,
   ChangeFeedResponseSchema,
+  type GlobalChangeFeedResponse,
+  GlobalChangeFeedResponseSchema,
 } from "@core/types/sync/change-feed.contracts";
 import {
   type CommandSubmitRequest,
@@ -39,6 +41,7 @@ import { createHmac, randomUUID } from "node:crypto";
 const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 const CALENDARS_PATH = "/internal/calendars";
 const CHANGES_PATH = "/internal/changes";
+const CHANGES_ALL_PATH = "/internal/changes/all";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const EVENTS_FULL_PATH = "/internal/events/full";
@@ -120,6 +123,20 @@ function signRequest(
 ): string {
   return createHmac("sha256", secret)
     .update(`${timestamp}.${principal.tenantId}.${principal.principalId}`)
+    .digest("hex");
+}
+
+// Sign a request that acts on behalf of no single tenant/principal — today,
+// only the global change-feed poll. Domain-separated from signRequest above
+// (a distinct HMAC preimage, "service." vs "<timestamp>.<tenant>.<principal>")
+// so a per-principal-signed request can never be replayed here. Reimplemented
+// here for the same reason signRequest is: this client build-depends on
+// neither the Sync service nor its independently-deployable package; a
+// contract test proves this is accepted by the real verifier
+// (verifyServiceRequest).
+function signServiceRequest(secret: string, timestamp: number): string {
+  return createHmac("sha256", secret)
+    .update(`service.${timestamp}`)
     .digest("hex");
 }
 
@@ -285,6 +302,26 @@ export class SyncServiceClient {
     });
   }
 
+  // Resumable content-free invalidation page across EVERY tenant/principal —
+  // backs the single multiplexed change-feed poll the backend runs once per
+  // process instead of once per connected user. Signed as the service itself,
+  // not any principal (see signServiceRequest): there is no single tenant or
+  // principal this request acts on behalf of. Pass `null` to resume from now.
+  getGlobalChanges(
+    cursor: ChangeFeedCursor | null,
+    correlationId?: string,
+  ): Promise<SyncClientResult<GlobalChangeFeedResponse>> {
+    const params = new URLSearchParams();
+    if (cursor !== null) params.set("cursor", cursor);
+    return this.#requestUnscoped({
+      method: "GET",
+      path: CHANGES_ALL_PATH,
+      query: params,
+      schema: GlobalChangeFeedResponseSchema,
+      correlationId,
+    });
+  }
+
   // Hard-delete every Sync-held row for the signed principal (account deletion).
   // Served in Sync passive mode too. Idempotent: a retry returns zero counts.
   purgePrincipal(
@@ -320,7 +357,44 @@ export class SyncServiceClient {
       "x-sync-signature": signRequest(this.#secret, timestamp, input.principal),
       "x-correlation-id": correlationId,
     };
+    return this.#send({ ...input, headers, correlationId });
+  }
 
+  // Same signed-request/timeout/parse machinery as #request, for a route that
+  // acts on behalf of no single tenant/principal (today, only the global
+  // change-feed poll). Signs a domain-separated payload with no identity
+  // claim — see signServiceRequest — so it can never be confused with, or
+  // used to replay, a per-principal-signed request.
+  async #requestUnscoped<T>(input: {
+    method: "GET";
+    path: string;
+    query?: URLSearchParams;
+    schema: z.ZodType<T>;
+    correlationId?: string;
+    timeoutMs?: number;
+  }): Promise<SyncClientResult<T>> {
+    const correlationId = input.correlationId ?? this.#newCorrelationId();
+    const timestamp = this.#now();
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "x-sync-timestamp": String(timestamp),
+      "x-sync-signature": signServiceRequest(this.#secret, timestamp),
+      "x-correlation-id": correlationId,
+    };
+    return this.#send({ ...input, headers, correlationId });
+  }
+
+  async #send<T>(input: {
+    method: "GET" | "POST" | "DELETE";
+    path: string;
+    query?: URLSearchParams;
+    body?: unknown;
+    schema: z.ZodType<T>;
+    correlationId: string;
+    headers: Record<string, string>;
+    timeoutMs?: number;
+  }): Promise<SyncClientResult<T>> {
+    const { correlationId } = input;
     const queryString = input.query?.toString();
     const url =
       queryString !== undefined && queryString.length > 0
@@ -334,7 +408,7 @@ export class SyncServiceClient {
     try {
       response = await this.#fetch(url, {
         method: input.method,
-        headers,
+        headers: input.headers,
         body: input.body === undefined ? undefined : JSON.stringify(input.body),
         signal: controller.signal,
       });

--- a/packages/backend/src/events/controllers/events.controller.ts
+++ b/packages/backend/src/events/controllers/events.controller.ts
@@ -1,7 +1,6 @@
 import { type Request, type Response } from "express";
 import { Logger } from "@core/logger/winston.logger";
 import { sseServer } from "@backend/servers/sse/sse.server";
-import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 
@@ -13,14 +12,12 @@ class EventsController {
 
     try {
       // Subscribe immediately so no events are missed during the metadata fetch.
+      // The Sync change-feed bridge polls independently of any one connection
+      // (a single global poller for the whole process, not one per user) and
+      // fans out to whoever is subscribed, so no per-connection wiring is
+      // needed here beyond the subscription itself.
       const unsubscribe = sseServer.subscribe(userId, res);
-      // When Sync is configured, poll its invalidation outbox for this user and
-      // publish typed browser SSE. No-op when Sync is not wired (legacy-only).
-      syncChangeFeedBridge.onSubscribe(userId);
-      req.on("close", () => {
-        unsubscribe();
-        syncChangeFeedBridge.onUnsubscribe(userId);
-      });
+      req.on("close", unsubscribe);
 
       // Replay current state after subscribing — client is never stuck on reconnect.
       const metadata = await userMetadataService.fetchUserMetadata(userId);

--- a/packages/backend/src/servers/sse/sse.server.ts
+++ b/packages/backend/src/servers/sse/sse.server.ts
@@ -54,10 +54,18 @@ class SSEServer {
     };
   }
 
-  // Active SSE connections for a user. The Sync change-feed bridge uses this
-  // to stop polling when the last tab closes.
+  // Active SSE connections for a user.
   subscriberCount(userId: string): number {
     return this.connections.get(userId)?.size ?? 0;
+  }
+
+  // Every currently-connected user id. The Sync change-feed bridge's single
+  // global poller uses this to broad-invalidate everyone on a
+  // resyncRequired: with one shared cursor for the whole process, a stale
+  // cursor means any currently-subscribed user may have missed something,
+  // not just one.
+  connectedUserIds(): string[] {
+    return [...this.connections.keys()];
   }
 
   publish(userId: string, message: ServerMessage): void {

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.test.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.test.ts
@@ -1,0 +1,273 @@
+import { faker } from "@faker-js/faker";
+import { type CalendarId, type EventId } from "@core/types/domain-primitives";
+import { type ServerMessage } from "@core/types/server-message.contracts";
+import {
+  SyncChangeFeedBridge,
+  type SyncChangeFeedBridgeDeps,
+} from "@backend/servers/sse/sync-change-feed.bridge";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+// Captures every scheduled tick without real timers; a test fires the next
+// one explicitly, so ticks run deterministically and instantly.
+class FakeScheduler {
+  pending: Array<{ delayMs: number; tick: () => void }> = [];
+
+  schedule = (tick: () => void, delayMs: number): { clear: () => void } => {
+    const entry = { delayMs, tick };
+    this.pending.push(entry);
+    return {
+      clear: () => {
+        this.pending = this.pending.filter((e) => e !== entry);
+      },
+    };
+  };
+
+  // Run the next scheduled tick (and await any promise it kicks off).
+  async fireNext(): Promise<void> {
+    const entry = this.pending.shift();
+    if (!entry) throw new Error("no tick scheduled");
+    entry.tick();
+    // Let the async #tick body run to its next await point and back.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
+
+class FakeClient {
+  calls: Array<string | null> = [];
+  #responses: Array<Awaited<ReturnType<FakeClient["getGlobalChanges"]>>>;
+
+  constructor(
+    responses: Array<Awaited<ReturnType<FakeClient["getGlobalChanges"]>>>,
+  ) {
+    this.#responses = responses;
+  }
+
+  getGlobalChanges = async (
+    cursor: string | null,
+  ): ReturnType<SyncChangeFeedBridgeDeps["client"]["getGlobalChanges"]> => {
+    this.calls.push(cursor);
+    const next = this.#responses.shift();
+    if (!next) throw new Error("no response queued");
+    return next as never;
+  };
+}
+
+class FakeSse {
+  published: Array<{ userId: string; message: ServerMessage }> = [];
+  #connected: string[];
+
+  constructor(connected: string[] = []) {
+    this.#connected = connected;
+  }
+
+  connectedUserIds = (): string[] => this.#connected;
+  publish = (userId: string, message: ServerMessage): void => {
+    this.published.push({ userId, message });
+  };
+  publishCalendarsChanged = (
+    userId: string,
+    calendarIds: CalendarId[],
+  ): void => {
+    this.published.push({
+      userId,
+      message: { type: "calendarsChanged", calendarIds },
+    });
+  };
+  publishEventsChanged = (
+    userId: string,
+    payload: {
+      calendarId: CalendarId;
+      eventIds: EventId[];
+      reason: "created" | "updated" | "deleted" | "reconciled";
+    },
+  ): void => {
+    this.published.push({
+      userId,
+      message: { type: "eventsChanged", ...payload },
+    });
+  };
+}
+
+describe("SyncChangeFeedBridge", () => {
+  it("fans an invalidation out to the envelope's own principal, not a fixed one", async () => {
+    const userA = objectId();
+    const userB = objectId();
+    const scheduler = new FakeScheduler();
+    const client = new FakeClient([
+      {
+        ok: true,
+        correlationId: "c1",
+        value: {
+          kind: "ok",
+          invalidations: [
+            {
+              invalidation: { kind: "connection", connectionId: objectId() },
+              emittedAt: "2026-07-30T00:00:00.000Z",
+              tenantId: userA,
+              principalId: userA,
+            },
+            {
+              invalidation: {
+                kind: "event",
+                eventId: objectId(),
+                calendarId: objectId(),
+              },
+              emittedAt: "2026-07-30T00:00:01.000Z",
+              tenantId: userB,
+              principalId: userB,
+            },
+          ],
+          nextCursor: objectId(),
+        },
+      },
+    ]);
+    const sse = new FakeSse();
+    const bridge = new SyncChangeFeedBridge(
+      { client, sse: sse as never },
+      { schedule: scheduler.schedule },
+    );
+
+    bridge.start();
+    await scheduler.fireNext();
+    bridge.stop();
+
+    expect(client.calls).toEqual([null]);
+    // A "connection" invalidation translates to 2 messages (calendarsChanged
+    // + eventsChanged), an "event" invalidation to 1 — see
+    // sync-invalidation.to-server-message.ts. Each set must land on its OWN
+    // envelope's principal, not the other's — the whole point of carrying
+    // principalId on the wire for the global feed.
+    const forA = sse.published.filter((p) => p.userId === userA);
+    const forB = sse.published.filter((p) => p.userId === userB);
+    expect(forA.map((p) => p.message.type).sort()).toEqual([
+      "calendarsChanged",
+      "eventsChanged",
+    ]);
+    expect(forB.map((p) => p.message.type)).toEqual(["eventsChanged"]);
+    expect(forA.length + forB.length).toBe(sse.published.length);
+  });
+
+  it("carries the cursor forward across ticks", async () => {
+    const cursor1 = objectId();
+    const cursor2 = objectId();
+    const scheduler = new FakeScheduler();
+    const client = new FakeClient([
+      {
+        ok: true,
+        correlationId: "c1",
+        value: { kind: "ok", invalidations: [], nextCursor: cursor1 },
+      },
+      {
+        ok: true,
+        correlationId: "c2",
+        value: { kind: "ok", invalidations: [], nextCursor: cursor2 },
+      },
+    ]);
+    const bridge = new SyncChangeFeedBridge(
+      { client, sse: new FakeSse() as never },
+      { schedule: scheduler.schedule },
+    );
+
+    bridge.start();
+    await scheduler.fireNext();
+    await scheduler.fireNext();
+    bridge.stop();
+
+    expect(client.calls).toEqual([null, cursor1]);
+  });
+
+  it("broad-invalidates every currently-connected user on resyncRequired and resets the cursor", async () => {
+    const userA = objectId();
+    const userB = objectId();
+    const scheduler = new FakeScheduler();
+    const client = new FakeClient([
+      {
+        ok: true,
+        correlationId: "c1",
+        value: { kind: "ok", invalidations: [], nextCursor: objectId() },
+      },
+      { ok: true, correlationId: "c2", value: { kind: "resyncRequired" } },
+      {
+        ok: true,
+        correlationId: "c3",
+        value: { kind: "ok", invalidations: [], nextCursor: objectId() },
+      },
+    ]);
+    const sse = new FakeSse([userA, userB]);
+    const bridge = new SyncChangeFeedBridge(
+      { client, sse: sse as never },
+      { schedule: scheduler.schedule },
+    );
+
+    bridge.start();
+    await scheduler.fireNext(); // establishes a cursor
+    await scheduler.fireNext(); // resyncRequired
+    await scheduler.fireNext(); // next tick resumes from null again
+    bridge.stop();
+
+    expect(client.calls).toEqual([null, client.calls[1], null]);
+    const eventsChangedRecipients = sse.published
+      .filter((p) => p.message.type === "eventsChanged")
+      .map((p) => p.userId);
+    expect(eventsChangedRecipients.sort()).toEqual([userA, userB].sort());
+  });
+
+  it("backs off on a poll failure without publishing anything", async () => {
+    const scheduler = new FakeScheduler();
+    const client = new FakeClient([
+      {
+        ok: false,
+        error: { kind: "unavailable", correlationId: "c1" },
+      },
+    ]);
+    const sse = new FakeSse();
+    const bridge = new SyncChangeFeedBridge(
+      { client, sse: sse as never },
+      { schedule: scheduler.schedule, errorBackoffMs: 9999 },
+    );
+
+    bridge.start();
+    await scheduler.fireNext();
+    bridge.stop();
+
+    expect(sse.published).toEqual([]);
+    expect(scheduler.pending).toEqual([]); // stop() cleared the backoff timer
+  });
+
+  it("start() is idempotent — a second call does not schedule a duplicate poll", async () => {
+    const scheduler = new FakeScheduler();
+    const client = new FakeClient([
+      {
+        ok: true,
+        correlationId: "c1",
+        value: { kind: "ok", invalidations: [], nextCursor: objectId() },
+      },
+    ]);
+    const bridge = new SyncChangeFeedBridge(
+      { client, sse: new FakeSse() as never },
+      { schedule: scheduler.schedule },
+    );
+
+    bridge.start();
+    bridge.start();
+    expect(scheduler.pending).toHaveLength(1);
+    bridge.stop();
+  });
+
+  it("stop() clears the pending tick before it ever runs", () => {
+    const scheduler = new FakeScheduler();
+    const client = new FakeClient([]);
+    const bridge = new SyncChangeFeedBridge(
+      { client, sse: new FakeSse() as never },
+      { schedule: scheduler.schedule },
+    );
+
+    bridge.start();
+    expect(scheduler.pending).toHaveLength(1);
+    bridge.stop();
+    expect(scheduler.pending).toEqual([]);
+  });
+});

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
@@ -1,6 +1,6 @@
 import { Logger } from "@core/logger/winston.logger";
 import { type ChangeFeedCursor } from "@core/types/sync/change-feed.contracts";
-import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import { sseServer } from "@backend/servers/sse/sse.server";
 import {
@@ -13,95 +13,142 @@ const logger = Logger("app:sse.sync-change-feed");
 const POLL_INTERVAL_MS = 2000;
 const ERROR_BACKOFF_MS = 5000;
 
-interface Poller {
-  stop: () => void;
+export interface SyncChangeFeedBridgeDeps {
+  client: Pick<SyncServiceClient, "getGlobalChanges">;
+  sse: Pick<
+    typeof sseServer,
+    | "connectedUserIds"
+    | "publish"
+    | "publishCalendarsChanged"
+    | "publishEventsChanged"
+  >;
 }
 
-// While a user has at least one SSE connection, poll GET /internal/changes
-// and publish typed browser SSE. Cursor is in-memory per user for the life of
-// the connection set; reconnect starts from now.
-class SyncChangeFeedBridge {
-  readonly #pollers = new Map<string, Poller>();
+export interface SyncChangeFeedBridgeOptions {
+  pollIntervalMs?: number;
+  errorBackoffMs?: number;
+  // Injectable timer so tests can drive ticks deterministically.
+  schedule?: (tick: () => void, delayMs: number) => { clear: () => void };
+}
 
-  onSubscribe(userId: string): void {
-    if (this.#pollers.has(userId)) return;
-    this.#pollers.set(userId, this.#start(userId));
+// Polls Sync's single, global (cross-tenant) change feed with ONE shared
+// cursor for the life of the process, and fans invalidations out to whichever
+// SSE subscribers happen to be locally connected — publish() no-ops for a
+// user with none, so nothing here needs to know who is connected before it
+// fetches.
+//
+// This replaces one poller per connected user: O(backend replicas) HTTP
+// chatter to Sync instead of O(connected users), and the cursor now survives
+// a user's SSE reconnect churn — previously a per-user cursor reset to "now"
+// every time that user's last tab closed, silently skipping whatever
+// happened in the gap (masked only by the client's initial refetch).
+export class SyncChangeFeedBridge {
+  readonly #client: SyncChangeFeedBridgeDeps["client"];
+  readonly #sse: SyncChangeFeedBridgeDeps["sse"];
+  readonly #pollIntervalMs: number;
+  readonly #errorBackoffMs: number;
+  readonly #schedule: (
+    tick: () => void,
+    delayMs: number,
+  ) => { clear: () => void };
+
+  #cursor: ChangeFeedCursor | null = null;
+  #stopped = true;
+  #timer: { clear: () => void } | null = null;
+
+  constructor(
+    deps: SyncChangeFeedBridgeDeps,
+    options: SyncChangeFeedBridgeOptions = {},
+  ) {
+    this.#client = deps.client;
+    this.#sse = deps.sse;
+    this.#pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+    this.#errorBackoffMs = options.errorBackoffMs ?? ERROR_BACKOFF_MS;
+    this.#schedule = options.schedule ?? defaultSchedule;
   }
 
-  onUnsubscribe(userId: string): void {
-    if (sseServer.subscriberCount(userId) > 0) return;
-    const poller = this.#pollers.get(userId);
-    if (!poller) return;
-    poller.stop();
-    this.#pollers.delete(userId);
+  // Begin polling. Idempotent: a second call while running is a no-op.
+  start(): void {
+    if (!this.#stopped) return;
+    this.#stopped = false;
+    this.#scheduleNext(0);
   }
 
-  #start(userId: string): Poller {
-    let stopped = false;
-    let cursor: ChangeFeedCursor | null = null;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+  // Stop polling. Idempotent and safe to call when never started.
+  stop(): void {
+    this.#stopped = true;
+    this.#timer?.clear();
+    this.#timer = null;
+  }
 
-    const schedule = (delayMs: number) => {
-      if (stopped) return;
-      timer = setTimeout(() => {
-        void tick();
-      }, delayMs);
-      timer.unref?.();
-    };
+  #scheduleNext(delayMs: number): void {
+    if (this.#stopped) return;
+    this.#timer = this.#schedule(() => void this.#tick(), delayMs);
+  }
 
-    const tick = async () => {
-      if (stopped) return;
-      const client = getSyncServiceClient();
-      const result = await client.getChanges(toSyncPrincipal(userId), cursor);
-      if (stopped) return;
+  async #tick(): Promise<void> {
+    if (this.#stopped) return;
+    const result = await this.#client.getGlobalChanges(this.#cursor);
+    if (this.#stopped) return;
 
-      if (!result.ok) {
-        logger.warn(
-          `Sync change-feed poll failed for user ${userId}: ${result.error.kind}`,
-        );
-        schedule(ERROR_BACKOFF_MS);
-        return;
-      }
+    if (!result.ok) {
+      logger.warn(`Sync global change-feed poll failed: ${result.error.kind}`);
+      this.#scheduleNext(this.#errorBackoffMs);
+      return;
+    }
 
-      const page = result.value;
-      if (page.kind === "resyncRequired") {
-        // Broad invalidate; client refetches canonical state. Resume from
-        // now. Events too, not just calendars — a gap wide enough to need a
-        // resync (the cursor fell outside the retention window) means events
-        // may have changed as well, and the client's eventsChanged handler is
-        // the only thing that ever refetches the event queries themselves.
-        sseServer.publishCalendarsChanged(userId, []);
-        sseServer.publishEventsChanged(userId, {
+    const page = result.value;
+    if (page.kind === "resyncRequired") {
+      // The shared cursor fell outside Sync's retention window. There is no
+      // per-user cursor anymore to say who specifically missed something, so
+      // every currently-connected user gets the broad invalidate.
+      for (const userId of this.#sse.connectedUserIds()) {
+        this.#sse.publishCalendarsChanged(userId, []);
+        this.#sse.publishEventsChanged(userId, {
           calendarId: UNKNOWN_CALENDAR_ID,
           eventIds: [],
           reason: "reconciled",
         });
-        cursor = null;
-        schedule(POLL_INTERVAL_MS);
-        return;
       }
+      this.#cursor = null;
+      this.#scheduleNext(this.#pollIntervalMs);
+      return;
+    }
 
-      for (const envelope of page.invalidations) {
-        for (const message of syncInvalidationToServerMessages(
-          envelope.invalidation,
-        )) {
-          sseServer.publish(userId, message);
-        }
+    for (const envelope of page.invalidations) {
+      for (const message of syncInvalidationToServerMessages(
+        envelope.invalidation,
+      )) {
+        this.#sse.publish(envelope.principalId, message);
       }
-      cursor = page.nextCursor;
-      schedule(POLL_INTERVAL_MS);
-    };
-
-    // Prime with a from-now watermark, then poll.
-    schedule(0);
-
-    return {
-      stop: () => {
-        stopped = true;
-        if (timer !== undefined) clearTimeout(timer);
-      },
-    };
+    }
+    this.#cursor = page.nextCursor;
+    this.#scheduleNext(this.#pollIntervalMs);
   }
 }
 
-export const syncChangeFeedBridge = new SyncChangeFeedBridge();
+// Real timer used when the caller injects none. .unref() keeps it from
+// holding the process open in tests or graceful shutdown.
+function defaultSchedule(
+  tick: () => void,
+  delayMs: number,
+): { clear: () => void } {
+  const timer = setTimeout(tick, delayMs);
+  timer.unref?.();
+  return { clear: () => clearTimeout(timer) };
+}
+
+// Constructed but NOT started here: this module is imported for its types by
+// tests that have no interest in a real, live network poller running for the
+// rest of that test process. The real backend process starts it explicitly
+// (see app.ts) — the one place import.meta.main gates production bootstrap
+// from a test importing the same module.
+export const syncChangeFeedBridge = new SyncChangeFeedBridge({
+  // Deferred rather than resolved eagerly: getSyncServiceClient() reads
+  // global CONFIG, and this singleton is constructed at module import time.
+  client: {
+    getGlobalChanges: (cursor, correlationId) =>
+      getSyncServiceClient().getGlobalChanges(cursor, correlationId),
+  },
+  sse: sseServer,
+});

--- a/packages/core/src/types/sync/change-feed.contracts.ts
+++ b/packages/core/src/types/sync/change-feed.contracts.ts
@@ -3,8 +3,10 @@ import { DateTimeSchema, EventIdSchema } from "@core/types/domain-primitives";
 import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
 import {
   ConnectionIdSchema,
+  PrincipalIdSchema,
   ProviderCalendarIdSchema,
   SyncCommandIdSchema,
+  TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
 
 // Resumable internal change-feed contracts for Compass Sync.
@@ -109,8 +111,10 @@ const ChangeFeedOkSchema = z.strictObject({
 });
 
 // Sent when a resume cursor is no longer valid; the caller must invalidate
-// all affected cached queries rather than trust a partial replay.
-const ChangeFeedResyncRequiredSchema = z.strictObject({
+// all affected cached queries rather than trust a partial replay. Exported so
+// the global (cross-tenant) feed's response union below can reuse it verbatim
+// — "the cursor is stale" means the same thing on both feeds.
+export const ChangeFeedResyncRequiredSchema = z.strictObject({
   kind: z.literal("resyncRequired"),
 });
 
@@ -119,3 +123,30 @@ export const ChangeFeedResponseSchema = z.discriminatedUnion("kind", [
   ChangeFeedResyncRequiredSchema,
 ]);
 export type ChangeFeedResponse = z.infer<typeof ChangeFeedResponseSchema>;
+
+// The global feed's envelope carries tenantId/principalId — unlike the
+// per-principal feed above, where scope is implicit from the signed caller —
+// so the one backend poller reading across every tenant can route each
+// invalidation to the right user's SSE subscribers.
+export const GlobalInvalidationEnvelopeSchema =
+  InvalidationEnvelopeSchema.extend({
+    tenantId: TenantIdSchema,
+    principalId: PrincipalIdSchema,
+  });
+export type GlobalInvalidationEnvelope = z.infer<
+  typeof GlobalInvalidationEnvelopeSchema
+>;
+
+const GlobalChangeFeedOkSchema = z.strictObject({
+  kind: z.literal("ok"),
+  invalidations: z.array(GlobalInvalidationEnvelopeSchema).readonly(),
+  nextCursor: ChangeFeedCursorSchema,
+});
+
+export const GlobalChangeFeedResponseSchema = z.discriminatedUnion("kind", [
+  GlobalChangeFeedOkSchema,
+  ChangeFeedResyncRequiredSchema,
+]);
+export type GlobalChangeFeedResponse = z.infer<
+  typeof GlobalChangeFeedResponseSchema
+>;

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,5 +1,8 @@
 import { Logger } from "@core/logger/winston.logger";
-import { createInternalAuthMiddleware } from "@sync/auth/internal-auth";
+import {
+  createInternalAuthMiddleware,
+  createInternalServiceAuthMiddleware,
+} from "@sync/auth/internal-auth";
 import { loadSyncConfig, type SyncConfig } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import {
@@ -78,6 +81,9 @@ export function createSyncService(
   const connectionApi = deps.mongo
     ? {
         authMiddleware: createInternalAuthMiddleware({
+          secret: config.INTERNAL_AUTH_TOKEN,
+        }),
+        serviceAuthMiddleware: createInternalServiceAuthMiddleware({
           secret: config.INTERNAL_AUTH_TOKEN,
         }),
         mongo: deps.mongo,

--- a/packages/sync/src/auth/internal-auth.test.ts
+++ b/packages/sync/src/auth/internal-auth.test.ts
@@ -3,7 +3,9 @@ import {
   DEFAULT_FRESHNESS_MS,
   INTERNAL_AUTH_HEADERS,
   signInternalRequest,
+  signServiceRequest,
   verifyInternalRequest,
+  verifyServiceRequest,
 } from "@sync/auth/internal-auth";
 
 const SECRET = "internal-service-secret";
@@ -146,6 +148,101 @@ describe("verifyInternalRequest", () => {
       secret: SECRET,
       headers,
       now: 1000,
+    });
+    expect(result).toEqual({ ok: false, reason: "invalidSignature" });
+  });
+});
+
+// The narrower scheme for the global (cross-tenant) change-feed poll: no
+// tenant/principal claim, only proof the caller holds the secret.
+describe("verifyServiceRequest", () => {
+  const serviceHeaders = (
+    overrides: { secret?: string; timestamp?: number } = {},
+  ) => {
+    const timestamp = overrides.timestamp ?? 1_000_000;
+    return {
+      [INTERNAL_AUTH_HEADERS.timestamp]: String(timestamp),
+      [INTERNAL_AUTH_HEADERS.signature]: signServiceRequest(
+        overrides.secret ?? SECRET,
+        timestamp,
+      ),
+    };
+  };
+
+  it("accepts a correctly signed, fresh request with no identity headers at all", () => {
+    const headers = serviceHeaders({ timestamp: 1_000_000 });
+    const result = verifyServiceRequest({
+      secret: SECRET,
+      headers,
+      now: 1_000_500,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects a request missing the timestamp or signature header", () => {
+    for (const missing of [
+      INTERNAL_AUTH_HEADERS.timestamp,
+      INTERNAL_AUTH_HEADERS.signature,
+    ]) {
+      const headers = serviceHeaders({ timestamp: 1_000_000 }) as Record<
+        string,
+        string
+      >;
+      delete headers[missing];
+      const result = verifyServiceRequest({
+        secret: SECRET,
+        headers,
+        now: 1_000_000,
+      });
+      expect(result).toEqual({ ok: false, reason: "missing" });
+    }
+  });
+
+  it("rejects a signature made with the wrong secret", () => {
+    const headers = serviceHeaders({
+      secret: "attacker-secret",
+      timestamp: 1000,
+    });
+    const result = verifyServiceRequest({ secret: SECRET, headers, now: 1000 });
+    expect(result).toEqual({ ok: false, reason: "invalidSignature" });
+  });
+
+  it("rejects a replayed request outside the freshness window", () => {
+    const headers = serviceHeaders({ timestamp: 1_000_000 });
+    const result = verifyServiceRequest({
+      secret: SECRET,
+      headers,
+      now: 1_000_000 + DEFAULT_FRESHNESS_MS + 1,
+    });
+    expect(result).toEqual({ ok: false, reason: "stale" });
+  });
+
+  it("rejects a non-numeric timestamp as malformed", () => {
+    const headers = serviceHeaders({ timestamp: 1000 }) as Record<
+      string,
+      string
+    >;
+    headers[INTERNAL_AUTH_HEADERS.timestamp] = "not-a-number";
+    const result = verifyServiceRequest({ secret: SECRET, headers, now: 1000 });
+    expect(result).toEqual({ ok: false, reason: "malformed" });
+  });
+
+  it("never accepts a per-principal-signed request (different HMAC preimage)", () => {
+    // A valid, correctly signed per-principal request must NOT be replayable
+    // against the service scheme — domain separation is the whole point.
+    const timestamp = 1_000_000;
+    const headers = {
+      [INTERNAL_AUTH_HEADERS.timestamp]: String(timestamp),
+      [INTERNAL_AUTH_HEADERS.signature]: signInternalRequest(SECRET, {
+        timestamp,
+        tenantId: objectId(),
+        principalId: objectId(),
+      }),
+    };
+    const result = verifyServiceRequest({
+      secret: SECRET,
+      headers,
+      now: timestamp,
     });
     expect(result).toEqual({ ok: false, reason: "invalidSignature" });
   });

--- a/packages/sync/src/auth/internal-auth.ts
+++ b/packages/sync/src/auth/internal-auth.ts
@@ -161,3 +161,86 @@ export function createInternalAuthMiddleware(deps: {
     next();
   };
 }
+
+// A second, narrower auth scheme for routes that act on behalf of no single
+// tenant/principal — today, only the global (cross-tenant) change-feed poll
+// the backend runs once per process instead of once per connected user.
+// Reuses the same shared secret and the same timestamp/signature headers, but
+// signs a domain-separated payload with no identity claim, so:
+// - a per-principal-signed request can never be replayed here (different HMAC
+//   preimage, see signaturePayload above), and
+// - this route can never assert ownership of any tenant's data by
+//   construction — there is no tenant/principal to derive, only proof the
+//   caller holds the secret.
+function servicePayload(timestamp: number): string {
+  return `service.${timestamp}`;
+}
+
+export function signServiceRequest(secret: string, timestamp: number): string {
+  return createHmac("sha256", secret)
+    .update(servicePayload(timestamp))
+    .digest("hex");
+}
+
+export type VerifyServiceResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: VerifyReason };
+
+export function verifyServiceRequest(input: {
+  readonly secret: string;
+  readonly headers: Record<string, string | string[] | undefined>;
+  readonly now: number;
+  readonly freshnessMs?: number;
+}): VerifyServiceResult {
+  const rawTimestamp = header(input.headers, INTERNAL_AUTH_HEADERS.timestamp);
+  const rawSignature = header(input.headers, INTERNAL_AUTH_HEADERS.signature);
+
+  if (!rawTimestamp || !rawSignature) {
+    return { ok: false, reason: "missing" };
+  }
+
+  const timestamp = Number(rawTimestamp);
+  if (!Number.isFinite(timestamp)) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  const freshnessMs = input.freshnessMs ?? DEFAULT_FRESHNESS_MS;
+  if (Math.abs(input.now - timestamp) > freshnessMs) {
+    return { ok: false, reason: "stale" };
+  }
+
+  const expected = signServiceRequest(input.secret, timestamp);
+  if (!signaturesMatch(expected, rawSignature)) {
+    return { ok: false, reason: "invalidSignature" };
+  }
+
+  return { ok: true };
+}
+
+// Express middleware guarding the global change-feed route. Unlike
+// createInternalAuthMiddleware, success attaches no auth context — there is
+// no principal to scope this request to.
+export function createInternalServiceAuthMiddleware(deps: {
+  secret: string;
+  freshnessMs?: number;
+  now?: () => number;
+}) {
+  const now = deps.now ?? Date.now;
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = verifyServiceRequest({
+      secret: deps.secret,
+      headers: req.headers,
+      now: now(),
+      freshnessMs: deps.freshnessMs,
+    });
+
+    if (!result.ok) {
+      res
+        .status(Status.UNAUTHORIZED)
+        .json({ error: "unauthorized", reason: result.reason });
+      return;
+    }
+
+    next();
+  };
+}

--- a/packages/sync/src/domain/change-feed.service.ts
+++ b/packages/sync/src/domain/change-feed.service.ts
@@ -3,6 +3,8 @@ import {
   type ChangeFeedCursor,
   ChangeFeedCursorSchema,
   type ChangeFeedResponse,
+  type GlobalChangeFeedResponse,
+  type GlobalInvalidationEnvelope,
   type InvalidationEnvelope,
 } from "@core/types/sync/change-feed.contracts";
 import {
@@ -47,12 +49,7 @@ export async function readChangeFeed(
     };
   }
 
-  if (!ObjectId.isValid(cursor) || cursor.length !== 24) {
-    return { kind: "resyncRequired" };
-  }
-
-  const cursorTime = ObjectId.createFromHexString(cursor).getTimestamp();
-  if (at.getTime() - cursorTime.getTime() > INVALIDATION_RETENTION_MS) {
+  if (isStaleOrMalformed(cursor, at)) {
     return { kind: "resyncRequired" };
   }
 
@@ -72,6 +69,59 @@ export async function readChangeFeed(
   const nextCursor = last ? asCursor(last._id) : asCursor(cursor);
 
   return { kind: "ok", invalidations: envelopes, nextCursor };
+}
+
+// Resume the GLOBAL (cross-tenant) content-free invalidation feed — the
+// single multiplexed poll the backend runs once per process instead of once
+// per connected user (S-multiplex). Same resume semantics as readChangeFeed,
+// just unscoped; each envelope carries its own tenantId/principalId so the
+// one caller can route to the right user's SSE subscribers.
+export async function readGlobalChangeFeed(
+  deps: ChangeFeedDeps,
+  cursor: string | null,
+  now: () => Date = () => new Date(),
+): Promise<GlobalChangeFeedResponse> {
+  const at = now();
+
+  if (cursor === null) {
+    const highWater = await deps.invalidations.latestIdGlobal();
+    return {
+      kind: "ok",
+      invalidations: [],
+      nextCursor: asCursor(highWater ?? new ObjectId().toHexString()),
+    };
+  }
+
+  if (isStaleOrMalformed(cursor, at)) {
+    return { kind: "resyncRequired" };
+  }
+
+  const rows = await deps.invalidations.listAfterGlobal(
+    cursor,
+    CHANGE_FEED_PAGE_SIZE,
+  );
+
+  const envelopes: GlobalInvalidationEnvelope[] = rows.map((row) => ({
+    invalidation: row.invalidation,
+    emittedAt: row.emittedAt.toISOString() as InvalidationEnvelope["emittedAt"],
+    tenantId: row.tenantId,
+    principalId: row.principalId,
+  }));
+
+  const last = rows.at(-1);
+  const nextCursor = last ? asCursor(last._id) : asCursor(cursor);
+
+  return { kind: "ok", invalidations: envelopes, nextCursor };
+}
+
+// A resume cursor is unusable either because it is not a well-formed ObjectId
+// (a client bug or tampering) or because it points further back than the
+// outbox's retention window — either way the caller must resync rather than
+// trust what would be a partial replay. Shared by both feeds above.
+function isStaleOrMalformed(cursor: string, at: Date): boolean {
+  if (!ObjectId.isValid(cursor) || cursor.length !== 24) return true;
+  const cursorTime = ObjectId.createFromHexString(cursor).getTimestamp();
+  return at.getTime() - cursorTime.getTime() > INVALIDATION_RETENTION_MS;
 }
 
 function asCursor(id: string): ChangeFeedCursor {

--- a/packages/sync/src/server/change-feed.routes.db.test.ts
+++ b/packages/sync/src/server/change-feed.routes.db.test.ts
@@ -4,9 +4,15 @@ import { NodeEnv } from "@core/constants/core.constants";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
-import { signInternalRequest } from "@sync/auth/internal-auth";
+import {
+  signInternalRequest,
+  signServiceRequest,
+} from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
-import { CHANGES_PATH } from "@sync/server/change-feed.routes";
+import {
+  CHANGES_ALL_PATH,
+  CHANGES_PATH,
+} from "@sync/server/change-feed.routes";
 import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { type AddressInfo } from "node:net";
@@ -42,6 +48,14 @@ const signedHeaders = (
       tenantId,
       principalId,
     }),
+  };
+};
+
+const serviceHeaders = (): Record<string, string> => {
+  const timestamp = Date.now();
+  return {
+    "x-sync-timestamp": String(timestamp),
+    "x-sync-signature": signServiceRequest(SECRET, timestamp),
   };
 };
 
@@ -210,6 +224,129 @@ describe("GET /internal/changes", () => {
   it("rejects an unsigned request", async () => {
     await startService();
     const res = await fetch(`${base}${CHANGES_PATH}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /internal/changes/all (the multiplexed, cross-tenant feed)", () => {
+  let mongo: SyncMongoService;
+  let invalidations: InvalidationRepository;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async (config: SyncConfig = testConfig()) => {
+    service = createSyncService(config, { mongo });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  const getGlobal = (query = "") =>
+    fetch(`${base}${CHANGES_ALL_PATH}${query}`, { headers: serviceHeaders() });
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    invalidations = new InvalidationRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  it("returns an empty page and watermark cursor when resuming from now", async () => {
+    await startService();
+    const res = await getGlobal();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      kind: string;
+      invalidations: unknown[];
+      nextCursor: string;
+    };
+    expect(body.kind).toBe("ok");
+    expect(body.invalidations).toEqual([]);
+    expect(ObjectId.isValid(body.nextCursor)).toBe(true);
+  });
+
+  it("delivers invalidations across DIFFERENT tenants/principals, each tagged with its owner", async () => {
+    await startService();
+    const tenantA = objectId();
+    const principalA = objectId();
+    const tenantB = objectId();
+    const principalB = objectId();
+
+    const boot = (await (await getGlobal()).json()) as { nextCursor: string };
+
+    await invalidations.append({
+      tenantId: tenantA,
+      principalId: principalA,
+      invalidation: { kind: "connection", connectionId: objectId() as never },
+      emittedAt: new Date(),
+    });
+    await invalidations.append({
+      tenantId: tenantB,
+      principalId: principalB,
+      invalidation: {
+        kind: "event",
+        eventId: objectId() as never,
+        calendarId: objectId() as never,
+      },
+      emittedAt: new Date(),
+    });
+
+    const page = (await (
+      await getGlobal(`?cursor=${boot.nextCursor}`)
+    ).json()) as {
+      kind: string;
+      invalidations: Array<{
+        invalidation: { kind: string };
+        tenantId: string;
+        principalId: string;
+      }>;
+    };
+
+    expect(page.kind).toBe("ok");
+    expect(
+      page.invalidations.map((e) => [
+        e.invalidation.kind,
+        e.tenantId,
+        e.principalId,
+      ]),
+    ).toEqual([
+      ["connection", tenantA, principalA],
+      ["event", tenantB, principalB],
+    ]);
+  });
+
+  it("returns resyncRequired for a malformed or expired cursor", async () => {
+    await startService();
+
+    const bad = await getGlobal("?cursor=not-an-object-id");
+    expect(await bad.json()).toEqual({ kind: "resyncRequired" });
+
+    const stale = ObjectId.createFromTime(
+      Math.floor((Date.now() - 8 * 24 * 60 * 60 * 1000) / 1000),
+    ).toHexString();
+    const expired = await getGlobal(`?cursor=${stale}`);
+    expect(await expired.json()).toEqual({ kind: "resyncRequired" });
+  });
+
+  it("serves the feed in passive mode", async () => {
+    await startService(testConfig({ EXECUTION: "passive" }));
+    const res = await getGlobal();
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an unsigned request", async () => {
+    await startService();
+    const res = await fetch(`${base}${CHANGES_ALL_PATH}`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a per-principal-signed request (wrong scheme)", async () => {
+    await startService();
+    const res = await fetch(`${base}${CHANGES_ALL_PATH}`, {
+      headers: signedHeaders(objectId(), objectId()),
+    });
     expect(res.status).toBe(401);
   });
 });

--- a/packages/sync/src/server/change-feed.routes.ts
+++ b/packages/sync/src/server/change-feed.routes.ts
@@ -1,10 +1,19 @@
-import { type Express, type RequestHandler } from "express";
+import {
+  type Express,
+  type Request,
+  type RequestHandler,
+  type Response,
+} from "express";
 import { Status } from "@core/errors/status.codes";
 import {
   ChangeFeedResponseSchema,
   ChangeFeedResumeQuerySchema,
+  GlobalChangeFeedResponseSchema,
 } from "@core/types/sync/change-feed.contracts";
-import { readChangeFeed } from "@sync/domain/change-feed.service";
+import {
+  readChangeFeed,
+  readGlobalChangeFeed,
+} from "@sync/domain/change-feed.service";
 import {
   ensureConnected,
   internalRateLimit,
@@ -15,10 +24,37 @@ import { InvalidationRepository } from "@sync/storage/repositories/invalidation.
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
 export const CHANGES_PATH = "/internal/changes";
+// The global (cross-tenant) variant: one multiplexed poll for the whole
+// backend process instead of one poller per connected user (S-multiplex).
+// Guarded by serviceAuthMiddleware, not authMiddleware — this request acts on
+// behalf of no single tenant/principal.
+export const CHANGES_ALL_PATH = "/internal/changes/all";
 
 export interface ChangeFeedApiDeps {
   authMiddleware: RequestHandler;
+  serviceAuthMiddleware: RequestHandler;
   mongo: SyncMongoService;
+}
+
+// Omit / empty / explicit "null" → resume from now. A repeated query key
+// arrives as an array from Express and is rejected. Returns `undefined` when
+// the request was already responded to (400).
+function parseCursorQuery(
+  req: Request,
+  res: Response,
+): string | null | undefined {
+  const rawCursor = req.query["cursor"];
+  let cursor: string | null = null;
+  if (rawCursor !== undefined) {
+    if (Array.isArray(rawCursor) || typeof rawCursor !== "string") {
+      res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
+      return undefined;
+    }
+    if (rawCursor !== "" && rawCursor !== "null") {
+      cursor = rawCursor;
+    }
+  }
+  return cursor;
 }
 
 // Internal, authenticated change-feed poll. Serves content-free invalidation
@@ -38,24 +74,8 @@ export function registerChangeFeedRoutes(
       if (!auth) return;
       if (!ensureConnected(deps.mongo, res)) return;
 
-      const rawCursor = req.query["cursor"];
-      // Omit / empty / explicit "null" → resume from now. A repeated query key
-      // arrives as an array from Express and is rejected.
-      let cursor: string | null = null;
-      if (rawCursor !== undefined) {
-        if (Array.isArray(rawCursor)) {
-          res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
-          return;
-        }
-        if (typeof rawCursor !== "string") {
-          res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
-          return;
-        }
-        if (rawCursor !== "" && rawCursor !== "null") {
-          cursor = rawCursor;
-        }
-      }
-
+      const cursor = parseCursorQuery(req, res);
+      if (cursor === undefined) return;
       const parsed = ChangeFeedResumeQuerySchema.safeParse({ cursor });
       if (!parsed.success) {
         res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
@@ -70,6 +90,37 @@ export function registerChangeFeedRoutes(
           parsed.data.cursor,
         );
         res.status(Status.OK).json(ChangeFeedResponseSchema.parse(response));
+      } catch {
+        respondInternalError(res);
+      }
+    },
+  );
+
+  // The global (cross-tenant) poll a single backend process runs instead of
+  // one poller per connected user. Read-only, available in passive mode.
+  app.get(
+    CHANGES_ALL_PATH,
+    internalRateLimit,
+    deps.serviceAuthMiddleware,
+    async (req, res) => {
+      if (!ensureConnected(deps.mongo, res)) return;
+
+      const cursor = parseCursorQuery(req, res);
+      if (cursor === undefined) return;
+      const parsed = ChangeFeedResumeQuerySchema.safeParse({ cursor });
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_cursor" });
+        return;
+      }
+
+      try {
+        const response = await readGlobalChangeFeed(
+          { invalidations: new InvalidationRepository(deps.mongo.db) },
+          parsed.data.cursor,
+        );
+        res
+          .status(Status.OK)
+          .json(GlobalChangeFeedResponseSchema.parse(response));
       } catch {
         respondInternalError(res);
       }

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -76,6 +76,10 @@ const DEFAULT_EVENT_PAGE_LIMIT = 500;
 
 export interface ConnectionApiDeps {
   authMiddleware: RequestHandler;
+  // Guards the global (cross-tenant) change-feed poll only — see
+  // change-feed.routes.ts. Carried here because this is the shared deps bag
+  // every internal route slice is wired from.
+  serviceAuthMiddleware: RequestHandler;
   mongo: SyncMongoService;
   // Disconnect and begin make provider calls, so they are gated on execution.
   execution: SyncExecutionMode;

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -44,6 +44,7 @@ export function buildSyncApp(deps: {
     // Resumable invalidation outbox for Compass API → browser SSE (S40).
     registerChangeFeedRoutes(app, {
       authMiddleware: deps.connectionApi.authMiddleware,
+      serviceAuthMiddleware: deps.connectionApi.serviceAuthMiddleware,
       mongo: deps.connectionApi.mongo,
     });
     // Account-deletion hard purge for the signed principal (S43). Served in

--- a/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
@@ -88,4 +88,73 @@ describe("InvalidationRepository", () => {
     expect(ttl?.key).toEqual({ expiresAt: 1 });
     expect(ttl?.expireAfterSeconds).toBe(0);
   });
+
+  describe("global (cross-tenant) scan — backs the multiplexed change-feed poll", () => {
+    it("keyset-lists rows across every tenant/principal after a cursor", async () => {
+      const connectionId = objectId() as ConnectionId;
+      const first = await repo.append({
+        tenantId: objectId(),
+        principalId: objectId(),
+        invalidation: { kind: "connection", connectionId },
+        emittedAt: new Date(),
+      });
+      const second = await repo.append({
+        tenantId: objectId(),
+        principalId: objectId(),
+        invalidation: { kind: "connection", connectionId },
+        emittedAt: new Date(),
+      });
+      const third = await repo.append({
+        tenantId: objectId(),
+        principalId: objectId(),
+        invalidation: { kind: "connection", connectionId },
+        emittedAt: new Date(),
+      });
+
+      const fromStart = await repo.listAfterGlobal(null, 10);
+      expect(fromStart.map((r) => r._id)).toEqual([
+        first._id,
+        second._id,
+        third._id,
+      ]);
+
+      const page = await repo.listAfterGlobal(first._id, 10);
+      expect(page.map((r) => r._id)).toEqual([second._id, third._id]);
+    });
+
+    it("bounds the global page to the given limit", async () => {
+      const connectionId = objectId() as ConnectionId;
+      for (let i = 0; i < 3; i += 1) {
+        await repo.append({
+          tenantId: objectId(),
+          principalId: objectId(),
+          invalidation: { kind: "connection", connectionId },
+          emittedAt: new Date(),
+        });
+      }
+
+      const page = await repo.listAfterGlobal(null, 2);
+      expect(page).toHaveLength(2);
+    });
+
+    it("reports the highest retained id across every tenant/principal, or null when empty", async () => {
+      expect(await repo.latestIdGlobal()).toBeNull();
+
+      const connectionId = objectId() as ConnectionId;
+      await repo.append({
+        tenantId: objectId(),
+        principalId: objectId(),
+        invalidation: { kind: "connection", connectionId },
+        emittedAt: new Date(),
+      });
+      const last = await repo.append({
+        tenantId: objectId(),
+        principalId: objectId(),
+        invalidation: { kind: "connection", connectionId },
+        emittedAt: new Date(),
+      });
+
+      expect(await repo.latestIdGlobal()).toBe(last._id);
+    });
+  });
 });

--- a/packages/sync/src/storage/repositories/invalidation.repository.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.ts
@@ -94,6 +94,37 @@ export class InvalidationRepository {
     return row?._id ?? null;
   }
 
+  // Keyset page strictly after `afterId` across EVERY tenant/principal —
+  // backs the single multiplexed change-feed poll the backend runs instead of
+  // one poller per connected user (S-multiplex). Same semantics as
+  // listAfter, just unscoped; the caller routes each row by its own
+  // tenantId/principalId.
+  async listAfterGlobal(
+    afterId: string | null,
+    limit: number,
+  ): Promise<InvalidationRecord[]> {
+    const filter: Record<string, unknown> = {};
+    if (afterId !== null) {
+      filter["_id"] = { $gt: afterId };
+    }
+    const rows = await this.collection
+      .find(filter)
+      .sort({ _id: 1 })
+      .limit(limit)
+      .toArray();
+    return rows.map((row) => InvalidationRecordSchema.parse(row));
+  }
+
+  // Highest retained outbox id across every tenant/principal, or null when
+  // the outbox is empty. The global feed's "resume from now" watermark.
+  async latestIdGlobal(): Promise<string | null> {
+    const row = await this.collection.findOne(
+      {},
+      { sort: { _id: -1 }, projection: { _id: 1 } },
+    );
+    return row?._id ?? null;
+  }
+
   // Hard-delete every invalidation for a principal (account deletion).
   async deleteByPrincipal(
     tenantId: TenantId,


### PR DESCRIPTION
## Summary
- The backend ran **one 2-second HTTP poll loop per connected user** against Sync's per-principal `GET /internal/changes`, each with its own in-memory cursor tied to that user's SSE subscription lifecycle. That's O(connected users) chatter to Sync, and the cursor reset to "now" on every reconnect (a user's last tab closing then reopening), silently skipping whatever invalidations happened in the gap — masked only by the client's own initial refetch.
- Collapses this to **one multiplexed feed**: Sync gains a global (cross-tenant) change-feed endpoint (`GET /internal/changes/all`) driven by a single cursor over the same `invalidations` outbox (`InvalidationRepository.listAfterGlobal`/`latestIdGlobal`, `readGlobalChangeFeed`). The backend runs exactly one poll loop for the life of the process (`SyncChangeFeedBridge`, rewritten from a per-user `Map` of pollers into a single-instance class), fanning each envelope out to whichever SSE subscribers are locally connected, keyed by the envelope's own `principalId`. The cursor now survives a user's reconnect churn, since it's no longer reset per subscribe/unsubscribe — it's tied to the process, not the connection.
- The global route acts on behalf of no single tenant/principal, so it needed a caller identity that isn't scoped that way. Added a narrower internal-auth scheme (`signServiceRequest`/`verifyServiceRequest`/`createInternalServiceAuthMiddleware`) that proves only that the caller holds the shared secret, signing a domain-separated payload (`service.<timestamp>`) so it can never be confused with, or used to replay, the existing per-principal HMAC (`<timestamp>.<tenantId>.<principalId>`). Every existing per-principal internal route is untouched.
- `events.controller.ts` drops its per-connection `onSubscribe`/`onUnsubscribe` wiring — the bridge no longer needs to know about individual SSE connects/disconnects.
- The bridge singleton is constructed but not auto-started at module import (a test importing it for its types shouldn't spin up a live network poller); it's started explicitly from the backend's own process bootstrap (`app.ts`, under `import.meta.main`) and stopped on graceful shutdown.

## Test plan
- [x] `bun run type-check`
- [x] `TZ=Etc/UTC bun run test:sync` (713 passing — new coverage for `verifyServiceRequest`, the global repository/service/route layers, cross-tenant delivery, and rejecting a per-principal-signed request on the service route)
- [x] Targeted backend suites (`sync-service.client.test.ts`, the new `sync-change-feed.bridge.test.ts`, `events.controller.db.test.ts`) all green in isolation — new unit coverage for cross-principal fan-out, cursor continuity across ticks, resyncRequired broad-invalidating every connected user, error backoff, and start/stop idempotency
- [x] `./node_modules/.bin/biome check .`
- [x] `bun run knip`

Note: this environment's full `bun run test:backend` run has ~26 pre-existing failures (SuperTokens init / SSE E2E timeouts) that reproduce identically on a clean `main` checkout with none of this branch's changes — confirmed via a stash-diff of failing test names before/after. Unrelated to this change; the same suite's CI job passed cleanly on the immediately prior PR (#2491).

🤖 Generated with [Claude Code](https://claude.com/claude-code)