### PR TITLE
fix(sync): resolve custom event-label colors during calendar repair

### DIFF
--- a/packages/sync/src/domain/calendar-repair.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-repair.service.db.test.ts
@@ -103,7 +103,9 @@ describe("repairCalendar", () => {
     custody: tokenSource,
   });
 
-  const seedCalendar = (): Promise<ProviderCalendarRecord> =>
+  const seedCalendar = (
+    eventLabels: ProviderCalendarRecord["eventLabels"] = [],
+  ): Promise<ProviderCalendarRecord> =>
     calendars.upsertByProviderCalendar({
       tenantId: objectId() as ProviderCalendarRecord["tenantId"],
       principalId: objectId() as ProviderCalendarRecord["principalId"],
@@ -111,6 +113,7 @@ describe("repairCalendar", () => {
       providerCalendarId: "primary@google.com",
       displayName: "Google",
       color: null,
+      eventLabels,
       active: true,
       primary: true,
       accessRole: "owner",
@@ -331,6 +334,24 @@ describe("repairCalendar", () => {
         .collection(SYNC_COLLECTIONS.eventOccurrences)
         .countDocuments({ calendarId: calendar._id }),
     ).toBe(1);
+  });
+
+  it("passes the calendar's event-color labels to the reader", async () => {
+    // Repair rebuilds the whole calendar via the same reader port import/pull
+    // use, so a repaired calendar must resolve custom label colors the same
+    // way — this was missing until now, silently dropping colorHex for any
+    // calendar that went through a repair rather than a plain pull.
+    const calendar = await seedCalendar([{ id: "label-1", hex: "#009688" }]);
+    await seedImported(calendar);
+    const reader = new FakeReader([
+      page([single("keep")], { nextSyncToken: "cursor-1" }),
+    ]);
+
+    await repairCalendar(deps(reader), calendar, now);
+
+    expect(reader.calls[0]?.colorLabels).toEqual(
+      new Map([["label-1", "#009688"]]),
+    );
   });
 
   it("stamps the attempt even when the token fetch throws", async () => {

--- a/packages/sync/src/domain/calendar-repair.service.ts
+++ b/packages/sync/src/domain/calendar-repair.service.ts
@@ -1,3 +1,4 @@
+import { toColorLabelMap } from "@sync/domain/color-label-map";
 import { type AccessTokenSource } from "@sync/domain/provider-command.service";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
 import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
@@ -101,6 +102,7 @@ export async function repairCalendar(
     newGeneration,
     now,
   );
+  const colorLabels = toColorLabelMap(calendar.eventLabels);
   let pageToken: string | null = null;
   let cursor: string | null = null;
   do {
@@ -108,6 +110,7 @@ export async function repairCalendar(
       accessToken,
       calendarId: calendar.providerCalendarId,
       pageToken,
+      colorLabels,
     });
     await applier.applyPage(page.events);
     pageToken = page.nextPageToken;


### PR DESCRIPTION
## Summary
Item 3 of the recent post-cutover review asked Sync to read Google's per-calendar custom event-color labels (`eventLabelId` + `labelProperties`), on the premise that the repo read neither and every label-colored event silently rendered in the theme default. That premise was stale by the time the review was written: `PR #2444` (merged 2026-07-28, two days before the review) already built this end-to-end — calendar discovery fetches each calendar's label definitions via `calendars.get`, stores them (`eventLabels`), and both `calendar-import.service.ts` and `calendar-pull.service.ts` resolve them into a `colorHex` on every normalized event, all the way through to the web view-model and grid rendering.

Tracing the three places the reader port is actually called turned up the one real gap: `calendar-repair.service.ts` calls the same `reader.listEventPage()` port as import and pull, but never passed `colorLabels`. A calendar that goes through a repair (an invalid cursor, a post-gap reconciliation) silently lost custom label-color resolution for every event it rebuilt — falling back to the theme default color, exactly the symptom the review described, just narrower in scope and cause than described.

Fix: thread the same `toColorLabelMap(calendar.eventLabels)` already used by import and pull into repair's reader call. No other reader call site was missing it (verified — there are only three total).

## Test plan
- [x] `bun run type-check`
- [x] `TZ=Etc/UTC bun run test:sync` (714 passing, including a new test asserting repair passes the calendar's resolved label colors to the reader, mirroring the existing equivalent test on the pull path)
- [x] `./node_modules/.bin/biome check .`
- [x] `bun run knip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)