### PR TITLE
perf(sync): batch occurrence-projection writes within an import page

### DIFF
--- a/packages/sync/src/domain/provider-page-applier.db.test.ts
+++ b/packages/sync/src/domain/provider-page-applier.db.test.ts
@@ -157,4 +157,23 @@ describe("ProviderPageApplier", () => {
     expect(orphans).toBe(1);
     expect(run.importedCount).toBe(0);
   });
+
+  it("writes every event's occurrences for a page larger than one projection batch", async () => {
+    // PROJECTION_BATCH_SIZE is 200 — a page bigger than that must still
+    // project every event correctly, chunked across multiple transactions
+    // rather than dropping/duplicating anything at the boundary.
+    const calendar = await seedCalendar();
+    const run = applier(calendar);
+    const ids = Array.from({ length: 250 }, (_, i) => `bulk-${i}`);
+
+    await run.applyPage(ids.map((id) => single(id)));
+
+    expect(run.importedCount).toBe(250);
+    const occCount = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .countDocuments({ calendarId: calendar._id });
+    // One single-occurrence event each.
+    expect(occCount).toBe(250);
+  });
 });

--- a/packages/sync/src/domain/provider-page-applier.ts
+++ b/packages/sync/src/domain/provider-page-applier.ts
@@ -1,7 +1,10 @@
 import { type DateTime, type EventId } from "@core/types/domain-primitives";
 import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { occurrenceScheduleAt } from "@sync/domain/occurrence-projection";
-import { reprojectOccurrences } from "@sync/domain/reproject";
+import {
+  type ReprojectBatchEntry,
+  reprojectOccurrencesBatch,
+} from "@sync/domain/reproject";
 import {
   type ProviderEvent,
   type ProviderEventCancellation,
@@ -11,6 +14,12 @@ import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+
+// Events per batched occurrence-projection transaction. A single Google page
+// can hold up to 2500 events (google-event-reader.adapter.ts's maxResults);
+// keeping each transaction to a few hundred events comfortably avoids Atlas's
+// 60s transaction lifetime limit on the shared tier.
+const PROJECTION_BATCH_SIZE = 200;
 
 // Applies pages of provider event reads to the canonical store, shared by
 // initial import and incremental pull. It owns the parts both paths do
@@ -34,6 +43,11 @@ export class ProviderPageApplier {
   #masters = new Map<string, EventRecord>();
   // Series members read before their master, awaiting it.
   #pending: ProviderEventRead[] = [];
+  // Occurrence reprojections accumulated across the page (singles, masters,
+  // exceptions), written in one batched transaction per flush instead of one
+  // transaction per event — see event-occurrence.repository.ts's
+  // replaceForEvents. Cleared by #flushProjections.
+  #pendingProjections: ReprojectBatchEntry[] = [];
 
   constructor(
     private readonly events: EventRepository,
@@ -73,7 +87,7 @@ export class ProviderPageApplier {
     for (const read of reads) {
       if (read.kind === "event" && read.recurrence.kind === "single") {
         const single = await this.#upsertRead(read, { kind: "single" });
-        await reprojectOccurrences(this.occurrences, single, this.now);
+        this.#pendingProjections.push({ event: single });
       } else if (this.#needsMaster(read)) {
         const master = await this.#link(read);
         if (master) touchedSeries.set(master._id, master);
@@ -91,6 +105,7 @@ export class ProviderPageApplier {
     for (const master of touchedSeries.values()) {
       await this.#projectSeries(master);
     }
+    await this.#flushProjections();
 
     return standaloneCancellations;
   }
@@ -102,9 +117,26 @@ export class ProviderPageApplier {
     for (const master of await this.#drainPending()) {
       await this.#projectSeries(master);
     }
+    await this.#flushProjections();
     const orphans = this.#pending.length;
     this.#pending = [];
     return orphans;
+  }
+
+  // Write every accumulated projection in this page as one batched
+  // transaction (chunked so a very large page never approaches Atlas's 60s
+  // transaction lifetime limit — see event-occurrence.repository.ts).
+  async #flushProjections(): Promise<void> {
+    if (this.#pendingProjections.length === 0) return;
+    const batch = this.#pendingProjections;
+    this.#pendingProjections = [];
+    for (let i = 0; i < batch.length; i += PROJECTION_BATCH_SIZE) {
+      await reprojectOccurrencesBatch(
+        this.occurrences,
+        batch.slice(i, i + PROJECTION_BATCH_SIZE),
+        this.now,
+      );
+    }
   }
 
   // Whether a read is a series member that must resolve to a master before it
@@ -240,9 +272,12 @@ export class ProviderPageApplier {
       }
       return exception.recurrence.recurrenceId;
     });
-    await reprojectOccurrences(this.occurrences, master, this.now, instants);
+    this.#pendingProjections.push({
+      event: master,
+      excludedInstants: instants,
+    });
     for (const exception of exceptions) {
-      await reprojectOccurrences(this.occurrences, exception, this.now);
+      this.#pendingProjections.push({ event: exception });
     }
   }
 

--- a/packages/sync/src/domain/reproject.ts
+++ b/packages/sync/src/domain/reproject.ts
@@ -17,3 +17,28 @@ export async function reprojectOccurrences(
   const rows = projectOccurrences(event, syncHorizon(now()), excludedInstants);
   await occurrences.replaceForEvent(event._id, event.generation, rows);
 }
+
+export interface ReprojectBatchEntry {
+  event: EventRecord;
+  excludedInstants?: readonly DateTime[];
+}
+
+// Batched form of reprojectOccurrences: every entry's rows are computed the
+// same way, but written in one transaction instead of one per event. For a
+// provider page touching hundreds/thousands of events (an initial import),
+// this is what lets provider-page-applier.ts collapse its per-event
+// transaction count.
+export async function reprojectOccurrencesBatch(
+  occurrences: EventOccurrenceRepository,
+  entries: readonly ReprojectBatchEntry[],
+  now: () => Date,
+): Promise<void> {
+  if (entries.length === 0) return;
+  const horizon = syncHorizon(now());
+  const replacements = entries.map(({ event, excludedInstants = [] }) => ({
+    eventId: event._id,
+    generation: event.generation,
+    occurrences: projectOccurrences(event, horizon, excludedInstants),
+  }));
+  await occurrences.replaceForEvents(replacements);
+}

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
@@ -110,6 +110,86 @@ describe("EventOccurrenceRepository", () => {
     ).toBe(0);
   });
 
+  describe("replaceForEvents", () => {
+    it("writes every entry's rows in one call, matching sequential replaceForEvent", async () => {
+      const eventA = objectId() as OccurrenceInput["eventId"];
+      const eventB = objectId() as OccurrenceInput["eventId"];
+      const eventC = objectId() as OccurrenceInput["eventId"];
+
+      await repo.replaceForEvents([
+        {
+          eventId: eventA,
+          generation: 0,
+          occurrences: [
+            occurrence({ eventId: eventA, occurrenceKey: `${eventA}:a1` }),
+            occurrence({ eventId: eventA, occurrenceKey: `${eventA}:a2` }),
+          ],
+        },
+        {
+          eventId: eventB,
+          generation: 0,
+          occurrences: [
+            occurrence({ eventId: eventB, occurrenceKey: `${eventB}:b1` }),
+          ],
+        },
+        // An empty occurrence set (e.g. a fully-truncated recurring series)
+        // must still clear any prior rows for that event.
+        { eventId: eventC, generation: 0, occurrences: [] },
+      ]);
+
+      const docs = await db.collection("event_occurrences").find({}).toArray();
+      expect(docs.map((d) => d.occurrenceKey).sort()).toEqual(
+        [`${eventA}:a1`, `${eventA}:a2`, `${eventB}:b1`].sort(),
+      );
+    });
+
+    it("replaces stale rows for every entry, not just the first", async () => {
+      const eventA = objectId() as OccurrenceInput["eventId"];
+      const eventB = objectId() as OccurrenceInput["eventId"];
+      await repo.replaceForEvent(eventA, 0, [
+        occurrence({ eventId: eventA, occurrenceKey: `${eventA}:old` }),
+      ]);
+      await repo.replaceForEvent(eventB, 0, [
+        occurrence({ eventId: eventB, occurrenceKey: `${eventB}:old` }),
+      ]);
+
+      await repo.replaceForEvents([
+        {
+          eventId: eventA,
+          generation: 0,
+          occurrences: [
+            occurrence({ eventId: eventA, occurrenceKey: `${eventA}:new` }),
+          ],
+        },
+        {
+          eventId: eventB,
+          generation: 0,
+          occurrences: [
+            occurrence({ eventId: eventB, occurrenceKey: `${eventB}:new` }),
+          ],
+        },
+      ]);
+
+      const docs = await db.collection("event_occurrences").find({}).toArray();
+      expect(docs.map((d) => d.occurrenceKey).sort()).toEqual(
+        [`${eventA}:new`, `${eventB}:new`].sort(),
+      );
+    });
+
+    it("is a no-op for an empty entry list", async () => {
+      const eventId = objectId() as OccurrenceInput["eventId"];
+      await repo.replaceForEvent(eventId, 0, [
+        occurrence({ eventId, occurrenceKey: `${eventId}:kept` }),
+      ]);
+
+      await repo.replaceForEvents([]);
+
+      expect(
+        await db.collection("event_occurrences").countDocuments({ eventId }),
+      ).toBe(1);
+    });
+  });
+
   describe("listByCalendarRange", () => {
     const tenantId = objectId();
     const principalId = objectId();

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -83,18 +83,50 @@ export class EventOccurrenceRepository {
     generation: number,
     occurrences: OccurrenceInput[],
   ): Promise<void> {
-    const docs = occurrences.map((occurrence) =>
-      EventOccurrenceRecordSchema.parse({
-        _id: new ObjectId().toHexString(),
-        ...occurrence,
-      }),
-    );
+    await this.replaceForEvents([{ eventId, generation, occurrences }]);
+  }
+
+  // Batched form of replaceForEvent: every entry's delete+insert runs in ONE
+  // transaction instead of one per event. A single-event import page can touch
+  // thousands of events, and a separate Mongo transaction per event (each its
+  // own commit round-trip) was the dominant cost of an initial import — see
+  // provider-page-applier.ts, which accumulates a page's projections and
+  // flushes them through this method in chunks (bounded by the caller so one
+  // transaction never approaches Atlas's 60s transaction lifetime limit).
+  // Same per-event safety as replaceForEvent: each entry is scoped to its own
+  // (eventId, generation), so entries never touch each other's rows; grouping
+  // them in one transaction only changes when the commit happens, not what
+  // becomes visible together.
+  async replaceForEvents(
+    entries: readonly {
+      eventId: EventId;
+      generation: number;
+      occurrences: OccurrenceInput[];
+    }[],
+  ): Promise<void> {
+    if (entries.length === 0) return;
 
     const session = this.client.startSession();
     try {
       await session.withTransaction(async () => {
-        await this.collection.deleteMany({ eventId, generation }, { session });
-        if (docs.length > 0) {
+        // Delete-then-insert PER ENTRY (not a batched delete phase followed by
+        // a batched insert phase): if the same (eventId, generation) somehow
+        // appeared twice in one call, a split-phase delete-all-then-insert-all
+        // would silently duplicate that event's rows, since the second entry's
+        // delete would find nothing left to remove. Interleaving keeps the
+        // same one-transaction win (a single commit) without that risk.
+        for (const entry of entries) {
+          await this.collection.deleteMany(
+            { eventId: entry.eventId, generation: entry.generation },
+            { session },
+          );
+          if (entry.occurrences.length === 0) continue;
+          const docs = entry.occurrences.map((occurrence) =>
+            EventOccurrenceRecordSchema.parse({
+              _id: new ObjectId().toHexString(),
+              ...occurrence,
+            }),
+          );
           await this.collection.insertMany(docs, { session });
         }
       });

--- a/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
@@ -46,6 +46,45 @@ describe("InvalidationRepository", () => {
     ]);
   });
 
+  it("appendMany writes every invalidation with the same emittedAt/TTL", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const connectionId = objectId() as ConnectionId;
+    const eventId = objectId() as never;
+    const calendarId = objectId() as never;
+    const emittedAt = new Date("2026-07-24T12:00:00.000Z");
+
+    const rows = await repo.appendMany(
+      tenantId,
+      principalId,
+      [
+        { kind: "connection", connectionId },
+        { kind: "event", eventId, calendarId },
+      ],
+      emittedAt,
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.invalidation.kind).sort()).toEqual([
+      "connection",
+      "event",
+    ]);
+    for (const row of rows) {
+      expect(row.emittedAt).toEqual(emittedAt);
+      expect(row.expiresAt.getTime()).toBe(
+        emittedAt.getTime() + INVALIDATION_RETENTION_MS,
+      );
+    }
+    // Every row actually landed in storage, not just returned in memory.
+    const listed = await repo.listAfter(tenantId, principalId, null, 10);
+    expect(listed).toHaveLength(2);
+  });
+
+  it("appendMany is a no-op for an empty list", async () => {
+    const rows = await repo.appendMany(objectId(), objectId(), []);
+    expect(rows).toEqual([]);
+  });
+
   it("keyset-lists only the caller's rows after a cursor", async () => {
     const tenantId = objectId();
     const mine = objectId();

--- a/packages/sync/src/storage/repositories/invalidation.repository.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.ts
@@ -50,13 +50,21 @@ export class InvalidationRepository {
     invalidations: readonly SyncInvalidation[],
     emittedAt: Date = new Date(),
   ): Promise<InvalidationRecord[]> {
-    const out: InvalidationRecord[] = [];
-    for (const invalidation of invalidations) {
-      out.push(
-        await this.append({ tenantId, principalId, invalidation, emittedAt }),
-      );
-    }
-    return out;
+    if (invalidations.length === 0) return [];
+
+    const expiresAt = new Date(emittedAt.getTime() + INVALIDATION_RETENTION_MS);
+    const records = invalidations.map((invalidation) =>
+      InvalidationRecordSchema.parse({
+        _id: new ObjectId().toHexString(),
+        tenantId,
+        principalId,
+        invalidation,
+        emittedAt,
+        expiresAt,
+      }),
+    );
+    await this.collection.insertMany(records);
+    return records;
   }
 
   // Keyset page strictly after `afterId` for the signed principal. `afterId`


### PR DESCRIPTION
## Summary
Initial import ran one MongoDB transaction per event: `replaceForEvent` opens a session and commits a transaction for every single event, every series master, AND every series exception. A page can carry up to 2500 events (`google-event-reader.adapter.ts`'s `maxResults`), so a single page could cost thousands of transaction commits — the dominant cost behind the ~11 events/s import throughput on Atlas's shared tier, and the documented cause of an initial import stalling every queued pull for hours after the 2026-07-29 production cutover.

- **`EventOccurrenceRepository.replaceForEvents`**: the same delete-then-insert per `(eventId, generation)` as `replaceForEvent`, but every entry runs in ONE transaction (one commit) instead of one each. Interleaves each entry's delete immediately before its own insert (not a batched delete phase followed by a batched insert phase) so a duplicate `eventId` within one call can never end up with both old and new rows inserted. `replaceForEvent` is now a one-entry call to this.
- **`reproject.ts`**: `reprojectOccurrencesBatch` computes each entry's rows the same way `reprojectOccurrences` does, then writes them all through `replaceForEvents`.
- **`provider-page-applier.ts`**: `applyPage`/`finish`/`#projectSeries` now accumulate every single/master/exception's projection into a page-level buffer instead of writing immediately, then flush once per page in chunks of 200 (comfortably under Atlas's 60s transaction lifetime limit on the shared tier) via `reprojectOccurrencesBatch`.
- **`invalidation.repository.ts`**: `appendMany` was N sequential `insertOne` calls; now one `insertMany`.

**Not touched** (explicitly out of scope): job fairness, the change-feed page cap, and index changes — separate concerns. Cross-page series reprojection dedup (the same series touched by multiple pages still reprojects once per page, not once per run) is a deeper, riskier change left for a follow-up.

## Test plan
- [x] `bun run type-check` — clean
- [x] `./node_modules/.bin/biome check` on all changed files — clean
- [x] New test: a 250-event page (`provider-page-applier.db.test.ts`) crossing the 200-event chunk boundary — every event's occurrence projects correctly
- [x] New direct repository tests for `replaceForEvents` (multi-event batch matches sequential `replaceForEvent`, stale-row replacement across every entry, empty-list no-op) and `appendMany` (multi-row write, empty-list no-op)
- [x] Full `bun run test:sync` — 720 pass (up from 714), 0 fail — includes all pre-existing occurrence/series/import/pull coverage, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)