### PR TITLE
fix(sync): stop one unreadable job doc from freezing every sweep

### DIFF
--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -407,7 +407,15 @@ function buildSchedulers(
     {
       sweep: async (before) => {
         const enqueued = await reconcileStaleCalendars(
-          { resources, jobs },
+          {
+            resources,
+            jobs,
+            onEnqueueError: (error, resourceId) =>
+              logger.error(
+                `Sync reconcile sweep could not enqueue resource ${resourceId}; skipping it and continuing`,
+                error,
+              ),
+          },
           before,
           () => new Date(),
         );
@@ -431,7 +439,15 @@ function buildSchedulers(
     {
       sweep: (before) =>
         maintainExpiringSubscriptions(
-          { resources, jobs },
+          {
+            resources,
+            jobs,
+            onEnqueueError: (error, resourceId) =>
+              logger.error(
+                `Sync subscription sweep could not enqueue resource ${resourceId}; skipping it and continuing`,
+                error,
+              ),
+          },
           before,
           () => new Date(),
         ),

--- a/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
+++ b/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
@@ -102,4 +102,30 @@ describe("requeueFailedJobs", () => {
       exhaustedJobs: [],
     });
   });
+
+  it("requeues a job written before requeuedCount existed", async () => {
+    // Mongo's {$lt: n} does not match a missing field, so the self-heal sweep
+    // could not see the very jobs most likely to be wedged: the ones old
+    // enough to predate its own bookkeeping field. Three such jobs sat failed
+    // in prod while this sweep reported nothing to do (2026-07-31).
+    const id = await seedFailed({
+      runAfter: new Date("2026-07-20T10:00:00.000Z"),
+    });
+    await storage
+      .db()
+      .collection("jobs")
+      .updateOne({ _id: id as never }, { $unset: { requeuedCount: "" } });
+
+    const result = await requeueFailedJobs(deps(), cooldownBefore, now, 3);
+
+    expect(result.requeued).toBe(1);
+    expect(result.exhausted).toBe(0);
+    const raw = await storage
+      .db()
+      .collection("jobs")
+      .findOne({ _id: id as never });
+    expect(raw?.state).toBe("pending");
+    // Absence counted as zero, so the requeue is its first, not its last.
+    expect(raw?.requeuedCount).toBe(1);
+  });
 });

--- a/packages/sync/src/domain/reconcile.service.db.test.ts
+++ b/packages/sync/src/domain/reconcile.service.db.test.ts
@@ -183,4 +183,56 @@ describe("reconcileStaleCalendars", () => {
     expect(await jobByKey(`incrementalPull:${healthy._id}`)).not.toBeNull();
     expect(await jobByKey(`incrementalPull:${deadCredential._id}`)).toBeNull();
   });
+
+  it("skips a resource whose existing job cannot be read and sweeps the rest", async () => {
+    // 2026-07-31: three job docs written before `requeuedCount` existed made
+    // enqueue's coalescing read throw, and the sweep's loop had no per-item
+    // guard — so one unreadable doc abandoned the whole batch on every cycle
+    // and froze calendar sync fleet-wide for 23h. The finders sort
+    // deterministically, so the poisoned resource re-won the front of the
+    // ordering every time; nothing behind it ever ran again.
+    const poisoned = await seedResource(new Date("2026-07-01T00:00:00.000Z"));
+    const healthy = await seedResource(new Date("2026-07-02T00:00:00.000Z"));
+    // A job doc that cannot be parsed back out (kind is not a JobKind), sitting
+    // on the coalescing key the sweep is about to reuse.
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .insertOne({
+        _id: objectId(),
+        coalescingKey: `incrementalPull:${poisoned._id}`,
+        kind: "notAJobKind",
+      } as never);
+    const failures: string[] = [];
+
+    const enqueued = await reconcileStaleCalendars(
+      { resources, jobs, onEnqueueError: (_e, id) => failures.push(id) },
+      staleBefore,
+      now,
+    );
+
+    // The healthy resource behind the poisoned one still got its pull, and the
+    // count reflects what was actually enqueued rather than what was found.
+    expect(enqueued).toBe(1);
+    expect(await jobByKey(`incrementalPull:${healthy._id}`)).not.toBeNull();
+    expect(failures).toEqual([poisoned._id]);
+  });
+
+  it("enqueues onto a job written before requeuedCount existed", async () => {
+    // The specific doc shape that caused the freeze: valid work, just older
+    // than the field. It must read back as zero requeues, not as an error.
+    const stale = await seedResource(new Date("2026-07-01T00:00:00.000Z"));
+    await reconcileStaleCalendars(deps(), staleBefore, now);
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.jobs)
+      .updateOne(
+        { coalescingKey: `incrementalPull:${stale._id}` },
+        { $unset: { requeuedCount: "" } },
+      );
+
+    const enqueued = await reconcileStaleCalendars(deps(), staleBefore, now);
+
+    expect(enqueued).toBe(1);
+  });
 });

--- a/packages/sync/src/domain/reconcile.service.ts
+++ b/packages/sync/src/domain/reconcile.service.ts
@@ -5,6 +5,8 @@ import { type SyncResourceRepository } from "@sync/storage/repositories/sync-res
 export interface ReconcileDeps {
   resources: SyncResourceRepository;
   jobs: JobRepository;
+  // Reported per resource that fails to enqueue; the sweep continues.
+  onEnqueueError?: (error: unknown, resourceId: string) => void;
 }
 
 // The reconcile sweep — the missed-webhook fallback. Find events resources that

--- a/packages/sync/src/domain/resource-sweep-enqueue.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.ts
@@ -7,11 +7,23 @@ import { type JobRepository } from "@sync/storage/repositories/job.repository";
 
 // The shared shape behind reconcile.service.ts and subscription-sweep.service.ts:
 // find due resources with `finder`, enqueue one `kind` job per resource, and
-// return how many. The only difference between the two sweeps is which finder
-// they call and which job kind they enqueue — everything else, including the
-// coalescing key template, is identical.
+// return how many were enqueued. The only difference between the two sweeps is
+// which finder they call and which job kind they enqueue — everything else,
+// including the coalescing key template, is identical.
+//
+// Each resource is enqueued independently: one that throws is reported and
+// skipped, never allowed to abandon the rest of the batch. The sweeps are the
+// only liveness path for resources without a push channel, and the finders sort
+// deterministically, so a single doomed resource at the front of the ordering
+// would otherwise starve every resource behind it on every cycle, forever
+// (2026-07-31: one unparseable job doc froze calendar sync fleet-wide for 23h).
 export async function enqueueForResources(
-  deps: { jobs: JobRepository },
+  deps: {
+    jobs: JobRepository;
+    // Called once per resource that could not be enqueued. The sweep keeps
+    // going; the caller decides how loud to be.
+    onEnqueueError?: (error: unknown, resourceId: string) => void;
+  },
   finder: (before: Date, limit: number) => Promise<SyncResourceRecord[]>,
   kind: JobKind,
   before: Date,
@@ -19,6 +31,7 @@ export async function enqueueForResources(
   limit = 100,
 ): Promise<number> {
   const due = await finder(before, limit);
+  let enqueued = 0;
   for (const resource of due) {
     const enqueue: JobEnqueue = {
       tenantId: resource.tenantId,
@@ -31,7 +44,12 @@ export async function enqueueForResources(
       runAfter: now(),
       coalescingKey: `${kind}:${resource._id}`,
     };
-    await deps.jobs.enqueue(enqueue);
+    try {
+      await deps.jobs.enqueue(enqueue);
+      enqueued += 1;
+    } catch (error) {
+      deps.onEnqueueError?.(error, resource._id);
+    }
   }
-  return due.length;
+  return enqueued;
 }

--- a/packages/sync/src/domain/subscription-sweep.service.ts
+++ b/packages/sync/src/domain/subscription-sweep.service.ts
@@ -5,6 +5,8 @@ import { type SyncResourceRepository } from "@sync/storage/repositories/sync-res
 export interface SubscriptionSweepDeps {
   resources: SyncResourceRepository;
   jobs: JobRepository;
+  // Reported per resource that fails to enqueue; the sweep continues.
+  onEnqueueError?: (error: unknown, resourceId: string) => void;
 }
 
 // The subscription-maintenance sweep. Find events resources whose push channel

--- a/packages/sync/src/storage/contracts/job.contracts.ts
+++ b/packages/sync/src/storage/contracts/job.contracts.ts
@@ -54,7 +54,13 @@ export const JobRecordSchema = z.strictObject({
   // state:"failed". Distinct from `attempt` (which a requeue resets to give
   // the job a fresh retry ladder) so a resource that keeps failing cannot be
   // requeued forever — the sweep stops once this hits its cap.
-  requeuedCount: z.number().int().min(0),
+  //
+  // Defaulted, not required: this field was introduced after jobs already
+  // existed in production, and a job doc predating it is still perfectly
+  // valid work. Parsing one must not throw — enqueue coalesces onto whatever
+  // doc already holds a key and re-parses it, so a single unparseable job
+  // took down every sweep fleet-wide for 23h (2026-07-31).
+  requeuedCount: z.number().int().min(0).default(0),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -22,6 +22,9 @@ export type ExhaustedFailedJob = {
   updatedAt: Date;
 };
 
+// The exact complement of listFailedForRequeue's eligibility filter: {$gte}
+// does not match a missing requeuedCount, so a legacy job counts as eligible
+// there and never as exhausted here. Keep the two in step.
 function exhaustedFailedFilter(maxRequeues: number) {
   return {
     state: "failed" as const,
@@ -251,7 +254,15 @@ export class JobRepository {
       .find({
         state: "failed",
         failureClass: { $ne: "permanent" },
-        requeuedCount: { $lt: maxRequeues },
+        // A job predating the requeuedCount field has been requeued zero
+        // times, not too many. Mongo's {$lt: n} does not match a missing
+        // field, so the absence has to be spelled out — otherwise the very
+        // jobs most likely to be wedged (the oldest ones) are the only ones
+        // the self-heal sweep can never see.
+        $or: [
+          { requeuedCount: { $lt: maxRequeues } },
+          { requeuedCount: { $exists: false } },
+        ],
         runAfter: { $lte: before },
       })
       .sort({ runAfter: 1 })


### PR DESCRIPTION
## What happened

Calendar sync stopped fleet-wide for ~23h (2026-07-31 01:08 UTC onward). Three job docs written before `requeuedCount` was introduced could not be parsed back out. `JobRepository.enqueue` coalesces onto whatever doc already holds a key and re-parses the result, and the sweep loop had no per-item guard, so a single unreadable doc threw and abandoned the entire batch.

The finders sort deterministically, so the poisoned resource re-won the front of the ordering on every cycle and nothing behind it ever ran again. Push channels cover only a handful of resources today, so the reconcile sweep is the only liveness path for nearly everyone.

## Changes

- **`requeuedCount` defaults to `0` when absent.** A job doc predating the field is still valid work; parsing one must not throw.
- **The sweep enqueues each resource independently.** One that throws is reported via a new `onEnqueueError` and skipped; the rest of the batch proceeds. It now returns what it actually enqueued rather than what it found, which is what the doc comment already claimed.
- **The self-heal sweep can see pre-field jobs.** Mongo's `{$lt: n}` does not match a missing field, so the jobs most likely to be wedged (the oldest ones) were the only ones it could never requeue. `exhaustedFailedFilter` is its exact complement and is unchanged.

No production data write is needed — the schema default heals the existing docs on read.

## Tests

Three regression tests, each pinned to the failure it encodes:
- a sweep survives an unreadable job doc and still enqueues the resource behind it
- enqueue succeeds onto a job doc missing `requeuedCount`
- the self-heal sweep requeues a job doc missing `requeuedCount`, counting the absence as zero

748/748 sync tests pass; type-check clean.

## Follow-ups (not in this PR)

- Occurrences from provider-linked creates are stamped `generation: 0`, which is wrong when a repair has advanced the calendar. It self-heals via the next pull, which is exactly what this outage removed. Separate PR.
- Nothing alerts on "no pending jobs while everything is stale" — the signal was in telemetry the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)