### PR TITLE
fix(sync): require readiness for deploy health

### DIFF
--- a/.github/scripts/deploy-health-check.sh
+++ b/.github/scripts/deploy-health-check.sh
@@ -368,14 +368,14 @@ ssh_remote() {
 
 remote_compose_prefix() {
   if [ "${PROFILE:-}" = "selfhosted" ]; then
-    printf 'cd ~/compass && COMPOSE_PROFILES=selfhosted docker compose --project-name compass -f compose.yaml'
+    printf 'cd ~/compass && COMPOSE_PROFILES=selfhosted,sync docker compose --project-name compass -f compose.yaml'
   else
-    printf 'cd ~/compass && docker compose --project-name compass -f compose.yaml'
+    printf 'cd ~/compass && COMPOSE_PROFILES=sync docker compose --project-name compass -f compose.yaml'
   fi
 }
 
 remote_check_stack() {
-  local expected_services=("web" "backend")
+  local expected_services=("web" "backend" "sync")
   local version=${RELEASE_TAG:-${TAG:-}}
   version=${version#v}
 
@@ -407,7 +407,7 @@ for service in \$services; do
   fi
 done
 
-for service in web backend; do
+for service in web backend sync; do
   line=\$(printf '%s\n' "\$ps_output" | awk -v service="\$service" '\$1 == service { print }')
   # web uses an environment-prefixed tag (e.g. staging-selfhosted-0.5.25); backend uses :0.5.25.
   # Check that the version string appears anywhere in the image tag for both.

--- a/self-host/compass
+++ b/self-host/compass
@@ -315,7 +315,7 @@ case $command_name in
     compose pull || fail "Could not pull updated Compass images from Docker Hub."
     if ! compose up -d --remove-orphans --wait; then
       compose ps -a >&2 || true
-      compose logs --tail=100 mongo backend >&2 || true
+      compose logs --tail=100 mongo backend sync >&2 || true
       fail "Docker Compose failed to start updated Compass."
     fi
     prune_unused_images
@@ -323,7 +323,7 @@ case $command_name in
       info "Compass updated and running at $APP_URL"
     else
       compose ps -a >&2 || true
-      compose logs --tail=100 mongo backend >&2 || true
+      compose logs --tail=100 mongo backend sync >&2 || true
       fail "Compass updated, but the backend health check did not pass. Run './compass logs' for details."
     fi
     ;;

--- a/self-host/compose.selfhosted.yaml
+++ b/self-host/compose.selfhosted.yaml
@@ -7,3 +7,7 @@ services:
     depends_on:
       mongo:
         condition: service_healthy
+  sync:
+    depends_on:
+      mongo:
+        condition: service_healthy

--- a/self-host/compose.yaml
+++ b/self-host/compose.yaml
@@ -68,7 +68,8 @@ services:
     # Bound to loopback only so the host Caddy can reverse-proxy the public
     # `/sync/*` OAuth + webhook paths; not exposed on a public interface.
     # No depends_on mongo: Atlas environments have no mongo container, and the
-    # service tolerates a not-yet-ready store (liveness stays up, readiness 503).
+    # service tolerates a not-yet-ready store while its readiness probe stays
+    # unhealthy until storage is available.
     profiles: [sync]
     ports:
       - *sync-port
@@ -88,7 +89,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "bun -e \"fetch('http://127.0.0.1:3010/health/live').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\"",
+          "bun -e \"fetch('http://127.0.0.1:3010/health/ready').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\"",
         ]
       interval: 10s
       timeout: 5s

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -162,7 +162,7 @@ describe("self-host docker compose", () => {
     expect(compose).toContain("stop_grace_period: 30s");
   });
 
-  it("waits for mongo before starting backend via the selfhosted overlay", () => {
+  it("waits for mongo before starting backend and sync via the selfhosted overlay", () => {
     const overlay = readFileSync(
       join(import.meta.dir, "compose.selfhosted.yaml"),
       { encoding: "utf8" },
@@ -172,6 +172,7 @@ describe("self-host docker compose", () => {
     expect(overlay).toContain("mongo:");
     expect(overlay).toContain("condition: service_healthy");
     expect(overlay).not.toContain("required: false");
+    expect(overlay).toContain("  sync:\n    depends_on:");
   });
 });
 

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -119,8 +119,8 @@ describe("self-host docker compose", () => {
     });
 
     expect(compose).toContain("switchbacktech/compass-sync:");
-    // Liveness probe, not readiness: a store-less passive service stays up.
-    expect(compose).toContain("http://127.0.0.1:3010/health/live");
+    // Sync must be ready to reach storage before a deploy is healthy.
+    expect(compose).toContain("http://127.0.0.1:3010/health/ready");
     // "  sync:\n" (colon-then-newline) picks the services.sync: block, not
     // the earlier "  sync: &sync-port ..." x-local-bindings anchor line.
     const syncBlock = compose
@@ -711,13 +711,22 @@ describe("deploy health check script", () => {
     expect(result.stderr).toContain("expected 0.5.27, got 0.5.26");
   });
 
-  it("uses selfhosted profile for selfhosted deployments", async () => {
+  it("uses the sync profile for cloud deployments", async () => {
+    const result = await runHealthScriptFunction("remote_compose_prefix", {
+      PROFILE: "cloud",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("COMPOSE_PROFILES=sync");
+  });
+
+  it("uses selfhosted and sync profiles for selfhosted deployments", async () => {
     const result = await runHealthScriptFunction("remote_compose_prefix", {
       PROFILE: "selfhosted",
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("COMPOSE_PROFILES=selfhosted");
+    expect(result.stdout).toContain("COMPOSE_PROFILES=selfhosted,sync");
     expect(result.stdout).toContain("docker compose --project-name compass");
   });
 });


### PR DESCRIPTION
## Summary
- require Sync storage readiness for Docker and deploy health checks
- include Sync in cloud and self-hosted deployment inspection and version validation
- gate self-hosted Sync startup on healthy Mongo so it cannot remain permanently not-ready after a startup race

## Validation
- `bun test self-host/docker-compose.test.ts` (42 passing)
- `bun test packages/sync/src/server/sync.server.test.ts` (8 passing)
- `bun run verify` (core/web/type-check/lint/a11y passed; existing non-failing axe incomplete reports only)
- `bun run lint`
- `bun run type-check`

## Review
- Simplification: no simplification was appropriate; the profile selection and service checks are separate deployment boundaries.
- Independent review: no remaining actionable findings after adding the Mongo startup gate.