### PR TITLE
chore(web): bump posthog-js to 1.409.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -141,7 +141,7 @@
         "dayjs": "^1.10.7",
         "dexie": "^4.2.1",
         "fast-deep-equal": "^3.1.3",
-        "posthog-js": "^1.396.3",
+        "posthog-js": "^1.409.5",
         "react": "^18.1.0",
         "react-datepicker": "^4.2.1",
         "react-dom": "^18.1.0",
@@ -469,9 +469,11 @@
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
-    "@posthog/core": ["@posthog/core@1.39.2", "", { "dependencies": { "@posthog/types": "^1.392.0" } }, "sha512-G/TL5Xykl+9xCDtBwHHPRSToS/43UjzyxKOfhlTwu/hJHt3v39Q2OFu8hdum71Iu7+tuxxISGVcFMlIST7ksjA=="],
+    "@posthog/browser-common": ["@posthog/browser-common@0.3.1", "", { "dependencies": { "@posthog/core": "^1.46.0", "@posthog/types": "^1.399.0" } }, "sha512-1nhMVY1wnHADTg8tR9yvm+lPAz5ROxznfQlBtLzB2FFo4lp/LU8lk9KyFPsARDkBxCfYachsJfvRjocL1G/AJQ=="],
 
-    "@posthog/types": ["@posthog/types@1.392.0", "", {}, "sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw=="],
+    "@posthog/core": ["@posthog/core@1.46.1", "", { "dependencies": { "@posthog/types": "^1.399.0" } }, "sha512-EoCFduRkvrg9E5ylMi4QnZCjlAdRJCq6tJouWfngBVR79XSI4iPvIWYA+CdzokAjk+TfSVBFVJ++4Im3r+T0Dg=="],
+
+    "@posthog/types": ["@posthog/types@1.399.0", "", {}, "sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw=="],
 
     "@react-oauth/google": ["@react-oauth/google@0.7.3", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-sGlysUSEH5cQu6mRgXA/3deYDMl0YIn/OWM1H3QiPVVJxGNlPLACe5J6s/jKGaxVWb+8OMNrVE573+tWMJFCFw=="],
 
@@ -1391,7 +1393,7 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
-    "posthog-js": ["posthog-js@1.396.3", "", { "dependencies": { "@posthog/core": "^1.39.1", "@posthog/types": "^1.392.0", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-CL4mH3F2azsONko/zC2931RLdt6RxTsEr7x7Lyk0SDmj5hZuvBCTbg9MKViXwSRhBr3/SaGcaHS1n95WxTrsCw=="],
+    "posthog-js": ["posthog-js@1.409.5", "", { "dependencies": { "@posthog/browser-common": "^0.3.1", "@posthog/core": "^1.46.1", "@posthog/types": "^1.399.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-s1iJz+vq0YAluUD4OwLjUFIJt/9pqiiB6MITvHWIS16a7pqTJqbSLXsd5/8kJcIgfrOSZHe+mdYAXLYcJCS4LQ=="],
 
     "preact": ["preact@10.29.3", "", {}, "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,7 +19,7 @@
     "dayjs": "^1.10.7",
     "dexie": "^4.2.1",
     "fast-deep-equal": "^3.1.3",
-    "posthog-js": "^1.396.3",
+    "posthog-js": "^1.409.5",
     "react": "^18.1.0",
     "react-datepicker": "^4.2.1",
     "react-dom": "^18.1.0",


### PR DESCRIPTION
## Summary

- Bump `posthog-js` from `1.396.3` to `1.409.5` so production traffic reports a current Web SDK and clears the PostHog outdated-SDK health alert.
- Lockfile updated to resolve `posthog-js@1.409.5` and its `@posthog/*` companions; no application code changes.

## Simplicity

Dependency-only bump. No simplification pass needed beyond keeping the change scoped to `@compass/web` (avoided adding `posthog-js` to the root package).

## Automated validation

- `http://localhost:9083/week`: anonymous week view loaded with sample events (Previous/Next week, sidebar calendars, Up next). No page load failure after the SDK bump.
- PostHog is not necessarily initialized in local anonymous mode; smoke covered app boot with the new package installed.

## Independent review

Fresh read-only review of the final diff: **no findings**. Integration surfaces (`init`, `before_send`/`CaptureResult`, React provider/hooks, survey capture helpers) still type-check against 1.409.5.

## Test plan

- `bun test:web packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts packages/web/src/components/Feedback/feedback.posthog.test.ts` — 10 pass
- `bun run lint` — pass
- `bun run type-check` — pass