### PR TITLE
fix(web): keep Enter as newline in description editor

### DIFF
--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -8,6 +8,7 @@ import {
   isEditableKeyboardTarget,
   isEventFormKeyboardTarget,
   isEventFormOpen,
+  shouldDeferEnterToTarget,
 } from "./form.util";
 import {
   afterEach,
@@ -200,6 +201,46 @@ describe("form.util", () => {
       const select = document.createElement("select");
 
       expect(isEditableKeyboardTarget(createEvent(select))).toBe(true);
+    });
+  });
+
+  describe("shouldDeferEnterToTarget", () => {
+    const createEvent = (element: HTMLElement | null) =>
+      ({ target: element }) as unknown as KeyboardEvent;
+
+    it("defers Enter for contenteditable targets", () => {
+      const editable = document.createElement("div");
+      editable.contentEditable = "true";
+
+      expect(shouldDeferEnterToTarget(createEvent(editable))).toBe(true);
+    });
+
+    it("defers Enter for textareas", () => {
+      const textarea = document.createElement("textarea");
+
+      expect(shouldDeferEnterToTarget(createEvent(textarea))).toBe(true);
+    });
+
+    it("defers Enter for buttons", () => {
+      const button = document.createElement("button");
+
+      expect(shouldDeferEnterToTarget(createEvent(button))).toBe(true);
+    });
+
+    it("defers Enter for role=button and links", () => {
+      const roleButton = document.createElement("div");
+      roleButton.setAttribute("role", "button");
+      const link = document.createElement("a");
+      link.setAttribute("href", "https://example.com");
+
+      expect(shouldDeferEnterToTarget(createEvent(roleButton))).toBe(true);
+      expect(shouldDeferEnterToTarget(createEvent(link))).toBe(true);
+    });
+
+    it("does not defer Enter for single-line inputs", () => {
+      const input = document.createElement("input");
+
+      expect(shouldDeferEnterToTarget(createEvent(input))).toBe(false);
     });
   });
 

--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -210,9 +210,20 @@ describe("form.util", () => {
 
     it("defers Enter for contenteditable targets", () => {
       const editable = document.createElement("div");
-      editable.contentEditable = "true";
+      // Set the attribute explicitly: jsdom often leaves isContentEditable
+      // undefined even after assigning the contentEditable property.
+      editable.setAttribute("contenteditable", "true");
 
       expect(shouldDeferEnterToTarget(createEvent(editable))).toBe(true);
+    });
+
+    it("defers Enter for descendants of a contenteditable host", () => {
+      const editable = document.createElement("div");
+      editable.setAttribute("contenteditable", "true");
+      const paragraph = document.createElement("p");
+      editable.appendChild(paragraph);
+
+      expect(shouldDeferEnterToTarget(createEvent(paragraph))).toBe(true);
     });
 
     it("defers Enter for textareas", () => {

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -71,6 +71,29 @@ export const isEditableKeyboardTarget = (
   return tagName === "input" || tagName === "textarea" || tagName === "select";
 };
 
+/**
+ * Targets where Enter has a native meaning and the event-form Enter-to-save
+ * hotkey must stand down: multiline editing (TipTap contenteditable /
+ * textarea), buttons (toolbar + Save/Cancel), and focused links.
+ * Single-line inputs are intentionally excluded so title/location Enter
+ * still submits.
+ */
+export const shouldDeferEnterToTarget = (
+  keyboardEvent: Pick<KeyboardEvent, "target">,
+) => {
+  const target = getKeyboardTarget(keyboardEvent);
+  if (!target) return false;
+
+  if (target.isContentEditable) return true;
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === "textarea" || tagName === "button") return true;
+  if (tagName === "a" && target.hasAttribute("href")) return true;
+  if (target.getAttribute("role") === "button") return true;
+
+  return false;
+};
+
 export const isEventFormKeyboardTarget = (
   keyboardEvent: Pick<KeyboardEvent, "target">,
 ) => {

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -56,6 +56,15 @@ export const isComboboxInteraction = (
   return Boolean(container);
 };
 
+// Prefer the contenteditable attribute (and ancestors) over
+// `HTMLElement.isContentEditable`: jsdom often leaves that getter undefined
+// even when TipTap has set contenteditable="true" on the focused node.
+const isContentEditableElement = (target: HTMLElement) =>
+  Boolean(
+    target.isContentEditable ||
+      target.closest("[contenteditable='true'], [contenteditable='']"),
+  );
+
 export const isEditableKeyboardTarget = (
   keyboardEvent: Pick<KeyboardEvent, "target">,
 ) => {
@@ -64,7 +73,7 @@ export const isEditableKeyboardTarget = (
   const target = getKeyboardTarget(keyboardEvent);
   if (!target) return false;
 
-  if (target.isContentEditable) return true;
+  if (isContentEditableElement(target)) return true;
 
   const tagName = target.tagName.toLowerCase();
 
@@ -84,7 +93,7 @@ export const shouldDeferEnterToTarget = (
   const target = getKeyboardTarget(keyboardEvent);
   if (!target) return false;
 
-  if (target.isContentEditable) return true;
+  if (isContentEditableElement(target)) return true;
 
   const tagName = target.tagName.toLowerCase();
   if (tagName === "textarea" || tagName === "button") return true;

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { DescriptionEditor } from "@web/components/DescriptionEditor/DescriptionEditor";
 import { describe, expect, it, mock } from "bun:test";
 
@@ -23,12 +24,34 @@ describe("DescriptionEditor", () => {
       />,
     );
 
-    expect(screen.getByRole("textbox", { name: "Description" })).toBeTruthy();
+    const textbox = screen.getByRole("textbox", { name: "Description" });
+    expect(textbox).toBeTruthy();
+    expect(textbox).toHaveAttribute("aria-multiline", "true");
     // TipTap's `content` option is only read at editor creation - onUpdate
     // must not fire just from mounting with existing content, or the
     // dirty-check (DirtyParser.isGridDraftDirty) would show every opened
     // event as dirty before the user touches anything.
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("reports an empty string when the document is cleared", async () => {
+    const user = userEvent.setup();
+    const onChange = mock();
+    render(
+      <DescriptionEditor
+        value="<p>Hello</p>"
+        onChange={onChange}
+        editable={true}
+        resetKey="test-empty"
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Description" });
+    await user.click(textbox);
+    await user.keyboard("{Control>}a{/Control}{Backspace}");
+
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("");
   });
 
   it("hides the toolbar and marks the textbox non-editable when read-only", () => {

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
@@ -142,10 +142,14 @@ export const DescriptionEditor = ({
         attributes: {
           role: "textbox",
           "aria-label": placeholder,
+          "aria-multiline": "true",
           ...(id ? { id } : {}),
         },
       },
-      onUpdate: ({ editor: updated }) => onChange(updated.getHTML()),
+      // TipTap's empty document is still `<p></p>` from getHTML(); normalize
+      // to "" so DirtyParser and persistence treat "cleared" like never set.
+      onUpdate: ({ editor: updated }) =>
+        onChange(updated.isEmpty ? "" : updated.getHTML()),
       onFocus: () => setIsFocused(true),
       onBlur: () => setIsFocused(false),
     },

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -409,6 +409,36 @@ describe("EventForm", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("does not submit when Enter is pressed in the description field", async () => {
+    // Regression: existing-event Enter-to-save used ignoreInputs:false and
+    // skipped only drafts/comboboxes, so TipTap never received Enter as a
+    // newline. shouldDeferEnterToTarget must stand the hotkey down here.
+    const user = userEvent.setup();
+    const onSubmit = mock();
+
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft({ description: "Plan the launch" })}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={onSubmit}
+        setDraft={mock()}
+      />,
+    );
+
+    const descriptionField = screen.getByRole("textbox", {
+      name: "Description",
+    });
+    act(() => descriptionField.focus());
+
+    await user.keyboard("{Enter}");
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("still deletes an existing event when Delete is pressed on a non-text form target", async () => {
     const onClose = mock();
     const onDelete = mock();

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -439,6 +439,33 @@ describe("EventForm", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("submits when Enter is pressed on the focused Save button", async () => {
+    // Companion to the description carve-out: Enter hotkey must not
+    // preventDefault when deferring to buttons, or Tab→Save→Enter dies.
+    const user = userEvent.setup();
+    const onSubmit = mock();
+
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft()}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={onSubmit}
+        setDraft={mock()}
+      />,
+    );
+
+    const save = screen.getByRole("button", { name: "Save" });
+    act(() => save.focus());
+
+    await user.keyboard("{Enter}");
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it("still deletes an existing event when Delete is pressed on a non-text form target", async () => {
     const onClose = mock();
     const onDelete = mock();

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -611,6 +611,9 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
     );
 
+    // preventDefault/stopPropagation stay off until we actually submit:
+    // TanStack applies those before the callback, so an early return for
+    // TipTap/buttons would otherwise swallow native Enter (newline / click).
     useAppShortcut(
       "Enter",
       (keyboardEvent) => {
@@ -626,9 +629,15 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           return;
         }
 
+        keyboardEvent.preventDefault();
+        keyboardEvent.stopPropagation();
         onSubmitForm();
       },
-      EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
+      {
+        ...EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
+        preventDefault: false,
+        stopPropagation: false,
+      },
     );
 
     useAppShortcut(

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -31,6 +31,7 @@ import { getVisibleGridStartMinute } from "@web/common/utils/draft/draft.util";
 import {
   isComboboxInteraction,
   isDeleteTextEditingTarget,
+  shouldDeferEnterToTarget,
 } from "@web/common/utils/form/form.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { DescriptionEditor } from "@web/components/DescriptionEditor/DescriptionEditor";
@@ -618,6 +619,10 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         }
 
         if (isComboboxInteraction(keyboardEvent)) {
+          return;
+        }
+
+        if (shouldDeferEnterToTarget(keyboardEvent)) {
           return;
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Editing an existing event’s description and pressing Enter was saving the form instead of inserting a new line. The TipTap editor is fine — the event form’s global Enter-to-save hotkey used `ignoreInputs: false` and only skipped drafts/comboboxes, so it stole Enter from `contenteditable`.

## Changes

- Add `shouldDeferEnterToTarget` and use it in the Enter hotkey so multiline editing (and buttons/links) keep native Enter behavior; title/location Enter-to-save is unchanged
- Detect contenteditable via the attribute (and ancestors), not only `isContentEditable` — jsdom leaves that getter undefined for TipTap
- Keep TanStack `preventDefault`/`stopPropagation` off until we actually submit, so deferring Enter does not swallow TipTap newlines or Save-button activation
- Normalize empty TipTap documents to `""` instead of `"<p></p>"` so dirty-check / persistence stay correct when cleared
- Set `aria-multiline="true"` on the description textbox
- Regression tests for the helper, Enter-in-description, Save-button Enter, empty clear, and aria attribute

## Simplicity

Small helper next to the existing form keyboard utilities; Enter hotkey gains one early return and conditional preventDefault. No TipTap API or Mod+Enter changes. `/simplify` found nothing further to remove.

## Automated validation

- `bun test:web` on `form.util.test.ts`, `DescriptionEditor.test.tsx`, `EventForm.test.tsx`, `EventForm.readOnly.test.tsx` — 67 pass
- `bun lint` — clean for this diff (pre-existing warnings only)
- Playwright against local app: create event, reopen existing edit, type in Description, press Enter → 2 paragraphs, form stayed open, Save still worked

![Description multiline after Enter](https://cursor.com/artifacts/c/art-32074653-5c04-4991-9e59-08523bcfad3e)

## Independent review

Fresh read-only review after the preventDefault fix: no confirmed findings. An earlier review caught that deferring Enter while TanStack still preventDefaulted would break TipTap newlines and Tab→Save→Enter; fixed before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78aad784-c577-42f1-83b0-a012e848c719?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78aad784-c577-42f1-83b0-a012e848c719&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

