### PR TITLE
fix(sync): emit a reconcile-sweep-completion event instead of relying on a gauge

### DIFF
--- a/packages/core/src/types/sync/health.contracts.ts
+++ b/packages/core/src/types/sync/health.contracts.ts
@@ -61,3 +61,23 @@ export const SyncHealthSnapshotSchema = z.strictObject({
 export type SyncHealthSnapshot = z.infer<typeof SyncHealthSnapshotSchema>;
 
 export const SYNC_HEALTH_SNAPSHOT_EVENT = "sync_health_snapshot" as const;
+
+// Emitted once per reconcile-sweep cycle completion (~every 10 min), rather
+// than on a fixed telemetry timer like the health snapshot above. A queue
+// depth GAUGE sampled every 5 minutes cannot reliably detect a sweep that
+// enqueues and fully drains work in well under a minute — an alert built on
+// jobs.pending fired repeatedly on a healthy fleet because the 5-minute
+// sampler almost never caught the queue non-empty (2026-08-01). Counting
+// discrete sweep-completion events instead sidesteps the sampling gap
+// entirely: a sweep either ran or it didn't, with nothing in between for a
+// sampler to miss.
+export const SyncReconcileSweepEventSchema = z.strictObject({
+  environment: z.string().min(1),
+  service: z.literal("compass-sync"),
+  enqueued: z.number().int().nonnegative(),
+});
+export type SyncReconcileSweepEvent = z.infer<
+  typeof SyncReconcileSweepEventSchema
+>;
+
+export const SYNC_RECONCILE_SWEEP_EVENT = "sync_reconcile_sweep" as const;

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,5 +1,9 @@
 import { Logger } from "@core/logger/winston.logger";
 import {
+  SYNC_RECONCILE_SWEEP_EVENT,
+  SyncReconcileSweepEventSchema,
+} from "@core/types/sync/health.contracts";
+import {
   createInternalAuthMiddleware,
   createInternalServiceAuthMiddleware,
 } from "@sync/auth/internal-auth";
@@ -37,6 +41,7 @@ import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
 import { emitHealthSnapshot } from "@sync/telemetry/health-snapshot.service";
 import {
+  captureSafely,
   createPostHogCaptureClient,
   DEFAULT_POSTHOG_HOST,
   type PostHogCaptureClient,
@@ -225,7 +230,12 @@ async function start(): Promise<void> {
     // Active, provider-configured deployments also drain jobs and renew
     // channels. Those register AFTER the mongo drain so teardown stops them
     // first and closes mongo last.
-    const schedulers = buildSchedulers(config, mongo);
+    const schedulers = buildSchedulers(
+      config,
+      mongo,
+      service.identity,
+      posthog,
+    );
     if (schedulers) {
       service.shutdown.register("scheduler", async () => {
         // Stop every drain; each releases only its own owner's held jobs.
@@ -350,6 +360,8 @@ function buildRetentionSweep(mongo: SyncMongoService): SweepScheduler {
 function buildSchedulers(
   config: SyncConfig,
   mongo: SyncMongoService,
+  identity: ReturnType<typeof buildServiceIdentity>,
+  posthog: PostHogCaptureClient | null,
 ): {
   drains: SyncScheduler[];
   reconcile: SweepScheduler;
@@ -425,6 +437,22 @@ function buildSchedulers(
         if (enqueued > 0) {
           logger.info(`Sync reconcile sweep enqueued ${enqueued} pull(s)`);
         }
+        // Captured on every cycle, including enqueued: 0 — this is a
+        // liveness heartbeat, not a backlog report (the health snapshot's
+        // jobs.pending already covers backlog, and is too coarse a sample
+        // rate to catch a queue that drains in seconds; see the event's own
+        // doc comment). An alert built on "N of these landed in the last
+        // hour" can't be fooled by sampling gaps the way a periodic gauge
+        // read can.
+        await captureSafely(posthog, {
+          event: SYNC_RECONCILE_SWEEP_EVENT,
+          distinctId: "compass-sync",
+          properties: SyncReconcileSweepEventSchema.parse({
+            environment: identity.environment,
+            service: "compass-sync",
+            enqueued,
+          }),
+        });
         return enqueued;
       },
     },


### PR DESCRIPTION
## Problem

A work-starvation alert built this morning (fires when `jobs.pending` shows zero for too long) started firing repeatedly on a healthy fleet — 5 notification emails over 9 hours.

Investigated with real data rather than trusting the first plausible explanation: cross-checked `compass-sync-1`'s logs against a 5-hour window (06:21–11:12) where PostHog's `jobs.pending` snapshot showed 0 in 59 of 60 samples. The sweep ran flawlessly the entire time — 100 pulls enqueued every ~10 minutes, zero gaps, zero errors. The queue really is draining in well under a minute now (a direct result of this morning's own reliability fixes), and a 5-minute point-in-time sample essentially never lands while anything is queued.

No window width fixes this. At a ~2% hit rate, reliably catching even one nonzero sample needs a window pushing 20+ hours — which defeats the purpose of a same-day alert. A gauge sampled periodically is the wrong tool once the thing it measures moves faster than the sample rate.

## Change

Emit `sync_reconcile_sweep` on every sweep cycle completion (including `enqueued: 0`), independent of the 5-minute health-snapshot cadence. This sidesteps the sampling problem entirely — counting discrete completion events in a window ("did N sweeps complete in the last hour") can't be fooled by sampling gaps the way reading a periodic gauge can. A sweep either ran or it didn't; there's no brief window for a sampler to miss.

Threads `posthog` and `identity` into `buildSchedulers`, following the same `captureSafely` pattern the health-snapshot sweep already uses.

## Tests

753/753 sync tests pass, type-check and lint clean. No dedicated test added for the `app.ts` wiring itself — that file has no existing test coverage (it's integration wiring exercised by the full service), consistent with the current codebase.

## Follow-up (not in this PR)

Once this ships and events start flowing in prod, the disabled `Sync reconcile sweep starved (production)` PostHog alert will be rebuilt on top of `count(sync_reconcile_sweep events in trailing N minutes)` instead of the gauge, then re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)