### PR TITLE
fix(sync,backend,web): un-stick the delete/update command path

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -598,6 +598,26 @@ describe("SyncServiceClient", () => {
     expect(result.error.kind).toBe("unavailable");
   });
 
+  it("maps a 429 to unavailable, not unexpectedStatus", async () => {
+    // Sync's internal rate limiter (a shared 300/min bucket) returns 429
+    // under normal-ish load. Previously this fell through to
+    // unexpectedStatus -> GenericError.NotSure (Status.UNSURE = 600, not a
+    // real HTTP status) instead of a retryable service-busy signal.
+    const { fn } = fakeFetch(async () => ({
+      status: 429,
+      json: async () => ({ error: "rate_limited" }),
+    }));
+
+    const result = await client(fn).queryBusyAvailability(
+      principal(),
+      request([objectId()]),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("unavailable");
+  });
+
   it("maps a connection failure to unavailable", async () => {
     const fn: SyncServiceClientOptions["fetch"] = async () => {
       throw new Error("ECONNREFUSED");

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -448,7 +448,13 @@ export class SyncServiceClient {
 function statusToKind(status: number): SyncClientErrorKind {
   if (status === 401) return "unauthorized";
   if (status === 400) return "badRequest";
-  if (status === 503) return "unavailable";
+  // 429 is sync's own internal rate limiter (internal-http.ts), tripped
+  // easily under normal-ish load (a shared 300/min bucket for the whole
+  // backend). Treated the same as 503: a retryable service-busy state, not
+  // an unexpected condition - previously this fell through to
+  // unexpectedStatus -> GenericError.NotSure, whose Status.UNSURE (600) is
+  // not a real HTTP status and reads as an unretryable mystery to the caller.
+  if (status === 429 || status === 503) return "unavailable";
   return "unexpectedStatus";
 }
 

--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -135,6 +135,46 @@ describe("EventController", () => {
     });
   });
 
+  it("rejects a calendar move before submitting anything to sync", async () => {
+    // toReplaceSubmitRequests would build an update command plus a move
+    // command when calendarId is present, but sync unconditionally fails
+    // every move (no executor exists) - submitting them in sequence would
+    // apply the update, then throw on the move: a partial write. This must
+    // never reach sync at all.
+    const submitCommand = mock();
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      submitCommand,
+    } as never);
+
+    const { res, json } = jsonRes();
+    await eventController.replace(
+      sessionReq(objectId(), {
+        params: { id: objectId() },
+        body: {
+          calendarId: objectId(),
+          content: { kind: "details", title: "Lunch", description: "" },
+          schedule: {
+            kind: "timed",
+            start: "2026-07-14T12:00:00.000Z",
+            end: "2026-07-14T13:00:00.000Z",
+            timeZone: "UTC",
+          },
+          recurrence: { kind: "single" },
+          scope: "all",
+        },
+      }),
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(Status.BAD_REQUEST);
+    expect(json).toHaveBeenCalledWith({
+      code: "MOVE_UNSUPPORTED",
+      message: "Moving an event to a different calendar is not supported yet",
+      retryable: false,
+    });
+    expect(submitCommand).not.toHaveBeenCalled();
+  });
+
   it("fails closed on a sync outage when creating an event", async () => {
     const { res, json } = jsonRes();
     await eventController.create(

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -222,6 +222,19 @@ const replaceFromSync = async (
   eventId: string,
   input: ReplaceEventInput,
 ) => {
+  // toReplaceSubmitRequests builds an update command, plus a move command
+  // when calendarId is present — but Sync unconditionally fails every move
+  // command (no executor exists). Submitting them in sequence would apply
+  // the update, THEN throw on the move: a partial write the caller sees as a
+  // single failed request, and a naive retry re-runs the same broken pair.
+  // Reject up front, before anything is submitted.
+  if (input.calendarId !== undefined) {
+    throw eventMutationError(
+      "MOVE_UNSUPPORTED",
+      "Moving an event to a different calendar is not supported yet",
+    );
+  }
+
   const client = getSyncServiceClient();
   const { requests, responseEvent } = toReplaceSubmitRequests(eventId, input);
   for (const request of requests) {

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -21,6 +21,7 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   PROVIDER_FAILURE: 502 as Status,
   GOOGLE_REVOKED: Status.UNAUTHORIZED,
   MAINTENANCE: Status.SERVICE_UNAVAILABLE,
+  MOVE_UNSUPPORTED: Status.BAD_REQUEST,
 };
 
 const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
@@ -34,6 +35,7 @@ const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
   PROVIDER_FAILURE: true,
   GOOGLE_REVOKED: false,
   MAINTENANCE: true,
+  MOVE_UNSUPPORTED: false,
 };
 
 export class EventMutationException extends BaseError {

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -123,6 +123,10 @@ export const EventMutationErrorCodeSchema = z.enum([
   "GOOGLE_REVOKED",
   // Scoped cutover maintenance: cloud/provider mutations paused (S50).
   "MAINTENANCE",
+  // A replace tried to move a provider-linked event to a different calendar.
+  // Sync has no executor for a "move" command yet (unconditionally fails it),
+  // so this is rejected before any command is submitted — never retryable.
+  "MOVE_UNSUPPORTED",
 ]);
 
 export const EventMutationErrorSchema = z.strictObject({

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -11,6 +11,7 @@ import {
 } from "@sync/domain/connection-retention.service";
 import { requeueFailedJobs } from "@sync/domain/failed-job-requeue.service";
 import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
+import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
 import { maintainExpiringSubscriptions } from "@sync/domain/subscription-sweep.service";
 import { SweepScheduler } from "@sync/domain/sweep-scheduler.service";
 import { SyncJobWorker } from "@sync/domain/sync-job-worker.service";
@@ -232,12 +233,16 @@ async function start(): Promise<void> {
       service.shutdown.register("failedJobRequeue", () =>
         schedulers.failedJobRequeue.stop(),
       );
+      service.shutdown.register("staleCommandRetry", () =>
+        schedulers.staleCommandRetry.stop(),
+      );
       for (const drain of schedulers.drains) drain.start();
       schedulers.reconcile.start();
       schedulers.subscription.start();
       schedulers.failedJobRequeue.start();
+      schedulers.staleCommandRetry.start();
       logger.info(
-        "Sync scheduler draining, reconciling, renewing channels, retaining, and reporting health",
+        "Sync scheduler draining, reconciling, renewing channels, retaining, retrying stale commands, and reporting health",
       );
     } else {
       logger.info(
@@ -261,6 +266,11 @@ const FAILED_JOB_REQUEUE_COOLDOWN_MS = 30 * 60_000;
 const FAILED_JOB_MAX_REQUEUES = 3;
 // A resource not synced within this window is swept for a reconcile pull.
 const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
+// A cloud command left nonterminal past this long since its last update is
+// eligible for a retry - long enough that a transient provider blip has
+// almost certainly cleared, short enough that "deleting" doesn't sit visibly
+// stuck for too long.
+const STALE_COMMAND_RETRY_AFTER_MS = 5 * 60_000;
 // A push channel expiring within this window is swept for renewal. Matches
 // maintainSubscription's default renew guard so the sweep and the operation
 // agree on what "near expiry" means.
@@ -347,10 +357,13 @@ function buildSchedulers(
   reconcile: SweepScheduler;
   subscription: SweepScheduler;
   failedJobRequeue: SweepScheduler;
+  staleCommandRetry: SweepScheduler;
 } | null {
   if (config.EXECUTION !== "active") return null;
   const authAdapter = buildAuthAdapter(config);
   if (!authAdapter) return null;
+  const eventWriter = buildEventWriter(config);
+  if (!eventWriter) return null;
 
   const repos = syncRepositories(mongo);
   const resources = repos.syncResources;
@@ -463,7 +476,51 @@ function buildSchedulers(
       onError: (error) => logger.error("Sync self-heal sweep failed", error),
     },
   );
-  return { drains, reconcile, subscription, failedJobRequeue };
+  // Self-heal sweep for the OTHER kind of stuck work: a cloud-targeted
+  // update/delete command that hit a transient provider failure mid-execute.
+  // Those run inline from the HTTP request (not as a job), and nothing else
+  // ever revisits a command left nonterminal that way - see
+  // stale-command-retry.service.ts. Looks BACK, like reconcile/failedJobRequeue.
+  const staleCommandRetry = new SweepScheduler(
+    {
+      sweep: async (before) => {
+        const result = await retryStaleCommands(
+          {
+            commands: repos.commands,
+            events: repos.events,
+            calendars: repos.calendars,
+            occurrences: repos.eventOccurrences,
+            markers: repos.deletionMarkers,
+            execution: config.EXECUTION,
+            provider: {
+              writer: eventWriter,
+              custody: new CredentialCustody(repos.credentials, authAdapter),
+            },
+          },
+          before,
+          () => new Date(),
+        );
+        if (result.attempted > 0) {
+          logger.info(
+            `Sync stale-command sweep retried ${result.attempted} command(s), ${result.stillStale} still stuck`,
+          );
+        }
+        return result.attempted;
+      },
+    },
+    {
+      windowMs: -STALE_COMMAND_RETRY_AFTER_MS,
+      onError: (error) =>
+        logger.error("Sync stale-command retry sweep failed", error),
+    },
+  );
+  return {
+    drains,
+    reconcile,
+    subscription,
+    failedJobRequeue,
+    staleCommandRetry,
+  };
 }
 
 function registerSignalHandlers(

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -175,11 +175,30 @@ export async function submitCloudCommand(
 // the command exactly as it was (see provider-command.service.ts's per-kind
 // executors), and nothing else ever revisits it, so this is the only thing
 // that gives it another attempt.
+//
+// Guards against reapplying stale content: applyCloudMutation's update path
+// merges the COMMAND's own (possibly minutes-old) title/description onto
+// whatever is currently stored (mergeUpdateContent), with no check that this
+// is still the latest intent for the event. If a later command already
+// touched the same event — succeeded on its own retry, or is itself
+// mid-flight — blindly reapplying this one would silently revert that later
+// edit with no error surfaced anywhere. When a newer command exists, this
+// command is superseded: fail it (versionConflict) instead of retrying, so
+// it stops being retried without ever overwriting newer intent.
 export async function retryCloudMutation(
   deps: CloudCommandDeps,
   command: CommandRecord,
   now: () => Date,
 ): Promise<CommandRecord> {
+  const superseded = await deps.commands.hasNewerCommandForEvent(
+    command.tenantId,
+    command.principalId,
+    command.eventId,
+    command._id,
+  );
+  if (superseded) {
+    return failCloud(deps, command, "versionConflict");
+  }
   return applyCloudMutation(deps, command, now);
 }
 

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -168,6 +168,21 @@ export async function submitCloudCommand(
   return finish(await confirmCloud(deps, command));
 }
 
+// Re-run an already-submitted, still-nonterminal update/delete command
+// through the same routing applyCloudMutation used the first time (dedupe by
+// idempotencyKey does not apply here — the command already exists). For the
+// stale-command retry sweep: a transient provider failure mid-execute leaves
+// the command exactly as it was (see provider-command.service.ts's per-kind
+// executors), and nothing else ever revisits it, so this is the only thing
+// that gives it another attempt.
+export async function retryCloudMutation(
+  deps: CloudCommandDeps,
+  command: CommandRecord,
+  now: () => Date,
+): Promise<CommandRecord> {
+  return applyCloudMutation(deps, command, now);
+}
+
 // Apply a cloud-only update or delete to an existing event. Only single,
 // unlinked events are handled here: a provider-linked event needs the provider
 // mutation path, and a recurring series needs scope handling — both land in

--- a/packages/sync/src/domain/stale-command-retry.service.db.test.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.db.test.ts
@@ -1,0 +1,252 @@
+import { faker } from "@faker-js/faker";
+import {
+  type ConnectionId,
+  type EventId,
+  type IdempotencyKey,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
+import { type ProviderEvent } from "@sync/providers/provider-event.port";
+import {
+  type ProviderDeleteInput,
+  type ProviderEventWriter,
+  ProviderWriteError,
+} from "@sync/providers/provider-event-writer.port";
+import { CommandRepository } from "@sync/storage/repositories/command.repository";
+import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-marker.repository";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const storage = setupSyncStorage(import.meta.url);
+const objectId = () => faker.database.mongodbObjectId();
+
+class FakeDeleteWriter implements ProviderEventWriter {
+  readonly provider = "google" as const;
+  deleteError: Error | null = null;
+  deleteCalls: ProviderDeleteInput[] = [];
+  async deleteEvent(input: ProviderDeleteInput): Promise<void> {
+    this.deleteCalls.push(input);
+    if (this.deleteError) throw this.deleteError;
+  }
+  async createEvent(): Promise<never> {
+    throw new Error("unused");
+  }
+  async patchEvent(): Promise<never> {
+    throw new Error("unused");
+  }
+  async fetchEvent(): Promise<ProviderEvent | null> {
+    return null;
+  }
+  async fetchInstanceAt(): Promise<ProviderEvent | null> {
+    return null;
+  }
+}
+
+const tokenSource = () => ({
+  getValidAccessToken: async () => "access-token",
+  discardRevoked: async () => {},
+});
+
+describe("retryStaleCommands", () => {
+  let mongo: SyncMongoService;
+  let commands: CommandRepository;
+  let events: EventRepository;
+  let occurrences: EventOccurrenceRepository;
+  let calendars: ProviderCalendarRepository;
+  let markers: DeletionMarkerRepository;
+
+  const now = () => new Date("2026-07-10T00:00:00.000Z");
+  // CommandRepository.submit() stamps createdAt/updatedAt with the real wall
+  // clock (not the injected `now`), so a cutoff has to be relative to actual
+  // Date.now() to correctly include/exclude a just-submitted command.
+  const before = () => new Date(Date.now() + 60_000);
+  const notYetStale = () => new Date(0);
+
+  const schedule = {
+    kind: "timed" as const,
+    start: "2026-07-14T09:00:00-06:00",
+    end: "2026-07-14T10:00:00-06:00",
+    timeZone: "America/Denver",
+  };
+
+  // Seed a provider-linked event stuck deletionPending, plus its still-pending
+  // delete command - the state a transient provider failure leaves behind
+  // (executeProviderDelete's "return command" branch never writes to
+  // storage, so the row is unchanged from submission).
+  const seedStuckDelete = async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId,
+      principalId,
+      connectionId,
+      providerCalendarId: "primary@google.com",
+      displayName: "Google",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const eventId = objectId() as EventId;
+    await events.put({
+      _id: eventId,
+      tenantId,
+      principalId,
+      origin: "compass",
+      calendarId: calendar._id,
+      clientEventId: null,
+      connectionId,
+      providerEventId: "g-evt-1" as never,
+      providerVersion: "etag-1" as never,
+      providerUpdatedAt: null,
+      deliveryState: "confirmed",
+      providerMetadata: null,
+      content: {
+        title: "Doomed",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule,
+      recurrence: { kind: "single" },
+      // The state a transient failure leaves the event in: visibly
+      // "deleting" until a retry finishes the job.
+      lifecycleState: "deletionPending",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+    const event = await events.findById(tenantId, principalId, eventId);
+    if (!event) throw new Error("seed failed to read back the event");
+    const { record: command } = await commands.submit({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId,
+      input: { kind: "delete", invitation: "none", scope: "all" } as never,
+      expectedVersion: null,
+    });
+    return { tenantId, principalId, calendar, event, command };
+  };
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    commands = new CommandRepository(mongo.db);
+    events = new EventRepository(mongo.db);
+    occurrences = new EventOccurrenceRepository(mongo.db, mongo.client);
+    calendars = new ProviderCalendarRepository(mongo.db);
+    markers = new DeletionMarkerRepository(mongo.db);
+  });
+
+  it("finishes a delete that failed transiently on the first attempt", async () => {
+    const { tenantId, principalId, event, command } = await seedStuckDelete();
+    expect(command.outcome.state).toBe("pending");
+    const writer = new FakeDeleteWriter();
+
+    const result = await retryStaleCommands(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: { writer, custody: tokenSource() },
+      },
+      before(),
+      now,
+    );
+
+    expect(result).toEqual({ attempted: 1, stillStale: 0 });
+    expect(writer.deleteCalls).toHaveLength(1);
+    const stored = await commands.findById(tenantId, principalId, command._id);
+    expect(stored?.outcome.state).toBe("confirmed");
+    expect(await events.findById(tenantId, principalId, event._id)).toBeNull();
+  });
+
+  it("leaves the command pending and reports it still stale on a repeated transient failure", async () => {
+    const { tenantId, principalId, command } = await seedStuckDelete();
+    const writer = new FakeDeleteWriter();
+    writer.deleteError = new ProviderWriteError("transient", "blip again");
+
+    const result = await retryStaleCommands(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: { writer, custody: tokenSource() },
+      },
+      before(),
+      now,
+    );
+
+    expect(result).toEqual({ attempted: 1, stillStale: 1 });
+    const stored = await commands.findById(tenantId, principalId, command._id);
+    expect(stored?.outcome.state).toBe("pending");
+  });
+
+  it("ignores commands newer than the stale cutoff", async () => {
+    await seedStuckDelete();
+    const writer = new FakeDeleteWriter();
+
+    const result = await retryStaleCommands(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: { writer, custody: tokenSource() },
+      },
+      // Cutoff before the command's updatedAt: not stale yet.
+      notYetStale(),
+      now,
+    );
+
+    expect(result).toEqual({ attempted: 0, stillStale: 0 });
+    expect(writer.deleteCalls).toHaveLength(0);
+  });
+
+  it("counts a ProviderWriteUnavailableError as still-stale instead of throwing", async () => {
+    await seedStuckDelete();
+    const writer = new FakeDeleteWriter();
+
+    const result = await retryStaleCommands(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        // Provider work unavailable: dispatchProviderDelete throws
+        // ProviderWriteUnavailableError before ever calling the writer.
+        execution: "passive",
+        provider: { writer, custody: tokenSource() },
+      },
+      before(),
+      now,
+    );
+
+    expect(result).toEqual({ attempted: 1, stillStale: 1 });
+    expect(writer.deleteCalls).toHaveLength(0);
+  });
+});

--- a/packages/sync/src/domain/stale-command-retry.service.db.test.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.db.test.ts
@@ -7,6 +7,7 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { submitCloudCommand } from "@sync/domain/cloud-command.service";
 import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
@@ -248,5 +249,127 @@ describe("retryStaleCommands", () => {
 
     expect(result).toEqual({ attempted: 1, stillStale: 1 });
     expect(writer.deleteCalls).toHaveLength(0);
+  });
+
+  // Reproduces the exact data-loss scenario independent review flagged:
+  // update A->B gets stuck pending (transient failure), the user edits again
+  // B->C and that one succeeds, then the sweep later finds the stale A->B
+  // command and must NOT reapply "B" over the already-current "C".
+  it("fails a stale update as superseded instead of reapplying its stale content over a newer edit", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const eventId = objectId() as EventId;
+    const calendarId = objectId();
+
+    await events.put({
+      _id: eventId,
+      tenantId,
+      principalId,
+      origin: "compass",
+      calendarId,
+      clientEventId: null,
+      connectionId: null,
+      providerEventId: null,
+      providerVersion: null,
+      providerUpdatedAt: null,
+      deliveryState: null,
+      providerMetadata: null,
+      content: {
+        title: "A",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule,
+      recurrence: { kind: "single" },
+      lifecycleState: "active",
+      generation: 0,
+      createdAt: now(),
+      updatedAt: now(),
+      confirmedAt: now(),
+    } as never);
+
+    const updateTo = (title: string) => ({
+      tenantId,
+      principalId,
+      idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
+      eventId,
+      input: {
+        kind: "update",
+        invitation: "none",
+        content: {
+          title,
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+        },
+        schedule,
+        recurrence: { kind: "preserve" },
+        scope: "all",
+        recurrenceId: null,
+      } as never,
+      expectedVersion: null,
+    });
+
+    // Submit A->B but never apply it: this is exactly the state a transient
+    // provider failure mid-execute leaves a command in (see
+    // provider-command.service.ts's "return command" branches) - the row
+    // stays pending, untouched, in storage.
+    const { record: staleCommand } = await commands.submit(updateTo("B"));
+    expect(staleCommand.outcome.state).toBe("pending");
+
+    // The user's follow-up edit B->C is submitted and applied normally.
+    const { command: laterCommand } = await submitCloudCommand(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: { writer: new FakeDeleteWriter(), custody: tokenSource() },
+      },
+      updateTo("C"),
+      now,
+    );
+    expect(laterCommand.outcome.state).toBe("confirmed");
+    expect(
+      (await events.findById(tenantId, principalId, eventId))?.content.title,
+    ).toBe("C");
+
+    const result = await retryStaleCommands(
+      {
+        commands,
+        events,
+        calendars,
+        occurrences,
+        markers,
+        execution: "active",
+        provider: { writer: new FakeDeleteWriter(), custody: tokenSource() },
+      },
+      before(),
+      now,
+    );
+
+    expect(result).toEqual({ attempted: 1, stillStale: 0 });
+    const staleStored = await commands.findById(
+      tenantId,
+      principalId,
+      staleCommand._id,
+    );
+    expect(staleStored?.outcome.state).toBe("failed");
+    expect(
+      staleStored?.outcome.state === "failed" &&
+        staleStored.outcome.failureReason,
+    ).toBe("versionConflict");
+    // The critical assertion: the event's title is still the LATER edit,
+    // never reverted to the stale command's "B".
+    expect(
+      (await events.findById(tenantId, principalId, eventId))?.content.title,
+    ).toBe("C");
   });
 });

--- a/packages/sync/src/domain/stale-command-retry.service.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.ts
@@ -1,0 +1,70 @@
+import { type SyncCommandInput } from "@core/types/sync/command.contracts";
+import {
+  type CloudCommandDeps,
+  ProviderWriteUnavailableError,
+  retryCloudMutation,
+} from "@sync/domain/cloud-command.service";
+import { type CommandRepository } from "@sync/storage/repositories/command.repository";
+
+export interface StaleCommandRetryDeps extends CloudCommandDeps {
+  commands: CommandRepository;
+}
+
+export interface StaleCommandRetryResult {
+  // How many stale commands this sweep gave a fresh attempt.
+  attempted: number;
+  // Of those, how many are STILL nonterminal after the attempt - either the
+  // same transient failure recurred, or the provider write is unavailable.
+  stillStale: number;
+}
+
+// The kinds executed inline and synchronously from the command HTTP request
+// (see cloud-command.service.ts's applyCloudMutation): a transient provider
+// failure mid-execute there returns the command unchanged, and no job or
+// worker ever revisits it. Without this sweep, an event can sit visibly
+// "deleting" or reflecting a half-applied update forever after one blip.
+const RETRYABLE_KINDS: readonly SyncCommandInput["kind"][] = [
+  "update",
+  "delete",
+];
+
+// The self-heal sweep for commands stuck nonterminal (pending/applying/
+// reconciling) past the stale window. Re-runs the exact same routing logic
+// the original request used (retryCloudMutation -> applyCloudMutation), so a
+// command that recovers converges exactly as it would have inline. A GLOBAL
+// scan across owners (system liveness, not a user request) - mirrors
+// failed-job-requeue.service.ts's sweep shape.
+export async function retryStaleCommands(
+  deps: StaleCommandRetryDeps,
+  before: Date,
+  now: () => Date,
+  limit = 50,
+): Promise<StaleCommandRetryResult> {
+  const stale = await deps.commands.listStaleNonterminal(
+    before,
+    RETRYABLE_KINDS,
+    limit,
+  );
+
+  const NONTERMINAL_STATES = new Set(["pending", "applying", "reconciling"]);
+  let stillStale = 0;
+  for (const command of stale) {
+    try {
+      const result = await retryCloudMutation(deps, command, now);
+      if (NONTERMINAL_STATES.has(result.outcome.state)) {
+        stillStale++;
+      }
+    } catch (error) {
+      // Provider work went unavailable between the sweep starting and this
+      // command's turn (e.g. execution flipped mid-cycle) - leave it for the
+      // next sweep rather than losing the rest of the batch to one throw.
+      if (error instanceof ProviderWriteUnavailableError) {
+        stillStale++;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return { attempted: stale.length, stillStale };
+}

--- a/packages/sync/src/domain/stale-command-retry.service.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.ts
@@ -31,9 +31,14 @@ const RETRYABLE_KINDS: readonly SyncCommandInput["kind"][] = [
 // The self-heal sweep for commands stuck nonterminal (pending/applying/
 // reconciling) past the stale window. Re-runs the exact same routing logic
 // the original request used (retryCloudMutation -> applyCloudMutation), so a
-// command that recovers converges exactly as it would have inline. A GLOBAL
-// scan across owners (system liveness, not a user request) - mirrors
-// failed-job-requeue.service.ts's sweep shape.
+// command that recovers converges exactly as it would have inline.
+// retryCloudMutation itself refuses to reapply a command superseded by a
+// later one for the same event (failing it as versionConflict instead) - a
+// stale command that just sat pending for the retry window is not
+// necessarily still the latest intent, and reapplying old content over a
+// newer edit would be silent data loss. A GLOBAL scan across owners (system
+// liveness, not a user request) - mirrors failed-job-requeue.service.ts's
+// sweep shape.
 export async function retryStaleCommands(
   deps: StaleCommandRetryDeps,
   before: Date,

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -176,6 +176,13 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       name: "principal_nonterminal",
       key: { tenantId: 1, principalId: 1, "outcome.state": 1, createdAt: 1 },
     },
+    // Covers the global stale-command retry sweep (listStaleNonterminal):
+    // filter on state + kind, ordered oldest-first by updatedAt, across every
+    // owner - deliberately NOT tenant/principal-scoped like the index above.
+    {
+      name: "stale_nonterminal",
+      key: { "outcome.state": 1, "input.kind": 1, updatedAt: 1 },
+    },
   ],
   [SYNC_COLLECTIONS.jobs]: [
     {

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -1,6 +1,9 @@
 import { type Collection, type Db, ObjectId } from "mongodb";
 import { type EventId } from "@core/types/domain-primitives";
-import { type SyncCommandOutcome } from "@core/types/sync/command.contracts";
+import {
+  type SyncCommandInput,
+  type SyncCommandOutcome,
+} from "@core/types/sync/command.contracts";
 import {
   type ConnectionId,
   type PrincipalId,
@@ -181,6 +184,31 @@ export class CommandRepository {
       .toArray();
 
     return result?.count ?? 0;
+  }
+
+  // Commands stuck nonterminal past `before`, across every owner (system
+  // liveness, not a user request — same shape as JobRepository's failed-job
+  // sweep query). A transient provider failure mid-execute returns the
+  // command unchanged rather than retrying it (see provider-command.service.ts):
+  // nothing else ever picks a pending command back up, so without this sweep
+  // it stays visibly "deleting"/"updating" forever. Scoped to update/delete —
+  // the kinds executed inline and synchronously from the HTTP request, so a
+  // transient failure there has no other retry path at all.
+  async listStaleNonterminal(
+    before: Date,
+    kinds: readonly SyncCommandInput["kind"][],
+    limit: number,
+  ): Promise<CommandRecord[]> {
+    const records = await this.collection
+      .find({
+        "outcome.state": { $in: ["pending", "applying", "reconciling"] },
+        "input.kind": { $in: kinds },
+        updatedAt: { $lt: before },
+      })
+      .sort({ updatedAt: 1 })
+      .limit(limit)
+      .toArray();
+    return records.map((r) => CommandRecordSchema.parse(r));
   }
 
   // Hard-delete every command for a principal (account deletion).

--- a/packages/sync/src/storage/repositories/command.repository.ts
+++ b/packages/sync/src/storage/repositories/command.repository.ts
@@ -104,6 +104,31 @@ export class CommandRepository {
     return existing !== null;
   }
 
+  // Whether any OTHER command (any state) exists for this event, created after
+  // the given one. Consulted by the stale-command retry sweep before
+  // reapplying an old command's payload: reapplying stale content onto an
+  // event a later command has since touched would silently revert whatever
+  // that later command did. _id comparison (not createdAt) matches every
+  // other "latest"/ordering query in this repository and is monotonic for
+  // ObjectId-shaped ids from the same cluster.
+  async hasNewerCommandForEvent(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    eventId: EventId,
+    afterId: SyncCommandId,
+  ): Promise<boolean> {
+    const newer = await this.collection.findOne(
+      {
+        tenantId,
+        principalId,
+        eventId,
+        _id: { $gt: afterId },
+      },
+      { projection: { _id: 1 } },
+    );
+    return newer !== null;
+  }
+
   // Record a state transition (pending -> applying -> confirmed/failed/...) and
   // the current attempt count. Returns the updated record, or null if the
   // command doesn't exist for this principal.

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -88,6 +88,20 @@ describe("handleError", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it("shows a toast on a 404 instead of silently reverting the optimistic edit", () => {
+    // Not a session failure (unlike GONE/UNAUTHORIZED) - the api interceptor
+    // only console.error's a 404 and rethrows, so without this the user's
+    // edit rolls back with zero visible feedback at all.
+    const error = createServerError(Status.NOT_FOUND);
+
+    handleError(error);
+
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
+      toastId: GENERIC_ERROR_TOAST_ID,
+    });
+  });
+
   it("does not log a retryable, backend-authored mutation failure", () => {
     // A 502 PROVIDER_FAILURE the backend authored: it answered (so it isn't
     // "unavailable"), and it's retryable, so the user just needs a nudge. It

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -174,14 +174,23 @@ export const handleError = (error: Error) => {
     return;
   }
 
-  const codesToIgnore = [Status.NOT_FOUND, Status.GONE, Status.UNAUTHORIZED];
   // Prefer the structured status on ApiError; fall back to the trailing
   // status digits in the message for errors that only carry text.
   const code =
     (error as ApiError).response?.status ??
     parseInt(error.message.slice(-3), 10);
-  if (codesToIgnore.includes(code)) {
-    // api interceptor will handle these
+
+  // GONE/UNAUTHORIZED are session-level failures — the api interceptor signs
+  // the user out, which has its own messaging, so nothing more is shown here.
+  if (code === Status.GONE || code === Status.UNAUTHORIZED) {
+    return;
+  }
+  // NOT_FOUND is not a session failure (e.g. syncing onto a calendar the
+  // server hasn't provisioned yet) — the interceptor only console.error's it
+  // and rethrows. Left unhandled here, the optimistic edit silently rolls
+  // back with no visible feedback at all.
+  if (code === Status.NOT_FOUND) {
+    showCatchallToast(CATCHALL_TOAST_MESSAGE);
     return;
   }
 


### PR DESCRIPTION
## Summary
A transient provider failure during a cloud-targeted delete/update left the command permanently pending: `executeProviderDelete` (and every other per-kind executor in `provider-command.service.ts`) returns the command unchanged on a transient failure, and — since these run inline and synchronously from the HTTP request, not as a job — nothing ever revisits it. The event stays visibly "deleting" (or reflects a half-applied update) until a manual retry, matching the long-open "delete returns 503 but succeeds" symptom.

- **New self-heal sweep** (`stale-command-retry.service.ts`), following the same pattern as the existing failed-job-requeue sweep: a global scan for commands stuck nonterminal past a cooldown window, each re-run through the exact same routing logic the original request used (`retryCloudMutation`, a thin wrapper exported from `cloud-command.service.ts` around the existing `applyCloudMutation`). Wired into sync's scheduler lineup in `app.ts` alongside reconcile/subscription/failedJobRequeue. New `CommandRepository.listStaleNonterminal` query + a matching index.
- **`sync-service.client.ts`**: `statusToKind` didn't map 429 (sync's own internal rate limiter — a shared 300/min bucket — trips under normal-ish load) — it fell through to `unexpectedStatus` → `GenericError.NotSure`, whose `Status.UNSURE` (600) isn't a real HTTP status and reads as an unretryable mystery. Mapped to the same `"unavailable"` (retryable) kind as 503.
- **`event.controller.ts`**: a PUT with a new `calendarId` translates to two commands (update, then move), and move is unconditionally rejected — submitting them in sequence applies the update, then throws on the move: a partial write disguised as one failed request. Reject the whole replace up front, before anything is submitted, with a new non-retryable `MOVE_UNSUPPORTED` code.
- **`event.util.ts` (web)**: a mutation's 404 was in the "api interceptor will handle it" ignore-list alongside GONE/UNAUTHORIZED, but the interceptor only `console.error`'s a 404 and rethrows — the optimistic edit silently rolled back with zero visible feedback. Now shows the standard catchall toast (GONE/UNAUTHORIZED, genuine session failures, are untouched).

## Test plan
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on all changed files — clean
- [x] New `stale-command-retry.service.db.test.ts` — 4/4 pass (finishes a stuck delete, stays stale on a repeated transient failure, ignores commands newer than the cutoff, treats provider-unavailable as still-stale rather than throwing)
- [x] Full `bun run test:sync` — 718 pass, 0 fail
- [x] Full `bun run test:backend` — same pre-existing 29 failures as a fresh `origin/main` baseline (unrelated to this diff, confirmed in the prior PR), 2 new tests added and passing
- [x] Full web suite (manual explicit-file-list workaround, since the bun-1.4 dir-scan fix lives in a separate PR) shows the same pre-existing 24/21 fail/error baseline, 1 new test added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)