### PR TITLE
fix(web): capture unexpected event failures

### DIFF
--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -12,7 +12,21 @@ import {
   refocusEventElement,
 } from "@web/common/utils/event/event.util";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+const mockCaptureException = mock();
+
+mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
+  getPosthogClient: () => ({ captureException: mockCaptureException }),
+}));
 
 const { handleError } = await import("@web/common/utils/event/event.util");
 
@@ -30,6 +44,7 @@ describe("handleError", () => {
   beforeEach(() => {
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
     mocks.error.mockClear();
+    mockCaptureException.mockClear();
     mocks.isActive.mockReturnValue(false);
     registerToastPort(port);
   });
@@ -60,6 +75,11 @@ describe("handleError", () => {
     // proves handleError reached the notify path (rather than early-returning).
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      $exception_handled: true,
+      $exception_source: "event-mutation",
+      httpStatus: Status.INTERNAL_SERVER,
+    });
     expect(mocks.error).toHaveBeenCalledTimes(1);
     expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
       toastId: GENERIC_ERROR_TOAST_ID,
@@ -86,6 +106,7 @@ describe("handleError", () => {
     handleError(error);
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
   it("shows a toast on a 404 instead of silently reverting the optimistic edit", () => {
@@ -102,7 +123,7 @@ describe("handleError", () => {
     });
   });
 
-  it("does not log a retryable, backend-authored mutation failure", () => {
+  it("does not report a backend-authored mutation failure", () => {
     // A 502 PROVIDER_FAILURE the backend authored: it answered (so it isn't
     // "unavailable"), and it's retryable, so the user just needs a nudge. It
     // must not console.error - otherwise every transient provider hiccup
@@ -120,10 +141,27 @@ describe("handleError", () => {
     handleError(error);
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
     expect(mocks.error).toHaveBeenCalledTimes(1);
     expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
       toastId: GENERIC_ERROR_TOAST_ID,
     });
+  });
+
+  it("does not report a non-retryable domain mutation failure", () => {
+    const error = createServerError(Status.FORBIDDEN);
+    error.response = {
+      status: Status.FORBIDDEN,
+      data: {
+        code: "CALENDAR_READ_ONLY",
+        message: "Calendar is read-only",
+        retryable: false,
+      },
+    } as ApiResponse<unknown>;
+
+    handleError(error);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -11,6 +11,7 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type ApiError } from "@web/api/api.types";
 import { isBackendUnavailableError } from "@web/api/util/backend-unavailable-error.util";
 import { getUserId } from "@web/auth/compass/session/session.util";
+import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import { GENERIC_ERROR_TOAST_ID } from "@web/common/constants/toast.constants";
 import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
@@ -150,17 +151,14 @@ export const getWeekDayLabel = (day: Dayjs | Date) => {
 };
 
 /**
- * A retryable mutation failure the backend authored - e.g. a 502
- * PROVIDER_FAILURE thrown when Google rejects a write. The app already treats
- * these as retryable, so they only warrant a toast; console.error'ing them
- * re-surfaces every routine provider hiccup as a brand-new error-tracking issue
- * (capture_console_errors turns deliberate logging into exception capture).
+ * A known mutation failure authored by the backend. These have user-facing
+ * feedback already, so they must not create error-tracking issues.
  */
-const isRetryableMutationError = (error: Error): boolean => {
+const isExpectedMutationError = (error: Error): boolean => {
   const parsed = EventMutationErrorSchema.safeParse(
     (error as ApiError).response?.data,
   );
-  return parsed.success && parsed.data.retryable;
+  return parsed.success;
 };
 
 const CATCHALL_TOAST_MESSAGE =
@@ -194,12 +192,18 @@ export const handleError = (error: Error) => {
     return;
   }
 
-  if (isRetryableMutationError(error)) {
-    // Expected transient failure: nudge the user to retry without logging it.
+  if (isExpectedMutationError(error)) {
+    // The backend authored a known mutation failure. Show its existing UI
+    // feedback without creating an error-tracking issue.
     showCatchallToast(CATCHALL_TOAST_MESSAGE);
     return;
   }
 
+  getPosthogClient()?.captureException(error, {
+    $exception_handled: true,
+    $exception_source: "event-mutation",
+    httpStatus: Number.isNaN(code) ? undefined : code,
+  });
   console.error(error);
 
   if (code === Status.INTERNAL_SERVER) {


### PR DESCRIPTION
## Summary
- report unexpected handled event-mutation failures to PostHog
- exclude offline, auth, missing-resource, and retryable failures

## Validation
- bun test:web -- --runInBand packages/web/src/common/utils/event/event.util.test.ts
- bun run lint