### PR TITLE
perf(web): fix broken week-view card memoization chain

### DIFF
--- a/packages/web/src/calendars/calendar.query.ts
+++ b/packages/web/src/calendars/calendar.query.ts
@@ -1,5 +1,4 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
-import { useCallback } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { CalendarApi } from "@web/api/calendar.api";
 import { useSession } from "@web/auth/compass/session/useSession";
@@ -35,16 +34,48 @@ export function calendarsQueryOptions(authenticated: boolean) {
   });
 }
 
+// ~20 call sites read this query. TanStack Query mounts a separate observer
+// per useQuery() call site even when they share a queryKey, so a
+// useCallback-per-consumer `select` (its previous form) both allocates a new
+// function every render AND still runs applyClientVisibility's map+spread
+// once per consumer, since each observer only caches against its own last
+// select result. Cache the RESULT here, keyed on the (hiddenIds, data)
+// reference pair - both are stable across renders until the underlying
+// store/query data actually changes (see useHiddenCalendarIds and this
+// query's staleTime) - so every consumer on the same versions gets back the
+// exact same output array. That's also what lets
+// filter-events-by-visible-calendars.ts's WeakMap dedupe downstream instead
+// of re-filtering per consumer.
+const visibilityResultCache = new WeakMap<
+  ReadonlySet<string>,
+  WeakMap<Calendar[], Calendar[]>
+>();
+
+function selectVisibleCalendars(
+  calendars: Calendar[],
+  hiddenIds: ReadonlySet<string>,
+): Calendar[] {
+  let byData = visibilityResultCache.get(hiddenIds);
+  if (!byData) {
+    byData = new WeakMap();
+    visibilityResultCache.set(hiddenIds, byData);
+  }
+
+  let result = byData.get(calendars);
+  if (!result) {
+    result = applyClientVisibility(calendars, hiddenIds);
+    byData.set(calendars, result);
+  }
+  return result;
+}
+
 export function useCalendarsQuery() {
   const { authenticated } = useSession();
   const hiddenIds = useHiddenCalendarIds();
-  // A fresh arrow function every render would recompute select's full
-  // map+spread over every calendar on every render, not just when hiddenIds
-  // (or the underlying data) actually changes.
-  const select = useCallback(
-    (calendars: Calendar[]) => applyClientVisibility(calendars, hiddenIds),
-    [hiddenIds],
-  );
 
-  return useQuery({ ...calendarsQueryOptions(authenticated), select });
+  return useQuery({
+    ...calendarsQueryOptions(authenticated),
+    select: (calendars: Calendar[]) =>
+      selectVisibleCalendars(calendars, hiddenIds),
+  });
 }

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
@@ -19,6 +18,30 @@ export function buildCalendarLookup(
   return new Map(calendars.map((calendar) => [calendar.id, calendar]));
 }
 
+// Keyed on the calendars-query data reference, shared across every
+// useCalendarLookup() call site rather than a per-component useMemo: with
+// useCalendarsQuery's result now cached per (hiddenIds, data) (see
+// calendar.query.ts), every consumer in a render tree gets back the same
+// `data` reference, so a per-component useMemo would still rebuild the same
+// map once per consumer instead of once total.
+const lookupCache = new WeakMap<
+  Calendar[],
+  ReadonlyMap<CalendarId, Calendar>
+>();
+
+function getCalendarLookup(
+  data: Calendar[] | undefined,
+): ReadonlyMap<CalendarId, Calendar> {
+  if (!data) return EMPTY_CALENDAR_LOOKUP;
+
+  let lookup = lookupCache.get(data);
+  if (!lookup) {
+    lookup = buildCalendarLookup(data);
+    lookupCache.set(data, lookup);
+  }
+  return lookup;
+}
+
 /**
  * Memoized id -> Calendar lookup, built once per calendars-query data
  * reference rather than rescanned per event/card render.
@@ -29,7 +52,7 @@ export function buildCalendarLookup(
 export function useCalendarLookup(): ReadonlyMap<CalendarId, Calendar> {
   const { data } = useCalendarsQuery();
 
-  return useMemo(() => buildCalendarLookup(data), [data]);
+  return getCalendarLookup(data);
 }
 
 export type CalendarCardIdentity = {

--- a/packages/web/src/grid/hooks/useGridMeasurements.ts
+++ b/packages/web/src/grid/hooks/useGridMeasurements.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 import {
   type GridMeasurement,
@@ -161,30 +161,42 @@ export const useGridMeasurements = ({
     timedColumnsRef.current = node;
   }, []);
 
-  const colWidths = allDayColumnsMeasurements?.width
-    ? Array(safeVisibleDateCount).fill(
-        allDayColumnsMeasurements.width / safeVisibleDateCount,
-      )
-    : [];
+  const colWidths = useMemo(
+    () =>
+      allDayColumnsMeasurements?.width
+        ? Array(safeVisibleDateCount).fill(
+            allDayColumnsMeasurements.width / safeVisibleDateCount,
+          )
+        : [],
+    [allDayColumnsMeasurements?.width, safeVisibleDateCount],
+  );
 
-  const gridRefs: GridRefs = {
-    allDayRef,
-    allDayColumnsRef,
-    allDayRowRef,
-    mainGridElementRef,
-    mainGridRef,
-    timedColumnsElementRef,
-    timedColumnsRef,
-  };
+  const gridRefs: GridRefs = useMemo(
+    () => ({
+      allDayRef,
+      allDayColumnsRef,
+      allDayRowRef,
+      mainGridElementRef,
+      mainGridRef,
+      timedColumnsElementRef,
+      timedColumnsRef,
+    }),
+    // allDayColumnsRef/mainGridRef/timedColumnsRef are refs - stable identity,
+    // no need to depend on them.
+    [allDayRef, allDayRowRef, mainGridElementRef, timedColumnsElementRef],
+  );
 
-  const measurements: GridMeasurements = {
-    allDayRow: allDayMeasurements,
-    colWidths,
-    hourHeight: mainMeasurements?.height
-      ? mainMeasurements.height / TIMED_VISIBLE_HOURS
-      : 0,
-    mainGrid: mainMeasurements,
-  };
+  const measurements: GridMeasurements = useMemo(
+    () => ({
+      allDayRow: allDayMeasurements,
+      colWidths,
+      hourHeight: mainMeasurements?.height
+        ? mainMeasurements.height / TIMED_VISIBLE_HOURS
+        : 0,
+      mainGrid: mainMeasurements,
+    }),
+    [allDayMeasurements, colWidths, mainMeasurements],
+  );
 
   return {
     gridRefs,

--- a/packages/web/src/views/Week/components/Draft/context/DraftProvider.tsx
+++ b/packages/web/src/views/Week/components/Draft/context/DraftProvider.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useMemo } from "react";
 import { type DateCalcs } from "@web/views/Week/hooks/grid/useDateCalcs";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 import { useDraftActions } from "../hooks/actions/useDraftActions";
@@ -17,10 +18,9 @@ export const DraftProvider = ({
 }: DraftProviderProps) => {
   const { state, setters } = useDraftState();
   const actions = useDraftActions(state, setters, dateCalcs, weekProps);
+  const value = useMemo(() => ({ state, actions }), [state, actions]);
 
   return (
-    <DraftContext.Provider value={{ state, actions }}>
-      {children}
-    </DraftContext.Provider>
+    <DraftContext.Provider value={value}>{children}</DraftContext.Provider>
   );
 };

--- a/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/state/useDraftState.ts
@@ -105,18 +105,32 @@ export const useDraftState = () => {
 
   const draft = useDraftStore(selectGridDraft);
 
-  const state: State_Draft_Local = {
-    draft,
-    dragOffset,
-    dragStatus,
-    gestureOriginDraft,
-    isDragging,
-    isFormOpen,
-    isResizing,
-    resizeStatus,
-    dateBeingChanged,
-    isFormOpenBeforeDragging,
-  };
+  const state: State_Draft_Local = useMemo(
+    () => ({
+      draft,
+      dragOffset,
+      dragStatus,
+      gestureOriginDraft,
+      isDragging,
+      isFormOpen,
+      isResizing,
+      resizeStatus,
+      dateBeingChanged,
+      isFormOpenBeforeDragging,
+    }),
+    [
+      draft,
+      dragOffset,
+      dragStatus,
+      gestureOriginDraft,
+      isDragging,
+      isFormOpen,
+      isResizing,
+      resizeStatus,
+      dateBeingChanged,
+      isFormOpenBeforeDragging,
+    ],
+  );
 
   // Stable identity so discard/effects can depend on `setters` without
   // re-running every render. useState setters are stable; setIsFormOpen is

--- a/packages/web/src/views/Week/hooks/useToday.ts
+++ b/packages/web/src/views/Week/hooks/useToday.ts
@@ -1,7 +1,28 @@
-import dayjs from "@core/util/date/dayjs";
+import { useEffect, useState } from "react";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 
+const CHECK_INTERVAL_MS = 60_000;
+
+// A fresh dayjs() every render permanently invalidates every memo/comparator
+// downstream that takes `today` as a dependency (weekProps, grid layout,
+// etc.), since it never equals the previous render's instance even though
+// the calendar day hasn't changed. Keep the same reference across renders
+// within a day; only swap it (checked once a minute) when the day rolls
+// over.
 export const useToday = () => {
-  const today = dayjs();
+  const [today, setToday] = useState<Dayjs>(() => dayjs());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setToday((current) => {
+        const next = dayjs();
+        return current.isSame(next, "day") ? current : next;
+      });
+    }, CHECK_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, []);
+
   const todayIndex = today.get("day");
 
   return { today, todayIndex };

--- a/packages/web/src/views/Week/hooks/useWeek.ts
+++ b/packages/web/src/views/Week/hooks/useWeek.ts
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ROOT_ROUTES, ROUTE_IDS } from "@web/common/constants/routes";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
@@ -37,11 +37,14 @@ export const useWeek = (
     () => dayjs(anchorDateString, DATE_FORMAT),
     [anchorDateString],
   );
-  const setAnchor = (date: Dayjs) =>
-    navigate({
-      to: ROOT_ROUTES.WEEK_DATE,
-      params: { dateString: date.format(DATE_FORMAT) },
-    });
+  const setAnchor = useCallback(
+    (date: Dayjs) =>
+      navigate({
+        to: ROOT_ROUTES.WEEK_DATE,
+        params: { dateString: date.format(DATE_FORMAT) },
+      }),
+    [navigate],
+  );
   const navigationSourceRef = useRef<WeekNavigationSource>("manual");
 
   const start = useMemo(() => anchor.startOf("day"), [anchor]);
@@ -102,28 +105,41 @@ export const useWeek = (
     });
   }, [end, start]);
 
-  const goToDate = (date: Dayjs) => {
-    navigationSourceRef.current = "manual";
-    setAnchor(date);
-  };
+  const goToDate = useCallback(
+    (date: Dayjs) => {
+      navigationSourceRef.current = "manual";
+      setAnchor(date);
+    },
+    [setAnchor],
+  );
 
-  const pageWindow = (direction: 1 | -1, source: WeekNavigationSource) => {
-    navigationSourceRef.current = source;
-    setAnchor(start.add(direction * visibleDayCount, "day"));
-  };
+  const pageWindow = useCallback(
+    (direction: 1 | -1, source: WeekNavigationSource) => {
+      navigationSourceRef.current = source;
+      setAnchor(start.add(direction * visibleDayCount, "day"));
+    },
+    [setAnchor, start, visibleDayCount],
+  );
 
-  const incrementWeek = (source: WeekNavigationSource = "manual") =>
-    pageWindow(1, source);
+  const incrementWeek = useCallback(
+    (source: WeekNavigationSource = "manual") => pageWindow(1, source),
+    [pageWindow],
+  );
 
-  const decrementWeek = (source: WeekNavigationSource = "manual") =>
-    pageWindow(-1, source);
+  const decrementWeek = useCallback(
+    (source: WeekNavigationSource = "manual") => pageWindow(-1, source),
+    [pageWindow],
+  );
 
-  const shiftViewByDay = (direction: 1 | -1) => {
-    navigationSourceRef.current = "day-shift";
-    setAnchor(start.add(direction, "day"));
-  };
+  const shiftViewByDay = useCallback(
+    (direction: 1 | -1) => {
+      navigationSourceRef.current = "day-shift";
+      setAnchor(start.add(direction, "day"));
+    },
+    [setAnchor, start],
+  );
 
-  const goToToday = () => {
+  const goToToday = useCallback(() => {
     const navigationSource = navigationSourceRef.current;
     navigationSourceRef.current = "manual";
     if (!isCurrentWeek) {
@@ -134,32 +150,62 @@ export const useWeek = (
           : 0;
       setAnchor(todayWindowStart.add(shiftedWindowOffset, "day"));
     }
-  };
+  }, [isCurrentWeek, setAnchor, start, today]);
 
-  const getLastNavigationSource = () => navigationSourceRef.current;
+  const getLastNavigationSource = useCallback(
+    () => navigationSourceRef.current,
+    [],
+  );
 
-  const weekProps = {
-    component: {
+  const componentProps = useMemo(
+    () => ({
       category: (isCurrentWeek ? "current" : "pastFuture") as Category_View,
       endOfView: end,
       isCurrentWeek,
       startOfView: start,
       week,
       weekDays,
-    },
-    query: {
+    }),
+    [isCurrentWeek, end, start, week, weekDays],
+  );
+
+  const queryProps = useMemo(
+    () => ({
       endOfView: queryEnd,
       startOfView: start,
-    },
-    state: { goToDate },
-    util: {
+    }),
+    [queryEnd, start],
+  );
+
+  const stateProps = useMemo(() => ({ goToDate }), [goToDate]);
+
+  const utilProps = useMemo(
+    () => ({
       decrementWeek,
       getLastNavigationSource,
       goToToday,
       incrementWeek,
       shiftViewByDay,
-    },
-  };
+    }),
+    [
+      decrementWeek,
+      getLastNavigationSource,
+      goToToday,
+      incrementWeek,
+      shiftViewByDay,
+    ],
+  );
+
+  const weekProps = useMemo(
+    () => ({
+      component: componentProps,
+      query: queryProps,
+      state: stateProps,
+      util: utilProps,
+    }),
+    [componentProps, queryProps, stateProps, utilProps],
+  );
+
   return weekProps;
 };
 


### PR DESCRIPTION
## Summary
`GridEventMemo`'s comparator checks `prev.measurements === next.measurements` ([GridEvent.tsx:171](packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx#L171)), but `useGridMeasurements` rebuilt `measurements`, `gridRefs`, and `colWidths` as fresh object/array literals every render — always failing that check, so every timed event card re-rendered on every WeekView render regardless of what actually changed. The comment above the comparator makes clear this memoization was intentional; it just never worked.

- `useGridMeasurements`: `useMemo` `colWidths`/`gridRefs`/`measurements` on their real inputs.
- `useWeek`: `useCallback` the navigation functions (`goToDate`, `incrementWeek`, `decrementWeek`, `shiftViewByDay`, `goToToday`), `useMemo` `weekProps` and its sub-objects.
- `DraftProvider`/`useDraftState`: memoize the context value and local state object.
- `calendar.query.ts`/`useCalendarLookup.ts`: `useCalendarsQuery`'s `select` was a `useCallback` keyed on `hiddenIds`, but each of ~20 call sites mounts a separate TanStack observer that doesn't share select results across observers — so `applyClientVisibility`'s map+spread ran once per consumer even when `hiddenIds` was unchanged. Cache the result keyed on the `(hiddenIds, data)` reference pair instead, so every consumer on the same versions gets back the same output array; same treatment for the built id→Calendar lookup map, keyed on the `data` reference.
- `useToday`: returned a fresh `dayjs()` every render, permanently invalidating every downstream memo keyed on `today`. Now keeps the same reference within a calendar day, checked once a minute.

Not touched: `useDraftActions`' returned object isn't memoized, so `DraftProvider`'s new context-value memo is correctly wired but doesn't yet prevent re-renders end-to-end — fixing that needs its own audit of a larger action-builder file and felt out of scope here. The `MainGridCalendar` no-children branch of `MainGrid.tsx` looked dead but is directly exercised by `MainGrid.test.tsx`, so it's left alone.

## Test plan
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on all changed files — clean
- [x] Targeted `bun test` run (`useGridMeasurements`, `useWeek`, `MainGrid` test files) — 33 pass, 0 fail
- [x] Full web suite (manual explicit-file-list workaround, since the bun-1.4 dir-scan fix lives in a separate PR) shows the same pre-existing 3 failures as before this change — no regressions
- [x] Verified in the browser preview: anon session → week view renders demo events, Previous/Next week navigation both work, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)