### PR TITLE
refactor(web,sync): simplify runtime lifecycle ownership

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -230,21 +230,17 @@ async function start(): Promise<void> {
         // Stop every drain; each releases only its own owner's held jobs.
         await Promise.all(schedulers.drains.map((drain) => drain.stop()));
       });
-      service.shutdown.register("reconcile", () => schedulers.reconcile.stop());
-      service.shutdown.register("subscription", () =>
-        schedulers.subscription.stop(),
-      );
-      service.shutdown.register("failedJobRequeue", () =>
-        schedulers.failedJobRequeue.stop(),
-      );
-      service.shutdown.register("staleCommandRetry", () =>
-        schedulers.staleCommandRetry.stop(),
-      );
+      const sweeps = [
+        ["reconcile", schedulers.reconcile],
+        ["subscription", schedulers.subscription],
+        ["failedJobRequeue", schedulers.failedJobRequeue],
+        ["staleCommandRetry", schedulers.staleCommandRetry],
+      ] as const;
+      for (const [name, sweep] of sweeps) {
+        service.shutdown.register(name, () => sweep.stop());
+      }
       for (const drain of schedulers.drains) drain.start();
-      schedulers.reconcile.start();
-      schedulers.subscription.start();
-      schedulers.failedJobRequeue.start();
-      schedulers.staleCommandRetry.start();
+      for (const [, sweep] of sweeps) sweep.start();
       logger.info(
         "Sync scheduler draining, reconciling, renewing channels, retaining, retrying stale commands, and reporting health",
       );

--- a/packages/web/src/__tests__/web.test.init.ts
+++ b/packages/web/src/__tests__/web.test.init.ts
@@ -1,6 +1,2 @@
 process.env.API_BASEURL = "http://localhost:3000/api";
 process.env.GOOGLE_CLIENT_ID = "mockedClientId";
-// Distinct from NODE_ENV=test, which the e2e webServer also sets (see
-// routers/loaders.ts) — this marks specifically a `bun test` process, so
-// posthog-react.ts can skip loading the real SDK only here.
-process.env.BUN_TEST_RUN = "true";

--- a/packages/web/src/auth/posthog/posthog-react.ts
+++ b/packages/web/src/auth/posthog/posthog-react.ts
@@ -1,21 +1,17 @@
-import { createElement, Fragment, type PropsWithChildren } from "react";
+import { type PostHog } from "posthog-js";
+import {
+  createContext,
+  createElement,
+  type PropsWithChildren,
+  useContext,
+} from "react";
 
-// posthog-js/react performs real network I/O as a load-time side effect of
-// being required, independent of whether <PostHogProvider> ever renders (the
-// app already gates rendering on isPosthogEnabled()). In a `bun test`
-// process that XHR can fire asynchronously after the importing test
-// finishes, landing inside SuperTokens' XMLHttpRequest interceptor mid-way
-// through an unrelated later file and crashing it. Skip the real SDK there.
-const posthogReact = process.env.BUN_TEST_RUN
-  ? ({
-      PostHogProvider: ({ children }: PropsWithChildren) =>
-        createElement(Fragment, null, children),
-      // The real usePostHog is typed as always returning PostHog (it isn't,
-      // context can default to undefined), so match that declared shape here
-      // rather than infer a wider, more "honest" union.
-      usePostHog: () => undefined,
-    } as unknown as typeof import("posthog-js/react"))
-  : (require("posthog-js/react") as typeof import("posthog-js/react"));
+const PostHogContext = createContext<PostHog | undefined>(undefined);
 
-export const PostHogProvider = posthogReact.PostHogProvider;
-export const usePostHog = posthogReact.usePostHog;
+export const PostHogProvider = ({
+  children,
+  client,
+}: PropsWithChildren<{ client: PostHog }>) =>
+  createElement(PostHogContext.Provider, { value: client }, children);
+
+export const usePostHog = () => useContext(PostHogContext);

--- a/packages/web/src/auth/posthog/posthog.bootstrap.ts
+++ b/packages/web/src/auth/posthog/posthog.bootstrap.ts
@@ -12,11 +12,10 @@ let client: PostHog | undefined;
  * `capture_unhandled_errors`/`capture_unhandled_rejections` handlers are
  * installed before IndexedDB and `sessionInit()` are awaited. A throw during
  * boot - the exact shape that left session 019fb57e blank with zero telemetry -
- * is then captured instead of vanishing. Idempotent: the React provider calls
- * it again during render and gets the same already-initialized instance back.
+ * is then captured instead of vanishing. The React provider reads this client
+ * after boot rather than owning a second initialization path.
  */
 export function initPosthog(): PostHog | undefined {
-  if (process.env.BUN_TEST_RUN) return undefined;
   if (!isPosthogEnabled()) return undefined;
   if (client) return client;
 

--- a/packages/web/src/auth/posthog/useIdentifyUser.ts
+++ b/packages/web/src/auth/posthog/useIdentifyUser.ts
@@ -1,5 +1,5 @@
-import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
+import { usePostHog } from "@web/auth/posthog/posthog-react";
 
 /**
  * Identifies the user in PostHog when `userId` and profile email are available.

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -1,15 +1,14 @@
-// biome-ignore-all assist/source/organizeImports: PostHog must load before SuperTokens patches XMLHttpRequest in tests.
-import { PostHogProvider } from "@web/auth/posthog/posthog-react";
-import { type PropsWithChildren } from "react";
-import { Slide, ToastContainer } from "react-toastify";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
-import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { SessionProvider } from "@web/auth/compass/session/SessionProvider";
-import { initPosthog } from "@web/auth/posthog/posthog.bootstrap";
-import { ENV_WEB } from "@web/common/constants/env.constants";
+import { type PropsWithChildren } from "react";
+import { Slide, ToastContainer } from "react-toastify";
 import { queryClient as defaultQueryClient } from "@web/api/query-client";
+import { SessionProvider } from "@web/auth/compass/session/SessionProvider";
+import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
+import { PostHogProvider } from "@web/auth/posthog/posthog-react";
+import { ENV_WEB } from "@web/common/constants/env.constants";
 import { DeleteAccountConfirmationProvider } from "@web/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider";
 import { FeedbackDialogHost } from "@web/components/Feedback/FeedbackDialogHost";
 import { IconProvider } from "@web/components/IconProvider/IconProvider";
@@ -77,11 +76,7 @@ export const CompassRequiredProviders = ({
 );
 
 export const CompassOptionalProviders = ({ children }: PropsWithChildren) => {
-  // PostHog is initialized once outside the React tree (see index.tsx) so its
-  // exception handlers cover boot before this ever mounts. initPosthog() is
-  // idempotent: here it just hands back that already-initialized instance (or
-  // undefined when PostHog is disabled, e.g. in tests).
-  const posthogClient = initPosthog();
+  const posthogClient = getPosthogClient();
 
   if (!posthogClient) {
     return children;

--- a/packages/web/src/components/Feedback/FeedbackDialogHost.tsx
+++ b/packages/web/src/components/Feedback/FeedbackDialogHost.tsx
@@ -23,7 +23,7 @@ export function FeedbackDialogHost() {
   const posthog = usePostHog();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  if (!request) return null;
+  if (!request || !posthog) return null;
 
   const handleSubmit = async (details: string) => {
     if (isSubmitting) return;

--- a/packages/web/src/grid/hooks/useGridMeasurements.ts
+++ b/packages/web/src/grid/hooks/useGridMeasurements.ts
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 import {
   type GridMeasurement,
@@ -54,65 +61,11 @@ export const useGridMeasurements = ({
   const timedColumnsRef = useRef<HTMLDivElement | null>(null);
   const observersRef = useRef(new Map<string, ResizeObserver>());
 
-  const updateAllDayRowMeasurement = useCallback(
-    (node: HTMLElement) => {
-      if (isInteractionMotionActive()) {
-        return;
-      }
-
-      const next = toMeasurementSnapshot(node.getBoundingClientRect());
-      setAllDayMeasurements((current) => {
-        if (isInteractionMotionActive()) {
-          return current;
-        }
-
-        return areMeasurementsEqual(current, next) ? current : next;
-      });
-    },
-    [isInteractionMotionActive],
-  );
-
-  const updateAllDayColumnsMeasurement = useCallback(
-    (node: HTMLDivElement) => {
-      if (isInteractionMotionActive()) {
-        return;
-      }
-
-      const next = toMeasurementSnapshot(node.getBoundingClientRect());
-      setAllDayColumnsMeasurements((current) => {
-        if (isInteractionMotionActive()) {
-          return current;
-        }
-
-        return areMeasurementsEqual(current, next) ? current : next;
-      });
-    },
-    [isInteractionMotionActive],
-  );
-
-  const updateMainGridMeasurement = useCallback(
-    (node: HTMLElement) => {
-      if (isInteractionMotionActive()) {
-        return;
-      }
-
-      const next = toMeasurementSnapshot(node.getBoundingClientRect());
-      setMainMeasurements((current) => {
-        if (isInteractionMotionActive()) {
-          return current;
-        }
-
-        return areMeasurementsEqual(current, next) ? current : next;
-      });
-    },
-    [isInteractionMotionActive],
-  );
-
   const observeElement = useCallback(
-    <T extends HTMLElement>(
+    (
       key: string,
-      node: T | null,
-      measure: (node: T) => void,
+      node: HTMLElement | null,
+      setMeasurement: Dispatch<SetStateAction<GridMeasurement | null>>,
     ) => {
       observersRef.current.get(key)?.disconnect();
       observersRef.current.delete(key);
@@ -121,40 +74,50 @@ export const useGridMeasurements = ({
         return;
       }
 
-      measure(node);
+      const measure = () => {
+        if (isInteractionMotionActive()) return;
+
+        const next = toMeasurementSnapshot(node.getBoundingClientRect());
+        setMeasurement((current) => {
+          if (isInteractionMotionActive()) return current;
+          return areMeasurementsEqual(current, next) ? current : next;
+        });
+      };
+
+      measure();
 
       if (typeof ResizeObserver === "undefined") {
         return;
       }
 
-      const observer = new ResizeObserver(() => measure(node));
+      const observer = new ResizeObserver(measure);
       observer.observe(node);
       observersRef.current.set(key, observer);
     },
-    [],
+    [isInteractionMotionActive],
   );
 
   const allDayRowRef = useCallback(
     (node: HTMLElement | null) => {
-      observeElement("allDayRow", node, updateAllDayRowMeasurement);
+      observeElement("allDayRow", node, setAllDayMeasurements);
     },
-    [observeElement, updateAllDayRowMeasurement],
+    [observeElement],
   );
 
   const allDayRef = useCallback(
     (node: HTMLDivElement | null) => {
       allDayColumnsRef.current = node;
-      observeElement("allDayColumns", node, updateAllDayColumnsMeasurement);
+      observeElement("allDayColumns", node, setAllDayColumnsMeasurements);
     },
-    [observeElement, updateAllDayColumnsMeasurement],
+    [observeElement],
   );
 
   const mainGridElementRef = useCallback(
     (node: HTMLElement | null) => {
       mainGridRef.current = node;
-      observeElement("mainGrid", node, updateMainGridMeasurement);
+      observeElement("mainGrid", node, setMainMeasurements);
     },
-    [observeElement, updateMainGridMeasurement],
+    [observeElement],
   );
 
   const timedColumnsElementRef = useCallback((node: HTMLDivElement | null) => {


### PR DESCRIPTION
## Summary

- make the web entrypoint the single owner of PostHog initialization and expose the client through a small local React context
- consolidate grid element measurement into one observer pipeline
- express sync sweep registration and startup as one ordered lifecycle list

## Simplicity

This removes 55 net lines across eight files. It eliminates duplicated observer callbacks, duplicated sweep lifecycle calls, the test-only `BUN_TEST_RUN` analytics branch, and a broad PostHog provider cast while preserving runtime behavior.

## Automated validation

- `bun test:web` — 1,506 passed
- `bun test:sync` — 745 passed
- `bun type-check`
- `bun lint`
- `bun run build:web`
- `bun run build:sync`
- `bun knip`
- `bun test:a11y` — 7 passed; only documented axe incomplete contrast checks
- local browser smoke at `http://localhost:9084/week` — calendar grid rendered with non-zero dimensions and no console warnings/errors

## Independent review

An independent reviewer found no actionable issues. Residual runtime assumptions were followed up with the full sync suite and a real-browser calendar/grid smoke check; local analytics are disabled, so the enabled PostHog branch remains covered by focused tests and code review.

## Test plan

1. Load the anonymous week calendar and confirm the timed grid renders and resizes normally.
2. Run the focused web and sync suites.
3. Confirm type-check, lint, builds, knip, and accessibility checks pass.
