### PR TITLE
fix(web): stop UNTIL from double-floating in the recurrence form

### DIFF
--- a/packages/core/src/util/event/compass.event.rrule.test.ts
+++ b/packages/core/src/util/event/compass.event.rrule.test.ts
@@ -527,6 +527,69 @@ describe("CompassEventRRule: ", () => {
       expect(rrule.toRecurrence()).toEqual(rule);
     });
 
+    it("until returns the real instant, not the internal floating stand-in", () => {
+      const until = dayjs
+        .tz("2027-05-31 19:00", denver)
+        .utc()
+        .format("YYYYMMDD[T]HHmmss[Z]");
+      const rule = [`RRULE:FREQ=WEEKLY;BYDAY=SA;UNTIL=${until}`];
+      const baseEvent = createMockBaseEvent({
+        startDate: thursday,
+        endDate: endOfThursday,
+        recurrence: { rule },
+      });
+      const rrule = new CompassEventRRule(
+        { ...baseEvent, _id: new ObjectId(baseEvent._id) },
+        { tzid: denver },
+      );
+
+      expect(rrule.until).not.toBeNull();
+      expect(dayjs(rrule.until).utc().format("YYYYMMDD[T]HHmmss[Z]")).toEqual(
+        until,
+      );
+      // Feeding it straight back into `_options.until` (as useRecurrence
+      // does every render) must not float it a second time - the round trip
+      // that used to double-float and never converge, exercised end-to-end
+      // in useRecurrence.test.ts's "real setDraft feedback loop" case.
+      const rebuilt = new CompassEventRRule(
+        {
+          ...baseEvent,
+          _id: new ObjectId(baseEvent._id),
+          recurrence: { rule: [] },
+        },
+        { ...rrule.options, until: rrule.until, tzid: denver },
+      );
+      expect(rebuilt.until?.toISOString()).toEqual(rrule.until?.toISOString());
+    });
+
+    it("until is null when the rule has no UNTIL", () => {
+      const rule = ["RRULE:FREQ=WEEKLY;BYDAY=SA"];
+      const baseEvent = createMockBaseEvent({
+        startDate: thursday,
+        endDate: endOfThursday,
+        recurrence: { rule },
+      });
+      const rrule = new CompassEventRRule(
+        { ...baseEvent, _id: new ObjectId(baseEvent._id) },
+        { tzid: denver },
+      );
+
+      expect(rrule.until).toBeNull();
+    });
+
+    it("until returns an all-day UNTIL unmodified (never floated)", () => {
+      const date = dayjs.tz("2027-05-31", denver);
+      const dates = generateCompassEventDates({ date, allDay: true });
+      const rule = ["RRULE:FREQ=DAILY;UNTIL=20270615"];
+      const baseEvent = createMockBaseEvent({ ...dates, recurrence: { rule } });
+      const rrule = new CompassEventRRule(
+        { ...baseEvent, _id: new ObjectId(baseEvent._id) },
+        { tzid: denver },
+      );
+
+      expect(rrule.until).toEqual(rrule.options.until);
+    });
+
     it("keeps the wall-clock time across the DST fallback boundary", () => {
       const rule = ["RRULE:FREQ=WEEKLY;BYDAY=TH;COUNT=20"];
       const baseEvent = createMockBaseEvent({

--- a/packages/core/src/util/event/compass.event.rrule.ts
+++ b/packages/core/src/util/event/compass.event.rrule.ts
@@ -42,7 +42,12 @@ function toFloatingDate(wall: Dayjs): Date {
 
 // The inverse: re-anchors a floating date (UTC fields = wall clock) back onto
 // the real timeline as the civil wall time in `timezone` (DST-aware).
-function localizeFloatingDate(floating: Date, timezone: string): Date {
+// Exported so callers that read `.options.until` off a constructed
+// CompassEventRRule (e.g. useRecurrence, to seed editable state) can undo the
+// float before feeding the value back into a new instance - otherwise
+// #initOptions floats an already-floating Date a second time, drifting it by
+// the timezone offset on every round trip.
+export function localizeFloatingDate(floating: Date, timezone: string): Date {
   const wall = dayjs.utc(floating).format("YYYY-MM-DDTHH:mm:ss.SSS");
 
   return dayjs.tz(wall, timezone).toDate();

--- a/packages/core/src/util/event/compass.event.rrule.ts
+++ b/packages/core/src/util/event/compass.event.rrule.ts
@@ -90,6 +90,19 @@ export class CompassEventRRule extends RRule {
     this.#durationMs = this.#endDate.diff(this.#startDate, "milliseconds");
   }
 
+  // `this.options.until` (inherited from RRule) is the internal floating
+  // value used for candidate expansion - not a real instant. This is the
+  // outbound counterpart to #initOptions' inbound floating: it un-floats
+  // before handing `until` to a caller, the same way `all()` already
+  // un-floats its returned dates, so round-tripping this value back into a
+  // new CompassEventRRule's `options.until` is idempotent by construction.
+  get until(): Date | null {
+    const until = this.options.until;
+    if (!until) return null;
+
+    return this.#isTimed ? localizeFloatingDate(until, this.#timezone) : until;
+  }
+
   static #initOptions(
     event: WithObjectId<Omit<BaseEvent, "_id">>,
     _options: Partial<Options> = {},

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
@@ -1,16 +1,18 @@
 import { renderHook } from "@testing-library/react";
-import { act } from "react";
+import { act, type Dispatch, type SetStateAction } from "react";
 import { Frequency } from "rrule";
 import { EventIdSchema } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
   editGridEventDraft,
+  resolveDraftRecurrenceRules,
 } from "@web/events/grid-event-draft.adapter";
 import { useRecurrence } from "./useRecurrence";
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 const SCHEDULE = EventScheduleSchema.parse({
   kind: "timed",
@@ -195,5 +197,78 @@ describe("useRecurrence hook", () => {
     rerender({ setDraftProp: nextSetDraft });
 
     expect(nextSetDraft).not.toHaveBeenCalled();
+  });
+
+  // Regression for React error #185 (max update depth exceeded): a timed
+  // UNTIL rule crashed the whole app for any non-UTC user. `options.until`
+  // off a parsed CompassEventRRule is in the floating frame used for
+  // candidate expansion; seeding editable state with it directly meant the
+  // rebuilt rrule floated it a second time, drifting the persisted UNTIL by
+  // the timezone offset on every render and never converging. The suite runs
+  // under TZ=Etc/UTC (packages/scripts/src/testing/...), which hides the
+  // drift, so this mocks dayjs.tz.guess() to reproduce a non-UTC host
+  // instead - same pattern as getRecurringDraftPreviews.test.ts.
+  describe("on a non-UTC host (America/Denver), with a real setDraft feedback loop", () => {
+    const denver = "America/Denver";
+
+    afterEach(() => {
+      (
+        dayjs.tz.guess as unknown as { mockRestore: () => void }
+      ).mockRestore?.();
+    });
+
+    it("converges instead of looping when editing a timed UNTIL rule", () => {
+      spyOn(dayjs.tz, "guess").mockReturnValue(denver);
+
+      const untilRule = "RRULE:FREQ=WEEKLY;UNTIL=20260810T010000Z;BYDAY=SA";
+      const source = createMockEvent({
+        schedule: EventScheduleSchema.parse({
+          kind: "timed",
+          start: "2026-07-12T01:15:00.000Z",
+          end: "2026-07-12T01:45:00.000Z",
+          timeZone: denver,
+        }),
+        recurrence: { kind: "series", rules: [untilRule] },
+      });
+      const editedDraft = editGridEventDraft(source);
+      if (!editedDraft) throw new Error("expected edit draft");
+
+      let draft: GridEventDraft = {
+        ...editedDraft,
+        values: {
+          ...editedDraft.values,
+          recurrence: { kind: "series" as const, rules: [untilRule] },
+        },
+      } as GridEventDraft;
+
+      let setDraftCalls = 0;
+      const setDraft: Dispatch<SetStateAction<GridEventDraft | null>> = (
+        updater,
+      ) => {
+        setDraftCalls++;
+        const next = typeof updater === "function" ? updater(draft) : updater;
+        if (next) draft = next;
+      };
+
+      const { rerender } = renderHook(() => useRecurrence(draft, { setDraft }));
+
+      // A real infinite loop would still be climbing after a handful of
+      // renders (React itself aborts at 50 nested updates). A convergent
+      // rule stabilizes in one write and stays stable.
+      const callCountsAfterEachRender: number[] = [];
+      for (let i = 0; i < 6; i++) {
+        rerender();
+        callCountsAfterEachRender.push(setDraftCalls);
+      }
+
+      const last = callCountsAfterEachRender.at(-1)!;
+      const secondToLast = callCountsAfterEachRender.at(-2)!;
+      expect(last).toBe(secondToLast);
+      expect(last).toBeLessThan(3);
+
+      const finalRules = resolveDraftRecurrenceRules(draft);
+      expect(finalRules).toHaveLength(1);
+      expect(finalRules[0]).toContain("UNTIL=20260810T010000Z");
+    });
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.test.ts
@@ -250,7 +250,9 @@ describe("useRecurrence hook", () => {
         if (next) draft = next;
       };
 
-      const { rerender } = renderHook(() => useRecurrence(draft, { setDraft }));
+      const { result, rerender } = renderHook(() =>
+        useRecurrence(draft, { setDraft }),
+      );
 
       // A real infinite loop would still be climbing after a handful of
       // renders (React itself aborts at 50 nested updates). A convergent
@@ -269,6 +271,15 @@ describe("useRecurrence hook", () => {
       const finalRules = resolveDraftRecurrenceRules(draft);
       expect(finalRules).toHaveLength(1);
       expect(finalRules[0]).toContain("UNTIL=20260810T010000Z");
+
+      // The hook's own returned `until` (what EndsOnDate's DatePicker
+      // renders) must be the real instant, not the floating stand-in - a
+      // pre-existing display bug in this same path (the "Ends on" date
+      // showing a day earlier for non-UTC users) that CompassEventRRule's
+      // `until` getter now fixes alongside the loop.
+      expect(result.current.until?.toISOString()).toBe(
+        "2026-08-10T01:00:00.000Z",
+      );
     });
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
@@ -10,11 +10,7 @@ import {
 } from "react";
 import { Frequency, type Options, RRule, type Weekday } from "rrule";
 import dayjs from "@core/util/date/dayjs";
-import {
-  CompassEventRRule,
-  localizeFloatingDate,
-} from "@core/util/event/compass.event.rrule";
-import { getCompassEventDateFormat } from "@core/util/event/event.util";
+import { CompassEventRRule } from "@core/util/event/compass.event.rrule";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   patchGridDraftRecurrence,
@@ -103,7 +99,7 @@ export const useRecurrence = (
   const { startDate, endDate } = scheduleDatesFromDraft(draft);
   const _startDate = dayjs(startDate);
 
-  const { options } = useMemo(() => {
+  const parsed = useMemo(() => {
     if (!hasRecurrence) {
       return {
         options: {
@@ -112,19 +108,22 @@ export const useRecurrence = (
           byweekday: undefined,
           wkst: WEEKDAY_MAP[0].weekday,
           count: null,
-          until: null,
           dtstart: _startDate.toDate(),
         },
+        until: null as Date | null,
       };
     }
 
-    return new CompassEventRRule({
+    const rrule = new CompassEventRRule({
       _id: new ObjectId(),
       startDate,
       endDate,
       recurrence: { rule: currentRules },
     });
+
+    return { options: rrule.options, until: rrule.until };
   }, [_startDate, startDate, endDate, hasRecurrence, currentRules]);
+  const { options } = parsed;
 
   const defaultWeekDay: typeof WEEKDAYS = useMemo(
     () => options?.byweekday?.map((day) => weekdayKeyFromByweekday(day)) ?? [],
@@ -138,25 +137,16 @@ export const useRecurrence = (
     [options?.wkst],
   );
 
-  // `options.until` (off the RRule library's internal, parsed representation)
-  // is in the floating frame used for candidate expansion for TIMED events
-  // only (see CompassEventRRule#initOptions - all-day UNTILs are never
-  // floated). Un-float a timed UNTIL before storing as editable state - the
-  // rebuilt `rrule` below feeds `until` back in as `_options.until`, which
-  // #initOptions floats again; seeding state with the already-floating value
-  // would double-float it every render and drift the persisted UNTIL by the
-  // timezone offset each time (never converging - the deep-equal guard in
-  // the effect below never passes).
-  const isTimed =
-    getCompassEventDateFormat(startDate) !==
-    dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
-  const timezone = dayjs.tz.guess();
-  const toRealUntil = (floating: Date | null): Date | null =>
-    floating && isTimed ? localizeFloatingDate(floating, timezone) : floating;
-
+  // `parsed.until` is already un-floated (CompassEventRRule#until handles
+  // the timed-vs-all-day distinction) - it's a real instant, safe to feed
+  // back into a new CompassEventRRule's `options.until` below without
+  // drifting it on every render (the bug this guards against: seeding from
+  // the still-floating `options.until` would double-float on round-trip and
+  // never converge, since the deep-equal guard in the effect below would
+  // never pass).
   const [freq, setFreq] = useState<Frequency>(options.freq);
   const [interval, setInterval] = useState<number>(options.interval);
-  const [until, setUntil] = useState<Date | null>(toRealUntil(options.until));
+  const [until, setUntil] = useState<Date | null>(() => parsed.until);
   const [count, setCount] = useState<number | null>(options.count);
   const [wkst, setWkst] = useState<Weekday | null>(defaultWkst);
   const [weekDays, setWeekDays] = useState<typeof WEEKDAYS>(defaultWeekDay);
@@ -168,7 +158,7 @@ export const useRecurrence = (
     setSyncedRuleSeedKey(ruleSeedKey);
     setFreq(options.freq);
     setInterval(options.interval);
-    setUntil(toRealUntil(options.until));
+    setUntil(parsed.until);
     setCount(options.count);
     setWkst(defaultWkst);
     setWeekDays(defaultWeekDay);
@@ -260,7 +250,7 @@ export const useRecurrence = (
     weekDays,
     interval: rrule.options.interval,
     freq: rrule.options.freq as FrequencyValues,
-    until: rrule.options.until,
+    until: rrule.until,
     setFreq,
     setInterval,
     setUntil,

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/useRecurrence/useRecurrence.ts
@@ -10,7 +10,11 @@ import {
 } from "react";
 import { Frequency, type Options, RRule, type Weekday } from "rrule";
 import dayjs from "@core/util/date/dayjs";
-import { CompassEventRRule } from "@core/util/event/compass.event.rrule";
+import {
+  CompassEventRRule,
+  localizeFloatingDate,
+} from "@core/util/event/compass.event.rrule";
+import { getCompassEventDateFormat } from "@core/util/event/event.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   patchGridDraftRecurrence,
@@ -134,9 +138,25 @@ export const useRecurrence = (
     [options?.wkst],
   );
 
+  // `options.until` (off the RRule library's internal, parsed representation)
+  // is in the floating frame used for candidate expansion for TIMED events
+  // only (see CompassEventRRule#initOptions - all-day UNTILs are never
+  // floated). Un-float a timed UNTIL before storing as editable state - the
+  // rebuilt `rrule` below feeds `until` back in as `_options.until`, which
+  // #initOptions floats again; seeding state with the already-floating value
+  // would double-float it every render and drift the persisted UNTIL by the
+  // timezone offset each time (never converging - the deep-equal guard in
+  // the effect below never passes).
+  const isTimed =
+    getCompassEventDateFormat(startDate) !==
+    dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+  const timezone = dayjs.tz.guess();
+  const toRealUntil = (floating: Date | null): Date | null =>
+    floating && isTimed ? localizeFloatingDate(floating, timezone) : floating;
+
   const [freq, setFreq] = useState<Frequency>(options.freq);
   const [interval, setInterval] = useState<number>(options.interval);
-  const [until, setUntil] = useState<Date | null>(options.until);
+  const [until, setUntil] = useState<Date | null>(toRealUntil(options.until));
   const [count, setCount] = useState<number | null>(options.count);
   const [wkst, setWkst] = useState<Weekday | null>(defaultWkst);
   const [weekDays, setWeekDays] = useState<typeof WEEKDAYS>(defaultWeekDay);
@@ -148,7 +168,7 @@ export const useRecurrence = (
     setSyncedRuleSeedKey(ruleSeedKey);
     setFreq(options.freq);
     setInterval(options.interval);
-    setUntil(options.until);
+    setUntil(toRealUntil(options.until));
     setCount(options.count);
     setWkst(defaultWkst);
     setWeekDays(defaultWeekDay);


### PR DESCRIPTION
## Summary

Opening the event form on a timed recurring event whose rule has `UNTIL` crashed the whole app for any user off UTC (minified React error #185, "Maximum update depth exceeded"). Reported via a series titled "Review KPIs, Weekly Review" that repeats until a fixed date - clicking it in the week grid took down the page.

- `useRecurrence` seeded its editable `until` state directly from `CompassEventRRule`'s parsed `options.until`, which is already in the "floating" frame `CompassEventRRule` uses internally for candidate expansion (UTC calendar fields holding the wall-clock digits).
- Feeding that already-floating value back into a second `CompassEventRRule` (to rebuild the rule string as the user edits) caused `#initOptions` to float it *again*.
- The persisted `UNTIL` therefore drifted by one timezone offset on every render. The sync effect's deep-equal guard never converged, so it kept calling `setDraft`, which re-rendered the hook, which drifted `UNTIL` again - until React aborted at its nested-update limit and the error boundary took down the page.
- Reproduced locally: with `TZ=America/Denver`, the reported rule's `UNTIL` walked back 6 hours per render with no convergence.

Fix, in two commits:
1. Un-float `until` (timed events only - `#initOptions` never floats all-day `UNTIL`) before storing it as editable state, so the round trip through the rebuilt `CompassEventRRule` floats it exactly once and stays stable.
2. `/simplify` review surfaced that only the *inbound* seeding was fixed - the hook's *returned* `until` (what feeds the "Ends on" `DatePicker`) still read the raw, still-floating `rrule.options.until`, so the picker showed a day earlier than selected for non-UTC users. Pushed the un-floating into a new public `CompassEventRRule#until` getter (mirroring the un-floating `all()` already does for its returned dates) so round-tripping `until` is idempotent by construction for any caller, not just this one - and `useRecurrence.ts` now uses it for both directions, dropping a duplicated `isTimed` re-derivation in the process.

## Simplicity

Ran `/simplify` (reuse, simplification, efficiency, altitude passes) against the diff:
- **Reuse**: `useRecurrence.ts` was re-deriving "is this event timed" via a date-string-format round-trip when `draft.values.schedule.kind` already had the answer. Superseded by pushing the fix into `CompassEventRRule#until`, which removed the re-derivation entirely rather than just simplifying it.
- **Efficiency**: applied - `until` state now uses React's lazy `useState(() => ...)` initializer so the (now cheaper) un-float only runs on mount, not every render.
- **Altitude**: the most consequential finding - fixing only the caller (`useRecurrence.ts`) was a bandaid on an asymmetric class API (`CompassEventRRule` floats `until` on the way in via `#initOptions` but didn't un-float it on the way out). Pushed the fix down into the class via a new `until` getter, matching the precedent already set by `all()`. Confirmed via grep that `useRecurrence.ts` is the only production caller reading `.options.until`/`.until` off a constructed instance today, so this also forecloses the same bug for any future caller.

## Automated validation

Browser (anonymous/IndexedDB mode, `bun dev:web`, real host timezone `America/Denver` - no override needed):
- Created a timed weekly recurring event, set an "Ends on" date via the DatePicker, saved - no crash, console clean.
- Reopened the same recurring event (both grid occurrences) 5+ times in a row (the exact reported repro) - stable, no crash, no drift in the displayed `Ends on` date.
- Converted the same event to all-day live in the editor with an existing `UNTIL` rule still applied, saved, reopened - no crash (exercises the `isTimed` guard's other branch).
- Confirmed the display-bug fix directly: before the getter fix, picking "July 31" in the DatePicker displayed "Ends on: 7-30-2026" (one day short, matching the Denver UTC-6 offset); after the fix, the same persisted event correctly reopens showing "Ends on: 7-31-2026".

## Independent review

Two independent passes, both via fresh subagents with no access to the implementation's own conclusions:
- `/simplify`'s 4 parallel angle-reviewers (reuse/simplification/efficiency/altitude) - findings applied, see Simplicity above.
- A separate fresh code-reviewer given only the diff, `AGENTS.md`, and the stated task intent (not told which findings had already been applied). Verified the root-cause claim against the actual code, confirmed the regression test uses a real (non-mocked) `setDraft` feedback loop rather than the mocked pattern used elsewhere in the file, confirmed private field ordering (`#isTimed`/`#timezone`) is safe for the new getter, and checked every other production `CompassEventRRule` construction site is unaffected. No blocking findings. One coverage gap flagged (the new getter was only proven indirectly via the web-layer test) - addressed in a follow-up commit adding direct core-package unit tests.

## Test plan

- `cd packages/web && TZ=Etc/UTC NODE_ENV=test bun test src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/` - 23 pass
- `cd packages/core && TZ=Etc/UTC NODE_ENV=test bun test src/util/event/compass.event.rrule.test.ts` - 27 pass
- `bun run type-check` - clean
- `biome check` on all touched files - clean