### PR TITLE
feat(scripts): backfill Google event colors onto legacy-migrated events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@compass/core": "1.0.0",
+        "@googleapis/calendar": "^14.1.0",
         "commander": "^10.0.0",
+        "google-auth-library": "^10.6.2",
         "yaml": "^2.9.0",
       },
       "devDependencies": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -7,7 +7,9 @@
   "private": true,
   "dependencies": {
     "@compass/core": "1.0.0",
+    "@googleapis/calendar": "^14.1.0",
     "commander": "^10.0.0",
+    "google-auth-library": "^10.6.2",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,4 +1,5 @@
 import { CliValidator } from "@scripts/cli.validator";
+import { runBackfillEventColors } from "@scripts/commands/backfill-event-colors";
 import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
 import { runPurgeUser } from "@scripts/commands/purge-user";
 import { runRefreshConnectionStates } from "@scripts/commands/refresh-connection-states";
@@ -26,6 +27,9 @@ export default class CompassCLI {
         break;
       case cmd === "purge-user":
         await runPurgeUser();
+        break;
+      case cmd === "backfill-event-colors":
+        await runBackfillEventColors();
         break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
@@ -59,6 +63,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Re-derive every provider connection's stored state from live evidence (--apply to write)",
+      );
+
+    program
+      .command("backfill-event-colors")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Copy Google event colors onto stored events that predate color sync (--apply to write)",
       );
 
     return program;

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,8 +1,4 @@
 import { CliValidator } from "@scripts/cli.validator";
-import { runBackfillEventColors } from "@scripts/commands/backfill-event-colors";
-import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
-import { runPurgeUser } from "@scripts/commands/purge-user";
-import { runRefreshConnectionStates } from "@scripts/commands/refresh-connection-states";
 import { Command } from "commander";
 
 export default class CompassCLI {
@@ -18,19 +14,36 @@ export default class CompassCLI {
   public async run() {
     const cmd = this.program.args[0];
 
+    // Commands load lazily so one command's config demands (e.g. purge-user
+    // pulls in the backend, which hard-requires sync.serviceUrl) never block
+    // running an unrelated command.
     switch (true) {
-      case cmd === "purge-corrupt-sync-events":
+      case cmd === "purge-corrupt-sync-events": {
+        const { runPurgeCorruptSyncEvents } = await import(
+          "@scripts/commands/purge-corrupt-sync-events"
+        );
         await runPurgeCorruptSyncEvents();
         break;
-      case cmd === "refresh-connection-states":
+      }
+      case cmd === "refresh-connection-states": {
+        const { runRefreshConnectionStates } = await import(
+          "@scripts/commands/refresh-connection-states"
+        );
         await runRefreshConnectionStates();
         break;
-      case cmd === "purge-user":
+      }
+      case cmd === "purge-user": {
+        const { runPurgeUser } = await import("@scripts/commands/purge-user");
         await runPurgeUser();
         break;
-      case cmd === "backfill-event-colors":
+      }
+      case cmd === "backfill-event-colors": {
+        const { runBackfillEventColors } = await import(
+          "@scripts/commands/backfill-event-colors"
+        );
         await runBackfillEventColors();
         break;
+      }
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }

--- a/packages/scripts/src/commands/backfill-event-colors.ts
+++ b/packages/scripts/src/commands/backfill-event-colors.ts
@@ -1,0 +1,138 @@
+import { calendar } from "@googleapis/calendar";
+import {
+  type BackfillDeps,
+  backfillEventColors,
+} from "@scripts/commands/backfill-event-colors/backfill";
+import { OAuth2Client } from "google-auth-library";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
+import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.backfill-event-colors");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before backfill-event-colors",
+    );
+  }
+  return uri;
+}
+
+function googleClientCredentials(): { clientId: string; clientSecret: string } {
+  const google = loadCompassConfig().google;
+  const clientId =
+    process.env["GOOGLE_CLIENT_ID"]?.trim() || google?.clientId?.trim();
+  const clientSecret =
+    process.env["GOOGLE_CLIENT_SECRET"]?.trim() || google?.clientSecret?.trim();
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Set GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET or add google.clientId/clientSecret to compass.yaml before backfill-event-colors",
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+function parseArgs(argv: string[]): {
+  dryRun: boolean;
+  connectionId?: string;
+} {
+  const connectionFlag = argv.indexOf("--connection");
+  const connectionId =
+    connectionFlag >= 0 ? argv[connectionFlag + 1]?.trim() : undefined;
+  if (connectionFlag >= 0 && !connectionId) {
+    throw new Error("--connection requires a connection id");
+  }
+  return {
+    dryRun: !argv.includes("--apply"),
+    ...(connectionId ? { connectionId } : {}),
+  };
+}
+
+// A fields-limited events.list: id + color fields only, not full payloads -
+// two orders of magnitude less bandwidth than the sync reader, and no strict
+// normalization that would drop rows this pass doesn't care about.
+const listColorPage: BackfillDeps["listColorPage"] = async ({
+  accessToken,
+  providerCalendarId,
+  pageToken,
+}) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
+  const { data } = await gcal.events.list({
+    calendarId: providerCalendarId,
+    pageToken,
+    // Masters and exceptions as distinct items, matching how sync stores
+    // providerEventIds.
+    singleEvents: false,
+    showDeleted: false,
+    maxResults: 2500,
+    fields: "items(id,colorId,eventLabelId),nextPageToken",
+  });
+  return {
+    items: data.items ?? [],
+    nextPageToken: data.nextPageToken ?? null,
+  };
+};
+
+/**
+ * Copy Google event colors onto stored sync events that predate color import
+ * (legacy-migrated content never had them). Default dry-run; `--apply`
+ * persists; `--connection <id>` scopes to one connection. Safe to rerun.
+ *
+ *   bun run cli backfill-event-colors [--apply] [--connection <id>]
+ */
+export async function runBackfillEventColors(): Promise<void> {
+  const syncMongo = new SyncMongoService();
+  try {
+    const { dryRun, connectionId } = parseArgs(process.argv.slice(3));
+    const { clientId, clientSecret } = googleClientCredentials();
+
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    const custody = new CredentialCustody(
+      new CredentialRepository(syncMongo.db),
+      new GoogleAuthAdapter(clientId, clientSecret),
+    );
+
+    const report = await backfillEventColors(
+      syncMongo.db,
+      {
+        getAccessToken: (id) => custody.getValidAccessToken(id),
+        listColorPage,
+      },
+      { dryRun, ...(connectionId ? { connectionId } : {}) },
+    );
+
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `backfill-event-colors dryRun=${report.dryRun} coloredInGoogle=${report.coloredInGoogle} matchedMissingColor=${report.matchedMissingColor} updated=${report.updated}`,
+    );
+    await syncMongo.disconnect();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/backfill-event-colors.ts
+++ b/packages/scripts/src/commands/backfill-event-colors.ts
@@ -27,11 +27,13 @@ function syncMongoUri(): string {
 }
 
 function googleClientCredentials(): { clientId: string; clientSecret: string } {
-  const google = loadCompassConfig().google;
-  const clientId =
-    process.env["GOOGLE_CLIENT_ID"]?.trim() || google?.clientId?.trim();
-  const clientSecret =
-    process.env["GOOGLE_CLIENT_SECRET"]?.trim() || google?.clientSecret?.trim();
+  let clientId = process.env["GOOGLE_CLIENT_ID"]?.trim();
+  let clientSecret = process.env["GOOGLE_CLIENT_SECRET"]?.trim();
+  if (!clientId || !clientSecret) {
+    const google = loadCompassConfig().google;
+    clientId ||= google?.clientId?.trim();
+    clientSecret ||= google?.clientSecret?.trim();
+  }
   if (!clientId || !clientSecret) {
     throw new Error(
       "Set GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET or add google.clientId/clientSecret to compass.yaml before backfill-event-colors",

--- a/packages/scripts/src/commands/backfill-event-colors/backfill.db.test.ts
+++ b/packages/scripts/src/commands/backfill-event-colors/backfill.db.test.ts
@@ -1,0 +1,278 @@
+import {
+  type BackfillDeps,
+  backfillEventColors,
+  type GoogleColorItem,
+} from "@scripts/commands/backfill-event-colors/backfill";
+import { ObjectId } from "mongodb";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const objectId = () => new ObjectId().toHexString();
+
+describe("backfillEventColors", () => {
+  const storage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+  let calendars: ProviderCalendarRepository;
+
+  beforeEach(() => {
+    connections = new ProviderConnectionRepository(storage.db());
+    calendars = new ProviderCalendarRepository(storage.db());
+  });
+
+  async function seedConnection(): Promise<ProviderConnectionRecord> {
+    return connections.upsertByProviderAccount({
+      tenantId: objectId(),
+      principalId: objectId(),
+      provider: "google",
+      account: {
+        providerAccountId: objectId(),
+        email: "user@example.com",
+        displayName: "User",
+      },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "healthy",
+      stateReason: null,
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+    });
+  }
+
+  async function seedCalendar(
+    connection: ProviderConnectionRecord,
+    eventLabels: Array<{ id: string; hex: string }> = [],
+  ): Promise<ProviderCalendarRecord> {
+    return calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "user@example.com",
+      displayName: "Primary",
+      color: null,
+      eventLabels,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+  }
+
+  // Raw insert mirroring a preseed-migrated row: provider-owned, colorless
+  // content, sentinel providerVersion.
+  async function seedEvent(
+    connection: ProviderConnectionRecord,
+    calendar: ProviderCalendarRecord,
+    providerEventId: string,
+    content: Partial<EventRecord["content"]> = {},
+  ): Promise<string> {
+    const _id = objectId();
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .insertOne({
+        _id,
+        tenantId: connection.tenantId,
+        principalId: connection.principalId,
+        origin: "provider",
+        calendarId: calendar._id,
+        clientEventId: null,
+        connectionId: connection._id,
+        providerEventId,
+        providerVersion: "migrated-from-legacy",
+        providerUpdatedAt: new Date("2024-01-01T00:00:00Z"),
+        deliveryState: null,
+        providerMetadata: null,
+        content: {
+          title: "Dad's Birthday",
+          description: "",
+          location: null,
+          organizer: null,
+          attendees: [],
+          conference: null,
+          ...content,
+        },
+        schedule: { kind: "allDay", start: "2026-08-20", end: "2026-08-21" },
+        recurrence: { kind: "single" },
+        lifecycleState: "active",
+        generation: 0,
+        createdAt: new Date("2026-07-25T00:00:00Z"),
+        updatedAt: new Date("2026-07-25T00:00:00Z"),
+        confirmedAt: null,
+      });
+    return _id;
+  }
+
+  function depsWithPages(
+    pages: GoogleColorItem[][],
+    options: { failConnectionIds?: string[] } = {},
+  ): BackfillDeps {
+    let call = 0;
+    return {
+      getAccessToken: (connectionId) => {
+        if (options.failConnectionIds?.includes(connectionId)) {
+          return Promise.reject(
+            new ProviderAuthError("missingRefreshToken", "no credential"),
+          );
+        }
+        return Promise.resolve("token");
+      },
+      listColorPage: () => {
+        const items = pages[call] ?? [];
+        call += 1;
+        return Promise.resolve({
+          items,
+          nextPageToken: call < pages.length ? `page-${call}` : null,
+        });
+      },
+    };
+  }
+
+  const findEvent = async (id: string) =>
+    (await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.events)
+      .findOne({ _id: id })) as unknown as EventRecord;
+
+  it("sets slot colors from colorId and hex colors from event labels, across pages", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection, [
+      { id: "label-1", hex: "#AB1010" },
+    ]);
+    const slotEventId = await seedEvent(connection, calendar, "ev-colorid");
+    const labelEventId = await seedEvent(connection, calendar, "ev-label");
+
+    const report = await backfillEventColors(
+      storage.db(),
+      depsWithPages([
+        [{ id: "ev-colorid", colorId: "11" }],
+        [{ id: "ev-label", eventLabelId: "label-1" }],
+      ]),
+      { dryRun: false },
+    );
+
+    expect(report.coloredInGoogle).toBe(2);
+    expect(report.updated).toBe(2);
+    const slotEvent = await findEvent(slotEventId);
+    expect(slotEvent.content.color).toBe("red");
+    expect(slotEvent.content.colorHex).toBeUndefined();
+    expect(slotEvent.providerVersion).toBe("migrated-from-legacy");
+    const labelEvent = await findEvent(labelEventId);
+    expect(labelEvent.content.colorHex).toBe("#AB1010");
+    expect(labelEvent.content.color).toBeUndefined();
+  });
+
+  it("never touches an event that already has a color, including an explicit null clear", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const coloredId = await seedEvent(connection, calendar, "ev-colored", {
+      color: "blue",
+    });
+    const clearedId = await seedEvent(connection, calendar, "ev-cleared", {
+      color: null,
+    });
+
+    const report = await backfillEventColors(
+      storage.db(),
+      depsWithPages([
+        [
+          { id: "ev-colored", colorId: "11" },
+          { id: "ev-cleared", colorId: "11" },
+        ],
+      ]),
+      { dryRun: false },
+    );
+
+    expect(report.coloredInGoogle).toBe(2);
+    expect(report.matchedMissingColor).toBe(0);
+    expect(report.updated).toBe(0);
+    expect((await findEvent(coloredId)).content.color).toBe("blue");
+    expect((await findEvent(clearedId)).content.color).toBeNull();
+  });
+
+  it("writes nothing for events Google reports colorless, and for unknown label ids", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const plainId = await seedEvent(connection, calendar, "ev-plain");
+
+    const report = await backfillEventColors(
+      storage.db(),
+      depsWithPages([
+        [{ id: "ev-plain" }, { id: "ev-plain", eventLabelId: "label-deleted" }],
+      ]),
+      { dryRun: false },
+    );
+
+    expect(report.googleEventsSeen).toBe(2);
+    expect(report.coloredInGoogle).toBe(0);
+    expect(report.updated).toBe(0);
+    const plain = await findEvent(plainId);
+    expect(plain.content.color).toBeUndefined();
+    expect(plain.content.colorHex).toBeUndefined();
+  });
+
+  it("dry-run reports matches without persisting; rerun after apply is a no-op", async () => {
+    const connection = await seedConnection();
+    const calendar = await seedCalendar(connection);
+    const eventId = await seedEvent(connection, calendar, "ev-colorid");
+    const pages = () => depsWithPages([[{ id: "ev-colorid", colorId: "3" }]]);
+
+    const dry = await backfillEventColors(storage.db(), pages(), {
+      dryRun: true,
+    });
+    expect(dry.matchedMissingColor).toBe(1);
+    expect(dry.updated).toBe(0);
+    expect(dry.samples).toEqual([
+      {
+        connectionId: connection._id,
+        calendarId: calendar._id,
+        providerEventId: "ev-colorid",
+        color: "plum",
+      },
+    ]);
+    expect((await findEvent(eventId)).content.color).toBeUndefined();
+
+    const applied = await backfillEventColors(storage.db(), pages(), {
+      dryRun: false,
+    });
+    expect(applied.updated).toBe(1);
+    expect((await findEvent(eventId)).content.color).toBe("plum");
+
+    const rerun = await backfillEventColors(storage.db(), pages(), {
+      dryRun: false,
+    });
+    expect(rerun.matchedMissingColor).toBe(0);
+    expect(rerun.updated).toBe(0);
+  });
+
+  it("skips a credential-less connection and still processes the rest", async () => {
+    const doomed = await seedConnection();
+    await seedCalendar(doomed);
+    const healthy = await seedConnection();
+    const healthyCalendar = await seedCalendar(healthy);
+    const eventId = await seedEvent(healthy, healthyCalendar, "ev-colorid");
+
+    const report = await backfillEventColors(
+      storage.db(),
+      depsWithPages([[{ id: "ev-colorid", colorId: "11" }]], {
+        failConnectionIds: [doomed._id],
+      }),
+      { dryRun: false },
+    );
+
+    expect(report.connections).toBe(2);
+    expect(report.connectionsSkipped).toBe(1);
+    expect(report.updated).toBe(1);
+    expect((await findEvent(eventId)).content.color).toBe("red");
+  });
+});

--- a/packages/scripts/src/commands/backfill-event-colors/backfill.ts
+++ b/packages/scripts/src/commands/backfill-event-colors/backfill.ts
@@ -1,0 +1,244 @@
+import { type AnyBulkWriteOperation, type Db } from "mongodb";
+import { Logger } from "@core/logger/winston.logger";
+import { type EventColorSlot } from "@core/types/event-color.contracts";
+import {
+  type ConnectionId,
+  type ProviderEventId,
+} from "@core/types/sync/identity.contracts";
+import { toColorLabelMap } from "@sync/domain/color-label-map";
+import { googleColorIdToSlot } from "@sync/providers/google/google-color.map";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { ProviderConnectionRecordSchema } from "@sync/storage/contracts/provider-connection.contracts";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+
+const logger = Logger("scripts.commands.backfill-event-colors");
+
+export type BackfillEventColorsReport = {
+  generatedAt: string;
+  dryRun: boolean;
+  connections: number;
+  connectionsSkipped: number;
+  calendars: number;
+  calendarsFailed: number;
+  googleEventsSeen: number;
+  coloredInGoogle: number;
+  matchedMissingColor: number;
+  updated: number;
+  samples: Array<{
+    connectionId: string;
+    calendarId: string;
+    providerEventId: string;
+    color?: EventColorSlot;
+    colorHex?: string;
+  }>;
+};
+
+// The only two Google fields the backfill reads per event, plus the id to
+// match stored rows by.
+export interface GoogleColorItem {
+  readonly id?: string | null;
+  readonly colorId?: string | null;
+  readonly eventLabelId?: string | null;
+}
+
+// Injected I/O so tests can script pages and tokens without network access.
+export interface BackfillDeps {
+  getAccessToken(connectionId: ConnectionId): Promise<string>;
+  listColorPage(input: {
+    accessToken: string;
+    providerCalendarId: string;
+    pageToken?: string;
+  }): Promise<{
+    items: readonly GoogleColorItem[];
+    nextPageToken: string | null;
+  }>;
+}
+
+/**
+ * Copy Google event colors onto stored sync events that predate color import.
+ *
+ * The preseed migration copied event content from the legacy database, which
+ * never stored colors, and Google's incremental sync only re-delivers events
+ * that change - so an unchanged event keeps its colorless migrated content
+ * forever. This walks every readable Google calendar with a fields-limited
+ * events.list and sets `content.color` / `content.colorHex` on stored events
+ * that lack both, leaving `providerVersion` untouched so incremental sync
+ * keeps flowing. Idempotent; safe to rerun.
+ */
+export async function backfillEventColors(
+  db: Db,
+  deps: BackfillDeps,
+  options: { dryRun: boolean; connectionId?: string },
+): Promise<BackfillEventColorsReport> {
+  const calendars = new ProviderCalendarRepository(db);
+  const events = db.collection<EventRecord>(SYNC_COLLECTIONS.events);
+
+  const report: BackfillEventColorsReport = {
+    generatedAt: new Date().toISOString(),
+    dryRun: options.dryRun,
+    connections: 0,
+    connectionsSkipped: 0,
+    calendars: 0,
+    calendarsFailed: 0,
+    googleEventsSeen: 0,
+    coloredInGoogle: 0,
+    matchedMissingColor: 0,
+    updated: 0,
+    samples: [],
+  };
+
+  const connectionFilter: Record<string, unknown> = {
+    provider: "google",
+    disconnectedAt: null,
+  };
+  if (options.connectionId) connectionFilter["_id"] = options.connectionId;
+
+  const cursor = db
+    .collection(SYNC_COLLECTIONS.providerConnections)
+    .find(connectionFilter);
+
+  for await (const doc of cursor) {
+    const connection = ProviderConnectionRecordSchema.parse(doc);
+    report.connections += 1;
+
+    let accessToken: string;
+    try {
+      accessToken = await deps.getAccessToken(connection._id);
+    } catch (error) {
+      if (error instanceof ProviderAuthError) {
+        logger.warn(
+          `Skipping connection ${connection._id}: ${error.reason ?? error.message}`,
+        );
+        report.connectionsSkipped += 1;
+        continue;
+      }
+      throw error;
+    }
+
+    const connectionCalendars = await calendars.listByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    );
+
+    for (const calendar of connectionCalendars) {
+      if (!calendar.active || !calendar.capabilities.canReadEvents) continue;
+      report.calendars += 1;
+
+      try {
+        const labelMap = toColorLabelMap(calendar.eventLabels);
+        let pageToken: string | undefined;
+
+        do {
+          const page = await deps.listColorPage({
+            accessToken,
+            providerCalendarId: calendar.providerCalendarId,
+            pageToken,
+          });
+          report.googleEventsSeen += page.items.length;
+
+          // Only events Google actually colors get a write; everything else
+          // (the vast majority) is skipped outright.
+          const colored = new Map<
+            string,
+            { color?: EventColorSlot; colorHex?: string }
+          >();
+          for (const item of page.items) {
+            if (!item.id) continue;
+            const color = googleColorIdToSlot(item.colorId);
+            const colorHex = item.eventLabelId
+              ? labelMap.get(item.eventLabelId)
+              : undefined;
+            if (!color && !colorHex) continue;
+            colored.set(item.id, {
+              ...(color ? { color } : {}),
+              ...(colorHex ? { colorHex } : {}),
+            });
+          }
+          report.coloredInGoogle += colored.size;
+
+          if (colored.size > 0) {
+            // Scope guard: only rows missing BOTH fields, so a color set by a
+            // user (including an explicit `color: null` clear) or already
+            // synced from Google is never clobbered.
+            const missingColor = await events
+              .find(
+                {
+                  connectionId: connection._id,
+                  calendarId: calendar._id,
+                  // Google ids are plain strings; the stored field is branded.
+                  providerEventId: {
+                    $in: [...colored.keys()] as ProviderEventId[],
+                  },
+                  "content.color": { $exists: false },
+                  "content.colorHex": { $exists: false },
+                },
+                { projection: { providerEventId: 1 } },
+              )
+              .toArray();
+            const matchedIds = missingColor
+              .map((match) => match.providerEventId)
+              .filter((id): id is ProviderEventId => id !== null);
+            report.matchedMissingColor += matchedIds.length;
+
+            for (const providerEventId of matchedIds) {
+              if (report.samples.length >= 20) break;
+              report.samples.push({
+                connectionId: connection._id,
+                calendarId: calendar._id,
+                providerEventId,
+                ...colored.get(providerEventId),
+              });
+            }
+
+            if (!options.dryRun && matchedIds.length > 0) {
+              const now = new Date();
+              const writes: AnyBulkWriteOperation<EventRecord>[] =
+                matchedIds.map((providerEventId) => {
+                  const resolved = colored.get(providerEventId);
+                  return {
+                    updateOne: {
+                      filter: {
+                        connectionId: connection._id,
+                        calendarId: calendar._id,
+                        providerEventId,
+                        "content.color": { $exists: false },
+                        "content.colorHex": { $exists: false },
+                      },
+                      update: {
+                        $set: {
+                          ...(resolved?.color
+                            ? { "content.color": resolved.color }
+                            : {}),
+                          ...(resolved?.colorHex
+                            ? { "content.colorHex": resolved.colorHex }
+                            : {}),
+                          updatedAt: now,
+                        },
+                      },
+                    },
+                  };
+                });
+              const result = await events.bulkWrite(writes);
+              report.updated += result.modifiedCount;
+            }
+          }
+
+          pageToken = page.nextPageToken ?? undefined;
+        } while (pageToken);
+      } catch (error) {
+        // Rerunnable by design: log the calendar and keep going rather than
+        // failing the fleet pass.
+        report.calendarsFailed += 1;
+        logger.error(
+          `Backfill failed for calendar ${calendar._id} (connection ${connection._id})`,
+          error,
+        );
+      }
+    }
+  }
+
+  return report;
+}

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -1,5 +1,6 @@
 import { calendar } from "@googleapis/calendar";
 import { OAuth2Client } from "google-auth-library";
+import { Logger } from "@core/logger/winston.logger";
 import {
   type gCalendar,
   type gSchema$Calendar,
@@ -17,6 +18,8 @@ import {
   ProviderCalendarError,
 } from "@sync/providers/provider-calendar.port";
 import { redactedCause } from "@sync/safety/redact-error";
+
+const logger = Logger("sync:google-calendar.adapter");
 
 // One page of a Google calendar-list read, narrowed to the fields discovery
 // needs. Google returns `nextSyncToken` only on the final page; intermediate
@@ -87,7 +90,11 @@ const defaultApiFactory: GoogleCalendarListApiFactory = (accessToken) => {
       } catch {
         // A label-fetch failure (permissions, transient error) should never
         // fail calendar discovery — the calendar just discovers with no
-        // custom colors resolvable this pass.
+        // custom colors resolvable this pass. Warn so a systemic failure is
+        // visible instead of silently rendering label-colored events default.
+        logger.warn(
+          "Event-label fetch failed for a calendar; its custom colors are unresolvable this discovery pass",
+        );
         return [];
       }
       return (data.labelProperties?.eventLabels ?? [])


### PR DESCRIPTION
## Why

Events colored in Google Calendar render in the default neutral fill in Compass when they were imported by the preseed migration. The color pipeline itself works (normalizer maps `colorId`/`eventLabelId`, web renders both), but the preseed copied event content from the legacy database, which never stored colors - and Google's incremental sync only re-delivers events whose `updated` timestamp changes. Result: ~96% of prod events (481k of ~502k, `providerVersion: "migrated-from-legacy"`) will never pick up their Google color unless individually edited in Google.

## What

- New `backfill-event-colors` operator command (mirrors `refresh-connection-states`):
  - Per healthy Google connection, per active readable calendar, pages a fields-limited `events.list` (`items(id,colorId,eventLabelId)` only, ~200 HTTP calls fleet-wide).
  - Maps via the existing `googleColorIdToSlot` / `toColorLabelMap` helpers.
  - `$set`s `content.color`/`content.colorHex` only on stored events missing BOTH fields (never clobbers a user-set color, including an explicit `color: null` clear), matched on the unique `(connectionId, calendarId, providerEventId)` index.
  - Leaves `providerVersion` untouched so incremental sync keeps flowing. No occurrence reprojection needed - instance content is assembled from the parent event doc at read time.
  - Dry-run by default; `--apply` to write; `--connection <id>` to scope. Idempotent and rerunnable.
- CLI commands now lazy-load, so purge-user's backend config requirements (sync.serviceUrl etc.) can't block running an unrelated command.
- `getEventLabels` now warn-logs its previously silent failure, which otherwise renders label-colored events default with no diagnostic trail.

## Testing

- 5 new db tests (mongodb-memory-server): slot + label mapping across pages, scope guard (colored and null-cleared untouched), colorless events produce zero writes, dry-run persists nothing + apply-then-rerun is a no-op, credential-less connection skipped while others process.
- `bun run type-check` clean; `test:scripts:db` 13/13.

## Prod runbook (operator laptop)

1. Dry-run scoped to one connection, inspect report samples.
2. `--apply` for that connection; verify the event doc gained `content.color` with `providerVersion` unchanged; verify red render in web.
3. Fleet dry-run, sanity-check counts, fleet `--apply`, rerun to confirm `updated: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)