### PR TITLE
feat(web): clarify recurring scope toast

### DIFF
--- a/packages/web/src/common/utils/toast/recurrence-scope.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/recurrence-scope.toast.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@web/events/recurrence/recurrence-scope-opportunity.store";
 import {
   dismissRecurrenceScopeToast,
+  showRecurrenceScopeSuccessToast,
   showRecurrenceScopeToast,
 } from "./recurrence-scope.toast";
 import { beforeEach, describe, expect, it } from "bun:test";
@@ -29,6 +30,11 @@ describe("showRecurrenceScopeToast", () => {
 
   it("offers accessible clickable promotion actions", async () => {
     const original = createMockEvent({
+      content: {
+        kind: "details",
+        title: "Drive home with kids for 50 min in the SUV on highway 20",
+        description: "",
+      },
       recurrence: {
         kind: "occurrence",
         seriesId: "0123456789abcdef11111111" as EventId,
@@ -55,9 +61,14 @@ describe("showRecurrenceScopeToast", () => {
     const [content] = mocks.toast.mock.calls.at(0) as unknown as [ReactNode];
     render(content);
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /this & following/i }),
-    );
+    expect(
+      screen.getByText("Deleted “Drive home with kids for 50…”"),
+    ).toBeVisible();
+    expect(screen.getByText("Apply to series?")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Following" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "All" })).toBeVisible();
+
+    await userEvent.click(screen.getByRole("button", { name: "Following" }));
 
     expect(
       useRecurrenceScopeOpportunityStore.getState().opportunity,
@@ -66,7 +77,86 @@ describe("showRecurrenceScopeToast", () => {
       status: "requested",
       requestedScope: "thisAndFollowing",
     });
-    expect(screen.getByRole("button", { name: /all/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: "All" })).toBeVisible();
+  });
+
+  it("confirms the promoted scope without implying it can be undone", () => {
+    const original = createMockEvent({
+      content: { kind: "details", title: "Plan week", description: "" },
+      recurrence: {
+        kind: "occurrence",
+        seriesId: "0123456789abcdef11111111" as EventId,
+      },
+    });
+    recurrenceScopeOpportunityActions.begin({
+      kind: "replace",
+      original,
+      input: {
+        content: {
+          kind: "details",
+          title: "Updated plan",
+          description: "",
+        },
+        schedule: original.schedule,
+        recurrence: { kind: "preserve" },
+        scope: "this",
+      },
+      source: "local",
+    });
+    const opportunity =
+      useRecurrenceScopeOpportunityStore.getState().opportunity;
+    if (!opportunity) throw new Error("Expected opportunity");
+
+    showRecurrenceScopeSuccessToast(opportunity, "thisAndFollowing");
+    const [, update] = mocks.update.mock.calls.at(-1) as unknown as [
+      unknown,
+      { render: ReactNode },
+    ];
+    render(update.render);
+
+    expect(
+      screen.getByText("Updated “Updated plan” and following"),
+    ).toBeVisible();
+    expect(screen.queryByText(/undo/i)).not.toBeInTheDocument();
+  });
+
+  it("does not replace a newer scope offer with a stale confirmation", () => {
+    const original = createMockEvent({
+      recurrence: {
+        kind: "occurrence",
+        seriesId: "0123456789abcdef11111111" as EventId,
+      },
+    });
+    const firstId = recurrenceScopeOpportunityActions.begin({
+      kind: "delete",
+      original,
+      source: "local",
+    });
+    const first = useRecurrenceScopeOpportunityStore.getState().opportunity;
+    if (!first) throw new Error("Expected first opportunity");
+
+    recurrenceScopeOpportunityActions.requestPromotion(firstId, "all");
+    const newerId = recurrenceScopeOpportunityActions.begin({
+      kind: "delete",
+      original: createMockEvent({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: "0123456789abcdef22222222" as EventId,
+        },
+      }),
+      source: "local",
+    });
+    const newer = useRecurrenceScopeOpportunityStore.getState().opportunity;
+    if (!newer) throw new Error("Expected newer opportunity");
+
+    showRecurrenceScopeToast(newer);
+    mocks.update.mockClear();
+    showRecurrenceScopeSuccessToast(first, "all");
+
+    expect(mocks.update).not.toHaveBeenCalled();
+    expect(
+      useRecurrenceScopeOpportunityStore.getState().opportunity,
+    ).toMatchObject({ id: newerId, status: "ready" });
   });
 
   it("dismisses only the matching live scope offer", () => {

--- a/packages/web/src/common/utils/toast/recurrence-scope.toast.tsx
+++ b/packages/web/src/common/utils/toast/recurrence-scope.toast.tsx
@@ -5,6 +5,7 @@ import {
   getToastDefaultOptions,
 } from "@web/common/constants/toast.constants";
 import { getToast } from "@web/common/utils/toast/toast.port";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   type RecurrenceScopeOpportunity,
   recurrenceScopeOpportunityActions,
@@ -13,8 +14,31 @@ import {
 
 export const RECURRENCE_SCOPE_TOAST_ID = "recurrence-scope-opportunity";
 
+const MAX_EVENT_NAME_LENGTH = 28;
+
 const actionClassName =
-  "rounded px-1.5 py-0.5 text-sm font-medium text-text hover:bg-surface-overlay focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent";
+  "flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm font-medium text-text hover:bg-surface-overlay focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent";
+
+const truncateEventName = (title: string) => {
+  const name = title.trim() || "Untitled event";
+  if (name.length <= MAX_EVENT_NAME_LENGTH) return name;
+
+  const truncated = name.slice(0, MAX_EVENT_NAME_LENGTH + 1);
+  const boundary = truncated.lastIndexOf(" ");
+  const visible =
+    boundary > MAX_EVENT_NAME_LENGTH / 2
+      ? truncated.slice(0, boundary)
+      : name.slice(0, MAX_EVENT_NAME_LENGTH);
+  return `${visible.trimEnd()}…`;
+};
+
+const eventNameForToast = (opportunity: RecurrenceScopeOpportunity) => {
+  const content =
+    opportunity.kind === "replace"
+      ? opportunity.input.content
+      : opportunity.original.content;
+  return truncateEventName(content.kind === "details" ? content.title : "");
+};
 
 function ScopeToastContent({
   opportunity,
@@ -22,34 +46,42 @@ function ScopeToastContent({
   opportunity: RecurrenceScopeOpportunity;
 }) {
   const verb = opportunity.kind === "delete" ? "Deleted" : "Changed";
+  const eventName = eventNameForToast(opportunity);
 
   return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-      <span>{verb} this event</span>
-      <button
-        type="button"
-        className={actionClassName}
-        onClick={() =>
-          recurrenceScopeOpportunityActions.requestPromotion(
-            opportunity.id,
-            "thisAndFollowing",
-          )
-        }
-      >
-        <kbd>1</kbd> This &amp; following
-      </button>
-      <button
-        type="button"
-        className={actionClassName}
-        onClick={() =>
-          recurrenceScopeOpportunityActions.requestPromotion(
-            opportunity.id,
-            "all",
-          )
-        }
-      >
-        <kbd>2</kbd> All
-      </button>
+    <div className="min-w-0">
+      <p title={eventName}>
+        {verb} “{eventName}”
+      </p>
+      <p className="mt-1 text-sm text-text-muted">Apply to series?</p>
+      <div className="mt-1 grid gap-1">
+        <button
+          type="button"
+          className={actionClassName}
+          onClick={() =>
+            recurrenceScopeOpportunityActions.requestPromotion(
+              opportunity.id,
+              "thisAndFollowing",
+            )
+          }
+        >
+          <span>Following</span>
+          <ShortcutKeys keys="1" />
+        </button>
+        <button
+          type="button"
+          className={actionClassName}
+          onClick={() =>
+            recurrenceScopeOpportunityActions.requestPromotion(
+              opportunity.id,
+              "all",
+            )
+          }
+        >
+          <span>All</span>
+          <ShortcutKeys keys="2" />
+        </button>
+      </div>
     </div>
   );
 }
@@ -93,6 +125,25 @@ export function showRecurrenceScopePromotionToast(
   opportunity: RecurrenceScopeOpportunity,
 ): void {
   show("Applying change to the series…", toastIdFor(opportunity));
+}
+
+export function showRecurrenceScopeSuccessToast(
+  opportunity: RecurrenceScopeOpportunity,
+  scope: "thisAndFollowing" | "all",
+): void {
+  if (
+    useRecurrenceScopeOpportunityStore.getState().opportunity?.id !==
+    opportunity.id
+  ) {
+    return;
+  }
+  const verb = opportunity.kind === "delete" ? "Deleted" : "Updated";
+  const eventName = eventNameForToast(opportunity);
+  const message =
+    scope === "all"
+      ? `${verb} all events in “${eventName}”`
+      : `${verb} “${eventName}” and following`;
+  show(<span>{message}</span>, toastIdFor(opportunity));
 }
 
 export function dismissRecurrenceScopeToast(opportunityId?: number): void {

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@core/types/event-command.contracts";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { EVENT_DELETED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { RECURRENCE_SCOPE_TOAST_ID } from "@web/common/utils/toast/recurrence-scope.toast";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
@@ -162,6 +163,8 @@ describe("useEventMutations", () => {
   });
 
   test("promotes a deleted occurrence even after the narrow optimistic delete removes it from cache", async () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
     const context = setup();
     const seriesId = event().id;
     const first = occurrence(seriesId);
@@ -212,6 +215,12 @@ describe("useEventMutations", () => {
       });
     });
     context.pending.resolve();
+    await waitFor(() => {
+      expect(mocks.update).toHaveBeenCalledWith(
+        EVENT_DELETED_TOAST_ID,
+        expect.objectContaining({ render: expect.anything() }),
+      );
+    });
   });
 
   test("does not coalesce a promoted series edit behind a later narrow edit", async () => {

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -19,7 +19,10 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { handleError } from "@web/common/utils/event/event.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
-import { dismissRecurrenceScopeToast } from "@web/common/utils/toast/recurrence-scope.toast";
+import {
+  dismissRecurrenceScopeToast,
+  showRecurrenceScopeSuccessToast,
+} from "@web/common/utils/toast/recurrence-scope.toast";
 import {
   applyEventProjectionAcrossQueries,
   eventBelongsToEntry,
@@ -654,6 +657,9 @@ export function useEventMutations(
         const seriesId = seriesIdOf(opportunity.original);
         if (seriesId) undoHistoryActions.discardSeries(seriesId);
 
+        const onSuccess = () => {
+          showRecurrenceScopeSuccessToast(opportunity, scope);
+        };
         const onSettled = () => {
           recurrenceScopeOpportunityActions.complete(opportunity.id);
         };
@@ -668,7 +674,7 @@ export function useEventMutations(
               writeKey: opportunity.original.id as EventId,
               originalOverride: opportunity.original,
             },
-            { onSettled },
+            { onSuccess, onSettled },
           );
           return;
         }
@@ -681,7 +687,7 @@ export function useEventMutations(
             skipRepository: false,
             originalOverride: opportunity.original,
           },
-          { onSettled },
+          { onSuccess, onSettled },
         );
       },
     }),


### PR DESCRIPTION
## Summary
- present recurrence scope actions as clear, clickable rows with 1/2 shortcut hints and event-title truncation
- replace the in-progress message with a matching success confirmation after the promoted series mutation succeeds
- preserve a newer scope offer when an earlier promoted mutation settles later
- intentionally do not advertise Undo for this-and-following/all promotions because those server-side series transformations do not yet have a safe inverse

## Validation
- bun run verify web
- focused recurrence scope toast, mutation, and host tests
- browser check of the rendered offer and title truncation
- independent release and accessibility review