### PR TITLE
fix(sync): stop idle job claims from walking pending backoff rows

### DIFF
--- a/packages/sync/src/storage/index-manifest.db.test.ts
+++ b/packages/sync/src/storage/index-manifest.db.test.ts
@@ -107,6 +107,32 @@ describe("installIndexManifest", () => {
     expect(ttl?.expireAfterSeconds).toBe(0);
   });
 
+  it("installs due-claim and connection-led indexes on jobs", async () => {
+    const indexes = await db.collection(SYNC_COLLECTIONS.jobs).indexes();
+    const dueClaim = indexes.find((i) => i.name === "state_runafter_priority");
+    expect(dueClaim?.key).toEqual({ state: 1, runAfter: 1, priority: -1 });
+    // The priority-led predecessor walked every pending-not-due row on idle claim.
+    expect(indexes.some((i) => i.name === "state_priority_runafter")).toBe(
+      false,
+    );
+    expect(indexes.some((i) => i.name === "connection_runafter")).toBe(true);
+  });
+
+  it("installs owner-calendar and resourceKind-led indexes on sync_resources", async () => {
+    const indexes = await db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .indexes();
+    expect(indexes.some((i) => i.name === "principal_resource_calendar")).toBe(
+      true,
+    );
+    const lastSuccess = indexes.find((i) => i.name === "resource_last_success");
+    expect(lastSuccess?.key).toEqual({ resourceKind: 1, lastSuccessAt: 1 });
+    const lastAttempt = indexes.find((i) => i.name === "resource_last_attempt");
+    expect(lastAttempt?.key).toEqual({ resourceKind: 1, lastAttemptAt: 1 });
+    expect(indexes.some((i) => i.name === "last_success")).toBe(false);
+    expect(indexes.some((i) => i.name === "last_attempt")).toBe(false);
+  });
+
   it("enforces the unique command idempotency key", async () => {
     const commands = db.collection(SYNC_COLLECTIONS.commands);
     const key = {

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -304,10 +304,11 @@ export async function installIndexManifest(
     // OPERATIONAL CAVEAT: against a LARGE, POPULATED collection this is unsafe to
     // run inline at startup — dropping then rebuilding a unique index leaves a
     // window with no uniqueness enforced and blocks readiness on a foreground
-    // build. Fine today: sync isn't serving production data yet, so collections
-    // are empty or tiny and no concurrent writer exists at connect time. Before
-    // sync carries real data, a key change on a populated collection must move to
-    // a rolling/online index migration instead of this inline drop-and-rebuild.
+    // build. Fine for today's jobs/sync_resources renames (small collections,
+    // non-unique secondary indexes, createIndex finishes in seconds). A key
+    // change on events/event_occurrences (hundreds of thousands of docs) must
+    // move to a rolling/online index migration instead of this inline
+    // drop-and-rebuild.
     const declared = new Set(entries.map((e) => e.name));
     const present = await collection.indexes().catch(() => []);
     for (const index of present) {

--- a/packages/sync/src/storage/index-manifest.ts
+++ b/packages/sync/src/storage/index-manifest.ts
@@ -146,6 +146,19 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       options: { unique: true },
     },
     {
+      // Owner-scoped calendar lookups (activeGenerationByCalendar,
+      // listEventResourceFreshnessByCalendar) filter on
+      // (tenantId, principalId, resourceKind, calendarId) — the unique
+      // connection-led index above cannot serve that shape.
+      name: "principal_resource_calendar",
+      key: {
+        tenantId: 1,
+        principalId: 1,
+        resourceKind: 1,
+        calendarId: 1,
+      },
+    },
+    {
       name: "subscription_expiry",
       key: { subscriptionExpiresAt: 1 },
       options: { sparse: true },
@@ -157,10 +170,19 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       key: { subscriptionId: 1 },
       options: { sparse: true },
     },
-    { name: "last_success", key: { lastSuccessAt: 1 } },
-    // Backs the reconcile sweep's round-robin sort (lastAttemptAt asc, nulls
-    // first). The filter still selects on lastSuccessAt via last_success.
-    { name: "last_attempt", key: { lastAttemptAt: 1 } },
+    // Reconcile always filters resourceKind:"events" before lastSuccessAt /
+    // lastAttemptAt, so lead with resourceKind to avoid walking every
+    // calendarList row on each sweep. New names (not last_success /
+    // last_attempt) so installIndexManifest drops the old single-field keys
+    // instead of conflicting on same-name/different-spec.
+    {
+      name: "resource_last_success",
+      key: { resourceKind: 1, lastSuccessAt: 1 },
+    },
+    {
+      name: "resource_last_attempt",
+      key: { resourceKind: 1, lastAttemptAt: 1 },
+    },
   ],
   [SYNC_COLLECTIONS.commands]: [
     {
@@ -191,11 +213,21 @@ export const SYNC_INDEX_MANIFEST: IndexManifest = {
       options: { unique: true },
     },
     {
-      // Field order matches the due-job claim: filter on state, then sort by
-      // priority (desc) then runAfter (asc), so the claim is served from the
-      // index without a blocking in-memory sort.
-      name: "state_priority_runafter",
-      key: { state: 1, priority: -1, runAfter: 1 },
+      // Due-job claim filters `{ state, runAfter: { $lte: now } }`. Leading with
+      // runAfter (not priority) means pending-but-not-due backoff jobs are NOT
+      // examined — the previous `{ state, priority, runAfter }` ordering walked
+      // every pending row on every idle claim, which is what kept Atlas Query
+      // Targeting above 1000 after the events COLLSCAN fix (#2473). Due matches
+      // are usually few, so an in-memory priority sort of that small set is fine.
+      name: "state_runafter_priority",
+      key: { state: 1, runAfter: 1, priority: -1 },
+    },
+    {
+      // Connection-state refresh asks for the oldest overdue job per connection
+      // on every GET /internal/connections. Without a connection-led index that
+      // is a jobs COLLSCAN per connection.
+      name: "connection_runafter",
+      key: { connectionId: 1, runAfter: 1 },
     },
     {
       name: "lease_expiry",

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
@@ -3,6 +3,7 @@ import { type Db } from "mongodb";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurrence.contracts";
 import {
+  BUSY_MAX_LOOKBACK_MS,
   EventOccurrenceRepository,
   type OccurrenceInput,
 } from "@sync/storage/repositories/event-occurrence.repository";
@@ -356,6 +357,78 @@ describe("EventOccurrenceRepository", () => {
       });
       expect(repaired).toHaveLength(1);
       expect(repaired[0]?.occurrenceKey).toBe(`${cal}:repair`);
+    });
+  });
+
+  describe("listBusyOverlapping", () => {
+    it("includes overlapping busy rows inside the lookback and skips older starts", async () => {
+      const tenantId = objectId() as OccurrenceInput["tenantId"];
+      const principalId = objectId() as OccurrenceInput["principalId"];
+      const calendarId = objectId() as OccurrenceInput["calendarId"];
+      const windowStart = new Date("2026-07-14T00:00:00.000Z");
+      const windowEnd = new Date("2026-07-15T00:00:00.000Z");
+      const inLookbackStart = new Date(
+        windowStart.getTime() - BUSY_MAX_LOOKBACK_MS + 60_000,
+      );
+      const outOfLookbackStart = new Date(
+        windowStart.getTime() - BUSY_MAX_LOOKBACK_MS - 60_000,
+      );
+
+      const eventIn = objectId() as OccurrenceInput["eventId"];
+      const eventOut = objectId() as OccurrenceInput["eventId"];
+      await repo.replaceForEvents([
+        {
+          eventId: eventIn,
+          generation: 0,
+          occurrences: [
+            occurrence({
+              tenantId,
+              principalId,
+              calendarId,
+              eventId: eventIn,
+              occurrenceKey: `${eventIn}:in`,
+              startAt: inLookbackStart,
+              endAt: windowEnd,
+              schedule: {
+                kind: "timed",
+                start: inLookbackStart.toISOString(),
+                end: windowEnd.toISOString(),
+                timeZone: "UTC",
+              },
+            }),
+          ],
+        },
+        {
+          eventId: eventOut,
+          generation: 0,
+          occurrences: [
+            occurrence({
+              tenantId,
+              principalId,
+              calendarId,
+              eventId: eventOut,
+              occurrenceKey: `${eventOut}:out`,
+              startAt: outOfLookbackStart,
+              endAt: windowEnd,
+              schedule: {
+                kind: "timed",
+                start: outOfLookbackStart.toISOString(),
+                end: windowEnd.toISOString(),
+                timeZone: "UTC",
+              },
+            }),
+          ],
+        },
+      ]);
+
+      const busy = await repo.listBusyOverlapping({
+        tenantId,
+        principalId,
+        calendars: [{ calendarId, generation: 0 }],
+        start: windowStart,
+        end: windowEnd,
+      });
+      expect(busy).toEqual([{ startAt: inLookbackStart, endAt: windowEnd }]);
     });
   });
 });

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -15,7 +15,7 @@ export type OccurrenceInput = Omit<EventOccurrenceRecord, "_id">;
 
 // Longest occurrence start we still consider when answering a busy window.
 // Keeps calendar_gen_start range-bounded; see listBusyOverlapping.
-const BUSY_MAX_LOOKBACK_MS = 366 * 24 * 60 * 60 * 1000;
+export const BUSY_MAX_LOOKBACK_MS = 366 * 24 * 60 * 60 * 1000;
 
 export interface OccurrenceRangeCursor {
   startAt: Date;

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -13,6 +13,10 @@ import {
 
 export type OccurrenceInput = Omit<EventOccurrenceRecord, "_id">;
 
+// Longest occurrence start we still consider when answering a busy window.
+// Keeps calendar_gen_start range-bounded; see listBusyOverlapping.
+export const BUSY_MAX_LOOKBACK_MS = 366 * 24 * 60 * 60 * 1000;
+
 export interface OccurrenceRangeCursor {
   startAt: Date;
   id: string;
@@ -224,10 +228,17 @@ export class EventOccurrenceRepository {
   // it is included. Cancelled occurrences are not busy and are excluded; one with
   // no endAt (predating the field and not yet reprojected) is excluded until it
   // reprojects — the `endAt > start` filter never matches a missing field.
+  //
+  // `startAt` is also lower-bounded by (windowStart - BUSY_MAX_LOOKBACK_MS): an
+  // unbounded `startAt < end` walks the entire historical calendar_gen_start
+  // range on every busy query. Occurrences longer than the lookback are still
+  // found when they start inside it; longer-than-lookback events are outside
+  // Compass's practical horizon (multi-year single instances).
   async listBusyOverlapping(
     query: BusyOverlapQuery,
   ): Promise<OccurrenceInterval[]> {
     if (query.calendars.length === 0) return [];
+    const startAtFloor = new Date(query.start.getTime() - BUSY_MAX_LOOKBACK_MS);
     const filter = {
       tenantId: query.tenantId,
       principalId: query.principalId,
@@ -240,7 +251,7 @@ export class EventOccurrenceRepository {
             generation: c.generation,
           })),
         },
-        { startAt: { $lt: query.end } },
+        { startAt: { $gte: startAtFloor, $lt: query.end } },
         { endAt: { $gt: query.start } },
       ],
     };

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -15,7 +15,7 @@ export type OccurrenceInput = Omit<EventOccurrenceRecord, "_id">;
 
 // Longest occurrence start we still consider when answering a busy window.
 // Keeps calendar_gen_start range-bounded; see listBusyOverlapping.
-export const BUSY_MAX_LOOKBACK_MS = 366 * 24 * 60 * 60 * 1000;
+const BUSY_MAX_LOOKBACK_MS = 366 * 24 * 60 * 60 * 1000;
 
 export interface OccurrenceRangeCursor {
   startAt: Date;

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -404,10 +404,9 @@ describe("JobRepository", () => {
       expect(winning).toContain("state_runafter_priority");
       expect(winning).not.toContain("COLLSCAN");
       // With runAfter leading after state, future backoff rows are not examined.
-      const examined =
-        (plan as { executionStats?: { totalKeysExamined?: number } })
-          .executionStats?.totalKeysExamined ?? Number.POSITIVE_INFINITY;
-      expect(examined).toBeLessThanOrEqual(1);
+      expect(
+        plan.executionStats?.totalKeysExamined ?? Infinity,
+      ).toBeLessThanOrEqual(1);
     });
 
     it("connection overdue filter is served by connection_runafter", async () => {

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -377,4 +377,72 @@ describe("JobRepository", () => {
       ).toBeNull();
     });
   });
+
+  // Plan pins for the Atlas Query Targeting residual after #2473: idle claims
+  // must not walk pending-not-due backoff jobs, and connection overdue lookups
+  // must not COLLSCAN the jobs collection.
+  describe("index plans", () => {
+    const NOW = new Date("2026-07-20T12:00:00.000Z");
+
+    it("due-pending claim filter is served by state_runafter_priority", async () => {
+      // Seed many future-backoff jobs so a wrong index order would examine them.
+      for (let i = 0; i < 20; i += 1) {
+        await repo.enqueue(
+          enqueue({
+            coalescingKey: `backoff:${i}`,
+            runAfter: new Date(NOW.getTime() + (i + 1) * 60_000),
+          }),
+        );
+      }
+
+      const plan = await db
+        .collection("jobs")
+        .find({ state: "pending", runAfter: { $lte: NOW } })
+        .sort({ priority: -1, runAfter: 1 })
+        .explain("executionStats");
+      const winning = JSON.stringify(plan);
+      expect(winning).toContain("state_runafter_priority");
+      expect(winning).not.toContain("COLLSCAN");
+      // With runAfter leading after state, future backoff rows are not examined.
+      const examined =
+        (plan as { executionStats?: { totalKeysExamined?: number } })
+          .executionStats?.totalKeysExamined ?? Number.POSITIVE_INFINITY;
+      expect(examined).toBeLessThanOrEqual(1);
+    });
+
+    it("connection overdue filter is served by connection_runafter", async () => {
+      const connectionId = objectId();
+      await repo.enqueue(
+        enqueue({
+          connectionId: connectionId as JobEnqueue["connectionId"],
+          runAfter: NOW,
+        }),
+      );
+      // Noise on other connections.
+      for (let i = 0; i < 10; i += 1) {
+        await repo.enqueue(
+          enqueue({
+            coalescingKey: `other:${i}`,
+            runAfter: NOW,
+          }),
+        );
+      }
+
+      const plan = await db
+        .collection("jobs")
+        .find({
+          connectionId,
+          $or: [
+            { state: "pending", runAfter: { $lte: NOW } },
+            { state: "claimed", leaseExpiresAt: { $lt: NOW } },
+            { state: "failed" },
+          ],
+        })
+        .sort({ runAfter: 1 })
+        .explain("queryPlanner");
+      const winning = JSON.stringify(plan);
+      expect(winning).toContain("connection_runafter");
+      expect(winning).not.toContain("COLLSCAN");
+    });
+  });
 });

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -150,6 +150,30 @@ describe("JobRepository", () => {
       expect(reclaimed?.attempt).toBe(2);
     });
 
+    // Load-bearing with the split claim arms: reclaim must not wait for the
+    // entire pending queue to drain, or a crashed worker's coalesced resource
+    // stays stuck under a sustained backlog.
+    it("reclaims an expired lease even when other pending work is due", async () => {
+      await repo.enqueue(
+        enqueue({ coalescingKey: "stuck", priority: 1, runAfter: past(1000) }),
+      );
+      const stuck = await repo.claimDueJob("crashed-worker", NOW, LEASE_MS);
+      expect(stuck?.coalescingKey).toBe("stuck");
+
+      await repo.enqueue(
+        enqueue({
+          coalescingKey: "backlog",
+          priority: 9,
+          runAfter: past(500),
+        }),
+      );
+
+      const later = future(LEASE_MS + 1000);
+      const next = await repo.claimDueJob("fresh-worker", later, LEASE_MS);
+      expect(next?._id).toBe(stuck?._id);
+      expect(next?.leaseOwner).toBe("fresh-worker");
+    });
+
     it("does not let a stale worker heartbeat, complete, retry, or fail", async () => {
       await repo.enqueue(enqueue({ runAfter: past(1000) }));
       const job = await repo.claimDueJob("owner", NOW, LEASE_MS);

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -84,31 +84,45 @@ export class JobRepository {
 
   // Atomically claim the highest-priority due job for one worker. A job is due
   // when it's pending and its runAfter has passed, OR it's claimed but its
-  // lease has expired (the previous owner crashed). Because findOneAndUpdate is
-  // a single atomic operation, two workers racing for the same job can never
-  // both win — the loser simply gets the next job or null. Returns null when no
-  // job is due.
+  // lease has expired (the previous owner crashed). The two arms are claimed
+  // separately so each can use its own index (state_runafter_priority /
+  // lease_expiry) — a single $or + sort forced the planner to walk every
+  // pending-not-due backoff job on every idle poll. Due pending work is
+  // preferred over lease reclaim; within each arm, priority then age wins.
+  // findOneAndUpdate stays atomic per arm, so two workers still never both
+  // win the same job. Returns null when no job is due.
   async claimDueJob(
     owner: string,
     now: Date,
     leaseDurationMs: number,
   ): Promise<JobRecord | null> {
     const leaseExpiresAt = new Date(now.getTime() + leaseDurationMs);
-    const result = await this.collection.findOneAndUpdate(
-      {
-        $or: [
-          { state: "pending", runAfter: { $lte: now } },
-          { state: "claimed", leaseExpiresAt: { $lt: now } },
-        ],
-      },
-      {
-        $set: { state: "claimed", leaseOwner: owner, leaseExpiresAt },
-        $inc: { attempt: 1 },
-        $currentDate: { updatedAt: true },
-      },
-      { sort: { priority: -1, runAfter: 1 }, returnDocument: "after" },
+    const claimUpdate = {
+      $set: { state: "claimed" as const, leaseOwner: owner, leaseExpiresAt },
+      $inc: { attempt: 1 },
+      $currentDate: { updatedAt: true as const },
+    };
+    const claimOpts = {
+      sort: { priority: -1 as const, runAfter: 1 as const },
+      returnDocument: "after" as const,
+    };
+
+    // Prefer due pending work; only then reclaim an expired lease. Splitting
+    // the former $or keeps each arm on its own index (see state_runafter_priority
+    // / lease_expiry in the manifest).
+    const duePending = await this.collection.findOneAndUpdate(
+      { state: "pending", runAfter: { $lte: now } },
+      claimUpdate,
+      claimOpts,
     );
-    return result ? JobRecordSchema.parse(result) : null;
+    if (duePending) return JobRecordSchema.parse(duePending);
+
+    const expiredLease = await this.collection.findOneAndUpdate(
+      { state: "claimed", leaseExpiresAt: { $lt: now } },
+      claimUpdate,
+      claimOpts,
+    );
+    return expiredLease ? JobRecordSchema.parse(expiredLease) : null;
   }
 
   // Extend the lease while a worker is still processing. Only the current owner

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -107,22 +107,18 @@ export class JobRepository {
       returnDocument: "after" as const,
     };
 
-    // Prefer due pending work; only then reclaim an expired lease. Splitting
-    // the former $or keeps each arm on its own index (see state_runafter_priority
-    // / lease_expiry in the manifest).
-    const duePending = await this.collection.findOneAndUpdate(
-      { state: "pending", runAfter: { $lte: now } },
-      claimUpdate,
-      claimOpts,
-    );
-    if (duePending) return JobRecordSchema.parse(duePending);
-
-    const expiredLease = await this.collection.findOneAndUpdate(
-      { state: "claimed", leaseExpiresAt: { $lt: now } },
-      claimUpdate,
-      claimOpts,
-    );
-    return expiredLease ? JobRecordSchema.parse(expiredLease) : null;
+    for (const filter of [
+      { state: "pending" as const, runAfter: { $lte: now } },
+      { state: "claimed" as const, leaseExpiresAt: { $lt: now } },
+    ]) {
+      const claimed = await this.collection.findOneAndUpdate(
+        filter,
+        claimUpdate,
+        claimOpts,
+      );
+      if (claimed) return JobRecordSchema.parse(claimed);
+    }
+    return null;
   }
 
   // Extend the lease while a worker is still processing. Only the current owner

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -87,8 +87,10 @@ export class JobRepository {
   // lease has expired (the previous owner crashed). The two arms are claimed
   // separately so each can use its own index (state_runafter_priority /
   // lease_expiry) — a single $or + sort forced the planner to walk every
-  // pending-not-due backoff job on every idle poll. Due pending work is
-  // preferred over lease reclaim; within each arm, priority then age wins.
+  // pending-not-due backoff job on every idle poll. Expired-lease reclaim
+  // runs FIRST so a sustained pending backlog cannot starve crash recovery
+  // (a coalesced resource stuck in claimed-with-expired-lease would otherwise
+  // never get a fresh pending row). Within each arm, priority then age wins.
   // findOneAndUpdate stays atomic per arm, so two workers still never both
   // win the same job. Returns null when no job is due.
   async claimDueJob(
@@ -108,8 +110,8 @@ export class JobRepository {
     };
 
     for (const filter of [
-      { state: "pending" as const, runAfter: { $lte: now } },
       { state: "claimed" as const, leaseExpiresAt: { $lt: now } },
+      { state: "pending" as const, runAfter: { $lte: now } },
     ]) {
       const claimed = await this.collection.findOneAndUpdate(
         filter,

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -324,7 +324,8 @@ export class SyncResourceRepository {
   // it is a GLOBAL scan across owners, not owner-scoped: each returned resource
   // carries its own (tenantId, principalId) for the job the caller enqueues. A
   // never-synced resource (lastSuccessAt null) sorts first so bootstrapping a
-  // new calendar is not starved by the stale ones. Uses the last_success index.
+  // new calendar is not starved by the stale ones. Uses the
+  // resource_last_success index.
   async listStaleEvents(
     before: Date,
     limit: number,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Residual Atlas **Query Targeting: Scanned Objects / Returned > 1000** alert on Production1 (~2866 after #2473 dropped it from ~45k) traced to the sync job claim hot path: `claimDueJob` filtered `{ state:"pending", runAfter:{$lte:now} }` but the index was `{ state, priority, runAfter }`, so every idle poll examined all pending-not-due backoff jobs. Atlas treats `nreturned=0` as ÷1, so ~3k examined keys ≈ the alert magnitude. Self-heal (#2491) made this worse by growing the backoff population.
- Fix: replace that index with `{ state, runAfter, priority }`, split the claim `$or` into two indexed arms (expired-lease reclaim first, then due pending — so a backlog cannot starve crash recovery), add `connection_runafter` for `findOldestOverdueByConnection`, add owner/calendar + resourceKind-led indexes on `sync_resources`, and bound busy-overlap `startAt` lookback so historical calendars are not walked end-to-end.

## Simplicity

Index/query-shape only. Collapsed the two claim arms into an ordered filter loop after review; no new abstractions. Considered keeping a single `$or` (rejected: sort across arms prevented bounding the pending arm) and denormalizing overdue watermarks onto connections (rejected: index is enough).

## Automated validation

- `TZ=UTC bun run test:sync --` job / index-manifest / event-occurrence repository db tests (including new plan pins, reclaim-under-backlog, busy lookback)
- `TZ=UTC bun run test:sync --` busy-query / sync-job-worker / reconcile / connection-state-refresh domain db tests
- `bunx typescript@7.0.2 --noEmit -p packages/sync/tsconfig.json`
- `bun run lint`

## Independent review

Fresh-eyes review confirmed: (1) pending-first arm order could starve lease reclaim under backlog — fixed by reclaiming expired leases first + regression test; (2) index rename drop-then-create risk on large collections — documented as safe for small jobs/sync_resources only; (3) busy lookback is a silent product bound — covered with a unit test. No remaining must-fix findings.

## Test plan

- `TZ=UTC bun run test:sync -- packages/sync/src/storage/repositories/job.repository.db.test.ts packages/sync/src/storage/index-manifest.db.test.ts packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts`
- `TZ=UTC bun run test:sync -- packages/sync/src/domain/busy-query.service.db.test.ts packages/sync/src/domain/sync-job-worker.service.db.test.ts packages/sync/src/domain/reconcile.service.db.test.ts packages/sync/src/domain/connection-state-refresh.service.db.test.ts`
- `bunx typescript@7.0.2 --noEmit -p packages/sync/tsconfig.json`
- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0db08708-f1c9-4ef3-a7a2-c620104b21b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0db08708-f1c9-4ef3-a7a2-c620104b21b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

