### PR TITLE
fix(ci): derive runtime.nodeEnv from the deploy target, not a hardcoded literal

### DIFF
--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -96,11 +96,20 @@ jobs:
           SUPERTOKENS_URI: ${{ secrets.SUPERTOKENS_URI }}
         run: |
           echo "Deploying Compass ${RELEASE_TAG} (image version: ${IMAGE_VERSION}) to ${{ inputs.environment }}"
+          # Only "production" ever runs the production runtime.nodeEnv; every
+          # other GitHub Environment (staging-cloud, staging-selfhosted, ...)
+          # is "staging". This used to be hardcoded to "production"
+          # unconditionally, so staging told its own telemetry it was
+          # production and polluted any prod-scoped alert or dashboard
+          # (2026-08-01).
           if [ "${{ inputs.environment }}" = "production" ]; then
+            NODE_ENV="production"
             if [ -z "$KIT_API_SECRET" ]; then
               echo "Production deploy requires KIT_API_SECRET." >&2
               exit 1
             fi
+          else
+            NODE_ENV="staging"
           fi
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/staging_key
@@ -141,7 +150,7 @@ jobs:
             printf '%s\n' \
               'runtime:' \
               "  version: \"${IMAGE_VERSION}\"" \
-              '  nodeEnv: production' \
+              "  nodeEnv: ${NODE_ENV}" \
               '  timezone: Etc/UTC' \
               'web:' \
               '  port: 9080' \

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -456,6 +456,20 @@ describe("staging deploy workflow", () => {
     expect(workflow).not.toContain('if [ -n "$DEPLOY_PROFILES" ]; then');
   });
 
+  it("derives runtime.nodeEnv from the GitHub Environment instead of hardcoding production", () => {
+    // 2026-08-01: this was unconditionally "production" for every GitHub
+    // Environment, including staging-cloud and staging-selfhosted. Staging
+    // told its own telemetry (and any prod-scoped alert reading it) that it
+    // was production, which silently polluted health signals with an idle
+    // environment's data alongside the real thing.
+    const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
+
+    expect(workflow).not.toContain("'  nodeEnv: production'");
+    expect(workflow).toContain('"  nodeEnv: ${NODE_ENV}"');
+    expect(workflow).toContain('NODE_ENV="production"');
+    expect(workflow).toContain('NODE_ENV="staging"');
+  });
+
   it("falls back to the release tag when a configured compose ref is unavailable", () => {
     const workflow = readRepoFile(".github/workflows/_deploy-environment.yml");
 


### PR DESCRIPTION
## Problem

Every deploy — production, staging-cloud, staging-selfhosted — wrote `nodeEnv: production` into `compass.yaml` unconditionally (`_deploy-environment.yml`). Staging's sync service therefore reports `environment: production` to PostHog, and its telemetry (all-zero snapshots, since staging idles) silently interleaves with real production health data.

Found while diagnosing tonight's sync outage: a second process reporting `environment: production` against an empty database, active since staging's last deploy. Beyond confusing incident diagnosis, it blocks a straightforward fix: an alert on `jobs.pending == 0 AND freshness.percentOver30s == 100` scoped to `environment: production` would misread idle staging as a production incident, or a real prod gap could get lost in staging's noise.

## Change

Derive `NODE_ENV` from `inputs.environment` (the GitHub Environment name already passed to this reusable workflow): `production` maps to `production`, every other environment (`staging-cloud`, `staging-selfhosted`) maps to `staging`.

Confirmed this is a corrected label, not a behavior change — nothing in the app gates on `=== NodeEnv.Production` specifically: `isDev()` only matches `Development`, and the PostHog logging gate already explicitly anticipates `Staging || Production` together, meaning the codebase was designed for staging to identify itself accurately.

Also manually corrected the currently-live staging deploy (`nodeEnv: production` → `staging` in its `compass.yaml`, all three processes restarted, each verified from its own startup log — `compass-sync listening on 3010 (staging, execution=active)`) so the fix takes effect immediately rather than waiting for the next staging deploy.

## Tests

New assertion in `self-host/docker-compose.test.ts`'s existing text-based workflow suite: the hardcoded literal is gone, `NODE_ENV` is derived, and both branches (`production` / `staging`) are present. 43/43 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)