### PR TITLE
fix(web): submit event form with Mod+Enter from color swatch

### DIFF
--- a/packages/web/src/shortcuts/useAppShortcut.test.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.test.ts
@@ -112,6 +112,40 @@ describe("useAppShortcut", () => {
     document.body.removeChild(input);
   });
 
+  it("keeps Mod shortcuts active on focused radios after re-render", async () => {
+    // Omitting ignoreInputs must not clobber TanStack's Mod default
+    // (ignoreInputs: false) via setOptions({ ignoreInputs: undefined }).
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    document.body.appendChild(radio);
+    radio.focus();
+
+    const modifierKey = resolveModifier("Mod");
+    const isCtrl = modifierKey === "Control";
+
+    const { rerender } = renderHook(() =>
+      useAppShortcut("Mod+Enter", mockHandler),
+    );
+
+    rerender();
+
+    dispatchKeyEvent(
+      "Enter",
+      "keydown",
+      {
+        ctrlKey: isCtrl,
+        metaKey: !isCtrl,
+      },
+      radio,
+    );
+
+    await waitFor(() => {
+      expect(mockHandler).toHaveBeenCalledTimes(1);
+    });
+
+    document.body.removeChild(radio);
+  });
+
   it("blurs the active element before handling the shortcut when requested", async () => {
     const input = document.createElement("input");
     const blurSpy = mock();

--- a/packages/web/src/shortcuts/useAppShortcut.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.ts
@@ -37,6 +37,8 @@ export function useAppShortcut(
     conflictBehavior = "allow",
   } = options;
 
+  // Omit undefined option keys so TanStack's setOptions cannot clobber
+  // registration defaults (e.g. Mod shortcuts resolve ignoreInputs: false).
   useHotkey(
     hotkey,
     (event) => {
@@ -52,11 +54,11 @@ export function useAppShortcut(
     },
     {
       enabled,
-      ignoreInputs,
       eventType,
-      preventDefault,
-      stopPropagation,
       conflictBehavior,
+      ...(ignoreInputs !== undefined ? { ignoreInputs } : {}),
+      ...(preventDefault !== undefined ? { preventDefault } : {}),
+      ...(stopPropagation !== undefined ? { stopPropagation } : {}),
     },
   );
 }

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -108,6 +108,22 @@ function dispatchModD(target: HTMLElement) {
   );
 }
 
+function dispatchModEnter(target: HTMLElement) {
+  const modifierKey = resolveModifier("Mod");
+  const isControl = modifierKey === "Control";
+
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      ctrlKey: isControl,
+      key: "Enter",
+      metaKey: !isControl,
+    }),
+  );
+}
+
 function dispatchArrowDown(target: HTMLElement) {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
@@ -464,6 +480,58 @@ describe("EventForm", () => {
     await user.keyboard("{Enter}");
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits with Mod+Enter while a color swatch is focused", async () => {
+    // Color radios are HTMLInputElements; after a color change the form
+    // re-renders with focus still on the swatch. Mod+Enter must still submit
+    // (ignoreInputs: false), not only when focus returns to a text field.
+    const user = userEvent.setup();
+    const onSubmit = mock();
+
+    function Harness() {
+      const [draft, setDraftState] = useState<GridEventDraft>(
+        createEditDraft(),
+      );
+      const setDraftFromForm = (
+        nextDraft: SetStateAction<GridEventDraft | null>,
+      ) => {
+        setDraftState((currentDraft) => {
+          const resolvedDraft =
+            typeof nextDraft === "function"
+              ? nextDraft(currentDraft)
+              : nextDraft;
+
+          return resolvedDraft ?? currentDraft;
+        });
+      };
+
+      return (
+        <EventForm
+          draft={draft}
+          isDraft={false}
+          isExistingEvent={true}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={onSubmit}
+          setDraft={setDraftFromForm}
+        />
+      );
+    }
+
+    renderWithStore(<Harness />);
+
+    const blueSwatch = screen.getByRole("radio", { name: "Blue" });
+    await user.click(blueSwatch);
+
+    expect(blueSwatch).toHaveFocus();
+
+    dispatchModEnter(blueSwatch);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("still deletes an existing event when Delete is pressed on a non-text form target", async () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -92,7 +92,7 @@ mock.module("@web/views/Forms/EventForm/SaveSection", () => ({
 
 const { EventForm } = require("./EventForm") as typeof import("./EventForm");
 
-function dispatchModD(target: HTMLElement) {
+function dispatchModKey(target: HTMLElement, key: string) {
   const modifierKey = resolveModifier("Mod");
   const isControl = modifierKey === "Control";
 
@@ -102,23 +102,7 @@ function dispatchModD(target: HTMLElement) {
       cancelable: true,
       composed: true,
       ctrlKey: isControl,
-      key: "d",
-      metaKey: !isControl,
-    }),
-  );
-}
-
-function dispatchModEnter(target: HTMLElement) {
-  const modifierKey = resolveModifier("Mod");
-  const isControl = modifierKey === "Control";
-
-  target.dispatchEvent(
-    new KeyboardEvent("keydown", {
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-      ctrlKey: isControl,
-      key: "Enter",
+      key,
       metaKey: !isControl,
     }),
   );
@@ -337,7 +321,7 @@ describe("EventForm", () => {
     const titleField = screen.getByPlaceholderText("Title");
     act(() => titleField.focus());
 
-    dispatchModD(titleField);
+    dispatchModKey(titleField, "d");
 
     await waitFor(() => {
       expect(onDuplicate).toHaveBeenCalledTimes(1);
@@ -490,21 +474,11 @@ describe("EventForm", () => {
     const onSubmit = mock();
 
     function Harness() {
-      const [draft, setDraftState] = useState<GridEventDraft>(
+      const [draft, setDraft] = useState<GridEventDraft | null>(
         createEditDraft(),
       );
-      const setDraftFromForm = (
-        nextDraft: SetStateAction<GridEventDraft | null>,
-      ) => {
-        setDraftState((currentDraft) => {
-          const resolvedDraft =
-            typeof nextDraft === "function"
-              ? nextDraft(currentDraft)
-              : nextDraft;
 
-          return resolvedDraft ?? currentDraft;
-        });
-      };
+      if (!draft) return null;
 
       return (
         <EventForm
@@ -515,7 +489,7 @@ describe("EventForm", () => {
           onDelete={mock()}
           onDuplicate={mock()}
           onSubmit={onSubmit}
-          setDraft={setDraftFromForm}
+          setDraft={setDraft}
         />
       );
     }
@@ -527,7 +501,35 @@ describe("EventForm", () => {
 
     expect(blueSwatch).toHaveFocus();
 
-    dispatchModEnter(blueSwatch);
+    dispatchModKey(blueSwatch, "Enter");
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("submits exactly once with Mod+Enter from the title field", async () => {
+    // Local handleIgnoredKeys only preventDefaults Mod+Enter; the global
+    // useAppShortcut owns submit. Both must not call onSubmit.
+    const onSubmit = mock();
+
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft()}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={onSubmit}
+        setDraft={mock()}
+      />,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    dispatchModKey(titleField, "Enter");
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledTimes(1);

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -437,7 +437,6 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
       if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
         e.preventDefault();
-        onSubmitForm();
       }
     };
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -656,9 +656,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         e.preventDefault();
         onSubmitForm();
       },
-      {
-        enabled: true,
-      },
+      EVENT_FORM_PLAIN_HOTKEY_OPTIONS,
     );
 
     useEscapeToCloseForm(onClose);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CMD/Ctrl+Enter did nothing when focus stayed on an event color radio after changing color. `Mod+Enter` was registered without `ignoreInputs: false`, and `useAppShortcut` passed `ignoreInputs: undefined` into TanStack `setOptions`, which clobbered the Mod-key default (`ignoreInputs: false`) on re-render. Title/description still worked via a local `onKeyDown` path that color radios never received.

This registers `Mod+Enter` with `EVENT_FORM_PLAIN_HOTKEY_OPTIONS` (same as `Mod+D`), omits undefined hotkey option keys so TanStack defaults survive re-renders, and stops the local field handler from also calling `onSubmitForm` so text fields submit exactly once.

## Simplicity

Minimal fix: reuse the existing form hotkey options constant, build `useHotkey` options without spreading `undefined`, and align local Mod+Enter with Mod+D (preventDefault only). Test helpers merged to one Mod dispatch.

## Automated validation

- Focused web tests for `useAppShortcut` and `EventForm` (color-swatch Mod+Enter, title once-submit, Mod+radio after rerender): 41 pass
- `bun lint`: clean for touched files (3 pre-existing warnings elsewhere)

## Independent review

Confirmed high finding fixed: dual Mod+Enter submit from text fields after enabling global ignoreInputs:false. Local handler now only preventDefaults; once-submit regression added. No other confirmed findings.

## Test plan

- `bun test:web packages/web/src/shortcuts/useAppShortcut.test.ts packages/web/src/views/Forms/EventForm/EventForm.test.tsx`
- `bun lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af0478d3-e7a4-45bb-a110-9b66c7f9b66a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af0478d3-e7a4-45bb-a110-9b66c7f9b66a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

