### PR TITLE
fix(web): wrap grid event titles at word boundaries instead of mid-word

### DIFF
--- a/packages/web/src/common/utils/grid/grid.util.ts
+++ b/packages/web/src/common/utils/grid/grid.util.ts
@@ -1,6 +1,7 @@
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   GRID_EVENT_TITLE_LINE_HEIGHT_PX,
+  GRID_EVENT_TITLE_VERTICAL_SLACK_PX,
   TIMED_VISIBLE_HOURS,
 } from "@web/grid/grid.constants";
 import {
@@ -83,8 +84,10 @@ export const getFlexBasis = (day: Dayjs, week: number, today: Dayjs) => {
 
 export const getLineClamp = (height: number) => {
   const min = 1;
-  // 7px accounts for the card's vertical padding/slack around the text block.
-  const computed = Math.round((height - 7) / GRID_EVENT_TITLE_LINE_HEIGHT_PX);
+  const computed = Math.round(
+    (height - GRID_EVENT_TITLE_VERTICAL_SLACK_PX) /
+      GRID_EVENT_TITLE_LINE_HEIGHT_PX,
+  );
   const lineClamp = Math.max(min, computed);
   return lineClamp;
 };

--- a/packages/web/src/common/utils/grid/grid.util.ts
+++ b/packages/web/src/common/utils/grid/grid.util.ts
@@ -1,5 +1,8 @@
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
-import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
+import {
+  GRID_EVENT_TITLE_LINE_HEIGHT_PX,
+  TIMED_VISIBLE_HOURS,
+} from "@web/grid/grid.constants";
 import {
   AFTER_TMRW_MULTIPLE,
   FLEX_EQUAL,
@@ -80,7 +83,8 @@ export const getFlexBasis = (day: Dayjs, week: number, today: Dayjs) => {
 
 export const getLineClamp = (height: number) => {
   const min = 1;
-  const computed = Math.round((height - 7) / 16);
+  // 7px accounts for the card's vertical padding/slack around the text block.
+  const computed = Math.round((height - 7) / GRID_EVENT_TITLE_LINE_HEIGHT_PX);
   const lineClamp = Math.max(min, computed);
   return lineClamp;
 };

--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { getEventPalette } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import {
+  GRID_EVENT_TITLE_COMPACT_FONT_SIZE,
+  GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT,
+  GRID_EVENT_TITLE_FONT_SIZE,
+} from "@web/grid/grid.constants";
 import { describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
 
@@ -82,6 +87,56 @@ describe("EventCard", () => {
 
     fireEvent.mouseDown(card);
     expect(onEventMouseDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps a long timed event title at word boundaries and clamps with an ellipsis", () => {
+    render(
+      <TimedEventCard
+        displayMode="saved"
+        event={createEvent({
+          startDate: "2099-01-15T09:00:00.000Z",
+          endDate: "2099-01-15T10:00:00.000Z",
+          title:
+            "Journaling-Flow-Experiment with James: Part 2/2: The Miner's Sifting Pan",
+        })}
+        motionMode="idle"
+        position={position}
+      />,
+    );
+
+    const title = screen.getByText(
+      "Journaling-Flow-Experiment with James: Part 2/2: The Miner's Sifting Pan",
+    );
+
+    // Word-boundary wrapping with a mid-word fallback for unbreakable tokens,
+    // not the old wordBreak: "break-all" that split every word.
+    expect(title.style.overflowWrap).toBe("anywhere");
+    expect(title.style.wordBreak).toBe("");
+    expect(title.style.fontSize).toBe(GRID_EVENT_TITLE_FONT_SIZE);
+
+    // -webkit-line-clamp renders the trailing ellipsis itself once the title
+    // overflows its clamped line count.
+    expect(title.style.display).toBe("-webkit-box");
+    expect(title.style.webkitLineClamp).toBe("3");
+  });
+
+  it("renders a compact single-line title for a very short event", () => {
+    render(
+      <TimedEventCard
+        displayMode="saved"
+        event={createEvent({
+          startDate: "2099-01-15T09:00:00.000Z",
+          endDate: "2099-01-15T09:15:00.000Z",
+        })}
+        motionMode="idle"
+        position={{ ...position, height: 15 }}
+      />,
+    );
+
+    const title = screen.getByText("Planning block");
+    expect(title.style.fontSize).toBe(GRID_EVENT_TITLE_COMPACT_FONT_SIZE);
+    expect(title.style.lineHeight).toBe(GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT);
+    expect(title.style.webkitLineClamp).toBe("1");
   });
 
   it("keeps the timed selected state on the flat event color", () => {

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -21,9 +21,13 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
 import { getLineClamp } from "@web/common/utils/grid/grid.util";
 import {
+  COMPACT_EVENT_MAX_HEIGHT,
   GRID_EVENT_TIME_LABEL_FONT_SIZE,
   GRID_EVENT_TIME_LABEL_LINE_HEIGHT,
   GRID_EVENT_TIME_LABEL_OPACITY,
+  GRID_EVENT_TITLE_COMPACT_FONT_SIZE,
+  GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT,
+  GRID_EVENT_TITLE_FONT_SIZE,
   GRID_EVENT_TITLE_LINE_HEIGHT,
   MIN_EVENT_HEIGHT_FOR_TIME_LABEL,
   MIN_EVENT_WIDTH_FOR_TIME_LABEL,
@@ -179,14 +183,22 @@ const TimedEventCardBase = (
     filter: isDraft ? "drop-shadow(2px 4px 4px black)" : undefined,
   } as CSSProperties;
 
+  const isCompactEvent = position.height <= COMPACT_EVENT_MAX_HEIGHT;
+
   const titleStyle: CSSProperties = {
-    fontSize: position.height <= 15 ? "10px" : "13px",
-    lineHeight: position.height <= 15 ? "1.1" : GRID_EVENT_TITLE_LINE_HEIGHT,
+    fontSize: isCompactEvent
+      ? GRID_EVENT_TITLE_COMPACT_FONT_SIZE
+      : GRID_EVENT_TITLE_FONT_SIZE,
+    lineHeight: isCompactEvent
+      ? GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT
+      : GRID_EVENT_TITLE_LINE_HEIGHT,
     minHeight: "3px",
     display: "-webkit-box",
     overflow: "hidden",
-    textOverflow: "ellipsis",
-    wordBreak: "break-all",
+    // overflowWrap wraps at word boundaries and only breaks mid-word when a
+    // single token (e.g. a long URL) can't fit; -webkit-line-clamp supplies
+    // the trailing ellipsis itself, so text-overflow has no effect here.
+    overflowWrap: "anywhere",
     WebkitBoxOrient: "vertical",
     WebkitLineClamp: lineClamp,
   };

--- a/packages/web/src/grid/grid.constants.ts
+++ b/packages/web/src/grid/grid.constants.ts
@@ -13,10 +13,14 @@ export const GRID_EVENT_TIME_LABEL_OPACITY = "0.82";
 // so the label keeps its row instead of being pushed past the card's clipped edge.
 export const GRID_EVENT_TIME_LABEL_LINE_HEIGHT = 13;
 // Numeric line-height getLineClamp divides by to convert a card's remaining
-// pixel height into a clamp line count; keep the two in sync.
+// pixel height into a clamp line count. Only reflects the normal-height
+// title; getLineClamp doesn't special-case the shorter compact line-height
+// below, which predates this constant.
 export const GRID_EVENT_TITLE_LINE_HEIGHT_PX = 16;
 export const GRID_EVENT_TITLE_LINE_HEIGHT = `${GRID_EVENT_TITLE_LINE_HEIGHT_PX}px`;
 export const GRID_EVENT_TITLE_FONT_SIZE = "13px";
+// Vertical padding/slack getLineClamp reserves around the title text block.
+export const GRID_EVENT_TITLE_VERTICAL_SLACK_PX = 7;
 // Below this height the card only has room for a single cramped line.
 export const COMPACT_EVENT_MAX_HEIGHT = 15;
 export const GRID_EVENT_TITLE_COMPACT_FONT_SIZE = "10px";

--- a/packages/web/src/grid/grid.constants.ts
+++ b/packages/web/src/grid/grid.constants.ts
@@ -12,7 +12,15 @@ export const GRID_EVENT_TIME_LABEL_OPACITY = "0.82";
 // Line box the 11px time label occupies. The title's line clamp subtracts this
 // so the label keeps its row instead of being pushed past the card's clipped edge.
 export const GRID_EVENT_TIME_LABEL_LINE_HEIGHT = 13;
-export const GRID_EVENT_TITLE_LINE_HEIGHT = "16px";
+// Numeric line-height getLineClamp divides by to convert a card's remaining
+// pixel height into a clamp line count; keep the two in sync.
+export const GRID_EVENT_TITLE_LINE_HEIGHT_PX = 16;
+export const GRID_EVENT_TITLE_LINE_HEIGHT = `${GRID_EVENT_TITLE_LINE_HEIGHT_PX}px`;
+export const GRID_EVENT_TITLE_FONT_SIZE = "13px";
+// Below this height the card only has room for a single cramped line.
+export const COMPACT_EVENT_MAX_HEIGHT = 15;
+export const GRID_EVENT_TITLE_COMPACT_FONT_SIZE = "10px";
+export const GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT = "1.1";
 export const MIN_EVENT_HEIGHT_FOR_TIME_LABEL = 36;
 export const MIN_EVENT_WIDTH_FOR_TIME_LABEL = 90;
 export const EVENT_WIDTH_MINIMUM = 80;


### PR DESCRIPTION
## Summary

Long event titles in the week/day grid were breaking mid-word (`wordBreak: "break-all"`), e.g. "Journaling-Flow-Experime" / "nt with James: Part 2/2: The M" / "iner's Sifting Pan" — hard to read at a glance.

Switched `packages/web/src/grid/components/TimedEventCard.tsx`'s title style to `overflowWrap: "anywhere"`, which wraps at word boundaries and only breaks mid-word as a last resort (e.g. a single unbreakable token wider than the card). The existing `display: -webkit-box` + `WebkitLineClamp` mechanism already renders a trailing ellipsis when the title overflows its clamped line count, so the dead `textOverflow: "ellipsis"` (a no-op inside `-webkit-box`) was removed too. All-day events are unaffected — they already use single-line Tailwind `truncate` in a fixed-height row, which is correct there.

Accessibility: unaffected. The card's `aria-label` is built from the full, unclamped title independent of the visually clamped `<span>`, so screen readers already get the complete title.

## Simplicity

While touching this code, named the previously-inline magic numbers it depended on:
- `packages/web/src/grid/grid.constants.ts`: added `COMPACT_EVENT_MAX_HEIGHT`, `GRID_EVENT_TITLE_FONT_SIZE`, `GRID_EVENT_TITLE_COMPACT_FONT_SIZE`, `GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT`, `GRID_EVENT_TITLE_LINE_HEIGHT_PX` (numeric form `GRID_EVENT_TITLE_LINE_HEIGHT` derives from), and `GRID_EVENT_TITLE_VERTICAL_SLACK_PX`.
- `TimedEventCard.tsx`: hoisted the duplicated `position.height <= 15` check (previously inlined separately for `fontSize` and `lineHeight`) into one `isCompactEvent` boolean.
- `packages/web/src/common/utils/grid/grid.util.ts`: `getLineClamp`'s hardcoded `16` and `7` now reference the named constants above instead of bare literals, and a comment now accurately notes that `getLineClamp` doesn't special-case the compact-event branch's shorter line-height (pre-existing behavior, out of scope for this fix — flagged by an independent review pass rather than silently changed, since it would be a behavior change beyond the mid-word-break bug).

Ran a 4-agent parallel `/simplify` pass (reuse, simplification, efficiency, altitude) over the diff: reuse and efficiency came back clean; simplification and altitude both converged on naming the `7` constant, which was applied in a separate commit.

## Automated validation

- Started the local dev server (`bun dev:web`, this worktree's port 9086) and created/edited events with the title `"Journaling-Flow-Experiment with James: Part 2/2: The Miner's Sifting Pan"` in the week grid via the anonymous session.
- Verified via `javascript_tool` against the live rendered DOM: `overflowWrap: "anywhere"` applied, `wordBreak` back to unset/`"normal"` (no more `break-all`), and `-webkit-line-clamp` engaged — matching the code change exactly.
- No console or dev-server errors during the session.

## Independent review

Ran two rounds of a fresh, diff-first reviewer (`feature-dev:code-reviewer`, no access to my analysis) — once after the initial fix, once again after the simplify-pass commit since the diff changed. Both rounds: **no confirmed findings**. The reviewer independently re-derived the `getLineClamp` math, the `isCompactEvent` boundary, and the new test assertions by hand and confirmed all values, and confirmed the accessibility and CSS-correctness claims against the actual code.

## Test plan

```
cd packages/web && TZ=UTC NODE_ENV=test PORT=3000 bun test ./src/grid/components/EventCard.test.tsx ./src/common/utils/grid/grid.util.test.ts ./src/views/Week/interaction/registry/week-event.registry.test.tsx
bun test:web       # full web suite, 1476 pass
bun type-check
bun lint
```

Added two new tests to `EventCard.test.tsx`: word-boundary wrapping + ellipsis-clamp assertions on a long-titled 1-hour event, and a compact single-line rendering assertion on a 15-minute event.