### PR TITLE
fix(web): Up Next banner contrast and dismiss/entrance polish

### DIFF
--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.test.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.test.tsx
@@ -159,15 +159,20 @@ describe("UpNextBanner", () => {
     });
   });
 
-  it("dismissing hides the banner and it stays hidden for that event", () => {
+  it("dismissing fades the banner out, then hides it for that event", async () => {
     render(<UpNextBanner />, {
       events: [timedEvent(SOON_EVENT_ID, "Soon Event", 2)],
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
 
-    expect(screen.queryByText("Soon Event")).toBeNull();
-    expect(screen.queryByRole("status")).toBeNull();
+    // Stays mounted for the fade-out beat rather than vanishing instantly.
+    expect(screen.getByRole("status")).toHaveAttribute("data-closing");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Soon Event")).toBeNull();
+      expect(screen.queryByRole("status")).toBeNull();
+    });
   });
 
   it("pressing Escape dismisses the banner", async () => {
@@ -180,7 +185,9 @@ describe("UpNextBanner", () => {
 
     await user.keyboard("{Escape}");
 
-    expect(screen.queryByText("Soon Event")).toBeNull();
-    expect(screen.queryByRole("status")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByText("Soon Event")).toBeNull();
+      expect(screen.queryByRole("status")).toBeNull();
+    });
   });
 });

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.tsx
@@ -13,9 +13,12 @@ const MINUTES_BEFORE_START = 2;
  * start, mirroring Vimcal. N opens the event's details; when the event has a
  * meeting link, the primary action switches to V for "Join" instead.
  */
+const DISMISS_ANIMATION_MS = 200;
+
 export const UpNextBanner: FC = () => {
   const { now, openEventDetails, upNext, conferenceUrl } = useUpNextEvent();
   const [dismissedId, setDismissedId] = useState<string | undefined>(undefined);
+  const [isClosing, setIsClosing] = useState(false);
 
   const isWithinWindow =
     Boolean(upNext) &&
@@ -25,6 +28,22 @@ export const UpNextBanner: FC = () => {
   const openConference = () =>
     window.open(conferenceUrl, "_blank", "noopener,noreferrer");
 
+  // Keeps the banner mounted for one fade-out beat instead of yanking it
+  // instantly, matching ReleaseNotesPrompt's dismiss pattern.
+  const dismiss = () => {
+    if (isClosing) return;
+    setIsClosing(true);
+    const reducedMotion =
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    window.setTimeout(
+      () => {
+        setDismissedId(upNext?._id);
+        setIsClosing(false);
+      },
+      reducedMotion ? 0 : DISMISS_ANIMATION_MS,
+    );
+  };
+
   useAppShortcutUp("N", () => openEventDetails("keyboardEdit"));
   useAppShortcutUp("V", openConference, {
     enabled: Boolean(conferenceUrl) && isWithinWindow,
@@ -33,9 +52,7 @@ export const UpNextBanner: FC = () => {
   // other Escape handling (e.g. useEscapeToCloseForm closing the event form)
   // the same way every other Escape shortcut in the app does - Escape is
   // never scoped to "not while typing" here, matching that convention.
-  useAppShortcutUp("Escape", () => setDismissedId(upNext?._id), {
-    enabled: isVisible,
-  });
+  useAppShortcutUp("Escape", dismiss, { enabled: isVisible });
 
   if (!isVisible || !upNext) {
     return null;
@@ -45,7 +62,9 @@ export const UpNextBanner: FC = () => {
 
   return (
     <div
-      className="fixed bottom-6 left-1/2 flex w-72 -translate-x-1/2 items-center gap-3 rounded border border-border bg-surface-overlay px-3 py-2 text-sm text-text shadow-lg"
+      aria-atomic="true"
+      className="fixed bottom-6 left-1/2 flex w-72 -translate-x-1/2 starting:translate-y-2 items-center gap-3 rounded-lg border border-border bg-surface-panel/80 px-3 py-2 text-sm text-text starting:opacity-0 shadow-xl backdrop-blur-md transition-all duration-300 ease-out data-closing:opacity-0 motion-reduce:transition-none"
+      data-closing={isClosing || undefined}
       role="status"
       style={{ zIndex: Z_INDEX_FLOATING_MENU }}
     >
@@ -72,7 +91,7 @@ export const UpNextBanner: FC = () => {
       <button
         aria-label="Dismiss"
         className="c-focus-ring shrink-0 rounded-xs px-1 text-text-muted hover:text-text"
-        onClick={() => setDismissedId(upNext._id)}
+        onClick={dismiss}
         type="button"
       >
         &times;


### PR DESCRIPTION
## Summary
- Fixes low contrast on the Up Next banner: it used `bg-surface-overlay`, a ~6-7% opacity token meant for subtle overlays on the app's own background, so it was nearly unreadable sitting on top of a colored event card. Switches to an 80%-opaque `bg-surface-panel` fill plus `backdrop-blur-md` — a real frosted-glass treatment that stays legible against any event color while still reading as glass, not a flat card.
- Adds a gentle entrance transition (Tailwind v4's `starting:` variant, CSS-only) and a matching exit fade on dismiss, reusing this codebase's own established `data-closing` pattern from `ReleaseNotesPrompt`.
- Adds `aria-atomic="true"` so screen readers announce the countdown + title as one unit rather than a partial diff.

## Test plan
- [x] `bun run type-check` clean
- [x] `bun run lint` clean (no new warnings)
- [x] Web: 18 targeted tests pass (`UpNextBanner`, `UpNextCard`), including an updated dismiss test that asserts the `data-closing` fade state before the banner actually unmounts
- [x] Manually verified in the browser (both the contrast fix over a colored event and the dismiss fade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)