### PR TITLE
fix(web): default grid click draft to 30 minutes

### DIFF
--- a/packages/web/src/grid/grid.constants.ts
+++ b/packages/web/src/grid/grid.constants.ts
@@ -1,4 +1,4 @@
-export const DRAFT_DURATION_MIN = 15;
+export const DRAFT_DURATION_MIN = 30;
 export const DRAFT_PADDING_BOTTOM = 3;
 export const EVENT_ALLDAY_HEIGHT = 20;
 export const EVENT_ALLDAY_GAP = 3;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Empty-grid timed drafts (click-to-create) used a 15-minute default length via `DRAFT_DURATION_MIN`.
- Bumps that constant to 30 so quick clicks open a half-hour draft; drag-to-resize still extends past the minimum.

## Test plan
- [ ] Click empty timed grid in week/day view and confirm draft ends 30 minutes after the snapped start.
- [ ] Drag down past 30 minutes while creating and confirm the draft end follows the pointer.
- [ ] Focused: `bun test packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx`
- [ ] `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74aa8911-fb74-408d-9823-a542cf439090?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74aa8911-fb74-408d-9823-a542cf439090&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

