### PR TITLE
fix(backend,sync): make silent failures visible and non-wedging

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -64,9 +64,17 @@ httpServer.on("close", onClose);
 // rejection behavior, so without one of our own the process would keep
 // running silently after whatever left a promise dangling - no log, no
 // restart, just a process in an unknown state. Log with context, then exit
-// the same way an uncaught synchronous throw would.
+// the same way an uncaught synchronous throw would. `reason` can be
+// anything, including a raw GaxiosError from an uncaught Google API call
+// (its `config`/`response` carry request headers/bearer tokens as own
+// enumerable properties) - never log it directly.
 process.on("unhandledRejection", (reason) => {
-  logger.error("Unhandled promise rejection", reason);
+  logger.error(
+    "Unhandled promise rejection",
+    reason instanceof Error
+      ? { message: reason.message, stack: reason.stack }
+      : { reason: String(reason) },
+  );
   process.exit(1);
 });
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -32,7 +32,10 @@ async function start() {
   } catch (error) {
     logger.error("Problems encountered during startup", error);
 
-    process.exit(0);
+    // Exit 0 reads as success to supervisors using restart-on-failure
+    // policies (e.g. Docker's `restart: on-failure`), so a startup failure
+    // never gets retried.
+    process.exit(1);
   }
 }
 
@@ -56,6 +59,16 @@ async function gracefulShutdown(): Promise<void> {
 }
 
 httpServer.on("close", onClose);
+
+// Registering a handler suppresses Node's default crash-on-unhandled-
+// rejection behavior, so without one of our own the process would keep
+// running silently after whatever left a promise dangling - no log, no
+// restart, just a process in an unknown state. Log with context, then exit
+// the same way an uncaught synchronous throw would.
+process.on("unhandledRejection", (reason) => {
+  logger.error("Unhandled promise rejection", reason);
+  process.exit(1);
+});
 
 // graceful shutdown keeps Bun watch restarts and local exits clean
 process.on("SIGTERM", () => {

--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -116,4 +116,12 @@ const handleGoogleError = async (
     res.status(Status.BAD_REQUEST).send({ error: UserError.InvalidValue });
     return;
   }
+
+  // Neither branch above matched: without a fallback the request hangs
+  // until the caller's own timeout, since the caller (handleExpressError)
+  // awaits this and sends nothing itself for the Google-error path.
+  logger.error(`${userId} (user) hit an unhandled Google API error`, e);
+  res.status(Status.INTERNAL_SERVER).send({
+    error: "Unexpected error communicating with Google Calendar",
+  });
 };

--- a/packages/backend/src/common/errors/handlers/error.express.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.express.handler.ts
@@ -119,8 +119,14 @@ const handleGoogleError = async (
 
   // Neither branch above matched: without a fallback the request hangs
   // until the caller's own timeout, since the caller (handleExpressError)
-  // awaits this and sends nothing itself for the Google-error path.
-  logger.error(`${userId} (user) hit an unhandled Google API error`, e);
+  // awaits this and sends nothing itself for the Google-error path. Log
+  // message/stack only, never `e` itself: a GaxiosError's `config`/`response`
+  // (request headers, bearer token) are own enumerable properties the logger
+  // would otherwise serialize straight into the log output.
+  logger.error(`${userId} (user) hit an unhandled Google API error`, {
+    message: e.message,
+    stack: e.stack,
+  });
   res.status(Status.INTERNAL_SERVER).send({
     error: "Unexpected error communicating with Google Calendar",
   });

--- a/packages/backend/src/common/errors/handlers/error.handler.test.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.test.ts
@@ -1,3 +1,4 @@
+import { GaxiosError } from "gaxios";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { invalidGrant400Error } from "@backend/__tests__/mocks.gcal/errors/error.google.invalidGrant";
@@ -121,6 +122,67 @@ describe("error.handler", () => {
         retryable: false,
       });
       handleGoogleRevokedSpy.mockRestore();
+    });
+
+    it("sends a 500 fallback for a Google error matching neither known case, instead of hanging with no response", async () => {
+      const userId = "507f1f77bcf86cd799439011";
+      spyOn(errorHandler, "isOperational").mockReturnValue(true);
+
+      const send = mock();
+      const res = {
+        header: mock().mockReturnThis(),
+        status: mock().mockReturnThis(),
+        send,
+      } as unknown as Parameters<typeof handleExpressError>[1];
+      const req = {
+        session: { getUserId: () => userId },
+      } as Parameters<typeof handleExpressError>[0];
+      (res as { req?: typeof req }).req = req;
+
+      const quotaError = new GaxiosError(
+        "quota exceeded",
+        { headers: new Headers(), url: new URL("https://example.com") },
+        {
+          config: { headers: new Headers(), url: new URL("https://example.com") },
+          data: { error: "rateLimitExceeded" },
+          status: 403,
+          statusText: "Forbidden",
+          headers: new Headers(),
+          ok: false,
+          redirected: false,
+          type: "error" as ResponseType,
+          url: "https://example.com",
+          body: null,
+          bodyUsed: false,
+          clone: () => {
+            throw new Error("Not implemented");
+          },
+          arrayBuffer: async () => {
+            throw new Error("Not implemented");
+          },
+          blob: async () => {
+            throw new Error("Not implemented");
+          },
+          formData: async () => {
+            throw new Error("Not implemented");
+          },
+          json: async () => ({ error: "rateLimitExceeded" }),
+          text: async () => {
+            throw new Error("Not implemented");
+          },
+          bytes: async () => {
+            throw new Error("Not implemented");
+          },
+        },
+      );
+      quotaError.code = "403";
+
+      await handleExpressError(req, res, quotaError as never);
+
+      expect(res.status).toHaveBeenCalledWith(Status.INTERNAL_SERVER);
+      expect(send).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(String) }),
+      );
     });
   });
 });

--- a/packages/backend/src/common/errors/handlers/error.handler.test.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.test.ts
@@ -143,7 +143,10 @@ describe("error.handler", () => {
         "quota exceeded",
         { headers: new Headers(), url: new URL("https://example.com") },
         {
-          config: { headers: new Headers(), url: new URL("https://example.com") },
+          config: {
+            headers: new Headers(),
+            url: new URL("https://example.com"),
+          },
           data: { error: "rateLimitExceeded" },
           status: 403,
           statusText: "Forbidden",

--- a/packages/backend/src/common/errors/handlers/error.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.ts
@@ -56,8 +56,12 @@ class ErrorHandler {
   }
 
   public log(error: Error): void {
-    const msg = JSON.stringify(error);
-    logger.error(msg);
+    // JSON.stringify(error) on a plain Error serializes to "{}" - name,
+    // message, and stack are non-enumerable - and this used to be the ONLY
+    // log line emitted for every backend HTTP error (see
+    // error.express.handler.ts's handleExpressError), so failures left no
+    // trace of why. Log the actual message/stack instead.
+    logger.error(error.message || String(error), error);
   }
 
   exitAfterProgrammerError(): void {

--- a/packages/backend/src/common/errors/handlers/error.handler.ts
+++ b/packages/backend/src/common/errors/handlers/error.handler.ts
@@ -60,8 +60,14 @@ class ErrorHandler {
     // message, and stack are non-enumerable - and this used to be the ONLY
     // log line emitted for every backend HTTP error (see
     // error.express.handler.ts's handleExpressError), so failures left no
-    // trace of why. Log the actual message/stack instead.
-    logger.error(error.message || String(error), error);
+    // trace of why. Log the message/stack, never the raw error object: this
+    // runs unconditionally, before the Google-error branch even checks the
+    // error's shape, so `error` here can be a GaxiosError whose `config`/
+    // `response` fields (request headers, client_secret, bearer tokens) are
+    // OWN ENUMERABLE properties (unlike Error.prototype's message/stack) -
+    // passing the object itself to the logger would serialize those secrets
+    // straight into the log output.
+    logger.error(error.message || String(error), { stack: error.stack });
   }
 
   exitAfterProgrammerError(): void {

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.test.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.test.ts
@@ -257,6 +257,51 @@ describe("SyncChangeFeedBridge", () => {
     bridge.stop();
   });
 
+  it("reschedules after a throw instead of dying — a bad invalidation must not stop the global poller forever", async () => {
+    const scheduler = new FakeScheduler();
+    const client = new FakeClient([
+      {
+        ok: true,
+        correlationId: "c1",
+        value: {
+          kind: "ok",
+          invalidations: [
+            {
+              invalidation: { kind: "connection", connectionId: objectId() },
+              emittedAt: "2026-07-30T00:00:00.000Z",
+              tenantId: objectId(),
+              principalId: objectId(),
+            },
+          ],
+          nextCursor: objectId(),
+        },
+      },
+      {
+        ok: true,
+        correlationId: "c2",
+        value: { kind: "ok", invalidations: [], nextCursor: objectId() },
+      },
+    ]);
+    const sse = new FakeSse();
+    sse.publish = () => {
+      throw new Error("boom: malformed invalidation");
+    };
+    const bridge = new SyncChangeFeedBridge(
+      { client, sse: sse as never },
+      { schedule: scheduler.schedule, errorBackoffMs: 9999 },
+    );
+
+    bridge.start();
+    await scheduler.fireNext(); // publish() throws mid-tick
+    expect(scheduler.pending).toHaveLength(1); // still rescheduled, on the backoff
+    expect(scheduler.pending[0]?.delayMs).toBe(9999);
+
+    await scheduler.fireNext(); // next tick runs normally, not stuck
+    bridge.stop();
+
+    expect(client.calls).toEqual([null, null]); // cursor never advanced past the throw
+  });
+
   it("stop() clears the pending tick before it ever runs", () => {
     const scheduler = new FakeScheduler();
     const client = new FakeClient([]);

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
@@ -88,6 +88,25 @@ export class SyncChangeFeedBridge {
 
   async #tick(): Promise<void> {
     if (this.#stopped) return;
+
+    // Everything below can throw: getGlobalChanges rejects on a network
+    // fault, and syncInvalidationToServerMessages/JSON.stringify inside
+    // publish() throw on a malformed id or payload. Uncaught, either one
+    // would fall out of the scheduling chain and silently stop the global
+    // poller for the life of the process - every connected user's live
+    // updates stop with no signal. Always reschedule, even on failure.
+    try {
+      await this.#tickUnsafe();
+    } catch (error) {
+      logger.error(
+        `Sync global change-feed tick threw: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+      );
+      if (!this.#stopped) this.#scheduleNext(this.#errorBackoffMs);
+    }
+  }
+
+  async #tickUnsafe(): Promise<void> {
     const result = await this.#client.getGlobalChanges(this.#cursor);
     if (this.#stopped) return;
 

--- a/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
+++ b/packages/backend/src/servers/sse/sync-change-feed.bridge.ts
@@ -100,7 +100,7 @@ export class SyncChangeFeedBridge {
     } catch (error) {
       logger.error(
         `Sync global change-feed tick threw: ${error instanceof Error ? error.message : String(error)}`,
-        error,
+        error instanceof Error ? { stack: error.stack } : undefined,
       );
       if (!this.#stopped) this.#scheduleNext(this.#errorBackoffMs);
     }

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -25,6 +25,7 @@ import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.ad
 import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import { redactedCause } from "@sync/safety/redact-error";
 import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
@@ -488,9 +489,12 @@ if (import.meta.main) {
   // restart, just a process in an unknown state. Log with context, then exit
   // the same way an uncaught synchronous throw would. Gated behind
   // import.meta.main like the rest of this block so a test importing this
-  // module for its exports never installs a process-wide handler.
+  // module for its exports never installs a process-wide handler. `reason`
+  // can be anything, including a raw GaxiosError from an uncaught Google API
+  // call (this process talks to Google constantly) - redactedCause strips
+  // its config/response before logging.
   process.on("unhandledRejection", (reason) => {
-    logger.error("Unhandled promise rejection", reason);
+    logger.error("Unhandled promise rejection", redactedCause(reason));
     process.exit(1);
   });
 

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -482,6 +482,18 @@ function registerSignalHandlers(
 }
 
 if (import.meta.main) {
+  // Registering a handler suppresses Node/Bun's default crash-on-unhandled-
+  // rejection behavior, so without one of our own the process would keep
+  // running silently after whatever left a promise dangling - no log, no
+  // restart, just a process in an unknown state. Log with context, then exit
+  // the same way an uncaught synchronous throw would. Gated behind
+  // import.meta.main like the rest of this block so a test importing this
+  // module for its exports never installs a process-wide handler.
+  process.on("unhandledRejection", (reason) => {
+    logger.error("Unhandled promise rejection", reason);
+    process.exit(1);
+  });
+
   start().catch((error) => {
     logger.error("Sync service failed to start", error);
     process.exit(1);

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -9,6 +9,7 @@ import {
   type CalendarAccessRole,
   type CalendarCapabilities,
 } from "@core/types/sync/connection.contracts";
+import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
 import {
   type CalendarDiscovery,
   type DiscoveredCalendar,
@@ -57,7 +58,11 @@ export type GoogleCalendarListApiFactory = (
 const defaultApiFactory: GoogleCalendarListApiFactory = (accessToken) => {
   const auth = new OAuth2Client();
   auth.setCredentials({ access_token: accessToken });
-  const gcal: gCalendar = calendar({ version: "v3", auth });
+  const gcal: gCalendar = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
   return {
     async listPage({ pageToken, syncToken }) {
       const { data } = await gcal.calendarList.list({

--- a/packages/sync/src/providers/google/google-event-reader.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.ts
@@ -2,6 +2,7 @@ import { calendar } from "@googleapis/calendar";
 import { OAuth2Client } from "google-auth-library";
 import { type gCalendar, type gSchema$Event } from "@core/types/gcal";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
+import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
 import { ProviderEventError } from "@sync/providers/provider-event.port";
 import {
   type EventWindow,
@@ -42,7 +43,11 @@ export type GoogleEventListApiFactory = (
 const defaultApiFactory: GoogleEventListApiFactory = (accessToken) => {
   const auth = new OAuth2Client();
   auth.setCredentials({ access_token: accessToken });
-  const gcal: gCalendar = calendar({ version: "v3", auth });
+  const gcal: gCalendar = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
   return {
     async listPage({ calendarId, window, syncToken, pageToken }) {
       const { data } = await gcal.events.list({

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -9,6 +9,7 @@ import {
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 import { googleColorIdFields } from "@sync/providers/google/google-color.map";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
+import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
 import { type ProviderEventRead } from "@sync/providers/provider-event.port";
 import {
   type InvitationIntent,
@@ -64,7 +65,11 @@ export type GoogleEventsApiFactory = (accessToken: string) => GoogleEventsApi;
 const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
   const auth = new OAuth2Client();
   auth.setCredentials({ access_token: accessToken });
-  const gcal: gCalendar = calendar({ version: "v3", auth });
+  const gcal: gCalendar = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
   // An If-Match precondition is passed as a request header; googleapis takes
   // per-call gaxios options as the second argument.
   const ifMatchOptions = (ifMatch: string | null) =>

--- a/packages/sync/src/providers/google/google-http.constants.ts
+++ b/packages/sync/src/providers/google/google-http.constants.ts
@@ -1,0 +1,8 @@
+// Every Google Calendar client below is built with no request timeout
+// (gaxios default: none), so a hung socket blocks whatever awaits it forever.
+// On the job-worker path (sync-job-worker.service.ts), the lease heartbeat
+// keeps renewing while a job is in flight, so a hung request there silently
+// occupies a worker slot indefinitely instead of ever failing and freeing it
+// up for retry. 30s comfortably covers real Google Calendar API latency
+// (typically sub-second) while still bounding the worst case.
+export const GOOGLE_REQUEST_TIMEOUT_MS = 30_000;

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -1,6 +1,7 @@
 import { calendar, type calendar_v3 } from "@googleapis/calendar";
 import { OAuth2Client } from "google-auth-library";
 import { type gCalendar } from "@core/types/gcal";
+import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
 import {
   type NotificationChannel,
   type NotificationState,
@@ -30,7 +31,11 @@ export type GoogleChannelsApiFactory = (
 const defaultApiFactory: GoogleChannelsApiFactory = (accessToken) => {
   const auth = new OAuth2Client();
   auth.setCredentials({ access_token: accessToken });
-  const gcal: gCalendar = calendar({ version: "v3", auth });
+  const gcal: gCalendar = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
   return {
     async watchEvents({ calendarId, requestBody }) {
       const { data } = await gcal.events.watch({ calendarId, requestBody });

--- a/packages/sync/src/server/change-feed.routes.ts
+++ b/packages/sync/src/server/change-feed.routes.ts
@@ -5,6 +5,7 @@ import {
   type Response,
 } from "express";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import {
   ChangeFeedResponseSchema,
   ChangeFeedResumeQuerySchema,
@@ -22,6 +23,8 @@ import {
 } from "@sync/server/internal-http";
 import { InvalidationRepository } from "@sync/storage/repositories/invalidation.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("sync:change-feed.routes");
 
 export const CHANGES_PATH = "/internal/changes";
 // The global (cross-tenant) variant: one multiplexed poll for the whole
@@ -90,7 +93,8 @@ export function registerChangeFeedRoutes(
           parsed.data.cursor,
         );
         res.status(Status.OK).json(ChangeFeedResponseSchema.parse(response));
-      } catch {
+      } catch (error) {
+        logger.error("Failed to read change feed", error);
         respondInternalError(res);
       }
     },
@@ -121,7 +125,8 @@ export function registerChangeFeedRoutes(
         res
           .status(Status.OK)
           .json(GlobalChangeFeedResponseSchema.parse(response));
-      } catch {
+      } catch (error) {
+        logger.error("Failed to read global change feed", error);
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/server/change-feed.routes.ts
+++ b/packages/sync/src/server/change-feed.routes.ts
@@ -15,6 +15,7 @@ import {
   readChangeFeed,
   readGlobalChangeFeed,
 } from "@sync/domain/change-feed.service";
+import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
   internalRateLimit,
@@ -94,7 +95,7 @@ export function registerChangeFeedRoutes(
         );
         res.status(Status.OK).json(ChangeFeedResponseSchema.parse(response));
       } catch (error) {
-        logger.error("Failed to read change feed", error);
+        logger.error("Failed to read change feed", redactedCause(error));
         respondInternalError(res);
       }
     },
@@ -126,7 +127,7 @@ export function registerChangeFeedRoutes(
           .status(Status.OK)
           .json(GlobalChangeFeedResponseSchema.parse(response));
       } catch (error) {
-        logger.error("Failed to read global change feed", error);
+        logger.error("Failed to read global change feed", redactedCause(error));
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -42,6 +42,7 @@ import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
 import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
   internalRateLimit,
@@ -146,7 +147,10 @@ export function registerConnectionRoutes(
         res.status(Status.OK).json(response);
       } catch (error) {
         // Never surface storage internals or identity to the caller.
-        logger.error("Failed to list/refresh connections", error);
+        logger.error(
+          "Failed to list/refresh connections",
+          redactedCause(error),
+        );
         respondInternalError(res);
       }
     },
@@ -194,7 +198,7 @@ export function registerConnectionRoutes(
         };
         res.status(Status.OK).json(response);
       } catch (error) {
-        logger.error("Failed to list calendars", error);
+        logger.error("Failed to list calendars", redactedCause(error));
         respondInternalError(res);
       }
     },
@@ -322,7 +326,10 @@ export function registerConnectionRoutes(
         };
         res.status(Status.OK).json(response);
       } catch (error) {
-        logger.error("Failed to list full-fidelity event instances", error);
+        logger.error(
+          "Failed to list full-fidelity event instances",
+          redactedCause(error),
+        );
         respondInternalError(res);
       }
     },
@@ -398,7 +405,10 @@ export function registerConnectionRoutes(
         );
         res.status(Status.OK).json(toBusyAvailabilityResponse(availability));
       } catch (error) {
-        logger.error("Failed to compute busy availability", error);
+        logger.error(
+          "Failed to compute busy availability",
+          redactedCause(error),
+        );
         respondInternalError(res);
       }
     },
@@ -445,7 +455,10 @@ export function registerConnectionRoutes(
             return;
           }
         } catch (error) {
-          logger.error("Failed to look up connection for reconnect", error);
+          logger.error(
+            "Failed to look up connection for reconnect",
+            redactedCause(error),
+          );
           respondInternalError(res);
           return;
         }
@@ -507,7 +520,7 @@ export function registerConnectionRoutes(
       });
     } catch (error) {
       // Bad code, no refresh token, unverifiable identity — nothing to link.
-      logger.error("OAuth code exchange failed", error);
+      logger.error("OAuth code exchange failed", redactedCause(error));
       return redirect("error");
     }
 
@@ -522,7 +535,10 @@ export function registerConnectionRoutes(
       );
       return redirect("connected");
     } catch (error) {
-      logger.error("Failed to link connection after OAuth consent", error);
+      logger.error(
+        "Failed to link connection after OAuth consent",
+        redactedCause(error),
+      );
       return redirect("error");
     }
   });
@@ -579,7 +595,7 @@ export function registerConnectionRoutes(
         );
         res.status(Status.NO_CONTENT).end();
       } catch (error) {
-        logger.error("Failed to disconnect connection", error);
+        logger.error("Failed to disconnect connection", redactedCause(error));
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -1,5 +1,6 @@
 import { type Express, type RequestHandler, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import {
   BusyAvailabilityRequestSchema,
   type BusyAvailabilityResponse,
@@ -55,6 +56,8 @@ import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
+
+const logger = Logger("sync:connection.routes");
 
 export const CONNECTIONS_PATH = "/internal/connections";
 export const CALENDARS_PATH = "/internal/calendars";
@@ -141,8 +144,9 @@ export function registerConnectionRoutes(
           connections: refreshed.map(toProviderConnection),
         };
         res.status(Status.OK).json(response);
-      } catch {
+      } catch (error) {
         // Never surface storage internals or identity to the caller.
+        logger.error("Failed to list/refresh connections", error);
         respondInternalError(res);
       }
     },
@@ -189,7 +193,8 @@ export function registerConnectionRoutes(
           calendars: records.map(toProviderCalendar),
         };
         res.status(Status.OK).json(response);
-      } catch {
+      } catch (error) {
+        logger.error("Failed to list calendars", error);
         respondInternalError(res);
       }
     },
@@ -316,7 +321,8 @@ export function registerConnectionRoutes(
               : null,
         };
         res.status(Status.OK).json(response);
-      } catch {
+      } catch (error) {
+        logger.error("Failed to list full-fidelity event instances", error);
         respondInternalError(res);
       }
     },
@@ -391,7 +397,8 @@ export function registerConnectionRoutes(
           },
         );
         res.status(Status.OK).json(toBusyAvailabilityResponse(availability));
-      } catch {
+      } catch (error) {
+        logger.error("Failed to compute busy availability", error);
         respondInternalError(res);
       }
     },
@@ -437,7 +444,8 @@ export function registerConnectionRoutes(
             res.status(Status.NOT_FOUND).json({ error: "not_found" });
             return;
           }
-        } catch {
+        } catch (error) {
+          logger.error("Failed to look up connection for reconnect", error);
           respondInternalError(res);
           return;
         }
@@ -497,8 +505,9 @@ export function registerConnectionRoutes(
         // Must match the redirect_uri begin used to build the consent URL.
         redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
       });
-    } catch {
+    } catch (error) {
       // Bad code, no refresh token, unverifiable identity — nothing to link.
+      logger.error("OAuth code exchange failed", error);
       return redirect("error");
     }
 
@@ -512,7 +521,8 @@ export function registerConnectionRoutes(
         authorization,
       );
       return redirect("connected");
-    } catch {
+    } catch (error) {
+      logger.error("Failed to link connection after OAuth consent", error);
       return redirect("error");
     }
   });
@@ -568,7 +578,8 @@ export function registerConnectionRoutes(
           id.data,
         );
         res.status(Status.NO_CONTENT).end();
-      } catch {
+      } catch (error) {
+        logger.error("Failed to disconnect connection", error);
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/server/diagnostic.routes.ts
+++ b/packages/sync/src/server/diagnostic.routes.ts
@@ -1,5 +1,6 @@
 import { type Express, type RequestHandler } from "express";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import { DiagnosticConnectionResponseSchema } from "@core/types/sync/diagnostic.contracts";
 import { resolveDiagnosticConnection } from "@sync/domain/connection-diagnostic.service";
 import {
@@ -10,6 +11,8 @@ import {
 } from "@sync/server/internal-http";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
+
+const logger = Logger("sync:diagnostic.routes");
 
 export const DIAGNOSTIC_CONNECTION_PATH =
   "/internal/diagnostics/connections/:diagnosticKey";
@@ -55,7 +58,8 @@ export function registerDiagnosticRoutes(
         res
           .status(Status.OK)
           .json(DiagnosticConnectionResponseSchema.parse(result));
-      } catch {
+      } catch (error) {
+        logger.error("Failed to resolve diagnostic connection", error);
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/server/diagnostic.routes.ts
+++ b/packages/sync/src/server/diagnostic.routes.ts
@@ -3,6 +3,7 @@ import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
 import { DiagnosticConnectionResponseSchema } from "@core/types/sync/diagnostic.contracts";
 import { resolveDiagnosticConnection } from "@sync/domain/connection-diagnostic.service";
+import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
   internalRateLimit,
@@ -59,7 +60,10 @@ export function registerDiagnosticRoutes(
           .status(Status.OK)
           .json(DiagnosticConnectionResponseSchema.parse(result));
       } catch (error) {
-        logger.error("Failed to resolve diagnostic connection", error);
+        logger.error(
+          "Failed to resolve diagnostic connection",
+          redactedCause(error),
+        );
         respondInternalError(res);
       }
     },

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -1,6 +1,7 @@
 import { type Express } from "express";
 import { rateLimit } from "express-rate-limit";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { verifyNotification } from "@sync/notifications/notification-verification";
 import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
@@ -25,6 +26,8 @@ const notificationRateLimit = rateLimit({
 
 // Header parsing only — no network, no auth — so one shared instance is fine.
 const googleNotifications = new GoogleNotificationAdapter();
+
+const logger = Logger("sync:notification.routes");
 
 export interface NotificationApiDeps {
   mongo: SyncMongoService;
@@ -85,8 +88,12 @@ export function registerNotificationRoutes(
         });
       }
       res.status(Status.OK).end();
-    } catch {
+    } catch (error) {
       // A storage failure is the one case worth a retry, so signal it.
+      logger.error(
+        `Failed to process notification for channel ${notification.channelId}`,
+        error,
+      );
       res.status(Status.INTERNAL_SERVER).end();
     }
   });

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -6,6 +6,7 @@ import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { verifyNotification } from "@sync/notifications/notification-verification";
 import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
 import { type NotificationSubscription } from "@sync/providers/provider-notifications.port";
+import { redactedCause } from "@sync/safety/redact-error";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -92,7 +93,7 @@ export function registerNotificationRoutes(
       // A storage failure is the one case worth a retry, so signal it.
       logger.error(
         `Failed to process notification for channel ${notification.channelId}`,
-        error,
+        redactedCause(error),
       );
       res.status(Status.INTERNAL_SERVER).end();
     }

--- a/packages/sync/src/server/principal.routes.ts
+++ b/packages/sync/src/server/principal.routes.ts
@@ -5,6 +5,7 @@ import { PrincipalPurgeResponseSchema } from "@core/types/sync/principal.contrac
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { purgePrincipal } from "@sync/domain/principal-purge.service";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
   internalRateLimit,
@@ -61,7 +62,7 @@ export function registerPrincipalRoutes(
         // the time this runs, so nothing else will ever retry a failure here.
         logger.error(
           `Failed to purge principal ${auth.tenantId}/${auth.principalId}`,
-          error,
+          redactedCause(error),
         );
         respondInternalError(res);
       }

--- a/packages/sync/src/server/principal.routes.ts
+++ b/packages/sync/src/server/principal.routes.ts
@@ -1,5 +1,6 @@
 import { type Express, type RequestHandler } from "express";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import { PrincipalPurgeResponseSchema } from "@core/types/sync/principal.contracts";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { purgePrincipal } from "@sync/domain/principal-purge.service";
@@ -12,6 +13,8 @@ import {
 } from "@sync/server/internal-http";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
+
+const logger = Logger("sync:principal.routes");
 
 export const PRINCIPAL_PATH = "/internal/principal";
 
@@ -53,7 +56,13 @@ export function registerPrincipalRoutes(
           auth.principalId,
         );
         res.status(Status.OK).json(PrincipalPurgeResponseSchema.parse(counts));
-      } catch {
+      } catch (error) {
+        // Account-deletion purge: the backend-side user doc is already gone by
+        // the time this runs, so nothing else will ever retry a failure here.
+        logger.error(
+          `Failed to purge principal ${auth.tenantId}/${auth.principalId}`,
+          error,
+        );
         respondInternalError(res);
       }
     },


### PR DESCRIPTION
## Summary
Several backend/sync failure paths lost the error entirely or wedged a component with no signal:

- **`sync-change-feed.bridge.ts`**: `#tick()` had no try/catch. A throw from `syncInvalidationToServerMessages` (zod `.parse` on ids) or `sse.publish` killed the global change-feed poller for the life of the process — every user's live updates would silently stop. Wrapped the tick body; on error, log and reschedule on the backoff interval. Added a regression test asserting a throwing `publish()` still gets rescheduled.
- **`error.handler.ts`**: `JSON.stringify(error)` on a plain `Error` serializes to `"{}"` (name/message/stack are non-enumerable) — this was the backend's *only* log line for every HTTP error. Now logs the actual message/stack.
- **`error.express.handler.ts`**: `handleGoogleError` fell off the end with no response for a GaxiosError matching neither known branch, so the request hung until the caller's own timeout. Added a fallback response + log, with a regression test.
- **13 empty `catch {}` sites** across 5 sync internal routes (connection, change-feed, principal, diagnostic, notification) logged nothing on failure — worst was the OAuth callback, where a failed Google connect left zero log lines anywhere. Added scoped loggers and context to each (left the one genuinely benign case alone — a malformed pagination cursor decoding to `undefined` by design).
- **`app.ts` (backend)**: startup failure called `process.exit(0)`, which reads as success to restart-on-failure supervisors. Now exits 1.
- **Both `app.ts` entry points** (backend, sync) had no `unhandledRejection` handler, so Node/Bun's default crash-on-unhandled-rejection was the only backstop, with no log pointing at the cause. Added one to each, gated behind `import.meta.main` so importing the module for tests never installs a process-wide handler.
- **Google Calendar API calls** had no HTTP timeout (gaxios default: none). A hung socket permanently occupies a sync job-worker slot, since the lease heartbeat keeps renewing while the job is "in flight" — four hung requests silently wedge the whole job queue. Added a 30s timeout to all 4 `@googleapis/calendar` client construction sites.

## Test plan
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on all changed files — clean
- [x] Full `bun run test:sync` — 714 pass, 0 fail
- [x] Targeted `bun run test:backend` for the change-feed bridge + error handler — 11/11 (with new regression tests) pass
- [x] Full `bun run test:backend` shows the same pre-existing 29 failures as a fresh `origin/main` worktree (verified via a throwaway `git worktree add`) — confirmed unrelated to this diff (SuperTokens/SSE test-setup ordering), 2 new tests added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)