### PR TITLE
fix(web): localize event time labels instead of the stored offset

### DIFF
--- a/packages/web/src/common/utils/datetime/date.label.test.ts
+++ b/packages/web/src/common/utils/datetime/date.label.test.ts
@@ -6,14 +6,14 @@ const meridians = (label: string) =>
 describe("Time Labels", () => {
   it("removes minutes and am/pm when possible", () => {
     const morningLabel = getTimesLabel(
-      "2022-07-06T06:00:00-05:00",
-      "2022-07-06T07:00:00-05:00",
+      "2022-07-06T06:00:00Z",
+      "2022-07-06T07:00:00Z",
     );
     expect(meridians(morningLabel)).toBe(1);
 
     const eveningLabel = getTimesLabel(
-      "2022-07-06T20:00:00-05:00",
-      "2022-07-06T23:00:00-05:00",
+      "2022-07-06T20:00:00Z",
+      "2022-07-06T23:00:00Z",
     );
     expect(meridians(eveningLabel)).toBe(1);
   });
@@ -22,34 +22,39 @@ describe("Time Labels", () => {
   // space with it, so every same-meridiem label - most of them - rendered as
   // "6  - 7 AM" on the card and in its aria-label. Assert the whole string.
   it("reads as one range when both ends share a meridiem", () => {
-    expect(
-      getTimesLabel("2022-07-06T06:00:00-05:00", "2022-07-06T07:00:00-05:00"),
-    ).toBe("6 - 7 AM");
-    expect(
-      getTimesLabel("2022-07-06T10:45:00-05:00", "2022-07-06T11:00:00-05:00"),
-    ).toBe("10:45 - 11 AM");
+    expect(getTimesLabel("2022-07-06T06:00:00Z", "2022-07-06T07:00:00Z")).toBe(
+      "6 - 7 AM",
+    );
+    expect(getTimesLabel("2022-07-06T10:45:00Z", "2022-07-06T11:00:00Z")).toBe(
+      "10:45 - 11 AM",
+    );
   });
 
   it("keeps both meridiems when the range crosses noon", () => {
-    expect(
-      getTimesLabel("2022-07-06T11:00:00-05:00", "2022-07-06T13:00:00-05:00"),
-    ).toBe("11 AM - 1 PM");
+    expect(getTimesLabel("2022-07-06T11:00:00Z", "2022-07-06T13:00:00Z")).toBe(
+      "11 AM - 1 PM",
+    );
   });
 
   it("preserves am/pm when needed", () => {
-    const label = getTimesLabel(
-      "2022-07-06T01:00:00-05:00",
-      "2022-07-06T18:00:00-05:00",
-    );
+    const label = getTimesLabel("2022-07-06T01:00:00Z", "2022-07-06T18:00:00Z");
     expect(label.includes("AM")).toBe(true);
     expect(label.includes("PM")).toBe(true);
   });
   it("preserves minutes when needed", () => {
-    const label = getTimesLabel(
-      "2022-07-06T09:45:00-05:00",
-      "2022-07-06T19:15:00-05:00",
-    );
+    const label = getTimesLabel("2022-07-06T09:45:00Z", "2022-07-06T19:15:00Z");
     expect(label.includes(":45")).toBe(true);
     expect(label.includes(":15")).toBe(true);
+  });
+
+  // Regression: an event synced from an external calendar in a different
+  // timezone (e.g. a subscribed Berlin +02:00 calendar) used to have its
+  // label re-pinned to the SOURCE offset instead of the viewer's local time,
+  // even though the grid position was already correctly localized. CI runs
+  // with TZ=Etc/UTC, so a +02:00 input should read 2 hours earlier here.
+  it("localizes the label to the viewer's timezone, not the stored offset", () => {
+    expect(
+      getTimesLabel("2026-07-31T17:00:00+02:00", "2026-07-31T18:30:00+02:00"),
+    ).toBe("3 - 4:30 PM");
   });
 });

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -202,34 +202,8 @@ const _cleanStartMeridiem = (start: string, end: string) => {
   return start;
 };
 
-const _isoUtcOffsetMinutes = (value: string): number | undefined => {
-  const trimmed = value.trim();
-
-  if (/Z$/i.test(trimmed)) {
-    return 0;
-  }
-
-  const match = trimmed.match(/([+-])(\d{2}):(\d{2})$/);
-
-  if (!match) {
-    return undefined;
-  }
-
-  const sign = match[1] === "+" ? 1 : -1;
-
-  return sign * (parseInt(match[2], 10) * 60 + parseInt(match[3], 10));
-};
-
-const _getTimeLabel = (date: string) => {
-  const offsetMinutes = _isoUtcOffsetMinutes(date);
-  const parsed = dayjs(date);
-  const formatted =
-    offsetMinutes !== undefined
-      ? parsed.utcOffset(offsetMinutes).format(HOURS_AM_FORMAT)
-      : parsed.format(HOURS_AM_FORMAT);
-
-  return formatted.replace(":00", "");
-};
+const _getTimeLabel = (date: string) =>
+  dayjs(date).format(HOURS_AM_FORMAT).replace(":00", "");
 
 export const computeCurrentEventDateRange = (
   to: {

--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -203,7 +203,7 @@ const _cleanStartMeridiem = (start: string, end: string) => {
 };
 
 const _getTimeLabel = (date: string) =>
-  dayjs(date).format(HOURS_AM_FORMAT).replace(":00", "");
+  getTimeLabel(dayjs(date).format(HOURS_AM_FORMAT));
 
 export const computeCurrentEventDateRange = (
   to: {

--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -83,13 +83,13 @@ test("replaces only the draft schedule during a drag or resize", () => {
 });
 
 test("keeps the schedule's own UTC offset instead of forcing Z", () => {
-  // _getTimeLabel (web.date.util.ts) reads the offset embedded in
-  // CompassEvent.startDate/endDate to decide what time to display - it does
-  // not localize to the browser's timezone. Date#toISOString() always
-  // produces a "Z" (UTC) suffix, which made every grid-created/dragged event
-  // display in UTC instead of local time for any non-UTC browser. dayjs's
-  // default format() preserves the local offset instead, matching every
-  // other CompassEvent producer (draft.util.ts, etc).
+  // Grid position and time label both localize CompassEvent.startDate/
+  // endDate to the browser's timezone on read, so the stored offset itself
+  // doesn't affect what's displayed - but Date#toISOString() always produces
+  // a "Z" (UTC) suffix, which is a needless loss of the source offset and
+  // out of step with every other CompassEvent producer. dayjs's default
+  // format() preserves the local offset instead, matching every other
+  // CompassEvent producer (draft.util.ts, etc).
   const draft = editGridEventDraft(timedEvent);
   if (!draft) throw new Error("Expected scheduled event draft");
 


### PR DESCRIPTION
## Summary
- Fixes a bug where an event's time label (e.g. "5 - 6:30 PM") showed the timezone offset embedded in the stored ISO string instead of the viewer's local time, while the event's grid position was already correctly localized.
- Reproduces for any event synced from an external/subscribed calendar whose source timezone differs from the viewer's browser timezone (surfaced by a subscription in `Europe/Berlin`).
- `_getTimeLabel` in `packages/web/src/common/utils/datetime/web.date.util.ts` was the only place in the repo calling `dayjs().utcOffset(...)`; it re-pinned the wall clock to the offset baked into the stored `startDate`/`endDate` string. Grid positioning (`getTimedEventPosition`) has always parsed with plain `dayjs(...)`, i.e. browser-local. Reverted the label to match, and reused the file's existing `getTimeLabel` `":00"`-stripping helper instead of duplicating it inline.
- Compass-created events were unaffected by coincidence: they're stamped with the browser's own offset at creation time, so "source offset" and "viewer offset" happened to be the same value.
- The single shared formatter (`getTimesLabel`) covers every render path: the visible card text and its `aria-label` (`TimedEventCard.tsx`), busy-block `aria-label`s (Week/Day `*BusyPeriods.tsx`), and the live drag-tooltip label (`grid/interaction/dom.ts`).

## Simplification performed
- Ran `/simplify` over the diff (4-agent reuse/simplification/efficiency/altitude pass). One finding applied: `_getTimeLabel` was inlining `.replace(":00", "")`, duplicating the file's existing `getTimeLabel` helper — now reuses it. No other findings.

## Validation
- `TZ=UTC NODE_ENV=test PORT=9080 bun test ./src/common/utils/datetime/date.label.test.ts ./src/common/utils/datetime/web.date.util.test.ts ./src/events/grid-event-draft.adapter.test.ts` — 55 pass / 0 fail
- Repo-wide `bun run type-check` — clean
- `./node_modules/.bin/biome check` on changed files — clean
- Added a regression test asserting a `+02:00`-offset input renders in the runner's local time (CI pins `TZ: Etc/UTC`); confirmed it fails against pre-fix code and passes against the fix
- **Live browser repro**: ran the anon-mode dev server, patched a demo event's stored schedule to a `+02:00` Berlin offset representing the same instant as the original `-06:00` (Denver) time, reloaded, and confirmed the card's accessible label changed from the pre-fix "5 - 5:30 PM" to the correct "9 - 9:30 AM", matching its unchanged grid row. Other demo events (still `-06:00`, matching the browser's `America/Denver` zone) continued to render correctly — no regression on the common path.

## Independent review
- Fresh read-only reviewer (no access to this session's conclusions) reviewed the final diff against AGENTS.md conventions, coverage across all render paths, boundary conditions (offset-less/floating strings, `Z` suffix, all-day events, DST), and regression-test validity. No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)