### PR TITLE
fix(web): harden description link paste, attendee a11y, richer demo data

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -136,6 +136,7 @@
         "@tanstack/react-hotkeys": "^0.3.1",
         "@tanstack/react-query": "^5",
         "@tanstack/react-router": "^1.170.17",
+        "@tiptap/extension-link": "^3.29.2",
         "@tiptap/extension-placeholder": "^3.29.2",
         "@tiptap/pm": "^3.29.2",
         "@tiptap/react": "^3.29.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-hotkeys": "^0.3.1",
     "@tanstack/react-query": "^5",
     "@tanstack/react-router": "^1.170.17",
+    "@tiptap/extension-link": "^3.29.2",
     "@tiptap/extension-placeholder": "^3.29.2",
     "@tiptap/pm": "^3.29.2",
     "@tiptap/react": "^3.29.2",

--- a/packages/web/src/common/storage/migrations/external/demo-data-seed.ts
+++ b/packages/web/src/common/storage/migrations/external/demo-data-seed.ts
@@ -4,6 +4,11 @@ import {
   type EventContent,
   EventScheduleSchema,
 } from "@core/types/event.contracts";
+import {
+  type Attendee,
+  type Conference,
+  type Organizer,
+} from "@core/types/event-attendance.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
@@ -23,12 +28,24 @@ function createEventRecord(overrides: {
   schedule:
     | { kind: "timed"; start: string; end: string; timeZone: string }
     | { kind: "allDay"; start: string; end: string };
+  // Read-only, provider-sourced fields on a real synced event - only
+  // showcased here so first-time users (who never connect Google before
+  // seeing the calendar) discover the meeting-link/location/attendees UI at
+  // all, since it otherwise only ever renders for Google-synced events.
+  location?: string;
+  organizer?: Organizer;
+  attendees?: Attendee[];
+  conference?: Conference;
 }): LocalEventRecord {
   const id = EventIdSchema.parse(createObjectIdString());
   const content: EventContent = {
     kind: "details",
     title: overrides.title,
     description: overrides.description ?? "",
+    location: overrides.location,
+    organizer: overrides.organizer,
+    attendees: overrides.attendees,
+    conference: overrides.conference,
   };
   const now = DateTimeSchema.parse(new Date().toISOString());
 
@@ -70,6 +87,36 @@ function generateDemoData() {
         end: todayAt(9, 30),
         timeZone,
       },
+      // Showcases the meeting-link and attendee UI (normally only populated
+      // from a synced Google event) for first-time users who haven't
+      // connected Google yet.
+      conference: {
+        url: "https://meet.google.com/abc-defg-hij",
+        label: "Google Meet",
+      },
+      organizer: { email: "avery@example.com", displayName: "Avery" },
+      attendees: [
+        {
+          email: "avery@example.com",
+          displayName: "Avery",
+          responseStatus: "accepted",
+        },
+        {
+          email: "sam@example.com",
+          displayName: "Sam",
+          responseStatus: "accepted",
+        },
+        {
+          email: "jordan@example.com",
+          displayName: "Jordan",
+          responseStatus: "tentative",
+        },
+        {
+          email: "riley@example.com",
+          displayName: "Riley",
+          responseStatus: "needsAction",
+        },
+      ],
     }),
     createEventRecord({
       title: "Try Compass",
@@ -85,6 +132,8 @@ function generateDemoData() {
     createEventRecord({
       title: "Exercise",
       description: "I'm sorry for what I said during burpees.",
+      // Showcases the location → Google Maps link.
+      location: "Fitness First Gym, 123 Main St",
       schedule: {
         kind: "timed",
         start: todayAt(12, 0),

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
@@ -86,6 +86,44 @@ describe("DescriptionEditor", () => {
     expect(textbox.textContent).toContain("Safe text");
   });
 
+  it("preserves a plain link and forces target/rel regardless of the source", () => {
+    // Meeting links pasted into a Google description (Zoom/Teams - the
+    // structured `conference` field only ever covers Google Meet) must stay
+    // clickable rather than getting flattened to plain text by sanitization.
+    render(
+      <DescriptionEditor
+        value='Join here: <a href="https://zoom.us/j/123456789" target="_self" rel="opener">Zoom meeting</a>'
+        onChange={mock()}
+        editable={false}
+        resetKey="test-5"
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Zoom meeting" });
+    expect(link).toHaveAttribute("href", "https://zoom.us/j/123456789");
+    // Forced at render time by the Link extension's HTMLAttributes, not
+    // read from the source - an attacker-controlled target/rel in the
+    // source HTML (target="_self" rel="opener" above) must never survive.
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer nofollow");
+  });
+
+  it("neutralizes a javascript: href instead of rendering it as a link", () => {
+    render(
+      <DescriptionEditor
+        value='<a href="javascript:alert(1)">click me</a>'
+        onChange={mock()}
+        editable={false}
+        resetKey="test-6"
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Description" });
+    expect(textbox.innerHTML).not.toContain("javascript:");
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(textbox.textContent).toBe("click me");
+  });
+
   it("re-syncs contenteditable when editable flips on the same event", () => {
     // Regression: useEditor only recreates the editor when `resetKey`
     // changes, so `editable` must be applied via editor.setEditable in its

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
@@ -108,6 +108,44 @@ describe("DescriptionEditor", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer nofollow");
   });
 
+  it("neutralizes attacker-supplied target/rel pasted mid-session, not just on load", () => {
+    // The previous test only covers the `value`-prop load path, which goes
+    // through DOMPurify. Pasting into a live editor skips DOMPurify entirely
+    // and goes straight through ProseMirror's own HTML parser instead - this
+    // is the path the stock TipTap Link mark left unguarded (it reads
+    // target/rel/class straight off the pasted <a> when no parseHTML is
+    // configured for them), which is what SafeLink's addAttributes override
+    // closes.
+    render(
+      <DescriptionEditor
+        value=""
+        onChange={mock()}
+        editable={true}
+        resetKey="test-paste"
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Description" });
+
+    // jsdom has no DataTransfer (jsdom/jsdom#1568) - RTL's fireEvent falls
+    // back to assigning a plain object as `clipboardData` verbatim when
+    // window.DataTransfer isn't a constructor, so a minimal getData stub is
+    // enough for ProseMirror's paste handler to read the pasted HTML.
+    const clipboardData = {
+      getData: (type: string) =>
+        type === "text/html"
+          ? '<a href="https://evil.example" target="_self" rel="opener">click</a>'
+          : "",
+    };
+
+    fireEvent.paste(textbox, { clipboardData });
+
+    const link = screen.getByRole("link", { name: "click" });
+    expect(link).toHaveAttribute("href", "https://evil.example");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer nofollow");
+  });
+
   it("neutralizes a javascript: href instead of rendering it as a link", () => {
     render(
       <DescriptionEditor

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
@@ -17,15 +17,41 @@ import { Divider } from "@web/components/Divider/Divider";
 // formatting this editor actually supports. TipTap's own schema (StarterKit
 // with headings/code/blockquote/etc disabled below) is a second filter: any
 // surviving tag it doesn't recognize as a node/mark just becomes plain text.
-// `href` is the only attribute let through - the Link extension below
-// applies its own target/rel at render time regardless of what (if
-// anything) survived on the source tag, so a malicious rel/target in the
-// source HTML can never reach the DOM.
+// `href` is the only attribute let through - target/rel are forced by the
+// SafeLink mark below regardless of what (if anything) survived on the
+// source tag.
 const sanitizeDescriptionHtml = (html: string): string =>
   DOMPurify.sanitize(html, {
     ALLOWED_TAGS: ["p", "br", "b", "strong", "i", "em", "ul", "ol", "li", "a"],
     ALLOWED_ATTR: ["href"],
   });
+
+// DOMPurify only runs on the `value` prop at (re)creation - pasting into a
+// live editor goes straight through ProseMirror's own HTML parser instead,
+// bypassing it entirely. TipTap's stock Link mark reads target/rel/class off
+// the source element when no `parseHTML` is configured for them (only
+// `href` gets one upstream), so without this override a pasted
+// `<a target="_self" rel="opener">` would carry its attacker-supplied
+// target/rel straight into the DOM - defeating the point of forcing safe
+// values in HTMLAttributes below. `parseHTML: () => null` makes the mark
+// itself incapable of reading these from any source, paste included, so the
+// guarantee doesn't depend on which entry point fed it HTML.
+const SafeLink = Link.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      target: {
+        default: this.options.HTMLAttributes.target,
+        parseHTML: () => null,
+      },
+      rel: { default: this.options.HTMLAttributes.rel, parseHTML: () => null },
+      class: {
+        default: this.options.HTMLAttributes.class,
+        parseHTML: () => null,
+      },
+    };
+  },
+});
 
 interface DescriptionEditorProps {
   value: string;
@@ -91,9 +117,9 @@ export const DescriptionEditor = ({
         // so clicking mid-edit places the cursor instead of navigating away
         // (matches Google Docs/Notion) - a read-only region already lets
         // native `<a>` clicks through once contenteditable is false.
-        // HTMLAttributes are applied at render time regardless of what
-        // survived sanitization, so target/rel are never attacker-controlled.
-        Link.configure({
+        // SafeLink (not the stock Link mark) is what makes target/rel
+        // untouchable by source HTML - see its definition above.
+        SafeLink.configure({
           openOnClick: false,
           autolink: true,
           defaultProtocol: "https",

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
@@ -4,6 +4,7 @@ import {
   TextBIcon,
   TextItalicIcon,
 } from "@phosphor-icons/react";
+import { Link } from "@tiptap/extension-link";
 import { Placeholder } from "@tiptap/extension-placeholder";
 import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
@@ -16,10 +17,14 @@ import { Divider } from "@web/components/Divider/Divider";
 // formatting this editor actually supports. TipTap's own schema (StarterKit
 // with headings/code/blockquote/etc disabled below) is a second filter: any
 // surviving tag it doesn't recognize as a node/mark just becomes plain text.
+// `href` is the only attribute let through - the Link extension below
+// applies its own target/rel at render time regardless of what (if
+// anything) survived on the source tag, so a malicious rel/target in the
+// source HTML can never reach the DOM.
 const sanitizeDescriptionHtml = (html: string): string =>
   DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ["p", "br", "b", "strong", "i", "em", "ul", "ol", "li"],
-    ALLOWED_ATTR: [],
+    ALLOWED_TAGS: ["p", "br", "b", "strong", "i", "em", "ul", "ol", "li", "a"],
+    ALLOWED_ATTR: ["href"],
   });
 
 interface DescriptionEditorProps {
@@ -78,6 +83,26 @@ export const DescriptionEditor = ({
           strike: false,
           underline: false,
           link: false,
+        }),
+        // Preserve-only, not editable via the toolbar: a meeting link pasted
+        // into a Google description (Zoom/Teams, most often - `conference`
+        // only ever covers Google Meet) should stay clickable rather than
+        // getting flattened to plain text. openOnClick is off in BOTH modes
+        // so clicking mid-edit places the cursor instead of navigating away
+        // (matches Google Docs/Notion) - a read-only region already lets
+        // native `<a>` clicks through once contenteditable is false.
+        // HTMLAttributes are applied at render time regardless of what
+        // survived sanitization, so target/rel are never attacker-controlled.
+        Link.configure({
+          openOnClick: false,
+          autolink: true,
+          defaultProtocol: "https",
+          protocols: ["http", "https"],
+          HTMLAttributes: {
+            target: "_blank",
+            rel: "noopener noreferrer nofollow",
+            class: "text-accent underline",
+          },
         }),
         Placeholder.configure({ placeholder }),
       ],

--- a/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
@@ -83,22 +83,32 @@ export const EventDetailsSection = ({ details }: EventDetailsSectionProps) => {
             </span>
           </div>
           <ul className="flex flex-col gap-1 pl-6">
-            {visibleAttendees.map((attendee) => (
-              <li
-                key={attendee.email}
-                className="flex items-center gap-2"
-                title={attendeeStatusLabel(attendee.responseStatus)}
-              >
-                <span
-                  aria-hidden
-                  className={`size-2.5 shrink-0 rounded-full ${ATTENDEE_STATUS_DOT[attendee.responseStatus]}`}
-                />
-                <span className="min-w-0 flex-1 truncate">
-                  {attendee.displayName ?? attendee.email}
-                  {organizer?.email === attendee.email && " (organizer)"}
-                </span>
-              </li>
-            ))}
+            {visibleAttendees.map((attendee) => {
+              const name = attendee.displayName ?? attendee.email;
+              const isOrganizer = organizer?.email === attendee.email;
+              // The dot alone is a color-only signal (bg-success vs
+              // bg-error), invisible to colorblind users and unannounced by
+              // screen readers - title is a mouse-only tooltip, so the row's
+              // aria-label carries the same info as accessible text.
+              const statusText = attendeeStatusLabel(attendee.responseStatus);
+              return (
+                <li
+                  key={attendee.email}
+                  className="flex items-center gap-2"
+                  aria-label={`${name}, ${statusText}${isOrganizer ? ", organizer" : ""}`}
+                >
+                  <span
+                    aria-hidden
+                    title={statusText}
+                    className={`size-2.5 shrink-0 rounded-full ${ATTENDEE_STATUS_DOT[attendee.responseStatus]}`}
+                  />
+                  <span aria-hidden className="min-w-0 flex-1 truncate">
+                    {name}
+                    {isOrganizer && " (organizer)"}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
           {hiddenAttendeeCount > 0 && (
             <button

--- a/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
@@ -102,7 +102,7 @@ export const EventDetailsSection = ({ details }: EventDetailsSectionProps) => {
                     title={statusText}
                     className={`size-2.5 shrink-0 rounded-full ${ATTENDEE_STATUS_DOT[attendee.responseStatus]}`}
                   />
-                  <span aria-hidden className="min-w-0 flex-1 truncate">
+                  <span className="min-w-0 flex-1 truncate">
                     {name}
                     {isOrganizer && " (organizer)"}
                   </span>

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -1107,6 +1107,15 @@ describe("EventForm", () => {
       expect(screen.getByText("2 guests")).toBeInTheDocument();
       expect(screen.getByText("Team Lead (organizer)")).toBeInTheDocument();
       expect(screen.getByText("guest@example.com")).toBeInTheDocument();
+
+      // RSVP status is otherwise a color-only dot - each row needs an
+      // accessible name carrying the same status text for screen readers.
+      expect(
+        screen.getByLabelText("Team Lead, accepted, organizer"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("guest@example.com, declined"),
+      ).toBeInTheDocument();
     });
 
     it("renders nothing when the event has no location, attendees, or conference", () => {


### PR DESCRIPTION
## Summary
Follow-up to #2555 (meeting links, location, attendees, rich-text descriptions), addressing three items from a PM-style follow-up review:

- **Security fix**: `DescriptionEditor`'s link handling forced safe `target`/`rel` for links loaded via the `value` prop (through DOMPurify), but pasting a link into a live editor bypasses DOMPurify entirely and goes through ProseMirror's own HTML parser instead. TipTap's stock `Link` mark has no `parseHTML` override for `target`/`rel`/`class`, so a pasted `<a target="_self" rel="opener">` could carry attacker-controlled values straight into the DOM, reintroducing the reverse-tabnabbing risk `rel="noopener noreferrer"` is meant to prevent. Fixed with a `SafeLink` extension that pins `target`/`rel`/`class` to their configured defaults via `parseHTML: () => null`, closing the gap regardless of entry point.
- **Accessibility**: added `aria-label` to each attendee row (name + RSVP status + organizer marker) so screen readers get the same info as the color-coded status dot; removed a now-redundant `aria-hidden` the dot's parent `li` already made a no-op.
- **Demo data**: enriched two seeded local events (a Google Meet standup with organizer/attendees, a gym event with a location) so first-time users who haven't connected Google yet can discover the new meeting-link/location/attendees UI.

## Test plan
- [x] `bun run type-check` (root) — clean
- [x] `bun run knip` — clean
- [x] `biome check` — clean (formatted the new code)
- [x] Targeted tests: `DescriptionEditor.test.tsx` (8/8, including a new paste-path regression test using `fireEvent.paste`) and `EventForm.test.tsx` (27/27)
- [x] Full `packages/web` suite: 1566/1566 pass
- [x] Independent code review of the security fix, confirming the `parseHTML: () => null` pattern and paste-path test are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)