### PR TITLE
fix(auth): connect sync during google sign-in

### DIFF
--- a/packages/backend/src/auth/services/google/google.auth.scopes.ts
+++ b/packages/backend/src/auth/services/google/google.auth.scopes.ts
@@ -1,0 +1,8 @@
+// Keep the scopes configured for SuperTokens and the scopes persisted in Sync
+// together. The browser independently verifies that Google granted this set
+// before it sends its authorization code to Compass.
+export const GOOGLE_AUTH_SCOPES: string[] = [
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+];

--- a/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
@@ -9,8 +9,10 @@ import {
 import { getTestLoggerInfoCalls } from "@backend/__tests__/helpers/mock.setup";
 import * as googleAuthUtil from "@backend/auth/services/google/util/google.auth.util";
 import mongoService from "@backend/common/services/mongo.service";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
+import { GOOGLE_AUTH_SCOPES } from "./google.auth.scopes";
 import {
   type AuthDecision,
   type GoogleSignInSuccess,
@@ -33,6 +35,18 @@ let googleAuthService: Awaited<
 describe("googleAuthService", () => {
   beforeAll(async () => {
     spyOn(googleAuthUtil, "determineGoogleAuthMode");
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      adoptGoogleAuthorization: async () => ({
+        ok: true,
+        value: {},
+        correlationId: "corr-1",
+      }),
+      listConnections: async () => ({
+        ok: true,
+        value: { connections: [] },
+        correlationId: "corr-1",
+      }),
+    } as ReturnType<typeof syncServiceFactory.getSyncServiceClient>);
     ({ googleAuthService } = await import("./google.auth.service"));
   });
   beforeEach(() => setupTestDb(import.meta.url));
@@ -57,20 +71,24 @@ describe("googleAuthService", () => {
       ({
         refresh_token: faker.string.uuid(),
         access_token: faker.internet.jwt(),
-      }) as Pick<Credentials, "refresh_token" | "access_token">;
+        scope: GOOGLE_AUTH_SCOPES.join(" "),
+      }) as Pick<Credentials, "refresh_token" | "access_token" | "scope">;
 
     const makeOAuthTokensNoRefresh = () =>
       ({
         access_token: faker.internet.jwt(),
-      }) as Pick<Credentials, "refresh_token" | "access_token">;
+        scope: GOOGLE_AUTH_SCOPES.join(" "),
+      }) as Pick<Credentials, "refresh_token" | "access_token" | "scope">;
 
     beforeEach(() => {
       mockDetermineGoogleAuthMode().mockReset();
       spyOn(googleAuthService, "googleSignup").mockResolvedValue({
         cUserId: "signup-id",
+        refreshToken: faker.string.uuid(),
       });
       spyOn(googleAuthService, "repairGoogleConnection").mockResolvedValue({
         cUserId: "repair-id",
+        refreshToken: faker.string.uuid(),
       });
     });
 
@@ -248,7 +266,7 @@ describe("googleAuthService", () => {
 
       await userService.pruneGoogleData(compassUserId);
 
-      const result: { cUserId: string } =
+      const result: { cUserId: string; refreshToken: string } =
         await googleAuthService.repairGoogleConnection(
           compassUserId,
           gUser,
@@ -259,7 +277,10 @@ describe("googleAuthService", () => {
       const metadata =
         await userMetadataService.fetchUserMetadata(compassUserId);
 
-      expect(result).toEqual({ cUserId: compassUserId });
+      expect(result).toEqual({
+        cUserId: compassUserId,
+        refreshToken: oAuthTokens.refresh_token,
+      });
       expect(updatedUser?._id.toString()).toBe(compassUserId);
       expect(updatedUser?.google?.googleId).toBe(gUser.sub);
       expect(updatedUser?.google?.picture).toBe(gUser.picture);
@@ -291,6 +312,7 @@ describe("googleAuthService", () => {
           providerUser,
           oAuthTokens: {
             access_token: faker.internet.jwt(),
+            scope: GOOGLE_AUTH_SCOPES.join(" "),
           },
           createdNewRecipeUser: false,
           recipeUserId: compassUserId,
@@ -336,7 +358,10 @@ describe("googleAuthService", () => {
         .find({ email: normalizedEmail })
         .toArray();
 
-      expect(result).toEqual({ cUserId: existingUser._id.toString() });
+      expect(result).toEqual({
+        cUserId: existingUser._id.toString(),
+        refreshToken,
+      });
       expect(storedUsers).toHaveLength(1);
       expect(storedUsers[0]?._id).toEqual(existingUser._id);
       expect(storedUsers[0]?.google?.googleId).toBe(providerUser.sub);

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -1,18 +1,27 @@
 import { type Credentials, type TokenPayload } from "google-auth-library";
 import { LoggerFactory } from "@core/logger/logger.factory";
+import {
+  type ProviderAccountFacts,
+  ProviderAccountFactsSchema,
+} from "@core/types/sync/connection.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
 import {
   determineGoogleAuthMode,
   parseReconnectGoogleParams,
 } from "@backend/auth/services/google/util/google.auth.util";
 import { CONFIG } from "@backend/common/constants/config.constants";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { UserError } from "@backend/common/errors/user/user.errors";
 import { normalizeEmail } from "@backend/common/helpers/email.util";
 import mongoService from "@backend/common/services/mongo.service";
+import { adoptGoogleAuthorization } from "@backend/common/services/sync-service/sync-connection-adoption";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import { findCompassUserBy } from "@backend/user/queries/user.queries";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
+import { GOOGLE_AUTH_SCOPES } from "./google.auth.scopes";
 import {
   type AuthDecision,
   type GoogleSignInSuccess,
@@ -87,7 +96,7 @@ async function persistGoogleConnection(
     },
   });
 
-  return { cUserId: compassUserId };
+  return { cUserId: compassUserId, refreshToken };
 }
 
 async function persistStoredGoogleConnection(
@@ -117,7 +126,7 @@ async function persistStoredGoogleConnection(
     },
   });
 
-  return { cUserId };
+  return { cUserId, refreshToken: existingUser.google.gRefreshToken };
 }
 
 async function googleSignup(
@@ -151,7 +160,7 @@ async function googleSignup(
       },
     });
 
-    return { cUserId: cUser.user.userId };
+    return { cUserId: cUser.user.userId, refreshToken };
   });
 
   return user;
@@ -175,6 +184,45 @@ async function repairGoogleConnection(
   return persistGoogleConnection(cUserId, validatedGUser, refreshToken);
 }
 
+function googleAccount(providerUser: TokenPayload): ProviderAccountFacts {
+  return ProviderAccountFactsSchema.parse({
+    providerAccountId: providerUser.sub,
+    email: providerUser.email ?? null,
+    displayName: providerUser.name ?? null,
+  });
+}
+
+function grantedGoogleScopes(scope: string | null | undefined): string[] {
+  const grantedScopes = (scope ?? "").split(/\s+/).filter(Boolean);
+  if (
+    !GOOGLE_AUTH_SCOPES.every((required) => grantedScopes.includes(required))
+  ) {
+    throw error(
+      AuthError.InadequatePermissions,
+      "Google Calendar permissions are required",
+    );
+  }
+  return grantedScopes;
+}
+
+async function adoptConnection(
+  compassUserId: string,
+  providerUser: TokenPayload,
+  refreshToken: string,
+  grantedScopes: readonly string[],
+): Promise<void> {
+  const request = {
+    account: googleAccount(providerUser),
+    refreshToken,
+    grantedScopes,
+  };
+  await adoptGoogleAuthorization(
+    syncServiceFactory.getSyncServiceClient(),
+    toSyncPrincipal(compassUserId),
+    request,
+  );
+}
+
 async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
   const {
     providerUser,
@@ -188,6 +236,7 @@ async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
   if (!googleUserId) {
     throw new Error("Google user ID (sub) is required");
   }
+  const scopes = grantedGoogleScopes(oAuthTokens.scope);
 
   // Determine auth mode based on server-side state
   const decision = await determineGoogleAuthMode(
@@ -226,10 +275,16 @@ async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
         throw new Error("Refresh token expected for new user sign-up");
       }
 
-      await googleAuthService.googleSignup(
+      const persisted = await googleAuthService.googleSignup(
         providerUser,
         refreshToken,
         recipeUserId,
+      );
+      await adoptConnection(
+        persisted.cUserId,
+        providerUser,
+        persisted.refreshToken,
+        scopes,
       );
       return;
     }
@@ -244,10 +299,16 @@ async function handleGoogleAuth(success: GoogleSignInSuccess): Promise<void> {
         throw new Error("Compass user ID expected for Google sign-in");
       }
 
-      await googleAuthService.repairGoogleConnection(
+      const persisted = await googleAuthService.repairGoogleConnection(
         compassUserId,
         providerUser,
         oAuthTokens,
+      );
+      await adoptConnection(
+        persisted.cUserId,
+        providerUser,
+        persisted.refreshToken,
+        scopes,
       );
       return;
     }

--- a/packages/backend/src/auth/services/google/google.auth.success.service.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.success.service.test.ts
@@ -1,11 +1,13 @@
 import { faker } from "@faker-js/faker";
 import { type Credentials, type TokenPayload } from "google-auth-library";
 import { restoreFileMocks } from "@backend/__tests__/helpers/mock.setup";
+import { GOOGLE_AUTH_SCOPES } from "@backend/auth/services/google/google.auth.scopes";
 import {
   type AuthDecision,
   type GoogleSignInSuccess,
 } from "@backend/auth/services/google/google.auth.types";
 import * as googleAuthUtil from "@backend/auth/services/google/util/google.auth.util";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import {
   afterAll,
   beforeAll,
@@ -31,11 +33,12 @@ function makeProviderUser(overrides?: Partial<TokenPayload>): TokenPayload {
 
 function makeOAuthTokens(): Pick<
   Credentials,
-  "refresh_token" | "access_token"
+  "refresh_token" | "access_token" | "scope"
 > {
   return {
     refresh_token: faker.string.uuid(),
     access_token: faker.internet.jwt(),
+    scope: GOOGLE_AUTH_SCOPES.join(" "),
   };
 }
 
@@ -52,6 +55,7 @@ describe("handleGoogleAuth", () => {
   let mockDetermineGoogleAuthMode: Mock<
     typeof googleAuthUtil.determineGoogleAuthMode
   >;
+  let adoptCalls: Array<[unknown, unknown]>;
 
   beforeAll(async () => {
     mockDetermineGoogleAuthMode = spyOn(
@@ -63,14 +67,31 @@ describe("handleGoogleAuth", () => {
     ));
     spyOn(googleAuthService, "repairGoogleConnection").mockResolvedValue({
       cUserId: "repair-id",
+      refreshToken: faker.string.uuid(),
     });
     spyOn(googleAuthService, "googleSignup").mockResolvedValue({
       cUserId: "signup-id",
+      refreshToken: faker.string.uuid(),
     });
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockImplementation(
+      () =>
+        ({
+          listConnections: async () => ({
+            ok: true,
+            value: { connections: [] },
+            correlationId: "corr-1",
+          }),
+          adoptGoogleAuthorization: async (...args: [unknown, unknown]) => {
+            adoptCalls.push(args);
+            return { ok: true, value: {}, correlationId: "corr-1" };
+          },
+        }) as ReturnType<typeof syncServiceFactory.getSyncServiceClient>,
+    );
   });
 
   beforeEach(() => {
     mockDetermineGoogleAuthMode.mockReset();
+    adoptCalls = [];
     (googleAuthService.repairGoogleConnection as Mock).mockClear();
     (googleAuthService.googleSignup as Mock).mockClear();
   });
@@ -106,12 +127,28 @@ describe("handleGoogleAuth", () => {
         recipeUserId,
       );
       expect(googleAuthService.repairGoogleConnection).not.toHaveBeenCalled();
+      expect(adoptCalls).toHaveLength(1);
+      expect(adoptCalls[0]).toEqual([
+        { tenantId: "signup-id", principalId: "signup-id" },
+        expect.objectContaining({
+          account: expect.objectContaining({
+            providerAccountId: providerUser.sub,
+          }),
+          refreshToken: expect.any(String),
+          grantedScopes: expect.arrayContaining([
+            "https://www.googleapis.com/auth/calendar.events",
+          ]),
+        }),
+      ]);
     });
 
     it("throws when refresh_token is missing for new user", async () => {
       const success: GoogleSignInSuccess = {
         providerUser: makeProviderUser(),
-        oAuthTokens: { access_token: faker.internet.jwt() },
+        oAuthTokens: {
+          access_token: faker.internet.jwt(),
+          scope: GOOGLE_AUTH_SCOPES.join(" "),
+        },
         createdNewRecipeUser: true,
         recipeUserId: faker.database.mongodbObjectId(),
         loginMethodsLength: 1,
@@ -126,6 +163,32 @@ describe("handleGoogleAuth", () => {
       );
 
       expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
+      expect(adoptCalls).toHaveLength(0);
+    });
+
+    it("rejects missing server-returned calendar scopes before sign-up", async () => {
+      const success: GoogleSignInSuccess = {
+        providerUser: makeProviderUser(),
+        oAuthTokens: {
+          access_token: faker.internet.jwt(),
+          refresh_token: faker.string.uuid(),
+          scope: "https://www.googleapis.com/auth/userinfo.email",
+        },
+        createdNewRecipeUser: true,
+        recipeUserId: faker.database.mongodbObjectId(),
+        loginMethodsLength: 1,
+      };
+      mockDetermineGoogleAuthMode.mockResolvedValue(
+        makeDecision({ authMode: "SIGNUP" }),
+      );
+
+      await expect(
+        googleAuthService.handleGoogleAuth(success),
+      ).rejects.toMatchObject({
+        result: "Google Calendar permissions are required",
+      });
+      expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
+      expect(adoptCalls).toHaveLength(0);
     });
   });
 
@@ -160,6 +223,7 @@ describe("handleGoogleAuth", () => {
         oAuthTokens,
       );
       expect(googleAuthService.googleSignup).not.toHaveBeenCalled();
+      expect(adoptCalls).toHaveLength(1);
     });
   });
 

--- a/packages/backend/src/auth/services/google/google.auth.types.ts
+++ b/packages/backend/src/auth/services/google/google.auth.types.ts
@@ -10,7 +10,7 @@ export type AuthDecision = {
 
 export type GoogleSignInSuccess = {
   providerUser: TokenPayload;
-  oAuthTokens: Pick<Credentials, "refresh_token" | "access_token">;
+  oAuthTokens: Pick<Credentials, "refresh_token" | "access_token" | "scope">;
   createdNewRecipeUser: boolean;
   recipeUserId: string;
   loginMethodsLength: number;

--- a/packages/backend/src/auth/services/google/util/google.auth.util.ts
+++ b/packages/backend/src/auth/services/google/util/google.auth.util.ts
@@ -31,7 +31,7 @@ export async function determineGoogleAuthMode(
 export function parseReconnectGoogleParams(
   compassUserId: string,
   gUser: TokenPayload,
-  oAuthTokens: Pick<Credentials, "refresh_token" | "access_token">,
+  oAuthTokens: Pick<Credentials, "refresh_token" | "access_token" | "scope">,
 ): ParsedReconnectGoogleParams {
   const cUserId = zObjectId.parse(compassUserId).toString();
   StringV4Schema.parse(gUser.sub);

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -12,6 +12,7 @@ import UserMetadata from "supertokens-node/recipe/usermetadata";
 import { APP_NAME } from "@core/constants/core.constants";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
+import { GOOGLE_AUTH_SCOPES } from "@backend/auth/services/google/google.auth.scopes";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { isGoogleConfigured } from "@backend/common/constants/config.util";
 import {
@@ -24,12 +25,6 @@ import {
   sendPasswordResetEmail,
 } from "@backend/common/middleware/supertokens.middleware.handlers";
 
-const GOOGLE_SCOPES = [
-  "https://www.googleapis.com/auth/userinfo.email",
-  "https://www.googleapis.com/auth/calendar.readonly",
-  "https://www.googleapis.com/auth/calendar.events",
-];
-
 const createGoogleProvider = (
   clientId: string,
   clientSecret: string,
@@ -41,7 +36,7 @@ const createGoogleProvider = (
         clientType: "web",
         clientId,
         clientSecret,
-        scope: GOOGLE_SCOPES,
+        scope: GOOGLE_AUTH_SCOPES,
       },
     ],
   },

--- a/packages/backend/src/common/middleware/supertokens.middleware.types.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.types.ts
@@ -22,7 +22,7 @@ type ThirdPartySignInUpSuccess = Extract<
 >;
 type GoogleThirdPartySignInUpSuccess = ThirdPartySignInUpSuccess & {
   rawUserInfoFromProvider: { fromIdTokenPayload: TokenPayload };
-  oAuthTokens: Pick<Credentials, "refresh_token" | "access_token">;
+  oAuthTokens: Pick<Credentials, "refresh_token" | "access_token" | "scope">;
   user: { id: string; loginMethods: unknown[] };
   session?: SessionContainerInterface;
 };

--- a/packages/backend/src/common/services/sync-service/sync-connection-adoption.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-adoption.test.ts
@@ -1,0 +1,81 @@
+import { type BaseError } from "@core/errors/errors.base";
+import { Status } from "@core/errors/status.codes";
+import { adoptGoogleAuthorization } from "./sync-connection-adoption";
+import { describe, expect, it } from "bun:test";
+
+const principal = {
+  tenantId: "64b7f9c2e1a2b3c4d5e6f7a8",
+  principalId: "64b7f9c2e1a2b3c4d5e6f7a8",
+};
+const request = {
+  account: {
+    providerAccountId: "google-sub-1",
+    email: "connected@example.com",
+    displayName: "Connected User",
+  },
+  refreshToken: "server-exchanged-refresh-token",
+  grantedScopes: ["https://www.googleapis.com/auth/calendar.events"],
+};
+
+describe("adoptGoogleAuthorization", () => {
+  it("returns when Sync durably adopts the authorization", async () => {
+    const client = {
+      listConnections: async () => ({
+        ok: true as const,
+        value: { connections: [] },
+        correlationId: "corr-1",
+      }),
+      adoptGoogleAuthorization: async () => ({
+        ok: true as const,
+        value: {},
+        correlationId: "corr-1",
+      }),
+    };
+
+    await expect(
+      adoptGoogleAuthorization(client, principal, request),
+    ).resolves.toEqual({});
+  });
+
+  it("maps Sync failures to a safe 503", async () => {
+    const client = {
+      listConnections: async () => ({
+        ok: true as const,
+        value: { connections: [] },
+        correlationId: "corr-1",
+      }),
+      adoptGoogleAuthorization: async () => ({
+        ok: false as const,
+        error: { kind: "timeout" as const, correlationId: "corr-1" },
+      }),
+    };
+
+    await expect(
+      adoptGoogleAuthorization(client, principal, request),
+    ).rejects.toMatchObject({
+      statusCode: Status.SERVICE_UNAVAILABLE,
+    } satisfies Partial<BaseError>);
+  });
+
+  it("does not restart an already-live connection for the same account", async () => {
+    let adopted = false;
+    const client = {
+      listConnections: async () => ({
+        ok: true as const,
+        value: {
+          connections: [{ account: request.account, state: "healthy" }],
+        },
+        correlationId: "corr-1",
+      }),
+      adoptGoogleAuthorization: async () => {
+        adopted = true;
+        return { ok: true as const, value: {}, correlationId: "corr-1" };
+      },
+    };
+
+    await expect(
+      adoptGoogleAuthorization(client as never, principal, request),
+    ).resolves.toEqual({});
+    expect(adopted).toBe(false);
+  });
+});

--- a/packages/backend/src/common/services/sync-service/sync-connection-adoption.ts
+++ b/packages/backend/src/common/services/sync-service/sync-connection-adoption.ts
@@ -1,0 +1,67 @@
+import { Logger } from "@core/logger/winston.logger";
+import {
+  type GoogleConnectionAdoptionRequest,
+  type GoogleConnectionAdoptionResponse,
+  type ProviderAccountFacts,
+  type ProviderConnection,
+} from "@core/types/sync/connection.contracts";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import {
+  type SyncPrincipal,
+  type SyncServiceClient,
+} from "./sync-service.client";
+
+const logger = Logger("app:sync-connection-adoption");
+
+// Make the one-click Google sign-in authorization durable in Sync. On failure
+// sign-in fails visibly rather than creating a session that looks connected but
+// can never import calendars.
+export async function adoptGoogleAuthorization(
+  client: Pick<
+    SyncServiceClient,
+    "adoptGoogleAuthorization" | "listConnections"
+  >,
+  principal: SyncPrincipal,
+  request: Omit<GoogleConnectionAdoptionRequest, "credential"> & {
+    refreshToken: string;
+  },
+): Promise<GoogleConnectionAdoptionResponse> {
+  const existing = await client.listConnections(principal);
+  if (!existing.ok) {
+    throwUnavailable(existing.error.kind, existing.error.correlationId);
+  }
+  if (
+    existing.value.connections.some((connection) =>
+      isLiveSameAccount(connection, request.account),
+    )
+  ) {
+    return {};
+  }
+
+  const result = await client.adoptGoogleAuthorization(principal, request);
+  if (result.ok) return result.value;
+
+  throwUnavailable(result.error.kind, result.error.correlationId);
+}
+
+function isLiveSameAccount(
+  connection: ProviderConnection,
+  account: ProviderAccountFacts,
+): boolean {
+  return (
+    connection.account.providerAccountId === account.providerAccountId &&
+    !["actionRequired", "disconnected"].includes(connection.state)
+  );
+}
+
+function throwUnavailable(kind: string, correlationId: string): never {
+  logger.warn(
+    `Sync Google authorization adoption failed (${kind}) ` +
+      `[correlationId=${correlationId}]`,
+  );
+  throw error(
+    AuthError.SyncConnectionUnavailable,
+    "Failed to connect Google Calendar",
+  );
+}

--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { decryptInternalCredential } from "@core/security/internal-credential-envelope";
 import { type BusyAvailabilityRequest } from "@core/types/sync/availability.contracts";
 import { type CommandSubmitRequest } from "@core/types/sync/command.contracts";
 import { type EventInstanceListQuery } from "@core/types/sync/event.contracts";
@@ -13,6 +14,7 @@ import {
 } from "@sync/server/change-feed.routes";
 import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
+  ADOPT_GOOGLE_AUTHORIZATION_PATH,
   AVAILABILITY_BUSY_PATH,
   BEGIN_PATH,
   CALENDARS_PATH,
@@ -511,6 +513,54 @@ describe("SyncServiceClient", () => {
     // No connectionId given: a fresh connection sends an empty body.
     expect(JSON.parse(sent?.body ?? "{}")).toEqual({});
 
+    const verdict = verifyInternalRequest({
+      secret: SECRET,
+      headers: sent?.headers ?? {},
+      now: NOW,
+    });
+    if (!verdict.ok) throw new Error(`verify failed: ${verdict.reason}`);
+    expect(verdict.context.principalId).toBe(who.principalId);
+  });
+
+  it("adopts a server-exchanged Google authorization with a signed POST", async () => {
+    const who = principal();
+    const request = {
+      account: {
+        providerAccountId: "google-sub-1",
+        email: "connected@example.com",
+        displayName: "Connected User",
+      },
+      refreshToken: "server-exchanged-refresh-token",
+      grantedScopes: ["https://www.googleapis.com/auth/calendar.events"],
+    };
+    const { fn, calls } = fakeFetch(async () => ({
+      status: 200,
+      json: async () => ({}),
+    }));
+
+    const result = await client(fn).adoptGoogleAuthorization(who, request);
+
+    if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+    expect(result.value).toEqual({});
+    const sent = calls[0];
+    expect(sent?.url).toBe(`${BASE_URL}${ADOPT_GOOGLE_AUTHORIZATION_PATH}`);
+    expect(sent?.method).toBe("POST");
+    const body = JSON.parse(sent?.body ?? "") as {
+      account: unknown;
+      credential: unknown;
+      grantedScopes: unknown;
+    };
+    expect(body.account).toEqual(request.account);
+    expect(body.grantedScopes).toEqual(request.grantedScopes);
+    expect(JSON.stringify(body)).not.toContain(request.refreshToken);
+    expect(
+      decryptInternalCredential(SECRET, body.credential as never, {
+        tenantId: who.tenantId,
+        principalId: who.principalId,
+        account: request.account,
+        grantedScopes: request.grantedScopes,
+      }),
+    ).toBe(request.refreshToken);
     const verdict = verifyInternalRequest({
       secret: SECRET,
       headers: sent?.headers ?? {},

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -1,4 +1,5 @@
 import { type z } from "zod/v4";
+import { encryptInternalCredential } from "@core/security/internal-credential-envelope";
 import {
   type BusyAvailabilityRequest,
   type BusyAvailabilityResponse,
@@ -26,6 +27,9 @@ import {
   ConnectionListResponseSchema,
   type ConnectionRefreshResponse,
   ConnectionRefreshResponseSchema,
+  type GoogleConnectionAdoptionRequest,
+  type GoogleConnectionAdoptionResponse,
+  GoogleConnectionAdoptionResponseSchema,
 } from "@core/types/sync/connection.contracts";
 import {
   type EventInstanceListQuery,
@@ -47,6 +51,8 @@ const CHANGES_ALL_PATH = "/internal/changes/all";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
 const CONNECTIONS_REFRESH_PATH = "/internal/connections/refresh";
+const ADOPT_GOOGLE_AUTHORIZATION_PATH =
+  "/internal/connections/adopt-google-authorization";
 const EVENTS_FULL_PATH = "/internal/events/full";
 const COMMANDS_PATH = "/internal/commands";
 const PRINCIPAL_PATH = "/internal/principal";
@@ -212,6 +218,38 @@ export class SyncServiceClient {
       principal,
       body: request,
       schema: ConnectionBeginResponseSchema,
+      correlationId,
+    });
+  }
+
+  // Adopt a Google authorization that Compass API exchanged during sign-in.
+  // This is trusted internal traffic; refresh tokens never cross the browser.
+  adoptGoogleAuthorization(
+    principal: SyncPrincipal,
+    request: Omit<GoogleConnectionAdoptionRequest, "credential"> & {
+      refreshToken: string;
+    },
+    correlationId?: string,
+  ): Promise<SyncClientResult<GoogleConnectionAdoptionResponse>> {
+    return this.#request({
+      method: "POST",
+      path: ADOPT_GOOGLE_AUTHORIZATION_PATH,
+      principal,
+      body: {
+        account: request.account,
+        credential: encryptInternalCredential(
+          this.#secret,
+          request.refreshToken,
+          {
+            tenantId: principal.tenantId,
+            principalId: principal.principalId,
+            account: request.account,
+            grantedScopes: request.grantedScopes,
+          },
+        ),
+        grantedScopes: request.grantedScopes,
+      },
+      schema: GoogleConnectionAdoptionResponseSchema,
       correlationId,
     });
   }

--- a/packages/core/src/security/internal-credential-envelope.test.ts
+++ b/packages/core/src/security/internal-credential-envelope.test.ts
@@ -1,0 +1,69 @@
+import {
+  decryptInternalCredential,
+  encryptInternalCredential,
+} from "./internal-credential-envelope";
+import { describe, expect, it } from "bun:test";
+
+describe("internal credential envelope", () => {
+  const context = {
+    tenantId: "64b7f9c2e1a2b3c4d5e6f7a8",
+    principalId: "64b7f9c2e1a2b3c4d5e6f7a8",
+    account: {
+      providerAccountId: "google-sub-1",
+      email: "connected@example.com",
+      displayName: "Connected User",
+    },
+    grantedScopes: ["https://www.googleapis.com/auth/calendar.events"],
+  };
+
+  it("round-trips a credential without exposing it in the envelope", () => {
+    const credential = "server-exchanged-refresh-token";
+    const envelope = encryptInternalCredential(
+      "shared-secret",
+      credential,
+      context,
+    );
+
+    expect(JSON.stringify(envelope)).not.toContain(credential);
+    expect(decryptInternalCredential("shared-secret", envelope, context)).toBe(
+      credential,
+    );
+  });
+
+  it("rejects a modified ciphertext", () => {
+    const envelope = encryptInternalCredential(
+      "shared-secret",
+      "credential",
+      context,
+    );
+    const modified = {
+      ...envelope,
+      ciphertext: `${envelope.ciphertext.slice(0, -2)}AA`,
+    };
+
+    expect(() =>
+      decryptInternalCredential("shared-secret", modified, context),
+    ).toThrow();
+  });
+
+  it("rejects a credential envelope replayed for another principal", () => {
+    const envelope = encryptInternalCredential(
+      "shared-secret",
+      "credential",
+      context,
+    );
+
+    expect(() =>
+      decryptInternalCredential("shared-secret", envelope, {
+        ...context,
+        principalId: "64b7f9c2e1a2b3c4d5e6f7a9",
+      }),
+    ).toThrow();
+    expect(() =>
+      decryptInternalCredential("shared-secret", envelope, {
+        ...context,
+        grantedScopes: ["https://www.googleapis.com/auth/calendar.readonly"],
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/core/src/security/internal-credential-envelope.ts
+++ b/packages/core/src/security/internal-credential-envelope.ts
@@ -1,0 +1,87 @@
+import {
+  type EncryptedCredentialEnvelope,
+  EncryptedCredentialEnvelopeSchema,
+  type ProviderAccountFacts,
+} from "@core/types/sync/connection.contracts";
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const ROUTE = "POST /internal/connections/adopt-google-authorization";
+
+function encryptionKey(secret: string): Buffer {
+  return createHash("sha256")
+    .update("compass.internal-credential-envelope.v1")
+    .update(secret)
+    .digest();
+}
+
+export type GoogleConnectionCredentialContext = {
+  tenantId: string;
+  principalId: string;
+  account: ProviderAccountFacts;
+  grantedScopes: readonly string[];
+};
+
+// Bind every non-secret authorization fact to the credential. Any attempt to
+// replay it under another principal or substitute an account/scope set fails
+// AES-GCM authentication before Sync can persist a connection.
+function additionalAuthenticatedData(
+  context: GoogleConnectionCredentialContext,
+): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      version: 1,
+      route: ROUTE,
+      tenantId: context.tenantId,
+      principalId: context.principalId,
+      account: context.account,
+      grantedScopes: [...context.grantedScopes].sort(),
+    }),
+  );
+}
+
+// Encrypt a credential before it crosses the Compass API → Sync service hop.
+// The shared internal secret provides confidentiality and authentication even
+// when the service mesh itself is configured with an http:// URL.
+export function encryptInternalCredential(
+  secret: string,
+  credential: string,
+  context: GoogleConnectionCredentialContext,
+): EncryptedCredentialEnvelope {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(ALGORITHM, encryptionKey(secret), iv);
+  cipher.setAAD(additionalAuthenticatedData(context));
+  const ciphertext = Buffer.concat([
+    cipher.update(credential, "utf8"),
+    cipher.final(),
+  ]);
+  return {
+    iv: iv.toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+    authTag: cipher.getAuthTag().toString("base64"),
+  };
+}
+
+export function decryptInternalCredential(
+  secret: string,
+  envelope: EncryptedCredentialEnvelope,
+  context: GoogleConnectionCredentialContext,
+): string {
+  const parsed = EncryptedCredentialEnvelopeSchema.parse(envelope);
+  const decipher = createDecipheriv(
+    ALGORITHM,
+    encryptionKey(secret),
+    Buffer.from(parsed.iv, "base64"),
+  );
+  decipher.setAAD(additionalAuthenticatedData(context));
+  decipher.setAuthTag(Buffer.from(parsed.authTag, "base64"));
+  return Buffer.concat([
+    decipher.update(Buffer.from(parsed.ciphertext, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+}

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -5,6 +5,7 @@ import {
   CalendarListResponseSchema,
   ConnectionListResponseSchema,
   ConnectionStateSchema,
+  GoogleConnectionAdoptionRequestSchema,
   ProviderAccountFactsSchema,
   ProviderCalendarSchema,
   ProviderConnectionSchema,
@@ -185,6 +186,44 @@ describe("Sync connection contracts", () => {
         refreshToken: "leak",
       };
       expect(ProviderAccountFactsSchema.safeParse(facts).success).toBe(false);
+    });
+  });
+
+  describe("GoogleConnectionAdoptionRequestSchema", () => {
+    it("accepts the trusted server-side authorization handoff", () => {
+      expect(
+        GoogleConnectionAdoptionRequestSchema.safeParse({
+          account: {
+            providerAccountId: "1122334455",
+            email: "connected@example.com",
+            displayName: "Connected User",
+          },
+          credential: {
+            iv: "aGVsbG8=",
+            ciphertext: "Y2lwaGVydGV4dA==",
+            authTag: "dGFn",
+          },
+          grantedScopes: ["https://www.googleapis.com/auth/calendar.readonly"],
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects an empty scope set", () => {
+      expect(
+        GoogleConnectionAdoptionRequestSchema.safeParse({
+          account: {
+            providerAccountId: "1122334455",
+            email: null,
+            displayName: null,
+          },
+          credential: {
+            iv: "aGVsbG8=",
+            ciphertext: "Y2lwaGVydGV4dA==",
+            authTag: "dGFn",
+          },
+          grantedScopes: [],
+        }).success,
+      ).toBe(false);
     });
   });
 

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -51,6 +51,38 @@ export const ProviderAccountFactsSchema = z.strictObject({
 });
 export type ProviderAccountFacts = z.infer<typeof ProviderAccountFactsSchema>;
 
+// Opaque authenticated-encryption envelope for credentials sent between the
+// Compass API and Sync services. The browser never sees this transport type.
+export const EncryptedCredentialEnvelopeSchema = z.strictObject({
+  iv: z.string().base64().min(1).max(128),
+  ciphertext: z.string().base64().min(1).max(8192),
+  authTag: z.string().base64().min(1).max(128),
+});
+export type EncryptedCredentialEnvelope = z.infer<
+  typeof EncryptedCredentialEnvelopeSchema
+>;
+
+// Trusted Compass API → Sync handoff after the normal Google sign-in flow has
+// exchanged an authorization code. This is intentionally an internal contract:
+// the browser never receives or submits the credential.
+export const GoogleConnectionAdoptionRequestSchema = z.strictObject({
+  account: ProviderAccountFactsSchema,
+  credential: EncryptedCredentialEnvelopeSchema,
+  grantedScopes: z
+    .array(z.string().trim().min(1).max(512))
+    .min(1)
+    .max(64)
+    .readonly(),
+});
+export type GoogleConnectionAdoptionRequest = z.infer<
+  typeof GoogleConnectionAdoptionRequestSchema
+>;
+
+export const GoogleConnectionAdoptionResponseSchema = z.strictObject({});
+export type GoogleConnectionAdoptionResponse = z.infer<
+  typeof GoogleConnectionAdoptionResponseSchema
+>;
+
 const STATES_WITH_REASON: ReadonlySet<ConnectionState> = new Set([
   "delayed",
   "actionRequired",

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -103,6 +103,7 @@ export function createSyncService(
         // secret (domain-separated from internal-auth signing); the callback
         // resolves against the public base URL.
         stateSecret: deriveOAuthStateSecret(config.INTERNAL_AUTH_TOKEN),
+        credentialEncryptionSecret: config.INTERNAL_AUTH_TOKEN,
         callbackBaseUrl: config.CALLBACK_BASE_URL,
         // Fall back to the callback base when no explicit redirect is set.
         postConnectRedirectUrl:

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
+import { encryptInternalCredential } from "@core/security/internal-credential-envelope";
 import {
   type ConnectionId,
   type PrincipalId,
@@ -22,6 +23,7 @@ import {
 } from "@sync/providers/provider-auth.port";
 import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
+  ADOPT_GOOGLE_AUTHORIZATION_PATH,
   BEGIN_PATH,
   CALENDARS_PATH,
   CONNECTIONS_PATH,
@@ -797,6 +799,138 @@ describe("GET /sync/google", () => {
 
     expect(statusOf(res)).toBe("error");
     expect(adapter.exchanges).toHaveLength(0);
+  });
+});
+
+describe("POST /internal/connections/adopt-google-authorization", () => {
+  let mongo: SyncMongoService;
+  let connections: ProviderConnectionRepository;
+  let credentials: CredentialRepository;
+  let service: SyncService;
+  let base: string;
+
+  const startService = async () => {
+    service = createSyncService(testConfig({ EXECUTION: "active" }), {
+      mongo,
+      authAdapter: new FakeAuthAdapter(),
+    });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    connections = new ProviderConnectionRepository(mongo.db);
+    credentials = new CredentialRepository(mongo.db);
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  it("adopts a signed Google authorization and bootstraps its import", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const account = {
+      providerAccountId: "google-sub-from-signin",
+      email: "connected@example.com",
+      displayName: "Connected User",
+    };
+    const grantedScopes = [
+      "https://www.googleapis.com/auth/calendar.readonly",
+      "https://www.googleapis.com/auth/calendar.events",
+    ];
+    await startService();
+
+    const res = await fetch(`${base}${ADOPT_GOOGLE_AUTHORIZATION_PATH}`, {
+      method: "POST",
+      headers: {
+        ...signedHeaders(tenantId, principalId),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        account,
+        credential: encryptInternalCredential(
+          SECRET,
+          "server-exchanged-refresh-token",
+          { tenantId, principalId, account, grantedScopes },
+        ),
+        grantedScopes,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({});
+    const [connection] = await connections.listByPrincipal(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+    );
+    expect(connection?.state).toBe("importing");
+    expect(connection?.account.providerAccountId).toBe(
+      "google-sub-from-signin",
+    );
+    const stored = await credentials.findByConnection(connection!._id);
+    expect(stored?.refreshToken).toBe("server-exchanged-refresh-token");
+    const job = await mongo.db.collection(SYNC_COLLECTIONS.jobs).findOne({
+      coalescingKey: `calendarListSync:${connection!._id}`,
+    });
+    expect(job?.kind).toBe("calendarListSync");
+  });
+
+  it("rejects an envelope replayed under another principal", async () => {
+    const tenantId = objectId();
+    const sourcePrincipalId = objectId();
+    const targetPrincipalId = objectId();
+    const account = {
+      providerAccountId: "google-sub-from-signin",
+      email: "connected@example.com",
+      displayName: "Connected User",
+    };
+    const grantedScopes = ["https://www.googleapis.com/auth/calendar.events"];
+    await startService();
+
+    const res = await fetch(`${base}${ADOPT_GOOGLE_AUTHORIZATION_PATH}`, {
+      method: "POST",
+      headers: {
+        ...signedHeaders(tenantId, targetPrincipalId),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        account,
+        credential: encryptInternalCredential(
+          SECRET,
+          "server-exchanged-refresh-token",
+          {
+            tenantId,
+            principalId: sourcePrincipalId,
+            account,
+            grantedScopes,
+          },
+        ),
+        grantedScopes,
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    await expect(
+      connections.listByPrincipal(
+        tenantId as TenantId,
+        targetPrincipalId as PrincipalId,
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("rejects an unsigned authorization adoption", async () => {
+    await startService();
+
+    const res = await fetch(`${base}${ADOPT_GOOGLE_AUTHORIZATION_PATH}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(401);
   });
 });
 

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -1,6 +1,7 @@
 import { type Express, type RequestHandler, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
+import { decryptInternalCredential } from "@core/security/internal-credential-envelope";
 import {
   BusyAvailabilityRequestSchema,
   type BusyAvailabilityResponse,
@@ -10,6 +11,7 @@ import {
   type CalendarListResponse,
   type ConnectionListResponse,
   ConnectionRefreshResponseSchema,
+  GoogleConnectionAdoptionRequestSchema,
   type ProviderCalendar,
   ProviderCalendarSchema,
   type ProviderConnection,
@@ -68,6 +70,8 @@ export const EVENTS_FULL_PATH = "/internal/events/full";
 export const AVAILABILITY_BUSY_PATH = "/internal/availability/busy";
 export const BEGIN_PATH = "/internal/connections/begin";
 export const REFRESH_PATH = "/internal/connections/refresh";
+export const ADOPT_GOOGLE_AUTHORIZATION_PATH =
+  "/internal/connections/adopt-google-authorization";
 // Where the provider redirects the browser after consent; `begin` builds the
 // redirect_uri from it and the public callback route below mounts on it.
 // Public reverse-proxy path (Caddy `/sync/*` → sync). Must match the Google
@@ -106,6 +110,8 @@ export interface ConnectionApiDeps {
   postConnectRedirectUrl: string;
   // Injectable clock so state issuance/verification is deterministic in tests.
   now?: () => number;
+  // Shared secret that encrypts credentials on the Compass API → Sync hop.
+  credentialEncryptionSecret: string;
 }
 
 // Internal, authenticated connection endpoints. The tenant/principal comes from
@@ -479,6 +485,60 @@ export function registerConnectionRoutes(
         redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
       });
       res.status(Status.OK).json({ authorizationUrl });
+    },
+  );
+
+  // The regular Compass Google sign-in flow already exchanged consent with
+  // Google. Adopt that server-side authorization into Sync so sign-up creates
+  // the same connection and initial import as the dedicated Connect flow.
+  app.post(
+    ADOPT_GOOGLE_AUTHORIZATION_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+      if (deps.execution === "passive" || !deps.authAdapter) {
+        res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+        return;
+      }
+
+      const parsed = GoogleConnectionAdoptionRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_authorization" });
+        return;
+      }
+
+      try {
+        const refreshToken = decryptInternalCredential(
+          deps.credentialEncryptionSecret,
+          parsed.data.credential,
+          {
+            tenantId: auth.tenantId,
+            principalId: auth.principalId,
+            account: parsed.data.account,
+            grantedScopes: parsed.data.grantedScopes,
+          },
+        );
+        await linkConnection(
+          deps,
+          deps.authAdapter,
+          {
+            tenantId: auth.tenantId,
+            principalId: auth.principalId,
+            connectionId: null,
+          },
+          { ...parsed.data, refreshToken },
+        );
+        res.status(Status.OK).json({});
+      } catch (error) {
+        logger.error(
+          "Failed to adopt Google authorization",
+          redactedCause(error),
+        );
+        respondInternalError(res);
+      }
     },
   );
 


### PR DESCRIPTION
## Summary
- adopt a Google Calendar Sync connection during successful Google sign-up/sign-in
- validate returned Google Calendar scopes server-side before persistence
- keep refresh tokens inside the service boundary in a request-bound encrypted envelope
- avoid restarting already-live connections and add recovery coverage for existing legacy sign-ins

## Root cause
Google authentication only stored legacy OAuth metadata. It never created a Sync connection, so the UI correctly reported Connect Google Calendar and rendered only local events.

## Validation
- bun run verify
- bun type-check
- bun lint
- independent security review