### PR TITLE
feat(web): auto-refresh Google Calendar sync on app focus

### DIFF
--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -98,37 +98,47 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
     void start();
   }, [state, stopConnecting, syncConnection?.id]);
 
-  const onRefreshGoogle = useCallback(() => {
-    if (isRefreshingRef.current || isConnectingRef.current) {
-      return;
-    }
-
-    isRefreshingRef.current = true;
-    setIsRefreshing(true);
-    setSyncingSyncIndicatorOverride();
-    settingsActions.closeCmdPalette();
-
-    const run = async () => {
-      try {
-        await AuthApi.refreshGoogleSync();
-        await refreshUserMetadata({ force: true });
-        void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
-      } catch {
-        showErrorToast(
-          "We couldn't refresh your calendar. Please try again in a moment.",
-          { toastId: GOOGLE_REFRESH_FAILED_TOAST_ID },
-        );
-      } finally {
-        // Drop the optimistic syncing override once the request settles.
-        // Metadata/SSE still drive IMPORTING when a real import is in flight.
-        clearSyncingSyncIndicatorOverride();
-        isRefreshingRef.current = false;
-        setIsRefreshing(false);
+  const onRefreshGoogle = useCallback(
+    (options?: { silent?: boolean }) => {
+      if (isRefreshingRef.current || isConnectingRef.current) {
+        return;
       }
-    };
 
-    void run();
-  }, [queryClient]);
+      isRefreshingRef.current = true;
+      setIsRefreshing(true);
+      setSyncingSyncIndicatorOverride();
+      if (!options?.silent) {
+        settingsActions.closeCmdPalette();
+      }
+
+      const run = async () => {
+        try {
+          await AuthApi.refreshGoogleSync();
+          await refreshUserMetadata({ force: true });
+          void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+        } catch {
+          // A background-triggered refresh (tab focus) failing transiently
+          // isn't worth interrupting the user for — only a refresh they
+          // explicitly asked for surfaces the failure.
+          if (!options?.silent) {
+            showErrorToast(
+              "We couldn't refresh your calendar. Please try again in a moment.",
+              { toastId: GOOGLE_REFRESH_FAILED_TOAST_ID },
+            );
+          }
+        } finally {
+          // Drop the optimistic syncing override once the request settles.
+          // Metadata/SSE still drive IMPORTING when a real import is in flight.
+          clearSyncingSyncIndicatorOverride();
+          isRefreshingRef.current = false;
+          setIsRefreshing(false);
+        }
+      };
+
+      void run();
+    },
+    [queryClient],
+  );
 
   return {
     ...getGoogleConnectionConfig(state, {

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
@@ -30,7 +30,10 @@ export type UseConnectGoogleResult = GoogleUiConfig & {
   connect: () => void;
   /**
    * Enqueue Sync catch-up pulls for the signed-in user's calendars. Used by
-   * the ATTENTION / delayed Refresh CTA and delayed toast.
+   * the ATTENTION / delayed Refresh CTA, the delayed toast, and an automatic
+   * focus-triggered check (useSyncFocusRefresh). Pass `silent: true` for a
+   * background trigger the user didn't ask for, so a transient failure
+   * doesn't surface an error toast or close an open command palette.
    */
-  refresh: () => void;
+  refresh: (options?: { silent?: boolean }) => void;
 };

--- a/packages/web/src/common/hooks/useVisibleAfterHidden.test.ts
+++ b/packages/web/src/common/hooks/useVisibleAfterHidden.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { useVisibleAfterHidden } from "@web/common/hooks/useVisibleAfterHidden";
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+  spyOn,
+} from "bun:test";
+
+const THRESHOLD_MS = 30_000;
+
+describe("useVisibleAfterHidden", () => {
+  let visibilityState = "visible";
+
+  const setVisibility = (state: "visible" | "hidden") => {
+    visibilityState = state;
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  };
+
+  const reset = () => {
+    visibilityState = "visible";
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+    setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+  };
+
+  afterEach(() => {
+    setSystemTime();
+  });
+
+  it("calls onVisible when the tab is hidden long enough before returning", () => {
+    reset();
+    const onVisible = mock();
+    renderHook(() => useVisibleAfterHidden(onVisible, THRESHOLD_MS));
+
+    act(() => {
+      setVisibility("hidden");
+      setSystemTime(new Date(Date.now() + THRESHOLD_MS + 1_000));
+      setVisibility("visible");
+    });
+
+    expect(onVisible).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onVisible for a hide shorter than the threshold", () => {
+    reset();
+    const onVisible = mock();
+    renderHook(() => useVisibleAfterHidden(onVisible, THRESHOLD_MS));
+
+    act(() => {
+      setVisibility("hidden");
+      setSystemTime(new Date(Date.now() + THRESHOLD_MS - 1_000));
+      setVisibility("visible");
+    });
+
+    expect(onVisible).not.toHaveBeenCalled();
+  });
+
+  it("does not install a listener when disabled", () => {
+    reset();
+    const addEventListenerSpy = spyOn(document, "addEventListener");
+
+    renderHook(() => useVisibleAfterHidden(mock(), THRESHOLD_MS, false));
+
+    expect(
+      addEventListenerSpy.mock.calls.some(
+        ([eventName]) => eventName === "visibilitychange",
+      ),
+    ).toBe(false);
+
+    addEventListenerSpy.mockRestore();
+  });
+
+  it("removes the listener on unmount", () => {
+    reset();
+    const addEventListenerSpy = spyOn(document, "addEventListener");
+    const removeEventListenerSpy = spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() =>
+      useVisibleAfterHidden(mock(), THRESHOLD_MS),
+    );
+    const handler = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === "visibilitychange",
+    )?.[1];
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      handler,
+    );
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it("always calls the latest onVisible, not a stale closure from mount", () => {
+    reset();
+    const first = mock();
+    const second = mock();
+    const { rerender } = renderHook(
+      ({ onVisible }) => useVisibleAfterHidden(onVisible, THRESHOLD_MS),
+      { initialProps: { onVisible: first } },
+    );
+
+    rerender({ onVisible: second });
+
+    act(() => {
+      setVisibility("hidden");
+      setSystemTime(new Date(Date.now() + THRESHOLD_MS + 1_000));
+      setVisibility("visible");
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/common/hooks/useVisibleAfterHidden.ts
+++ b/packages/web/src/common/hooks/useVisibleAfterHidden.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Calls `onVisible` when the tab regains visibility after being hidden for at
+ * least `thresholdMs`. A quick alt-tab doesn't count as "away" long enough to
+ * warrant a recheck. Pass `enabled: false` to skip installing the listener
+ * entirely (e.g. while there's nothing to check).
+ */
+export const useVisibleAfterHidden = (
+  onVisible: () => void,
+  thresholdMs: number,
+  enabled = true,
+): void => {
+  const hiddenAtRef = useRef<number | null>(null);
+  const onVisibleRef = useRef(onVisible);
+  onVisibleRef.current = onVisible;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenAtRef.current = Date.now();
+        return;
+      }
+      if (document.visibilityState !== "visible") return;
+
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+      if (hiddenAt === null) return;
+
+      if (Date.now() - hiddenAt >= thresholdMs) {
+        onVisibleRef.current();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [thresholdMs, enabled]);
+};

--- a/packages/web/src/components/Sidebar/SidebarActions/useVersionCheck.ts
+++ b/packages/web/src/components/Sidebar/SidebarActions/useVersionCheck.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import * as envConstants from "@web/common/constants/env.constants";
 import { APP_VERSION } from "@web/common/constants/version.constants";
+import { useVisibleAfterHidden } from "@web/common/hooks/useVisibleAfterHidden";
 
 const MIN_HIDDEN_DURATION_MS = 30_000;
 const BACKUP_CHECK_INTERVAL_MS = 5 * 60 * 1000;
@@ -40,7 +41,6 @@ export interface VersionCheckResult {
  */
 export const useVersionCheck = (): VersionCheckResult => {
   const [isUpdateAvailable, setIsUpdateAvailable] = useState(false);
-  const hiddenAtRef = useRef<number | null>(null);
   const isCheckingRef = useRef(false);
 
   const checkVersion = useCallback(async () => {
@@ -92,42 +92,22 @@ export const useVersionCheck = (): VersionCheckResult => {
       return;
     }
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        hiddenAtRef.current = Date.now();
-        return;
-      }
-
-      if (document.visibilityState !== "visible") {
-        return;
-      }
-
-      const hiddenAt = hiddenAtRef.current;
-      hiddenAtRef.current = null;
-
-      if (hiddenAt === null) {
-        return;
-      }
-
-      const hiddenDuration = Date.now() - hiddenAt;
-      if (hiddenDuration >= MIN_HIDDEN_DURATION_MS) {
-        checkVersion();
-      }
-    };
-
     checkVersion();
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
     const backupInterval = window.setInterval(
       checkVersion,
       BACKUP_CHECK_INTERVAL_MS,
     );
 
     return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
       clearInterval(backupInterval);
     };
   }, [checkVersion]);
+
+  useVisibleAfterHidden(
+    checkVersion,
+    MIN_HIDDEN_DURATION_MS,
+    !envConstants.IS_DEV,
+  );
 
   return { isUpdateAvailable, currentVersion: APP_VERSION };
 };

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
@@ -1,0 +1,110 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { type UseConnectGoogleResult } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
+import { useSyncFocusRefresh } from "@web/sse/hooks/useSyncFocusRefresh";
+import { afterEach, describe, expect, it, mock, setSystemTime } from "bun:test";
+
+const MIN_HIDDEN_DURATION_MS = 30_000;
+
+const fakeConnectGoogle = (
+  overrides: Partial<UseConnectGoogleResult> = {},
+): UseConnectGoogleResult => ({
+  commandAction: null,
+  isAvailable: true,
+  isConnecting: false,
+  isRefreshing: false,
+  state: "HEALTHY",
+  connect: mock(),
+  refresh: mock(),
+  ...overrides,
+});
+
+describe("useSyncFocusRefresh", () => {
+  let visibilityState = "visible";
+
+  const setVisibility = (state: "visible" | "hidden") => {
+    visibilityState = state;
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  };
+
+  afterEach(() => {
+    visibilityState = "visible";
+    setSystemTime();
+  });
+
+  it("refreshes on mount for a healthy connection", () => {
+    const refresh = mock();
+    renderHook(() => useSyncFocusRefresh(() => fakeConnectGoogle({ refresh })));
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes on mount for an ATTENTION connection", () => {
+    const refresh = mock();
+    renderHook(() =>
+      useSyncFocusRefresh(() =>
+        fakeConnectGoogle({ refresh, state: "ATTENTION" }),
+      ),
+    );
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "NOT_CONNECTED",
+    "RECONNECT_REQUIRED",
+    "IMPORTING",
+  ] as const)("does not refresh on mount for %s", (state) => {
+    const refresh = mock();
+    renderHook(() =>
+      useSyncFocusRefresh(() => fakeConnectGoogle({ refresh, state })),
+    );
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh when Google is unavailable", () => {
+    const refresh = mock();
+    renderHook(() =>
+      useSyncFocusRefresh(() =>
+        fakeConnectGoogle({ refresh, isAvailable: false }),
+      ),
+    );
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("refreshes again when the tab regains focus after being hidden long enough", () => {
+    setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+    const refresh = mock();
+    renderHook(() => useSyncFocusRefresh(() => fakeConnectGoogle({ refresh })));
+    refresh.mockClear();
+
+    act(() => {
+      setVisibility("hidden");
+      setSystemTime(new Date(Date.now() + MIN_HIDDEN_DURATION_MS + 1_000));
+      setVisibility("visible");
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh on a short hide", () => {
+    setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+    const refresh = mock();
+    renderHook(() => useSyncFocusRefresh(() => fakeConnectGoogle({ refresh })));
+    refresh.mockClear();
+
+    act(() => {
+      setVisibility("hidden");
+      setSystemTime(new Date(Date.now() + MIN_HIDDEN_DURATION_MS - 1_000));
+      setVisibility("visible");
+    });
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
@@ -36,11 +36,12 @@ describe("useSyncFocusRefresh", () => {
     setSystemTime();
   });
 
-  it("refreshes on mount for a healthy connection", () => {
+  it("silently refreshes on mount for a healthy connection", () => {
     const refresh = mock();
     renderHook(() => useSyncFocusRefresh(() => fakeConnectGoogle({ refresh })));
 
     expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledWith({ silent: true });
   });
 
   it("refreshes on mount for an ATTENTION connection", () => {
@@ -91,6 +92,7 @@ describe("useSyncFocusRefresh", () => {
     });
 
     expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledWith({ silent: true });
   });
 
   it("does not refresh on a short hide", () => {

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { type UseConnectGoogleResult } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
+import { useVisibleAfterHidden } from "@web/common/hooks/useVisibleAfterHidden";
+
+// A tab hidden for less than this is treated as a quick alt-tab, not a
+// meaningful gap in attention — mirrors useVersionCheck's threshold.
+const MIN_HIDDEN_DURATION_MS = 30_000;
+
+/**
+ * Triggers the same Google Calendar sync refresh as the sidebar's "Refresh
+ * calendar" CTA (`useConnectGoogle().refresh`), automatically: on mount and
+ * whenever the tab regains focus after being hidden for 30+ seconds. Without
+ * this, a user only sees a caught-up calendar if they remember to click
+ * Refresh themselves. `refresh()` already guards against concurrent calls
+ * and the sync service coalesces redundant enqueues, so firing this
+ * alongside a manual click is harmless.
+ *
+ * No-ops while there's no established connection worth refreshing (not yet
+ * connected, reconnect required, or still on the initial import).
+ *
+ * `useConnectGoogleImpl` is a test seam (default: the real hook) so tests can
+ * pass a fake implementation instead of mock.module-ing a hook other files
+ * also mock.
+ */
+export const useSyncFocusRefresh = (
+  useConnectGoogleImpl: () => UseConnectGoogleResult = useConnectGoogle,
+) => {
+  const { isAvailable, refresh, state } = useConnectGoogleImpl();
+  const canRefresh =
+    isAvailable && (state === "HEALTHY" || state === "ATTENTION");
+
+  useEffect(() => {
+    if (!canRefresh) return;
+    refresh();
+  }, [canRefresh, refresh]);
+
+  useVisibleAfterHidden(refresh, MIN_HIDDEN_DURATION_MS, canRefresh);
+};

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { type UseConnectGoogleResult } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
 import { useVisibleAfterHidden } from "@web/common/hooks/useVisibleAfterHidden";
@@ -12,9 +12,13 @@ const MIN_HIDDEN_DURATION_MS = 30_000;
  * calendar" CTA (`useConnectGoogle().refresh`), automatically: on mount and
  * whenever the tab regains focus after being hidden for 30+ seconds. Without
  * this, a user only sees a caught-up calendar if they remember to click
- * Refresh themselves. `refresh()` already guards against concurrent calls
- * and the sync service coalesces redundant enqueues, so firing this
- * alongside a manual click is harmless.
+ * Refresh themselves. Passes `silent: true` — the user didn't ask for this
+ * one, so a transient failure shouldn't surface an error toast the way a
+ * manual click's would. The sync service still coalesces redundant enqueues
+ * regardless. This mounts its own `useConnectGoogle()` instance (independent
+ * of the sidebar's), so its in-flight guard is independent too — a refresh
+ * from here and a near-simultaneous manual click aren't deduplicated against
+ * each other, only against repeats of themselves.
  *
  * No-ops while there's no established connection worth refreshing (not yet
  * connected, reconnect required, or still on the initial import).
@@ -29,11 +33,12 @@ export const useSyncFocusRefresh = (
   const { isAvailable, refresh, state } = useConnectGoogleImpl();
   const canRefresh =
     isAvailable && (state === "HEALTHY" || state === "ATTENTION");
+  const silentRefresh = useCallback(() => refresh({ silent: true }), [refresh]);
 
   useEffect(() => {
     if (!canRefresh) return;
-    refresh();
-  }, [canRefresh, refresh]);
+    silentRefresh();
+  }, [canRefresh, silentRefresh]);
 
-  useVisibleAfterHidden(refresh, MIN_HIDDEN_DURATION_MS, canRefresh);
+  useVisibleAfterHidden(silentRefresh, MIN_HIDDEN_DURATION_MS, canRefresh);
 };

--- a/packages/web/src/sse/provider/SSEProvider.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.test.tsx
@@ -9,6 +9,23 @@ const mockUseUser = mock();
 const openStream = mock();
 const closeStream = mock();
 const getStream = mock(() => null);
+// SSEProvider mounts useSyncFocusRefresh, which calls the real
+// useConnectGoogle() by default. mock.module leaks process-wide across the
+// full test suite (not scoped to this file), so without an explicit mock
+// here this file is at the mercy of whichever OTHER file's useConnectGoogle
+// mock happened to load last — e.g. CalendarListHeader.test.tsx's mock omits
+// `refresh` entirely, which throws when useSyncFocusRefresh calls it. This
+// test isn't about Google/sync behavior, so give it its own stable, complete
+// fake rather than relying on load order.
+const mockUseConnectGoogle = mock(() => ({
+  commandAction: null,
+  isAvailable: false,
+  isConnecting: false,
+  isRefreshing: false,
+  state: "NOT_CONNECTED" as const,
+  connect: mock(),
+  refresh: mock(),
+}));
 
 mock.module("@web/auth/compass/session/useSession", () => ({
   useSession: mockUseSession,
@@ -18,6 +35,9 @@ mock.module("@web/auth/compass/user/hooks/useUser", () => ({
 }));
 mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
   refreshUserMetadata: mock().mockResolvedValue(undefined),
+}));
+mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
+  useConnectGoogle: mockUseConnectGoogle,
 }));
 mock.module("../client/sse.client", () => ({
   openStream,

--- a/packages/web/src/sse/provider/SSEProvider.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import { useEventSSE } from "../hooks/useEventSSE";
 import { useGcalSSE } from "../hooks/useGcalSSE";
 import { useSSEConnection } from "../hooks/useSSEConnection";
+import { useSyncFocusRefresh } from "../hooks/useSyncFocusRefresh";
 
 export * from "../client/sse.client";
 
@@ -9,6 +10,7 @@ const SSEProvider = ({ children }: { children: ReactNode }) => {
   useSSEConnection();
   useEventSSE();
   useGcalSSE();
+  useSyncFocusRefresh();
 
   return children;
 };


### PR DESCRIPTION
## Summary

A user asked whether "Last synced N minutes ago" being 20+ minutes old meant sync was broken or slower on staging vs prod. It wasn't — the timestamp is honest (advances on every successful check, even no-change ones), but nothing triggered a fresh check while a user was actively looking at the app; only Google webhooks (on real changes) and a background reconcile sweep with a 15-minute staleness floor did.

`origin/main` already ships a manual "Refresh calendar" CTA for this (#2512, #2537). This PR adds the missing piece: the same refresh now fires **automatically** — on app mount and whenever the tab regains focus after being hidden 30+ seconds — so a user doesn't have to remember to click the button. It reuses `useConnectGoogle().refresh()` end to end (no new backend route), gated to healthy/attention connections so it's a no-op with nothing to refresh, and passes a new `silent` option so a transient background failure doesn't surface an error toast the way an explicit click's failure should.

Also extracts the "recheck after N seconds hidden" visibility-change pattern into a shared `useVisibleAfterHidden` hook, since `useVersionCheck.ts` was about to gain a second hand-rolled copy of the identical logic.

## Simplicity

Originally built as a larger, independent feature (new backend route, new sidebar freshness UI) before discovering it substantially overlapped with already-merged work. Reworked down to just the additive piece on top of current `main`: no new backend/sync-service code, no UI changes to the already-shipped sync status row — only the automatic trigger plus the shared hook extraction.

## Automated validation

Google OAuth/live sync isn't provisioned in this environment (no SuperTokens/Google credentials), so end-to-end browser validation of the actual refresh call wasn't possible here. Verified instead via focused test coverage and manual trace of the call chain (`useSyncFocusRefresh` → `useConnectGoogle().refresh` → `AuthApi.refreshGoogleSync` → existing `/api/auth/google/sync/refresh` → sync's `refreshPrincipalCalendars`, all pre-existing and unchanged).

## Independent review

Two rounds of fresh, diff-first review (via a separate reviewing agent) on the final diff. First pass: clean. Second pass caught two real issues, both fixed:
- An auto-triggered refresh could surface an unsolicited "couldn't refresh your calendar" error toast on a transient failure for a perfectly healthy connection, purely from a tab focus — fixed by adding a `silent` option to `refresh()` that this hook opts into.
- A doc comment overclaimed that mounting a second `useConnectGoogle()` instance was fully safe against concurrent refreshes — corrected to accurately describe the (narrow, low-impact) limitation instead of re-architecting the existing global sync-indicator state.

## Test plan

```bash
cd packages/web && bun test src/sse/hooks/useSyncFocusRefresh.test.ts src/common/hooks/useVisibleAfterHidden.test.ts src/components/Sidebar/SidebarActions/useVersionCheck.test.ts src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
bun run type-check
bun run lint
```
All green.