### PR TITLE
fix(sync,web): surface exhausted jobs and skip draft compass hop

### DIFF
--- a/packages/core/src/types/sync/diagnostic.contracts.test.ts
+++ b/packages/core/src/types/sync/diagnostic.contracts.test.ts
@@ -18,6 +18,8 @@ const sample = (): DiagnosticConnectionResponse => ({
   disconnectedAt: null,
   calendarCount: 2,
   pendingJobCount: 1,
+  failedJobCount: 0,
+  exhaustedJobCount: 0,
   pendingCommandCount: 0,
 });
 

--- a/packages/core/src/types/sync/diagnostic.contracts.ts
+++ b/packages/core/src/types/sync/diagnostic.contracts.ts
@@ -31,7 +31,13 @@ export const DiagnosticConnectionResponseSchema = z.strictObject({
   lastHealthyAt: DateTimeSchema.nullable(),
   disconnectedAt: DateTimeSchema.nullable(),
   calendarCount: z.number().int().nonnegative(),
+  // pending + claimed only — active work still eligible to run.
   pendingJobCount: z.number().int().nonnegative(),
+  // All failed jobs for the connection (including permanent and exhausted).
+  failedJobCount: z.number().int().nonnegative(),
+  // Failed jobs that exhausted the self-heal requeue budget and need an
+  // operator (`bun run cli manage-failed-jobs …`).
+  exhaustedJobCount: z.number().int().nonnegative(),
   pendingCommandCount: z.number().int().nonnegative(),
 });
 export type DiagnosticConnectionResponse = z.infer<

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,4 +1,5 @@
 import { CliValidator } from "@scripts/cli.validator";
+import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeCorruptSyncEvents } from "@scripts/commands/purge-corrupt-sync-events";
 import { runPurgeUser } from "@scripts/commands/purge-user";
 import { runRefreshConnectionStates } from "@scripts/commands/refresh-connection-states";
@@ -24,6 +25,9 @@ export default class CompassCLI {
         break;
       case cmd === "refresh-connection-states":
         await runRefreshConnectionStates();
+        break;
+      case cmd === "manage-failed-jobs":
+        await runManageFailedJobs();
         break;
       case cmd === "purge-user":
         await runPurgeUser();
@@ -71,6 +75,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Re-derive every provider connection's stored state from live evidence (--apply to write)",
+      );
+
+    program
+      .command("manage-failed-jobs")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "List/clear/requeue Sync jobs that exhausted the self-heal budget (list | clear | requeue)",
       );
 
     return program;

--- a/packages/scripts/src/commands/manage-failed-jobs.ts
+++ b/packages/scripts/src/commands/manage-failed-jobs.ts
@@ -1,0 +1,150 @@
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import { SyncJobIdSchema } from "@core/types/sync/identity.contracts";
+import { FAILED_JOB_MAX_REQUEUES } from "@sync/domain/failed-job-requeue.service";
+import { JobRepository } from "@sync/storage/repositories/job.repository";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.manage-failed-jobs");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before manage-failed-jobs",
+    );
+  }
+  return uri;
+}
+
+function flagValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  return args[index + 1];
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
+}
+
+/**
+ * Operator tooling for Sync jobs that exhausted the self-heal requeue budget
+ * and still occupy a coalescing key. Default actions are dry-run; `--apply`
+ * persists.
+ *
+ *   bun run cli manage-failed-jobs list
+ *   bun run cli manage-failed-jobs clear --id <id> --coalescing-key <key> [--apply]
+ *   bun run cli manage-failed-jobs requeue --id <id> [--apply]
+ */
+export async function runManageFailedJobs(): Promise<void> {
+  const args = process.argv.slice(3);
+  const action = args[0];
+  if (action !== "list" && action !== "clear" && action !== "requeue") {
+    throw new Error(
+      "Usage: manage-failed-jobs <list|clear|requeue> [--id …] [--coalescing-key …] [--apply]",
+    );
+  }
+
+  const apply = hasFlag(args, "--apply");
+  const syncMongo = new SyncMongoService();
+  try {
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+    const jobs = new JobRepository(syncMongo.db);
+
+    if (action === "list") {
+      const exhausted = await jobs.listExhaustedFailed(FAILED_JOB_MAX_REQUEUES);
+      const report = {
+        maxRequeues: FAILED_JOB_MAX_REQUEUES,
+        count: exhausted.length,
+        jobs: exhausted.map((job) => ({
+          id: job.id,
+          coalescingKey: job.coalescingKey,
+          connectionId: job.connectionId,
+          failureClass: job.failureClass,
+          requeuedCount: job.requeuedCount,
+          updatedAt: job.updatedAt.toISOString(),
+        })),
+      };
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      logger.info(
+        `manage-failed-jobs list count=${report.count} maxRequeues=${FAILED_JOB_MAX_REQUEUES}`,
+      );
+      await syncMongo.disconnect();
+      process.exit(0);
+    }
+
+    const idRaw = flagValue(args, "--id");
+    if (!idRaw) {
+      throw new Error(`manage-failed-jobs ${action} requires --id <SyncJobId>`);
+    }
+    const id = SyncJobIdSchema.parse(idRaw);
+    const existing = await jobs.findByIdUnscoped(id);
+    if (!existing) {
+      throw new Error(`No job found for id=${id}`);
+    }
+
+    if (action === "clear") {
+      const coalescingKey =
+        flagValue(args, "--coalescing-key") ?? existing.coalescingKey;
+      if (coalescingKey !== existing.coalescingKey) {
+        throw new Error(
+          `coalescing-key mismatch for id=${id}: expected ${existing.coalescingKey}`,
+        );
+      }
+      const report = {
+        dryRun: !apply,
+        action: "clear",
+        id,
+        coalescingKey,
+        state: existing.state,
+      };
+      if (apply) {
+        await jobs.remove(id, coalescingKey);
+      }
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+      logger.info(
+        `manage-failed-jobs clear dryRun=${report.dryRun} id=${id} key=${coalescingKey}`,
+      );
+      await syncMongo.disconnect();
+      process.exit(0);
+    }
+
+    // requeue
+    if (existing.state !== "failed") {
+      throw new Error(
+        `Job id=${id} is state=${existing.state}; requeue only accepts failed jobs`,
+      );
+    }
+    const report = {
+      dryRun: !apply,
+      action: "requeue",
+      id,
+      coalescingKey: existing.coalescingKey,
+      requeuedCount: existing.requeuedCount,
+    };
+    if (apply) {
+      const ok = await jobs.requeue(id, new Date());
+      if (!ok) {
+        throw new Error(`Failed to requeue id=${id}`);
+      }
+    }
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(`manage-failed-jobs requeue dryRun=${report.dryRun} id=${id}`);
+    await syncMongo.disconnect();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/manage-failed-jobs.ts
+++ b/packages/scripts/src/commands/manage-failed-jobs.ts
@@ -25,10 +25,6 @@ function flagValue(args: string[], name: string): string | undefined {
   return args[index + 1];
 }
 
-function hasFlag(args: string[], name: string): boolean {
-  return args.includes(name);
-}
-
 /**
  * Operator tooling for Sync jobs that exhausted the self-heal requeue budget
  * and still occupy a coalescing key. Default actions are dry-run; `--apply`
@@ -47,7 +43,7 @@ export async function runManageFailedJobs(): Promise<void> {
     );
   }
 
-  const apply = hasFlag(args, "--apply");
+  const apply = args.includes("--apply");
   const syncMongo = new SyncMongoService();
   try {
     await syncMongo.connect({
@@ -58,11 +54,16 @@ export async function runManageFailedJobs(): Promise<void> {
     const jobs = new JobRepository(syncMongo.db);
 
     if (action === "list") {
-      const exhausted = await jobs.listExhaustedFailed(FAILED_JOB_MAX_REQUEUES);
+      const [count, sample] = await Promise.all([
+        jobs.countExhaustedFailed(FAILED_JOB_MAX_REQUEUES),
+        jobs.listExhaustedFailed(FAILED_JOB_MAX_REQUEUES),
+      ]);
       const report = {
         maxRequeues: FAILED_JOB_MAX_REQUEUES,
-        count: exhausted.length,
-        jobs: exhausted.map((job) => ({
+        count,
+        sampleSize: sample.length,
+        truncated: count > sample.length,
+        jobs: sample.map((job) => ({
           id: job.id,
           coalescingKey: job.coalescingKey,
           connectionId: job.connectionId,
@@ -73,7 +74,7 @@ export async function runManageFailedJobs(): Promise<void> {
       };
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
       logger.info(
-        `manage-failed-jobs list count=${report.count} maxRequeues=${FAILED_JOB_MAX_REQUEUES}`,
+        `manage-failed-jobs list count=${report.count} sample=${report.sampleSize} truncated=${report.truncated}`,
       );
       await syncMongo.disconnect();
       process.exit(0);
@@ -88,6 +89,11 @@ export async function runManageFailedJobs(): Promise<void> {
     if (!existing) {
       throw new Error(`No job found for id=${id}`);
     }
+    if (existing.state !== "failed") {
+      throw new Error(
+        `Job id=${id} is state=${existing.state}; ${action} only accepts failed jobs`,
+      );
+    }
 
     if (action === "clear") {
       const coalescingKey =
@@ -99,13 +105,16 @@ export async function runManageFailedJobs(): Promise<void> {
       }
       const report = {
         dryRun: !apply,
-        action: "clear",
+        action: "clear" as const,
         id,
         coalescingKey,
         state: existing.state,
       };
       if (apply) {
-        await jobs.remove(id, coalescingKey);
+        const ok = await jobs.remove(id, coalescingKey);
+        if (!ok) {
+          throw new Error(`Failed to clear id=${id} key=${coalescingKey}`);
+        }
       }
       process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
       logger.info(
@@ -115,15 +124,9 @@ export async function runManageFailedJobs(): Promise<void> {
       process.exit(0);
     }
 
-    // requeue
-    if (existing.state !== "failed") {
-      throw new Error(
-        `Job id=${id} is state=${existing.state}; requeue only accepts failed jobs`,
-      );
-    }
     const report = {
       dryRun: !apply,
-      action: "requeue",
+      action: "requeue" as const,
       id,
       coalescingKey: existing.coalescingKey,
       requeuedCount: existing.requeuedCount,

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -9,7 +9,10 @@ import {
   CONNECTION_CACHE_RETENTION_MS,
   purgeExpiredDisconnectedConnections,
 } from "@sync/domain/connection-retention.service";
-import { requeueFailedJobs } from "@sync/domain/failed-job-requeue.service";
+import {
+  FAILED_JOB_MAX_REQUEUES,
+  requeueFailedJobs,
+} from "@sync/domain/failed-job-requeue.service";
 import { reconcileStaleCalendars } from "@sync/domain/reconcile.service";
 import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
 import { maintainExpiringSubscriptions } from "@sync/domain/subscription-sweep.service";
@@ -262,9 +265,6 @@ async function start(): Promise<void> {
 // at least this long — long enough that a real provider outage has had a
 // chance to clear before we burn another retry ladder on it.
 const FAILED_JOB_REQUEUE_COOLDOWN_MS = 30 * 60_000;
-// How many times the self-heal sweep will requeue the same job before
-// leaving it failed for an operator instead.
-const FAILED_JOB_MAX_REQUEUES = 3;
 // A resource not synced within this window is swept for a reconcile pull.
 const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
 // A cloud command left nonterminal past this long since its last update is
@@ -467,6 +467,16 @@ function buildSchedulers(
         if (result.exhausted > 0) {
           logger.error(
             `Sync self-heal sweep: ${result.exhausted} failed job(s) exhausted their requeue budget and need operator attention`,
+            {
+              exhaustedJobs: result.exhaustedJobs.map((job) => ({
+                id: job.id,
+                coalescingKey: job.coalescingKey,
+                connectionId: job.connectionId,
+                failureClass: job.failureClass,
+                requeuedCount: job.requeuedCount,
+                updatedAt: job.updatedAt.toISOString(),
+              })),
+            },
           );
         }
         return result.requeued;

--- a/packages/sync/src/domain/connection-diagnostic.service.ts
+++ b/packages/sync/src/domain/connection-diagnostic.service.ts
@@ -2,6 +2,7 @@ import {
   type DiagnosticConnectionResponse,
   DiagnosticConnectionResponseSchema,
 } from "@core/types/sync/diagnostic.contracts";
+import { FAILED_JOB_MAX_REQUEUES } from "@sync/domain/failed-job-requeue.service";
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
 import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
@@ -19,6 +20,7 @@ export interface ConnectionDiagnosticDeps {
 export async function resolveDiagnosticConnection(
   deps: ConnectionDiagnosticDeps,
   diagnosticKey: string,
+  maxRequeues: number = FAILED_JOB_MAX_REQUEUES,
 ): Promise<DiagnosticConnectionResponse | null> {
   const connection = await deps.connections.findByDiagnosticKey(diagnosticKey);
   if (!connection) return null;
@@ -28,11 +30,27 @@ export async function resolveDiagnosticConnection(
     connection.principalId,
     connection._id,
   );
-  const [pendingJobCount, pendingCommandCount] = await Promise.all([
+  const [
+    pendingJobCount,
+    failedJobCount,
+    exhaustedJobCount,
+    pendingCommandCount,
+  ] = await Promise.all([
     deps.jobs.countOutstandingByConnection(
       connection.tenantId,
       connection.principalId,
       connection._id,
+    ),
+    deps.jobs.countFailedByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+    ),
+    deps.jobs.countExhaustedFailedByConnection(
+      connection.tenantId,
+      connection.principalId,
+      connection._id,
+      maxRequeues,
     ),
     deps.commands.countNonterminalByConnection(
       connection.tenantId,
@@ -56,6 +74,8 @@ export async function resolveDiagnosticConnection(
     disconnectedAt: connection.disconnectedAt?.toISOString() ?? null,
     calendarCount: calendars.length,
     pendingJobCount,
+    failedJobCount,
+    exhaustedJobCount,
     pendingCommandCount,
   });
 }

--- a/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
+++ b/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
@@ -49,7 +49,7 @@ describe("requeueFailedJobs", () => {
 
     const result = await requeueFailedJobs(deps(), cooldownBefore, now, 3);
 
-    expect(result).toEqual({ requeued: 1, exhausted: 0 });
+    expect(result).toEqual({ requeued: 1, exhausted: 0, exhaustedJobs: [] });
     const raw = await storage
       .db()
       .collection("jobs")
@@ -64,7 +64,7 @@ describe("requeueFailedJobs", () => {
 
     const result = await requeueFailedJobs(deps(), cooldownBefore, now, 3);
 
-    expect(result).toEqual({ requeued: 0, exhausted: 0 });
+    expect(result).toEqual({ requeued: 0, exhausted: 0, exhaustedJobs: [] });
   });
 
   it("stops requeuing once a job hits the cap and reports it as exhausted", async () => {
@@ -84,13 +84,22 @@ describe("requeueFailedJobs", () => {
 
     const result = await requeueFailedJobs(deps(), cooldownBefore, now, 2);
 
-    expect(result).toEqual({ requeued: 0, exhausted: 1 });
+    expect(result.requeued).toBe(0);
+    expect(result.exhausted).toBe(1);
+    expect(result.exhaustedJobs).toEqual([
+      expect.objectContaining({
+        id,
+        failureClass: "retryableTransient",
+        requeuedCount: 2,
+      }),
+    ]);
   });
 
   it("does nothing when there are no failed jobs", async () => {
     expect(await requeueFailedJobs(deps(), cooldownBefore, now, 3)).toEqual({
       requeued: 0,
       exhausted: 0,
+      exhaustedJobs: [],
     });
   });
 });

--- a/packages/sync/src/domain/failed-job-requeue.service.ts
+++ b/packages/sync/src/domain/failed-job-requeue.service.ts
@@ -1,4 +1,12 @@
-import { type JobRepository } from "@sync/storage/repositories/job.repository";
+import {
+  type ExhaustedFailedJob,
+  type JobRepository,
+} from "@sync/storage/repositories/job.repository";
+
+// How many times the self-heal sweep will requeue the same job before leaving
+// it failed for an operator instead. Shared with diagnostics so exhausted
+// counts use the same budget the sweep enforces.
+export const FAILED_JOB_MAX_REQUEUES = 3;
 
 export interface FailedJobRequeueDeps {
   jobs: JobRepository;
@@ -10,6 +18,8 @@ export interface FailedJobRequeueResult {
   // How many failed jobs have hit the requeue cap and re-failed anyway — the
   // sweep will not touch them again; they need an operator.
   exhausted: number;
+  // Bounded sample of exhausted rows for operator-facing logs / CLI.
+  exhaustedJobs: ExhaustedFailedJob[];
 }
 
 // The self-heal sweep for jobs terminalized as state:"failed". A worker marks
@@ -34,7 +44,7 @@ export async function requeueFailedJobs(
   deps: FailedJobRequeueDeps,
   before: Date,
   now: () => Date,
-  maxRequeues: number,
+  maxRequeues: number = FAILED_JOB_MAX_REQUEUES,
   limit = 100,
 ): Promise<FailedJobRequeueResult> {
   const candidates = await deps.jobs.listFailedForRequeue(
@@ -45,6 +55,13 @@ export async function requeueFailedJobs(
   for (const job of candidates) {
     await deps.jobs.requeue(job._id, now());
   }
-  const exhausted = await deps.jobs.countExhaustedFailed(maxRequeues);
-  return { requeued: candidates.length, exhausted };
+  const [exhausted, exhaustedJobs] = await Promise.all([
+    deps.jobs.countExhaustedFailed(maxRequeues),
+    deps.jobs.listExhaustedFailed(maxRequeues),
+  ]);
+  return {
+    requeued: candidates.length,
+    exhausted,
+    exhaustedJobs,
+  };
 }

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -310,6 +310,56 @@ describe("JobRepository", () => {
       );
       expect(underCap).toHaveLength(0);
       expect(await repo.countExhaustedFailed(2)).toBe(1);
+      expect(await repo.listExhaustedFailed(2)).toEqual([
+        expect.objectContaining({
+          id,
+          failureClass: "retryableTransient",
+          requeuedCount: 2,
+        }),
+      ]);
+    });
+
+    it("counts failed and exhausted jobs per connection", async () => {
+      const connectionId = objectId() as JobEnqueue["connectionId"];
+      const tenantId = objectId() as JobEnqueue["tenantId"];
+      const principalId = objectId() as JobEnqueue["principalId"];
+      const id = await seedFailed({
+        tenantId,
+        principalId,
+        connectionId,
+        runAfter: past(60 * 60_000),
+        coalescingKey: `pull:${objectId()}`,
+      });
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        await repo.requeue(id, past(50 * 60_000));
+        const reclaimed = await repo.claimDueJob("worker", NOW, 60_000);
+        await repo.fail(reclaimed!._id, "worker", "retryableTransient");
+      }
+      // A second failed job under the same connection, still under the cap.
+      await seedFailed({
+        tenantId,
+        principalId,
+        connectionId,
+        runAfter: past(60 * 60_000),
+        coalescingKey: `pull:${objectId()}`,
+      });
+
+      expect(
+        await repo.countFailedByConnection(tenantId, principalId, connectionId),
+      ).toBe(2);
+      expect(
+        await repo.countExhaustedFailedByConnection(
+          tenantId,
+          principalId,
+          connectionId,
+          2,
+        ),
+      ).toBe(1);
+      expect(await repo.findByIdUnscoped(id)).toMatchObject({
+        _id: id,
+        state: "failed",
+        requeuedCount: 2,
+      });
     });
 
     it("excludes a permanently classed failure from requeue and exhaustion", async () => {

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -22,6 +22,14 @@ export type ExhaustedFailedJob = {
   updatedAt: Date;
 };
 
+function exhaustedFailedFilter(maxRequeues: number) {
+  return {
+    state: "failed" as const,
+    failureClass: { $ne: "permanent" as const },
+    requeuedCount: { $gte: maxRequeues },
+  };
+}
+
 // Repository for `jobs`. Enqueue coalesces on a unique key so repeated
 // notifications for the same resource collapse into one pending job instead of
 // an unbounded queue. Terminal jobs are removed so a later notification can
@@ -283,11 +291,7 @@ export class JobRepository {
   // the sweep will not touch them again; an operator must. Used to drive a
   // loud, recurring alert rather than a silent terminal state.
   async countExhaustedFailed(maxRequeues: number): Promise<number> {
-    return this.collection.countDocuments({
-      state: "failed",
-      failureClass: { $ne: "permanent" },
-      requeuedCount: { $gte: maxRequeues },
-    });
+    return this.collection.countDocuments(exhaustedFailedFilter(maxRequeues));
   }
 
   // Same filter as countExhaustedFailed, returning the rows an operator needs
@@ -297,11 +301,7 @@ export class JobRepository {
     limit = 50,
   ): Promise<ExhaustedFailedJob[]> {
     const rows = await this.collection
-      .find({
-        state: "failed",
-        failureClass: { $ne: "permanent" },
-        requeuedCount: { $gte: maxRequeues },
-      })
+      .find(exhaustedFailedFilter(maxRequeues))
       .sort({ updatedAt: 1 })
       .limit(limit)
       .project({
@@ -315,7 +315,7 @@ export class JobRepository {
       .toArray();
 
     return rows.map((row) => ({
-      id: row._id as SyncJobId,
+      id: row["_id"] as SyncJobId,
       coalescingKey: String(row["coalescingKey"]),
       connectionId: row["connectionId"] as ConnectionId,
       failureClass: (row["failureClass"] ?? "retryableTransient") as Exclude<
@@ -351,9 +351,7 @@ export class JobRepository {
       tenantId,
       principalId,
       connectionId,
-      state: "failed",
-      failureClass: { $ne: "permanent" },
-      requeuedCount: { $gte: maxRequeues },
+      ...exhaustedFailedFilter(maxRequeues),
     });
   }
 

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -13,6 +13,15 @@ import {
   JobRecordSchema,
 } from "@sync/storage/contracts/job.contracts";
 
+export type ExhaustedFailedJob = {
+  id: SyncJobId;
+  coalescingKey: string;
+  connectionId: ConnectionId;
+  failureClass: Exclude<JobRecord["failureClass"], null>;
+  requeuedCount: number;
+  updatedAt: Date;
+};
+
 // Repository for `jobs`. Enqueue coalesces on a unique key so repeated
 // notifications for the same resource collapse into one pending job instead of
 // an unbounded queue. Terminal jobs are removed so a later notification can
@@ -279,6 +288,80 @@ export class JobRepository {
       failureClass: { $ne: "permanent" },
       requeuedCount: { $gte: maxRequeues },
     });
+  }
+
+  // Same filter as countExhaustedFailed, returning the rows an operator needs
+  // to clear or requeue (bounded so the sweep log stays readable).
+  async listExhaustedFailed(
+    maxRequeues: number,
+    limit = 50,
+  ): Promise<ExhaustedFailedJob[]> {
+    const rows = await this.collection
+      .find({
+        state: "failed",
+        failureClass: { $ne: "permanent" },
+        requeuedCount: { $gte: maxRequeues },
+      })
+      .sort({ updatedAt: 1 })
+      .limit(limit)
+      .project({
+        _id: 1,
+        coalescingKey: 1,
+        connectionId: 1,
+        failureClass: 1,
+        requeuedCount: 1,
+        updatedAt: 1,
+      })
+      .toArray();
+
+    return rows.map((row) => ({
+      id: row._id as SyncJobId,
+      coalescingKey: String(row["coalescingKey"]),
+      connectionId: row["connectionId"] as ConnectionId,
+      failureClass: (row["failureClass"] ?? "retryableTransient") as Exclude<
+        JobRecord["failureClass"],
+        null
+      >,
+      requeuedCount: Number(row["requeuedCount"] ?? 0),
+      updatedAt:
+        row["updatedAt"] instanceof Date ? row["updatedAt"] : new Date(0),
+    }));
+  }
+
+  async countFailedByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<number> {
+    return this.collection.countDocuments({
+      tenantId,
+      principalId,
+      connectionId,
+      state: "failed",
+    });
+  }
+
+  async countExhaustedFailedByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+    maxRequeues: number,
+  ): Promise<number> {
+    return this.collection.countDocuments({
+      tenantId,
+      principalId,
+      connectionId,
+      state: "failed",
+      failureClass: { $ne: "permanent" },
+      requeuedCount: { $gte: maxRequeues },
+    });
+  }
+
+  // Operator tooling only — looks up by id without tenant/principal scope.
+  // Prefer findById(tenantId, principalId, id) for request-path reads.
+  async findByIdUnscoped(id: SyncJobId): Promise<JobRecord | null> {
+    const row = await this.collection.findOne({ _id: id });
+    return row ? JobRecordSchema.parse(row) : null;
   }
 
   // The oldest piece of overdue work for one connection, if any: a pending

--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -3,6 +3,7 @@ import {
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { type Event } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
@@ -134,17 +135,33 @@ test("duplicate defaults to the source event's calendar when it's still writable
   });
 });
 
-test("projects a grid draft into a grid event", () => {
-  const draft = createGridEventDraft({
+test("projects a grid draft into a grid event without a CompassEvent bridge", () => {
+  const allDay = createGridEventDraft({
     kind: "allDay",
     start: new Date("2026-05-20"),
     end: new Date("2026-05-21"),
   });
-  const gridEvent = gridEventDraftToGridEvent(draft);
+  allDay.values.title = "All day";
+  allDay.values.calendarId = timedEvent.calendarId;
+  const allDayGrid = gridEventDraftToGridEvent(allDay);
 
-  expect(gridEvent.startDate).toBe("2026-05-20");
-  expect(gridEvent.endDate).toBe("2026-05-21");
-  expect(gridEvent.isAllDay).toBe(true);
+  expect(allDayGrid.startDate).toBe("2026-05-20");
+  expect(allDayGrid.endDate).toBe("2026-05-21");
+  expect(allDayGrid.isAllDay).toBe(true);
+  expect(allDayGrid.title).toBe("All day");
+  expect(allDayGrid.calendarId).toBe(timedEvent.calendarId);
+  expect(allDayGrid.origin).toBe("compass");
+
+  const timed = editGridEventDraft(timedEvent);
+  if (!timed) throw new Error("Expected timed edit draft");
+  timed.values.color = "tomato";
+  const timedGrid = gridEventDraftToGridEvent(timed);
+
+  expect(timedGrid.isAllDay).toBe(false);
+  expect(timedGrid.startDate).toBe(dayjs(timed.values.schedule.start).format());
+  expect(timedGrid.endDate).toBe(dayjs(timed.values.schedule.end).format());
+  expect(timedGrid.color).toBe("tomato");
+  expect(timedGrid.isBusy).toBe(false);
 });
 
 test("duplicate falls back to no calendar (later defaulted) when the source calendar is read-only", () => {

--- a/packages/web/src/events/grid-event-draft.adapter.test.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.test.ts
@@ -1,3 +1,4 @@
+import { Origin } from "@core/constants/core.constants";
 import {
   type Calendar,
   getCalendarCapabilities,
@@ -150,17 +151,17 @@ test("projects a grid draft into a grid event without a CompassEvent bridge", ()
   expect(allDayGrid.isAllDay).toBe(true);
   expect(allDayGrid.title).toBe("All day");
   expect(allDayGrid.calendarId).toBe(timedEvent.calendarId);
-  expect(allDayGrid.origin).toBe("compass");
+  expect(allDayGrid.origin).toBe(Origin.COMPASS);
 
   const timed = editGridEventDraft(timedEvent);
   if (!timed) throw new Error("Expected timed edit draft");
-  timed.values.color = "tomato";
+  timed.values.color = "coral";
   const timedGrid = gridEventDraftToGridEvent(timed);
 
   expect(timedGrid.isAllDay).toBe(false);
   expect(timedGrid.startDate).toBe(dayjs(timed.values.schedule.start).format());
   expect(timedGrid.endDate).toBe(dayjs(timed.values.schedule.end).format());
-  expect(timedGrid.color).toBe("tomato");
+  expect(timedGrid.color).toBe("coral");
   expect(timedGrid.isBusy).toBe(false);
 });
 

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -1,4 +1,5 @@
 import fastDeepEqual from "fast-deep-equal/react";
+import { Origin } from "@core/constants/core.constants";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type CalendarId, type EventId } from "@core/types/domain-primitives";
@@ -11,7 +12,7 @@ import { type RecurrenceScope } from "@core/types/event-command.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
-import { assembleGridEvent } from "@web/common/utils/event/event.util";
+import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
   type ParseEventDraftResult,
   parseEventDraft,
@@ -261,13 +262,35 @@ export function getGridDraftId(draft: GridEventDraft): string | undefined {
   return draft.kind === "edit" ? draft.source.id : draft.clientId;
 }
 
+/**
+ * Direct GridEventDraft → GridEvent for the draft render hot path.
+ * Avoids the CompassEvent bridge (`gridEventDraftToSchemaEvent`); overlays /
+ * Day placeholders that still need CompassEvent keep that helper separately.
+ */
 export function gridEventDraftToGridEvent(draft: GridEventDraft): GridEvent {
-  const schemaEvent = gridEventDraftToSchemaEvent(draft);
-  return assembleGridEvent({
-    ...schemaEvent,
-    startDate: schemaEvent.startDate!,
-    endDate: schemaEvent.endDate!,
-  });
+  const { schedule } = draft.values;
+  const color = draft.values.color ?? undefined;
+  const isAllDay = schedule.kind === "allDay";
+
+  return {
+    _id: getGridDraftId(draft)!,
+    title: draft.values.title,
+    description: draft.values.description,
+    origin: Origin.COMPASS,
+    user: "",
+    isAllDay,
+    startDate: isAllDay
+      ? toDateOnlyString(schedule.start)
+      : dayjs(schedule.start).format(),
+    endDate: isAllDay
+      ? toDateOnlyString(schedule.end)
+      : dayjs(schedule.end).format(),
+    recurrence: legacyRecurrenceFromDraft(draft),
+    position: gridEventDefaultPosition,
+    calendarId: draft.values.calendarId ?? undefined,
+    isBusy: draft.kind === "edit" && draft.source.content.kind === "busy",
+    ...withColor(color),
+  };
 }
 
 // Converts a grid draft to the CompassEvent-shaped view used by schema

--- a/packages/web/src/views/Week/components/Draft/Draft.tsx
+++ b/packages/web/src/views/Week/components/Draft/Draft.tsx
@@ -1,10 +1,8 @@
 import { type FC, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { Origin } from "@core/constants/core.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getDraftContainer } from "@web/common/utils/draft/draft.util";
-import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
-import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
+import { gridEventDraftToGridEvent } from "@web/events/grid-event-draft.adapter";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import { positionAllDayDraftEvent } from "@web/grid/layout/all-day-draft.position";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
@@ -32,22 +30,10 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   const { state } = useDraftContext();
   const { draft } = state;
 
-  // GridEvent-shaped projection of the canonical GridEventDraft, for
-  // the still-unconverted grid-layout helpers below (deck layout, all-day
-  // positioning, recurrence previews) — see grid-event-draft.adapter.ts's
-  // gridEventDraftToSchemaEvent doc comment. `position` is a placeholder
-  // default: these helpers never read it, only startDate/endDate/isAllDay/
-  // recurrence/_id.
-  const draftSchemaEvent: GridEvent | null = useMemo(
-    () =>
-      draft
-        ? ({
-            ...gridEventDraftToSchemaEvent(draft),
-            origin: Origin.COMPASS,
-            user: "",
-            position: gridEventDefaultPosition,
-          } as GridEvent)
-        : null,
+  // Direct GridEventDraft → GridEvent for deck layout / recurrence previews.
+  // Cards still consume GridEvent; this skips the CompassEvent bridge.
+  const draftGridEvent: GridEvent | null = useMemo(
+    () => (draft ? gridEventDraftToGridEvent(draft) : null),
     [draft],
   );
   const activeAllDayDraftEvent = useMemo(
@@ -60,21 +46,21 @@ export const Draft: FC<Props> = ({ measurements, weekProps }) => {
   );
   const deckLayout = useMemo(
     () =>
-      getActiveTimedDraftDeckLayout(draftSchemaEvent, [
+      getActiveTimedDraftDeckLayout(draftGridEvent, [
         ...timedEvents,
         ...allDayEvents,
       ]),
-    [allDayEvents, draftSchemaEvent, timedEvents],
+    [allDayEvents, draftGridEvent, timedEvents],
   );
   const recurringPreviews = useMemo(
     () =>
       getRecurringDraftPreviews(
-        draftSchemaEvent,
+        draftGridEvent,
         weekProps.component.startOfView,
         weekProps.component.endOfView,
       ),
     [
-      draftSchemaEvent,
+      draftGridEvent,
       weekProps.component.startOfView,
       weekProps.component.endOfView,
     ],

--- a/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
+++ b/packages/web/src/views/Week/components/Draft/grid/GridDraft.tsx
@@ -1,6 +1,4 @@
 import { type FC, type MouseEvent } from "react";
-import { Origin } from "@core/constants/core.constants";
-import { type CompassEvent } from "@core/types/compass-event.contracts";
 import { type PartialMouseEvent } from "@web/common/types/util.types";
 import { type GridEvent as GridEventEntity } from "@web/common/types/web.event.types";
 import {
@@ -8,7 +6,7 @@ import {
   gridEventDefaultPosition,
 } from "@web/common/utils/event/event.util";
 import { focusEventFormTitle } from "@web/common/utils/form/form.util";
-import { gridEventDraftToSchemaEvent } from "@web/events/grid-event-draft.adapter";
+import { gridEventDraftToGridEvent } from "@web/events/grid-event-draft.adapter";
 import {
   selectDraftActivity,
   useDraftStore,
@@ -49,20 +47,13 @@ export const GridDraft: FC<Props> = ({
   // the draft. It just isn't a local resize, so `isResizing` stays false.
   const isCreating = useDraftStore(selectDraftActivity) === "creating";
 
-  // GridEvent-shaped projection of the canonical GridEventDraft, for
-  // the still-unconverted renderer components (GridEvent/AllDayEventMemo)
-  // and the forms cluster (EventForm/RecurrenceSection) — see
-  // grid-event-draft.adapter.ts's gridEventDraftToSchemaEvent doc comment.
-  const draftSchemaEvent: CompassEvent | null = draft
-    ? gridEventDraftToSchemaEvent(draft)
-    : null;
-  const draftAsGridEvent: GridEventEntity | null = draftSchemaEvent
-    ? ({
-        ...draftSchemaEvent,
-        origin: draftSchemaEvent.origin ?? Origin.COMPASS,
-        user: draftSchemaEvent.user ?? "",
+  // Direct GridEventDraft → GridEvent for card renderers; live dragOffset is
+  // applied onto the default position without a CompassEvent hop.
+  const draftAsGridEvent: GridEventEntity | null = draft
+    ? {
+        ...gridEventDraftToGridEvent(draft),
         position: { ...gridEventDefaultPosition, dragOffset },
-      } as GridEventEntity)
+      }
     : null;
 
   const handleDrag = (_: GridEventEntity, moveEvent: PartialMouseEvent) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surfaces Sync jobs that exhausted the self-heal requeue budget so operators can find and clear/requeue wedged work, and removes the unnecessary CompassEvent hop on the Week draft render path.

- Diagnostics include `failedJobCount` / `exhaustedJobCount`
- Self-heal sweep logs a bounded sample of exhausted job ids/keys
- New CLI: `bun run cli manage-failed-jobs list|clear|requeue`
- Week `Draft` / `GridDraft` project `GridEventDraft → GridEvent` directly

## Simplicity

Shared the exhausted-job Mongo filter between count/list helpers. CLI `list` reports true count + truncation rather than treating the sample length as the total. No new React state/effects.

## Automated validation

- Focused sync DB tests for job repository + failed-job requeue (pass)
- Diagnostic contracts + diagnostic routes DB tests (pass)
- Web: grid-event-draft adapter + GridDraft tests (pass)
- `bun run type-check` and `bun run lint` (pass)

## Independent review

Fresh diff review confirmed three CLI issues; all fixed before merge:
1. `list` under-reported when sample capped — now uses `countExhaustedFailed` + `truncated`
2. `clear` could delete non-failed jobs — now requires `state === "failed"`
3. `clear --apply` ignored `remove()` failure — now throws on false

No confirmed defects on the draft → GridEvent projection path.

## Test plan

- `bun packages/scripts/src/testing/test-mongo-env.ts sync -- packages/sync/src/storage/repositories/job.repository.db.test.ts packages/sync/src/domain/failed-job-requeue.service.db.test.ts packages/sync/src/server/diagnostic.routes.db.test.ts`
- `bun test packages/core/src/types/sync/diagnostic.contracts.test.ts`
- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/events/grid-event-draft.adapter.test.ts packages/web/src/views/Week/components/Draft/grid/GridDraft.test.tsx packages/web/src/grid/layout/all-day-draft.position.test.ts`
- `bun run type-check`
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-872e130f-f9ef-47fb-9d33-a8ace9d2f6e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-872e130f-f9ef-47fb-9d33-a8ace9d2f6e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

