### PR TITLE
fix(web): defer anonymous save toast during auth

### DIFF
--- a/packages/web/src/common/utils/toast/anonymous-save.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/anonymous-save.toast.test.tsx
@@ -1,0 +1,37 @@
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { maybeShowAnonymousSaveToast } from "@web/common/utils/toast/anonymous-save.toast";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("maybeShowAnonymousSaveToast", () => {
+  const { port, mocks } = createTestToastPort();
+
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, "", "/week");
+    mocks.toast.mockClear();
+    mocks.update.mockClear();
+    registerToastPort(port);
+  });
+
+  it("shows after an anonymous calendar write", () => {
+    maybeShowAnonymousSaveToast();
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+    expect(
+      localStorage.getItem(STORAGE_KEYS.HAS_SEEN_ANONYMOUS_SAVE_TOAST),
+    ).toBe("true");
+  });
+
+  it("does not interrupt an open sign-up flow", () => {
+    window.history.replaceState({}, "", "/week?auth=signup");
+
+    maybeShowAnonymousSaveToast();
+
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(
+      localStorage.getItem(STORAGE_KEYS.HAS_SEEN_ANONYMOUS_SAVE_TOAST),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/common/utils/toast/anonymous-save.toast.tsx
+++ b/packages/web/src/common/utils/toast/anonymous-save.toast.tsx
@@ -8,6 +8,13 @@ import { VIEW_TO_PARAM } from "@web/components/AuthModal/hooks/useAuthModal";
 
 const ANONYMOUS_SAVE_TOAST_ID: Id = "anonymous-save-toast";
 
+function isAuthModalOpen(): boolean {
+  if (typeof window === "undefined") return false;
+
+  const auth = new URLSearchParams(window.location.search).get("auth");
+  return Object.values(VIEW_TO_PARAM).includes(auth?.toLowerCase() ?? "");
+}
+
 function hasSeenAnonymousSaveToast(): boolean {
   if (!persistentBrowserStore.isAvailable()) return true;
   return (
@@ -61,7 +68,7 @@ const AnonymousSaveToast = ({ toastId }: AnonymousSaveToastProps) => {
 };
 
 export function maybeShowAnonymousSaveToast(): void {
-  if (hasSeenAnonymousSaveToast()) return;
+  if (isAuthModalOpen() || hasSeenAnonymousSaveToast()) return;
 
   markAnonymousSaveToastSeen();
   showStatusToast(


### PR DESCRIPTION
## Summary

Prevents the anonymous “Sign up to save your calendar across devices” toast from appearing while the sign-up or sign-in modal is open. The prompt is no longer marked as seen when suppressed, so it remains eligible after a later calendar write.

## Simplicity

Added one direct URL-state guard at the toast boundary. No queues, timers, or new shared state were needed.

## Automated validation

- Local browser: opened `http://localhost:9090/week?auth=signup`; the sign-up modal rendered with no anonymous-save toast and no console warnings/errors.
- Regression test covers normal calendar eligibility and the sign-up modal suppression.

## Independent review

Fresh diff-first review found no confirmed actionable issues.

## Test plan

- `bun run test:web` — 1,528 passing
- `bun run type-check`
- `bun run lint`
- `bun run test:a11y` — 7 passing (existing Axe incomplete notices only)
- `git diff --check origin/main...HEAD`
