### PR TITLE
fix(sync): close google onboarding sync gap

### DIFF
--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -106,7 +106,6 @@ describe("refreshConnectionState", () => {
       "list-cursor",
       new Date(),
     );
-
     const eventsResource = await resources.ensure({
       tenantId: connection.tenantId,
       principalId: connection.principalId,
@@ -119,24 +118,73 @@ describe("refreshConnectionState", () => {
       connection.principalId,
       eventsResource._id,
       "events-cursor",
-      new Date(),
+      new Date("2026-07-11T00:00:00.000Z"),
+    );
+    await resources.setBootstrapState(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "ready",
     );
 
     const after = await refreshConnectionState(deps(), connection);
     expect(after.state).toBe("healthy");
     expect(after.stateReason).toBeNull();
     expect(after.lastHealthyAt).toBeInstanceOf(Date);
-    expect(after.lastSyncedAt).toBeInstanceOf(Date);
+    expect(after.lastSyncedAt).toEqual(new Date("2026-07-11T00:00:00.000Z"));
+
+    const slowerCalendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "shared@example.com" as ProviderCalendarSourceId,
+      displayName: "Shared",
+      color: null,
+      active: true,
+      primary: false,
+      accessRole: "viewer",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: false,
+        canReadBusy: true,
+        canInviteAttendees: false,
+      },
+    });
+    const slowerResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: slowerCalendar._id as ProviderCalendarId,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      slowerResource._id,
+      "shared-cursor",
+      new Date("2026-07-10T00:00:00.000Z"),
+    );
+    await resources.setBootstrapState(
+      connection.tenantId,
+      connection.principalId,
+      slowerResource._id,
+      "ready",
+    );
+
+    const withSlowerCalendar = await refreshConnectionState(deps(), after);
+    expect(withSlowerCalendar.lastSyncedAt).toEqual(
+      new Date("2026-07-10T00:00:00.000Z"),
+    );
   });
 
-  it("reports delayed/providerErrors when a job for the connection is wedged in state:failed", async () => {
+  it("reports delayed/providerErrors when a failed bootstrap would otherwise keep syncing", async () => {
     // The 2026-07-30 gap: oldestDueWorkAt was hardcoded to null here, so a job
     // that exhausted its retry ladder and terminalized as state:"failed" was
     // invisible to the connection's own health state — every signal green
     // while a calendar sat unsynced for ~25h. A failed job is unconditionally
     // overdue (see findOldestOverdueByConnection), so this must flip the
     // connection to delayed the moment one exists, independent of any
-    // otherwise-healthy import evidence.
+    // otherwise-incomplete bootstrap evidence.
     const connection = await seedImportingConnection();
     const calendar = await calendars.upsertByProviderCalendar({
       tenantId: connection.tenantId,
@@ -183,17 +231,16 @@ describe("refreshConnectionState", () => {
       "events-cursor",
       new Date(),
     );
-
     await jobs.enqueue({
       tenantId: connection.tenantId,
       principalId: connection.principalId,
       connectionId: connection._id,
       resourceId: eventsResource._id,
       commandId: null,
-      kind: "incrementalPull",
+      kind: "bootstrapCatchup",
       priority: 0,
       runAfter: new Date("2026-01-01T00:00:00.000Z"),
-      coalescingKey: `incrementalPull:${eventsResource._id}`,
+      coalescingKey: `bootstrapCatchup:${eventsResource._id}`,
     } as JobEnqueue);
     const claimed = await jobs.claimDueJob(
       "worker",
@@ -250,6 +297,127 @@ describe("refreshConnectionState", () => {
 
     const after = await refreshConnectionState(deps(), connection);
     expect(after.state).toBe("importing");
+  });
+
+  it("keeps importing after a cursor until the post-watch catch-up is ready", async () => {
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    const eventsResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "events-cursor",
+      new Date(),
+    );
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("importing");
+  });
+
+  it("reports catchingUp while a user-requested pull is queued", async () => {
+    const connection = await seedImportingConnection();
+    const calendar = await calendars.upsertByProviderCalendar({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      providerCalendarId: "primary@example.com" as ProviderCalendarSourceId,
+      displayName: "Primary",
+      color: null,
+      active: true,
+      primary: true,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
+    const listResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      listResource._id,
+      "list-cursor",
+      new Date(),
+    );
+    const eventsResource = await resources.ensure({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceKind: "events",
+      calendarId: calendar._id as ProviderCalendarId,
+    });
+    await resources.advanceCursor(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "events-cursor",
+      new Date(),
+    );
+    await resources.setBootstrapState(
+      connection.tenantId,
+      connection.principalId,
+      eventsResource._id,
+      "ready",
+    );
+    await jobs.enqueue({
+      tenantId: connection.tenantId,
+      principalId: connection.principalId,
+      connectionId: connection._id,
+      resourceId: eventsResource._id,
+      commandId: null,
+      kind: "incrementalPull",
+      priority: 0,
+      runAfter: new Date(),
+      coalescingKey: `incrementalPull:${eventsResource._id}`,
+    } as JobEnqueue);
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.state).toBe("catchingUp");
   });
 
   it("reports delayed/providerErrors when an active calendar's reads durably fail", async () => {

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -34,10 +34,7 @@ export async function refreshConnectionState(
   const evidence = await gatherConnectionStateEvidence(deps, connection, at);
   const derived = deriveConnectionState(evidence, at);
 
-  const lastSyncedAt = maxDate(
-    connection.lastSyncedAt,
-    ...evidence.resourceSuccessAts,
-  );
+  const lastSyncedAt = evidence.lastSyncedAt;
   const lastHealthyAt =
     derived.state === "healthy"
       ? (connection.lastHealthyAt ?? at)
@@ -84,26 +81,32 @@ export async function gatherConnectionStateEvidence(
   deps: ConnectionStateRefreshDeps,
   connection: ProviderConnectionRecord,
   now: Date,
-): Promise<ConnectionStateEvidence & { resourceSuccessAts: Date[] }> {
-  const [credential, calendars, resources, oldestOverdue] = await Promise.all([
-    deps.credentials.findByConnection(connection._id),
-    deps.calendars.listByConnection(
-      connection.tenantId,
-      connection.principalId,
-      connection._id,
-    ),
-    deps.resources.listByConnection(
-      connection.tenantId,
-      connection.principalId,
-      connection._id,
-    ),
-    deps.jobs.findOldestOverdueByConnection(
-      connection.tenantId,
-      connection.principalId,
-      connection._id,
-      now,
-    ),
-  ]);
+): Promise<ConnectionStateEvidence & { lastSyncedAt: Date | null }> {
+  const [credential, calendars, resources, oldestOverdue, catchingUp] =
+    await Promise.all([
+      deps.credentials.findByConnection(connection._id),
+      deps.calendars.listByConnection(
+        connection.tenantId,
+        connection.principalId,
+        connection._id,
+      ),
+      deps.resources.listByConnection(
+        connection.tenantId,
+        connection.principalId,
+        connection._id,
+      ),
+      deps.jobs.findOldestOverdueByConnection(
+        connection.tenantId,
+        connection.principalId,
+        connection._id,
+        now,
+      ),
+      deps.jobs.hasOutstandingReadWorkByConnection(
+        connection.tenantId,
+        connection.principalId,
+        connection._id,
+      ),
+    ]);
 
   const activeCalendars = calendars.filter((c) => c.active);
   const eventsByCalendar = new Map(
@@ -113,15 +116,28 @@ export async function gatherConnectionStateEvidence(
   );
   const calendarList = resources.find((r) => r.resourceKind === "calendarList");
   const discoveryDone = calendarList?.lastSuccessAt != null;
-  const allActiveImported =
+  const allActiveBootstrapReady =
     activeCalendars.length === 0 ||
-    activeCalendars.every(
-      (c) => eventsByCalendar.get(c._id)?.syncCursor != null,
-    );
+    activeCalendars.every((c) => {
+      const resource = eventsByCalendar.get(c._id);
+      return (
+        resource?.syncCursor != null && resource.bootstrapState === "ready"
+      );
+    });
 
-  const resourceSuccessAts = resources
-    .map((r) => r.lastSuccessAt)
-    .filter((d): d is Date => d instanceof Date);
+  // "Last synced" must be as old as the least-recent active calendar. Taking
+  // the newest success would let one busy calendar say "just now" while a
+  // second visible calendar is stale. No active calendars fall back to the
+  // calendar-list pass, which is the only provider data remaining to sync.
+  const activeEventSuccessAts = activeCalendars.map(
+    (calendar) => eventsByCalendar.get(calendar._id)?.lastSuccessAt ?? null,
+  );
+  const lastSyncedAt =
+    activeEventSuccessAts.length === 0
+      ? (calendarList?.lastSuccessAt ?? null)
+      : activeEventSuccessAts.every((at) => at instanceof Date)
+        ? minDate(...activeEventSuccessAts)
+        : null;
 
   return {
     disconnectedAt: connection.disconnectedAt,
@@ -134,14 +150,15 @@ export async function gatherConnectionStateEvidence(
     ),
     accountIdentified: Boolean(connection.account.providerAccountId),
     // Discovery must have finished, and every currently-active calendar must
-    // hold a durable events cursor (the initialImport settle condition).
-    initialImportComplete: discoveryDone && allActiveImported,
-    catchingUp: false,
+    // have a cursor plus a successful post-watch catch-up pull. A cursor alone
+    // has a gap between the import and the provider watch registration.
+    initialImportComplete: discoveryDone && allActiveBootstrapReady,
+    catchingUp,
     oldestDueWorkAt: oldestOverdue?.runAfter ?? null,
     // A job that used up its retry ladder on retryableTransient failures is
     // itself provider-error evidence, distinct from a plain backlog.
     recentProviderErrors: oldestOverdue?.failureClass === "retryableTransient",
-    resourceSuccessAts,
+    lastSyncedAt,
   };
 }
 
@@ -152,13 +169,13 @@ function credentialState(
   return "valid";
 }
 
-function maxDate(...dates: Array<Date | null | undefined>): Date | null {
-  let max: Date | null = null;
+function minDate(...dates: Array<Date | null | undefined>): Date | null {
+  let min: Date | null = null;
   for (const d of dates) {
     if (!(d instanceof Date)) continue;
-    if (!max || d.getTime() > max.getTime()) max = d;
+    if (!min || d.getTime() < min.getTime()) min = d;
   }
-  return max;
+  return min;
 }
 
 function sameDate(a: Date | null, b: Date | null): boolean {

--- a/packages/sync/src/domain/connection-state.test.ts
+++ b/packages/sync/src/domain/connection-state.test.ts
@@ -67,7 +67,7 @@ describe("deriveConnectionState", () => {
     });
   });
 
-  it("is importing until the first in-horizon import completes", () => {
+  it("is importing until the first sync bootstrap completes", () => {
     expect(derive({ initialImportComplete: false })).toEqual({
       state: "importing",
       reason: null,
@@ -164,22 +164,22 @@ describe("deriveConnectionState", () => {
       ).toBe("connecting");
     });
 
-    it("importing dominates overdue work (no delayed during first import)", () => {
+    it("surfaces overdue bootstrap work instead of importing forever", () => {
       expect(
         derive({
           initialImportComplete: false,
           oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 1000),
         }).state,
-      ).toBe("importing");
+      ).toBe("delayed");
     });
 
-    it("catchingUp dominates overdue work", () => {
+    it("surfaces overdue catch-up work instead of syncing forever", () => {
       expect(
         derive({
           catchingUp: true,
           oldestDueWorkAt: agoMs(DELAYED_THRESHOLD_MS + 1000),
         }).state,
-      ).toBe("catchingUp");
+      ).toBe("delayed");
     });
   });
 });

--- a/packages/sync/src/domain/connection-state.ts
+++ b/packages/sync/src/domain/connection-state.ts
@@ -31,7 +31,7 @@ export interface ConnectionStateEvidence {
   readonly durableReadFailure: boolean;
   // The provider account identity has been resolved.
   readonly accountIdentified: boolean;
-  // The first complete in-horizon import has finished.
+  // The first import, watch setup, and post-watch catch-up have finished.
   readonly initialImportComplete: boolean;
   // A non-destructive repair or post-gap reconciliation is running while
   // existing data stays queryable.
@@ -92,19 +92,23 @@ export function deriveConnectionState(
     return { state: "connecting", reason: null };
   }
 
+  // Do not let a failed or overdue bootstrap hide behind a perpetual
+  // "importing"/"syncing" message. The normal threshold preserves a calm
+  // progress state for active work, while terminal jobs are immediately
+  // overdue (their original runAfter is in the past).
+  if (isOverdue(evidence.oldestDueWorkAt, now)) {
+    return {
+      state: "delayed",
+      reason: evidence.recentProviderErrors ? "providerErrors" : "workOverdue",
+    };
+  }
+
   if (!evidence.initialImportComplete) {
     return { state: "importing", reason: null };
   }
 
   if (evidence.catchingUp) {
     return { state: "catchingUp", reason: null };
-  }
-
-  if (isOverdue(evidence.oldestDueWorkAt, now)) {
-    return {
-      state: "delayed",
-      reason: evidence.recentProviderErrors ? "providerErrors" : "workOverdue",
-    };
   }
 
   return { state: "healthy", reason: null };

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -222,6 +222,15 @@ describe("dispatchSyncJob", () => {
         cursor,
         now(),
       );
+      // A seeded cursor represents an established calendar from before this
+      // test's job begins; new connections exercise the bootstrap lifecycle
+      // explicitly below.
+      await resources.setBootstrapState(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+        "ready",
+      );
     }
     return resource;
   };
@@ -388,7 +397,10 @@ describe("dispatchSyncJob", () => {
       jobFor(resource, "repair"),
       now,
     );
-    expect(outcome).toEqual({ result: "done" });
+    expect(outcome).toMatchObject({
+      result: "done",
+      followup: { kind: "subscriptionMaintain" },
+    });
   });
 
   it("retries a repair that did not complete", async () => {
@@ -537,6 +549,119 @@ describe("dispatchSyncJob", () => {
       resource._id,
     );
     expect(saved?.subscriptionResourceId).toBe("provider-resource");
+  });
+
+  it("does not declare a fresh calendar ready until the post-watch pull completes", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    notifications.watched = [];
+
+    const importOutcome = await dispatchSyncJob(
+      deps(
+        new FakeReader([
+          page([single("imported")]),
+          page([single("imported")], "cursor-1"),
+        ]),
+      ),
+      jobFor(resource, "initialImport"),
+      now,
+    );
+    expect(importOutcome).toMatchObject({
+      result: "done",
+      followup: { kind: "subscriptionMaintain" },
+    });
+    expect(
+      (
+        await resources.findById(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+        )
+      )?.bootstrapState,
+    ).toBe("watching");
+
+    const subscriptionOutcome = await dispatchSyncJob(
+      deps(new FakeReader([])),
+      jobFor(resource, "subscriptionMaintain"),
+      now,
+    );
+    expect(subscriptionOutcome).toMatchObject({
+      result: "done",
+      followup: {
+        kind: "bootstrapCatchup",
+        coalescingKey: `bootstrapCatchup:${resource._id}`,
+      },
+    });
+    expect(
+      (
+        await resources.findById(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+        )
+      )?.bootstrapState,
+    ).toBe("catchingUp");
+
+    const catchupOutcome = await dispatchSyncJob(
+      deps(
+        new FakeReader([page([single("created-after-import")], "cursor-2")]),
+      ),
+      jobFor(resource, "bootstrapCatchup"),
+      now,
+    );
+    expect(catchupOutcome).toEqual({ result: "done" });
+    expect(
+      (
+        await resources.findById(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+        )
+      )?.bootstrapState,
+    ).toBe("ready");
+  });
+
+  it("bootstraps a legacy no-cursor resource through the post-watch pull", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    // Simulate a deployment while an older version's initial import was in
+    // flight. Parsing a missing field intentionally yields ready for established
+    // rows, but its absent cursor must still make this row bootstrap.
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .updateOne({ _id: resource._id }, { $unset: { bootstrapState: "" } });
+    const legacyResource = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(legacyResource?.bootstrapState).toBe("ready");
+
+    const outcome = await dispatchSyncJob(
+      deps(
+        new FakeReader([
+          page([single("imported")]),
+          page([single("imported")], "cursor-1"),
+        ]),
+      ),
+      jobFor(legacyResource!, "initialImport"),
+      now,
+    );
+
+    expect(outcome).toMatchObject({
+      result: "done",
+      followup: { kind: "subscriptionMaintain" },
+    });
+    expect(
+      (
+        await resources.findById(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+        )
+      )?.bootstrapState,
+    ).toBe("watching");
   });
 
   const calendarListJob = (

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -170,6 +170,7 @@ async function runSyncJob(
 
   if (
     job.kind !== "initialImport" &&
+    job.kind !== "bootstrapCatchup" &&
     job.kind !== "incrementalPull" &&
     job.kind !== "repair" &&
     job.kind !== "subscriptionMaintain"
@@ -221,8 +222,20 @@ async function runSyncJob(
           await appendCalendarInvalidation(deps, calendar, now());
         },
       });
-      // Full import finished — surface the remaining events and let metadata
-      // leave IMPORTING once connection-state refresh runs.
+      // A cursor is not yet a trustworthy initial sync: Google changes can
+      // land after the import's cursor but before the push channel exists.
+      // Established resources stay ready during an idempotent import; a legacy
+      // row without a cursor still follows the bootstrap path.
+      if (needsBootstrapCompletion(resource)) {
+        await deps.resources.setBootstrapState(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+          "watching",
+        );
+      }
+      // Full import finished — surface the remaining events. Connection state
+      // leaves IMPORTING only after the subscription and post-watch pull.
       await appendCalendarInvalidation(deps, calendar, now());
       // Bootstrap the push channel once the calendar is imported. The followup
       // is coalesced and maintainSubscription no-ops on an already-live channel,
@@ -263,12 +276,39 @@ async function runSyncJob(
       // cursorExpired: the provider cursor is unusable; a repair rebuilds.
       return { result: "done", followup: repairFollowup(resource, now) };
     }
+    case "bootstrapCatchup": {
+      // This pull closes the gap between saving the import cursor and making a
+      // provider watch durable. It deliberately has its own job kind so an
+      // unrelated reconcile/manual pull can never make a new connection look
+      // ready before watch setup has completed.
+      const pull = await pullCalendarChanges(deps, calendar, now);
+      if (pull.status === "applied") {
+        await deps.resources.setBootstrapState(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+          "ready",
+        );
+        await appendCalendarInvalidation(deps, calendar, now());
+        return { result: "done" };
+      }
+      if (pull.status === "notImported") {
+        return { result: "done", followup: importFollowup(resource, now) };
+      }
+      return { result: "done", followup: repairFollowup(resource, now) };
+    }
     case "repair": {
       const repair = await repairCalendar(deps, calendar, now);
       // An incomplete repair (the pass yielded no durable cursor) left the old
       // generation intact; retry the whole rebuild later rather than settle.
       if (repair.status === "repaired") {
         await appendCalendarInvalidation(deps, calendar, now());
+        if (needsBootstrapCompletion(resource)) {
+          return {
+            result: "done",
+            followup: subscriptionFollowup(repair.resource, now),
+          };
+        }
         return { result: "done" };
       }
       return {
@@ -281,7 +321,27 @@ async function runSyncJob(
       // Open or renew the push channel. Every terminal outcome (watched /
       // renewed / current / unsupported / authRevoked) settles the job; a
       // transient watch failure throws and the worker retries with backoff.
-      await maintainSubscription(deps, calendar, resource, now);
+      const subscription = await maintainSubscription(
+        deps,
+        calendar,
+        resource,
+        now,
+      );
+      if (
+        needsBootstrapCompletion(resource) &&
+        subscription.status !== "authRevoked"
+      ) {
+        await deps.resources.setBootstrapState(
+          resource.tenantId,
+          resource.principalId,
+          resource._id,
+          "catchingUp",
+        );
+        return {
+          result: "done",
+          followup: bootstrapCatchupFollowup(resource, now),
+        };
+      }
       return { result: "done" };
     }
   }
@@ -319,6 +379,31 @@ function importFollowup(
     runAfter: now(),
     coalescingKey: `initialImport:${resource._id}`,
   };
+}
+
+function bootstrapCatchupFollowup(
+  resource: SyncResourceRecord,
+  now: () => Date,
+): JobEnqueue {
+  return {
+    tenantId: resource.tenantId,
+    principalId: resource.principalId,
+    connectionId: resource.connectionId,
+    resourceId: resource._id,
+    commandId: null,
+    kind: "bootstrapCatchup",
+    priority: 0,
+    runAfter: now(),
+    coalescingKey: `bootstrapCatchup:${resource._id}`,
+  };
+}
+
+// Rows written before bootstrapState existed parse as ready so an established
+// calendar does not restart its onboarding after deploy. A missing cursor is
+// the important exception: it proves the old row was still mid-import and
+// must complete the watch + post-watch pull boundary before becoming healthy.
+function needsBootstrapCompletion(resource: SyncResourceRecord): boolean {
+  return resource.bootstrapState !== "ready" || resource.syncCursor == null;
 }
 
 async function appendCalendarInvalidation(

--- a/packages/sync/src/storage/contracts/job.contracts.ts
+++ b/packages/sync/src/storage/contracts/job.contracts.ts
@@ -10,6 +10,7 @@ import {
 export const JobKindSchema = z.enum([
   "calendarListSync",
   "initialImport",
+  "bootstrapCatchup",
   "incrementalPull",
   "commandApply",
   "reconcile",

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -12,6 +12,18 @@ import { ObjectIdStringSchema } from "@core/types/type.utils";
 export const ResourceKindSchema = z.enum(["calendarList", "events"]);
 export type ResourceKind = z.infer<typeof ResourceKindSchema>;
 
+// A newly discovered calendar does not become ready merely because its first
+// import produced a cursor. It must also establish its watch (or prove watch is
+// unsupported) and complete one incremental pull after that boundary. Rows
+// created before this invariant existed default to ready so the rollout does
+// not regress established connections into an endless import state.
+export const ResourceBootstrapStateSchema = z
+  .enum(["importing", "watching", "catchingUp", "ready"])
+  .default("ready");
+export type ResourceBootstrapState = z.infer<
+  typeof ResourceBootstrapStateSchema
+>;
+
 // Persistence record for `sync_resources` — one independently synchronized
 // provider resource with its cursors, import generation, timing, and push
 // subscription. A calendar-list resource has no calendarId (there is one per
@@ -53,6 +65,9 @@ export const SyncResourceRecordSchema = z.strictObject({
   lastReadFailureAt: z.date().nullable().default(null),
   // The redacted failure detail (HTTP status + provider reason) for triage.
   lastReadFailureDetail: z.string().min(1).nullable().default(null),
+  // Fresh resources progress importing -> watching -> catchingUp -> ready.
+  // See ResourceBootstrapStateSchema for why absent legacy values are ready.
+  bootstrapState: ResourceBootstrapStateSchema,
   // Push subscription: the provider channel id, its opaque resource id, the
   // per-channel secret the provider echoes back on callbacks, and when it
   // expires. All null when no subscription is active.

--- a/packages/sync/src/storage/repositories/job.repository.ts
+++ b/packages/sync/src/storage/repositories/job.repository.ts
@@ -426,6 +426,35 @@ export class JobRepository {
     });
   }
 
+  // Read work that makes a connected calendar's freshness unknown. Command
+  // writes and subscription renewal are intentionally excluded: they should
+  // not turn an otherwise current sidebar into a broad "Syncing" state.
+  async hasOutstandingReadWorkByConnection(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    connectionId: ConnectionId,
+  ): Promise<boolean> {
+    const job = await this.collection.findOne(
+      {
+        tenantId,
+        principalId,
+        connectionId,
+        state: { $in: ["pending", "claimed"] },
+        kind: {
+          $in: [
+            "calendarListSync",
+            "initialImport",
+            "bootstrapCatchup",
+            "incrementalPull",
+            "repair",
+          ],
+        },
+      },
+      { projection: { _id: 1 } },
+    );
+    return job !== null;
+  }
+
   // Hard-delete every job for one connection (post-disconnect retention).
   async deleteByConnection(
     tenantId: TenantId,

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -7,6 +7,7 @@ import {
 } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
+  type ResourceBootstrapState,
   type SyncResourceRecord,
   SyncResourceRecordSchema,
   type SyncResourceUpsert,
@@ -57,6 +58,8 @@ export class SyncResourceRepository {
           lastSuccessAt: null,
           lastReadFailureAt: null,
           lastReadFailureDetail: null,
+          bootstrapState:
+            fields.resourceKind === "events" ? "importing" : "ready",
           subscriptionId: null,
           subscriptionResourceId: null,
           subscriptionToken: null,
@@ -147,6 +150,22 @@ export class SyncResourceRepository {
         },
       },
     ]);
+  }
+
+  // Advance first-connection readiness only after the caller has completed a
+  // durable boundary (initial import, watch setup, or the post-watch pull).
+  // Existing rows default to ready at read time; this method only writes the
+  // stricter lifecycle for calendars created after the invariant was added.
+  async setBootstrapState(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    bootstrapState: ResourceBootstrapState,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id, tenantId, principalId },
+      { $set: { bootstrapState, updatedAt: new Date() } },
+    );
   }
 
   async updateSubscription(

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.ts
@@ -2,11 +2,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { AuthApi } from "@web/api/auth.api";
-import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
 import {
-  clearSyncingSyncIndicatorOverride,
-  setSyncingSyncIndicatorOverride,
-} from "@web/auth/google/state/google.sync.state";
+  refreshGoogleSync,
+  useIsGoogleSyncRefreshInFlight,
+} from "@web/auth/google/state/google.sync.refresh";
 import { syncPendingLocalEvents } from "@web/auth/google/util/google.auth.util";
 import {
   selectGoogleSyncConnection,
@@ -30,11 +29,10 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
   const syncConnection = useUserMetadataStore(selectGoogleSyncConnection);
   const queryClient = useQueryClient();
   const [isConnecting, setIsConnecting] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
   // Sync guard so rapid re-clicks before React re-renders cannot start a
   // second OAuth attempt; isConnecting alone would still be false in-handler.
   const isConnectingRef = useRef(false);
-  const isRefreshingRef = useRef(false);
+  const isRefreshing = useIsGoogleSyncRefreshInFlight();
   const stopConnecting = useCallback(() => {
     isConnectingRef.current = false;
     setIsConnecting(false);
@@ -100,23 +98,19 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
 
   const onRefreshGoogle = useCallback(
     (options?: { silent?: boolean }) => {
-      if (isRefreshingRef.current || isConnectingRef.current) {
+      if (isConnectingRef.current) {
         return;
       }
 
-      isRefreshingRef.current = true;
-      setIsRefreshing(true);
-      setSyncingSyncIndicatorOverride();
       if (!options?.silent) {
         settingsActions.closeCmdPalette();
       }
 
-      const run = async () => {
-        try {
-          await AuthApi.refreshGoogleSync();
-          await refreshUserMetadata({ force: true });
+      void refreshGoogleSync()
+        .then(() => {
           void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
-        } catch {
+        })
+        .catch(() => {
           // A background-triggered refresh (tab focus) failing transiently
           // isn't worth interrupting the user for — only a refresh they
           // explicitly asked for surfaces the failure.
@@ -126,16 +120,7 @@ export const useConnectGoogle = (): UseConnectGoogleResult => {
               { toastId: GOOGLE_REFRESH_FAILED_TOAST_ID },
             );
           }
-        } finally {
-          // Drop the optimistic syncing override once the request settles.
-          // Metadata/SSE still drive IMPORTING when a real import is in flight.
-          clearSyncingSyncIndicatorOverride();
-          isRefreshingRef.current = false;
-          setIsRefreshing(false);
-        }
-      };
-
-      void run();
+        });
     },
     [queryClient],
   );

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.types.ts
@@ -17,7 +17,7 @@ export type UseConnectGoogleResult = GoogleUiConfig & {
   isAvailable: boolean;
   /** True while connect/reconnect OAuth is starting (before redirect). */
   isConnecting: boolean;
-  /** True while a user-triggered Sync refresh is in flight. */
+  /** True while any Compass surface is requesting a Sync refresh. */
   isRefreshing: boolean;
   state: GoogleUiState;
   /**
@@ -33,7 +33,8 @@ export type UseConnectGoogleResult = GoogleUiConfig & {
    * the ATTENTION / delayed Refresh CTA, the delayed toast, and an automatic
    * focus-triggered check (useSyncFocusRefresh). Pass `silent: true` for a
    * background trigger the user didn't ask for, so a transient failure
-   * doesn't surface an error toast or close an open command palette.
+   * doesn't surface an error toast or close an open command palette. All
+   * callers share one in-flight request.
    */
   refresh: (options?: { silent?: boolean }) => void;
 };

--- a/packages/web/src/auth/google/state/google.sync.refresh.test.ts
+++ b/packages/web/src/auth/google/state/google.sync.refresh.test.ts
@@ -1,0 +1,27 @@
+import { createGoogleSyncRefreshCoordinator } from "@web/auth/google/state/google.sync.refresh";
+import { describe, expect, it, mock } from "bun:test";
+
+describe("createGoogleSyncRefreshCoordinator", () => {
+  it("shares one in-flight refresh across callers", async () => {
+    let resolveRequest: (() => void) | undefined;
+    const request = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+    const coordinator = createGoogleSyncRefreshCoordinator(request);
+
+    const first = coordinator.refresh();
+    const second = coordinator.refresh();
+
+    expect(second).toBe(first);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(coordinator.getIsRefreshing()).toBe(true);
+
+    resolveRequest?.();
+    await first;
+
+    expect(coordinator.getIsRefreshing()).toBe(false);
+  });
+});

--- a/packages/web/src/auth/google/state/google.sync.refresh.ts
+++ b/packages/web/src/auth/google/state/google.sync.refresh.ts
@@ -1,0 +1,63 @@
+import { useSyncExternalStore } from "react";
+import { AuthApi } from "@web/api/auth.api";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+
+type Listener = () => void;
+
+// One browser-wide refresh owns the enqueue request and metadata recheck. This
+// prevents the sidebar, delayed toast, and focus hook from racing each other
+// while still letting every caller react to the same success or failure.
+export const createGoogleSyncRefreshCoordinator = (
+  requestRefresh: () => Promise<void>,
+) => {
+  const listeners = new Set<Listener>();
+  let inFlight: Promise<void> | null = null;
+
+  const emit = () => {
+    listeners.forEach((listener) => listener());
+  };
+
+  const refresh = (): Promise<void> => {
+    if (inFlight) return inFlight;
+
+    const request = requestRefresh();
+    inFlight = request;
+    emit();
+    void request.then(
+      () => {
+        if (inFlight !== request) return;
+        inFlight = null;
+        emit();
+      },
+      () => {
+        if (inFlight !== request) return;
+        inFlight = null;
+        emit();
+      },
+    );
+    return request;
+  };
+
+  return {
+    refresh,
+    getIsRefreshing: () => inFlight !== null,
+    subscribe: (listener: Listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+};
+
+const coordinator = createGoogleSyncRefreshCoordinator(async () => {
+  await AuthApi.refreshGoogleSync();
+  await refreshUserMetadata({ force: true });
+});
+
+export const refreshGoogleSync = () => coordinator.refresh();
+
+export const useIsGoogleSyncRefreshInFlight = () =>
+  useSyncExternalStore(
+    coordinator.subscribe,
+    coordinator.getIsRefreshing,
+    coordinator.getIsRefreshing,
+  );

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -329,7 +329,7 @@ describe("CalendarListHeader", () => {
     expect(connectButton).toHaveAttribute("aria-busy", "true");
   });
 
-  it("shows an immediate refreshing status while a calendar refresh starts", () => {
+  it("shows an immediate refresh-request status while a calendar refresh starts", () => {
     mockEmail = "ahab@pequod.com";
     mockGoogleState = "ATTENTION";
     mockIsRefreshing = true;
@@ -340,7 +340,7 @@ describe("CalendarListHeader", () => {
       name: "Refreshing…",
     });
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Refreshing your calendar…",
+      "Requesting a calendar refresh…",
     );
     expect(refreshButton).toBeDisabled();
     expect(refreshButton).toHaveAttribute("aria-busy", "true");

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -72,7 +72,7 @@ const getSidebarSyncStatus = ({
   }
 
   if (isRefreshing) {
-    return { variant: "syncing", text: "Refreshing your calendar…" };
+    return { variant: "syncing", text: "Requesting a calendar refresh…" };
   }
 
   if (googleStatus && googleStatus.variant !== "healthy") {

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
@@ -79,6 +79,21 @@ describe("useSyncFocusRefresh", () => {
     expect(refresh).not.toHaveBeenCalled();
   });
 
+  it("does not retrigger when shared refresh status changes", () => {
+    const refresh = mock();
+    let isRefreshing = false;
+    const hook = renderHook(() =>
+      useSyncFocusRefresh(() => fakeConnectGoogle({ refresh, isRefreshing })),
+    );
+
+    isRefreshing = true;
+    hook.rerender();
+    isRefreshing = false;
+    hook.rerender();
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
   it("refreshes again when the tab regains focus after being hidden long enough", () => {
     setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
     const refresh = mock();

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.ts
@@ -15,10 +15,9 @@ const MIN_HIDDEN_DURATION_MS = 30_000;
  * Refresh themselves. Passes `silent: true` — the user didn't ask for this
  * one, so a transient failure shouldn't surface an error toast the way a
  * manual click's would. The sync service still coalesces redundant enqueues
- * regardless. This mounts its own `useConnectGoogle()` instance (independent
- * of the sidebar's), so its in-flight guard is independent too — a refresh
- * from here and a near-simultaneous manual click aren't deduplicated against
- * each other, only against repeats of themselves.
+ * regardless. Every `useConnectGoogle()` instance delegates to the same
+ * browser-wide refresh coordinator, so a focus refresh and a manual click
+ * share work and status instead of racing each other.
  *
  * No-ops while there's no established connection worth refreshing (not yet
  * connected, reconnect required, or still on the initial import).


### PR DESCRIPTION
## What changed
- Make first Google sync durably complete only after import, watch setup, and one post-watch pull.
- Share one browser refresh request so focus, manual refresh, and sidebar status cannot race or loop.
- Keep status honest while refresh work is queued, surface stalled bootstrap work, and compute last-synced from the stalest active calendar.
- Preserve in-flight legacy imports by recognizing no-cursor resources.

## Validation
- `bun test:sync` (757 passing)
- `bun test:web` (1543 passing)
- `bun type-check`
- `bun lint`
- `bun test:e2e` (21 passing)
- `bun test:a11y` (7 passing)
- Independent read-only review; two bootstrap edge cases found, fixed, and re-reviewed clean.

Live Google OAuth was not exercised locally because production credentials are not available in this workspace.