### PR TITLE
fix(web): keep the signed-out message alive and unqueued

### DIFF
--- a/packages/web/src/api/util/api.util.test.ts
+++ b/packages/web/src/api/util/api.util.test.ts
@@ -268,4 +268,28 @@ describe("handleErrorResponse", () => {
     expect(signOutSpy).toHaveBeenCalledTimes(1);
     signOutSpy.mockRestore();
   });
+
+  it("leaves a non-calendar route through the router, not a document navigation", async () => {
+    // A document navigation tears down the toast signOut just raised, so on
+    // every route that actually needed it the "you've been signed out" message
+    // was destroyed before it could be read. Routing in-app keeps it alive.
+    window.history.pushState({}, "", "/day/2026-07-31");
+    const navigate = mock((_options: { to: string }) => Promise.resolve());
+    mock.module("@web/routers", () => ({ router: { navigate } }));
+    const signOutSpy = spyOn(session, "signOut").mockResolvedValue(undefined);
+    const error = createApiError(
+      { status: Status.UNAUTHORIZED },
+      { url: "/event" },
+    );
+
+    await expect(
+      handleErrorResponse(error, { onGoogleRevoked: undefined }),
+    ).rejects.toBe(error);
+
+    expect(signOutSpy).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith({ to: "/week" });
+    signOutSpy.mockRestore();
+    window.history.pushState({}, "", "/week");
+  });
 });

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -7,7 +7,6 @@ import {
 import { session } from "@web/auth/compass/session/Session";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
-import { assignLocation } from "@web/common/utils/browser/browser-navigation.util";
 import {
   showErrorToast,
   showSessionExpiredToast,
@@ -91,7 +90,13 @@ export const signOut = async (status: SignoutStatus) => {
   if (window.location.pathname.startsWith(DEFAULT_CALENDAR_ROUTE)) {
     return;
   }
-  assignLocation(DEFAULT_CALENDAR_ROUTE);
+  // Navigate in-app rather than assigning window.location: a document
+  // navigation tears down the toast we just raised, so the one message telling
+  // the user they were signed out was destroyed on every route that needed it.
+  // Imported dynamically for the same module-cycle reason SessionExpiredToast
+  // documents (this file sits on the API error path the router pulls back in).
+  const { router } = await import("@web/routers");
+  await router.navigate({ to: DEFAULT_CALENDAR_ROUTE });
 };
 
 export const getRequestUrl = (url: string): string => {

--- a/packages/web/src/common/utils/browser/browser-navigation.util.ts
+++ b/packages/web/src/common/utils/browser/browser-navigation.util.ts
@@ -1,7 +1,3 @@
-export function assignLocation(url: string): void {
-  window.location.assign(url);
-}
-
 export function reloadLocation(): void {
   window.location.reload();
 }

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -40,10 +40,7 @@ function ThemeAwareToastContainer() {
       draggable
       pauseOnHover
       theme={theme === "dark-abyss" ? "dark" : "light"}
-      // Not 1: with a single slot, a routine toast already on screen (an undo
-      // notice, an autosave) silently queues out a critical one behind it, so
-      // "your session expired" or "that didn't save" could never appear.
-      limit={3}
+      limit={1}
       transition={Slide}
     />
   );

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -40,7 +40,10 @@ function ThemeAwareToastContainer() {
       draggable
       pauseOnHover
       theme={theme === "dark-abyss" ? "dark" : "light"}
-      limit={1}
+      // Not 1: with a single slot, a routine toast already on screen (an undo
+      // notice, an autosave) silently queues out a critical one behind it, so
+      // "your session expired" or "that didn't save" could never appear.
+      limit={3}
       transition={Slide}
     />
   );


### PR DESCRIPTION
## Problem

Investigating a report of "my event disappeared and I got no indication of an error", two independent ways the one message telling a user their write failed could never reach them:

1. **A document navigation destroyed it.** `signOut()` raises a toast and then calls `window.location.assign("/week")`. That is a full page load, so the toast is torn down before it can be read. The early return means this only happens when the user is *not* already on the calendar route — which is precisely the case where the message matters, since they are also being moved away from where they were.

2. **The toast could be silently queued out.** `ToastContainer` had `limit={1}`, so any routine toast already on screen (an undo notice, an autosave confirmation) pushes a critical "you've been signed out" into a queue the user may never see.

Together: the user's write fails, their optimistic edit rolls back, and nothing explains why.

## Changes

- `signOut` routes in-app via the router singleton instead of assigning `window.location`. `SessionExpiredToast` already reaches the router this way, including the dynamic import that avoids the module cycle, so this follows an established path rather than inventing one.
- `limit={1}` → `limit={3}`.

## Tests

The navigating branch of `signOut` had no coverage — the existing test pins the *already-on-calendar* case and notes it does so specifically to skip the jsdom-unsupported navigation. Adds a test for the branch that was actually broken.

24/24 api.util tests pass, 1519/1519 web tests pass (checked for `mock.module` leakage across files), type-check and lint clean.

## Not included

The mutation layer still swallows 401 in `handleError`, deferring to this interceptor. That is now a safe assumption again since the interceptor's message survives, but it is worth revisiting alongside a `MutationCache.onError` backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)