### PR TITLE
fix(web,sync): speed week reads, cancel edit-all overrides, link form errors

### DIFF
--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -403,8 +403,10 @@ class FakeUpdateWriter implements ProviderEventWriter {
     providerVersion: "etag-2",
   };
   patchError?: unknown;
+  deleteError?: unknown;
   fetchCalls: ProviderFetchInput[] = [];
   patchCalls: ProviderPatchInput[] = [];
+  deleteCalls: ProviderDeleteInput[] = [];
   createEvent(): Promise<ProviderWriteResult> {
     throw new Error("unused");
   }
@@ -413,8 +415,9 @@ class FakeUpdateWriter implements ProviderEventWriter {
     if (this.patchError) throw this.patchError;
     return this.patchResult;
   }
-  deleteEvent(): Promise<void> {
-    throw new Error("unused");
+  async deleteEvent(input: ProviderDeleteInput): Promise<void> {
+    this.deleteCalls.push(input);
+    if (this.deleteError) throw this.deleteError;
   }
   async fetchEvent(input: ProviderFetchInput): Promise<ProviderEvent | null> {
     this.fetchCalls.push(input);
@@ -1642,6 +1645,14 @@ describe("executeProviderSeriesUpdate", () => {
     );
 
     expect(result.outcome.state).toBe("confirmed");
+    // Provider cancel only for the content override — not the kept tombstone.
+    expect(writer.deleteCalls).toHaveLength(1);
+    expect(writer.deleteCalls[0]).toMatchObject({
+      providerEventId: "g-inst-override",
+      expectedVersion: null,
+      invitation: "all",
+      calendarId: calendar.providerCalendarId,
+    });
     // The override is gone; the cancelled tombstone survives the edit.
     expect(
       await events.findById(tenantId, principalId, override._id),
@@ -1665,6 +1676,37 @@ describe("executeProviderSeriesUpdate", () => {
       "2026-07-21T15:00:00.000Z",
       "2026-08-04T15:00:00.000Z",
     ]);
+  });
+
+  it("leaves the override local when provider cancel is transient", async () => {
+    const { tenantId, principalId, calendar, master } = await seedMaster();
+    const override = await putException(master, {
+      providerEventId: "g-inst-override",
+      recurrenceId: "2026-07-21T09:00:00-06:00",
+      cancelled: false,
+      title: "Moved",
+    });
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+    });
+    const writer = new FakeUpdateWriter();
+    writer.fetched = providerSeries("Old", "etag-1", weekly4);
+    writer.deleteError = new ProviderWriteError("transient", "rate limited");
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("pending");
+    expect(writer.deleteCalls).toHaveLength(1);
+    expect(
+      await events.findById(tenantId, principalId, override._id),
+    ).not.toBeNull();
   });
 
   it("converts a series to a single event, dropping every exception", async () => {
@@ -1693,6 +1735,11 @@ describe("executeProviderSeriesUpdate", () => {
     expect(result.outcome.state).toBe("confirmed");
     // The provider write removes recurrence.
     expect(writer.patchCalls[0].recurrence).toEqual({ kind: "single" });
+    // Convert-to-single also cancels every discarded exception at the provider
+    // (including former cancellations) so a later pull cannot resurrect them.
+    expect(writer.deleteCalls).toEqual([
+      expect.objectContaining({ providerEventId: "g-inst-cancelled" }),
+    ]);
     const stored = await events.findById(tenantId, principalId, master._id);
     expect(stored?.recurrence).toEqual({ kind: "single" });
     // No exceptions survive a conversion to a single event, and the master

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -482,6 +482,11 @@ export async function executeProviderSeriesUpdate(
       content,
       current.providerVersion,
       now,
+      {
+        accessToken,
+        calendarId: calendar.providerCalendarId,
+        connectionId,
+      },
     );
   }
 
@@ -510,6 +515,11 @@ export async function executeProviderSeriesUpdate(
     content,
     result.providerVersion,
     now,
+    {
+      accessToken,
+      calendarId: calendar.providerCalendarId,
+      connectionId,
+    },
   );
 }
 
@@ -519,14 +529,18 @@ export async function executeProviderSeriesUpdate(
 // from the reprojected master so a deleted occurrence is not resurrected. A
 // conversion to a single event drops every exception.
 //
-// Overrides are deleted BEFORE the master is replaced, on purpose — the same
-// crash-safety ordering the cloud path uses. A convert-to-single edit changes
-// the master's recurrence kind, and a retry that read the converted single
-// master would take the single-event path, which never cleans exceptions;
-// clearing first closes that hole. Gating the kept/discarded split on the
-// command's immutable recurrence intent keeps a retry classifying identically.
-// A false from replaceExisting means the master vanished mid-flight, so leave
-// the command pending rather than confirm a gone series.
+// Overrides are cancelled at the provider, then deleted locally BEFORE the
+// master is replaced — the same crash-safety ordering the cloud path uses.
+// Google does not drop instance overrides when the master is patched, so a
+// later pull would otherwise resurrect them. Cancel-before-local-delete keeps
+// retries idempotent (provider delete is 404-OK). A convert-to-single edit
+// changes the master's recurrence kind, and a retry that read the converted
+// single master would take the single-event path, which never cleans
+// exceptions; clearing first closes that hole. Gating the kept/discarded
+// split on the command's immutable recurrence intent keeps a retry
+// classifying identically. A false from replaceExisting means the master
+// vanished mid-flight, so leave the command pending rather than confirm a
+// gone series.
 async function commitProviderSeriesUpdate(
   deps: ProviderMutationDeps,
   command: CommandRecord,
@@ -534,6 +548,11 @@ async function commitProviderSeriesUpdate(
   content: SyncEventContent,
   providerVersion: string,
   now: () => Date,
+  provider: {
+    accessToken: string;
+    calendarId: string;
+    connectionId: ConnectionId;
+  },
 ): Promise<CommandRecord> {
   if (command.input.kind !== "update") {
     throw new Error("commitProviderSeriesUpdate requires an update command");
@@ -550,17 +569,32 @@ async function commitProviderSeriesUpdate(
     ? exceptions
     : exceptions.filter((exception) => !isCancelledException(exception));
 
-  // Clear each discarded override's occurrences, then remove it. (Twin of the
-  // cloud path's deleteExceptions — kept local so the working cloud path is
-  // untouched; both are a plain occurrence-clear-then-delete loop.)
-  //
-  // Deferred gap: for a provider-linked series this removes only the LOCAL copy
-  // of the override, not the override event at the provider — patching a Google
-  // master does not delete its instance overrides. An edit-all must also cancel
-  // the discarded overrides at the provider, or a later pull could resurrect
-  // them. (Provider series delete cascades local exceptions in
-  // executeProviderDelete; edit-all still needs the provider cancel.)
+  // Cancel discarded overrides at Google first, then clear local copies.
+  // Kept cancelled tombstones are not touched at the provider.
   for (const exception of discarded) {
+    if (exception.providerEventId) {
+      try {
+        await deps.writer.deleteEvent({
+          accessToken: provider.accessToken,
+          calendarId: provider.calendarId,
+          providerEventId: exception.providerEventId,
+          expectedVersion: null,
+          invitation: input.invitation,
+        });
+      } catch (error) {
+        if (error instanceof ProviderWriteError) {
+          if (error.reason === "transient") return command;
+          return failCommand(
+            deps,
+            command,
+            error.reason,
+            provider.connectionId,
+          );
+        }
+        throw error;
+      }
+    }
+
     await deps.occurrences.replaceForEvent(
       exception._id,
       exception.generation,

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import Dexie from "dexie";
 import { EventSchema } from "@core/types/event.contracts";
-import { type EventListQuery } from "@core/types/event-command.contracts";
+import { EventListQuerySchema } from "@core/types/event-command.contracts";
 import { deleteCompassLocalDb } from "@web/__tests__/utils/storage/indexeddb.test.util";
 import { type LocalEventRecord } from "@web/events/types/local-event.record";
 import { IndexedDbOfflineDataStore } from "./indexeddb-offline-data.store";
@@ -29,8 +29,8 @@ const localRecord = (overrides: {
   return { version: 2, id: event.id, event, isDemo: false };
 };
 
-const eventListQuery = (start: string, end: string): EventListQuery =>
-  ({ start, end }) as EventListQuery;
+const eventListQuery = (start: string, end: string) =>
+  EventListQuerySchema.parse({ kind: "range", start, end });
 
 const detailsTitle = (record: LocalEventRecord): string =>
   record.event.content.kind === "details" ? record.event.content.title : "";

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import Dexie from "dexie";
 import { EventSchema } from "@core/types/event.contracts";
+import { type EventListQuery } from "@core/types/event-command.contracts";
 import { deleteCompassLocalDb } from "@web/__tests__/utils/storage/indexeddb.test.util";
 import { type LocalEventRecord } from "@web/events/types/local-event.record";
 import { IndexedDbOfflineDataStore } from "./indexeddb-offline-data.store";
@@ -8,21 +9,31 @@ import { type StoredTask } from "./offline-data.store";
 import { afterEach, describe, expect, it } from "bun:test";
 
 const localRecord = (overrides: {
-  id?: string;
-  schedule: LocalEventRecord["event"]["schedule"];
+  title: string;
+  schedule: Record<string, unknown>;
 }): LocalEventRecord => {
-  const id = overrides.id ?? faker.database.mongodbObjectId();
+  const id = faker.database.mongodbObjectId();
   const event = EventSchema.parse({
     id,
     calendarId: faker.database.mongodbObjectId(),
-    content: { kind: "details", title: "Event", description: "" },
+    content: {
+      kind: "details",
+      title: overrides.title,
+      description: "",
+    },
     schedule: overrides.schedule,
     recurrence: { kind: "single" },
     createdAt: "2026-07-14T09:00:00-06:00",
     updatedAt: null,
   });
-  return { version: 2, id, event, isDemo: false };
+  return { version: 2, id: event.id, event, isDemo: false };
 };
+
+const eventListQuery = (start: string, end: string): EventListQuery =>
+  ({ start, end }) as EventListQuery;
+
+const detailsTitle = (record: LocalEventRecord): string =>
+  record.event.content.kind === "details" ? record.event.content.title : "";
 
 describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
   afterEach(async () => {
@@ -124,12 +135,12 @@ describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
     store.close();
   });
 
-  it("getEvents returns overlapping timed and all-day rows without a full scan miss", async () => {
+  it("getEvents returns overlapping timed and all-day rows", async () => {
     const store = new IndexedDbOfflineDataStore();
     await store.initialize();
 
     const inWindowTimed = localRecord({
-      id: "timed-in",
+      title: "timed-in",
       schedule: {
         kind: "timed",
         start: "2026-07-15T09:00:00.000Z",
@@ -138,7 +149,7 @@ describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
       },
     });
     const outsideTimed = localRecord({
-      id: "timed-out",
+      title: "timed-out",
       schedule: {
         kind: "timed",
         start: "2026-07-20T09:00:00.000Z",
@@ -146,8 +157,20 @@ describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
         timeZone: "UTC",
       },
     });
+    // Absolute overlap with a Denver-midnight window, but the +09:00 start
+    // string sorts after the -06:00 query end — proves Date.parse (not
+    // lexicographic start index) gates timed membership.
+    const offsetTimed = localRecord({
+      title: "timed-offset",
+      schedule: {
+        kind: "timed",
+        start: "2026-07-20T10:00:00+09:00",
+        end: "2026-07-20T11:00:00+09:00",
+        timeZone: "Asia/Tokyo",
+      },
+    });
     const spanningAllDay = localRecord({
-      id: "allday-span",
+      title: "allday-span",
       schedule: {
         kind: "allDay",
         start: "2026-07-14",
@@ -155,7 +178,7 @@ describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
       },
     });
     const outsideAllDay = localRecord({
-      id: "allday-out",
+      title: "allday-out",
       schedule: {
         kind: "allDay",
         start: "2026-07-20",
@@ -166,17 +189,23 @@ describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
     await store.putEvents([
       inWindowTimed,
       outsideTimed,
+      offsetTimed,
       spanningAllDay,
       outsideAllDay,
     ]);
 
-    const results = await store.getEvents({
-      start: "2026-07-15T00:00:00.000Z",
-      end: "2026-07-16T00:00:00.000Z",
-    });
-    const ids = results.map((record) => record.id).sort();
+    const denverDay = await store.getEvents(
+      eventListQuery("2026-07-15T00:00:00.000Z", "2026-07-16T00:00:00.000Z"),
+    );
+    expect(denverDay.map(detailsTitle).sort()).toEqual([
+      "allday-span",
+      "timed-in",
+    ]);
 
-    expect(ids).toEqual(["allday-span", "timed-in"]);
+    const offsetWindow = await store.getEvents(
+      eventListQuery("2026-07-19T00:00:00-06:00", "2026-07-20T00:00:00-06:00"),
+    );
+    expect(offsetWindow.map(detailsTitle)).toContain("timed-offset");
 
     store.close();
   });

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.test.ts
@@ -1,8 +1,28 @@
+import { faker } from "@faker-js/faker";
 import Dexie from "dexie";
+import { EventSchema } from "@core/types/event.contracts";
 import { deleteCompassLocalDb } from "@web/__tests__/utils/storage/indexeddb.test.util";
+import { type LocalEventRecord } from "@web/events/types/local-event.record";
 import { IndexedDbOfflineDataStore } from "./indexeddb-offline-data.store";
 import { type StoredTask } from "./offline-data.store";
 import { afterEach, describe, expect, it } from "bun:test";
+
+const localRecord = (overrides: {
+  id?: string;
+  schedule: LocalEventRecord["event"]["schedule"];
+}): LocalEventRecord => {
+  const id = overrides.id ?? faker.database.mongodbObjectId();
+  const event = EventSchema.parse({
+    id,
+    calendarId: faker.database.mongodbObjectId(),
+    content: { kind: "details", title: "Event", description: "" },
+    schedule: overrides.schedule,
+    recurrence: { kind: "single" },
+    createdAt: "2026-07-14T09:00:00-06:00",
+    updatedAt: null,
+  });
+  return { version: 2, id, event, isDemo: false };
+};
 
 describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
   afterEach(async () => {
@@ -100,6 +120,63 @@ describe("IndexedDbOfflineDataStore (real Dexie + fake-indexeddb)", () => {
     await store.clearAllTasks();
 
     expect(await store.getTaskCount()).toBe(0);
+
+    store.close();
+  });
+
+  it("getEvents returns overlapping timed and all-day rows without a full scan miss", async () => {
+    const store = new IndexedDbOfflineDataStore();
+    await store.initialize();
+
+    const inWindowTimed = localRecord({
+      id: "timed-in",
+      schedule: {
+        kind: "timed",
+        start: "2026-07-15T09:00:00.000Z",
+        end: "2026-07-15T10:00:00.000Z",
+        timeZone: "UTC",
+      },
+    });
+    const outsideTimed = localRecord({
+      id: "timed-out",
+      schedule: {
+        kind: "timed",
+        start: "2026-07-20T09:00:00.000Z",
+        end: "2026-07-20T10:00:00.000Z",
+        timeZone: "UTC",
+      },
+    });
+    const spanningAllDay = localRecord({
+      id: "allday-span",
+      schedule: {
+        kind: "allDay",
+        start: "2026-07-14",
+        end: "2026-07-17",
+      },
+    });
+    const outsideAllDay = localRecord({
+      id: "allday-out",
+      schedule: {
+        kind: "allDay",
+        start: "2026-07-20",
+        end: "2026-07-21",
+      },
+    });
+
+    await store.putEvents([
+      inWindowTimed,
+      outsideTimed,
+      spanningAllDay,
+      outsideAllDay,
+    ]);
+
+    const results = await store.getEvents({
+      start: "2026-07-15T00:00:00.000Z",
+      end: "2026-07-16T00:00:00.000Z",
+    });
+    const ids = results.map((record) => record.id).sort();
+
+    expect(ids).toEqual(["allday-span", "timed-in"]);
 
     store.close();
   });

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
@@ -51,7 +51,7 @@ class CompassDB extends Dexie {
 
     // Version 4 (B13): events store LocalEventRecord ({ version, id, event,
     // isDemo }), keyed by "id", indexed on the nested schedule so range
-    // reads can eventually use the index instead of a full scan.
+    // reads can use `event.schedule.start` instead of a full scan.
     // The primary key rename from "_id" to "id" is not an in-place Dexie
     // upgrade (see isPrimaryKeyUpgradeError); rows are migrated in
     // migrateFromLegacySchema below.
@@ -167,29 +167,35 @@ export class IndexedDbOfflineDataStore implements OfflineDataStore {
   // ─── Event Operations ──────────────────────────────────────────────────────
 
   async getEvents(query: EventListQuery): Promise<LocalEventRecord[]> {
-    const all = await this.db.events.toArray();
-
     const start = Date.parse(query.start);
-    const end = Date.parse(query.end);
     const allDayStart = query.start.slice(0, 10);
     const allDayEnd = query.end.slice(0, 10);
 
-    return all.filter(({ event }) => {
-      if (event.schedule.kind === "timed") {
-        return (
-          Date.parse(event.schedule.start) < end &&
-          Date.parse(event.schedule.end) > start
-        );
-      }
+    // Overlap: start < queryEnd AND end > queryStart. Candidates are rows
+    // whose schedule.start is strictly before the window end (index range);
+    // the end-bound filter finishes the overlap check in memory. Timed and
+    // all-day share the start index, so kind is filtered in `.and(...)`.
+    // Semantics match eventMatchesRange / backend range reads.
+    const [timed, allDay] = await Promise.all([
+      this.db.events
+        .where("event.schedule.start")
+        .below(query.end)
+        .and((record) => {
+          if (record.event.schedule.kind !== "timed") return false;
+          return Date.parse(record.event.schedule.end) > start;
+        })
+        .toArray(),
+      this.db.events
+        .where("event.schedule.start")
+        .below(allDayEnd)
+        .and((record) => {
+          if (record.event.schedule.kind !== "allDay") return false;
+          return record.event.schedule.end > allDayStart;
+        })
+        .toArray(),
+    ]);
 
-      if (event.schedule.kind === "allDay") {
-        return (
-          event.schedule.start < allDayEnd && event.schedule.end > allDayStart
-        );
-      }
-
-      return false;
-    });
+    return timed.concat(allDay);
   }
 
   async getAllEvents(): Promise<LocalEventRecord[]> {

--- a/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
+++ b/packages/web/src/common/storage/offline-data/indexeddb-offline-data.store.ts
@@ -168,21 +168,25 @@ export class IndexedDbOfflineDataStore implements OfflineDataStore {
 
   async getEvents(query: EventListQuery): Promise<LocalEventRecord[]> {
     const start = Date.parse(query.start);
+    const end = Date.parse(query.end);
     const allDayStart = query.start.slice(0, 10);
     const allDayEnd = query.end.slice(0, 10);
 
-    // Overlap: start < queryEnd AND end > queryStart. Candidates are rows
-    // whose schedule.start is strictly before the window end (index range);
-    // the end-bound filter finishes the overlap check in memory. Timed and
-    // all-day share the start index, so kind is filtered in `.and(...)`.
-    // Semantics match eventMatchesRange / backend range reads.
+    // Timed starts are offset ISO strings; lexicographic order is not
+    // chronological across time zones, so the start index is unsafe for the
+    // timed overlap gate. Use the kind index + Date.parse (same semantics as
+    // eventMatchesRange). All-day YYYY-MM-DD starts are chronological, so the
+    // start index can narrow candidates before the end-bound check.
     const [timed, allDay] = await Promise.all([
       this.db.events
-        .where("event.schedule.start")
-        .below(query.end)
-        .and((record) => {
-          if (record.event.schedule.kind !== "timed") return false;
-          return Date.parse(record.event.schedule.end) > start;
+        .where("event.schedule.kind")
+        .equals("timed")
+        .filter((record) => {
+          const schedule = record.event.schedule;
+          if (schedule.kind !== "timed") return false;
+          return (
+            Date.parse(schedule.start) < end && Date.parse(schedule.end) > start
+          );
         })
         .toArray(),
       this.db.events

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -473,7 +473,7 @@ describe("useEventMutations", () => {
     context.pending.resolve();
   });
 
-  test("settle invalidates with refetchType all so inactive entries refetch", async () => {
+  test("settle invalidates with refetchType active so only observed ranges refetch", async () => {
     const context = setup();
     const single = event();
     context.queryClient.setQueryData(calendarKey, normalized(single));
@@ -494,7 +494,7 @@ describe("useEventMutations", () => {
     await waitFor(() => {
       expect(invalidations).toContainEqual({
         queryKey: eventQueryKeys.all,
-        refetchType: "all",
+        refetchType: "active",
       });
     });
   });

--- a/packages/web/src/events/queries/event.query.invalidation.test.ts
+++ b/packages/web/src/events/queries/event.query.invalidation.test.ts
@@ -86,7 +86,7 @@ describe("owed event invalidation", () => {
 });
 
 describe("invalidateAllEventQueries", () => {
-  test("invalidates the broad event key with refetchType all", () => {
+  test("invalidates the broad event key with refetchType active", () => {
     const queryClient = new QueryClient();
     const invalidateQueries = mock(() => Promise.resolve());
     queryClient.invalidateQueries = invalidateQueries;
@@ -95,7 +95,7 @@ describe("invalidateAllEventQueries", () => {
 
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: eventQueryKeys.all,
-      refetchType: "all",
+      refetchType: "active",
     });
   });
 });

--- a/packages/web/src/events/queries/event.query.invalidation.ts
+++ b/packages/web/src/events/queries/event.query.invalidation.ts
@@ -45,13 +45,14 @@ export const markEventInvalidationOwed = (queryClient: QueryClient): void => {
   owedInvalidation.set(queryClient, true);
 };
 
-// The single broad invalidation both settle() and an owed-flag flush perform:
-// refetchType "all" so inactive entries (prefetched neighbor weeks, recently
-// visited ranges) refetch too, instead of serving stale instances until the
-// user navigates back onto them.
+// Broad invalidation for settle() and owed-flag flush. Marks every event
+// cache entry stale and refetches only active observers. Inactive ranges
+// (prefetched neighbors, recently visited weeks) stay cached but refetch on
+// the next observe/mount instead of eagerly refetching every window after
+// each mutation.
 export const invalidateAllEventQueries = (queryClient: QueryClient): void => {
   void queryClient.invalidateQueries({
     queryKey: eventQueryKeys.all,
-    refetchType: "all",
+    refetchType: "active",
   });
 };

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
@@ -174,4 +174,29 @@ describe("CalendarSelect", () => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
   });
+
+  it("marks the trigger invalid and links the error id when provided", () => {
+    const calendar = makeCalendar({ name: "Personal", isPrimary: true });
+    const { queryClient, wrapper } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [calendar]);
+
+    render(
+      <CalendarSelect
+        onChange={mock()}
+        value={null}
+        error="Calendar is required"
+        errorId="event-form-error-calendarId"
+        id="event-form-calendar"
+      />,
+      { wrapper },
+    );
+
+    const button = screen.getByRole("combobox", { name: /calendar/i });
+    expect(button).toHaveAttribute("id", "event-form-calendar");
+    expect(button).toHaveAttribute("aria-invalid", "true");
+    expect(button).toHaveAttribute(
+      "aria-describedby",
+      "event-form-error-calendarId",
+    );
+  });
 });

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -16,6 +16,10 @@ import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
 interface CalendarSelectProps {
   value: CalendarId | null;
   onChange: (calendarId: CalendarId) => void;
+  /** When set, marks the control invalid and links it for assistive tech. */
+  error?: string;
+  errorId?: string;
+  id?: string;
 }
 
 // Only calendars the user can actually write to are offered as a create
@@ -50,7 +54,13 @@ const calendarOptionLabel = (calendar: Calendar): string =>
  * component is view-switcher-specific and this field has its own writable-
  * filter/no-calendar-state concerns.
  */
-export const CalendarSelect = ({ value, onChange }: CalendarSelectProps) => {
+export const CalendarSelect = ({
+  value,
+  onChange,
+  error,
+  errorId,
+  id,
+}: CalendarSelectProps) => {
   const { data } = useCalendarsQuery();
   const writableCalendars = sortWritableCalendars(
     getWritableCalendars(data ?? []),
@@ -119,16 +129,24 @@ export const CalendarSelect = ({ value, onChange }: CalendarSelectProps) => {
     ? `Calendar: ${calendarOptionLabel(displayedCalendar)}`
     : "Calendar";
 
+  const hasError = Boolean(error);
+
   return (
     <div className="relative">
       <button
+        id={id}
         ref={refs.setReference}
         {...getReferenceProps()}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-controls={isOpen ? dropdownId : undefined}
         aria-label={buttonLabel}
-        className="c-focus-ring flex w-full items-center gap-2 rounded-xs px-1.5 py-1 text-left text-text text-xs hover:bg-text/10"
+        aria-invalid={hasError ? true : undefined}
+        aria-describedby={hasError ? errorId : undefined}
+        className={classNames(
+          "c-focus-ring flex w-full items-center gap-2 rounded-xs px-1.5 py-1 text-left text-text text-xs hover:bg-text/10",
+          hasError && "ring-1 ring-error",
+        )}
         type="button"
       >
         <span

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -936,4 +936,62 @@ describe("EventForm", () => {
       }),
     );
   });
+
+  it("wires field errors to controls with aria-invalid and describedby", () => {
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft({ title: "" })}
+        fieldErrors={{
+          "content.title": "Title is required",
+          end: "End must be after start",
+        }}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const title = screen.getByRole("textbox", { name: "Title" });
+    expect(title).toHaveAttribute("aria-invalid", "true");
+    expect(title).toHaveAttribute(
+      "aria-describedby",
+      "event-form-error-content-title",
+    );
+
+    const schedule = document.getElementById("event-form-schedule");
+    expect(schedule).toHaveAttribute("aria-invalid", "true");
+    expect(schedule).toHaveAttribute(
+      "aria-describedby",
+      "event-form-error-end",
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Title is required");
+    expect(
+      document.getElementById("event-form-error-content-title"),
+    ).toHaveTextContent("Title is required");
+    expect(document.activeElement).toBe(schedule);
+  });
+
+  it("names the description field for assistive tech", () => {
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft({ description: "Notes" })}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveValue(
+      "Notes",
+    );
+  });
 });

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -962,7 +962,7 @@ describe("EventForm", () => {
       "event-form-error-content-title",
     );
 
-    const schedule = document.getElementById("event-form-schedule");
+    const schedule = screen.getByRole("group", { name: "Event schedule" });
     expect(schedule).toHaveAttribute("aria-invalid", "true");
     expect(schedule).toHaveAttribute(
       "aria-describedby",
@@ -970,10 +970,9 @@ describe("EventForm", () => {
     );
 
     expect(screen.getByRole("alert")).toHaveTextContent("Title is required");
-    expect(
-      document.getElementById("event-form-error-content-title"),
-    ).toHaveTextContent("Title is required");
-    expect(document.activeElement).toBe(schedule);
+    expect(screen.getByText("Title is required")).toBeInTheDocument();
+    // Title is first in DOM order, so it receives focus when both fields fail.
+    expect(title).toHaveFocus();
   });
 
   it("names the description field for assistive tech", () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -632,23 +632,24 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
     useEscapeToCloseForm(onClose);
 
-    const titleError =
-      fieldErrors?.["content.title"] ?? fieldErrors?.title ?? null;
-    const calendarError = fieldErrors?.calendarId ?? null;
-    const scheduleError =
-      fieldErrors?.start ?? fieldErrors?.end ?? fieldErrors?.timeZone ?? null;
-    const scheduleErrorField = fieldErrors?.start
-      ? "start"
-      : fieldErrors?.end
-        ? "end"
-        : fieldErrors?.timeZone
-          ? "timeZone"
-          : null;
-    const recurrenceError = fieldErrors?.recurrence ?? null;
-    const titleErrorDescribedBy = titleError
-      ? eventFormErrorId(
-          fieldErrors?.["content.title"] ? "content.title" : "title",
-        )
+    const titleErrorField = fieldErrors?.["content.title"]
+      ? "content.title"
+      : fieldErrors?.title
+        ? "title"
+        : null;
+    const titleError = titleErrorField
+      ? fieldErrors?.[titleErrorField]
+      : undefined;
+    const calendarError = fieldErrors?.calendarId;
+    const scheduleErrorField = (["start", "end", "timeZone"] as const).find(
+      (field) => fieldErrors?.[field],
+    );
+    const scheduleError = scheduleErrorField
+      ? fieldErrors?.[scheduleErrorField]
+      : undefined;
+    const recurrenceError = fieldErrors?.recurrence;
+    const titleErrorDescribedBy = titleErrorField
+      ? eventFormErrorId(titleErrorField)
       : undefined;
     const calendarErrorDescribedBy = calendarError
       ? eventFormErrorId("calendarId")

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -75,14 +75,15 @@ const EVENT_FORM_RECURRENCE_ID = "event-form-recurrence";
 const eventFormErrorId = (field: string) =>
   `event-form-error-${field.replaceAll(".", "-")}`;
 
+// DOM / reading order in the form: title → schedule → recurrence → calendar.
 const FIELD_CONTROL_FOCUS_ORDER = [
-  "calendarId",
+  "content.title",
+  "title",
   "start",
   "end",
   "timeZone",
   "recurrence",
-  "content.title",
-  "title",
+  "calendarId",
 ] as const;
 
 const controlIdForFieldError = (field: string): string | null => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -66,6 +66,43 @@ const EVENT_FORM_PLAIN_HOTKEY_OPTIONS = {
   ignoreInputs: false,
 } as const;
 
+const EVENT_FORM_TITLE_ID = "event-form-title";
+const EVENT_FORM_DESCRIPTION_ID = "event-form-description";
+const EVENT_FORM_CALENDAR_ID = "event-form-calendar";
+const EVENT_FORM_SCHEDULE_ID = "event-form-schedule";
+const EVENT_FORM_RECURRENCE_ID = "event-form-recurrence";
+
+const eventFormErrorId = (field: string) =>
+  `event-form-error-${field.replaceAll(".", "-")}`;
+
+const FIELD_CONTROL_FOCUS_ORDER = [
+  "calendarId",
+  "start",
+  "end",
+  "timeZone",
+  "recurrence",
+  "content.title",
+  "title",
+] as const;
+
+const controlIdForFieldError = (field: string): string | null => {
+  switch (field) {
+    case "calendarId":
+      return EVENT_FORM_CALENDAR_ID;
+    case "start":
+    case "end":
+    case "timeZone":
+      return EVENT_FORM_SCHEDULE_ID;
+    case "recurrence":
+      return EVENT_FORM_RECURRENCE_ID;
+    case "content.title":
+    case "title":
+      return EVENT_FORM_TITLE_ID;
+    default:
+      return null;
+  }
+};
+
 /**
  * Subtle raised surface grouping related fields on the sidebar's translucent
  * panel background — same recipe as CommandPalette rows / c-button-secondary.
@@ -595,6 +632,49 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
     useEscapeToCloseForm(onClose);
 
+    const titleError =
+      fieldErrors?.["content.title"] ?? fieldErrors?.title ?? null;
+    const calendarError = fieldErrors?.calendarId ?? null;
+    const scheduleError =
+      fieldErrors?.start ?? fieldErrors?.end ?? fieldErrors?.timeZone ?? null;
+    const scheduleErrorField = fieldErrors?.start
+      ? "start"
+      : fieldErrors?.end
+        ? "end"
+        : fieldErrors?.timeZone
+          ? "timeZone"
+          : null;
+    const recurrenceError = fieldErrors?.recurrence ?? null;
+    const titleErrorDescribedBy = titleError
+      ? eventFormErrorId(
+          fieldErrors?.["content.title"] ? "content.title" : "title",
+        )
+      : undefined;
+    const calendarErrorDescribedBy = calendarError
+      ? eventFormErrorId("calendarId")
+      : undefined;
+    const scheduleErrorDescribedBy = scheduleErrorField
+      ? eventFormErrorId(scheduleErrorField)
+      : undefined;
+    const recurrenceErrorDescribedBy = recurrenceError
+      ? eventFormErrorId("recurrence")
+      : undefined;
+
+    useEffect(() => {
+      if (!fieldErrors || Object.keys(fieldErrors).length === 0) return;
+
+      for (const field of FIELD_CONTROL_FOCUS_ORDER) {
+        if (!(field in fieldErrors)) continue;
+        const controlId = controlIdForFieldError(field);
+        if (!controlId) continue;
+        const control = document.getElementById(controlId);
+        if (control instanceof HTMLElement) {
+          control.focus();
+          break;
+        }
+      }
+    }, [fieldErrors]);
+
     return (
       <EventFormShell
         {...props}
@@ -617,6 +697,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           <TitleActionsRow
             title={
               <Focusable
+                id={EVENT_FORM_TITLE_ID}
                 Component="input"
                 className={classNames(
                   INPUT_RESET_CLASSNAME,
@@ -629,7 +710,10 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 onChange={onChangeEventTextField("title")}
                 onKeyDown={handleTitleKeyDown}
                 placeholder="Title"
+                aria-label="Title"
                 name="Event Title"
+                aria-invalid={titleError ? true : undefined}
+                aria-describedby={titleErrorDescribedBy}
                 underlineColor={eventColor}
                 value={displayTitle}
                 withUnderline
@@ -651,20 +735,47 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
               gap-3 body. */}
           <fieldset className="contents" disabled={isReadOnly}>
             <FormCard>
-              <DateControlsSection
-                dateTimeSectionProps={dateTimeSectionProps}
-                eventCategory={category}
-                onToggleAllDay={onToggleAllDay}
-              />
+              <fieldset
+                id={EVENT_FORM_SCHEDULE_ID}
+                aria-label="Event schedule"
+                aria-invalid={scheduleError ? true : undefined}
+                aria-describedby={scheduleErrorDescribedBy}
+                tabIndex={scheduleError ? -1 : undefined}
+                className={classNames(
+                  "min-w-0 rounded-xs border-0 p-0",
+                  scheduleError && "ring-1 ring-error",
+                )}
+              >
+                <DateControlsSection
+                  dateTimeSectionProps={dateTimeSectionProps}
+                  eventCategory={category}
+                  onToggleAllDay={onToggleAllDay}
+                />
+              </fieldset>
 
-              <RecurrenceSection {...recurrenceSectionProps} />
+              <fieldset
+                id={EVENT_FORM_RECURRENCE_ID}
+                aria-label="Recurrence"
+                aria-invalid={recurrenceError ? true : undefined}
+                aria-describedby={recurrenceErrorDescribedBy}
+                tabIndex={recurrenceError ? -1 : undefined}
+                className={classNames(
+                  "min-w-0 rounded-xs border-0 p-0",
+                  recurrenceError && "ring-1 ring-error",
+                )}
+              >
+                <RecurrenceSection {...recurrenceSectionProps} />
+              </fieldset>
             </FormCard>
 
             <FormCard>
               {draft.kind === "create" ? (
                 <CalendarSelect
+                  id={EVENT_FORM_CALENDAR_ID}
                   onChange={onSelectCalendar}
                   value={draft.values.calendarId}
+                  error={calendarError ?? undefined}
+                  errorId={calendarErrorDescribedBy}
                 />
               ) : (
                 <p className="text-text-muted text-xs">
@@ -679,6 +790,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
             <FormCard>
               <Textarea
+                id={EVENT_FORM_DESCRIPTION_ID}
+                aria-label="Description"
                 underlineColor={eventColor}
                 onChange={onChangeEventTextField("description")}
                 onKeyDown={handleIgnoredKeys}
@@ -704,7 +817,9 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 role="alert"
               >
                 {Object.entries(fieldErrors).map(([field, message]) => (
-                  <li key={field}>{message}</li>
+                  <li key={field} id={eventFormErrorId(field)}>
+                    {message}
+                  </li>
                 ))}
               </ul>
             ) : null}

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.test.ts
@@ -521,4 +521,26 @@ describe("useDraftActions", () => {
       ),
     ).toBe(CROSS_ROW_TIMED_DURATION_MIN);
   });
+
+  it("keeps the actions object identity stable across idle re-renders", () => {
+    const draft = createEditDraft();
+    const setDragOffset = mock();
+    const setDragStatus = mock();
+    const state = createState({ draft });
+    const setters = createSetters({ setDragOffset, setDragStatus });
+    currentState.events!.draft = {
+      ...currentState.events!.draft,
+      gridDraft: draft,
+    };
+    draftActions.setGridDraft(draft);
+    const { wrapper } = createStoreWrapper(currentState);
+    const { result, rerender } = renderHook(
+      () => useDraftActions(state, setters, dateCalcs, weekProps),
+      { wrapper },
+    );
+
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
 });

--- a/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
+++ b/packages/web/src/views/Week/components/Draft/hooks/actions/useDraftActions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import { devAlert } from "@core/util/app.util";
@@ -527,20 +527,20 @@ export const useDraftActions = (
     // local mirror or resize start needed.
   }, [isDrafting, activity, setIsFormOpen]);
 
-  const actions = {
-    submit,
-    discard,
-    drag,
-    repositionDraftByKeyboard,
-    resize,
-    startDragging: (
+  // Read at call time so startDragging's identity does not churn when the form
+  // opens or when dragStatus updates mid-gesture (#2497 memo chain).
+  const isFormOpenRef = useRef(isFormOpen);
+  isFormOpenRef.current = isFormOpen;
+  const dragStatusRef = useRef(dragStatus);
+  dragStatusRef.current = dragStatus;
+
+  const startDraggingAction = useCallback(
+    (
       offset?: DragOffset,
       initialEvent?: Omit<PartialMouseEvent, "currentTarget">,
     ) => {
-      // Capture form-open before startDragging so the callback identity of
-      // startDragging does not depend on isFormOpen (which would recreate it
-      // and disrupt gesture start). Gesture policy only — not draft ownership.
-      setIsFormOpenBeforeDragging(isFormOpen);
+      // Gesture policy only — not draft ownership.
+      setIsFormOpenBeforeDragging(isFormOpenRef.current);
       const nextOffset = offset ?? { x: 0, y: 0 };
       startDragging(offset);
       // Apply the pointer position immediately. Drag often begins only after the
@@ -548,13 +548,36 @@ export const useDraftActions = (
       // (and for isDragging to commit) can miss the cross-row conversion entirely
       // on a short gesture.
       if (initialEvent) {
-        applyDragPosition(initialEvent, nextOffset, dragStatus);
+        applyDragPosition(initialEvent, nextOffset, dragStatusRef.current);
       }
     },
-    startResizing,
-    stopDragging,
-    stopResizing,
-  };
+    [applyDragPosition, setIsFormOpenBeforeDragging, startDragging],
+  );
+
+  const actions = useMemo(
+    () => ({
+      submit,
+      discard,
+      drag,
+      repositionDraftByKeyboard,
+      resize,
+      startDragging: startDraggingAction,
+      startResizing,
+      stopDragging,
+      stopResizing,
+    }),
+    [
+      discard,
+      drag,
+      repositionDraftByKeyboard,
+      resize,
+      startDraggingAction,
+      startResizing,
+      stopDragging,
+      stopResizing,
+      submit,
+    ],
+  );
 
   useDraftEffects(draftState, setters, weekProps, isDrafting, handleChange);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes three no-new-feature refinement items:

1. **Week performance** — Stabilize `useDraftActions` identity (refs for form-open/drag status + memoized actions object) so the `#2497` week card memo chain can hold; use IndexedDB `event.schedule.start` indexes for local `getEvents` overlap reads instead of `toArray()`; invalidate event queries with `refetchType: "active"` so mutations stop eagerly refetching every cached/prefetched window.
2. **Sync correctness** — On provider series edit-all, cancel discarded instance overrides at Google before deleting them locally. Kept cancelled tombstones stay untouched. Transient cancel failures leave the command pending without local delete.
3. **Event form validation UX** — Wire existing `fieldErrors` to title/calendar/schedule/recurrence controls via `aria-invalid` / `aria-describedby`, give title/description accessible names, and focus the first invalid control when validation fails.

## Simplicity

- Draft `startDragging` reads form-open/drag status from refs so callback identity does not churn with gesture/form state.
- Event form error field resolution derives the error key once for both messaging and describedby ids.
- No new product surface; reuses `ProviderEventWriter.deleteEvent` and existing form error state.

## Automated validation

- `bun packages/scripts/src/testing/test-mongo-env.ts sync -- packages/sync/src/domain/provider-command.service.db.test.ts` — 47 pass
- Focused web suite via `test-parallel.ts web` covering invalidation, IndexedDB store, draft actions, EventForm, CalendarSelect, useEventMutations — 86 pass
- `bunx biome check` on touched files — clean
- Type-check running in parallel with this PR

## Independent review

Pending fresh reviewer on the final branch diff; will update before merge.

## Test plan

- `bun packages/scripts/src/testing/test-mongo-env.ts sync -- packages/sync/src/domain/provider-command.service.db.test.ts`
- `bun packages/scripts/src/testing/test-parallel.ts web --` focused files above
- `bun run type-check`
- `bun run lint` (pre-merge)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-872e130f-f9ef-47fb-9d33-a8ace9d2f6e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-872e130f-f9ef-47fb-9d33-a8ace9d2f6e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

