### PR TITLE
fix(web): keep deleted anonymous recurring occurrences gone

### DIFF
--- a/packages/web/src/events/repositories/local.event.repository.test.ts
+++ b/packages/web/src/events/repositories/local.event.repository.test.ts
@@ -186,10 +186,65 @@ describe("LocalEventRepository", () => {
     await repository.delete(id, "this");
 
     expect(deleteEvent).toHaveBeenCalledWith(id);
+    // Stored in schedule.start format (RFC3339 offset), not the id-suffix ISO.
     expect(putEvent.mock.calls[0][0]).toMatchObject({
       id: record.id,
-      exdates: [occurrenceStart],
+      exdates: ["2026-05-06T09:00:00+00:00"],
     });
+  });
+
+  it("delete scope this round-trips: occurrence stays gone after list refetch", async () => {
+    const record = seriesRecord();
+    getAllEvents.mockResolvedValue([record]);
+
+    const before = await repository.list(rangeQuery as never);
+    const target = before.find(
+      (event) =>
+        event.recurrence.kind === "occurrence" &&
+        event.schedule.start.startsWith("2026-05-06"),
+    );
+    expect(target).toBeDefined();
+
+    await repository.delete(target!.id, "this");
+    getAllEvents.mockResolvedValue([putEvent.mock.calls[0][0]]);
+
+    const after = await repository.list(rangeQuery as never);
+    expect(after.some((event) => event.id === target!.id)).toBe(false);
+  });
+
+  it("delete scope this round-trips for all-day series", async () => {
+    const record = createMockLocalEventRecord({
+      schedule: {
+        kind: "allDay",
+        start: "2026-07-06" as never,
+        end: "2026-07-07" as never,
+      },
+      recurrence: {
+        kind: "series",
+        rules: ["RRULE:FREQ=DAILY;COUNT=5"] as never,
+      },
+    });
+    getAllEvents.mockResolvedValue([record]);
+    const allDayRange = {
+      kind: "range" as const,
+      start: "2026-07-05T00:00:00.000Z" as never,
+      end: "2026-07-12T00:00:00.000Z" as never,
+    };
+
+    const before = await repository.list(allDayRange as never);
+    const target = before.find(
+      (event) =>
+        event.recurrence.kind === "occurrence" &&
+        event.schedule.start === "2026-07-08",
+    );
+    expect(target).toBeDefined();
+
+    await repository.delete(target!.id, "this");
+    expect(putEvent.mock.calls[0][0].exdates).toEqual(["2026-07-08"]);
+    getAllEvents.mockResolvedValue([putEvent.mock.calls[0][0]]);
+
+    const after = await repository.list(allDayRange as never);
+    expect(after.some((event) => event.id === target!.id)).toBe(false);
   });
 
   it("delete scope thisAndFollowing truncates the series rules", async () => {

--- a/packages/web/src/events/repositories/local.event.repository.ts
+++ b/packages/web/src/events/repositories/local.event.repository.ts
@@ -7,6 +7,7 @@ import {
   type ReplaceEventInput,
 } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { getCompassEventDateFormat } from "@core/util/event/event.util";
 import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
 import {
   getOfflineDataStore,
@@ -285,10 +286,15 @@ export class LocalEventRepository implements EventRepository {
 
     // "this": exclude the date from expansion, and drop any stored override
     // record for this occurrence so it can't resurface via the id dedupe.
+    // Occurrence ids embed a canonical ISO recurrenceId (Z / midnight-Z);
+    // expansion skips by schedule.start format (RFC3339 offset or YYYY-MM-DD),
+    // so normalize before storing.
+    const format = getCompassEventDateFormat(record.event.schedule.start);
+    const exdate = dayjs(occurrenceStart).format(format);
     await this.store.deleteEvent(id);
     await this.store.putEvent({
       ...record,
-      exdates: [...(record.exdates ?? []), occurrenceStart],
+      exdates: [...(record.exdates ?? []), exdate],
     });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Anonymous "delete this occurrence" showed the Deleted toast but the event rematerialized after settle. Local delete stored the occurrence-id ISO suffix in `exdates`, while read-time expansion excludes by `schedule.start` format (RFC3339 offset / `YYYY-MM-DD`), so the exclusion never matched.

Normalize the exdate to the series schedule format in `LocalEventRepository.delete` before persisting, matching `projectSeriesMaterialization` and signup promotion.

## Simplicity

One write-path normalize in the local repository; no UI, toast, or mutation changes.

## Automated validation

- `bun test packages/web/src/events/repositories/local.event.repository.test.ts` — 14 pass (including timed + all-day delete round-trips)
- `bun lint` — clean

## Independent review

Not run in this turn; change is a focused format fix with regression coverage.

## Test plan

- `bun test packages/web/src/events/repositories/local.event.repository.test.ts`
- `bun lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7131e25-cc43-4737-a9aa-e73af81b4df5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7131e25-cc43-4737-a9aa-e73af81b4df5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

