### PR TITLE
fix(web): keep sidebar closable on narrow viewports

### DIFF
--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -3,9 +3,14 @@ import { type FC } from "react";
 import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { ArrowButton } from "@web/components/Button/ArrowButton";
 import { SelectView } from "@web/components/SelectView/SelectView";
+import { useIsNarrowSidebarLayout } from "@web/components/Sidebar/hooks/useIsNarrowSidebarLayout";
 import { useVersionCheck } from "@web/components/Sidebar/SidebarActions/useVersionCheck";
 import { SidebarToggleButton } from "@web/components/Sidebar/SidebarToggleButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import {
+  selectIsSidebarOpen,
+  useViewStore,
+} from "@web/events/stores/view.store";
 
 interface Props {
   /** Left-aligned heading text (e.g. "June 2026" or "Wednesday, July 1"). */
@@ -38,6 +43,11 @@ export const CalendarHeader: FC<Props> = ({
   showNavigation = true,
 }) => {
   const { isUpdateAvailable } = useVersionCheck();
+  const isSidebarOpen = useViewStore(selectIsSidebarOpen);
+  const isNarrowLayout = useIsNarrowSidebarLayout();
+  // On narrow layouts the open sidebar hosts its own close control; keep a
+  // single "Close sidebar" name in the accessibility tree.
+  const showHeaderSidebarToggle = !isNarrowLayout || !isSidebarOpen;
 
   return (
     <div className="flex h-12 w-full shrink-0 items-center gap-3 text-text-muted">
@@ -80,9 +90,11 @@ export const CalendarHeader: FC<Props> = ({
         ) : null}
       </div>
 
-      <div className="z-2 ml-auto flex shrink-0 items-center pr-5">
-        <SidebarToggleButton />
-      </div>
+      {showHeaderSidebarToggle ? (
+        <div className="z-2 flex shrink-0 items-center pr-5">
+          <SidebarToggleButton />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -3,14 +3,9 @@ import { type FC } from "react";
 import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { ArrowButton } from "@web/components/Button/ArrowButton";
 import { SelectView } from "@web/components/SelectView/SelectView";
-import { useIsNarrowSidebarLayout } from "@web/components/Sidebar/hooks/useIsNarrowSidebarLayout";
 import { useVersionCheck } from "@web/components/Sidebar/SidebarActions/useVersionCheck";
 import { SidebarToggleButton } from "@web/components/Sidebar/SidebarToggleButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
-import {
-  selectIsSidebarOpen,
-  useViewStore,
-} from "@web/events/stores/view.store";
 
 interface Props {
   /** Left-aligned heading text (e.g. "June 2026" or "Wednesday, July 1"). */
@@ -43,18 +38,13 @@ export const CalendarHeader: FC<Props> = ({
   showNavigation = true,
 }) => {
   const { isUpdateAvailable } = useVersionCheck();
-  const isSidebarOpen = useViewStore(selectIsSidebarOpen);
-  const isNarrowLayout = useIsNarrowSidebarLayout();
-  // On narrow layouts the open sidebar hosts its own close control; keep a
-  // single "Close sidebar" name in the accessibility tree.
-  const showHeaderSidebarToggle = !isNarrowLayout || !isSidebarOpen;
 
   return (
     <div className="flex h-12 w-full shrink-0 items-center gap-3 text-text-muted">
-      {/* min-w-0 + overflow-hidden lets the title cluster yield space so the
-          sidebar toggle (shrink-0) stays visible when the main column is
-          squeezed by an open sidebar on a narrow viewport. */}
-      <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden">
+      {/* min-w-0 lets the title cluster shrink so the sidebar toggle stays in
+          layout. Avoid overflow-hidden here — SelectView's menu is absolutely
+          positioned inside this cluster and must paint below the header. */}
+      <div className="flex min-w-0 flex-1 items-center gap-3">
         {showNavigation && onPrev && onNext && (
           <>
             <TooltipWrapper shortcut="J">
@@ -90,11 +80,9 @@ export const CalendarHeader: FC<Props> = ({
         ) : null}
       </div>
 
-      {showHeaderSidebarToggle ? (
-        <div className="z-2 flex shrink-0 items-center pr-5">
-          <SidebarToggleButton />
-        </div>
-      ) : null}
+      <div className="z-2 flex shrink-0 items-center pr-5">
+        <SidebarToggleButton />
+      </div>
     </div>
   );
 };

--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -1,17 +1,11 @@
 import { ArrowClockwiseIcon } from "@phosphor-icons/react";
 import { type FC } from "react";
-import { colors } from "@web/common/styles/colors";
 import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { ArrowButton } from "@web/components/Button/ArrowButton";
-import { SidebarIcon } from "@web/components/Icons/Sidebar";
 import { SelectView } from "@web/components/SelectView/SelectView";
 import { useVersionCheck } from "@web/components/Sidebar/SidebarActions/useVersionCheck";
+import { SidebarToggleButton } from "@web/components/Sidebar/SidebarToggleButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
-import {
-  selectIsSidebarOpen,
-  useViewStore,
-  viewActions,
-} from "@web/events/stores/view.store";
 
 interface Props {
   /** Left-aligned heading text (e.g. "June 2026" or "Wednesday, July 1"). */
@@ -43,51 +37,51 @@ export const CalendarHeader: FC<Props> = ({
   nextLabel = "Next",
   showNavigation = true,
 }) => {
-  const isSidebarOpen = useViewStore(selectIsSidebarOpen);
   const { isUpdateAvailable } = useVersionCheck();
 
   return (
     <div className="flex h-12 w-full shrink-0 items-center gap-3 text-text-muted">
-      {showNavigation && onPrev && onNext && (
-        <>
-          <TooltipWrapper shortcut="J">
-            <ArrowButton direction="left" label={prevLabel} onClick={onPrev} />
-          </TooltipWrapper>
-          <TooltipWrapper shortcut="K">
-            <ArrowButton direction="right" label={nextLabel} onClick={onNext} />
-          </TooltipWrapper>
-        </>
-      )}
-      <SelectView label={label} onToday={onToday} />
-      {isUpdateAvailable ? (
-        <TooltipWrapper
-          description="Get latest version"
-          onClick={reloadLocation}
-        >
-          <button
-            aria-label="Get latest version"
-            className="flex size-7 items-center justify-center rounded-default text-accent transition hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-            type="button"
+      {/* min-w-0 + overflow-hidden lets the title cluster yield space so the
+          sidebar toggle (shrink-0) stays visible when the main column is
+          squeezed by an open sidebar on a narrow viewport. */}
+      <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden">
+        {showNavigation && onPrev && onNext && (
+          <>
+            <TooltipWrapper shortcut="J">
+              <ArrowButton
+                direction="left"
+                label={prevLabel}
+                onClick={onPrev}
+              />
+            </TooltipWrapper>
+            <TooltipWrapper shortcut="K">
+              <ArrowButton
+                direction="right"
+                label={nextLabel}
+                onClick={onNext}
+              />
+            </TooltipWrapper>
+          </>
+        )}
+        <SelectView label={label} onToday={onToday} />
+        {isUpdateAvailable ? (
+          <TooltipWrapper
+            description="Get latest version"
+            onClick={reloadLocation}
           >
-            <ArrowClockwiseIcon aria-hidden="true" size={16} />
-          </button>
-        </TooltipWrapper>
-      ) : null}
+            <button
+              aria-label="Get latest version"
+              className="flex size-7 shrink-0 items-center justify-center rounded-default text-accent transition hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              type="button"
+            >
+              <ArrowClockwiseIcon aria-hidden="true" size={16} />
+            </button>
+          </TooltipWrapper>
+        ) : null}
+      </div>
 
-      <div className="z-2 ml-auto flex items-center pr-5">
-        <TooltipWrapper
-          description={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-          onClick={() => viewActions.toggleSidebar()}
-          shortcut="]"
-        >
-          <button
-            type="button"
-            aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-            className="c-focus-ring flex h-6 w-6 cursor-pointer items-center justify-center"
-          >
-            <SidebarIcon color={colors.textMuted} size={21} />
-          </button>
-        </TooltipWrapper>
+      <div className="z-2 ml-auto flex shrink-0 items-center pr-5">
+        <SidebarToggleButton />
       </div>
     </div>
   );

--- a/packages/web/src/components/Sidebar/SidebarCloseButton.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarCloseButton.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import {
+  selectIsSidebarOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+import { SidebarCloseButton } from "./SidebarCloseButton";
+import { SidebarToggleButton } from "./SidebarToggleButton";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+function Harness() {
+  const isOpen = useViewStore(selectIsSidebarOpen);
+  return (
+    <div>
+      <SidebarToggleButton />
+      {isOpen ? <SidebarCloseButton /> : null}
+    </div>
+  );
+}
+
+describe("SidebarCloseButton", () => {
+  beforeEach(() => {
+    viewActions.setSidebarOpen(true);
+  });
+
+  it("closes the sidebar and focuses the header open control", async () => {
+    const user = userEvent.setup();
+    const { wrapper } = createStoreWrapper();
+
+    render(<Harness />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Dismiss sidebar" }));
+
+    expect(
+      screen.queryByRole("button", { name: "Dismiss sidebar" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Open sidebar" }),
+      ).toHaveFocus();
+    });
+  });
+});

--- a/packages/web/src/components/Sidebar/SidebarCloseButton.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarCloseButton.test.tsx
@@ -2,6 +2,15 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import {
+  draftActions,
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
+import {
   selectIsSidebarOpen,
   useViewStore,
   viewActions,
@@ -12,19 +21,21 @@ import { beforeEach, describe, expect, it } from "bun:test";
 
 function Harness() {
   const isOpen = useViewStore(selectIsSidebarOpen);
+  const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
   return (
     <div>
       <SidebarToggleButton />
-      {isOpen ? <SidebarCloseButton /> : null}
+      {isOpen || isEventFormOpen ? <SidebarCloseButton /> : null}
     </div>
   );
 }
 
-describe("SidebarCloseButton", () => {
-  beforeEach(() => {
-    viewActions.setSidebarOpen(true);
-  });
+beforeEach(() => {
+  viewActions.setSidebarOpen(true);
+  draftActions.discard();
+});
 
+describe("SidebarCloseButton", () => {
   it("closes the sidebar and focuses the header open control", async () => {
     const user = userEvent.setup();
     const { wrapper } = createStoreWrapper();
@@ -41,5 +52,30 @@ describe("SidebarCloseButton", () => {
         screen.getByRole("button", { name: "Open sidebar" }),
       ).toHaveFocus();
     });
+  });
+
+  it("also discards an open event form so the panel can fully close", async () => {
+    const user = userEvent.setup();
+    const { wrapper } = createStoreWrapper();
+    viewActions.setSidebarOpen(false);
+    draftActions.startGridDraft({
+      activity: "gridClick",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000Z"),
+          new Date("2026-05-20T10:00:00.000Z"),
+        ),
+      ),
+    });
+    draftActions.setFormOpen(true);
+
+    render(<Harness />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Dismiss sidebar" }));
+
+    expect(selectIsEventFormOpen(useDraftStore.getState())).toBe(false);
+    expect(
+      screen.queryByRole("button", { name: "Dismiss sidebar" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarCloseButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarCloseButton.tsx
@@ -1,20 +1,32 @@
 import { XIcon } from "@phosphor-icons/react";
 import { type FC } from "react";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import {
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { viewActions } from "@web/events/stores/view.store";
+import { useCloseEventForm } from "@web/views/Forms/hooks/useCloseEventForm";
 
 /**
  * Narrow-layout dismiss control rendered inside the sidebar. Uses a distinct
  * accessible name from the header toggle so the two controls do not collide
- * while the panel is open, and restores focus to the header "Open sidebar"
- * control after close.
+ * while the panel is open. Closes both the sidebar preference and any open
+ * event form (Day/Week keep the panel mounted for event details), then
+ * restores focus to the header "Open sidebar" control.
  */
 export const SidebarCloseButton: FC = () => {
+  const closeEventForm = useCloseEventForm();
+  const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
+
   return (
     <TooltipWrapper
       description="Close sidebar"
       onClick={() => {
         viewActions.setSidebarOpen(false);
+        if (isEventFormOpen) {
+          closeEventForm();
+        }
         // The header toggle stays mounted and flips to "Open sidebar"; move
         // focus there after this in-sidebar control unmounts.
         window.setTimeout(() => {

--- a/packages/web/src/components/Sidebar/SidebarCloseButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarCloseButton.tsx
@@ -1,0 +1,37 @@
+import { XIcon } from "@phosphor-icons/react";
+import { type FC } from "react";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import { viewActions } from "@web/events/stores/view.store";
+
+/**
+ * Narrow-layout dismiss control rendered inside the sidebar. Uses a distinct
+ * accessible name from the header toggle so the two controls do not collide
+ * while the panel is open, and restores focus to the header "Open sidebar"
+ * control after close.
+ */
+export const SidebarCloseButton: FC = () => {
+  return (
+    <TooltipWrapper
+      description="Close sidebar"
+      onClick={() => {
+        viewActions.setSidebarOpen(false);
+        // The header toggle stays mounted and flips to "Open sidebar"; move
+        // focus there after this in-sidebar control unmounts.
+        window.setTimeout(() => {
+          document
+            .querySelector<HTMLButtonElement>('[aria-label="Open sidebar"]')
+            ?.focus();
+        }, 0);
+      }}
+      shortcut="]"
+    >
+      <button
+        type="button"
+        aria-label="Dismiss sidebar"
+        className="c-focus-ring flex h-6 w-6 cursor-pointer items-center justify-center text-text-muted"
+      >
+        <XIcon aria-hidden="true" size={16} />
+      </button>
+    </TooltipWrapper>
+  );
+};

--- a/packages/web/src/components/Sidebar/SidebarShell.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
@@ -41,8 +41,8 @@ function renderShell() {
       onCloseShortcuts={mock()}
       onToggleShortcuts={mock()}
       shortcutSections={[]}
-      SidebarActionsComponent={() => null}
-      ShortcutsOverlayComponent={() => null}
+      SidebarActionsComponent={() => <></>}
+      ShortcutsOverlayComponent={() => <></>}
     >
       <div>Sidebar body</div>
     </SidebarShell>,
@@ -89,17 +89,19 @@ describe("SidebarShell", () => {
 
   it("keeps dismiss available on narrow layouts while an event form is open", () => {
     mockViewport(true);
-    viewActions.setSidebarOpen(false);
-    draftActions.startGridDraft({
-      activity: "gridClick",
-      draft: createGridEventDraft(
-        timedGridSchedule(
-          new Date("2026-05-20T09:00:00.000Z"),
-          new Date("2026-05-20T10:00:00.000Z"),
+    act(() => {
+      viewActions.setSidebarOpen(false);
+      draftActions.startGridDraft({
+        activity: "gridClick",
+        draft: createGridEventDraft(
+          timedGridSchedule(
+            new Date("2026-05-20T09:00:00.000Z"),
+            new Date("2026-05-20T10:00:00.000Z"),
+          ),
         ),
-      ),
+      });
+      draftActions.setFormOpen(true);
     });
-    draftActions.setFormOpen(true);
 
     renderShell();
 

--- a/packages/web/src/components/Sidebar/SidebarShell.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
+import { viewActions } from "@web/events/stores/view.store";
+import { SidebarShell } from "./SidebarShell";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const originalMatchMedia = window.matchMedia;
+
+function mockViewport(isNarrow: boolean) {
+  window.matchMedia = mock((query: string) => {
+    const matchesMinWidth = query.includes(
+      `min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px`,
+    )
+      ? !isNarrow
+      : false;
+    return {
+      matches: matchesMinWidth,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => true,
+    } as MediaQueryList;
+  }) as typeof window.matchMedia;
+}
+
+function renderShell() {
+  const { wrapper } = createStoreWrapper();
+  return render(
+    <SidebarShell
+      isShortcutsOpen={false}
+      onCloseShortcuts={mock()}
+      onToggleShortcuts={mock()}
+      shortcutSections={[]}
+      SidebarActionsComponent={() => null}
+      ShortcutsOverlayComponent={() => null}
+    >
+      <div>Sidebar body</div>
+    </SidebarShell>,
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  viewActions.setSidebarOpen(true);
+  mockViewport(false);
+});
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+describe("SidebarShell", () => {
+  it("keeps the close control out of the sidebar on wide layouts", () => {
+    mockViewport(false);
+    renderShell();
+
+    expect(
+      screen.queryByRole("button", { name: "Close sidebar" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Sidebar body")).toBeInTheDocument();
+  });
+
+  it("shows a close control inside the sidebar on narrow layouts", async () => {
+    const user = userEvent.setup();
+    mockViewport(true);
+    renderShell();
+
+    const closeButton = screen.getByRole("button", { name: "Close sidebar" });
+    expect(closeButton).toBeInTheDocument();
+
+    await user.click(closeButton);
+
+    expect(
+      screen.getByRole("button", { name: "Open sidebar" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/Sidebar/SidebarShell.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.test.tsx
@@ -76,7 +76,7 @@ describe("SidebarShell", () => {
     await user.click(closeButton);
 
     expect(
-      screen.getByRole("button", { name: "Open sidebar" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Close sidebar" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarShell.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.test.tsx
@@ -55,28 +55,28 @@ afterEach(() => {
 });
 
 describe("SidebarShell", () => {
-  it("keeps the close control out of the sidebar on wide layouts", () => {
+  it("keeps the dismiss control out of the sidebar on wide layouts", () => {
     mockViewport(false);
     renderShell();
 
     expect(
-      screen.queryByRole("button", { name: "Close sidebar" }),
+      screen.queryByRole("button", { name: "Dismiss sidebar" }),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Sidebar body")).toBeInTheDocument();
   });
 
-  it("shows a close control inside the sidebar on narrow layouts", async () => {
+  it("shows a dismiss control inside the sidebar on narrow layouts", async () => {
     const user = userEvent.setup();
     mockViewport(true);
     renderShell();
 
-    const closeButton = screen.getByRole("button", { name: "Close sidebar" });
+    const closeButton = screen.getByRole("button", { name: "Dismiss sidebar" });
     expect(closeButton).toBeInTheDocument();
 
     await user.click(closeButton);
 
     expect(
-      screen.queryByRole("button", { name: "Close sidebar" }),
+      screen.queryByRole("button", { name: "Dismiss sidebar" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarShell.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
 import { viewActions } from "@web/events/stores/view.store";
 import { SidebarShell } from "./SidebarShell";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
@@ -47,11 +52,13 @@ function renderShell() {
 
 beforeEach(() => {
   viewActions.setSidebarOpen(true);
+  draftActions.discard();
   mockViewport(false);
 });
 
 afterEach(() => {
   window.matchMedia = originalMatchMedia;
+  draftActions.discard();
 });
 
 describe("SidebarShell", () => {
@@ -78,5 +85,26 @@ describe("SidebarShell", () => {
     expect(
       screen.queryByRole("button", { name: "Dismiss sidebar" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps dismiss available on narrow layouts while an event form is open", () => {
+    mockViewport(true);
+    viewActions.setSidebarOpen(false);
+    draftActions.startGridDraft({
+      activity: "gridClick",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000Z"),
+          new Date("2026-05-20T10:00:00.000Z"),
+        ),
+      ),
+    });
+    draftActions.setFormOpen(true);
+
+    renderShell();
+
+    expect(
+      screen.getByRole("button", { name: "Dismiss sidebar" }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarShell.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.tsx
@@ -2,6 +2,10 @@ import { type HTMLAttributes, type ReactNode } from "react";
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type ShortcutOverlaySection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutsOverlay";
 import {
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
+import {
   selectIsSidebarOpen,
   useViewStore,
 } from "@web/events/stores/view.store";
@@ -34,8 +38,10 @@ export function SidebarShell({
 }: SidebarShellProps) {
   const isNarrowLayout = useIsNarrowSidebarLayout();
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
-  // Only while open: during the collapse transition the shell stays mounted.
-  const showSidebarClose = isNarrowLayout && isSidebarOpen;
+  const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
+  // Day/Week keep the panel mounted for event details even when the sidebar
+  // preference is closed; keep dismiss available for that case too.
+  const showSidebarClose = isNarrowLayout && (isSidebarOpen || isEventFormOpen);
 
   return (
     <aside

--- a/packages/web/src/components/Sidebar/SidebarShell.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.tsx
@@ -1,6 +1,10 @@
 import { type HTMLAttributes, type ReactNode } from "react";
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type ShortcutOverlaySection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutsOverlay";
+import {
+  selectIsSidebarOpen,
+  useViewStore,
+} from "@web/events/stores/view.store";
 import { useIsNarrowSidebarLayout } from "./hooks/useIsNarrowSidebarLayout";
 import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
 import { SidebarActions } from "./SidebarActions/SidebarActions";
@@ -29,6 +33,10 @@ export function SidebarShell({
   ...props
 }: SidebarShellProps) {
   const isNarrowLayout = useIsNarrowSidebarLayout();
+  const isSidebarOpen = useViewStore(selectIsSidebarOpen);
+  // Only while open: during the collapse transition the shell stays mounted,
+  // and a still-rendered toggle would duplicate the header's "Open sidebar".
+  const showSidebarClose = isNarrowLayout && isSidebarOpen;
 
   return (
     <aside
@@ -37,7 +45,7 @@ export function SidebarShell({
       className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-surface-panel pt-5 text-text"
       id={ID_SIDEBAR}
     >
-      {isNarrowLayout ? (
+      {showSidebarClose ? (
         <div className="flex shrink-0 items-center justify-end px-5 pb-2">
           <SidebarToggleButton />
         </div>

--- a/packages/web/src/components/Sidebar/SidebarShell.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.tsx
@@ -1,8 +1,10 @@
 import { type HTMLAttributes, type ReactNode } from "react";
 import { ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { type ShortcutOverlaySection } from "@web/components/Shortcuts/ShortcutOverlay/ShortcutsOverlay";
+import { useIsNarrowSidebarLayout } from "./hooks/useIsNarrowSidebarLayout";
 import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
 import { SidebarActions } from "./SidebarActions/SidebarActions";
+import { SidebarToggleButton } from "./SidebarToggleButton";
 
 interface SidebarShellProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode;
@@ -26,6 +28,8 @@ export function SidebarShell({
   ShortcutsOverlayComponent = ShortcutsOverlay,
   ...props
 }: SidebarShellProps) {
+  const isNarrowLayout = useIsNarrowSidebarLayout();
+
   return (
     <aside
       {...props}
@@ -33,6 +37,11 @@ export function SidebarShell({
       className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-surface-panel pt-5 text-text"
       id={ID_SIDEBAR}
     >
+      {isNarrowLayout ? (
+        <div className="flex shrink-0 items-center justify-end px-5 pb-2">
+          <SidebarToggleButton />
+        </div>
+      ) : null}
       {children}
       <SidebarActionsComponent
         isShortcutsOpen={isShortcutsOpen}

--- a/packages/web/src/components/Sidebar/SidebarShell.tsx
+++ b/packages/web/src/components/Sidebar/SidebarShell.tsx
@@ -8,7 +8,7 @@ import {
 import { useIsNarrowSidebarLayout } from "./hooks/useIsNarrowSidebarLayout";
 import { ShortcutsOverlay } from "./ShortcutsOverlay/ShortcutsOverlay";
 import { SidebarActions } from "./SidebarActions/SidebarActions";
-import { SidebarToggleButton } from "./SidebarToggleButton";
+import { SidebarCloseButton } from "./SidebarCloseButton";
 
 interface SidebarShellProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode;
@@ -34,8 +34,7 @@ export function SidebarShell({
 }: SidebarShellProps) {
   const isNarrowLayout = useIsNarrowSidebarLayout();
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);
-  // Only while open: during the collapse transition the shell stays mounted,
-  // and a still-rendered toggle would duplicate the header's "Open sidebar".
+  // Only while open: during the collapse transition the shell stays mounted.
   const showSidebarClose = isNarrowLayout && isSidebarOpen;
 
   return (
@@ -47,7 +46,7 @@ export function SidebarShell({
     >
       {showSidebarClose ? (
         <div className="flex shrink-0 items-center justify-end px-5 pb-2">
-          <SidebarToggleButton />
+          <SidebarCloseButton />
         </div>
       ) : null}
       {children}

--- a/packages/web/src/components/Sidebar/SidebarToggleButton.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarToggleButton.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { viewActions } from "@web/events/stores/view.store";
+import { SidebarToggleButton } from "./SidebarToggleButton";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("SidebarToggleButton", () => {
+  beforeEach(() => {
+    viewActions.setSidebarOpen(false);
+  });
+
+  it("opens the sidebar when labeled open", async () => {
+    const user = userEvent.setup();
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarToggleButton />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Open sidebar" }));
+
+    expect(
+      screen.getByRole("button", { name: "Close sidebar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the sidebar when labeled close", async () => {
+    const user = userEvent.setup();
+    const { wrapper } = createStoreWrapper();
+    viewActions.setSidebarOpen(true);
+
+    render(<SidebarToggleButton />, { wrapper });
+
+    await user.click(screen.getByRole("button", { name: "Close sidebar" }));
+
+    expect(
+      screen.getByRole("button", { name: "Open sidebar" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
@@ -9,9 +9,9 @@ import {
 } from "@web/events/stores/view.store";
 
 /**
- * Shared open/close control for the right sidebar. Used in the calendar
- * header and, on narrow viewports, inside the sidebar itself when the
- * header control is squeezed out of view.
+ * Shared open/close control for the right sidebar. Lives in the calendar
+ * header; on narrow viewports SidebarShell also hosts a close control so the
+ * panel can be dismissed when this header control is hard to reach.
  */
 export const SidebarToggleButton: FC = () => {
   const isSidebarOpen = useViewStore(selectIsSidebarOpen);

--- a/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
@@ -1,0 +1,34 @@
+import { type FC } from "react";
+import { colors } from "@web/common/styles/colors";
+import { SidebarIcon } from "@web/components/Icons/Sidebar";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import {
+  selectIsSidebarOpen,
+  useViewStore,
+  viewActions,
+} from "@web/events/stores/view.store";
+
+/**
+ * Shared open/close control for the right sidebar. Used in the calendar
+ * header and, on narrow viewports, inside the sidebar itself when the
+ * header control is squeezed out of view.
+ */
+export const SidebarToggleButton: FC = () => {
+  const isSidebarOpen = useViewStore(selectIsSidebarOpen);
+
+  return (
+    <TooltipWrapper
+      description={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+      onClick={() => viewActions.toggleSidebar()}
+      shortcut="]"
+    >
+      <button
+        type="button"
+        aria-label={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
+        className="c-focus-ring flex h-6 w-6 cursor-pointer items-center justify-center"
+      >
+        <SidebarIcon color={colors.textMuted} size={21} />
+      </button>
+    </TooltipWrapper>
+  );
+};

--- a/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarToggleButton.tsx
@@ -19,7 +19,18 @@ export const SidebarToggleButton: FC = () => {
   return (
     <TooltipWrapper
       description={isSidebarOpen ? "Close sidebar" : "Open sidebar"}
-      onClick={() => viewActions.toggleSidebar()}
+      onClick={() => {
+        const willOpen = !isSidebarOpen;
+        viewActions.toggleSidebar();
+        if (!willOpen) return;
+        // On narrow layouts the header control can be clipped once the panel
+        // opens; move focus to the in-sidebar dismiss control when present.
+        window.setTimeout(() => {
+          document
+            .querySelector<HTMLButtonElement>('[aria-label="Dismiss sidebar"]')
+            ?.focus();
+        }, 0);
+      }}
       shortcut="]"
     >
       <button

--- a/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.test.ts
+++ b/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.test.ts
@@ -7,8 +7,11 @@ const originalMatchMedia = window.matchMedia;
 
 function mockMatchMedia(matchesMinWidth: boolean) {
   const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = matchesMinWidth;
   const query = {
-    matches: matchesMinWidth,
+    get matches() {
+      return matches;
+    },
     media: `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
     onchange: null,
     addEventListener: mock(
@@ -32,14 +35,16 @@ function mockMatchMedia(matchesMinWidth: boolean) {
     }
     return {
       ...query,
-      matches: false,
+      get matches() {
+        return false;
+      },
       media,
     } as MediaQueryList;
   }) as typeof window.matchMedia;
 
   return {
     setMatches(next: boolean) {
-      query.matches = next;
+      matches = next;
       const event = { matches: next } as MediaQueryListEvent;
       listeners.forEach((listener) => listener(event));
     },

--- a/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.test.ts
+++ b/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook } from "@testing-library/react";
+import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
+import { useIsNarrowSidebarLayout } from "./useIsNarrowSidebarLayout";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+const originalMatchMedia = window.matchMedia;
+
+function mockMatchMedia(matchesMinWidth: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const query = {
+    matches: matchesMinWidth,
+    media: `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
+    onchange: null,
+    addEventListener: mock(
+      (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.add(listener);
+      },
+    ),
+    removeEventListener: mock(
+      (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener);
+      },
+    ),
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => true,
+  } as MediaQueryList;
+
+  window.matchMedia = mock((media: string) => {
+    if (media.includes(`min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px`)) {
+      return query;
+    }
+    return {
+      ...query,
+      matches: false,
+      media,
+    } as MediaQueryList;
+  }) as typeof window.matchMedia;
+
+  return {
+    setMatches(next: boolean) {
+      query.matches = next;
+      const event = { matches: next } as MediaQueryListEvent;
+      listeners.forEach((listener) => listener(event));
+    },
+  };
+}
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+describe("useIsNarrowSidebarLayout", () => {
+  it("is true below the sidebar auto-collapse breakpoint", () => {
+    mockMatchMedia(false);
+
+    const { result } = renderHook(() => useIsNarrowSidebarLayout());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("is false at or above the sidebar auto-collapse breakpoint", () => {
+    mockMatchMedia(true);
+
+    const { result } = renderHook(() => useIsNarrowSidebarLayout());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("updates when the breakpoint is crossed", () => {
+    const media = mockMatchMedia(true);
+    const { result } = renderHook(() => useIsNarrowSidebarLayout());
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      media.setMatches(false);
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
+++ b/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
@@ -1,0 +1,29 @@
+import { useLayoutEffect, useState } from "react";
+import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
+
+/**
+ * True when the viewport is below the sidebar auto-collapse breakpoint.
+ * On these widths the open sidebar can squeeze the calendar header enough
+ * that its toggle is clipped, so the sidebar itself must host a close
+ * control.
+ */
+export function useIsNarrowSidebarLayout() {
+  const [isNarrow, setIsNarrow] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return !window.matchMedia(
+      `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
+    ).matches;
+  });
+
+  useLayoutEffect(() => {
+    const query = window.matchMedia(
+      `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
+    );
+    const onChange = () => setIsNarrow(!query.matches);
+    onChange();
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+
+  return isNarrow;
+}

--- a/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
+++ b/packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.ts
@@ -8,12 +8,11 @@ import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedL
  * control.
  */
 export function useIsNarrowSidebarLayout() {
-  const [isNarrow, setIsNarrow] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return !window.matchMedia(
-      `(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`,
-    ).matches;
-  });
+  const [isNarrow, setIsNarrow] = useState(
+    () =>
+      !window.matchMedia(`(min-width: ${SIDEBAR_AUTO_COLLAPSE_BREAKPOINT}px)`)
+        .matches,
+  );
 
   useLayoutEffect(() => {
     const query = window.matchMedia(

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode } from "react";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
@@ -369,6 +375,38 @@ describe("LifeView", () => {
     expect(
       screen.queryByRole("button", { name: /zoom/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("lets a narrow viewport close the sidebar from inside the sidebar", async () => {
+    const user = userEvent.setup();
+    mockViewport(true);
+    // Narrow mounts auto-collapse the sidebar; reopen as a user would.
+    renderLifeView();
+    act(() => {
+      viewActions.setSidebarOpen(true);
+    });
+    const sidebar = await screen.findByRole("complementary", {
+      name: "Sidebar",
+    });
+
+    const closeButtons = screen.getAllByRole("button", {
+      name: "Close sidebar",
+    });
+    const inSidebarClose = closeButtons.find((button) =>
+      sidebar.contains(button),
+    );
+    expect(inSidebarClose).toBeTruthy();
+
+    await user.click(inSidebarClose!);
+
+    // Collapse keeps the panel mounted until the width transition ends; the
+    // toggle label flipping off "Close" is the observable close signal in jsdom.
+    expect(
+      screen.queryByRole("button", { name: "Close sidebar" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "Open sidebar" }).length,
+    ).toBeGreaterThan(0);
   });
 
   it("shows the privacy tooltip on the date of birth label", async () => {

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -389,24 +389,21 @@ describe("LifeView", () => {
       name: "Sidebar",
     });
 
-    const closeButtons = screen.getAllByRole("button", {
+    const inSidebarClose = screen.getByRole("button", {
       name: "Close sidebar",
     });
-    const inSidebarClose = closeButtons.find((button) =>
-      sidebar.contains(button),
-    );
-    expect(inSidebarClose).toBeTruthy();
+    expect(sidebar.contains(inSidebarClose)).toBe(true);
 
-    await user.click(inSidebarClose!);
+    await user.click(inSidebarClose);
 
     // Collapse keeps the panel mounted until the width transition ends; the
-    // toggle label flipping off "Close" is the observable close signal in jsdom.
+    // header "Open sidebar" control returning is the observable close signal.
     expect(
       screen.queryByRole("button", { name: "Close sidebar" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getAllByRole("button", { name: "Open sidebar" }).length,
-    ).toBeGreaterThan(0);
+      screen.getByRole("button", { name: "Open sidebar" }),
+    ).toBeInTheDocument();
   });
 
   it("shows the privacy tooltip on the date of birth label", async () => {

--- a/packages/web/src/views/Life/LifeView.test.tsx
+++ b/packages/web/src/views/Life/LifeView.test.tsx
@@ -390,20 +390,20 @@ describe("LifeView", () => {
     });
 
     const inSidebarClose = screen.getByRole("button", {
-      name: "Close sidebar",
+      name: "Dismiss sidebar",
     });
     expect(sidebar.contains(inSidebarClose)).toBe(true);
 
     await user.click(inSidebarClose);
 
-    // Collapse keeps the panel mounted until the width transition ends; the
-    // header "Open sidebar" control returning is the observable close signal.
     expect(
-      screen.queryByRole("button", { name: "Close sidebar" }),
+      screen.queryByRole("button", { name: "Dismiss sidebar" }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Open sidebar" }),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Open sidebar" }),
+      ).toHaveFocus();
+    });
   });
 
   it("shows the privacy tooltip on the date of birth label", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On narrow viewports, opening the sidebar squeezed the main column so the calendar header's "Close sidebar" toggle was clipped by flex overflow — leaving no visible way to dismiss the panel.

- Keep the header sidebar toggle in a `shrink-0` column so left-side nav/title content yields first (without `overflow-hidden`, so the SelectView menu still paints).
- Extract a shared `SidebarToggleButton` for the header.
- Host a distinct in-sidebar **Dismiss sidebar** (X) control in `SidebarShell` below the auto-collapse breakpoint (`1280px`), including while Day/Week event details keep the panel open.
- Dismiss closes the sidebar preference and discards any open event form, then returns focus to the header open control. Opening from the header on narrow moves focus to the dismiss control when present.

## Simplicity

Reuse the existing toggle for the header; add a small dedicated dismiss control for the narrow in-sidebar case rather than remounting one control between header and sidebar (which caused focus/a11y issues).

## Automated validation

Browser (http://localhost:9080/life):
- 450px: open sidebar → **Dismiss sidebar** X visible → click closes sidebar; focus returns to header open control
- Wide: SelectView Day/Week/Life dropdown fully visible (not clipped)

## Independent review

Confirmed findings fixed:
- SelectView clipping from header `overflow-hidden` — removed
- Focus loss from remounting one toggle — replaced with dedicated dismiss + focus handoff
- Dismiss leaving event-details panel open — also discards draft / keeps dismiss while form open
- Focus stuck on clipped header after open — moves focus to dismiss when present

## Test plan

- `bun test:web packages/web/src/components/Sidebar/SidebarShell.test.tsx packages/web/src/components/Sidebar/SidebarToggleButton.test.tsx packages/web/src/components/Sidebar/SidebarCloseButton.test.tsx packages/web/src/components/Sidebar/hooks/useIsNarrowSidebarLayout.test.ts packages/web/src/views/Life/LifeView.test.tsx`
- `bun run lint`
- `bun run type-check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffbcca45-7e7c-40e0-8428-87d7a8622b4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffbcca45-7e7c-40e0-8428-87d7a8622b4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

