### PR TITLE
feat(core,sync,backend,web): make event location editable

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.test.ts
@@ -22,10 +22,29 @@ const timedSchedule = {
 
 describe("toSyncContent", () => {
   it("pads browser details into the full sync content shape", () => {
-    expect(toSyncContent({ title: "Standup", description: "Daily" })).toEqual({
+    expect(
+      toSyncContent({ title: "Standup", description: "Daily", location: "" }),
+    ).toEqual({
       title: "Standup",
       description: "Daily",
-      location: null,
+      location: "",
+      organizer: null,
+      attendees: [],
+      conference: null,
+    });
+  });
+
+  it("forwards the browser's location onto sync content", () => {
+    expect(
+      toSyncContent({
+        title: "Standup",
+        description: "Daily",
+        location: "Room A",
+      }),
+    ).toEqual({
+      title: "Standup",
+      description: "Daily",
+      location: "Room A",
       organizer: null,
       attendees: [],
       conference: null,
@@ -34,11 +53,16 @@ describe("toSyncContent", () => {
 
   it("forwards an optional color onto sync content", () => {
     expect(
-      toSyncContent({ title: "Standup", description: "Daily", color: "coral" }),
+      toSyncContent({
+        title: "Standup",
+        description: "Daily",
+        location: "",
+        color: "coral",
+      }),
     ).toEqual({
       title: "Standup",
       description: "Daily",
-      location: null,
+      location: "",
       organizer: null,
       attendees: [],
       conference: null,
@@ -48,7 +72,7 @@ describe("toSyncContent", () => {
 
   it("omits color when the browser did not set one", () => {
     expect(
-      toSyncContent({ title: "Standup", description: "Daily" }),
+      toSyncContent({ title: "Standup", description: "Daily", location: "" }),
     ).not.toHaveProperty("color");
   });
 });
@@ -117,7 +141,12 @@ describe("toCreateSubmitRequest", () => {
     const { request, responseEvent } = toCreateSubmitRequest({
       id: eventId,
       calendarId,
-      content: { kind: "details", title: "Lunch", description: "" },
+      content: {
+        kind: "details",
+        title: "Lunch",
+        description: "",
+        location: "",
+      },
       schedule: timedSchedule,
       recurrence: { kind: "single" },
     });
@@ -140,7 +169,7 @@ describe("toCreateSubmitRequest", () => {
   it("mints an eventId when the client omits one", () => {
     const { request } = toCreateSubmitRequest({
       calendarId: objectId(),
-      content: { kind: "details", title: "X", description: "" },
+      content: { kind: "details", title: "X", description: "", location: "" },
       schedule: timedSchedule,
       recurrence: { kind: "single" },
     });
@@ -158,7 +187,12 @@ describe("toReplaceSubmitRequests", () => {
   it("emits a single update for a plain-id replace without a calendar move", () => {
     const eventId = objectId();
     const { requests, responseEvent } = toReplaceSubmitRequests(eventId, {
-      content: { kind: "details", title: "Renamed", description: "" },
+      content: {
+        kind: "details",
+        title: "Renamed",
+        description: "",
+        location: "",
+      },
       schedule: timedSchedule,
       recurrence: { kind: "preserve" },
       scope: "this",
@@ -178,7 +212,12 @@ describe("toReplaceSubmitRequests", () => {
     const recurrenceId = "2026-07-14T09:00:00.000Z";
     const id = composeOccurrenceId({ eventId, recurrenceId });
     const { requests } = toReplaceSubmitRequests(id, {
-      content: { kind: "details", title: "Moved", description: "" },
+      content: {
+        kind: "details",
+        title: "Moved",
+        description: "",
+        location: "",
+      },
       schedule: timedSchedule,
       recurrence: { kind: "preserve" },
       scope: "this",
@@ -197,7 +236,7 @@ describe("toReplaceSubmitRequests", () => {
     const calendarId = objectId();
     const { requests } = toReplaceSubmitRequests(eventId, {
       calendarId,
-      content: { kind: "details", title: "X", description: "" },
+      content: { kind: "details", title: "X", description: "", location: "" },
       schedule: timedSchedule,
       recurrence: { kind: "single" },
       scope: "this",

--- a/packages/backend/src/common/services/sync-service/event-command.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-command.translation.ts
@@ -36,21 +36,22 @@ import { createHash } from "node:crypto";
 const UNKNOWN_CALENDAR_ID = CalendarIdSchema.parse("000000000000000000000000");
 
 // Expand browser details-content into sync's fuller content shape. Browser
-// edits never touch location/organizer/attendees/conference — pad with nulls
-// so the strict SyncEventContent schema accepts the wire payload. On create
-// those nulls are correct (new event). On update, sync's apply path merges
-// title/description onto the existing record (mergeUpdateContent) so a rename
-// cannot wipe provider-sourced attendees/location/conference. Optional color
-// is forwarded when the browser sets one; omitted color leaves merge to keep
-// whatever Sync already stores.
+// edits never touch organizer/attendees/conference — pad with nulls so the
+// strict SyncEventContent schema accepts the wire payload. On create those
+// nulls are correct (new event). On update, sync's apply path merges
+// title/description/location onto the existing record (mergeUpdateContent)
+// so a rename cannot wipe provider-sourced attendees/conference. Optional
+// color is forwarded when the browser sets one; omitted color leaves merge
+// to keep whatever Sync already stores.
 export const toSyncContent = (content: {
   title: string;
   description: string;
+  location: string;
   color?: EventColorSlot | null;
 }): SyncEventContent => ({
   title: content.title,
   description: content.description,
-  location: null,
+  location: content.location,
   organizer: null,
   attendees: [],
   conference: null,

--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -40,7 +40,7 @@ const jsonRes = () => {
 const sampleCreateBody = () => ({
   id: objectId(),
   calendarId: objectId(),
-  content: { kind: "details", title: "Lunch", description: "" },
+  content: { kind: "details", title: "Lunch", description: "", location: "" },
   schedule: {
     kind: "timed",
     start: "2026-07-14T12:00:00.000Z",
@@ -152,7 +152,12 @@ describe("EventController", () => {
         params: { id: objectId() },
         body: {
           calendarId: objectId(),
-          content: { kind: "details", title: "Lunch", description: "" },
+          content: {
+            kind: "details",
+            title: "Lunch",
+            description: "",
+            location: "",
+          },
           schedule: {
             kind: "timed",
             start: "2026-07-14T12:00:00.000Z",
@@ -182,7 +187,12 @@ describe("EventController", () => {
         body: {
           id: objectId(),
           calendarId: objectId(),
-          content: { kind: "details", title: "Lunch", description: "" },
+          content: {
+            kind: "details",
+            title: "Lunch",
+            description: "",
+            location: "",
+          },
           schedule: {
             kind: "timed",
             start: "2026-07-14T12:00:00.000Z",
@@ -206,7 +216,12 @@ describe("EventController", () => {
       sessionReq(objectId(), {
         params: { id: objectId() },
         body: {
-          content: { kind: "details", title: "Renamed", description: "" },
+          content: {
+            kind: "details",
+            title: "Renamed",
+            description: "",
+            location: "",
+          },
           schedule: {
             kind: "timed",
             start: "2026-07-14T12:00:00.000Z",

--- a/packages/core/src/types/event-command.contracts.test.ts
+++ b/packages/core/src/types/event-command.contracts.test.ts
@@ -12,7 +12,12 @@ import {
 const calendarId = () => faker.database.mongodbObjectId();
 const eventId = () => faker.database.mongodbObjectId();
 
-const content = { kind: "details", title: "Standup", description: "" };
+const content = {
+  kind: "details",
+  title: "Standup",
+  description: "",
+  location: "",
+};
 const timedSchedule = {
   kind: "timed",
   start: "2026-07-14T09:00:00-06:00",

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -17,6 +17,10 @@ const EditableContentSchema = z.strictObject({
   kind: z.literal("details"),
   title: z.string(),
   description: z.string(),
+  // Same convention as description: empty string means no location, always
+  // sent and always overwritten on save (no separate "leave alone" state -
+  // location has no calendar-default to inherit the way color does).
+  location: z.string(),
   // Null clears a previously set color on replace; omit leaves sync color
   // alone when the client did not touch it.
   color: OptionalNullableEventColorSchema,

--- a/packages/sync/src/domain/merge-update-content.test.ts
+++ b/packages/sync/src/domain/merge-update-content.test.ts
@@ -2,7 +2,7 @@ import { mergeUpdateContent, omitNullColor } from "./merge-update-content";
 import { describe, expect, it } from "bun:test";
 
 describe("mergeUpdateContent", () => {
-  it("updates title and description without wiping richer fields", () => {
+  it("updates title, description, and location without wiping richer fields", () => {
     const existing = {
       title: "Old",
       description: "Old desc",
@@ -20,7 +20,7 @@ describe("mergeUpdateContent", () => {
     const incoming = {
       title: "New",
       description: "New desc",
-      location: null,
+      location: "Room B",
       organizer: null,
       attendees: [],
       conference: null,
@@ -29,7 +29,7 @@ describe("mergeUpdateContent", () => {
     expect(mergeUpdateContent(existing, incoming)).toEqual({
       title: "New",
       description: "New desc",
-      location: "Room A",
+      location: "Room B",
       organizer: existing.organizer,
       attendees: existing.attendees,
       conference: existing.conference,

--- a/packages/sync/src/domain/merge-update-content.ts
+++ b/packages/sync/src/domain/merge-update-content.ts
@@ -1,9 +1,9 @@
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 
-// Browser edits only title + description (+ optional color). An update command
-// still carries a full SyncEventContent (strict schema), and the Compass API
-// pads richer fields with null/[] — applying that verbatim would wipe
-// attendees/location/conference Sync already holds from the provider.
+// Browser edits only title + description + location (+ optional color). An
+// update command still carries a full SyncEventContent (strict schema), and
+// the Compass API pads richer fields with null/[] — applying that verbatim
+// would wipe attendees/conference Sync already holds from the provider.
 //
 // Merge editable fields from the command; keep the rest from existing.
 // Color: slot replaces, null clears (omit the field), omit keeps existing.
@@ -16,6 +16,7 @@ export function mergeUpdateContent(
     ...existingWithoutColor,
     title: incoming.title,
     description: incoming.description,
+    location: incoming.location,
   };
 
   if (incoming.color === null) return merged;

--- a/packages/sync/src/providers/google/google-event.normalizer.test.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.test.ts
@@ -122,9 +122,10 @@ describe("normalizeGoogleEvent", () => {
       start: "2022-02-22",
       end: "2022-02-23",
     });
-    // No description/location on this fixture; absence becomes empty/null.
+    // No description/location on this fixture; absence becomes empty string
+    // for both, matching the editable-write side's "no location" convention.
     expect(read.content.description).toBe("");
-    expect(read.content.location).toBeNull();
+    expect(read.content.location).toBe("");
     // Organizer without a display name normalizes to null, not "".
     expect(read.content.organizer).toEqual({
       email: "foo@gmail.com",

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -105,7 +105,11 @@ function mapContent(
     // contract models those as empty strings, not absence.
     title: item.summary ?? "",
     description: item.description ?? "",
-    location: item.location ?? null,
+    // Same convention as title/description above (empty string, not
+    // absence) - toSyncContent's editable-write side always sends a
+    // definite string for location too, so matchesIntendedEdit's replay
+    // comparison needs both sides using the same "no location" value.
+    location: item.location ?? "",
     organizer: mapOrganizer(item.organizer),
     attendees: mapAttendees(item.attendees),
     conference: mapConference(item),

--- a/packages/web/src/common/utils/parse/dirty.parser.ts
+++ b/packages/web/src/common/utils/parse/dirty.parser.ts
@@ -131,6 +131,7 @@ export class DirtyParser {
 
     if (values.title !== orig.title) return true;
     if (values.description !== orig.description) return true;
+    if (values.location !== orig.location) return true;
     if (values.calendarId !== orig.calendarId) return true;
     if (values.schedule.kind !== orig.schedule.kind) return true;
     if (values.schedule.start.getTime() !== orig.schedule.start.getTime()) {

--- a/packages/web/src/common/utils/sync/local-event-sync.util.test.ts
+++ b/packages/web/src/common/utils/sync/local-event-sync.util.test.ts
@@ -72,6 +72,23 @@ describe("syncLocalEventsToCloud", () => {
     expect(clearAllEvents).toHaveBeenCalledTimes(1);
   });
 
+  it("defaults location to an empty string for a record that predates the field", async () => {
+    // createMockLocalEventRecord's default content has no `location` key at
+    // all (matching a real pre-existing local record) - CreateEventInput
+    // requires a definite string, and the backend's strict schema rejects a
+    // POST body missing it outright.
+    const record = createMockLocalEventRecord({}, false);
+    getAllEvents.mockResolvedValue([record]);
+
+    await syncLocalEventsToCloud();
+
+    expect(createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({ location: "" }),
+      }),
+    );
+  });
+
   it("clears local demo events without sending them to the backend", async () => {
     getAllEvents.mockResolvedValue([createMockLocalEventRecord({}, true)]);
 

--- a/packages/web/src/common/utils/sync/local-event-sync.util.ts
+++ b/packages/web/src/common/utils/sync/local-event-sync.util.ts
@@ -9,6 +9,7 @@ import {
   getOfflineDataStore,
 } from "@web/common/storage/offline-data/offline-data.store.registry";
 import { EventApi } from "@web/events/event.api";
+import { detailsLocation } from "@web/events/grid-event-draft.adapter";
 import { type LocalEventRecord } from "@web/events/types/local-event.record";
 
 type LocalEventSyncStorage = Pick<
@@ -55,6 +56,16 @@ function toCreateInput(
 ): CreateEventInput {
   const recurrence = record.event.recurrence;
   const allDay = record.event.schedule.kind === "allDay";
+  // Local storage only ever holds "details" content (never a synthesized
+  // "busy" block), so this narrowing cast is safe - but its location is
+  // read-side optional/nullable (a record predating this field, or one that
+  // never had a location), while CreateEventInput requires a definite
+  // string, so it needs the same default every other editable-content
+  // consumer uses.
+  const content = record.event.content as Extract<
+    typeof record.event.content,
+    { kind: "details" }
+  >;
 
   return {
     // Composed occurrence ids (`${seriesId}::${start}`, minted by local-mode
@@ -73,9 +84,10 @@ function toCreateInput(
             ],
           }
         : { kind: "single" },
-    // Local storage only ever holds "details" content (never a synthesized
-    // "busy" block), so this narrowing cast is safe.
-    content: record.event.content as CreateEventInput["content"],
+    content: {
+      ...content,
+      location: detailsLocation(content),
+    } as CreateEventInput["content"],
   };
 }
 

--- a/packages/web/src/common/utils/toast/recurrence-scope.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/recurrence-scope.toast.test.tsx
@@ -96,6 +96,7 @@ describe("showRecurrenceScopeToast", () => {
           kind: "details",
           title: "Updated plan",
           description: "",
+          location: "",
         },
         schedule: original.schedule,
         recurrence: { kind: "preserve" },
@@ -170,7 +171,12 @@ describe("showRecurrenceScopeToast", () => {
       kind: "replace",
       original,
       input: {
-        content: { kind: "details", title: "Original", description: "" },
+        content: {
+          kind: "details",
+          title: "Original",
+          description: "",
+          location: "",
+        },
         schedule: original.schedule,
         recurrence: { kind: "preserve" },
         scope: "this",

--- a/packages/web/src/events/event-draft.parser.test.ts
+++ b/packages/web/src/events/event-draft.parser.test.ts
@@ -44,6 +44,7 @@ const newFormValues = (
 ): NewEventFormValues => ({
   title: "Standup",
   description: "",
+  location: "",
   schedule: timedSchedule(),
   calendarId: calendarId(),
   color: null,
@@ -65,6 +66,7 @@ const editFormValues = (
 ): EditEventFormValues => ({
   title: "Standup",
   description: "",
+  location: "",
   schedule: timedSchedule(),
   calendarId: calendarId(),
   color: null,
@@ -111,6 +113,7 @@ describe("parseEventDraft", () => {
         kind: "details",
         title: "Standup",
         description: "",
+        location: "",
         color: "coral",
       });
 
@@ -118,6 +121,13 @@ describe("parseEventDraft", () => {
       expect(cleared.ok).toBe(true);
       if (!cleared.ok) throw new Error("expected ok");
       expect(cleared.input.content.color).toBeNull();
+    });
+
+    it("includes the edited location", () => {
+      const result = parseEventDraft(newDraft({ location: "Room A" }));
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected ok");
+      expect(result.input.content.location).toBe("Room A");
     });
 
     it("normalizes a same-day all-day selection to an exclusive end", () => {

--- a/packages/web/src/events/event-draft.parser.ts
+++ b/packages/web/src/events/event-draft.parser.ts
@@ -200,6 +200,7 @@ export function parseEventDraft(draft: EventDraft): ParseEventDraftResult {
     kind: "details" as const,
     title: draft.values.title,
     description: draft.values.description,
+    location: draft.values.location,
     // Always include: a slot sets the tag, null clears it on edit (and is a
     // no-op clear on create). Omitting would preserve an existing sync color
     // on title-only saves that still carry an explicit draft color of null.

--- a/packages/web/src/events/event-draft.types.ts
+++ b/packages/web/src/events/event-draft.types.ts
@@ -29,6 +29,8 @@ export type EditEventRecurrenceDraft =
 type SharedEventFormValues = {
   title: string;
   description: string;
+  // Same convention as description: empty string means no location.
+  location: string;
   schedule: EventScheduleDraft;
   // Null means calendar-default / no event color tag.
   color: EventColorSlot | null;

--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -54,6 +54,7 @@ export function createGridEventDraft(
     values: {
       title: "",
       description: "",
+      location: "",
       schedule,
       calendarId,
       color: null,
@@ -439,7 +440,10 @@ export function patchGridDraftScheduleDates(
 export function patchGridDraftFields(
   current: GridEventDraft,
   patch: Partial<
-    Pick<GridEventDraft["values"], "title" | "description" | "color">
+    Pick<
+      GridEventDraft["values"],
+      "title" | "description" | "location" | "color"
+    >
   >,
 ): GridEventDraft {
   // Branching on kind keeps create/edit values correlated with the
@@ -457,11 +461,17 @@ export function patchGridDraftFields(
 }
 
 const applyDraftFieldPatch = <
-  T extends Pick<GridEventDraft["values"], "title" | "description" | "color">,
+  T extends Pick<
+    GridEventDraft["values"],
+    "title" | "description" | "location" | "color"
+  >,
 >(
   values: T,
   patch: Partial<
-    Pick<GridEventDraft["values"], "title" | "description" | "color">
+    Pick<
+      GridEventDraft["values"],
+      "title" | "description" | "location" | "color"
+    >
   >,
 ): T => ({
   ...values,
@@ -469,18 +479,35 @@ const applyDraftFieldPatch = <
   ...(patch.description !== undefined
     ? { description: patch.description }
     : {}),
+  ...(patch.location !== undefined ? { location: patch.location } : {}),
   ...(patch.color !== undefined ? { color: patch.color } : {}),
 });
 
+// Event["content"].location is nullable/optional (a provider-sourced event
+// may never have set one, and older local records predate the field
+// entirely), but every editable-content consumer (draft values, replay
+// payloads sent to mutations.replace/create) needs a definite string. Shared
+// so every read of a stored event's location defaults it the same way -
+// also used by useUndoRedo.ts's replay/comparison paths.
+export const detailsLocation = (
+  content: Extract<Event["content"], { kind: "details" }>,
+): string => content.location ?? "";
+
 const editableDetailsFromEvent = (
   event: Event,
-): { title: string; description: string; color: EventColorSlot | null } => {
+): {
+  title: string;
+  description: string;
+  location: string;
+  color: EventColorSlot | null;
+} => {
   if (event.content.kind !== "details") {
-    return { title: "", description: "", color: null };
+    return { title: "", description: "", location: "", color: null };
   }
   return {
     title: event.content.title,
     description: event.content.description,
+    location: detailsLocation(event.content),
     color: event.content.color ?? null,
   };
 };

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -146,7 +146,12 @@ const replacePayload = (
 ) => ({
   id,
   input: {
-    content: { kind: "details" as const, title: "Original", description: "" },
+    content: {
+      kind: "details" as const,
+      title: "Original",
+      description: "",
+      location: "",
+    },
     schedule: timedSchedule(
       "2026-07-02T16:00:00.000Z",
       "2026-07-02T17:00:00.000Z",
@@ -242,6 +247,7 @@ describe("useEventMutations", () => {
             kind: "details",
             title: "First narrow edit",
             description: "",
+            location: "",
           },
         }),
       ),
@@ -265,6 +271,7 @@ describe("useEventMutations", () => {
             kind: "details",
             title: "Later narrow edit",
             description: "",
+            location: "",
           },
         }),
       ),
@@ -309,6 +316,7 @@ describe("useEventMutations", () => {
             kind: "details",
             title: "Updated series",
             description: "",
+            location: "",
           },
           schedule: first.schedule as ReplaceEventInput["schedule"],
           scope: "all",
@@ -476,7 +484,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.create({
         calendarId: event().calendarId,
-        content: { kind: "details", title: "New series", description: "" },
+        content: {
+          kind: "details",
+          title: "New series",
+          description: "",
+          location: "",
+        },
         schedule: timedSchedule(
           "2026-07-02T16:00:00.000Z",
           "2026-07-02T17:00:00.000Z",
@@ -648,7 +661,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(first.id, {
-          content: { kind: "details", title: "First edit", description: "" },
+          content: {
+            kind: "details",
+            title: "First edit",
+            description: "",
+            location: "",
+          },
           scope: "all",
         }),
       ),
@@ -662,7 +680,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(second.id, {
-          content: { kind: "details", title: "Second edit", description: "" },
+          content: {
+            kind: "details",
+            title: "Second edit",
+            description: "",
+            location: "",
+          },
           scope: "all",
         }),
       ),
@@ -695,6 +718,7 @@ describe("useEventMutations", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: created.schedule as never,
         recurrence: { kind: "single" },
@@ -731,7 +755,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(original.id, {
-          content: { kind: "details", title: "Changed", description: "" },
+          content: {
+            kind: "details",
+            title: "Changed",
+            description: "",
+            location: "",
+          },
         }),
       ),
     );
@@ -766,7 +795,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(item.id, {
-          content: { kind: "details", title: "Changed", description: "" },
+          content: {
+            kind: "details",
+            title: "Changed",
+            description: "",
+            location: "",
+          },
         }),
       ),
     );
@@ -791,7 +825,7 @@ describe("useEventMutations", () => {
     const editEvent = (title: string) =>
       context.hook.result.current.mutations.replace(
         replacePayload(original.id, {
-          content: { kind: "details", title, description: "" },
+          content: { kind: "details", title, description: "", location: "" },
         }),
       );
 
@@ -840,7 +874,7 @@ describe("useEventMutations", () => {
     const editEvent = (title: string) =>
       context.hook.result.current.mutations.replace(
         replacePayload(original.id, {
-          content: { kind: "details", title, description: "" },
+          content: { kind: "details", title, description: "", location: "" },
         }),
       );
 
@@ -888,7 +922,7 @@ describe("useEventMutations", () => {
     const editEvent = (title: string) =>
       context.hook.result.current.mutations.replace(
         replacePayload(original.id, {
-          content: { kind: "details", title, description: "" },
+          content: { kind: "details", title, description: "", location: "" },
         }),
       );
 
@@ -945,7 +979,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(doomed.id, {
-          content: { kind: "details", title: "Doomed", description: "" },
+          content: {
+            kind: "details",
+            title: "Doomed",
+            description: "",
+            location: "",
+          },
         }),
       ),
     );
@@ -957,7 +996,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(other.id, {
-          content: { kind: "details", title: "Survivor", description: "" },
+          content: {
+            kind: "details",
+            title: "Survivor",
+            description: "",
+            location: "",
+          },
         }),
       ),
     );
@@ -1024,6 +1068,7 @@ describe("useEventMutations", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: created.schedule as never,
         recurrence: { kind: "single" },
@@ -1073,6 +1118,7 @@ describe("useEventMutations", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: created.schedule as never,
         recurrence: { kind: "single" },
@@ -1111,6 +1157,7 @@ describe("useEventMutations", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: created.schedule as never,
         recurrence: { kind: "single" },
@@ -1125,7 +1172,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(created.id, {
-          content: { kind: "details", title: "Edited", description: "" },
+          content: {
+            kind: "details",
+            title: "Edited",
+            description: "",
+            location: "",
+          },
         }),
       ),
     );
@@ -1178,7 +1230,12 @@ describe("useEventMutations", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(movedIn.id, {
-          content: { kind: "details", title: "Moved In", description: "" },
+          content: {
+            kind: "details",
+            title: "Moved In",
+            description: "",
+            location: "",
+          },
           schedule: timedSchedule(
             "2026-07-04T16:00:00.000Z",
             "2026-07-04T17:00:00.000Z",
@@ -1232,7 +1289,12 @@ describe("undo history recording", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(original.id, {
-          content: { kind: "details", title: "Moved", description: "" },
+          content: {
+            kind: "details",
+            title: "Moved",
+            description: "",
+            location: "",
+          },
         }),
       ),
     );
@@ -1278,7 +1340,12 @@ describe("undo history recording", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(instance.id, {
-          content: { kind: "details", title: "Moved", description: "" },
+          content: {
+            kind: "details",
+            title: "Moved",
+            description: "",
+            location: "",
+          },
         }),
       ),
     );
@@ -1302,7 +1369,12 @@ describe("undo history recording", () => {
     act(() =>
       context.hook.result.current.mutations.replace(
         replacePayload(seriesBase.id, {
-          content: { kind: "details", title: "Moved", description: "" },
+          content: {
+            kind: "details",
+            title: "Moved",
+            description: "",
+            location: "",
+          },
           scope: "all",
         }),
       ),
@@ -1326,6 +1398,7 @@ describe("undo history recording", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: created.schedule as never,
         recurrence: { kind: "single" },
@@ -1352,6 +1425,7 @@ describe("undo history recording", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: seriesCreated.schedule as never,
         recurrence: {
@@ -1431,7 +1505,12 @@ describe("undo history recording", () => {
       act(() =>
         context.hook.result.current.mutations.replace(
           replacePayload(original.id, {
-            content: { kind: "details", title: "Replayed", description: "" },
+            content: {
+              kind: "details",
+              title: "Replayed",
+              description: "",
+              location: "",
+            },
           }),
         ),
       );
@@ -1449,6 +1528,7 @@ describe("undo history recording", () => {
             kind: "details";
             title: string;
             description: string;
+            location: string;
           },
           schedule: original.schedule as never,
           recurrence: { kind: "single" },
@@ -1485,6 +1565,7 @@ describe("undo history recording", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: original.schedule as never,
         recurrence: { kind: "single" },
@@ -1529,6 +1610,7 @@ describe("undo history recording", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: original.schedule as never,
         recurrence: { kind: "single" },

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -147,11 +147,12 @@ function optimisticEventFromCreate(input: CreateEventInput): Event {
   };
 }
 
-// The form only ever submits the editable subset (title/description/color) —
-// location/organizer/attendees/conference are read-only, provider-sourced
-// fields the server never asks the client to resubmit. Merging input.content
-// wholesale onto the optimistic cache entry would make those fields flicker
-// away until the settle-time refetch restores them from the server.
+// The form only ever submits the editable subset (title/description/
+// location/color) — organizer/attendees/conference are read-only,
+// provider-sourced fields the server never asks the client to resubmit.
+// Merging input.content wholesale onto the optimistic cache entry would make
+// those fields flicker away until the settle-time refetch restores them from
+// the server.
 function mergeReplaceContent(
   existing: Event["content"],
   input: ReplaceEventInput["content"],

--- a/packages/web/src/events/mutations/useUndoRedo.test.tsx
+++ b/packages/web/src/events/mutations/useUndoRedo.test.tsx
@@ -94,6 +94,7 @@ describe("useUndoRedo", () => {
             kind: "details";
             title: string;
             description: string;
+            location: string;
           },
           schedule: {
             kind: "timed",
@@ -156,6 +157,7 @@ describe("useUndoRedo", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: created.schedule as never,
         recurrence: { kind: "single" },
@@ -318,7 +320,12 @@ describe("useUndoRedo", () => {
       context.hook.result.current.mutations.replace({
         id: instance.id,
         input: {
-          content: { kind: "details", title: "Moved", description: "" },
+          content: {
+            kind: "details",
+            title: "Moved",
+            description: "",
+            location: "",
+          },
           schedule: instance.schedule as never,
           recurrence: { kind: "preserve" },
           scope: "this",
@@ -364,7 +371,12 @@ describe("useUndoRedo", () => {
       context.hook.result.current.mutations.replace({
         id: instance.id,
         input: {
-          content: { kind: "details", title: "Changed", description: "" },
+          content: {
+            kind: "details",
+            title: "Changed",
+            description: "",
+            location: "",
+          },
           schedule: instance.schedule as never,
           recurrence: { kind: "preserve" },
           scope: "this",
@@ -384,7 +396,12 @@ describe("useUndoRedo", () => {
       context.hook.result.current.mutations.replace({
         id: other.id,
         input: {
-          content: { kind: "details", title: "Later", description: "" },
+          content: {
+            kind: "details",
+            title: "Later",
+            description: "",
+            location: "",
+          },
           schedule: other.schedule as never,
           recurrence: { kind: "preserve" },
           scope: "this",
@@ -414,7 +431,12 @@ describe("useUndoRedo", () => {
       context.hook.result.current.mutations.replace({
         id: original.id,
         input: {
-          content: { kind: "details", title: "Moved", description: "" },
+          content: {
+            kind: "details",
+            title: "Moved",
+            description: "",
+            location: "",
+          },
           schedule: original.schedule as never,
           recurrence: { kind: "preserve" },
           scope: "this",
@@ -466,6 +488,7 @@ describe("useUndoRedo", () => {
           kind: "details";
           title: string;
           description: string;
+          location: string;
         },
         schedule: created.schedule as never,
         recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },

--- a/packages/web/src/events/mutations/useUndoRedo.ts
+++ b/packages/web/src/events/mutations/useUndoRedo.ts
@@ -7,6 +7,7 @@ import { DATA_EVENT_ELEMENT_ID } from "@web/common/constants/web.constants";
 import { showRestoredToast } from "@web/common/utils/toast/deleted-toast.util";
 import { dismissRecurrenceScopeToast } from "@web/common/utils/toast/recurrence-scope.toast";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { detailsLocation } from "@web/events/grid-event-draft.adapter";
 import {
   type EventMutationDependencies,
   useEventMutations,
@@ -67,6 +68,19 @@ const refocusAfterReplay = (eventId: string) => {
 const showUndoDeclinedToast = () =>
   showStatusToast(UNDO_DECLINED_TOAST_ID, "Can't undo — event changed since");
 
+// A snapshot recorded before this event was ever replayed may omit `location`
+// entirely (an older local record, or any Event built without it) — replaying
+// it always fills the key in (replaySnapshot below), since the editable-
+// content contract requires a definite string. Comparing raw JSON.stringify
+// output would then read "gained a location key" as an external change.
+// Normalizing both sides the same way (via the same detailsLocation default
+// replaySnapshot/undoDelete/redo use below) keeps the comparison about the
+// actual value, not whether the key happened to be present.
+const normalizedDetailsContent = (content: Event["content"]) =>
+  content.kind === "details"
+    ? { ...content, location: detailsLocation(content) }
+    : content;
+
 // Whether `current` still matches the state an undo/redo entry expects to
 // find before it replays — the staleness guard. Deliberately narrow: it
 // compares only the fields our own snapshots capture and our own replays
@@ -79,7 +93,10 @@ const showUndoDeclinedToast = () =>
 // toast instead of applying stale data.
 function snapshotMatches(current: Event, expected: Event): boolean {
   if (current.calendarId !== expected.calendarId) return false;
-  if (JSON.stringify(current.content) !== JSON.stringify(expected.content)) {
+  if (
+    JSON.stringify(normalizedDetailsContent(current.content)) !==
+    JSON.stringify(normalizedDetailsContent(expected.content))
+  ) {
     return false;
   }
   return JSON.stringify(current.schedule) === JSON.stringify(expected.schedule);
@@ -120,7 +137,10 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
           // Restores the snapshot's calendar too, so undoing a cross-calendar
           // move puts the event back on its original calendar.
           calendarId: snapshot.calendarId,
-          content: snapshot.content,
+          content: {
+            ...snapshot.content,
+            location: detailsLocation(snapshot.content),
+          },
           schedule: snapshot.schedule,
           // "preserve" keeps whatever recurrence linkage the target already
           // has (single, or one occurrence of a series) — scope "this"
@@ -159,7 +179,7 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
       mutations.create({
         id: event.id,
         calendarId: event.calendarId,
-        content: event.content,
+        content: { ...event.content, location: detailsLocation(event.content) },
         schedule: event.schedule,
         recurrence:
           event.recurrence.kind === "series"
@@ -250,7 +270,10 @@ export function useUndoRedo(dependencies: EventMutationDependencies = {}) {
         mutations.create({
           id: event.id,
           calendarId: event.calendarId,
-          content: event.content,
+          content: {
+            ...event.content,
+            location: detailsLocation(event.content),
+          },
           schedule: event.schedule,
           recurrence:
             event.recurrence.kind === "series"

--- a/packages/web/src/events/repositories/local.event.repository.test.ts
+++ b/packages/web/src/events/repositories/local.event.repository.test.ts
@@ -34,7 +34,12 @@ describe("LocalEventRepository", () => {
     getAllEvents.mockResolvedValue([existing]);
 
     await repository.replace(existing.id, {
-      content: { kind: "details", title: "Renamed sample", description: "" },
+      content: {
+        kind: "details",
+        title: "Renamed sample",
+        description: "",
+        location: "",
+      },
       schedule: existing.event.schedule,
       recurrence: { kind: "preserve" },
       scope: "this",
@@ -51,7 +56,7 @@ describe("LocalEventRepository", () => {
 
     const id = "c".repeat(24) as EventId;
     const result = await repository.replace(id, {
-      content: { kind: "details", title: "x", description: "" },
+      content: { kind: "details", title: "x", description: "", location: "" },
       schedule: {
         kind: "timed",
         start: DateTimeSchema.parse("2026-05-05T09:00:00.000-05:00"),
@@ -77,7 +82,7 @@ describe("LocalEventRepository", () => {
     const id = "d".repeat(24) as EventId;
     const calendarId = "e".repeat(24) as EventId;
     const result = await repository.replace(id, {
-      content: { kind: "details", title: "y", description: "" },
+      content: { kind: "details", title: "y", description: "", location: "" },
       calendarId: calendarId as unknown as CalendarId,
       schedule: {
         kind: "timed",
@@ -324,7 +329,12 @@ describe("LocalEventRepository", () => {
     const result = await repository.replace(
       `${record.id}::2026-05-06T09:00:00Z` as EventId,
       {
-        content: { kind: "details", title: "Renamed series", description: "" },
+        content: {
+          kind: "details",
+          title: "Renamed series",
+          description: "",
+          location: "",
+        },
         schedule: record.event.schedule,
         recurrence: {
           kind: "series",
@@ -351,7 +361,12 @@ describe("LocalEventRepository", () => {
     const id = `${record.id}::${occurrenceStart}` as EventId;
 
     const result = await repository.replace(id, {
-      content: { kind: "details", title: "New leg", description: "" },
+      content: {
+        kind: "details",
+        title: "New leg",
+        description: "",
+        location: "",
+      },
       schedule: {
         kind: "timed",
         start: DateTimeSchema.parse("2026-05-06T11:00:00.000Z"),

--- a/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
@@ -1,4 +1,4 @@
-import { MapPinIcon, UsersIcon, VideoCameraIcon } from "@phosphor-icons/react";
+import { UsersIcon, VideoCameraIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { type EventContent } from "@core/types/event.contracts";
 import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
@@ -6,10 +6,7 @@ import { type AttendeeResponseStatus } from "@core/types/event-attendance.contra
 type EventDetails = Extract<EventContent, { kind: "details" }>;
 
 interface EventDetailsSectionProps {
-  details: Pick<
-    EventDetails,
-    "location" | "organizer" | "attendees" | "conference"
-  >;
+  details: Pick<EventDetails, "organizer" | "attendees" | "conference">;
 }
 
 const ATTENDEE_STATUS_DOT: Record<AttendeeResponseStatus, string> = {
@@ -22,24 +19,22 @@ const ATTENDEE_STATUS_DOT: Record<AttendeeResponseStatus, string> = {
 const attendeeStatusLabel = (status: AttendeeResponseStatus): string =>
   status === "needsAction" ? "hasn't responded" : status;
 
-const mapsUrlForLocation = (location: string) =>
-  `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
-
 const MAX_VISIBLE_ATTENDEES = 6;
 
 /**
  * Read-only display for provider-sourced event fields Compass doesn't let
- * the user edit: the Google Meet link, location (linked out to Maps), and
- * the attendee list with RSVP status. Rendered only when the event has at
+ * the user edit: the Google Meet link and the attendee list with RSVP
+ * status. Location is editable now (see EventForm.tsx's own location
+ * field) and no longer rendered here. Rendered only when the event has at
  * least one of these - absent for a plain Compass-native event and for a
  * busy-projection event (whose content carries none of this).
  */
 export const EventDetailsSection = ({ details }: EventDetailsSectionProps) => {
-  const { location, organizer, attendees = [], conference } = details;
+  const { organizer, attendees = [], conference } = details;
   const [showAllAttendees, setShowAllAttendees] = useState(false);
   const hasAttendees = attendees.length > 0;
 
-  if (!location && !conference && !hasAttendees) return null;
+  if (!conference && !hasAttendees) return null;
 
   const visibleAttendees = showAllAttendees
     ? attendees
@@ -59,18 +54,6 @@ export const EventDetailsSection = ({ details }: EventDetailsSectionProps) => {
           <span className="min-w-0 flex-1 truncate">
             {conference.label ?? "Join meeting"}
           </span>
-        </a>
-      )}
-
-      {location && (
-        <a
-          href={mapsUrlForLocation(location)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 hover:underline"
-        >
-          <MapPinIcon size={16} className="shrink-0 text-text-muted" />
-          <span className="min-w-0 flex-1 truncate">{location}</span>
         </a>
       )}
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx
@@ -86,6 +86,7 @@ describe("EventForm read-only gate", () => {
     const { container } = renderEventForm(draft, [readOnlyCalendar]);
 
     expect(screen.getByPlaceholderText("Title")).toBeDisabled();
+    expect(screen.getByRole("textbox", { name: "Location" })).toBeDisabled();
     // The description editor is a contenteditable div, not a native form
     // control - <fieldset disabled> has no effect on it, so read-only is
     // expressed via TipTap's own `editable` option instead (EventForm.tsx
@@ -172,6 +173,9 @@ describe("EventForm read-only gate", () => {
     });
 
     expect(screen.getByPlaceholderText("Title")).not.toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: "Location" }),
+    ).not.toBeDisabled();
     expect(
       screen.getByRole("textbox", { name: "Description" }),
     ).toHaveAttribute("contenteditable", "true");

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -1022,7 +1022,7 @@ describe("EventForm", () => {
     ).toBe("Notes");
   });
 
-  describe("read-only event details (meeting link, location, attendees)", () => {
+  describe("event details (meeting link, location, attendees)", () => {
     it("shows a meeting link that opens in a new tab", () => {
       renderWithStore(
         <EventForm
@@ -1051,7 +1051,7 @@ describe("EventForm", () => {
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });
 
-    it("shows the location linking out to Google Maps", () => {
+    it("shows an editable location field with a link to Google Maps", () => {
       renderWithStore(
         <EventForm
           draft={createEditDraft({ location: "200 Main St, Anytown" })}
@@ -1065,15 +1065,69 @@ describe("EventForm", () => {
         />,
       );
 
-      const link = screen.getByRole("link", {
-        name: "200 Main St, Anytown",
-      });
+      expect(screen.getByRole("textbox", { name: "Location" })).toHaveValue(
+        "200 Main St, Anytown",
+      );
+
+      const link = screen.getByRole("link", { name: "Open in Google Maps" });
       expect(link).toHaveAttribute(
         "href",
         "https://www.google.com/maps/search/?api=1&query=200%20Main%20St%2C%20Anytown",
       );
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
+    it("updates the draft location as the user types and shows the Maps link once populated", async () => {
+      const user = userEvent.setup();
+
+      function Harness() {
+        const [draft, setDraftState] = useState<GridEventDraft>(
+          createEditDraft({ location: "" }),
+        );
+        const setDraftFromForm = (
+          nextDraft: SetStateAction<GridEventDraft | null>,
+        ) => {
+          setDraftState((currentDraft) => {
+            const resolvedDraft =
+              typeof nextDraft === "function"
+                ? nextDraft(currentDraft)
+                : nextDraft;
+
+            return resolvedDraft ?? currentDraft;
+          });
+        };
+
+        return (
+          <EventForm
+            draft={draft}
+            isDraft={false}
+            isExistingEvent={true}
+            onClose={mock()}
+            onDelete={mock()}
+            onDuplicate={mock()}
+            onSubmit={mock()}
+            setDraft={setDraftFromForm}
+          />
+        );
+      }
+
+      renderWithStore(<Harness />);
+
+      expect(
+        screen.queryByRole("link", { name: "Open in Google Maps" }),
+      ).not.toBeInTheDocument();
+
+      const locationField = screen.getByRole("textbox", { name: "Location" });
+      await user.type(locationField, "200 Main St");
+
+      expect(locationField).toHaveValue("200 Main St");
+      expect(
+        screen.getByRole("link", { name: "Open in Google Maps" }),
+      ).toHaveAttribute(
+        "href",
+        "https://www.google.com/maps/search/?api=1&query=200%20Main%20St",
+      );
     });
 
     it("shows attendees with RSVP status and marks the organizer", () => {
@@ -1118,7 +1172,7 @@ describe("EventForm", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders nothing when the event has no location, attendees, or conference", () => {
+    it("renders an empty, link-less location field and no attendees/conference section when the event has none of them", () => {
       renderWithStore(
         <EventForm
           draft={createEditDraft()}
@@ -1132,6 +1186,7 @@ describe("EventForm", () => {
         />,
       );
 
+      expect(screen.getByRole("textbox", { name: "Location" })).toHaveValue("");
       expect(screen.queryByRole("link")).not.toBeInTheDocument();
       expect(screen.queryByText(/guest/)).not.toBeInTheDocument();
     });

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -1,3 +1,4 @@
+import { MapPinIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import fastDeepEqual from "fast-deep-equal/react";
 import type React from "react";
@@ -115,6 +116,9 @@ const FormCard = ({ children }: { children: ReactNode }) => (
   </div>
 );
 
+const mapsUrlForLocation = (location: string) =>
+  `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
+
 interface EventFormDateTimeState {
   displayEndDate: Date;
   endTime: SelectOption<string>;
@@ -218,7 +222,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         ? seriesBase.recurrence.rules
         : undefined;
 
-    const { title, description, color } = draft.values;
+    const { title, description, location, color } = draft.values;
     const { base: eventColor } = useEventPalette(color ?? undefined);
     const category =
       draft.values.schedule.kind === "allDay"
@@ -360,7 +364,10 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     const patchDraftFields = useCallback(
       (
         patch: Partial<
-          Pick<GridEventDraft["values"], "title" | "description" | "color">
+          Pick<
+            GridEventDraft["values"],
+            "title" | "description" | "location" | "color"
+          >
         >,
       ) => {
         setLatestDraft((current) => {
@@ -390,6 +397,10 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
      **********/
     const onChangeTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
       patchDraftFields({ title: e.target.value });
+    };
+
+    const onChangeLocation = (e: React.ChangeEvent<HTMLInputElement>) => {
+      patchDraftFields({ location: e.target.value });
     };
 
     const onClose = useCallback(() => {
@@ -793,6 +804,38 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 value={color}
                 onChange={(next) => patchDraftFields({ color: next })}
               />
+            </FormCard>
+
+            <FormCard>
+              <div className="flex items-center gap-2">
+                {location ? (
+                  <a
+                    href={mapsUrlForLocation(location)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Open in Google Maps"
+                    className="shrink-0 text-text-muted hover:text-text"
+                  >
+                    <MapPinIcon size={16} />
+                  </a>
+                ) : (
+                  <MapPinIcon size={16} className="shrink-0 text-text-muted" />
+                )}
+                <Focusable
+                  Component="input"
+                  className={classNames(
+                    INPUT_RESET_CLASSNAME,
+                    "w-full bg-transparent text-sm",
+                  )}
+                  disabled={isReadOnly}
+                  onChange={onChangeLocation}
+                  onKeyDown={handleIgnoredKeys}
+                  placeholder="Location"
+                  aria-label="Location"
+                  name="Event Location"
+                  value={location}
+                />
+              </div>
             </FormCard>
 
             <FormCard>


### PR DESCRIPTION
## Summary
Follow-up to #2555/#2556 — makes the event `location` field editable (previously read-only, display-only via a Maps link), per a PM-style follow-up review that identified this as the clearest next increment: the write path already existed for it in Sync, only the Compass-side contract needed widening.

- **`location` added to `EditableContentSchema`** (core) as a plain required string, deliberately mirroring `description`'s convention (empty = none) rather than `color`'s 3-state omit/null/value pattern — location has no "inherit calendar default" concept that would need a "leave alone" state.
- **Backend/Sync**: `toSyncContent` forwards `location` instead of hardcoding `null`; `mergeUpdateContent` overwrites it like title/description (previously preserved from existing, since it was never editable). `toGoogleBody` and `matchesIntendedEdit` already handled location from the original read-only feature — no changes needed there directly, but see the follow-up fix below.
- **Web**: new editable location `<input>` in `EventForm`, paired with a live "Open in Google Maps" link (rendered only when there's a value); the link stays clickable even on a read-only event since `fieldset[disabled]` doesn't affect anchor tags.
- **`useUndoRedo.ts`**: replay/comparison paths needed the same "default a possibly-missing location to an empty string" logic used everywhere else — centralized as `grid-event-draft.adapter.ts`'s exported `detailsLocation` helper instead of repeating the fallback (a `/simplify` review caught 4 duplicate inline implementations of this; consolidated into one).
- **Two additional fixes from independent review**, after the above shipped: `google-event.normalizer.ts` mapped an absent Google location to `null` while title/description use `""`, causing `matchesIntendedEdit` to permanently mismatch on nearly every event without a location; `local-event-sync.util.ts`'s `toCreateInput` cast local-storage content straight through without defaulting `location`, which would've permanently blocked pre-existing local records (and everything queued after them) from ever promoting to the cloud, since the backend's schema now requires the field. Both now use the same `detailsLocation` default, with regression tests.

## Test plan
- [x] `bun run type-check` (root) — clean
- [x] `bun run knip` — clean
- [x] `biome check` — clean
- [x] Full test suite (`bun run test`): core/sync/web/backend/scripts all green
- [x] `/simplify`-style 4-dimension review (reuse, simplification, efficiency, altitude) — one real finding (duplicated location-defaulting logic), fixed
- [x] Independent correctness review — found and fixed the two read-side gaps above, each with a new regression test
- [x] Manual browser verification: edited a demo event's location, saved, reloaded, confirmed persistence and a reactively-updating Maps link; confirmed the read-only meeting-link/attendees section (untouched by this change) still renders correctly with no regression; zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)