### PR TITLE
feat(web): show a Join link on the Up Next card

### DIFF
--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
@@ -189,6 +189,48 @@ describe("UpNextCard", () => {
       );
     });
   });
+
+  it("shows a Join link to the meeting when the event has a conference", () => {
+    const start = dayjs().add(30, "minute");
+    render(<UpNextCard />, {
+      events: [
+        createMockEvent({
+          id: EventIdSchema.parse(SOON_EVENT_ID),
+          content: {
+            kind: "details",
+            title: "Soon Event",
+            description: "",
+            conference: {
+              url: "https://meet.google.com/abc-defg-hij",
+              label: "Google Meet",
+            },
+          },
+          schedule: EventScheduleSchema.parse({
+            kind: "timed",
+            start: start.format(),
+            end: start.add(30, "minute").format(),
+            timeZone: "UTC",
+          }),
+        }),
+      ],
+    });
+
+    const link = screen.getByRole("link", { name: "Join" });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://meet.google.com/abc-defg-hij",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("shows no Join link when the event has no conference", () => {
+    render(<UpNextCard />, {
+      events: [timedEvent(SOON_EVENT_ID, "Soon Event", 30)],
+    });
+
+    expect(screen.queryByRole("link", { name: "Join" })).toBeNull();
+  });
 });
 
 describe("useUpNextEventShortcut", () => {

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
@@ -1,3 +1,4 @@
+import { VideoCameraIcon } from "@phosphor-icons/react";
 import { type FC } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
@@ -36,20 +37,40 @@ export const UpNextCard: FC = () => {
   return (
     <section aria-label="Up next">
       {upNext ? (
-        <button
-          aria-label={`Up next: ${upNext.title}. ${countdown}.`}
-          className="c-focus-ring group relative flex min-h-14 w-full min-w-0 flex-col gap-0.5 rounded border border-border bg-surface px-2 py-1.5 text-left hover:brightness-110"
-          onClick={() => openEventDetails("gridClick")}
-          type="button"
-        >
+        <div className="group relative flex min-h-14 w-full min-w-0 flex-col gap-0.5 rounded border border-border bg-surface px-2 py-1.5 hover:brightness-110">
+          {/* Covers the whole card so clicking anywhere opens the event -
+              the Join link below sits in normal flow above this in paint
+              order (via relative + z-10), so it still receives its own
+              clicks instead of the card intercepting them. */}
+          <button
+            aria-label={`Up next: ${upNext.title}. ${countdown}.`}
+            className="c-focus-ring absolute inset-0 w-full text-left"
+            onClick={() => openEventDetails("gridClick")}
+            type="button"
+          />
           <span className="pr-8 text-accent text-xs">{countdown}</span>
-          <ShortcutHint className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+          {/* group-has-[:focus-visible], not group-focus-visible: the
+              focusable element is this button's sibling (a descendant of
+              .group), not .group itself, so a plain :focus-visible variant
+              on the group never matches. */}
+          <ShortcutHint className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100 group-has-[:focus-visible]:opacity-100">
             N
           </ShortcutHint>
           <span className="min-w-0 truncate font-medium text-sm text-text">
             {upNext.title}
           </span>
-        </button>
+          {upNext.conference && (
+            <a
+              href={upNext.conference.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="c-focus-ring relative z-10 flex w-fit items-center gap-1 text-accent text-xs hover:underline"
+            >
+              <VideoCameraIcon size={12} />
+              Join
+            </a>
+          )}
+        </div>
       ) : (
         <p className="flex min-h-14 items-center rounded border border-border bg-surface px-2 py-1.5 font-medium text-sm text-text-muted">
           All clear


### PR DESCRIPTION
## Summary
Follow-up to #2557 (editable location) — the "up next" sidebar card previously showed only a countdown and title, even for a meeting with a Google Meet link. That's exactly the moment a user glances at this card wanting one-click access, so this surfaces it: `GridEvent` already carries `conference` from the original meeting-link feature (#2555), so this is presentation-only, no new plumbing.

- An `<a>` can't nest inside the card's `<button>` (invalid HTML, and click-bubbling would fire both the "open details" and "join meeting" actions), so the card is now a wrapper `<div>` with an absolutely-positioned `<button>` covering it for the "open details" click, and the Join link painted above it via `relative z-10` (the standard "stretched link" pattern) so it captures its own clicks independently.
- Independent review caught a real regression this restructure introduced: moving the focusable element off the `.group` container broke `group-focus-visible` on the "N" keyboard-shortcut hint (a plain `group-*` variant only tracks the group element's own focus state, not a descendant's) — swapped to `group-has-[:focus-visible]`, which tracks descendant focus correctly.

## Test plan
- [x] `bun run type-check` — clean
- [x] `bun run knip` — clean
- [x] `biome check` — clean
- [x] Full web test suite: 1571/1571 pass, including 2 new tests (Join link renders with correct href/target/rel when the event has a conference; no Join link when it doesn't)
- [x] Independent review confirmed the overlay/z-index click-through logic is correct (traced against CSS paint-order rules, not just eyeballed) and tab order/reachability is unaffected
- [x] Manual browser verification: clicking the card without a conference still opens the event form correctly (unaffected by the button→div restructure), confirmed via accessibility tree that the button's role/name is unchanged, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)