### PR TITLE
fix(web): focus life birth date without opening picker

### DIFF
--- a/packages/web/src/views/Life/LifeSidebarContent.tsx
+++ b/packages/web/src/views/Life/LifeSidebarContent.tsx
@@ -146,11 +146,26 @@ export function LifeSidebarContent({
               }
             }}
             onInputClick={() => setIsBirthDatePickerOpen(true)}
+            // Keep first impression on the grid: focus the field for new users
+            // without popping the calendar. Enter/arrows still open it.
+            onKeyDown={(event) => {
+              if (isBirthDatePickerOpen) return;
+              if (
+                event.key !== "Enter" &&
+                event.key !== "ArrowDown" &&
+                event.key !== "ArrowUp"
+              ) {
+                return;
+              }
+              event.preventDefault();
+              setIsBirthDatePickerOpen(true);
+            }}
             onSelect={(date) => {
               if (!date) return;
               setBirthDate(date);
             }}
             placeholderText="Select date"
+            preventOpenOnFocus
             selected={birthDate ?? undefined}
             title="Date of birth"
             view="grid"

--- a/packages/web/src/views/Life/LifeSidebarContent.tsx
+++ b/packages/web/src/views/Life/LifeSidebarContent.tsx
@@ -146,8 +146,9 @@ export function LifeSidebarContent({
               }
             }}
             onInputClick={() => setIsBirthDatePickerOpen(true)}
-            // Keep first impression on the grid: focus the field for new users
-            // without popping the calendar. Enter/arrows still open it.
+            // Keep first impression on the grid: focus without opening. Enter/
+            // arrows open via click so react-datepicker's internal open state
+            // stays in sync (Escape / day-grid focus depend on it).
             onKeyDown={(event) => {
               if (isBirthDatePickerOpen) return;
               if (
@@ -158,7 +159,7 @@ export function LifeSidebarContent({
                 return;
               }
               event.preventDefault();
-              setIsBirthDatePickerOpen(true);
+              (event.target as HTMLElement).click();
             }}
             onSelect={(date) => {
               if (!date) return;

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -126,6 +126,11 @@ describe("LifeView", () => {
     expect(
       screen.getByRole("textbox", { name: "Date of birth" }),
     ).toHaveFocus();
+    // New users get the birth-date field focused, but the calendar stays closed
+    // so the first impression stays on the life grid.
+    expect(
+      screen.queryByRole("button", { name: "Previous month" }),
+    ).not.toBeInTheDocument();
     expect(
       (screen.getByLabelText(/age of death/i) as HTMLInputElement).value,
     ).toBe("77");
@@ -153,6 +158,25 @@ describe("LifeView", () => {
       screen.queryByRole("button", { name: /zoom/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/ctrl\+scroll|pinch/i)).not.toBeInTheDocument();
+  });
+
+  it("opens the birth date picker when Enter is pressed on the focused field", async () => {
+    const user = userEvent.setup({ skipHover: true });
+    await renderLifeViewWithSidebar();
+
+    const birthDateInput = screen.getByRole("textbox", {
+      name: "Date of birth",
+    });
+    expect(birthDateInput).toHaveFocus();
+    expect(
+      screen.queryByRole("button", { name: "Previous month" }),
+    ).not.toBeInTheDocument();
+
+    await user.keyboard("{Enter}");
+
+    expect(
+      screen.getByRole("button", { name: "Previous month" }),
+    ).toBeInTheDocument();
   });
 
   it("updates weeks lived when the birth date changes", async () => {

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -177,6 +177,14 @@ describe("LifeView", () => {
     expect(
       screen.getByRole("button", { name: "Previous month" }),
     ).toBeInTheDocument();
+
+    // Keyboard-open must use react-datepicker's click/open path so Escape
+    // still closes (that path keeps internal open state in sync).
+    await user.keyboard("{Escape}");
+    expect(
+      screen.queryByRole("button", { name: "Previous month" }),
+    ).not.toBeInTheDocument();
+    expect(birthDateInput).toHaveFocus();
   });
 
   it("updates weeks lived when the birth date changes", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

For new Life view users, the date of birth field stays focused so keyboard users can find it, but the calendar no longer auto-opens on that focus. Enter / ArrowUp / ArrowDown open the picker through the input click path (so react-datepicker internal open state stays in sync for Escape and day-grid focus); click still opens it as before. This keeps the first impression on the life grid.

## Simplicity

Uses react-datepicker's `preventOpenOnFocus` plus a small keydown handler that opens via `.click()` — the same path as pointer open — instead of setting controlled open alone. No new components or state. Comment retained to document the library constraint.

## Automated validation

- `bun test:web packages/web/src/views/Life/LifeView.test.tsx` — 14 pass (includes Enter opens + Escape closes after keyboard open)
- `bun lint` on changed files — clean
- Manual browser check at `/life` with cleared life preferences: calendar closed on load, grid visible, Enter/ArrowDown open, Escape/outside click close, click reopen

## Independent review

Fresh review after the keyboard-open fix: **approve**. Prior medium finding (keyboard open left `state.open` false) fixed by routing through `.click()`. No remaining confirmed actionable findings.

## Test plan

- `bun test:web packages/web/src/views/Life/LifeView.test.tsx`
- `bun lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02c7d2a6-87dc-492f-a08e-1ffcf957cc70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02c7d2a6-87dc-492f-a08e-1ffcf957cc70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

