### PR TITLE
fix(ci): always configure required Sync on deploy

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -106,14 +106,36 @@ jobs:
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/staging_key
           chmod 600 ~/.ssh/staging_key
           ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
-          # Sync activates only when BOTH its secrets are present. Sync is an
-          # optional passive add-on, so a half-provisioned config must never
-          # block the web/backend deploy — skip it cleanly instead.
-          SYNC_ENABLED=""
-          if [ -n "$SYNC_MONGO_URI" ] && [ -n "$SYNC_INTERNAL_AUTH_TOKEN" ]; then
-            SYNC_ENABLED="1"
-          elif [ -n "$SYNC_MONGO_URI" ] || [ -n "$SYNC_INTERNAL_AUTH_TOKEN" ]; then
-            echo "Note: sync is only partially configured (need both SYNC_MONGO_URI and SYNC_INTERNAL_AUTH_TOKEN); skipping sync." >&2
+          # Sync is required on every deploy: the backend hard-requires
+          # SYNC_SERVICE_URL + SYNC_INTERNAL_AUTH_TOKEN at startup (#2480) and
+          # there is no legacy in-backend engine to fall back to. Fail early
+          # with a clear message rather than writing a compass.yaml the
+          # backend will reject after compose starts.
+          if [ -z "$SYNC_INTERNAL_AUTH_TOKEN" ]; then
+            echo "Deploy requires SYNC_INTERNAL_AUTH_TOKEN." >&2
+            exit 1
+          fi
+          # Cloud uses an isolated Atlas sync DB (SYNC_MONGO_URI secret) with
+          # a scoped user, so least-privilege enforcement stays on. Selfhosted
+          # reuses the bundled mongo's compass_sync database — same derived
+          # URI as install.sh / compass.example.yaml — and turns enforcement
+          # off because the bundled image has no separate sync DB user.
+          SYNC_ENFORCE_LEAST_PRIVILEGE="true"
+          if [ -z "$SYNC_MONGO_URI" ]; then
+            case ",${COMPOSE_PROFILES}," in
+              *,selfhosted,*)
+                if [ -z "$MONGO_PASSWORD" ]; then
+                  echo "Selfhosted sync requires MONGO_PASSWORD to derive sync.mongoUri." >&2
+                  exit 1
+                fi
+                SYNC_MONGO_URI="mongodb://compass:${MONGO_PASSWORD}@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0"
+                SYNC_ENFORCE_LEAST_PRIVILEGE="false"
+                ;;
+              *)
+                echo "Cloud deploy requires SYNC_MONGO_URI." >&2
+                exit 1
+                ;;
+            esac
           fi
           {
             printf '%s\n' \
@@ -159,24 +181,20 @@ jobs:
                 'email:' \
                 "  kitApiSecret: \"${KIT_API_SECRET}\""
             fi
-            # The scoped Atlas user for the isolated sync database must be
-            # denied the API database, so least-privilege enforcement is on.
-            if [ -n "$SYNC_ENABLED" ]; then
-              printf '%s\n' \
-                'sync:' \
-                "  mongoUri: \"${SYNC_MONGO_URI}\"" \
-                "  internalAuthToken: \"${SYNC_INTERNAL_AUTH_TOKEN}\"" \
-                "  callbackBaseUrl: \"${FRONTEND_URL}\"" \
-                '  serviceUrl: "http://sync:3010"' \
-                '  enforceLeastPrivilege: true'
-              # Optional per-environment execution/mutation-mode knobs (GitHub
-              # Environment vars). Empty → schema defaults (enabled / passive).
-              if [ -n "$SYNC_CLOUD_MUTATION_MODE" ]; then
-                printf '%s\n' "  cloudMutationMode: \"${SYNC_CLOUD_MUTATION_MODE}\""
-              fi
-              if [ -n "$SYNC_EXECUTION" ]; then
-                printf '%s\n' "  execution: \"${SYNC_EXECUTION}\""
-              fi
+            printf '%s\n' \
+              'sync:' \
+              "  mongoUri: \"${SYNC_MONGO_URI}\"" \
+              "  internalAuthToken: \"${SYNC_INTERNAL_AUTH_TOKEN}\"" \
+              "  callbackBaseUrl: \"${FRONTEND_URL}\"" \
+              '  serviceUrl: "http://sync:3010"' \
+              "  enforceLeastPrivilege: ${SYNC_ENFORCE_LEAST_PRIVILEGE}"
+            # Optional per-environment execution/mutation-mode knobs (GitHub
+            # Environment vars). Empty → schema defaults (enabled / passive).
+            if [ -n "$SYNC_CLOUD_MUTATION_MODE" ]; then
+              printf '%s\n' "  cloudMutationMode: \"${SYNC_CLOUD_MUTATION_MODE}\""
+            fi
+            if [ -n "$SYNC_EXECUTION" ]; then
+              printf '%s\n' "  execution: \"${SYNC_EXECUTION}\""
             fi
           } | ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" \
                 "umask 077 && mkdir -p ~/compass && cat > ~/compass/compass.yaml && chmod 644 ~/compass/compass.yaml"
@@ -189,15 +207,8 @@ jobs:
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.yaml -o ~/compass/compose.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compose.selfhosted.yaml -o ~/compass/compose.selfhosted.yaml"
           ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "curl -fsSL https://raw.githubusercontent.com/SwitchbackTech/compass/${COMPOSE_GIT_REF}/self-host/compass -o ~/compass/compass && chmod +x ~/compass/compass"
-          # Enable the `sync` profile only when sync is fully configured, so the
-          # container starts exactly where its config was written (never against
-          # a compass.yaml that has no sync section).
-          DEPLOY_PROFILES="$COMPOSE_PROFILES"
-          if [ -n "$SYNC_ENABLED" ]; then
-            DEPLOY_PROFILES="${DEPLOY_PROFILES:+${DEPLOY_PROFILES},}sync"
-          fi
-          if [ -n "$DEPLOY_PROFILES" ]; then
-            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES='${DEPLOY_PROFILES}' ./compass update"
-          else
-            ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && ./compass update"
-          fi
+          # Always enable the sync profile: config is always written above, and
+          # an explicit COMPOSE_PROFILES var (e.g. `selfhosted`) would otherwise
+          # override the helper's default_profiles() and leave sync unstarted.
+          DEPLOY_PROFILES="${COMPOSE_PROFILES:+${COMPOSE_PROFILES},}sync"
+          ssh -i ~/.ssh/staging_key "$SSH_USER@$SSH_HOST" "cd ~/compass && COMPOSE_PROFILES='${DEPLOY_PROFILES}' ./compass update"

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -108,7 +108,7 @@ Secrets and variables are split between repository level (shared across workflow
 | `DOCKERHUB_TOKEN` | Docker Hub personal access token (Read & Write) |
 | `DISCORD_DEPLOY_WEBHOOK_URL` | Discord webhook for deploy health check failure alerts |
 
-**`Staging` environment** — GitHub → Settings → Environments → Staging:
+**Staging environments** (`staging-cloud`, `staging-selfhosted`) — GitHub → Settings → Environments:
 
 | Secret | Value |
 |---|---|
@@ -117,9 +117,13 @@ Secrets and variables are split between repository level (shared across workflow
 | `GCAL_NOTIFICATION_TOKEN` | Google Calendar notification token |
 | `GOOGLE_CLIENT_SECRET` | OAuth client secret |
 | `MONGO_PASSWORD` | MongoDB compass user password |
-| `MONGO_REPLICA_SET_KEY` | MongoDB replica set key |
+| `MONGO_REPLICA_SET_KEY` | MongoDB replica set key (`staging-selfhosted`) |
+| `MONGO_URI` | Backend MongoDB URI |
 | `SUPERTOKENS_KEY` | SuperTokens API key |
-| `SUPERTOKENS_POSTGRES_PASSWORD` | SuperTokens PostgreSQL password |
+| `SUPERTOKENS_POSTGRES_PASSWORD` | SuperTokens PostgreSQL password (`staging-selfhosted`) |
+| `SUPERTOKENS_URI` | SuperTokens connection URI |
+| `SYNC_INTERNAL_AUTH_TOKEN` | Shared secret between backend and Sync (required) |
+| `SYNC_MONGO_URI` | Isolated Sync MongoDB URI (`staging-cloud` / production; selfhosted derives this from `MONGO_PASSWORD`) |
 
 | Variable | Value |
 |---|---|
@@ -128,6 +132,7 @@ Secrets and variables are split between repository level (shared across workflow
 | `BACKEND_API_URL` | Staging backend API URL |
 | `FRONTEND_URL` | Staging frontend URL |
 | `GOOGLE_CLIENT_ID` | OAuth client ID |
+| `COMPOSE_PROFILES` | Compose profiles (`selfhosted` on `staging-selfhosted`; sync is always appended by the deploy) |
 
 ---
 

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -436,11 +436,23 @@ describe("self-host helper", () => {
 });
 
 describe("staging deploy workflow", () => {
-  it("lets the self-host helper default compose profiles when none are set", () => {
+  it("always passes COMPOSE_PROFILES including sync to compass update", () => {
     const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
 
-    expect(workflow).toContain('if [ -n "$DEPLOY_PROFILES" ]; then');
-    expect(workflow).toContain("cd ~/compass && ./compass update");
+    // Sync is required, so the deploy never falls back to an unscoped
+    // `./compass update` that could omit the sync profile when an explicit
+    // COMPOSE_PROFILES var (e.g. `selfhosted`) is set.
+    expect(workflow).toContain(
+      'DEPLOY_PROFILES="$'.concat(
+        "{COMPOSE_PROFILES:+$",
+        '{COMPOSE_PROFILES},}sync"',
+      ),
+    );
+    expect(workflow).toContain(
+      "cd ~/compass && COMPOSE_PROFILES='$" +
+        "{DEPLOY_PROFILES}' ./compass update",
+    );
+    expect(workflow).not.toContain('if [ -n "$DEPLOY_PROFILES" ]; then');
   });
 
   it("falls back to the release tag when a configured compose ref is unavailable", () => {
@@ -495,7 +507,7 @@ describe("staging deploy workflow", () => {
     expect(dockerfile).toContain("'posthog:'");
   });
 
-  it("configures sync and enables its profile only when both secrets are set", () => {
+  it("always configures sync and fails early when required secrets are missing", () => {
     const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
 
     expect(workflow).toContain(
@@ -506,30 +518,35 @@ describe("staging deploy workflow", () => {
         "{{ secrets.SYNC_INTERNAL_AUTH_TOKEN }}",
       ),
     );
-    // Both secrets gate a single SYNC_ENABLED flag; a half-provisioned config
-    // must never abort the deploy, so there is no `exit` in the sync path.
+    // Sync is required (#2480): missing auth token aborts before compose starts.
+    expect(workflow).toContain('if [ -z "$SYNC_INTERNAL_AUTH_TOKEN" ]; then');
+    expect(workflow).toContain("Deploy requires SYNC_INTERNAL_AUTH_TOKEN");
+    // Cloud still needs an isolated SYNC_MONGO_URI; selfhosted derives one
+    // from the bundled mongo, matching install.sh / compass.example.yaml.
+    expect(workflow).toContain("Cloud deploy requires SYNC_MONGO_URI");
     expect(workflow).toContain(
-      'if [ -n "$SYNC_MONGO_URI" ] && [ -n "$SYNC_INTERNAL_AUTH_TOKEN" ]; then',
+      "mongodb://compass:$".concat(
+        "{MONGO_PASSWORD}@mongo:27017/compass_sync?authSource=admin&replicaSet=rs0",
+      ),
     );
-    expect(workflow).toContain('SYNC_ENABLED="1"');
-    expect(workflow).not.toContain(
-      "Sync deploy requires SYNC_INTERNAL_AUTH_TOKEN",
-    );
-    // Both the config section and the profile gate on the same flag, so the
-    // container never starts against a compass.yaml with no sync section.
-    expect(workflow).toContain('if [ -n "$SYNC_ENABLED" ]; then');
+    expect(workflow).toContain('SYNC_ENFORCE_LEAST_PRIVILEGE="false"');
+    // Sync config + profile are unconditional — never skip and leave the
+    // backend without SYNC_SERVICE_URL / SYNC_INTERNAL_AUTH_TOKEN.
+    expect(workflow).not.toContain("SYNC_ENABLED=");
+    expect(workflow).not.toContain("skipping sync");
     expect(workflow).toContain("'sync:'");
     expect(workflow).toContain('mongoUri: \\"$'.concat('{SYNC_MONGO_URI}\\"'));
-    expect(workflow).toContain("enforceLeastPrivilege: true");
-    // Backend reaches sync on the compose network.
+    expect(workflow).toContain(
+      "enforceLeastPrivilege: $".concat("{SYNC_ENFORCE_LEAST_PRIVILEGE}"),
+    );
     expect(workflow).toContain('serviceUrl: "http://sync:3010"');
     expect(workflow).toContain(
       "SYNC_EXECUTION: $".concat("{{ vars.SYNC_EXECUTION }}"),
     );
     expect(workflow).toContain(
       'DEPLOY_PROFILES="$'.concat(
-        "{DEPLOY_PROFILES:+$",
-        '{DEPLOY_PROFILES},}sync"',
+        "{COMPOSE_PROFILES:+$",
+        '{COMPOSE_PROFILES},}sync"',
       ),
     );
   });


### PR DESCRIPTION
## Summary

Staging-selfhosted deploy on main failed after #2480: the backend hard-requires `SYNC_SERVICE_URL` + `SYNC_INTERNAL_AUTH_TOKEN`, but `_deploy-environment.yml` still treated Sync as optional and skipped writing the `sync:` section when secrets were missing. Backend then exited during compose startup.

Deploy now always writes Sync config, fails early if `SYNC_INTERNAL_AUTH_TOKEN` is absent, derives `sync.mongoUri` from the bundled mongo on selfhosted (same as `install.sh`), and always enables the `sync` compose profile. The missing `SYNC_INTERNAL_AUTH_TOKEN` secret was also provisioned on the `staging-selfhosted` GitHub Environment.

## Simplicity

No separate simplify commit. The change replaces the optional `SYNC_ENABLED` gate with straight-line required-config validation and one selfhosted URI derivation path matching `install.sh`.

## Automated validation

- `bun test self-host/docker-compose.test.ts` — 41 pass
- `bun run lint` — pass
- Confirmed `staging-selfhosted` previously lacked `SYNC_INTERNAL_AUTH_TOKEN` / `SYNC_MONGO_URI`; `staging-cloud` and `production` already have both
- Independent read-only review of `main...HEAD` — no confirmed findings

## Independent review

Fresh diff-first review against `main`: no confirmed findings.

## Test plan

- `bun test self-host/docker-compose.test.ts`
- `bun run lint`
- After merge: watch release-on-main through staging-selfhosted deploy + health check