### PR TITLE
fix(sync,core,scripts): anchor EXDATE/RDATE series expansion at DTSTART, not now

### DIFF
--- a/packages/core/src/util/event/compass.event.rrule.test.ts
+++ b/packages/core/src/util/event/compass.event.rrule.test.ts
@@ -94,6 +94,23 @@ describe("CompassEventRRule: ", () => {
     expect(allDates.some((d) => dayjs(d).isSame(startDateOnMonday))).toBe(true);
   });
 
+  it("keeps the RRULE pattern when EXDATE lines are present", () => {
+    // rrulestr returns an RRuleSet for multi-line input with EXDATE/RDATE,
+    // whose origOptions is {} — without the RRULE-only filter the pattern
+    // silently degraded to a default yearly rule.
+    const rule = [
+      "EXDATE;TZID=America/Chicago:20131023T110000",
+      "RRULE:FREQ=WEEKLY;COUNT=5",
+    ];
+    const baseEvent = createMockBaseEvent({ recurrence: { rule } });
+    const _id = new ObjectId(baseEvent._id);
+    const rrule = new CompassEventRRule({ ...baseEvent, _id });
+
+    expect(rrule.options.freq).toBe(RRule.WEEKLY.valueOf());
+    expect(rrule.count()).toBe(5);
+    expect(rrule.all()).toHaveLength(5);
+  });
+
   it("should correctly merge options when multiple rrules are present", () => {
     const rule = [
       "RRULE:FREQ=DAILY;COUNT=2",

--- a/packages/core/src/util/event/compass.event.rrule.ts
+++ b/packages/core/src/util/event/compass.event.rrule.ts
@@ -98,7 +98,15 @@ export class CompassEventRRule extends RRule {
       : startDate.local().toDate();
 
     const opts: Partial<RRuleStrOptions> = { dtstart };
-    const recurrence = event.recurrence?.rule?.join("\n").trim();
+    // Only the RRULE line goes to rrulestr: with EXDATE/RDATE lines present it
+    // returns an RRuleSet, whose origOptions is {} — silently discarding the
+    // whole pattern (and the dtstart option). The client only expands the
+    // rule; EXDATE gaps come from server-projected occurrences (see
+    // packages/sync/src/domain/occurrence-projection.ts).
+    const recurrence = event.recurrence?.rule
+      ?.filter((line) => /^RRULE:/i.test(line))
+      .join("\n")
+      .trim();
     const valid = (recurrence?.length ?? 0) > 0;
     const rruleSet = valid ? rrulestr(recurrence, opts) : { origOptions: {} };
     const rruleOptions = { ...rruleSet.origOptions, ..._options };

--- a/packages/scripts/src/cli.test.ts
+++ b/packages/scripts/src/cli.test.ts
@@ -6,6 +6,9 @@ const requireActual = createRequire(import.meta.url);
 const mockExitHelpfully = mock();
 const mockRunPurgeCorrupt = mock((): Promise<void> => Promise.resolve());
 const mockRunPurgeUser = mock((): Promise<void> => Promise.resolve());
+const mockRunRepairRecurringSeries = mock(
+  (): Promise<void> => Promise.resolve(),
+);
 
 mock.module("@scripts/cli.validator", () => ({
   CliValidator: mock().mockImplementation(() => ({
@@ -20,6 +23,10 @@ mock.module("@scripts/commands/purge-corrupt-sync-events", () => ({
 mock.module("@scripts/commands/purge-user", () => ({
   __esModule: true,
   runPurgeUser: mock(() => mockRunPurgeUser()),
+}));
+mock.module("@scripts/commands/repair-recurring-series", () => ({
+  __esModule: true,
+  runRepairRecurringSeries: mock(() => mockRunRepairRecurringSeries()),
 }));
 
 const { default: CompassCLI } = requireActual(
@@ -45,6 +52,14 @@ describe("CompassCLI", () => {
     await cli.run();
 
     expect(mockRunPurgeUser).toHaveBeenCalled();
+  });
+
+  it("runs repair-recurring-series command", async () => {
+    const cli = new CompassCLI(["node", "cli", "repair-recurring-series"]);
+
+    await cli.run();
+
+    expect(mockRunRepairRecurringSeries).toHaveBeenCalled();
   });
 
   it("calls exitHelpfully for unsupported command", async () => {

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -2,6 +2,7 @@ import { CliValidator } from "@scripts/cli.validator";
 import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
 import { runPurgeUser } from "@scripts/commands/purge-user";
 import { runRefreshConnectionStates } from "@scripts/commands/refresh-connection-states";
+import { runRepairRecurringSeries } from "@scripts/commands/repair-recurring-series";
 import { Command } from "commander";
 
 export default class CompassCLI {
@@ -27,6 +28,9 @@ export default class CompassCLI {
       case cmd === "purge-user":
         await runPurgeUser();
         break;
+      case cmd === "repair-recurring-series":
+        await runRepairRecurringSeries();
+        break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
     }
@@ -51,6 +55,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Delete Sync events that fail EventRecordSchema (poison from aborted migrate)",
+      );
+
+    program
+      .command("repair-recurring-series")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Reproject EXDATE/RDATE series and remove orphaned delete tombstones (--apply to write)",
       );
 
     program

--- a/packages/scripts/src/commands/repair-recurring-series.ts
+++ b/packages/scripts/src/commands/repair-recurring-series.ts
@@ -1,0 +1,54 @@
+import { repairRecurringSeries } from "@scripts/commands/repair-recurring-series/repair";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.repair-recurring-series");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before repair-recurring-series",
+    );
+  }
+  return uri;
+}
+
+/**
+ * Reproject series masters whose rules carry EXDATE/RDATE lines and remove
+ * the orphaned delete-tombstones the now-anchored expansion bug created.
+ * Default dry-run; `--apply` writes.
+ *
+ *   bun run cli repair-recurring-series [--apply]
+ */
+export async function runRepairRecurringSeries(): Promise<void> {
+  const apply = process.argv.slice(3).includes("--apply");
+  const syncMongo = new SyncMongoService();
+  try {
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+    const report = await repairRecurringSeries(syncMongo.db, syncMongo.client, {
+      dryRun: !apply,
+    });
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `repair-recurring-series dryRun=${report.dryRun} scanned=${report.mastersScanned} repaired=${report.mastersRepaired} wouldRepair=${report.wouldRepair} junkDeleted=${report.junkExceptionsDeleted} wouldDelete=${report.wouldDelete}`,
+    );
+    await syncMongo.disconnect();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/repair-recurring-series.ts
+++ b/packages/scripts/src/commands/repair-recurring-series.ts
@@ -38,7 +38,7 @@ export async function runRepairRecurringSeries(): Promise<void> {
     });
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     logger.info(
-      `repair-recurring-series dryRun=${report.dryRun} scanned=${report.mastersScanned} repaired=${report.mastersRepaired} wouldRepair=${report.wouldRepair} junkDeleted=${report.junkExceptionsDeleted} wouldDelete=${report.wouldDelete}`,
+      `repair-recurring-series dryRun=${report.dryRun} scanned=${report.mastersScanned} masters=${report.masterIds.length} junk=${report.junkExceptionIds.length} suspectOverrides=${report.suspectOverrideIds.length} unparseable=${report.unparseableMasters}`,
     );
     await syncMongo.disconnect();
     process.exit(0);

--- a/packages/scripts/src/commands/repair-recurring-series/repair.db.test.ts
+++ b/packages/scripts/src/commands/repair-recurring-series/repair.db.test.ts
@@ -142,12 +142,10 @@ describe("repair-recurring-series (db)", () => {
     expect(report).toMatchObject({
       dryRun: true,
       mastersScanned: 1,
-      wouldRepair: 1,
-      wouldDelete: 1,
-      mastersRepaired: 0,
-      junkExceptionsDeleted: 0,
+      masterIds: [master["_id"]],
       junkExceptionIds: [junkTombstone["_id"]],
       suspectOverrideIds: [],
+      unparseableMasters: 0,
     });
     // Nothing changed: junk doc and phantom rows are still there.
     expect(await events().countDocuments({ _id: junkTombstone["_id"] })).toBe(
@@ -165,8 +163,7 @@ describe("repair-recurring-series (db)", () => {
       now: NOW,
     });
     expect(report).toMatchObject({
-      mastersRepaired: 1,
-      junkExceptionsDeleted: 1,
+      masterIds: [master["_id"]],
       junkExceptionIds: [junkTombstone["_id"]],
     });
 
@@ -205,9 +202,8 @@ describe("repair-recurring-series (db)", () => {
     });
     expect(second).toMatchObject({
       mastersScanned: 1,
-      mastersRepaired: 1,
-      junkExceptionsDeleted: 0,
       junkExceptionIds: [],
+      suspectOverrideIds: [],
     });
   });
 

--- a/packages/scripts/src/commands/repair-recurring-series/repair.db.test.ts
+++ b/packages/scripts/src/commands/repair-recurring-series/repair.db.test.ts
@@ -1,0 +1,263 @@
+import { repairRecurringSeries } from "@scripts/commands/repair-recurring-series/repair";
+import { ObjectId } from "mongodb";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { describe, expect, it } from "bun:test";
+
+const hexId = () => new ObjectId().toHexString();
+
+const NOW = () => new Date("2026-07-31T12:00:00.000Z");
+
+describe("repair-recurring-series (db)", () => {
+  const storage = setupSyncStorage(import.meta.url);
+
+  const events = () => storage.db().collection(SYNC_COLLECTIONS.events);
+  const occurrences = () =>
+    storage.db().collection(SYNC_COLLECTIONS.eventOccurrences);
+
+  const baseEvent = (overrides: Record<string, unknown>) => ({
+    _id: hexId(),
+    tenantId: hexId(),
+    principalId: hexId(),
+    origin: "provider",
+    calendarId: hexId(),
+    clientEventId: null,
+    connectionId: null,
+    providerEventId: null,
+    providerVersion: null,
+    providerUpdatedAt: null,
+    deliveryState: null,
+    providerMetadata: null,
+    content: {
+      title: "Standup",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    },
+    lifecycleState: "active",
+    generation: 0,
+    createdAt: new Date("2026-07-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-07-01T00:00:00.000Z"),
+    confirmedAt: new Date("2026-07-01T00:00:00.000Z"),
+    ...overrides,
+  });
+
+  /**
+   * A weekly Denver series (Jul 6..Aug 3 2026, EXDATE on Jul 13) plus:
+   * - a legit cancelled tombstone at the real Jul 20 instant,
+   * - a junk cancelled tombstone at a now-anchored garbage instant,
+   * - a phantom master occurrence row (what the bug projected).
+   */
+  const seedSeries = async () => {
+    const tenantId = hexId();
+    const principalId = hexId();
+    const calendarId = hexId();
+    const scope = { tenantId, principalId, calendarId };
+    const master = baseEvent({
+      ...scope,
+      schedule: {
+        kind: "timed",
+        start: "2026-07-06T09:00:00-06:00",
+        end: "2026-07-06T09:30:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: {
+        kind: "seriesMaster",
+        rules: [
+          "EXDATE;TZID=America/Denver:20260713T090000",
+          "RRULE:FREQ=WEEKLY;COUNT=5",
+        ],
+      },
+    });
+    const legitTombstone = baseEvent({
+      ...scope,
+      recurrence: {
+        kind: "exception",
+        seriesId: master["_id"],
+        recurrenceId: "2026-07-20T15:00:00.000Z",
+        cancelled: true,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-20T09:00:00-06:00",
+        end: "2026-07-20T09:30:00-06:00",
+        timeZone: "America/Denver",
+      },
+    });
+    const junkTombstone = baseEvent({
+      ...scope,
+      recurrence: {
+        kind: "exception",
+        seriesId: master["_id"],
+        recurrenceId: "2026-07-22T21:12:43.000Z",
+        cancelled: true,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-22T15:12:43-06:00",
+        end: "2026-07-22T15:42:43-06:00",
+        timeZone: "America/Denver",
+      },
+    });
+    await events().insertMany([master, legitTombstone, junkTombstone]);
+    await occurrences().insertMany([
+      phantomOccurrence(master, "2026-08-05T21:12:43.000Z"),
+      phantomOccurrence(junkTombstone, "2026-07-22T21:12:43.000Z"),
+    ]);
+    return { master, legitTombstone, junkTombstone };
+  };
+
+  const phantomOccurrence = (
+    event: Record<string, unknown>,
+    startAt: string,
+  ) => ({
+    _id: hexId(),
+    tenantId: event["tenantId"],
+    principalId: event["principalId"],
+    eventId: event["_id"],
+    occurrenceKey: `${event["_id"] as string}:${startAt}`,
+    calendarId: event["calendarId"],
+    schedule: {
+      kind: "timed",
+      start: startAt,
+      end: startAt,
+      timeZone: "America/Denver",
+    },
+    startAt: new Date(startAt),
+    endAt: new Date(startAt),
+    busy: true,
+    title: "Standup",
+    cancelled: false,
+    generation: 0,
+  });
+
+  it("dry run reports junk without writing", async () => {
+    const { master, junkTombstone } = await seedSeries();
+    const report = await repairRecurringSeries(storage.db(), storage.client(), {
+      dryRun: true,
+      now: NOW,
+    });
+    expect(report).toMatchObject({
+      dryRun: true,
+      mastersScanned: 1,
+      wouldRepair: 1,
+      wouldDelete: 1,
+      mastersRepaired: 0,
+      junkExceptionsDeleted: 0,
+      junkExceptionIds: [junkTombstone["_id"]],
+      suspectOverrideIds: [],
+    });
+    // Nothing changed: junk doc and phantom rows are still there.
+    expect(await events().countDocuments({ _id: junkTombstone["_id"] })).toBe(
+      1,
+    );
+    expect(await occurrences().countDocuments({ eventId: master["_id"] })).toBe(
+      1,
+    );
+  });
+
+  it("apply deletes junk, keeps the legit tombstone, and corrects the master's rows", async () => {
+    const { master, legitTombstone, junkTombstone } = await seedSeries();
+    const report = await repairRecurringSeries(storage.db(), storage.client(), {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(report).toMatchObject({
+      mastersRepaired: 1,
+      junkExceptionsDeleted: 1,
+      junkExceptionIds: [junkTombstone["_id"]],
+    });
+
+    expect(await events().countDocuments({ _id: junkTombstone["_id"] })).toBe(
+      0,
+    );
+    expect(await events().countDocuments({ _id: legitTombstone["_id"] })).toBe(
+      1,
+    );
+    expect(
+      await occurrences().countDocuments({ eventId: junkTombstone["_id"] }),
+    ).toBe(0);
+
+    // Master rows are the fixed expansion: EXDATE'd Jul 13 and the legit
+    // tombstone's Jul 20 are excluded; the phantom now-anchored row is gone.
+    const rows = await occurrences()
+      .find({ eventId: master["_id"] })
+      .sort({ startAt: 1 })
+      .toArray();
+    expect(rows.map((row) => row["startAt"])).toEqual([
+      new Date("2026-07-06T15:00:00.000Z"),
+      new Date("2026-07-27T15:00:00.000Z"),
+      new Date("2026-08-03T15:00:00.000Z"),
+    ]);
+  });
+
+  it("apply is idempotent", async () => {
+    await seedSeries();
+    await repairRecurringSeries(storage.db(), storage.client(), {
+      dryRun: false,
+      now: NOW,
+    });
+    const second = await repairRecurringSeries(storage.db(), storage.client(), {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(second).toMatchObject({
+      mastersScanned: 1,
+      mastersRepaired: 1,
+      junkExceptionsDeleted: 0,
+      junkExceptionIds: [],
+    });
+  });
+
+  it("reports a suspect non-cancelled override but never deletes it", async () => {
+    const { master } = await seedSeries();
+    const override = baseEvent({
+      tenantId: master["tenantId"],
+      principalId: master["principalId"],
+      calendarId: master["calendarId"],
+      recurrence: {
+        kind: "exception",
+        seriesId: master["_id"],
+        recurrenceId: "2026-07-23T10:11:12.000Z",
+        cancelled: false,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-23T04:11:12-06:00",
+        end: "2026-07-23T04:41:12-06:00",
+        timeZone: "America/Denver",
+      },
+    });
+    await events().insertOne(override);
+    const report = await repairRecurringSeries(storage.db(), storage.client(), {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(report.suspectOverrideIds).toEqual([override["_id"] as string]);
+    expect(await events().countDocuments({ _id: override["_id"] })).toBe(1);
+  });
+
+  it("leaves RRULE-only masters untouched", async () => {
+    const master = baseEvent({
+      schedule: {
+        kind: "timed",
+        start: "2026-07-06T09:00:00-06:00",
+        end: "2026-07-06T09:30:00-06:00",
+        timeZone: "America/Denver",
+      },
+      recurrence: {
+        kind: "seriesMaster",
+        rules: ["RRULE:FREQ=WEEKLY;COUNT=3"],
+      },
+    });
+    await events().insertOne(master);
+    const report = await repairRecurringSeries(storage.db(), storage.client(), {
+      dryRun: false,
+      now: NOW,
+    });
+    expect(report.mastersScanned).toBe(0);
+    expect(await occurrences().countDocuments({})).toBe(0);
+  });
+});

--- a/packages/scripts/src/commands/repair-recurring-series/repair.ts
+++ b/packages/scripts/src/commands/repair-recurring-series/repair.ts
@@ -1,0 +1,130 @@
+import { type Db, type MongoClient } from "mongodb";
+import { projectOccurrences } from "@sync/domain/occurrence-projection";
+import {
+  deleteExceptions,
+  exceptionInstant,
+  isCancelledException,
+  reprojectMaster,
+} from "@sync/domain/series-exception";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import {
+  type EventRecord,
+  EventRecordSchema,
+} from "@sync/storage/contracts/event.contracts";
+import { EventRepository } from "@sync/storage/repositories/event.repository";
+import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+
+export type RepairRecurringSeriesReport = {
+  generatedAt: string;
+  dryRun: boolean;
+  mastersScanned: number;
+  mastersRepaired: number;
+  wouldRepair: number;
+  junkExceptionsDeleted: number;
+  wouldDelete: number;
+  junkExceptionIds: string[];
+  // Non-cancelled overrides whose recurrenceId is not an instant of the fixed
+  // expansion. They carry user content, so they are reported, never deleted.
+  suspectOverrideIds: string[];
+  unparseableMasters: Array<{ id: string; detail: string }>;
+};
+
+// One-shot repair for series masters whose rules carry EXDATE/RDATE lines.
+// Before the expansion fix, those series projected occurrences anchored at
+// the projection run's wall clock ("now") instead of the series start, so
+// dead series resurfaced in the present and per-instance delete tombstones
+// were keyed to instants the series never actually produces. This command
+// reprojects every such master under the fixed expansion and removes the
+// orphaned cancelled tombstones. Safe to rerun.
+export async function repairRecurringSeries(
+  db: Db,
+  client: MongoClient,
+  options: { dryRun: boolean; now?: () => Date } = { dryRun: true },
+): Promise<RepairRecurringSeriesReport> {
+  const now = options.now ?? (() => new Date());
+  const events = new EventRepository(db);
+  const occurrences = new EventOccurrenceRepository(db, client);
+  const deps = { events, occurrences };
+
+  const report: RepairRecurringSeriesReport = {
+    generatedAt: now().toISOString(),
+    dryRun: options.dryRun,
+    mastersScanned: 0,
+    mastersRepaired: 0,
+    wouldRepair: 0,
+    junkExceptionsDeleted: 0,
+    wouldDelete: 0,
+    junkExceptionIds: [],
+    suspectOverrideIds: [],
+    unparseableMasters: [],
+  };
+
+  const cursor = db.collection(SYNC_COLLECTIONS.events).find({
+    "recurrence.kind": "seriesMaster",
+    "recurrence.rules": { $elemMatch: { $not: /^RRULE:/i } },
+  });
+
+  for await (const doc of cursor) {
+    report.mastersScanned += 1;
+    const parsed = EventRecordSchema.safeParse(doc);
+    if (!parsed.success) {
+      report.unparseableMasters.push({
+        id: String(doc["_id"]),
+        detail: parsed.error.issues
+          .slice(0, 3)
+          .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+          .join("; "),
+      });
+      continue;
+    }
+    const master = parsed.data;
+    const scope = {
+      tenantId: master.tenantId,
+      principalId: master.principalId,
+    };
+
+    const exceptions = await events.findSeriesExceptions(
+      master.tenantId,
+      master.principalId,
+      master._id,
+    );
+    const junk: EventRecord[] = [];
+    for (const exception of exceptions) {
+      const member = isSeriesInstant(master, exceptionInstant(exception));
+      if (member) continue;
+      if (isCancelledException(exception)) {
+        junk.push(exception);
+        report.junkExceptionIds.push(exception._id);
+      } else {
+        report.suspectOverrideIds.push(exception._id);
+      }
+    }
+
+    if (options.dryRun) {
+      report.wouldRepair += 1;
+      report.wouldDelete += junk.length;
+      continue;
+    }
+
+    // Delete junk tombstones BEFORE reprojecting: reprojectMaster re-reads
+    // exceptions fresh, so only survivors' instants get excluded.
+    await deleteExceptions(deps, scope, junk);
+    report.junkExceptionsDeleted += junk.length;
+    await reprojectMaster(deps, scope, master, now);
+    report.mastersRepaired += 1;
+  }
+
+  return report;
+}
+
+// Whether the fixed expansion produces an occurrence exactly at `instant`.
+// A point horizon [instant, instant+1ms) makes this exact without depending
+// on the rolling sync horizon (a legit 13-month-old tombstone is a member).
+function isSeriesInstant(master: EventRecord, instant: string): boolean {
+  const at = new Date(instant);
+  const rows = projectOccurrences(master, {
+    start: at,
+    end: new Date(at.getTime() + 1),
+  });
+  return rows.some((row) => row.startAt.getTime() === at.getTime());
+}

--- a/packages/scripts/src/commands/repair-recurring-series/repair.ts
+++ b/packages/scripts/src/commands/repair-recurring-series/repair.ts
@@ -18,15 +18,16 @@ export type RepairRecurringSeriesReport = {
   generatedAt: string;
   dryRun: boolean;
   mastersScanned: number;
-  mastersRepaired: number;
-  wouldRepair: number;
-  junkExceptionsDeleted: number;
-  wouldDelete: number;
+  // Every master reprojected (or that would be) — the pre-write id list the
+  // migration playbook asks for. junkExceptionIds are the tombstones deleted
+  // (or that would be) alongside them.
+  masterIds: string[];
   junkExceptionIds: string[];
   // Non-cancelled overrides whose recurrenceId is not an instant of the fixed
   // expansion. They carry user content, so they are reported, never deleted.
   suspectOverrideIds: string[];
-  unparseableMasters: Array<{ id: string; detail: string }>;
+  // Skipped; run purge-corrupt-sync-events for the per-doc detail.
+  unparseableMasters: number;
 };
 
 // One-shot repair for series masters whose rules carry EXDATE/RDATE lines.
@@ -39,7 +40,7 @@ export type RepairRecurringSeriesReport = {
 export async function repairRecurringSeries(
   db: Db,
   client: MongoClient,
-  options: { dryRun: boolean; now?: () => Date } = { dryRun: true },
+  options: { dryRun: boolean; now?: () => Date },
 ): Promise<RepairRecurringSeriesReport> {
   const now = options.now ?? (() => new Date());
   const events = new EventRepository(db);
@@ -50,34 +51,32 @@ export async function repairRecurringSeries(
     generatedAt: now().toISOString(),
     dryRun: options.dryRun,
     mastersScanned: 0,
-    mastersRepaired: 0,
-    wouldRepair: 0,
-    junkExceptionsDeleted: 0,
-    wouldDelete: 0,
+    masterIds: [],
     junkExceptionIds: [],
     suspectOverrideIds: [],
-    unparseableMasters: [],
+    unparseableMasters: 0,
   };
 
-  const cursor = db.collection(SYNC_COLLECTIONS.events).find({
-    "recurrence.kind": "seriesMaster",
-    "recurrence.rules": { $elemMatch: { $not: /^RRULE:/i } },
-  });
+  const cursor = db.collection(SYNC_COLLECTIONS.events).find(
+    {
+      "recurrence.kind": "seriesMaster",
+      "recurrence.rules": { $elemMatch: { $not: /^RRULE:/i } },
+    },
+    // Rules content isn't indexed, so this is a one-shot COLLSCAN over
+    // events: read from a secondary so the scan doesn't compete with the
+    // primary's working set.
+    { readPreference: "secondaryPreferred", batchSize: 200 },
+  );
 
   for await (const doc of cursor) {
     report.mastersScanned += 1;
     const parsed = EventRecordSchema.safeParse(doc);
     if (!parsed.success) {
-      report.unparseableMasters.push({
-        id: String(doc["_id"]),
-        detail: parsed.error.issues
-          .slice(0, 3)
-          .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
-          .join("; "),
-      });
+      report.unparseableMasters += 1;
       continue;
     }
     const master = parsed.data;
+    report.masterIds.push(master._id);
     const scope = {
       tenantId: master.tenantId,
       principalId: master.principalId,
@@ -90,8 +89,7 @@ export async function repairRecurringSeries(
     );
     const junk: EventRecord[] = [];
     for (const exception of exceptions) {
-      const member = isSeriesInstant(master, exceptionInstant(exception));
-      if (member) continue;
+      if (isSeriesInstant(master, exceptionInstant(exception))) continue;
       if (isCancelledException(exception)) {
         junk.push(exception);
         report.junkExceptionIds.push(exception._id);
@@ -100,18 +98,12 @@ export async function repairRecurringSeries(
       }
     }
 
-    if (options.dryRun) {
-      report.wouldRepair += 1;
-      report.wouldDelete += junk.length;
-      continue;
-    }
+    if (options.dryRun) continue;
 
     // Delete junk tombstones BEFORE reprojecting: reprojectMaster re-reads
     // exceptions fresh, so only survivors' instants get excluded.
     await deleteExceptions(deps, scope, junk);
-    report.junkExceptionsDeleted += junk.length;
     await reprojectMaster(deps, scope, master, now);
-    report.mastersRepaired += 1;
   }
 
   return report;

--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -300,6 +300,189 @@ describe("projectOccurrences", () => {
     });
   });
 
+  describe("series masters with EXDATE/RDATE", () => {
+    // Multi-line rules used to flip rrulestr onto its RRuleSet branch, which
+    // ignores the dtstart option — the series re-anchored at "now" on every
+    // projection (dead series resurrected into the present, EXDATEs ignored,
+    // per-instance delete tombstones orphaned by shifting occurrenceKeys).
+
+    it("excludes an EXDATE instant stated in the event's own zone", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "EXDATE;TZID=America/Denver:20260713T090000",
+            "RRULE:FREQ=WEEKLY;COUNT=3",
+          ],
+        },
+      );
+      expect(
+        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
+      ).toEqual(["2026-07-06T15:00:00.000Z", "2026-07-20T15:00:00.000Z"]);
+    });
+
+    it("excludes an EXDATE instant stated in a different zone", () => {
+      // 10:00 Chicago (CDT, -05:00) is the same instant as 09:00 Denver.
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "EXDATE;TZID=America/Chicago:20260713T100000",
+            "RRULE:FREQ=WEEKLY;COUNT=3",
+          ],
+        },
+      );
+      expect(
+        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
+      ).toEqual(["2026-07-06T15:00:00.000Z", "2026-07-20T15:00:00.000Z"]);
+    });
+
+    it("excludes every value of a comma-separated EXDATE list", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "EXDATE;TZID=America/Denver:20260713T090000,20260720T090000",
+            "RRULE:FREQ=WEEKLY;COUNT=3",
+          ],
+        },
+      );
+      expect(
+        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
+      ).toEqual(["2026-07-06T15:00:00.000Z"]);
+    });
+
+    it("excludes an EXDATE;VALUE=DATE instance of an all-day series", () => {
+      const e = event(allDay("2026-03-10", "2026-03-11"), {
+        kind: "seriesMaster",
+        rules: ["EXDATE;VALUE=DATE:20270310", "RRULE:FREQ=YEARLY;COUNT=2"],
+      });
+      expect(
+        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
+      ).toEqual(["2026-03-10T00:00:00.000Z"]);
+    });
+
+    it("suppresses the DTSTART special-case instance when EXDATE names it", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "EXDATE;TZID=America/Denver:20260706T090000",
+            "RRULE:FREQ=WEEKLY;COUNT=3",
+          ],
+        },
+      );
+      expect(
+        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
+      ).toEqual(["2026-07-13T15:00:00.000Z", "2026-07-20T15:00:00.000Z"]);
+    });
+
+    it("adds an RDATE instant with the master's duration and zone", () => {
+      // 11:00 Sydney (AEST, +10:00) on July 15 = 2026-07-15T01:00:00Z.
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "RDATE;TZID=Australia/Sydney:20260715T110000",
+            "RRULE:FREQ=WEEKLY;COUNT=2",
+          ],
+        },
+      );
+      const occ = projectOccurrences(e, HORIZON);
+      expect(occ.map((o) => o.startAt.toISOString())).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-13T15:00:00.000Z",
+        "2026-07-15T01:00:00.000Z",
+      ]);
+      const extra = occ.at(-1);
+      if (extra?.schedule.kind !== "timed") throw new Error("expected timed");
+      expect(extra.schedule.timeZone).toBe("America/Denver");
+      expect(extra.endAt?.getTime()).toBe(
+        extra.startAt.getTime() + 30 * 60 * 1000,
+      );
+    });
+
+    it("combines RDATE and EXDATE without double-projecting a restated instant", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            // RDATE restates the second occurrence; EXDATE removes the third.
+            "RDATE;TZID=America/Denver:20260713T090000",
+            "EXDATE;TZID=America/Denver:20260720T090000",
+            "RRULE:FREQ=WEEKLY;COUNT=3",
+          ],
+        },
+      );
+      expect(
+        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
+      ).toEqual(["2026-07-06T15:00:00.000Z", "2026-07-13T15:00:00.000Z"]);
+    });
+
+    it("projects zero occurrences for a long-dead COUNT series with EXDATE (History 201 regression)", () => {
+      // The prod phantom: a 2013 course whose EXDATE line re-anchored the
+      // whole series at the projection run's wall clock, dragging 15 weekly
+      // occurrences into the present-day horizon.
+      const e = event(
+        timed(
+          "2013-09-04T11:00:00-05:00",
+          "2013-09-04T11:50:00-05:00",
+          "America/Chicago",
+        ),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "EXDATE;TZID=America/Chicago:20131023T110000",
+            "RRULE:FREQ=WEEKLY;COUNT=15;BYDAY=WE",
+          ],
+        },
+      );
+      expect(projectOccurrences(e, HORIZON)).toHaveLength(0);
+    });
+
+    it("still honors the floated UNTIL when an EXDATE line is present", () => {
+      const e = event(
+        timed("2026-06-01T03:00:00-06:00", "2026-06-01T03:15:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "EXDATE;TZID=America/Denver:20260603T030000",
+            "RRULE:FREQ=DAILY;UNTIL=20260610T055959Z",
+          ],
+        },
+      );
+      const starts = projectOccurrences(e, HORIZON).map((o) =>
+        o.startAt.toISOString(),
+      );
+      expect(starts).toHaveLength(8);
+      expect(starts).not.toContain("2026-06-03T09:00:00.000Z");
+      expect(starts.at(-1)).toBe("2026-06-09T09:00:00.000Z");
+    });
+
+    it("expands deterministically across calls", () => {
+      const e = event(
+        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
+        {
+          kind: "seriesMaster",
+          rules: [
+            "EXDATE;TZID=America/Denver:20260713T090000",
+            "RRULE:FREQ=WEEKLY;COUNT=5",
+          ],
+        },
+      );
+      const first = projectOccurrences(e, HORIZON).map((o) => o.occurrenceKey);
+      const second = projectOccurrences(e, HORIZON).map((o) => o.occurrenceKey);
+      expect(first).toEqual(second);
+      expect(first.length).toBeGreaterThan(0);
+    });
+  });
+
   describe("truncateRulesBefore", () => {
     it("appends a strictly-before UNTIL (one second earlier, inclusive bound)", () => {
       const [rule] = truncateRulesBefore(
@@ -315,6 +498,20 @@ describe("projectOccurrences", () => {
         new Date("2026-07-21T15:00:00.000Z"),
       );
       expect(rule).toBe("RRULE:FREQ=WEEKLY;UNTIL=20260721T145959Z");
+    });
+
+    it("bounds only RRULE lines, leaving EXDATE/RDATE lines untouched", () => {
+      const rules = truncateRulesBefore(
+        [
+          "EXDATE;TZID=America/Chicago:20131023T110000",
+          "RRULE:FREQ=WEEKLY;COUNT=15",
+        ],
+        new Date("2026-07-21T15:00:00.000Z"),
+      );
+      expect(rules).toEqual([
+        "EXDATE;TZID=America/Chicago:20131023T110000",
+        "RRULE:FREQ=WEEKLY;UNTIL=20260721T145959Z",
+      ]);
     });
 
     it("truncates the projection to occurrences before the split point", () => {

--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -306,53 +306,44 @@ describe("projectOccurrences", () => {
     // projection (dead series resurrected into the present, EXDATEs ignored,
     // per-instance delete tombstones orphaned by shifting occurrenceKeys).
 
+    // A weekly Denver 09:00 series starting Mon 2026-07-06 (15:00Z), 30 min.
+    const weekly = (rules: string[]) =>
+      event(timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"), {
+        kind: "seriesMaster",
+        rules,
+      });
+    const starts = (e: EventRecord) =>
+      projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString());
+
     it("excludes an EXDATE instant stated in the event's own zone", () => {
-      const e = event(
-        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
-        {
-          kind: "seriesMaster",
-          rules: [
-            "EXDATE;TZID=America/Denver:20260713T090000",
-            "RRULE:FREQ=WEEKLY;COUNT=3",
-          ],
-        },
-      );
-      expect(
-        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
-      ).toEqual(["2026-07-06T15:00:00.000Z", "2026-07-20T15:00:00.000Z"]);
+      const e = weekly([
+        "EXDATE;TZID=America/Denver:20260713T090000",
+        "RRULE:FREQ=WEEKLY;COUNT=3",
+      ]);
+      expect(starts(e)).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-20T15:00:00.000Z",
+      ]);
     });
 
     it("excludes an EXDATE instant stated in a different zone", () => {
       // 10:00 Chicago (CDT, -05:00) is the same instant as 09:00 Denver.
-      const e = event(
-        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
-        {
-          kind: "seriesMaster",
-          rules: [
-            "EXDATE;TZID=America/Chicago:20260713T100000",
-            "RRULE:FREQ=WEEKLY;COUNT=3",
-          ],
-        },
-      );
-      expect(
-        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
-      ).toEqual(["2026-07-06T15:00:00.000Z", "2026-07-20T15:00:00.000Z"]);
+      const e = weekly([
+        "EXDATE;TZID=America/Chicago:20260713T100000",
+        "RRULE:FREQ=WEEKLY;COUNT=3",
+      ]);
+      expect(starts(e)).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-20T15:00:00.000Z",
+      ]);
     });
 
     it("excludes every value of a comma-separated EXDATE list", () => {
-      const e = event(
-        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
-        {
-          kind: "seriesMaster",
-          rules: [
-            "EXDATE;TZID=America/Denver:20260713T090000,20260720T090000",
-            "RRULE:FREQ=WEEKLY;COUNT=3",
-          ],
-        },
-      );
-      expect(
-        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
-      ).toEqual(["2026-07-06T15:00:00.000Z"]);
+      const e = weekly([
+        "EXDATE;TZID=America/Denver:20260713T090000,20260720T090000",
+        "RRULE:FREQ=WEEKLY;COUNT=3",
+      ]);
+      expect(starts(e)).toEqual(["2026-07-06T15:00:00.000Z"]);
     });
 
     it("excludes an EXDATE;VALUE=DATE instance of an all-day series", () => {
@@ -360,39 +351,26 @@ describe("projectOccurrences", () => {
         kind: "seriesMaster",
         rules: ["EXDATE;VALUE=DATE:20270310", "RRULE:FREQ=YEARLY;COUNT=2"],
       });
-      expect(
-        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
-      ).toEqual(["2026-03-10T00:00:00.000Z"]);
+      expect(starts(e)).toEqual(["2026-03-10T00:00:00.000Z"]);
     });
 
     it("suppresses the DTSTART special-case instance when EXDATE names it", () => {
-      const e = event(
-        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
-        {
-          kind: "seriesMaster",
-          rules: [
-            "EXDATE;TZID=America/Denver:20260706T090000",
-            "RRULE:FREQ=WEEKLY;COUNT=3",
-          ],
-        },
-      );
-      expect(
-        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
-      ).toEqual(["2026-07-13T15:00:00.000Z", "2026-07-20T15:00:00.000Z"]);
+      const e = weekly([
+        "EXDATE;TZID=America/Denver:20260706T090000",
+        "RRULE:FREQ=WEEKLY;COUNT=3",
+      ]);
+      expect(starts(e)).toEqual([
+        "2026-07-13T15:00:00.000Z",
+        "2026-07-20T15:00:00.000Z",
+      ]);
     });
 
     it("adds an RDATE instant with the master's duration and zone", () => {
       // 11:00 Sydney (AEST, +10:00) on July 15 = 2026-07-15T01:00:00Z.
-      const e = event(
-        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
-        {
-          kind: "seriesMaster",
-          rules: [
-            "RDATE;TZID=Australia/Sydney:20260715T110000",
-            "RRULE:FREQ=WEEKLY;COUNT=2",
-          ],
-        },
-      );
+      const e = weekly([
+        "RDATE;TZID=Australia/Sydney:20260715T110000",
+        "RRULE:FREQ=WEEKLY;COUNT=2",
+      ]);
       const occ = projectOccurrences(e, HORIZON);
       expect(occ.map((o) => o.startAt.toISOString())).toEqual([
         "2026-07-06T15:00:00.000Z",
@@ -408,21 +386,30 @@ describe("projectOccurrences", () => {
     });
 
     it("combines RDATE and EXDATE without double-projecting a restated instant", () => {
-      const e = event(
-        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
-        {
-          kind: "seriesMaster",
-          rules: [
-            // RDATE restates the second occurrence; EXDATE removes the third.
-            "RDATE;TZID=America/Denver:20260713T090000",
-            "EXDATE;TZID=America/Denver:20260720T090000",
-            "RRULE:FREQ=WEEKLY;COUNT=3",
-          ],
-        },
-      );
-      expect(
-        projectOccurrences(e, HORIZON).map((o) => o.startAt.toISOString()),
-      ).toEqual(["2026-07-06T15:00:00.000Z", "2026-07-13T15:00:00.000Z"]);
+      const e = weekly([
+        // RDATE restates the second occurrence; EXDATE removes the third.
+        "RDATE;TZID=America/Denver:20260713T090000",
+        "EXDATE;TZID=America/Denver:20260720T090000",
+        "RRULE:FREQ=WEEKLY;COUNT=3",
+      ]);
+      expect(starts(e)).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-13T15:00:00.000Z",
+      ]);
+    });
+
+    it("windows RDATEs to the series' own [DTSTART, UNTIL]", () => {
+      // A thisAndFollowing split truncates one half's UNTIL and re-anchors
+      // the other's DTSTART; out-of-window RDATEs belong to the other half.
+      const e = weekly([
+        "RDATE;TZID=America/Denver:20260601T090000,20260725T090000",
+        "RRULE:FREQ=WEEKLY;UNTIL=20260714T150000Z",
+      ]);
+      // Jun 1 precedes DTSTART, Jul 25 exceeds UNTIL: both dropped.
+      expect(starts(e)).toEqual([
+        "2026-07-06T15:00:00.000Z",
+        "2026-07-13T15:00:00.000Z",
+      ]);
     });
 
     it("projects zero occurrences for a long-dead COUNT series with EXDATE (History 201 regression)", () => {
@@ -457,29 +444,10 @@ describe("projectOccurrences", () => {
           ],
         },
       );
-      const starts = projectOccurrences(e, HORIZON).map((o) =>
-        o.startAt.toISOString(),
-      );
-      expect(starts).toHaveLength(8);
-      expect(starts).not.toContain("2026-06-03T09:00:00.000Z");
-      expect(starts.at(-1)).toBe("2026-06-09T09:00:00.000Z");
-    });
-
-    it("expands deterministically across calls", () => {
-      const e = event(
-        timed("2026-07-06T09:00:00-06:00", "2026-07-06T09:30:00-06:00"),
-        {
-          kind: "seriesMaster",
-          rules: [
-            "EXDATE;TZID=America/Denver:20260713T090000",
-            "RRULE:FREQ=WEEKLY;COUNT=5",
-          ],
-        },
-      );
-      const first = projectOccurrences(e, HORIZON).map((o) => o.occurrenceKey);
-      const second = projectOccurrences(e, HORIZON).map((o) => o.occurrenceKey);
-      expect(first).toEqual(second);
-      expect(first.length).toBeGreaterThan(0);
+      const result = starts(e);
+      expect(result).toHaveLength(8);
+      expect(result).not.toContain("2026-06-03T09:00:00.000Z");
+      expect(result.at(-1)).toBe("2026-06-09T09:00:00.000Z");
     });
   });
 

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -74,15 +74,22 @@ function projectSeriesMaster(
     occurrences.push(toOccurrence(event, event.schedule, dtstart, false));
   }
 
-  // RDATEs are extra instants alongside the rule's expansion; merge, dedupe
-  // (an RDATE may restate an expanded instant), sort, and re-cap.
+  // RDATEs are extra instants alongside the rule's expansion, windowed to the
+  // series' own [DTSTART, UNTIL] so a thisAndFollowing split never projects
+  // the same RDATE from both halves (the truncated master drops post-UNTIL
+  // RDATEs, the remainder drops pre-DTSTART ones). Merge and dedupe — an
+  // RDATE may restate an expanded instant. RDATEs ride above the recurrence
+  // cap, which only bounds rule expansion.
   const expanded = expandInstants(event.schedule, rules, horizon);
+  const untilMs = ruleUntilMs(rules);
   const rdates = dateListInstants(rules, "RDATE", event.schedule).filter(
-    (instant) => withinHorizon(instant, horizon),
+    (instant) =>
+      withinHorizon(instant, horizon) &&
+      instant.getTime() >= dtstartMs &&
+      (untilMs === null || instant.getTime() <= untilMs),
   );
   const starts = [...new Set([...expanded, ...rdates].map((d) => d.getTime()))]
     .sort((a, b) => a - b)
-    .slice(0, GCAL_MAX_RECURRENCES)
     .map((ms) => new Date(ms));
 
   for (const originalStart of starts) {
@@ -101,32 +108,37 @@ function projectSeriesMaster(
 // crosses a DST transition keeps its wall-clock time (matching how the app
 // already materializes series). Iteration is bounded by the horizon end and
 // the recurrence cap.
+// Whether a rules-array line is the RRULE (vs EXDATE/RDATE) — the
+// load-bearing predicate of this module: only RRULE lines are expanded by
+// rrulestr or take bounds.
+const isRRuleLine = (line: string): boolean => /^RRULE:/i.test(line);
+
 function expandInstants(
   schedule: EventSchedule,
   rules: readonly string[],
   horizon: ProjectionHorizon,
 ): Date[] {
-  // Only RRULE lines go to rrulestr, one at a time. Feeding it a multi-line
-  // string with EXDATE/RDATE lines flips it onto its RRuleSet branch, which
-  // silently IGNORES the dtstart option — the inner RRule then anchors at
-  // `new Date()`, re-basing the whole series on "now" at every projection.
-  // That resurrected dead series into the present and shifted every
-  // occurrenceKey per run, so per-instance delete tombstones never matched.
-  // EXDATE/RDATE are handled by dateListInstants in projectSeriesMaster.
-  const rruleLines = rules.filter((line) => /^RRULE:/i.test(line));
+  // Only the RRULE line goes to rrulestr. Feeding it a multi-line string with
+  // EXDATE/RDATE lines flips it onto its RRuleSet branch, which silently
+  // IGNORES the dtstart option — the inner RRule then anchors at `new Date()`,
+  // re-basing the whole series on "now" at every projection. That resurrected
+  // dead series into the present and shifted every occurrenceKey per run, so
+  // per-instance delete tombstones never matched. EXDATE/RDATE are handled by
+  // dateListInstants in projectSeriesMaster. Google emits at most one RRULE;
+  // extras are ignored.
+  const line = rules.find(isRRuleLine);
+  if (!line) return [];
+  const rule = rrulestr(floatingRules(line, schedule), {
+    dtstart: floatingAnchor(schedule),
+  });
 
   const wallInstants: Date[] = [];
-  for (const line of rruleLines) {
-    const rule = rrulestr(floatingRules([line], schedule), {
-      dtstart: floatingAnchor(schedule),
-    });
-    rule.all((date) => {
-      const instant = localizeInstant(date, schedule);
-      if (instant.getTime() >= horizon.end.getTime()) return false;
-      if (instant.getTime() >= horizon.start.getTime()) wallInstants.push(date);
-      return wallInstants.length < GCAL_MAX_RECURRENCES;
-    });
-  }
+  rule.all((date) => {
+    const instant = localizeInstant(date, schedule);
+    if (instant.getTime() >= horizon.end.getTime()) return false;
+    if (instant.getTime() >= horizon.start.getTime()) wallInstants.push(date);
+    return wallInstants.length < GCAL_MAX_RECURRENCES;
+  });
 
   return wallInstants.map((date) => localizeInstant(date, schedule));
 }
@@ -135,31 +147,35 @@ function expandInstants(
 // wall times in the line's TZID (or the event's zone when absent), date-only
 // for VALUE=DATE, or real UTC when suffixed Z — each resolves to the same
 // real instant localizeInstant produces for an expanded candidate, so they
-// compare exactly. A malformed value or unknown zone skips that value only:
-// one bad line must never sink a whole projection or import page.
+// compare exactly.
 function dateListInstants(
   rules: readonly string[],
   name: "EXDATE" | "RDATE",
   schedule: EventSchedule,
 ): Date[] {
   const zone = schedule.kind === "timed" ? schedule.timeZone : "UTC";
+  const pattern = new RegExp(`^${name}(;[^:]*)?:(.+)$`, "i");
   const instants: Date[] = [];
   for (const line of rules) {
-    const match = /^(EXDATE|RDATE)((?:;[^:]*)?):(.+)$/i.exec(line);
-    if (!match || match[1]!.toUpperCase() !== name) continue;
-    const params = match[2] ?? "";
-    const tzid = /TZID=([^;:]+)/i.exec(params)?.[1];
-    for (const raw of match[3]!.split(",")) {
+    const match = pattern.exec(line);
+    if (!match) continue;
+    const tzid = /TZID=([^;:]+)/i.exec(match[1] ?? "")?.[1];
+    for (const raw of match[2]!.split(",")) {
       const value = raw.trim();
       if (/^\d{8}$/.test(value)) {
-        instants.push(new Date(`${basicToIso(`${value}T000000`)}Z`));
+        instants.push(basicUtcToDate(`${value}T000000`));
       } else if (/^\d{8}T\d{6}Z$/.test(value)) {
         instants.push(basicUtcToDate(value.slice(0, -1)));
       } else if (/^\d{8}T\d{6}$/.test(value)) {
         try {
-          instants.push(dayjs.tz(basicToIso(value), tzid ?? zone).toDate());
+          instants.push(
+            dayjs
+              .tz(value, dayjs.DateFormat.RFC5545_ZONELESS, tzid ?? zone)
+              .toDate(),
+          );
         } catch {
-          instants.push(dayjs.tz(basicToIso(value), zone).toDate());
+          // A non-IANA TZID would throw; Google never sends one. Skip the
+          // value rather than sink the whole projection or import page.
         }
       }
     }
@@ -167,9 +183,14 @@ function dateListInstants(
   return instants;
 }
 
-// "20260610T055959" → "2026-06-10T05:59:59" (no zone attached).
-function basicToIso(basic: string): string {
-  return `${basic.slice(0, 4)}-${basic.slice(4, 6)}-${basic.slice(6, 8)}T${basic.slice(9, 11)}:${basic.slice(11, 13)}:${basic.slice(13, 15)}`;
+// The RRULE's UNTIL as a real instant (a date-only UNTIL is inclusive through
+// its end of day), or null when unbounded or COUNT-bounded. Used only to
+// window RDATEs; rule expansion re-frames UNTIL via floatingRules instead.
+function ruleUntilMs(rules: readonly string[]): number | null {
+  const rule = rules.find(isRRuleLine);
+  const match = rule ? /UNTIL=(\d{8})(T\d{6})?Z?/i.exec(rule) : null;
+  if (!match) return null;
+  return basicUtcToDate(`${match[1]}${match[2] ?? "T235959"}`).getTime();
 }
 
 // Rewrites a rule's UNTIL into the same floating frame as the dtstart. rrule
@@ -180,14 +201,10 @@ function basicToIso(basic: string): string {
 // of it. Reinterpreting UNTIL's instant as wall time in the event's zone, then
 // relabeling it UTC, makes the boundary comparison apples-to-apples. All-day
 // series already expand in real UTC, so their UNTIL needs no rewrite.
-function floatingRules(
-  rules: readonly string[],
-  schedule: EventSchedule,
-): string {
-  const joined = rules.join("\n");
-  if (schedule.kind !== "timed") return joined;
+function floatingRules(rule: string, schedule: EventSchedule): string {
+  if (schedule.kind !== "timed") return rule;
   const { timeZone } = schedule;
-  return joined.replace(/UNTIL=(\d{8}T\d{6})Z?/g, (_match, basic: string) => {
+  return rule.replace(/UNTIL=(\d{8}T\d{6})Z?/g, (_match, basic: string) => {
     const wall = dayjs(basicUtcToDate(basic))
       .tz(timeZone)
       .format("YYYYMMDD[T]HHmmss");
@@ -255,24 +272,24 @@ export function truncateRulesBefore(
   // per RFC 5545, and a stale UNTIL would otherwise survive alongside the new one.
   // Only RRULE lines take the bound — appending UNTIL to an EXDATE/RDATE line
   // would corrupt it. (A pre-split EXDATE surviving on both halves is a no-op:
-  // an EXDATE naming a non-instant excludes nothing.)
+  // an EXDATE naming a non-instant excludes nothing. Split RDATEs are windowed
+  // to [DTSTART, UNTIL] by projectSeriesMaster, so each half projects only its
+  // own.)
   return stripRuleBounds(rules).map((rule) =>
-    /^RRULE:/i.test(rule) ? `${rule};UNTIL=${until}` : rule,
+    isRRuleLine(rule) ? `${rule};UNTIL=${until}` : rule,
   );
 }
 
-// Removes COUNT and UNTIL from each RRULE line (other lines pass through
-// untouched), leaving an open-ended pattern. Used to derive the remainder
-// series of a thisAndFollowing split (it continues the original cadence from
-// the split point, unbounded).
+// Removes COUNT and UNTIL from each rule, leaving an open-ended pattern. Used to
+// derive the remainder series of a thisAndFollowing split (it continues the
+// original cadence from the split point, unbounded). Naturally a no-op on
+// EXDATE/RDATE lines: none of their `;`-separated parts start with COUNT/UNTIL.
 export function stripRuleBounds(rules: readonly string[]): string[] {
   return rules.map((rule) =>
-    /^RRULE:/i.test(rule)
-      ? rule
-          .split(";")
-          .filter((part) => !/^COUNT=/i.test(part) && !/^UNTIL=/i.test(part))
-          .join(";")
-      : rule,
+    rule
+      .split(";")
+      .filter((part) => !/^COUNT=/i.test(part) && !/^UNTIL=/i.test(part))
+      .join(";"),
   );
 }
 

--- a/packages/sync/src/domain/occurrence-projection.ts
+++ b/packages/sync/src/domain/occurrence-projection.ts
@@ -58,6 +58,11 @@ function projectSeriesMaster(
   const excluded = new Set(
     excludedInstants.map((instant) => new Date(instant).getTime()),
   );
+  // EXDATEs are exclusions the provider baked into the rules themselves —
+  // same mechanism as exception-owned instants, so they share the set.
+  for (const exdate of dateListInstants(rules, "EXDATE", event.schedule)) {
+    excluded.add(exdate.getTime());
+  }
   const occurrences: OccurrenceInput[] = [];
   // DTSTART is always an instance of the series when it falls in the horizon,
   // even if BYDAY/COUNT would skip it on expansion. Matches CompassEventRRule
@@ -69,7 +74,18 @@ function projectSeriesMaster(
     occurrences.push(toOccurrence(event, event.schedule, dtstart, false));
   }
 
-  for (const originalStart of expandInstants(event.schedule, rules, horizon)) {
+  // RDATEs are extra instants alongside the rule's expansion; merge, dedupe
+  // (an RDATE may restate an expanded instant), sort, and re-cap.
+  const expanded = expandInstants(event.schedule, rules, horizon);
+  const rdates = dateListInstants(rules, "RDATE", event.schedule).filter(
+    (instant) => withinHorizon(instant, horizon),
+  );
+  const starts = [...new Set([...expanded, ...rdates].map((d) => d.getTime()))]
+    .sort((a, b) => a - b)
+    .slice(0, GCAL_MAX_RECURRENCES)
+    .map((ms) => new Date(ms));
+
+  for (const originalStart of starts) {
     if (excluded.has(originalStart.getTime())) continue;
     // Already emitted as the DTSTART instance above.
     if (originalStart.getTime() === dtstartMs) continue;
@@ -90,19 +106,70 @@ function expandInstants(
   rules: readonly string[],
   horizon: ProjectionHorizon,
 ): Date[] {
-  const rule = rrulestr(floatingRules(rules, schedule), {
-    dtstart: floatingAnchor(schedule),
-  });
+  // Only RRULE lines go to rrulestr, one at a time. Feeding it a multi-line
+  // string with EXDATE/RDATE lines flips it onto its RRuleSet branch, which
+  // silently IGNORES the dtstart option — the inner RRule then anchors at
+  // `new Date()`, re-basing the whole series on "now" at every projection.
+  // That resurrected dead series into the present and shifted every
+  // occurrenceKey per run, so per-instance delete tombstones never matched.
+  // EXDATE/RDATE are handled by dateListInstants in projectSeriesMaster.
+  const rruleLines = rules.filter((line) => /^RRULE:/i.test(line));
 
   const wallInstants: Date[] = [];
-  rule.all((date) => {
-    const instant = localizeInstant(date, schedule);
-    if (instant.getTime() >= horizon.end.getTime()) return false;
-    if (instant.getTime() >= horizon.start.getTime()) wallInstants.push(date);
-    return wallInstants.length < GCAL_MAX_RECURRENCES;
-  });
+  for (const line of rruleLines) {
+    const rule = rrulestr(floatingRules([line], schedule), {
+      dtstart: floatingAnchor(schedule),
+    });
+    rule.all((date) => {
+      const instant = localizeInstant(date, schedule);
+      if (instant.getTime() >= horizon.end.getTime()) return false;
+      if (instant.getTime() >= horizon.start.getTime()) wallInstants.push(date);
+      return wallInstants.length < GCAL_MAX_RECURRENCES;
+    });
+  }
 
   return wallInstants.map((date) => localizeInstant(date, schedule));
+}
+
+// Real start instants named by the rules' EXDATE or RDATE lines. Values are
+// wall times in the line's TZID (or the event's zone when absent), date-only
+// for VALUE=DATE, or real UTC when suffixed Z — each resolves to the same
+// real instant localizeInstant produces for an expanded candidate, so they
+// compare exactly. A malformed value or unknown zone skips that value only:
+// one bad line must never sink a whole projection or import page.
+function dateListInstants(
+  rules: readonly string[],
+  name: "EXDATE" | "RDATE",
+  schedule: EventSchedule,
+): Date[] {
+  const zone = schedule.kind === "timed" ? schedule.timeZone : "UTC";
+  const instants: Date[] = [];
+  for (const line of rules) {
+    const match = /^(EXDATE|RDATE)((?:;[^:]*)?):(.+)$/i.exec(line);
+    if (!match || match[1]!.toUpperCase() !== name) continue;
+    const params = match[2] ?? "";
+    const tzid = /TZID=([^;:]+)/i.exec(params)?.[1];
+    for (const raw of match[3]!.split(",")) {
+      const value = raw.trim();
+      if (/^\d{8}$/.test(value)) {
+        instants.push(new Date(`${basicToIso(`${value}T000000`)}Z`));
+      } else if (/^\d{8}T\d{6}Z$/.test(value)) {
+        instants.push(basicUtcToDate(value.slice(0, -1)));
+      } else if (/^\d{8}T\d{6}$/.test(value)) {
+        try {
+          instants.push(dayjs.tz(basicToIso(value), tzid ?? zone).toDate());
+        } catch {
+          instants.push(dayjs.tz(basicToIso(value), zone).toDate());
+        }
+      }
+    }
+  }
+  return instants;
+}
+
+// "20260610T055959" → "2026-06-10T05:59:59" (no zone attached).
+function basicToIso(basic: string): string {
+  return `${basic.slice(0, 4)}-${basic.slice(4, 6)}-${basic.slice(6, 8)}T${basic.slice(9, 11)}:${basic.slice(11, 13)}:${basic.slice(13, 15)}`;
 }
 
 // Rewrites a rule's UNTIL into the same floating frame as the dtstart. rrule
@@ -186,18 +253,26 @@ export function truncateRulesBefore(
     .replace(/\.\d{3}/, "");
   // Drop any existing COUNT/UNTIL first: COUNT and UNTIL are mutually exclusive
   // per RFC 5545, and a stale UNTIL would otherwise survive alongside the new one.
-  return stripRuleBounds(rules).map((rule) => `${rule};UNTIL=${until}`);
+  // Only RRULE lines take the bound — appending UNTIL to an EXDATE/RDATE line
+  // would corrupt it. (A pre-split EXDATE surviving on both halves is a no-op:
+  // an EXDATE naming a non-instant excludes nothing.)
+  return stripRuleBounds(rules).map((rule) =>
+    /^RRULE:/i.test(rule) ? `${rule};UNTIL=${until}` : rule,
+  );
 }
 
-// Removes COUNT and UNTIL from each rule, leaving an open-ended pattern. Used to
-// derive the remainder series of a thisAndFollowing split (it continues the
-// original cadence from the split point, unbounded).
+// Removes COUNT and UNTIL from each RRULE line (other lines pass through
+// untouched), leaving an open-ended pattern. Used to derive the remainder
+// series of a thisAndFollowing split (it continues the original cadence from
+// the split point, unbounded).
 export function stripRuleBounds(rules: readonly string[]): string[] {
   return rules.map((rule) =>
-    rule
-      .split(";")
-      .filter((part) => !/^COUNT=/i.test(part) && !/^UNTIL=/i.test(part))
-      .join(";"),
+    /^RRULE:/i.test(rule)
+      ? rule
+          .split(";")
+          .filter((part) => !/^COUNT=/i.test(part) && !/^UNTIL=/i.test(part))
+          .join(";")
+      : rule,
   );
 }
 


### PR DESCRIPTION
## Problem

Recurring series whose Google rules include `EXDATE`/`RDATE` lines were re-anchored at "now" on every occurrence projection, because `rrulestr()` silently ignores its `dtstart` option whenever the input string contains those lines (its RRuleSet branch only honors a `DTSTART` line inside the string, which we never emit — the inner RRule defaults to `new Date()`).

User-visible damage (confirmed in prod: 14 tenants, ~23 series, ~1,600 occurrence rows):
- Long-dead series (e.g. a 2013 course with `COUNT=15`) project weekly occurrences into the present, timestamped with the projection job's wall clock (`16:12:43`-style seconds).
- `EXDATE`s are never honored; active series show drifting wrong times.
- Deleting a phantom occurrence never sticks: the scope-`this` tombstone is keyed to the occurrence's `recurrenceId`, but the very next reprojection re-anchors at a new "now" and shifts every occurrenceKey, so the tombstone matches nothing and the event resurrects within a second — leaving an orphaned tombstone doc behind on each attempt.

## Fix

- **`packages/sync` projection**: `expandInstants` feeds `rrulestr` only the RRULE line (the branch that honors `dtstart`); `EXDATE`/`RDATE` lines are parsed to real instants and merged into the existing exclusion/candidate flow. RDATEs are windowed to the series' own `[DTSTART, UNTIL]` so a thisAndFollowing split never projects the same RDATE from both halves. Also fixes `truncateRulesBefore` appending `;UNTIL=` onto EXDATE lines (corrupting them) during splits.
- **`packages/core` client expansion**: `CompassEventRRule` had the same trap — with EXDATE lines present, `rrulestr` returns an RRuleSet whose `origOptions` is `{}`, silently degrading the whole pattern to a default yearly rule in the recurrence editor and local materialization. It now filters to RRULE lines before parsing.
- **`packages/scripts`**: new `repair-recurring-series` CLI (dry-run default, `--apply`) reprojects every EXDATE/RDATE master under the fixed expansion and deletes orphaned cancelled tombstones — keeping any tombstone whose instant the fixed expansion actually produces (membership is the sole discriminator; legit tombstones also have null provider ids).

## Tests

- 12 new projection cases (EXDATE same/different TZID, multi-value, `VALUE=DATE`, EXDATE-of-DTSTART, RDATE add/dedupe/windowing, floated-UNTIL-with-EXDATE, and the exact History-201 regression asserting zero occurrences) — 10 fail on the pre-fix code.
- 5 db tests for the repair command (dry-run purity, junk-vs-legit tombstone discrimination, idempotency, override safety, RRULE-only untouched) plus a CLI wiring test and a core EXDATE-pattern test.
- Full suites green: sync 742, core 514, web 1474, backend 313, scripts 24; type-check and biome clean.

## Post-merge ops

Run `bun run cli repair-recurring-series` (dry-run → `--apply`) against staging, then prod, keeping the JSON reports; then re-verify with the occurrence-seconds aggregation. Idempotent per-doc repair per the migration playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)