### PR TITLE
fix(web): allow 15-min draft drag without flip

### DIFF
--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -209,6 +209,7 @@ describe("EventCard", () => {
     expect(card.style.getPropertyValue("--event-bg")).toBe(
       getEventPalette("red").base,
     );
+    expect(card.style.filter).toBe("drop-shadow(0 1px 2px rgb(0 0 0 / 0.28))");
   });
 
   it("keeps timed event keyboard activation from reaching parent shortcuts", () => {

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -133,7 +133,8 @@ const TimedEventCardBase = (
   );
   // Draft fills use the same base as saved cards so the Week overlay matches
   // the form/context-menu swatch (and the eventual save). Draft vs saved is
-  // carried by the drop-shadow filter below, not by darkening the color away.
+  // carried by a light drop-shadow below — enough lift to read as a draft
+  // without a heavy bottom shadow that obscures the end edge.
   // Past events recede in the direction of the theme's grid: the dark theme's
   // light steel fill dims slightly, the light theme's ink fill fades toward
   // the paper (brighten 14 keeps light text >= 4.5:1 and stays clearly apart
@@ -180,7 +181,7 @@ const TimedEventCardBase = (
     width: position.width || 0,
     zIndex: position.zIndex ?? ZIndex.LAYER_1,
     boxShadow: eventBoxShadow,
-    filter: isDraft ? "drop-shadow(2px 4px 4px black)" : undefined,
+    filter: isDraft ? "drop-shadow(0 1px 2px rgb(0 0 0 / 0.28))" : undefined,
   } as CSSProperties;
 
   const isCompactEvent = position.height <= COMPACT_EVENT_MAX_HEIGHT;

--- a/packages/web/src/grid/hooks/useTimedDraftCreation.ts
+++ b/packages/web/src/grid/hooks/useTimedDraftCreation.ts
@@ -13,7 +13,7 @@ import {
   selectIsDrafting,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { DRAFT_DURATION_MIN } from "@web/grid/grid.constants";
+import { DRAFT_DURATION_MIN, GRID_TIME_STEP } from "@web/grid/grid.constants";
 import {
   hasExceededInteractionMoveThreshold,
   isEligibleInteractionPointerDown,
@@ -89,18 +89,29 @@ export const useTimedDraftCreation = ({
     let isPreviewStarted = false;
 
     const resolveDraftForPointer = (point: { x: number; y: number }) => {
-      const minimumEndDate = start.add(DRAFT_DURATION_MIN, "minutes");
+      // Clicks keep the 30-minute default. Once the pointer has moved, the end
+      // can shrink to one grid step (15) without flipping past the origin.
+      const defaultEndDate = start.add(DRAFT_DURATION_MIN, "minutes");
+      const minimumEndDate = start.add(GRID_TIME_STEP, "minutes");
       const pointerDate = getStartDate(point);
-      const isSameDayDrag = hasMoved && pointerDate.isSame(start, "day");
+
+      if (!hasMoved) {
+        return replaceGridDraftSchedule(
+          draftEvent,
+          timedGridSchedule(start.toDate(), defaultEndDate.toDate()),
+        );
+      }
+
+      const isSameDayDrag = pointerDate.isSame(start, "day");
       const isUpwardDrag = isSameDayDrag && pointerDate.isBefore(start);
-      const isDownwardDragPastMinimum =
-        isSameDayDrag && pointerDate.isAfter(minimumEndDate);
       const resolvedStartDate = isUpwardDrag ? pointerDate : start;
-      const resolvedEndDate = isDownwardDragPastMinimum
-        ? pointerDate
-        : isUpwardDrag
-          ? start
-          : minimumEndDate;
+      const resolvedEndDate = isUpwardDrag
+        ? start
+        : isSameDayDrag
+          ? pointerDate.isBefore(minimumEndDate)
+            ? minimumEndDate
+            : pointerDate
+          : defaultEndDate;
 
       return replaceGridDraftSchedule(
         draftEvent,

--- a/packages/web/src/grid/hooks/useTimedDraftCreation.ts
+++ b/packages/web/src/grid/hooks/useTimedDraftCreation.ts
@@ -92,8 +92,6 @@ export const useTimedDraftCreation = ({
       // Clicks keep the 30-minute default. Once the pointer has moved, the end
       // can shrink to one grid step (15) without flipping past the origin.
       const defaultEndDate = start.add(DRAFT_DURATION_MIN, "minutes");
-      const minimumEndDate = start.add(GRID_TIME_STEP, "minutes");
-      const pointerDate = getStartDate(point);
 
       if (!hasMoved) {
         return replaceGridDraftSchedule(
@@ -102,16 +100,22 @@ export const useTimedDraftCreation = ({
         );
       }
 
+      const minimumEndDate = start.add(GRID_TIME_STEP, "minutes");
+      const pointerDate = getStartDate(point);
       const isSameDayDrag = pointerDate.isSame(start, "day");
       const isUpwardDrag = isSameDayDrag && pointerDate.isBefore(start);
-      const resolvedStartDate = isUpwardDrag ? pointerDate : start;
-      const resolvedEndDate = isUpwardDrag
-        ? start
-        : isSameDayDrag
-          ? pointerDate.isBefore(minimumEndDate)
-            ? minimumEndDate
-            : pointerDate
-          : defaultEndDate;
+
+      let resolvedStartDate = start;
+      let resolvedEndDate = defaultEndDate;
+
+      if (isUpwardDrag) {
+        resolvedStartDate = pointerDate;
+        resolvedEndDate = start;
+      } else if (isSameDayDrag) {
+        resolvedEndDate = pointerDate.isBefore(minimumEndDate)
+          ? minimumEndDate
+          : pointerDate;
+      }
 
       return replaceGridDraftSchedule(
         draftEvent,

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -1052,6 +1052,34 @@ describe("DayCalendarGrid", () => {
     });
   });
 
+  it("shrinks a downward drag to one grid step without flipping the start", async () => {
+    renderDayCalendarGrid();
+
+    fireEvent.mouseDown(getTimedSlot(3), {
+      button: 0,
+      clientX: 100,
+      clientY: 120,
+    });
+    fireEvent.mouseMove(window, {
+      buttons: 1,
+      clientX: 100,
+      clientY: 135,
+    });
+    fireEvent.mouseUp(window, {
+      button: 0,
+      clientX: 100,
+      clientY: 135,
+    });
+
+    await waitFor(() => {
+      const draft = getDraft();
+
+      expect(draft).not.toBeNull();
+      expect(dayjs(draft?.startDate).format("HH:mm")).toBe("02:00");
+      expect(dayjs(draft?.endDate).format("HH:mm")).toBe("02:15");
+    });
+  });
+
   it("opens the timed draft form after stray zero-button mousemove events", async () => {
     renderDayCalendarGrid();
 

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
@@ -32,7 +32,11 @@ import {
   selectGridDraft,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { DECK_INDENT, DRAFT_DURATION_MIN } from "@web/grid/grid.constants";
+import {
+  DECK_INDENT,
+  DRAFT_DURATION_MIN,
+  GRID_TIME_STEP,
+} from "@web/grid/grid.constants";
 import { DraftContext } from "@web/views/Week/components/Draft/context/DraftContext";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import {
@@ -497,6 +501,21 @@ describe("MainGrid empty-grid draft creation", () => {
     await expectDraftRange(
       startOfView.add(11, "hour").format(),
       startOfView.add(11, "hour").add(DRAFT_DURATION_MIN, "minute").format(),
+    );
+  });
+
+  it("shrinks a downward drag to one grid step without flipping the start", async () => {
+    const { container } = renderMainGrid();
+    const row = getFirstTimedGridRow(container);
+
+    dragEmptyGrid(row, {
+      fromMinute: 11 * 60,
+      toMinute: 11 * 60 + GRID_TIME_STEP,
+    });
+
+    await expectDraftRange(
+      startOfView.add(11, "hour").format(),
+      startOfView.add(11, "hour").add(GRID_TIME_STEP, "minute").format(),
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Drag-create timed drafts can shrink to 15 minutes while keeping the start fixed; clicks still default to 30 minutes.
- Softens the draft card drop-shadow so the end edge/time stays readable.

## Test plan

- [x] `bun test:web` focused cases for MainGrid create, Day create, and TimedEventCard draft style
- [ ] Manually: click empty slot → 30-min draft; drag bottom of preview up to one slot → 15-min draft without flipping; drag past origin still flips

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43012f60-8d15-4b1a-b6ca-062becb35a49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43012f60-8d15-4b1a-b6ca-062becb35a49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

