### PR TITLE
fix(sync): bootstrap a push channel for an imported calendar that lacks one

### DIFF
--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -260,7 +260,9 @@ describe("dispatchSyncJob", () => {
       jobFor(resource, "incrementalPull"),
       now,
     );
-    expect(outcome).toEqual({ result: "done" });
+    // Subject is the invalidation feed; this seed has no channel, so it also
+    // carries a bootstrap followup that is not what this test is about.
+    expect(outcome.result).toBe("done");
 
     const feed = await storage
       .db()
@@ -275,9 +277,20 @@ describe("dispatchSyncJob", () => {
     });
   });
 
-  it("settles an applied incremental pull as done with no followup", async () => {
+  it("settles an applied incremental pull as done when the channel is already live", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");
+    await resources.updateSubscription(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+      {
+        subscriptionId: "channel-1",
+        subscriptionResourceId: "provider-resource-1",
+        subscriptionToken: "token-1",
+        subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+      },
+    );
     const reader = new FakeReader([page([single("new-1")], "cursor-1")]);
 
     const outcome = await dispatchSyncJob(
@@ -298,6 +311,34 @@ describe("dispatchSyncJob", () => {
       connectionId: calendar.connectionId,
       calendarId: calendar._id,
     });
+  });
+
+  it("bootstraps a push channel when an applied pull finds the calendar has none", async () => {
+    // The initialImport followup used to be the only thing that ever opened a
+    // channel, and the renewal sweep only renews channels that already exist,
+    // so a calendar imported by any other route could never become watchable.
+    // Production preseeded 938 calendars straight into the store during the
+    // Sync cutover: cursors present, syncing fine, no channel, and nothing in
+    // the system able to give them one (2026-08-01).
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-0");
+    expect(resource.subscriptionId).toBeNull();
+    const reader = new FakeReader([page([single("new-1")], "cursor-1")]);
+
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    if (outcome.result !== "done" || !outcome.followup) {
+      throw new Error("expected a followup");
+    }
+    expect(outcome.followup.kind).toBe("subscriptionMaintain");
+    expect(outcome.followup.coalescingKey).toBe(
+      `subscriptionMaintain:${resource._id}`,
+    );
+    expect(outcome.followup.resourceId).toBe(resource._id);
   });
 
   it("hands off an expired-cursor pull to a repair followup", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -233,6 +233,27 @@ async function runSyncJob(
       const pull = await pullCalendarChanges(deps, calendar, now);
       if (pull.status === "applied") {
         await appendCalendarInvalidation(deps, calendar, now());
+        // Bootstrap a channel for an imported calendar that has none. The
+        // initialImport followup is otherwise the ONLY thing that ever opens
+        // one, and the renewal sweep only renews channels that already exist
+        // (listExpiringSubscriptions filters on subscriptionId), so a calendar
+        // imported by any other route could never become watchable. Production
+        // preseeded 938 calendars straight into the store during the Sync
+        // cutover, bypassing that job: they held cursors, synced correctly, and
+        // had no push channel with nothing in the system able to give them one
+        // (2026-08-01). Pulls already run for every stale calendar, so
+        // piggybacking here needs no new sweep and heals the whole fleet.
+        //
+        // Wart: a calendar the provider refuses to watch reports "unsupported"
+        // and is not recorded as such, so it re-attempts one watch per pull
+        // (~1/100min at current sweep cadence). Cheap, bounded, and self-
+        // limiting in practice since unwatchable calendars are rare.
+        if (pull.resource.subscriptionId === null) {
+          return {
+            result: "done",
+            followup: subscriptionFollowup(pull.resource, now),
+          };
+        }
         return { result: "done" };
       }
       if (pull.status === "notImported") {

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -614,7 +614,11 @@ describe("SyncJobWorker", () => {
       ]),
     ).drain();
 
-    expect(processed).toBe(2);
+    // Four, not two: neither seeded resource has a push channel, so each
+    // applied pull enqueues a subscriptionMaintain followup that this same
+    // drain then picks up. That is the property under test — drain keeps going
+    // until nothing is due, including work spawned partway through it.
+    expect(processed).toBe(4);
     expect(
       await storage
         .db()


### PR DESCRIPTION
## The gap

Only **4 of 1786** sync resources in production hold a push subscription. Everything else depends entirely on the reconcile sweep, which is what turned a three-document schema bug into a 23-hour fleet-wide outage (#2527).

The cause is a hole in the channel lifecycle:

- `subscriptionFollowup` is enqueued from exactly one place — the `initialImport` dispatch branch.
- The renewal sweep's finder, `listExpiringSubscriptions`, filters on `subscriptionId: { $ne: null }`. It renews channels that exist; it cannot create one.

So a calendar that reaches an imported state by any route other than the `initialImport` job can **never** become watchable, and nothing detects or repairs it.

Production got there by preseeding: the Sync cutover wrote events and cursors straight into the store, bypassing the import job. The data confirms it — 938 resources created 2026-07-26 have a cursor and no subscription, while the only 4 with channels are from the same day via the live connect path.

The practical cost: with ~1000 active resources swept 100 at a time every ~10 minutes, any given calendar is refreshed roughly every 100 minutes. That is the floor on freshness for nearly every user, and it is why the sweep is a single point of failure.

## Change

Enqueue the bootstrap followup after an applied incremental pull when the resource has no channel.

Pulls already run for every stale calendar, so this needs no new sweep, no migration, and no operator step — the existing fleet heals as each calendar comes around. The followup uses the same coalescing key as the renewal sweep, so a bootstrap and a renewal can never open two channels.

### Known wart, stated plainly

A calendar the provider refuses to watch returns `unsupported`, and that verdict is not recorded anywhere. Such a calendar re-attempts one watch per pull (~1 per 100 min at current cadence). Cheap and bounded, but it is a real cost rather than something that self-heals. Recording the verdict would need a new schema field, which is deliberately out of scope here given #2527.

## Tests

- New: an applied pull on a channel-less resource emits a `subscriptionMaintain` followup.
- Updated: the existing "no followup" test now seeds a live channel, which is the case it was actually describing.
- Updated: the worker-drain test expects 4 rather than 2, and now demonstrates that drain also processes work spawned partway through it.

750/750 sync tests pass; type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)