### PR TITLE
fix(web): make grid event shortcuts focused-only and consistent

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -52,8 +52,11 @@ Helpful notes:
 | `U`                         | Day view  | Focus first calendar event        |
 | `C`                         | Day view  | Create timed event                |
 | `A`                         | Day view  | Create all-day event              |
-| `Delete`                    | Day view  | Delete focused/hovered event      |
+| `Delete`                    | Day view  | Delete focused event              |
+| `ArrowUp` / `ArrowDown`     | Day view  | Focus previous/next event         |
 | `Arrow keys`                | Day view  | Move open draft event             |
+| `Enter`                     | Day view  | Open focused event                |
+| `Cmd+D` / `Ctrl+D`          | Day view  | Duplicate focused event           |
 | `Shift+ArrowLeft`           | Day view  | Move focused event to previous day |
 | `Shift+ArrowRight`          | Day view  | Move focused event to next day    |
 | `Shift+ArrowUp` / `Shift+ArrowDown` | Day view | Move focused timed event 15 min earlier/later |
@@ -64,11 +67,16 @@ Helpful notes:
 | `A`                         | Week view | Create all-day event              |
 | `I`                         | Week view | Focus sidebar                     |
 | `U`                         | Week view | Focus first calendar event        |
-| `Delete`                    | Week view | Delete focused/hovered event      |
+| `Delete`                    | Week view | Delete focused event              |
+| `ArrowUp` / `ArrowDown`     | Week view | Focus previous/next event         |
 | `Arrow keys`                | Week view | Move open draft event             |
+| `Enter`                     | Week view | Open focused event                |
+| `Cmd+D` / `Ctrl+D`          | Week view | Duplicate focused event           |
 | `Shift+ArrowLeft`           | Week view | Move focused event to previous day |
 | `Shift+ArrowRight`          | Week view | Move focused event to next day    |
 | `Shift+ArrowUp` / `Shift+ArrowDown` | Week view | Move focused timed event 15 min earlier/later |
+| `L`                         | Global    | Navigate to Life view             |
+| `Cmd+Enter` / `Ctrl+Enter`  | Form      | Save event form                   |
 
 ---
 
@@ -241,19 +249,20 @@ Pressing `]` toggles the sidebar open or closed from any view.
 
 ### UX
 
-Pressing Delete while an event is focused or hovered in the Day or Week grid deletes it — equivalent to a mouse-driven delete action.
+Pressing Delete while an event is focused in the Day or Week grid deletes it — equivalent to a mouse-driven delete action. Hover alone is not enough; the event must be focused.
 
 ### Steps
 
 1. Navigate to `/week`.
-2. Focus or hover an event in the grid.
+2. Focus an event in the grid (click it or press `U` then ArrowUp/ArrowDown).
 3. Press Delete.
-4. Navigate to `/day` and repeat with a focused or hovered event.
+4. Navigate to `/day` and repeat with a focused event.
 
 ### Expected Results
 
 - The event is removed from the grid in both views.
 - An undo toast appears.
+- Pressing Delete with no focused event does nothing (even if the mouse is hovering an event).
 
 ---
 
@@ -308,8 +317,10 @@ If time is limited, run these checks before shipping shortcut-related changes:
 4. Cmd+K opens the command palette; Escape closes it without action.
 5. `C` opens a timed event form and `A` an all-day event form, in both Day and Week view.
 6. `]` toggles the sidebar in both Week and Day view.
-7. Delete removes a focused/hovered event in Day and Week view and shows an undo toast.
+7. Delete removes a focused event in Day and Week view and shows an undo toast.
 8. Cmd+Z / Ctrl+Z undoes the last event action; Cmd+Shift+Z / Ctrl+Shift+Z redoes it.
 9. No shortcuts fire inside a focused text input except Cmd+K.
 10. Shift+ArrowLeft/Right move a focused event by one day in both Day and Week view.
 11. Arrow keys reposition an open draft in both Day and Week view.
+12. With a focused event and no draft open, ArrowUp/ArrowDown move focus to the previous/next event chronologically.
+13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.

--- a/packages/web/src/__tests__/setup/test-lifecycle.ts
+++ b/packages/web/src/__tests__/setup/test-lifecycle.ts
@@ -25,6 +25,7 @@ expect.extend(jestDomMatchers);
 const { cleanup, configure } = await import("@testing-library/react");
 const { resetAllStores } = await import("../utils/state/reset-stores");
 const { BaseApi } = await import("@web/api/base/base.api");
+const { clearAppLockReasons } = await import("@web/shortcuts/app-lock");
 
 configure({ asyncUtilTimeout: 5000 });
 
@@ -33,6 +34,7 @@ function resetDocument() {
   document.body.removeAttribute("style");
   document.body.removeAttribute("class");
   document.body.removeAttribute("data-app-locked");
+  clearAppLockReasons();
   document.documentElement.removeAttribute("style");
   for (const style of document.head.querySelectorAll("style")) {
     if (

--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@web/common/utils/toast/error-toast.util";
 import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { ForgotPasswordForm } from "./forms/ForgotPasswordForm";
 import { LogInForm } from "./forms/LogInForm";
 import { ResetPasswordForm } from "./forms/ResetPasswordForm";
@@ -38,6 +39,7 @@ function getInitialAuthToken(search: AuthSearch): string | undefined {
  */
 export const AuthModal: FC = () => {
   const { isOpen, currentView, closeModal, setView } = useAuthModal();
+  useAppLockReason("authModal", isOpen);
   const handleGoogleAuthStart = useCallback(() => {
     dismissErrorToast(SESSION_EXPIRED_TOAST_ID);
   }, []);

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -34,6 +34,7 @@ import {
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
 import { type CommandSection } from "./command-palette.types";
 
@@ -252,6 +253,7 @@ export const CommandPalette = ({
   mutationDependencies,
 }: CommandPaletteProps) => {
   const open = useSettingsStore(selectIsCmdPaletteOpen);
+  useAppLockReason("commandPalette", open);
   const navigate = useNavigate();
   const { items: calendarCmdItems } = useCalendarSyncCmdItems();
   const subscribeCmdItems = useSubscribeCmdItems(open);
@@ -327,6 +329,7 @@ export const LifeCommandPalette = ({
   placeholder: string;
 }) => {
   const open = useSettingsStore(selectIsCmdPaletteOpen);
+  useAppLockReason("commandPalette", open);
   const navigate = useNavigate();
   const themeCmdItems = useThemeCmdItems();
 

--- a/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
+++ b/packages/web/src/components/ReleaseNotesPrompt/ReleaseNotesPrompt.tsx
@@ -9,6 +9,7 @@ import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { releaseNotesPromptActions } from "@web/components/ReleaseNotesPrompt/release-notes-prompt.store";
 import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 
 type PromptState =
   | "asking"
@@ -20,6 +21,7 @@ type PromptState =
 export function ReleaseNotesPrompt() {
   const [state, setState] = useState<PromptState>("asking");
   const [closing, setClosing] = useState(false);
+  useAppLockReason("releaseNotes", true);
 
   // RootShell mounts this only while the store flag is open, so each open is a
   // fresh mount (state starts at "asking", no reset effect needed). A callback

--- a/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
+++ b/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
@@ -31,8 +31,12 @@ export function useSidebarShortcuts({
     setIsShortcutsOpen((isOpen) => !isOpen);
   }, [isSidebarOpen, onToggleSidebar]);
 
-  useAppShortcutUp(TOGGLE_SHORTCUTS_HOTKEY, toggleShortcuts);
-  useAppShortcutUp(TOGGLE_SHORTCUTS_SLASH_HOTKEY, toggleShortcuts);
+  useAppShortcutUp(TOGGLE_SHORTCUTS_HOTKEY, toggleShortcuts, {
+    ignoreAppLock: true,
+  });
+  useAppShortcutUp(TOGGLE_SHORTCUTS_SLASH_HOTKEY, toggleShortcuts, {
+    ignoreAppLock: true,
+  });
 
   useEffect(() => {
     if (!isSidebarOpen) {

--- a/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
+++ b/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 
 const TOGGLE_SHORTCUTS_HOTKEY = { key: "?", shift: true } as const;
@@ -14,6 +15,7 @@ export function useSidebarShortcuts({
   onToggleSidebar,
 }: UseSidebarShortcutsArgs) {
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
+  useAppLockReason("shortcutsOverlay", isShortcutsOpen);
 
   const closeShortcuts = useCallback(() => {
     setIsShortcutsOpen(false);

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideModal.tsx
@@ -5,12 +5,14 @@ import {
   useState,
 } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { PixelPirate } from "./PixelPirate";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { welcomeGuideActions } from "./welcome.guide.store";
 
 export function WelcomeGuideModal() {
   const [closing, setClosing] = useState(false);
+  useAppLockReason("welcomeGuide", true);
 
   const focusOnMount = useCallback((node: HTMLDivElement | null) => {
     node?.focus();

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -14,6 +14,7 @@ import {
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { maybeShowCmdPaletteHint } from "./cmd-palette-hint.util";
 import { PixelPirate } from "./PixelPirate";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
@@ -32,6 +33,7 @@ export function WelcomeModal() {
   // screen simply hides while it is open and reappears when the browser
   // back button (or Escape) removes the param again.
   const visible = isOpen && !isAuthModalOpen && !authenticated;
+  useAppLockReason("welcomeModal", visible);
 
   useEffect(() => {
     if (visible) {

--- a/packages/web/src/grid/interaction/event.targeting.ts
+++ b/packages/web/src/grid/interaction/event.targeting.ts
@@ -28,34 +28,7 @@ export const createGridEventTargeting = <TType extends string>({
     };
   };
 
-  return {
-    clearHoveredGridEventTarget: (element?: HTMLElement): void => {
-      if (!element || hoveredEventElement === element) {
-        hoveredEventElement = null;
-      }
-    },
-    focusGridEventTarget: (target: GridEventTarget<TType>): void => {
-      target.element.focus();
-    },
-    getFirstVisibleGridEventTarget: (
-      root: ParentNode = document,
-    ): GridEventTarget<TType> | null => {
-      const visible = listVisible(root);
-      return visible[0] ?? null;
-    },
-    listVisibleGridEventTargets: (
-      root: ParentNode = document,
-    ): GridEventTarget<TType>[] => listVisible(root),
-    getFocusedGridEventTarget: (): GridEventTarget<TType> | null =>
-      toTarget(document.activeElement),
-    getHoveredGridEventTarget: (): GridEventTarget<TType> | null =>
-      toTarget(hoveredEventElement),
-    setHoveredGridEventTarget: (element: HTMLElement | null): void => {
-      hoveredEventElement = element;
-    },
-  };
-
-  function listVisible(root: ParentNode): GridEventTarget<TType>[] {
+  function listVisible(root: ParentNode = document): GridEventTarget<TType>[] {
     const candidates = root.querySelectorAll(targetSelector);
     const visible: GridEventTarget<TType>[] = [];
 
@@ -68,6 +41,28 @@ export const createGridEventTargeting = <TType extends string>({
 
     return visible;
   }
+
+  return {
+    clearHoveredGridEventTarget: (element?: HTMLElement): void => {
+      if (!element || hoveredEventElement === element) {
+        hoveredEventElement = null;
+      }
+    },
+    focusGridEventTarget: (target: GridEventTarget<TType>): void => {
+      target.element.focus();
+    },
+    getFirstVisibleGridEventTarget: (
+      root: ParentNode = document,
+    ): GridEventTarget<TType> | null => listVisible(root)[0] ?? null,
+    listVisibleGridEventTargets: listVisible,
+    getFocusedGridEventTarget: (): GridEventTarget<TType> | null =>
+      toTarget(document.activeElement),
+    getHoveredGridEventTarget: (): GridEventTarget<TType> | null =>
+      toTarget(hoveredEventElement),
+    setHoveredGridEventTarget: (element: HTMLElement | null): void => {
+      hoveredEventElement = element;
+    },
+  };
 };
 
 const isVisibleEventElement = (element: HTMLElement): boolean => {

--- a/packages/web/src/grid/interaction/event.targeting.ts
+++ b/packages/web/src/grid/interaction/event.targeting.ts
@@ -40,17 +40,12 @@ export const createGridEventTargeting = <TType extends string>({
     getFirstVisibleGridEventTarget: (
       root: ParentNode = document,
     ): GridEventTarget<TType> | null => {
-      const candidates = root.querySelectorAll(targetSelector);
-
-      for (const candidate of candidates) {
-        const target = toTarget(candidate);
-        if (target && isVisibleEventElement(target.element)) {
-          return target;
-        }
-      }
-
-      return null;
+      const visible = listVisible(root);
+      return visible[0] ?? null;
     },
+    listVisibleGridEventTargets: (
+      root: ParentNode = document,
+    ): GridEventTarget<TType>[] => listVisible(root),
     getFocusedGridEventTarget: (): GridEventTarget<TType> | null =>
       toTarget(document.activeElement),
     getHoveredGridEventTarget: (): GridEventTarget<TType> | null =>
@@ -59,6 +54,20 @@ export const createGridEventTargeting = <TType extends string>({
       hoveredEventElement = element;
     },
   };
+
+  function listVisible(root: ParentNode): GridEventTarget<TType>[] {
+    const candidates = root.querySelectorAll(targetSelector);
+    const visible: GridEventTarget<TType>[] = [];
+
+    for (const candidate of candidates) {
+      const target = toTarget(candidate);
+      if (target && isVisibleEventElement(target.element)) {
+        visible.push(target);
+      }
+    }
+
+    return visible;
+  }
 };
 
 const isVisibleEventElement = (element: HTMLElement): boolean => {

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
@@ -1,0 +1,85 @@
+import { Origin } from "@core/constants/core.constants";
+import { type GridEvent } from "@web/common/types/web.event.types";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import { getChronologicallyAdjacentTarget } from "@web/grid/shortcuts/focus-adjacent-grid-event";
+import { describe, expect, it } from "bun:test";
+
+const event = (id: string, startDate: string, isAllDay = false): GridEvent => ({
+  _id: id,
+  endDate: isAllDay ? "2026-05-21" : "2026-05-20T10:00:00.000",
+  isAllDay,
+  origin: Origin.COMPASS,
+  position: gridEventDefaultPosition,
+  startDate,
+  title: id,
+  user: "user-1",
+});
+
+const target = (
+  eventId: string,
+  eventType: "all-day" | "timed",
+  element = document.createElement("button"),
+) => ({ element, eventId, eventType });
+
+describe("getChronologicallyAdjacentTarget", () => {
+  it("returns the next later event", () => {
+    const earlier = target("a", "timed");
+    const later = target("b", "timed");
+    const next = getChronologicallyAdjacentTarget({
+      allDayEvents: [],
+      direction: "next",
+      focused: earlier,
+      timedEvents: [
+        event("a", "2026-05-20T09:00:00.000"),
+        event("b", "2026-05-20T11:00:00.000"),
+      ],
+      visible: [later, earlier],
+    });
+
+    expect(next?.eventId).toBe("b");
+  });
+
+  it("returns the previous earlier event", () => {
+    const earlier = target("a", "timed");
+    const later = target("b", "timed");
+    const previous = getChronologicallyAdjacentTarget({
+      allDayEvents: [],
+      direction: "previous",
+      focused: later,
+      timedEvents: [
+        event("a", "2026-05-20T09:00:00.000"),
+        event("b", "2026-05-20T11:00:00.000"),
+      ],
+      visible: [earlier, later],
+    });
+
+    expect(previous?.eventId).toBe("a");
+  });
+
+  it("prefers all-day before timed on the same start day", () => {
+    const allDay = target("all", "all-day");
+    const timed = target("timed", "timed");
+    const next = getChronologicallyAdjacentTarget({
+      allDayEvents: [event("all", "2026-05-20", true)],
+      direction: "next",
+      focused: allDay,
+      timedEvents: [event("timed", "2026-05-20T09:00:00.000")],
+      visible: [timed, allDay],
+    });
+
+    expect(next?.eventId).toBe("timed");
+  });
+
+  it("stops at the ends without wrapping", () => {
+    const only = target("a", "timed");
+    expect(
+      getChronologicallyAdjacentTarget({
+        allDayEvents: [],
+        direction: "previous",
+        focused: only,
+        timedEvents: [event("a", "2026-05-20T09:00:00.000")],
+        visible: [only],
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
@@ -29,16 +29,16 @@ export function getChronologicallyAdjacentTarget({
 }): FocusableGridEventTarget | null {
   if (visible.length === 0 || !focused) return null;
 
-  const startById = new Map<string, string>();
+  const startMsById = new Map<string, number>();
   for (const event of [...allDayEvents, ...timedEvents]) {
     if (event._id && event.startDate) {
-      startById.set(event._id, event.startDate);
+      startMsById.set(event._id, dayjs(event.startDate).valueOf());
     }
   }
 
   const sorted = [...visible].sort((a, b) => {
-    const aStart = dayjs(startById.get(a.eventId) ?? 0).valueOf();
-    const bStart = dayjs(startById.get(b.eventId) ?? 0).valueOf();
+    const aStart = startMsById.get(a.eventId) ?? 0;
+    const bStart = startMsById.get(b.eventId) ?? 0;
     if (aStart !== bStart) return aStart - bStart;
     if (a.eventType !== b.eventType) {
       return a.eventType === "all-day" ? -1 : 1;

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
@@ -1,0 +1,58 @@
+import dayjs from "@core/util/date/dayjs";
+import { type GridEvent } from "@web/common/types/web.event.types";
+
+export type GridEventShortcutTarget = {
+  eventId: string;
+  eventType: "all-day" | "timed";
+};
+
+export type FocusableGridEventTarget = GridEventShortcutTarget & {
+  element: HTMLElement;
+};
+
+/**
+ * Order visible grid targets chronologically: earlier start first; on a tie,
+ * all-day before timed. Stops at ends (no wrap).
+ */
+export function getChronologicallyAdjacentTarget({
+  allDayEvents,
+  direction,
+  focused,
+  timedEvents,
+  visible,
+}: {
+  allDayEvents: GridEvent[];
+  direction: "previous" | "next";
+  focused: GridEventShortcutTarget | null;
+  timedEvents: GridEvent[];
+  visible: FocusableGridEventTarget[];
+}): FocusableGridEventTarget | null {
+  if (visible.length === 0 || !focused) return null;
+
+  const startById = new Map<string, string>();
+  for (const event of [...allDayEvents, ...timedEvents]) {
+    if (event._id && event.startDate) {
+      startById.set(event._id, event.startDate);
+    }
+  }
+
+  const sorted = [...visible].sort((a, b) => {
+    const aStart = dayjs(startById.get(a.eventId) ?? 0).valueOf();
+    const bStart = dayjs(startById.get(b.eventId) ?? 0).valueOf();
+    if (aStart !== bStart) return aStart - bStart;
+    if (a.eventType !== b.eventType) {
+      return a.eventType === "all-day" ? -1 : 1;
+    }
+    return a.eventId.localeCompare(b.eventId);
+  });
+
+  const index = sorted.findIndex(
+    (target) =>
+      target.eventId === focused.eventId &&
+      target.eventType === focused.eventType,
+  );
+  if (index < 0) return null;
+
+  const nextIndex = direction === "previous" ? index - 1 : index + 1;
+  return sorted[nextIndex] ?? null;
+}

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -1,4 +1,6 @@
+import { useQueryClient } from "@tanstack/react-query";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   isGridEventInteractionReadOnly,
   useCalendarLookup,
@@ -13,25 +15,29 @@ import {
   isEventFormKeyboardTarget,
   isEventFormOpen,
 } from "@web/common/utils/form/form.util";
+import { duplicateGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import {
   type EventMutationDependencies,
   useEventMutations,
 } from "@web/events/mutations/useEventMutations";
 import { useUpdateEvent } from "@web/events/mutations/useUpdateEvent";
+import { findEventInCache } from "@web/events/queries/event.query.cache";
 import { draftActions } from "@web/events/stores/draft.store";
+import {
+  type FocusableGridEventTarget,
+  type GridEventShortcutTarget,
+  getChronologicallyAdjacentTarget,
+} from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
+
+export type { GridEventShortcutTarget };
 
 const DRAFT_MOVEMENT_HOTKEY_OPTIONS = {
   ignoreInputs: false,
   preventDefault: false,
   stopPropagation: false,
 } as const;
-
-export type GridEventShortcutTarget = {
-  eventId: string;
-  eventType: "all-day" | "timed";
-};
 
 export type GridEventEditDayBoundary =
   | {
@@ -46,9 +52,10 @@ export type GridEventEditDayBoundary =
     };
 
 /**
- * Shared Delete / Shift+arrow nudge / draft Arrow reposition shortcuts for
- * Day and Week. Targeting, day-boundary policy, and draft reposition stay
- * view-specific (Day follows across midnight; Week clamps to weekDays).
+ * Shared Delete / Mod+D / Shift+arrow nudge / draft Arrow reposition / focus
+ * traversal shortcuts for Day and Week. Targeting, day-boundary policy, and
+ * draft reposition stay view-specific (Day follows across midnight; Week
+ * clamps to weekDays).
  *
  * Handlers close over latest render values; TanStack Hotkeys syncs the
  * callback each render, so event-list refs are unnecessary.
@@ -70,13 +77,15 @@ export function useGridEventEditShortcuts({
    */
   repositionDraftByKey: (key: string) => boolean;
   targeting: {
+    focus: (target: FocusableGridEventTarget) => void;
     getFocused: () => GridEventShortcutTarget | null;
-    getHovered: () => GridEventShortcutTarget | null;
-    getFirstVisible: () => GridEventShortcutTarget | null;
+    listVisible: () => FocusableGridEventTarget[];
   };
   timedEvents: GridEvent[];
 }) {
   const calendarLookup = useCalendarLookup();
+  const { data: calendars } = useCalendarsQuery();
+  const queryClient = useQueryClient();
   const { delete: deleteEvent } = useEventMutations(dependencies);
   const updateEvent = useUpdateEvent(dependencies);
 
@@ -85,7 +94,7 @@ export function useGridEventEditShortcuts({
     return events.find((candidate) => candidate._id === target.eventId) ?? null;
   };
 
-  const deleteTargetedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
+  const deleteFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
     if (
       isDeleteTextEditingTarget(keyboardEvent) ||
       isEventFormKeyboardTarget(keyboardEvent)
@@ -97,10 +106,9 @@ export function useGridEventEditShortcuts({
       return;
     }
 
-    const target =
-      targeting.getFocused() ??
-      targeting.getHovered() ??
-      targeting.getFirstVisible();
+    // Focused only (no hover/first-visible fallback): destructive actions
+    // must demand an explicit target.
+    const target = targeting.getFocused();
     if (!target) return;
 
     const event = findCalendarEventForTarget(target);
@@ -113,6 +121,37 @@ export function useGridEventEditShortcuts({
     keyboardEvent.preventDefault();
     keyboardEvent.stopPropagation();
     deleteEventAndDiscardDraft(deleteEvent, event);
+  };
+
+  const duplicateFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
+    if (isEventFormOpen() || isEventFormKeyboardTarget(keyboardEvent)) {
+      return;
+    }
+
+    if (document.activeElement?.closest(`#${ID_SIDEBAR}`)) {
+      return;
+    }
+
+    const target = targeting.getFocused();
+    if (!target) return;
+
+    const gridEvent = findCalendarEventForTarget(target);
+    if (!gridEvent?._id) return;
+
+    if (isGridEventInteractionReadOnly(calendarLookup, gridEvent)) {
+      return;
+    }
+
+    const sourceEvent = findEventInCache(queryClient, gridEvent._id);
+    if (!sourceEvent) return;
+
+    const duplicate = duplicateGridEventDraft(sourceEvent, calendars ?? []);
+    if (!duplicate) return;
+
+    keyboardEvent.preventDefault();
+    keyboardEvent.stopPropagation();
+    draftActions.startGridDraft({ activity: "gridClick", draft: duplicate });
+    draftActions.setFormOpen(true);
   };
 
   const moveFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
@@ -168,37 +207,61 @@ export function useGridEventEditShortcuts({
     });
   };
 
-  const moveShortcutCreatedDraft = (keyboardEvent: KeyboardEvent) => {
+  const moveDraftOrFocusAdjacent = (keyboardEvent: KeyboardEvent) => {
     if (isEditableKeyboardTarget(keyboardEvent)) return;
 
     const didMove = repositionDraftByKey(keyboardEvent.key);
-    if (!didMove) return;
+    if (didMove) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      return;
+    }
+
+    if (isEventFormOpen()) return;
+    if (keyboardEvent.key !== "ArrowUp" && keyboardEvent.key !== "ArrowDown") {
+      return;
+    }
+
+    const adjacent = getChronologicallyAdjacentTarget({
+      allDayEvents,
+      direction: keyboardEvent.key === "ArrowUp" ? "previous" : "next",
+      focused: targeting.getFocused(),
+      timedEvents,
+      visible: targeting.listVisible(),
+    });
+    if (!adjacent) return;
 
     keyboardEvent.preventDefault();
     keyboardEvent.stopPropagation();
+    adjacent.element.scrollIntoView({ block: "nearest" });
+    targeting.focus(adjacent);
   };
 
-  useAppShortcut("Delete", deleteTargetedCalendarEvent, {
+  useAppShortcut("Delete", deleteFocusedCalendarEvent, {
     ignoreInputs: false,
+  });
+  useAppShortcut("Mod+D", duplicateFocusedCalendarEvent, {
+    ignoreInputs: false,
+    conflictBehavior: "allow",
   });
   useAppShortcut(
     "ArrowUp",
-    moveShortcutCreatedDraft,
+    moveDraftOrFocusAdjacent,
     DRAFT_MOVEMENT_HOTKEY_OPTIONS,
   );
   useAppShortcut(
     "ArrowDown",
-    moveShortcutCreatedDraft,
+    moveDraftOrFocusAdjacent,
     DRAFT_MOVEMENT_HOTKEY_OPTIONS,
   );
   useAppShortcut(
     "ArrowLeft",
-    moveShortcutCreatedDraft,
+    moveDraftOrFocusAdjacent,
     DRAFT_MOVEMENT_HOTKEY_OPTIONS,
   );
   useAppShortcut(
     "ArrowRight",
-    moveShortcutCreatedDraft,
+    moveDraftOrFocusAdjacent,
     DRAFT_MOVEMENT_HOTKEY_OPTIONS,
   );
   useAppShortcut("Shift+ArrowUp", moveFocusedCalendarEvent);

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -31,8 +31,6 @@ import {
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
 
-export type { GridEventShortcutTarget };
-
 const DRAFT_MOVEMENT_HOTKEY_OPTIONS = {
   ignoreInputs: false,
   preventDefault: false,
@@ -94,6 +92,25 @@ export function useGridEventEditShortcuts({
     return events.find((candidate) => candidate._id === target.eventId) ?? null;
   };
 
+  // Focused only (no hover/first-visible fallback): edit actions must
+  // demand an explicit target.
+  const getFocusedMutableCalendarEvent = () => {
+    const target = targeting.getFocused();
+    if (!target) return null;
+
+    const event = findCalendarEventForTarget(target);
+    if (!event) return null;
+
+    if (isGridEventInteractionReadOnly(calendarLookup, event)) {
+      return null;
+    }
+
+    return event;
+  };
+
+  const isFocusInSidebar = () =>
+    Boolean(document.activeElement?.closest(`#${ID_SIDEBAR}`));
+
   const deleteFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
     if (
       isDeleteTextEditingTarget(keyboardEvent) ||
@@ -102,21 +119,10 @@ export function useGridEventEditShortcuts({
       return;
     }
 
-    if (document.activeElement?.closest(`#${ID_SIDEBAR}`)) {
-      return;
-    }
+    if (isFocusInSidebar()) return;
 
-    // Focused only (no hover/first-visible fallback): destructive actions
-    // must demand an explicit target.
-    const target = targeting.getFocused();
-    if (!target) return;
-
-    const event = findCalendarEventForTarget(target);
+    const event = getFocusedMutableCalendarEvent();
     if (!event) return;
-
-    if (isGridEventInteractionReadOnly(calendarLookup, event)) {
-      return;
-    }
 
     keyboardEvent.preventDefault();
     keyboardEvent.stopPropagation();
@@ -128,19 +134,10 @@ export function useGridEventEditShortcuts({
       return;
     }
 
-    if (document.activeElement?.closest(`#${ID_SIDEBAR}`)) {
-      return;
-    }
+    if (isFocusInSidebar()) return;
 
-    const target = targeting.getFocused();
-    if (!target) return;
-
-    const gridEvent = findCalendarEventForTarget(target);
+    const gridEvent = getFocusedMutableCalendarEvent();
     if (!gridEvent?._id) return;
-
-    if (isGridEventInteractionReadOnly(calendarLookup, gridEvent)) {
-      return;
-    }
 
     const sourceEvent = findEventInCache(queryClient, gridEvent._id);
     if (!sourceEvent) return;
@@ -157,17 +154,8 @@ export function useGridEventEditShortcuts({
   const moveFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
     if (isEventFormOpen()) return;
 
-    // Focused only (no hover/first-visible fallback): moving an event the
-    // user isn't focused on would be surprising.
-    const target = targeting.getFocused();
-    if (!target) return;
-
-    const event = findCalendarEventForTarget(target);
+    const event = getFocusedMutableCalendarEvent();
     if (!event?._id) return;
-
-    if (isGridEventInteractionReadOnly(calendarLookup, event)) {
-      return;
-    }
 
     const movement = getArrowKeyMovement(
       keyboardEvent.key,

--- a/packages/web/src/shortcuts/app-lock.test.ts
+++ b/packages/web/src/shortcuts/app-lock.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  clearAppLockReasons,
+  setAppLockReason,
+  useAppLockReason,
+} from "@web/shortcuts/app-lock";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  clearAppLockReasons();
+});
+
+describe("app-lock", () => {
+  it("sets and clears dataset.appLocked from named reasons", () => {
+    setAppLockReason("a", true);
+    expect(document.body.dataset.appLocked).toBe("true");
+
+    setAppLockReason("b", true);
+    setAppLockReason("a", false);
+    expect(document.body.dataset.appLocked).toBe("true");
+
+    setAppLockReason("b", false);
+    expect(document.body.dataset.appLocked).toBeUndefined();
+  });
+
+  it("useAppLockReason syncs with locked and cleans up on unmount", () => {
+    const { rerender, unmount } = renderHook(
+      ({ locked }) => useAppLockReason("hook", locked),
+      { initialProps: { locked: true } },
+    );
+
+    expect(document.body.dataset.appLocked).toBe("true");
+
+    act(() => {
+      rerender({ locked: false });
+    });
+    expect(document.body.dataset.appLocked).toBeUndefined();
+
+    act(() => {
+      rerender({ locked: true });
+    });
+    expect(document.body.dataset.appLocked).toBe("true");
+
+    unmount();
+    expect(document.body.dataset.appLocked).toBeUndefined();
+  });
+});

--- a/packages/web/src/shortcuts/app-lock.ts
+++ b/packages/web/src/shortcuts/app-lock.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+const lockReasons = new Set<string>();
+
+function syncAppLockedDataset() {
+  if (lockReasons.size > 0) {
+    document.body.dataset.appLocked = "true";
+    return;
+  }
+
+  delete document.body.dataset.appLocked;
+}
+
+/**
+ * Named lock reasons so overlapping overlays (palette + welcome, etc.) can
+ * open/close independently without clearing each other's lock.
+ */
+export function setAppLockReason(reason: string, locked: boolean) {
+  if (locked) {
+    lockReasons.add(reason);
+  } else {
+    lockReasons.delete(reason);
+  }
+  syncAppLockedDataset();
+}
+
+/** Clears every reason — used by tests between cases. */
+export function clearAppLockReasons() {
+  lockReasons.clear();
+  syncAppLockedDataset();
+}
+
+export function useAppLockReason(reason: string, locked: boolean) {
+  useEffect(() => {
+    setAppLockReason(reason, locked);
+    return () => setAppLockReason(reason, false);
+  }, [locked, reason]);
+}

--- a/packages/web/src/shortcuts/data/shortcuts.data.test.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.test.ts
@@ -141,9 +141,47 @@ describe("shortcuts.data", () => {
 
         expect(edit?.shortcuts).toContainEqual({
           keys: ["Delete"],
-          label: "Delete calendar event",
+          label: "Delete focused event",
+        });
+        expect(edit?.shortcuts).toContainEqual({
+          keys: ["Mod", "D"],
+          label: "Duplicate focused event",
+        });
+        expect(edit?.shortcuts).toContainEqual({
+          keys: ["ArrowUp"],
+          label: "Focus previous event",
+        });
+        expect(edit?.shortcuts).toContainEqual({
+          keys: ["ArrowDown"],
+          label: "Focus next event",
+        });
+        expect(edit?.shortcuts).toContainEqual({
+          keys: ["Enter"],
+          label: "Open focused event",
         });
       }
+    });
+
+    it("lists Life and undo/redo in day/week navigate and other sections", () => {
+      const sections = getShortcutMenuSections({
+        view: "day",
+        isViewingCurrentPeriod: true,
+      });
+      const navigate = sections.find((section) => section.id === "navigate");
+      const other = sections.find((section) => section.id === "other");
+
+      expect(navigate?.shortcuts).toContainEqual({
+        keys: ["l"],
+        label: "Go to Life view",
+      });
+      expect(other?.shortcuts).toContainEqual({
+        keys: ["Mod", "Z"],
+        label: "Undo last change",
+      });
+      expect(other?.shortcuts).toContainEqual({
+        keys: ["Mod", "Shift", "Z"],
+        label: "Redo last change",
+      });
     });
 
     it("lists Shift+Arrow reschedule shortcuts in the day and week Edit sections", () => {

--- a/packages/web/src/shortcuts/data/shortcuts.data.ts
+++ b/packages/web/src/shortcuts/data/shortcuts.data.ts
@@ -1,6 +1,9 @@
 import { type ShortcutOverlaySection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutsOverlay";
 import { type Shortcut } from "@web/shortcuts/global.shortcut.types";
-import { VIEW_SHORTCUTS } from "@web/shortcuts/shortcuts.constants";
+import {
+  LIFE_SHORTCUT,
+  VIEW_SHORTCUTS,
+} from "@web/shortcuts/shortcuts.constants";
 
 export type ShortcutMenuView = "day" | "week" | "life";
 
@@ -49,6 +52,10 @@ const getNavigateShortcuts = ({
       keys: [alternateView.key],
       label: `Go to ${alternateView.label} view`,
     },
+    {
+      keys: [LIFE_SHORTCUT.key],
+      label: `Go to ${LIFE_SHORTCUT.label} view`,
+    },
   ];
 };
 
@@ -64,13 +71,21 @@ const getEditShortcuts = (view: ShortcutMenuView): Shortcut[] =>
   view === "life"
     ? []
     : [
-        { keys: ["Delete"], label: "Delete calendar event" },
+        { keys: ["Enter"], label: "Open focused event" },
+        { keys: ["Delete"], label: "Delete focused event" },
+        { keys: ["Mod", "D"], label: "Duplicate focused event" },
+        { keys: ["Mod", "Enter"], label: "Save event form" },
+        { keys: ["ArrowUp"], label: "Focus previous event" },
+        { keys: ["ArrowDown"], label: "Focus next event" },
         { keys: ["Arrow keys"], label: "Move draft event" },
         {
           keys: ["Shift", "ArrowLeft"],
           label: "Move event to previous day",
         },
-        { keys: ["Shift", "ArrowRight"], label: "Move event to next day" },
+        {
+          keys: ["Shift", "ArrowRight"],
+          label: "Move event to next day",
+        },
         { keys: ["Shift", "ArrowUp"], label: "Move event 15 min earlier" },
         { keys: ["Shift", "ArrowDown"], label: "Move event 15 min later" },
       ];
@@ -87,6 +102,8 @@ const getOtherShortcuts = (): Shortcut[] => [
   { keys: ["]"], label: "Toggle sidebar" },
   { keys: ["?"], label: "Toggle shortcuts" },
   { keys: ["Mod", "k"], label: "Command Palette" },
+  { keys: ["Mod", "Z"], label: "Undo last change" },
+  { keys: ["Mod", "Shift", "Z"], label: "Redo last change" },
 ];
 
 /**

--- a/packages/web/src/shortcuts/useAppShortcut.test.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.test.ts
@@ -150,4 +150,16 @@ describe("useAppShortcut", () => {
       expect(mockHandler).not.toHaveBeenCalled();
     });
   });
+
+  it("still calls the handler when locked if ignoreAppLock is true", async () => {
+    document.body.dataset.appLocked = "true";
+
+    renderHook(() => useAppShortcut("A", mockHandler, { ignoreAppLock: true }));
+
+    dispatchKeyEvent("a", "keydown");
+
+    await waitFor(() => {
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/web/src/shortcuts/useAppShortcut.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.ts
@@ -11,6 +11,12 @@ export interface UseAppShortcutOptions {
   eventType?: "keydown" | "keyup";
   preventDefault?: boolean;
   stopPropagation?: boolean;
+  /**
+   * When true, the handler still runs while `document.body.dataset.appLocked`
+   * is set. Use for the keys that open/close those locks (Mod+K, Shift+?,
+   * Escape) so overlays remain dismissible from the keyboard.
+   */
+  ignoreAppLock?: boolean;
   /** @default 'allow' — multiple features often register the same global key (e.g. Escape). */
   conflictBehavior?: ConflictBehavior;
 }
@@ -27,13 +33,14 @@ export function useAppShortcut(
     eventType = "keydown",
     preventDefault,
     stopPropagation,
+    ignoreAppLock = false,
     conflictBehavior = "allow",
   } = options;
 
   useHotkey(
     hotkey,
     (event) => {
-      if (document.body.dataset.appLocked === "true") {
+      if (!ignoreAppLock && document.body.dataset.appLocked === "true") {
         return;
       }
 

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -88,6 +88,10 @@ const focusCalendarTarget = (
   eventType: "all-day" | "timed",
 ) => {
   const button = document.createElement("button");
+  Object.defineProperty(button, "offsetParent", {
+    configurable: true,
+    get: () => document.body,
+  });
   document.body.appendChild(button);
   dayEventRegistry.register({
     element: button,
@@ -294,7 +298,7 @@ describe("useDayEventNudgeShortcuts", () => {
     ).toBe(TIMED_EVENT_ID);
   });
 
-  it("deletes the hovered calendar event with Delete when no event is focused", () => {
+  it("does not delete a hovered calendar event with Delete when nothing is focused", () => {
     const button = focusCalendarTarget(TIMED_EVENT_ID, "timed");
     button.blur();
     setHoveredDayGridEventTarget(button);
@@ -302,9 +306,40 @@ describe("useDayEventNudgeShortcuts", () => {
 
     pressKey("Delete");
 
-    expect(
-      (getDeleteMutation(queryClient)?.state.variables as { id?: string })?.id,
-    ).toBe(TIMED_EVENT_ID);
+    expect(getDeleteMutation(queryClient)).toBeUndefined();
+  });
+
+  it("duplicates the focused calendar event with Mod+D", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    renderEditShortcuts();
+
+    pressKey("d", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    const state = useDraftStore.getState();
+    expect(state.status?.isFormOpen).toBe(true);
+    expect(state.gridDraft?.kind).toBe("create");
+    expect(state.gridDraft?.values.title).toBe("Timed event");
+  });
+
+  it("focuses the chronologically next event with ArrowDown", () => {
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const laterEvent: GridEvent = {
+      ...timedEvent,
+      _id: "cccccccccccccccccccccccc",
+      startDate: "2026-05-20T11:00:00.000",
+      endDate: "2026-05-20T12:00:00.000",
+      title: "Later event",
+    };
+    const later = focusCalendarTarget(laterEvent._id!, "timed");
+    earlier.focus();
+    renderEditShortcuts({ timedEvents: [timedEvent, laterEvent] });
+
+    pressKey("ArrowDown");
+
+    expect(document.activeElement).toBe(later);
   });
 
   it("does not delete a grid event when Delete is pressed inside an open event form", () => {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -5,15 +5,16 @@ import { type EventMutationDependencies } from "@web/events/mutations/useEventMu
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import {
-  getFirstVisibleDayGridEventTarget,
+  focusDayGridEventTarget,
   getFocusedDayGridEventTarget,
-  getHoveredDayGridEventTarget,
+  listVisibleDayGridEventTargets,
 } from "@web/views/Day/interaction/targeting/day-event.targeting";
 
 /**
- * Day-view edit shortcuts: Delete, Shift+arrows (nudge / day-move), and
- * Arrow keys to reposition an open draft. Shift+ArrowLeft/Right move a
- * focused event by one day and follow that day in the Day view.
+ * Day-view edit shortcuts: Delete, Mod+D, Shift+arrows (nudge / day-move),
+ * Arrow keys to reposition an open draft or focus the neighboring event.
+ * Shift+ArrowLeft/Right move a focused event by one day and follow that day
+ * in the Day view.
  */
 export function useDayEventNudgeShortcuts({
   allDayEvents = [],
@@ -36,9 +37,9 @@ export function useDayEventNudgeShortcuts({
       onCrossed: (date) => navigateToDate?.(date),
     },
     targeting: {
+      focus: focusDayGridEventTarget,
       getFocused: getFocusedDayGridEventTarget,
-      getHovered: getHoveredDayGridEventTarget,
-      getFirstVisible: getFirstVisibleDayGridEventTarget,
+      listVisible: listVisibleDayGridEventTargets,
     },
     repositionDraftByKey: (key) => {
       const { gridDraft, status } = useDraftStore.getState();

--- a/packages/web/src/views/Day/interaction/targeting/day-event.targeting.ts
+++ b/packages/web/src/views/Day/interaction/targeting/day-event.targeting.ts
@@ -29,9 +29,6 @@ export const clearHoveredDayGridEventTarget =
 export const getFocusedDayGridEventTarget =
   dayGridEventTargeting.getFocusedGridEventTarget;
 
-export const getHoveredDayGridEventTarget =
-  dayGridEventTargeting.getHoveredGridEventTarget;
-
 export const getFirstVisibleDayGridEventTarget =
   dayGridEventTargeting.getFirstVisibleGridEventTarget;
 

--- a/packages/web/src/views/Day/interaction/targeting/day-event.targeting.ts
+++ b/packages/web/src/views/Day/interaction/targeting/day-event.targeting.ts
@@ -35,5 +35,8 @@ export const getHoveredDayGridEventTarget =
 export const getFirstVisibleDayGridEventTarget =
   dayGridEventTargeting.getFirstVisibleGridEventTarget;
 
+export const listVisibleDayGridEventTargets =
+  dayGridEventTargeting.listVisibleGridEventTargets;
+
 export const focusDayGridEventTarget =
   dayGridEventTargeting.focusGridEventTarget;

--- a/packages/web/src/views/Week/hooks/grid/useScroll.ts
+++ b/packages/web/src/views/Week/hooks/grid/useScroll.ts
@@ -3,7 +3,6 @@ import {
   getCurrentMinute,
   getMinuteHeight,
 } from "@web/common/utils/grid/grid.util";
-import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 export const useScroll = (
   timedGridRef: MutableRefObject<HTMLElement | null>,
@@ -24,10 +23,8 @@ export const useScroll = (
     }
   }, [timedGridRef]);
 
-  // Scroll when pressing "c"
-  useAppShortcut("C", scrollToNow);
-
-  // Optional: scroll to now on mount
+  // Optional: scroll to now on mount. "t" (today) owns scroll-to-now while
+  // viewing the current week; do not bind "c" here — that creates a draft.
   useEffect(() => {
     if (!timedGridRef.current) return;
     scrollToNow();

--- a/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useGlobalShortcuts.ts
@@ -80,6 +80,7 @@ export function useNavigationShortcuts() {
     {
       ignoreInputs: false,
       blurOnTrigger: true,
+      ignoreAppLock: true,
     },
   );
 
@@ -91,6 +92,7 @@ export function useNavigationShortcuts() {
     {
       ignoreInputs: false,
       blurOnTrigger: true,
+      ignoreAppLock: true,
     },
   );
 }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.test.tsx
@@ -351,22 +351,52 @@ describe("useWeekShortcuts calendar event targeting", () => {
     ).toBe(true);
   });
 
-  it("deletes the hovered calendar event with Delete when no event is focused", () => {
+  it("does not delete a hovered calendar event with Delete when nothing is focused", () => {
     const button = addCalendarTarget();
     setHoveredWeekGridEventTarget(button);
 
     const { queryClient } = renderShortcuts();
     pressKey("Delete");
 
-    expect(
-      queryClient
-        .getMutationCache()
-        .getAll()
-        .some(
-          (mutation) =>
-            (mutation.state.variables as { id?: string }).id === EVENT_1_ID,
-        ),
-    ).toBe(true);
+    expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+  });
+
+  it("duplicates the focused calendar event with Mod+D", () => {
+    const button = addCalendarTarget();
+    button.focus();
+    renderShortcuts();
+
+    pressKey("d", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    const state = useDraftStore.getState();
+    expect(state.status?.isFormOpen).toBe(true);
+    expect(state.gridDraft?.kind).toBe("create");
+    expect(state.gridDraft?.values.title).toBe("Editable event");
+  });
+
+  it("focuses the chronologically next event with ArrowDown", () => {
+    const earlier = addCalendarTarget(leftmostEvent.id);
+    const later = addCalendarTarget(editableEvent.id);
+    earlier.focus();
+    renderShortcuts({ includeLeftmostEvent: true });
+
+    pressKey("ArrowDown");
+
+    expect(document.activeElement).toBe(later);
+  });
+
+  it("focuses the chronologically previous event with ArrowUp", () => {
+    const earlier = addCalendarTarget(leftmostEvent.id);
+    const later = addCalendarTarget(editableEvent.id);
+    later.focus();
+    renderShortcuts({ includeLeftmostEvent: true });
+
+    pressKey("ArrowUp");
+
+    expect(document.activeElement).toBe(earlier);
   });
 
   it("deletes pending calendar events with Delete", () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcuts.ts
@@ -25,7 +25,7 @@ import {
   focusWeekGridEventTarget,
   getFirstVisibleWeekGridEventTarget,
   getFocusedWeekGridEventTarget,
-  getHoveredWeekGridEventTarget,
+  listVisibleWeekGridEventTargets,
 } from "@web/views/Week/interaction/targeting/week-event.targeting";
 
 export interface ShortcutProps {
@@ -168,9 +168,9 @@ export const useWeekShortcuts = ({
     timedEvents,
     dayBoundary: { kind: "clamp", weekDays },
     targeting: {
+      focus: focusWeekGridEventTarget,
       getFocused: getFocusedWeekGridEventTarget,
-      getHovered: getHoveredWeekGridEventTarget,
-      getFirstVisible: getFirstVisibleWeekGridEventTarget,
+      listVisible: listVisibleWeekGridEventTargets,
     },
     repositionDraftByKey: repositionDraftByKeyboard,
   });

--- a/packages/web/src/views/Week/interaction/targeting/week-event.targeting.test.ts
+++ b/packages/web/src/views/Week/interaction/targeting/week-event.targeting.test.ts
@@ -5,6 +5,7 @@ import {
   getFirstVisibleWeekGridEventTarget,
   getFocusedWeekGridEventTarget,
   getHoveredWeekGridEventTarget,
+  listVisibleWeekGridEventTargets,
   setHoveredWeekGridEventTarget,
 } from "./week-event.targeting";
 import { afterEach, describe, expect, it } from "bun:test";
@@ -91,5 +92,16 @@ describe("weekGridEventTargeting", () => {
     focusWeekGridEventTarget(target);
 
     expect(document.activeElement).toBe(button);
+  });
+
+  it("lists every visible registered event", () => {
+    addEventButton({ eventId: "hidden", isVisible: false });
+    const first = addEventButton({ eventId: "first" });
+    const second = addEventButton({ eventId: "second" });
+
+    expect(listVisibleWeekGridEventTargets()).toEqual([
+      expect.objectContaining({ element: first, eventId: "first" }),
+      expect.objectContaining({ element: second, eventId: "second" }),
+    ]);
   });
 });

--- a/packages/web/src/views/Week/interaction/targeting/week-event.targeting.ts
+++ b/packages/web/src/views/Week/interaction/targeting/week-event.targeting.ts
@@ -37,5 +37,8 @@ export const getHoveredWeekGridEventTarget =
 export const getFirstVisibleWeekGridEventTarget =
   weekGridEventTargeting.getFirstVisibleGridEventTarget;
 
+export const listVisibleWeekGridEventTargets =
+  weekGridEventTargeting.listVisibleGridEventTargets;
+
 export const focusWeekGridEventTarget =
   weekGridEventTargeting.focusGridEventTarget;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes Day/Week grid keyboard shortcuts safe and consistent, and aligns the shortcut help system with what the app actually does.

### Event actions (#1)
- **Delete** and **Mod+D** act only on an explicitly focused event (no hover / first-visible fallback)
- **ArrowUp/ArrowDown** move focus chronologically between visible events when no draft is being repositioned
- **Enter** to open and draft-arrow repositioning are unchanged

### Shortcut consistency (#5)
- Removed Week’s `c` scroll binding (create stays on `c`; scroll-to-now stays on `t`)
- Overlays (command palette, shortcuts help, welcome, auth, release notes) set `appLocked` so bare-letter shortcuts don’t leak
- Shift+? catalog and acceptance docs now include undo/redo, Life (`l`), Enter-to-open, Mod+D, focus neighbors, and focused-only Delete

## Validation
- `bun test:web --` focused suites for week/day shortcuts, targeting, app-lock, help catalog, focus-adjacent
- `bun run lint`
- `bun run type-check`

## Out of scope
NL quick-create, palette omnisearch, and silent-failure work (already shipped earlier).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4734c607-1bb6-45ec-b2d9-ebf7e8aa3b00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4734c607-1bb6-45ec-b2d9-ebf7e8aa3b00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

